### PR TITLE
Sensor model repeatability & robustness: analysis + plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,8 @@ Camera images may be mirrored horizontally and/or vertically depending on the op
 
 ## Plans Workflow
 
-- All implementation plans are saved in the `plans/` folder with a meaningful filename based on the plan goal (e.g., `plans/tilt-adapter-screw-calibration-wizard.md`).
+- **Every new plan MUST be written to the `plans/` folder** — never leave a plan only in chat, in another directory, or in a scratch file. This applies to all plans regardless of size or how they were produced (planning mode, brainstorming, ad-hoc requests, etc.).
+- Use a meaningful filename based on the plan goal (e.g., `plans/tilt-adapter-screw-calibration-wizard.md`).
 - **Clear your Claude Code context (`/clear`) before executing a plan** to avoid stale context from the planning session affecting implementation.
 - The user will explicitly say when a plan is ready to execute.
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorOptionsTests.cs
@@ -204,6 +204,40 @@ public class InspectorOptionsTests {
     }
 
     [Test]
+    public void FitQualityThresholds_HaveDocumentedDefaults() {
+        var (options, _, _) = Build();
+        Assert.Multiple(() => {
+            Assert.That(options.AcceptableReducedChiSquared, Is.EqualTo(5.0));
+            Assert.That(options.AcceptableRSquaredMin, Is.EqualTo(0.05));
+        });
+    }
+
+    [Test]
+    public void FitQualityThresholds_PersistToAccessor() {
+        var (options, store, _) = Build();
+        options.AcceptableReducedChiSquared = 8.5;
+        options.AcceptableRSquaredMin = 0.2;
+        Assert.Multiple(() => {
+            Assert.That(store.Snapshot[nameof(InspectorOptions.AcceptableReducedChiSquared)], Is.EqualTo(8.5));
+            Assert.That(store.Snapshot[nameof(InspectorOptions.AcceptableRSquaredMin)], Is.EqualTo(0.2));
+        });
+    }
+
+    [Test]
+    public void FitQualityThresholds_ResetToDefaults() {
+        var (options, _, _) = Build();
+        options.AcceptableReducedChiSquared = 8.5;
+        options.AcceptableRSquaredMin = 0.2;
+
+        options.ResetDefaults();
+
+        Assert.Multiple(() => {
+            Assert.That(options.AcceptableReducedChiSquared, Is.EqualTo(5.0));
+            Assert.That(options.AcceptableRSquaredMin, Is.EqualTo(0.05));
+        });
+    }
+
+    [Test]
     public void Constructor_ThrowsOnNullAccessor() {
         var profile = Substitute.For<IProfileService>();
         Assert.Throws<ArgumentNullException>(() => new InspectorOptions(profile, null));

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorOptionsTests.cs
@@ -204,37 +204,26 @@ public class InspectorOptionsTests {
     }
 
     [Test]
-    public void FitQualityThresholds_HaveDocumentedDefaults() {
+    public void AcceptableRSquaredMin_HasDocumentedDefault() {
         var (options, _, _) = Build();
-        Assert.Multiple(() => {
-            Assert.That(options.AcceptableReducedChiSquared, Is.EqualTo(5.0));
-            Assert.That(options.AcceptableRSquaredMin, Is.EqualTo(0.05));
-        });
+        Assert.That(options.AcceptableRSquaredMin, Is.EqualTo(0.05));
     }
 
     [Test]
-    public void FitQualityThresholds_PersistToAccessor() {
+    public void AcceptableRSquaredMin_PersistsToAccessor() {
         var (options, store, _) = Build();
-        options.AcceptableReducedChiSquared = 8.5;
         options.AcceptableRSquaredMin = 0.2;
-        Assert.Multiple(() => {
-            Assert.That(store.Snapshot[nameof(InspectorOptions.AcceptableReducedChiSquared)], Is.EqualTo(8.5));
-            Assert.That(store.Snapshot[nameof(InspectorOptions.AcceptableRSquaredMin)], Is.EqualTo(0.2));
-        });
+        Assert.That(store.Snapshot[nameof(InspectorOptions.AcceptableRSquaredMin)], Is.EqualTo(0.2));
     }
 
     [Test]
-    public void FitQualityThresholds_ResetToDefaults() {
+    public void AcceptableRSquaredMin_ResetsToDefault() {
         var (options, _, _) = Build();
-        options.AcceptableReducedChiSquared = 8.5;
         options.AcceptableRSquaredMin = 0.2;
 
         options.ResetDefaults();
 
-        Assert.Multiple(() => {
-            Assert.That(options.AcceptableReducedChiSquared, Is.EqualTo(5.0));
-            Assert.That(options.AcceptableRSquaredMin, Is.EqualTo(0.05));
-        });
+        Assert.That(options.AcceptableRSquaredMin, Is.EqualTo(0.05));
     }
 
     [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorOptionsTests.cs
@@ -44,8 +44,8 @@ public class InspectorOptionsTests {
             Assert.That(options.PreviousRunBrightnessDiff, Is.EqualTo(0.1));
             Assert.That(options.StartingBrightnessDiff, Is.EqualTo(-1));
             Assert.That(options.RejectBadBrightnessMatches, Is.False);
-            Assert.That(options.RejectBadlyFittingMatches, Is.False);
-            Assert.That(options.UseRANSAC, Is.False);
+            Assert.That(options.RejectBadlyFittingMatches, Is.True);
+            Assert.That(options.UseRANSAC, Is.True);
             Assert.That(options.SaveImagesOnReruns, Is.False);
             Assert.That(options.SaveAlignmentImages, Is.False);
             Assert.That(options.MaxStarsPerRegion, Is.EqualTo(-1));
@@ -76,8 +76,8 @@ public class InspectorOptionsTests {
         options.PreviousRunBrightnessDiff = 0.2;
         options.StartingBrightnessDiff = 0.3;
         options.RejectBadBrightnessMatches = true;
-        options.RejectBadlyFittingMatches = true;
-        options.UseRANSAC = true;
+        options.RejectBadlyFittingMatches = false;
+        options.UseRANSAC = false;
         options.SaveImagesOnReruns = true;
         options.SaveAlignmentImages = true;
         options.MaxStarsPerRegion = 50;
@@ -103,8 +103,8 @@ public class InspectorOptionsTests {
             Assert.That(store.Snapshot[nameof(InspectorOptions.PreviousRunBrightnessDiff)], Is.EqualTo(0.2));
             Assert.That(store.Snapshot[nameof(InspectorOptions.StartingBrightnessDiff)], Is.EqualTo(0.3));
             Assert.That(store.Snapshot[nameof(InspectorOptions.RejectBadBrightnessMatches)], Is.True);
-            Assert.That(store.Snapshot[nameof(InspectorOptions.RejectBadlyFittingMatches)], Is.True);
-            Assert.That(store.Snapshot[nameof(InspectorOptions.UseRANSAC)], Is.True);
+            Assert.That(store.Snapshot[nameof(InspectorOptions.RejectBadlyFittingMatches)], Is.False);
+            Assert.That(store.Snapshot[nameof(InspectorOptions.UseRANSAC)], Is.False);
             Assert.That(store.Snapshot[nameof(InspectorOptions.SaveImagesOnReruns)], Is.True);
             Assert.That(store.Snapshot[nameof(InspectorOptions.SaveAlignmentImages)], Is.True);
             Assert.That(store.Snapshot[nameof(InspectorOptions.MaxStarsPerRegion)], Is.EqualTo(50));
@@ -178,7 +178,7 @@ public class InspectorOptionsTests {
     [TestCase(nameof(InspectorOptions.LoopingExposureAnalysisEnabled), true)]
     [TestCase(nameof(InspectorOptions.MicronsPerFocuserStep), 2.5)]
     [TestCase(nameof(InspectorOptions.SensorROI), 0.6)]
-    [TestCase(nameof(InspectorOptions.UseRANSAC), true)]
+    [TestCase(nameof(InspectorOptions.UseRANSAC), false)]
     [TestCase(nameof(InspectorOptions.MaxStarsPerRegion), 30)]
     public void Setter_RaisesPropertyChanged(string propertyName, object newValue) {
         var (options, _, _) = Build();

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
@@ -27,6 +27,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
         public bool FixedSensorCenter { get; set; } = true;
         public bool UseRANSAC { get; set; }
         public bool UseAffineAlignment { get; set; }
+        public bool AstigmaticCurvatureEnabled { get; set; }
         public bool RejectBadBrightnessMatches { get; set; }
         public bool RejectBadlyFittingMatches { get; set; }
         public double PreviousRunBrightnessDiff { get; set; } = 0.1;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
@@ -35,7 +35,6 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
         public bool SaveImagesOnReruns { get; set; }
         public bool SaveAlignmentImages { get; set; }
         public int MaxStarsPerRegion { get; set; } = -1;
-        public double AcceptableReducedChiSquared { get; set; } = 5.0;
         public double AcceptableRSquaredMin { get; set; } = 0.05;
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
@@ -1,0 +1,61 @@
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using System.ComponentModel;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
+
+    internal sealed class FakeInspectorOptions : IInspectorOptions {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public int StepCount { get; set; }
+        public int StepSize { get; set; }
+        public int FramesPerPoint { get; set; }
+        public int TimeoutSeconds { get; set; }
+        public int NumRegionsWide { get; set; } = 7;
+        public double SimpleExposureSeconds { get; set; }
+        public double DetailedAnalysisExposureSeconds { get; set; }
+        public bool LoopingExposureAnalysisEnabled { get; set; }
+        public double MicronsPerFocuserStep { get; set; }
+        public bool EccentricityColorMapEnabled { get; set; }
+        public bool MouseOnChartsEnabled { get; set; }
+        public bool SensorCurveModelEnabled { get; set; }
+        public bool ShowSensorModel { get; set; }
+        public double SensorROI { get; set; } = 1.0;
+        public double CornersROI { get; set; } = 1.0;
+        public bool InterpolationEnabled { get; set; }
+        public InterpolationAlgoEnum InterpolationAlgo { get; set; } = InterpolationAlgoEnum.MultiQuadric;
+        public InterpolationAmountEnum InterpolationAmount { get; set; } = InterpolationAmountEnum.Medium;
+        public bool FixedSensorCenter { get; set; } = true;
+        public bool UseRANSAC { get; set; }
+        public bool UseAffineAlignment { get; set; }
+        public bool RejectBadBrightnessMatches { get; set; }
+        public bool RejectBadlyFittingMatches { get; set; }
+        public double PreviousRunBrightnessDiff { get; set; } = 0.1;
+        public double StartingBrightnessDiff { get; set; } = -1;
+        public bool SaveImagesOnReruns { get; set; }
+        public bool SaveAlignmentImages { get; set; }
+        public int MaxStarsPerRegion { get; set; } = -1;
+    }
+
+    internal sealed class FakeAutoFocusOptions : IAutoFocusOptions {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public int MaxConcurrent { get; set; }
+        public bool FastFocusModeEnabled { get; set; }
+        public int FastStepSize { get; set; }
+        public int FastOffsetSteps { get; set; }
+        public int FastThreshold_Seconds { get; set; }
+        public int FastThreshold_Celcius { get; set; }
+        public int FastThreshold_FocuserPosition { get; set; }
+        public bool ValidateHfrImprovement { get; set; }
+        public double HFRImprovementThreshold { get; set; }
+        public int AutoFocusTimeoutSeconds { get; set; }
+        public string SavePath { get; set; }
+        public bool Save { get; set; }
+        public string LastSelectedLoadPath { get; set; }
+        public int FocuserOffset { get; set; }
+        public int MaxOutlierRejections { get; set; }
+        public double OutlierRejectionConfidence { get; set; } = 0.95;
+        public bool UnevenHyperbolicFitEnabled { get; set; }
+        public bool WeightedHyperbolicFitEnabled { get; set; }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
@@ -35,6 +35,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
         public bool SaveImagesOnReruns { get; set; }
         public bool SaveAlignmentImages { get; set; }
         public int MaxStarsPerRegion { get; set; } = -1;
+        public double AcceptableReducedChiSquared { get; set; } = 5.0;
+        public double AcceptableRSquaredMin { get; set; } = 0.05;
     }
 
     internal sealed class FakeAutoFocusOptions : IAutoFocusOptions {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorAberrationCalculatorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorAberrationCalculatorTests.cs
@@ -8,30 +8,47 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection;
 [TestFixture]
 public class SensorAberrationCalculatorTests {
 
+    private const double MaxChi = SensorAberrationCalculator.DefaultAcceptableReducedChiSquared;   // 5.0
+    private const double MinRSquared = SensorAberrationCalculator.DefaultAcceptableRSquaredMin;     // 0.05
+
     [Test]
     public void IsReducedChiSquaredAcceptable_NullFit_IsFalse() {
-        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(null), Is.False);
+        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(null, MaxChi), Is.False);
     }
 
     [Test]
     public void IsReducedChiSquaredAcceptable_NearOne_IsTrue() {
-        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(1.0)), Is.True);
+        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(1.0), MaxChi), Is.True);
     }
 
     [Test]
     public void IsReducedChiSquaredAcceptable_SmallValue_IsTrue() {
         // Residuals smaller than the declared σ (reduced χ² well below 1) is still a good fit.
-        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(0.1)), Is.True);
+        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(0.1), MaxChi), Is.True);
     }
 
     [Test]
     public void IsReducedChiSquaredAcceptable_LargeValue_IsFalse() {
-        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(50.0)), Is.False);
+        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(50.0), MaxChi), Is.False);
     }
 
     [Test]
     public void IsReducedChiSquaredAcceptable_NaN_IsFalse() {
-        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(double.NaN)), Is.False);
+        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(double.NaN), MaxChi), Is.False);
+    }
+
+    [Test]
+    public void IsReducedChiSquaredAcceptable_Infinity_IsFalse() {
+        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(double.PositiveInfinity), MaxChi), Is.False);
+    }
+
+    [Test]
+    public void IsReducedChiSquaredAcceptable_RespectsConfiguredMax() {
+        // A χ² of 8 is rejected at the default cap of 5 but accepted when the cap is raised to 10.
+        Assert.Multiple(() => {
+            Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(8.0), MaxChi), Is.False);
+            Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(8.0), 10.0), Is.True);
+        });
     }
 
     [Test]
@@ -40,7 +57,84 @@ public class SensorAberrationCalculatorTests {
         // measurement errors (reduced χ² ≈ 1) is accepted, where an R² target would have rejected it.
         var nearlyFlatButConsistent = WithReducedChiSquared(1.0);
         SetGoodness(nearlyFlatButConsistent, 0.02);
-        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(nearlyFlatButConsistent), Is.True);
+        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(nearlyFlatButConsistent, MaxChi), Is.True);
+    }
+
+    // --- IsModelAcceptable: combined R²/χ² rejection rule (truth table) ---
+
+    [Test]
+    public void IsModelAcceptable_NullFit_IsFalse() {
+        Assert.That(SensorAberrationCalculator.IsModelAcceptable(null, MaxChi, MinRSquared), Is.False);
+    }
+
+    [Test]
+    public void IsModelAcceptable_GoodChiSquaredLowRSquared_Accepts() {
+        // Flat sensor: χ² ≈ 1 (well below the 0.6·max=3.0 good band) with very low R² → accept.
+        Assert.That(SensorAberrationCalculator.IsModelAcceptable(WithFit(reducedChiSquared: 1.0, goodness: 0.02), MaxChi, MinRSquared), Is.True);
+    }
+
+    [Test]
+    public void IsModelAcceptable_MarginalChiSquaredLowRSquared_Rejects() {
+        // χ² ≥ 0.6·max=3.0 AND R² below min → the low R² now matters → reject.
+        Assert.That(SensorAberrationCalculator.IsModelAcceptable(WithFit(reducedChiSquared: 3.5, goodness: 0.02), MaxChi, MinRSquared), Is.False);
+    }
+
+    [Test]
+    public void IsModelAcceptable_MarginalChiSquaredAdequateRSquared_Accepts() {
+        // Same elevated χ² but R² above min → accept.
+        Assert.That(SensorAberrationCalculator.IsModelAcceptable(WithFit(reducedChiSquared: 3.5, goodness: 0.5), MaxChi, MinRSquared), Is.True);
+    }
+
+    [Test]
+    public void IsModelAcceptable_ChiSquaredAboveMax_RejectsRegardlessOfRSquared() {
+        // Above the cap, a high R² cannot rescue the fit (acceptance uses χ² <= max, so values strictly
+        // above the cap are rejected even when R² is excellent).
+        Assert.Multiple(() => {
+            Assert.That(SensorAberrationCalculator.IsModelAcceptable(WithFit(reducedChiSquared: 6.0, goodness: 0.99), MaxChi, MinRSquared), Is.False);
+            Assert.That(SensorAberrationCalculator.IsModelAcceptable(WithFit(reducedChiSquared: 5.0001, goodness: 0.99), MaxChi, MinRSquared), Is.False);
+        });
+    }
+
+    [Test]
+    public void IsModelAcceptable_NaNChiSquared_Rejects() {
+        Assert.That(SensorAberrationCalculator.IsModelAcceptable(WithFit(reducedChiSquared: double.NaN, goodness: 0.99), MaxChi, MinRSquared), Is.False);
+    }
+
+    [Test]
+    public void IsModelAcceptable_InfinityChiSquared_Rejects() {
+        Assert.That(SensorAberrationCalculator.IsModelAcceptable(WithFit(reducedChiSquared: double.PositiveInfinity, goodness: 0.99), MaxChi, MinRSquared), Is.False);
+    }
+
+    // --- ClassifyReducedChiSquared: display-band boundaries (good band = 0.6·max = 3.0) ---
+
+    [Test]
+    public void ClassifyReducedChiSquared_JustBelowGoodBand_IsGood() {
+        Assert.That(SensorAberrationCalculator.ClassifyReducedChiSquared(2.99, MaxChi), Is.EqualTo(SensorAberrationCalculator.FitQualityBand.Good));
+    }
+
+    [Test]
+    public void ClassifyReducedChiSquared_AtGoodBand_IsMarginal() {
+        Assert.That(SensorAberrationCalculator.ClassifyReducedChiSquared(3.0, MaxChi), Is.EqualTo(SensorAberrationCalculator.FitQualityBand.Marginal));
+    }
+
+    [Test]
+    public void ClassifyReducedChiSquared_JustBelowMax_IsMarginal() {
+        Assert.That(SensorAberrationCalculator.ClassifyReducedChiSquared(4.99, MaxChi), Is.EqualTo(SensorAberrationCalculator.FitQualityBand.Marginal));
+    }
+
+    [Test]
+    public void ClassifyReducedChiSquared_AtMax_IsRejected() {
+        Assert.That(SensorAberrationCalculator.ClassifyReducedChiSquared(5.0, MaxChi), Is.EqualTo(SensorAberrationCalculator.FitQualityBand.Rejected));
+    }
+
+    [Test]
+    public void ClassifyReducedChiSquared_NaN_IsRejected() {
+        Assert.That(SensorAberrationCalculator.ClassifyReducedChiSquared(double.NaN, MaxChi), Is.EqualTo(SensorAberrationCalculator.FitQualityBand.Rejected));
+    }
+
+    [Test]
+    public void ClassifyReducedChiSquared_Infinity_IsRejected() {
+        Assert.That(SensorAberrationCalculator.ClassifyReducedChiSquared(double.PositiveInfinity, MaxChi), Is.EqualTo(SensorAberrationCalculator.FitQualityBand.Rejected));
     }
 
     [Test]
@@ -203,6 +297,12 @@ public class SensorAberrationCalculatorTests {
     private static SensorParaboloidModel WithReducedChiSquared(double reducedChiSquared) {
         var model = new SensorParaboloidModel();
         typeof(SensorParaboloidModel).GetProperty(nameof(SensorParaboloidModel.ReducedChiSquared)).SetValue(model, reducedChiSquared);
+        return model;
+    }
+
+    private static SensorParaboloidModel WithFit(double reducedChiSquared, double goodness) {
+        var model = WithReducedChiSquared(reducedChiSquared);
+        SetGoodness(model, goodness);
         return model;
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorAberrationCalculatorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorAberrationCalculatorTests.cs
@@ -8,20 +8,39 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection;
 [TestFixture]
 public class SensorAberrationCalculatorTests {
 
-    [TestCase(0.0, 0.9)]
-    [TestCase(0.5, 0.9)]
-    [TestCase(0.999, 0.9)]
-    [TestCase(1.0, 0.8)]
-    [TestCase(2.5, 0.8)]
-    [TestCase(2.999, 0.8)]
-    [TestCase(3.0, 0.7)]
-    [TestCase(4.5, 0.7)]
-    [TestCase(4.999, 0.7)]
-    [TestCase(5.0, 0.6)]
-    [TestCase(60.0, 0.6)]
-    public void TargetR2BasedOnTimeTaken_ReturnsExpectedTier(double seconds, double expected) {
-        var actual = SensorAberrationCalculator.TargetR2BasedOnTimeTaken(TimeSpan.FromSeconds(seconds));
-        Assert.That(actual, Is.EqualTo(expected).Within(1e-12));
+    [Test]
+    public void IsReducedChiSquaredAcceptable_NullFit_IsFalse() {
+        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(null), Is.False);
+    }
+
+    [Test]
+    public void IsReducedChiSquaredAcceptable_NearOne_IsTrue() {
+        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(1.0)), Is.True);
+    }
+
+    [Test]
+    public void IsReducedChiSquaredAcceptable_SmallValue_IsTrue() {
+        // Residuals smaller than the declared σ (reduced χ² well below 1) is still a good fit.
+        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(0.1)), Is.True);
+    }
+
+    [Test]
+    public void IsReducedChiSquaredAcceptable_LargeValue_IsFalse() {
+        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(50.0)), Is.False);
+    }
+
+    [Test]
+    public void IsReducedChiSquaredAcceptable_NaN_IsFalse() {
+        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(double.NaN)), Is.False);
+    }
+
+    [Test]
+    public void IsReducedChiSquaredAcceptable_IsIndependentOfGoodnessOfFit() {
+        // Magnitude independence: a near-flat sensor (very low R²) with residuals consistent with the
+        // measurement errors (reduced χ² ≈ 1) is accepted, where an R² target would have rejected it.
+        var nearlyFlatButConsistent = WithReducedChiSquared(1.0);
+        SetGoodness(nearlyFlatButConsistent, 0.02);
+        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(nearlyFlatButConsistent), Is.True);
     }
 
     [Test]
@@ -173,8 +192,17 @@ public class SensorAberrationCalculatorTests {
 
     private static SensorParaboloidModel WithGoodness(double goodness) {
         var model = new SensorParaboloidModel();
-        var prop = typeof(SensorParaboloidModel).GetProperty(nameof(SensorParaboloidModel.GoodnessOfFit));
-        prop.SetValue(model, goodness);
+        SetGoodness(model, goodness);
+        return model;
+    }
+
+    private static void SetGoodness(SensorParaboloidModel model, double goodness) {
+        typeof(SensorParaboloidModel).GetProperty(nameof(SensorParaboloidModel.GoodnessOfFit)).SetValue(model, goodness);
+    }
+
+    private static SensorParaboloidModel WithReducedChiSquared(double reducedChiSquared) {
+        var model = new SensorParaboloidModel();
+        typeof(SensorParaboloidModel).GetProperty(nameof(SensorParaboloidModel.ReducedChiSquared)).SetValue(model, reducedChiSquared);
         return model;
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorAberrationCalculatorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorAberrationCalculatorTests.cs
@@ -8,47 +8,37 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection;
 [TestFixture]
 public class SensorAberrationCalculatorTests {
 
-    private const double MaxChi = SensorAberrationCalculator.DefaultAcceptableReducedChiSquared;   // 5.0
     private const double MinRSquared = SensorAberrationCalculator.DefaultAcceptableRSquaredMin;     // 0.05
 
     [Test]
     public void IsReducedChiSquaredAcceptable_NullFit_IsFalse() {
-        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(null, MaxChi), Is.False);
+        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(null), Is.False);
     }
 
     [Test]
     public void IsReducedChiSquaredAcceptable_NearOne_IsTrue() {
-        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(1.0), MaxChi), Is.True);
+        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(1.0)), Is.True);
     }
 
     [Test]
     public void IsReducedChiSquaredAcceptable_SmallValue_IsTrue() {
         // Residuals smaller than the declared σ (reduced χ² well below 1) is still a good fit.
-        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(0.1), MaxChi), Is.True);
+        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(0.1)), Is.True);
     }
 
     [Test]
     public void IsReducedChiSquaredAcceptable_LargeValue_IsFalse() {
-        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(50.0), MaxChi), Is.False);
+        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(50.0)), Is.False);
     }
 
     [Test]
     public void IsReducedChiSquaredAcceptable_NaN_IsFalse() {
-        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(double.NaN), MaxChi), Is.False);
+        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(double.NaN)), Is.False);
     }
 
     [Test]
     public void IsReducedChiSquaredAcceptable_Infinity_IsFalse() {
-        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(double.PositiveInfinity), MaxChi), Is.False);
-    }
-
-    [Test]
-    public void IsReducedChiSquaredAcceptable_RespectsConfiguredMax() {
-        // A χ² of 8 is rejected at the default cap of 5 but accepted when the cap is raised to 10.
-        Assert.Multiple(() => {
-            Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(8.0), MaxChi), Is.False);
-            Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(8.0), 10.0), Is.True);
-        });
+        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(WithReducedChiSquared(double.PositiveInfinity)), Is.False);
     }
 
     [Test]
@@ -57,84 +47,48 @@ public class SensorAberrationCalculatorTests {
         // measurement errors (reduced χ² ≈ 1) is accepted, where an R² target would have rejected it.
         var nearlyFlatButConsistent = WithReducedChiSquared(1.0);
         SetGoodness(nearlyFlatButConsistent, 0.02);
-        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(nearlyFlatButConsistent, MaxChi), Is.True);
+        Assert.That(SensorAberrationCalculator.IsReducedChiSquaredAcceptable(nearlyFlatButConsistent), Is.True);
     }
 
-    // --- IsModelAcceptable: combined R²/χ² rejection rule (truth table) ---
+    // --- IsModelAcceptable: reduced χ² is only a rejection criterion when R² is very low ---
 
     [Test]
     public void IsModelAcceptable_NullFit_IsFalse() {
-        Assert.That(SensorAberrationCalculator.IsModelAcceptable(null, MaxChi, MinRSquared), Is.False);
+        Assert.That(SensorAberrationCalculator.IsModelAcceptable(null, MinRSquared), Is.False);
     }
 
     [Test]
-    public void IsModelAcceptable_GoodChiSquaredLowRSquared_Accepts() {
-        // Flat sensor: χ² ≈ 1 (well below the 0.6·max=3.0 good band) with very low R² → accept.
-        Assert.That(SensorAberrationCalculator.IsModelAcceptable(WithFit(reducedChiSquared: 1.0, goodness: 0.02), MaxChi, MinRSquared), Is.True);
+    public void IsModelAcceptable_LowRSquaredGoodChiSquared_Accepts() {
+        // Flat sensor: low R² but χ² within the cap → χ² does not reject → accept.
+        Assert.That(SensorAberrationCalculator.IsModelAcceptable(WithFit(reducedChiSquared: 1.0, goodness: 0.02), MinRSquared), Is.True);
     }
 
     [Test]
-    public void IsModelAcceptable_MarginalChiSquaredLowRSquared_Rejects() {
-        // χ² ≥ 0.6·max=3.0 AND R² below min → the low R² now matters → reject.
-        Assert.That(SensorAberrationCalculator.IsModelAcceptable(WithFit(reducedChiSquared: 3.5, goodness: 0.02), MaxChi, MinRSquared), Is.False);
+    public void IsModelAcceptable_LowRSquaredHighChiSquared_Rejects() {
+        // The model is rejected only when R² is very low AND reduced χ² also exceeds the cap.
+        Assert.That(SensorAberrationCalculator.IsModelAcceptable(WithFit(reducedChiSquared: 50.0, goodness: 0.02), MinRSquared), Is.False);
     }
 
     [Test]
-    public void IsModelAcceptable_MarginalChiSquaredAdequateRSquared_Accepts() {
-        // Same elevated χ² but R² above min → accept.
-        Assert.That(SensorAberrationCalculator.IsModelAcceptable(WithFit(reducedChiSquared: 3.5, goodness: 0.5), MaxChi, MinRSquared), Is.True);
+    public void IsModelAcceptable_AdequateRSquaredHighChiSquared_Accepts() {
+        // R² is adequate, so a very high χ² is ignored (the "well-fit model with huge reduced χ²" case).
+        Assert.That(SensorAberrationCalculator.IsModelAcceptable(WithFit(reducedChiSquared: 11427.0, goodness: 0.61), MinRSquared), Is.True);
     }
 
     [Test]
-    public void IsModelAcceptable_ChiSquaredAboveMax_RejectsRegardlessOfRSquared() {
-        // Above the cap, a high R² cannot rescue the fit (acceptance uses χ² <= max, so values strictly
-        // above the cap are rejected even when R² is excellent).
-        Assert.Multiple(() => {
-            Assert.That(SensorAberrationCalculator.IsModelAcceptable(WithFit(reducedChiSquared: 6.0, goodness: 0.99), MaxChi, MinRSquared), Is.False);
-            Assert.That(SensorAberrationCalculator.IsModelAcceptable(WithFit(reducedChiSquared: 5.0001, goodness: 0.99), MaxChi, MinRSquared), Is.False);
-        });
+    public void IsModelAcceptable_AdequateRSquaredGoodChiSquared_Accepts() {
+        Assert.That(SensorAberrationCalculator.IsModelAcceptable(WithFit(reducedChiSquared: 1.0, goodness: 0.8), MinRSquared), Is.True);
     }
 
     [Test]
-    public void IsModelAcceptable_NaNChiSquared_Rejects() {
-        Assert.That(SensorAberrationCalculator.IsModelAcceptable(WithFit(reducedChiSquared: double.NaN, goodness: 0.99), MaxChi, MinRSquared), Is.False);
+    public void IsModelAcceptable_LowRSquaredNaNChiSquared_Rejects() {
+        // Non-finite χ² is "not acceptable", so with a very low R² the combined rule rejects.
+        Assert.That(SensorAberrationCalculator.IsModelAcceptable(WithFit(reducedChiSquared: double.NaN, goodness: 0.02), MinRSquared), Is.False);
     }
 
     [Test]
-    public void IsModelAcceptable_InfinityChiSquared_Rejects() {
-        Assert.That(SensorAberrationCalculator.IsModelAcceptable(WithFit(reducedChiSquared: double.PositiveInfinity, goodness: 0.99), MaxChi, MinRSquared), Is.False);
-    }
-
-    // --- ClassifyReducedChiSquared: display-band boundaries (good band = 0.6·max = 3.0) ---
-
-    [Test]
-    public void ClassifyReducedChiSquared_JustBelowGoodBand_IsGood() {
-        Assert.That(SensorAberrationCalculator.ClassifyReducedChiSquared(2.99, MaxChi), Is.EqualTo(SensorAberrationCalculator.FitQualityBand.Good));
-    }
-
-    [Test]
-    public void ClassifyReducedChiSquared_AtGoodBand_IsMarginal() {
-        Assert.That(SensorAberrationCalculator.ClassifyReducedChiSquared(3.0, MaxChi), Is.EqualTo(SensorAberrationCalculator.FitQualityBand.Marginal));
-    }
-
-    [Test]
-    public void ClassifyReducedChiSquared_JustBelowMax_IsMarginal() {
-        Assert.That(SensorAberrationCalculator.ClassifyReducedChiSquared(4.99, MaxChi), Is.EqualTo(SensorAberrationCalculator.FitQualityBand.Marginal));
-    }
-
-    [Test]
-    public void ClassifyReducedChiSquared_AtMax_IsRejected() {
-        Assert.That(SensorAberrationCalculator.ClassifyReducedChiSquared(5.0, MaxChi), Is.EqualTo(SensorAberrationCalculator.FitQualityBand.Rejected));
-    }
-
-    [Test]
-    public void ClassifyReducedChiSquared_NaN_IsRejected() {
-        Assert.That(SensorAberrationCalculator.ClassifyReducedChiSquared(double.NaN, MaxChi), Is.EqualTo(SensorAberrationCalculator.FitQualityBand.Rejected));
-    }
-
-    [Test]
-    public void ClassifyReducedChiSquared_Infinity_IsRejected() {
-        Assert.That(SensorAberrationCalculator.ClassifyReducedChiSquared(double.PositiveInfinity, MaxChi), Is.EqualTo(SensorAberrationCalculator.FitQualityBand.Rejected));
+    public void IsModelAcceptable_AdequateRSquaredNaNChiSquared_Accepts() {
+        Assert.That(SensorAberrationCalculator.IsModelAcceptable(WithFit(reducedChiSquared: double.NaN, goodness: 0.8), MinRSquared), Is.True);
     }
 
     [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorModelAberrationResultTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorModelAberrationResultTests.cs
@@ -1,5 +1,6 @@
 using NINA.Joko.Plugins.HocusFocus.Inspection;
 using NUnit.Framework;
+using System.Linq;
 
 namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection;
 
@@ -9,53 +10,55 @@ public class SensorModelAberrationResultTests {
     private const double MinRSquared = 0.05;   // reduced χ² cap is the fixed SensorAberrationCalculator constant (5.0)
 
     [Test]
-    public void BuildFitQualityResults_ProducesBothRowsWithExpectedNames() {
-        var (rSquared, reducedChiSquared) = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.8, reducedChiSquared: 1.0), MinRSquared);
+    public void BuildFitQualityResults_AdequateRSquared_ShowsOnlyRSquaredRow() {
+        // Reduced χ² is irrelevant while R² is adequate, so its row is omitted from the table.
+        var results = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.8, reducedChiSquared: 1.0), MinRSquared);
         Assert.Multiple(() => {
-            Assert.That(rSquared.Name, Is.EqualTo("Model Fit (R²)"));
-            Assert.That(reducedChiSquared.Name, Is.EqualTo("Reduced χ²"));
-            Assert.That(rSquared.Value, Does.Contain("R²"));
-            Assert.That(reducedChiSquared.Value, Does.Not.Contain("R²"));
+            Assert.That(results.Select(r => r.Name), Is.EqualTo(new[] { "Model Fit (R²)" }));
+            Assert.That(results[0].Acceptable, Is.True);
+            Assert.That(results[0].Value, Does.Contain("R²"));
         });
     }
 
     [Test]
-    public void BuildFitQualityResults_FlatSensorGoodChiSquaredLowRSquared_BothAcceptable() {
-        // A near-flat sensor: low R² but χ² within the cap → model accepted → both rows acceptable.
-        var (rSquared, reducedChiSquared) = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.02, reducedChiSquared: 1.0), MinRSquared);
+    public void BuildFitQualityResults_AdequateRSquaredHighChiSquared_HidesReducedChiSquaredRow() {
+        // The user's case: adequate R² with a huge reduced χ² → χ² row hidden, model accepted.
+        var results = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.61, reducedChiSquared: 11427.48), MinRSquared);
         Assert.Multiple(() => {
-            Assert.That(rSquared.Acceptable, Is.True);
-            Assert.That(reducedChiSquared.Acceptable, Is.True);
+            Assert.That(results.Any(r => r.Name == "Reduced χ²"), Is.False);
+            Assert.That(results.Single().Acceptable, Is.True);
         });
     }
 
     [Test]
-    public void BuildFitQualityResults_AdequateRSquaredHighChiSquared_BothAcceptable() {
-        // The user's case: a well-fit model (adequate R²) with a huge reduced χ². χ² only matters when R²
-        // is very low, so the model is accepted and neither row is flagged.
-        var (rSquared, reducedChiSquared) = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.61, reducedChiSquared: 11427.48), MinRSquared);
+    public void BuildFitQualityResults_LowRSquaredGoodChiSquared_ShowsBothRowsAcceptable() {
+        // Low R²: the reduced χ² row appears (it now matters); good χ² keeps the model accepted.
+        var results = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.02, reducedChiSquared: 1.0), MinRSquared);
         Assert.Multiple(() => {
-            Assert.That(rSquared.Acceptable, Is.True);
-            Assert.That(reducedChiSquared.Acceptable, Is.True);
+            Assert.That(results.Select(r => r.Name), Is.EqualTo(new[] { "Model Fit (R²)", "Reduced χ²" }));
+            Assert.That(results.All(r => r.Acceptable), Is.True);
         });
     }
 
     [Test]
-    public void BuildFitQualityResults_LowRSquaredHighChiSquared_BothRowsFail() {
-        // Very low R² AND χ² above the cap → model rejected → both rows flagged.
-        var (rSquared, reducedChiSquared) = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.02, reducedChiSquared: 50.0), MinRSquared);
+    public void BuildFitQualityResults_LowRSquaredHighChiSquared_ShowsBothRowsRejected() {
+        // Low R² AND χ² above the cap → model rejected → both rows shown and flagged.
+        var results = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.02, reducedChiSquared: 50.0), MinRSquared);
         Assert.Multiple(() => {
-            Assert.That(rSquared.Acceptable, Is.False);
-            Assert.That(reducedChiSquared.Acceptable, Is.False);
+            Assert.That(results.Select(r => r.Name), Is.EqualTo(new[] { "Model Fit (R²)", "Reduced χ²" }));
+            Assert.That(results.All(r => !r.Acceptable), Is.True);
+            Assert.That(results.Single(r => r.Name == "Reduced χ²").Value, Does.Not.Contain("R²"));
         });
     }
 
     [Test]
-    public void BuildFitQualityResults_AdequateRSquaredGoodChiSquared_BothAcceptable() {
-        var (rSquared, reducedChiSquared) = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.8, reducedChiSquared: 1.0), MinRSquared);
+    public void BuildFitQualityResults_ReducedChiSquaredRowAppearsExactlyAtThreshold() {
+        // R² exactly at the min is NOT "< min", so the χ² row stays hidden; just below it appears.
+        var atThreshold = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: MinRSquared, reducedChiSquared: 1.0), MinRSquared);
+        var belowThreshold = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: MinRSquared - 0.001, reducedChiSquared: 1.0), MinRSquared);
         Assert.Multiple(() => {
-            Assert.That(rSquared.Acceptable, Is.True);
-            Assert.That(reducedChiSquared.Acceptable, Is.True);
+            Assert.That(atThreshold.Any(r => r.Name == "Reduced χ²"), Is.False);
+            Assert.That(belowThreshold.Any(r => r.Name == "Reduced χ²"), Is.True);
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorModelAberrationResultTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorModelAberrationResultTests.cs
@@ -6,12 +6,11 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection;
 [TestFixture]
 public class SensorModelAberrationResultTests {
 
-    private const double MaxChi = 5.0;       // good/marginal boundary = 0.6 * 5 = 3.0
-    private const double MinRSquared = 0.05;
+    private const double MinRSquared = 0.05;   // reduced χ² cap is the fixed SensorAberrationCalculator constant (5.0)
 
     [Test]
     public void BuildFitQualityResults_ProducesBothRowsWithExpectedNames() {
-        var (rSquared, reducedChiSquared) = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.8, reducedChiSquared: 1.0), MaxChi, MinRSquared);
+        var (rSquared, reducedChiSquared) = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.8, reducedChiSquared: 1.0), MinRSquared);
         Assert.Multiple(() => {
             Assert.That(rSquared.Name, Is.EqualTo("Model Fit (R²)"));
             Assert.That(reducedChiSquared.Name, Is.EqualTo("Reduced χ²"));
@@ -22,28 +21,8 @@ public class SensorModelAberrationResultTests {
 
     [Test]
     public void BuildFitQualityResults_FlatSensorGoodChiSquaredLowRSquared_BothAcceptable() {
-        // A near-flat sensor: low R² but χ² well within the good band → both rows acceptable.
-        var (rSquared, reducedChiSquared) = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.02, reducedChiSquared: 1.0), MaxChi, MinRSquared);
-        Assert.Multiple(() => {
-            Assert.That(rSquared.Acceptable, Is.True, "Low R² alone must not fail the R² row while χ² is good");
-            Assert.That(reducedChiSquared.Acceptable, Is.True);
-        });
-    }
-
-    [Test]
-    public void BuildFitQualityResults_LowRSquaredElevatedChiSquared_OnlyRSquaredRowFails() {
-        // Low R² AND elevated χ² (>= 0.6*max=3.0 but < max=5.0): the R² row now contributes to rejection,
-        // while the χ² row is still within the acceptable cap (marginal).
-        var (rSquared, reducedChiSquared) = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.02, reducedChiSquared: 3.5), MaxChi, MinRSquared);
-        Assert.Multiple(() => {
-            Assert.That(rSquared.Acceptable, Is.False);
-            Assert.That(reducedChiSquared.Acceptable, Is.True);
-        });
-    }
-
-    [Test]
-    public void BuildFitQualityResults_AdequateRSquaredElevatedChiSquared_BothAcceptable() {
-        var (rSquared, reducedChiSquared) = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.5, reducedChiSquared: 3.5), MaxChi, MinRSquared);
+        // A near-flat sensor: low R² but χ² within the cap → model accepted → both rows acceptable.
+        var (rSquared, reducedChiSquared) = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.02, reducedChiSquared: 1.0), MinRSquared);
         Assert.Multiple(() => {
             Assert.That(rSquared.Acceptable, Is.True);
             Assert.That(reducedChiSquared.Acceptable, Is.True);
@@ -51,21 +30,32 @@ public class SensorModelAberrationResultTests {
     }
 
     [Test]
-    public void BuildFitQualityResults_ChiSquaredAboveMax_OnlyChiSquaredRowFails_WhenRSquaredAdequate() {
-        // χ² above the cap → χ² row rejected. R² is adequate, so it does not contribute → R² row acceptable.
-        var (rSquared, reducedChiSquared) = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.8, reducedChiSquared: 6.0), MaxChi, MinRSquared);
+    public void BuildFitQualityResults_AdequateRSquaredHighChiSquared_BothAcceptable() {
+        // The user's case: a well-fit model (adequate R²) with a huge reduced χ². χ² only matters when R²
+        // is very low, so the model is accepted and neither row is flagged.
+        var (rSquared, reducedChiSquared) = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.61, reducedChiSquared: 11427.48), MinRSquared);
         Assert.Multiple(() => {
             Assert.That(rSquared.Acceptable, Is.True);
+            Assert.That(reducedChiSquared.Acceptable, Is.True);
+        });
+    }
+
+    [Test]
+    public void BuildFitQualityResults_LowRSquaredHighChiSquared_BothRowsFail() {
+        // Very low R² AND χ² above the cap → model rejected → both rows flagged.
+        var (rSquared, reducedChiSquared) = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.02, reducedChiSquared: 50.0), MinRSquared);
+        Assert.Multiple(() => {
+            Assert.That(rSquared.Acceptable, Is.False);
             Assert.That(reducedChiSquared.Acceptable, Is.False);
         });
     }
 
     [Test]
-    public void BuildFitQualityResults_ChiSquaredAboveMaxAndLowRSquared_BothRowsFail() {
-        var (rSquared, reducedChiSquared) = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.02, reducedChiSquared: 6.0), MaxChi, MinRSquared);
+    public void BuildFitQualityResults_AdequateRSquaredGoodChiSquared_BothAcceptable() {
+        var (rSquared, reducedChiSquared) = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.8, reducedChiSquared: 1.0), MinRSquared);
         Assert.Multiple(() => {
-            Assert.That(rSquared.Acceptable, Is.False);
-            Assert.That(reducedChiSquared.Acceptable, Is.False);
+            Assert.That(rSquared.Acceptable, Is.True);
+            Assert.That(reducedChiSquared.Acceptable, Is.True);
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorModelAberrationResultTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorModelAberrationResultTests.cs
@@ -1,0 +1,78 @@
+using NINA.Joko.Plugins.HocusFocus.Inspection;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection;
+
+[TestFixture]
+public class SensorModelAberrationResultTests {
+
+    private const double MaxChi = 5.0;       // good/marginal boundary = 0.6 * 5 = 3.0
+    private const double MinRSquared = 0.05;
+
+    [Test]
+    public void BuildFitQualityResults_ProducesBothRowsWithExpectedNames() {
+        var (rSquared, reducedChiSquared) = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.8, reducedChiSquared: 1.0), MaxChi, MinRSquared);
+        Assert.Multiple(() => {
+            Assert.That(rSquared.Name, Is.EqualTo("Model Fit (R²)"));
+            Assert.That(reducedChiSquared.Name, Is.EqualTo("Reduced χ²"));
+            Assert.That(rSquared.Value, Does.Contain("R²"));
+            Assert.That(reducedChiSquared.Value, Does.Not.Contain("R²"));
+        });
+    }
+
+    [Test]
+    public void BuildFitQualityResults_FlatSensorGoodChiSquaredLowRSquared_BothAcceptable() {
+        // A near-flat sensor: low R² but χ² well within the good band → both rows acceptable.
+        var (rSquared, reducedChiSquared) = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.02, reducedChiSquared: 1.0), MaxChi, MinRSquared);
+        Assert.Multiple(() => {
+            Assert.That(rSquared.Acceptable, Is.True, "Low R² alone must not fail the R² row while χ² is good");
+            Assert.That(reducedChiSquared.Acceptable, Is.True);
+        });
+    }
+
+    [Test]
+    public void BuildFitQualityResults_LowRSquaredElevatedChiSquared_OnlyRSquaredRowFails() {
+        // Low R² AND elevated χ² (>= 0.6*max=3.0 but < max=5.0): the R² row now contributes to rejection,
+        // while the χ² row is still within the acceptable cap (marginal).
+        var (rSquared, reducedChiSquared) = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.02, reducedChiSquared: 3.5), MaxChi, MinRSquared);
+        Assert.Multiple(() => {
+            Assert.That(rSquared.Acceptable, Is.False);
+            Assert.That(reducedChiSquared.Acceptable, Is.True);
+        });
+    }
+
+    [Test]
+    public void BuildFitQualityResults_AdequateRSquaredElevatedChiSquared_BothAcceptable() {
+        var (rSquared, reducedChiSquared) = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.5, reducedChiSquared: 3.5), MaxChi, MinRSquared);
+        Assert.Multiple(() => {
+            Assert.That(rSquared.Acceptable, Is.True);
+            Assert.That(reducedChiSquared.Acceptable, Is.True);
+        });
+    }
+
+    [Test]
+    public void BuildFitQualityResults_ChiSquaredAboveMax_OnlyChiSquaredRowFails_WhenRSquaredAdequate() {
+        // χ² above the cap → χ² row rejected. R² is adequate, so it does not contribute → R² row acceptable.
+        var (rSquared, reducedChiSquared) = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.8, reducedChiSquared: 6.0), MaxChi, MinRSquared);
+        Assert.Multiple(() => {
+            Assert.That(rSquared.Acceptable, Is.True);
+            Assert.That(reducedChiSquared.Acceptable, Is.False);
+        });
+    }
+
+    [Test]
+    public void BuildFitQualityResults_ChiSquaredAboveMaxAndLowRSquared_BothRowsFail() {
+        var (rSquared, reducedChiSquared) = SensorModelAberrationResult.BuildFitQualityResults(BuildModel(goodness: 0.02, reducedChiSquared: 6.0), MaxChi, MinRSquared);
+        Assert.Multiple(() => {
+            Assert.That(rSquared.Acceptable, Is.False);
+            Assert.That(reducedChiSquared.Acceptable, Is.False);
+        });
+    }
+
+    private static SensorParaboloidModel BuildModel(double goodness, double reducedChiSquared) {
+        var model = new SensorParaboloidModel(x0: 0, y0: 0, z0: 30000, gx: 0.001, gy: 0.001, k: 1e-6);
+        typeof(SensorParaboloidModel).GetProperty(nameof(SensorParaboloidModel.GoodnessOfFit)).SetValue(model, goodness);
+        typeof(SensorParaboloidModel).GetProperty(nameof(SensorParaboloidModel.ReducedChiSquared)).SetValue(model, reducedChiSquared);
+        return model;
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorModelRepeatabilityTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorModelRepeatabilityTests.cs
@@ -114,7 +114,11 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
                 RejectBadlyFittingMatches = false,
                 StartingBrightnessDiff = -1,
                 MaxStarsPerRegion = -1,
-                FixedSensorCenter = true
+                FixedSensorCenter = true,
+                // The synthetic data is noiseless, so each per-star best-focus σ is essentially zero and
+                // the model's reduced χ² is degenerately huge despite a perfect (R² = 1) fit. Disable the
+                // χ² acceptance gate for this fixture: it proves determinism, not fit quality.
+                AcceptableReducedChiSquared = double.MaxValue
             };
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorModelRepeatabilityTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorModelRepeatabilityTests.cs
@@ -114,11 +114,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
                 RejectBadlyFittingMatches = false,
                 StartingBrightnessDiff = -1,
                 MaxStarsPerRegion = -1,
-                FixedSensorCenter = true,
-                // The synthetic data is noiseless, so each per-star best-focus σ is essentially zero and
-                // the model's reduced χ² is degenerately huge despite a perfect (R² = 1) fit. Disable the
-                // χ² acceptance gate for this fixture: it proves determinism, not fit quality.
-                AcceptableReducedChiSquared = double.MaxValue
+                FixedSensorCenter = true
             };
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorModelRepeatabilityTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorModelRepeatabilityTests.cs
@@ -1,0 +1,176 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Model;
+using NINA.Image.ImageAnalysis;
+using NINA.Joko.Plugins.HocusFocus.Inspection;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NINA.Profile.Interfaces;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Threading;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
+
+    /// <summary>
+    /// The headline proof of the repeatability goal: running the entire registration + per-star
+    /// hyperbolic + paraboloid fit pipeline twice, from scratch, on identical synthetic data must
+    /// produce an identical model. Before the determinism work (seeded RANSAC sampling, stateless
+    /// brightness search, wall-clock-free acceptance) this would diverge run-to-run. The synthetic
+    /// data is generated fresh for each run because <see cref="SensorModel.RegisterStarsAndFit"/>
+    /// mutates the input stars (brightness normalisation, alignment transforms), so sharing the list
+    /// would not represent "running the unchanged process again".
+    /// </summary>
+    [TestFixture]
+    public class SensorModelRepeatabilityTests {
+        private const int ImageWidth = 1000;
+        private const int ImageHeight = 1000;
+        private const double CenterX = ImageWidth / 2.0;
+        private const double CenterY = ImageHeight / 2.0;
+        private const double FocuserSizeMicrons = 5.0;
+        private const double PixelSize = 3.76;
+        private const int StepSize = 2000;
+        private const double FinalFocusPosition = 30000.0;
+
+        // 9-position focuser sweep centred on FinalFocusPosition, comfortably bracketing every star's
+        // best-focus position so each per-star hyperbola is well constrained.
+        private static readonly int[] FocuserOffsets = { -8000, -6000, -4000, -2000, 0, 2000, 4000, 6000, 8000 };
+
+        private IAlglibAPI alglibAPI;
+
+        [SetUp]
+        public void SetUp() {
+            alglibAPI = new AlglibAPI();
+        }
+
+        [Test]
+        public void RegisterStarsAndFit_RunTwiceOnIdenticalData_ProducesIdenticalModel() {
+            var first = RunPipeline();
+            var second = RunPipeline();
+
+            Assert.That(first, Is.Not.Null, "First run failed to produce a model");
+            Assert.That(second, Is.Not.Null, "Second run failed to produce a model");
+            Assert.That(first.StarsInModel, Is.GreaterThanOrEqualTo(9), "Too few stars entered the model to be a meaningful test");
+
+            Assert.Multiple(() => {
+                Assert.That(second.StarsInModel, Is.EqualTo(first.StarsInModel), "StarsInModel differs between runs");
+                Assert.That(second.X0, Is.EqualTo(first.X0).Within(1e-9), "X0 differs between runs");
+                Assert.That(second.Y0, Is.EqualTo(first.Y0).Within(1e-9), "Y0 differs between runs");
+                Assert.That(second.Z0, Is.EqualTo(first.Z0).Within(1e-9), "Z0 differs between runs");
+                Assert.That(second.Gx, Is.EqualTo(first.Gx).Within(1e-9), "Gx (tilt gradient) differs between runs");
+                Assert.That(second.Gy, Is.EqualTo(first.Gy).Within(1e-9), "Gy (tilt gradient) differs between runs");
+                Assert.That(second.K, Is.EqualTo(first.K).Within(1e-9), "K (curvature) differs between runs");
+                Assert.That(second.GoodnessOfFit, Is.EqualTo(first.GoodnessOfFit).Within(1e-9), "GoodnessOfFit differs between runs");
+                Assert.That(second.ReducedChiSquared, Is.EqualTo(first.ReducedChiSquared).Within(1e-9), "ReducedChiSquared differs between runs");
+                Assert.That(second.RMSErrorMicrons, Is.EqualTo(first.RMSErrorMicrons).Within(1e-9), "RMSErrorMicrons differs between runs");
+            });
+        }
+
+        private SensorParaboloidModel RunPipeline() {
+            var sensorModel = new SensorModel(
+                Substitute.For<IProfileService>(),
+                BuildInspectorOptions(),
+                new FakeAutoFocusOptions(),
+                alglibAPI) {
+                // Route report messages away from the UI-bound (dispatcher-backed) collection so the
+                // core can run headless.
+                RegistrationReportSink = _ => { }
+            };
+
+            var frames = BuildFrames();
+            var (model, _) = sensorModel.RegisterStarsAndFit(
+                frames,
+                new Size(ImageWidth, ImageHeight),
+                FocuserSizeMicrons,
+                FinalFocusPosition,
+                PixelSize,
+                progress: new Progress<ApplicationStatus>(),
+                stepSize: StepSize,
+                ct: CancellationToken.None);
+            return model;
+        }
+
+        private static FakeInspectorOptions BuildInspectorOptions() {
+            return new FakeInspectorOptions {
+                // Exercise the seeded-RANSAC alignment path (the original repeatability killer).
+                UseRANSAC = true,
+                // Keep the brightness search to a single deterministic pass; the determinism of the
+                // search itself is covered separately. We are proving the fit pipeline is repeatable.
+                RejectBadBrightnessMatches = false,
+                RejectBadlyFittingMatches = false,
+                StartingBrightnessDiff = -1,
+                MaxStarsPerRegion = -1,
+                FixedSensorCenter = true
+            };
+        }
+
+        // Deterministically constructs a multi-frame synthetic AF run. Each call returns an independent
+        // object graph so the second pipeline run starts from pristine, identical inputs.
+        private static List<SensorDetectedStars> BuildFrames() {
+            // 5x5 grid of stars with a fixed per-index jitter so triangles are non-degenerate (distinct
+            // shapes) for RANSAC, while remaining identical across both runs.
+            var starSpecs = new List<(double X, double Y, double BestFocus, double AvgBrightness)>();
+            double[] grid = { 180, 330, 500, 670, 820 };
+            int index = 0;
+            foreach (var gx in grid) {
+                foreach (var gy in grid) {
+                    var jitterX = ((index * 37) % 11 - 5) * 1.3;
+                    var jitterY = ((index * 53) % 11 - 5) * 1.3;
+                    var x = gx + jitterX;
+                    var y = gy + jitterY;
+                    var dx = x - CenterX;
+                    var dy = y - CenterY;
+                    // True best-focus surface: tilt + mild curvature, in focuser steps. Gives each star a
+                    // distinct hyperbola minimum so the paraboloid is non-degenerate.
+                    var bestFocus = FinalFocusPosition + 0.9 * dx + 0.6 * dy + 0.0008 * (dx * dx + dy * dy);
+                    var avgBrightness = 800.0 + 40.0 * index;
+                    starSpecs.Add((x, y, bestFocus, avgBrightness));
+                    ++index;
+                }
+            }
+
+            const double minHfr = 1.5;
+            const double slopePerStep = 1.5 / 3000.0;
+            const double background = 80.0;
+
+            var frames = new List<SensorDetectedStars>();
+            foreach (var offset in FocuserOffsets) {
+                var focuserPosition = FinalFocusPosition + offset;
+                var starList = new List<DetectedStar>();
+                foreach (var spec in starSpecs) {
+                    var fromMin = focuserPosition - spec.BestFocus;
+                    var hfr = Math.Sqrt(minHfr * minHfr + slopePerStep * slopePerStep * fromMin * fromMin);
+                    starList.Add(new HocusFocusDetectedStar {
+                        HFR = hfr,
+                        Position = new Accord.Point((float)spec.X, (float)spec.Y),
+                        AverageBrightness = spec.AvgBrightness,
+                        MaxBrightness = spec.AvgBrightness * 2.0,
+                        Background = background,
+                        BoundingBox = new Rectangle((int)(spec.X - 5), (int)(spec.Y - 5), 10, 10)
+                    });
+                }
+
+                var result = new HocusFocusStarDetectionResult {
+                    StarList = starList,
+                    ImageSize = new Size(ImageWidth, ImageHeight)
+                };
+                frames.Add(new SensorDetectedStars(focuserPosition, result, image: null));
+            }
+            return frames;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorParaboloidDataTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorParaboloidDataTests.cs
@@ -98,8 +98,9 @@ public class SensorParaboloidModelExtraTests {
 
     [TestCase(null)]
     [TestCase(new double[] { 1, 2, 3 })]
-    [TestCase(new double[] { 1, 2, 3, 4, 5, 6, 7 })]
+    [TestCase(new double[] { 1, 2, 3, 4, 5, 6, 7, 8 })]
     public void FromArray_RejectsWrongShape(double[] input) {
+        // 6 elements (isotropic) and 7 elements (astigmatic) are the only valid shapes.
         var m = new SensorParaboloidModel();
         Assert.Throws<ArgumentException>(() => m.FromArray(input));
     }
@@ -119,7 +120,8 @@ public class SensorParaboloidModelExtraTests {
             Assert.That(s, Does.Contain("Z0="));
             Assert.That(s, Does.Contain("Gx="));
             Assert.That(s, Does.Contain("Gy="));
-            Assert.That(s, Does.Contain("K="));
+            Assert.That(s, Does.Contain("Kx="));
+            Assert.That(s, Does.Contain("Ky="));
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorParaboloidDataTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorParaboloidDataTests.cs
@@ -47,15 +47,25 @@ public class SensorParaboloidDataPointTests {
 public class SensorParaboloidModelExtraTests {
 
     [Test]
-    public void ParameterizedConstructor_StoresAllValues() {
-        var m = new SensorParaboloidModel(x0: 1, y0: 2, z0: 3, theta: 0.1, phi: 0.2, c: 0.05);
+    public void ParameterizedConstructor_StoresCanonicalValues() {
+        var m = new SensorParaboloidModel(x0: 1, y0: 2, z0: 3, gx: 0.1, gy: 0.2, k: 0.05);
         Assert.Multiple(() => {
             Assert.That(m.X0, Is.EqualTo(1));
             Assert.That(m.Y0, Is.EqualTo(2));
             Assert.That(m.Z0, Is.EqualTo(3));
-            Assert.That(m.Theta, Is.EqualTo(0.1));
-            Assert.That(m.Phi, Is.EqualTo(0.2));
-            Assert.That(m.C, Is.EqualTo(0.05));
+            Assert.That(m.Gx, Is.EqualTo(0.1));
+            Assert.That(m.Gy, Is.EqualTo(0.2));
+            Assert.That(m.K, Is.EqualTo(0.05));
+        });
+    }
+
+    [Test]
+    public void FromTiltCurvature_RoundTripsThroughDerivedDisplayProperties() {
+        var m = SensorParaboloidModel.FromTiltCurvature(x0: 1, y0: 2, z0: 3, theta: 0.1, phi: 0.2, c: 0.05);
+        Assert.Multiple(() => {
+            Assert.That(m.Theta, Is.EqualTo(0.1).Within(1e-9));
+            Assert.That(m.Phi, Is.EqualTo(0.2).Within(1e-9));
+            Assert.That(m.C, Is.EqualTo(0.05).Within(1e-9));
         });
     }
 
@@ -66,9 +76,9 @@ public class SensorParaboloidModelExtraTests {
             Assert.That(m.X0, Is.EqualTo(0));
             Assert.That(m.Y0, Is.EqualTo(0));
             Assert.That(m.Z0, Is.EqualTo(0));
-            Assert.That(m.Theta, Is.EqualTo(0));
-            Assert.That(m.Phi, Is.EqualTo(0));
-            Assert.That(m.C, Is.EqualTo(0));
+            Assert.That(m.Gx, Is.EqualTo(0));
+            Assert.That(m.Gy, Is.EqualTo(0));
+            Assert.That(m.K, Is.EqualTo(0));
         });
     }
 
@@ -80,9 +90,9 @@ public class SensorParaboloidModelExtraTests {
             Assert.That(m.X0, Is.EqualTo(1));
             Assert.That(m.Y0, Is.EqualTo(2));
             Assert.That(m.Z0, Is.EqualTo(3));
-            Assert.That(m.Theta, Is.EqualTo(4));
-            Assert.That(m.Phi, Is.EqualTo(5));
-            Assert.That(m.C, Is.EqualTo(6));
+            Assert.That(m.Gx, Is.EqualTo(4));
+            Assert.That(m.Gy, Is.EqualTo(5));
+            Assert.That(m.K, Is.EqualTo(6));
         });
     }
 
@@ -96,51 +106,51 @@ public class SensorParaboloidModelExtraTests {
 
     [Test]
     public void ToArray_ReturnsAllParametersInOrder() {
-        var m = new SensorParaboloidModel(x0: 1, y0: 2, z0: 3, theta: 0.4, phi: 0.5, c: 0.6);
+        var m = new SensorParaboloidModel(x0: 1, y0: 2, z0: 3, gx: 0.4, gy: 0.5, k: 0.6);
         Assert.That(m.ToArray(), Is.EqualTo(new[] { 1.0, 2.0, 3.0, 0.4, 0.5, 0.6 }));
     }
 
     [Test]
     public void ToString_ContainsAllParameterNames() {
-        var s = new SensorParaboloidModel(x0: 1, y0: 2, z0: 3, theta: 0.1, phi: 0.2, c: 0.05).ToString();
+        var s = new SensorParaboloidModel(x0: 1, y0: 2, z0: 3, gx: 0.1, gy: 0.2, k: 0.05).ToString();
         Assert.Multiple(() => {
             Assert.That(s, Does.Contain("X0="));
             Assert.That(s, Does.Contain("Y0="));
             Assert.That(s, Does.Contain("Z0="));
-            Assert.That(s, Does.Contain("Theta="));
-            Assert.That(s, Does.Contain("Phi="));
-            Assert.That(s, Does.Contain("C="));
+            Assert.That(s, Does.Contain("Gx="));
+            Assert.That(s, Does.Contain("Gy="));
+            Assert.That(s, Does.Contain("K="));
         });
     }
 
     [Test]
-    public void TiltAt_WithZeroTheta_IsZero() {
-        var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 0, theta: 0, phi: 0, c: 0);
+    public void TiltAt_WithZeroGradients_IsZero() {
+        var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 0, gx: 0, gy: 0, k: 0);
         Assert.That(m.TiltAt(100, 200), Is.EqualTo(0).Within(1e-12));
     }
 
     [Test]
     public void CurvatureAt_WithZeroCurvature_IsZero() {
-        var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 0, theta: 0, phi: 0, c: 0);
+        var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 0, gx: 0, gy: 0, k: 0);
         Assert.That(m.CurvatureAt(100, 200), Is.EqualTo(0).Within(1e-12));
     }
 
     [Test]
-    public void CurvatureAt_PositiveC_IsPositive() {
-        var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 0, theta: 0, phi: 0, c: 0.1);
-        // C2 = +0.01, x²+y² = 100, so result = 1
+    public void CurvatureAt_PositiveK_IsPositive() {
+        var m = SensorParaboloidModel.FromTiltCurvature(x0: 0, y0: 0, z0: 0, theta: 0, phi: 0, c: 0.1);
+        // K = +0.01, x²+y² = 100, so result = 1
         Assert.That(m.CurvatureAt(10, 0), Is.EqualTo(1.0).Within(1e-9));
     }
 
     [Test]
-    public void CurvatureAt_NegativeC_IsNegative() {
-        var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 0, theta: 0, phi: 0, c: -0.1);
+    public void CurvatureAt_NegativeK_IsNegative() {
+        var m = SensorParaboloidModel.FromTiltCurvature(x0: 0, y0: 0, z0: 0, theta: 0, phi: 0, c: -0.1);
         Assert.That(m.CurvatureAt(10, 0), Is.EqualTo(-1.0).Within(1e-9));
     }
 
     [Test]
     public void Volume_ScalesWithSensorArea() {
-        var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 5, theta: 0, phi: 0, c: 0);
+        var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 5, gx: 0, gy: 0, k: 0);
         // Z0 only contribution: Z0 * w * h = 5 * 1000 * 2000 = 10_000_000
         Assert.That(m.Volume(1000, 2000), Is.EqualTo(10_000_000.0).Within(1e-3));
     }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorParaboloidModelTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorParaboloidModelTests.cs
@@ -15,18 +15,18 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
             alglibAPI = new AlglibAPI();
         }
 
-        // SensorParaboloidModel z(x,y) = (x' cosφ + y' sinφ) tanθ + sign(c)c²·(x'² + y'²) + z0
-        // where x' = x - x0, y' = y - y0
+        // SensorParaboloidModel z(x,y) = Gx·x' + Gy·y' + K·(x'² + y'²) + z0, where x' = x - x0, y' = y - y0.
+        // Tilt/curvature display parameters: tanθ = hypot(Gx,Gy), φ = atan2(Gy,Gx), K = sign(c)·c².
         [Test]
         public void ValueAt_NoTiltNoCurvature_ReturnsZ0() {
-            var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 100, theta: 0, phi: 0, c: 0);
+            var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 100, gx: 0, gy: 0, k: 0);
             Assert.That(m.ValueAt(50, 50), Is.EqualTo(100).Within(1e-9));
         }
 
         [Test]
         public void ValueAt_PureCurvaturePositive_ReturnsZ0PlusCurvature() {
-            // c = 0.1 → C2 = 0.01; r² = 100 → ZPrime = 1
-            var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 100, theta: 0, phi: 0, c: 0.1);
+            // K = 0.01; r² = 100 → curvature = 1
+            var m = SensorParaboloidModel.FromTiltCurvature(x0: 0, y0: 0, z0: 100, theta: 0, phi: 0, c: 0.1);
             Assert.That(m.ValueAt(10, 0), Is.EqualTo(101.0).Within(1e-9));
             Assert.That(m.ValueAt(0, 10), Is.EqualTo(101.0).Within(1e-9));
             Assert.That(m.ValueAt(0, 0), Is.EqualTo(100.0).Within(1e-9));
@@ -34,10 +34,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
 
         [Test]
         public void ValueAt_NegativeCurvature_FlipsSign() {
-            var positive = new SensorParaboloidModel(x0: 0, y0: 0, z0: 100, theta: 0, phi: 0, c: 0.1);
-            var negative = new SensorParaboloidModel(x0: 0, y0: 0, z0: 100, theta: 0, phi: 0, c: -0.1);
+            var positive = SensorParaboloidModel.FromTiltCurvature(x0: 0, y0: 0, z0: 100, theta: 0, phi: 0, c: 0.1);
+            var negative = SensorParaboloidModel.FromTiltCurvature(x0: 0, y0: 0, z0: 100, theta: 0, phi: 0, c: -0.1);
 
-            // r² = 100, so positive curvature contributes +1, negative contributes -1
             Assert.Multiple(() => {
                 Assert.That(positive.ValueAt(10, 0), Is.EqualTo(101.0).Within(1e-9));
                 Assert.That(negative.ValueAt(10, 0), Is.EqualTo(99.0).Within(1e-9));
@@ -46,39 +45,56 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
 
         [Test]
         public void ValueAt_TiltAlongXOnly_AppliesLinearSlope() {
-            // φ = 0 → tilt direction along x. theta = atan(0.1) → tanθ = 0.1
-            var theta = Math.Atan(0.1);
-            var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 100, theta: theta, phi: 0, c: 0);
+            // Gx = 0.1, Gy = 0
+            var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 100, gx: 0.1, gy: 0, k: 0);
             Assert.Multiple(() => {
                 Assert.That(m.ValueAt(0, 0), Is.EqualTo(100.0).Within(1e-9));
                 Assert.That(m.ValueAt(10, 0), Is.EqualTo(101.0).Within(1e-9));
-                Assert.That(m.ValueAt(0, 10), Is.EqualTo(100.0).Within(1e-9)); // sin(0) = 0
+                Assert.That(m.ValueAt(0, 10), Is.EqualTo(100.0).Within(1e-9));
             });
         }
 
         [Test]
-        public void TiltAt_IsValueAtMinusZ0AndCurvature() {
-            var theta = Math.Atan(0.1);
-            var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 100, theta: theta, phi: 0, c: 0);
+        public void TiltAt_LinearInGradients() {
+            var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 100, gx: 0.1, gy: 0, k: 0);
             Assert.That(m.TiltAt(15, 7), Is.EqualTo(1.5).Within(1e-9));
         }
 
         [Test]
-        public void CurvatureAt_PureCurvature_ReturnsCSquaredTimesRSquared() {
-            var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 0, theta: 0, phi: 0, c: 0.2);
-            // r² = 4² + 3² = 25, c² = 0.04 → 1.0
+        public void DerivedThetaPhi_RecoverTiltAngleAndAzimuth() {
+            var m = SensorParaboloidModel.FromTiltCurvature(x0: 0, y0: 0, z0: 0, theta: 0.2, phi: 0.6, c: 0.0);
+            Assert.Multiple(() => {
+                Assert.That(m.Theta, Is.EqualTo(0.2).Within(1e-9));
+                Assert.That(m.Phi, Is.EqualTo(0.6).Within(1e-9));
+            });
+        }
+
+        [Test]
+        public void DerivedC_RecoversSignedCurvature() {
+            var pos = SensorParaboloidModel.FromTiltCurvature(x0: 0, y0: 0, z0: 0, theta: 1e-6, phi: 0, c: 0.05);
+            var neg = SensorParaboloidModel.FromTiltCurvature(x0: 0, y0: 0, z0: 0, theta: 1e-6, phi: 0, c: -0.05);
+            Assert.Multiple(() => {
+                Assert.That(pos.C, Is.EqualTo(0.05).Within(1e-9));
+                Assert.That(neg.C, Is.EqualTo(-0.05).Within(1e-9));
+            });
+        }
+
+        [Test]
+        public void CurvatureAt_PureCurvature_ReturnsKTimesRSquared() {
+            var m = SensorParaboloidModel.FromTiltCurvature(x0: 0, y0: 0, z0: 0, theta: 0, phi: 0, c: 0.2);
+            // K = 0.04, r² = 25 → 1.0
             Assert.That(m.CurvatureAt(4, 3), Is.EqualTo(1.0).Within(1e-9));
         }
 
         [Test]
         public void CurvatureAt_NegativeC_ReturnsNegativeSquaredCurvature() {
-            var m = new SensorParaboloidModel(x0: 0, y0: 0, z0: 0, theta: 0, phi: 0, c: -0.2);
+            var m = SensorParaboloidModel.FromTiltCurvature(x0: 0, y0: 0, z0: 0, theta: 0, phi: 0, c: -0.2);
             Assert.That(m.CurvatureAt(4, 3), Is.EqualTo(-1.0).Within(1e-9));
         }
 
         [Test]
-        public void ToArray_FromArray_RoundTrip() {
-            var original = new SensorParaboloidModel(x0: 1.1, y0: 2.2, z0: 3.3, theta: 0.4, phi: 0.5, c: 0.6);
+        public void ToArray_FromArray_RoundTripsCanonicalParameters() {
+            var original = new SensorParaboloidModel(x0: 1.1, y0: 2.2, z0: 3.3, gx: 0.01, gy: -0.02, k: 5e-4);
             var clone = new SensorParaboloidModel();
             clone.FromArray(original.ToArray());
 
@@ -86,9 +102,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
                 Assert.That(clone.X0, Is.EqualTo(1.1));
                 Assert.That(clone.Y0, Is.EqualTo(2.2));
                 Assert.That(clone.Z0, Is.EqualTo(3.3));
-                Assert.That(clone.Theta, Is.EqualTo(0.4));
-                Assert.That(clone.Phi, Is.EqualTo(0.5));
-                Assert.That(clone.C, Is.EqualTo(0.6));
+                Assert.That(clone.Gx, Is.EqualTo(0.01));
+                Assert.That(clone.Gy, Is.EqualTo(-0.02));
+                Assert.That(clone.K, Is.EqualTo(5e-4));
             });
         }
 
@@ -98,47 +114,231 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
             Assert.Throws<ArgumentException>(() => m.FromArray(new double[] { 1, 2, 3 }));
         }
 
-        [Test]
-        public void Solver_OnSyntheticParaboloid_RecoversCurvatureAndTilt() {
-            const double trueX0 = 0;
-            const double trueY0 = 0;
-            const double trueZ0 = 1000;
-            const double truePhi = 0;
-            var trueTheta = Math.Atan(0.001); // gentle tilt
-            const double trueC = 5e-4;
-
-            var truth = new SensorParaboloidModel(
-                x0: trueX0, y0: trueY0, z0: trueZ0,
-                theta: trueTheta, phi: truePhi, c: trueC);
-
-            // Sample on a 5x5 grid spanning ±1000 microns
+        private static List<SensorParaboloidDataPoint> SampleGrid(SensorParaboloidModel truth, int half = 2, double step = 500, double span = 1000, Func<double, double> perturb = null) {
             var pts = new List<SensorParaboloidDataPoint>();
-            for (var iy = -2; iy <= 2; ++iy) {
-                for (var ix = -2; ix <= 2; ++ix) {
-                    double x = ix * 500;
-                    double y = iy * 500;
+            for (var iy = -half; iy <= half; ++iy) {
+                for (var ix = -half; ix <= half; ++ix) {
+                    double x = ix * step;
+                    double y = iy * step;
                     var z = truth.ValueAt(x, y);
+                    if (perturb != null) {
+                        z += perturb(x + y);
+                    }
                     pts.Add(new SensorParaboloidDataPoint(x: x, y: y, focuserPosition: z, rSquared: 0.99));
                 }
             }
+            return pts;
+        }
 
+        private NonLinearLeastSquaresSolver<SensorParaboloidSolver, SensorParaboloidDataPoint, SensorParaboloidModel> SolveModel(
+            List<SensorParaboloidDataPoint> pts, out SensorParaboloidModel result, double sensorHalf = 4000) {
             var solver = new SensorParaboloidSolver(
                 dataPoints: pts,
-                sensorSizeMicronsX: 4000,
-                sensorSizeMicronsY: 4000,
-                inFocusMicrons: trueZ0,
-                fixedSensorCenter: true) {
-                PositiveCurvature = true
-            };
+                sensorSizeMicronsX: sensorHalf * 2,
+                sensorSizeMicronsY: sensorHalf * 2,
+                inFocusMicrons: 1000,
+                fixedSensorCenter: true);
             var nlls = new NonLinearLeastSquaresSolver<SensorParaboloidSolver, SensorParaboloidDataPoint, SensorParaboloidModel>(alglibAPI);
-            var result = nlls.Solve(solver, tolerance: 1e-10);
+            result = nlls.Solve(solver, tolerance: 1e-12);
+            return nlls;
+        }
+
+        [Test]
+        public void Solver_PositiveCurvature_RecoversCurvatureAndTilt() {
+            var truth = new SensorParaboloidModel(x0: 0, y0: 0, z0: 1000, gx: 0.001, gy: 0.0, k: 5e-7);
+            var pts = SampleGrid(truth);
+
+            SolveModel(pts, out var result);
 
             Assert.Multiple(() => {
-                Assert.That(result.Z0, Is.EqualTo(trueZ0).Within(1.0));
-                // Curvature recovery — sign-and-magnitude
-                Assert.That(Math.Abs(result.C), Is.EqualTo(Math.Abs(trueC)).Within(1e-4));
-                Assert.That(Math.Sign(result.C), Is.EqualTo(Math.Sign(trueC)));
+                Assert.That(result.Z0, Is.EqualTo(1000).Within(1.0));
+                Assert.That(result.Gx, Is.EqualTo(0.001).Within(1e-5));
+                Assert.That(result.K, Is.EqualTo(5e-7).Within(1e-8));
             });
+        }
+
+        [Test]
+        public void Solver_NegativeCurvature_RecoversSignWithoutDoubleSolve() {
+            // The single signed-K solve must recover negative curvature directly.
+            var truth = new SensorParaboloidModel(x0: 0, y0: 0, z0: 1000, gx: 0.0, gy: 0.002, k: -8e-7);
+            var pts = SampleGrid(truth);
+
+            SolveModel(pts, out var result);
+
+            Assert.Multiple(() => {
+                Assert.That(result.Gy, Is.EqualTo(0.002).Within(1e-5));
+                Assert.That(result.K, Is.EqualTo(-8e-7).Within(1e-8));
+                Assert.That(Math.Sign(result.K), Is.EqualTo(-1));
+            });
+        }
+
+        [Test]
+        public void Solver_FlatField_HandlesZeroCurvatureWithoutSingularity() {
+            // k ≈ 0 was the discontinuity case for the old sign(c)·c² parameterization. The signed-K
+            // single solve must handle a flat field cleanly and return near-zero curvature/tilt.
+            var truth = new SensorParaboloidModel(x0: 0, y0: 0, z0: 1000, gx: 0.0, gy: 0.0, k: 0.0);
+            var pts = SampleGrid(truth);
+
+            SolveModel(pts, out var result);
+
+            Assert.Multiple(() => {
+                Assert.That(result.Z0, Is.EqualTo(1000).Within(1e-3));
+                Assert.That(result.K, Is.EqualTo(0.0).Within(1e-9));
+                Assert.That(result.Gx, Is.EqualTo(0.0).Within(1e-6));
+                Assert.That(result.Gy, Is.EqualTo(0.0).Within(1e-6));
+            });
+        }
+
+        // ---- χ² acceptance statistic ----
+
+        private static Func<double, double> GaussianNoise(int seed, double sigma) {
+            var rng = new Random(seed);
+            return _ => {
+                // Box-Muller
+                double u1 = 1.0 - rng.NextDouble();
+                double u2 = 1.0 - rng.NextDouble();
+                return sigma * Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Cos(2.0 * Math.PI * u2);
+            };
+        }
+
+        private List<SensorParaboloidDataPoint> NoisyGrid(SensorParaboloidModel truth, double sigma, double declaredSigma, int seed, int half = 7, double step = 700) {
+            var noise = GaussianNoise(seed, sigma);
+            var pts = new List<SensorParaboloidDataPoint>();
+            for (var iy = -half; iy <= half; ++iy) {
+                for (var ix = -half; ix <= half; ++ix) {
+                    double x = ix * step;
+                    double y = iy * step;
+                    var z = truth.ValueAt(x, y) + noise(0);
+                    pts.Add(new SensorParaboloidDataPoint(x: x, y: y, focuserPosition: z, rSquared: 0.99, focuserPositionStdDev: declaredSigma));
+                }
+            }
+            return pts;
+        }
+
+        [Test]
+        public void ReducedChiSquared_WithCorrectlyDeclaredSigma_IsApproximatelyOne() {
+            var truth = new SensorParaboloidModel(x0: 0, y0: 0, z0: 1000, gx: 0.003, gy: -0.001, k: 1e-7);
+            const double sigma = 2.0;
+            var pts = NoisyGrid(truth, sigma: sigma, declaredSigma: sigma, seed: 4242);
+
+            var nlls = SolveModel(pts, out var result, sensorHalf: 6000);
+            var reducedChiSq = nlls.ReducedChiSquared(nlls.Solver, result);
+
+            // dof ≈ 225 - 6, so the standard deviation of reduced χ² ≈ sqrt(2/dof) ≈ 0.10; ±0.4 is generous.
+            Assert.That(reducedChiSq, Is.EqualTo(1.0).Within(0.4));
+        }
+
+        [Test]
+        public void ReducedChiSquared_ScalesQuadraticallyWithMisstatedSigma() {
+            // Declaring 2x the true sigma must divide reduced χ² by 4 (uniform sigma ⇒ identical fit/residuals).
+            var truth = new SensorParaboloidModel(x0: 0, y0: 0, z0: 1000, gx: 0.003, gy: -0.001, k: 1e-7);
+            const double sigma = 2.0;
+
+            var ptsCorrect = NoisyGrid(truth, sigma: sigma, declaredSigma: sigma, seed: 99);
+            var ptsDoubled = NoisyGrid(truth, sigma: sigma, declaredSigma: 2.0 * sigma, seed: 99);
+
+            // Fit once (correct σ), then evaluate that SAME model under both weightings so the residuals
+            // are identical and only the 1/σ weighting differs — isolating the quadratic σ dependence.
+            var nllsCorrect = SolveModel(ptsCorrect, out var model, sensorHalf: 6000);
+            var nllsDoubled = SolveModel(ptsDoubled, out _, sensorHalf: 6000); // initializes the 1/(2σ) weights
+
+            var chiCorrect = nllsCorrect.ChiSquared(nllsCorrect.Solver, model);
+            var chiDoubled = nllsDoubled.ChiSquared(nllsDoubled.Solver, model);
+            Assert.That(chiCorrect / chiDoubled, Is.EqualTo(4.0).Within(1e-9));
+        }
+
+        [Test]
+        public void ReducedChiSquared_IsMagnitudeIndependentWhereR2IsNot() {
+            // Same residual noise, two very different tilt magnitudes. Reduced χ² depends only on residuals
+            // vs σ (so both ≈ 1), but R² inflates with signal magnitude — the exact reason R² is a poor,
+            // non-repeatable acceptance metric and reduced χ² replaces it.
+            const double sigma = 2.0;
+            var nearlyFlat = new SensorParaboloidModel(x0: 0, y0: 0, z0: 1000, gx: 1e-5, gy: 0, k: 0);
+            var stronglyTilted = new SensorParaboloidModel(x0: 0, y0: 0, z0: 1000, gx: 2e-2, gy: 0, k: 0);
+
+            var flatPts = NoisyGrid(nearlyFlat, sigma: sigma, declaredSigma: sigma, seed: 7);
+            var tiltedPts = NoisyGrid(stronglyTilted, sigma: sigma, declaredSigma: sigma, seed: 7);
+
+            var nllsFlat = SolveModel(flatPts, out var flatResult, sensorHalf: 6000);
+            var nllsTilted = SolveModel(tiltedPts, out var tiltedResult, sensorHalf: 6000);
+
+            var flatReduced = nllsFlat.ReducedChiSquared(nllsFlat.Solver, flatResult);
+            var tiltedReduced = nllsTilted.ReducedChiSquared(nllsTilted.Solver, tiltedResult);
+            // Solve() does not populate the model's display stats, so query R² via the solver.
+            var flatR2 = nllsFlat.GoodnessOfFit(nllsFlat.Solver, flatResult);
+            var tiltedR2 = nllsTilted.GoodnessOfFit(nllsTilted.Solver, tiltedResult);
+
+            Assert.Multiple(() => {
+                // Reduced χ² ~ 1 for both, regardless of signal magnitude.
+                Assert.That(flatReduced, Is.EqualTo(1.0).Within(0.4));
+                Assert.That(tiltedReduced, Is.EqualTo(1.0).Within(0.4));
+                Assert.That(Math.Abs(flatReduced - tiltedReduced), Is.LessThan(0.4));
+                // R² collapses on the near-flat field but is near 1 for the strongly tilted one.
+                Assert.That(flatR2, Is.LessThan(0.5));
+                Assert.That(tiltedR2, Is.GreaterThan(0.95));
+            });
+        }
+
+        /// <summary>
+        /// Composite Simpson 2D integration of an arbitrary surface over [-w/2,w/2] x [-h/2,h/2].
+        /// Simpson is exact for polynomials up to degree 3 per axis, and the paraboloid surface is
+        /// degree 2 in x and y, so this is an exact, parameterization-independent oracle for Volume().
+        /// </summary>
+        private static double SimpsonIntegrate2D(Func<double, double, double> f, double w, double h, int n = 8) {
+            if (n % 2 != 0) {
+                throw new ArgumentException("n must be even");
+            }
+            double ax = -w / 2.0, ay = -h / 2.0;
+            double dx = w / n, dy = h / n;
+
+            double SimpsonWeight(int i) => (i == 0 || i == n) ? 1.0 : (i % 2 == 1 ? 4.0 : 2.0);
+
+            double total = 0.0;
+            for (int i = 0; i <= n; i++) {
+                double x = ax + i * dx;
+                double wx = SimpsonWeight(i);
+                for (int j = 0; j <= n; j++) {
+                    double y = ay + j * dy;
+                    double wy = SimpsonWeight(j);
+                    total += wx * wy * f(x, y);
+                }
+            }
+            return total * dx * dy / 9.0;
+        }
+
+        [Test]
+        public void Volume_MatchesNumericalIntegralOfValueAt_WithOffsetCenter() {
+            // Nonzero Y0 (and X0) with nonzero curvature is exactly the case the Y0+Y0 vs Y0*Y0 bug
+            // got wrong: it only manifests when the curvature center is offset in Y.
+            var model = SensorParaboloidModel.FromTiltCurvature(x0: 1500.0, y0: -900.0, z0: 25000.0, theta: 0.01, phi: 0.7, c: 0.05);
+            double w = 23000.0, h = 16000.0;
+
+            var analytic = model.Volume(w, h);
+            var numeric = SimpsonIntegrate2D((x, y) => model.ValueAt(x, y), w, h);
+
+            Assert.That(analytic, Is.EqualTo(numeric).Within(Math.Abs(numeric) * 1e-9 + 1e-3));
+        }
+
+        [Test]
+        public void Volume_MatchesNumericalIntegralOfValueAt_FlatTiltedField() {
+            var model = SensorParaboloidModel.FromTiltCurvature(x0: 0.0, y0: 0.0, z0: 10000.0, theta: 0.02, phi: 1.2, c: 1e-6);
+            double w = 20000.0, h = 13000.0;
+
+            var analytic = model.Volume(w, h);
+            var numeric = SimpsonIntegrate2D((x, y) => model.ValueAt(x, y), w, h);
+
+            Assert.That(analytic, Is.EqualTo(numeric).Within(Math.Abs(numeric) * 1e-9 + 1e-3));
+        }
+
+        [Test]
+        public void Volume_OffsetCenterCurvature_IsSymmetricInY0() {
+            // Regression guard for the specific bug: with X0 = 0 and no tilt, the only Y-center contribution
+            // to the curvature volume is Y0², so the volume must be symmetric about Y0 = 0.
+            var pos = SensorParaboloidModel.FromTiltCurvature(x0: 0.0, y0: 800.0, z0: 0.0, theta: 1e-6, phi: 0.0, c: 0.05);
+            var neg = SensorParaboloidModel.FromTiltCurvature(x0: 0.0, y0: -800.0, z0: 0.0, theta: 1e-6, phi: 0.0, c: 0.05);
+            double w = 10000.0, h = 10000.0;
+
+            Assert.That(pos.Volume(w, h), Is.EqualTo(neg.Volume(w, h)).Within(1e-6));
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorParaboloidModelTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorParaboloidModelTests.cs
@@ -204,6 +204,40 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
         }
 
         [Test]
+        public void Solver_WeightedFit_AnalyticJacobianMatchesWeightedResiduals() {
+            // Regression: the analytic Jacobian must carry the same per-point 1/σ weight as the residuals.
+            // With non-uniform σ, an unweighted Jacobian is inconsistent with the weighted residual function;
+            // OptGuard (analytic-vs-numerical gradient check) throws OptGuardBadGradientException when that
+            // happens. Uniform-σ fits would not expose the bug, so the σ here are deliberately varied.
+            var truth = new SensorParaboloidModel(x0: 0, y0: 0, z0: 1000, gx: 0.001, gy: -0.0005, k: 3e-7);
+            var pts = new List<SensorParaboloidDataPoint>();
+            int idx = 0;
+            for (var iy = -2; iy <= 2; ++iy) {
+                for (var ix = -2; ix <= 2; ++ix) {
+                    double x = ix * 500, y = iy * 500;
+                    double sigma = 1.0 + (idx % 5) * 10.0;
+                    pts.Add(new SensorParaboloidDataPoint(x: x, y: y, focuserPosition: truth.ValueAt(x, y), rSquared: 0.99, focuserPositionStdDev: sigma));
+                    ++idx;
+                }
+            }
+
+            var solver = new SensorParaboloidSolver(
+                dataPoints: pts, sensorSizeMicronsX: 8000, sensorSizeMicronsY: 8000,
+                inFocusMicrons: 1000, fixedSensorCenter: true);
+            var nlls = new NonLinearLeastSquaresSolver<SensorParaboloidSolver, SensorParaboloidDataPoint, SensorParaboloidModel>(alglibAPI) {
+                OptGuardEnabled = true
+            };
+
+            SensorParaboloidModel result = null;
+            Assert.DoesNotThrow(() => result = nlls.Solve(solver, tolerance: 1e-12));
+            Assert.Multiple(() => {
+                Assert.That(result.Gx, Is.EqualTo(0.001).Within(1e-5));
+                Assert.That(result.Gy, Is.EqualTo(-0.0005).Within(1e-5));
+                Assert.That(result.K, Is.EqualTo(3e-7).Within(1e-8));
+            });
+        }
+
+        [Test]
         public void Astigmatic_Solver_RecoversIndependentKxKy() {
             // A saddle-shaped field (Kx and Ky of opposite sign) cannot be represented by the isotropic
             // single-K model; the astigmatic 7-parameter solve must recover both coefficients.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorParaboloidModelTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorParaboloidModelTests.cs
@@ -143,6 +143,20 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
             return nlls;
         }
 
+        private NonLinearLeastSquaresSolver<SensorParaboloidSolver, SensorParaboloidDataPoint, SensorParaboloidModel> SolveModelAstigmatic(
+            List<SensorParaboloidDataPoint> pts, out SensorParaboloidModel result, double sensorHalf = 4000) {
+            var solver = new SensorParaboloidSolver(
+                dataPoints: pts,
+                sensorSizeMicronsX: sensorHalf * 2,
+                sensorSizeMicronsY: sensorHalf * 2,
+                inFocusMicrons: 1000,
+                fixedSensorCenter: true,
+                astigmatic: true);
+            var nlls = new NonLinearLeastSquaresSolver<SensorParaboloidSolver, SensorParaboloidDataPoint, SensorParaboloidModel>(alglibAPI);
+            result = nlls.Solve(solver, tolerance: 1e-12);
+            return nlls;
+        }
+
         [Test]
         public void Solver_PositiveCurvature_RecoversCurvatureAndTilt() {
             var truth = new SensorParaboloidModel(x0: 0, y0: 0, z0: 1000, gx: 0.001, gy: 0.0, k: 5e-7);
@@ -187,6 +201,88 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
                 Assert.That(result.Gx, Is.EqualTo(0.0).Within(1e-6));
                 Assert.That(result.Gy, Is.EqualTo(0.0).Within(1e-6));
             });
+        }
+
+        [Test]
+        public void Astigmatic_Solver_RecoversIndependentKxKy() {
+            // A saddle-shaped field (Kx and Ky of opposite sign) cannot be represented by the isotropic
+            // single-K model; the astigmatic 7-parameter solve must recover both coefficients.
+            var truth = new SensorParaboloidModel(x0: 0, y0: 0, z0: 1000, gx: 0.001, gy: -0.0005, kx: 6e-7, ky: -4e-7);
+            var pts = SampleGrid(truth);
+
+            SolveModelAstigmatic(pts, out var result);
+
+            Assert.Multiple(() => {
+                Assert.That(result.Astigmatic, Is.True);
+                Assert.That(result.Z0, Is.EqualTo(1000).Within(1.0));
+                Assert.That(result.Gx, Is.EqualTo(0.001).Within(1e-5));
+                Assert.That(result.Gy, Is.EqualTo(-0.0005).Within(1e-5));
+                Assert.That(result.Kx, Is.EqualTo(6e-7).Within(1e-8));
+                Assert.That(result.Ky, Is.EqualTo(-4e-7).Within(1e-8));
+            });
+        }
+
+        [Test]
+        public void Astigmatic_IsotropicData_RecoversEqualKxKy() {
+            // Fed isotropic data, the astigmatic solver must still converge with Kx ≈ Ky (no spurious split).
+            var truth = new SensorParaboloidModel(x0: 0, y0: 0, z0: 1000, gx: 0.0, gy: 0.0, k: 5e-7);
+            var pts = SampleGrid(truth);
+
+            SolveModelAstigmatic(pts, out var result);
+
+            Assert.Multiple(() => {
+                Assert.That(result.Kx, Is.EqualTo(5e-7).Within(1e-8));
+                Assert.That(result.Ky, Is.EqualTo(5e-7).Within(1e-8));
+                Assert.That(result.Kx, Is.EqualTo(result.Ky).Within(1e-8));
+            });
+        }
+
+        [Test]
+        public void Astigmatic_ToArrayFromArray_RoundTripsSevenParameters() {
+            var model = new SensorParaboloidModel(x0: 10, y0: -20, z0: 1234, gx: 0.003, gy: -0.002, kx: 7e-7, ky: -3e-7);
+            var array = model.ToArray();
+
+            Assert.That(array.Length, Is.EqualTo(7));
+
+            var roundTripped = new SensorParaboloidModel();
+            roundTripped.FromArray(array);
+
+            Assert.Multiple(() => {
+                Assert.That(roundTripped.Astigmatic, Is.True);
+                Assert.That(roundTripped.Kx, Is.EqualTo(7e-7));
+                Assert.That(roundTripped.Ky, Is.EqualTo(-3e-7));
+                Assert.That(roundTripped.K, Is.EqualTo(0.5 * (7e-7 + -3e-7)));
+            });
+        }
+
+        [Test]
+        public void Isotropic_ToArray_RemainsSixParameters() {
+            // Guards the default path: isotropic models must continue to emit a 6-element array so the
+            // 6-parameter solve and all existing behaviour are unchanged.
+            var model = new SensorParaboloidModel(x0: 0, y0: 0, z0: 1000, gx: 0.001, gy: 0.0, k: 5e-7);
+
+            Assert.That(model.ToArray().Length, Is.EqualTo(6));
+            Assert.That(model.Astigmatic, Is.False);
+            Assert.That(model.Kx, Is.EqualTo(model.Ky));
+        }
+
+        [Test]
+        public void CurvatureAt_Astigmatic_UsesSeparateKxKy() {
+            var model = new SensorParaboloidModel(x0: 0, y0: 0, z0: 0, gx: 0.0, gy: 0.0, kx: 2e-6, ky: 5e-6);
+
+            // Kx·x² + Ky·y²
+            Assert.That(model.CurvatureAt(100.0, 200.0), Is.EqualTo(2e-6 * 100.0 * 100.0 + 5e-6 * 200.0 * 200.0).Within(1e-12));
+        }
+
+        [Test]
+        public void Volume_Astigmatic_MatchesNumericalIntegral() {
+            var model = new SensorParaboloidModel(x0: 1500.0, y0: -900.0, z0: 25000.0, gx: 0.004, gy: -0.002, kx: 6e-7, ky: -3e-7);
+            double w = 23000.0, h = 16000.0;
+
+            var analytic = model.Volume(w, h);
+            var numeric = SimpsonIntegrate2D((x, y) => model.ValueAt(x, y), w, h);
+
+            Assert.That(analytic, Is.EqualTo(numeric).Within(Math.Abs(numeric) * 1e-9 + 1e-3));
         }
 
         // ---- χ² acceptance statistic ----

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/HyperbolicFittingAlglibTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/HyperbolicFittingAlglibTests.cs
@@ -119,6 +119,44 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
         }
 
         [Test]
+        public void MinimumStdError_NoiselessFit_IsFiniteAndSmall() {
+            var pts = SyntheticFocusCurveSamples.SymmetricHyperbolaPoints(
+                x0: 5000, y0: 0.0, a: 2.0, b: 80.0,
+                xStart: 4800, xStep: 25, count: 17);
+            var fit = HyperbolicFittingAlglib.Create(alglibAPI, pts, useWeights: false);
+            Assert.That(fit.Solve(), Is.True);
+
+            Assert.Multiple(() => {
+                Assert.That(double.IsNaN(fit.MinimumStdError), Is.False);
+                Assert.That(fit.MinimumStdError, Is.GreaterThanOrEqualTo(0.0));
+                // Perfect data ⇒ the best-focus position is essentially exactly determined.
+                Assert.That(fit.MinimumStdError, Is.LessThan(1.0));
+            });
+        }
+
+        [Test]
+        public void MinimumStdError_NoisyFit_IsPositiveAndFinite() {
+            var clean = SyntheticFocusCurveSamples.SymmetricHyperbolaPoints(
+                x0: 5000, y0: 0.0, a: 2.0, b: 80.0,
+                xStart: 4700, xStep: 25, count: 25);
+            var rng = new System.Random(13);
+            var noisy = new System.Collections.Generic.List<OxyPlot.Series.ScatterErrorPoint>();
+            foreach (var p in clean) {
+                var n = (rng.NextDouble() - 0.5) * 0.4; // ~±0.2 HFR noise
+                noisy.Add(new OxyPlot.Series.ScatterErrorPoint(p.X, p.Y + n, 0, 1.0));
+            }
+
+            var fit = HyperbolicFittingAlglib.Create(alglibAPI, noisy, useWeights: false);
+            Assert.That(fit.Solve(), Is.True);
+
+            Assert.Multiple(() => {
+                Assert.That(double.IsNaN(fit.MinimumStdError), Is.False);
+                Assert.That(double.IsInfinity(fit.MinimumStdError), Is.False);
+                Assert.That(fit.MinimumStdError, Is.GreaterThan(0.0));
+            });
+        }
+
+        [Test]
         public void Minimum_AtMinimumXValue_EqualsAPlusY0() {
             var pts = SyntheticFocusCurveSamples.SymmetricHyperbolaPoints(
                 x0: 5000, y0: 1.5, a: 2.0, b: 80.0,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/RANSACRegistrationTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/RANSACRegistrationTests.cs
@@ -51,6 +51,20 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Utility {
         }
 
         [Test]
+        public void SimilarityTransform_ToMatrix3x2_ProducesIdenticalPointMapping() {
+            var t = new SimilarityTransform(scale: 1.5, rotation: 0.3, tx: 10.0, ty: -4.0);
+            var m = t.ToMatrix3x2();
+            foreach (var p in new[] { new Point2D(7.0, 11.0), new Point2D(-3.0, 2.0), new Point2D(0.0, 0.0) }) {
+                var viaT = t.Transform(p);
+                var viaM = m.Transform(p);
+                Assert.Multiple(() => {
+                    Assert.That(viaM.X, Is.EqualTo(viaT.X).Within(1e-9));
+                    Assert.That(viaM.Y, Is.EqualTo(viaT.Y).Within(1e-9));
+                });
+            }
+        }
+
+        [Test]
         public void Matrix3x2_Identity_LeavesPointsUnchanged() {
             var m = Matrix3x2.Identity;
             var p = new Point2D(2.5, -3.5);
@@ -309,6 +323,79 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Utility {
                 img, refStars, maxDistance: 5.0, relativeBrightnessDiff: 0.1, status: null);
             Assert.That(src.Count, Is.EqualTo(0));
             Assert.That(dst.Count, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Builds a deterministic set of correspondences: <paramref name="inlierCount"/> points mapped by a
+        /// known similarity transform with sub-pixel noise (well within the inlier threshold), plus a few
+        /// gross outliers. The test RNG is fixed-seed so the data itself is identical every run.
+        /// </summary>
+        private static (List<Point2D> src, List<Point2D> dst) BuildNoisyCorrespondences(
+            double scale, double rotation, double tx, double ty, int inlierCount = 30) {
+            var rng = new Random(20240526);
+            var truth = new SimilarityTransform(scale, rotation, tx, ty);
+            var src = new List<Point2D>();
+            var dst = new List<Point2D>();
+            for (int i = 0; i < inlierCount; i++) {
+                var p = new Point2D(rng.NextDouble() * 1000.0, rng.NextDouble() * 1000.0);
+                var t = truth.Transform(p);
+                // Sub-pixel noise (|d| < 0.25px) keeps every point inside the 3px inlier threshold.
+                src.Add(p);
+                dst.Add(new Point2D(t.X + (rng.NextDouble() - 0.5) * 0.5, t.Y + (rng.NextDouble() - 0.5) * 0.5));
+            }
+            // Gross outliers RANSAC must reject.
+            src.Add(new Point2D(500, 500)); dst.Add(new Point2D(5, 990));
+            src.Add(new Point2D(100, 900)); dst.Add(new Point2D(950, 30));
+            return (src, dst);
+        }
+
+        [Test]
+        public void EstimateSimilarityTransform_RecoversKnownTransform() {
+            double scale = 1.0, rotation = 0.05, tx = 12.0, ty = -7.0;
+            var (src, dst) = BuildNoisyCorrespondences(scale, rotation, tx, ty);
+
+            var result = RANSACRegistration.EstimateSimilarityTransform(src, dst, status: null, progress: null);
+
+            Assert.Multiple(() => {
+                Assert.That(result.Scale, Is.EqualTo(scale).Within(0.01));
+                Assert.That(result.Rotation, Is.EqualTo(rotation).Within(0.01));
+                Assert.That(result.Tx, Is.EqualTo(tx).Within(1.0));
+                Assert.That(result.Ty, Is.EqualTo(ty).Within(1.0));
+            });
+        }
+
+        [Test]
+        public void EstimateSimilarityTransform_FixedSeed_IsBitForBitDeterministic() {
+            var (src, dst) = BuildNoisyCorrespondences(1.0, 0.05, 12.0, -7.0);
+
+            // Small maxIterations forces the seeded subsampling path (fewer samples than candidate pairs),
+            // which is exactly where the old shared unseeded RNG produced run-to-run variation.
+            var a = RANSACRegistration.EstimateSimilarityTransform(src, dst, null, null, maxIterations: 8);
+            var b = RANSACRegistration.EstimateSimilarityTransform(src, dst, null, null, maxIterations: 8);
+
+            Assert.Multiple(() => {
+                Assert.That(a.Scale, Is.EqualTo(b.Scale));
+                Assert.That(a.Rotation, Is.EqualTo(b.Rotation));
+                Assert.That(a.Tx, Is.EqualTo(b.Tx));
+                Assert.That(a.Ty, Is.EqualTo(b.Ty));
+            });
+        }
+
+        [Test]
+        public void EstimateAffineTransform_FixedSeed_IsBitForBitDeterministic() {
+            var (src, dst) = BuildNoisyCorrespondences(1.0, 0.05, 12.0, -7.0);
+
+            var a = RANSACRegistration.EstimateAffineTransform(src, dst, null, null, maxIterations: 8);
+            var b = RANSACRegistration.EstimateAffineTransform(src, dst, null, null, maxIterations: 8);
+
+            Assert.Multiple(() => {
+                Assert.That(a.M11, Is.EqualTo(b.M11));
+                Assert.That(a.M12, Is.EqualTo(b.M12));
+                Assert.That(a.M21, Is.EqualTo(b.M21));
+                Assert.That(a.M22, Is.EqualTo(b.M22));
+                Assert.That(a.M31, Is.EqualTo(b.M31));
+                Assert.That(a.M32, Is.EqualTo(b.M32));
+            });
         }
 
         [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/RANSACRegistrationTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/RANSACRegistrationTests.cs
@@ -1,3 +1,4 @@
+using NINA.Core.Model;
 using NINA.Joko.Plugins.HocusFocus.Utility;
 using NUnit.Framework;
 using System;
@@ -414,6 +415,111 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Utility {
                 searchSquareSide: 250, onePerPoint: true, isReference: true);
             // We have two well-separated clusters of three; we expect at most 2 triangles.
             Assert.That(triangles.Count, Is.LessThanOrEqualTo(2));
+        }
+
+        // ---- Similarity-invariant shape descriptor + KdTree triangle matching ----
+
+        private static readonly System.Drawing.Size MatchImageSize = new System.Drawing.Size(2000, 2000);
+
+        private static RANSACRegistration.StarTriangle Tri(
+            (double X, double Y) a, (double X, double Y) b, (double X, double Y) c,
+            bool isReference = false, int referenceID = 0,
+            double ba = 0.5, double bb = 0.5, double bc = 0.5) {
+            return new RANSACRegistration.StarTriangle(
+                MatchImageSize, minBrightness: 0.0, maxBrightness: 1.0,
+                p1: new Point2D(a.X, a.Y, ba),
+                p2: new Point2D(b.X, b.Y, bb),
+                p3: new Point2D(c.X, c.Y, bc),
+                isReference: isReference, referenceID: referenceID);
+        }
+
+        private static (double X, double Y) SimilarityMap((double X, double Y) p, double scale, double thetaRad, double tx, double ty) {
+            var cos = Math.Cos(thetaRad);
+            var sin = Math.Sin(thetaRad);
+            return (scale * (cos * p.X - sin * p.Y) + tx, scale * (sin * p.X + cos * p.Y) + ty);
+        }
+
+        [Test]
+        public void ShapeDescriptor_IsInvariantToSimilarityAndVertexOrder() {
+            var a = (10.0, 20.0);
+            var b = (130.0, 25.0);
+            var c = (60.0, 110.0);
+            var reference = Tri(a, b, c).ShapeDescriptor();
+
+            // Same triangle, transformed by a rotation+scale+translation and with the vertices supplied in
+            // a different (and handedness-reversed) order. A similarity-invariant descriptor must be unchanged.
+            var a2 = SimilarityMap(a, 1.7, 0.9, 500, -300);
+            var b2 = SimilarityMap(b, 1.7, 0.9, 500, -300);
+            var c2 = SimilarityMap(c, 1.7, 0.9, 500, -300);
+            var transformed = Tri(c2, a2, b2).ShapeDescriptor();
+
+            Assert.Multiple(() => {
+                Assert.That(transformed[0], Is.EqualTo(reference[0]).Within(1e-9));
+                Assert.That(transformed[1], Is.EqualTo(reference[1]).Within(1e-9));
+            });
+        }
+
+        [Test]
+        public void GeneratePutativeMatches_MatchesSimilarityTransformedCopyWithinTolerance() {
+            var refTris = new List<RANSACRegistration.StarTriangle> {
+                Tri((10, 20), (130, 25), (60, 110), isReference: true, referenceID: 1)
+            };
+            // The same triangle rotated, scaled and translated — a perfect similarity, so shape distance ≈ 0.
+            var img = new List<RANSACRegistration.StarTriangle> {
+                Tri(SimilarityMap((10, 20), 1.3, 0.5, 200, 150),
+                    SimilarityMap((130, 25), 1.3, 0.5, 200, 150),
+                    SimilarityMap((60, 110), 1.3, 0.5, 200, 150))
+            };
+
+            var (src, dst) = RANSACRegistration.GeneratePutativeMatchesUsingSimilarTriangles(
+                img, refTris, new ApplicationStatus(), maxShapeDistance: 0.02);
+
+            Assert.Multiple(() => {
+                Assert.That(dst.Count, Is.EqualTo(3), "Expected the reference triangle's three vertices");
+                Assert.That(src.Count, Is.EqualTo(3), "Expected the matched image triangle's three vertices");
+                Assert.That(img[0].Matched, Is.True);
+            });
+        }
+
+        [Test]
+        public void GeneratePutativeMatches_RejectsDissimilarShapeBeyondTolerance() {
+            var refTris = new List<RANSACRegistration.StarTriangle> {
+                Tri((10, 20), (130, 25), (60, 110), isReference: true, referenceID: 1)
+            };
+            // A very different (near-degenerate, flat) triangle — large shape-descriptor distance.
+            var img = new List<RANSACRegistration.StarTriangle> {
+                Tri((0, 0), (300, 0), (150, 6))
+            };
+
+            var (src, dst) = RANSACRegistration.GeneratePutativeMatchesUsingSimilarTriangles(
+                img, refTris, new ApplicationStatus(), maxShapeDistance: 0.02);
+
+            Assert.Multiple(() => {
+                Assert.That(src, Is.Empty);
+                Assert.That(dst, Is.Empty);
+                Assert.That(img[0].Matched, Is.False);
+            });
+        }
+
+        [Test]
+        public void GeneratePutativeMatches_IsDeterministicAcrossRuns() {
+            List<RANSACRegistration.StarTriangle> BuildRef() => new() {
+                Tri((10, 20), (130, 25), (60, 110), isReference: true, referenceID: 1),
+                Tri((400, 400), (520, 410), (450, 500), isReference: true, referenceID: 2)
+            };
+            List<RANSACRegistration.StarTriangle> BuildImg() => new() {
+                Tri(SimilarityMap((10, 20), 1.1, 0.3, 50, 60), SimilarityMap((130, 25), 1.1, 0.3, 50, 60), SimilarityMap((60, 110), 1.1, 0.3, 50, 60)),
+                Tri(SimilarityMap((400, 400), 1.1, 0.3, 50, 60), SimilarityMap((520, 410), 1.1, 0.3, 50, 60), SimilarityMap((450, 500), 1.1, 0.3, 50, 60))
+            };
+
+            var (src1, dst1) = RANSACRegistration.GeneratePutativeMatchesUsingSimilarTriangles(BuildImg(), BuildRef(), new ApplicationStatus(), 0.05);
+            var (src2, dst2) = RANSACRegistration.GeneratePutativeMatchesUsingSimilarTriangles(BuildImg(), BuildRef(), new ApplicationStatus(), 0.05);
+
+            Assert.Multiple(() => {
+                Assert.That(src2.Select(p => (p.X, p.Y)), Is.EqualTo(src1.Select(p => (p.X, p.Y))));
+                Assert.That(dst2.Select(p => (p.X, p.Y)), Is.EqualTo(dst1.Select(p => (p.X, p.Y))));
+                Assert.That(dst1.Count, Is.GreaterThan(0));
+            });
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/RANSACRegistrationTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/RANSACRegistrationTests.cs
@@ -263,7 +263,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Utility {
                 Assert.That(tri.NormalizedLengths.Count, Is.EqualTo(3));
                 Assert.That(tri.NormalizedBrightnesses.Count, Is.EqualTo(3));
                 Assert.That(tri.AsPositionMatrix().Length, Is.EqualTo(6));
-                Assert.That(tri.AsShapeMatrix().Length, Is.EqualTo(3));
+                Assert.That(tri.ShapeDescriptor().Length, Is.EqualTo(2));
                 Assert.That(tri.AsBrightnessMatrix().Length, Is.EqualTo(3));
                 Assert.That(tri.AsShapeAndBrightnessMatrix().Length, Is.EqualTo(6));
                 Assert.That(tri.IsReference, Is.True);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -43,7 +43,7 @@
     <TextBlock x:Key="SensorModel_TiltEffect_Tooltip" Text="The maximum nominal distance from the corners of the sensor to the center, due purely to the modeled tilt." />
     <TextBlock x:Key="SensorModel_AutoFocusOffset_Tooltip" Text="The number of focuser steps between the AutoFocus position and the Sensor Mean Focuser Position. You can set this value in the AF Offset setting in Auto Focus Options." />
     <TextBlock x:Key="SensorModel_StarsInModel_Tooltip" Text="The number of stars used in the sensor model. Each star needs to be matched across at least 5 of the frames, and some star fits are rejected as outliers during modeling." />
-    <TextBlock x:Key="SensorModel_ReducedChiSquared_Tooltip" Text="Reduced χ² measures how well the model fits the per-star best-focus positions relative to their estimated uncertainties (≈1 means it fits within measurement error). Unlike R², it is independent of the overall tilt/curvature magnitude, so a flat sensor is not penalized. The per-star σ is approximate and does not capture model error, so reduced χ² typically runs above 1 even for good fits and its absolute scale is rig-dependent — tune the acceptance threshold per rig." />
+    <TextBlock x:Key="SensorModel_ReducedChiSquared_Tooltip" Text="Reduced χ² measures how well the model fits the per-star best-focus positions relative to their estimated uncertainties (≈1 means it fits within measurement error). The per-star σ is approximate and does not capture model error, so reduced χ² routinely runs far above 1 even for good fits and its absolute scale is rig-dependent. It is shown for information and is only used as a rejection criterion when the R² is also very low." />
     <TextBlock x:Key="InterpolationEnabled_Tooltip" Text="Use interpolated points evenly spaced along a grid instead of the individual stars themselves. This should improve consistency of results and prevent overfitting where there are more stars." />
     <TextBlock x:Key="FixedSensorCenter_Tooltip" Text="Assume the sensor is perfectly centered in the optical train. If this option is off, the sensor location will be modeled along with the other model parameters." />
 
@@ -1660,8 +1660,8 @@
                                     Grid.Column="0"
                                     Margin="5"
                                     VerticalAlignment="Center"
-                                    Text="Max reduced χ² (rejection)"
-                                    ToolTip="The largest reduced χ² a sensor model may have and still be accepted. Reduced χ² ≈ 1 means the model fits the per-star best-focus positions within their estimated uncertainties; the model is rejected outright when it exceeds this cap. Because the per-star σ is approximate and does not capture model error, reduced χ² typically runs above 1 even for good fits and its absolute scale is rig-dependent, so this is deliberately generous and may need tuning per rig. A low R² only causes rejection when reduced χ² also reaches 0.6× this value." />
+                                    Text="Min R² (rejection)"
+                                    ToolTip="The smallest R² (fraction of best-focus variance explained) the model may have before its low R² is allowed to contribute to rejection. On its own a low R² never rejects the model — a near-flat sensor legitimately scores a low R². The model is rejected only when R² falls below this value AND the reduced χ² is also high (above a fixed sanity cap of 5)." />
                                 <StackPanel
                                     Grid.Row="4"
                                     Grid.Column="1"
@@ -1674,44 +1674,7 @@
                                         VerticalContentAlignment="Center"
                                         Foreground="{StaticResource PrimaryBrush}"
                                         TextAlignment="Left"
-                                        ToolTip="The largest reduced χ² a sensor model may have and still be accepted. Reduced χ² ≈ 1 means the model fits the per-star best-focus positions within their estimated uncertainties; the model is rejected outright when it exceeds this cap. Because the per-star σ is approximate and does not capture model error, reduced χ² typically runs above 1 even for good fits and its absolute scale is rig-dependent, so this is deliberately generous and may need tuning per rig. A low R² only causes rejection when reduced χ² also reaches 0.6× this value.">
-                                        <ninactrl:UnitTextBox.Text>
-                                            <Binding
-                                                Mode="TwoWay"
-                                                Path="InspectorOptions.AcceptableReducedChiSquared"
-                                                UpdateSourceTrigger="LostFocus">
-                                                <Binding.ValidationRules>
-                                                    <rules:DoubleRangeRule>
-                                                        <rules:DoubleRangeRule.ValidRange>
-                                                            <rules:DoubleRangeChecker Maximum="1000" Minimum="0.01" />
-                                                        </rules:DoubleRangeRule.ValidRange>
-                                                    </rules:DoubleRangeRule>
-                                                </Binding.ValidationRules>
-                                            </Binding>
-                                        </ninactrl:UnitTextBox.Text>
-                                    </ninactrl:UnitTextBox>
-                                </StackPanel>
-
-                                <TextBlock
-                                    Grid.Row="4"
-                                    Grid.Column="2"
-                                    Margin="5"
-                                    VerticalAlignment="Center"
-                                    Text="Min R² (rejection)"
-                                    ToolTip="The smallest R² (fraction of best-focus variance explained) the model may have before its low R² is allowed to contribute to rejection. On its own a low R² never rejects the model — a near-flat sensor legitimately scores a low R² — it only matters when the reduced χ² is also elevated (≥ 0.6× the max reduced χ²)." />
-                                <StackPanel
-                                    Grid.Row="4"
-                                    Grid.Column="3"
-                                    Orientation="Horizontal">
-                                    <ninactrl:UnitTextBox
-                                        MinWidth="40"
-                                        Margin="5,0,0,0"
-                                        VerticalAlignment="Center"
-                                        HorizontalContentAlignment="Left"
-                                        VerticalContentAlignment="Center"
-                                        Foreground="{StaticResource PrimaryBrush}"
-                                        TextAlignment="Left"
-                                        ToolTip="The smallest R² (fraction of best-focus variance explained) the model may have before its low R² is allowed to contribute to rejection. On its own a low R² never rejects the model — a near-flat sensor legitimately scores a low R² — it only matters when the reduced χ² is also elevated (≥ 0.6× the max reduced χ²).">
+                                        ToolTip="The smallest R² (fraction of best-focus variance explained) the model may have before its low R² is allowed to contribute to rejection. On its own a low R² never rejects the model — a near-flat sensor legitimately scores a low R². The model is rejected only when R² falls below this value AND the reduced χ² is also high (above a fixed sanity cap of 5).">
                                         <ninactrl:UnitTextBox.Text>
                                             <Binding
                                                 Mode="TwoWay"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -1528,7 +1528,8 @@
                                     Grid.Column="0"
                                     Margin="5"
                                     VerticalAlignment="Center"
-                                    Text="Align images before matching" />
+                                    Text="Align images before matching"
+                                    ToolTip="When on, each frame's stars are aligned to the reference frame (using a RANSAC similarity transform) before they are matched, correcting for small drift, rotation, or flexure between exposures in the autofocus run. Enable this when there is movement between frames; it allows stars to be matched with a tighter search radius and generally produces a more reliable model." />
                                 <StackPanel
                                     Grid.Row="0"
                                     Grid.Column="1"
@@ -1556,7 +1557,8 @@
                                     Grid.Column="0"
                                     Margin="5"
                                     VerticalAlignment="Center"
-                                    Text="Outlier rejection" />
+                                    Text="Outlier rejection"
+                                    ToolTip="When on, measurement points that fit poorly to a star's hyperbolic focus curve are iteratively rejected before that star's best-focus position is used, so a few bad measurements do not bias the result. Slightly increases per-star fitting time." />
                                 <StackPanel
                                     Grid.Row="1"
                                     Grid.Column="1"
@@ -1585,7 +1587,8 @@
                                     Grid.Column="0"
                                     Margin="5"
                                     VerticalAlignment="Center"
-                                    Text="Match using brightness" />
+                                    Text="Match using brightness"
+                                    ToolTip="When on, candidate star matches whose relative brightness differs by more than the brightness tolerance are rejected, reducing mismatches in crowded fields. The tolerance is searched automatically, starting from the 'Starting Brightness Tolerance' value." />
                                 <StackPanel
                                     Grid.Row="2"
                                     Grid.Column="1"
@@ -1598,7 +1601,8 @@
                                     Grid.Column="2"
                                     Margin="5"
                                     VerticalAlignment="Center"
-                                    Text="Starting Brightness Tolerance" />
+                                    Text="Starting Brightness Tolerance"
+                                    ToolTip="The starting point for the automatic brightness-tolerance search used to match stars across all regions of all images. Leave blank to start from a fixed default. Only used when 'Match using brightness' is enabled." />
                                 <StackPanel
                                     Grid.Row="2"
                                     Grid.Column="3"
@@ -1612,7 +1616,7 @@
                                         Foreground="{StaticResource PrimaryBrush}"
                                         HintText="{Binding InspectorOptions.BrightnessToleranceHint}"
                                         TextAlignment="Left"
-                                        ToolTip="If set, this value may be used as a starting point by the process to achieve a good set of matched stars across all regions of all images.  Leave this blank to use the previously successful value as the starting point">
+                                        ToolTip="If set, this value is used as the starting point for the automatic search that finds a brightness tolerance giving a good set of matched stars across all regions of all images. Leave this blank to start from a fixed default.">
                                         <ninactrl:HintTextBox.Text>
                                             <Binding
                                                 Converter="{StaticResource HF_DoubleNegativeToEmptyStringConverter}"
@@ -1628,7 +1632,8 @@
                                     Grid.Column="0"
                                     Margin="5"
                                     VerticalAlignment="Center"
-                                    Text="Save annotated images when rerunning a saved autofocus" />
+                                    Text="Save annotated images when rerunning a saved autofocus"
+                                    ToolTip="When on, re-running a previously saved autofocus run also writes the annotated star-detection images to that run's folder. A fresh run always saves them; this controls whether reruns do too. Off by default to avoid rewriting files on every rerun." />
                                 <StackPanel
                                     Grid.Row="3"
                                     Grid.Column="1"
@@ -1640,7 +1645,8 @@
                                     Grid.Column="2"
                                     Margin="5"
                                     VerticalAlignment="Center"
-                                    Text="Save alignment images" />
+                                    Text="Save alignment images"
+                                    ToolTip="When on, also saves the per-frame alignment images (each frame's detected stars transformed onto the reference frame, with matched triangles overlaid) when images are written, for diagnosing registration. Off by default." />
                                 <StackPanel
                                     Grid.Row="3"
                                     Grid.Column="3"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -1567,6 +1567,20 @@
                                 </StackPanel>
 
                                 <TextBlock
+                                    Grid.Row="1"
+                                    Grid.Column="2"
+                                    Margin="5"
+                                    VerticalAlignment="Center"
+                                    Text="Astigmatic field curvature"
+                                    ToolTip="When off (default), field curvature is modeled as rotationally symmetric (a single curvature coefficient), which fits a typical refractor or reflector. Enable to fit independent X and Y curvature, representing the saddle-shaped field of an astigmatic optical train. Adds one free parameter to the surface fit." />
+                                <StackPanel
+                                    Grid.Row="1"
+                                    Grid.Column="3"
+                                    Orientation="Horizontal">
+                                    <CheckBox Margin="5,0,0,0" IsChecked="{Binding InspectorOptions.AstigmaticCurvatureEnabled}" />
+                                </StackPanel>
+
+                                <TextBlock
                                     Grid.Row="2"
                                     Grid.Column="0"
                                     Margin="5"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -43,6 +43,7 @@
     <TextBlock x:Key="SensorModel_TiltEffect_Tooltip" Text="The maximum nominal distance from the corners of the sensor to the center, due purely to the modeled tilt." />
     <TextBlock x:Key="SensorModel_AutoFocusOffset_Tooltip" Text="The number of focuser steps between the AutoFocus position and the Sensor Mean Focuser Position. You can set this value in the AF Offset setting in Auto Focus Options." />
     <TextBlock x:Key="SensorModel_StarsInModel_Tooltip" Text="The number of stars used in the sensor model. Each star needs to be matched across at least 5 of the frames, and some star fits are rejected as outliers during modeling." />
+    <TextBlock x:Key="SensorModel_ReducedChiSquared_Tooltip" Text="Reduced χ² measures how well the model fits the per-star best-focus positions relative to their estimated uncertainties (≈1 means it fits within measurement error). Unlike R², it is independent of the overall tilt/curvature magnitude, so a flat sensor is not penalized. The per-star σ is approximate and does not capture model error, so reduced χ² typically runs above 1 even for good fits and its absolute scale is rig-dependent — tune the acceptance threshold per rig." />
     <TextBlock x:Key="InterpolationEnabled_Tooltip" Text="Use interpolated points evenly spaced along a grid instead of the individual stars themselves. This should improve consistency of results and prevent overfitting where there are more stars." />
     <TextBlock x:Key="FixedSensorCenter_Tooltip" Text="Assume the sensor is perfectly centered in the optical train. If this option is off, the sensor location will be modeled along with the other model parameters." />
 
@@ -1653,6 +1654,80 @@
                                     Orientation="Horizontal">
                                     <CheckBox Margin="5,0,0,0" IsChecked="{Binding InspectorOptions.SaveAlignmentImages}" />
                                 </StackPanel>
+
+                                <TextBlock
+                                    Grid.Row="4"
+                                    Grid.Column="0"
+                                    Margin="5"
+                                    VerticalAlignment="Center"
+                                    Text="Max reduced χ² (rejection)"
+                                    ToolTip="The largest reduced χ² a sensor model may have and still be accepted. Reduced χ² ≈ 1 means the model fits the per-star best-focus positions within their estimated uncertainties; the model is rejected outright when it exceeds this cap. Because the per-star σ is approximate and does not capture model error, reduced χ² typically runs above 1 even for good fits and its absolute scale is rig-dependent, so this is deliberately generous and may need tuning per rig. A low R² only causes rejection when reduced χ² also reaches 0.6× this value." />
+                                <StackPanel
+                                    Grid.Row="4"
+                                    Grid.Column="1"
+                                    Orientation="Horizontal">
+                                    <ninactrl:UnitTextBox
+                                        MinWidth="40"
+                                        Margin="5,0,0,0"
+                                        VerticalAlignment="Center"
+                                        HorizontalContentAlignment="Left"
+                                        VerticalContentAlignment="Center"
+                                        Foreground="{StaticResource PrimaryBrush}"
+                                        TextAlignment="Left"
+                                        ToolTip="The largest reduced χ² a sensor model may have and still be accepted. Reduced χ² ≈ 1 means the model fits the per-star best-focus positions within their estimated uncertainties; the model is rejected outright when it exceeds this cap. Because the per-star σ is approximate and does not capture model error, reduced χ² typically runs above 1 even for good fits and its absolute scale is rig-dependent, so this is deliberately generous and may need tuning per rig. A low R² only causes rejection when reduced χ² also reaches 0.6× this value.">
+                                        <ninactrl:UnitTextBox.Text>
+                                            <Binding
+                                                Mode="TwoWay"
+                                                Path="InspectorOptions.AcceptableReducedChiSquared"
+                                                UpdateSourceTrigger="LostFocus">
+                                                <Binding.ValidationRules>
+                                                    <rules:DoubleRangeRule>
+                                                        <rules:DoubleRangeRule.ValidRange>
+                                                            <rules:DoubleRangeChecker Maximum="1000" Minimum="0.01" />
+                                                        </rules:DoubleRangeRule.ValidRange>
+                                                    </rules:DoubleRangeRule>
+                                                </Binding.ValidationRules>
+                                            </Binding>
+                                        </ninactrl:UnitTextBox.Text>
+                                    </ninactrl:UnitTextBox>
+                                </StackPanel>
+
+                                <TextBlock
+                                    Grid.Row="4"
+                                    Grid.Column="2"
+                                    Margin="5"
+                                    VerticalAlignment="Center"
+                                    Text="Min R² (rejection)"
+                                    ToolTip="The smallest R² (fraction of best-focus variance explained) the model may have before its low R² is allowed to contribute to rejection. On its own a low R² never rejects the model — a near-flat sensor legitimately scores a low R² — it only matters when the reduced χ² is also elevated (≥ 0.6× the max reduced χ²)." />
+                                <StackPanel
+                                    Grid.Row="4"
+                                    Grid.Column="3"
+                                    Orientation="Horizontal">
+                                    <ninactrl:UnitTextBox
+                                        MinWidth="40"
+                                        Margin="5,0,0,0"
+                                        VerticalAlignment="Center"
+                                        HorizontalContentAlignment="Left"
+                                        VerticalContentAlignment="Center"
+                                        Foreground="{StaticResource PrimaryBrush}"
+                                        TextAlignment="Left"
+                                        ToolTip="The smallest R² (fraction of best-focus variance explained) the model may have before its low R² is allowed to contribute to rejection. On its own a low R² never rejects the model — a near-flat sensor legitimately scores a low R² — it only matters when the reduced χ² is also elevated (≥ 0.6× the max reduced χ²).">
+                                        <ninactrl:UnitTextBox.Text>
+                                            <Binding
+                                                Mode="TwoWay"
+                                                Path="InspectorOptions.AcceptableRSquaredMin"
+                                                UpdateSourceTrigger="LostFocus">
+                                                <Binding.ValidationRules>
+                                                    <rules:DoubleRangeRule>
+                                                        <rules:DoubleRangeRule.ValidRange>
+                                                            <rules:DoubleRangeChecker Maximum="0.9999" Minimum="0" />
+                                                        </rules:DoubleRangeRule.ValidRange>
+                                                    </rules:DoubleRangeRule>
+                                                </Binding.ValidationRules>
+                                            </Binding>
+                                        </ninactrl:UnitTextBox.Text>
+                                    </ninactrl:UnitTextBox>
+                                </StackPanel>
                             </Grid>
                         </Expander>
                         <!--
@@ -2886,6 +2961,20 @@
                                 ToolTip="{StaticResource SensorModel_CriticalFocus_Tooltip}">
                                 <Run Text="{Binding SensorModel.SensorModelResult.CriticalFocusMicrons, StringFormat=\{0:0.0\}, Mode=OneWay}" /> <Run Text="microns" />
                             </TextBlock>
+                            <TextBlock
+                                Grid.Row="4"
+                                Grid.Column="2"
+                                Margin="5"
+                                VerticalAlignment="Center"
+                                Text="Reduced χ²"
+                                ToolTip="{StaticResource SensorModel_ReducedChiSquared_Tooltip}" />
+                            <TextBlock
+                                Grid.Row="4"
+                                Grid.Column="3"
+                                Margin="5"
+                                VerticalAlignment="Center"
+                                Text="{Binding SensorModel.SensorModelResult.Model.ReducedChiSquared, StringFormat=\{0:0.00\}, Mode=OneWay}"
+                                ToolTip="{StaticResource SensorModel_ReducedChiSquared_Tooltip}" />
                         </Grid>
                         <Grid
                             Grid.Row="4"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -1536,6 +1536,22 @@
                                     <CheckBox Margin="5,0,0,0" IsChecked="{Binding InspectorOptions.UseRANSAC}" />
                                 </StackPanel>
                                 <TextBlock
+                                    Grid.Row="0"
+                                    Grid.Column="2"
+                                    Margin="5"
+                                    VerticalAlignment="Center"
+                                    Text="Use affine alignment (diagnostic)"
+                                    ToolTip="When off (default), images are aligned with a 4-DOF similarity transform (translation, rotation, uniform scale), which is the physically correct model for a single autofocus run and gives more robust, repeatable results. Enable only to diagnose alignment by allowing the less-constrained 6-DOF affine transform (adds shear and anisotropic scale)." />
+                                <StackPanel
+                                    Grid.Row="0"
+                                    Grid.Column="3"
+                                    Orientation="Horizontal">
+                                    <CheckBox
+                                        Margin="5,0,0,0"
+                                        IsChecked="{Binding InspectorOptions.UseAffineAlignment}"
+                                        IsEnabled="{Binding InspectorOptions.UseRANSAC}" />
+                                </StackPanel>
+                                <TextBlock
                                     Grid.Row="1"
                                     Grid.Column="0"
                                     Margin="5"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
@@ -68,6 +68,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             rejectBadBrightnessMatches = optionsAccessor.GetValueBoolean(nameof(RejectBadBrightnessMatches), false);
             rejectBadlyFittingMatches = optionsAccessor.GetValueBoolean(nameof(RejectBadlyFittingMatches), false);
             useRANSAC = optionsAccessor.GetValueBoolean(nameof(UseRANSAC), false);
+            useAffineAlignment = optionsAccessor.GetValueBoolean(nameof(UseAffineAlignment), false);
             saveImagesOnReruns = optionsAccessor.GetValueBoolean(nameof(SaveImagesOnReruns), false);
             saveAlignmentImages = optionsAccessor.GetValueBoolean(nameof(SaveAlignmentImages), false);
             maxStarsPerRegion = optionsAccessor.GetValueInt32(nameof(MaxStarsPerRegion), -1);
@@ -95,6 +96,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             startingBrightnessDiff = -1;
             rejectBadBrightnessMatches = false;
             rejectBadlyFittingMatches = false;
+            useAffineAlignment = false;
         }
 
         private int stepCount;
@@ -370,6 +372,19 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 if (useRANSAC != value) {
                     useRANSAC = value;
                     optionsAccessor.SetValueBoolean(nameof(UseRANSAC), useRANSAC);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool useAffineAlignment = false;
+
+        public bool UseAffineAlignment {
+            get => useAffineAlignment;
+            set {
+                if (useAffineAlignment != value) {
+                    useAffineAlignment = value;
+                    optionsAccessor.SetValueBoolean(nameof(UseAffineAlignment), useAffineAlignment);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
@@ -67,8 +67,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             previousRunBrightnessDiff = optionsAccessor.GetValueDouble(nameof(PreviousRunBrightnessDiff), 0.1d);
             startingBrightnessDiff = optionsAccessor.GetValueDouble(nameof(StartingBrightnessDiff), -1);
             rejectBadBrightnessMatches = optionsAccessor.GetValueBoolean(nameof(RejectBadBrightnessMatches), false);
-            rejectBadlyFittingMatches = optionsAccessor.GetValueBoolean(nameof(RejectBadlyFittingMatches), false);
-            useRANSAC = optionsAccessor.GetValueBoolean(nameof(UseRANSAC), false);
+            rejectBadlyFittingMatches = optionsAccessor.GetValueBoolean(nameof(RejectBadlyFittingMatches), true);
+            useRANSAC = optionsAccessor.GetValueBoolean(nameof(UseRANSAC), true);
             useAffineAlignment = optionsAccessor.GetValueBoolean(nameof(UseAffineAlignment), false);
             astigmaticCurvatureEnabled = optionsAccessor.GetValueBoolean(nameof(AstigmaticCurvatureEnabled), false);
             saveImagesOnReruns = optionsAccessor.GetValueBoolean(nameof(SaveImagesOnReruns), false);
@@ -98,7 +98,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             previousRunBrightnessDiff = -1;
             startingBrightnessDiff = -1;
             rejectBadBrightnessMatches = false;
-            rejectBadlyFittingMatches = false;
+            rejectBadlyFittingMatches = true;
+            useRANSAC = true;
             useAffineAlignment = false;
             astigmaticCurvatureEnabled = false;
             AcceptableRSquaredMin = SensorAberrationCalculator.DefaultAcceptableRSquaredMin;
@@ -369,7 +370,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             }
         }
 
-        private bool useRANSAC = false;
+        private bool useRANSAC = true;
 
         public bool UseRANSAC {
             get => useRANSAC;
@@ -421,7 +422,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             }
         }
 
-        private bool rejectBadlyFittingMatches = false;
+        private bool rejectBadlyFittingMatches = true;
 
         public bool RejectBadlyFittingMatches {
             get => rejectBadlyFittingMatches;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
@@ -74,7 +74,6 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             saveImagesOnReruns = optionsAccessor.GetValueBoolean(nameof(SaveImagesOnReruns), false);
             saveAlignmentImages = optionsAccessor.GetValueBoolean(nameof(SaveAlignmentImages), false);
             maxStarsPerRegion = optionsAccessor.GetValueInt32(nameof(MaxStarsPerRegion), -1);
-            acceptableReducedChiSquared = optionsAccessor.GetValueDouble(nameof(AcceptableReducedChiSquared), SensorAberrationCalculator.DefaultAcceptableReducedChiSquared);
             acceptableRSquaredMin = optionsAccessor.GetValueDouble(nameof(AcceptableRSquaredMin), SensorAberrationCalculator.DefaultAcceptableRSquaredMin);
         }
 
@@ -102,7 +101,6 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             rejectBadlyFittingMatches = false;
             useAffineAlignment = false;
             astigmaticCurvatureEnabled = false;
-            AcceptableReducedChiSquared = SensorAberrationCalculator.DefaultAcceptableReducedChiSquared;
             AcceptableRSquaredMin = SensorAberrationCalculator.DefaultAcceptableRSquaredMin;
         }
 
@@ -500,19 +498,6 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 if (maxStarsPerRegion != value) {
                     maxStarsPerRegion = value;
                     optionsAccessor.SetValueInt32(nameof(MaxStarsPerRegion), maxStarsPerRegion);
-                    RaisePropertyChanged();
-                }
-            }
-        }
-
-        private double acceptableReducedChiSquared;
-
-        public double AcceptableReducedChiSquared {
-            get => acceptableReducedChiSquared;
-            set {
-                if (acceptableReducedChiSquared != value) {
-                    acceptableReducedChiSquared = value;
-                    optionsAccessor.SetValueDouble(nameof(AcceptableReducedChiSquared), acceptableReducedChiSquared);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
@@ -11,6 +11,7 @@
 #endregion "copyright"
 
 using NINA.Core.Utility;
+using NINA.Joko.Plugins.HocusFocus.Inspection;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Profile;
 using NINA.Profile.Interfaces;
@@ -73,6 +74,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             saveImagesOnReruns = optionsAccessor.GetValueBoolean(nameof(SaveImagesOnReruns), false);
             saveAlignmentImages = optionsAccessor.GetValueBoolean(nameof(SaveAlignmentImages), false);
             maxStarsPerRegion = optionsAccessor.GetValueInt32(nameof(MaxStarsPerRegion), -1);
+            acceptableReducedChiSquared = optionsAccessor.GetValueDouble(nameof(AcceptableReducedChiSquared), SensorAberrationCalculator.DefaultAcceptableReducedChiSquared);
+            acceptableRSquaredMin = optionsAccessor.GetValueDouble(nameof(AcceptableRSquaredMin), SensorAberrationCalculator.DefaultAcceptableRSquaredMin);
         }
 
         public void ResetDefaults() {
@@ -99,6 +102,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             rejectBadlyFittingMatches = false;
             useAffineAlignment = false;
             astigmaticCurvatureEnabled = false;
+            AcceptableReducedChiSquared = SensorAberrationCalculator.DefaultAcceptableReducedChiSquared;
+            AcceptableRSquaredMin = SensorAberrationCalculator.DefaultAcceptableRSquaredMin;
         }
 
         private int stepCount;
@@ -495,6 +500,32 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 if (maxStarsPerRegion != value) {
                     maxStarsPerRegion = value;
                     optionsAccessor.SetValueInt32(nameof(MaxStarsPerRegion), maxStarsPerRegion);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private double acceptableReducedChiSquared;
+
+        public double AcceptableReducedChiSquared {
+            get => acceptableReducedChiSquared;
+            set {
+                if (acceptableReducedChiSquared != value) {
+                    acceptableReducedChiSquared = value;
+                    optionsAccessor.SetValueDouble(nameof(AcceptableReducedChiSquared), acceptableReducedChiSquared);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private double acceptableRSquaredMin;
+
+        public double AcceptableRSquaredMin {
+            get => acceptableRSquaredMin;
+            set {
+                if (acceptableRSquaredMin != value) {
+                    acceptableRSquaredMin = value;
+                    optionsAccessor.SetValueDouble(nameof(AcceptableRSquaredMin), acceptableRSquaredMin);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
@@ -69,6 +69,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             rejectBadlyFittingMatches = optionsAccessor.GetValueBoolean(nameof(RejectBadlyFittingMatches), false);
             useRANSAC = optionsAccessor.GetValueBoolean(nameof(UseRANSAC), false);
             useAffineAlignment = optionsAccessor.GetValueBoolean(nameof(UseAffineAlignment), false);
+            astigmaticCurvatureEnabled = optionsAccessor.GetValueBoolean(nameof(AstigmaticCurvatureEnabled), false);
             saveImagesOnReruns = optionsAccessor.GetValueBoolean(nameof(SaveImagesOnReruns), false);
             saveAlignmentImages = optionsAccessor.GetValueBoolean(nameof(SaveAlignmentImages), false);
             maxStarsPerRegion = optionsAccessor.GetValueInt32(nameof(MaxStarsPerRegion), -1);
@@ -97,6 +98,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             rejectBadBrightnessMatches = false;
             rejectBadlyFittingMatches = false;
             useAffineAlignment = false;
+            astigmaticCurvatureEnabled = false;
         }
 
         private int stepCount;
@@ -385,6 +387,19 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 if (useAffineAlignment != value) {
                     useAffineAlignment = value;
                     optionsAccessor.SetValueBoolean(nameof(UseAffineAlignment), useAffineAlignment);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool astigmaticCurvatureEnabled = false;
+
+        public bool AstigmaticCurvatureEnabled {
+            get => astigmaticCurvatureEnabled;
+            set {
+                if (astigmaticCurvatureEnabled != value) {
+                    astigmaticCurvatureEnabled = value;
+                    optionsAccessor.SetValueBoolean(nameof(AstigmaticCurvatureEnabled), astigmaticCurvatureEnabled);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -1970,16 +1970,19 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
         private void ActivateExposureAnalysis() {
             // Only surface the FWHM contour map and eccentricity vectors when the analyzed validation image
-            // actually produced stars to compute them from. A final-folder image that yields no detected
-            // stars would otherwise show empty plots, so treat it as "no final validation image" and stay
-            // hidden (the expanders' visibility is bound to ExposureAnalysisActivatedOnce).
-            var hasValidationData = (SnapshotAnalysisStarDetectionResult?.StarList?.Count ?? 0) > 0;
+            // produced stars with a fitted PSF. Both plots skip stars whose PSF could not be modeled
+            // (FWHMContourControl and the eccentricity vector field both ignore PSF == null), so a result
+            // with detections but no usable PSFs would render empty panels. Treat that as "no final
+            // validation data" and stay hidden (the expanders' visibility is bound to
+            // ExposureAnalysisActivatedOnce).
+            var hasValidationData = SnapshotAnalysisStarDetectionResult?.StarList?
+                .OfType<HocusFocusDetectedStar>().Any(s => s.PSF != null) ?? false;
             FWHMContoursActive = hasValidationData;
             EccentricityVectorsActive = hasValidationData;
             ExposureAnalysisActivatedOnce = hasValidationData;
             if (!hasValidationData) {
-                SimpleAnalysisErrorText = "Cannot display FWHM Contour and Eccentricity Vectors.\nNo stars were detected in the final validation image.";
-                Logger.Warning("Final validation image produced no detected stars; hiding FWHM contour and eccentricity vectors.");
+                SimpleAnalysisErrorText = "Cannot display FWHM Contour and Eccentricity Vectors.\nThe final validation image produced no usable star measurements (no fitted PSFs).";
+                Logger.Warning("Final validation image produced no PSF-modeled stars; hiding FWHM contour and eccentricity vectors.");
             }
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -1969,9 +1969,18 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         }
 
         private void ActivateExposureAnalysis() {
-            FWHMContoursActive = true;
-            EccentricityVectorsActive = true;
-            ExposureAnalysisActivatedOnce = true;
+            // Only surface the FWHM contour map and eccentricity vectors when the analyzed validation image
+            // actually produced stars to compute them from. A final-folder image that yields no detected
+            // stars would otherwise show empty plots, so treat it as "no final validation image" and stay
+            // hidden (the expanders' visibility is bound to ExposureAnalysisActivatedOnce).
+            var hasValidationData = (SnapshotAnalysisStarDetectionResult?.StarList?.Count ?? 0) > 0;
+            FWHMContoursActive = hasValidationData;
+            EccentricityVectorsActive = hasValidationData;
+            ExposureAnalysisActivatedOnce = hasValidationData;
+            if (!hasValidationData) {
+                SimpleAnalysisErrorText = "Cannot display FWHM Contour and Eccentricity Vectors.\nNo stars were detected in the final validation image.";
+                Logger.Warning("Final validation image produced no detected stars; hiding FWHM contour and eccentricity vectors.");
+            }
         }
 
         private void DeactivateAutoFocusAnalysis() {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorAberrationCalculator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorAberrationCalculator.cs
@@ -23,22 +23,27 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
     public static class SensorAberrationCalculator {
 
         /// <summary>
-        /// Returns the goodness-of-fit (R²) target for an iteration that has already taken the
-        /// supplied amount of time. Faster iterations get a stricter target since we can afford
-        /// to keep searching; slower iterations get a relaxed target so we converge in time.
+        /// Upper bound on reduced χ² for a paraboloid fit to be accepted (and the brightness-tolerance
+        /// search to stop). Reduced χ² ≈ 1 means the model fits the measured best-focus positions to
+        /// within their standard errors; values far above 1 indicate a poor fit. Unlike an R² target,
+        /// this is independent of the overall tilt/curvature magnitude, so a near-flat but well-measured
+        /// sensor is accepted rather than rejected for "low R²". The bound is generous to tolerate the
+        /// approximate per-star uncertainties.
         /// </summary>
-        public static double TargetR2BasedOnTimeTaken(TimeSpan timeSpan) {
-            double secondsTaken = timeSpan.TotalSeconds;
-            if (secondsTaken < 1) {
-                return 0.9;
+        public const double AcceptableReducedChiSquaredMax = 5.0;
+
+        /// <summary>
+        /// True if the fit's reduced χ² is finite and within the acceptable bound. A fit with very small
+        /// reduced χ² (residuals smaller than the declared σ) is still acceptable — only large values,
+        /// indicating the model cannot explain the data within its uncertainties, are rejected.
+        /// </summary>
+        public static bool IsReducedChiSquaredAcceptable(SensorParaboloidModel fit) {
+            if (fit == null) {
+                return false;
             }
-            if (secondsTaken < 3) {
-                return 0.8;
-            }
-            if (secondsTaken < 5) {
-                return 0.7;
-            }
-            return 0.6;
+            var reducedChiSquared = fit.ReducedChiSquared;
+            return !double.IsNaN(reducedChiSquared) && !double.IsInfinity(reducedChiSquared)
+                && reducedChiSquared <= AcceptableReducedChiSquaredMax;
         }
 
         /// <summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorAberrationCalculator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorAberrationCalculator.cs
@@ -23,85 +23,51 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
     public static class SensorAberrationCalculator {
 
         /// <summary>
-        /// Default upper bound on reduced χ² for a paraboloid fit to be accepted (and the brightness-tolerance
-        /// search to stop). Reduced χ² ≈ 1 means the model fits the measured best-focus positions to
-        /// within their standard errors; values far above 1 indicate a poor fit. Unlike an R² target,
-        /// this is independent of the overall tilt/curvature magnitude, so a near-flat but well-measured
-        /// sensor is accepted rather than rejected for "low R²". The bound is generous to tolerate the
-        /// approximate per-star uncertainties, and is user-configurable per rig via the inspector options.
+        /// Upper bound on reduced χ² used as a secondary rejection criterion (see <see cref="IsModelAcceptable"/>).
+        /// Reduced χ² ≈ 1 means the model fits the measured best-focus positions to within their standard
+        /// errors. Because the per-star σ is approximate and does not capture model error, reduced χ²
+        /// routinely runs far above 1 even for good fits and its absolute scale is rig-dependent — so a high
+        /// reduced χ² is only treated as a failure when the R² is also very low. This cap is therefore a
+        /// fixed sanity bound rather than a tunable option.
         /// </summary>
-        public const double DefaultAcceptableReducedChiSquared = 5.0;
+        public const double AcceptableReducedChiSquared = 5.0;
 
         /// <summary>
         /// Default lower bound on R² (variance explained) below which the fit is considered statistically
-        /// questionable — but only enough to reject when the reduced χ² is also elevated (see
-        /// <see cref="IsModelAcceptable"/>). A near-flat sensor legitimately scores a low R², so R² alone
-        /// never rejects a model.
+        /// questionable. Only when R² falls below this AND the reduced χ² is unacceptable is the model
+        /// rejected; a near-flat sensor legitimately scores a low R², so R² alone never rejects a model.
         /// </summary>
         public const double DefaultAcceptableRSquaredMin = 0.05;
-
-        /// <summary>
-        /// Fraction of the acceptable reduced-χ² cap that separates a "good" fit from a "marginal" one.
-        /// At the default cap of 5.0 this puts the good/marginal boundary at 3.0.
-        /// </summary>
-        private const double GoodReducedChiSquaredFraction = 0.6;
-
-        /// <summary>
-        /// Display band for a fit's reduced χ² relative to the configured acceptable cap.
-        /// </summary>
-        public enum FitQualityBand {
-            Good,
-            Marginal,
-            Rejected
-        }
 
         /// <summary>
         /// True if the fit's reduced χ² is finite and within the acceptable bound. A fit with very small
         /// reduced χ² (residuals smaller than the declared σ) is still acceptable — only large values,
         /// indicating the model cannot explain the data within its uncertainties, are rejected.
         /// </summary>
-        public static bool IsReducedChiSquaredAcceptable(SensorParaboloidModel fit, double maxReducedChiSquared) {
+        public static bool IsReducedChiSquaredAcceptable(SensorParaboloidModel fit) {
             if (fit == null) {
                 return false;
             }
             var reducedChiSquared = fit.ReducedChiSquared;
             return !double.IsNaN(reducedChiSquared) && !double.IsInfinity(reducedChiSquared)
-                && reducedChiSquared <= maxReducedChiSquared;
+                && reducedChiSquared <= AcceptableReducedChiSquared;
         }
 
         /// <summary>
-        /// Combined acceptance rule that keeps the magnitude-independence benefit of reduced χ² while
-        /// letting a low R² matter when the fit is also statistically questionable. Reject if
-        /// χ² ≥ <paramref name="maxReducedChiSquared"/>, OR if R² &lt; <paramref name="minRSquared"/> AND
-        /// χ² ≥ 0.6·max. A flat but well-measured sensor (good χ², low R²) is still accepted.
+        /// Acceptance rule: the reduced χ² is only a rejection criterion when the R² is very low. A model is
+        /// rejected only when R² &lt; <paramref name="minRSquared"/> AND its reduced χ² is unacceptable
+        /// (above the fixed <see cref="AcceptableReducedChiSquared"/> cap, or non-finite). A well-fit model
+        /// with an adequate R² is accepted even when its reduced χ² is very large, and a near-flat sensor
+        /// (low R², good χ²) is likewise accepted.
         /// </summary>
-        public static bool IsModelAcceptable(SensorParaboloidModel fit, double maxReducedChiSquared, double minRSquared) {
+        public static bool IsModelAcceptable(SensorParaboloidModel fit, double minRSquared) {
             if (fit == null) {
                 return false;
             }
-            if (!IsReducedChiSquaredAcceptable(fit, maxReducedChiSquared)) {
-                return false;   // χ² rejected outright
-            }
-            var goodBand = GoodReducedChiSquaredFraction * maxReducedChiSquared;
-            var chiElevated = fit.ReducedChiSquared >= goodBand;
-            if (fit.GoodnessOfFit < minRSquared && chiElevated) {
-                return false;   // low R² only contributes when χ² is also elevated
+            if (fit.GoodnessOfFit < minRSquared && !IsReducedChiSquaredAcceptable(fit)) {
+                return false;
             }
             return true;
-        }
-
-        /// <summary>
-        /// Classify a fit's reduced χ² into a display band relative to the configured acceptable cap.
-        /// Good below 0.6·max, Marginal between 0.6·max and max, Rejected at/above max (or non-finite).
-        /// </summary>
-        public static FitQualityBand ClassifyReducedChiSquared(double reducedChiSquared, double maxReducedChiSquared) {
-            if (double.IsNaN(reducedChiSquared) || double.IsInfinity(reducedChiSquared) || reducedChiSquared >= maxReducedChiSquared) {
-                return FitQualityBand.Rejected;
-            }
-            if (reducedChiSquared < GoodReducedChiSquaredFraction * maxReducedChiSquared) {
-                return FitQualityBand.Good;
-            }
-            return FitQualityBand.Marginal;
         }
 
         /// <summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorAberrationCalculator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorAberrationCalculator.cs
@@ -23,27 +23,85 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
     public static class SensorAberrationCalculator {
 
         /// <summary>
-        /// Upper bound on reduced χ² for a paraboloid fit to be accepted (and the brightness-tolerance
+        /// Default upper bound on reduced χ² for a paraboloid fit to be accepted (and the brightness-tolerance
         /// search to stop). Reduced χ² ≈ 1 means the model fits the measured best-focus positions to
         /// within their standard errors; values far above 1 indicate a poor fit. Unlike an R² target,
         /// this is independent of the overall tilt/curvature magnitude, so a near-flat but well-measured
         /// sensor is accepted rather than rejected for "low R²". The bound is generous to tolerate the
-        /// approximate per-star uncertainties.
+        /// approximate per-star uncertainties, and is user-configurable per rig via the inspector options.
         /// </summary>
-        public const double AcceptableReducedChiSquaredMax = 5.0;
+        public const double DefaultAcceptableReducedChiSquared = 5.0;
+
+        /// <summary>
+        /// Default lower bound on R² (variance explained) below which the fit is considered statistically
+        /// questionable — but only enough to reject when the reduced χ² is also elevated (see
+        /// <see cref="IsModelAcceptable"/>). A near-flat sensor legitimately scores a low R², so R² alone
+        /// never rejects a model.
+        /// </summary>
+        public const double DefaultAcceptableRSquaredMin = 0.05;
+
+        /// <summary>
+        /// Fraction of the acceptable reduced-χ² cap that separates a "good" fit from a "marginal" one.
+        /// At the default cap of 5.0 this puts the good/marginal boundary at 3.0.
+        /// </summary>
+        private const double GoodReducedChiSquaredFraction = 0.6;
+
+        /// <summary>
+        /// Display band for a fit's reduced χ² relative to the configured acceptable cap.
+        /// </summary>
+        public enum FitQualityBand {
+            Good,
+            Marginal,
+            Rejected
+        }
 
         /// <summary>
         /// True if the fit's reduced χ² is finite and within the acceptable bound. A fit with very small
         /// reduced χ² (residuals smaller than the declared σ) is still acceptable — only large values,
         /// indicating the model cannot explain the data within its uncertainties, are rejected.
         /// </summary>
-        public static bool IsReducedChiSquaredAcceptable(SensorParaboloidModel fit) {
+        public static bool IsReducedChiSquaredAcceptable(SensorParaboloidModel fit, double maxReducedChiSquared) {
             if (fit == null) {
                 return false;
             }
             var reducedChiSquared = fit.ReducedChiSquared;
             return !double.IsNaN(reducedChiSquared) && !double.IsInfinity(reducedChiSquared)
-                && reducedChiSquared <= AcceptableReducedChiSquaredMax;
+                && reducedChiSquared <= maxReducedChiSquared;
+        }
+
+        /// <summary>
+        /// Combined acceptance rule that keeps the magnitude-independence benefit of reduced χ² while
+        /// letting a low R² matter when the fit is also statistically questionable. Reject if
+        /// χ² ≥ <paramref name="maxReducedChiSquared"/>, OR if R² &lt; <paramref name="minRSquared"/> AND
+        /// χ² ≥ 0.6·max. A flat but well-measured sensor (good χ², low R²) is still accepted.
+        /// </summary>
+        public static bool IsModelAcceptable(SensorParaboloidModel fit, double maxReducedChiSquared, double minRSquared) {
+            if (fit == null) {
+                return false;
+            }
+            if (!IsReducedChiSquaredAcceptable(fit, maxReducedChiSquared)) {
+                return false;   // χ² rejected outright
+            }
+            var goodBand = GoodReducedChiSquaredFraction * maxReducedChiSquared;
+            var chiElevated = fit.ReducedChiSquared >= goodBand;
+            if (fit.GoodnessOfFit < minRSquared && chiElevated) {
+                return false;   // low R² only contributes when χ² is also elevated
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Classify a fit's reduced χ² into a display band relative to the configured acceptable cap.
+        /// Good below 0.6·max, Marginal between 0.6·max and max, Rejected at/above max (or non-finite).
+        /// </summary>
+        public static FitQualityBand ClassifyReducedChiSquared(double reducedChiSquared, double maxReducedChiSquared) {
+            if (double.IsNaN(reducedChiSquared) || double.IsInfinity(reducedChiSquared) || reducedChiSquared >= maxReducedChiSquared) {
+                return FitQualityBand.Rejected;
+            }
+            if (reducedChiSquared < GoodReducedChiSquaredFraction * maxReducedChiSquared) {
+                return FitQualityBand.Good;
+            }
+            return FitQualityBand.Marginal;
         }
 
         /// <summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
@@ -154,7 +154,6 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                     focuserStepSizeMicrons: focuserSizeMicrons,
                     finalFocusPosition: finalFocusPosition,
                     registeredStars: fitResult.RegisteredStars,
-                    acceptableReducedChiSquared: inspectorOptions.AcceptableReducedChiSquared,
                     acceptableRSquaredMin: inspectorOptions.AcceptableRSquaredMin);
 
                 var historyId = Interlocked.Increment(ref nextHistoryId);
@@ -475,8 +474,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                         // has enough stars and a reduced χ² within the acceptable band. This replaces the
                         // former R²-vs-target test (and the wall-clock target removed in Phase 1), which
                         // rejected near-flat-but-good sensors and varied with machine load.
-                        if ((pfit != null) && ((pfit.StarsInModel < 10) || !SensorAberrationCalculator.IsModelAcceptable(pfit, inspectorOptions.AcceptableReducedChiSquared, inspectorOptions.AcceptableRSquaredMin))) {
-                            Logger.Debug($"Only have {pfit.StarsInModel} stars and reduced χ² of {pfit.ReducedChiSquared:#.##} (max is {inspectorOptions.AcceptableReducedChiSquared:#.##}, R² {pfit.GoodnessOfFit:#.##} vs min {inspectorOptions.AcceptableRSquaredMin:#.##}) with a brightness tolerance of {maxNormalisedBrightnessDiff:#.##}");
+                        if ((pfit != null) && ((pfit.StarsInModel < 10) || !SensorAberrationCalculator.IsModelAcceptable(pfit, inspectorOptions.AcceptableRSquaredMin))) {
+                            Logger.Debug($"Only have {pfit.StarsInModel} stars and reduced χ² of {pfit.ReducedChiSquared:#.##} (cap {SensorAberrationCalculator.AcceptableReducedChiSquared:#.##} only applies when R² {pfit.GoodnessOfFit:#.##} < min {inspectorOptions.AcceptableRSquaredMin:#.##}) with a brightness tolerance of {maxNormalisedBrightnessDiff:#.##}");
                             retry = true;
                         }
 
@@ -561,11 +560,12 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                 if (bestPfit == null) {
                     throw new Exception("Failed to find a good model.");
                 }
-                // Reject via the combined rule: fail when reduced χ² exceeds the acceptable cap, or when a
-                // low R² coincides with an elevated χ². A near-flat but well-measured sensor has low R² yet
-                // acceptable reduced χ², and is still accepted.
-                if (!SensorAberrationCalculator.IsModelAcceptable(bestPfit, inspectorOptions.AcceptableReducedChiSquared, inspectorOptions.AcceptableRSquaredMin)) {
-                    throw new Exception($"Sensor modeling failed. R² = {bestPfit.GoodnessOfFit:#.00} (min {inspectorOptions.AcceptableRSquaredMin:#.00}), reduced χ² = {bestPfit.ReducedChiSquared:#.00} (max {inspectorOptions.AcceptableReducedChiSquared:#.00})");
+                // Reduced χ² is only a rejection criterion when R² is very low: fail only when the model
+                // explains almost no variance (R² below the minimum) AND cannot fit the best-focus positions
+                // within their uncertainties (reduced χ² above the fixed cap). A well-fit model with an
+                // adequate R² is accepted even when its reduced χ² is large.
+                if (!SensorAberrationCalculator.IsModelAcceptable(bestPfit, inspectorOptions.AcceptableRSquaredMin)) {
+                    throw new Exception($"Sensor modeling failed. R² = {bestPfit.GoodnessOfFit:#.00} (min {inspectorOptions.AcceptableRSquaredMin:#.00}) and reduced χ² = {bestPfit.ReducedChiSquared:#.00} exceeds {SensorAberrationCalculator.AcceptableReducedChiSquared:#.00}");
                 }
 
                 if (bestPfit.StarsInModel < 10) {
@@ -1024,7 +1024,6 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                 sensorModel: historyModel.SensorModel, imageSize: historyModel.ImageSize, pixelSizeMicrons: historyModel.PixelSizeMicrons,
                 fRatio: historyModel.FRatio, focuserStepSizeMicrons: historyModel.FocuserSizeMicrons, finalFocusPosition: historyModel.FinalFocusPosition,
                 registeredStars: [],
-                acceptableReducedChiSquared: inspectorOptions.AcceptableReducedChiSquared,
                 acceptableRSquaredMin: inspectorOptions.AcceptableRSquaredMin);
             DisplayedSensorModel = historyModel.SensorModel;
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
@@ -612,6 +612,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                 bool rejectBadlyFittingMatches) {
             int discardedStarCount = 0;
             var sensorModelDataPoints = new List<SensorParaboloidDataPoint>();
+            // Best-focus points collected with their per-star σ (NaN when the hyperbolic fit could not
+            // estimate a standard error). σ is resolved to a concrete weight in a second pass below.
+            var pendingPoints = new List<(double X, double Y, double FocuserMicrons, double RSquared, double StdDevMicrons)>();
             var maxOutlierRejectedPoints = this.autoFocusOptions.MaxOutlierRejections;
             var rejectionConfidence = this.autoFocusOptions.OutlierRejectionConfidence;
             const int minStarCountForFitting = 5;
@@ -665,15 +668,26 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                     var dataPointY = (registeredStar.RegistrationY - (imageSize.Height / 2.0)) * pixelSize;
                     var focuserMicrons = fitting.Minimum.X * focuserSizeMicrons;
                     // Propagate the standard error of this star's best-focus position into the paraboloid
-                    // fit so it is weighted by 1/σ². Falls back to unit weight when unavailable.
+                    // fit so it is weighted by 1/σ². NaN marks "no estimate available"; resolved below to the
+                    // median of the available σ (rather than a fixed 1 µm, which would give such points a far
+                    // larger weight than well-measured stars and distort the χ² gate).
                     var bestFocusStdDevMicrons = (!double.IsNaN(fitting.MinimumStdError) && !double.IsInfinity(fitting.MinimumStdError) && fitting.MinimumStdError > 0.0)
                         ? fitting.MinimumStdError * focuserSizeMicrons
-                        : 1.0;
-                    var dataPoint = new SensorParaboloidDataPoint(dataPointX, dataPointY, focuserMicrons, fitting.RSquared, bestFocusStdDevMicrons);
-                    sensorModelDataPoints.Add(dataPoint);
+                        : double.NaN;
+                    pendingPoints.Add((dataPointX, dataPointY, focuserMicrons, fitting.RSquared, bestFocusStdDevMicrons));
                 } catch (Exception e) {
                     Logger.Error(e, $"Failed to calculate hyperbolic at ({registeredStar.RegistrationX}, {registeredStar.RegistrationY}). Error={e.Message}");
                 }
+            }
+
+            // Resolve missing σ to the median of the available ones (or 1.0 if none could be estimated), so a
+            // star whose best-focus standard error is unknown is weighted like a typical star rather than
+            // dominating the fit.
+            var availableStdDevs = pendingPoints.Where(p => !double.IsNaN(p.StdDevMicrons)).Select(p => p.StdDevMicrons).ToList();
+            var fallbackStdDevMicrons = availableStdDevs.Count > 0 ? availableStdDevs.MedianMAD().Item1 : 1.0;
+            foreach (var p in pendingPoints) {
+                var stdDev = double.IsNaN(p.StdDevMicrons) ? fallbackStdDevMicrons : p.StdDevMicrons;
+                sensorModelDataPoints.Add(new SensorParaboloidDataPoint(p.X, p.Y, p.FocuserMicrons, p.RSquared, stdDev));
             }
 
             stopwatch.RecordEntry("fitcurves");
@@ -903,12 +917,17 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                 var nextStarIndexMap = starIndexMap[imageIndex];
                 var matchedGlobalStars = new bool[globalRegistry.Count];
                 var matchedSourceStars = new bool[nextStarTree.Count];
+                // Tracks whether a source star had ANY registry star within the search radius (regardless of
+                // brightness or one-to-one contention). Used below to restrict frame-union reinjection to
+                // stars that are genuinely absent from the registry's neighborhood.
+                var sourceHadGlobalNeighbor = new bool[nextStarTree.Count];
                 var queue = new KdTree.PriorityQueue<MatchingPair, double>(new DoubleMath());
                 foreach (var (starNode, starNodeIndex) in nextStarTree.Select((starNode, starNodeIndex) => (starNode, starNodeIndex))) {
                     var sourceStar = starNode.Value.DetectedStar;
                     var sourcePoint = starNode.Point;
                     var sourceIndex = starNode.Value.Index;
                     var globalNeighbors = globalRegistry.RadialSearch(sourcePoint, searchRadius);
+                    sourceHadGlobalNeighbor[sourceIndex] = globalNeighbors.Length > 0;
                     int queuedCount = 0;
                     foreach (var globalNeighbor in
                         maxNormalisedBrightnessDiff == -1 ? globalNeighbors :
@@ -944,14 +963,17 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                     matchedSourceStars[nextCandidate.SourceIndex] = true;
                 }
 
-                // Frame-union coverage: a source star that matched nothing in the existing registry is a
-                // physical star not present in (or not detectable from) the reference frame. Add it as a new
+                // Frame-union coverage: a source star with NO registry star within the search radius is a
+                // physical star not present in (or not detectable from) the earlier frames. Add it as a new
                 // registry entry so it still contributes to the model and can be matched by later frames.
-                // The per-frame one-to-one constraint (matchedSourceStars) prevents double-counting, and the
-                // new entries are appended after this frame's matching so they cannot match this same frame.
+                // Only genuinely-absent stars are added: a star that HAD a neighbor but went unmatched (lost
+                // the one-to-one contention, or was rejected on brightness) is an ambiguous detection, not a
+                // new star — reinjecting it would duplicate a nearby registry star and partially undo the
+                // brightness filter. Restricting to no-neighbor stars also guarantees the new point cannot
+                // coincide with an existing one, so globalRegistry's AddDuplicateBehavior.Error never trips.
                 foreach (var starNode in nextStarTree) {
                     var unmatchedSourceIndex = starNode.Value.Index;
-                    if (matchedSourceStars[unmatchedSourceIndex]) {
+                    if (matchedSourceStars[unmatchedSourceIndex] || sourceHadGlobalNeighbor[unmatchedSourceIndex]) {
                         continue;
                     }
                     var newGlobalIndex = globalRegistry.Count;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
@@ -703,8 +703,12 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             }
         }
 
-        private const double minCosSimStrict = 0.999999; // Cosine similarity threshold for accepting a match
-        private const double minCosSimRelaxed = 0.99999; // Cosine similarity threshold for accepting a match
+        // Max Euclidean distance, in similarity-invariant shape-descriptor space (sorted side-length ratios),
+        // for two triangles to be accepted as a putative match. Replaces the former near-1 cosine-similarity
+        // thresholds, which were brittle to seeing/centroiding noise. Strict is tried first; if it yields too
+        // few matches the relaxed (larger) tolerance is used. Ratios are O(1), so these are small fractions.
+        private const double maxShapeDistanceStrict = 0.02;
+        private const double maxShapeDistanceRelaxed = 0.05;
 
         private int AlignStarsWithRANSAC(
             List<SensorDetectedStars> allDetectedStars,
@@ -787,15 +791,19 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                     theseTriangles,
                     refTriangles,
                     status,
-                    minCosSimStrict);
+                    maxShapeDistanceStrict);
 
                 if (putativeDst.Count < 20) {
-                    Logger.Debug($"Image {imageIndex}: too few triangles ({putativeDst.Count}) with strict cosineSimilarity, switching to relaxed mode");
+                    Logger.Debug($"Image {imageIndex}: too few triangles ({putativeDst.Count}) with strict shape tolerance, switching to relaxed mode");
+                    // Reset the matched flags set by the strict pass so the relaxed pass can re-match freely.
+                    foreach (var t in theseTriangles) {
+                        t.ResetMatch();
+                    }
                     (putativeSrc, putativeDst) = RANSACRegistration.GeneratePutativeMatchesUsingSimilarTriangles(
                         theseTriangles,
                         refTriangles,
                         status,
-                        minCosSimRelaxed);
+                        maxShapeDistanceRelaxed);
                 }
                 try {
                     Logger.Info($"Image {imageIndex}, putative star matches: {putativeDst.Count} out of {theseStars.Count()} stars");

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
@@ -153,7 +153,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                     fRatio: fRatio,
                     focuserStepSizeMicrons: focuserSizeMicrons,
                     finalFocusPosition: finalFocusPosition,
-                    registeredStars: fitResult.RegisteredStars);
+                    registeredStars: fitResult.RegisteredStars,
+                    acceptableReducedChiSquared: inspectorOptions.AcceptableReducedChiSquared,
+                    acceptableRSquaredMin: inspectorOptions.AcceptableRSquaredMin);
 
                 var historyId = Interlocked.Increment(ref nextHistoryId);
                 SensorTiltHistoryModels.Insert(0, new SensorParaboloidTiltHistoryModel(
@@ -473,8 +475,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                         // has enough stars and a reduced χ² within the acceptable band. This replaces the
                         // former R²-vs-target test (and the wall-clock target removed in Phase 1), which
                         // rejected near-flat-but-good sensors and varied with machine load.
-                        if ((pfit != null) && ((pfit.StarsInModel < 10) || !SensorAberrationCalculator.IsReducedChiSquaredAcceptable(pfit))) {
-                            Logger.Debug($"Only have {pfit.StarsInModel} stars and reduced χ² of {pfit.ReducedChiSquared:#.##} (max is {SensorAberrationCalculator.AcceptableReducedChiSquaredMax:#.##}, R² {pfit.GoodnessOfFit:#.##}) with a brightness tolerance of {maxNormalisedBrightnessDiff:#.##}");
+                        if ((pfit != null) && ((pfit.StarsInModel < 10) || !SensorAberrationCalculator.IsModelAcceptable(pfit, inspectorOptions.AcceptableReducedChiSquared, inspectorOptions.AcceptableRSquaredMin))) {
+                            Logger.Debug($"Only have {pfit.StarsInModel} stars and reduced χ² of {pfit.ReducedChiSquared:#.##} (max is {inspectorOptions.AcceptableReducedChiSquared:#.##}, R² {pfit.GoodnessOfFit:#.##} vs min {inspectorOptions.AcceptableRSquaredMin:#.##}) with a brightness tolerance of {maxNormalisedBrightnessDiff:#.##}");
                             retry = true;
                         }
 
@@ -559,12 +561,11 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                 if (bestPfit == null) {
                     throw new Exception("Failed to find a good model.");
                 }
-                // Fail only when the model is bad by both measures: it explains almost no variance (R²)
-                // AND it cannot fit the best-focus positions within their uncertainties (reduced χ²). A
-                // near-flat but well-measured sensor has low R² yet acceptable reduced χ², and must not
-                // be rejected.
-                if (bestPfit.GoodnessOfFit < 0.05 && !SensorAberrationCalculator.IsReducedChiSquaredAcceptable(bestPfit)) {
-                    throw new Exception($"Sensor modeling failed. R² = {bestPfit.GoodnessOfFit:#.00}, reduced χ² = {bestPfit.ReducedChiSquared:#.00}");
+                // Reject via the combined rule: fail when reduced χ² exceeds the acceptable cap, or when a
+                // low R² coincides with an elevated χ². A near-flat but well-measured sensor has low R² yet
+                // acceptable reduced χ², and is still accepted.
+                if (!SensorAberrationCalculator.IsModelAcceptable(bestPfit, inspectorOptions.AcceptableReducedChiSquared, inspectorOptions.AcceptableRSquaredMin)) {
+                    throw new Exception($"Sensor modeling failed. R² = {bestPfit.GoodnessOfFit:#.00} (min {inspectorOptions.AcceptableRSquaredMin:#.00}), reduced χ² = {bestPfit.ReducedChiSquared:#.00} (max {inspectorOptions.AcceptableReducedChiSquared:#.00})");
                 }
 
                 if (bestPfit.StarsInModel < 10) {
@@ -1022,7 +1023,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             SensorModelResult.Update(
                 sensorModel: historyModel.SensorModel, imageSize: historyModel.ImageSize, pixelSizeMicrons: historyModel.PixelSizeMicrons,
                 fRatio: historyModel.FRatio, focuserStepSizeMicrons: historyModel.FocuserSizeMicrons, finalFocusPosition: historyModel.FinalFocusPosition,
-                registeredStars: []);
+                registeredStars: [],
+                acceptableReducedChiSquared: inspectorOptions.AcceptableReducedChiSquared,
+                acceptableRSquaredMin: inspectorOptions.AcceptableRSquaredMin);
             DisplayedSensorModel = historyModel.SensorModel;
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
@@ -193,18 +193,15 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                 inFocusMicrons: finalFocusPosition * focuserSizeMicrons,
                 fixedSensorCenter: inspectorOptions.FixedSensorCenter);
             var nlSolver = new NonLinearLeastSquaresSolver<SensorParaboloidSolver, SensorParaboloidDataPoint, SensorParaboloidModel>(this.alglibAPI);
-            sensorModelSolver.PositiveCurvature = true;
-            var positiveCurvatureSolution = nlSolver.SolveWinsorizedResiduals(sensorModelSolver, ct: ct, progress: progress);
-            ct.ThrowIfCancellationRequested();
-            positiveCurvatureSolution.EvaluateFit(nlSolver, sensorModelSolver);
 
-            sensorModelSolver.PositiveCurvature = false;
-            var negativeCurvatureSolution = nlSolver.SolveWinsorizedResiduals(sensorModelSolver, ct: ct, progress: progress);
+            // Single solve: the signed curvature coefficient K can cross zero, so one fit covers both
+            // curvature signs (the old code solved once forcing positive curvature and once forcing
+            // negative, then kept the lower-RMS result — double the optimizer work and a discontinuity
+            // at flat fields).
+            var solution = nlSolver.SolveWinsorizedResiduals(sensorModelSolver, ct: ct, progress: progress);
             ct.ThrowIfCancellationRequested();
-            negativeCurvatureSolution.EvaluateFit(nlSolver, sensorModelSolver);
-
-            var solution = positiveCurvatureSolution.RMSErrorMicrons < negativeCurvatureSolution.RMSErrorMicrons ? positiveCurvatureSolution : negativeCurvatureSolution;
-            Logger.Info($"Solved surface model: {solution}. RMS = {solution.RMSErrorMicrons:0.0000}, GoD: {solution.GoodnessOfFit:0.0000}, Stars: {solution.StarsInModel}");
+            solution.EvaluateFit(nlSolver, sensorModelSolver);
+            Logger.Info($"Solved surface model: {solution}. RMS = {solution.RMSErrorMicrons:0.0000}, GoD: {solution.GoodnessOfFit:0.0000}, ReducedChiSq: {solution.ReducedChiSquared:0.0000}, Stars: {solution.StarsInModel}");
 
             return solution;
         }
@@ -345,7 +342,34 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
         private const int searchRadiusRANSAC = 10;
         private const int searchRadiusNonRANSAC = 30;
 
-        private (SensorParaboloidModel, RegistrationAndFitResult) RegisterStarsAndFit(
+        // Fixed default starting point for the brightness-tolerance search when StartingBrightnessDiff
+        // is set to "auto" (-1). Previously the search seeded from (and wrote back to) the cross-run
+        // PreviousRunBrightnessDiff state, which made consecutive runs of the unchanged process diverge.
+        private const double DefaultStartingBrightnessDiff = 0.1d;
+
+        // Hard cap on the brightness-tolerance search so acceptance no longer depends on wall-clock
+        // time (which previously relaxed the R² target on slow machines) and the loop always terminates.
+        private const int MaxBrightnessSearchIterations = 12;
+
+        /// <summary>
+        /// Optional sink for human-readable registration/fit messages. When set (e.g. by tests), report
+        /// messages bypass the UI-bound <see cref="RegistrationAndFitReport"/> collection, allowing the
+        /// registration+fit core to run headless without a dispatcher.
+        /// </summary>
+        public Action<string> RegistrationReportSink { get; set; }
+
+        private void Report(string message) {
+            if (RegistrationReportSink != null) {
+                RegistrationReportSink(message);
+            } else {
+                RegistrationAndFitReport.Add(message);
+            }
+        }
+
+        // Public testability seam: runs the full registration + per-star + paraboloid fit on the supplied
+        // frames and returns the model. Decoupled from UI (via RegistrationReportSink) so it can be driven
+        // end-to-end from tests. Production callers go through UpdateModel.
+        public (SensorParaboloidModel, RegistrationAndFitResult) RegisterStarsAndFit(
             List<SensorDetectedStars> allDetectedStars,
             System.Drawing.Size imageSize,
             double focuserSizeMicrons,
@@ -359,9 +383,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                 int maxStars = 0;
                 int refIndex = -1;
                 for (int i = 0; i < allDetectedStars.Count; ++i) {
-                    if (allDetectedStars[i].StarDetectionResult.DetectedStars > maxStars) {
+                    if (allDetectedStars[i].StarDetectionResult.StarList.Count > maxStars) {
                         refIndex = i;
-                        maxStars = allDetectedStars[i].StarDetectionResult.DetectedStars;
+                        maxStars = allDetectedStars[i].StarDetectionResult.StarList.Count;
                     }
                 }
                 ReferenceImage = refIndex;
@@ -390,15 +414,19 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                     if (ransacAligned < allDetectedStars.Count) {
                         Logger.Info("Ransac failed on at least one image.  Search radius will remain the same as for non-aligned processing");
                         if (ransacAligned == 1) { // ransacAligned starts at 1 for the reference image so if it's still 1 it means no other images aligned
-                            RegistrationAndFitReport.Add("All frames failed to align.  An autofocus run where all images align will give more reliable results.");
+                            Report("All frames failed to align.  An autofocus run where all images align will give more reliable results.");
                         } else {
-                            RegistrationAndFitReport.Add($"{allDetectedStars.Count - ransacAligned} frames failed to align.  An autofocus run where all images align will give more reliable results.");
+                            Report($"{allDetectedStars.Count - ransacAligned} frames failed to align.  An autofocus run where all images align will give more reliable results.");
                         }
                     }
                 }
                 ct.ThrowIfCancellationRequested();
 
-                double maxNormalisedBrightnessDiff = (inspectorOptions.StartingBrightnessDiff != -1) ? inspectorOptions.StartingBrightnessDiff : inspectorOptions.PreviousRunBrightnessDiff;
+                // Stateless starting point: the configured StartingBrightnessDiff, or a fixed default
+                // when set to "auto" (-1). startingBrightnessDiff is a local pivot for the bidirectional
+                // up/down search below, so the search no longer depends on (or mutates) cross-run state.
+                double startingBrightnessDiff = (inspectorOptions.StartingBrightnessDiff != -1) ? inspectorOptions.StartingBrightnessDiff : DefaultStartingBrightnessDiff;
+                double maxNormalisedBrightnessDiff = startingBrightnessDiff;
                 SensorParaboloidModel bestPfit = null;
                 RegistrationAndFitResult bestReg = null;
                 double bestBrightnessDiff = maxNormalisedBrightnessDiff;
@@ -414,7 +442,10 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
 
                 int iterations = 0;
                 for (bool retry = true; retry;) {
-                    var startTime = DateTime.Now;
+                    if (iterations++ >= MaxBrightnessSearchIterations) {
+                        Logger.Warning($"Brightness-tolerance search hit the {MaxBrightnessSearchIterations}-iteration cap; stopping further iterations.");
+                        break;
+                    }
                     retry = false;
                     int rejectionsOnBrightnessDiff;
                     (registeredStars, rejectionsOnBrightnessDiff) = MatchStarsUsingKdTree(allDetectedStars,
@@ -437,10 +468,12 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                     }
 
                     if (inspectorOptions.RejectBadBrightnessMatches) {
-                        double targetR2 = TargetR2BasedOnTimeTaken(DateTime.Now - startTime);  // an R2 of greater than this value will be acceptible and halt further iterations
-                        Logger.Debug($"Target R2 {targetR2:#.##}");
-                        if ((pfit != null) && ((pfit.StarsInModel < 10) || (pfit.GoodnessOfFit < targetR2) || IsFitTooGood(pfit))) {
-                            Logger.Debug($"Only have {pfit.StarsInModel} stars and R2 of {pfit.GoodnessOfFit:#.##} (target is {targetR2:#.##}) with a brightness tolerance of {maxNormalisedBrightnessDiff:#.##}");
+                        // Uncertainty-aware, magnitude-independent acceptance: stop iterating once the fit
+                        // has enough stars and a reduced χ² within the acceptable band. This replaces the
+                        // former R²-vs-target test (and the wall-clock target removed in Phase 1), which
+                        // rejected near-flat-but-good sensors and varied with machine load.
+                        if ((pfit != null) && ((pfit.StarsInModel < 10) || !SensorAberrationCalculator.IsReducedChiSquaredAcceptable(pfit))) {
+                            Logger.Debug($"Only have {pfit.StarsInModel} stars and reduced χ² of {pfit.ReducedChiSquared:#.##} (max is {SensorAberrationCalculator.AcceptableReducedChiSquaredMax:#.##}, R² {pfit.GoodnessOfFit:#.##}) with a brightness tolerance of {maxNormalisedBrightnessDiff:#.##}");
                             retry = true;
                         }
 
@@ -466,9 +499,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                                     if (downExhausted) { // all tried, no retry
                                         retry = false;
                                     } else {
-                                        if (maxNormalisedBrightnessDiff != inspectorOptions.PreviousRunBrightnessDiff)
+                                        if (maxNormalisedBrightnessDiff != startingBrightnessDiff)
                                             upExhausted = true;
-                                        maxNormalisedBrightnessDiff = inspectorOptions.PreviousRunBrightnessDiff / 1.5;
+                                        maxNormalisedBrightnessDiff = startingBrightnessDiff / 1.5;
                                         direction = IterationDirection.Down;
                                         Logger.Debug($"Switching direction to {direction}");
                                     }
@@ -483,9 +516,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                                     if (upExhausted) { // all tried, no retry
                                         retry = false;
                                     } else {
-                                        if (maxNormalisedBrightnessDiff != inspectorOptions.PreviousRunBrightnessDiff)
+                                        if (maxNormalisedBrightnessDiff != startingBrightnessDiff)
                                             downExhausted = true;
-                                        maxNormalisedBrightnessDiff = inspectorOptions.PreviousRunBrightnessDiff * 1.5;
+                                        maxNormalisedBrightnessDiff = startingBrightnessDiff * 1.5;
                                         direction = IterationDirection.Up;
                                         Logger.Debug($"Switching direction to {direction}");
                                     }
@@ -503,7 +536,6 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
 
                         prevFit = pfit;
                         prevReg = reg;
-                        iterations++;
 
                         Logger.Debug($"End of registerStarsAndFit iteration with R2 of {bestPfit?.GoodnessOfFit:#.##}, retry is {retry}");
                     } else {        // we're not trying to find a better return as we're not rejecting on brightness
@@ -516,6 +548,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
 
                 progress.Report(new ApplicationStatus());
 
+                // Display-only: surfaces the winning tolerance in the UI hint. The search no longer
+                // reads this value back, so writing it here does not affect the repeatability of future runs.
                 inspectorOptions.PreviousRunBrightnessDiff = bestBrightnessDiff;
                 previousRuns.Select(r => (r.Key, r.Value.Item1?.GoodnessOfFit, r.Value.Item1?.StarsInModel))
                     .ToList()
@@ -524,15 +558,19 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                 if (bestPfit == null) {
                     throw new Exception("Failed to find a good model.");
                 }
-                if (bestPfit.GoodnessOfFit < 0.05) {
-                    throw new Exception($"Sensor modeling failed. R² = {bestPfit.GoodnessOfFit:#.00}");
+                // Fail only when the model is bad by both measures: it explains almost no variance (R²)
+                // AND it cannot fit the best-focus positions within their uncertainties (reduced χ²). A
+                // near-flat but well-measured sensor has low R² yet acceptable reduced χ², and must not
+                // be rejected.
+                if (bestPfit.GoodnessOfFit < 0.05 && !SensorAberrationCalculator.IsReducedChiSquaredAcceptable(bestPfit)) {
+                    throw new Exception($"Sensor modeling failed. R² = {bestPfit.GoodnessOfFit:#.00}, reduced χ² = {bestPfit.ReducedChiSquared:#.00}");
                 }
 
                 if (bestPfit.StarsInModel < 10) {
                     if (inspectorOptions.UseRANSAC) {
-                        RegistrationAndFitReport.Add($"There are very few stars in the model ({bestPfit.StarsInModel}).  There may be poor transparancy or seeing.  Frames with more stars will give more reliable results.");
+                        Report($"There are very few stars in the model ({bestPfit.StarsInModel}).  There may be poor transparancy or seeing.  Frames with more stars will give more reliable results.");
                     } else {
-                        RegistrationAndFitReport.Add($"There are very few stars in the model ({bestPfit.StarsInModel}).  If there is movement between the frames, it may help to enable the 'align images' option.");
+                        Report($"There are very few stars in the model ({bestPfit.StarsInModel}).  If there is movement between the frames, it may help to enable the 'align images' option.");
                     }
                 }
 
@@ -540,8 +578,18 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             }
         }
 
-        private static double TargetR2BasedOnTimeTaken(TimeSpan timeSpan) =>
-            SensorAberrationCalculator.TargetR2BasedOnTimeTaken(timeSpan);
+        // Rough per-detection HFR uncertainty used to weight the per-star hyperbolic fit by 1/σ². HFR is a
+        // size measurement whose relative error scales ~1/SNR; the SNR proxy uses the only fields available
+        // on a detected star (mean brightness above background, with a shot-noise-like denominator). This
+        // makes the previously no-op WeightedHyperbolicFitEnabled meaningful. It does not affect the
+        // best-focus standard error, which is self-calibrated from the fit residuals.
+        private static double EstimateHfrStdDev(HocusFocusDetectedStar star) {
+            var signal = star.AverageBrightness - star.Background;
+            var noise = Math.Sqrt(Math.Max(star.AverageBrightness, 1.0));
+            var snr = signal > 0 ? signal / noise : 0.0;
+            var sigma = star.HFR / Math.Max(snr, 1.0);
+            return Math.Max(sigma, 1e-3);
+        }
 
         private static bool IsFitTooGood(SensorParaboloidModel fit) =>
             SensorAberrationCalculator.IsFitTooGood(fit);
@@ -573,7 +621,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                 }
 
                 try {
-                    var points = registeredStar.MatchedStars.Select(s => new ScatterErrorPoint(s.FocuserPosition, s.Star.HFR, 0.0d, 0.0d)).ToList();
+                    var points = registeredStar.MatchedStars.Select(s => new ScatterErrorPoint(s.FocuserPosition, s.Star.HFR, 0.0d, EstimateHfrStdDev(s.Star))).ToList();
                     var rejectedPoints = new List<ScatterErrorPoint>();
                     bool continueFitting;
                     AlglibHyperbolicFitting fitting;
@@ -615,7 +663,12 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                     var dataPointX = (registeredStar.RegistrationX - (imageSize.Width / 2.0)) * pixelSize;
                     var dataPointY = (registeredStar.RegistrationY - (imageSize.Height / 2.0)) * pixelSize;
                     var focuserMicrons = fitting.Minimum.X * focuserSizeMicrons;
-                    var dataPoint = new SensorParaboloidDataPoint(dataPointX, dataPointY, focuserMicrons, fitting.RSquared);
+                    // Propagate the standard error of this star's best-focus position into the paraboloid
+                    // fit so it is weighted by 1/σ². Falls back to unit weight when unavailable.
+                    var bestFocusStdDevMicrons = (!double.IsNaN(fitting.MinimumStdError) && !double.IsInfinity(fitting.MinimumStdError) && fitting.MinimumStdError > 0.0)
+                        ? fitting.MinimumStdError * focuserSizeMicrons
+                        : 1.0;
+                    var dataPoint = new SensorParaboloidDataPoint(dataPointX, dataPointY, focuserMicrons, fitting.RSquared, bestFocusStdDevMicrons);
                     sensorModelDataPoints.Add(dataPoint);
                 } catch (Exception e) {
                     Logger.Error(e, $"Failed to calculate hyperbolic at ({registeredStar.RegistrationX}, {registeredStar.RegistrationY}). Error={e.Message}");
@@ -745,8 +798,14 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                 }
                 try {
                     Logger.Info($"Image {imageIndex}, putative star matches: {putativeDst.Count} out of {theseStars.Count()} stars");
-                    // calculate the transform needed to register this image
-                    var transform = RANSACRegistration.EstimateAffineTransform(putativeSrc, putativeDst, status, progress);
+                    // Calculate the transform needed to register this image. Frames in a single AF run differ
+                    // only by small translation/rotation/scale, so a 4-DOF similarity transform is the
+                    // physically correct model. The 6-DOF affine adds shear + anisotropic scale that let RANSAC
+                    // "explain" mismatches by warping the field — degrading the data the paraboloid then fits.
+                    // Affine is retained behind UseAffineAlignment for diagnostics only.
+                    Matrix3x2 transform = inspectorOptions.UseAffineAlignment
+                        ? RANSACRegistration.EstimateAffineTransform(putativeSrc, putativeDst, status, progress)
+                        : RANSACRegistration.EstimateSimilarityTransform(putativeSrc, putativeDst, status, progress).ToMatrix3x2();
                     allDetectedStars[imageIndex].AlignmentTransform = transform;
 
                     // adjust each star according to the transform
@@ -777,11 +836,11 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                     TooFewTrianglesImages++;    // include the reference image in this message
                 }
                 var imageCount = (TooFewTrianglesImages == allDetectedStars.Count) ? "All" : TooFewTrianglesImages.ToString();
-                RegistrationAndFitReport.Add($"{imageCount} images had too few star triangles for reliable alignment.  Alignment may have failed for these images.  Check image quality or star detection parameters.");
+                Report($"{imageCount} images had too few star triangles for reliable alignment.  Alignment may have failed for these images.  Check image quality or star detection parameters.");
             } else {
                 if (refTriangles.Count < minTri) {
                     Logger.Warning("Too few star triangles found in reference image for reliable alignment.  Alignment may fail.");
-                    RegistrationAndFitReport.Add("Too few star triangles found in reference image for reliable alignment.  Check image quality or star detection parameters.");
+                    Report("Too few star triangles found in reference image for reliable alignment.  Check image quality or star detection parameters.");
                 }
             }
 
@@ -874,6 +933,21 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                     nextStarIndexMap.Add(nextCandidate.SourceIndex, nextCandidate.GlobalIndex);
                     matchedGlobalStars[nextCandidate.GlobalIndex] = true;
                     matchedSourceStars[nextCandidate.SourceIndex] = true;
+                }
+
+                // Frame-union coverage: a source star that matched nothing in the existing registry is a
+                // physical star not present in (or not detectable from) the reference frame. Add it as a new
+                // registry entry so it still contributes to the model and can be matched by later frames.
+                // The per-frame one-to-one constraint (matchedSourceStars) prevents double-counting, and the
+                // new entries are appended after this frame's matching so they cannot match this same frame.
+                foreach (var starNode in nextStarTree) {
+                    var unmatchedSourceIndex = starNode.Value.Index;
+                    if (matchedSourceStars[unmatchedSourceIndex]) {
+                        continue;
+                    }
+                    var newGlobalIndex = globalRegistry.Count;
+                    globalRegistry.Add(starNode.Point, new DetectedStarIndex(newGlobalIndex, starNode.Value.DetectedStar));
+                    nextStarIndexMap.Add(unmatchedSourceIndex, newGlobalIndex);
                 }
             }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
@@ -191,7 +191,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                 sensorSizeMicronsX: imageSize.Width * pixelSize,
                 sensorSizeMicronsY: imageSize.Height * pixelSize,
                 inFocusMicrons: finalFocusPosition * focuserSizeMicrons,
-                fixedSensorCenter: inspectorOptions.FixedSensorCenter);
+                fixedSensorCenter: inspectorOptions.FixedSensorCenter,
+                astigmatic: inspectorOptions.AstigmaticCurvatureEnabled);
             var nlSolver = new NonLinearLeastSquaresSolver<SensorParaboloidSolver, SensorParaboloidDataPoint, SensorParaboloidModel>(this.alglibAPI);
 
             // Single solve: the signed curvature coefficient K can cross zero, so one fit covers both

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModelAberrationResult.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModelAberrationResult.cs
@@ -241,7 +241,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             double fRatio,
             double focuserStepSizeMicrons,
             double finalFocusPosition,
-            SensorModel.RegisteredStar[] registeredStars) {
+            SensorModel.RegisteredStar[] registeredStars,
+            double acceptableReducedChiSquared,
+            double acceptableRSquaredMin) {
             ImageSize = imageSize;
             FRatio = fRatio;
             PixelSizeMicrons = pixelSizeMicrons;
@@ -275,7 +277,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             TiltPlaneModel = tiltPlaneModel;
 
             AnalysisResults.Clear();
-            AnalyzeSensorModelFit(sensorModel);
+            AnalyzeSensorModelFit(sensorModel, acceptableReducedChiSquared, acceptableRSquaredMin);
             AnalyzeCurvature(CurvatureRadiusMillimeters, CurvatureEffectMicrons, criticalFocusMicrons);
             AnalyzeTilt(TiltEffectMicrons, Tilt, criticalFocusMicrons);
             AnalyzeCentering(sensorModel, pixelSizeMicrons);
@@ -283,17 +285,52 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             Model = sensorModel;
         }
 
-        private void AnalyzeSensorModelFit(SensorParaboloidModel sensorModel) {
-            var result = new SensorModelAnalysisResult() {
-                Name = "Model Fit",
-                Value = $"{sensorModel.GoodnessOfFit:0.00} R²",
-                Acceptable = sensorModel.GoodnessOfFit > 0.6,
-                Details = "Sensor model fits well"
+        private void AnalyzeSensorModelFit(SensorParaboloidModel sensorModel, double acceptableReducedChiSquared, double acceptableRSquaredMin) {
+            var (rSquaredResult, reducedChiSquaredResult) = BuildFitQualityResults(sensorModel, acceptableReducedChiSquared, acceptableRSquaredMin);
+            AnalysisResults.Add(rSquaredResult);
+            AnalysisResults.Add(reducedChiSquaredResult);
+        }
+
+        /// <summary>
+        /// Builds the two fit-quality analysis rows (R² and reduced χ²) from a fitted model and the
+        /// configurable acceptance thresholds, applying the same combined rule used to accept/reject the
+        /// model: the R² row only fails when a low R² coincides with an elevated χ² (so a near-flat sensor
+        /// is not penalized for low R²), while the χ² row fails whenever reduced χ² reaches the cap.
+        /// Pure and side-effect-free so it can be unit tested without the dispatcher-backed result state.
+        /// </summary>
+        public static (SensorModelAnalysisResult rSquared, SensorModelAnalysisResult reducedChiSquared) BuildFitQualityResults(
+            SensorParaboloidModel sensorModel, double acceptableReducedChiSquared, double acceptableRSquaredMin) {
+            var goodnessOfFit = sensorModel.GoodnessOfFit;
+            var reducedChiSquared = sensorModel.ReducedChiSquared;
+            var band = SensorAberrationCalculator.ClassifyReducedChiSquared(reducedChiSquared, acceptableReducedChiSquared);
+            var chiSquaredElevated = band != SensorAberrationCalculator.FitQualityBand.Good;
+            var lowRSquared = goodnessOfFit < acceptableRSquaredMin;
+
+            var rSquaredResult = new SensorModelAnalysisResult() {
+                Name = "Model Fit (R²)",
+                Value = $"{goodnessOfFit:0.00} R²",
+                // Red only when R² actually contributes to rejection (low R² alongside an elevated χ²).
+                Acceptable = !(lowRSquared && chiSquaredElevated)
             };
-            if (!result.Acceptable) {
-                result.Details = "Sensor model R² is below 0.6, which indicates a weak model fit. You might need to review your star detection options, but your equipment might not be capable of better around the edges";
+            if (!rSquaredResult.Acceptable) {
+                rSquaredResult.Details = $"R² is below {acceptableRSquaredMin:0.00} while reduced χ² is also elevated, indicating a weak model fit. You might need to review your star detection options, but your equipment might not be capable of better around the edges.";
+            } else if (lowRSquared) {
+                rSquaredResult.Details = "Low R² is expected for a near-flat sensor and is fine while reduced χ² is good.";
+            } else {
+                rSquaredResult.Details = "Sensor model explains the best-focus variance well.";
             }
-            AnalysisResults.Add(result);
+
+            var reducedChiSquaredResult = new SensorModelAnalysisResult() {
+                Name = "Reduced χ²",
+                Value = $"{reducedChiSquared:0.00}",
+                Acceptable = band != SensorAberrationCalculator.FitQualityBand.Rejected,
+                Details = band switch {
+                    SensorAberrationCalculator.FitQualityBand.Good => "Fits within measurement uncertainty.",
+                    SensorAberrationCalculator.FitQualityBand.Marginal => "Acceptable but elevated — likely model error or under-estimated per-star σ.",
+                    _ => $"Exceeds the acceptable limit of {acceptableReducedChiSquared:0.00}; model rejected."
+                }
+            };
+            return (rSquaredResult, reducedChiSquaredResult);
         }
 
         private void AnalyzeTilt(double tiltEffectMicrons, Angle tilt, double criticalFocus) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModelAberrationResult.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModelAberrationResult.cs
@@ -242,7 +242,6 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             double focuserStepSizeMicrons,
             double finalFocusPosition,
             SensorModel.RegisteredStar[] registeredStars,
-            double acceptableReducedChiSquared,
             double acceptableRSquaredMin) {
             ImageSize = imageSize;
             FRatio = fRatio;
@@ -277,7 +276,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             TiltPlaneModel = tiltPlaneModel;
 
             AnalysisResults.Clear();
-            AnalyzeSensorModelFit(sensorModel, acceptableReducedChiSquared, acceptableRSquaredMin);
+            AnalyzeSensorModelFit(sensorModel, acceptableRSquaredMin);
             AnalyzeCurvature(CurvatureRadiusMillimeters, CurvatureEffectMicrons, criticalFocusMicrons);
             AnalyzeTilt(TiltEffectMicrons, Tilt, criticalFocusMicrons);
             AnalyzeCentering(sensorModel, pixelSizeMicrons);
@@ -285,37 +284,39 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             Model = sensorModel;
         }
 
-        private void AnalyzeSensorModelFit(SensorParaboloidModel sensorModel, double acceptableReducedChiSquared, double acceptableRSquaredMin) {
-            var (rSquaredResult, reducedChiSquaredResult) = BuildFitQualityResults(sensorModel, acceptableReducedChiSquared, acceptableRSquaredMin);
+        private void AnalyzeSensorModelFit(SensorParaboloidModel sensorModel, double acceptableRSquaredMin) {
+            var (rSquaredResult, reducedChiSquaredResult) = BuildFitQualityResults(sensorModel, acceptableRSquaredMin);
             AnalysisResults.Add(rSquaredResult);
             AnalysisResults.Add(reducedChiSquaredResult);
         }
 
         /// <summary>
-        /// Builds the two fit-quality analysis rows (R² and reduced χ²) from a fitted model and the
-        /// configurable acceptance thresholds, applying the same combined rule used to accept/reject the
-        /// model: the R² row only fails when a low R² coincides with an elevated χ² (so a near-flat sensor
-        /// is not penalized for low R²), while the χ² row fails whenever reduced χ² reaches the cap.
-        /// Pure and side-effect-free so it can be unit tested without the dispatcher-backed result state.
+        /// Builds the two fit-quality analysis rows (R² and reduced χ²) from a fitted model, both reflecting
+        /// the acceptance rule that reduced χ² is only a failure when the R² is also very low. Both values
+        /// are always displayed; the rows are flagged (unacceptable) only when R² &lt;
+        /// <paramref name="acceptableRSquaredMin"/> AND the reduced χ² exceeds the fixed cap. A well-fit
+        /// model with an adequate R² is never flagged for a high reduced χ². Pure and side-effect-free so it
+        /// can be unit tested without the dispatcher-backed result state.
         /// </summary>
         public static (SensorModelAnalysisResult rSquared, SensorModelAnalysisResult reducedChiSquared) BuildFitQualityResults(
-            SensorParaboloidModel sensorModel, double acceptableReducedChiSquared, double acceptableRSquaredMin) {
+            SensorParaboloidModel sensorModel, double acceptableRSquaredMin) {
             var goodnessOfFit = sensorModel.GoodnessOfFit;
             var reducedChiSquared = sensorModel.ReducedChiSquared;
-            var band = SensorAberrationCalculator.ClassifyReducedChiSquared(reducedChiSquared, acceptableReducedChiSquared);
-            var chiSquaredElevated = band != SensorAberrationCalculator.FitQualityBand.Good;
+            var chiSquaredAcceptable = SensorAberrationCalculator.IsReducedChiSquaredAcceptable(sensorModel);
             var lowRSquared = goodnessOfFit < acceptableRSquaredMin;
+            // The model is rejected only when both metrics are bad; reduced χ² alone never rejects it.
+            var modelAcceptable = !(lowRSquared && !chiSquaredAcceptable);
+            var chiCap = SensorAberrationCalculator.AcceptableReducedChiSquared;
 
             var rSquaredResult = new SensorModelAnalysisResult() {
                 Name = "Model Fit (R²)",
                 Value = $"{goodnessOfFit:0.00} R²",
-                // Red only when R² actually contributes to rejection (low R² alongside an elevated χ²).
-                Acceptable = !(lowRSquared && chiSquaredElevated)
+                Acceptable = modelAcceptable
             };
-            if (!rSquaredResult.Acceptable) {
-                rSquaredResult.Details = $"R² is below {acceptableRSquaredMin:0.00} while reduced χ² is also elevated, indicating a weak model fit. You might need to review your star detection options, but your equipment might not be capable of better around the edges.";
+            if (!modelAcceptable) {
+                rSquaredResult.Details = $"R² is below {acceptableRSquaredMin:0.00} and reduced χ² is also too high; the model is rejected. Review your star detection options, but your equipment might not be capable of better around the edges.";
             } else if (lowRSquared) {
-                rSquaredResult.Details = "Low R² is expected for a near-flat sensor and is fine while reduced χ² is good.";
+                rSquaredResult.Details = "Low R² is expected for a near-flat sensor and is fine while reduced χ² is acceptable.";
             } else {
                 rSquaredResult.Details = "Sensor model explains the best-focus variance well.";
             }
@@ -323,13 +324,15 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             var reducedChiSquaredResult = new SensorModelAnalysisResult() {
                 Name = "Reduced χ²",
                 Value = $"{reducedChiSquared:0.00}",
-                Acceptable = band != SensorAberrationCalculator.FitQualityBand.Rejected,
-                Details = band switch {
-                    SensorAberrationCalculator.FitQualityBand.Good => "Fits within measurement uncertainty.",
-                    SensorAberrationCalculator.FitQualityBand.Marginal => "Acceptable but elevated — likely model error or under-estimated per-star σ.",
-                    _ => $"Exceeds the acceptable limit of {acceptableReducedChiSquared:0.00}; model rejected."
-                }
+                Acceptable = modelAcceptable
             };
+            if (!modelAcceptable) {
+                reducedChiSquaredResult.Details = $"Reduced χ² exceeds {chiCap:0.00} and R² is also very low; the model is rejected.";
+            } else if (!chiSquaredAcceptable) {
+                reducedChiSquaredResult.Details = $"Reduced χ² is high, but it only indicates a problem when R² is also very low (< {acceptableRSquaredMin:0.00}). The per-star σ is approximate and rig-dependent, so a large value here is often benign.";
+            } else {
+                reducedChiSquaredResult.Details = "Fits within measurement uncertainty.";
+            }
             return (rSquaredResult, reducedChiSquaredResult);
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModelAberrationResult.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModelAberrationResult.cs
@@ -13,6 +13,7 @@
 using NINA.Astrometry;
 using NINA.Core.Utility;
 using DrawingSize = System.Drawing.Size;
+using System.Collections.Generic;
 using System.Linq;
 using NINA.Joko.Plugins.HocusFocus.AutoFocus;
 using System;
@@ -285,20 +286,20 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
         }
 
         private void AnalyzeSensorModelFit(SensorParaboloidModel sensorModel, double acceptableRSquaredMin) {
-            var (rSquaredResult, reducedChiSquaredResult) = BuildFitQualityResults(sensorModel, acceptableRSquaredMin);
-            AnalysisResults.Add(rSquaredResult);
-            AnalysisResults.Add(reducedChiSquaredResult);
+            foreach (var result in BuildFitQualityResults(sensorModel, acceptableRSquaredMin)) {
+                AnalysisResults.Add(result);
+            }
         }
 
         /// <summary>
-        /// Builds the two fit-quality analysis rows (R² and reduced χ²) from a fitted model, both reflecting
-        /// the acceptance rule that reduced χ² is only a failure when the R² is also very low. Both values
-        /// are always displayed; the rows are flagged (unacceptable) only when R² &lt;
-        /// <paramref name="acceptableRSquaredMin"/> AND the reduced χ² exceeds the fixed cap. A well-fit
-        /// model with an adequate R² is never flagged for a high reduced χ². Pure and side-effect-free so it
-        /// can be unit tested without the dispatcher-backed result state.
+        /// Builds the fit-quality analysis rows to display from a fitted model. The R² row is always shown;
+        /// the reduced χ² row is only included when R² &lt; <paramref name="acceptableRSquaredMin"/>, because
+        /// reduced χ² only matters as a rejection criterion when the R² is very low (its per-star σ is
+        /// approximate and rig-dependent, so it routinely runs high even for good fits). The model is rejected
+        /// only when R² is below the minimum AND the reduced χ² exceeds the fixed cap. Pure and
+        /// side-effect-free so it can be unit tested without the dispatcher-backed result state.
         /// </summary>
-        public static (SensorModelAnalysisResult rSquared, SensorModelAnalysisResult reducedChiSquared) BuildFitQualityResults(
+        public static IReadOnlyList<SensorModelAnalysisResult> BuildFitQualityResults(
             SensorParaboloidModel sensorModel, double acceptableRSquaredMin) {
             var goodnessOfFit = sensorModel.GoodnessOfFit;
             var reducedChiSquared = sensorModel.ReducedChiSquared;
@@ -321,19 +322,24 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                 rSquaredResult.Details = "Sensor model explains the best-focus variance well.";
             }
 
-            var reducedChiSquaredResult = new SensorModelAnalysisResult() {
-                Name = "Reduced χ²",
-                Value = $"{reducedChiSquared:0.00}",
-                Acceptable = modelAcceptable
-            };
-            if (!modelAcceptable) {
-                reducedChiSquaredResult.Details = $"Reduced χ² exceeds {chiCap:0.00} and R² is also very low; the model is rejected.";
-            } else if (!chiSquaredAcceptable) {
-                reducedChiSquaredResult.Details = $"Reduced χ² is high, but it only indicates a problem when R² is also very low (< {acceptableRSquaredMin:0.00}). The per-star σ is approximate and rig-dependent, so a large value here is often benign.";
-            } else {
-                reducedChiSquaredResult.Details = "Fits within measurement uncertainty.";
+            var results = new List<SensorModelAnalysisResult> { rSquaredResult };
+
+            // Reduced χ² is only meaningful as a gate when R² is very low, so only surface its row then.
+            if (lowRSquared) {
+                var reducedChiSquaredResult = new SensorModelAnalysisResult() {
+                    Name = "Reduced χ²",
+                    Value = $"{reducedChiSquared:0.00}",
+                    Acceptable = modelAcceptable
+                };
+                if (!modelAcceptable) {
+                    reducedChiSquaredResult.Details = $"Reduced χ² exceeds {chiCap:0.00} and R² is also very low; the model is rejected.";
+                } else {
+                    reducedChiSquaredResult.Details = $"Reduced χ² is within the acceptable limit of {chiCap:0.00}, so the low R² does not reject the model.";
+                }
+                results.Add(reducedChiSquaredResult);
             }
-            return (rSquaredResult, reducedChiSquaredResult);
+
+            return results;
         }
 
         private void AnalyzeTilt(double tiltEffectMicrons, Angle tilt, double criticalFocus) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorParaboloidModel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorParaboloidModel.cs
@@ -1,4 +1,4 @@
-﻿#region "copyright"
+#region "copyright"
 
 /*
     Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
@@ -19,17 +19,25 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
 
     public class SensorParaboloidDataPoint : INonLinearLeastSquaresDataPoint {
 
-        public SensorParaboloidDataPoint(double x, double y, double focuserPosition, double rSquared) {
+        public SensorParaboloidDataPoint(double x, double y, double focuserPosition, double rSquared, double focuserPositionStdDev = 1.0) {
             this.X = x;
             this.Y = y;
             this.FocuserPosition = focuserPosition;
             this.RSquared = rSquared;
+            this.FocuserPositionStdDev = focuserPositionStdDev;
         }
 
         public double X { get; private set; }
         public double Y { get; private set; }
         public double FocuserPosition { get; private set; }
         public double RSquared { get; private set; }
+
+        /// <summary>
+        /// 1-sigma uncertainty of <see cref="FocuserPosition"/> (the standard error of this star's
+        /// best-focus position, propagated from its hyperbolic fit). Used to weight the paraboloid fit
+        /// by 1/σ². Defaults to 1.0 (unweighted) when no uncertainty is available.
+        /// </summary>
+        public double FocuserPositionStdDev { get; private set; }
 
         public double[] ToInput() {
             return new double[] { X, Y };
@@ -39,8 +47,12 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             return FocuserPosition;
         }
 
+        public double ToOutputStdDev() {
+            return FocuserPositionStdDev;
+        }
+
         public override string ToString() {
-            return $"{{{nameof(X)}={X.ToString()}, {nameof(Y)}={Y.ToString()}, {nameof(FocuserPosition)}={FocuserPosition.ToString()}, {nameof(RSquared)}={RSquared.ToString()}}}";
+            return $"{{{nameof(X)}={X.ToString()}, {nameof(Y)}={Y.ToString()}, {nameof(FocuserPosition)}={FocuserPosition.ToString()}, {nameof(RSquared)}={RSquared.ToString()}, {nameof(FocuserPositionStdDev)}={FocuserPositionStdDev.ToString()}}}";
         }
     }
 
@@ -55,18 +67,43 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
         public RegisteredStar[] RegisteredStars { get; private set; }
     }
 
+    /// <summary>
+    /// Tilted paraboloid sensor model. The surface is parameterized by linear tilt gradients (Gx, Gy)
+    /// and a single signed curvature coefficient (K):
+    ///
+    ///     z(x, y) = Gx·(x − X0) + Gy·(y − Y0) + K·((x − X0)² + (y − Y0)²) + Z0
+    ///
+    /// This linear-in-(Gx, Gy, K) form replaces the older (θ, φ, c) parameterization, which injected
+    /// trigonometric nonlinearity, a φ-unidentifiability/local-minimum trap at θ = 0 (worked around by
+    /// forcing θ ≥ 1e-5), and a sign(c)·c² curvature that could not cross zero (forcing two solves).
+    /// The legacy tilt/curvature quantities remain available as derived display properties.
+    /// </summary>
     public class SensorParaboloidModel : INonLinearLeastSquaresParameters {
 
-        public SensorParaboloidModel(double x0, double y0, double z0, double theta, double phi, double c) {
+        public SensorParaboloidModel(double x0, double y0, double z0, double gx, double gy, double k) {
             this.X0 = x0;
             this.Y0 = y0;
             this.Z0 = z0;
-            this.Theta = theta;
-            this.Phi = phi;
-            this.C = c;
+            this.Gx = gx;
+            this.Gy = gy;
+            this.K = k;
         }
 
         public SensorParaboloidModel() {
+        }
+
+        /// <summary>
+        /// Builds a model from the legacy display parameters (tilt angle θ, tilt azimuth φ, curvature c),
+        /// converting them to the canonical (Gx, Gy, K) representation. Provided for readability and for
+        /// tests; the optimizer always works in canonical parameters via <see cref="ToArray"/>.
+        /// </summary>
+        public static SensorParaboloidModel FromTiltCurvature(double x0, double y0, double z0, double theta, double phi, double c) {
+            var tanTheta = Math.Tan(theta);
+            return new SensorParaboloidModel(
+                x0: x0, y0: y0, z0: z0,
+                gx: tanTheta * Math.Cos(phi),
+                gy: tanTheta * Math.Sin(phi),
+                k: Math.Sign(c) * c * c);
         }
 
         public void FromArray(double[] parameters) {
@@ -77,9 +114,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             this.X0 = parameters[0];
             this.Y0 = parameters[1];
             this.Z0 = parameters[2];
-            this.Theta = parameters[3];
-            this.Phi = parameters[4];
-            this.C = parameters[5];
+            this.Gx = parameters[3];
+            this.Gy = parameters[4];
+            this.K = parameters[5];
         }
 
         public double[] ToArray() {
@@ -87,81 +124,77 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                 this.X0,
                 this.Y0,
                 this.Z0,
-                this.Theta,
-                this.Phi,
-                this.C
+                this.Gx,
+                this.Gy,
+                this.K
             };
         }
 
         public double X0 { get; private set; }
         public double Y0 { get; private set; }
         public double Z0 { get; private set; }
-        public double Theta { get; private set; }
-        public double Phi { get; private set; }
-        public double C { get; private set; }
+
+        /// <summary>Tilt gradient along X: change in focuser position per micron of sensor X (dimensionless).</summary>
+        public double Gx { get; private set; }
+
+        /// <summary>Tilt gradient along Y: change in focuser position per micron of sensor Y (dimensionless).</summary>
+        public double Gy { get; private set; }
+
+        /// <summary>Signed curvature coefficient: curvature contribution is K·r². Equivalent to the old sign(c)·c².</summary>
+        public double K { get; private set; }
+
+        // Derived display parameters, kept for back-compat with the (θ, φ, c) form used by the UI/result layer.
+        public double Theta => Math.Atan(Math.Sqrt(Gx * Gx + Gy * Gy));
+        public double Phi => Math.Atan2(Gy, Gx);
+        public double C => Math.Sign(K) * Math.Sqrt(Math.Abs(K));
+
         public int StarsInModel { get; private set; }
         public double GoodnessOfFit { get; private set; }
         public double RMSErrorMicrons { get; private set; }
+        public double ReducedChiSquared { get; private set; }
+        public double ChiSquaredPValue { get; private set; }
 
         public void EvaluateFit(NonLinearLeastSquaresSolver<SensorParaboloidSolver, SensorParaboloidDataPoint, SensorParaboloidModel> nlSolver, SensorParaboloidSolver sensorModelSolver) {
             StarsInModel = nlSolver.InputEnabledCount;
             GoodnessOfFit = nlSolver.GoodnessOfFit(sensorModelSolver, this);
             RMSErrorMicrons = nlSolver.RMSError(sensorModelSolver, this);
+            ReducedChiSquared = nlSolver.ReducedChiSquared(sensorModelSolver, this);
+            ChiSquaredPValue = nlSolver.ChiSquaredPValue(sensorModelSolver, this);
         }
 
         public override string ToString() {
-            return $"{{{nameof(X0)}={X0.ToString()}, {nameof(Y0)}={Y0.ToString()}, {nameof(Z0)}={Z0.ToString()}, {nameof(Theta)}={Theta.ToString()}, {nameof(Phi)}={Phi.ToString()}, {nameof(C)}={C.ToString()}}}";
+            return $"{{{nameof(X0)}={X0.ToString()}, {nameof(Y0)}={Y0.ToString()}, {nameof(Z0)}={Z0.ToString()}, {nameof(Gx)}={Gx.ToString()}, {nameof(Gy)}={Gy.ToString()}, {nameof(K)}={K.ToString()}}}";
         }
 
         public double ValueAt(double x, double y) {
             var XPrime = x - X0;
             var YPrime = y - Y0;
-            var XPrime2 = XPrime * XPrime;
-            var YPrime2 = YPrime * YPrime;
-            var C2 = Math.Sign(C) * C * C;
-
-            var ZPrime = C2 * (XPrime2 + YPrime2);
-            var tanTheta = Math.Tan(Theta);
-            var sinPhi = Math.Sin(Phi);
-            var cosPhi = Math.Cos(Phi);
-            var result = (XPrime * cosPhi + YPrime * sinPhi) * tanTheta + ZPrime + Z0;
-            return result;
+            var tilt = Gx * XPrime + Gy * YPrime;
+            var curvature = K * (XPrime * XPrime + YPrime * YPrime);
+            return tilt + curvature + Z0;
         }
 
         public double TiltAt(double x, double y) {
-            var XPrime = x;
-            var YPrime = y;
-            var tanTheta = Math.Tan(Theta);
-            var sinPhi = Math.Sin(Phi);
-            var cosPhi = Math.Cos(Phi);
-            var result = (XPrime * cosPhi + YPrime * sinPhi) * tanTheta;
-            return result;
+            return Gx * x + Gy * y;
         }
 
         public double CurvatureAt(double x, double y) {
-            var XPrime = x;
-            var YPrime = y;
-            var C2 = Math.Sign(C) * C * C;
-            var result = C2 * (XPrime * XPrime + YPrime * YPrime);
-            return result;
+            return K * (x * x + y * y);
         }
 
         public double Volume(double widthMicrons, double heightMicrons) {
             var w = widthMicrons;
             var h = heightMicrons;
-            var C2 = Math.Sign(C) * C * C;
 
-            var cosP = Math.Cos(Phi);
-            var sinP = Math.Sin(Phi);
-            var tanT = Math.Tan(Theta);
-
-            // Double integral from [-w/2,w/2] and [-h/2,h/2]
-            var part1 = C2 * w * h * (X0 * X0 + Y0 + Y0);
-            var part2 = 1.0 / 12.0 * C2 * w * h * (w * w + h * h);
-            var part3 = -w * h * tanT * (X0 * cosP + Y0 * sinP);
-            var part4 = Z0 * w * h;
-            var result = part1 + part2 + part3 + part4;
-            return result;
+            // Closed-form double integral of ValueAt over [-w/2,w/2] x [-h/2,h/2]:
+            //   tilt:      -w·h·(Gx·X0 + Gy·Y0)
+            //   curvature:  K·w·h·(X0² + Y0²) + (1/12)·K·w·h·(w² + h²)
+            //   offset:     Z0·w·h
+            var tiltPart = -w * h * (Gx * X0 + Gy * Y0);
+            var curvatureCenterPart = K * w * h * (X0 * X0 + Y0 * Y0);
+            var curvatureSpreadPart = 1.0 / 12.0 * K * w * h * (w * w + h * h);
+            var offsetPart = Z0 * w * h;
+            return tiltPart + curvatureCenterPart + curvatureSpreadPart + offsetPart;
         }
     }
 
@@ -185,88 +218,55 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
 
         public override bool UseJacobian => true;
 
-        public bool PositiveCurvature { get; set; } = true;
-
+        // z = Gx·(X-x0) + Gy·(Y-y0) + K·((X-x0)² + (Y-y0)²) + z0
         public override double Value(double[] parameters, double[] input) {
             var X = input[0];
             var Y = input[1];
-            var x0 = parameters[0]; // u
-            var y0 = parameters[1]; // v
-            var z0 = parameters[2]; // w
-            var theta = parameters[3]; // t
-            var phi = parameters[4]; // p
-            var c = parameters[5]; // c
+            var x0 = parameters[0];
+            var y0 = parameters[1];
+            var z0 = parameters[2];
+            var gx = parameters[3];
+            var gy = parameters[4];
+            var k = parameters[5];
 
             var XPrime = X - x0;
             var YPrime = Y - y0;
-            var XPrime2 = XPrime * XPrime;
-            var YPrime2 = YPrime * YPrime;
-            var C2 = Math.Sign(c) * c * c;
-
-            var ZPrime = C2 * (XPrime2 + YPrime2);
-            var tanTheta = Math.Tan(theta);
-            var sinPhi = Math.Sin(phi);
-            var cosPhi = Math.Cos(phi);
-            var result = (XPrime * cosPhi + YPrime * sinPhi) * tanTheta + ZPrime + z0;
-            return result;
+            return gx * XPrime + gy * YPrime + k * (XPrime * XPrime + YPrime * YPrime) + z0;
         }
 
         public override void Gradient(double[] parameters, double[] input, double[] result) {
             var X = input[0];
             var Y = input[1];
-            var x0 = parameters[0]; // u
-            var y0 = parameters[1]; // v
-            var z0 = parameters[2]; // w
-            var theta = parameters[3]; // t
-            var phi = parameters[4]; // p
-            var c = parameters[5]; // c
+            var x0 = parameters[0];
+            var y0 = parameters[1];
+            var gx = parameters[3];
+            var gy = parameters[4];
+            var k = parameters[5];
 
-            var C2 = c * c;
-            var SignedC2 = Math.Sign(c) * C2;
             var XPrime = X - x0;
-            var XPrime2 = XPrime * XPrime;
             var YPrime = Y - y0;
-            var YPrime2 = YPrime * YPrime;
-            var cosPhi = Math.Cos(phi);
-            var sinPhi = Math.Sin(phi);
-            var tanTheta = Math.Tan(theta);
-            var cosTheta = Math.Cos(theta);
-            var cosTheta2 = cosTheta * cosTheta;
-            var secTheta2 = 1.0 / cosTheta2;
 
-            // d/du = https://www.wolframalpha.com/input?i2d=true&i=differentiate+%5C%2840%29%5C%2840%29x+-+u%5C%2841%29*Cos%5Bp%5D%2B%5C%2840%29y-v%5C%2841%29*Sin%5Bp%5D%5C%2841%29*Tan%5Bt%5D%2Bsign%5C%2840%29c%5C%2841%29*Power%5Bc%2C2%5D*%5C%2840%29Power%5B%5C%2840%29x-u%5C%2841%29%2C2%5D%2BPower%5B%5C%2840%29y-v%5C%2841%29%2C2%5D%5C%2841%29%2Bw+with+respect+to+u
-            var d_du = -2.0 * SignedC2 * XPrime - cosPhi * tanTheta;
-
-            // d/dv = https://www.wolframalpha.com/input?i2d=true&i=differentiate+%5C%2840%29%5C%2840%29x+-+u%5C%2841%29*Cos%5Bp%5D%2B%5C%2840%29y-v%5C%2841%29*Sin%5Bp%5D%5C%2841%29*Tan%5Bt%5D%2Bsign%5C%2840%29c%5C%2841%29*Power%5Bc%2C2%5D*%5C%2840%29Power%5B%5C%2840%29x-u%5C%2841%29%2C2%5D%2BPower%5B%5C%2840%29y-v%5C%2841%29%2C2%5D%5C%2841%29%2Bw+with+respect+to+v
-            var d_dv = -2.0 * SignedC2 * YPrime - sinPhi * tanTheta;
-
-            // d/dw = https://www.wolframalpha.com/input?i2d=true&i=differentiate+%5C%2840%29%5C%2840%29x+-+u%5C%2841%29*Cos%5Bp%5D%2B%5C%2840%29y-v%5C%2841%29*Sin%5Bp%5D%5C%2841%29*Tan%5Bt%5D%2Bsign%5C%2840%29c%5C%2841%29*Power%5Bc%2C2%5D*%5C%2840%29Power%5B%5C%2840%29x-u%5C%2841%29%2C2%5D%2BPower%5B%5C%2840%29y-v%5C%2841%29%2C2%5D%5C%2841%29%2Bw+with+respect+to+w
-            var d_dw = 1.0;
-
-            // d/dt = https://www.wolframalpha.com/input?i2d=true&i=differentiate+%5C%2840%29%5C%2840%29x+-+u%5C%2841%29*Cos%5Bp%5D%2B%5C%2840%29y-v%5C%2841%29*Sin%5Bp%5D%5C%2841%29*Tan%5Bt%5D%2Bsign%5C%2840%29c%5C%2841%29*Power%5Bc%2C2%5D*%5C%2840%29Power%5B%5C%2840%29x-u%5C%2841%29%2C2%5D%2BPower%5B%5C%2840%29y-v%5C%2841%29%2C2%5D%5C%2841%29%2Bw+with+respect+to+t
-            var d_dt = secTheta2 * (cosPhi * XPrime + sinPhi * YPrime);
-
-            // d/dp = https://www.wolframalpha.com/input?i2d=true&i=differentiate+%5C%2840%29%5C%2840%29x+-+u%5C%2841%29*Cos%5Bp%5D%2B%5C%2840%29y-v%5C%2841%29*Sin%5Bp%5D%5C%2841%29*Tan%5Bt%5D%2Bsign%5C%2840%29c%5C%2841%29*Power%5Bc%2C2%5D*%5C%2840%29Power%5B%5C%2840%29x-u%5C%2841%29%2C2%5D%2BPower%5B%5C%2840%29y-v%5C%2841%29%2C2%5D%5C%2841%29%2Bw+with+respect+to+p
-            var d_dp = tanTheta * (cosPhi * YPrime - sinPhi * XPrime);
-
-            // d/dc = https://www.wolframalpha.com/input?i2d=true&i=differentiate+%5C%2840%29%5C%2840%29x+-+u%5C%2841%29*Cos%5Bp%5D%2B%5C%2840%29y-v%5C%2841%29*Sin%5Bp%5D%5C%2841%29*Tan%5Bt%5D%2Bsign%5C%2840%29c%5C%2841%29*Power%5Bc%2C2%5D*%5C%2840%29Power%5B%5C%2840%29x-u%5C%2841%29%2C2%5D%2BPower%5B%5C%2840%29y-v%5C%2841%29%2C2%5D%5C%2841%29%2Bw+with+respect+to+c
-            var d_dc = 2.0 * c * Math.Sign(c) * (XPrime2 + YPrime2);
-
-            result[0] = d_du;
-            result[1] = d_dv;
-            result[2] = d_dw;
-            result[3] = d_dt;
-            result[4] = d_dp;
-            result[5] = d_dc;
+            // d/dx0 [Gx·(X-x0) + K·(X-x0)²] = -Gx - 2K·(X-x0)
+            result[0] = -gx - 2.0 * k * XPrime;
+            // d/dy0
+            result[1] = -gy - 2.0 * k * YPrime;
+            // d/dz0
+            result[2] = 1.0;
+            // d/dGx
+            result[3] = XPrime;
+            // d/dGy
+            result[4] = YPrime;
+            // d/dK
+            result[5] = XPrime * XPrime + YPrime * YPrime;
         }
 
         public override void SetInitialGuess(double[] initialGuess) {
             initialGuess[0] = 0.0;
             initialGuess[1] = 0.0;
             initialGuess[2] = inFocusMicrons;
-            initialGuess[3] = 1E-5;
+            initialGuess[3] = 0.0;
             initialGuess[4] = 0.0;
-            initialGuess[5] = PositiveCurvature ? 1E-4 : -1E-4;
+            initialGuess[5] = 0.0;
         }
 
         public override void SetBounds(double[] lowerBounds, double[] upperBounds) {
@@ -282,24 +282,27 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                 upperBounds[1] = sensorSizeMicronsY / 2.0;
             }
 
+            // z0, the tilt gradients, and the signed curvature coefficient are all unbounded. The linear
+            // tilt parameterization has no singularity (so no θ ≥ 1e-5 hack is needed), and K can cross
+            // zero freely (so a single solve covers both curvature signs — no positive/negative double solve).
             lowerBounds[2] = double.NegativeInfinity;
-            lowerBounds[3] = 1E-5; // Ensure tilt never goes to 0, since perfection is impossible. This forces calculation of phi, and avoids situations where we're stuck at a local minima
-            lowerBounds[4] = -Math.PI;
-            lowerBounds[5] = PositiveCurvature ? 1E-4 : double.NegativeInfinity;
+            lowerBounds[3] = double.NegativeInfinity;
+            lowerBounds[4] = double.NegativeInfinity;
+            lowerBounds[5] = double.NegativeInfinity;
 
             upperBounds[2] = double.PositiveInfinity;
-            upperBounds[3] = Math.PI - double.Epsilon;
-            upperBounds[4] = Math.PI - double.Epsilon;
-            upperBounds[5] = PositiveCurvature ? double.PositiveInfinity : -1E-4;
+            upperBounds[3] = double.PositiveInfinity;
+            upperBounds[4] = double.PositiveInfinity;
+            upperBounds[5] = double.PositiveInfinity;
         }
 
         public override void SetScale(double[] scales) {
             scales[0] = 1.0;
             scales[1] = 1.0;
             scales[2] = 1.0;
-            scales[3] = 1E-2;
-            scales[4] = 1.0;
-            scales[5] = 1E-2;
+            scales[3] = 1E-3;
+            scales[4] = 1E-3;
+            scales[5] = 1E-6;
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorParaboloidModel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorParaboloidModel.cs
@@ -69,11 +69,16 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
 
     /// <summary>
     /// Tilted paraboloid sensor model. The surface is parameterized by linear tilt gradients (Gx, Gy)
-    /// and a single signed curvature coefficient (K):
+    /// and curvature coefficients:
     ///
-    ///     z(x, y) = Gx·(x − X0) + Gy·(y − Y0) + K·((x − X0)² + (y − Y0)²) + Z0
+    ///     z(x, y) = Gx·(x − X0) + Gy·(y − Y0) + Kx·(x − X0)² + Ky·(y − Y0)² + Z0
     ///
-    /// This linear-in-(Gx, Gy, K) form replaces the older (θ, φ, c) parameterization, which injected
+    /// In the default <b>isotropic</b> mode Kx == Ky == K (a single curvature coefficient, 6 free
+    /// parameters), reproducing the rotationally-symmetric field curvature of a typical refractor or
+    /// reflector. In the optional <b>astigmatic</b> mode Kx and Ky are fit independently (7 parameters),
+    /// allowing the saddle-shaped field of an astigmatic optical train to be represented.
+    ///
+    /// This linear-in-(Gx, Gy, Kx, Ky) form replaces the older (θ, φ, c) parameterization, which injected
     /// trigonometric nonlinearity, a φ-unidentifiability/local-minimum trap at θ = 0 (worked around by
     /// forcing θ ≥ 1e-5), and a sign(c)·c² curvature that could not cross zero (forcing two solves).
     /// The legacy tilt/curvature quantities remain available as derived display properties.
@@ -86,7 +91,20 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             this.Z0 = z0;
             this.Gx = gx;
             this.Gy = gy;
-            this.K = k;
+            this.Kx = k;
+            this.Ky = k;
+            this.Astigmatic = false;
+        }
+
+        public SensorParaboloidModel(double x0, double y0, double z0, double gx, double gy, double kx, double ky) {
+            this.X0 = x0;
+            this.Y0 = y0;
+            this.Z0 = z0;
+            this.Gx = gx;
+            this.Gy = gy;
+            this.Kx = kx;
+            this.Ky = ky;
+            this.Astigmatic = true;
         }
 
         public SensorParaboloidModel() {
@@ -106,9 +124,12 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                 k: Math.Sign(c) * c * c);
         }
 
+        // The parameter-array length is the single source of truth for the mode: 6 elements => isotropic
+        // (one curvature coefficient), 7 elements => astigmatic (independent Kx, Ky). The solver creates the
+        // model via new() + FromArray, so inferring the mode here keeps the two in sync without extra wiring.
         public void FromArray(double[] parameters) {
-            if (parameters == null || parameters.Length != 6) {
-                throw new ArgumentException($"Expected a 6-element array of parameters");
+            if (parameters == null || (parameters.Length != 6 && parameters.Length != 7)) {
+                throw new ArgumentException($"Expected a 6- or 7-element array of parameters");
             }
 
             this.X0 = parameters[0];
@@ -116,18 +137,22 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             this.Z0 = parameters[2];
             this.Gx = parameters[3];
             this.Gy = parameters[4];
-            this.K = parameters[5];
+            if (parameters.Length == 7) {
+                this.Kx = parameters[5];
+                this.Ky = parameters[6];
+                this.Astigmatic = true;
+            } else {
+                this.Kx = parameters[5];
+                this.Ky = parameters[5];
+                this.Astigmatic = false;
+            }
         }
 
         public double[] ToArray() {
-            return new double[] {
-                this.X0,
-                this.Y0,
-                this.Z0,
-                this.Gx,
-                this.Gy,
-                this.K
-            };
+            if (Astigmatic) {
+                return new double[] { this.X0, this.Y0, this.Z0, this.Gx, this.Gy, this.Kx, this.Ky };
+            }
+            return new double[] { this.X0, this.Y0, this.Z0, this.Gx, this.Gy, this.K };
         }
 
         public double X0 { get; private set; }
@@ -140,8 +165,20 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
         /// <summary>Tilt gradient along Y: change in focuser position per micron of sensor Y (dimensionless).</summary>
         public double Gy { get; private set; }
 
-        /// <summary>Signed curvature coefficient: curvature contribution is K·r². Equivalent to the old sign(c)·c².</summary>
-        public double K { get; private set; }
+        /// <summary>Signed curvature coefficient along X: the X² curvature contribution is Kx·(x−X0)².</summary>
+        public double Kx { get; private set; }
+
+        /// <summary>Signed curvature coefficient along Y: the Y² curvature contribution is Ky·(y−Y0)².</summary>
+        public double Ky { get; private set; }
+
+        /// <summary>True when Kx and Ky are fit independently (astigmatic field); false for isotropic curvature.</summary>
+        public bool Astigmatic { get; private set; }
+
+        /// <summary>
+        /// Mean signed curvature coefficient. Equals the single coefficient in isotropic mode and the
+        /// average of Kx, Ky in astigmatic mode. Curvature contribution is K·r² only when isotropic.
+        /// </summary>
+        public double K => 0.5 * (Kx + Ky);
 
         // Derived display parameters, kept for back-compat with the (θ, φ, c) form used by the UI/result layer.
         public double Theta => Math.Atan(Math.Sqrt(Gx * Gx + Gy * Gy));
@@ -163,14 +200,14 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
         }
 
         public override string ToString() {
-            return $"{{{nameof(X0)}={X0.ToString()}, {nameof(Y0)}={Y0.ToString()}, {nameof(Z0)}={Z0.ToString()}, {nameof(Gx)}={Gx.ToString()}, {nameof(Gy)}={Gy.ToString()}, {nameof(K)}={K.ToString()}}}";
+            return $"{{{nameof(X0)}={X0.ToString()}, {nameof(Y0)}={Y0.ToString()}, {nameof(Z0)}={Z0.ToString()}, {nameof(Gx)}={Gx.ToString()}, {nameof(Gy)}={Gy.ToString()}, {nameof(Kx)}={Kx.ToString()}, {nameof(Ky)}={Ky.ToString()}, {nameof(Astigmatic)}={Astigmatic.ToString()}}}";
         }
 
         public double ValueAt(double x, double y) {
             var XPrime = x - X0;
             var YPrime = y - Y0;
             var tilt = Gx * XPrime + Gy * YPrime;
-            var curvature = K * (XPrime * XPrime + YPrime * YPrime);
+            var curvature = Kx * XPrime * XPrime + Ky * YPrime * YPrime;
             return tilt + curvature + Z0;
         }
 
@@ -179,7 +216,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
         }
 
         public double CurvatureAt(double x, double y) {
-            return K * (x * x + y * y);
+            return Kx * x * x + Ky * y * y;
         }
 
         public double Volume(double widthMicrons, double heightMicrons) {
@@ -188,11 +225,12 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
 
             // Closed-form double integral of ValueAt over [-w/2,w/2] x [-h/2,h/2]:
             //   tilt:      -w·h·(Gx·X0 + Gy·Y0)
-            //   curvature:  K·w·h·(X0² + Y0²) + (1/12)·K·w·h·(w² + h²)
+            //   curvature:  w·h·(Kx·X0² + Ky·Y0²) + (1/12)·w·h·(Kx·w² + Ky·h²)
             //   offset:     Z0·w·h
+            // (Isotropic Kx = Ky = K collapses the curvature terms to K·w·h·(X0²+Y0²) + (1/12)·K·w·h·(w²+h²).)
             var tiltPart = -w * h * (Gx * X0 + Gy * Y0);
-            var curvatureCenterPart = K * w * h * (X0 * X0 + Y0 * Y0);
-            var curvatureSpreadPart = 1.0 / 12.0 * K * w * h * (w * w + h * h);
+            var curvatureCenterPart = w * h * (Kx * X0 * X0 + Ky * Y0 * Y0);
+            var curvatureSpreadPart = 1.0 / 12.0 * w * h * (Kx * w * w + Ky * h * h);
             var offsetPart = Z0 * w * h;
             return tiltPart + curvatureCenterPart + curvatureSpreadPart + offsetPart;
         }
@@ -203,22 +241,27 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
         private readonly double sensorSizeMicronsX;
         private readonly double sensorSizeMicronsY;
         private readonly bool fixedSensorCenter;
+        private readonly bool astigmatic;
 
         public SensorParaboloidSolver(
             List<SensorParaboloidDataPoint> dataPoints,
             double sensorSizeMicronsX,
             double sensorSizeMicronsY,
             double inFocusMicrons,
-            bool fixedSensorCenter) : base(dataPoints, 6) {
+            bool fixedSensorCenter,
+            bool astigmatic = false) : base(dataPoints, astigmatic ? 7 : 6) {
             this.sensorSizeMicronsX = sensorSizeMicronsX;
             this.sensorSizeMicronsY = sensorSizeMicronsY;
             this.inFocusMicrons = inFocusMicrons;
             this.fixedSensorCenter = fixedSensorCenter;
+            this.astigmatic = astigmatic;
         }
 
         public override bool UseJacobian => true;
 
-        // z = Gx·(X-x0) + Gy·(Y-y0) + K·((X-x0)² + (Y-y0)²) + z0
+        // Isotropic (6 params):  z = Gx·(X-x0) + Gy·(Y-y0) + K·((X-x0)² + (Y-y0)²) + z0
+        // Astigmatic (7 params): z = Gx·(X-x0) + Gy·(Y-y0) + Kx·(X-x0)² + Ky·(Y-y0)² + z0
+        // The parameter-array length is authoritative so the same Value/Gradient work for either mode.
         public override double Value(double[] parameters, double[] input) {
             var X = input[0];
             var Y = input[1];
@@ -227,11 +270,12 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             var z0 = parameters[2];
             var gx = parameters[3];
             var gy = parameters[4];
-            var k = parameters[5];
+            var kx = parameters[5];
+            var ky = parameters.Length == 7 ? parameters[6] : parameters[5];
 
             var XPrime = X - x0;
             var YPrime = Y - y0;
-            return gx * XPrime + gy * YPrime + k * (XPrime * XPrime + YPrime * YPrime) + z0;
+            return gx * XPrime + gy * YPrime + kx * XPrime * XPrime + ky * YPrime * YPrime + z0;
         }
 
         public override void Gradient(double[] parameters, double[] input, double[] result) {
@@ -241,23 +285,30 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             var y0 = parameters[1];
             var gx = parameters[3];
             var gy = parameters[4];
-            var k = parameters[5];
+            var kx = parameters[5];
+            var ky = parameters.Length == 7 ? parameters[6] : parameters[5];
 
             var XPrime = X - x0;
             var YPrime = Y - y0;
 
-            // d/dx0 [Gx·(X-x0) + K·(X-x0)²] = -Gx - 2K·(X-x0)
-            result[0] = -gx - 2.0 * k * XPrime;
+            // d/dx0 [Gx·(X-x0) + Kx·(X-x0)²] = -Gx - 2·Kx·(X-x0)
+            result[0] = -gx - 2.0 * kx * XPrime;
             // d/dy0
-            result[1] = -gy - 2.0 * k * YPrime;
+            result[1] = -gy - 2.0 * ky * YPrime;
             // d/dz0
             result[2] = 1.0;
             // d/dGx
             result[3] = XPrime;
             // d/dGy
             result[4] = YPrime;
-            // d/dK
-            result[5] = XPrime * XPrime + YPrime * YPrime;
+            if (result.Length == 7) {
+                // d/dKx, d/dKy
+                result[5] = XPrime * XPrime;
+                result[6] = YPrime * YPrime;
+            } else {
+                // d/dK (isotropic: Kx and Ky are the same parameter)
+                result[5] = XPrime * XPrime + YPrime * YPrime;
+            }
         }
 
         public override void SetInitialGuess(double[] initialGuess) {
@@ -267,6 +318,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             initialGuess[3] = 0.0;
             initialGuess[4] = 0.0;
             initialGuess[5] = 0.0;
+            if (astigmatic) {
+                initialGuess[6] = 0.0;
+            }
         }
 
         public override void SetBounds(double[] lowerBounds, double[] upperBounds) {
@@ -282,18 +336,13 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                 upperBounds[1] = sensorSizeMicronsY / 2.0;
             }
 
-            // z0, the tilt gradients, and the signed curvature coefficient are all unbounded. The linear
-            // tilt parameterization has no singularity (so no θ ≥ 1e-5 hack is needed), and K can cross
-            // zero freely (so a single solve covers both curvature signs — no positive/negative double solve).
-            lowerBounds[2] = double.NegativeInfinity;
-            lowerBounds[3] = double.NegativeInfinity;
-            lowerBounds[4] = double.NegativeInfinity;
-            lowerBounds[5] = double.NegativeInfinity;
-
-            upperBounds[2] = double.PositiveInfinity;
-            upperBounds[3] = double.PositiveInfinity;
-            upperBounds[4] = double.PositiveInfinity;
-            upperBounds[5] = double.PositiveInfinity;
+            // z0, the tilt gradients, and the curvature coefficient(s) are all unbounded. The linear
+            // tilt parameterization has no singularity (so no θ ≥ 1e-5 hack is needed), and the curvature
+            // can cross zero freely (so a single solve covers both curvature signs — no double solve).
+            for (int i = 2; i < lowerBounds.Length; ++i) {
+                lowerBounds[i] = double.NegativeInfinity;
+                upperBounds[i] = double.PositiveInfinity;
+            }
         }
 
         public override void SetScale(double[] scales) {
@@ -303,6 +352,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             scales[3] = 1E-3;
             scales[4] = 1E-3;
             scales[5] = 1E-6;
+            if (astigmatic) {
+                scales[6] = 1E-6;
+            }
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IInspectorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IInspectorOptions.cs
@@ -66,6 +66,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         bool FixedSensorCenter { get; set; }
         bool UseRANSAC { get; set; }
         bool UseAffineAlignment { get; set; }
+        bool AstigmaticCurvatureEnabled { get; set; }
         bool RejectBadBrightnessMatches { get; set; }
         bool RejectBadlyFittingMatches { get; set; }
         double PreviousRunBrightnessDiff { get; set; }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IInspectorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IInspectorOptions.cs
@@ -74,5 +74,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         bool SaveImagesOnReruns { get; set; }
         bool SaveAlignmentImages { get; set; }
         int MaxStarsPerRegion { get; set; }
+        double AcceptableReducedChiSquared { get; set; }
+        double AcceptableRSquaredMin { get; set; }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IInspectorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IInspectorOptions.cs
@@ -74,7 +74,6 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         bool SaveImagesOnReruns { get; set; }
         bool SaveAlignmentImages { get; set; }
         int MaxStarsPerRegion { get; set; }
-        double AcceptableReducedChiSquared { get; set; }
         double AcceptableRSquaredMin { get; set; }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IInspectorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IInspectorOptions.cs
@@ -65,6 +65,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         InterpolationAmountEnum InterpolationAmount { get; set; }
         bool FixedSensorCenter { get; set; }
         bool UseRANSAC { get; set; }
+        bool UseAffineAlignment { get; set; }
         bool RejectBadBrightnessMatches { get; set; }
         bool RejectBadlyFittingMatches { get; set; }
         double PreviousRunBrightnessDiff { get; set; }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
@@ -22,8 +22,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new release build of a plugin
-[assembly: AssemblyVersion("3.0.0.26")]
-[assembly: AssemblyFileVersion("3.0.0.26")]
+[assembly: AssemblyVersion("3.0.0.28")]
+[assembly: AssemblyFileVersion("3.0.0.28")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("Hocus Focus")]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
@@ -22,8 +22,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new release build of a plugin
-[assembly: AssemblyVersion("3.0.0.27")]
-[assembly: AssemblyFileVersion("3.0.0.27")]
+[assembly: AssemblyVersion("3.0.0.26")]
+[assembly: AssemblyFileVersion("3.0.0.26")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("Hocus Focus")]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/AlglibHyperbolicFitting.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/AlglibHyperbolicFitting.cs
@@ -21,6 +21,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
         public int StepSize { get; protected set; }
         public bool OptGuardEnabled { get; set; } = false;
 
+        /// <summary>
+        /// Standard error of the fitted minimum's focuser position (parameter x0), propagated from the
+        /// fit covariance. <see cref="double.NaN"/> when not computed (e.g. too few points, or a fitting
+        /// variant that does not estimate it). Used downstream to weight the paraboloid fit by 1/σ².
+        /// </summary>
+        public double MinimumStdError { get; protected set; } = double.NaN;
+
         public abstract bool Solve();
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HyperbolicFittingAlglib.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HyperbolicFittingAlglib.cs
@@ -11,6 +11,7 @@
 #endregion "copyright"
 
 using Accord.Math.Optimization.Losses;
+using MathNet.Numerics.LinearAlgebra;
 using NINA.Joko.Plugins.HocusFocus.Utility;
 using OxyPlot;
 using OxyPlot.Series;
@@ -216,6 +217,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                     transformed[i] = Fitting(Inputs[i][0]);
                 }
                 RSquared = rSquared.Loss(transformed);
+                ComputeMinimumStdError(solution);
                 return true;
             } finally {
                 if (state != null) {
@@ -224,6 +226,50 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                 if (rep != null) {
                     this.alglibAPI.deallocateimmediately(ref rep);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Estimates the standard error of the fitted minimum position x0 from the fit covariance
+        /// Cov ≈ s²·(JᵀWJ)⁻¹, where J is the analytic Jacobian of the hyperbola at the solution,
+        /// W = diag(weight²), and s² = weighted RSS/(n−p) is a robust variance estimate. Using the
+        /// data-driven s² makes se(x0) a genuine standard error in focuser-position units even when the
+        /// per-point HFR uncertainties are only relative (or unweighted). Guarded so a failure here never
+        /// affects the fit result; <see cref="AlglibHyperbolicFitting.MinimumStdError"/> stays NaN.
+        /// </summary>
+        private void ComputeMinimumStdError(double[] solution) {
+            try {
+                const int p = 4;
+                int n = Inputs.Length;
+                if (n <= p) {
+                    MinimumStdError = double.NaN;
+                    return;
+                }
+
+                var gradient = GetGradientForParameters(solution);
+                var fit = GetFittingForParameters(solution);
+                var jtwj = Matrix<double>.Build.Dense(p, p);
+                var g = new double[p];
+                var weightedRss = 0.0;
+                for (int i = 0; i < n; i++) {
+                    var x = Inputs[i][0];
+                    var w2 = Weights[i] * Weights[i];
+                    gradient(x, g);
+                    for (int r = 0; r < p; r++) {
+                        for (int c = 0; c < p; c++) {
+                            jtwj[r, c] += w2 * g[r] * g[c];
+                        }
+                    }
+                    var residual = fit(x) - Outputs[i];
+                    weightedRss += w2 * residual * residual;
+                }
+
+                var s2 = weightedRss / (n - p);
+                var cov = jtwj.Inverse();
+                var varX0 = s2 * cov[0, 0];
+                MinimumStdError = varX0 > 0 && !double.IsNaN(varX0) && !double.IsInfinity(varX0) ? Math.Sqrt(varX0) : double.NaN;
+            } catch (Exception) {
+                MinimumStdError = double.NaN;
             }
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/NonLinearLeastSquaresSolver.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/NonLinearLeastSquaresSolver.cs
@@ -270,7 +270,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
             this.weights = new double[solver.Inputs.Length];
             this.inputEnabled = new bool[solver.Inputs.Length];
             for (int i = 0; i < weights.Length; ++i) {
-                weights[i] = 1.0;
+                // χ² weighting: weight = 1/σ so the optimizer minimizes Σ((estimated-observed)/σ)².
+                // σ defaults to 1.0 (unweighted) when callers do not supply per-point uncertainties.
+                weights[i] = 1.0 / Math.Max(solver.OutputStdDevs[i], 1e-9);
                 inputEnabled[i] = true;
             }
         }
@@ -347,10 +349,15 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
             return 1 - rss / tss;
         }
 
+        /// <summary>
+        /// Unweighted RMS of the residuals over the enabled points, in the native units of the output
+        /// (e.g. focuser microns). Reported as an intuitive display statistic independent of the χ²
+        /// weighting that the optimizer minimizes.
+        /// </summary>
         public double RMSError(S solver, U model) {
             var parameters = model.ToArray();
             var rss = 0.0d;
-            double weightedPixelCount = 0.0d;
+            int count = 0;
             for (int i = 0; i < solver.Inputs.Length; ++i) {
                 if (!inputEnabled[i]) {
                     continue;
@@ -358,13 +365,50 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
 
                 var input = solver.Inputs[i];
                 var observedValue = solver.Outputs[i];
-                var weight = this.weights[i];
                 var estimatedValue = solver.Value(parameters, input);
-                var residual = weight * (estimatedValue - observedValue);
+                var residual = estimatedValue - observedValue;
                 rss += residual * residual;
-                weightedPixelCount += weight;
+                ++count;
             }
-            return Math.Sqrt(rss / weightedPixelCount);
+            return count > 0 ? Math.Sqrt(rss / count) : 0.0;
+        }
+
+        /// <summary>Degrees of freedom of the fit: enabled observations minus free parameters (at least 1).</summary>
+        public int DegreesOfFreedom(S solver) => Math.Max(1, InputEnabledCount - solver.NumParameters);
+
+        /// <summary>
+        /// χ² = Σ ((estimated − observed)/σ)² over the enabled points (weight = 1/σ). When per-point σ
+        /// are the true measurement uncertainties, a well-specified model gives χ² ≈ degrees of freedom.
+        /// </summary>
+        public double ChiSquared(S solver, U model) {
+            var parameters = model.ToArray();
+            var chiSquared = 0.0d;
+            for (int i = 0; i < solver.Inputs.Length; ++i) {
+                if (!inputEnabled[i]) {
+                    continue;
+                }
+
+                var residual = this.weights[i] * (solver.Value(parameters, solver.Inputs[i]) - solver.Outputs[i]);
+                chiSquared += residual * residual;
+            }
+            return chiSquared;
+        }
+
+        /// <summary>
+        /// Reduced χ² = χ²/dof. Unlike R², this is independent of overall signal magnitude: a near-flat
+        /// sensor with good residuals and a strongly-tilted one with the same residuals both score ≈ 1,
+        /// which is the property that makes it a repeatable acceptance criterion.
+        /// </summary>
+        public double ReducedChiSquared(S solver, U model) => ChiSquared(solver, model) / DegreesOfFreedom(solver);
+
+        /// <summary>
+        /// Upper-tail p-value P(χ² ≥ observed) for the fit's degrees of freedom. Small values indicate a
+        /// poor fit (or underestimated σ); values near 1 indicate residuals smaller than σ would predict.
+        /// </summary>
+        public double ChiSquaredPValue(S solver, U model) {
+            var dof = DegreesOfFreedom(solver);
+            var chiSquared = ChiSquared(solver, model);
+            return 1.0 - new MathNet.Numerics.Distributions.ChiSquared(dof).CumulativeDistribution(chiSquared);
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/NonLinearLeastSquaresSolver.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/NonLinearLeastSquaresSolver.cs
@@ -313,8 +313,13 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
                 }
 
                 Solver.Gradient(parameters, Solver.Inputs[i], singleGradient);
+                // The residual is weight·(f(θ)−y), so its derivative is weight·∂f/∂θ. The Jacobian must
+                // carry the same per-point weight as FitResiduals; otherwise, with non-uniform 1/σ weights,
+                // the optimizer's gradient is inconsistent with its residuals — biasing the LM step and
+                // tripping OptGuard. With uniform weights (1.0) this reduces to the plain gradient.
+                var weight = this.weights[i];
                 for (int j = 0; j < parameters.Length; ++j) {
-                    jac[i, j] = singleGradient[j];
+                    jac[i, j] = weight * singleGradient[j];
                 }
             }
         }
@@ -331,7 +336,23 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
             var rss = 0.0d;
             var tss = 0.0d;
             int pixelCount = solver.Inputs.Length;
-            var yBar = solver.Outputs.Where((o, idx) => inputEnabled[idx]).Average();
+
+            // Weighted mean, so the weighted total sum of squares is taken about the correct center. Using
+            // a plain (unweighted) mean here while weighting the dispersion makes 1 − RSS/TSS no longer a
+            // valid R² (it can exceed 1 or go negative) once the per-point weights are non-uniform (1/σ).
+            // With uniform weights this reduces to the ordinary arithmetic mean.
+            var sumW2 = 0.0d;
+            var sumW2Y = 0.0d;
+            for (int i = 0; i < pixelCount; ++i) {
+                if (!inputEnabled[i]) {
+                    continue;
+                }
+                var w2 = this.weights[i] * this.weights[i];
+                sumW2 += w2;
+                sumW2Y += w2 * solver.Outputs[i];
+            }
+            var yBar = sumW2 > 0.0 ? sumW2Y / sumW2 : 0.0;
+
             for (int i = 0; i < pixelCount; ++i) {
                 if (!inputEnabled[i]) {
                     continue;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/NonLinearLeastSquaresSolverBase.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/NonLinearLeastSquaresSolverBase.cs
@@ -21,6 +21,12 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
         double[] ToInput();
 
         double ToOutput();
+
+        /// <summary>
+        /// The 1-sigma measurement uncertainty of <see cref="ToOutput"/>, in the same units as the
+        /// output. Used to weight the fit by 1/σ (χ²). The default of 1.0 reduces to an unweighted fit.
+        /// </summary>
+        double ToOutputStdDev() => 1.0;
     }
 
     public interface INonLinearLeastSquaresParameters {
@@ -37,11 +43,15 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
         protected NonLinearLeastSquaresSolverBase(List<T> dataPoints, int numParameters) {
             this.Inputs = dataPoints.Select(p => p.ToInput()).ToArray();
             this.Outputs = dataPoints.Select(p => p.ToOutput()).ToArray();
+            this.OutputStdDevs = dataPoints.Select(p => p.ToOutputStdDev()).ToArray();
             this.NumParameters = numParameters;
         }
 
         public double[][] Inputs { get; private set; }
         public double[] Outputs { get; private set; }
+
+        /// <summary>Per-observation 1-sigma uncertainties of <see cref="Outputs"/> (used for χ² weighting).</summary>
+        public double[] OutputStdDevs { get; private set; }
 
         public int NumParameters { get; private set; }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/RANSACRegistration.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/RANSACRegistration.cs
@@ -82,13 +82,108 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
             return new Point2D(x, y);
         }
 
+        /// <summary>
+        /// Expresses this similarity transform as an equivalent affine <see cref="Matrix3x2"/> so that
+        /// callers can use a single downstream transform path regardless of which estimator produced it.
+        /// </summary>
+        public Matrix3x2 ToMatrix3x2() {
+            return new Matrix3x2(
+                Scale * cosTheta, -Scale * sinTheta,
+                Scale * sinTheta, Scale * cosTheta,
+                Tx, Ty);
+        }
+
         public override string ToString() {
             return $"S:{Scale}, R:{Rotation}, Tx:{Tx}, Ty:{Ty}";
         }
     }
 
     public class RANSACRegistration {
-        private static Random RNG = new();
+
+        /// <summary>
+        /// Derives a stable RNG seed from the correspondence set so that RANSAC sampling is fully
+        /// deterministic: the same input points always produce the same candidate ordering, and
+        /// therefore the same transform and inlier set, across repeated runs. This is the core of
+        /// the repeatability fix — previously a shared unseeded <see cref="Random"/> made every run
+        /// shuffle differently. Using a hash of the inputs (rather than a fixed constant) keeps the
+        /// seed independent of call order while still being reproducible for identical inputs.
+        /// </summary>
+        private static int ComputeDeterministicSeed(IReadOnlyList<Point2D> srcPoints, IReadOnlyList<Point2D> dstPoints) {
+            unchecked {
+                const int prime = 16777619;
+                int hash = (int)2166136261;
+
+                void MixDouble(double value) {
+                    long bits = BitConverter.DoubleToInt64Bits(value);
+                    for (int b = 0; b < 8; ++b) {
+                        hash = (hash ^ (int)(bits & 0xFF)) * prime;
+                        bits >>= 8;
+                    }
+                }
+
+                MixDouble(srcPoints.Count);
+                int n = Math.Min(srcPoints.Count, dstPoints.Count);
+                for (int i = 0; i < n; ++i) {
+                    MixDouble(srcPoints[i].X);
+                    MixDouble(srcPoints[i].Y);
+                    MixDouble(dstPoints[i].X);
+                    MixDouble(dstPoints[i].Y);
+                }
+                return hash;
+            }
+        }
+
+        /// <summary>
+        /// Lazily yields candidate index pairs for RANSAC sampling. When the full set of C(n,2) pairs fits
+        /// within the iteration budget they are all enumerated (in deterministic order); otherwise
+        /// <paramref name="maxIterations"/> pairs are drawn on demand with the seeded RNG. This avoids
+        /// materializing (and shuffling) the entire O(n²) candidate list before a single model is tested.
+        /// </summary>
+        private static IEnumerable<(int, int)> SamplePairs(int n, long totalPairs, int maxIterations, Random rng) {
+            if (totalPairs <= maxIterations) {
+                for (int i = 0; i < n; i++) {
+                    for (int j = i + 1; j < n; j++) {
+                        yield return (i, j);
+                    }
+                }
+            } else {
+                for (int s = 0; s < maxIterations; s++) {
+                    int i, j;
+                    do {
+                        i = rng.Next(n);
+                        j = rng.Next(n);
+                    } while (i == j);
+                    yield return (i, j);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Lazily yields candidate index triplets for RANSAC sampling. As with <see cref="SamplePairs"/>,
+        /// the full C(n,3) set is enumerated only when it fits the budget; otherwise triplets are drawn on
+        /// demand with the seeded RNG, avoiding O(n³) materialization.
+        /// </summary>
+        private static IEnumerable<(int, int, int)> SampleTriplets(int n, long totalTriplets, int maxIterations, Random rng) {
+            if (totalTriplets <= maxIterations) {
+                for (int i = 0; i < n; i++) {
+                    for (int j = i + 1; j < n; j++) {
+                        for (int k = j + 1; k < n; k++) {
+                            yield return (i, j, k);
+                        }
+                    }
+                }
+            } else {
+                for (int s = 0; s < maxIterations; s++) {
+                    int i, j, k;
+                    do {
+                        i = rng.Next(n);
+                        j = rng.Next(n);
+                        k = rng.Next(n);
+                    } while (i == j || j == k || i == k);
+                    yield return (i, j, k);
+                }
+            }
+        }
 
         // Generate putative matches using nearest neighbor
         public static (List<Point2D> srcPoints, List<Point2D> dstPoints) GeneratePutativeMatchesUsingNN(
@@ -280,6 +375,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
             // first pass - build list of triangles in reference image
             var triangles = new List<StarTriangle>();
             var pointsUsed = new HashSet<Point2D>();
+            // De-duplicate triangles by their ordered point identities via an O(1) hash-set lookup instead
+            // of an O(n) SameTriangle scan per candidate. Point2D uses reference equality, matching SameTriangle.
+            var seenTriangles = new HashSet<(Point2D, Point2D, Point2D)>();
             int id = 0;
             var brightnesses = point2Ds.Select(p => p.NormalisedBrightness);
             var minBrightness = brightnesses.Min();
@@ -316,7 +414,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
                         for (int k = j + 1; k < nearbyPoints.Count; k++) {
                             var p3 = nearbyPoints[k];
                             var triangle = new StarTriangle(imageSize, minBrightness, maxBrightness, pt, p2, p3, isReference, id++);
-                            if (triangles.Count(tri => tri.SameTriangle(triangle)) == 0)    // avoid duplicates
+                            if (seenTriangles.Add((triangle.P1, triangle.P2, triangle.P3)))    // avoid duplicates
                                 triangles.Add(triangle);
                         }
                     }
@@ -410,16 +508,13 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
             double bestInlierAveDistance = double.MaxValue;
             SimilarityTransform bestTransform = null;
 
-            // build randomized list of pairs of points
-            List<(int, int)> randIndices = new List<(int, int)>();
-            for (int i = 0; i < srcPoints.Count; i++) {
-                for (int j = i + 1; j < srcPoints.Count; j++) {
-                    randIndices.Add((i, j));
-                }
-            }
-            randIndices = randIndices.OrderBy(x => RNG.Next()).Take(maxIterations).ToList();
+            // Seed the RNG deterministically from the inputs so the candidate sampling (and therefore
+            // the resulting transform) is identical across repeated runs on the same data.
+            var rng = new Random(ComputeDeterministicSeed(srcPoints, dstPoints));
+            int pointCount = srcPoints.Count;
+            long totalPairs = (long)pointCount * (pointCount - 1) / 2;
 
-            foreach ((int idx1, int idx2) in randIndices) {
+            foreach ((int idx1, int idx2) in SamplePairs(pointCount, totalPairs, maxIterations, rng)) {
                 var sampleSrc = new List<Point2D>() { srcPoints[idx1], srcPoints[idx2] };
                 var sampleDst = new List<Point2D>() { dstPoints[idx1], dstPoints[idx2] };
 
@@ -485,18 +580,13 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
             double bestInlierAveDistance = double.MaxValue;
             Matrix3x2 bestTransform = null;
 
-            // build randomized list of pairs of points
-            List<(int, int, int)> randIndices = new List<(int, int, int)>();
-            for (int i = 0; i < srcPoints.Count; i++) {
-                for (int j = i + 1; j < srcPoints.Count; j++) {
-                    for (int k = j + 1; k < srcPoints.Count; k++) {
-                        randIndices.Add((i, j, k));
-                    }
-                }
-            }
-            randIndices = randIndices.OrderBy(x => RNG.Next()).Take(maxIterations).ToList();
+            // Seed the RNG deterministically from the inputs so the candidate sampling (and therefore
+            // the resulting transform) is identical across repeated runs on the same data.
+            var rng = new Random(ComputeDeterministicSeed(srcPoints, dstPoints));
+            int pointCount = srcPoints.Count;
+            long totalTriplets = (long)pointCount * (pointCount - 1) * (pointCount - 2) / 6;
 
-            foreach ((int idx1, int idx2, int idx3) in randIndices) {
+            foreach ((int idx1, int idx2, int idx3) in SampleTriplets(pointCount, totalTriplets, maxIterations, rng)) {
                 var sampleSrc = new List<Point2D>() { srcPoints[idx1], srcPoints[idx2], srcPoints[idx3] };
                 var sampleDst = new List<Point2D>() { dstPoints[idx1], dstPoints[idx2], dstPoints[idx3] };
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/RANSACRegistration.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/RANSACRegistration.cs
@@ -228,6 +228,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
             private List<double> normalizedLengths;
             private List<double> normalizedBrightnesses;
             private List<Point2D> normalizedPoints;
+            private readonly double[] shapeDescriptor;
             private bool matched;
             private bool isReference;   // just used for annotating images with triangles
             private double matchScore;
@@ -247,6 +248,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
                 normalizedLengths = normalizeLength();
                 normalizedBrightnesses = normalizeBrightnesses(minBrightness, maxBrightness);
                 normalizedPoints = normalizePositions(imageSize, minBrightness, maxBrightness);
+                shapeDescriptor = ComputeShapeDescriptor();
             }
 
             public bool SameTriangle(StarTriangle other) {
@@ -302,23 +304,20 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
                 };
             }
 
-            public double[] AsShapeMatrix() {
-                return new double[] {
-                    normalizedLengths[0],
-                    normalizedLengths[1],
-                    normalizedLengths[2],
-                };
-            }
-
             /// <summary>
             /// Similarity-invariant shape descriptor: the two longer side lengths expressed as ratios to the
             /// shortest side, with the sides sorted by length. Because the sides are sorted, the descriptor is
-            /// independent of vertex ordering and handedness — unlike <see cref="AsShapeMatrix"/>, whose entries
-            /// follow the anchor-relative traversal order and so can differ for the same physical triangle seen
-            /// in two frames. Two triangles are similar iff their descriptors coincide; the Euclidean distance
-            /// between descriptors is a well-behaved shape-difference metric used for tolerance-bounded matching.
+            /// independent of vertex ordering and handedness, so the same physical triangle seen in two frames
+            /// yields the same descriptor. Two triangles are similar iff their descriptors coincide; the
+            /// Euclidean distance between descriptors is a well-behaved shape-difference metric used for
+            /// tolerance-bounded matching. Computed once in the constructor and cached (it is read in the
+            /// matcher's hot sort path).
             /// </summary>
             public double[] ShapeDescriptor() {
+                return shapeDescriptor;
+            }
+
+            private double[] ComputeShapeDescriptor() {
                 var squared = new[] {
                     lineLengthSquared(Points[0], Points[1]),
                     lineLengthSquared(Points[1], Points[2]),
@@ -594,7 +593,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
                     }
                 }
 
-                double aveInlierDistance = inlierDistanceTotal / inlierIndices.Count;
+                // Guard the 0/0 when a sampled transform has no inliers: treat it as worst-possible so it
+                // can never win the tie-break (NaN comparisons are always false, which only worked by luck).
+                double aveInlierDistance = inlierIndices.Count > 0 ? inlierDistanceTotal / inlierIndices.Count : double.MaxValue;
 
                 //Trace.WriteLine($"{idx1},{idx2}: {sampleSrc[0]}, {sampleSrc[1]} -> {sampleDst[0]}, {sampleDst[1]} = {transform}, {inlierIndices.Count*100/srcPoints.Count:0.####}%");
 
@@ -667,7 +668,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
                     }
                 }
 
-                double aveInlierDistance = inlierDistanceTotal / inlierIndices.Count;
+                // Guard the 0/0 when a sampled transform has no inliers: treat it as worst-possible so it
+                // can never win the tie-break (NaN comparisons are always false, which only worked by luck).
+                double aveInlierDistance = inlierIndices.Count > 0 ? inlierDistanceTotal / inlierIndices.Count : double.MaxValue;
 
                 //Trace.WriteLine($"{idx1},{idx2}: {sampleSrc[0]}, {sampleSrc[1]} -> {sampleDst[0]}, {sampleDst[1]} = {transform}, {inlierIndices.Count*100/srcPoints.Count:0.####}%");
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/RANSACRegistration.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/RANSACRegistration.cs
@@ -10,6 +10,8 @@
 
 #endregion "copyright"
 
+using KdTree;
+using KdTree.Math;
 using MathNet.Numerics.LinearAlgebra;
 using NINA.Core.Model;
 using NINA.Core.Utility;
@@ -308,6 +310,31 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
                 };
             }
 
+            /// <summary>
+            /// Similarity-invariant shape descriptor: the two longer side lengths expressed as ratios to the
+            /// shortest side, with the sides sorted by length. Because the sides are sorted, the descriptor is
+            /// independent of vertex ordering and handedness — unlike <see cref="AsShapeMatrix"/>, whose entries
+            /// follow the anchor-relative traversal order and so can differ for the same physical triangle seen
+            /// in two frames. Two triangles are similar iff their descriptors coincide; the Euclidean distance
+            /// between descriptors is a well-behaved shape-difference metric used for tolerance-bounded matching.
+            /// </summary>
+            public double[] ShapeDescriptor() {
+                var squared = new[] {
+                    lineLengthSquared(Points[0], Points[1]),
+                    lineLengthSquared(Points[1], Points[2]),
+                    lineLengthSquared(Points[2], Points[0])
+                };
+                Array.Sort(squared);
+                var shortest = squared[0];
+                if (shortest <= 0.0) {
+                    return new double[] { 1.0, 1.0 };
+                }
+                return new double[] {
+                    Math.Sqrt(squared[1] / shortest),
+                    Math.Sqrt(squared[2] / shortest)
+                };
+            }
+
             public double[] AsBrightnessMatrix() {
                 return new double[] {
                     NormalizedBrightnesses[0],
@@ -339,6 +366,19 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
                 matched = true;
                 this.referenceID = referenceID;
                 this.matchScore = matchScore;
+            }
+
+            /// <summary>
+            /// Clears the matched state so the triangle can participate in a subsequent matching pass. Used
+            /// when the strict-tolerance pass yields too few matches and the whole match is re-run with a
+            /// relaxed tolerance, so the relaxed pass produces a superset rather than only the leftovers.
+            /// </summary>
+            public void ResetMatch() {
+                matched = false;
+                matchScore = 0.0;
+                if (!isReference) {
+                    referenceID = 0;
+                }
             }
 
             public string MatchString {
@@ -423,58 +463,73 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
             return triangles;
         }
 
-        // Generate putative matches using triangles
+        // Generate putative matches using triangles. Triangles are matched in a similarity-invariant
+        // shape space (sorted side-length ratios, see StarTriangle.ShapeDescriptor) via a 2-D KdTree
+        // radial search bounded by maxShapeDistance. This replaces the former O(refTri × imgTri)
+        // cosine-similarity scan over vertex-order-dependent side-length vectors gated by a brittle
+        // near-1 cosine threshold: the descriptor is order/handedness invariant, the KdTree makes the
+        // search roughly O(n log n), and a Euclidean ratio tolerance is far more forgiving of seeing/
+        // centroiding noise than a 0.999999 cosine cutoff while still being scale/rotation invariant.
         public static (List<Point2D> srcPoints, List<Point2D> dstPoints) GeneratePutativeMatchesUsingSimilarTriangles(
             List<StarTriangle> imageTriangles,
             List<StarTriangle> referenceTriangles,
             ApplicationStatus status,
-            double minCosSim) {
+            double maxShapeDistance) {
             var srcPoints = new List<Point2D>();
             var dstPoints = new List<Point2D>();
 
-            // For each triangle in the reference image, find closest match in this image
+            // Index the image triangles by shape descriptor. Skip exact-descriptor duplicates (vanishingly
+            // rare with real centroids) to keep the tree valued one-per-point; insertion order is the
+            // deterministic image-triangle order, so the index is reproducible across runs.
+            var tree = new KdTree<double, StarTriangle>(2, new DoubleMath(), AddDuplicateBehavior.Skip);
+            foreach (var imageTriangle in imageTriangles) {
+                tree.Add(imageTriangle.ShapeDescriptor(), imageTriangle);
+            }
 
-            for (int i = 0; i < referenceTriangles.Count; i++) {
-                var referenceTriangle = referenceTriangles[i];
-                double bestCosSimLoc = minCosSim;
-                StarTriangle bestMatch = null;
-                List<(StarTriangle, double)> matches = new();
-                foreach (var imageTriangle in imageTriangles.Where(t => !t.Matched)) {
-                    var cosSim = CosineSimilarity(referenceTriangle.AsShapeMatrix(), imageTriangle.AsShapeMatrix());
-                    if (cosSim > minCosSim) {
-                        matches.Add((imageTriangle, cosSim));
-                    }
+            // For each reference triangle, find the closest-shape unmatched image triangle within tolerance.
+            foreach (var referenceTriangle in referenceTriangles) {
+                var refDescriptor = referenceTriangle.ShapeDescriptor();
+                var neighbors = tree.RadialSearch(refDescriptor, maxShapeDistance, imageTriangles.Count);
+
+                // Order candidates deterministically by shape distance, then by geometry, so ties resolve
+                // identically every run (image triangles carry no stable id of their own).
+                var candidates = neighbors
+                    .Select(n => n.Value)
+                    .Where(t => !t.Matched)
+                    .OrderBy(t => ShapeDistance(refDescriptor, t.ShapeDescriptor()))
+                    .ThenBy(t => t.P1.X).ThenBy(t => t.P1.Y)
+                    .ThenBy(t => t.P2.X).ThenBy(t => t.P2.Y)
+                    .ThenBy(t => t.P3.X).ThenBy(t => t.P3.Y)
+                    .ToList();
+                if (candidates.Count == 0) {
+                    continue;
                 }
 
-                if (matches.Count > 1) {
-                    // examine matches and pick best on brightness - these matches are already pretty close matches based on location (>0.99999)
-                    double bestCosSimBri = 0;
-
-                    foreach (var (tri, cs) in matches) {
-                        var cosSim = CosineSimilarity(referenceTriangle.AsBrightnessMatrix(), tri.AsBrightnessMatrix());
-
+                StarTriangle bestMatch = candidates[0];
+                if (candidates.Count > 1) {
+                    // Multiple near-equal shapes: disambiguate by brightness similarity, as before.
+                    double bestCosSimBri = CosineSimilarity(referenceTriangle.AsBrightnessMatrix(), candidates[0].AsBrightnessMatrix());
+                    foreach (var candidate in candidates.Skip(1)) {
+                        var cosSim = CosineSimilarity(referenceTriangle.AsBrightnessMatrix(), candidate.AsBrightnessMatrix());
                         if (cosSim > bestCosSimBri) {
-                            bestMatch = tri;
+                            bestMatch = candidate;
                             bestCosSimBri = cosSim;
                         }
                     }
-                    //Logger.Debug($"Multiple ({matches.Count}) matches for ref triangle {i} - selected triangle with briCosSim of {bestCosSimBri}");
-                } else {
-                    if (matches.Count == 1) {
-                        var best = matches.First();
-                        bestMatch = best.Item1;
-                        bestCosSimLoc = best.Item2;
-                    }
                 }
 
-                if (bestMatch != null) {
-                    srcPoints.AddRange(new List<Point2D> { bestMatch.P1, bestMatch.P2, bestMatch.P3 });
-                    dstPoints.AddRange(new List<Point2D> { referenceTriangle.P1, referenceTriangle.P2, referenceTriangle.P3 });
-                    bestMatch.MarkAsMatched(referenceTriangle.ReferenceID, bestCosSimLoc);
-                }
+                srcPoints.AddRange(new List<Point2D> { bestMatch.P1, bestMatch.P2, bestMatch.P3 });
+                dstPoints.AddRange(new List<Point2D> { referenceTriangle.P1, referenceTriangle.P2, referenceTriangle.P3 });
+                bestMatch.MarkAsMatched(referenceTriangle.ReferenceID, ShapeDistance(refDescriptor, bestMatch.ShapeDescriptor()));
             }
 
             return (srcPoints, dstPoints);
+        }
+
+        private static double ShapeDistance(double[] a, double[] b) {
+            var dx = a[0] - b[0];
+            var dy = a[1] - b[1];
+            return Math.Sqrt(dx * dx + dy * dy);
         }
 
         private static double CosineSimilarity(double[] vecA, double[] vecB) {

--- a/plans/sensor-model-fit-quality-thresholds.md
+++ b/plans/sensor-model-fit-quality-thresholds.md
@@ -1,0 +1,199 @@
+# Sensor Model — Configurable R²/χ² Fit-Quality Thresholds & Dual-Metric Display
+
+## Context
+
+The sensor model fits a tilted paraboloid to per-star best-focus positions. Two
+goodness-of-fit statistics are already computed on `SensorParaboloidModel`
+(`Inspection/SensorParaboloidModel.cs`, set in `EvaluateFit`):
+
+- **`GoodnessOfFit`** — R² (variance explained). *Scale-dependent*: a near-flat but
+  well-measured sensor scores low R² despite being a great fit; a strongly-tilted sensor
+  with sloppy data can score high R². Intuitive and familiar, but wrong as a sole gate.
+- **`ReducedChiSquared`** — χ²/dof against each star's propagated best-focus σ.
+  *Magnitude-independent* (≈1 = fits within measurement error). The statistically correct
+  fit-quality measure. **Caveat:** σ here is an approximate per-star standard error that
+  does not capture model error, so reduced χ² tends to run above 1 even for good fits and
+  its absolute calibration is rig-dependent — which is exactly why the threshold should be
+  user-configurable and the bands generous.
+
+Today both thresholds are **hardcoded constants** and only R² is surfaced:
+
+| Concern | Current state |
+|---|---|
+| χ² acceptance cap | `SensorAberrationCalculator.AcceptableReducedChiSquaredMax = 5.0` (const) |
+| χ² acceptance test | `SensorAberrationCalculator.IsReducedChiSquaredAcceptable(fit)` (uses the const) |
+| Brightness-search stop | `SensorModel.cs:~476` — `StarsInModel < 10 || !IsReducedChiSquaredAcceptable(pfit)` |
+| Final "modeling failed" throw | `SensorModel.cs:~566` — `bestPfit.GoodnessOfFit < 0.05 && !IsReducedChiSquaredAcceptable(bestPfit)` (AND) |
+| Model Properties grid (UI) | `AutoFocus/DataTemplates.xaml:~2686` — shows **R² only** ("Model R²") |
+| Analysis table below it | `AutoFocus/DataTemplates.xaml:~2925` — `ItemsSource = …AnalysisResults`; `SensorModelAberrationResult.AnalyzeSensorModelFit` adds one "Model Fit" R² row |
+| Result populate method | `SensorModelAberrationResult.Update(...)`, called from `SensorModel.cs:~149` and `~1022` (both have `inspectorOptions` in scope) |
+
+### Goals
+
+1. Expose **both** rejection thresholds as configurable options.
+2. Reject the model with a **combined rule** that keeps the χ² magnitude-independence
+   benefit (flat sensors still accepted) while letting a low R² matter when the fit is
+   also statistically questionable.
+3. Display **both** R² and reduced χ² in the Model Properties grid **and** the analysis
+   table below it.
+
+### Decisions (settled during design)
+
+- Threshold drives **both** acceptance and display (single source of truth).
+- Two options, defaults preserving today's behavior: `AcceptableReducedChiSquared = 5.0`,
+  `AcceptableRSquaredMin = 0.05`.
+- Good/marginal χ² boundary is **derived** as `0.6 × AcceptableReducedChiSquared`
+  (= 3.0 at default) — not a separate knob.
+- **Combined rejection rule:** reject if
+  `χ² ≥ maxChi` **OR** `(R² < minR² AND χ² ≥ 0.6·maxChi)`.
+  Equivalently, accept iff `χ² < maxChi AND NOT(R² < minR² AND χ² ≥ 0.6·maxChi)`.
+- YAGNI: no good/marginal knob, no p-value display, no low-χ² overfit flag.
+
+> Execute on a fresh branch off the merged PR #43 result (or `develop` if merged).
+> Run `/clear` first. Each phase ends green:
+> `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`.
+> Author/committer email `322725+ghilios@users.noreply.github.com`; never push to `develop`.
+
+---
+
+## Phase 1 — Acceptance logic in `SensorAberrationCalculator` (pure, test-first)
+
+`SensorAberrationCalculator` is a pure, unit-tested helper — start here with TDD.
+
+- Replace the `AcceptableReducedChiSquaredMax = 5.0` const with default constants:
+  - `public const double DefaultAcceptableReducedChiSquared = 5.0;`
+  - `public const double DefaultAcceptableRSquaredMin = 0.05;`
+  - `private const double GoodReducedChiSquaredFraction = 0.6;` (good/marginal boundary).
+- Parameterize the χ² test:
+  ```csharp
+  public static bool IsReducedChiSquaredAcceptable(SensorParaboloidModel fit, double maxReducedChiSquared) {
+      if (fit == null) return false;
+      var rcs = fit.ReducedChiSquared;
+      return !double.IsNaN(rcs) && !double.IsInfinity(rcs) && rcs <= maxReducedChiSquared;
+  }
+  ```
+- Add the combined acceptance rule:
+  ```csharp
+  public static bool IsModelAcceptable(SensorParaboloidModel fit, double maxReducedChiSquared, double minRSquared) {
+      if (fit == null) return false;
+      if (!IsReducedChiSquaredAcceptable(fit, maxReducedChiSquared)) return false; // χ² rejected outright
+      var goodBand = GoodReducedChiSquaredFraction * maxReducedChiSquared;
+      var chiElevated = fit.ReducedChiSquared >= goodBand;
+      if (fit.GoodnessOfFit < minRSquared && chiElevated) return false;            // low R² only when χ² also elevated
+      return true;
+  }
+  ```
+- Add a display-band classifier:
+  ```csharp
+  public enum FitQualityBand { Good, Marginal, Rejected }
+  public static FitQualityBand ClassifyReducedChiSquared(double reducedChiSquared, double maxReducedChiSquared) {
+      if (double.IsNaN(reducedChiSquared) || double.IsInfinity(reducedChiSquared) || reducedChiSquared >= maxReducedChiSquared)
+          return FitQualityBand.Rejected;
+      if (reducedChiSquared < GoodReducedChiSquaredFraction * maxReducedChiSquared)
+          return FitQualityBand.Good;
+      return FitQualityBand.Marginal;
+  }
+  ```
+
+**Tests** (`SensorAberrationCalculatorTests`): truth table for `IsModelAcceptable` —
+- good χ² + low R² → **accept** (flat sensor);
+- marginal χ² (≥ 0.6·max) + low R² → **reject**;
+- marginal χ² + adequate R² → **accept**;
+- χ² ≥ max → **reject** regardless of R²;
+- null / NaN / Inf → reject.
+Band classifier boundaries (just below/above `0.6·max` and `max`). Update existing
+`IsReducedChiSquaredAcceptable` tests to the new signature. Verify defaults reproduce
+today's numbers (5.0, 0.05).
+
+---
+
+## Phase 2 — Options plumbing
+
+- **`IInspectorOptions`**: add `double AcceptableReducedChiSquared { get; set; }` and
+  `double AcceptableRSquaredMin { get; set; }`.
+- **`InspectorOptions`** (follow the existing option pattern): backing fields, `InitializeOptions`
+  load (`GetValueDouble(nameof(...), 5.0 / 0.05)`), property setters with
+  `SetValueDouble` + `RaisePropertyChanged`, and `ResetDefaults` (5.0 / 0.05).
+- **`FakeInspectorOptions`** (test double): add both auto-properties, defaulting to 5.0 / 0.05.
+
+**Tests:** an `InspectorOptions` round-trip/reset test for both new options (mirroring any
+existing options test), or extend the fake-backed options test if present.
+
+---
+
+## Phase 3 — Wire acceptance through `SensorModel`
+
+Replace both hardcoded uses with the configurable combined rule:
+
+- Brightness-search stop (`~:476`): retry while
+  `pfit == null || pfit.StarsInModel < 10 || !SensorAberrationCalculator.IsModelAcceptable(pfit, inspectorOptions.AcceptableReducedChiSquared, inspectorOptions.AcceptableRSquaredMin)`.
+  Update the debug log to print both thresholds.
+- Final throw (`~:566`): replace
+  `if (bestPfit.GoodnessOfFit < 0.05 && !IsReducedChiSquaredAcceptable(bestPfit))`
+  with `if (!SensorAberrationCalculator.IsModelAcceptable(bestPfit, …AcceptableReducedChiSquared, …AcceptableRSquaredMin))`.
+  Update the exception message to report both R² and reduced χ² and both thresholds.
+
+At the default 5.0 / 0.05 the *only* behavioral change versus today is the intended one:
+the rule is now the combined OR-with-guard instead of the old AND (a marginal-χ²-and-low-R²
+fit that the AND would have accepted is now rejected; a flat good-χ² fit still accepts).
+
+**Verification:** full suite green; the `SensorModelRepeatabilityTests` harness still passes
+(determinism unaffected). Add an integration-style assertion only if cheap; the rule itself
+is covered by Phase 1 unit tests.
+
+---
+
+## Phase 4 — Display both metrics
+
+### 4a. Model Properties grid (`AutoFocus/DataTemplates.xaml:~2686`)
+R² already appears ("Model R²" → `Model.GoodnessOfFit`). Add a **"Reduced χ²"** label +
+value bound to `SensorModel.SensorModelResult.Model.ReducedChiSquared`
+(`StringFormat={0:0.00}`) in a free cell of the 5-row × 6-col grid (add a row if needed).
+Add a tooltip resource explaining reduced χ² and the σ-calibration caveat.
+
+### 4b. Analysis table below (`SensorModelAberrationResult` + `:~2925`)
+- `Update(...)` gains `acceptableReducedChiSquared` and `acceptableRSquaredMin` params;
+  pass `inspectorOptions.AcceptableReducedChiSquared` / `.AcceptableRSquaredMin` from both
+  call sites in `SensorModel` (`~:149`, `~:1022`).
+- `AnalyzeSensorModelFit` produces **two** rows:
+  - **"Model Fit (R²)"** — value `R²`; `Acceptable = !(R² < minR² && χ² ≥ 0.6·maxChi)`
+    (red only when R² actually contributes to rejection); details adapt ("low R² is
+    expected for a near-flat sensor and is fine while χ² is good").
+  - **"Reduced χ²"** — value `χ²`; `Acceptable = χ² < maxChi`; details by
+    `ClassifyReducedChiSquared`: Good = "fits within measurement uncertainty",
+    Marginal = "acceptable but elevated — model error or under-estimated σ",
+    Rejected = "exceeds the acceptable limit; model rejected".
+- Existing `AnalysisResults` binding renders the extra row automatically (no XAML change
+  needed for 4b beyond what already iterates the collection).
+
+**Verification:** build (XAML compiles); full suite green. If `AnalyzeSensorModelFit` is
+reachable in tests, assert the two rows and their `Acceptable` flags for representative
+fits (flat/good, marginal/low-R², rejected).
+
+---
+
+## Phase 5 — Options UI
+
+In the inspector's **Experimental** options group (`AutoFocus/DataTemplates.xaml`), add two
+numeric inputs (follow the existing `ninactrl:UnitTextBox` / `HintTextBox` + `DoubleRangeRule`
+pattern used by "Starting Brightness Tolerance"):
+
+- **"Max reduced χ² (rejection)"** → `InspectorOptions.AcceptableReducedChiSquared`,
+  range e.g. (0, 1000].
+- **"Min R² (rejection)"** → `InspectorOptions.AcceptableRSquaredMin`, range [0, 1).
+
+Each with an inline tooltip (matching the section's style) explaining the metric, the
+combined rule, and that χ² runs above 1 even for good fits (tune per rig). Place them in
+free cells / new rows of the Experimental grid.
+
+**Verification:** build; full suite green; manually confirm the controls bind and persist.
+
+---
+
+## Verification (whole feature)
+
+- `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo` green after each phase.
+- Defaults (5.0 / 0.05) reproduce current acceptance except the intended AND→combined change.
+- Manual smoke: run the Aberration Inspector; confirm Model Properties shows R² **and**
+  reduced χ², the analysis table shows both rows with sensible Good/Marginal/Rejected status,
+  and changing either threshold in options changes acceptance + the displayed bands.

--- a/plans/sensor-model-repeatability-and-robustness.md
+++ b/plans/sensor-model-repeatability-and-robustness.md
@@ -1,0 +1,247 @@
+# Sensor Model & RANSAC Registration — Analysis and Improvement Plan
+
+> Note: this plan was authored in plan mode at the harness-mandated path. Per `CLAUDE.md`,
+> before execution it should be copied to `plans/sensor-model-repeatability-and-robustness.md`.
+
+## Context
+
+The aberration **Sensor Model** quantifies sensor tilt and field curvature. The user's
+mental model (confirmed) of the pipeline is:
+
+1. **One** autofocus run captures frames, each at a different focuser position.
+2. Stars are **matched across frames** (RANSAC alignment + KdTree nearest-neighbor) so the
+   same physical star is tracked through the focus sweep.
+3. A **hyperbolic HFR-vs-focuser curve** is fit per matched star to find that star's optimal
+   focuser position.
+4. A **6-parameter tilted paraboloid** is fit to the (sensor-X, sensor-Y, optimal-focuser)
+   points to model tilt + curvature.
+
+The user's definition of **robustness is repeatability**: *"I can run the whole process
+multiple times without changing anything and get repeatable, consistent behavior."* Today it
+does **not** — there are several deliberate and accidental sources of non-determinism, plus a
+math bug and modeling/perf weaknesses. The user asked to fix all four areas: correctness bugs,
+registration robustness, model/optimizer quality, and performance.
+
+### Where the code lives
+
+| Concern | File |
+|---|---|
+| Pipeline orchestration, registration loop, KdTree matching, per-star fit | `Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs` |
+| RANSAC, triangle matching, transforms | `Joko.NINA.Plugins.HocusFocus/Utility/RANSACRegistration.cs` |
+| Paraboloid model + solver (Value/Gradient/bounds) | `Joko.NINA.Plugins.HocusFocus/Inspection/SensorParaboloidModel.cs` |
+| Levenberg–Marquardt wrapper, winsorization, R²/RMS | `Joko.NINA.Plugins.HocusFocus/Utility/NonLinearLeastSquaresSolver.cs` |
+| Fit-acceptance heuristics (pure, unit-tested) | `Joko.NINA.Plugins.HocusFocus/Inspection/SensorAberrationCalculator.cs` |
+| Derived metrics (tilt°, curvature radius, mean elevation) | `Joko.NINA.Plugins.HocusFocus/Inspection/SensorModelAberrationResult.cs` |
+| Existing tests | `Joko.NINA.Plugins.HocusFocus.Tests/Utility/RANSACRegistrationTests.cs` |
+
+---
+
+## Findings
+
+### A. Sources of non-determinism (the headline problem)
+
+1. **Unseeded shared RNG drives RANSAC.** `RANSACRegistration.cs:91` declares
+   `private static Random RNG = new();`. It is used to shuffle candidate triplets in
+   `EstimateAffineTransform` (`randIndices.OrderBy(x => RNG.Next()).Take(maxIterations)`,
+   `:497`) and the analogous `EstimateSimilarityTransform` (`:420`). Different shuffles select
+   different sample sets → different transform → different alignment → different KdTree matches
+   → **different model every run.** This is the primary repeatability killer.
+
+2. **Run results leak into the next run's starting point.** `RegisterStarsAndFit` reads
+   `inspectorOptions.PreviousRunBrightnessDiff` as the seed for the brightness-tolerance search
+   (`SensorModel.cs:401`) and **writes the winning value back** (`:519`). So "running the
+   unchanged process again" starts from different state and can converge differently. By design,
+   consecutive runs are *not* independent.
+
+3. **Model acceptance depends on wall-clock time.** `SensorAberrationCalculator
+   .TargetR2BasedOnTimeTaken` (`:30`) relaxes the accepted R² target from 0.9 → 0.6 based on how
+   many seconds the iteration took. The same data accepts a different model on a busy vs idle
+   machine. Used at `SensorModel.cs:440`.
+
+4a. **R² is the wrong goodness-of-fit statistic for acceptance.** R² = 1 − RSS/TSS is
+   *scale-dependent* (inflates with large tilt/curvature signal, collapses on near-flat sensors)
+   and ignores per-point measurement uncertainty and DOF. Its denominator TSS depends on *which*
+   stars matched, so the value jitters run-to-run with the non-deterministic registration —
+   directly undermining repeatability. The project already does the right thing where noise is
+   known: `PSFModel.ReducedChiSquared = rss / (nPixels · noiseSigma²)`
+   (`StarDetection/PSFModel.cs:74`), keeping R² only as a secondary intuitive number. The sensor
+   pipeline does **not** carry per-point uncertainties: the per-star hyperbolic points are built
+   with zero error (`SensorModel.cs:576`, also why weighted-fit is a no-op, finding #12), and the
+   paraboloid fit weights every star equally despite very heterogeneous best-focus-position
+   uncertainties.
+
+4. **Greedy, order-dependent triangle matching.** `GeneratePutativeMatchesUsingSimilarTriangles`
+   marks triangles matched as it scans (`MarkAsMatched`, `:375`) and depends on reference-triangle
+   iteration order; combined with (1) this compounds variance.
+
+### B. Correctness bugs
+
+5. **`Volume()` formula bug.** `SensorParaboloidModel.cs:159`:
+   `part1 = C2 * w * h * (X0 * X0 + Y0 + Y0)` — the `Y0 + Y0` term must be `Y0 * Y0`. This feeds
+   `SensorMeanElevation` in `SensorModelAberrationResult`, so the reported mean elevation is wrong
+   whenever the curvature center is offset in Y.
+
+6. **6-DOF affine where physics allows only a similarity.** Frames in one AF run differ by small
+   translation (drift/flexure), maybe a tiny rotation, negligible scale. `AlignStarsWithRANSAC`
+   uses `EstimateAffineTransform` (`SensorModel.cs:749`), which permits shear + anisotropic scale.
+   Those extra DOFs let RANSAC "explain" mismatches by warping the field, displacing star
+   positions that the paraboloid then treats as truth. A `SimilarityTransform` (4-DOF) already
+   exists in `RANSACRegistration.cs:61` but is **never used**.
+
+### C. Registration robustness
+
+7. **Reference-frame-only star registry.** `MatchStarsUsingKdTree` seeds the global registry
+   *only* from the reference frame (the frame with the most detected stars, `SensorModel.cs:361`,
+   `:814`) and never adds stars seen in other frames but absent there. Stars not detectable at the
+   sharpest frame can never be registered, reducing spatial coverage and biasing the paraboloid.
+
+8. **Weak triangle descriptor + brittle threshold.** Matching uses cosine similarity of a
+   3-vector of normalized squared side-lengths (`AsShapeMatrix`, `:208`) with thresholds
+   `0.999999` / `0.99999` (`SensorModel.cs:652`). Cosine similarity of side-length ratios is a
+   poor shape metric (insensitive to the right things, ignores handedness), and the near-1
+   threshold is fragile to seeing/centroiding noise.
+
+### D. Model / optimizer quality
+
+9. **Curvature requires two full solves.** Because curvature is parameterized as
+   `sign(c)·c²` with `|c| ≥ 1e-4` (cannot cross zero), `FitParaboloidModel` solves once with
+   `PositiveCurvature=true`, again with `false`, and keeps the lower-RMS result
+   (`SensorModel.cs:196–206`). Doubles optimizer work and adds a discontinuity at flat fields.
+
+10. **Tilt parameterization has a built-in singularity.** Tilt uses `(theta, phi)` with
+    `theta ≥ 1e-5` forced (`SensorParaboloidModel.cs:286`) precisely to dodge the
+    `phi`-unidentifiability and local minimum at `theta=0`. The tilt plane is otherwise *linear*;
+    the `(theta, phi)` form injects trig nonlinearity and a trap for no benefit.
+
+11. **Isotropic curvature only.** `C²·(x'²+y'²)` cannot represent astigmatic/saddle field
+    curvature. (Lower priority — a modeling enhancement, not a bug.)
+
+12. **Per-star hyperbolic fit weighting is a no-op.** Points are built as
+    `new ScatterErrorPoint(focuser, HFR, 0.0, 0.0)` (`SensorModel.cs:576`); the zero error means
+    `WeightedHyperbolicFitEnabled` weights nothing. The hard `R² ≥ 0.90` gate (`:608`) silently
+    discards stars with no SNR-aware weighting.
+
+### E. Performance
+
+13. **Triangle build is O(n²) with an O(n) dup check inside the loop.** Non-`onePerPoint` mode
+    builds every C(k,3) triangle per neighborhood and runs `triangles.Count(tri =>
+    tri.SameTriangle(triangle)) == 0` for each (`RANSACRegistration.cs:319`).
+
+14. **All triplets materialized before sampling.** `EstimateAffineTransform` enumerates the full
+    C(n,3) triplet list, then shuffles and takes 10,000 (`:489–497`) — O(n³) memory/time before a
+    single model is tested.
+
+15. **Brightness-tolerance retry loop** (`SensorModel.cs:416–515`) re-runs the entire
+    match+fit+paraboloid pipeline up to many times per analysis; interacts badly with (2) and (3).
+
+---
+
+## Improvement Plan
+
+Ordered so the repeatability fixes (the user's stated goal) land first and are independently
+verifiable. Each phase ends green (`dotnet test`).
+
+### Phase 1 — Determinism / repeatability (highest priority)
+
+- **Inject a seeded RNG into RANSAC.** Replace the static `RNG` (`RANSACRegistration.cs:91`) with
+  an instance seeded from a fixed constant (or a value derived deterministically from the input
+  star set, e.g., a hash of reference-star coordinates). Thread it through
+  `EstimateAffineTransform` / `EstimateSimilarityTransform` so a given input always yields the
+  same sampling. Expose the seed as an `InspectorOptions` value (default fixed) only if a user-
+  facing knob is wanted; otherwise keep it internal.
+- **Stop persisting search state across runs.** Make the brightness-tolerance search start from a
+  fixed, configured value each run instead of `PreviousRunBrightnessDiff`
+  (`SensorModel.cs:401`, `:519`). Either remove the write-back or gate it behind an explicit
+  "adaptive" option that defaults off, so the default path is stateless and repeatable.
+- **Remove wall-clock from model acceptance.** Replace `TargetR2BasedOnTimeTaken`
+  (`SensorAberrationCalculator.cs:30`, used at `SensorModel.cs:440`) with a fixed, uncertainty-aware
+  acceptance criterion (reduced-χ² / p-value — see Phase 4) and a fixed max-iteration budget. This
+  is a pure function already under test — update `SensorAberrationCalculatorTests` accordingly.
+- **Make tie-breaking deterministic.** Where RANSAC compares models with equal inlier counts it
+  already falls back to average inlier distance (`:530`); ensure any remaining ordering
+  (triangle iteration, dictionary enumeration) is stable and documented.
+
+### Phase 2 — Correctness bug fixes
+
+- **Fix `Volume()`**: `Y0 + Y0` → `Y0 * Y0` (`SensorParaboloidModel.cs:159`). Add a unit test that
+  pins `Volume`/`SensorMeanElevation` against an analytically integrated value for a known model.
+
+### Phase 3 — Registration robustness
+
+- **Switch alignment to the similarity transform.** Use the existing `SimilarityTransform` /
+  `EstimateSimilarityTransform` in `AlignStarsWithRANSAC` (`SensorModel.cs:749`) instead of the
+  affine path, optionally keeping affine behind an option for diagnostics. Reuses
+  `FitSimilarityTransform` (`RANSACRegistration.cs:550`) — already covered by transform tests.
+- **Seed the registry from a frame union (or symmetric scheme).** In `MatchStarsUsingKdTree`,
+  allow stars matched across frames but absent from the reference to be added to the global
+  registry, improving coverage. Guard against double-counting via the existing one-to-one
+  bipartite constraint (`matchedGlobalStars` / `matchedSourceStars`, `:836`).
+- **Strengthen the triangle descriptor** (if matching still proves fragile after the above): match
+  triangles in a proper invariant feature space (sorted side ratios) via a KdTree with a tolerance,
+  replacing the cosine-similarity scan and the `0.999999` thresholds.
+
+### Phase 4 — Model / optimizer quality
+
+- **Single-solve, linear curvature.** Reparameterize curvature as one signed coefficient
+  `k = sign(c)·c²` so `curvature = k·(x'²+y'²)`, `k ∈ ℝ`. Update `Value`, `Gradient`, bounds, and
+  initial guess in `SensorParaboloidSolver` and remove the positive/negative double solve in
+  `FitParaboloidModel` (`SensorModel.cs:196–206`). Eliminates the discontinuity and halves
+  optimizer work.
+- **Reparameterize tilt as linear gradients.** Replace `(theta, phi)` with `(gx, gy)` where
+  `tilt = gx·x' + gy·y'`; derive display `theta = atan(hypot(gx,gy))`, `phi = atan2(gy,gx)` in
+  `SensorModelAberrationResult`. Removes the `theta ≥ 1e-5` hack (`SensorParaboloidModel.cs:286`)
+  and the local-minimum trap, and makes most of the model linear (cleaner Jacobian, more
+  repeatable convergence).
+- **Adopt χ² (weighted least squares) end-to-end with real uncertainties.** This is the
+  statistically correct replacement for R² as the *acceptance* metric, following the
+  `PSFModel.ReducedChiSquared` precedent (`StarDetection/PSFModel.cs:74`):
+  - **Per-star hyperbolic fit:** assign each HFR point a σ estimated from the star's SNR (instead
+    of the current zero error at `SensorModel.cs:576`). This simultaneously makes
+    `WeightedHyperbolicFitEnabled` meaningful (finding #12) and lets the per-star gate use a real
+    reduced-χ² / p-value instead of the hard `R² ≥ 0.90` (`:608`).
+  - **Paraboloid fit:** propagate each star's best-focus-position uncertainty from its hyperbolic
+    fit (standard error of the hyperbola minimum, from the LM covariance) into the
+    `SensorParaboloidDataPoint`, and have `NonLinearLeastSquaresSolver` weight by `1/σ²`. Add a
+    `ReducedChiSquared` (and p-value) alongside the existing `GoodnessOfFit`/`RMSErrorMicrons` in
+    `SensorParaboloidModel.EvaluateFit`, and use reduced-χ² ≈ 1 (within a band) as the acceptance
+    criterion in `IsBetterFit` / the brightness loop — replacing `IsFitTooGood` (R²>0.995) and the
+    wall-clock target. Keep reporting R² in the UI as an intuitive secondary number.
+  - Keep the robust MAD/winsorization outlier step regardless (χ² assumes ~Gaussian errors, which
+    holds for high-SNR stars but not faint ones).
+- **(Optional) Astigmatic curvature** `kx·x'² + ky·y'²` behind an option, for saddle-shaped fields.
+
+### Phase 5 — Performance
+
+- **Lazy triplet sampling** in `EstimateAffineTransform`/`EstimateSimilarityTransform`: draw
+  random index combinations on demand with the seeded RNG instead of enumerating all C(n,3)
+  (`RANSACRegistration.cs:489`).
+- **De-dup triangles via a hash set** keyed on ordered point identities instead of the O(n)
+  `SameTriangle` scan (`:319`).
+- Re-measure the brightness retry loop after Phase 1; with stateless start + similarity transform
+  it should converge in fewer iterations.
+
+---
+
+## Verification
+
+- **Repeatability harness (new test).** Add a test in
+  `Joko.NINA.Plugins.HocusFocus.Tests` that runs `SensorModel.UpdateModel` (or the
+  `RegisterStarsAndFit` path) twice on a fixed synthetic star set spanning several focuser
+  positions and asserts the resulting model parameters (`Theta/Phi` or `gx/gy`, `C/k`, `Z0`,
+  `StarsInModel`, `GoodnessOfFit`) are bit-for-bit (or within 1e-9) identical. This is the direct
+  proof of the user's robustness goal and should fail on `develop` before Phase 1.
+- **Transform tests.** Extend `RANSACRegistrationTests` to confirm `EstimateSimilarityTransform`
+  recovers a known translation+rotation+scale from noisy correspondences, and that a fixed seed
+  yields identical inlier sets across repeated calls.
+- **`Volume`/mean-elevation test** as described in Phase 2.
+- **Solver tests.** Add a test fitting a synthetic tilted paraboloid (known `gx, gy, k, z0`) and
+  asserting recovery within tolerance, plus a flat-field (`k≈0`) case to prove the single-solve
+  reparameterization handles zero curvature without the old double solve.
+- **χ² tests.** Verify reduced-χ² ≈ 1 when synthetic points are perturbed by Gaussian noise of the
+  declared σ, that it scales correctly when σ is mis-stated (×2 → ÷4), and that the new acceptance
+  criterion is *invariant to overall signal magnitude* (a near-flat sensor with good residuals
+  accepts, where R² would have rejected it) — the magnitude-independence that motivated the change.
+- **Full suite:** `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo` after
+  every phase.
+- **Manual smoke (optional):** run the Aberration Inspector on a real/saved AF run twice and
+  confirm identical reported tilt/curvature and a stable `RegistrationAndFitReport`.

--- a/plans/sensor-model-review-followups.md
+++ b/plans/sensor-model-review-followups.md
@@ -1,0 +1,161 @@
+# Sensor Model — Code-Review Follow-Ups
+
+Deferred items from the thorough code review of branch
+`ghilios/sensor-model-repeatability-and-robustness` (PR #43). The high-severity
+correctness bugs and the safe robustness/cleanup fixes from that review were already
+applied on the branch (commits `03b5ce7` and `5381eb3`). This plan captures the items
+that were intentionally **not** done in that PR — two low-impact correctness/clarity
+issues and two larger structural refactors that carried regression risk too close to
+merge.
+
+> Execute against `develop` (or the merged result of PR #43) on a fresh feature
+> branch `ghilios/sensor-model-review-followups`. Run `/clear` before executing.
+> Each phase must end green: `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`.
+
+## Context
+
+The sensor model fits a tilted paraboloid (linear tilt gradients `Gx, Gy` + curvature
+`K`, or independent `Kx, Ky` in optional astigmatic mode) to per-star best-focus
+positions recovered from a focus sweep. Stars are registered across frames via a
+seeded RANSAC similarity transform plus a KdTree triangle matcher, and the paraboloid
+fit is a weighted (1/σ²) χ² least-squares solve.
+
+| Concern | File |
+|---|---|
+| Per-star fit, registration, brightness search | `Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs` |
+| Paraboloid model + solver (isotropic/astigmatic) | `Joko.NINA.Plugins.HocusFocus/Inspection/SensorParaboloidModel.cs` |
+| Derived display metrics (tilt°, curvature radius) | `Joko.NINA.Plugins.HocusFocus/Inspection/SensorModelAberrationResult.cs` |
+| RANSAC transforms, triangle matcher | `Joko.NINA.Plugins.HocusFocus/Utility/RANSACRegistration.cs` |
+| LM solver wrapper, χ²/R²/winsorization | `Joko.NINA.Plugins.HocusFocus/Utility/NonLinearLeastSquaresSolver.cs` |
+
+---
+
+## Phase 1 — Interpolated-grid points carry a real σ (low impact)
+
+**Problem.** In `SensorModel.FitImages`, when `inspectorOptions.InterpolationEnabled` is
+on, the per-star best-focus points are replaced by an interpolated grid via
+`ToInterpolatedGrid(...)`. Those grid points are constructed with the default
+`focuserPositionStdDev = 1.0` (see `ToInterpolatedGrid`, which builds
+`new SensorParaboloidDataPoint(x, y, focuser, rSquared: 1.0)` with no σ), whereas the
+non-interpolated path now passes a real per-point σ. So the paraboloid fit's weighting
+and the reduced-χ² acceptance gate behave inconsistently depending on whether
+interpolation is enabled. `InterpolationEnabled` is currently an experimental option
+whose UI is commented out, which is why this is low priority.
+
+**Approach.**
+- Propagate a representative σ into the interpolated points. Simplest defensible choice:
+  carry the median of the input points' `FocuserPositionStdDev` into every grid point
+  (interpolation smooths the surface, so a single representative uncertainty is
+  reasonable), or interpolate σ alongside the value if cheap.
+- Update `ToInterpolatedGrid` to accept/produce the σ and set it on each
+  `SensorParaboloidDataPoint`.
+
+**Alternative.** If interpolation is considered dead, delete the `InterpolationEnabled`
+path and `ToInterpolatedGrid` entirely rather than fixing its weighting. Decide with the
+maintainer before removing.
+
+**Verification.** Unit test: build interpolated grid from points with known σ and assert
+the grid points' `FocuserPositionStdDev` equals the intended representative value (not
+1.0). Full suite green.
+
+---
+
+## Phase 2 — Astigmatic curvature reporting (low impact, off by default)
+
+**Problem.** `SensorModelAberrationResult` computes
+`CurvatureRadiusMillimeters = 1.0 / (2 · C² · 1000)` where `C = sign(K)·√|K|` and
+`K = ½(Kx + Ky)` is the **mean** curvature. In astigmatic mode (`AstigmaticCurvatureEnabled`,
+off by default) `Kx ≠ Ky`, so a single radius derived from the mean is a physically
+meaningless blend — and for a saddle field (`Kx`, `Ky` opposite signs) the mean can be
+~0 while real curvature is large, making the reported radius blow up.
+
+**Approach.**
+- When `sensorModel.Astigmatic` is true, report the two principal curvature radii
+  (from `Kx` and `Ky`) instead of one, or label the single value clearly as a mean / mark
+  it N/A. Add an astigmatism indicator to the analysis result.
+- Keep the isotropic path (the default) exactly as-is.
+
+**Verification.** Unit test on `SensorModelAberrationResult` with an astigmatic model:
+assert the reported curvature reflects `Kx`/`Ky` rather than only the mean, and that a
+saddle field does not produce a single misleading radius. Full suite green.
+
+---
+
+## Phase 3 — Extract a shared generic RANSAC core (refactor, no behavior change)
+
+**Problem.** `RANSACRegistration.EstimateSimilarityTransform` and
+`EstimateAffineTransform` are now near-verbatim copies: same deterministic-seed setup
+(`ComputeDeterministicSeed`), same lazy sampler, same inlier-count / `aveInlierDistance`
+/ best-model loop, same refine-or-throw tail. They differ only in sample arity
+(pair vs triplet) and the `Fit*` call. Any future change to scoring or refinement must be
+applied in two places and will drift.
+
+**Approach.**
+- Extract a private generic core, e.g.
+  `EstimateTransform(srcPoints, dstPoints, sampleSize, sampler, fitFn, refineFn, status, progress)`,
+  parameterized by a sampler delegate (`SamplePairs`/`SampleTriplets`) and a fit/refine
+  delegate. The two public methods become thin wrappers.
+- Preserve current behavior **exactly**, including the deterministic seed and the
+  `aveInlierDistance` tie-break (already guarded against 0/0).
+
+**Verification.** This is behavior-preserving: the existing
+`EstimateSimilarityTransform_*` / `EstimateAffineTransform_*` tests (recovery + fixed-seed
+bit-for-bit determinism) must continue to pass unchanged. Full suite green. Do not add
+new behavior in this phase.
+
+---
+
+## Phase 4 — Single source of truth for the isotropic/astigmatic mode (refactor)
+
+**Problem.** Whether the paraboloid is isotropic (6 params) or astigmatic (7 params) is
+currently encoded three ways that must be kept in sync: `parameters.Length` (inferred in
+`SensorParaboloidModel.FromArray`/`ToArray` and `SensorParaboloidSolver.Value`/`Gradient`),
+the `SensorParaboloidModel.Astigmatic` bool, and the `SensorParaboloidSolver.astigmatic`
+field — each with its own `Length == 7 ? … : …` / `if (astigmatic)` branch scattered
+across `FromArray`, `ToArray`, `Value`, `Gradient`, `SetInitialGuess`, `SetBounds`,
+`SetScale`. Adding a parameter or mode means hunting down 6+ branches; missing one (e.g.
+`SetScale` forgetting index 6) silently mis-scales the fit.
+
+**Approach.**
+- Make `NumParameters` the single source of truth: a `bool IsAstigmatic => NumParameters == 7`
+  helper on the solver, and drive every solver branch from it. On the model, keep `Astigmatic`
+  derived consistently from `FromArray`'s array length (already the case) and centralize the
+  param-packing/unpacking so `ToArray`/`FromArray`/`Value`/`Gradient` share one notion of layout.
+- Consider a small private layout description (indices for z0/gx/gy/kx/ky) so bounds, scale,
+  initial guess, value, and gradient all read from it.
+
+**Verification.** Behavior-preserving. All existing `SensorParaboloidModelTests`
+(isotropic recovery, flat field, astigmatic Kx/Ky recovery, 6-/7-element round-trip,
+weighted-Jacobian OptGuard) must pass unchanged. Full suite green.
+
+---
+
+## Phase 5 (optional) — Build the triangle KdTree once across strict/relaxed passes
+
+**Problem.** `SensorModel.AlignStarsWithRANSAC` calls
+`GeneratePutativeMatchesUsingSimilarTriangles` twice (strict tolerance, then a relaxed
+retry when too few matches), and each call rebuilds the image-triangle KdTree from
+scratch. Caching `ShapeDescriptor` (done in PR #43) already removed the dominant
+recompute cost, so this is now minor.
+
+**Approach.**
+- Add an overload of `GeneratePutativeMatchesUsingSimilarTriangles` that accepts a
+  prebuilt `KdTree<double, StarTriangle>`; build the tree once in the caller and reuse it
+  for both passes (the same `StarTriangle` instances are reused, and `ResetMatch` already
+  clears their matched flags between passes, so the tree need not be rebuilt).
+- Keep the existing parameterless-tree wrapper for other callers/tests.
+
+**Verification.** Behavior-preserving: the matcher tests
+(`GeneratePutativeMatches_*`) and the end-to-end `SensorModelRepeatabilityTests` must pass
+unchanged. Full suite green. Skip this phase if the maintainer considers the win too small.
+
+---
+
+## Notes
+
+- Phases 1–2 are independent and small; Phases 3–4 are independent refactors; Phase 5 is
+  optional. They can be done in any order or as separate PRs.
+- None of these should change the model fit results on real data except Phase 1 (which
+  only affects the experimental interpolation path) and Phase 2 (display only).
+- Keep author/committer email `322725+ghilios@users.noreply.github.com` per `CLAUDE.md`,
+  branch off and PR into the appropriate base, and never push to `develop` directly.


### PR DESCRIPTION
## Summary

Sets up the work to make the aberration **Sensor Model** pipeline deterministic/repeatable and more robust. This PR lands the analysis and phased implementation plan (and a small `CLAUDE.md` workflow tweak); implementation phases will follow as commits on this branch.

The Sensor Model pipeline: one autofocus run captures frames at different focuser positions → stars matched across frames (RANSAC + KdTree) → per-star hyperbolic HFR-vs-focuser curves → tilted-paraboloid fit over each star's optimal focuser position.

**Robustness goal (per @ghilios):** running the unchanged process multiple times should yield consistent, repeatable results. Today it does not.

## Key findings

- **Unseeded shared RANSAC RNG** (`RANSACRegistration.cs`) — primary repeatability killer.
- **Run-to-run state leakage** via `PreviousRunBrightnessDiff` (read as the search seed, written back each run).
- **Wall-clock-dependent acceptance** (`TargetR2BasedOnTimeTaken`) — model accepted differently on busy vs idle machines.
- **`Volume()` math bug** (`Y0 + Y0` should be `Y0 * Y0`) → wrong reported mean elevation.
- **6-DOF affine** alignment where a physically-correct **similarity transform** (already implemented but unused) suffices.
- **R² is the wrong acceptance statistic**; adopt **reduced χ² / weighted least squares** with real per-point uncertainties, following the existing `PSFModel.ReducedChiSquared` precedent.

## Plan phases

1. Determinism / repeatability (seeded RNG, stateless brightness search, remove wall-clock target)
2. Correctness bug fixes (`Volume()`)
3. Registration robustness (similarity transform, registry coverage, triangle descriptor)
4. Model & optimizer quality (single-solve linear curvature, linear tilt gradients, χ² weighting)
5. Performance (lazy triplet sampling, hash-set triangle de-dup)

Full detail: `plans/sensor-model-repeatability-and-robustness.md`.

## Verification

Each phase ends green via `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`. A new repeatability harness test (model params identical across two unchanged runs) should fail on the parent branch and pass after Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)