### PR TITLE
Prevent filter changes when doing a rerun

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
@@ -926,8 +926,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             FilterInfo imagingFilter,
             List<StarDetectionRegion> regions,
             CancellationToken token,
-            IProgress<ApplicationStatus> progress) {
-            var autofocusFilter = await SetAutofocusFilter(imagingFilter, token, progress);
+            IProgress<ApplicationStatus> progress, bool forRerun = false) {
+            var autofocusFilter = forRerun ? imagingFilter : await SetAutofocusFilter(imagingFilter, token, progress);
             return new AutoFocusState(
                 options,
                 autofocusFilter,
@@ -1374,7 +1374,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         private async Task<AutoFocusResult> RerunImpl(AutoFocusEngineOptions options, SavedAutoFocusAttempt savedAttempt, FilterInfo imagingFilter, List<StarDetectionRegion> regions, CancellationToken token, IProgress<ApplicationStatus> progress) {
             OnStarted();
 
-            var state = await InitializeState(options, imagingFilter, regions, token, progress);
+            var state = await InitializeState(options, imagingFilter, regions, token, progress, true);
             InitializeSave(state);
 
             state.OnNextAttempt();


### PR DESCRIPTION
A pretty simple one...

Added forRerun flag (default to false) to InitializeState method of AutoFocus.  When that flag is true filter change is missed out.

RerunImpl sets the forRerun flag to true.  RunImpl does not.

As I don't have a license for ILNumerics, I can only test it so far.  But, my test does get past the change I've made before throwing a licence exception.