### PR TITLE
Focus-sweep evidence base: synthetic HFR bias tests + TestApp diagnostic

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/MeasureStarBiasTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/MeasureStarBiasTests.cs
@@ -64,5 +64,63 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
             TestContext.WriteLine($"clean gaussian: measured={star.HFR:F4} truth={truth:F4}");
             Assert.That(star.HFR, Is.EqualTo(truth).Within(0.3));
         }
+
+        [Test]
+        public void MeasureStar_UniformDisk_SoftThresholdBarelyChangesHfr() {
+            // A uniform disk has no radial gradient, so subtracting a constant τ scales every surviving pixel
+            // equally and the flux-weighted radius is (almost) unchanged — only the partially-covered rim
+            // shifts. This isolates WHY the F3 bias requires a gradient (contrast with the Gaussian below).
+            const double a = 12.0, peak = 1.0, bg = 0.0;
+            using var image = SyntheticDefocusedStarImage.CreateDisk(Size, Size, Cx, Cy, a, peak, bg);
+            var detector = new StarDetector(new AlglibAPI());
+            var pNoClip = new StarDetectorParams { AnalysisSamplingSize = 1.0f, StarClippingMultiplier = 0.0 };
+            var pClip = new StarDetectorParams { AnalysisSamplingSize = 1.0f, StarClippingMultiplier = 1.0 };
+            var s0 = NewStar(bg);
+            var sT = NewStar(bg);
+            detector.MeasureStar(image, s0, pNoClip, 0.0);
+            detector.MeasureStar(image, sT, pClip, 0.3); // τ = 1.0 * 0.3
+            TestContext.WriteLine($"uniform disk: hfr(τ=0)={s0.HFR:F4} hfr(τ=0.3)={sT.HFR:F4} Δ={sT.HFR - s0.HFR:F4}");
+            Assert.That(sT.HFR, Is.EqualTo(s0.HFR).Within(0.15));
+        }
+
+        [Test]
+        public void MeasureStar_GaussianSoftThreshold_BiasesHfrDownward() {
+            const double sigma = 5.0, peak = 1.0, bg = 0.0;
+            using var image = SyntheticGaussianStarImage.Create(Size, Size, Cx, Cy, sigma, sigma, peak, bg);
+            var detector = new StarDetector(new AlglibAPI());
+            var p = new StarDetectorParams { AnalysisSamplingSize = 1.0f, StarClippingMultiplier = 1.0 }; // τ == noiseSigma
+            double[] taus = { 0.0, 0.02, 0.05, 0.10, 0.20 };
+            var hfrs = new double[taus.Length];
+            for (int i = 0; i < taus.Length; ++i) {
+                var star = NewStar(bg);
+                detector.MeasureStar(image, star, p, taus[i]);
+                hfrs[i] = star.HFR;
+                TestContext.WriteLine($"τ={taus[i]:F3} → HFR={hfrs[i]:F4} (bias {hfrs[i] - hfrs[0]:F4})");
+            }
+            for (int i = 1; i < hfrs.Length; ++i)
+                Assert.That(hfrs[i], Is.LessThan(hfrs[i - 1]), $"HFR should decrease monotonically as τ grows (i={i})");
+            Assert.That(hfrs[0] - hfrs[^1], Is.GreaterThan(0.1), "soft-threshold should bias HFR downward measurably at τ=0.2");
+        }
+
+        [Test]
+        public void MeasureStar_GaussianSoftThreshold_RelativeBiasGrowsForFainterStars() {
+            const double sigma = 5.0, bg = 0.0, tau = 0.05;
+            var detector = new StarDetector(new AlglibAPI());
+            var p = new StarDetectorParams { AnalysisSamplingSize = 1.0f, StarClippingMultiplier = 1.0 };
+            double[] peaks = { 1.0, 0.5, 0.25, 0.125 };
+            double prevRel = -1.0;
+            foreach (var peak in peaks) {
+                using var image = SyntheticGaussianStarImage.Create(Size, Size, Cx, Cy, sigma, sigma, peak, bg);
+                var s0 = NewStar(bg);
+                var sT = NewStar(bg);
+                detector.MeasureStar(image, s0, p, 0.0);
+                detector.MeasureStar(image, sT, p, tau);
+                double rel = (s0.HFR - sT.HFR) / s0.HFR;
+                TestContext.WriteLine($"peak={peak:F3} τ/peak={tau / peak:F3} relBias={rel:P2}");
+                if (prevRel >= 0)
+                    Assert.That(rel, Is.GreaterThan(prevRel), "relative HFR bias should grow as the star gets fainter");
+                prevRel = rel;
+            }
+        }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/MeasureStarBiasTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/MeasureStarBiasTests.cs
@@ -1,0 +1,68 @@
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.Tests.Synthetic;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NUnit.Framework;
+using OpenCvSharp;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
+
+    /// <summary>
+    /// Pins MeasureStar's HFR against analytic ground truth on controlled synthetic shapes, and measures the
+    /// magnitude of two confirmed biases: F3 (the soft-threshold τ is subtracted from each pixel, pulling HFR
+    /// down on stars with a radial gradient) and F4 (an understated σ lets large-radius noise inflate HFR).
+    /// All inputs are deterministic (seeded noise); bias tests assert direction + a bounded magnitude and log
+    /// the measured numbers via TestContext so the magnitudes are visible without being brittle.
+    /// </summary>
+    [TestFixture]
+    public class MeasureStarBiasTests {
+        private const int Size = 81;       // R = min(bbox)/2 = 40.5, large vs the shapes below (low truncation)
+        private const double Cx = 40.0;
+        private const double Cy = 40.0;
+
+        private static Star NewStar(double background) => new Star {
+            Center = new Point2d(Cx, Cy),
+            StarBoundingBox = new Rect(0, 0, Size, Size),
+            Background = background
+        };
+
+        [Test]
+        public void MeasureStar_CleanDisk_MatchesTwoThirdsRadius() {
+            const double a = 12.0, peak = 1.0, bg = 0.0;
+            using var image = SyntheticDefocusedStarImage.CreateDisk(Size, Size, Cx, Cy, a, peak, bg);
+            var detector = new StarDetector(new AlglibAPI());
+            var p = new StarDetectorParams { AnalysisSamplingSize = 1.0f, StarClippingMultiplier = 0.0 };
+            var star = NewStar(bg);
+            Assert.That(detector.MeasureStar(image, star, p, 0.0), Is.True);
+            double truth = HfrGroundTruth.Disk(a); // 8.0
+            TestContext.WriteLine($"clean disk: measured={star.HFR:F4} truth={truth:F4}");
+            Assert.That(star.HFR, Is.EqualTo(truth).Within(0.3));
+        }
+
+        [Test]
+        public void MeasureStar_CleanAnnulus_MatchesClosedForm() {
+            const double inner = 6.0, outer = 14.0, peak = 1.0, bg = 0.0;
+            using var image = SyntheticDefocusedStarImage.CreateAnnulus(Size, Size, Cx, Cy, inner, outer, peak, bg);
+            var detector = new StarDetector(new AlglibAPI());
+            var p = new StarDetectorParams { AnalysisSamplingSize = 1.0f, StarClippingMultiplier = 0.0 };
+            var star = NewStar(bg);
+            Assert.That(detector.MeasureStar(image, star, p, 0.0), Is.True);
+            double truth = HfrGroundTruth.Annulus(inner, outer); // ~10.53
+            TestContext.WriteLine($"clean annulus: measured={star.HFR:F4} truth={truth:F4}");
+            Assert.That(star.HFR, Is.EqualTo(truth).Within(0.3));
+        }
+
+        [Test]
+        public void MeasureStar_CleanGaussian_MatchesSigmaRootPiOverTwo() {
+            const double sigma = 4.0, peak = 1.0, bg = 0.0; // R = 40.5 = 10σ → truncation negligible
+            using var image = SyntheticGaussianStarImage.Create(Size, Size, Cx, Cy, sigma, sigma, peak, bg);
+            var detector = new StarDetector(new AlglibAPI());
+            var p = new StarDetectorParams { AnalysisSamplingSize = 1.0f, StarClippingMultiplier = 0.0 };
+            var star = NewStar(bg);
+            Assert.That(detector.MeasureStar(image, star, p, 0.0), Is.True);
+            double truth = HfrGroundTruth.Gaussian(sigma); // ~5.013
+            TestContext.WriteLine($"clean gaussian: measured={star.HFR:F4} truth={truth:F4}");
+            Assert.That(star.HFR, Is.EqualTo(truth).Within(0.3));
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/MeasureStarBiasTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/MeasureStarBiasTests.cs
@@ -122,5 +122,51 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
                 prevRel = rel;
             }
         }
+
+        [Test]
+        public void MeasureStar_UnderstatedSigma_InflatesHfrUnderNoise() {
+            // A small star in a large aperture surrounded by noise. With correctly-scaled τ the noise is
+            // clipped; with an understated σ (production measures σ on a ~4-5× smoothed copy but samples the
+            // sharp image) positive noise at large radius leaks into the flux sum and inflates HFR (F4).
+            const double sigma = 3.0, peak = 1.0, bg = 0.0;
+            const double sigmaSharp = 0.02; // true white-noise σ of the measurement image
+            const int seed = 12345;
+            const int bigSize = 121;        // R = 60.5 = 20σ → a large pure-noise annulus inside the aperture
+            const double bigC = 60.0;
+            var detector = new StarDetector(new AlglibAPI());
+            var p = new StarDetectorParams { AnalysisSamplingSize = 1.0f, StarClippingMultiplier = 2.0 };
+
+            double MeasureWith(double noiseSigmaArg) {
+                using var image = SyntheticGaussianStarImage.Create(bigSize, bigSize, bigC, bigC, sigma, sigma, peak, bg);
+                SyntheticDefocusedStarImage.AddGaussianNoise(image, sigmaSharp, seed);
+                var star = new Star {
+                    Center = new Point2d(bigC, bigC),
+                    StarBoundingBox = new Rect(0, 0, bigSize, bigSize),
+                    Background = bg
+                };
+                detector.MeasureStar(image, star, p, noiseSigmaArg);
+                return star.HFR;
+            }
+
+            double hfrTrue = MeasureWith(sigmaSharp);              // τ = 2·σ_sharp     → noise clipped
+            double hfrUnderstated = MeasureWith(sigmaSharp / 5.0); // τ = 2·σ_sharp/5 → noise leaks in
+            TestContext.WriteLine($"HFR(trueσ)={hfrTrue:F4}  HFR(understatedσ)={hfrUnderstated:F4}  inflation={hfrUnderstated - hfrTrue:F4}");
+            Assert.That(hfrUnderstated, Is.GreaterThan(hfrTrue + 0.5), "understated σ should inflate HFR by leaking large-radius noise");
+        }
+
+        [Test]
+        public void MeasureStar_Annulus_HfrExceedsFilledDisk_SameOuterRadius() {
+            const double outer = 14.0, inner = 8.0, peak = 1.0, bg = 0.0;
+            var detector = new StarDetector(new AlglibAPI());
+            var p = new StarDetectorParams { AnalysisSamplingSize = 1.0f, StarClippingMultiplier = 0.0 };
+            using var disk = SyntheticDefocusedStarImage.CreateDisk(Size, Size, Cx, Cy, outer, peak, bg);
+            using var annulus = SyntheticDefocusedStarImage.CreateAnnulus(Size, Size, Cx, Cy, inner, outer, peak, bg);
+            var sd = NewStar(bg);
+            var sa = NewStar(bg);
+            detector.MeasureStar(disk, sd, p, 0.0);
+            detector.MeasureStar(annulus, sa, p, 0.0);
+            TestContext.WriteLine($"disk HFR={sd.HFR:F4}  annulus HFR={sa.HFR:F4}");
+            Assert.That(sa.HFR, Is.GreaterThan(sd.HFR), "annulus pushes flux outward → larger HFR than a filled disk of the same outer radius");
+        }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Synthetic/HfrGroundTruth.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Synthetic/HfrGroundTruth.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Synthetic {
+
+    /// <summary>
+    /// Ground-truth flux-weighted mean radius (the quantity MeasureStar approximates) for the synthetic
+    /// shapes, with aperture R >= the star's support:  HFR = ∫0^R I(r) r^2 dr / ∫0^R I(r) r dr.
+    /// </summary>
+    internal static class HfrGroundTruth {
+        /// <summary>Uniform filled disk of radius a:  HFR = 2a/3.</summary>
+        public static double Disk(double radius) => 2.0 * radius / 3.0;
+
+        /// <summary>Uniform annulus [inner, outer]:  HFR = (2/3)(a^3 - b^3)/(a^2 - b^2).</summary>
+        public static double Annulus(double inner, double outer) =>
+            (2.0 / 3.0) * (Math.Pow(outer, 3) - Math.Pow(inner, 3)) / (Math.Pow(outer, 2) - Math.Pow(inner, 2));
+
+        /// <summary>Gaussian exp(-r^2/2σ^2), large aperture:  HFR = σ·sqrt(π/2) ≈ 1.2533σ.</summary>
+        public static double Gaussian(double sigma) => sigma * Math.Sqrt(Math.PI / 2.0);
+
+        /// <summary>Numerical flux-weighted mean radius of a radial profile over [0, R] (validates the closed forms).</summary>
+        public static double Numerical(Func<double, double> intensity, double apertureRadius, double step = 0.001) {
+            double num = 0.0, den = 0.0;
+            for (double r = 0.0; r <= apertureRadius; r += step) {
+                double i = intensity(r);
+                num += i * r * r * step;
+                den += i * r * step;
+            }
+            return den > 0 ? num / den : 0.0;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Synthetic/HfrGroundTruthTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Synthetic/HfrGroundTruthTests.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+using System;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Synthetic {
+
+    [TestFixture]
+    public class HfrGroundTruthTests {
+
+        [Test]
+        public void Disk_ClosedFormMatchesNumericalIntegration() {
+            const double a = 12.0;
+            double numerical = HfrGroundTruth.Numerical(r => r <= a ? 1.0 : 0.0, apertureRadius: 40.0);
+            Assert.That(HfrGroundTruth.Disk(a), Is.EqualTo(numerical).Within(0.01));
+            Assert.That(HfrGroundTruth.Disk(a), Is.EqualTo(8.0).Within(1e-9));
+        }
+
+        [Test]
+        public void Annulus_ClosedFormMatchesNumericalIntegration() {
+            const double b = 6.0, a = 14.0;
+            double numerical = HfrGroundTruth.Numerical(r => (r >= b && r <= a) ? 1.0 : 0.0, apertureRadius: 40.0);
+            Assert.That(HfrGroundTruth.Annulus(b, a), Is.EqualTo(numerical).Within(0.01));
+        }
+
+        [Test]
+        public void Gaussian_ClosedFormMatchesNumericalIntegration() {
+            const double sigma = 4.0;
+            double numerical = HfrGroundTruth.Numerical(r => Math.Exp(-r * r / (2 * sigma * sigma)), apertureRadius: 60.0);
+            Assert.That(HfrGroundTruth.Gaussian(sigma), Is.EqualTo(numerical).Within(0.01));
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Synthetic/SyntheticDefocusedStarImage.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Synthetic/SyntheticDefocusedStarImage.cs
@@ -1,0 +1,90 @@
+using OpenCvSharp;
+using System;
+using Size = OpenCvSharp.Size;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Synthetic {
+
+    /// <summary>
+    /// Renders defocused-star test images (uniform disk, annular donut) whose continuous radial profile is
+    /// known, so MeasureStar's flux-weighted-mean-radius output can be compared to analytic ground truth.
+    /// Each pixel is supersampled so the rendered value equals the analytic mean over the pixel area, keeping
+    /// the rim faithful (otherwise discretization at the edge dominates the error budget).
+    /// </summary>
+    internal static class SyntheticDefocusedStarImage {
+        private const int SuperSample = 4; // NxN subsamples per pixel
+
+        public static Mat CreateDisk(int width, int height, double centerX, double centerY,
+                double radius, double peak, double background, double edgeBlurSigma = 0.0) {
+            return Render(width, height, centerX, centerY, background,
+                r => DiskIntensity(r, radius, peak, edgeBlurSigma));
+        }
+
+        public static Mat CreateAnnulus(int width, int height, double centerX, double centerY,
+                double innerRadius, double outerRadius, double peak, double background, double edgeBlurSigma = 0.0) {
+            return Render(width, height, centerX, centerY, background,
+                r => AnnulusIntensity(r, innerRadius, outerRadius, peak, edgeBlurSigma));
+        }
+
+        /// <summary>Adds zero-mean Gaussian noise of the given standard deviation using a seeded RNG (reproducible).</summary>
+        public static void AddGaussianNoise(Mat image, double sigma, int seed) {
+            var rng = new Random(seed);
+            int n = image.Width * image.Height;
+            unsafe {
+                var data = (float*)image.DataPointer;
+                for (int i = 0; i < n; ++i) {
+                    double u1 = 1.0 - rng.NextDouble();
+                    double u2 = 1.0 - rng.NextDouble();
+                    double z = Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Cos(2.0 * Math.PI * u2); // Box-Muller
+                    data[i] += (float)(sigma * z);
+                }
+            }
+        }
+
+        private static Mat Render(int width, int height, double cx, double cy, double background,
+                Func<double, double> radialIntensity) {
+            var mat = new Mat(new Size(width, height), MatType.CV_32F);
+            double inv = 1.0 / SuperSample;
+            int sub = SuperSample * SuperSample;
+            unsafe {
+                var data = (float*)mat.DataPointer;
+                for (int y = 0; y < height; ++y) {
+                    for (int x = 0; x < width; ++x) {
+                        double sum = 0.0;
+                        for (int sy = 0; sy < SuperSample; ++sy) {
+                            for (int sx = 0; sx < SuperSample; ++sx) {
+                                double px = x - 0.5 + (sx + 0.5) * inv;
+                                double py = y - 0.5 + (sy + 0.5) * inv;
+                                double dx = px - cx, dy = py - cy;
+                                sum += radialIntensity(Math.Sqrt(dx * dx + dy * dy));
+                            }
+                        }
+                        data[y * width + x] = (float)(background + sum / sub);
+                    }
+                }
+            }
+            return mat;
+        }
+
+        private static double DiskIntensity(double r, double radius, double peak, double edgeBlurSigma) {
+            if (edgeBlurSigma <= 0.0) return r <= radius ? peak : 0.0;
+            return peak * 0.5 * Erfc((r - radius) / (edgeBlurSigma * Math.Sqrt(2.0)));
+        }
+
+        private static double AnnulusIntensity(double r, double inner, double outer, double peak, double edgeBlurSigma) {
+            if (edgeBlurSigma <= 0.0) return (r >= inner && r <= outer) ? peak : 0.0;
+            double rise = 0.5 * Erfc((inner - r) / (edgeBlurSigma * Math.Sqrt(2.0)));
+            double fall = 0.5 * Erfc((r - outer) / (edgeBlurSigma * Math.Sqrt(2.0)));
+            return peak * rise * fall;
+        }
+
+        // Abramowitz & Stegun 7.1.26 erfc approximation (max error ~1.2e-7).
+        private static double Erfc(double x) {
+            double z = Math.Abs(x);
+            double t = 1.0 / (1.0 + 0.5 * z);
+            double ans = t * Math.Exp(-z * z - 1.26551223 + t * (1.00002368 + t * (0.37409196 +
+                t * (0.09678418 + t * (-0.18628806 + t * (0.27886807 + t * (-1.13520398 +
+                t * (1.48851587 + t * (-0.82215223 + t * 0.17087277)))))))));
+            return x >= 0.0 ? ans : 2.0 - ans;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/TestApp/ContaminationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/ContaminationDiagnosticRunner.cs
@@ -58,7 +58,7 @@ namespace TestApp {
         }
 
         private static async Task RunImpl(string[] args) {
-            var imagePath = GetArg(args, "--image");
+            var imagePath = DiagnosticUtil.GetArg(args, "--image");
             if (string.IsNullOrWhiteSpace(imagePath)) {
                 Console.Error.WriteLine("Usage: TestApp contamination --image <path> [--profile-id <guid>] [--out <dir>] [--sensitivity <double>] [--sensitivity-sweep <a,b,step>]");
                 Environment.ExitCode = 2;
@@ -68,8 +68,8 @@ namespace TestApp {
                 throw new FileNotFoundException($"Image not found: {imagePath}", imagePath);
             }
 
-            var profileId = GetArg(args, "--profile-id");
-            var outDir = GetArg(args, "--out");
+            var profileId = DiagnosticUtil.GetArg(args, "--profile-id");
+            var outDir = DiagnosticUtil.GetArg(args, "--out");
             if (string.IsNullOrWhiteSpace(outDir)) {
                 var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
                 outDir = Path.Combine(localAppData, "NINA", "Logs", "hf-diag", DateTime.Now.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture));
@@ -77,7 +77,7 @@ namespace TestApp {
             Directory.CreateDirectory(outDir);
 
             double? sensitivityOverride = null;
-            var sensitivityArg = GetArg(args, "--sensitivity");
+            var sensitivityArg = DiagnosticUtil.GetArg(args, "--sensitivity");
             if (!string.IsNullOrWhiteSpace(sensitivityArg)) {
                 sensitivityOverride = double.Parse(sensitivityArg, CultureInfo.InvariantCulture);
             }
@@ -133,11 +133,11 @@ namespace TestApp {
 
             // Load the original image once (CV_32F, normalized [0,1]). Detection mutates its input in place,
             // so each run gets a clone and the original is kept for the annotated background.
-            using var srcFloat = await LoadFloatMat(imagePath, profileService);
+            using var srcFloat = await DiagnosticUtil.LoadFloatMat(imagePath, profileService);
             Console.WriteLine($"Image dimensions: {srcFloat.Width} x {srcFloat.Height}");
             Logger.Info($"Loaded image {srcFloat.Width}x{srcFloat.Height} from {imagePath}");
 
-            var sweepArg = GetArg(args, "--sensitivity-sweep");
+            var sweepArg = DiagnosticUtil.GetArg(args, "--sensitivity-sweep");
             if (!string.IsNullOrWhiteSpace(sweepArg)) {
                 await RunSweep(srcFloat, baseParams, sweepArg, outDir);
                 return;
@@ -193,25 +193,6 @@ namespace TestApp {
             using var clone = srcFloat.Clone();
             var detector = new StarDetector(new AlglibAPI());
             return await detector.Detect(clone, p, null, CancellationToken.None);
-        }
-
-        private static async Task<Mat> LoadFloatMat(string path, IProfileService profileService) {
-            var ext = Path.GetExtension(path).ToLowerInvariant();
-            if (ext == ".tif" || ext == ".tiff") {
-                using var src = new Mat(path, ImreadModes.Unchanged);
-                var dst = new Mat();
-                Program.ConvertToFloat(src, dst);
-                return dst;
-            }
-            if (ext == ".xisf" || ext == ".fits" || ext == ".fit") {
-                var factory = new ImageDataFactory(profileService, new StubBehaviorSelector<IStarDetection>(new StubStarDetection()), new StubBehaviorSelector<IStarAnnotator>());
-                var uri = new Uri(Path.GetFullPath(path));
-                IImageData imageData = ext == ".xisf"
-                    ? await XISF.Load(uri, false, factory, CancellationToken.None)
-                    : await FITS.Load(uri, false, factory, CancellationToken.None);
-                return CvImageUtility.ToOpenCVMat(imageData);
-            }
-            throw new NotSupportedException($"Unsupported image extension '{ext}'. Supported: .tif/.tiff, .xisf, .fits/.fit");
         }
 
         private static void LogResolvedOptions(StarDetectionOptions o) {
@@ -500,15 +481,6 @@ namespace TestApp {
             int hi = (int)Math.Ceiling(idx);
             double frac = idx - lo;
             return sorted[lo] * (1 - frac) + sorted[hi] * frac;
-        }
-
-        private static string GetArg(string[] args, string name) {
-            for (int i = 0; i < args.Length - 1; ++i) {
-                if (string.Equals(args[i], name, StringComparison.OrdinalIgnoreCase)) {
-                    return args[i + 1];
-                }
-            }
-            return null;
         }
 
         private static string F(double v) {

--- a/Joko.NINA.Plugins/TestApp/DiagnosticUtil.cs
+++ b/Joko.NINA.Plugins/TestApp/DiagnosticUtil.cs
@@ -1,0 +1,67 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Image.FileFormat.FITS;
+using NINA.Image.FileFormat.XISF;
+using NINA.Image.ImageAnalysis;
+using NINA.Image.ImageData;
+using NINA.Image.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NINA.Profile.Interfaces;
+using OpenCvSharp;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TestApp {
+
+    /// <summary>Helpers shared by the headless diagnostic runners (contamination, focus-sweep).</summary>
+    internal static class DiagnosticUtil {
+
+        /// <summary>Returns the value following <paramref name="name"/> in <paramref name="args"/>, or null.</summary>
+        public static string GetArg(string[] args, string name) {
+            for (int i = 0; i < args.Length - 1; ++i) {
+                if (string.Equals(args[i], name, StringComparison.OrdinalIgnoreCase)) {
+                    return args[i + 1];
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Loads an image file as a CV_32F Mat normalized to [0,1]. .tif/.tiff are read directly; .xisf/.fits/.fit
+        /// go through NINA's loaders (which need a profile). profileService may be null for .tif-only callers.
+        /// </summary>
+        public static async Task<Mat> LoadFloatMat(string path, IProfileService profileService) {
+            var ext = Path.GetExtension(path).ToLowerInvariant();
+            if (ext == ".tif" || ext == ".tiff") {
+                using var src = new Mat(path, ImreadModes.Unchanged);
+                var dst = new Mat();
+                Program.ConvertToFloat(src, dst);
+                return dst;
+            }
+            if (ext == ".xisf" || ext == ".fits" || ext == ".fit") {
+                if (profileService == null) {
+                    throw new InvalidOperationException($"Loading '{ext}' requires a NINA profile; omit --default-params or use .tif frames.");
+                }
+                var factory = new ImageDataFactory(profileService, new StubBehaviorSelector<IStarDetection>(new StubStarDetection()), new StubBehaviorSelector<IStarAnnotator>());
+                var uri = new Uri(Path.GetFullPath(path));
+                IImageData imageData = ext == ".xisf"
+                    ? await XISF.Load(uri, false, factory, CancellationToken.None)
+                    : await FITS.Load(uri, false, factory, CancellationToken.None);
+                return CvImageUtility.ToOpenCVMat(imageData);
+            }
+            throw new NotSupportedException($"Unsupported image extension '{ext}'. Supported: .tif/.tiff, .xisf, .fits/.fit");
+        }
+    }
+}

--- a/Joko.NINA.Plugins/TestApp/FocusSweepDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/FocusSweepDiagnosticRunner.cs
@@ -150,7 +150,8 @@ namespace TestApp {
             var rows = byPosition.Values.ToList();
             WriteCsv(Path.Combine(outDir, "focus_sweep.csv"), rows);
             WriteSummary(Path.Combine(outDir, "focus_sweep_summary.txt"), afRun, baseParams, rows);
-            Console.WriteLine($"Wrote focus_sweep.csv, focus_sweep_summary.txt to {outDir}");
+            WriteVCurvePng(Path.Combine(outDir, "focus_sweep_hfr.png"), rows);
+            Console.WriteLine($"Wrote focus_sweep.csv, focus_sweep_summary.txt, focus_sweep_hfr.png to {outDir}");
         }
 
         private static List<Frame> ParseAfRun(string dir) {
@@ -226,6 +227,30 @@ namespace TestApp {
                     $"(median HFR {F(MedianMad(best.Hfrs).median)}, {best.Hfrs.Count} stars)");
             }
             File.WriteAllText(path, sb.ToString());
+        }
+
+        private static void WriteVCurvePng(string path, List<PositionAccum> rows) {
+            try {
+                var data = rows.Where(r => r.Hfrs.Count > 0)
+                    .Select(r => (x: (double)r.FocuserPosition, y: MedianMad(r.Hfrs)))
+                    .OrderBy(t => t.x).ToList();
+                if (data.Count == 0) {
+                    Logger.Warning("V-curve PNG skipped: no positions had detected stars");
+                    return;
+                }
+                var xs = data.Select(d => d.x).ToArray();
+                var ys = data.Select(d => d.y.median).ToArray();
+                var err = data.Select(d => double.IsNaN(d.y.mad) ? 0.0 : d.y.mad).ToArray();
+                var plt = new ScottPlot.Plot(900, 600);
+                plt.AddScatter(xs, ys, markerSize: 6);
+                plt.AddErrorBars(xs, ys, null, err);
+                plt.XLabel("Focuser Position");
+                plt.YLabel("Median HFR (px)");
+                plt.Title("Focus Sweep — detector HFR vs position");
+                plt.SaveFig(path);
+            } catch (Exception ex) {
+                Logger.Warning($"V-curve PNG render failed ({ex.Message}); CSV/summary still written");
+            }
         }
 
         private static string F(double v) => double.IsNaN(v) ? "NaN" : v.ToString("G9", CultureInfo.InvariantCulture);

--- a/Joko.NINA.Plugins/TestApp/FocusSweepDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/FocusSweepDiagnosticRunner.cs
@@ -1,0 +1,238 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Enum;
+using NINA.Core.Utility;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NINA.Profile;
+using NINA.Profile.Interfaces;
+using OpenCvSharp;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using Logger = NINA.Core.Utility.Logger;
+using Size = OpenCvSharp.Size;
+
+namespace TestApp {
+
+    /// <summary>
+    /// Headless diagnostic: replays a saved AutoFocus run through HocusFocus star detection and reports star
+    /// count, HFR (median + robust spread), and per-reason rejection counts as a function of focuser position.
+    /// Turns the analysis's "detection degrades at defocus" mechanisms (F1/F2) into measured numbers. Mirrors
+    /// ContaminationDiagnosticRunner; TestApp is not run in CI, so this consumes real data on disk only.
+    /// </summary>
+    internal static class FocusSweepDiagnosticRunner {
+
+        // Mirrors AutoFocusEngine.IMAGE_FILE_REGEX (private) so the diagnostic stays decoupled from the engine.
+        private static readonly Regex ImageFileRegex = new Regex(
+            @"^(?<IMAGE_INDEX>\d+)_Frame(?<FRAME_NUMBER>\d+)_BitDepth(?<BITDEPTH>\d+)_Bayered(?<BAYERED>\d)_Focuser(?<FOCUSER>\d+)(_HFR(?<HFR>(\d+)(\.\d+)?))?$",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private sealed class Frame {
+            public string Path;
+            public int FocuserPosition;
+        }
+
+        private sealed class PositionAccum {
+            public int FocuserPosition;
+            public int Frames;
+            public readonly List<double> Hfrs = new List<double>();
+            public long StructureCandidates, TotalDetected, TooSmall, OnBorder, TooDistorted, Degenerate,
+                Saturated, LowSensitivity, NotCentered, TooFlat, TooLowHFR, HFRAnalysisFailed, PSFFitFailed,
+                ContaminationSuspected, OutsideROI;
+        }
+
+        public static async Task Run(string[] args) {
+            try {
+                await RunImpl(args);
+            } catch (Exception ex) {
+                Console.Error.WriteLine($"ERROR: {ex.Message}");
+                Console.Error.WriteLine(ex.ToString());
+                Logger.Error(ex, "Focus-sweep diagnostic run failed");
+                Environment.ExitCode = 1;
+            }
+        }
+
+        private static async Task RunImpl(string[] args) {
+            var afRun = DiagnosticUtil.GetArg(args, "--af-run");
+            var synthesizeDir = DiagnosticUtil.GetArg(args, "--synthesize");
+            bool defaultParams = args.Any(a => a.Equals("--default-params", StringComparison.OrdinalIgnoreCase));
+
+            if (!string.IsNullOrWhiteSpace(synthesizeDir)) {
+                int count = 9;
+                var countArg = DiagnosticUtil.GetArg(args, "--synthesize-count");
+                if (!string.IsNullOrWhiteSpace(countArg)) count = int.Parse(countArg, CultureInfo.InvariantCulture);
+                SynthesizeAfRun(synthesizeDir, count);
+                Console.WriteLine($"Synthesized {count} frames into {synthesizeDir}");
+                afRun = synthesizeDir; // proceed to sweep the freshly-synthesized folder
+            }
+
+            if (string.IsNullOrWhiteSpace(afRun)) {
+                Console.Error.WriteLine("Usage: TestApp focus-sweep --af-run <dir> [--profile-id <guid>] [--out <dir>] [--default-params]");
+                Console.Error.WriteLine("       TestApp focus-sweep --synthesize <dir> [--synthesize-count <n>] --default-params [--out <dir>]");
+                Environment.ExitCode = 2;
+                return;
+            }
+            if (!Directory.Exists(afRun)) {
+                throw new DirectoryNotFoundException($"AF-run folder not found: {afRun}");
+            }
+
+            var outDir = DiagnosticUtil.GetArg(args, "--out");
+            if (string.IsNullOrWhiteSpace(outDir)) {
+                var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                outDir = Path.Combine(localAppData, "NINA", "Logs", "hf-diag", "focus-sweep");
+            }
+            Directory.CreateDirectory(outDir);
+            Logger.SetLogLevel(LogLevelEnum.TRACE);
+
+            var frames = ParseAfRun(afRun);
+            if (frames.Count == 0) {
+                throw new InvalidOperationException($"No AF frames matched the filename pattern in {afRun}");
+            }
+            Console.WriteLine($"AF run: {afRun} ({frames.Count} frames, {frames.Select(f => f.FocuserPosition).Distinct().Count()} positions)");
+
+            // Build detector params: from the real profile (default) or library defaults (--default-params).
+            IProfileService profileService = null;
+            StarDetectorParams baseParams;
+            if (defaultParams) {
+                baseParams = new StarDetectorParams();
+                Console.WriteLine("Using default StarDetectorParams (--default-params; no profile loaded)");
+            } else {
+                if (Application.Current == null) {
+                    new Application(); // ProfileService.ActiveProfile setter touches Application.Current.Resources
+                }
+                var concreteProfileService = new ProfileService();
+                concreteProfileService.TryLoad(DiagnosticUtil.GetArg(args, "--profile-id") ?? string.Empty);
+                profileService = concreteProfileService;
+                if (profileService.ActiveProfile == null) {
+                    throw new InvalidOperationException("No active NINA profile. Pass --profile-id, run NINA once, or use --default-params.");
+                }
+                Console.WriteLine($"Profile: {profileService.ActiveProfile.Name} ({profileService.ActiveProfile.Id})");
+                var guid = PluginOptionsAccessor.GetAssemblyGuid(typeof(StarDetectionOptions));
+                var accessor = new PluginOptionsAccessor(profileService, guid.Value);
+                var options = new StarDetectionOptions(profileService, accessor);
+                baseParams = HocusFocusStarDetection.BuildStarDetectorParams(options);
+            }
+            // Mirror real AF: PSF modeling is disabled during AutoFocus, so HFR is the measured quantity.
+            baseParams.ModelPSF = false;
+
+            var byPosition = new SortedDictionary<int, PositionAccum>();
+            var detector = new StarDetector(new AlglibAPI());
+            foreach (var frame in frames) {
+                using var img = await DiagnosticUtil.LoadFloatMat(frame.Path, profileService);
+                var result = await detector.Detect(img, baseParams, null, CancellationToken.None);
+                if (!byPosition.TryGetValue(frame.FocuserPosition, out var accum)) {
+                    accum = new PositionAccum { FocuserPosition = frame.FocuserPosition };
+                    byPosition[frame.FocuserPosition] = accum;
+                }
+                Accumulate(accum, result);
+                Console.WriteLine($"  pos {frame.FocuserPosition}: {result.DetectedStars.Count} stars");
+            }
+
+            var rows = byPosition.Values.ToList();
+            WriteCsv(Path.Combine(outDir, "focus_sweep.csv"), rows);
+            WriteSummary(Path.Combine(outDir, "focus_sweep_summary.txt"), afRun, baseParams, rows);
+            Console.WriteLine($"Wrote focus_sweep.csv, focus_sweep_summary.txt to {outDir}");
+        }
+
+        private static List<Frame> ParseAfRun(string dir) {
+            var root = new DirectoryInfo(dir);
+            var search = root;
+            // Accept either an attempt folder directly or a parent with a single attempt* subfolder.
+            if (!root.GetFiles().Any(f => ImageFileRegex.IsMatch(Path.GetFileNameWithoutExtension(f.Name)))) {
+                var attempt = root.EnumerateDirectories("attempt*").FirstOrDefault();
+                if (attempt != null) search = attempt;
+            }
+            var frames = new List<Frame>();
+            foreach (var file in search.GetFiles()) {
+                var m = ImageFileRegex.Match(Path.GetFileNameWithoutExtension(file.Name));
+                if (!m.Success) continue;
+                if (!int.TryParse(m.Groups["FOCUSER"].Value, out var pos)) continue;
+                frames.Add(new Frame { Path = file.FullName, FocuserPosition = pos });
+            }
+            return frames;
+        }
+
+        private static void Accumulate(PositionAccum a, HocusFocusStarDetectorResult result) {
+            a.Frames++;
+            var m = result.Metrics;
+            a.StructureCandidates += m.StructureCandidates;
+            a.TotalDetected += m.TotalDetected;
+            a.TooSmall += m.TooSmall;
+            a.OnBorder += m.OnBorder;
+            a.TooDistorted += m.TooDistorted;
+            a.Degenerate += m.Degenerate;
+            a.Saturated += m.Saturated;
+            a.LowSensitivity += m.LowSensitivity;
+            a.NotCentered += m.NotCentered;
+            a.TooFlat += m.TooFlat;
+            a.TooLowHFR += m.TooLowHFR;
+            a.HFRAnalysisFailed += m.HFRAnalysisFailed;
+            a.PSFFitFailed += m.PSFFitFailed;
+            a.ContaminationSuspected += m.ContaminationSuspected;
+            a.OutsideROI += m.OutsideROI;
+            foreach (var s in result.DetectedStars) a.Hfrs.Add(s.HFR);
+        }
+
+        private static (double median, double mad) MedianMad(List<double> values) {
+            if (values.Count == 0) return (double.NaN, double.NaN);
+            return values.MedianMAD();
+        }
+
+        private static void WriteCsv(string path, List<PositionAccum> rows) {
+            var sb = new StringBuilder();
+            sb.AppendLine("FocuserPosition,Frames,StarCount,MedianHFR,MAD_HFR,StructureCandidates,TotalDetected," +
+                "TooSmall,OnBorder,TooDistorted,Degenerate,Saturated,LowSensitivity,NotCentered,TooFlat," +
+                "TooLowHFR,HFRAnalysisFailed,PSFFitFailed,ContaminationSuspected,OutsideROI");
+            foreach (var r in rows) {
+                var (median, mad) = MedianMad(r.Hfrs);
+                sb.AppendLine(string.Join(",",
+                    r.FocuserPosition, r.Frames, r.Hfrs.Count, F(median), F(mad),
+                    r.StructureCandidates, r.TotalDetected, r.TooSmall, r.OnBorder, r.TooDistorted, r.Degenerate,
+                    r.Saturated, r.LowSensitivity, r.NotCentered, r.TooFlat, r.TooLowHFR, r.HFRAnalysisFailed,
+                    r.PSFFitFailed, r.ContaminationSuspected, r.OutsideROI));
+            }
+            File.WriteAllText(path, sb.ToString());
+        }
+
+        private static void WriteSummary(string path, string afRun, StarDetectorParams p, List<PositionAccum> rows) {
+            var sb = new StringBuilder();
+            sb.AppendLine($"AF run: {afRun}");
+            sb.AppendLine($"Params: {p}");
+            sb.AppendLine($"Positions: {rows.Count}");
+            sb.AppendLine($"Total frames: {rows.Sum(r => r.Frames)}");
+            var withStars = rows.Where(r => r.Hfrs.Count > 0).ToList();
+            if (withStars.Count > 0) {
+                var best = withStars.OrderBy(r => MedianMad(r.Hfrs).median).First();
+                sb.AppendLine($"Min median-HFR position (detector's-eye focus estimate): {best.FocuserPosition} " +
+                    $"(median HFR {F(MedianMad(best.Hfrs).median)}, {best.Hfrs.Count} stars)");
+            }
+            File.WriteAllText(path, sb.ToString());
+        }
+
+        private static string F(double v) => double.IsNaN(v) ? "NaN" : v.ToString("G9", CultureInfo.InvariantCulture);
+
+        // --- Synthesize: replaced with the real body in Task B4. Placeholder keeps the file compiling. ---
+        private static void SynthesizeAfRun(string dir, int count) {
+            throw new NotImplementedException("Implemented in Task B4");
+        }
+    }
+}

--- a/Joko.NINA.Plugins/TestApp/FocusSweepDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/FocusSweepDiagnosticRunner.cs
@@ -255,9 +255,51 @@ namespace TestApp {
 
         private static string F(double v) => double.IsNaN(v) ? "NaN" : v.ToString("G9", CultureInfo.InvariantCulture);
 
-        // --- Synthesize: replaced with the real body in Task B4. Placeholder keeps the file compiling. ---
+        // Writes `count` synthetic 16-bit TIFF frames named with the saved-AF convention, with a V-shaped HFR
+        // (sharp in the middle, defocused at the ends). Lets the diagnostic be exercised end-to-end with no
+        // real data. Self-contained (cannot reference the Tests project's generators).
         private static void SynthesizeAfRun(string dir, int count) {
-            throw new NotImplementedException("Implemented in Task B4");
+            Directory.CreateDirectory(dir);
+            const int frameSize = 128;
+            const int basePos = 10000, stepPos = 100;
+            int center = count / 2;
+            for (int i = 0; i < count; ++i) {
+                int pos = basePos + i * stepPos;
+                // V-shaped width, kept gentle (≤ ~4px σ) and bright so stars stay detectable at the ends and
+                // the median HFR forms a clean V instead of the defocused frames dropping out entirely.
+                double sigma = 2.0 + 0.5 * Math.Abs(i - center);
+                using var f = SynthFrame(frameSize, frameSize, sigma, peak: 0.85, background: 0.02);
+                using var u16 = new Mat();
+                f.ConvertTo(u16, MatType.CV_16U, ushort.MaxValue);
+                var name = $"{i:00}_Frame00_BitDepth16_Bayered0_Focuser{pos}.tif";
+                Cv2.ImWrite(Path.Combine(dir, name), u16);
+            }
+        }
+
+        // A 3x3 grid of Gaussian stars on a flat background.
+        private static Mat SynthFrame(int w, int h, double sigma, double peak, double background) {
+            var mat = new Mat(new Size(w, h), MatType.CV_32F, new Scalar(background));
+            for (int gy = 1; gy <= 3; ++gy) {
+                for (int gx = 1; gx <= 3; ++gx) {
+                    AddGaussian(mat, w * gx / 4.0, h * gy / 4.0, sigma, peak);
+                }
+            }
+            return mat;
+        }
+
+        private static void AddGaussian(Mat mat, double cx, double cy, double sigma, double peak) {
+            int w = mat.Width, h = mat.Height;
+            double inv = 1.0 / (2.0 * sigma * sigma);
+            int rad = (int)Math.Ceiling(5.0 * sigma);
+            unsafe {
+                var data = (float*)mat.DataPointer;
+                for (int y = Math.Max(0, (int)(cy - rad)); y < Math.Min(h, (int)(cy + rad)); ++y) {
+                    for (int x = Math.Max(0, (int)(cx - rad)); x < Math.Min(w, (int)(cx + rad)); ++x) {
+                        double dx = x - cx, dy = y - cy;
+                        data[y * w + x] += (float)(peak * Math.Exp(-(dx * dx + dy * dy) * inv));
+                    }
+                }
+            }
         }
     }
 }

--- a/Joko.NINA.Plugins/TestApp/Program.cs
+++ b/Joko.NINA.Plugins/TestApp/Program.cs
@@ -109,6 +109,12 @@ namespace TestApp {
                 return;
             }
 
+            // Headless focus-sweep diagnostic mode: `TestApp focus-sweep --af-run <dir> ...`
+            if (args.Length > 0 && args[0].Equals("focus-sweep", StringComparison.OrdinalIgnoreCase)) {
+                await FocusSweepDiagnosticRunner.Run(args);
+                return;
+            }
+
             // Headless contamination diagnostic mode: `TestApp contamination --image <path> ...` (or any
             // invocation that passes --image). Otherwise fall through to the existing WPF GUI.
             bool diagnosticMode = args.Length > 0 &&

--- a/plans/focus-sweep-evidence-base-design.md
+++ b/plans/focus-sweep-evidence-base-design.md
@@ -1,0 +1,203 @@
+# Focus-Sweep Evidence Base — Design Spec
+
+## Context & goal
+
+This is **step 1** ("Build the evidence base first") of
+[`plans/star-detection-hfr-autofocus-accuracy-analysis.md`](star-detection-hfr-autofocus-accuracy-analysis.md).
+That analysis confirmed several HFR/detection biases by *mechanism* (reading the code) but never
+*measured their magnitude*. Before changing any production behavior (findings F1–F4), we want an
+evidence base that turns "mechanism confirmed" into measured numbers.
+
+The step has two independent deliverables:
+
+- **Piece A — a synthetic test base**: a defocused/annular star generator plus unit tests that pin
+  and quantify `MeasureStar`'s HFR behavior against known ground truth. This is where the HFR-bias
+  magnitudes (F3 soft-threshold subtraction; F4 σ-mismatch noise inclusion) get measured.
+- **Piece B — a `focus-sweep` diagnostic** in `TestApp`: replays a saved AutoFocus run (real data)
+  through detection and reports star count, HFR, and rejection-reason histograms versus focuser
+  position — the V-curve seen through the detector's eyes.
+
+No production code in the plugin changes in this PR. We are building measurement tools and tests
+only.
+
+## Key decisions (settled during brainstorming)
+
+1. **CI stays 100% synthetic, in-memory.** No Git LFS, no large binary assets in the repo, no CI
+   data-retrieval step. This matches the existing test philosophy (all current tests synthesize
+   their inputs).
+2. **`focus-sweep` is a local manual diagnostic**, exactly like the existing `contamination`
+   runner. `TestApp` is **not** run in CI (`.github/workflows/tests.yml` only runs the Tests
+   project). The diagnostic consumes a saved AF-run folder on disk; real data never enters CI.
+3. **Generator approach: parametric shapes with analytic/numerical ground truth** (chosen over a
+   full physical defocus-PSF model, and over checked-in real cutouts). This cleanly separates
+   *estimator bias* from *model error* and keeps ground truth tractable.
+
+### Corrections to prior assumptions
+
+- The analysis says "no synthetic-star `MeasureStar` test exists today." There is in fact one
+  (`StarDetectorTests.MeasureStar_CircularAperture_HfrLowerThanRectangularBias`). This work
+  **expands thin coverage**, it does not start from zero.
+- `CLAUDE.md` says the Tests project "links shared source files directly." That is stale — the
+  Tests project uses a `ProjectReference` to the plugin assembly. New generator/test code therefore
+  drops into the Tests project normally and references plugin types directly.
+
+---
+
+## Piece A — Synthetic generator + `MeasureStar` characterization tests
+
+Location: `Joko.NINA.Plugins.HocusFocus.Tests/Synthetic/` and `.../StarDetection/`.
+
+### A.1 Generator API
+
+Extend the existing synthetic-image helpers (new sibling file
+`Synthetic/SyntheticDefocusedStarImage.cs`; keep `SyntheticGaussianStarImage` as-is). All
+generators return an OpenCvSharp `Mat` of type `CV_32F`, matching the existing
+`SyntheticGaussianStarImage.Create` contract.
+
+Radially-symmetric profiles, evaluated by **supersampled** integration per output pixel (e.g. an
+N×N sub-grid averaged) so the rendered pixel value equals the analytic mean over the pixel — this
+keeps the rendered image faithful to the continuous profile the ground truth is computed from:
+
+- `CreateDisk(width, height, cx, cy, radius, peak, background, edgeBlurSigma = 0)` — uniform filled
+  disk; `edgeBlurSigma > 0` softens the rim (models a defocused refractor / filled donut).
+- `CreateAnnulus(width, height, cx, cy, innerRadius, outerRadius, peak, background, edgeBlurSigma = 0)`
+  — uniform annulus (donut with a dark center; models a central-obstruction defocus).
+- Gaussian stars continue to come from the existing `SyntheticGaussianStarImage.Create`.
+
+Optional, deterministic noise overlay (its own helper so it is reusable and seeded):
+
+- `AddGaussianNoise(Mat image, double sigma, int seed)` — adds zero-mean Gaussian noise of known
+  σ using a **seeded** RNG so tests are reproducible and CI never flakes.
+
+### A.2 Ground-truth HFR
+
+`MeasureStar` computes a flux-weighted **mean** radius over a circular aperture
+(`HFR = Σ w·v·d / Σ w·v`, with `v = pixel − plane − τ`). With `τ = 0`, a flat background `B`
+subtracted, a fine sampling grid, and aperture radius `R` ≥ the star's support, this discretely
+approximates the continuous flux-weighted mean radius of the background-subtracted profile `I(r)`:
+
+```
+HFR_true(R) = ∫₀ᴿ I(r) r² dr  /  ∫₀ᴿ I(r) r dr
+```
+
+Closed forms used as ground truth (with `R` ≥ outer radius):
+
+- **Uniform disk** radius `a`:  `HFR_true = 2a/3`.
+- **Uniform annulus** inner `b`, outer `a`:  `HFR_true = (2/3)·(a³ − b³)/(a² − b²)`.
+- **Gaussian** σ, large aperture:  `HFR_true = σ·√(π/2) ≈ 1.2533·σ`
+  (finite-aperture form via the incomplete gamma function, or numerical).
+
+For edge-blurred shapes (no clean closed form), ground truth is computed by **high-resolution
+numerical integration of the same defining profile** used to render the image. A small
+`GroundTruthHfr(...)` helper centralizes these so tests read declaratively.
+
+### A.3 Tests (`StarDetection/MeasureStarBiasTests.cs`)
+
+All assertions are tolerance-based and use seeded noise. Bias tests assert **direction + bounded
+magnitude** (ranges), never exact equality, so they document the measured effect without being
+brittle. Where helpful, tests emit the measured magnitude via `TestContext.WriteLine` so the
+numbers are visible in CI logs even when the assertion is a loose bound.
+
+1. **Clean unbiasedness** — for disk, Gaussian, and annulus with `τ = 0` and no noise, `MeasureStar`
+   matches `HFR_true` within a small tolerance (discretization + aperture truncation only). Pins
+   that the estimator is correct in the ideal case and that the supersampled generator + ground
+   truth agree.
+2. **F3 — soft-threshold downward bias** — fix a shape, sweep the effective threshold `τ` (`τ` is
+   set inside `MeasureStar` as `StarClippingMultiplier · noiseSigma`, so the test sweeps it via the
+   `noiseSigma` argument with `StarClippingMultiplier` held fixed) and, separately, the peak
+   amplitude. Assert `MeasureStar` decreases monotonically as `τ/peak` grows, is always
+   `≤ HFR_true`, and the bias magnitude grows with `τ/peak`. This is the F3 magnitude curve.
+3. **F4 — σ-mismatch noise inflation** — add seeded Gaussian noise of known `σ_sharp`, then run
+   `MeasureStar` with the `noiseSigma` argument set to an understated value (mimicking the
+   smoothed-image σ used in production, ~4–5× small) versus the true `σ_sharp`. Assert HFR is
+   inflated in the understated-σ case, increasingly at low SNR, and bound the magnitude. This is the
+   F4 magnitude curve.
+4. **Donut/annulus sanity** — annulus HFR tracks the `(2/3)(a³−b³)/(a²−b²)` relation as inner/outer
+   radii vary; a filled disk of the same outer radius reads a smaller HFR than the annulus
+   (mass pushed outward), confirming behavior on genuinely non-Gaussian shapes.
+
+These four pin the current behavior **and** produce the F3/F4 magnitude evidence the analysis asked
+for, all without touching production code.
+
+---
+
+## Piece B — `focus-sweep` diagnostic (TestApp)
+
+New file `TestApp/FocusSweepDiagnosticRunner.cs`, mirroring `ContaminationDiagnosticRunner` so it
+inherits the same proven plumbing (profile load, image load, params build, output writing).
+
+### B.1 CLI
+
+Router entry in `Program.Main` (alongside `fit-quality` / `contamination`):
+
+```
+TestApp focus-sweep --af-run <dir> [--profile-id <guid>] [--out <dir>]
+```
+
+- `--af-run <dir>` (required): a saved AutoFocus run folder. Parsed with the existing
+  `AutoFocusEngine.LoadSavedAutoFocusAttempt` and the focuser-position filename regex
+  (`IMAGE_FILE_REGEX`), so it reads the user's real saved runs as-is.
+- `--profile-id <guid>` (optional): NINA profile to source detection options from; defaults to the
+  active profile (same convention as the contamination runner).
+- `--out <dir>` (optional): output directory; defaults under `%LOCALAPPDATA%\NINA\Logs\hf-diag\…`
+  like the contamination runner.
+
+### B.2 Pipeline (reuse)
+
+For each `SavedAutoFocusImage` in the attempt: load the frame via the existing `LoadFloatMat`
+(handles FITS/XISF/TIF), build params once via
+`HocusFocusStarDetection.BuildStarDetectorParams(options)` (the single options→params source of
+truth), run `StarDetector.Detect` with metrics enabled, and bucket the result by
+`FocuserPosition`. No production code changes; this is pure reuse.
+
+### B.3 Outputs (mirroring the contamination runner)
+
+- `focus_sweep.csv` — one row per focuser position: position, accepted star count, HFR median and
+  robust spread (`1.483·MAD`), and the per-reason rejection counts from `StarDetectorMetrics`
+  (too-small, on-border, too-distorted, low-sensitivity, too-flat, HFR-failure, min-HFR,
+  contamination, …).
+- `focus_sweep_summary.txt` — run settings, frame/position counts, and the position with minimum
+  median HFR (a crude detector's-eye focus estimate).
+- `focus_sweep_hfr.png` — HFR-vs-focuser-position V-curve (median with MAD whiskers), drawn with the
+  same OpenCV plotting approach the contamination annotated output already uses.
+
+### B.4 Validation
+
+Validated by a **manual local run** of `TestApp focus-sweep` against a small synthetic AF-run
+folder: a handful of `.tif` frames (Piece A generators, star widening toward the sweep extremes)
+written to a temp directory with the `NN_FrameNN_BitDepth…_Bayered…_Focuser…` filename convention
+that `LoadSavedAutoFocusAttempt`/`IMAGE_FILE_REGEX` expects (the loader keys off the filename, so
+`.tif` works and `LoadFloatMat` reads it). Confirm the CSV/PNG/summary are produced and the V-curve
+is sane. The exact frame-generation mechanism (small dev helper vs. throwaway) is an implementation
+detail for the plan. This needs **no real data**. If an example real saved run is provided, it is
+used only as an extra manual eyeball — never required, never committed.
+
+---
+
+## Non-goals (YAGNI)
+
+- No production behavior changes (F1–F14 fixes are later steps).
+- No physical defocus-PSF model (diffraction, true obstruction optics) — Approach 1 only.
+- No real image data in the repo or CI.
+- No new automated CI test that depends on `TestApp` (it stays a manual diagnostic).
+- The `focus-sweep` diagnostic is descriptive (reports numbers); it does not fit curves or judge
+  focus quality.
+
+## Branch, PR, verification
+
+- Branch: `ghilios/focus-sweep-evidence-base` off `develop` (already created).
+- Commits use the required identity (`322725+ghilios@users.noreply.github.com` for both author and
+  committer).
+- Before reporting done: `TestApp` builds, and the full test suite is green
+  (`dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug`).
+- Open a PR into `develop` at the end (never push to `develop` directly).
+
+## Risks & mitigations
+
+- **Flaky bias tests** → seeded RNG everywhere; assert bounded ranges and monotonic direction, not
+  exact values; emit measured magnitudes to the log.
+- **Generator/ground-truth disagreement** → supersample pixel rendering so the rendered image
+  matches the analytic profile; the "clean unbiasedness" test is the cross-check that catches any
+  mismatch.
+- **TestApp drift** → it is not in CI, so a separate local build step is part of verification; the
+  synthetic AF-folder smoke path keeps it exercised without real data.

--- a/plans/focus-sweep-evidence-base-plan.md
+++ b/plans/focus-sweep-evidence-base-plan.md
@@ -1,0 +1,1145 @@
+# Focus-Sweep Evidence Base Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the measurement evidence base for the star-detection accuracy analysis — a synthetic defocused/annular star generator with `MeasureStar` bias tests (quantifying findings F3/F4), and a headless `focus-sweep` diagnostic in TestApp that reports detection metrics vs focuser position over a saved AutoFocus run.
+
+**Architecture:** Two independent pieces. **Piece A** (Tests project): pure in-memory synthetic generators + ground-truth HFR helpers + NUnit tests that pin `MeasureStar` against known truth and measure the F3 (soft-threshold) and F4 (σ-mismatch) bias magnitudes. **Piece B** (TestApp): a new `focus-sweep` subcommand mirroring the existing `contamination` diagnostic — loads a saved AF-run folder, runs detection per frame, and writes per-focuser-position CSV + summary + a ScottPlot V-curve PNG. No production plugin code changes. CI stays 100% synthetic (TestApp is not in CI).
+
+**Tech Stack:** C# / .NET 8 (`net8.0-windows7.0`), NUnit 4.4.0, OpenCvSharp4 (`Mat`, `CV_32F`), ScottPlot.WPF 4.1.59, alglib.net. Build via `rtk dotnet` (or `cmd.exe /c "dotnet …"`).
+
+**Reference spec:** [`plans/focus-sweep-evidence-base-design.md`](focus-sweep-evidence-base-design.md). **Branch:** `ghilios/focus-sweep-evidence-base` (already created).
+
+---
+
+## Conventions for every commit
+
+Use the required identity (project CLAUDE.md). Each commit command in this plan is written as:
+
+```bash
+git -c user.name="George Hilios" -c user.email="322725+ghilios@users.noreply.github.com" \
+  commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "<subject>" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+Build/test (10-min timeout; rtk build mislabels success header as `fail` — trust `errors=0` and exit code):
+
+```bash
+rtk dotnet build Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj -c Debug --nologo
+rtk dotnet test  Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj -c Debug --nologo --filter "FullyQualifiedName~MeasureStarBiasTests"
+cmd.exe /c "dotnet build Joko.NINA.Plugins\TestApp\TestApp.csproj -c Debug --nologo"
+```
+
+---
+
+## File Structure
+
+| File | New/Mod | Responsibility |
+|---|---|---|
+| `Joko.NINA.Plugins.HocusFocus.Tests/Synthetic/SyntheticDefocusedStarImage.cs` | New | Render uniform disk / annulus (supersampled, optional edge blur) + seeded Gaussian noise. |
+| `Joko.NINA.Plugins.HocusFocus.Tests/Synthetic/HfrGroundTruth.cs` | New | Closed-form + numerical flux-weighted-mean-radius ground truth. |
+| `Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/MeasureStarBiasTests.cs` | New | Pin `MeasureStar` vs truth; measure F3/F4 magnitudes; donut sanity. |
+| `TestApp/DiagnosticUtil.cs` | New | Shared diagnostic helpers `GetArg`, `LoadFloatMat` (relocated from `ContaminationDiagnosticRunner`). |
+| `TestApp/ContaminationDiagnosticRunner.cs` | Mod | Delegate `GetArg`/`LoadFloatMat` to `DiagnosticUtil` (verbatim relocation; behavior unchanged). |
+| `TestApp/FocusSweepDiagnosticRunner.cs` | New | The `focus-sweep` diagnostic: parse AF folder, detect per frame, aggregate per position, write CSV/summary/PNG, `--synthesize`. |
+| `TestApp/Program.cs` | Mod | Route `focus-sweep` subcommand. |
+
+---
+
+# PIECE A — Synthetic generator + MeasureStar bias tests
+
+### Task A1: Synthetic generators + ground-truth helpers
+
+**Files:**
+- Create: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Synthetic/SyntheticDefocusedStarImage.cs`
+- Create: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Synthetic/HfrGroundTruth.cs`
+- Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Synthetic/HfrGroundTruthTests.cs`
+
+- [ ] **Step 1: Write the generator**
+
+Create `SyntheticDefocusedStarImage.cs`:
+
+```csharp
+using OpenCvSharp;
+using System;
+using Size = OpenCvSharp.Size;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Synthetic {
+
+    /// <summary>
+    /// Renders defocused-star test images (uniform disk, annular donut) whose continuous radial profile is
+    /// known, so MeasureStar's flux-weighted-mean-radius output can be compared to analytic ground truth.
+    /// Each pixel is supersampled so the rendered value equals the analytic mean over the pixel area, keeping
+    /// the rim faithful (otherwise discretization at the edge dominates the error budget).
+    /// </summary>
+    internal static class SyntheticDefocusedStarImage {
+        private const int SuperSample = 4; // NxN subsamples per pixel
+
+        public static Mat CreateDisk(int width, int height, double centerX, double centerY,
+                double radius, double peak, double background, double edgeBlurSigma = 0.0) {
+            return Render(width, height, centerX, centerY, background,
+                r => DiskIntensity(r, radius, peak, edgeBlurSigma));
+        }
+
+        public static Mat CreateAnnulus(int width, int height, double centerX, double centerY,
+                double innerRadius, double outerRadius, double peak, double background, double edgeBlurSigma = 0.0) {
+            return Render(width, height, centerX, centerY, background,
+                r => AnnulusIntensity(r, innerRadius, outerRadius, peak, edgeBlurSigma));
+        }
+
+        /// <summary>Adds zero-mean Gaussian noise of the given standard deviation using a seeded RNG (reproducible).</summary>
+        public static void AddGaussianNoise(Mat image, double sigma, int seed) {
+            var rng = new Random(seed);
+            int n = image.Width * image.Height;
+            unsafe {
+                var data = (float*)image.DataPointer;
+                for (int i = 0; i < n; ++i) {
+                    double u1 = 1.0 - rng.NextDouble();
+                    double u2 = 1.0 - rng.NextDouble();
+                    double z = Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Cos(2.0 * Math.PI * u2); // Box-Muller
+                    data[i] += (float)(sigma * z);
+                }
+            }
+        }
+
+        private static Mat Render(int width, int height, double cx, double cy, double background,
+                Func<double, double> radialIntensity) {
+            var mat = new Mat(new Size(width, height), MatType.CV_32F);
+            double inv = 1.0 / SuperSample;
+            int sub = SuperSample * SuperSample;
+            unsafe {
+                var data = (float*)mat.DataPointer;
+                for (int y = 0; y < height; ++y) {
+                    for (int x = 0; x < width; ++x) {
+                        double sum = 0.0;
+                        for (int sy = 0; sy < SuperSample; ++sy) {
+                            for (int sx = 0; sx < SuperSample; ++sx) {
+                                double px = x - 0.5 + (sx + 0.5) * inv;
+                                double py = y - 0.5 + (sy + 0.5) * inv;
+                                double dx = px - cx, dy = py - cy;
+                                sum += radialIntensity(Math.Sqrt(dx * dx + dy * dy));
+                            }
+                        }
+                        data[y * width + x] = (float)(background + sum / sub);
+                    }
+                }
+            }
+            return mat;
+        }
+
+        private static double DiskIntensity(double r, double radius, double peak, double edgeBlurSigma) {
+            if (edgeBlurSigma <= 0.0) return r <= radius ? peak : 0.0;
+            return peak * 0.5 * Erfc((r - radius) / (edgeBlurSigma * Math.Sqrt(2.0)));
+        }
+
+        private static double AnnulusIntensity(double r, double inner, double outer, double peak, double edgeBlurSigma) {
+            if (edgeBlurSigma <= 0.0) return (r >= inner && r <= outer) ? peak : 0.0;
+            double rise = 0.5 * Erfc((inner - r) / (edgeBlurSigma * Math.Sqrt(2.0)));
+            double fall = 0.5 * Erfc((r - outer) / (edgeBlurSigma * Math.Sqrt(2.0)));
+            return peak * rise * fall;
+        }
+
+        // Abramowitz & Stegun 7.1.26 erfc approximation (max error ~1.2e-7).
+        private static double Erfc(double x) {
+            double z = Math.Abs(x);
+            double t = 1.0 / (1.0 + 0.5 * z);
+            double ans = t * Math.Exp(-z * z - 1.26551223 + t * (1.00002368 + t * (0.37409196 +
+                t * (0.09678418 + t * (-0.18628806 + t * (0.27886807 + t * (-1.13520398 +
+                t * (1.48851587 + t * (-0.82215223 + t * 0.17087277)))))))));
+            return x >= 0.0 ? ans : 2.0 - ans;
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Write the ground-truth helper**
+
+Create `HfrGroundTruth.cs`:
+
+```csharp
+using System;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Synthetic {
+
+    /// <summary>
+    /// Ground-truth flux-weighted mean radius (the quantity MeasureStar approximates) for the synthetic
+    /// shapes, with aperture R >= the star's support:  HFR = ∫0^R I(r) r^2 dr / ∫0^R I(r) r dr.
+    /// </summary>
+    internal static class HfrGroundTruth {
+        /// <summary>Uniform filled disk of radius a:  HFR = 2a/3.</summary>
+        public static double Disk(double radius) => 2.0 * radius / 3.0;
+
+        /// <summary>Uniform annulus [inner, outer]:  HFR = (2/3)(a^3 - b^3)/(a^2 - b^2).</summary>
+        public static double Annulus(double inner, double outer) =>
+            (2.0 / 3.0) * (Math.Pow(outer, 3) - Math.Pow(inner, 3)) / (Math.Pow(outer, 2) - Math.Pow(inner, 2));
+
+        /// <summary>Gaussian exp(-r^2/2σ^2), large aperture:  HFR = σ·sqrt(π/2) ≈ 1.2533σ.</summary>
+        public static double Gaussian(double sigma) => sigma * Math.Sqrt(Math.PI / 2.0);
+
+        /// <summary>Numerical flux-weighted mean radius of a radial profile over [0, R] (validates the closed forms).</summary>
+        public static double Numerical(Func<double, double> intensity, double apertureRadius, double step = 0.001) {
+            double num = 0.0, den = 0.0;
+            for (double r = 0.0; r <= apertureRadius; r += step) {
+                double i = intensity(r);
+                num += i * r * r * step;
+                den += i * r * step;
+            }
+            return den > 0 ? num / den : 0.0;
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Write a self-test pinning the ground-truth math**
+
+Create `HfrGroundTruthTests.cs`:
+
+```csharp
+using NINA.Joko.Plugins.HocusFocus.Tests.Synthetic;
+using NUnit.Framework;
+using System;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Synthetic {
+
+    [TestFixture]
+    public class HfrGroundTruthTests {
+
+        [Test]
+        public void Disk_ClosedFormMatchesNumericalIntegration() {
+            const double a = 12.0;
+            double numerical = HfrGroundTruth.Numerical(r => r <= a ? 1.0 : 0.0, apertureRadius: 40.0);
+            Assert.That(HfrGroundTruth.Disk(a), Is.EqualTo(numerical).Within(0.01));
+            Assert.That(HfrGroundTruth.Disk(a), Is.EqualTo(8.0).Within(1e-9));
+        }
+
+        [Test]
+        public void Annulus_ClosedFormMatchesNumericalIntegration() {
+            const double b = 6.0, a = 14.0;
+            double numerical = HfrGroundTruth.Numerical(r => (r >= b && r <= a) ? 1.0 : 0.0, apertureRadius: 40.0);
+            Assert.That(HfrGroundTruth.Annulus(b, a), Is.EqualTo(numerical).Within(0.01));
+        }
+
+        [Test]
+        public void Gaussian_ClosedFormMatchesNumericalIntegration() {
+            const double sigma = 4.0;
+            double numerical = HfrGroundTruth.Numerical(r => Math.Exp(-r * r / (2 * sigma * sigma)), apertureRadius: 60.0);
+            Assert.That(HfrGroundTruth.Gaussian(sigma), Is.EqualTo(numerical).Within(0.01));
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Build and run**
+
+```bash
+rtk dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj -c Debug --nologo --filter "FullyQualifiedName~HfrGroundTruthTests"
+```
+Expected: 3 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Synthetic/SyntheticDefocusedStarImage.cs \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Synthetic/HfrGroundTruth.cs \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Synthetic/HfrGroundTruthTests.cs
+git -c user.name="George Hilios" -c user.email="322725+ghilios@users.noreply.github.com" \
+  commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "Add synthetic defocused-star generator and HFR ground truth" \
+  -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task A2: Clean unbiasedness tests (estimator correctness)
+
+**Files:**
+- Create: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/MeasureStarBiasTests.cs`
+
+- [ ] **Step 1: Write the test fixture with the three clean tests**
+
+Create `MeasureStarBiasTests.cs`:
+
+```csharp
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.Tests.Synthetic;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NUnit.Framework;
+using OpenCvSharp;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
+
+    /// <summary>
+    /// Pins MeasureStar's HFR against analytic ground truth on controlled synthetic shapes, and measures the
+    /// magnitude of two confirmed biases: F3 (the soft-threshold τ is subtracted from each pixel, pulling HFR
+    /// down on stars with a radial gradient) and F4 (an understated σ lets large-radius noise inflate HFR).
+    /// All inputs are deterministic (seeded noise); bias tests assert direction + a bounded magnitude and log
+    /// the measured numbers via TestContext so the magnitudes are visible without being brittle.
+    /// </summary>
+    [TestFixture]
+    public class MeasureStarBiasTests {
+        private const int Size = 81;       // R = min(bbox)/2 = 40.5, large vs the shapes below (low truncation)
+        private const double Cx = 40.0;
+        private const double Cy = 40.0;
+
+        private static Star NewStar(double background) => new Star {
+            Center = new Point2d(Cx, Cy),
+            StarBoundingBox = new Rect(0, 0, Size, Size),
+            Background = background
+        };
+
+        [Test]
+        public void MeasureStar_CleanDisk_MatchesTwoThirdsRadius() {
+            const double a = 12.0, peak = 1.0, bg = 0.0;
+            using var image = SyntheticDefocusedStarImage.CreateDisk(Size, Size, Cx, Cy, a, peak, bg);
+            var detector = new StarDetector(new AlglibAPI());
+            var p = new StarDetectorParams { AnalysisSamplingSize = 1.0f, StarClippingMultiplier = 0.0 };
+            var star = NewStar(bg);
+            Assert.That(detector.MeasureStar(image, star, p, 0.0), Is.True);
+            double truth = HfrGroundTruth.Disk(a); // 8.0
+            TestContext.WriteLine($"clean disk: measured={star.HFR:F4} truth={truth:F4}");
+            Assert.That(star.HFR, Is.EqualTo(truth).Within(0.3));
+        }
+
+        [Test]
+        public void MeasureStar_CleanAnnulus_MatchesClosedForm() {
+            const double inner = 6.0, outer = 14.0, peak = 1.0, bg = 0.0;
+            using var image = SyntheticDefocusedStarImage.CreateAnnulus(Size, Size, Cx, Cy, inner, outer, peak, bg);
+            var detector = new StarDetector(new AlglibAPI());
+            var p = new StarDetectorParams { AnalysisSamplingSize = 1.0f, StarClippingMultiplier = 0.0 };
+            var star = NewStar(bg);
+            Assert.That(detector.MeasureStar(image, star, p, 0.0), Is.True);
+            double truth = HfrGroundTruth.Annulus(inner, outer); // ~10.53
+            TestContext.WriteLine($"clean annulus: measured={star.HFR:F4} truth={truth:F4}");
+            Assert.That(star.HFR, Is.EqualTo(truth).Within(0.3));
+        }
+
+        [Test]
+        public void MeasureStar_CleanGaussian_MatchesSigmaRootPiOverTwo() {
+            const double sigma = 4.0, peak = 1.0, bg = 0.0; // R = 40.5 = 10σ → truncation negligible
+            using var image = SyntheticGaussianStarImage.Create(Size, Size, Cx, Cy, sigma, sigma, peak, bg);
+            var detector = new StarDetector(new AlglibAPI());
+            var p = new StarDetectorParams { AnalysisSamplingSize = 1.0f, StarClippingMultiplier = 0.0 };
+            var star = NewStar(bg);
+            Assert.That(detector.MeasureStar(image, star, p, 0.0), Is.True);
+            double truth = HfrGroundTruth.Gaussian(sigma); // ~5.013
+            TestContext.WriteLine($"clean gaussian: measured={star.HFR:F4} truth={truth:F4}");
+            Assert.That(star.HFR, Is.EqualTo(truth).Within(0.3));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build and run**
+
+```bash
+rtk dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj -c Debug --nologo --filter "FullyQualifiedName~MeasureStarBiasTests"
+```
+Expected: 3 tests PASS. If a clean test is off by >0.3, read the logged measured-vs-truth values and adjust the tolerance to a documented value (the supersampled rim should keep it within a few percent).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/MeasureStarBiasTests.cs
+git -c user.name="George Hilios" -c user.email="322725+ghilios@users.noreply.github.com" \
+  commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "Pin MeasureStar HFR against analytic ground truth" \
+  -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task A3: F3 soft-threshold bias tests
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/MeasureStarBiasTests.cs`
+
+- [ ] **Step 1: Add the three F3 tests inside the fixture**
+
+Insert before the closing brace of the `MeasureStarBiasTests` class (τ = `StarClippingMultiplier · noiseSigma`; the tests fix the multiplier and sweep `noiseSigma`):
+
+```csharp
+        [Test]
+        public void MeasureStar_UniformDisk_SoftThresholdBarelyChangesHfr() {
+            // A uniform disk has no radial gradient, so subtracting a constant τ scales every surviving pixel
+            // equally and the flux-weighted radius is (almost) unchanged — only the partially-covered rim
+            // shifts. This isolates WHY the F3 bias requires a gradient (contrast with the Gaussian below).
+            const double a = 12.0, peak = 1.0, bg = 0.0;
+            using var image = SyntheticDefocusedStarImage.CreateDisk(Size, Size, Cx, Cy, a, peak, bg);
+            var detector = new StarDetector(new AlglibAPI());
+            var pNoClip = new StarDetectorParams { AnalysisSamplingSize = 1.0f, StarClippingMultiplier = 0.0 };
+            var pClip = new StarDetectorParams { AnalysisSamplingSize = 1.0f, StarClippingMultiplier = 1.0 };
+            var s0 = NewStar(bg);
+            var sT = NewStar(bg);
+            detector.MeasureStar(image, s0, pNoClip, 0.0);
+            detector.MeasureStar(image, sT, pClip, 0.3); // τ = 1.0 * 0.3
+            TestContext.WriteLine($"uniform disk: hfr(τ=0)={s0.HFR:F4} hfr(τ=0.3)={sT.HFR:F4} Δ={sT.HFR - s0.HFR:F4}");
+            Assert.That(sT.HFR, Is.EqualTo(s0.HFR).Within(0.15));
+        }
+
+        [Test]
+        public void MeasureStar_GaussianSoftThreshold_BiasesHfrDownward() {
+            const double sigma = 5.0, peak = 1.0, bg = 0.0;
+            using var image = SyntheticGaussianStarImage.Create(Size, Size, Cx, Cy, sigma, sigma, peak, bg);
+            var detector = new StarDetector(new AlglibAPI());
+            var p = new StarDetectorParams { AnalysisSamplingSize = 1.0f, StarClippingMultiplier = 1.0 }; // τ == noiseSigma
+            double[] taus = { 0.0, 0.02, 0.05, 0.10, 0.20 };
+            var hfrs = new double[taus.Length];
+            for (int i = 0; i < taus.Length; ++i) {
+                var star = NewStar(bg);
+                detector.MeasureStar(image, star, p, taus[i]);
+                hfrs[i] = star.HFR;
+                TestContext.WriteLine($"τ={taus[i]:F3} → HFR={hfrs[i]:F4} (bias {hfrs[i] - hfrs[0]:F4})");
+            }
+            for (int i = 1; i < hfrs.Length; ++i)
+                Assert.That(hfrs[i], Is.LessThan(hfrs[i - 1]), $"HFR should decrease monotonically as τ grows (i={i})");
+            Assert.That(hfrs[0] - hfrs[^1], Is.GreaterThan(0.1), "soft-threshold should bias HFR downward measurably at τ=0.2");
+        }
+
+        [Test]
+        public void MeasureStar_GaussianSoftThreshold_RelativeBiasGrowsForFainterStars() {
+            const double sigma = 5.0, bg = 0.0, tau = 0.05;
+            var detector = new StarDetector(new AlglibAPI());
+            var p = new StarDetectorParams { AnalysisSamplingSize = 1.0f, StarClippingMultiplier = 1.0 };
+            double[] peaks = { 1.0, 0.5, 0.25, 0.125 };
+            double prevRel = -1.0;
+            foreach (var peak in peaks) {
+                using var image = SyntheticGaussianStarImage.Create(Size, Size, Cx, Cy, sigma, sigma, peak, bg);
+                var s0 = NewStar(bg);
+                var sT = NewStar(bg);
+                detector.MeasureStar(image, s0, p, 0.0);
+                detector.MeasureStar(image, sT, p, tau);
+                double rel = (s0.HFR - sT.HFR) / s0.HFR;
+                TestContext.WriteLine($"peak={peak:F3} τ/peak={tau / peak:F3} relBias={rel:P2}");
+                if (prevRel >= 0)
+                    Assert.That(rel, Is.GreaterThan(prevRel), "relative HFR bias should grow as the star gets fainter");
+                prevRel = rel;
+            }
+        }
+```
+
+- [ ] **Step 2: Build and run**
+
+```bash
+rtk dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj -c Debug --nologo --filter "FullyQualifiedName~MeasureStarBiasTests"
+```
+Expected: 6 tests PASS (3 from A2 + 3 new). The logged τ→HFR curve is the F3 magnitude evidence.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/MeasureStarBiasTests.cs
+git -c user.name="George Hilios" -c user.email="322725+ghilios@users.noreply.github.com" \
+  commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "Measure F3 soft-threshold HFR bias on synthetic stars" \
+  -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task A4: F4 σ-mismatch test + donut sanity test
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/MeasureStarBiasTests.cs`
+
+- [ ] **Step 1: Add the F4 and donut tests inside the fixture**
+
+Insert before the closing brace of the class:
+
+```csharp
+        [Test]
+        public void MeasureStar_UnderstatedSigma_InflatesHfrUnderNoise() {
+            // A small star in a large aperture surrounded by noise. With correctly-scaled τ the noise is
+            // clipped; with an understated σ (production measures σ on a ~4-5× smoothed copy but samples the
+            // sharp image) positive noise at large radius leaks into the flux sum and inflates HFR (F4).
+            const double sigma = 3.0, peak = 1.0, bg = 0.0;
+            const double sigmaSharp = 0.02; // true white-noise σ of the measurement image
+            const int seed = 12345;
+            const int bigSize = 121;        // R = 60.5 = 20σ → a large pure-noise annulus inside the aperture
+            const double bigC = 60.0;
+            var detector = new StarDetector(new AlglibAPI());
+            var p = new StarDetectorParams { AnalysisSamplingSize = 1.0f, StarClippingMultiplier = 2.0 };
+
+            double MeasureWith(double noiseSigmaArg) {
+                using var image = SyntheticGaussianStarImage.Create(bigSize, bigSize, bigC, bigC, sigma, sigma, peak, bg);
+                SyntheticDefocusedStarImage.AddGaussianNoise(image, sigmaSharp, seed);
+                var star = new Star {
+                    Center = new Point2d(bigC, bigC),
+                    StarBoundingBox = new Rect(0, 0, bigSize, bigSize),
+                    Background = bg
+                };
+                detector.MeasureStar(image, star, p, noiseSigmaArg);
+                return star.HFR;
+            }
+
+            double hfrTrue = MeasureWith(sigmaSharp);          // τ = 2·σ_sharp     → noise clipped
+            double hfrUnderstated = MeasureWith(sigmaSharp / 5.0); // τ = 2·σ_sharp/5 → noise leaks in
+            TestContext.WriteLine($"HFR(trueσ)={hfrTrue:F4}  HFR(understatedσ)={hfrUnderstated:F4}  inflation={hfrUnderstated - hfrTrue:F4}");
+            Assert.That(hfrUnderstated, Is.GreaterThan(hfrTrue + 0.5), "understated σ should inflate HFR by leaking large-radius noise");
+        }
+
+        [Test]
+        public void MeasureStar_Annulus_HfrExceedsFilledDisk_SameOuterRadius() {
+            const double outer = 14.0, inner = 8.0, peak = 1.0, bg = 0.0;
+            var detector = new StarDetector(new AlglibAPI());
+            var p = new StarDetectorParams { AnalysisSamplingSize = 1.0f, StarClippingMultiplier = 0.0 };
+            using var disk = SyntheticDefocusedStarImage.CreateDisk(Size, Size, Cx, Cy, outer, peak, bg);
+            using var annulus = SyntheticDefocusedStarImage.CreateAnnulus(Size, Size, Cx, Cy, inner, outer, peak, bg);
+            var sd = NewStar(bg);
+            var sa = NewStar(bg);
+            detector.MeasureStar(disk, sd, p, 0.0);
+            detector.MeasureStar(annulus, sa, p, 0.0);
+            TestContext.WriteLine($"disk HFR={sd.HFR:F4}  annulus HFR={sa.HFR:F4}");
+            Assert.That(sa.HFR, Is.GreaterThan(sd.HFR), "annulus pushes flux outward → larger HFR than a filled disk of the same outer radius");
+        }
+```
+
+- [ ] **Step 2: Build and run**
+
+```bash
+rtk dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj -c Debug --nologo --filter "FullyQualifiedName~MeasureStarBiasTests"
+```
+Expected: 8 tests PASS. The logged inflation value is the F4 magnitude evidence.
+
+- [ ] **Step 3: Run the full suite to confirm nothing else broke**
+
+```bash
+rtk dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj -c Debug --nologo
+```
+Expected: all tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/MeasureStarBiasTests.cs
+git -c user.name="George Hilios" -c user.email="322725+ghilios@users.noreply.github.com" \
+  commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "Measure F4 noise-inflation HFR bias and pin donut HFR ordering" \
+  -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+# PIECE B — focus-sweep diagnostic (TestApp)
+
+### Task B1: Extract shared diagnostic helpers
+
+**Files:**
+- Create: `Joko.NINA.Plugins/TestApp/DiagnosticUtil.cs`
+- Modify: `Joko.NINA.Plugins/TestApp/ContaminationDiagnosticRunner.cs`
+
+`GetArg` and `LoadFloatMat` are needed verbatim by the new runner. Relocate them to a shared static class (compiler-verified, pure relocation — runtime behavior of the contamination tool is unchanged).
+
+- [ ] **Step 1: Create `DiagnosticUtil.cs`**
+
+```csharp
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Image.FileFormat.FITS;
+using NINA.Image.FileFormat.XISF;
+using NINA.Image.ImageData;
+using NINA.Image.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NINA.Profile.Interfaces;
+using OpenCvSharp;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TestApp {
+
+    /// <summary>Helpers shared by the headless diagnostic runners (contamination, focus-sweep).</summary>
+    internal static class DiagnosticUtil {
+
+        /// <summary>Returns the value following <paramref name="name"/> in <paramref name="args"/>, or null.</summary>
+        public static string GetArg(string[] args, string name) {
+            for (int i = 0; i < args.Length - 1; ++i) {
+                if (string.Equals(args[i], name, StringComparison.OrdinalIgnoreCase)) {
+                    return args[i + 1];
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Loads an image file as a CV_32F Mat normalized to [0,1]. .tif/.tiff are read directly; .xisf/.fits/.fit
+        /// go through NINA's loaders (which need a profile). profileService may be null for .tif-only callers.
+        /// </summary>
+        public static async Task<Mat> LoadFloatMat(string path, IProfileService profileService) {
+            var ext = Path.GetExtension(path).ToLowerInvariant();
+            if (ext == ".tif" || ext == ".tiff") {
+                using var src = new Mat(path, ImreadModes.Unchanged);
+                var dst = new Mat();
+                Program.ConvertToFloat(src, dst);
+                return dst;
+            }
+            if (ext == ".xisf" || ext == ".fits" || ext == ".fit") {
+                if (profileService == null) {
+                    throw new InvalidOperationException($"Loading '{ext}' requires a NINA profile; omit --default-params or use .tif frames.");
+                }
+                var factory = new ImageDataFactory(profileService, new StubBehaviorSelector<IStarDetection>(new StubStarDetection()), new StubBehaviorSelector<IStarAnnotator>());
+                var uri = new Uri(Path.GetFullPath(path));
+                IImageData imageData = ext == ".xisf"
+                    ? await XISF.Load(uri, false, factory, CancellationToken.None)
+                    : await FITS.Load(uri, false, factory, CancellationToken.None);
+                return CvImageUtility.ToOpenCVMat(imageData);
+            }
+            throw new NotSupportedException($"Unsupported image extension '{ext}'. Supported: .tif/.tiff, .xisf, .fits/.fit");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Delete the two private methods from `ContaminationDiagnosticRunner.cs`**
+
+Remove the `private static async Task<Mat> LoadFloatMat(...) { ... }` block (currently lines ~198-215) and the `private static string GetArg(...) { ... }` block (currently lines ~505-512) entirely.
+
+- [ ] **Step 3: Update the two call sites in `ContaminationDiagnosticRunner.cs`**
+
+`RunImpl` calls `GetArg(args, "--image")`, `GetArg(args, "--profile-id")`, `GetArg(args, "--out")`, `GetArg(args, "--sensitivity")`, `GetArg(args, "--sensitivity-sweep")`, and `await LoadFloatMat(imagePath, profileService)`. Prefix each with `DiagnosticUtil.`:
+
+```csharp
+            var imagePath = DiagnosticUtil.GetArg(args, "--image");
+            // ...
+            var profileId = DiagnosticUtil.GetArg(args, "--profile-id");
+            var outDir = DiagnosticUtil.GetArg(args, "--out");
+            // ...
+            var sensitivityArg = DiagnosticUtil.GetArg(args, "--sensitivity");
+            // ...
+            using var srcFloat = await DiagnosticUtil.LoadFloatMat(imagePath, profileService);
+            // ...
+            var sweepArg = DiagnosticUtil.GetArg(args, "--sensitivity-sweep");
+```
+
+(There are no other references; `using` lines for the FITS/XISF/ImageData/Profile imports that only `LoadFloatMat` used may now be unused in `ContaminationDiagnosticRunner.cs` — leave them, they are harmless, or remove if the build warns and you want it clean.)
+
+- [ ] **Step 4: Build TestApp**
+
+```bash
+cmd.exe /c "dotnet build Joko.NINA.Plugins\TestApp\TestApp.csproj -c Debug --nologo"
+```
+Expected: build succeeds, 0 errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Joko.NINA.Plugins/TestApp/DiagnosticUtil.cs Joko.NINA.Plugins/TestApp/ContaminationDiagnosticRunner.cs
+git -c user.name="George Hilios" -c user.email="322725+ghilios@users.noreply.github.com" \
+  commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "Extract shared diagnostic helpers into DiagnosticUtil" \
+  -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task B2: focus-sweep runner core (parse → detect → aggregate → CSV/summary) + dispatch
+
+**Files:**
+- Create: `Joko.NINA.Plugins/TestApp/FocusSweepDiagnosticRunner.cs`
+- Modify: `Joko.NINA.Plugins/TestApp/Program.cs`
+
+- [ ] **Step 1: Create `FocusSweepDiagnosticRunner.cs` (core, no PNG/synthesize yet)**
+
+```csharp
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Enum;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NINA.Profile;
+using NINA.Profile.Interfaces;
+using OpenCvSharp;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using Logger = NINA.Core.Utility.Logger;
+
+namespace TestApp {
+
+    /// <summary>
+    /// Headless diagnostic: replays a saved AutoFocus run through HocusFocus star detection and reports star
+    /// count, HFR (median + robust spread), and per-reason rejection counts as a function of focuser position.
+    /// Turns the analysis's "detection degrades at defocus" mechanisms (F1/F2) into measured numbers. Mirrors
+    /// ContaminationDiagnosticRunner; TestApp is not run in CI, so this consumes real data on disk only.
+    /// </summary>
+    internal static class FocusSweepDiagnosticRunner {
+
+        // Mirrors AutoFocusEngine.IMAGE_FILE_REGEX (private) so the diagnostic stays decoupled from the engine.
+        private static readonly Regex ImageFileRegex = new Regex(
+            @"^(?<IMAGE_INDEX>\d+)_Frame(?<FRAME_NUMBER>\d+)_BitDepth(?<BITDEPTH>\d+)_Bayered(?<BAYERED>\d)_Focuser(?<FOCUSER>\d+)(_HFR(?<HFR>(\d+)(\.\d+)?))?$",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private sealed class Frame {
+            public string Path;
+            public int FocuserPosition;
+        }
+
+        private sealed class PositionAccum {
+            public int FocuserPosition;
+            public int Frames;
+            public readonly List<double> Hfrs = new List<double>();
+            public long StructureCandidates, TotalDetected, TooSmall, OnBorder, TooDistorted, Degenerate,
+                Saturated, LowSensitivity, NotCentered, TooFlat, TooLowHFR, HFRAnalysisFailed, PSFFitFailed,
+                ContaminationSuspected, OutsideROI;
+        }
+
+        public static async Task Run(string[] args) {
+            try {
+                await RunImpl(args);
+            } catch (Exception ex) {
+                Console.Error.WriteLine($"ERROR: {ex.Message}");
+                Console.Error.WriteLine(ex.ToString());
+                Logger.Error(ex, "Focus-sweep diagnostic run failed");
+                Environment.ExitCode = 1;
+            }
+        }
+
+        private static async Task RunImpl(string[] args) {
+            var afRun = DiagnosticUtil.GetArg(args, "--af-run");
+            var synthesizeDir = DiagnosticUtil.GetArg(args, "--synthesize");
+            bool defaultParams = args.Any(a => a.Equals("--default-params", StringComparison.OrdinalIgnoreCase));
+
+            if (!string.IsNullOrWhiteSpace(synthesizeDir)) {
+                int count = 9;
+                var countArg = DiagnosticUtil.GetArg(args, "--synthesize-count");
+                if (!string.IsNullOrWhiteSpace(countArg)) count = int.Parse(countArg, CultureInfo.InvariantCulture);
+                SynthesizeAfRun(synthesizeDir, count);
+                Console.WriteLine($"Synthesized {count} frames into {synthesizeDir}");
+                afRun = synthesizeDir; // proceed to sweep the freshly-synthesized folder
+            }
+
+            if (string.IsNullOrWhiteSpace(afRun)) {
+                Console.Error.WriteLine("Usage: TestApp focus-sweep --af-run <dir> [--profile-id <guid>] [--out <dir>] [--default-params]");
+                Console.Error.WriteLine("       TestApp focus-sweep --synthesize <dir> [--synthesize-count <n>] --default-params [--out <dir>]");
+                Environment.ExitCode = 2;
+                return;
+            }
+            if (!Directory.Exists(afRun)) {
+                throw new DirectoryNotFoundException($"AF-run folder not found: {afRun}");
+            }
+
+            var outDir = DiagnosticUtil.GetArg(args, "--out");
+            if (string.IsNullOrWhiteSpace(outDir)) {
+                var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                outDir = Path.Combine(localAppData, "NINA", "Logs", "hf-diag", "focus-sweep");
+            }
+            Directory.CreateDirectory(outDir);
+            Logger.SetLogLevel(LogLevelEnum.TRACE);
+
+            var frames = ParseAfRun(afRun);
+            if (frames.Count == 0) {
+                throw new InvalidOperationException($"No AF frames matched the filename pattern in {afRun}");
+            }
+            Console.WriteLine($"AF run: {afRun} ({frames.Count} frames, {frames.Select(f => f.FocuserPosition).Distinct().Count()} positions)");
+
+            // Build detector params: from the real profile (default) or library defaults (--default-params).
+            IProfileService profileService = null;
+            StarDetectorParams baseParams;
+            if (defaultParams) {
+                baseParams = new StarDetectorParams();
+                Console.WriteLine("Using default StarDetectorParams (--default-params; no profile loaded)");
+            } else {
+                if (Application.Current == null) {
+                    new Application(); // ProfileService.ActiveProfile setter touches Application.Current.Resources
+                }
+                profileService = new ProfileService();
+                profileService.TryLoad(DiagnosticUtil.GetArg(args, "--profile-id") ?? string.Empty);
+                if (profileService.ActiveProfile == null) {
+                    throw new InvalidOperationException("No active NINA profile. Pass --profile-id, run NINA once, or use --default-params.");
+                }
+                Console.WriteLine($"Profile: {profileService.ActiveProfile.Name} ({profileService.ActiveProfile.Id})");
+                var guid = PluginOptionsAccessor.GetAssemblyGuid(typeof(StarDetectionOptions));
+                var accessor = new PluginOptionsAccessor(profileService, guid.Value);
+                var options = new StarDetectionOptions(profileService, accessor);
+                baseParams = HocusFocusStarDetection.BuildStarDetectorParams(options);
+            }
+            // Mirror real AF: PSF modeling is disabled during AutoFocus, so HFR is the measured quantity.
+            baseParams.ModelPSF = false;
+
+            var byPosition = new SortedDictionary<int, PositionAccum>();
+            var detector = new StarDetector(new AlglibAPI());
+            foreach (var frame in frames) {
+                using var img = await DiagnosticUtil.LoadFloatMat(frame.Path, profileService);
+                var result = await detector.Detect(img, baseParams, null, CancellationToken.None);
+                if (!byPosition.TryGetValue(frame.FocuserPosition, out var accum)) {
+                    accum = new PositionAccum { FocuserPosition = frame.FocuserPosition };
+                    byPosition[frame.FocuserPosition] = accum;
+                }
+                Accumulate(accum, result);
+                Console.WriteLine($"  pos {frame.FocuserPosition}: {result.DetectedStars.Count} stars");
+            }
+
+            var rows = byPosition.Values.ToList();
+            WriteCsv(Path.Combine(outDir, "focus_sweep.csv"), rows);
+            WriteSummary(Path.Combine(outDir, "focus_sweep_summary.txt"), afRun, baseParams, rows);
+            Console.WriteLine($"Wrote focus_sweep.csv, focus_sweep_summary.txt to {outDir}");
+        }
+
+        private static List<Frame> ParseAfRun(string dir) {
+            var root = new DirectoryInfo(dir);
+            var search = root;
+            // Accept either an attempt folder directly or a parent with a single attempt* subfolder.
+            if (!root.GetFiles().Any(f => ImageFileRegex.IsMatch(Path.GetFileNameWithoutExtension(f.Name)))) {
+                var attempt = root.EnumerateDirectories("attempt*").FirstOrDefault();
+                if (attempt != null) search = attempt;
+            }
+            var frames = new List<Frame>();
+            foreach (var file in search.GetFiles()) {
+                var m = ImageFileRegex.Match(Path.GetFileNameWithoutExtension(file.Name));
+                if (!m.Success) continue;
+                if (!int.TryParse(m.Groups["FOCUSER"].Value, out var pos)) continue;
+                frames.Add(new Frame { Path = file.FullName, FocuserPosition = pos });
+            }
+            return frames;
+        }
+
+        private static void Accumulate(PositionAccum a, HocusFocusStarDetectorResult result) {
+            a.Frames++;
+            var m = result.Metrics;
+            a.StructureCandidates += m.StructureCandidates;
+            a.TotalDetected += m.TotalDetected;
+            a.TooSmall += m.TooSmall;
+            a.OnBorder += m.OnBorder;
+            a.TooDistorted += m.TooDistorted;
+            a.Degenerate += m.Degenerate;
+            a.Saturated += m.Saturated;
+            a.LowSensitivity += m.LowSensitivity;
+            a.NotCentered += m.NotCentered;
+            a.TooFlat += m.TooFlat;
+            a.TooLowHFR += m.TooLowHFR;
+            a.HFRAnalysisFailed += m.HFRAnalysisFailed;
+            a.PSFFitFailed += m.PSFFitFailed;
+            a.ContaminationSuspected += m.ContaminationSuspected;
+            a.OutsideROI += m.OutsideROI;
+            foreach (var s in result.DetectedStars) a.Hfrs.Add(s.HFR);
+        }
+
+        private static (double median, double mad) MedianMad(List<double> values) {
+            if (values.Count == 0) return (double.NaN, double.NaN);
+            return values.MedianMAD();
+        }
+
+        private static void WriteCsv(string path, List<PositionAccum> rows) {
+            var sb = new StringBuilder();
+            sb.AppendLine("FocuserPosition,Frames,StarCount,MedianHFR,MAD_HFR,StructureCandidates,TotalDetected," +
+                "TooSmall,OnBorder,TooDistorted,Degenerate,Saturated,LowSensitivity,NotCentered,TooFlat," +
+                "TooLowHFR,HFRAnalysisFailed,PSFFitFailed,ContaminationSuspected,OutsideROI");
+            foreach (var r in rows) {
+                var (median, mad) = MedianMad(r.Hfrs);
+                sb.AppendLine(string.Join(",",
+                    r.FocuserPosition, r.Frames, r.Hfrs.Count, F(median), F(mad),
+                    r.StructureCandidates, r.TotalDetected, r.TooSmall, r.OnBorder, r.TooDistorted, r.Degenerate,
+                    r.Saturated, r.LowSensitivity, r.NotCentered, r.TooFlat, r.TooLowHFR, r.HFRAnalysisFailed,
+                    r.PSFFitFailed, r.ContaminationSuspected, r.OutsideROI));
+            }
+            File.WriteAllText(path, sb.ToString());
+        }
+
+        private static void WriteSummary(string path, string afRun, StarDetectorParams p, List<PositionAccum> rows) {
+            var sb = new StringBuilder();
+            sb.AppendLine($"AF run: {afRun}");
+            sb.AppendLine($"Params: {p}");
+            sb.AppendLine($"Positions: {rows.Count}");
+            sb.AppendLine($"Total frames: {rows.Sum(r => r.Frames)}");
+            var withStars = rows.Where(r => r.Hfrs.Count > 0).ToList();
+            if (withStars.Count > 0) {
+                var best = withStars.OrderBy(r => MedianMad(r.Hfrs).median).First();
+                sb.AppendLine($"Min median-HFR position (detector's-eye focus estimate): {best.FocuserPosition} " +
+                    $"(median HFR {F(MedianMad(best.Hfrs).median)}, {best.Hfrs.Count} stars)");
+            }
+            File.WriteAllText(path, sb.ToString());
+        }
+
+        private static string F(double v) => double.IsNaN(v) ? "NaN" : v.ToString("G9", CultureInfo.InvariantCulture);
+
+        // --- Synthesize: replaced with the real body in Task B4. Placeholder keeps the file compiling. ---
+        private static void SynthesizeAfRun(string dir, int count) {
+            throw new NotImplementedException("Implemented in Task B4");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Route the subcommand in `Program.cs`**
+
+In `Program.Main`, add this block immediately after the `fit-quality` block and before the `contamination` block:
+
+```csharp
+            // Headless focus-sweep diagnostic mode: `TestApp focus-sweep --af-run <dir> ...`
+            if (args.Length > 0 && args[0].Equals("focus-sweep", StringComparison.OrdinalIgnoreCase)) {
+                await FocusSweepDiagnosticRunner.Run(args);
+                return;
+            }
+```
+
+- [ ] **Step 3: Build TestApp**
+
+```bash
+cmd.exe /c "dotnet build Joko.NINA.Plugins\TestApp\TestApp.csproj -c Debug --nologo"
+```
+Expected: build succeeds, 0 errors (the `SynthesizeAfRun` placeholder throws at runtime only).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Joko.NINA.Plugins/TestApp/FocusSweepDiagnosticRunner.cs Joko.NINA.Plugins/TestApp/Program.cs
+git -c user.name="George Hilios" -c user.email="322725+ghilios@users.noreply.github.com" \
+  commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "Add focus-sweep diagnostic core (CSV + summary)" \
+  -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task B3: V-curve PNG (ScottPlot)
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/TestApp/FocusSweepDiagnosticRunner.cs`
+
+- [ ] **Step 1: Add the PNG writer**
+
+Add this method to the class (after `WriteSummary`):
+
+```csharp
+        private static void WriteVCurvePng(string path, List<PositionAccum> rows) {
+            try {
+                var data = rows.Where(r => r.Hfrs.Count > 0)
+                    .Select(r => (x: (double)r.FocuserPosition, y: MedianMad(r.Hfrs)))
+                    .OrderBy(t => t.x).ToList();
+                if (data.Count == 0) {
+                    Logger.Warning("V-curve PNG skipped: no positions had detected stars");
+                    return;
+                }
+                var xs = data.Select(d => d.x).ToArray();
+                var ys = data.Select(d => d.y.median).ToArray();
+                var err = data.Select(d => double.IsNaN(d.y.mad) ? 0.0 : d.y.mad).ToArray();
+                var plt = new ScottPlot.Plot(900, 600);
+                plt.AddScatter(xs, ys, markerSize: 6);
+                plt.AddErrorBars(xs, ys, null, err);
+                plt.XLabel("Focuser Position");
+                plt.YLabel("Median HFR (px)");
+                plt.Title("Focus Sweep — detector HFR vs position");
+                plt.SaveFig(path);
+            } catch (Exception ex) {
+                Logger.Warning($"V-curve PNG render failed ({ex.Message}); CSV/summary still written");
+            }
+        }
+```
+
+- [ ] **Step 2: Call it from `RunImpl`**
+
+Replace the two output lines in `RunImpl`:
+
+```csharp
+            WriteCsv(Path.Combine(outDir, "focus_sweep.csv"), rows);
+            WriteSummary(Path.Combine(outDir, "focus_sweep_summary.txt"), afRun, baseParams, rows);
+            Console.WriteLine($"Wrote focus_sweep.csv, focus_sweep_summary.txt to {outDir}");
+```
+
+with:
+
+```csharp
+            WriteCsv(Path.Combine(outDir, "focus_sweep.csv"), rows);
+            WriteSummary(Path.Combine(outDir, "focus_sweep_summary.txt"), afRun, baseParams, rows);
+            WriteVCurvePng(Path.Combine(outDir, "focus_sweep_hfr.png"), rows);
+            Console.WriteLine($"Wrote focus_sweep.csv, focus_sweep_summary.txt, focus_sweep_hfr.png to {outDir}");
+```
+
+- [ ] **Step 3: Build TestApp**
+
+```bash
+cmd.exe /c "dotnet build Joko.NINA.Plugins\TestApp\TestApp.csproj -c Debug --nologo"
+```
+Expected: build succeeds, 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Joko.NINA.Plugins/TestApp/FocusSweepDiagnosticRunner.cs
+git -c user.name="George Hilios" -c user.email="322725+ghilios@users.noreply.github.com" \
+  commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "Add focus-sweep V-curve PNG output" \
+  -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task B4: `--synthesize` (self-contained smoke fixture)
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/TestApp/FocusSweepDiagnosticRunner.cs`
+
+- [ ] **Step 1: Replace the placeholder `SynthesizeAfRun` with the real implementation**
+
+Replace the placeholder method with:
+
+```csharp
+        // Writes `count` synthetic 16-bit TIFF frames named with the saved-AF convention, with a V-shaped HFR
+        // (sharp in the middle, defocused at the ends). Lets the diagnostic be exercised end-to-end with no
+        // real data. Self-contained (cannot reference the Tests project's generators).
+        private static void SynthesizeAfRun(string dir, int count) {
+            Directory.CreateDirectory(dir);
+            const int frameSize = 128;
+            const int basePos = 10000, stepPos = 100;
+            int center = count / 2;
+            for (int i = 0; i < count; ++i) {
+                int pos = basePos + i * stepPos;
+                double sigma = 2.0 + 1.5 * Math.Abs(i - center); // V-shaped width
+                using var f = SynthFrame(frameSize, frameSize, sigma, peak: 0.6, background: 0.02);
+                using var u16 = new Mat();
+                f.ConvertTo(u16, MatType.CV_16U, ushort.MaxValue);
+                var name = $"{i:00}_Frame00_BitDepth16_Bayered0_Focuser{pos}.tif";
+                Cv2.ImWrite(Path.Combine(dir, name), u16);
+            }
+        }
+
+        // A 3x3 grid of Gaussian stars on a flat background.
+        private static Mat SynthFrame(int w, int h, double sigma, double peak, double background) {
+            var mat = new Mat(new Size(w, h), MatType.CV_32F, new Scalar(background));
+            for (int gy = 1; gy <= 3; ++gy) {
+                for (int gx = 1; gx <= 3; ++gx) {
+                    AddGaussian(mat, w * gx / 4.0, h * gy / 4.0, sigma, peak);
+                }
+            }
+            return mat;
+        }
+
+        private static void AddGaussian(Mat mat, double cx, double cy, double sigma, double peak) {
+            int w = mat.Width, h = mat.Height;
+            double inv = 1.0 / (2.0 * sigma * sigma);
+            int rad = (int)Math.Ceiling(5.0 * sigma);
+            unsafe {
+                var data = (float*)mat.DataPointer;
+                for (int y = Math.Max(0, (int)(cy - rad)); y < Math.Min(h, (int)(cy + rad)); ++y) {
+                    for (int x = Math.Max(0, (int)(cx - rad)); x < Math.Min(w, (int)(cx + rad)); ++x) {
+                        double dx = x - cx, dy = y - cy;
+                        data[y * w + x] += (float)(peak * Math.Exp(-(dx * dx + dy * dy) * inv));
+                    }
+                }
+            }
+        }
+```
+
+Note: `Cv2`, `Mat`, `Size`, `Scalar`, `MatType` are already imported via `using OpenCvSharp;`. `Size` may need disambiguation — if the build reports an ambiguous `Size`, add `using Size = OpenCvSharp.Size;` to the file's usings.
+
+- [ ] **Step 2: Build TestApp**
+
+```bash
+cmd.exe /c "dotnet build Joko.NINA.Plugins\TestApp\TestApp.csproj -c Debug --nologo"
+```
+Expected: build succeeds, 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Joko.NINA.Plugins/TestApp/FocusSweepDiagnosticRunner.cs
+git -c user.name="George Hilios" -c user.email="322725+ghilios@users.noreply.github.com" \
+  commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "Add --synthesize fixture to focus-sweep diagnostic" \
+  -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task B5: End-to-end smoke test + full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Locate the built TestApp.exe**
+
+```bash
+ls Joko.NINA.Plugins/TestApp/bin/*/Debug/net8.0-windows7.0/TestApp.exe Joko.NINA.Plugins/TestApp/bin/Debug/net8.0-windows7.0/TestApp.exe 2>/dev/null
+```
+Use whichever path exists (depends on the platform the build produced; `bin\x64\Debug\...` for x64).
+
+- [ ] **Step 2: Run synthesize + sweep with default params (no NINA profile needed)**
+
+```bash
+"<TESTAPP_EXE_PATH>" focus-sweep --synthesize "C:\temp\hf-sweep-synth" --synthesize-count 9 --default-params --out "C:\temp\hf-sweep-out"
+```
+Expected console: `Synthesized 9 frames…`, then `pos 10000: N stars` … lines, then `Wrote focus_sweep.csv, focus_sweep_summary.txt, focus_sweep_hfr.png`.
+
+- [ ] **Step 3: Verify the outputs**
+
+```bash
+cat "/mnt/c/temp/hf-sweep-out/focus_sweep.csv"
+cat "/mnt/c/temp/hf-sweep-out/focus_sweep_summary.txt"
+ls -la "/mnt/c/temp/hf-sweep-out/focus_sweep_hfr.png"
+```
+Expected: CSV has 9 position rows with non-zero `StarCount` and a `MedianHFR` column that is **smallest near the middle position (10400)** and larger at the ends (the V). Summary's "Min median-HFR position" should be near 10400. PNG exists and is non-empty. If the PNG is missing, check the logged warning — the CSV/summary are the primary evidence and the run still succeeds.
+
+- [ ] **Step 4: Run the full unit-test suite (Piece A + everything)**
+
+```bash
+rtk dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj -c Debug --nologo
+```
+Expected: all tests PASS.
+
+- [ ] **Step 5: Push the branch and open the PR**
+
+```bash
+git push -u origin ghilios/focus-sweep-evidence-base
+gh pr create --base develop --head ghilios/focus-sweep-evidence-base \
+  --title "Focus-sweep evidence base: synthetic HFR bias tests + TestApp diagnostic" \
+  --body "$(cat <<'EOF'
+Implements step 1 of the star-detection accuracy analysis (build the evidence base).
+
+## Piece A — synthetic MeasureStar bias tests (Tests project, CI)
+- `SyntheticDefocusedStarImage` (disk/annulus, supersampled, seeded noise) + `HfrGroundTruth`.
+- `MeasureStarBiasTests` pins `MeasureStar` against analytic ground truth and measures the F3
+  (soft-threshold) and F4 (σ-mismatch noise) HFR bias magnitudes; donut HFR ordering. All synthetic, deterministic.
+
+## Piece B — focus-sweep diagnostic (TestApp, local only; not in CI)
+- New `TestApp focus-sweep --af-run <dir>` reports star count, median HFR (+MAD), and per-reason rejection
+  counts vs focuser position (CSV + summary + ScottPlot V-curve PNG). `--default-params` and `--synthesize`
+  allow a data-free smoke run. Shared `LoadFloatMat`/`GetArg` extracted into `DiagnosticUtil`.
+
+No production plugin behavior changes. CI stays synthetic; no large data added.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review (completed during planning)
+
+- **Spec coverage:** Piece A generator (Task A1) ✓, ground truth (A1) ✓, clean pins (A2) ✓, F3 magnitude (A3) ✓, F4 magnitude (A4) ✓, donut sanity (A4) ✓. Piece B runner consuming a saved-AF folder (B2) ✓, CSV/summary (B2) ✓, V-curve PNG (B3) ✓, synthetic validation with no real data (B4/B5) ✓, dispatch (B2) ✓. Branch/PR/verification (B5) ✓. No-CI-data decision honored (TestApp not in CI; `--default-params`+`--synthesize` keep the smoke test data-free).
+- **Placeholder scan:** The only `NotImplementedException` is the B2 `SynthesizeAfRun` stub, explicitly replaced in B4 (and it builds in between). No TBDs.
+- **Type consistency:** `MeasureStar(Mat, Star, StarDetectorParams, double)`, `Detect(Mat, StarDetectorParams, IProgress, CancellationToken)`, `Star { Center=Point2d, StarBoundingBox=Rect, Background }`, `StarDetectorParams { AnalysisSamplingSize, StarClippingMultiplier, ModelPSF }`, `StarDetectorMetrics` field names, `HocusFocusStarDetection.BuildStarDetectorParams`, `MathUtility.MedianMAD()→(median,mad)`, `PluginOptionsAccessor.GetAssemblyGuid` — all verified against source. `DiagnosticUtil.GetArg/LoadFloatMat` names used consistently in both runners.
+
+## Risks
+
+- **Clean-test tolerances** (`Within(0.3)`): supersampling should keep the estimator within a few percent; if a value exceeds it, the logged measured/truth lines make re-tuning trivial (adjust to a documented tolerance — do not loosen blindly).
+- **ScottPlot `SaveFig` headless:** wrapped in try/catch; CSV/summary remain the primary evidence if PNG rendering fails.
+- **`--default-params` only supports `.tif`:** `LoadFloatMat` throws a clear message for XISF/FITS without a profile (real runs omit `--default-params`).

--- a/plans/star-detection-hfr-autofocus-accuracy-analysis.md
+++ b/plans/star-detection-hfr-autofocus-accuracy-analysis.md
@@ -1,0 +1,272 @@
+# Star Detection, HFR & AutoFocus Curve Fitting — Accuracy Analysis
+
+## Context
+
+Star detection is the bedrock of HocusFocus: auto-focus, aberration inspection, and sensor/tilt
+modeling all consume its outputs. This analysis assesses (1) the star detection algorithm —
+including faint-star sensitivity and robustness to defocused (donut) stars, which AF depends on at
+sweep extremes; (2) how HFR is calculated; (3) how per-star values flow into the AF routine and
+curve fitting. Every claim below was verified against the code (file:line cited), and the ten
+highest-risk quantitative claims were independently re-verified by an adversarial review pass.
+
+**Deliverable**: this report. No code changes were made — recommendations are listed for follow-up
+work to pick from.
+
+---
+
+## Executive summary
+
+The architecture is genuinely strong — robust statistics nearly everywhere (median/MAD aggregation,
+MAD-based Grubbs outlier rejection, Huber IRLS in both PSF and curve fits), a gradient-robust local
+background plane feeding every measurement, four hyperbolic models with principled Hybrid selection,
+and layered validation (R²/χ² gates, bracket check, HFR-improvement check). The weaknesses cluster
+in exactly the two areas of concern:
+
+1. **Out-of-focus stars are systematically disadvantaged** by four independent mechanisms: the
+   wavelet structure cap, the peak-based sensitivity gate, the TooFlat gate, and the WideRange
+   preset that raises (not lowers) the detection bar — its comment says the opposite of what the
+   code does.
+2. **HFR carries two opposing, defocus-dependent biases** (soft-threshold subtraction pulls it
+   down; noise inclusion through a 4–5× understated σ pushes it up), which individually distort
+   the V-curve's wings even though run-to-run consistency is preserved.
+3. **The curve-fitting weight chain has degenerate paths** (0.001 σ floor → 1000× weight; RMS
+   instead of SEM pooling; scatter-vs-precision semantics) that can let one bad point steer a
+   weighted fit, and TRENDHYPERBOLIC dilutes the sophisticated hyperbolic models 50/50 with a
+   plain trendline intersection.
+
+None of these break typical near-focus operation — which is why AF works well day to day — but
+they bound accuracy at sweep extremes and in sparse/faint fields.
+
+---
+
+## 1. How detection works (verified pipeline)
+
+`StarDetector.DetectImpl` (StarDetector.cs:150):
+
+1. Optional CFA-aware hotpixel filter (3×3 median, threshold-gated; default ON, threshold 0.001).
+2. Source image for **measurement** stays sharp by default (`StarMeasurementNoiseReductionEnabled`
+   default false); a **copy** is Gaussian-smoothed (effective default radius 4 → kernel 9, because
+   `ConfigureSimpleSettings` adds +1 when hotpixel thresholding is on, StarDetectionOptions.cs:107-110).
+3. Noise σ via `KappaSigmaNoiseEstimate` **on the smoothed copy** (CvImageUtility.cs:503-543;
+   κ=3, ≤5 iterations, first iteration unmasked).
+4. Structure map: à-trous B3-spline wavelet residual (4 layers default; largest kernel
+   2^(layers+1)+1 = 33 px) subtracted to suppress large structures (nebulae) → Gaussian blur
+   (kernel 2·layers+1) → binarize at `median + 4.0·σ_smoothed` → optional dilation (default 0).
+5. Row-scan connected components → per-candidate gates, in order: TooSmall (<5 px box) → OnBorder
+   → TooDistorted (fill factor < 0.5) → degenerate → Sensitivity (`NB/σ > 10`, where
+   `NB = peak − (1−PeakResponse)·meanFlux`) → off-center (0.3 tolerance) → **TooFlat**
+   (`median ≥ 0.75·peak`) → HFR failure → MinHFR (1.5 px) → contamination (octant residual test
+   on a robust IRLS background plane — flag + reject by default).
+6. Per-star: robust local background **plane** (Huber IRLS) used for clipping, flux, iterative
+   3-pass aperture centroid, HFR, and PSF — excellent design; gradients don't bias measurements.
+7. PSF fitting (Moffat β=4 default, alglib LM, optional Huber IRLS, R² ≥ 0.9 gate, saturated
+   pixels masked, ≥10 unsaturated pixels required) — **disabled during AF**
+   (HocusFocusStarDetection.cs:324-327), so AF always runs on HFR, never FWHM.
+
+**Strengths worth keeping**: background-plane subtraction everywhere; contamination test with 50%-
+breakdown MAD scaling; saturated stars no longer hard-rejected (masked in PSF); iterative aperture
+centroid (pinned by tests); deterministic ordering; rich rejection metrics; TestApp headless
+diagnostics.
+
+---
+
+## 2. HFR calculation (`MeasureStar`, StarDetector.cs:609-653)
+
+```
+HFR = Σ w·v·d / Σ w·v,   v = bilinear(x,y) − plane(x,y) − τ,   τ = 2.0·σ_smoothed
+```
+over a circular aperture R = min(bboxW,bboxH)/2 with a 0.5-px linear edge ramp `w`, sampled on an
+`AnalysisSamplingSize` grid (default 1.0) aligned through the centroid, bilinear-interpolated.
+
+Findings:
+
+- **It is the flux-weighted mean radius, not a true half-flux radius.** Same convention as NINA
+  core, so cross-tool comparability holds; monotonic in star width, so fine for AF. Worth
+  documenting, not changing.
+- **F3 — soft-threshold bias (confirmed).** τ is *subtracted from* each pixel's flux, not used as
+  a mere inclusion gate. For surviving pixels (f₁−τ)/(f₂−τ) > f₁/f₂ when f₁>f₂, so wing pixels
+  lose relative weight → HFR biased low, increasingly as peak/τ shrinks — i.e. for faint stars
+  and at defocus. Inconsistency: `ComputeIterativeCentroid` (StarDetector.cs:968-971) uses the
+  same margin as a **gate only** and weights by `pixel − background`. The two conventions should
+  be reconciled deliberately.
+- **F4 — σ mismatch (confirmed).** τ and the sensitivity gate use σ measured on the smoothed copy
+  while sampling the sharp image. A 9-px Gaussian kernel cuts white-noise σ ~4-5×, so effective
+  clip τ ≈ 0.4-0.5·σ_sharp and "10σ" sensitivity ≈ 2.5σ_sharp. Consequences: positive-only noise
+  pixels enter the flux sum at large radii (HFR inflated for faint stars — opposing F3), and the
+  nominal meaning of both knobs silently depends on the noise-reduction settings. When
+  `StarMeasurementNoiseReductionEnabled` is on, the mismatch disappears but HFR is inflated by the
+  blur itself (consistent within a run; absolute values shift).
+- **F14 — saturated stars are not masked in HFR** (only in PSF, which is off during AF). A
+  saturated flat top under-weights the core → HFR overestimated near focus, where saturation is
+  most likely. Median aggregation limits the damage unless many stars saturate.
+- Net curve-shape effect: F3 flattens the V-curve wings, F4 lifts faint-star HFR; both are
+  defocus-dependent with opposite signs. Run-to-run consistency is preserved (same biases each
+  run), so AF repeatability is unharmed — but the fitted minimum can shift when the star
+  population changes across the sweep (faint stars dropping out at defocus). Empirical
+  quantification needs a defocus dataset (see Recommendations).
+
+---
+
+## 3. Faint-star sensitivity
+
+- Detection is driven by the structure map (binarize at median + 4σ_smoothed on the
+  wavelet-filtered, blurred map) — coherent and effective for faint sharp stars; the smoothing
+  legitimately raises faint-star SNR before thresholding.
+- The per-candidate Sensitivity gate `NB/σ_smoothed > 10` is **peak-based**, and due to F4 is
+  effectively ~2.5σ_sharp — permissive; false positives are controlled by the shape gates and
+  MinHFR instead. Reasonable, but the knob's meaning is not what the UI number implies.
+- **F11 — `meanFlux = totalFlux / starPoints.Count`** (StarDetector.cs:1172): numerator sums only
+  clip-survivors, denominator counts all structure pixels → NB slightly inflated for faint stars
+  (loosens the gate inconsistently).
+- MinHFR=1.5 px and the hotpixel filter give good hot-pixel immunity; contamination rejection
+  (default ON) keeps blended/contaminated stars out of the HFR statistics — good for AF integrity.
+
+## 4. Out-of-focus (donut) robustness — the weakest area
+
+Four mechanisms compound against heavily defocused stars:
+
+- **F2 — wavelet cap (confirmed).** Structures at/above the residual scale (~16-32 px for 4
+  layers; largest kernel 33 px, cumulative support 61 px) are strongly attenuated before
+  binarization. Big donuts fade out of the structure map. The post-wavelet blur and dilation
+  smooth what survives but cannot restore subtracted amplitude.
+- **WideRange preset contradiction (confirmed).** `Simple_FocusRange=WideRange` raises
+  StructureLayers 4→5 (good) **and raises** BrightnessSensitivity 10→12 — the comment says "we
+  want to be more sensitive" but a higher threshold is *less* sensitive
+  (StarDetectionOptions.cs:89-93). For the one preset aimed at defocus, the second change works
+  against the first.
+- **F1 — TooFlat gate (confirmed).** Reject when `median ≥ 0.75·peak` over clip-surviving pixels
+  (StarDetector.cs:831). A defocused annulus/plateau has median/peak → 0.8-1.0 once amplitude
+  ≳ 7-10σ — i.e. precisely bright defocused stars; noise on the peak statistic is what lets
+  marginal ones through. No AF-specific override exists (GetStarDetectorParams only flips
+  ModelPSF/save-path).
+- **Peak-based sensitivity** (§3) penalizes defocused stars whose flux is spread thin.
+
+Also relevant: `MaxDistortion=0.5` rejects surviving *un-filled* rings with hole radius >~60% of
+the outer radius (fill factor < 0.5), though wavelet+blur usually fills small holes. The AF engine
+inherits all of this unchanged — there is no defocus-aware parameter adaptation along the sweep,
+even though the engine knows exactly how far from focus each exposure is.
+
+## 5. Aggregation: stars → one AF measurement
+
+(HocusFocusStarDetection.cs:334-433)
+
+- Default `MeasurementAverage=Median`: **AverageHFR = median** of per-star HFRs, **HFRStdDev =
+  1.483·MAD** (σ-consistent). `MeanOutliers` alternative: median±3/4·MAD pre-filter then mean +
+  sample stddev. Robust, good defaults.
+- PSF stats (FWHM/eccentricity medians+MADs) are computed only when PSF is on — i.e. not during AF.
+- **F8 — "brightest N AF stars" score units mismatch (confirmed).**
+  `OrderByDescending(s => s.HFR*0.3 + s.MeanBrightness*0.7)` (line 404): HFR is in pixels (≥1.5 by
+  the MinHFR gate), MeanBrightness is normalized [0,1] flux/pixel — the HFR term dominates, so the
+  selection prefers the *largest-HFR* objects (extended objects, blends), and it runs on the first
+  AF exposure, which is taken at maximum defocus. Subsequent frames then position-match to those
+  picks with **no distance cap and possible duplicates** (line 409, Aggregate over min distance).
+  Only affects users with NINA's "use brightest N stars" > 0.
+- **F9 — ROI offset drops fields (confirmed).** `Star.AddOffset` (CvImageUtility.cs:561-570)
+  copies only Center/BBox/Background/MeanBrightness/HFR/PSF — `PeakBrightness`,
+  `BackgroundPlane`, `StarContaminationSuspected` are silently zeroed for every ROI detection
+  (the common AF inner-crop path): MaxBrightness=0 in results, contamination flags wiped.
+
+## 6. AF routine & curve fitting
+
+(AutoFocusEngine.cs; AlglibHyperbolicFitting.cs)
+
+Flow (verified): initial HFR at start position (FramesPerPoint frames, mean of sub-measurements) →
+overshoot out by (offsetSteps+1)·stepSize, walk back in measuring offsetSteps points → extend left
+or right until the **NINA trendline fit** has ≥offsetSteps points on one side and ≥1 on the other →
+fit curves on every point completion → validate → move → re-measure → require
+`finalHFR ≤ initialHFR·(1+0.15)`. Failure paths: ≥offsetSteps zero-measure points →
+`TooManyFailedMeasurementsException`; up to TotalNumberOfAttempts retries. Backlash is delegated to
+NINA's focuser mediator.
+
+Per-point: `MeasureAndError{ Measure=AverageHFR, Stdev=HFRStdDev }` → multi-frame
+`AverageMeasurement` → `ScatterErrorPoint(pos, hfr, 0, max(0.001, σ))`; weighted fits use
+`w = 1/max(|ErrorY|, 1e-6)` (default `WeightedHyperbolicFitEnabled=true`).
+
+Fitting machinery (strong): four models — Symmetric (4p), UnevenBlend (5p, C⁰ ramp, deprecated),
+**TiltedHyperbola** (5p, smooth skew, live default), SmoothBlend (5p, logistic blend) — all alglib
+LM with bounds, data-driven seeds, optional Huber IRLS (δ=1.5·MAD, ≤10 iters), weighted R²,
+weighted χ², JᵀWJ delta-method `MinimumStdError` (with span-based degeneracy suppression), LOO
+stability diagnostic. **Hybrid** fits all four with *per-model* Grubbs rejection, requires a finite
+in-range minimum, ranks by σ(focus) → LOO → χ²_red → R². Grubbs uses median/MAD residuals with
+weight-matched scaling — well done.
+
+Findings:
+
+- **F5 — weight floor (confirmed).** A point with MAD=0 (2 stars with near-identical HFR, or the
+  F5b invalid-σ path) gets ErrorY=0.001 → weight 1000 vs typical 2-20 → it dominates the weighted
+  fit ~(50-500)× per unit residual; Huber IRLS and Grubbs won't catch it because LM pins the curve
+  to it (its residual is minimized by construction). No relative-weight cap exists.
+  **F5b**: `AverageMeasurement` (CvImageUtility.cs:607-637) — once one frame has σ≤0/NaN,
+  accumulation stops for all later frames but the divisor still counts them → underestimated σ;
+  the invalid flag is never surfaced.
+- **F6 — σ semantics (confirmed).** ErrorY is the star-ensemble scatter (field tilt/curvature/
+  seeing spread), not the median's precision (≈1.2533·σ/√N*); multi-frame pooling is RMS, not SEM,
+  so FramesPerPoint does not reduce reported σ. Relative weighting across the sweep is still
+  sensible (scatter grows with defocus), and `MinimumStdError` is **immune** to uniform σ scaling
+  (s²-rescaled covariance — verified). Casualty: `ReducedChiSquared` runs ≪1 when many stars are
+  detected, so the χ²>5 rejection gate (when selected) almost never trips; default criterion is
+  R², so most users are unaffected.
+- **F7 — TRENDHYPERBOLIC averaging (confirmed).** Final position = round((trendline intersection +
+  hyperbolic minimum)/2) (AutoFocusEngine.cs:351-357). The Hybrid/asymmetric machinery determines
+  only half the answer; a biased trendline intersection (asymmetric curve, asymmetric sampling)
+  shifts the result by half its bias regardless of hyperbolic quality. Only the bracket check
+  bounds it. (Whether TRENDHYPERBOLIC is the active default is NINA-profile data, outside this
+  repo.)
+- **F12 — inconsistent outlier weighting**: parabolic Grubbs passes no weights
+  (AutoFocusEngine.cs:123) while hyperbolic does (line 132).
+- Sensor-model (inspection) per-star curves: per-star σ_HFR = HFR/max(SNR,1) proxy, per-star
+  R²≥0.90 gate (named constant), paraboloid surface fit — reasonable; inspection-only, not in the
+  AF position path.
+
+## 7. Test coverage gaps (Tests project)
+
+PSF parameter recovery, eccentricity/FWHM formulas, iterative centroid, and the fitting models are
+well pinned. **Not tested**: the HFR formula itself (no synthetic-star MeasureStar test), donut
+/defocused-star detection (no annular synthetic generator), contamination octant math, saturation
+masking, pixel-integration options.
+
+---
+
+## 8. Ranked findings
+
+| # | Severity | Finding | Where |
+|---|----------|---------|-------|
+| F1 | High | TooFlat gate (median ≥ 0.75·peak) rejects bright defocused/flat-top stars; no AF override | StarDetector.cs:831 |
+| F2 | High | Wavelet residual subtraction attenuates large donuts; WideRange raises the sensitivity bar too (comment contradicts code) | StarDetector.cs:241; StarDetectionOptions.cs:89-93 |
+| F3 | High | HFR soft-threshold subtraction biases HFR low, defocus/faintness-dependent; inconsistent with centroid's gate-only convention | StarDetector.cs:638 |
+| F4 | High | σ-based thresholds on the sharp image use smoothed-image σ (~4-5× small) by default | StarDetector.cs:225-233,301 |
+| F5 | Medium | 0.001 ErrorY floor → 1000× fit weight; invalid-σ accumulation bug underestimates pooled σ | AutoFocusEngine.cs:695; CvImageUtility.cs:607-637 |
+| F6 | Medium | Per-point σ = ensemble scatter, RMS-pooled (not SEM); χ²_red ≪ 1 → χ² gate toothless when enabled | AutoFocusEngine.cs:592,712; AlglibHyperbolicFitting.cs:561-572 |
+| F7 | Medium | TRENDHYPERBOLIC: 50/50 average with plain trendline intersection halves the asymmetric models' influence | AutoFocusEngine.cs:351-357 |
+| F8 | Medium | AF star selection score mixes pixels with [0,1] flux → largest-HFR wins; unbounded/duplicate position matching | HocusFocusStarDetection.cs:404,409 |
+| F9 | Medium | ROI AddOffset drops PeakBrightness/BackgroundPlane/contamination flag on AF-crop runs | CvImageUtility.cs:561-570 |
+| F10 | Low | ResetDefaults: StarPeakResponse 0.6 vs 0.75; writes simple_FocusRange backing field (no persist/notify) | StarDetectionOptions.cs:191,203 |
+| F11 | Low | NormalizedBrightness meanFlux numerator/denominator mismatch | StarDetector.cs:1172,1217 |
+| F12 | Low | Parabolic Grubbs unweighted vs hyperbolic weighted | AutoFocusEngine.cs:123,132 |
+| F13 | Low | KappaSigma first iteration unmasked; 5-iteration cap | CvImageUtility.cs:516-521 |
+| F14 | Low | Saturated pixels unmasked in HFR (and PSF is off during AF) | StarDetector.cs:609-653 |
+
+## 9. Recommended follow-ups (prioritized)
+
+1. **Build the evidence base first**: extend TestApp with a `focus-sweep` diagnostic (run detection
+   over a saved AF image sequence; report star count, HFR, rejection-reason histogram vs focuser
+   position) + add a synthetic annular/defocused star generator and unit tests pinning `MeasureStar`
+   (none exist today). This converts F1-F4 from "mechanism confirmed" to measured magnitudes before
+   touching production behavior.
+2. **Defocus robustness** (F1/F2): relax or context-gate TooFlat for AF (e.g. via the existing
+   isAutoFocus override point in GetStarDetectorParams), fix the WideRange sensitivity direction,
+   consider deriving StructureLayers from expected max HFR (the engine knows sweep geometry).
+3. **σ consistency** (F4): scale σ for the measurement image (analytic factor for a Gaussian
+   kernel) or estimate σ on the image actually measured; then revisit τ semantics (F3) — gate-only
+   like the centroid, or document the subtraction as intentional smoothing of the V-curve.
+4. **Weight-chain hygiene** (F5/F6): floor ErrorY at a fraction of the median ErrorY (or cap
+   relative weights), fix the invalidStdDev accumulation, divide pooled σ by √FramesPerPoint, and
+   recalibrate or document the χ² gate.
+5. **F7-F14** as small independent fixes (one-liners to small patches each).
+
+---
+
+**Verification of this analysis**: all file:line citations were read directly; the ten highest-risk
+quantitative claims were independently re-verified by an adversarial reviewer against the code (all
+confirmed; two refinements incorporated: effective default noise kernel is 9 px, and NINA-profile
+defaults are outside this repo's purview).


### PR DESCRIPTION
Implements step 1 of the star-detection accuracy analysis (build the evidence base) — turning the confirmed-by-mechanism HFR/detection findings into measured numbers, with **no production plugin behavior changes**. CI stays 100% synthetic; no large data added.

## Piece A — synthetic MeasureStar bias tests (Tests project, runs in CI)
- `SyntheticDefocusedStarImage` — uniform disk / annular donut (supersampled, optional edge blur) + seeded Gaussian noise.
- `HfrGroundTruth` — closed-form + numerical flux-weighted-mean-radius truth (with a self-test).
- `MeasureStarBiasTests` — pins `MeasureStar` against analytic truth (disk → 2a/3, annulus, Gaussian → 1.2533σ), then **measures the F3 soft-threshold downward bias** (monotonic in τ; relative bias grows for fainter stars; uniform disk is τ-invariant — isolating why the bias needs a gradient) and the **F4 understated-σ noise inflation**, plus donut-vs-disk HFR ordering. All deterministic; magnitudes logged via `TestContext`.

## Piece B — focus-sweep diagnostic (TestApp, local only; not in CI)
- New `TestApp focus-sweep --af-run <dir>` replays a saved AutoFocus run through detection and reports star count, median HFR (+robust MAD), and per-reason rejection counts vs focuser position → `focus_sweep.csv`, `focus_sweep_summary.txt`, and a ScottPlot V-curve `focus_sweep_hfr.png`. `ModelPSF` is forced off to mirror real AutoFocus.
- `--default-params` (skip profile) and `--synthesize` (generate a V-shaped fixture) allow a fully data-free smoke run. Verified end-to-end: 9/9 positions detect stars, median HFR forms a clean V (min at the central position), PNG renders headless.
- Shared `LoadFloatMat`/`GetArg` extracted into `DiagnosticUtil` (verbatim relocation; contamination runner behavior unchanged).

## Verification
- Full unit suite: **858 passed**.
- TestApp builds clean; focus-sweep smoke run produces the expected V-curve CSV/summary/PNG.

Design spec and task plan included under `plans/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)