### PR TITLE
Add CI workflow to run unit tests on PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,41 @@
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - develop
+  push:
+    branches:
+      - develop
+
+jobs:
+  test:
+    name: Run unit tests
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore test project
+        run: dotnet restore Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj
+
+      - name: Run tests
+        run: >
+          dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj
+          -c Debug
+          --no-restore
+          -p:PostBuildEvent=
+          --logger "trx;LogFileName=test-results.trx"
+          --results-directory TestResults
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: TestResults/*.trx


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/tests.yml` — runs `dotnet test` on the test project for every PR targeting `develop` and every push to `develop`.
- Uses `windows-latest` (the test project targets `net8.0-windows7.0` with WPF/WinForms enabled).
- Suppresses the local-only `PostBuildEvent` that copies binaries to `%localappdata%\NINA\Plugins`.
- Uploads the `.trx` as an artifact for failure triage.

## Required follow-up to actually block merges
This workflow only **runs** the tests — it does not by itself prevent merging a failing PR. To make the Tests check **required**, configure branch protection on `develop` in GitHub:

1. **Settings → Branches → Add branch protection rule** (or edit the existing `develop` rule)
2. Enable **Require status checks to pass before merging**
3. Search for and select **`Run unit tests`** (the job name from the workflow)
4. Save

Once one run of the workflow has appeared on `develop`, it will show up as a selectable required check.

## Test plan
- [ ] Confirm this PR's own CI run goes green
- [ ] After merge, configure branch protection on `develop` to require the `Run unit tests` check