### PR TITLE
Add MediatorBundle test double + VM behavioral tests (Inspector, HocusFocus, TiltAdapter)

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/HocusFocusVMBehavioralTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/HocusFocusVMBehavioralTests.cs
@@ -1,0 +1,160 @@
+using NINA.Core.Enum;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.Tests.Synthetic;
+using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NSubstitute;
+using NUnit.Framework;
+using OxyPlot;
+using OxyPlot.Series;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus;
+
+[TestFixture]
+public class HocusFocusVMBehavioralTests {
+
+    private static int CountChanges(INotifyPropertyChanged source, string propertyName, System.Action act) {
+        int n = 0;
+        PropertyChangedEventHandler handler = (_, e) => { if (e.PropertyName == propertyName) n++; };
+        source.PropertyChanged += handler;
+        try { act(); } finally { source.PropertyChanged -= handler; }
+        return n;
+    }
+
+    [Test]
+    public void Construct_WithBundle_PopulatesBaseline() {
+        var bundle = new MediatorBundle();
+        var vm = bundle.BuildHocusFocusVM();
+
+        Assert.Multiple(() => {
+            Assert.That(vm.FocusPoints, Is.Not.Null);
+            Assert.That(vm.PlotFocusPoints, Is.Not.Null);
+            Assert.That(vm.PlotRejectedFocusPoints, Is.Not.Null);
+            Assert.That(vm.AutoFocusInProgress, Is.False);
+            Assert.That(vm.LastReport, Is.Null);
+            Assert.That(vm.LoadSavedAutoFocusRunCommand, Is.Not.Null);
+            Assert.That(vm.CancelLoadSavedAutoFocusRunCommand, Is.Not.Null);
+        });
+    }
+
+    [TestCase(nameof(HocusFocusVM.InitialFocuserPosition), 1234, 1234, 5678)]
+    [TestCase(nameof(HocusFocusVM.FinalFocuserPosition), 1, 1, 2)]
+    public void IntProperty_RaisesOnlyOnChange(string propertyName, int v1, int v2, int v3) {
+        var vm = new MediatorBundle().BuildHocusFocusVM();
+        var prop = typeof(HocusFocusVM).GetProperty(propertyName);
+        var changes = CountChanges(vm, propertyName, () => {
+            prop.SetValue(vm, v1);
+            prop.SetValue(vm, v2);
+            prop.SetValue(vm, v3);
+        });
+        Assert.That(changes, Is.EqualTo(2));
+    }
+
+    [TestCase(nameof(HocusFocusVM.InitialHFR), 1.5, 1.5, 2.0)]
+    [TestCase(nameof(HocusFocusVM.FinalHFR), 0.0, 1.5, 1.5)]
+    public void DoubleProperty_RaisesOnlyOnChange(string propertyName, double v1, double v2, double v3) {
+        var vm = new MediatorBundle().BuildHocusFocusVM();
+        var prop = typeof(HocusFocusVM).GetProperty(propertyName);
+        var changes = CountChanges(vm, propertyName, () => {
+            prop.SetValue(vm, v1);
+            prop.SetValue(vm, v2);
+            prop.SetValue(vm, v3);
+        });
+        Assert.That(changes, Is.GreaterThanOrEqualTo(1));
+    }
+
+    [Test]
+    public void FinalFocusPoint_RoundsXIntoFinalFocuserPosition() {
+        var vm = new MediatorBundle().BuildHocusFocusVM();
+        vm.FinalFocusPoint = new DataPoint(123.49, 1.2);
+        Assert.That(vm.FinalFocuserPosition, Is.EqualTo(123));
+
+        vm.FinalFocusPoint = new DataPoint(123.51, 1.2);
+        Assert.That(vm.FinalFocuserPosition, Is.EqualTo(124));
+    }
+
+    [Test]
+    public void AutoFocusInProgress_DefaultsFalse() {
+        var vm = new MediatorBundle().BuildHocusFocusVM();
+        Assert.That(vm.AutoFocusInProgress, Is.False);
+    }
+
+    [Test]
+    public void AutoFocusChartMethod_Setter_RaisesPropertyChanged() {
+        var vm = new MediatorBundle().BuildHocusFocusVM();
+        var raised = new List<string>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+        vm.AutoFocusChartMethod = AFMethodEnum.CONTRASTDETECTION;
+        Assert.That(raised, Does.Contain(nameof(vm.AutoFocusChartMethod)));
+    }
+
+    [Test]
+    public void AutoFocusChartCurveFitting_Setter_RaisesPropertyChanged() {
+        var vm = new MediatorBundle().BuildHocusFocusVM();
+        var raised = new List<string>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+        vm.AutoFocusChartCurveFitting = AFCurveFittingEnum.PARABOLIC;
+        Assert.That(raised, Does.Contain(nameof(vm.AutoFocusChartCurveFitting)));
+    }
+
+    [Test]
+    public void SetCurveFittings_StarHFR_TrendParabolic_PopulatesQuadraticAndTrendline() {
+        var bundle = new MediatorBundle();
+        var vm = bundle.BuildHocusFocusVM();
+        // y = (x-100)^2 / 1000 + 1
+        for (int x = 50; x <= 150; x += 10) {
+            var y = (x - 100.0) * (x - 100.0) / 1000.0 + 1.0;
+            vm.FocusPoints.Add(new ScatterErrorPoint(x, y, 0, 0.1));
+        }
+
+        vm.SetCurveFittings(method: AFMethodEnum.STARHFR.ToString(), fitting: AFCurveFittingEnum.TRENDPARABOLIC.ToString());
+
+        Assert.Multiple(() => {
+            Assert.That(vm.QuadraticFitting, Is.Not.Null);
+            Assert.That(vm.TrendlineFitting, Is.Not.Null);
+            Assert.That(vm.HyperbolicFitting, Is.Null);
+        });
+    }
+
+    [Test]
+    public void SetCurveFittings_StarHFR_TrendHyperbolic_PopulatesHyperbolicAndTrendline() {
+        var bundle = new MediatorBundle();
+        var vm = bundle.BuildHocusFocusVM();
+        var pts = SyntheticFocusCurveSamples.SymmetricHyperbolaPoints(
+            x0: 5000, y0: 0.0, a: 2.0, b: 80.0, xStart: 4800, xStep: 25, count: 17);
+        foreach (var p in pts) vm.FocusPoints.Add(p);
+
+        vm.SetCurveFittings(method: AFMethodEnum.STARHFR.ToString(), fitting: AFCurveFittingEnum.TRENDHYPERBOLIC.ToString());
+
+        Assert.Multiple(() => {
+            Assert.That(vm.HyperbolicFitting, Is.Not.Null);
+            Assert.That(vm.TrendlineFitting, Is.Not.Null);
+            Assert.That(vm.QuadraticFitting, Is.Null);
+        });
+    }
+
+    [Test]
+    public void SetCurveFittings_StarHFR_Trendlines_OnlyPopulatesTrendline() {
+        var bundle = new MediatorBundle();
+        var vm = bundle.BuildHocusFocusVM();
+        for (int x = 50; x <= 150; x += 10) {
+            var y = (x - 100.0) * (x - 100.0) / 1000.0 + 1.0;
+            vm.FocusPoints.Add(new ScatterErrorPoint(x, y, 0, 0.1));
+        }
+
+        vm.SetCurveFittings(method: AFMethodEnum.STARHFR.ToString(), fitting: AFCurveFittingEnum.TRENDLINES.ToString());
+
+        Assert.Multiple(() => {
+            Assert.That(vm.TrendlineFitting, Is.Not.Null);
+            Assert.That(vm.HyperbolicFitting, Is.Null);
+            Assert.That(vm.QuadraticFitting, Is.Null);
+        });
+    }
+
+    [Test]
+    public void LoadSavedAutoFocusRunCommand_IsAvailable() {
+        var vm = new MediatorBundle().BuildHocusFocusVM();
+        Assert.That(vm.LoadSavedAutoFocusRunCommand.CanExecute(null), Is.True);
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMBehavioralTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMBehavioralTests.cs
@@ -1,0 +1,143 @@
+using NINA.Equipment.Equipment.MyCamera;
+using NINA.Equipment.Equipment.MyFocuser;
+using NINA.Equipment.Equipment.MyTelescope;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NSubstitute;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus;
+
+[TestFixture]
+[Apartment(System.Threading.ApartmentState.STA)]
+public class InspectorVMBehavioralTests {
+
+    private static int CountChanges(INotifyPropertyChanged source, string propertyName, System.Action act) {
+        int n = 0;
+        PropertyChangedEventHandler handler = (_, e) => { if (e.PropertyName == propertyName) n++; };
+        source.PropertyChanged += handler;
+        try { act(); } finally { source.PropertyChanged -= handler; }
+        return n;
+    }
+
+    [Test]
+    public void Construct_WithBundle_DoesNotThrow() {
+        var bundle = new MediatorBundle();
+        var vm = bundle.BuildInspectorVM();
+        Assert.That(vm, Is.Not.Null);
+    }
+
+    [Test]
+    public void HasTiltAdapterCalibration_RequiresCalibratedAndMatchingScrewCount() {
+        var bundle = new MediatorBundle();
+        bundle.TiltAdapterOptions.IsCalibrated.Returns(false);
+        bundle.TiltAdapterOptions.ScrewCount.Returns(3);
+        bundle.TiltAdapterOptions.CalibratedScrewCount.Returns(3);
+        var vm = bundle.BuildInspectorVM();
+        Assert.That(vm.HasTiltAdapterCalibration, Is.False);
+
+        bundle.TiltAdapterOptions.IsCalibrated.Returns(true);
+        Assert.That(vm.HasTiltAdapterCalibration, Is.True);
+
+        bundle.TiltAdapterOptions.CalibratedScrewCount.Returns(4);
+        Assert.That(vm.HasTiltAdapterCalibration, Is.False);
+    }
+
+    [Test]
+    public void UpdateDeviceInfo_Camera_FlipsCameraInfo() {
+        var bundle = new MediatorBundle();
+        var vm = bundle.BuildInspectorVM();
+        var info = new CameraInfo { Connected = true };
+        vm.UpdateDeviceInfo(info);
+        Assert.That(vm.CameraInfo, Is.SameAs(info));
+    }
+
+    [Test]
+    public void UpdateDeviceInfo_Focuser_FlipsFocuserInfo() {
+        var bundle = new MediatorBundle();
+        var vm = bundle.BuildInspectorVM();
+        var info = new FocuserInfo { Connected = true, Position = 5000 };
+        vm.UpdateDeviceInfo(info);
+        Assert.That(vm.FocuserInfo, Is.SameAs(info));
+    }
+
+    [Test]
+    public void UpdateDeviceInfo_Telescope_FlipsTelescopeInfo() {
+        var bundle = new MediatorBundle();
+        var vm = bundle.BuildInspectorVM();
+        var info = new TelescopeInfo { Connected = true };
+        vm.UpdateDeviceInfo(info);
+        Assert.That(vm.TelescopeInfo, Is.SameAs(info));
+    }
+
+    [TestCase(nameof(InspectorVM.SensorCurveModelActive))]
+    [TestCase(nameof(InspectorVM.TiltMeasurementActive))]
+    [TestCase(nameof(InspectorVM.TiltMeasurementHistoryActive))]
+    [TestCase(nameof(InspectorVM.AutoFocusChartActive))]
+    [TestCase(nameof(InspectorVM.FWHMContoursActive))]
+    [TestCase(nameof(InspectorVM.EccentricityVectorsActive))]
+    [TestCase(nameof(InspectorVM.AutoFocusChartActivatedOnce))]
+    [TestCase(nameof(InspectorVM.TiltMeasurementActivatedOnce))]
+    [TestCase(nameof(InspectorVM.ExposureAnalysisActivatedOnce))]
+    [TestCase(nameof(InspectorVM.AutoFocusCompleted))]
+    [TestCase(nameof(InspectorVM.SensorModel3DEnabled))]
+    public void BoolToggleProperty_RaisesPropertyChangedOnceOnFlip(string propertyName) {
+        var vm = new MediatorBundle().BuildInspectorVM();
+        var prop = typeof(InspectorVM).GetProperty(propertyName);
+        var initial = (bool)prop.GetValue(vm);
+        var changes = CountChanges(vm, propertyName, () => {
+            prop.SetValue(vm, !initial);
+            prop.SetValue(vm, !initial); // unchanged
+            prop.SetValue(vm, initial);
+        });
+        Assert.That(changes, Is.EqualTo(2));
+    }
+
+    [TestCase(nameof(InspectorVM.InspectorErrorText))]
+    [TestCase(nameof(InspectorVM.SimpleAnalysisErrorText))]
+    public void StringProperty_RaisesPropertyChangedOnlyOnChange(string propertyName) {
+        var vm = new MediatorBundle().BuildInspectorVM();
+        var prop = typeof(InspectorVM).GetProperty(propertyName);
+        var changes = CountChanges(vm, propertyName, () => {
+            prop.SetValue(vm, "hello");
+            prop.SetValue(vm, "hello"); // unchanged
+            prop.SetValue(vm, "world");
+            prop.SetValue(vm, string.Empty);
+        });
+        Assert.That(changes, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void LoopingExposureAnalysis_DelegatesToInspectorOptions() {
+        var bundle = new MediatorBundle();
+        bundle.InspectorOptions.LoopingExposureAnalysisEnabled.Returns(false);
+        var vm = bundle.BuildInspectorVM();
+        Assert.That(vm.LoopingExposureAnalysis, Is.False);
+
+        var raisedNames = new List<string>();
+        vm.PropertyChanged += (_, e) => raisedNames.Add(e.PropertyName);
+        vm.LoopingExposureAnalysis = true;
+
+        bundle.InspectorOptions.Received().LoopingExposureAnalysisEnabled = true;
+        Assert.That(raisedNames, Does.Contain(nameof(vm.LoopingExposureAnalysis)));
+    }
+
+    [Test]
+    public void IsTool_IsTrue() {
+        var vm = new MediatorBundle().BuildInspectorVM();
+        Assert.That(vm.IsTool, Is.True);
+    }
+
+    [Test]
+    public void Models_AreInitializedNonNull() {
+        var vm = new MediatorBundle().BuildInspectorVM();
+        Assert.Multiple(() => {
+            Assert.That(vm.TiltModel, Is.Not.Null);
+            Assert.That(vm.SensorModel, Is.Not.Null);
+            Assert.That(vm.TiltGuidance, Is.Not.Null);
+            Assert.That(vm.InspectorOptions, Is.Not.Null);
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TestDoubles/MediatorBundle.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TestDoubles/MediatorBundle.cs
@@ -1,0 +1,101 @@
+using NINA.Core.Interfaces;
+using NINA.Equipment.Equipment.MyCamera;
+using NINA.Equipment.Equipment.MyFilterWheel;
+using NINA.Equipment.Equipment.MyFocuser;
+using NINA.Equipment.Equipment.MyGuider;
+using NINA.Equipment.Equipment.MyTelescope;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Image.ImageAnalysis;
+using NINA.Image.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NINA.Profile.Interfaces;
+using NINA.WPF.Base.Interfaces.Mediator;
+using NSubstitute;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+
+internal sealed class MediatorBundle {
+    public IProfileService ProfileService { get; } = Substitute.For<IProfileService>();
+    public IApplicationStatusMediator ApplicationStatusMediator { get; } = Substitute.For<IApplicationStatusMediator>();
+    public IImagingMediator ImagingMediator { get; } = Substitute.For<IImagingMediator>();
+    public ICameraMediator CameraMediator { get; } = Substitute.For<ICameraMediator>();
+    public IFocuserMediator FocuserMediator { get; } = Substitute.For<IFocuserMediator>();
+    public IFilterWheelMediator FilterWheelMediator { get; } = Substitute.For<IFilterWheelMediator>();
+    public ITelescopeMediator TelescopeMediator { get; } = Substitute.For<ITelescopeMediator>();
+    public IGuiderMediator GuiderMediator { get; } = Substitute.For<IGuiderMediator>();
+    public IImageDataFactory ImageDataFactory { get; } = Substitute.For<IImageDataFactory>();
+
+    public IStarDetectionOptions StarDetectionOptions { get; } = Substitute.For<IStarDetectionOptions>();
+    public IStarAnnotatorOptions StarAnnotatorOptions { get; } = Substitute.For<IStarAnnotatorOptions>();
+    public IInspectorOptions InspectorOptions { get; } = Substitute.For<IInspectorOptions>();
+    public IAutoFocusOptions AutoFocusOptions { get; } = Substitute.For<IAutoFocusOptions>();
+    public ITiltAdapterOptions TiltAdapterOptions { get; } = Substitute.For<ITiltAdapterOptions>();
+
+    public IAutoFocusEngineFactory AutoFocusEngineFactory { get; } = Substitute.For<IAutoFocusEngineFactory>();
+    public IPluggableBehaviorSelector<IStarDetection> StarDetectionSelector { get; } = Substitute.For<IPluggableBehaviorSelector<IStarDetection>>();
+    public IPluggableBehaviorSelector<IStarAnnotator> StarAnnotatorSelector { get; } = Substitute.For<IPluggableBehaviorSelector<IStarAnnotator>>();
+    public IApplicationDispatcher ApplicationDispatcher { get; } = new SynchronousApplicationDispatcher();
+    public IAlglibAPI AlglibAPI { get; } = new AlglibAPI();
+
+    public MediatorBundle WithCameraConnected(bool connected = true) {
+        CameraMediator.GetInfo().Returns(new CameraInfo { Connected = connected });
+        return this;
+    }
+
+    public MediatorBundle WithFocuserConnected(bool connected = true, int position = 0) {
+        FocuserMediator.GetInfo().Returns(new FocuserInfo { Connected = connected, Position = position });
+        return this;
+    }
+
+    public MediatorBundle WithTelescopeConnected(bool connected = true) {
+        TelescopeMediator.GetInfo().Returns(new TelescopeInfo { Connected = connected });
+        return this;
+    }
+
+    public MediatorBundle WithFilterWheelConnected(bool connected = true) {
+        FilterWheelMediator.GetInfo().Returns(new FilterWheelInfo { Connected = connected });
+        return this;
+    }
+
+    public MediatorBundle WithGuiderConnected(bool connected = true) {
+        GuiderMediator.GetInfo().Returns(new GuiderInfo { Connected = connected });
+        return this;
+    }
+
+    public InspectorVM BuildInspectorVM() {
+        return new InspectorVM(
+            profileService: ProfileService,
+            applicationStatusMediator: ApplicationStatusMediator,
+            imagingMediator: ImagingMediator,
+            cameraMediator: CameraMediator,
+            focuserMediator: FocuserMediator,
+            filterWheelMediator: FilterWheelMediator,
+            telescopeMediator: TelescopeMediator,
+            starDetectionOptions: StarDetectionOptions,
+            starAnnotatorOptions: StarAnnotatorOptions,
+            inspectorOptions: InspectorOptions,
+            autoFocusOptions: AutoFocusOptions,
+            autoFocusEngineFactory: AutoFocusEngineFactory,
+            imageDataFactory: ImageDataFactory,
+            starDetectionSelector: StarDetectionSelector,
+            starAnnotatorSelector: StarAnnotatorSelector,
+            applicationDispatcher: ApplicationDispatcher,
+            alglibAPI: AlglibAPI,
+            tiltAdapterOptions: TiltAdapterOptions);
+    }
+
+    public HocusFocusVM BuildHocusFocusVM() {
+        return new HocusFocusVM(
+            profileService: ProfileService,
+            focuserMediator: FocuserMediator,
+            autoFocusEngineFactory: AutoFocusEngineFactory,
+            autoFocusOptions: AutoFocusOptions,
+            starDetectionOptions: StarDetectionOptions,
+            filterWheelMediator: FilterWheelMediator,
+            applicationStatusMediator: ApplicationStatusMediator,
+            starDetectionSelector: StarDetectionSelector,
+            alglibAPI: AlglibAPI);
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardBehavioralTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardBehavioralTests.cs
@@ -1,0 +1,143 @@
+using NINA.Equipment.Equipment.MyCamera;
+using NINA.Equipment.Equipment.MyFocuser;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
+using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NSubstitute;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard;
+
+[TestFixture]
+[Apartment(System.Threading.ApartmentState.STA)]
+public class TiltAdapterWizardBehavioralTests {
+
+    private static (TiltAdapterWizardVM vm, MediatorBundle bundle) Build(int screwCount = 3) {
+        var bundle = new MediatorBundle();
+        bundle.TiltAdapterOptions.ScrewCount.Returns(screwCount);
+        bundle.TiltAdapterOptions.MeasurementAverageCount.Returns(1);
+        var inspector = bundle.BuildInspectorVM();
+        var vm = new TiltAdapterWizardVM(
+            profileService: bundle.ProfileService,
+            applicationStatusMediator: bundle.ApplicationStatusMediator,
+            cameraMediator: bundle.CameraMediator,
+            focuserMediator: bundle.FocuserMediator,
+            inspector: inspector,
+            tiltAdapterOptions: bundle.TiltAdapterOptions);
+        return (vm, bundle);
+    }
+
+    [Test]
+    public void StartCommand_DoesNotChangeStepWhenAlreadyAtBaseline() {
+        var (vm, _) = Build();
+        Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Baseline));
+
+        vm.StartCommand.Execute(null);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Baseline));
+            Assert.That(vm.IsWizardRunning, Is.True);
+        });
+    }
+
+    [Test]
+    public void RestartCommand_AfterStart_RevertsState() {
+        var (vm, _) = Build();
+        vm.StartCommand.Execute(null);
+        Assert.That(vm.IsWizardRunning, Is.True);
+
+        vm.RestartCommand.Execute(null);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.IsWizardRunning, Is.False);
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Baseline));
+        });
+    }
+
+    [Test]
+    public void ConnectionWarningText_VariesWithConnectionState() {
+        var (vm, _) = Build();
+        // Both disconnected
+        Assert.That(vm.ConnectionWarningText, Does.Contain("Camera and focuser"));
+
+        // Camera-only connected
+        vm.UpdateDeviceInfo(new CameraInfo { Connected = true });
+        vm.UpdateDeviceInfo(new FocuserInfo { Connected = false });
+        Assert.That(vm.ConnectionWarningText, Does.Contain("Focuser"));
+        Assert.That(vm.ConnectionWarningText, Does.Not.Contain("Camera"));
+
+        // Focuser-only connected
+        vm.UpdateDeviceInfo(new CameraInfo { Connected = false });
+        vm.UpdateDeviceInfo(new FocuserInfo { Connected = true });
+        Assert.That(vm.ConnectionWarningText, Does.Contain("Camera"));
+        Assert.That(vm.ConnectionWarningText, Does.Not.Contain("Focuser"));
+
+        // Both connected
+        vm.UpdateDeviceInfo(new CameraInfo { Connected = true });
+        vm.UpdateDeviceInfo(new FocuserInfo { Connected = true });
+        Assert.That(vm.ConnectionWarningText, Is.Empty);
+    }
+
+    [Test]
+    public void UpdateDeviceInfo_FocuserUpdate_RaisesAreDevicesConnected() {
+        var (vm, _) = Build();
+        var raised = new List<string>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        vm.UpdateDeviceInfo(new CameraInfo { Connected = true });
+        vm.UpdateDeviceInfo(new FocuserInfo { Connected = true });
+
+        Assert.That(raised, Does.Contain(nameof(vm.AreDevicesConnected)));
+    }
+
+    [Test]
+    public void IsMeasuring_DefaultsFalse_AndDrivesHasMeasurementFeedback() {
+        var (vm, _) = Build();
+        Assert.That(vm.IsMeasuring, Is.False);
+        Assert.That(vm.HasMeasurementFeedback, Is.False);
+        Assert.That(vm.HasMeasurementResults, Is.False);
+    }
+
+    [Test]
+    public void HasCurvatureCalibration_RespondsToScrewInwardCurvatureSign() {
+        var (vm, bundle) = Build();
+        bundle.TiltAdapterOptions.ScrewInwardCurvatureSign.Returns(0);
+        Assert.That(vm.HasCurvatureCalibration, Is.False);
+        bundle.TiltAdapterOptions.ScrewInwardCurvatureSign.Returns(1);
+        Assert.That(vm.HasCurvatureCalibration, Is.True);
+    }
+
+    [Test]
+    public void IsCalibrationValid_RequiresMatchingScrewCount() {
+        var (vm, bundle) = Build(screwCount: 3);
+
+        bundle.TiltAdapterOptions.IsCalibrated.Returns(true);
+        bundle.TiltAdapterOptions.CalibratedScrewCount.Returns(3);
+        Assert.That(vm.IsCalibrationValid, Is.True);
+
+        bundle.TiltAdapterOptions.CalibratedScrewCount.Returns(4);
+        Assert.That(vm.IsCalibrationValid, Is.False);
+    }
+
+    [Test]
+    public void StepInstructions_NotEmpty_AtAllSteps() {
+        var (vm, _) = Build(screwCount: 3);
+        Assert.That(vm.StepInstructions, Is.Not.Empty);
+    }
+
+    [Test]
+    public void ShowRunColumn_RespectsMeasurementAverageCount() {
+        var (vm, bundle) = Build();
+        bundle.TiltAdapterOptions.MeasurementAverageCount.Returns(1);
+        Assert.That(vm.ShowRunColumn, Is.False);
+        bundle.TiltAdapterOptions.MeasurementAverageCount.Returns(5);
+        Assert.That(vm.ShowRunColumn, Is.True);
+    }
+
+    [Test]
+    public void IsOnMeasurementStep_TrueAtBaseline() {
+        var (vm, _) = Build();
+        Assert.That(vm.IsOnMeasurementStep, Is.True);
+        Assert.That(vm.IsComplete, Is.False);
+    }
+}


### PR DESCRIPTION
## Summary

- New MediatorBundle test double centralizes the ~10 mediator + 7 option substitutes that every VM constructor needs. Replaces ~15 lines of repetitive setup per fixture with a single Build() helper.
- 44 new behavioral tests across InspectorVM, HocusFocusVM, and TiltAdapterWizardVM. No production code changes. Workstream 4 of plans/coverage-to-60.md.

## What's covered

- **InspectorVM**: HasTiltAdapterCalibration, UpdateDeviceInfo per device type, ten observable bool toggles, error-text setters, LoopingExposureAnalysis option pass-through.
- **HocusFocusVM**: int/double property INPC, FinalFocusPoint rounding, AutoFocusChartMethod / CurveFitting setters, three additional curve-fitting modes (TrendParabolic, TrendHyperbolic, Trendlines).
- **TiltAdapterWizardVM**: StartCommand / RestartCommand state transitions, ConnectionWarningText for all four mediator-state combinations, IsCalibrationValid screw-count check, ShowRunColumn driven by MeasurementAverageCount.

## Test plan

- [x] All 430 tests pass locally (`dotnet test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)