### PR TITLE
Extract pure SensorModel helpers into SensorAberrationCalculator

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorAberrationCalculatorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorAberrationCalculatorTests.cs
@@ -1,0 +1,180 @@
+using NINA.Joko.Plugins.HocusFocus.Inspection;
+using NUnit.Framework;
+using System;
+using System.Linq;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection;
+
+[TestFixture]
+public class SensorAberrationCalculatorTests {
+
+    [TestCase(0.0, 0.9)]
+    [TestCase(0.5, 0.9)]
+    [TestCase(0.999, 0.9)]
+    [TestCase(1.0, 0.8)]
+    [TestCase(2.5, 0.8)]
+    [TestCase(2.999, 0.8)]
+    [TestCase(3.0, 0.7)]
+    [TestCase(4.5, 0.7)]
+    [TestCase(4.999, 0.7)]
+    [TestCase(5.0, 0.6)]
+    [TestCase(60.0, 0.6)]
+    public void TargetR2BasedOnTimeTaken_ReturnsExpectedTier(double seconds, double expected) {
+        var actual = SensorAberrationCalculator.TargetR2BasedOnTimeTaken(TimeSpan.FromSeconds(seconds));
+        Assert.That(actual, Is.EqualTo(expected).Within(1e-12));
+    }
+
+    [Test]
+    public void IsFitTooGood_NullFit_IsFalse() {
+        Assert.That(SensorAberrationCalculator.IsFitTooGood(null), Is.False);
+    }
+
+    [Test]
+    public void IsFitTooGood_LowGoodness_IsFalse() {
+        var m = new SensorParaboloidModel();
+        m.FromArray(new[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 });
+        // GoodnessOfFit defaults to 0; (1 - 0) = 1 which is not < 0.005
+        Assert.That(SensorAberrationCalculator.IsFitTooGood(m), Is.False);
+    }
+
+    [Test]
+    public void IsBetterFit_NullThis_IsFalse() {
+        var other = new SensorParaboloidModel();
+        Assert.That(SensorAberrationCalculator.IsBetterFit(null, other), Is.False);
+    }
+
+    [Test]
+    public void IsBetterFit_NullOther_IsTrue() {
+        var thisFit = new SensorParaboloidModel();
+        Assert.That(SensorAberrationCalculator.IsBetterFit(thisFit, null), Is.True);
+    }
+
+    [Test]
+    public void IsBetterFit_BothNull_IsFalse() {
+        Assert.That(SensorAberrationCalculator.IsBetterFit(null, null), Is.False);
+    }
+
+    [Test]
+    public void IsBetterFit_OtherZeroGoodness_IsTrue() {
+        var thisFit = new SensorParaboloidModel();
+        var other = new SensorParaboloidModel();
+        // Other has GoodnessOfFit = 0 (default), so this is "better"
+        Assert.That(SensorAberrationCalculator.IsBetterFit(thisFit, other), Is.True);
+    }
+
+    [Test]
+    public void IsBetterFit_HigherGoodness_IsTrue() {
+        // We can't set GoodnessOfFit directly (private setter populated by EvaluateFit). Use Reflection.
+        var thisFit = WithGoodness(0.85);
+        var otherFit = WithGoodness(0.75);
+        Assert.That(SensorAberrationCalculator.IsBetterFit(thisFit, otherFit), Is.True);
+    }
+
+    [Test]
+    public void IsBetterFit_EqualGoodness_IsTrue() {
+        var thisFit = WithGoodness(0.8);
+        var otherFit = WithGoodness(0.8);
+        Assert.That(SensorAberrationCalculator.IsBetterFit(thisFit, otherFit), Is.True);
+    }
+
+    [Test]
+    public void IsBetterFit_LowerGoodness_IsFalse() {
+        var thisFit = WithGoodness(0.6);
+        var otherFit = WithGoodness(0.85);
+        Assert.That(SensorAberrationCalculator.IsBetterFit(thisFit, otherFit), Is.False);
+    }
+
+    [Test]
+    public void IsBetterFit_OverfitVsHealthy_PrefersHealthy() {
+        var thisFit = WithGoodness(0.9999);   // overfit (1 - 0.9999 = 0.0001 < 0.005)
+        var otherFit = WithGoodness(0.85);
+        Assert.That(SensorAberrationCalculator.IsBetterFit(thisFit, otherFit), Is.False);
+        Assert.That(SensorAberrationCalculator.IsBetterFit(otherFit, thisFit), Is.True);
+    }
+
+    [Test]
+    public void IsBetterFit_BothOverfit_FallsThroughToFalse() {
+        var thisFit = WithGoodness(0.9999);
+        var otherFit = WithGoodness(0.99995);
+        // thisFit is too good, so IsBetterFit returns false even though numerically the same.
+        Assert.That(SensorAberrationCalculator.IsBetterFit(thisFit, otherFit), Is.False);
+    }
+
+    [Test]
+    public void IsFitTooGood_AtBoundary_IsTrue() {
+        var fit = WithGoodness(0.999);
+        Assert.That(SensorAberrationCalculator.IsFitTooGood(fit), Is.True);
+    }
+
+    [Test]
+    public void IsFitTooGood_JustBelowBoundary_IsFalse() {
+        var fit = WithGoodness(0.99);   // 1 - 0.99 = 0.01 > 0.005
+        Assert.That(SensorAberrationCalculator.IsFitTooGood(fit), Is.False);
+    }
+
+    [Test]
+    public void CreateFullRegionSet_OneByOne_ReturnsSingleFullRegion() {
+        var regions = SensorAberrationCalculator.CreateFullRegionSet(new System.Drawing.Size(100, 100), 1, 1);
+        Assert.Multiple(() => {
+            Assert.That(regions.Count, Is.EqualTo(1));
+            Assert.That(regions[0].OuterBoundary.Width, Is.EqualTo(1.0).Within(1e-9));
+            Assert.That(regions[0].OuterBoundary.Height, Is.EqualTo(1.0).Within(1e-9));
+            Assert.That(regions[0].Index, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void CreateFullRegionSet_TwoByTwo_TilesIntoFourQuadrants() {
+        var regions = SensorAberrationCalculator.CreateFullRegionSet(new System.Drawing.Size(100, 100), 2, 2);
+        Assert.That(regions.Count, Is.EqualTo(4));
+
+        // Indices are 1..4 in row-major order
+        Assert.That(regions.Select(r => r.Index), Is.EqualTo(new[] { 1, 2, 3, 4 }));
+
+        // First (top-left) starts at (0, 0)
+        Assert.Multiple(() => {
+            Assert.That(regions[0].OuterBoundary.StartX, Is.EqualTo(0.0).Within(1e-9));
+            Assert.That(regions[0].OuterBoundary.StartY, Is.EqualTo(0.0).Within(1e-9));
+            Assert.That(regions[0].OuterBoundary.Width, Is.EqualTo(0.5).Within(1e-9));
+            Assert.That(regions[0].OuterBoundary.Height, Is.EqualTo(0.5).Within(1e-9));
+            Assert.That(regions[3].OuterBoundary.StartX, Is.EqualTo(0.5).Within(1e-9));
+            Assert.That(regions[3].OuterBoundary.StartY, Is.EqualTo(0.5).Within(1e-9));
+        });
+    }
+
+    [Test]
+    public void CreateFullRegionSet_3x4_Returns12Regions() {
+        var regions = SensorAberrationCalculator.CreateFullRegionSet(new System.Drawing.Size(800, 600), rows: 3, cols: 4);
+        Assert.That(regions.Count, Is.EqualTo(12));
+        Assert.That(regions[regions.Count - 1].Index, Is.EqualTo(12));
+    }
+
+    [Test]
+    public void CreateFullRegionSet_Coverage_FillsUnitSquare() {
+        var regions = SensorAberrationCalculator.CreateFullRegionSet(new System.Drawing.Size(800, 600), 5, 5);
+        // Sum of areas of all regions in ratio space should equal 1.0
+        var totalArea = regions.Sum(r => r.OuterBoundary.Width * r.OuterBoundary.Height);
+        Assert.That(totalArea, Is.EqualTo(1.0).Within(1e-9));
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void CreateFullRegionSet_RejectsNonPositiveRows(int rows) {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            SensorAberrationCalculator.CreateFullRegionSet(new System.Drawing.Size(100, 100), rows: rows, cols: 2));
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void CreateFullRegionSet_RejectsNonPositiveCols(int cols) {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            SensorAberrationCalculator.CreateFullRegionSet(new System.Drawing.Size(100, 100), rows: 2, cols: cols));
+    }
+
+    private static SensorParaboloidModel WithGoodness(double goodness) {
+        var model = new SensorParaboloidModel();
+        var prop = typeof(SensorParaboloidModel).GetProperty(nameof(SensorParaboloidModel.GoodnessOfFit));
+        prop.SetValue(model, goodness);
+        return model;
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorAberrationCalculator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorAberrationCalculator.cs
@@ -1,0 +1,107 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using System;
+using System.Collections.Generic;
+
+namespace NINA.Joko.Plugins.HocusFocus.Inspection {
+
+    /// <summary>
+    /// Pure helpers used by SensorModel for fit comparison, region tiling, and time-based
+    /// goodness-of-fit targets. Kept dependency-free so they can be unit tested directly.
+    /// </summary>
+    public static class SensorAberrationCalculator {
+
+        /// <summary>
+        /// Returns the goodness-of-fit (R²) target for an iteration that has already taken the
+        /// supplied amount of time. Faster iterations get a stricter target since we can afford
+        /// to keep searching; slower iterations get a relaxed target so we converge in time.
+        /// </summary>
+        public static double TargetR2BasedOnTimeTaken(TimeSpan timeSpan) {
+            double secondsTaken = timeSpan.TotalSeconds;
+            if (secondsTaken < 1) {
+                return 0.9;
+            }
+            if (secondsTaken < 3) {
+                return 0.8;
+            }
+            if (secondsTaken < 5) {
+                return 0.7;
+            }
+            return 0.6;
+        }
+
+        /// <summary>
+        /// A fit with goodness-of-fit indistinguishable from 1.0 is treated as overfit /
+        /// suspicious — usually means too few points contributed to the fit.
+        /// </summary>
+        public static bool IsFitTooGood(SensorParaboloidModel fit) {
+            if (fit == null) {
+                return false;
+            }
+            return 1 - fit.GoodnessOfFit < 0.005;
+        }
+
+        /// <summary>
+        /// True if <paramref name="thisFit"/> is a strictly better fit than <paramref name="otherFit"/>:
+        /// non-null, non-zero R², not overfit, and at least as good as the alternative.
+        /// </summary>
+        public static bool IsBetterFit(SensorParaboloidModel thisFit, SensorParaboloidModel otherFit) {
+            if (thisFit == null) {
+                return false;
+            }
+            if (otherFit == null) {
+                return true;
+            }
+
+            if (otherFit.GoodnessOfFit == 0) {
+                return true;
+            }
+            if (thisFit.GoodnessOfFit == 0) {
+                return false;
+            }
+
+            if (IsFitTooGood(thisFit)) {
+                return false;
+            }
+            if (IsFitTooGood(otherFit)) {
+                return true;
+            }
+            return thisFit.GoodnessOfFit >= otherFit.GoodnessOfFit;
+        }
+
+        /// <summary>
+        /// Tile the unit ratio square into <paramref name="rows"/> × <paramref name="cols"/> equal
+        /// regions. Each region's <see cref="StarDetectionRegion.Index"/> increments in row-major
+        /// order starting at 1.
+        /// </summary>
+        public static List<StarDetectionRegion> CreateFullRegionSet(System.Drawing.Size imageSize, int rows, int cols) {
+            if (rows <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(rows), "rows must be positive");
+            }
+            if (cols <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(cols), "cols must be positive");
+            }
+            var xPart = 1.0d / cols;
+            var yPart = 1.0d / rows;
+            var regions = new List<StarDetectionRegion>();
+            int index = 0;
+            for (int r = 0; r < rows; r++) {
+                for (int c = 0; c < cols; c++) {
+                    regions.Add(new StarDetectionRegion(new RatioRect(c * xPart, r * yPart, xPart, yPart), ++index));
+                }
+            }
+            return regions;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
@@ -540,62 +540,17 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             }
         }
 
-        private double TargetR2BasedOnTimeTaken(TimeSpan timeSpan) {
-            double secondsTaken = timeSpan.TotalSeconds;
-            if (secondsTaken < 1) {     // iterations are quick so we'll be very demanding
-                return 0.9;
-            }
-            if (secondsTaken < 3) {
-                return 0.8;
-            }
-            if (secondsTaken < 5) {
-                return 0.7;
-            }
-            return 0.6; // iterations are slow so we'll set a low target
-        }
+        private static double TargetR2BasedOnTimeTaken(TimeSpan timeSpan) =>
+            SensorAberrationCalculator.TargetR2BasedOnTimeTaken(timeSpan);
 
-        private static bool IsFitTooGood(SensorParaboloidModel fit) {
-            if (1 - fit.GoodnessOfFit < 0.005) { // 1 means too good a fit - probably not enough points
-                return true;
-            } else {
-                return false;
-            }
-        }
+        private static bool IsFitTooGood(SensorParaboloidModel fit) =>
+            SensorAberrationCalculator.IsFitTooGood(fit);
 
-        private static bool IsBetterFit(SensorParaboloidModel thisFit, SensorParaboloidModel otherFit) {
-            if (thisFit == null) {
-                return false;
-            }
-            if (otherFit == null) {
-                return true;
-            }
+        private static bool IsBetterFit(SensorParaboloidModel thisFit, SensorParaboloidModel otherFit) =>
+            SensorAberrationCalculator.IsBetterFit(thisFit, otherFit);
 
-            if (otherFit.GoodnessOfFit == 0) {
-                return true;
-            }
-            if (thisFit.GoodnessOfFit == 0) {
-                return false;
-            }
-
-            if (IsFitTooGood(thisFit)) { // 1 means too good a fit - probably not enough points
-                return false;
-            }
-            if (IsFitTooGood(otherFit)) {
-                return true;
-            }
-            return (thisFit.GoodnessOfFit >= otherFit.GoodnessOfFit);
-        }
-
-        private static List<StarDetectionRegion> CreateFullRegionSet(System.Drawing.Size imageSize, int rows, int cols) {
-            var xPart = 1.0d / (double)cols;
-            var yPart = 1.0d / (double)rows;
-            var regions = new List<StarDetectionRegion>();
-            int index = 0;
-            for (int r = 0; r < rows; r++)
-                for (int c = 0; c < cols; c++)
-                    regions.Add(new StarDetectionRegion(new RatioRect(c * xPart, r * yPart, xPart, yPart), ++index));
-            return regions;
-        }
+        private static List<StarDetectionRegion> CreateFullRegionSet(System.Drawing.Size imageSize, int rows, int cols) =>
+            SensorAberrationCalculator.CreateFullRegionSet(imageSize, rows, cols);
 
         private RegistrationAndFitResult FitImages(
                 System.Drawing.Size imageSize,


### PR DESCRIPTION
## Summary

- Move four small pure helpers (TargetR2BasedOnTimeTaken, IsFitTooGood, IsBetterFit, CreateFullRegionSet) out of SensorModel into a new SensorAberrationCalculator static class so they're directly testable. SensorModel now forwards to the new class — no behavior change.
- Add 32 unit tests covering R² tier transitions, overfit detection, null/zero guards in IsBetterFit, and region tiling indexing and coverage.
- CreateFullRegionSet now rejects non-positive row/col counts (previously it silently produced degenerate output or divided by zero).
- Workstream 5 of plans/coverage-to-60.md.

## What I did *not* do

The plan's "split SensorModel.cs" was scoped wider than this PR — moving FitParaboloidModel, ToInterpolatedGrid, RegisterStarsAndFit, and FitImages into a pure calculator would require also lifting alglib state and observable-collection mutation out of those methods. Doing it cleanly is a bigger refactor than fits in a coverage-focused PR. Filing the heavy-lifting half of the split as a follow-up; this PR captures the cheap-but-meaningful subset.

## Test plan

- [x] All 418 tests pass locally (`dotnet test`)
- [x] HocusFocus plugin still builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)