### PR TITLE
Add Tier 2 unit tests; fix TiltPlaneModel negative-width validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,16 @@ Camera images may be mirrored horizontally and/or vertically depending on the op
 - **Clear your Claude Code context (`/clear`) before executing a plan** to avoid stale context from the planning session affecting implementation.
 - The user will explicitly say when a plan is ready to execute.
 
+## Git Workflow
+
+- **Never push to `develop` directly.** Create a feature branch (`ghilios/<topic>`), push it, and open a PR — `develop` is only updated via PR merges.
+- **Author + committer email** must be `322725+ghilios@users.noreply.github.com`. GitHub email-privacy blocks pushes from `ghilios@gmail.com`. When committing, set both:
+  ```
+  GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+    git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" -m "..."
+  ```
+  If a commit slips through with `ghilios@gmail.com`, amend it with `--author=` and the env vars above before pushing.
+
 ---
 
 ## Directory Structure

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/TiltPlaneModelTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/TiltPlaneModelTests.cs
@@ -1,0 +1,212 @@
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NUnit.Framework;
+using System;
+using System.Drawing;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
+
+    [TestFixture]
+    public class TiltPlaneModelTests {
+
+        private static TiltPlaneModel BuildEqualCorners(double focuser, double micronsPerStep = 5.0) {
+            return TiltPlaneModel.Create(
+                imageSize: new Size(2000, 1000),
+                fRatio: 5.0,
+                focuserStepSizeMicrons: micronsPerStep,
+                centerFocuser: focuser,
+                topLeftFocuser: focuser,
+                topRightFocuser: focuser,
+                bottomLeftFocuser: focuser,
+                bottomRightFocuser: focuser);
+        }
+
+        [Test]
+        public void Create_AllCornersEqual_PlaneIsFlatWithZeroAdjustment() {
+            const double focuser = 12345.0;
+            var model = BuildEqualCorners(focuser);
+
+            Assert.Multiple(() => {
+                Assert.That(model.A, Is.EqualTo(0.0).Within(1e-9));
+                Assert.That(model.B, Is.EqualTo(0.0).Within(1e-9));
+                Assert.That(model.C, Is.EqualTo(focuser).Within(1e-9));
+                Assert.That(model.MeanFocuserPosition, Is.EqualTo(focuser).Within(1e-9));
+                Assert.That(model.TopLeft.AdjustmentRequiredSteps, Is.EqualTo(0.0).Within(1e-9));
+                Assert.That(model.TopRight.AdjustmentRequiredSteps, Is.EqualTo(0.0).Within(1e-9));
+                Assert.That(model.BottomLeft.AdjustmentRequiredSteps, Is.EqualTo(0.0).Within(1e-9));
+                Assert.That(model.BottomRight.AdjustmentRequiredSteps, Is.EqualTo(0.0).Within(1e-9));
+                Assert.That(model.TopLeft.AdjustmentRequiredMicrons, Is.EqualTo(0.0).Within(1e-9));
+                Assert.That(model.TopRight.AdjustmentRequiredMicrons, Is.EqualTo(0.0).Within(1e-9));
+                Assert.That(model.BottomLeft.AdjustmentRequiredMicrons, Is.EqualTo(0.0).Within(1e-9));
+                Assert.That(model.BottomRight.AdjustmentRequiredMicrons, Is.EqualTo(0.0).Within(1e-9));
+            });
+        }
+
+        [Test]
+        public void Center_AdjustmentValues_AreNaN() {
+            var model = BuildEqualCorners(1000.0);
+            Assert.Multiple(() => {
+                Assert.That(double.IsNaN(model.Center.AdjustmentRequiredSteps), Is.True);
+                Assert.That(double.IsNaN(model.Center.AdjustmentRequiredMicrons), Is.True);
+            });
+        }
+
+        [Test]
+        public void Create_TiltedAlongX_RecoversAFromCornerDelta() {
+            // Right side higher than left by 100 steps (uniform top→bottom)
+            var model = TiltPlaneModel.Create(
+                imageSize: new Size(2000, 1000), fRatio: 5.0, focuserStepSizeMicrons: 5.0,
+                centerFocuser: 1000,
+                topLeftFocuser: 950, topRightFocuser: 1050,
+                bottomLeftFocuser: 950, bottomRightFocuser: 1050);
+
+            Assert.Multiple(() => {
+                // X spans from -0.5 to 0.5 = 1.0; deltaY across X = 100 → A = 100
+                Assert.That(model.A, Is.EqualTo(100.0).Within(1e-6));
+                Assert.That(model.B, Is.EqualTo(0.0).Within(1e-6));
+                Assert.That(model.C, Is.EqualTo(1000.0).Within(1e-6));
+            });
+        }
+
+        [Test]
+        public void Create_TiltedAlongY_RecoversBFromCornerDelta() {
+            var model = TiltPlaneModel.Create(
+                imageSize: new Size(2000, 1000), fRatio: 5.0, focuserStepSizeMicrons: 5.0,
+                centerFocuser: 1000,
+                topLeftFocuser: 950, topRightFocuser: 950,
+                bottomLeftFocuser: 1050, bottomRightFocuser: 1050);
+
+            Assert.Multiple(() => {
+                Assert.That(model.A, Is.EqualTo(0.0).Within(1e-6));
+                Assert.That(model.B, Is.EqualTo(100.0).Within(1e-6));
+                Assert.That(model.C, Is.EqualTo(1000.0).Within(1e-6));
+            });
+        }
+
+        [Test]
+        public void Create_AdjustmentMicrons_EqualStepsTimesStepSize() {
+            const double micronsPerStep = 7.5;
+            var model = TiltPlaneModel.Create(
+                imageSize: new Size(2000, 1000), fRatio: 5.0, focuserStepSizeMicrons: micronsPerStep,
+                centerFocuser: 1000,
+                topLeftFocuser: 950, topRightFocuser: 1050,
+                bottomLeftFocuser: 950, bottomRightFocuser: 1050);
+
+            Assert.Multiple(() => {
+                Assert.That(model.TopRight.AdjustmentRequiredMicrons,
+                    Is.EqualTo(model.TopRight.AdjustmentRequiredSteps * micronsPerStep).Within(1e-9));
+                Assert.That(model.TopLeft.AdjustmentRequiredMicrons,
+                    Is.EqualTo(model.TopLeft.AdjustmentRequiredSteps * micronsPerStep).Within(1e-9));
+            });
+        }
+
+        [Test]
+        public void EstimateFocusPosition_AtImageCenter_ReturnsC() {
+            // Coherent corners: TL/BR symmetric, TR/BL symmetric → OLS plane goes exactly through the center
+            const double tl = 950, tr = 1050, bl = 950, br = 1050;
+            var model = TiltPlaneModel.Create(
+                imageSize: new Size(2000, 1000), fRatio: 5.0, focuserStepSizeMicrons: 5.0,
+                centerFocuser: 1000,
+                topLeftFocuser: tl, topRightFocuser: tr,
+                bottomLeftFocuser: bl, bottomRightFocuser: br);
+
+            // Width=2000 → image center pixel x=1000 → modelX = 1000/2000 - 0.5 = 0
+            // Height=1000 → image center pixel y=500 → modelY = 500/1000 - 0.5 = 0
+            // So the plane evaluates to C = 1000 (the OLS intercept = mean of corners)
+            Assert.That(model.EstimateFocusPosition(1000, 500), Is.EqualTo(1000.0).Within(1e-6));
+        }
+
+        [Test]
+        public void EstimateFocusPosition_AtTopLeftPixel_MatchesTopLeftCornerInput() {
+            // Pixel (0, 0) maps to model coords (-0.5, -0.5), which is exactly the OLS top-left input,
+            // so for coherent corner data it should match the input value exactly.
+            const double tl = 950, tr = 1050, bl = 950, br = 1050;
+            var model = TiltPlaneModel.Create(
+                imageSize: new Size(2000, 1000), fRatio: 5.0, focuserStepSizeMicrons: 5.0,
+                centerFocuser: 1000,
+                topLeftFocuser: tl, topRightFocuser: tr,
+                bottomLeftFocuser: bl, bottomRightFocuser: br);
+
+            Assert.That(model.EstimateFocusPosition(0, 0), Is.EqualTo(tl).Within(1e-6));
+        }
+
+        [Test]
+        public void GetModelX_AtImageCenter_ReturnsApproximatelyZero() {
+            var model = BuildEqualCorners(1000.0);
+            // ImageSize.Width = 2000; Center pixel x=1000 → 1000/2000 - 0.5 = 0
+            Assert.That(model.GetModelX(1000), Is.EqualTo(0.0).Within(1e-9));
+        }
+
+        [Test]
+        public void GetModelX_AtLeftEdge_IsMinusOneHalf() {
+            var model = BuildEqualCorners(1000.0);
+            Assert.That(model.GetModelX(0), Is.EqualTo(-0.5).Within(1e-9));
+        }
+
+        [Test]
+        public void GetModelX_OutOfRange_Throws() {
+            var model = BuildEqualCorners(1000.0);
+            Assert.Multiple(() => {
+                Assert.Throws<ArgumentException>(() => model.GetModelX(-1));
+                Assert.Throws<ArgumentException>(() => model.GetModelX(2000));
+            });
+        }
+
+        [Test]
+        public void GetModelY_OutOfRange_Throws() {
+            var model = BuildEqualCorners(1000.0);
+            Assert.Multiple(() => {
+                Assert.Throws<ArgumentException>(() => model.GetModelY(-1));
+                Assert.Throws<ArgumentException>(() => model.GetModelY(1000));
+            });
+        }
+
+        [Test]
+        public void Constructor_NaNFRatio_DefaultsToFive() {
+            var model = TiltPlaneModel.Create(
+                imageSize: new Size(2000, 1000), fRatio: double.NaN, focuserStepSizeMicrons: 5.0,
+                centerFocuser: 1000, topLeftFocuser: 1000, topRightFocuser: 1000,
+                bottomLeftFocuser: 1000, bottomRightFocuser: 1000);
+            Assert.That(model.FRatio, Is.EqualTo(5.0));
+        }
+
+        [Test]
+        public void Constructor_ZeroWidth_Throws() {
+            Assert.Throws<ArgumentException>(() => new TiltPlaneModel(
+                imageSize: new Size(0, 1000), fRatio: 5.0,
+                a: 0, b: 0, c: 1000, mean: 1000, focuserStepSizeMicrons: 5.0,
+                centerPosition: 1000, topLeftPosition: 1000, topRightPosition: 1000,
+                bottomLeftPosition: 1000, bottomRightPosition: 1000));
+        }
+
+        [Test]
+        public void Constructor_ZeroHeight_Throws() {
+            Assert.Throws<ArgumentException>(() => new TiltPlaneModel(
+                imageSize: new Size(2000, 0), fRatio: 5.0,
+                a: 0, b: 0, c: 1000, mean: 1000, focuserStepSizeMicrons: 5.0,
+                centerPosition: 1000, topLeftPosition: 1000, topRightPosition: 1000,
+                bottomLeftPosition: 1000, bottomRightPosition: 1000));
+        }
+
+        // Spec-first divergence flag: per the comprehensive-unit-tests plan, the
+        // ctor at TiltModel.cs:40 reads `imageSize.Width == 0 || imageSize.Height <= 0`.
+        // A negative width is asymmetric — the spec says positive dimensions, so the
+        // negative-width case should also throw.
+        [Test]
+        public void Constructor_NegativeWidth_Throws_SPEC() {
+            Assert.Throws<ArgumentException>(() => new TiltPlaneModel(
+                imageSize: new Size(-1, 1000), fRatio: 5.0,
+                a: 0, b: 0, c: 1000, mean: 1000, focuserStepSizeMicrons: 5.0,
+                centerPosition: 1000, topLeftPosition: 1000, topRightPosition: 1000,
+                bottomLeftPosition: 1000, bottomRightPosition: 1000));
+        }
+
+        [Test]
+        public void Constructor_NegativeHeight_Throws() {
+            Assert.Throws<ArgumentException>(() => new TiltPlaneModel(
+                imageSize: new Size(2000, -1), fRatio: 5.0,
+                a: 0, b: 0, c: 1000, mean: 1000, focuserStepSizeMicrons: 5.0,
+                centerPosition: 1000, topLeftPosition: 1000, topRightPosition: 1000,
+                bottomLeftPosition: 1000, bottomRightPosition: 1000));
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorParaboloidModelTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorParaboloidModelTests.cs
@@ -1,0 +1,144 @@
+using NINA.Joko.Plugins.HocusFocus.Inspection;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
+
+    [TestFixture]
+    public class SensorParaboloidModelTests {
+        private IAlglibAPI alglibAPI;
+
+        [SetUp]
+        public void SetUp() {
+            alglibAPI = new AlglibAPI();
+        }
+
+        // SensorParaboloidModel z(x,y) = (x' cosφ + y' sinφ) tanθ + sign(c)c²·(x'² + y'²) + z0
+        // where x' = x - x0, y' = y - y0
+        [Test]
+        public void ValueAt_NoTiltNoCurvature_ReturnsZ0() {
+            var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 100, theta: 0, phi: 0, c: 0);
+            Assert.That(m.ValueAt(50, 50), Is.EqualTo(100).Within(1e-9));
+        }
+
+        [Test]
+        public void ValueAt_PureCurvaturePositive_ReturnsZ0PlusCurvature() {
+            // c = 0.1 → C2 = 0.01; r² = 100 → ZPrime = 1
+            var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 100, theta: 0, phi: 0, c: 0.1);
+            Assert.That(m.ValueAt(10, 0), Is.EqualTo(101.0).Within(1e-9));
+            Assert.That(m.ValueAt(0, 10), Is.EqualTo(101.0).Within(1e-9));
+            Assert.That(m.ValueAt(0, 0), Is.EqualTo(100.0).Within(1e-9));
+        }
+
+        [Test]
+        public void ValueAt_NegativeCurvature_FlipsSign() {
+            var positive = new SensorParaboloidModel(x0: 0, y0: 0, z0: 100, theta: 0, phi: 0, c: 0.1);
+            var negative = new SensorParaboloidModel(x0: 0, y0: 0, z0: 100, theta: 0, phi: 0, c: -0.1);
+
+            // r² = 100, so positive curvature contributes +1, negative contributes -1
+            Assert.Multiple(() => {
+                Assert.That(positive.ValueAt(10, 0), Is.EqualTo(101.0).Within(1e-9));
+                Assert.That(negative.ValueAt(10, 0), Is.EqualTo(99.0).Within(1e-9));
+            });
+        }
+
+        [Test]
+        public void ValueAt_TiltAlongXOnly_AppliesLinearSlope() {
+            // φ = 0 → tilt direction along x. theta = atan(0.1) → tanθ = 0.1
+            var theta = Math.Atan(0.1);
+            var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 100, theta: theta, phi: 0, c: 0);
+            Assert.Multiple(() => {
+                Assert.That(m.ValueAt(0, 0), Is.EqualTo(100.0).Within(1e-9));
+                Assert.That(m.ValueAt(10, 0), Is.EqualTo(101.0).Within(1e-9));
+                Assert.That(m.ValueAt(0, 10), Is.EqualTo(100.0).Within(1e-9)); // sin(0) = 0
+            });
+        }
+
+        [Test]
+        public void TiltAt_IsValueAtMinusZ0AndCurvature() {
+            var theta = Math.Atan(0.1);
+            var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 100, theta: theta, phi: 0, c: 0);
+            Assert.That(m.TiltAt(15, 7), Is.EqualTo(1.5).Within(1e-9));
+        }
+
+        [Test]
+        public void CurvatureAt_PureCurvature_ReturnsCSquaredTimesRSquared() {
+            var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 0, theta: 0, phi: 0, c: 0.2);
+            // r² = 4² + 3² = 25, c² = 0.04 → 1.0
+            Assert.That(m.CurvatureAt(4, 3), Is.EqualTo(1.0).Within(1e-9));
+        }
+
+        [Test]
+        public void CurvatureAt_NegativeC_ReturnsNegativeSquaredCurvature() {
+            var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 0, theta: 0, phi: 0, c: -0.2);
+            Assert.That(m.CurvatureAt(4, 3), Is.EqualTo(-1.0).Within(1e-9));
+        }
+
+        [Test]
+        public void ToArray_FromArray_RoundTrip() {
+            var original = new SensorParaboloidModel(x0: 1.1, y0: 2.2, z0: 3.3, theta: 0.4, phi: 0.5, c: 0.6);
+            var clone = new SensorParaboloidModel();
+            clone.FromArray(original.ToArray());
+
+            Assert.Multiple(() => {
+                Assert.That(clone.X0, Is.EqualTo(1.1));
+                Assert.That(clone.Y0, Is.EqualTo(2.2));
+                Assert.That(clone.Z0, Is.EqualTo(3.3));
+                Assert.That(clone.Theta, Is.EqualTo(0.4));
+                Assert.That(clone.Phi, Is.EqualTo(0.5));
+                Assert.That(clone.C, Is.EqualTo(0.6));
+            });
+        }
+
+        [Test]
+        public void FromArray_WrongLength_Throws() {
+            var m = new SensorParaboloidModel();
+            Assert.Throws<ArgumentException>(() => m.FromArray(new double[] { 1, 2, 3 }));
+        }
+
+        [Test]
+        public void Solver_OnSyntheticParaboloid_RecoversCurvatureAndTilt() {
+            const double trueX0 = 0;
+            const double trueY0 = 0;
+            const double trueZ0 = 1000;
+            const double truePhi = 0;
+            var trueTheta = Math.Atan(0.001); // gentle tilt
+            const double trueC = 5e-4;
+
+            var truth = new SensorParaboloidModel(
+                x0: trueX0, y0: trueY0, z0: trueZ0,
+                theta: trueTheta, phi: truePhi, c: trueC);
+
+            // Sample on a 5x5 grid spanning ±1000 microns
+            var pts = new List<SensorParaboloidDataPoint>();
+            for (var iy = -2; iy <= 2; ++iy) {
+                for (var ix = -2; ix <= 2; ++ix) {
+                    double x = ix * 500;
+                    double y = iy * 500;
+                    var z = truth.ValueAt(x, y);
+                    pts.Add(new SensorParaboloidDataPoint(x: x, y: y, focuserPosition: z, rSquared: 0.99));
+                }
+            }
+
+            var solver = new SensorParaboloidSolver(
+                dataPoints: pts,
+                sensorSizeMicronsX: 4000,
+                sensorSizeMicronsY: 4000,
+                inFocusMicrons: trueZ0,
+                fixedSensorCenter: true) {
+                PositiveCurvature = true
+            };
+            var nlls = new NonLinearLeastSquaresSolver<SensorParaboloidSolver, SensorParaboloidDataPoint, SensorParaboloidModel>(alglibAPI);
+            var result = nlls.Solve(solver, tolerance: 1e-10);
+
+            Assert.Multiple(() => {
+                Assert.That(result.Z0, Is.EqualTo(trueZ0).Within(1.0));
+                // Curvature recovery — sign-and-magnitude
+                Assert.That(Math.Abs(result.C), Is.EqualTo(Math.Abs(trueC)).Within(1e-4));
+                Assert.That(Math.Sign(result.C), Is.EqualTo(Math.Sign(trueC)));
+            });
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj
@@ -7,6 +7,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Scottplot/LinearColormapTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Scottplot/LinearColormapTests.cs
@@ -1,0 +1,103 @@
+using NINA.Joko.Plugins.HocusFocus.Scottplot;
+using NUnit.Framework;
+using System.Drawing;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Scottplot {
+
+    [TestFixture]
+    public class LinearColormapTests {
+
+        [Test]
+        public void GetRGB_AtZero_ReturnsLowColor() {
+            var lo = Color.FromArgb(10, 20, 30);
+            var mid = Color.FromArgb(100, 110, 120);
+            var hi = Color.FromArgb(200, 210, 220);
+            var cmap = new LinearColormap("test", lo, mid, hi);
+
+            var (r, g, b) = cmap.GetRGB(0);
+
+            Assert.Multiple(() => {
+                Assert.That(r, Is.EqualTo(lo.R));
+                Assert.That(g, Is.EqualTo(lo.G));
+                Assert.That(b, Is.EqualTo(lo.B));
+            });
+        }
+
+        [Test]
+        public void GetRGB_AtMidpoint_IsBetweenLowAndMid() {
+            var lo = Color.FromArgb(0, 0, 0);
+            var mid = Color.FromArgb(128, 128, 128);
+            var hi = Color.FromArgb(255, 255, 255);
+            var cmap = new LinearColormap("test", lo, mid, hi);
+
+            var atMid = cmap.GetRGB(128);
+
+            // value 128 / 255 = 0.502 — this falls into the second half (>= 0.5),
+            // so the constructor takes the "highColor branch". colorRatio = 0.004
+            // so r ≈ mid.R + 0.004 * (hi.R - mid.R) ≈ 128 (rounds to mid)
+            Assert.Multiple(() => {
+                Assert.That(atMid.r, Is.EqualTo((byte)128).Within(2));
+                Assert.That(atMid.g, Is.EqualTo((byte)128).Within(2));
+                Assert.That(atMid.b, Is.EqualTo((byte)128).Within(2));
+            });
+        }
+
+        [Test]
+        public void GetRGB_AtMaxValue_ReturnsHighColor() {
+            var lo = Color.FromArgb(10, 20, 30);
+            var mid = Color.FromArgb(100, 110, 120);
+            var hi = Color.FromArgb(200, 210, 220);
+            var cmap = new LinearColormap("test", lo, mid, hi);
+
+            var (r, g, b) = cmap.GetRGB(255);
+
+            Assert.Multiple(() => {
+                Assert.That(r, Is.EqualTo(hi.R));
+                Assert.That(g, Is.EqualTo(hi.G));
+                Assert.That(b, Is.EqualTo(hi.B));
+            });
+        }
+
+        [Test]
+        public void GetRGB_QuarterValue_InterpolatesLowToMid() {
+            var lo = Color.FromArgb(0, 0, 0);
+            var mid = Color.FromArgb(200, 200, 200);
+            var hi = Color.FromArgb(255, 255, 255);
+            var cmap = new LinearColormap("test", lo, mid, hi);
+
+            // ratio = 64/255 ≈ 0.251, in lower half. colorRatio = 0.502
+            // r ≈ 0 + 0.502 * 200 ≈ 100
+            var (r, g, b) = cmap.GetRGB(64);
+
+            Assert.Multiple(() => {
+                Assert.That(r, Is.InRange((byte)95, (byte)105));
+                Assert.That(g, Is.InRange((byte)95, (byte)105));
+                Assert.That(b, Is.InRange((byte)95, (byte)105));
+            });
+        }
+
+        [Test]
+        public void GetRGB_ThreeQuarterValue_InterpolatesMidToHigh() {
+            var lo = Color.FromArgb(0, 0, 0);
+            var mid = Color.FromArgb(100, 100, 100);
+            var hi = Color.FromArgb(200, 200, 200);
+            var cmap = new LinearColormap("test", lo, mid, hi);
+
+            // ratio = 192/255 ≈ 0.753, in upper half. colorRatio = (0.753-0.5)*2 ≈ 0.506
+            // r ≈ 100 + 0.506 * (200 - 100) ≈ 150
+            var (r, g, b) = cmap.GetRGB(192);
+
+            Assert.Multiple(() => {
+                Assert.That(r, Is.InRange((byte)145, (byte)155));
+                Assert.That(g, Is.InRange((byte)145, (byte)155));
+                Assert.That(b, Is.InRange((byte)145, (byte)155));
+            });
+        }
+
+        [Test]
+        public void Name_PreservedFromConstructor() {
+            var cmap = new LinearColormap("hocus", Color.Black, Color.Gray, Color.White);
+            Assert.That(cmap.Name, Is.EqualTo("hocus"));
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/HyperbolicFittingAlglibTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/HyperbolicFittingAlglibTests.cs
@@ -1,0 +1,82 @@
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.Tests.Synthetic;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
+
+    [TestFixture]
+    public class HyperbolicFittingAlglibTests {
+        private IAlglibAPI alglibAPI;
+
+        [SetUp]
+        public void SetUp() {
+            alglibAPI = new AlglibAPI();
+        }
+
+        [Test]
+        public void Solve_NoiselessSymmetricHyperbola_RecoversX0() {
+            const double trueX0 = 5000;
+            const double trueY0 = 0.0;
+            const double trueA = 2.0;
+            const double trueB = 80.0;
+            var pts = SyntheticFocusCurveSamples.SymmetricHyperbolaPoints(
+                x0: trueX0, y0: trueY0, a: trueA, b: trueB,
+                xStart: 4800, xStep: 25, count: 17);
+
+            var fit = HyperbolicFittingAlglib.Create(alglibAPI, pts, useWeights: false);
+            var ok = fit.Solve();
+
+            Assert.Multiple(() => {
+                Assert.That(ok, Is.True);
+                Assert.That(fit.Minimum.X, Is.EqualTo(trueX0).Within(1.0));
+                // Minimum.Y in HyperbolicFittingAlglib is (a + y0). At noiseless data, Y at x0 is also a + y0.
+                Assert.That(fit.Minimum.Y, Is.EqualTo(trueA + trueY0).Within(0.05));
+                Assert.That(fit.RSquared, Is.GreaterThan(0.99));
+            });
+        }
+
+        [Test]
+        public void Solve_EmptyInputs_ReturnsFalse() {
+            var fit = HyperbolicFittingAlglib.Create(
+                alglibAPI,
+                new System.Collections.Generic.List<OxyPlot.Series.ScatterErrorPoint>(),
+                useWeights: false);
+            Assert.That(fit.Solve(), Is.False);
+        }
+
+        [Test]
+        public void Solve_FilteredZeroOutputs_StillFitsHyperbola() {
+            // Add some zero-Y points that should be filtered out by the Y >= 0.1 gate.
+            var pts = SyntheticFocusCurveSamples.SymmetricHyperbolaPoints(
+                x0: 5000, y0: 0.0, a: 1.5, b: 50.0,
+                xStart: 4900, xStep: 20, count: 11);
+            pts.Add(new OxyPlot.Series.ScatterErrorPoint(5000, 0.0, 0, 1.0));
+            pts.Add(new OxyPlot.Series.ScatterErrorPoint(6000, 0.05, 0, 1.0));
+
+            var fit = HyperbolicFittingAlglib.Create(alglibAPI, pts, useWeights: false);
+            var ok = fit.Solve();
+
+            Assert.Multiple(() => {
+                Assert.That(ok, Is.True);
+                Assert.That(fit.RSquared, Is.GreaterThan(0.99));
+            });
+        }
+
+        [Test]
+        public void Solve_WithWeights_StillRecoversMinimum() {
+            const double trueX0 = 4000;
+            var pts = SyntheticFocusCurveSamples.SymmetricHyperbolaPoints(
+                x0: trueX0, y0: 0.0, a: 2.5, b: 60.0,
+                xStart: 3850, xStep: 30, count: 11);
+
+            var fit = HyperbolicFittingAlglib.Create(alglibAPI, pts, useWeights: true);
+            var ok = fit.Solve();
+
+            Assert.Multiple(() => {
+                Assert.That(ok, Is.True);
+                Assert.That(fit.Minimum.X, Is.EqualTo(trueX0).Within(2.0));
+            });
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/HyperbolicUnevenFittingAlglibTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/HyperbolicUnevenFittingAlglibTests.cs
@@ -1,0 +1,57 @@
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.Tests.Synthetic;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using OxyPlot.Series;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
+
+    [TestFixture]
+    public class HyperbolicUnevenFittingAlglibTests {
+        private IAlglibAPI alglibAPI;
+
+        [SetUp]
+        public void SetUp() {
+            alglibAPI = new AlglibAPI();
+        }
+
+        [Test]
+        public void Create_ZeroStepSize_Throws() {
+            var pts = new List<ScatterErrorPoint> {
+                new(1000, 1.0, 0, 1.0),
+                new(2000, 0.5, 0, 1.0),
+                new(3000, 1.0, 0, 1.0),
+            };
+            Assert.Throws<ArgumentException>(() =>
+                HyperbolicUnevenFittingAlglib.Create(alglibAPI, pts, stepSize: 0, useWeights: false));
+        }
+
+        [Test]
+        public void Solve_NoiselessSymmetricHyperbola_RecoversApproxMinimum() {
+            const double trueX0 = 5000;
+            const double trueA = 2.0;
+            const double trueB = 80.0;
+            var pts = SyntheticFocusCurveSamples.SymmetricHyperbolaPoints(
+                x0: trueX0, y0: 0.0, a: trueA, b: trueB,
+                xStart: 4800, xStep: 25, count: 17);
+
+            var fit = HyperbolicUnevenFittingAlglib.Create(alglibAPI, pts, stepSize: 25, useWeights: false);
+            var ok = fit.Solve();
+
+            Assert.Multiple(() => {
+                Assert.That(ok, Is.True);
+                Assert.That(fit.Minimum.X, Is.EqualTo(trueX0).Within(2.0));
+                Assert.That(fit.RSquared, Is.GreaterThan(0.99));
+            });
+        }
+
+        [Test]
+        public void Solve_EmptyInputs_ReturnsFalse() {
+            var fit = HyperbolicUnevenFittingAlglib.Create(
+                alglibAPI, new List<ScatterErrorPoint>(), stepSize: 25, useWeights: false);
+            Assert.That(fit.Solve(), Is.False);
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/PSFModelTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/PSFModelTests.cs
@@ -1,0 +1,118 @@
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NUnit.Framework;
+using System;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
+
+    [TestFixture]
+    public class PSFModelTests {
+
+        [Test]
+        public void Constructor_Round_StoresCircularEccentricity() {
+            var model = new PSFModel(
+                psfType: StarDetectorPSFFitType.Gaussian,
+                offsetX: 0, offsetY: 0,
+                peak: 1.0, background: 0.0,
+                sigmaX: 1.0, sigmaY: 1.0,
+                fwhmX: 2.355, fwhmY: 2.355,
+                thetaRadians: 0.0,
+                rSquared: 0.99,
+                pixelScale: 1.0);
+
+            Assert.That(model.Eccentricity, Is.EqualTo(0.0).Within(1e-12));
+        }
+
+        [Test]
+        public void Constructor_Elliptical_EccentricityIsBetweenZeroAndOne() {
+            var model = new PSFModel(
+                psfType: StarDetectorPSFFitType.Gaussian,
+                offsetX: 0, offsetY: 0,
+                peak: 1.0, background: 0.0,
+                sigmaX: 2.0, sigmaY: 1.0,
+                fwhmX: 4.0, fwhmY: 2.0,
+                thetaRadians: 0.0,
+                rSquared: 0.99,
+                pixelScale: 1.0);
+
+            // a = 4, b = 2 → ecc = sqrt(1 - 4/16) = sqrt(3)/2
+            Assert.That(model.Eccentricity, Is.EqualTo(Math.Sqrt(3.0) / 2.0).Within(1e-12));
+        }
+
+        [Test]
+        public void Constructor_AsymmetricInputs_EccentricityComputedFromMaxAndMin() {
+            // Even when fwhmY > fwhmX, the formula should still give a positive eccentricity.
+            var model = new PSFModel(
+                psfType: StarDetectorPSFFitType.Moffat_40,
+                offsetX: 0, offsetY: 0,
+                peak: 1.0, background: 0.0,
+                sigmaX: 1.0, sigmaY: 2.0,
+                fwhmX: 2.0, fwhmY: 4.0,
+                thetaRadians: 0.0,
+                rSquared: 0.99,
+                pixelScale: 1.0);
+
+            Assert.That(model.Eccentricity, Is.EqualTo(Math.Sqrt(3.0) / 2.0).Within(1e-12));
+        }
+
+        [Test]
+        public void Constructor_Sigma_IsGeometricMeanOfSigmaXAndSigmaY() {
+            var model = new PSFModel(
+                psfType: StarDetectorPSFFitType.Gaussian,
+                offsetX: 0, offsetY: 0,
+                peak: 1.0, background: 0.0,
+                sigmaX: 4.0, sigmaY: 9.0,
+                fwhmX: 1.0, fwhmY: 1.0,
+                thetaRadians: 0.0,
+                rSquared: 0.99,
+                pixelScale: 1.0);
+
+            Assert.That(model.Sigma, Is.EqualTo(6.0).Within(1e-12)); // sqrt(4*9) = 6
+        }
+
+        [Test]
+        public void Constructor_FWHMPixels_IsGeometricMeanOfFWHMXAndFWHMY() {
+            var model = new PSFModel(
+                psfType: StarDetectorPSFFitType.Gaussian,
+                offsetX: 0, offsetY: 0,
+                peak: 1.0, background: 0.0,
+                sigmaX: 1.0, sigmaY: 1.0,
+                fwhmX: 4.0, fwhmY: 9.0,
+                thetaRadians: 0.0,
+                rSquared: 0.99,
+                pixelScale: 1.0);
+
+            Assert.That(model.FWHMPixels, Is.EqualTo(6.0).Within(1e-12));
+        }
+
+        [Test]
+        public void Constructor_FWHMArcsecs_IsFWHMPixelsTimesPixelScale() {
+            var model = new PSFModel(
+                psfType: StarDetectorPSFFitType.Gaussian,
+                offsetX: 0, offsetY: 0,
+                peak: 1.0, background: 0.0,
+                sigmaX: 1.0, sigmaY: 1.0,
+                fwhmX: 4.0, fwhmY: 9.0,
+                thetaRadians: 0.0,
+                rSquared: 0.99,
+                pixelScale: 0.5);
+
+            Assert.That(model.FWHMArcsecs, Is.EqualTo(3.0).Within(1e-12)); // 6 * 0.5
+        }
+
+        [Test]
+        public void GaussianSigmaToFWHM_FactorIsTwoSqrtTwoLn2() {
+            var t = new GaussianPSFAlglibType(
+                alglibAPI: null,
+                inputs: new double[][] { new double[] { 0, 0 } },
+                outputs: new double[] { 0 },
+                centroidBrightness: 0.5,
+                starDetectionBackground: 0.0,
+                starBoundingBox: new OpenCvSharp.Rect(0, 0, 10, 10),
+                pixelScale: 1.0);
+
+            var fwhm = t.SigmaToFWHM(1.0);
+            Assert.That(fwhm, Is.EqualTo(2.0 * Math.Sqrt(2.0 * Math.Log(2.0))).Within(1e-12));
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/PSFModelerTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/PSFModelerTests.cs
@@ -1,0 +1,106 @@
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NUnit.Framework;
+using OpenCvSharp;
+using System;
+using System.Threading;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
+
+    [TestFixture]
+    public class PSFModelerTests {
+        private IAlglibAPI alglibAPI;
+
+        [SetUp]
+        public void SetUp() {
+            alglibAPI = new AlglibAPI();
+        }
+
+        // Sample a synthetic Gaussian on a regular grid centered on (0,0). The PSF model takes
+        // inputs as offsets from the centroid (dx, dy) and the corresponding pixel value.
+        private static (double[][] inputs, double[] outputs) SampleGaussian(
+            double sigmaX, double sigmaY, double peak, double background,
+            int radius = 5) {
+            int side = 2 * radius + 1;
+            var n = side * side;
+            var inputs = new double[n][];
+            var outputs = new double[n];
+            int idx = 0;
+            for (var y = -radius; y <= radius; ++y) {
+                for (var x = -radius; x <= radius; ++x) {
+                    var e = (x * x) / (2.0 * sigmaX * sigmaX) + (y * y) / (2.0 * sigmaY * sigmaY);
+                    inputs[idx] = new double[] { x, y };
+                    outputs[idx] = background + peak * Math.Exp(-e);
+                    idx++;
+                }
+            }
+            return (inputs, outputs);
+        }
+
+        [Test]
+        public void GaussianPSF_Solve_RecoversSigmasOnNoiselessSymmetricStar() {
+            const double trueSigma = 1.5;
+            const double peak = 0.8;
+            const double background = 0.05;
+            var (inputs, outputs) = SampleGaussian(trueSigma, trueSigma, peak, background);
+
+            var model = new GaussianPSFAlglibType(
+                alglibAPI: alglibAPI,
+                inputs: inputs, outputs: outputs,
+                centroidBrightness: peak + background,
+                starDetectionBackground: background,
+                starBoundingBox: new Rect(0, 0, 11, 11),
+                pixelScale: 1.0);
+
+            var sol = model.Solve(maxIterations: 200, tolerance: 1e-10, ct: CancellationToken.None);
+
+            Assert.Multiple(() => {
+                Assert.That(sol.SigmaX, Is.EqualTo(trueSigma).Within(0.1));
+                Assert.That(sol.SigmaY, Is.EqualTo(trueSigma).Within(0.1));
+                Assert.That(sol.X0, Is.EqualTo(0.0).Within(0.05));
+                Assert.That(sol.Y0, Is.EqualTo(0.0).Within(0.05));
+                Assert.That(sol.A, Is.EqualTo(peak).Within(0.05));
+            });
+        }
+
+        [Test]
+        public void GaussianPSF_Solve_GoodnessOfFit_NearOneOnNoiselessData() {
+            const double trueSigma = 2.0;
+            const double peak = 1.0;
+            const double background = 0.0;
+            var (inputs, outputs) = SampleGaussian(trueSigma, trueSigma, peak, background);
+
+            var model = new GaussianPSFAlglibType(
+                alglibAPI: alglibAPI,
+                inputs: inputs, outputs: outputs,
+                centroidBrightness: peak,
+                starDetectionBackground: background,
+                starBoundingBox: new Rect(0, 0, 11, 11),
+                pixelScale: 1.0);
+
+            var sol = model.Solve(maxIterations: 200, tolerance: 1e-10, ct: CancellationToken.None);
+            var rSq = model.GoodnessOfFit(sol.A, sol.B, sol.X0, sol.Y0, sol.SigmaX, sol.SigmaY, sol.Theta);
+
+            Assert.That(rSq, Is.GreaterThan(0.99));
+        }
+
+        [Test]
+        public void GaussianPSF_Solve_CancellationToken_PropagatesCancellation() {
+            const double trueSigma = 1.5;
+            var (inputs, outputs) = SampleGaussian(trueSigma, trueSigma, 1.0, 0.0);
+
+            var model = new GaussianPSFAlglibType(
+                alglibAPI: alglibAPI,
+                inputs: inputs, outputs: outputs,
+                centroidBrightness: 1.0,
+                starDetectionBackground: 0.0,
+                starBoundingBox: new Rect(0, 0, 11, 11),
+                pixelScale: 1.0);
+
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+            Assert.Throws<OperationCanceledException>(() =>
+                model.Solve(maxIterations: 200, tolerance: 1e-10, ct: cts.Token));
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Synthetic/SyntheticFocusCurveSamples.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Synthetic/SyntheticFocusCurveSamples.cs
@@ -1,0 +1,33 @@
+using OxyPlot.Series;
+using System;
+using System.Collections.Generic;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Synthetic {
+
+    internal static class SyntheticFocusCurveSamples {
+
+        // y = a / b * sqrt((x - x0)^2 + b^2) + y0
+        public static double Hyperbola(double x, double x0, double y0, double a, double b) {
+            var dx = x - x0;
+            return a / b * Math.Sqrt(dx * dx + b * b) + y0;
+        }
+
+        public static List<ScatterErrorPoint> SymmetricHyperbolaPoints(
+            double x0,
+            double y0,
+            double a,
+            double b,
+            double xStart,
+            double xStep,
+            int count,
+            double errorY = 1.0) {
+            var points = new List<ScatterErrorPoint>(count);
+            for (var i = 0; i < count; ++i) {
+                var x = xStart + i * xStep;
+                var y = Hyperbola(x, x0, y0, a, b);
+                points.Add(new ScatterErrorPoint(x, y, 0, errorY));
+            }
+            return points;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Synthetic/SyntheticGaussianStarImage.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Synthetic/SyntheticGaussianStarImage.cs
@@ -1,0 +1,41 @@
+using OpenCvSharp;
+using System;
+using Size = OpenCvSharp.Size;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Synthetic {
+
+    internal static class SyntheticGaussianStarImage {
+
+        public static Mat Create(
+            int width,
+            int height,
+            double centerX,
+            double centerY,
+            double sigmaX,
+            double sigmaY,
+            double peak,
+            double background) {
+            var mat = new Mat(new Size(width, height), MatType.CV_32F);
+            unsafe {
+                var data = (float*)mat.DataPointer;
+                var inv2sx2 = 1.0 / (2.0 * sigmaX * sigmaX);
+                var inv2sy2 = 1.0 / (2.0 * sigmaY * sigmaY);
+                for (var y = 0; y < height; ++y) {
+                    for (var x = 0; x < width; ++x) {
+                        var dx = x - centerX;
+                        var dy = y - centerY;
+                        var e = dx * dx * inv2sx2 + dy * dy * inv2sy2;
+                        data[y * width + x] = (float)(background + peak * Math.Exp(-e));
+                    }
+                }
+            }
+            return mat;
+        }
+
+        public static Mat CreateFlat(int width, int height, float value) {
+            var mat = new Mat(new Size(width, height), MatType.CV_32F);
+            mat.SetTo(new Scalar(value));
+            return mat;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/AlglibAPITests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/AlglibAPITests.cs
@@ -1,0 +1,54 @@
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Utility {
+
+    [TestFixture]
+    public class AlglibAPITests {
+
+        [Test]
+        public void MinLmCreateV_AllocatesState_AndDeallocatesCleanly() {
+            var api = new AlglibAPI();
+            var x = new double[] { 1.0, 2.0 };
+            api.minlmcreatev(2, x, 1e-4, out var state);
+            Assert.That(state, Is.Not.Null);
+            api.deallocateimmediately(ref state);
+        }
+
+        [Test]
+        public void MinLmCreateVj_AllocatesState_AndDeallocatesCleanly() {
+            var api = new AlglibAPI();
+            var x = new double[] { 1.0, 2.0 };
+            api.minlmcreatevj(2, x, out var state);
+            Assert.That(state, Is.Not.Null);
+            api.deallocateimmediately(ref state);
+        }
+
+        [Test]
+        public void RbfCreate_AllocatesModelCleanly() {
+            var api = new AlglibAPI();
+            api.rbfcreate(nx: 2, ny: 1, out var model);
+            Assert.That(model, Is.Not.Null);
+            api.deallocateimmediately(ref model);
+        }
+
+        [Test]
+        public void ParallelMinLmCreate_DoesNotThrow() {
+            var api = new AlglibAPI();
+            const int parallelism = 8;
+            var tasks = new Task[parallelism];
+            for (var i = 0; i < parallelism; ++i) {
+                tasks[i] = Task.Run(() => {
+                    for (var j = 0; j < 50; ++j) {
+                        var x = new double[] { 0.1, 0.2 };
+                        api.minlmcreatev(2, x, 1e-4, out var state);
+                        api.minlmsetcond(state, 1e-8, 100);
+                        api.deallocateimmediately(ref state);
+                    }
+                });
+            }
+            Assert.DoesNotThrow(() => Task.WaitAll(tasks));
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/CvImageUtilityTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/CvImageUtilityTests.cs
@@ -1,0 +1,197 @@
+using NINA.Joko.Plugins.HocusFocus.Tests.Synthetic;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NUnit.Framework;
+using OpenCvSharp;
+using System;
+using Size = OpenCvSharp.Size;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Utility {
+
+    [TestFixture]
+    public class CvImageUtilityTests {
+
+        [Test]
+        public void CalculateStatistics_FlatImage_ReturnsZeroStdDev() {
+            using var mat = SyntheticGaussianStarImage.CreateFlat(8, 8, 0.5f);
+            var stats = CvImageUtility.CalculateStatistics(mat);
+            Assert.Multiple(() => {
+                Assert.That(stats.Mean, Is.EqualTo(0.5).Within(1e-6));
+                Assert.That(stats.StdDev, Is.EqualTo(0.0).Within(1e-6));
+                Assert.That(stats.Median, Is.EqualTo(0.5).Within(1e-6));
+                Assert.That(stats.MAD, Is.EqualTo(0.0).Within(1e-6));
+            });
+        }
+
+        [Test]
+        public void CalculateStatistics_RejectsNonF32() {
+            using var mat = new Mat(new Size(4, 4), MatType.CV_8UC1);
+            Assert.Throws<ArgumentException>(() => CvImageUtility.CalculateStatistics(mat));
+        }
+
+        [Test]
+        public void CalculateStatistics_KnownValues_MeanIsCorrect() {
+            using var mat = new Mat(new Size(2, 2), MatType.CV_32F);
+            unsafe {
+                var p = (float*)mat.DataPointer;
+                p[0] = 0.1f; p[1] = 0.2f; p[2] = 0.3f; p[3] = 0.4f;
+            }
+            var stats = CvImageUtility.CalculateStatistics(mat);
+            Assert.That(stats.Mean, Is.EqualTo(0.25).Within(1e-6));
+        }
+
+        [Test]
+        public void CalculateStatistics_OnlyMeanFlag_ComputesMeanOnly() {
+            using var mat = SyntheticGaussianStarImage.CreateFlat(4, 4, 0.7f);
+            var stats = CvImageUtility.CalculateStatistics(mat, flags: CvImageStatisticsFlags.Mean);
+            Assert.Multiple(() => {
+                Assert.That(stats.Mean, Is.EqualTo(0.7).Within(1e-6));
+                Assert.That(stats.Median, Is.EqualTo(0.0));   // never set
+                Assert.That(stats.MAD, Is.EqualTo(0.0));      // never set
+                Assert.That(stats.StdDev, Is.EqualTo(0.0));   // never set
+            });
+        }
+
+        [Test]
+        public void ConvolveGaussian_RejectsEvenKernel() {
+            using var src = SyntheticGaussianStarImage.CreateFlat(8, 8, 0.5f);
+            using var dst = new Mat();
+            Assert.Throws<ArgumentException>(() => CvImageUtility.ConvolveGaussian(src, dst, kernelSize: 4));
+        }
+
+        [Test]
+        public void ConvolveGaussian_RejectsKernelSmallerThanThree() {
+            using var src = SyntheticGaussianStarImage.CreateFlat(8, 8, 0.5f);
+            using var dst = new Mat();
+            Assert.Throws<ArgumentException>(() => CvImageUtility.ConvolveGaussian(src, dst, kernelSize: 1));
+        }
+
+        [Test]
+        public void ConvolveGaussian_ConstantImage_StaysConstant() {
+            using var src = SyntheticGaussianStarImage.CreateFlat(16, 16, 0.42f);
+            using var dst = new Mat();
+            CvImageUtility.ConvolveGaussian(src, dst, kernelSize: 5);
+
+            unsafe {
+                var data = (float*)dst.DataPointer;
+                for (var i = 0; i < 16 * 16; ++i) {
+                    Assert.That(data[i], Is.EqualTo(0.42f).Within(1e-5));
+                }
+            }
+        }
+
+        [Test]
+        public void Binarize_AboveThresholdMapsToOne_BelowMapsToZero() {
+            using var src = new Mat(new Size(2, 2), MatType.CV_32F);
+            unsafe {
+                var p = (float*)src.DataPointer;
+                p[0] = 0.1f; p[1] = 0.4f; p[2] = 0.6f; p[3] = 0.9f;
+            }
+            using var dst = new Mat();
+            CvImageUtility.Binarize(src, dst, threshold: 0.5);
+
+            unsafe {
+                var p = (float*)dst.DataPointer;
+                Assert.Multiple(() => {
+                    Assert.That(p[0], Is.EqualTo(0.0f));
+                    Assert.That(p[1], Is.EqualTo(0.0f));
+                    Assert.That(p[2], Is.EqualTo(1.0f));
+                    Assert.That(p[3], Is.EqualTo(1.0f));
+                });
+            }
+        }
+
+        [Test]
+        public void ClampInPlace_ClipsBelowMinAndAboveMax() {
+            using var src = new Mat(new Size(2, 2), MatType.CV_32F);
+            unsafe {
+                var p = (float*)src.DataPointer;
+                p[0] = -0.5f; p[1] = 0.3f; p[2] = 0.5f; p[3] = 1.5f;
+            }
+            CvImageUtility.ClampInPlace(src, min: 0.0f, max: 1.0f);
+            unsafe {
+                var p = (float*)src.DataPointer;
+                Assert.Multiple(() => {
+                    Assert.That(p[0], Is.EqualTo(0.0f));
+                    Assert.That(p[1], Is.EqualTo(0.3f).Within(1e-6f));
+                    Assert.That(p[2], Is.EqualTo(0.5f).Within(1e-6f));
+                    Assert.That(p[3], Is.EqualTo(1.0f));
+                });
+            }
+        }
+
+        [Test]
+        public void Rescale_MapsMinToZeroAndMaxToOne() {
+            using var src = new Mat(new Size(2, 2), MatType.CV_32F);
+            unsafe {
+                var p = (float*)src.DataPointer;
+                p[0] = 100f; p[1] = 200f; p[2] = 300f; p[3] = 400f;
+            }
+            using var dst = CvImageUtility.Rescale(src);
+            unsafe {
+                var p = (float*)dst.DataPointer;
+                Assert.Multiple(() => {
+                    Assert.That(p[0], Is.EqualTo(0.0).Within(1e-5));
+                    Assert.That(p[3], Is.EqualTo(1.0).Within(1e-5));
+                });
+            }
+        }
+
+        [Test]
+        public void BilinearSamplePixelValue_OnPixelCenter_ReturnsExactPixelValue() {
+            using var mat = new Mat(new Size(4, 4), MatType.CV_32F);
+            unsafe {
+                var p = (float*)mat.DataPointer;
+                for (var i = 0; i < 16; ++i) p[i] = i * 0.05f;
+            }
+            // Pixel (1,2) → row 2, col 1 → flat index 2*4+1 = 9 → 0.45
+            var value = CvImageUtility.BilinearSamplePixelValue(mat, y: 2.0, x: 1.0);
+            Assert.That(value, Is.EqualTo(0.45f).Within(1e-5));
+        }
+
+        [Test]
+        public void BilinearSamplePixelValue_HalfwayBetweenPixels_AveragesNeighbors() {
+            using var mat = new Mat(new Size(2, 2), MatType.CV_32F);
+            unsafe {
+                var p = (float*)mat.DataPointer;
+                p[0] = 0; p[1] = 1; p[2] = 1; p[3] = 0;
+            }
+            // y=0.5, x=0.5 should be the average of all four (each weight 0.25) → 0.5
+            var value = CvImageUtility.BilinearSamplePixelValue(mat, y: 0.5, x: 0.5);
+            Assert.That(value, Is.EqualTo(0.5).Within(1e-6));
+        }
+
+        [Test]
+        public void KappaSigmaNoiseEstimate_FlatImage_GivesZeroSigma() {
+            using var mat = SyntheticGaussianStarImage.CreateFlat(32, 32, 0.5f);
+            var result = CvImageUtility.KappaSigmaNoiseEstimate(mat);
+            Assert.Multiple(() => {
+                Assert.That(result.Sigma, Is.EqualTo(0.0).Within(1e-6));
+                Assert.That(result.NumIterations, Is.GreaterThan(0));
+            });
+        }
+
+        [Test]
+        public void KappaSigmaNoiseEstimate_RejectsNonF32() {
+            using var mat = new Mat(new Size(4, 4), MatType.CV_8UC1);
+            Assert.Throws<ArgumentException>(() => CvImageUtility.KappaSigmaNoiseEstimate(mat));
+        }
+
+        [Test]
+        public void GetB3SplineFilter_FirstLayer_HasExpectedSeparatedCoefficients() {
+            using var filter = CvImageUtility.GetB3SplineFilter(0);
+            // Layer 0: size = (1<<2)+1 = 5
+            Assert.That(filter.Cols, Is.EqualTo(1));
+            Assert.That(filter.Rows, Is.EqualTo(5));
+            unsafe {
+                var p = (float*)filter.DataPointer;
+                Assert.Multiple(() => {
+                    Assert.That(p[0], Is.EqualTo(0.0625f).Within(1e-6f));
+                    Assert.That(p[1], Is.EqualTo(0.25f).Within(1e-6f));
+                    Assert.That(p[2], Is.EqualTo(0.375f).Within(1e-6f));
+                    Assert.That(p[3], Is.EqualTo(0.25f).Within(1e-6f));
+                    Assert.That(p[4], Is.EqualTo(0.0625f).Within(1e-6f));
+                });
+            }
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/HotpixelFilteringTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/HotpixelFilteringTests.cs
@@ -1,0 +1,102 @@
+using NINA.Core.Enum;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NUnit.Framework;
+using OpenCvSharp;
+using Size = OpenCvSharp.Size;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Utility {
+
+    [TestFixture]
+    public class HotpixelFilteringTests {
+
+        [Test]
+        public void RawImageData_LengthMismatch_Throws() {
+            Assert.Throws<System.ArgumentException>(() =>
+                new RawImageData(new ushort[10], width: 4, height: 4));
+        }
+
+        [Test]
+        public void RawImageData_GetSetPixel_RoundTrip() {
+            var data = new RawImageData(new ushort[16], 4, 4);
+            data.SetPixel(2, 1, 1234);
+            Assert.That(data.GetPixel(2, 1), Is.EqualTo(1234));
+        }
+
+        [Test]
+        public void HotpixelFilter_ReplacesIsolatedSpike_WithMedianBlur() {
+            using var mat = new Mat(new Size(5, 5), MatType.CV_16UC1, new Scalar(100));
+            mat.Set(2, 2, (ushort)10000);
+
+            HotpixelFiltering.HotpixelFilter(mat);
+
+            // Median of a 3x3 region of mostly 100s with one spike → 100
+            Assert.That((ushort)mat.At<ushort>(2, 2), Is.EqualTo(100));
+        }
+
+        [Test]
+        public void HotpixelFilterWithThresholding_CountsAndFixesSpike() {
+            using var mat = new Mat(new Size(5, 5), MatType.CV_16UC1, new Scalar(100));
+            mat.Set(2, 2, (ushort)10000);
+
+            var count = HotpixelFiltering.HotpixelFilterWithThresholding(mat, threshold: 1000);
+
+            Assert.Multiple(() => {
+                Assert.That(count, Is.EqualTo(1));
+                Assert.That((ushort)mat.At<ushort>(2, 2), Is.EqualTo(100));
+            });
+        }
+
+        [Test]
+        public void HotpixelFilterWithThresholding_BelowThreshold_DoesNotReplace() {
+            using var mat = new Mat(new Size(5, 5), MatType.CV_16UC1, new Scalar(100));
+            mat.Set(2, 2, (ushort)200);
+
+            var count = HotpixelFiltering.HotpixelFilterWithThresholding(mat, threshold: 1000);
+
+            Assert.Multiple(() => {
+                Assert.That(count, Is.EqualTo(0));
+                Assert.That((ushort)mat.At<ushort>(2, 2), Is.EqualTo(200));
+            });
+        }
+
+        [Test]
+        public void CFAHotpixelFilter_DetectsSpike_RGGB() {
+            // 8x8 RGGB with a single hot pixel (R) at (4,4)
+            const int W = 8, H = 8;
+            var arr = new ushort[W * H];
+            for (var i = 0; i < arr.Length; ++i) arr[i] = 100;
+            var raw = new RawImageData(arr, W, H);
+            raw.SetPixel(4, 4, 5000);
+
+            var count = HotpixelFiltering.CFAHotpixelFilter(raw, SensorType.RGGB, threshold: 1000);
+
+            Assert.Multiple(() => {
+                Assert.That(count, Is.GreaterThanOrEqualTo(1));
+                Assert.That(raw.GetPixel(4, 4), Is.LessThan((ushort)5000));
+            });
+        }
+
+        [Test]
+        public void CFAHotpixelFilter_FlatImage_FindsNoHotpixels() {
+            const int W = 16, H = 16;
+            var arr = new ushort[W * H];
+            for (var i = 0; i < arr.Length; ++i) arr[i] = 200;
+            var raw = new RawImageData(arr, W, H);
+
+            var count = HotpixelFiltering.CFAHotpixelFilter(raw, SensorType.RGGB, threshold: 50);
+
+            Assert.That(count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void CFAHotpixelFilter_UnsupportedPattern_Throws() {
+            const int W = 8, H = 8;
+            var arr = new ushort[W * H];
+            var raw = new RawImageData(arr, W, H);
+
+            // SensorType.Monochrome is not handled by the filter
+            Assert.Throws<Accord.Imaging.InvalidImagePropertiesException>(() =>
+                HotpixelFiltering.CFAHotpixelFilter(raw, SensorType.Monochrome, threshold: 100));
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/NonLinearLeastSquaresSolverTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/NonLinearLeastSquaresSolverTests.cs
@@ -1,0 +1,127 @@
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Utility {
+
+    // y = a + b*x
+    internal class LinearDataPoint : INonLinearLeastSquaresDataPoint {
+        public double X { get; set; }
+        public double Y { get; set; }
+
+        public double[] ToInput() => new double[] { X };
+
+        public double ToOutput() => Y;
+    }
+
+    internal class LinearParameters : INonLinearLeastSquaresParameters {
+        public double A { get; set; }
+        public double B { get; set; }
+
+        public void FromArray(double[] parameters) {
+            A = parameters[0];
+            B = parameters[1];
+        }
+
+        public double[] ToArray() => new[] { A, B };
+    }
+
+    internal class LinearSolver : NonLinearLeastSquaresSolverBase<LinearDataPoint, LinearParameters> {
+
+        public LinearSolver(List<LinearDataPoint> dataPoints) : base(dataPoints, numParameters: 2) {
+        }
+
+        public override double Value(double[] parameters, double[] input) {
+            return parameters[0] + parameters[1] * input[0];
+        }
+
+        public override void SetInitialGuess(double[] initialGuess) {
+            initialGuess[0] = 0.0;
+            initialGuess[1] = 0.0;
+        }
+
+        public override void SetBounds(double[] lowerBounds, double[] upperBounds) {
+            lowerBounds[0] = double.NegativeInfinity;
+            lowerBounds[1] = double.NegativeInfinity;
+            upperBounds[0] = double.PositiveInfinity;
+            upperBounds[1] = double.PositiveInfinity;
+        }
+
+        public override void SetScale(double[] scales) {
+            scales[0] = 1.0;
+            scales[1] = 1.0;
+        }
+    }
+
+    [TestFixture]
+    public class NonLinearLeastSquaresSolverTests {
+        private IAlglibAPI alglibAPI;
+
+        [SetUp]
+        public void SetUp() {
+            alglibAPI = new AlglibAPI();
+        }
+
+        private static List<LinearDataPoint> NoiselessLinearPoints(double a, double b, int count = 11) {
+            return Enumerable.Range(0, count)
+                .Select(i => new LinearDataPoint { X = i, Y = a + b * i })
+                .ToList();
+        }
+
+        [Test]
+        public void Solve_NoiselessLinearData_RecoversCoefficients() {
+            const double trueA = 3.5;
+            const double trueB = -1.25;
+            var solver = new LinearSolver(NoiselessLinearPoints(trueA, trueB));
+            var nlls = new NonLinearLeastSquaresSolver<LinearSolver, LinearDataPoint, LinearParameters>(alglibAPI);
+
+            var result = nlls.Solve(solver, tolerance: 1e-10);
+
+            Assert.Multiple(() => {
+                Assert.That(result.A, Is.EqualTo(trueA).Within(1e-4));
+                Assert.That(result.B, Is.EqualTo(trueB).Within(1e-4));
+            });
+        }
+
+        [Test]
+        public void GoodnessOfFit_NoiselessFit_IsApproximatelyOne() {
+            var solver = new LinearSolver(NoiselessLinearPoints(2.0, 0.5));
+            var nlls = new NonLinearLeastSquaresSolver<LinearSolver, LinearDataPoint, LinearParameters>(alglibAPI);
+            var result = nlls.Solve(solver, tolerance: 1e-10);
+
+            var rSquared = nlls.GoodnessOfFit(solver, result);
+            Assert.That(rSquared, Is.EqualTo(1.0).Within(1e-6));
+        }
+
+        [Test]
+        public void RMSError_NoiselessFit_IsApproximatelyZero() {
+            var solver = new LinearSolver(NoiselessLinearPoints(1.0, 1.0));
+            var nlls = new NonLinearLeastSquaresSolver<LinearSolver, LinearDataPoint, LinearParameters>(alglibAPI);
+            var result = nlls.Solve(solver, tolerance: 1e-10);
+
+            var rms = nlls.RMSError(solver, result);
+            Assert.That(rms, Is.LessThan(1e-4));
+        }
+
+        [Test]
+        public void SolveWinsorizedResiduals_OutlierCorrupted_ConvergesNearTruth() {
+            const double trueA = 5.0;
+            const double trueB = 2.0;
+            var pts = NoiselessLinearPoints(trueA, trueB, count: 21);
+            // Drop in two clear outliers
+            pts[3] = new LinearDataPoint { X = pts[3].X, Y = pts[3].Y + 50.0 };
+            pts[15] = new LinearDataPoint { X = pts[15].X, Y = pts[15].Y - 50.0 };
+
+            var solver = new LinearSolver(pts);
+            var nlls = new NonLinearLeastSquaresSolver<LinearSolver, LinearDataPoint, LinearParameters>(alglibAPI);
+
+            var result = nlls.SolveWinsorizedResiduals(solver, maxWinsorizedIterations: 5, winsorizationSigma: 1.5);
+
+            Assert.Multiple(() => {
+                Assert.That(result.A, Is.EqualTo(trueA).Within(0.5));
+                Assert.That(result.B, Is.EqualTo(trueB).Within(0.5));
+            });
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/RANSACRegistrationTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/RANSACRegistrationTests.cs
@@ -1,0 +1,183 @@
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Utility {
+
+    [TestFixture]
+    public class RANSACRegistrationTests {
+
+        [Test]
+        public void SimilarityTransform_IdentityTransform_ReturnsSamePoint() {
+            var t = new SimilarityTransform(scale: 1.0, rotation: 0.0, tx: 0.0, ty: 0.0);
+            var p = new Point2D(3.0, 4.0);
+            var transformed = t.Transform(p);
+            Assert.Multiple(() => {
+                Assert.That(transformed.X, Is.EqualTo(3.0).Within(1e-9));
+                Assert.That(transformed.Y, Is.EqualTo(4.0).Within(1e-9));
+            });
+        }
+
+        [Test]
+        public void SimilarityTransform_TranslationOnly_AppliesOffset() {
+            var t = new SimilarityTransform(scale: 1.0, rotation: 0.0, tx: 5.0, ty: -3.0);
+            var transformed = t.Transform(new Point2D(1.0, 2.0));
+            Assert.Multiple(() => {
+                Assert.That(transformed.X, Is.EqualTo(6.0).Within(1e-9));
+                Assert.That(transformed.Y, Is.EqualTo(-1.0).Within(1e-9));
+            });
+        }
+
+        [Test]
+        public void SimilarityTransform_NinetyDegRotation_RotatesPoint() {
+            var t = new SimilarityTransform(scale: 1.0, rotation: Math.PI / 2.0, tx: 0.0, ty: 0.0);
+            var transformed = t.Transform(new Point2D(1.0, 0.0));
+            Assert.Multiple(() => {
+                Assert.That(transformed.X, Is.EqualTo(0.0).Within(1e-9));
+                Assert.That(transformed.Y, Is.EqualTo(1.0).Within(1e-9));
+            });
+        }
+
+        [Test]
+        public void SimilarityTransform_Scaling_AppliesScale() {
+            var t = new SimilarityTransform(scale: 2.5, rotation: 0.0, tx: 0.0, ty: 0.0);
+            var transformed = t.Transform(new Point2D(2.0, 3.0));
+            Assert.Multiple(() => {
+                Assert.That(transformed.X, Is.EqualTo(5.0).Within(1e-9));
+                Assert.That(transformed.Y, Is.EqualTo(7.5).Within(1e-9));
+            });
+        }
+
+        [Test]
+        public void Matrix3x2_Identity_LeavesPointsUnchanged() {
+            var m = Matrix3x2.Identity;
+            var p = new Point2D(2.5, -3.5);
+            var t = m.Transform(p);
+            Assert.Multiple(() => {
+                Assert.That(t.X, Is.EqualTo(2.5));
+                Assert.That(t.Y, Is.EqualTo(-3.5));
+            });
+        }
+
+        [Test]
+        public void Matrix3x2_Determinant_KnownValue() {
+            var m = new Matrix3x2(2, 0, 0, 3, 100, 200);
+            Assert.That(m.GetDeterminant(), Is.EqualTo(6.0).Within(1e-9));
+        }
+
+        [Test]
+        public void Matrix3x2_Invert_RoundTripIsIdentity() {
+            var m = new Matrix3x2(2, 0, 0, 3, 100, 200);
+            Assert.That(m.Invert(out var inv), Is.True);
+
+            var p = new Point2D(7.0, 11.0);
+            var roundTrip = inv.Transform(m.Transform(p));
+            Assert.Multiple(() => {
+                Assert.That(roundTrip.X, Is.EqualTo(7.0).Within(1e-9));
+                Assert.That(roundTrip.Y, Is.EqualTo(11.0).Within(1e-9));
+            });
+        }
+
+        [Test]
+        public void Matrix3x2_InvertSingular_ReturnsFalse() {
+            var m = new Matrix3x2(0, 0, 0, 0, 5, 5);
+            Assert.That(m.Invert(out _), Is.False);
+        }
+
+        [Test]
+        public void FitAffineTransform_RecoversTranslation() {
+            var src = new List<Point2D> {
+                new(0, 0), new(1, 0), new(0, 1), new(1, 1),
+            };
+            var dst = src.Select(p => new Point2D(p.X + 10, p.Y - 5)).ToList();
+
+            var m = RANSACRegistration.FitAffineTransform(src, dst);
+            var t = m.Transform(new Point2D(2, 3));
+            Assert.Multiple(() => {
+                Assert.That(t.X, Is.EqualTo(12.0).Within(1e-6));
+                Assert.That(t.Y, Is.EqualTo(-2.0).Within(1e-6));
+            });
+        }
+
+        [Test]
+        public void FitAffineTransform_RecoversScaling() {
+            var src = new List<Point2D> { new(0, 0), new(1, 0), new(0, 1), new(1, 1) };
+            var dst = src.Select(p => new Point2D(p.X * 2.0, p.Y * 3.0)).ToList();
+
+            var m = RANSACRegistration.FitAffineTransform(src, dst);
+            var t = m.Transform(new Point2D(4, 5));
+            Assert.Multiple(() => {
+                Assert.That(t.X, Is.EqualTo(8.0).Within(1e-6));
+                Assert.That(t.Y, Is.EqualTo(15.0).Within(1e-6));
+            });
+        }
+
+        [Test]
+        public void FitAffineTransform_TooFewPoints_Throws() {
+            var src = new List<Point2D> { new(0, 0), new(1, 1) };
+            var dst = new List<Point2D> { new(0, 0), new(1, 1) };
+            Assert.Throws<ArgumentException>(() => RANSACRegistration.FitAffineTransform(src, dst));
+        }
+
+        [Test]
+        public void FitAffineTransform_MismatchedCount_Throws() {
+            var src = new List<Point2D> { new(0, 0), new(1, 0), new(0, 1) };
+            var dst = new List<Point2D> { new(0, 0), new(1, 0) };
+            Assert.Throws<ArgumentException>(() => RANSACRegistration.FitAffineTransform(src, dst));
+        }
+
+        [Test]
+        public void GeneratePutativeMatchesUsingNN_FindsExactMatches() {
+            var img = new List<Point2D> { new(10, 10, 0.5), new(20, 20, 0.5), new(30, 30, 0.5) };
+            var refStars = new List<Point2D> { new(10, 10, 0.5), new(21, 21, 0.5), new(50, 50, 0.5) };
+
+            var (src, dst) = RANSACRegistration.GeneratePutativeMatchesUsingNN(
+                img, refStars, maxDistance: 5.0, relativeBrightnessDiff: 0.1, status: null);
+
+            Assert.Multiple(() => {
+                Assert.That(src.Count, Is.EqualTo(2));
+                Assert.That(src[0].X, Is.EqualTo(10));
+                Assert.That(dst[0].X, Is.EqualTo(10));
+                Assert.That(src[1].X, Is.EqualTo(20));
+                Assert.That(dst[1].X, Is.EqualTo(21));
+            });
+        }
+
+        [Test]
+        public void GeneratePutativeMatchesUsingNN_BrightnessDifferenceFiltersOut() {
+            var img = new List<Point2D> { new(10, 10, 0.5) };
+            var refStars = new List<Point2D> { new(10, 10, 1.0) }; // brightness difference too large
+
+            var (src, dst) = RANSACRegistration.GeneratePutativeMatchesUsingNN(
+                img, refStars, maxDistance: 5.0, relativeBrightnessDiff: 0.1, status: null);
+
+            Assert.Multiple(() => {
+                Assert.That(src.Count, Is.EqualTo(0));
+                Assert.That(dst.Count, Is.EqualTo(0));
+            });
+        }
+
+        [Test]
+        public void AngleBetweenPoints_RightAngle_ReturnsPiOver2() {
+            var a = new Point2D(1.0, 0.0);
+            var b = new Point2D(0.0, 0.0);
+            var c = new Point2D(0.0, 1.0);
+            var theta = RANSACRegistration.AngleBetweenPoints(a, b, c);
+            Assert.That(theta, Is.EqualTo(Math.PI / 2.0).Within(1e-9));
+        }
+
+        [Test]
+        public void AngleFromHorizontal_AlongPositiveX_IsZero() {
+            var theta = RANSACRegistration.AngleFromHorizontal(new Point2D(0, 0), new Point2D(1, 0));
+            Assert.That(theta, Is.EqualTo(0.0).Within(1e-9));
+        }
+
+        [Test]
+        public void AngleFromHorizontal_AlongPositiveY_IsPiOver2() {
+            var theta = RANSACRegistration.AngleFromHorizontal(new Point2D(0, 0), new Point2D(0, 1));
+            Assert.That(theta, Is.EqualTo(Math.PI / 2.0).Within(1e-9));
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltModel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltModel.cs
@@ -37,7 +37,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             double topRightPosition,
             double bottomLeftPosition,
             double bottomRightPosition) {
-            if (imageSize.Width == 0 || imageSize.Height <= 0) {
+            if (imageSize.Width <= 0 || imageSize.Height <= 0) {
                 throw new ArgumentException($"ImageSize ({imageSize.Width}, {imageSize.Height}) dimensions must be positive");
             }
 

--- a/plans/comprehensive-unit-tests.md
+++ b/plans/comprehensive-unit-tests.md
@@ -41,8 +41,18 @@ The following utilities were originally scoped to Tier 1 but are heavily OpenCV/
 - `Utility/NonLinearLeastSquaresSolverBase.cs`
 - `Utility/RANSACRegistration.cs` (algorithmic, fits Tier 2)
 
+- **Tier 2 (algorithms with mocked dependencies)** ✅ — **309 tests, 0 failing**
+  - Added `Synthetic/SyntheticGaussianStarImage.cs`, `Synthetic/SyntheticFocusCurveSamples.cs`
+  - Test project gained `<AllowUnsafeBlocks>true</AllowUnsafeBlocks>` so tests can fill OpenCV `Mat` buffers via raw pointers
+  - Utility: `CvImageUtilityTests`, `HotpixelFilteringTests`, `AlglibAPITests` (incl. parallel-solve smoke), `NonLinearLeastSquaresSolverTests` (linear-recovery + winsorized outlier rejection), `RANSACRegistrationTests` (Matrix3x2 round-trip, FitAffineTransform translation/scale, NN match brightness gating)
+  - StarDetection: `PSFModelTests` (FWHM/eccentricity/Sigma round-trip, Gaussian σ→FWHM constant), `PSFModelerTests` (Gaussian σ recovery on synthetic star + cancellation), `HyperbolicFittingAlglibTests`, `HyperbolicUnevenFittingAlglibTests`
+  - Inspection: `SensorParaboloidModelTests` (Value/Tilt/Curvature math, FromArray/ToArray round-trip, full curvature recovery on synthetic paraboloid)
+  - AutoFocus: `TiltPlaneModelTests` (corner-equal/A-only/B-only OLS recovery, GetModelX/Y bounds, ctor validation)
+  - Scottplot: `LinearColormapTests`
+  - **1 real bug fixed during Tier 2** (driven by spec-first test):
+    1. `AutoFocus/TiltModel.cs:40` — `imageSize.Width == 0` → `imageSize.Width <= 0` so negative width is rejected symmetrically with negative height (which already used `<= 0`). Matches the "dimensions must be positive" error message and prevents `GetModelX` returning garbage on a negative-Width construction.
+
 ### Not yet started
-- **Tier 2 (algorithms with mocked dependencies)** — see plan below
 - **Tier 3 (engine, VMs, sequence items)** — see plan below
 
 ---
@@ -179,5 +189,5 @@ End-to-end (Tier 3 only): run the one full-pipeline star-detection test against 
 
 - ~~Tier 0 (setup) — confirm project builds before writing any new tests.~~ ✅
 - ~~Tier 1 — ping with the list of expected-vs-actual divergences found.~~ ✅ (5 bugs fixed)
-- **Tier 2 — ping with any algorithm divergences found.** ← next
-- Tier 3 — final pass; ping with anything VM-specific that warrants a refactor.
+- ~~Tier 2 — ping with any algorithm divergences found.~~ ✅ (1 bug fixed)
+- **Tier 3 — final pass; ping with anything VM-specific that warrants a refactor.** ← next


### PR DESCRIPTION
## Summary

- Adds 97 new unit tests across 12 files covering Utility, StarDetection, Inspection, AutoFocus, and Scottplot — Tier 2 of the comprehensive-unit-tests plan.
- Fixes one spec-first divergence: `TiltModel.cs:40` accepted negative widths because the check was `Width == 0 || Height <= 0`. Tightened to `Width <= 0` so the validation matches the existing "dimensions must be positive" error message and the symmetric Height check.
- Test project gains `<AllowUnsafeBlocks>true</AllowUnsafeBlocks>` so tests can fill OpenCV `Mat` buffers via raw pointers (used in synthetic image generation and statistics tests).

Total test count: 309 (212 from Tier 1 + 97 new). All passing.

## Coverage added

- **Utility**: `CvImageUtilityTests`, `HotpixelFilteringTests`, `AlglibAPITests` (incl. parallel-solve smoke), `NonLinearLeastSquaresSolverTests` (linear-recovery + winsorized outlier rejection), `RANSACRegistrationTests` (Matrix3x2 round-trip, FitAffineTransform translation/scale, NN match brightness gating)
- **StarDetection**: `PSFModelTests` (FWHM/eccentricity/Sigma round-trip, Gaussian σ→FWHM constant), `PSFModelerTests` (Gaussian σ recovery on synthetic star + cancellation propagation), `HyperbolicFittingAlglibTests`, `HyperbolicUnevenFittingAlglibTests`
- **Inspection**: `SensorParaboloidModelTests` (Value/Tilt/Curvature math, FromArray/ToArray round-trip, full curvature recovery on synthetic paraboloid)
- **AutoFocus**: `TiltPlaneModelTests` (corner-equal / A-only / B-only OLS recovery, GetModelX/Y bounds, ctor validation)
- **Scottplot**: `LinearColormapTests`

New `Synthetic/` helpers: `SyntheticGaussianStarImage` and `SyntheticFocusCurveSamples`.

## Test plan

- [x] `dotnet test -c Debug` — 309 passed, 0 failed
- [ ] Reviewer confirms the `TiltModel.cs` symmetric-validation fix matches the intended behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)