### PR TITLE
Fixed problem that was stopping reruns of AI when using multi frames per position

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
@@ -1395,14 +1395,14 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             });
 
             try {
-                var framesPerPoint = savedFiles.Max(f => f.FrameNumber);
+                var framesPerPoint = savedFiles.Max(f => f.FrameNumber)+1;
                 state.Options.FramesPerPoint = framesPerPoint;
                 foreach (var focuserPositionGroup in savedFiles.GroupBy(f => f.FocuserPosition)) {
                     var focuserPosition = focuserPositionGroup.Key;
 
                     // Previous versions mistakenly saved the initial image in the attempt folder, which led to duplicate key exceptions
-                    var imageNumber = focuserPositionGroup.Max(g => g.ImageNumber);
-                    var files = focuserPositionGroup.Where(g => g.ImageNumber == imageNumber).OrderBy(g => g.FrameNumber).ToList();
+                    //var imageNumber = focuserPositionGroup.Max(g => g.ImageNumber);
+                    var files = focuserPositionGroup./*Where(g => g.ImageNumber == imageNumber).*/OrderBy(g => g.FrameNumber).ToList();
                     var allMeasurementTasks = new List<Task>();
                     foreach (var savedFile in files) {
                         var imageState = await state.OnNextImage(savedFile.FrameNumber, savedFile.FocuserPosition, false, token);
@@ -1598,7 +1598,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 HFRImprovementThreshold = autoFocusOptions.HFRImprovementThreshold,
                 AutoFocusTimeout = TimeSpan.FromSeconds(autoFocusOptions.AutoFocusTimeoutSeconds),
                 AutoFocusInitialOffsetSteps = profileService.ActiveProfile.FocuserSettings.AutoFocusInitialOffsetSteps,
-                AutoFocusStepSize = savedAttempt?.StepSize ?? profileService.ActiveProfile.FocuserSettings.AutoFocusStepSize,
+                AutoFocusStepSize = (savedAttempt?.StepSize>0) ? savedAttempt.StepSize.Value : profileService.ActiveProfile.FocuserSettings.AutoFocusStepSize,
                 FocuserOffset = autoFocusOptions.FocuserOffset,
                 MaxOutlierRejections = autoFocusOptions.MaxOutlierRejections,
                 OutlierRejectionConfidence = autoFocusOptions.OutlierRejectionConfidence,


### PR DESCRIPTION
Corrected frame count for multiple frames per point processing in reruns.

Only one image per point was being processed but frame count was set to images per point -1

Changed to use all the images at each point and correctly set the frame count to number of images per point.

Final analysis fails because there is an explicit test to fail if there are more than 1 images in the final folder.  But there are multiple images in the final folder if there are multiple images per point.  Maybe it should analyse the last of the final images?