### PR TITLE
Test data and value classes (RatioRect, SurfacePlot, StarDetector*, SensorParaboloid)

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/HocusFocusReportTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/HocusFocusReportTests.cs
@@ -1,0 +1,170 @@
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus;
+
+[TestFixture]
+public class HocusFocusReportTests {
+
+    [Test]
+    public void Defaults_AreInitialized() {
+        var r = new HocusFocusReport();
+        Assert.Multiple(() => {
+            Assert.That(r.FinalHFR, Is.EqualTo(0.0));
+            Assert.That(r.Region, Is.SameAs(StarDetectionRegion.Full));
+            Assert.That(r.HocusFocusStarDetectionOptions, Is.Null);
+            Assert.That(r.HocusFocusAutoFocusOptions, Is.Null);
+            Assert.That(r.FocuserOptions, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Setters_RoundTrip() {
+        var r = new HocusFocusReport {
+            FinalHFR = 1.25,
+            Region = new StarDetectionRegion(new RatioRect(0.0, 0.0, 0.5, 0.5))
+        };
+        Assert.Multiple(() => {
+            Assert.That(r.FinalHFR, Is.EqualTo(1.25));
+            Assert.That(r.Region.OuterBoundary.Width, Is.EqualTo(0.5));
+        });
+    }
+}
+
+[TestFixture]
+public class StarDetectionRegionTests {
+
+    [Test]
+    public void Full_IsTheFullSentinel() {
+        Assert.That(StarDetectionRegion.Full.IsFull(), Is.True);
+        Assert.That(StarDetectionRegion.Full.OuterBoundary, Is.SameAs(RatioRect.Full));
+        Assert.That(StarDetectionRegion.Full.InnerCropBoundary, Is.Null);
+    }
+
+    [Test]
+    public void Constructor_RejectsNullOuterBoundary() {
+        Assert.Throws<System.ArgumentException>(() => new StarDetectionRegion(null));
+    }
+
+    [Test]
+    public void Constructor_RejectsInnerCropOutsideOuterBoundary() {
+        var outer = new RatioRect(0.25, 0.25, 0.5, 0.5);
+        var inner = new RatioRect(0.0, 0.0, 0.9, 0.9);
+        Assert.Throws<System.ArgumentException>(() => new StarDetectionRegion(outer, inner));
+    }
+
+    [Test]
+    public void Constructor_AcceptsInnerCropFullyContained() {
+        var outer = RatioRect.Full;
+        var inner = new RatioRect(0.4, 0.4, 0.2, 0.2);
+        var region = new StarDetectionRegion(outer, inner, index: 7);
+        Assert.Multiple(() => {
+            Assert.That(region.OuterBoundary, Is.SameAs(outer));
+            Assert.That(region.InnerCropBoundary, Is.SameAs(inner));
+            Assert.That(region.Index, Is.EqualTo(7));
+            Assert.That(region.IsFull(), Is.False);
+        });
+    }
+
+    [Test]
+    public void ToString_IncludesBoundaries() {
+        var s = StarDetectionRegion.Full.ToString();
+        Assert.Multiple(() => {
+            Assert.That(s, Does.Contain("OuterBoundary"));
+            Assert.That(s, Does.Contain("InnerCropBoundary"));
+        });
+    }
+}
+
+[TestFixture]
+public class StarDetectorParamsTests {
+
+    [Test]
+    public void Defaults_AreReasonable() {
+        var p = new StarDetectorParams();
+        Assert.Multiple(() => {
+            Assert.That(p.HotpixelFiltering, Is.True);
+            Assert.That(p.HotpixelThresholdingEnabled, Is.True);
+            Assert.That(p.HotpixelThreshold, Is.EqualTo(0.001));
+            Assert.That(p.NoiseReductionRadius, Is.EqualTo(3));
+            Assert.That(p.NoiseClippingMultiplier, Is.EqualTo(4.0));
+            Assert.That(p.StarClippingMultiplier, Is.EqualTo(2.0));
+            Assert.That(p.HotpixelFilterRadius, Is.EqualTo(1));
+            Assert.That(p.StructureLayers, Is.EqualTo(4));
+            Assert.That(p.StructureDilationSize, Is.EqualTo(3));
+            Assert.That(p.StructureDilationCount, Is.EqualTo(0));
+            Assert.That(p.Sensitivity, Is.EqualTo(10.0));
+            Assert.That(p.PeakResponse, Is.EqualTo(0.75));
+            Assert.That(p.MaxDistortion, Is.EqualTo(0.5));
+            Assert.That(p.StarCenterTolerance, Is.EqualTo(0.3));
+            Assert.That(p.BackgroundBoxExpansion, Is.EqualTo(3));
+            Assert.That(p.MinimumStarBoundingBoxSize, Is.EqualTo(5));
+            Assert.That(p.MinHFR, Is.EqualTo(1.5));
+            Assert.That(p.Region, Is.SameAs(StarDetectionRegion.Full));
+            Assert.That(p.AnalysisSamplingSize, Is.EqualTo(1.0f));
+            Assert.That(p.StoreStructureMap, Is.False);
+            Assert.That(p.SaveIntermediateFilesPath, Is.EqualTo(string.Empty));
+            Assert.That(p.SaturationThreshold, Is.EqualTo(0.99).Within(1e-6));
+            Assert.That(p.ModelPSF, Is.True);
+            Assert.That(p.PSFFitType, Is.EqualTo(StarDetectorPSFFitType.Moffat_40));
+            Assert.That(p.UsePSFAbsoluteDeviation, Is.False);
+            Assert.That(p.PSFGoodnessOfFitThreshold, Is.EqualTo(0.9));
+            Assert.That(p.PSFResolution, Is.EqualTo(10));
+            Assert.That(p.PSFParallelPartitionSize, Is.EqualTo(100));
+            Assert.That(p.PixelScale, Is.EqualTo(1.0));
+        });
+    }
+
+    [Test]
+    public void ToString_IncludesKeyFields() {
+        var s = new StarDetectorParams().ToString();
+        Assert.Multiple(() => {
+            Assert.That(s, Does.Contain("HotpixelFiltering"));
+            Assert.That(s, Does.Contain("Sensitivity"));
+            Assert.That(s, Does.Contain("PSFResolution"));
+        });
+    }
+}
+
+[TestFixture]
+public class StarDetectorMetricsTests {
+
+    [Test]
+    public void Counts_ReflectListLengths() {
+        var m = new StarDetectorMetrics();
+        m.TooDistortedBounds.Add(new OpenCvSharp.Rect(0, 0, 1, 1));
+        m.DegenerateBounds.Add(new OpenCvSharp.Rect(0, 0, 1, 1));
+        m.DegenerateBounds.Add(new OpenCvSharp.Rect(0, 0, 1, 1));
+        Assert.Multiple(() => {
+            Assert.That(m.TooDistorted, Is.EqualTo(1));
+            Assert.That(m.Degenerate, Is.EqualTo(2));
+            Assert.That(m.Saturated, Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void DirectSetters_OnComputedCounts_Throw() {
+        var m = new StarDetectorMetrics();
+        Assert.Throws<System.NotSupportedException>(() => m.TooDistorted = 5);
+        Assert.Throws<System.NotSupportedException>(() => m.Degenerate = 5);
+        Assert.Throws<System.NotSupportedException>(() => m.Saturated = 5);
+        Assert.Throws<System.NotSupportedException>(() => m.LowSensitivity = 5);
+        Assert.Throws<System.NotSupportedException>(() => m.NotCentered = 5);
+        Assert.Throws<System.NotSupportedException>(() => m.TooFlat = 5);
+    }
+
+    [Test]
+    public void AddROIOffset_ShiftsAllRectBounds() {
+        var m = new StarDetectorMetrics();
+        m.TooDistortedBounds.Add(new OpenCvSharp.Rect(10, 20, 5, 5));
+        m.SaturatedBounds.Add(new OpenCvSharp.Rect(0, 0, 1, 1));
+        m.AddROIOffset(100, 200);
+        Assert.Multiple(() => {
+            Assert.That(m.TooDistortedBounds[0].X, Is.EqualTo(110));
+            Assert.That(m.TooDistortedBounds[0].Y, Is.EqualTo(220));
+            Assert.That(m.SaturatedBounds[0].X, Is.EqualTo(100));
+            Assert.That(m.SaturatedBounds[0].Y, Is.EqualTo(200));
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Controls/SurfacePlotModelTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Controls/SurfacePlotModelTests.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Drawing;
+using NINA.Joko.Plugins.HocusFocus.Controls;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Controls;
+
+[TestFixture]
+public class PlotPoint3DTests {
+
+    [Test]
+    public void Constructor_StoresAllFields() {
+        var p = new PlotPoint3D(1.0, 2.0, 3.0, Color.Red, 7.5f, "label");
+        Assert.Multiple(() => {
+            Assert.That(p.X, Is.EqualTo(1.0));
+            Assert.That(p.Y, Is.EqualTo(2.0));
+            Assert.That(p.Z, Is.EqualTo(3.0));
+            Assert.That(p.Color, Is.EqualTo(Color.Red));
+            Assert.That(p.Size, Is.EqualTo(7.5f));
+            Assert.That(p.Label, Is.EqualTo("label"));
+        });
+    }
+
+    [Test]
+    public void Constructor_DefaultsSizeAndLabel() {
+        var p = new PlotPoint3D(1, 2, 3, Color.Blue);
+        Assert.That(p.Size, Is.EqualTo(5.0f));
+        Assert.That(p.Label, Is.Null);
+    }
+}
+
+[TestFixture]
+public class PlotTickTests {
+
+    [Test]
+    public void Constructor_NoColor_LeavesLabelColorNull() {
+        var t = new PlotTick(1.5, "tick");
+        Assert.Multiple(() => {
+            Assert.That(t.Value, Is.EqualTo(1.5));
+            Assert.That(t.Label, Is.EqualTo("tick"));
+            Assert.That(t.LabelColor, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Constructor_WithColor_StoresColor() {
+        var t = new PlotTick(2.0, "tick", Color.Magenta);
+        Assert.That(t.LabelColor, Is.EqualTo(Color.Magenta));
+    }
+}
+
+[TestFixture]
+public class ScreenLabelTests {
+
+    [Test]
+    public void Constructor_StoresAllFields() {
+        var l = new ScreenLabel("hello", 0.25f, 0.75f, Color.Cyan);
+        Assert.Multiple(() => {
+            Assert.That(l.Text, Is.EqualTo("hello"));
+            Assert.That(l.XRatio, Is.EqualTo(0.25f));
+            Assert.That(l.YRatio, Is.EqualTo(0.75f));
+            Assert.That(l.Color, Is.EqualTo(Color.Cyan));
+        });
+    }
+}
+
+[TestFixture]
+public class SurfaceColorMapTests {
+
+    [Test]
+    public void Constructor_RejectsNullStops() {
+        Assert.Throws<ArgumentException>(() => new SurfaceColorMap(null));
+    }
+
+    [Test]
+    public void Constructor_RejectsEmptyStops() {
+        Assert.Throws<ArgumentException>(() => new SurfaceColorMap(Array.Empty<(double, Color)>()));
+    }
+
+    [Test]
+    public void GetColor_SingleStop_ReturnsThatColor() {
+        var map = new SurfaceColorMap((0.5, Color.Red));
+        Assert.That(map.GetColor(0.0, 0.0, 1.0), Is.EqualTo(Color.Red));
+        Assert.That(map.GetColor(1.0, 0.0, 1.0), Is.EqualTo(Color.Red));
+    }
+
+    [Test]
+    public void GetColor_BelowFirstStop_ReturnsFirstStop() {
+        var black = Color.FromArgb(255, 0, 0, 0);
+        var white = Color.FromArgb(255, 255, 255, 255);
+        var map = new SurfaceColorMap((0.0, black), (1.0, white));
+        Assert.That(map.GetColor(0.0, 0.0, 1.0).ToArgb(), Is.EqualTo(black.ToArgb()));
+    }
+
+    [Test]
+    public void GetColor_AboveLastStop_ReturnsLastStop() {
+        var black = Color.FromArgb(255, 0, 0, 0);
+        var white = Color.FromArgb(255, 255, 255, 255);
+        var map = new SurfaceColorMap((0.0, black), (0.5, white));
+        Assert.That(map.GetColor(1.0, 0.0, 1.0).ToArgb(), Is.EqualTo(white.ToArgb()));
+    }
+
+    [Test]
+    public void GetColor_DegenerateRange_UsesMidpoint() {
+        var map = new SurfaceColorMap((0.0, Color.Black), (1.0, Color.White));
+        var c = map.GetColor(5.0, 1.0, 1.0);
+        Assert.That(c.R, Is.EqualTo(127).Within(2));
+    }
+
+    [Test]
+    public void GetColor_Midway_BlendsLinearly() {
+        var map = new SurfaceColorMap((0.0, Color.FromArgb(0, 0, 0)), (1.0, Color.FromArgb(200, 100, 50)));
+        var c = map.GetColor(0.5, 0.0, 1.0);
+        Assert.Multiple(() => {
+            Assert.That(c.R, Is.EqualTo(100).Within(2));
+            Assert.That(c.G, Is.EqualTo(50).Within(2));
+            Assert.That(c.B, Is.EqualTo(25).Within(2));
+        });
+    }
+
+    [Test]
+    public void GetColor_OrdersStopsByPosition() {
+        // Constructor should sort by position even if passed reversed.
+        var black = Color.FromArgb(255, 0, 0, 0);
+        var white = Color.FromArgb(255, 255, 255, 255);
+        var map = new SurfaceColorMap((1.0, white), (0.0, black));
+        Assert.That(map.GetColor(0.0, 0.0, 1.0).ToArgb(), Is.EqualTo(black.ToArgb()));
+        Assert.That(map.GetColor(1.0, 0.0, 1.0).ToArgb(), Is.EqualTo(white.ToArgb()));
+    }
+
+    [Test]
+    public void Blend_AtZero_ReturnsLeft() {
+        var c = SurfaceColorMap.Blend(Color.FromArgb(255, 10, 20, 30), Color.FromArgb(0, 200, 200, 200), 0.0);
+        Assert.Multiple(() => {
+            Assert.That(c.A, Is.EqualTo(255));
+            Assert.That(c.R, Is.EqualTo(10));
+            Assert.That(c.G, Is.EqualTo(20));
+            Assert.That(c.B, Is.EqualTo(30));
+        });
+    }
+
+    [Test]
+    public void Blend_AtOne_ReturnsRight() {
+        var c = SurfaceColorMap.Blend(Color.FromArgb(0, 0, 0, 0), Color.FromArgb(100, 50, 60, 70), 1.0);
+        Assert.Multiple(() => {
+            Assert.That(c.A, Is.EqualTo(100));
+            Assert.That(c.R, Is.EqualTo(50));
+            Assert.That(c.G, Is.EqualTo(60));
+            Assert.That(c.B, Is.EqualTo(70));
+        });
+    }
+
+    [Test]
+    public void Blend_ClampsRatio() {
+        var black = Color.FromArgb(255, 0, 0, 0);
+        var white = Color.FromArgb(255, 255, 255, 255);
+        var c1 = SurfaceColorMap.Blend(black, white, -1.0);
+        var c2 = SurfaceColorMap.Blend(black, white, 2.0);
+        Assert.That(c1.ToArgb(), Is.EqualTo(black.ToArgb()));
+        Assert.That(c2.ToArgb(), Is.EqualTo(white.ToArgb()));
+    }
+}
+
+[TestFixture]
+public class SurfacePlotModelDataTests {
+
+    [Test]
+    public void Defaults_AreReasonable() {
+        var m = new SurfacePlotModel();
+        Assert.Multiple(() => {
+            Assert.That(m.RotationXDegrees, Is.EqualTo(45.0));
+            Assert.That(m.RotationZDegrees, Is.EqualTo(25.0));
+            Assert.That(m.VerticalScale, Is.EqualTo(0.8));
+            Assert.That(m.ShowSurface, Is.True);
+            Assert.That(m.ContourCount, Is.EqualTo(10));
+            Assert.That(m.ContourLabelFormat, Is.EqualTo("0.0"));
+            Assert.That(m.BackgroundColor, Is.EqualTo(Color.Black));
+            Assert.That(m.TextColor, Is.EqualTo(Color.White));
+            Assert.That(m.Projection, Is.EqualTo(ProjectionType.RotationBased));
+            Assert.That(m.ObliqueYAngleDegrees, Is.EqualTo(30.0));
+            Assert.That(m.ObliqueYScale, Is.EqualTo(0.5));
+            Assert.That(m.ShowAxes, Is.True);
+        });
+    }
+
+    [Test]
+    public void Lists_AreInitializedNonNull() {
+        var m = new SurfacePlotModel();
+        Assert.Multiple(() => {
+            Assert.That(m.XTicks, Is.Empty);
+            Assert.That(m.YTicks, Is.Empty);
+            Assert.That(m.ZTicks, Is.Empty);
+            Assert.That(m.Points, Is.Empty);
+            Assert.That(m.ScreenLabels, Is.Empty);
+        });
+    }
+}
+
+[TestFixture]
+public class SurfacePlotRendererTests {
+
+    [Test]
+    public void Constructor_RejectsNullModel() {
+        Assert.Throws<ArgumentNullException>(() => new SurfacePlotRenderer(null, 10, 10));
+    }
+
+    [Test]
+    public void Constructor_ClampsDimensionsToAtLeastOne() {
+        // Should not throw.
+        var renderer = new SurfacePlotRenderer(new SurfacePlotModel(), 0, -5);
+        Assert.That(renderer, Is.Not.Null);
+    }
+
+    [Test]
+    public void Render_ThrowsWhenZIsMissing() {
+        var renderer = new SurfacePlotRenderer(new SurfacePlotModel(), 16, 16);
+        Assert.Throws<ArgumentException>(() => renderer.Render());
+    }
+
+    [Test]
+    public void Render_ProducesBitmapWhenZIsProvided() {
+        var z = new double[3, 3];
+        for (int j = 0; j < 3; j++) {
+            for (int i = 0; i < 3; i++) {
+                z[j, i] = i + j;
+            }
+        }
+        var model = new SurfacePlotModel { Z = z };
+        using var bmp = new SurfacePlotRenderer(model, 32, 32).Render();
+        Assert.Multiple(() => {
+            Assert.That(bmp.Width, Is.EqualTo(32));
+            Assert.That(bmp.Height, Is.EqualTo(32));
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorParaboloidDataTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorParaboloidDataTests.cs
@@ -1,0 +1,167 @@
+using NINA.Joko.Plugins.HocusFocus.Inspection;
+using NUnit.Framework;
+using System;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection;
+
+[TestFixture]
+public class SensorParaboloidDataPointTests {
+
+    [Test]
+    public void Constructor_StoresAllValues() {
+        var p = new SensorParaboloidDataPoint(x: 10, y: 20, focuserPosition: 1234, rSquared: 0.95);
+        Assert.Multiple(() => {
+            Assert.That(p.X, Is.EqualTo(10));
+            Assert.That(p.Y, Is.EqualTo(20));
+            Assert.That(p.FocuserPosition, Is.EqualTo(1234));
+            Assert.That(p.RSquared, Is.EqualTo(0.95));
+        });
+    }
+
+    [Test]
+    public void ToInput_ReturnsXY() {
+        var p = new SensorParaboloidDataPoint(x: 10, y: 20, focuserPosition: 1234, rSquared: 0.95);
+        Assert.That(p.ToInput(), Is.EqualTo(new[] { 10.0, 20.0 }));
+    }
+
+    [Test]
+    public void ToOutput_ReturnsFocuserPosition() {
+        var p = new SensorParaboloidDataPoint(x: 10, y: 20, focuserPosition: 1234, rSquared: 0.95);
+        Assert.That(p.ToOutput(), Is.EqualTo(1234));
+    }
+
+    [Test]
+    public void ToString_IncludesAllFields() {
+        var p = new SensorParaboloidDataPoint(x: 10, y: 20, focuserPosition: 1234, rSquared: 0.95);
+        var s = p.ToString();
+        Assert.Multiple(() => {
+            Assert.That(s, Does.Contain("X="));
+            Assert.That(s, Does.Contain("Y="));
+            Assert.That(s, Does.Contain("FocuserPosition="));
+            Assert.That(s, Does.Contain("RSquared="));
+        });
+    }
+}
+
+[TestFixture]
+public class SensorParaboloidModelExtraTests {
+
+    [Test]
+    public void ParameterizedConstructor_StoresAllValues() {
+        var m = new SensorParaboloidModel(x0: 1, y0: 2, z0: 3, theta: 0.1, phi: 0.2, c: 0.05);
+        Assert.Multiple(() => {
+            Assert.That(m.X0, Is.EqualTo(1));
+            Assert.That(m.Y0, Is.EqualTo(2));
+            Assert.That(m.Z0, Is.EqualTo(3));
+            Assert.That(m.Theta, Is.EqualTo(0.1));
+            Assert.That(m.Phi, Is.EqualTo(0.2));
+            Assert.That(m.C, Is.EqualTo(0.05));
+        });
+    }
+
+    [Test]
+    public void DefaultConstructor_HasAllZeros() {
+        var m = new SensorParaboloidModel();
+        Assert.Multiple(() => {
+            Assert.That(m.X0, Is.EqualTo(0));
+            Assert.That(m.Y0, Is.EqualTo(0));
+            Assert.That(m.Z0, Is.EqualTo(0));
+            Assert.That(m.Theta, Is.EqualTo(0));
+            Assert.That(m.Phi, Is.EqualTo(0));
+            Assert.That(m.C, Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void FromArray_CopiesParameters() {
+        var m = new SensorParaboloidModel();
+        m.FromArray(new[] { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 });
+        Assert.Multiple(() => {
+            Assert.That(m.X0, Is.EqualTo(1));
+            Assert.That(m.Y0, Is.EqualTo(2));
+            Assert.That(m.Z0, Is.EqualTo(3));
+            Assert.That(m.Theta, Is.EqualTo(4));
+            Assert.That(m.Phi, Is.EqualTo(5));
+            Assert.That(m.C, Is.EqualTo(6));
+        });
+    }
+
+    [TestCase(null)]
+    [TestCase(new double[] { 1, 2, 3 })]
+    [TestCase(new double[] { 1, 2, 3, 4, 5, 6, 7 })]
+    public void FromArray_RejectsWrongShape(double[] input) {
+        var m = new SensorParaboloidModel();
+        Assert.Throws<ArgumentException>(() => m.FromArray(input));
+    }
+
+    [Test]
+    public void ToArray_ReturnsAllParametersInOrder() {
+        var m = new SensorParaboloidModel(x0: 1, y0: 2, z0: 3, theta: 0.4, phi: 0.5, c: 0.6);
+        Assert.That(m.ToArray(), Is.EqualTo(new[] { 1.0, 2.0, 3.0, 0.4, 0.5, 0.6 }));
+    }
+
+    [Test]
+    public void ToString_ContainsAllParameterNames() {
+        var s = new SensorParaboloidModel(x0: 1, y0: 2, z0: 3, theta: 0.1, phi: 0.2, c: 0.05).ToString();
+        Assert.Multiple(() => {
+            Assert.That(s, Does.Contain("X0="));
+            Assert.That(s, Does.Contain("Y0="));
+            Assert.That(s, Does.Contain("Z0="));
+            Assert.That(s, Does.Contain("Theta="));
+            Assert.That(s, Does.Contain("Phi="));
+            Assert.That(s, Does.Contain("C="));
+        });
+    }
+
+    [Test]
+    public void TiltAt_WithZeroTheta_IsZero() {
+        var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 0, theta: 0, phi: 0, c: 0);
+        Assert.That(m.TiltAt(100, 200), Is.EqualTo(0).Within(1e-12));
+    }
+
+    [Test]
+    public void CurvatureAt_WithZeroCurvature_IsZero() {
+        var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 0, theta: 0, phi: 0, c: 0);
+        Assert.That(m.CurvatureAt(100, 200), Is.EqualTo(0).Within(1e-12));
+    }
+
+    [Test]
+    public void CurvatureAt_PositiveC_IsPositive() {
+        var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 0, theta: 0, phi: 0, c: 0.1);
+        // C2 = +0.01, x²+y² = 100, so result = 1
+        Assert.That(m.CurvatureAt(10, 0), Is.EqualTo(1.0).Within(1e-9));
+    }
+
+    [Test]
+    public void CurvatureAt_NegativeC_IsNegative() {
+        var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 0, theta: 0, phi: 0, c: -0.1);
+        Assert.That(m.CurvatureAt(10, 0), Is.EqualTo(-1.0).Within(1e-9));
+    }
+
+    [Test]
+    public void Volume_ScalesWithSensorArea() {
+        var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 5, theta: 0, phi: 0, c: 0);
+        // Z0 only contribution: Z0 * w * h = 5 * 1000 * 2000 = 10_000_000
+        Assert.That(m.Volume(1000, 2000), Is.EqualTo(10_000_000.0).Within(1e-3));
+    }
+}
+
+[TestFixture]
+public class SensorModelAnalysisResultTests {
+
+    [Test]
+    public void Setters_RoundTrip() {
+        var r = new SensorModelAnalysisResult {
+            Name = "Tilt",
+            Value = "0.05°",
+            Acceptable = true,
+            Details = "OK"
+        };
+        Assert.Multiple(() => {
+            Assert.That(r.Name, Is.EqualTo("Tilt"));
+            Assert.That(r.Value, Is.EqualTo("0.05°"));
+            Assert.That(r.Acceptable, Is.True);
+            Assert.That(r.Details, Is.EqualTo("OK"));
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Interfaces/RatioRectTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Interfaces/RatioRectTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Drawing;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Interfaces;
+
+[TestFixture]
+public class RatioRectTests {
+
+    [Test]
+    public void Constructor_StoresCoordinates() {
+        var r = new RatioRect(0.1, 0.2, 0.3, 0.4);
+        Assert.Multiple(() => {
+            Assert.That(r.StartX, Is.EqualTo(0.1));
+            Assert.That(r.StartY, Is.EqualTo(0.2));
+            Assert.That(r.Width, Is.EqualTo(0.3));
+            Assert.That(r.Height, Is.EqualTo(0.4));
+        });
+    }
+
+    [Test]
+    public void Constructor_ClampsWidthAndHeightToBounds() {
+        var r = new RatioRect(0.6, 0.7, 1.0, 1.0);
+        Assert.That(r.Width, Is.EqualTo(0.4).Within(1e-12));
+        Assert.That(r.Height, Is.EqualTo(0.3).Within(1e-12));
+    }
+
+    [TestCase(-0.1, 0.0, 0.5, 0.5)]
+    [TestCase(0.0, -0.1, 0.5, 0.5)]
+    [TestCase(1.0, 0.0, 0.5, 0.5)]
+    [TestCase(0.0, 1.0, 0.5, 0.5)]
+    [TestCase(0.1, 0.1, 0.0, 0.5)]
+    [TestCase(0.1, 0.1, 0.5, 0.0)]
+    [TestCase(0.1, 0.1, -0.5, 0.5)]
+    [TestCase(0.1, 0.1, 0.5, -0.5)]
+    public void Constructor_RejectsInvalidArgs(double sx, double sy, double w, double h) {
+        Assert.Throws<ArgumentException>(() => new RatioRect(sx, sy, w, h));
+    }
+
+    [Test]
+    public void Full_IsFullCoverage() {
+        Assert.That(RatioRect.Full.IsFull(), Is.True);
+        Assert.That(RatioRect.Full.StartX, Is.EqualTo(0.0));
+        Assert.That(RatioRect.Full.StartY, Is.EqualTo(0.0));
+        Assert.That(RatioRect.Full.Width, Is.EqualTo(1.0));
+        Assert.That(RatioRect.Full.Height, Is.EqualTo(1.0));
+    }
+
+    [Test]
+    public void EndExclusive_AddsStartAndExtent() {
+        var r = new RatioRect(0.1, 0.2, 0.3, 0.4);
+        Assert.That(r.EndExclusiveX(), Is.EqualTo(0.4).Within(1e-12));
+        Assert.That(r.EndExclusiveY(), Is.EqualTo(0.6).Within(1e-12));
+    }
+
+    [Test]
+    public void Contains_ReturnsTrueForInteriorRect() {
+        var outer = new RatioRect(0.0, 0.0, 1.0, 1.0);
+        var inner = new RatioRect(0.1, 0.1, 0.5, 0.5);
+        Assert.That(outer.Contains(inner), Is.True);
+    }
+
+    [Test]
+    public void Contains_ReturnsFalseWhenInnerStartsBeforeOuter() {
+        var outer = new RatioRect(0.5, 0.5, 0.4, 0.4);
+        var inner = new RatioRect(0.1, 0.6, 0.2, 0.2);
+        Assert.That(outer.Contains(inner), Is.False);
+    }
+
+    [Test]
+    public void Contains_ReturnsFalseWhenInnerExtendsBeyondOuter() {
+        var outer = new RatioRect(0.0, 0.0, 0.5, 0.5);
+        var inner = new RatioRect(0.1, 0.1, 0.7, 0.2);
+        Assert.That(outer.Contains(inner), Is.False);
+    }
+
+    [Test]
+    public void Contains_RectangleOverload_DelegatesToFromRectangle() {
+        var outer = new RatioRect(0.0, 0.0, 1.0, 1.0);
+        var rect = new Rectangle(10, 10, 50, 50);
+        Assert.That(outer.Contains(rect, new Size(100, 100)), Is.True);
+    }
+
+    [Test]
+    public void IsFull_FalseForPartialRect() {
+        Assert.That(new RatioRect(0.0, 0.0, 0.5, 1.0).IsFull(), Is.False);
+        Assert.That(new RatioRect(0.0, 0.0, 1.0, 0.5).IsFull(), Is.False);
+    }
+
+    [Test]
+    public void ToString_ContainsAllFields() {
+        var r = new RatioRect(0.1, 0.2, 0.3, 0.4);
+        var s = r.ToString();
+        Assert.Multiple(() => {
+            Assert.That(s, Does.Contain("StartX="));
+            Assert.That(s, Does.Contain("StartY="));
+            Assert.That(s, Does.Contain("Width="));
+            Assert.That(s, Does.Contain("Height="));
+        });
+    }
+
+    [Test]
+    public void FromCenterROI_ProducesCenteredRect() {
+        var r = RatioRect.FromCenterROI(0.5);
+        Assert.Multiple(() => {
+            Assert.That(r.StartX, Is.EqualTo(0.25).Within(1e-12));
+            Assert.That(r.StartY, Is.EqualTo(0.25).Within(1e-12));
+            Assert.That(r.Width, Is.EqualTo(0.5).Within(1e-12));
+            Assert.That(r.Height, Is.EqualTo(0.5).Within(1e-12));
+        });
+    }
+
+    [Test]
+    public void FromRectangle_ScalesByFullSize() {
+        var rect = new Rectangle(50, 100, 200, 300);
+        var r = RatioRect.FromRectangle(rect, new Size(1000, 2000));
+        Assert.Multiple(() => {
+            Assert.That(r.StartX, Is.EqualTo(0.05).Within(1e-12));
+            Assert.That(r.StartY, Is.EqualTo(0.05).Within(1e-12));
+            Assert.That(r.Width, Is.EqualTo(0.2).Within(1e-12));
+            Assert.That(r.Height, Is.EqualTo(0.15).Within(1e-12));
+        });
+    }
+
+    [Test]
+    public void ToRectangle_RoundsToPixelCoords() {
+        var r = new RatioRect(0.1, 0.1, 0.5, 0.5);
+        var rect = r.ToRectangle(new Size(100, 200));
+        Assert.Multiple(() => {
+            Assert.That(rect.X, Is.EqualTo(10));
+            Assert.That(rect.Y, Is.EqualTo(20));
+            Assert.That(rect.Width, Is.EqualTo(50));
+            Assert.That(rect.Height, Is.EqualTo(100));
+        });
+    }
+
+    [Test]
+    public void ToRect2D_AndToInt32Rect_AlsoRound() {
+        var r = new RatioRect(0.1, 0.1, 0.5, 0.5);
+        var size = new Size(100, 200);
+        var rect2d = r.ToRect2D(size);
+        var int32Rect = r.ToInt32Rect(size);
+        Assert.Multiple(() => {
+            Assert.That(rect2d.X, Is.EqualTo(10));
+            Assert.That(rect2d.Y, Is.EqualTo(20));
+            Assert.That(rect2d.Width, Is.EqualTo(50));
+            Assert.That(rect2d.Height, Is.EqualTo(100));
+            Assert.That(int32Rect.X, Is.EqualTo(10));
+            Assert.That(int32Rect.Y, Is.EqualTo(20));
+            Assert.That(int32Rect.Width, Is.EqualTo(50));
+            Assert.That(int32Rect.Height, Is.EqualTo(100));
+        });
+    }
+
+    [Test]
+    public void RoundTrip_FromRectangleAndBack_PreservesGeometryWithinRounding() {
+        var size = new Size(1024, 768);
+        var original = new Rectangle(100, 200, 300, 400);
+        var r = RatioRect.FromRectangle(original, size);
+        var roundTrip = r.ToRectangle(size);
+        Assert.Multiple(() => {
+            Assert.That(roundTrip.X, Is.EqualTo(original.X));
+            Assert.That(roundTrip.Y, Is.EqualTo(original.Y));
+            Assert.That(roundTrip.Width, Is.EqualTo(original.Width));
+            Assert.That(roundTrip.Height, Is.EqualTo(original.Height));
+        });
+    }
+}


### PR DESCRIPTION
## Summary

- Add ~70 small property/round-trip/constructor tests for shared data classes that were at 0% coverage. No production code changes.
- Workstream 2 of plans/coverage-to-60.md.

Covers: RatioRect (geometry + ToRectangle/ToRect2D round-trips), StarDetectionRegion, StarDetectorParams, StarDetectorMetrics, HocusFocusReport JSON-bag, SurfacePlot value types (PlotPoint3D / PlotTick / ScreenLabel / SurfaceColorMap blend), SurfacePlotRenderer null/empty input handling, SensorParaboloidModel constructors / FromArray / TiltAt / CurvatureAt / Volume.

## Test plan

- [x] All 461 tests pass locally (`dotnet test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)