### PR TITLE
Add IPluginOptionsAccessor seam to make options classes unit-testable

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusOptionsTests.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NINA.Profile.Interfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus;
+
+[TestFixture]
+public class AutoFocusOptionsTests {
+
+    private static (AutoFocusOptions options, InMemoryPluginOptionsAccessor store, IProfileService profile) Build() {
+        var profile = Substitute.For<IProfileService>();
+        var store = new InMemoryPluginOptionsAccessor();
+        var options = new AutoFocusOptions(profile, store);
+        return (options, store, profile);
+    }
+
+    [Test]
+    public void Defaults_AreLoadedFromAccessor() {
+        var (options, _, _) = Build();
+        Assert.Multiple(() => {
+            Assert.That(options.MaxConcurrent, Is.EqualTo(0));
+            Assert.That(options.FastFocusModeEnabled, Is.False);
+            Assert.That(options.FastStepSize, Is.EqualTo(1));
+            Assert.That(options.FastOffsetSteps, Is.EqualTo(4));
+            Assert.That(options.FastThreshold_Celcius, Is.EqualTo(5));
+            Assert.That(options.FastThreshold_FocuserPosition, Is.EqualTo(100));
+            Assert.That(options.FastThreshold_Seconds, Is.EqualTo((int)TimeSpan.FromMinutes(60).TotalSeconds));
+            Assert.That(options.AutoFocusTimeoutSeconds, Is.EqualTo((int)TimeSpan.FromMinutes(10).TotalSeconds));
+            Assert.That(options.ValidateHfrImprovement, Is.True);
+            Assert.That(options.HFRImprovementThreshold, Is.EqualTo(0.15));
+            Assert.That(options.SavePath, Is.EqualTo(""));
+            Assert.That(options.Save, Is.False);
+            Assert.That(options.LastSelectedLoadPath, Is.EqualTo(""));
+            Assert.That(options.FocuserOffset, Is.EqualTo(0));
+            Assert.That(options.MaxOutlierRejections, Is.EqualTo(1));
+            Assert.That(options.OutlierRejectionConfidence, Is.EqualTo(0.90));
+            Assert.That(options.UnevenHyperbolicFitEnabled, Is.True);
+            Assert.That(options.WeightedHyperbolicFitEnabled, Is.True);
+        });
+    }
+
+    [Test]
+    public void Setters_PersistToAccessor() {
+        var (options, store, _) = Build();
+        options.MaxConcurrent = 4;
+        options.FastFocusModeEnabled = true;
+        options.FastStepSize = 3;
+        options.FastOffsetSteps = 6;
+        options.FastThreshold_Celcius = 7;
+        options.FastThreshold_FocuserPosition = 250;
+        options.FastThreshold_Seconds = 1800;
+        options.AutoFocusTimeoutSeconds = 900;
+        options.ValidateHfrImprovement = false;
+        options.HFRImprovementThreshold = 0.25;
+        options.SavePath = @"C:\AF";
+        options.Save = true;
+        options.LastSelectedLoadPath = @"C:\AF\last";
+        options.FocuserOffset = -10;
+        options.MaxOutlierRejections = 3;
+        options.OutlierRejectionConfidence = 0.95;
+        options.UnevenHyperbolicFitEnabled = false;
+        options.WeightedHyperbolicFitEnabled = false;
+
+        Assert.Multiple(() => {
+            Assert.That(store.Snapshot["MaxConcurrent"], Is.EqualTo(4));
+            Assert.That(store.Snapshot["FastFocusModeEnabled"], Is.True);
+            Assert.That(store.Snapshot["FastStepSize"], Is.EqualTo(3));
+            Assert.That(store.Snapshot["FastOffsetSteps"], Is.EqualTo(6));
+            Assert.That(store.Snapshot["FastThreshold_Celcius"], Is.EqualTo(7));
+            Assert.That(store.Snapshot["FastThreshold_FocuserPosition"], Is.EqualTo(250));
+            Assert.That(store.Snapshot["FastThreshold_Seconds"], Is.EqualTo(1800));
+            Assert.That(store.Snapshot["AutoFocusTimeoutSeconds"], Is.EqualTo(900));
+            Assert.That(store.Snapshot["ValidateHfrImprovement"], Is.False);
+            Assert.That(store.Snapshot["HFRImprovementThreshold"], Is.EqualTo(0.25));
+            Assert.That(store.Snapshot["SavePath"], Is.EqualTo(@"C:\AF"));
+            Assert.That(store.Snapshot["Save"], Is.True);
+            Assert.That(store.Snapshot["LastSelectedLoadPath"], Is.EqualTo(@"C:\AF\last"));
+            Assert.That(store.Snapshot["FocuserOffset"], Is.EqualTo(-10));
+            Assert.That(store.Snapshot[nameof(AutoFocusOptions.MaxOutlierRejections)], Is.EqualTo(3));
+            Assert.That(store.Snapshot[nameof(AutoFocusOptions.OutlierRejectionConfidence)], Is.EqualTo(0.95));
+            Assert.That(store.Snapshot[nameof(AutoFocusOptions.UnevenHyperbolicFitEnabled)], Is.False);
+            Assert.That(store.Snapshot[nameof(AutoFocusOptions.WeightedHyperbolicFitEnabled)], Is.False);
+        });
+    }
+
+    [Test]
+    public void ResetDefaults_RestoresDocumentedDefaults() {
+        var (options, _, _) = Build();
+        options.MaxConcurrent = 8;
+        options.FastFocusModeEnabled = true;
+        options.HFRImprovementThreshold = 0.99;
+        options.Save = true;
+        options.MaxOutlierRejections = 4;
+
+        options.ResetDefaults();
+
+        Assert.Multiple(() => {
+            Assert.That(options.MaxConcurrent, Is.EqualTo(0));
+            Assert.That(options.FastFocusModeEnabled, Is.False);
+            Assert.That(options.HFRImprovementThreshold, Is.EqualTo(0.15));
+            Assert.That(options.Save, Is.False);
+            Assert.That(options.MaxOutlierRejections, Is.EqualTo(1));
+            Assert.That(options.OutlierRejectionConfidence, Is.EqualTo(0.90));
+            Assert.That(options.UnevenHyperbolicFitEnabled, Is.True);
+            Assert.That(options.WeightedHyperbolicFitEnabled, Is.True);
+        });
+    }
+
+    [TestCase(nameof(AutoFocusOptions.MaxConcurrent), 4)]
+    [TestCase(nameof(AutoFocusOptions.FastFocusModeEnabled), true)]
+    [TestCase(nameof(AutoFocusOptions.FastStepSize), 5)]
+    [TestCase(nameof(AutoFocusOptions.FastThreshold_Celcius), 7)]
+    [TestCase(nameof(AutoFocusOptions.AutoFocusTimeoutSeconds), 1200)]
+    [TestCase(nameof(AutoFocusOptions.ValidateHfrImprovement), false)]
+    [TestCase(nameof(AutoFocusOptions.HFRImprovementThreshold), 0.5)]
+    [TestCase(nameof(AutoFocusOptions.Save), true)]
+    [TestCase(nameof(AutoFocusOptions.SavePath), "x")]
+    [TestCase(nameof(AutoFocusOptions.LastSelectedLoadPath), "y")]
+    [TestCase(nameof(AutoFocusOptions.FocuserOffset), 5)]
+    [TestCase(nameof(AutoFocusOptions.MaxOutlierRejections), 2)]
+    [TestCase(nameof(AutoFocusOptions.OutlierRejectionConfidence), 0.95)]
+    [TestCase(nameof(AutoFocusOptions.UnevenHyperbolicFitEnabled), false)]
+    [TestCase(nameof(AutoFocusOptions.WeightedHyperbolicFitEnabled), false)]
+    public void Setter_RaisesPropertyChanged(string propertyName, object newValue) {
+        var (options, _, _) = Build();
+        var raised = new List<string>();
+        options.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+        var prop = typeof(AutoFocusOptions).GetProperty(propertyName);
+        prop.SetValue(options, Convert.ChangeType(newValue, prop.PropertyType));
+        Assert.That(raised, Does.Contain(propertyName));
+    }
+
+    [Test]
+    public void FastOffsetSteps_RejectsValuesLessThanTwo() {
+        var (options, _, _) = Build();
+        Assert.Throws<ArgumentException>(() => options.FastOffsetSteps = 1);
+    }
+
+    [TestCase(-1)]
+    public void FastThreshold_SecondsRejectsNegative(int v) {
+        var (options, _, _) = Build();
+        Assert.Throws<ArgumentException>(() => options.FastThreshold_Seconds = v);
+    }
+
+    [Test]
+    public void HFRImprovementThreshold_RejectsNonFinite() {
+        var (options, _, _) = Build();
+        Assert.Multiple(() => {
+            Assert.Throws<ArgumentException>(() => options.HFRImprovementThreshold = double.NaN);
+            Assert.Throws<ArgumentException>(() => options.HFRImprovementThreshold = double.PositiveInfinity);
+        });
+    }
+
+    [Test]
+    public void AutoFocusTimeoutSeconds_RejectsZeroOrNegative() {
+        var (options, _, _) = Build();
+        Assert.Throws<ArgumentException>(() => options.AutoFocusTimeoutSeconds = 0);
+        Assert.Throws<ArgumentException>(() => options.AutoFocusTimeoutSeconds = -5);
+    }
+
+    [Test]
+    public void OutlierRejectionConfidence_RejectsOutOfRange() {
+        var (options, _, _) = Build();
+        Assert.Throws<ArgumentException>(() => options.OutlierRejectionConfidence = 0.5);
+        Assert.Throws<ArgumentException>(() => options.OutlierRejectionConfidence = 1.0);
+    }
+
+    [Test]
+    public void Setter_DoesNotRaiseWhenUnchanged() {
+        var (options, _, _) = Build();
+        options.MaxConcurrent = 5;
+        var raised = new List<string>();
+        options.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+        options.MaxConcurrent = 5;
+        Assert.That(raised, Is.Empty);
+    }
+
+    [Test]
+    public void ProfileChanged_ReinitializesValues() {
+        var profile = Substitute.For<IProfileService>();
+        var store = new InMemoryPluginOptionsAccessor();
+        var options = new AutoFocusOptions(profile, store);
+        options.MaxConcurrent = 7;
+        Assert.That(options.MaxConcurrent, Is.EqualTo(7));
+
+        store.Clear();
+        profile.ProfileChanged += Raise.Event<EventHandler>(profile, EventArgs.Empty);
+
+        Assert.That(options.MaxConcurrent, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Constructor_ThrowsOnNullAccessor() {
+        var profile = Substitute.For<IProfileService>();
+        Assert.Throws<ArgumentNullException>(() => new AutoFocusOptions(profile, null));
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorOptionsTests.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NINA.Profile.Interfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus;
+
+[TestFixture]
+public class InspectorOptionsTests {
+
+    private static (InspectorOptions options, InMemoryPluginOptionsAccessor store, IProfileService profile) Build() {
+        var profile = Substitute.For<IProfileService>();
+        var store = new InMemoryPluginOptionsAccessor();
+        var options = new InspectorOptions(profile, store);
+        return (options, store, profile);
+    }
+
+    [Test]
+    public void Defaults_AreLoadedFromAccessor() {
+        var (options, _, _) = Build();
+        Assert.Multiple(() => {
+            Assert.That(options.StepCount, Is.EqualTo(-1));
+            Assert.That(options.StepSize, Is.EqualTo(-1));
+            Assert.That(options.FramesPerPoint, Is.EqualTo(-1));
+            Assert.That(options.TimeoutSeconds, Is.EqualTo(-1));
+            Assert.That(options.SimpleExposureSeconds, Is.EqualTo(-1));
+            Assert.That(options.DetailedAnalysisExposureSeconds, Is.EqualTo(-1));
+            Assert.That(options.NumRegionsWide, Is.EqualTo(7));
+            Assert.That(options.LoopingExposureAnalysisEnabled, Is.False);
+            Assert.That(options.MicronsPerFocuserStep, Is.EqualTo(-1));
+            Assert.That(options.EccentricityColorMapEnabled, Is.True);
+            Assert.That(options.MouseOnChartsEnabled, Is.True);
+            Assert.That(options.SensorCurveModelEnabled, Is.False);
+            Assert.That(options.ShowSensorModel, Is.True);
+            Assert.That(options.SensorROI, Is.EqualTo(1.0));
+            Assert.That(options.CornersROI, Is.EqualTo(1.0));
+            Assert.That(options.InterpolationAlgo, Is.EqualTo(InterpolationAlgoEnum.MultiQuadric));
+            Assert.That(options.InterpolationAmount, Is.EqualTo(InterpolationAmountEnum.Medium));
+            Assert.That(options.FixedSensorCenter, Is.True);
+            Assert.That(options.PreviousRunBrightnessDiff, Is.EqualTo(0.1));
+            Assert.That(options.StartingBrightnessDiff, Is.EqualTo(-1));
+            Assert.That(options.RejectBadBrightnessMatches, Is.False);
+            Assert.That(options.RejectBadlyFittingMatches, Is.False);
+            Assert.That(options.UseRANSAC, Is.False);
+            Assert.That(options.SaveImagesOnReruns, Is.False);
+            Assert.That(options.SaveAlignmentImages, Is.False);
+            Assert.That(options.MaxStarsPerRegion, Is.EqualTo(-1));
+            Assert.That(options.InterpolationEnabled, Is.False);
+        });
+    }
+
+    [Test]
+    public void Setters_PersistToAccessor() {
+        var (options, store, _) = Build();
+        options.StepCount = 5;
+        options.StepSize = 50;
+        options.FramesPerPoint = 3;
+        options.NumRegionsWide = 9;
+        options.SimpleExposureSeconds = 2.5;
+        options.DetailedAnalysisExposureSeconds = 4.0;
+        options.LoopingExposureAnalysisEnabled = true;
+        options.MicronsPerFocuserStep = 1.5;
+        options.EccentricityColorMapEnabled = false;
+        options.MouseOnChartsEnabled = false;
+        options.SensorCurveModelEnabled = true;
+        options.ShowSensorModel = false;
+        options.SensorROI = 0.5;
+        options.CornersROI = 0.75;
+        options.InterpolationAlgo = InterpolationAlgoEnum.ThinPlateSpline;
+        options.InterpolationAmount = InterpolationAmountEnum.Large;
+        options.FixedSensorCenter = false;
+        options.PreviousRunBrightnessDiff = 0.2;
+        options.StartingBrightnessDiff = 0.3;
+        options.RejectBadBrightnessMatches = true;
+        options.RejectBadlyFittingMatches = true;
+        options.UseRANSAC = true;
+        options.SaveImagesOnReruns = true;
+        options.SaveAlignmentImages = true;
+        options.MaxStarsPerRegion = 50;
+
+        Assert.Multiple(() => {
+            Assert.That(store.Snapshot[nameof(InspectorOptions.StepCount)], Is.EqualTo(5));
+            Assert.That(store.Snapshot[nameof(InspectorOptions.StepSize)], Is.EqualTo(50));
+            Assert.That(store.Snapshot[nameof(InspectorOptions.FramesPerPoint)], Is.EqualTo(3));
+            Assert.That(store.Snapshot[nameof(InspectorOptions.SimpleExposureSeconds)], Is.EqualTo(2.5));
+            Assert.That(store.Snapshot[nameof(InspectorOptions.DetailedAnalysisExposureSeconds)], Is.EqualTo(4.0));
+            Assert.That(store.Snapshot[nameof(InspectorOptions.NumRegionsWide)], Is.EqualTo(9));
+            Assert.That(store.Snapshot[nameof(InspectorOptions.LoopingExposureAnalysisEnabled)], Is.True);
+            Assert.That(store.Snapshot[nameof(InspectorOptions.MicronsPerFocuserStep)], Is.EqualTo(1.5));
+            Assert.That(store.Snapshot[nameof(InspectorOptions.EccentricityColorMapEnabled)], Is.False);
+            Assert.That(store.Snapshot[nameof(InspectorOptions.MouseOnChartsEnabled)], Is.False);
+            Assert.That(store.Snapshot[nameof(InspectorOptions.SensorCurveModelEnabled)], Is.True);
+            Assert.That(store.Snapshot[nameof(InspectorOptions.ShowSensorModel)], Is.False);
+            Assert.That(store.Snapshot[nameof(InspectorOptions.SensorROI)], Is.EqualTo(0.5));
+            Assert.That(store.Snapshot[nameof(InspectorOptions.CornersROI)], Is.EqualTo(0.75));
+            Assert.That(store.Snapshot[nameof(InspectorOptions.InterpolationAlgo)], Is.EqualTo(InterpolationAlgoEnum.ThinPlateSpline));
+            Assert.That(store.Snapshot[nameof(InspectorOptions.InterpolationAmount)], Is.EqualTo(InterpolationAmountEnum.Large));
+            Assert.That(store.Snapshot[nameof(InspectorOptions.FixedSensorCenter)], Is.False);
+            Assert.That(store.Snapshot[nameof(InspectorOptions.PreviousRunBrightnessDiff)], Is.EqualTo(0.2));
+            Assert.That(store.Snapshot[nameof(InspectorOptions.StartingBrightnessDiff)], Is.EqualTo(0.3));
+            Assert.That(store.Snapshot[nameof(InspectorOptions.RejectBadBrightnessMatches)], Is.True);
+            Assert.That(store.Snapshot[nameof(InspectorOptions.RejectBadlyFittingMatches)], Is.True);
+            Assert.That(store.Snapshot[nameof(InspectorOptions.UseRANSAC)], Is.True);
+            Assert.That(store.Snapshot[nameof(InspectorOptions.SaveImagesOnReruns)], Is.True);
+            Assert.That(store.Snapshot[nameof(InspectorOptions.SaveAlignmentImages)], Is.True);
+            Assert.That(store.Snapshot[nameof(InspectorOptions.MaxStarsPerRegion)], Is.EqualTo(50));
+        });
+    }
+
+    [TestCase(0.0, 0.1)]
+    [TestCase(0.05, 0.1)]
+    [TestCase(0.5, 0.5)]
+    [TestCase(1.0, 1.0)]
+    [TestCase(2.0, 1.0)]
+    [TestCase(double.NaN, 1.0)]
+    public void SensorROI_Clamps(double assigned, double expected) {
+        var (options, _, _) = Build();
+        options.SensorROI = assigned;
+        Assert.That(options.SensorROI, Is.EqualTo(expected));
+    }
+
+    [TestCase(0.0, 0.1)]
+    [TestCase(2.0, 1.0)]
+    [TestCase(double.NaN, 1.0)]
+    [TestCase(0.5, 0.5)]
+    public void CornersROI_Clamps(double assigned, double expected) {
+        var (options, _, _) = Build();
+        options.CornersROI = assigned;
+        Assert.That(options.CornersROI, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void BrightnessToleranceHint_ReflectsPreviousRunBrightnessDiff() {
+        var (options, _, _) = Build();
+        options.PreviousRunBrightnessDiff = 0.42;
+        Assert.That(options.BrightnessToleranceHint, Does.Contain("0.42"));
+    }
+
+    [Test]
+    public void PreviousRunBrightnessDiff_RaisesBrightnessToleranceHint() {
+        var (options, _, _) = Build();
+        var raised = new List<string>();
+        options.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+        options.PreviousRunBrightnessDiff = 0.5;
+        Assert.That(raised, Does.Contain("BrightnessToleranceHint"));
+    }
+
+    [Test]
+    public void MaxStarsPerRegionHint_IsConstant() {
+        var (options, _, _) = Build();
+        Assert.That(options.MaxStarsPerRegionHint, Does.Contain("unlimited"));
+    }
+
+    [Test]
+    public void ResetDefaults_RestoresDocumentedDefaults() {
+        var (options, _, _) = Build();
+        options.StepCount = 7;
+        options.NumRegionsWide = 10;
+        options.SensorROI = 0.5;
+        options.MouseOnChartsEnabled = false;
+
+        options.ResetDefaults();
+
+        Assert.Multiple(() => {
+            Assert.That(options.StepCount, Is.EqualTo(-1));
+            Assert.That(options.NumRegionsWide, Is.EqualTo(7));
+            Assert.That(options.SensorROI, Is.EqualTo(1.0));
+            Assert.That(options.MouseOnChartsEnabled, Is.True);
+            Assert.That(options.InterpolationAmount, Is.EqualTo(InterpolationAmountEnum.Medium));
+        });
+    }
+
+    [TestCase(nameof(InspectorOptions.StepCount), 4)]
+    [TestCase(nameof(InspectorOptions.LoopingExposureAnalysisEnabled), true)]
+    [TestCase(nameof(InspectorOptions.MicronsPerFocuserStep), 2.5)]
+    [TestCase(nameof(InspectorOptions.SensorROI), 0.6)]
+    [TestCase(nameof(InspectorOptions.UseRANSAC), true)]
+    [TestCase(nameof(InspectorOptions.MaxStarsPerRegion), 30)]
+    public void Setter_RaisesPropertyChanged(string propertyName, object newValue) {
+        var (options, _, _) = Build();
+        var raised = new List<string>();
+        options.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+        var prop = typeof(InspectorOptions).GetProperty(propertyName);
+        prop.SetValue(options, Convert.ChangeType(newValue, prop.PropertyType));
+        Assert.That(raised, Does.Contain(propertyName));
+    }
+
+    [Test]
+    public void ProfileChanged_ReinitializesOptions() {
+        var profile = Substitute.For<IProfileService>();
+        var store = new InMemoryPluginOptionsAccessor();
+        var options = new InspectorOptions(profile, store);
+        options.NumRegionsWide = 11;
+        Assert.That(options.NumRegionsWide, Is.EqualTo(11));
+
+        store.Clear();
+        profile.ProfileChanged += Raise.Event<EventHandler>(profile, EventArgs.Empty);
+
+        Assert.That(options.NumRegionsWide, Is.EqualTo(7));
+    }
+
+    [Test]
+    public void Constructor_ThrowsOnNullAccessor() {
+        var profile = Substitute.For<IProfileService>();
+        Assert.Throws<ArgumentNullException>(() => new InspectorOptions(profile, null));
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarAnnotatorOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarAnnotatorOptionsTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NINA.Profile.Interfaces;
+using NSubstitute;
+using NUnit.Framework;
+using Color = System.Windows.Media.Color;
+using FontFamily = System.Windows.Media.FontFamily;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection;
+
+[TestFixture]
+public class StarAnnotatorOptionsTests {
+
+    private static (StarAnnotatorOptions options, InMemoryPluginOptionsAccessor store, IProfileService profile) Build() {
+        var profile = Substitute.For<IProfileService>();
+        var store = new InMemoryPluginOptionsAccessor();
+        var options = new StarAnnotatorOptions(profile, store);
+        return (options, store, profile);
+    }
+
+    [Test]
+    public void Defaults_AreLoadedFromAccessor() {
+        var (options, _, _) = Build();
+        Assert.Multiple(() => {
+            Assert.That(options.ShowAnnotations, Is.True);
+            Assert.That(options.ShowAllStars, Is.True);
+            Assert.That(options.MaxStars, Is.EqualTo(200));
+            Assert.That(options.ShowStarBounds, Is.True);
+            Assert.That(options.StarBoundsColor, Is.EqualTo(Color.FromArgb(128, 255, 0, 0)));
+            Assert.That(options.ShowAnnotationType, Is.EqualTo(ShowAnnotationTypeEnum.HFR));
+            Assert.That(options.AnnotationFontFamily.FamilyNames.Values, Does.Contain("Arial"));
+            Assert.That(options.AnnotationFontSizePoints, Is.EqualTo(18f));
+            Assert.That(options.AnnotationColor, Is.EqualTo(Color.FromArgb(255, 255, 255, 0)));
+            Assert.That(options.StarBoundsType, Is.EqualTo(StarBoundsTypeEnum.Box));
+            Assert.That(options.ShowROI, Is.True);
+            Assert.That(options.ROIColor, Is.EqualTo(Color.FromArgb(255, 255, 255, 0)));
+            Assert.That(options.ShowStarCenter, Is.True);
+            Assert.That(options.StarCenterColor, Is.EqualTo(Color.FromArgb(128, 0, 0, 255)));
+            Assert.That(options.ShowTooDistorted, Is.False);
+            Assert.That(options.ShowDegenerate, Is.False);
+            Assert.That(options.ShowSaturated, Is.False);
+            Assert.That(options.ShowLowSensitivity, Is.False);
+            Assert.That(options.ShowNotCentered, Is.False);
+            Assert.That(options.ShowTooFlat, Is.False);
+            Assert.That(options.ShowStructureMap, Is.EqualTo(ShowStructureMapEnum.None));
+        });
+    }
+
+    [Test]
+    public void Setters_PersistToAccessor() {
+        var (options, store, _) = Build();
+        options.ShowAnnotations = false;
+        options.ShowAllStars = false;
+        options.MaxStars = 50;
+        options.ShowStarBounds = false;
+        options.StarBoundsColor = Color.FromRgb(10, 20, 30);
+        options.ShowAnnotationType = ShowAnnotationTypeEnum.Eccentricity;
+        options.AnnotationFontFamily = new FontFamily("Tahoma");
+        options.AnnotationFontSizePoints = 24f;
+        options.AnnotationColor = Color.FromRgb(40, 50, 60);
+        options.StarBoundsType = StarBoundsTypeEnum.Ellipse;
+        options.ShowROI = false;
+        options.ROIColor = Color.FromRgb(70, 80, 90);
+        options.ShowStarCenter = false;
+        options.StarCenterColor = Color.FromRgb(100, 110, 120);
+        options.ShowTooDistorted = true;
+        options.TooDistortedColor = Color.FromRgb(130, 140, 150);
+        options.ShowDegenerate = true;
+        options.DegenerateColor = Color.FromRgb(160, 170, 180);
+        options.ShowSaturated = true;
+        options.SaturatedColor = Color.FromRgb(190, 200, 210);
+        options.ShowLowSensitivity = true;
+        options.LowSensitivityColor = Color.FromRgb(220, 230, 240);
+        options.ShowNotCentered = true;
+        options.NotCenteredColor = Color.FromRgb(250, 5, 15);
+        options.ShowTooFlat = true;
+        options.TooFlatColor = Color.FromRgb(25, 35, 45);
+        options.ShowStructureMap = ShowStructureMapEnum.Original;
+        options.StructureMapColor = Color.FromRgb(55, 65, 75);
+
+        Assert.Multiple(() => {
+            Assert.That(store.Snapshot["ShowAnnotations"], Is.False);
+            Assert.That(store.Snapshot["ShowAllStars"], Is.False);
+            Assert.That(store.Snapshot["MaxStars"], Is.EqualTo(50));
+            Assert.That(store.Snapshot["ShowStarBounds"], Is.False);
+            Assert.That(store.Snapshot["StarBoundsColor"], Is.EqualTo(Color.FromRgb(10, 20, 30)));
+            Assert.That(store.Snapshot["ShowAnnotationType"], Is.EqualTo(ShowAnnotationTypeEnum.Eccentricity));
+            Assert.That(store.Snapshot["AnnotationFontFamily"], Is.EqualTo("Tahoma"));
+            Assert.That(store.Snapshot["AnnotationFontSizePoints"], Is.EqualTo(24f));
+            Assert.That(store.Snapshot["AnnotationColor"], Is.EqualTo(Color.FromRgb(40, 50, 60)));
+            Assert.That(store.Snapshot["StarBoundsType"], Is.EqualTo(StarBoundsTypeEnum.Ellipse));
+            Assert.That(store.Snapshot["ShowROI"], Is.False);
+            Assert.That(store.Snapshot["ROIColor"], Is.EqualTo(Color.FromRgb(70, 80, 90)));
+            Assert.That(store.Snapshot["ShowStarCenter"], Is.False);
+            Assert.That(store.Snapshot["StarCenterColor"], Is.EqualTo(Color.FromRgb(100, 110, 120)));
+            Assert.That(store.Snapshot["ShowTooDistorted"], Is.True);
+            Assert.That(store.Snapshot["TooDistortedColor"], Is.EqualTo(Color.FromRgb(130, 140, 150)));
+            Assert.That(store.Snapshot["ShowDegenerate"], Is.True);
+            Assert.That(store.Snapshot["DegenerateColor"], Is.EqualTo(Color.FromRgb(160, 170, 180)));
+            Assert.That(store.Snapshot["ShowSaturated"], Is.True);
+            Assert.That(store.Snapshot["SaturatedColor"], Is.EqualTo(Color.FromRgb(190, 200, 210)));
+            Assert.That(store.Snapshot["ShowLowSensitivity"], Is.True);
+            Assert.That(store.Snapshot["LowSensitivityColor"], Is.EqualTo(Color.FromRgb(220, 230, 240)));
+            Assert.That(store.Snapshot["ShowNotCentered"], Is.True);
+            Assert.That(store.Snapshot["NotCenteredColor"], Is.EqualTo(Color.FromRgb(250, 5, 15)));
+            Assert.That(store.Snapshot["ShowTooFlat"], Is.True);
+            Assert.That(store.Snapshot["TooFlatColor"], Is.EqualTo(Color.FromRgb(25, 35, 45)));
+            Assert.That(store.Snapshot["ShowStructureMap"], Is.EqualTo(ShowStructureMapEnum.Original));
+            Assert.That(store.Snapshot["StructureMapColor"], Is.EqualTo(Color.FromRgb(55, 65, 75)));
+        });
+    }
+
+    [TestCase(nameof(StarAnnotatorOptions.ShowAnnotations), false)]
+    [TestCase(nameof(StarAnnotatorOptions.ShowAllStars), false)]
+    [TestCase(nameof(StarAnnotatorOptions.MaxStars), 25)]
+    [TestCase(nameof(StarAnnotatorOptions.ShowStarBounds), false)]
+    [TestCase(nameof(StarAnnotatorOptions.ShowROI), false)]
+    [TestCase(nameof(StarAnnotatorOptions.ShowTooDistorted), true)]
+    [TestCase(nameof(StarAnnotatorOptions.ShowDegenerate), true)]
+    [TestCase(nameof(StarAnnotatorOptions.AnnotationFontSizePoints), 22f)]
+    public void Setter_RaisesPropertyChanged(string propertyName, object newValue) {
+        var (options, _, _) = Build();
+        var raised = new List<string>();
+        options.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+        var prop = typeof(StarAnnotatorOptions).GetProperty(propertyName);
+        prop.SetValue(options, Convert.ChangeType(newValue, prop.PropertyType));
+        Assert.That(raised, Does.Contain(propertyName));
+    }
+
+    [Test]
+    public void ColorSetter_RaisesPropertyChanged() {
+        var (options, _, _) = Build();
+        var raised = new List<string>();
+        options.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+        options.StarBoundsColor = Color.FromRgb(1, 2, 3);
+        Assert.That(raised, Does.Contain(nameof(StarAnnotatorOptions.StarBoundsColor)));
+    }
+
+    [Test]
+    public void ResetDefaults_RestoresDocumentedDefaults() {
+        var (options, _, _) = Build();
+        options.MaxStars = 5;
+        options.ShowAnnotations = false;
+        options.ShowStructureMap = ShowStructureMapEnum.Original;
+        options.AnnotationFontFamily = new FontFamily("Tahoma");
+
+        options.ResetDefaults();
+
+        Assert.Multiple(() => {
+            Assert.That(options.MaxStars, Is.EqualTo(200));
+            Assert.That(options.ShowAnnotations, Is.True);
+            Assert.That(options.ShowStructureMap, Is.EqualTo(ShowStructureMapEnum.None));
+            Assert.That(options.AnnotationFontFamily.FamilyNames.Values, Does.Contain("Arial"));
+        });
+    }
+
+    [Test]
+    public void ProfileChanged_ReinitializesOptions() {
+        var profile = Substitute.For<IProfileService>();
+        var store = new InMemoryPluginOptionsAccessor();
+        var options = new StarAnnotatorOptions(profile, store);
+        options.MaxStars = 5;
+        Assert.That(options.MaxStars, Is.EqualTo(5));
+
+        store.Clear();
+        profile.ProfileChanged += Raise.Event<EventHandler>(profile, EventArgs.Empty);
+
+        Assert.That(options.MaxStars, Is.EqualTo(200));
+    }
+
+    [Test]
+    public void Constructor_ThrowsOnNullAccessor() {
+        var profile = Substitute.For<IProfileService>();
+        Assert.Throws<ArgumentNullException>(() => new StarAnnotatorOptions(profile, null));
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionOptionsTests.cs
@@ -1,0 +1,307 @@
+using System;
+using System.Collections.Generic;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NINA.Profile.Interfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection;
+
+[TestFixture]
+public class StarDetectionOptionsTests {
+
+    private static (StarDetectionOptions options, InMemoryPluginOptionsAccessor store, IProfileService profile) Build() {
+        var profile = Substitute.For<IProfileService>();
+        var store = new InMemoryPluginOptionsAccessor();
+        var options = new StarDetectionOptions(profile, store);
+        return (options, store, profile);
+    }
+
+    [Test]
+    public void Defaults_AreLoadedFromAccessor() {
+        var (options, _, _) = Build();
+        Assert.Multiple(() => {
+            Assert.That(options.DebugMode, Is.False);
+            Assert.That(options.ModelPSF, Is.True);
+            Assert.That(options.UseAdvanced, Is.False);
+            Assert.That(options.PSFFitType, Is.EqualTo(StarDetectorPSFFitType.Moffat_40));
+            Assert.That(options.Simple_NoiseLevel, Is.EqualTo(NoiseLevelEnum.Typical));
+            Assert.That(options.Simple_PixelScale, Is.EqualTo(PixelScaleEnum.Typical));
+            Assert.That(options.Simple_FocusRange, Is.EqualTo(FocusRangeEnum.Typical));
+            Assert.That(options.HotpixelFiltering, Is.True);
+            Assert.That(options.HotpixelThresholdingEnabled, Is.True);
+            Assert.That(options.UseAutoFocusCrop, Is.True);
+            Assert.That(options.StarMeasurementNoiseReductionEnabled, Is.False);
+            Assert.That(options.MeasurementAverage, Is.EqualTo(MeasurementAverageEnum.Median));
+        });
+    }
+
+    [Test]
+    public void Setters_PersistToAccessor() {
+        var (options, store, _) = Build();
+        // Switch to advanced first so simple-mode auto-config doesn't override our values.
+        options.UseAdvanced = true;
+        options.DebugMode = true;
+        options.ModelPSF = false;
+        options.PSFFitType = StarDetectorPSFFitType.Gaussian;
+        options.HotpixelFiltering = false;
+        options.HotpixelThresholdingEnabled = false;
+        options.UseAutoFocusCrop = false;
+        options.StarMeasurementNoiseReductionEnabled = true;
+        options.NoiseReductionRadius = 7;
+        options.NoiseClippingMultiplier = 5.0;
+        options.StarClippingMultiplier = 3.0;
+        options.StructureLayers = 6;
+        options.BrightnessSensitivity = 12.5;
+        options.StarCenterTolerance = 0.5;
+        options.StarPeakResponse = 0.8;
+        options.MaxDistortion = 0.4;
+        options.StarBackgroundBoxExpansion = 4;
+        options.MinStarBoundingBoxSize = 6;
+        options.MinHFR = 1.0;
+        options.StructureDilationSize = 5;
+        options.StructureDilationCount = 1;
+        options.PixelSampleSize = 0.5;
+        options.PSFParallelPartitionSize = 200;
+        options.PSFResolution = 12;
+        options.PSFFitThreshold = 0.85;
+        options.UsePSFAbsoluteDeviation = true;
+        options.HotpixelThreshold = 0.01;
+        options.SaturationThreshold = 0.95;
+        options.MeasurementAverage = MeasurementAverageEnum.MeanOutliers;
+
+        Assert.Multiple(() => {
+            Assert.That(store.Snapshot["UseAdvanced"], Is.True);
+            Assert.That(store.Snapshot["DetectionDebugMode"], Is.True);
+            Assert.That(store.Snapshot["ModelPSF"], Is.False);
+            Assert.That(store.Snapshot["PSFFitType"], Is.EqualTo(StarDetectorPSFFitType.Gaussian));
+            Assert.That(store.Snapshot["HotpixelFiltering"], Is.False);
+            Assert.That(store.Snapshot[nameof(StarDetectionOptions.HotpixelThresholdingEnabled)], Is.False);
+            Assert.That(store.Snapshot["UseAutoFocusCrop"], Is.False);
+            Assert.That(store.Snapshot[nameof(StarDetectionOptions.StarMeasurementNoiseReductionEnabled)], Is.True);
+            Assert.That(store.Snapshot["NoiseReductionRadius"], Is.EqualTo(7));
+            Assert.That(store.Snapshot["NoiseClippingMultiplier"], Is.EqualTo(5.0));
+            Assert.That(store.Snapshot["StarClippingMultiplier"], Is.EqualTo(3.0));
+            Assert.That(store.Snapshot["StructureLayers"], Is.EqualTo(6));
+            Assert.That(store.Snapshot["BrightnessSensitivity"], Is.EqualTo(12.5));
+            Assert.That(store.Snapshot["StarCenterTolerance"], Is.EqualTo(0.5));
+            Assert.That(store.Snapshot["StarPeakResponse"], Is.EqualTo(0.8));
+            Assert.That(store.Snapshot["MaxDistortion"], Is.EqualTo(0.4));
+            Assert.That(store.Snapshot["StarBackgroundBoxExpansion"], Is.EqualTo(4));
+            Assert.That(store.Snapshot["MinStarBoundingBoxSize"], Is.EqualTo(6));
+            Assert.That(store.Snapshot["MinHFR"], Is.EqualTo(1.0));
+            Assert.That(store.Snapshot["StructureDilationSize"], Is.EqualTo(5));
+            Assert.That(store.Snapshot["StructureDilationCount"], Is.EqualTo(1));
+            Assert.That(store.Snapshot["PixelSampleSize"], Is.EqualTo(0.5));
+            Assert.That(store.Snapshot["PSFParallelPartitionSize"], Is.EqualTo(200));
+            Assert.That(store.Snapshot["PSFResolution"], Is.EqualTo(12));
+            Assert.That(store.Snapshot["PSFFitThreshold"], Is.EqualTo(0.85));
+            Assert.That(store.Snapshot[nameof(StarDetectionOptions.UsePSFAbsoluteDeviation)], Is.True);
+            Assert.That(store.Snapshot[nameof(StarDetectionOptions.HotpixelThreshold)], Is.EqualTo(0.01));
+            Assert.That(store.Snapshot[nameof(StarDetectionOptions.SaturationThreshold)], Is.EqualTo(0.95));
+            Assert.That(store.Snapshot[nameof(StarDetectionOptions.MeasurementAverage)], Is.EqualTo(MeasurementAverageEnum.MeanOutliers));
+        });
+    }
+
+    [Test]
+    public void SimpleMode_ChangingNoiseLevelToHigh_TogglesNoiseReduction() {
+        var (options, _, _) = Build();
+        options.UseAdvanced = false;
+        options.Simple_NoiseLevel = NoiseLevelEnum.High;
+        Assert.Multiple(() => {
+            Assert.That(options.StarMeasurementNoiseReductionEnabled, Is.True);
+            Assert.That(options.NoiseReductionRadius, Is.GreaterThanOrEqualTo(5));
+            Assert.That(options.HotpixelFiltering, Is.True);
+        });
+    }
+
+    [Test]
+    public void SimpleMode_NoiseLevelNone_DisablesHotpixelFiltering() {
+        var (options, _, _) = Build();
+        options.UseAdvanced = false;
+        options.Simple_NoiseLevel = NoiseLevelEnum.None;
+        Assert.Multiple(() => {
+            Assert.That(options.HotpixelFiltering, Is.False);
+            Assert.That(options.StarMeasurementNoiseReductionEnabled, Is.False);
+            Assert.That(options.NoiseReductionRadius, Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void SimpleMode_PixelScaleWideField_AdjustsStructure() {
+        var (options, _, _) = Build();
+        options.UseAdvanced = false;
+        options.Simple_PixelScale = PixelScaleEnum.WideField;
+        Assert.That(options.PixelSampleSize, Is.EqualTo(0.5));
+    }
+
+    [Test]
+    public void SimpleMode_PixelScaleLongFocalLength_BoostsBrightnessSensitivity() {
+        var (options, _, _) = Build();
+        options.UseAdvanced = false;
+        options.Simple_NoiseLevel = NoiseLevelEnum.Typical;
+        options.Simple_PixelScale = PixelScaleEnum.LongFocalLength;
+        Assert.That(options.BrightnessSensitivity, Is.GreaterThan(10.0));
+    }
+
+    [Test]
+    public void SimpleMode_FocusRangeWideRange_BoostsStructureLayers() {
+        var (options, _, _) = Build();
+        options.UseAdvanced = false;
+        options.Simple_PixelScale = PixelScaleEnum.Typical;
+        options.Simple_FocusRange = FocusRangeEnum.WideRange;
+        Assert.That(options.StructureLayers, Is.GreaterThanOrEqualTo(5));
+    }
+
+    [Test]
+    public void AdvancedMode_DoesNotAutoConfigure() {
+        var (options, _, _) = Build();
+        options.UseAdvanced = true;
+        options.NoiseReductionRadius = 9;
+        options.Simple_NoiseLevel = NoiseLevelEnum.High;
+        Assert.That(options.NoiseReductionRadius, Is.EqualTo(9));
+    }
+
+    [TestCase(-1)]
+    public void NoiseReductionRadius_RejectsNegative(int v) {
+        var (options, _, _) = Build();
+        options.UseAdvanced = true;
+        Assert.Throws<ArgumentException>(() => options.NoiseReductionRadius = v);
+    }
+
+    [Test]
+    public void StructureLayers_RejectsZeroOrNegative() {
+        var (options, _, _) = Build();
+        options.UseAdvanced = true;
+        Assert.Throws<ArgumentException>(() => options.StructureLayers = 0);
+        Assert.Throws<ArgumentException>(() => options.StructureLayers = -1);
+    }
+
+    [Test]
+    public void StarCenterTolerance_RejectsOutOfRange() {
+        var (options, _, _) = Build();
+        options.UseAdvanced = true;
+        Assert.Throws<ArgumentException>(() => options.StarCenterTolerance = 0);
+        Assert.Throws<ArgumentException>(() => options.StarCenterTolerance = 1.5);
+    }
+
+    [Test]
+    public void MaxDistortion_RejectsOutOfRange() {
+        var (options, _, _) = Build();
+        options.UseAdvanced = true;
+        Assert.Throws<ArgumentException>(() => options.MaxDistortion = -0.1);
+        Assert.Throws<ArgumentException>(() => options.MaxDistortion = 1.1);
+    }
+
+    [Test]
+    public void PixelSampleSize_RejectsOutOfRange() {
+        var (options, _, _) = Build();
+        options.UseAdvanced = true;
+        Assert.Throws<ArgumentException>(() => options.PixelSampleSize = 0);
+        Assert.Throws<ArgumentException>(() => options.PixelSampleSize = 1.1);
+    }
+
+    [Test]
+    public void StructureDilationSize_RejectsLessThan3() {
+        var (options, _, _) = Build();
+        options.UseAdvanced = true;
+        Assert.Throws<ArgumentException>(() => options.StructureDilationSize = 2);
+    }
+
+    [Test]
+    public void StarBackgroundBoxExpansion_RejectsLessThan1() {
+        var (options, _, _) = Build();
+        options.UseAdvanced = true;
+        Assert.Throws<ArgumentException>(() => options.StarBackgroundBoxExpansion = 0);
+    }
+
+    [Test]
+    public void MinStarBoundingBoxSize_RejectsLessThan1() {
+        var (options, _, _) = Build();
+        options.UseAdvanced = true;
+        Assert.Throws<ArgumentException>(() => options.MinStarBoundingBoxSize = 0);
+    }
+
+    [Test]
+    public void HotpixelThreshold_RejectsOutOfRange() {
+        var (options, _, _) = Build();
+        options.UseAdvanced = true;
+        Assert.Throws<ArgumentException>(() => options.HotpixelThreshold = 0);
+        Assert.Throws<ArgumentException>(() => options.HotpixelThreshold = 1.5);
+    }
+
+    [Test]
+    public void SaturationThreshold_RejectsOutOfRange() {
+        var (options, _, _) = Build();
+        options.UseAdvanced = true;
+        Assert.Throws<ArgumentException>(() => options.SaturationThreshold = 0);
+        Assert.Throws<ArgumentException>(() => options.SaturationThreshold = 1.5);
+    }
+
+    [Test]
+    public void PSFFitThreshold_RejectsOutOfRange() {
+        var (options, _, _) = Build();
+        options.UseAdvanced = true;
+        Assert.Throws<ArgumentException>(() => options.PSFFitThreshold = 0);
+        Assert.Throws<ArgumentException>(() => options.PSFFitThreshold = 1.1);
+    }
+
+    [TestCase(nameof(StarDetectionOptions.DebugMode), true)]
+    [TestCase(nameof(StarDetectionOptions.UseAdvanced), true)]
+    [TestCase(nameof(StarDetectionOptions.ModelPSF), false)]
+    [TestCase(nameof(StarDetectionOptions.UseAutoFocusCrop), false)]
+    [TestCase(nameof(StarDetectionOptions.HotpixelFiltering), false)]
+    [TestCase(nameof(StarDetectionOptions.HotpixelThresholdingEnabled), false)]
+    [TestCase(nameof(StarDetectionOptions.UsePSFAbsoluteDeviation), true)]
+    public void Setter_RaisesPropertyChanged(string propertyName, object newValue) {
+        var (options, _, _) = Build();
+        var raised = new List<string>();
+        options.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+        var prop = typeof(StarDetectionOptions).GetProperty(propertyName);
+        prop.SetValue(options, Convert.ChangeType(newValue, prop.PropertyType));
+        Assert.That(raised, Does.Contain(propertyName));
+    }
+
+    [Test]
+    public void ResetDefaults_RestoresDocumentedDefaults() {
+        var (options, _, _) = Build();
+        options.UseAdvanced = true;
+        options.NoiseReductionRadius = 9;
+        options.PSFFitType = StarDetectorPSFFitType.Gaussian;
+        options.MeasurementAverage = MeasurementAverageEnum.MeanOutliers;
+
+        options.ResetDefaults();
+
+        Assert.Multiple(() => {
+            Assert.That(options.UseAdvanced, Is.False);
+            Assert.That(options.NoiseReductionRadius, Is.EqualTo(3));
+            Assert.That(options.PSFFitType, Is.EqualTo(StarDetectorPSFFitType.Moffat_40));
+            Assert.That(options.MeasurementAverage, Is.EqualTo(MeasurementAverageEnum.Median));
+            Assert.That(options.HotpixelFiltering, Is.True);
+        });
+    }
+
+    [Test]
+    public void ProfileChanged_ReinitializesValues() {
+        var profile = Substitute.For<IProfileService>();
+        var store = new InMemoryPluginOptionsAccessor();
+        var options = new StarDetectionOptions(profile, store);
+        options.UseAdvanced = true;
+        options.MeasurementAverage = MeasurementAverageEnum.MeanOutliers;
+        Assert.That(options.MeasurementAverage, Is.EqualTo(MeasurementAverageEnum.MeanOutliers));
+
+        store.Clear();
+        profile.ProfileChanged += Raise.Event<EventHandler>(profile, EventArgs.Empty);
+
+        Assert.That(options.MeasurementAverage, Is.EqualTo(MeasurementAverageEnum.Median));
+        Assert.That(options.UseAdvanced, Is.False);
+    }
+
+    [Test]
+    public void Constructor_ThrowsOnNullAccessor() {
+        var profile = Substitute.For<IProfileService>();
+        Assert.Throws<ArgumentNullException>(() => new StarDetectionOptions(profile, null));
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TestDoubles/InMemoryPluginOptionsAccessor.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TestDoubles/InMemoryPluginOptionsAccessor.cs
@@ -1,0 +1,104 @@
+using NINA.Profile.Interfaces;
+using System;
+using System.Collections.Generic;
+using Color = System.Windows.Media.Color;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles {
+
+    public sealed class InMemoryPluginOptionsAccessor : IPluginOptionsAccessor {
+        private readonly Dictionary<string, object> store = new(StringComparer.Ordinal);
+
+        public IReadOnlyDictionary<string, object> Snapshot => store;
+
+        public int WriteCount { get; private set; }
+
+        public int ReadCount { get; private set; }
+
+        public void Clear() => store.Clear();
+
+        private T Get<T>(string key, T defaultValue) {
+            ReadCount++;
+            if (store.TryGetValue(key, out var value) && value is T typed) {
+                return typed;
+            }
+            return defaultValue;
+        }
+
+        private void Set<T>(string key, T value) {
+            WriteCount++;
+            store[key] = value;
+        }
+
+        public bool GetValueBoolean(string key, bool defaultValue) => Get(key, defaultValue);
+
+        public void SetValueBoolean(string key, bool value) => Set(key, value);
+
+        public byte GetValueByte(string key, byte defaultValue) => Get(key, defaultValue);
+
+        public void SetValueByte(string key, byte value) => Set(key, value);
+
+        public sbyte GetValueSByte(string key, sbyte defaultValue) => Get(key, defaultValue);
+
+        public void SetValueSByte(string key, sbyte value) => Set(key, value);
+
+        public char GetValueChar(string key, char defaultValue) => Get(key, defaultValue);
+
+        public void SetValueChar(string key, char value) => Set(key, value);
+
+        public decimal GetValueDecimal(string key, decimal defaultValue) => Get(key, defaultValue);
+
+        public void SetValueDecimal(string key, decimal value) => Set(key, value);
+
+        public double GetValueDouble(string key, double defaultValue) => Get(key, defaultValue);
+
+        public void SetValueDouble(string key, double value) => Set(key, value);
+
+        public float GetValueSingle(string key, float defaultValue) => Get(key, defaultValue);
+
+        public void SetValueSingle(string key, float value) => Set(key, value);
+
+        public int GetValueInt32(string key, int defaultValue) => Get(key, defaultValue);
+
+        public void SetValueInt32(string key, int value) => Set(key, value);
+
+        public uint GetValueUInt32(string key, uint defaultValue) => Get(key, defaultValue);
+
+        public void SetValueUInt32(string key, uint value) => Set(key, value);
+
+        public long GetValueInt64(string key, long defaultValue) => Get(key, defaultValue);
+
+        public void SetValueInt64(string key, long value) => Set(key, value);
+
+        public ulong GetValueUInt64(string key, ulong defaultValue) => Get(key, defaultValue);
+
+        public void SetValueUInt64(string key, ulong value) => Set(key, value);
+
+        public short GetValueInt16(string key, short defaultValue) => Get(key, defaultValue);
+
+        public void SetValueInt16(string key, short value) => Set(key, value);
+
+        public ushort GetValueUInt16(string key, ushort defaultValue) => Get(key, defaultValue);
+
+        public void SetValueUInt16(string key, ushort value) => Set(key, value);
+
+        public string GetValueString(string key, string defaultValue) => Get(key, defaultValue);
+
+        public void SetValueString(string key, string value) => Set(key, value);
+
+        public DateTime GetValueDateTime(string key, DateTime defaultValue) => Get(key, defaultValue);
+
+        public void SetValueDateTime(string key, DateTime value) => Set(key, value);
+
+        public Guid GetValueGuid(string key, Guid defaultValue) => Get(key, defaultValue);
+
+        public void SetValueGuid(string key, Guid value) => Set(key, value);
+
+        public Color GetValueColor(string key, Color defaultValue) => Get(key, defaultValue);
+
+        public void SetValueColor(string key, Color value) => Set(key, value);
+
+        public T GetValueEnum<T>(string key, T defaultValue) where T : struct, Enum => Get(key, defaultValue);
+
+        public void SetValueEnum<T>(string key, T value) where T : struct, Enum => Set(key, value);
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
+using NINA.Profile.Interfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard;
+
+[TestFixture]
+public class TiltAdapterOptionsTests {
+
+    private static (TiltAdapterOptions options, InMemoryPluginOptionsAccessor store, IProfileService profile) Build() {
+        var profile = Substitute.For<IProfileService>();
+        var store = new InMemoryPluginOptionsAccessor();
+        var options = new TiltAdapterOptions(profile, store);
+        return (options, store, profile);
+    }
+
+    [Test]
+    public void Defaults_AreLoadedFromAccessor() {
+        var (options, _, _) = Build();
+        Assert.Multiple(() => {
+            Assert.That(options.ScrewCount, Is.EqualTo(3));
+            Assert.That(options.IsCalibrated, Is.False);
+            Assert.That(options.Screw1AngleDegrees, Is.NaN);
+            Assert.That(options.Screw2AngleDegrees, Is.NaN);
+            Assert.That(options.Screw3AngleDegrees, Is.NaN);
+            Assert.That(options.Screw4AngleDegrees, Is.NaN);
+            Assert.That(options.CalibratedScrewCount, Is.EqualTo(0));
+            Assert.That(options.MeasurementAverageCount, Is.EqualTo(1));
+            Assert.That(options.ScrewInwardCurvatureSign, Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void Setter_PersistsAndRoundTrips() {
+        var (options, store, _) = Build();
+        options.ScrewCount = 4;
+        options.IsCalibrated = true;
+        options.Screw1AngleDegrees = 0;
+        options.Screw2AngleDegrees = 90;
+        options.Screw3AngleDegrees = 180;
+        options.Screw4AngleDegrees = 270;
+        options.CalibratedScrewCount = 4;
+        options.MeasurementAverageCount = 5;
+        options.ScrewInwardCurvatureSign = -1;
+
+        Assert.Multiple(() => {
+            Assert.That(store.Snapshot[nameof(options.ScrewCount)], Is.EqualTo(4));
+            Assert.That(store.Snapshot[nameof(options.IsCalibrated)], Is.EqualTo(true));
+            Assert.That(store.Snapshot[nameof(options.Screw1AngleDegrees)], Is.EqualTo(0d));
+            Assert.That(store.Snapshot[nameof(options.Screw2AngleDegrees)], Is.EqualTo(90d));
+            Assert.That(store.Snapshot[nameof(options.Screw3AngleDegrees)], Is.EqualTo(180d));
+            Assert.That(store.Snapshot[nameof(options.Screw4AngleDegrees)], Is.EqualTo(270d));
+            Assert.That(store.Snapshot[nameof(options.CalibratedScrewCount)], Is.EqualTo(4));
+            Assert.That(store.Snapshot[nameof(options.MeasurementAverageCount)], Is.EqualTo(5));
+            Assert.That(store.Snapshot[nameof(options.ScrewInwardCurvatureSign)], Is.EqualTo(-1));
+        });
+    }
+
+    [Test]
+    public void Setter_DoesNotWriteWhenValueUnchanged() {
+        var (options, store, _) = Build();
+        var beforeWrites = store.WriteCount;
+        options.ScrewCount = options.ScrewCount; // no-op assignment
+        Assert.That(store.WriteCount, Is.EqualTo(beforeWrites));
+    }
+
+    [TestCase(nameof(TiltAdapterOptions.ScrewCount), 4)]
+    [TestCase(nameof(TiltAdapterOptions.IsCalibrated), true)]
+    [TestCase(nameof(TiltAdapterOptions.Screw1AngleDegrees), 12.5)]
+    [TestCase(nameof(TiltAdapterOptions.Screw2AngleDegrees), 60.0)]
+    [TestCase(nameof(TiltAdapterOptions.Screw3AngleDegrees), 270.0)]
+    [TestCase(nameof(TiltAdapterOptions.Screw4AngleDegrees), 359.9)]
+    [TestCase(nameof(TiltAdapterOptions.CalibratedScrewCount), 3)]
+    [TestCase(nameof(TiltAdapterOptions.MeasurementAverageCount), 7)]
+    [TestCase(nameof(TiltAdapterOptions.ScrewInwardCurvatureSign), 1)]
+    public void Setter_RaisesPropertyChanged(string propertyName, object newValue) {
+        var (options, _, _) = Build();
+        var raised = new List<string>();
+        options.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+        var prop = typeof(TiltAdapterOptions).GetProperty(propertyName);
+        prop.SetValue(options, Convert.ChangeType(newValue, prop.PropertyType));
+        Assert.That(raised, Does.Contain(propertyName));
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusOptions.cs
@@ -21,17 +21,24 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
     [JsonObject]
     public class AutoFocusOptions : BaseINPC, IAutoFocusOptions {
-        private readonly PluginOptionsAccessor optionsAccessor;
+        private readonly IPluginOptionsAccessor optionsAccessor;
 
-        public AutoFocusOptions(IProfileService profileService) {
+        public AutoFocusOptions(IProfileService profileService)
+            : this(profileService, CreateDefaultAccessor(profileService)) {
+        }
+
+        internal AutoFocusOptions(IProfileService profileService, IPluginOptionsAccessor optionsAccessor) {
+            this.optionsAccessor = optionsAccessor ?? throw new ArgumentNullException(nameof(optionsAccessor));
+            profileService.ProfileChanged += ProfileService_ProfileChanged;
+            InitializeOptions();
+        }
+
+        private static IPluginOptionsAccessor CreateDefaultAccessor(IProfileService profileService) {
             var guid = PluginOptionsAccessor.GetAssemblyGuid(typeof(AutoFocusOptions));
             if (guid == null) {
                 throw new Exception($"Guid not found in assembly metadata");
             }
-
-            this.optionsAccessor = new PluginOptionsAccessor(profileService, guid.Value);
-            profileService.ProfileChanged += ProfileService_ProfileChanged;
-            InitializeOptions();
+            return new PluginOptionsAccessor(profileService, guid.Value);
         }
 
         private void ProfileService_ProfileChanged(object sender, EventArgs e) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
@@ -19,17 +19,24 @@ using System;
 namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
     public class InspectorOptions : BaseINPC, IInspectorOptions {
-        private readonly PluginOptionsAccessor optionsAccessor;
+        private readonly IPluginOptionsAccessor optionsAccessor;
 
-        public InspectorOptions(IProfileService profileService) {
+        public InspectorOptions(IProfileService profileService)
+            : this(profileService, CreateDefaultAccessor(profileService)) {
+        }
+
+        internal InspectorOptions(IProfileService profileService, IPluginOptionsAccessor optionsAccessor) {
+            this.optionsAccessor = optionsAccessor ?? throw new ArgumentNullException(nameof(optionsAccessor));
+            profileService.ProfileChanged += ProfileService_ProfileChanged;
+            InitializeOptions();
+        }
+
+        private static IPluginOptionsAccessor CreateDefaultAccessor(IProfileService profileService) {
             var guid = PluginOptionsAccessor.GetAssemblyGuid(typeof(AutoFocusOptions));
             if (guid == null) {
                 throw new Exception($"Guid not found in assembly metadata");
             }
-
-            this.optionsAccessor = new PluginOptionsAccessor(profileService, guid.Value);
-            profileService.ProfileChanged += ProfileService_ProfileChanged;
-            InitializeOptions();
+            return new PluginOptionsAccessor(profileService, guid.Value);
         }
 
         private void ProfileService_ProfileChanged(object sender, EventArgs e) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarAnnotatorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarAnnotatorOptions.cs
@@ -21,17 +21,24 @@ using System.Windows.Media;
 namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
 
     public class StarAnnotatorOptions : BaseINPC, IStarAnnotatorOptions {
-        private readonly PluginOptionsAccessor optionsAccessor;
+        private readonly IPluginOptionsAccessor optionsAccessor;
 
-        public StarAnnotatorOptions(IProfileService profileService) {
+        public StarAnnotatorOptions(IProfileService profileService)
+            : this(profileService, CreateDefaultAccessor(profileService)) {
+        }
+
+        internal StarAnnotatorOptions(IProfileService profileService, IPluginOptionsAccessor optionsAccessor) {
+            this.optionsAccessor = optionsAccessor ?? throw new ArgumentNullException(nameof(optionsAccessor));
+            profileService.ProfileChanged += ProfileService_ProfileChanged;
+            InitializeOptions();
+        }
+
+        private static IPluginOptionsAccessor CreateDefaultAccessor(IProfileService profileService) {
             var guid = PluginOptionsAccessor.GetAssemblyGuid(typeof(StarDetectionOptions));
             if (guid == null) {
                 throw new Exception($"Guid not found in assembly metadata");
             }
-
-            this.optionsAccessor = new PluginOptionsAccessor(profileService, guid.Value);
-            profileService.ProfileChanged += ProfileService_ProfileChanged;
-            InitializeOptions();
+            return new PluginOptionsAccessor(profileService, guid.Value);
         }
 
         private void ProfileService_ProfileChanged(object sender, EventArgs e) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
@@ -23,19 +23,25 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
 
     [JsonObject]
     public class StarDetectionOptions : BaseINPC, IStarDetectionOptions {
-        private readonly PluginOptionsAccessor optionsAccessor;
+        private readonly IPluginOptionsAccessor optionsAccessor;
 
-        public StarDetectionOptions(IProfileService profileService) {
+        public StarDetectionOptions(IProfileService profileService)
+            : this(profileService, CreateDefaultAccessor(profileService)) {
+        }
+
+        internal StarDetectionOptions(IProfileService profileService, IPluginOptionsAccessor optionsAccessor) {
+            this.optionsAccessor = optionsAccessor ?? throw new ArgumentNullException(nameof(optionsAccessor));
+            profileService.ProfileChanged += ProfileService_ProfileChanged;
+            this.PropertyChanged += StarDetectionOptions_PropertyChanged;
+            InitializeOptions();
+        }
+
+        private static IPluginOptionsAccessor CreateDefaultAccessor(IProfileService profileService) {
             var guid = PluginOptionsAccessor.GetAssemblyGuid(typeof(StarDetectionOptions));
             if (guid == null) {
                 throw new Exception($"Guid not found in assembly metadata");
             }
-
-            profileService.ProfileChanged += ProfileService_ProfileChanged;
-
-            this.optionsAccessor = new PluginOptionsAccessor(profileService, guid.Value);
-            this.PropertyChanged += StarDetectionOptions_PropertyChanged;
-            InitializeOptions();
+            return new PluginOptionsAccessor(profileService, guid.Value);
         }
 
         private void ProfileService_ProfileChanged(object sender, EventArgs e) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
@@ -20,17 +20,24 @@ using System;
 namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
     public class TiltAdapterOptions : BaseINPC, ITiltAdapterOptions {
-        private readonly PluginOptionsAccessor optionsAccessor;
+        private readonly IPluginOptionsAccessor optionsAccessor;
 
-        public TiltAdapterOptions(IProfileService profileService) {
+        public TiltAdapterOptions(IProfileService profileService)
+            : this(profileService, CreateDefaultAccessor(profileService)) {
+        }
+
+        internal TiltAdapterOptions(IProfileService profileService, IPluginOptionsAccessor optionsAccessor) {
+            this.optionsAccessor = optionsAccessor ?? throw new ArgumentNullException(nameof(optionsAccessor));
+            profileService.ProfileChanged += ProfileService_ProfileChanged;
+            InitializeOptions();
+        }
+
+        private static IPluginOptionsAccessor CreateDefaultAccessor(IProfileService profileService) {
             var guid = PluginOptionsAccessor.GetAssemblyGuid(typeof(AutoFocusOptions));
             if (guid == null) {
                 throw new Exception($"Guid not found in assembly metadata");
             }
-
-            this.optionsAccessor = new PluginOptionsAccessor(profileService, guid.Value);
-            profileService.ProfileChanged += ProfileService_ProfileChanged;
-            InitializeOptions();
+            return new PluginOptionsAccessor(profileService, guid.Value);
         }
 
         private void ProfileService_ProfileChanged(object sender, EventArgs e) {


### PR DESCRIPTION
## Summary

- Add an internal second constructor on each of the five options classes (AutoFocusOptions, InspectorOptions, StarDetectionOptions, StarAnnotatorOptions, TiltAdapterOptions) that accepts the existing NINA-provided IPluginOptionsAccessor, so tests can inject an in-memory fake instead of constructing a real PluginOptionsAccessor with a live NINA profile.
- Add InMemoryPluginOptionsAccessor test double + five new test fixtures (105 tests) covering defaults, setters, validation rules, ResetDefaults, PropertyChanged events, and ProfileChanged re-init.
- Workstream 1 of plans/coverage-to-60.md.

## Implementation note

The plan called for a new IPluginOptionsAccessor interface, but NINA already exposes one in NINA.Profile.Interfaces and PluginOptionsAccessor already implements it — so we just inject that directly and skip the adapter shim.

## Test plan

- [x] All 491 existing + new tests pass locally (`dotnet test`)
- [x] Solution builds with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)