### PR TITLE
Star Detection Optimization Wizard + optimizer perf (~10–13×) + defocus-aware donut recovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -661,6 +661,63 @@ set's median gradient slope/eccentricity vs sensitivity, from a single run); plu
 flag is false the detector fills no per-sector residual arrays and skips the diagnostic record (the plane fit
 + decision always run, since they are the production background/contamination path).
 
+### Star Detection Optimizer harnesses (`TestApp optimize` / `TestApp review`)
+
+The Star Detection Optimization Wizard ships with two `TestApp` subcommands that drive the **same**
+`StarDetectionOptimizer` the live wizard uses, so the optimizer can be exercised/tuned offline. Both load the
+user's real NINA profile and build the seed via `BuildStarDetectorParams` plus the AF overrides (`ModelPSF=false`,
+`Region=Full`, `SaveIntermediateFilesPath=""`, `PixelScale` from the profile × binning=1 for raw Mats). Both are
+**read-only with respect to the profile/options** (they never call a settings setter or touch the options
+accessor — NINA auto-saves the active profile, so mutating options would silently rewrite the user's settings).
+
+**`TestApp.exe optimize`** — headless driver of the optimizer. Args:
+`--runs <folder>` (required), `--per-run` (flag), `--profile-id <guid>` (default active), `--out <dir>`
+(default `%LOCALAPPDATA%\NINA\Logs\hf-diag\optimize\<timestamp>`), `--max-evals <int>` (override the
+optimizer budget), `--annotate extremes|all` (default `extremes` = min/max-focuser frames only),
+`--labels <dir>`.
+
+- **Run discovery is attempt-anchored** (pure logic in `OptimizationRunDiscovery`): it recursively finds
+  `attempt<NN>` folders (1–4 levels under `--runs`) that contain ≥3 distinct focuser positions, mirroring
+  `RunEvaluationData.MinPositionsForFit = 3`. Single-frame `final`/`initial` validation folders and frameless
+  `attempt` folders are skipped (recorded with a reason, not silently dropped). Back-compat: pointing `--runs`
+  directly at an `attempt01` folder works. Fallback: if no `attempt*` folders exist anywhere, each immediate
+  subfolder with ≥3 positions is a run. Frame filenames match `0_Frame1_BitDepth16_Bayered0_Focuser5000.fits`.
+- **Default = joint** optimization: all discovered runs are optimized together (N=1 reduces to a single run;
+  N>1 is the balanced blend). **Only group runs from the SAME optical setup** — a joint objective across
+  different cameras/scopes is meaningless. **`--per-run`** optimizes each discovered run independently, writing
+  one subfolder per run plus a top-level `aggregate_summary.txt` (one scannable row per run: load OK/failed,
+  hard-floor PASS/FAIL with min star count, seed→best J, σ_focus, recommended step, changed params). Use
+  `--per-run` to verify across a bank of many different setups in one command.
+- Detection deliberately scores the **full accepted-star set** (NumberOfAFStars=0 — no brightest-N trim),
+  matching the wizard's `RunEvaluationLoader` (HFR aggregation at the `HocusFocusDetectionParams` defaults,
+  high=4.0 / low=3.0; this is the loader path, NOT the live AF path). The whole-frame detection also keeps the
+  harness useful for sensor-modeling work.
+- Outputs (in `--out`, or per-run subfolders): `optimize_summary.txt` (seed→optimized `J`, per-run σ_focus /
+  R² / reducedχ², recommended step size, curated params old→new with `*` markers, hard-floor check, per-frame
+  star counts), `optimize_result.csv`, and stretched annotated PNG(s) (accepted = green circle + HFR; rejected
+  color-coded by reason from `StarDetectorMetrics.*Bounds`; **a real star with no marker = missed entirely**);
+  `--per-run` also writes `aggregate_summary.txt`. Verbose TRACE in `%LOCALAPPDATA%\NINA\Logs`.
+
+```bash
+./Joko.NINA.Plugins/TestApp/bin/Debug/net8.0-windows7.0/TestApp.exe \
+  optimize --runs "C:\Users\me\AppData\Local\NINA\AutoFocus" --out "C:\temp\hf-opt" --per-run
+```
+
+**`TestApp.exe review`** — interactive two-pass labeling dev tool (WPF; produces labels only). Args:
+`--runs <folder>` (required), `--labels <dir>` (default `<runs>\labels`; read+written, feeds `optimize --labels`),
+`--params optimized|current` (default `current` = profile-as-configured seed; `optimized` overlays the saved
+optimized snapshot), `--review low|uncertain|all` (default `low` = frames with `< N_review` accepted stars;
+`uncertain` adds the defocused extremes; `all`), `--profile-id <guid>`.
+
+- Detects every queued frame once, shows MTF-stretched frames with accepted/rejected-by-reason overlays (colors
+  match `optimize`'s PNG legend), zoom/pan, and two click modes: **Mark Missed** (false negatives → recall) and
+  **Mark Should-Reject** (false positives → precision). Labels reload incrementally (re-running merges).
+- The label JSON is consumed by `optimize --labels <dir>` to activate the objective's recall/precision term.
+  One file per run (`<runId>.json`, or any `*.json` whose embedded `runId` matches a discovered run); shape:
+  `{ "runId", "radiusPx", "positions": [ { "focuserPosition", "radiusPx"?, "missed": [{x,y}], "shouldReject": [{x,y}] } ] }`.
+- **Loop:** `optimize` (baseline) → `review --labels L` (mark misses / false positives) →
+  `optimize --labels L` (re-optimize with the recall/precision term active).
+
 ---
 
 ## Key File Locations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -661,20 +661,33 @@ set's median gradient slope/eccentricity vs sensitivity, from a single run); plu
 flag is false the detector fills no per-sector residual arrays and skips the diagnostic record (the plane fit
 + decision always run, since they are the production background/contamination path).
 
-### Star Detection Optimizer harnesses (`TestApp optimize` / `TestApp review`)
+### Star Detection Optimizer harnesses (`TestApp optimize` / `review` / `diagnose-labels`)
 
-The Star Detection Optimization Wizard ships with two `TestApp` subcommands that drive the **same**
-`StarDetectionOptimizer` the live wizard uses, so the optimizer can be exercised/tuned offline. Both load the
+The Star Detection Optimization Wizard ships with `TestApp` subcommands that drive the **same**
+`StarDetectionOptimizer` the live wizard uses, so the optimizer can be exercised/tuned offline. They load the
 user's real NINA profile and build the seed via `BuildStarDetectorParams` plus the AF overrides (`ModelPSF=false`,
-`Region=Full`, `SaveIntermediateFilesPath=""`, `PixelScale` from the profile × binning=1 for raw Mats). Both are
+`Region=Full`, `SaveIntermediateFilesPath=""`, `PixelScale` from the profile × binning=1 for raw Mats). All are
 **read-only with respect to the profile/options** (they never call a settings setter or touch the options
 accessor — NINA auto-saves the active profile, so mutating options would silently rewrite the user's settings).
+
+> **Perf:** detection is split into a cacheable EARLY context (`BuildDetectionContext`) + a cheap LATE
+> `GateAndMeasure`; `RunEvaluationData` caches the early context per (frame, early-key) and reuses it across
+> late-only candidate moves, plus bounded parallel per-frame detection. **Bit-identical, ~10–13× faster**, and
+> it benefits BOTH the live wizard and replay (both converge on `RunEvaluationLoader` → `RunEvaluationData` →
+> `HocusFocusSplitFrameDetector`). See `docs/star-detection-optimizer-performance-design.md`.
 
 **`TestApp.exe optimize`** — headless driver of the optimizer. Args:
 `--runs <folder>` (required), `--per-run` (flag), `--profile-id <guid>` (default active), `--out <dir>`
 (default `%LOCALAPPDATA%\NINA\Logs\hf-diag\optimize\<timestamp>`), `--max-evals <int>` (override the
-optimizer budget), `--annotate extremes|all` (default `extremes` = min/max-focuser frames only),
-`--labels <dir>`.
+optimizer budget; wizard default 400), `--annotate extremes|all` (default `extremes` = min/max-focuser frames
+only), `--labels <dir>` (label JSON dir; activates the recall/precision objective term), `--verbose` (restore
+TRACE logging; default INFO). Opt-in defocus-gate test switches (flip the gates ON on the built params only —
+do NOT touch the profile): `--defocus-distortion` (relax `MaxDistortion` for large/defocused candidates) and
+`--defocus-centering` (relax the centering gate); tuning overrides `--defocus-size-ref <px>` (strict-below
+size ref, shared by both gates; param default 30), `--defocus-min-factor <0..1>` (MaxDistortion floor; default
+0.25), `--defocus-center-factor <≥1>` (max StarCenterTolerance multiplier; default 2.0). It writes
+`optimized_settings.json` into **each focus run's source folder** (the review handoff) **and** the `--out`
+dir (or each per-run subfolder).
 
 - **Run discovery is attempt-anchored** (pure logic in `OptimizationRunDiscovery`): it recursively finds
   `attempt<NN>` folders (1–4 levels under `--runs`) that contain ≥3 distinct focuser positions, mirroring
@@ -703,20 +716,45 @@ optimizer budget), `--annotate extremes|all` (default `extremes` = min/max-focus
   optimize --runs "C:\Users\me\AppData\Local\NINA\AutoFocus" --out "C:\temp\hf-opt" --per-run
 ```
 
-**`TestApp.exe review`** — interactive two-pass labeling dev tool (WPF; produces labels only). Args:
-`--runs <folder>` (required), `--labels <dir>` (default `<runs>\labels`; read+written, feeds `optimize --labels`),
-`--params optimized|current` (default `current` = profile-as-configured seed; `optimized` overlays the saved
-optimized snapshot), `--review low|uncertain|all` (default `low` = frames with `< N_review` accepted stars;
-`uncertain` adds the defocused extremes; `all`), `--profile-id <guid>`.
+**`TestApp.exe review`** — interactive box-based labeling dev tool (WPF; produces labels only;
+**read-only on the profile**). Args: `--runs <folder>` (required), `--labels <dir>` (default `<runs>\labels`;
+read+written, feeds `optimize --labels`), `--params current|optimized` (default `current`), `--opt-results
+<dir>` (folder holding `optimized_settings.json`), `--review low|uncertain|all` (default `low` = frames with
+`< N_review` accepted stars; `uncertain` adds the defocused extremes; `all`), `--profile-id <guid>`.
 
+- **`--params optimized` load priority:** (1) explicit `--opt-results <dir>/optimized_settings.json`, then (2)
+  auto-discover `<runFolder>/optimized_settings.json` (where `optimize` wrote it), then (3) the profile
+  snapshot `options.GetOptimizedSettings()`, else (4) fall back to `current`.
 - Detects every queued frame once, shows MTF-stretched frames with accepted/rejected-by-reason overlays (colors
-  match `optimize`'s PNG legend), zoom/pan, and two click modes: **Mark Missed** (false negatives → recall) and
-  **Mark Should-Reject** (false positives → precision). Labels reload incrementally (re-running merges).
-- The label JSON is consumed by `optimize --labels <dir>` to activate the objective's recall/precision term.
-  One file per run (`<runId>.json`, or any `*.json` whose embedded `runId` matches a discovered run); shape:
-  `{ "runId", "radiusPx", "positions": [ { "focuserPosition", "radiusPx"?, "missed": [{x,y}], "shouldReject": [{x,y}] } ] }`.
-- **Loop:** `optimize` (baseline) → `review --labels L` (mark misses / false positives) →
-  `optimize --labels L` (re-optimize with the recall/precision term active).
+  match `optimize`'s PNG legend), zoom/pan, and **thick, zoom-invariant** markers. **Three box-based label
+  categories:** **missed** (false negative → recall) = drag a box on a real star with no marker;
+  **should-reject** (false positive → precision) = click an **accepted** box; **wrongly-rejected** (recall) =
+  click a **rejected** box. Labels reload incrementally (re-running merges).
+- The label JSON is consumed by `optimize --labels <dir>` to activate the objective's recall/precision term
+  (recall/precision are scored by **box containment**). One file per run (`<runId>.json`, or any `*.json` whose
+  embedded `runId` matches a discovered run); each labeled box carries a bounding box (legacy point-only files
+  auto-load with a default box).
+
+**`TestApp.exe diagnose-labels`** — classifies each labeled box against a fresh detection of the same frame to
+find **which gate rejects** flagged stars. Per box: **ACCEPTED** (overlaps an accepted star) /
+**REJECTED:<reason>** (overlaps a rejected candidate — reports the gate: TooDistorted, NotCentered, TooFlat,
+LowSensitivity, Saturated, Degenerate, Contaminated) / **NO CANDIDATE** (no candidate formed there = a true
+structure-detection gap, only fixable by detector-algorithm work). Args: `--runs` (required), `--labels`
+(default `<runs>\labels`), `--params current|optimized`, `--opt-results <dir>` (same load priority as
+`review`), `--profile-id`, `--out <dir>` (writes `diagnose_labels.txt`), plus the same opt-in defocus switches
+as `optimize` (`--defocus-distortion` / `--defocus-centering` / `--defocus-size-ref` / `--defocus-min-factor`
+/ `--defocus-center-factor`). Read-only on the profile.
+
+- **Loop:** `optimize` (baseline) → `review --labels L` (drag-box misses / click false positives / click
+  wrongly-rejected) → `optimize --labels L` (re-optimize with the box-containment recall/precision term
+  active). Use `diagnose-labels` to attribute each labeled miss to a specific gate vs. a structure gap.
+
+**Defocus-aware gates (Advanced options).** `StarDetectionOptions.DefocusAwareDistortion` and
+`DefocusAwareCentering` (both **opt-in, default OFF**, Advanced-only with CheckBox + tooltip in
+`OptionsDataTemplates.xaml`) relax the distortion / centering gates for large candidates (large size = defocus
+proxy) to recover bloated/donut defocused stars. Default-OFF returns the gates verbatim, keeping detection
+**bit-identical**. Tuned via the param fields `DefocusDistortionSizeReference` (30 px), `DefocusDistortionMinFactor`
+(0.25), `DefocusCenteringToleranceFactor` (2.0).
 
 ---
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj
@@ -21,6 +21,7 @@
     <Compile Include="..\TestApp\StarReview\StarReviewLabels.cs" Link="StarReview\StarReviewLabels.cs" />
     <Compile Include="..\TestApp\StarReview\StarReviewQueue.cs" Link="StarReview\StarReviewQueue.cs" />
     <Compile Include="..\TestApp\StarReview\StarReviewViewport.cs" Link="StarReview\StarReviewViewport.cs" />
+    <Compile Include="..\TestApp\OptimizationRunDiscovery.cs" Link="StarReview\OptimizationRunDiscovery.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj
@@ -14,6 +14,15 @@
     <ProjectReference Include="..\Joko.NINA.Plugins.HocusFocus\Joko.NINA.Plugins.HocusFocus.csproj" />
   </ItemGroup>
 
+  <!-- The TestApp project is a WPF Exe (not referenced as an assembly), so its pure-logic StarReview helpers are
+       linked in directly for unit testing — the same pattern the test project uses for other shared source. Only
+       the IO/JSON/queue/viewport files (no WPF, no plugin coupling) are linked; the WPF window/VM are not. -->
+  <ItemGroup>
+    <Compile Include="..\TestApp\StarReview\StarReviewLabels.cs" Link="StarReview\StarReviewLabels.cs" />
+    <Compile Include="..\TestApp\StarReview\StarReviewQueue.cs" Link="StarReview\StarReviewQueue.cs" />
+    <Compile Include="..\TestApp\StarReview\StarReviewViewport.cs" Link="StarReview\StarReviewViewport.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationObjectiveTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationObjectiveTests.cs
@@ -1,0 +1,373 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Optimization;
+
+[TestFixture]
+public class OptimizationObjectiveTests {
+
+    private static ObjectiveConstants C => new ObjectiveConstants();
+
+    // ---- SFocus ----
+
+    [Test]
+    public void SFocus_DecreasesMonotonicallyInSigma() {
+        var c = C;
+        // Smaller sigma (sharper focus relative to step) => higher score.
+        var sLow = OptimizationObjective.SFocus(sigmaFocus: 0.10, looStdError: double.NaN, stepSize: 1.0, c);
+        var sMid = OptimizationObjective.SFocus(sigmaFocus: 0.25, looStdError: double.NaN, stepSize: 1.0, c);
+        var sHigh = OptimizationObjective.SFocus(sigmaFocus: 1.0, looStdError: double.NaN, stepSize: 1.0, c);
+        Assert.Multiple(() => {
+            Assert.That(sLow, Is.GreaterThan(sMid));
+            Assert.That(sMid, Is.GreaterThan(sHigh));
+            Assert.That(sLow, Is.LessThanOrEqualTo(1.0));
+            Assert.That(sHigh, Is.GreaterThan(0.0));
+        });
+    }
+
+    [Test]
+    public void SFocus_AtRhoRef_IsOneHalf() {
+        var c = C; // RhoRef = 0.25
+        // rho = sigma/stepSize = RhoRef => 1/(1+1) = 0.5
+        var s = OptimizationObjective.SFocus(sigmaFocus: 0.25, looStdError: double.NaN, stepSize: 1.0, c);
+        Assert.That(s, Is.EqualTo(0.5).Within(1e-12));
+    }
+
+    [Test]
+    public void SFocus_FallsBackToLooStdError_WhenSigmaNotFinite() {
+        var c = C;
+        var fromLoo = OptimizationObjective.SFocus(sigmaFocus: double.NaN, looStdError: 0.25, stepSize: 1.0, c);
+        var direct = OptimizationObjective.SFocus(sigmaFocus: 0.25, looStdError: double.NaN, stepSize: 1.0, c);
+        Assert.That(fromLoo, Is.EqualTo(direct).Within(1e-12));
+    }
+
+    [Test]
+    public void SFocus_BothSigmaNonFinite_ReturnsNaN() {
+        var c = C;
+        var s = OptimizationObjective.SFocus(sigmaFocus: double.NaN, looStdError: double.NaN, stepSize: 1.0, c);
+        Assert.That(double.IsNaN(s), Is.True);
+    }
+
+    // ---- SStars ----
+
+    [Test]
+    public void SStars_IncreasesWithCounts() {
+        var c = C;
+        var low = OptimizationObjective.SStars(new[] { 2, 3, 4 }, c);
+        var high = OptimizationObjective.SStars(new[] { 30, 40, 50 }, c);
+        Assert.That(high, Is.GreaterThan(low));
+    }
+
+    [Test]
+    public void SStars_NMinDominates_PerWeights() {
+        var c = C; // 0.6 * min-term + 0.4 * median-term, NFloor=8, NTarget=20
+        // Case A: a single low frame drags nMin down even with high median.
+        var aMin = 0; // nMin -> 0
+        var manyHigh = Enumerable.Repeat(40, 9).ToList();
+        var withOneZero = new List<int> { aMin };
+        withOneZero.AddRange(manyHigh);
+        var scoreWithZero = OptimizationObjective.SStars(withOneZero, c);
+        // All-high frames score much higher because the min term is satisfied.
+        var allHigh = OptimizationObjective.SStars(manyHigh, c);
+        Assert.That(allHigh, Is.GreaterThan(scoreWithZero));
+        // The min term carries 0.6 weight: with nMin=0 the score can be at most 0.4 (the median term).
+        Assert.That(scoreWithZero, Is.LessThanOrEqualTo(0.4 + 1e-12));
+    }
+
+    [Test]
+    public void SStars_ClampsAtOne() {
+        var c = C;
+        var s = OptimizationObjective.SStars(new[] { 1000, 2000, 3000 }, c);
+        Assert.That(s, Is.EqualTo(1.0).Within(1e-12));
+    }
+
+    [Test]
+    public void SStars_AtFloorAndTarget_GivesFullSubScores() {
+        var c = C; // NFloor=8, NTarget=20
+        // nMin = 8 -> min-term clamps to 1.0; median = 20 -> median-term clamps to 1.0 -> total 1.0
+        var s = OptimizationObjective.SStars(new[] { 8, 20, 20 }, c);
+        Assert.That(s, Is.EqualTo(1.0).Within(1e-12));
+    }
+
+    // ---- SFit ----
+
+    [Test]
+    public void SFit_PenaltyIsOne_BelowChiTau() {
+        var c = C; // ChiTau = 2.0
+        var s = OptimizationObjective.SFit(rSquared: 1.0, reducedChiSquared: 1.0, c);
+        Assert.That(s, Is.EqualTo(1.0).Within(1e-12));
+    }
+
+    [Test]
+    public void SFit_PenaltyIsOne_WhenChiSquaredNaN() {
+        var c = C;
+        var s = OptimizationObjective.SFit(rSquared: 0.8, reducedChiSquared: double.NaN, c);
+        Assert.That(s, Is.EqualTo(0.8).Within(1e-12));
+    }
+
+    [Test]
+    public void SFit_PenaltyDecreasesAboveChiTau() {
+        var c = C; // penalty = ChiTau / reducedChiSquared above the knee
+        var atKnee = OptimizationObjective.SFit(rSquared: 1.0, reducedChiSquared: 2.0, c);
+        var above = OptimizationObjective.SFit(rSquared: 1.0, reducedChiSquared: 4.0, c);
+        var wayAbove = OptimizationObjective.SFit(rSquared: 1.0, reducedChiSquared: 8.0, c);
+        Assert.Multiple(() => {
+            Assert.That(atKnee, Is.EqualTo(1.0).Within(1e-12));
+            Assert.That(above, Is.LessThan(atKnee));
+            Assert.That(wayAbove, Is.LessThan(above));
+            // ChiTau/4 = 0.5, ChiTau/8 = 0.25
+            Assert.That(above, Is.EqualTo(0.5).Within(1e-12));
+            Assert.That(wayAbove, Is.EqualTo(0.25).Within(1e-12));
+        });
+    }
+
+    [Test]
+    public void SFit_MultipliesClampedRSquared() {
+        var c = C;
+        // R^2 negative -> clamps to 0; high chi -> still 0.
+        var sNeg = OptimizationObjective.SFit(rSquared: -3.0, reducedChiSquared: 1.0, c);
+        Assert.That(sNeg, Is.EqualTo(0.0).Within(1e-12));
+        // R^2 above 1 clamps to 1.
+        var sBig = OptimizationObjective.SFit(rSquared: 1.5, reducedChiSquared: 1.0, c);
+        Assert.That(sBig, Is.EqualTo(1.0).Within(1e-12));
+    }
+
+    // ---- JRun ----
+
+    private static RunEvaluationMetrics GoodRun(double sigmaFocus = 0.05, int frameCount = 10, int starsPerFrame = 40) {
+        return new RunEvaluationMetrics {
+            SigmaFocus = sigmaFocus,
+            LooStdError = double.NaN,
+            StepSize = 1.0,
+            RSquared = 0.99,
+            ReducedChiSquared = 1.0,
+            FrameStarCounts = Enumerable.Repeat(starsPerFrame, frameCount).ToList()
+        };
+    }
+
+    [Test]
+    public void JRun_HardFails_OnNaNFocus() {
+        var c = C;
+        var m = GoodRun();
+        m.SigmaFocus = double.NaN;
+        m.LooStdError = double.NaN;
+        var j = OptimizationObjective.JRun(m, c);
+        Assert.That(j, Is.EqualTo(0.0));
+    }
+
+    [Test]
+    public void JRun_HardFails_WhenTooManyFramesBelowHardFloor() {
+        var c = C; // NHard=3, MaxFramesBelowHardFloor=0
+        var m = GoodRun(frameCount: 10, starsPerFrame: 40);
+        // Inject one frame below the hard floor (2 < 3).
+        var counts = m.FrameStarCounts.ToList();
+        counts[0] = 2;
+        m.FrameStarCounts = counts;
+        var j = OptimizationObjective.JRun(m, c);
+        Assert.That(j, Is.EqualTo(0.0));
+    }
+
+    [Test]
+    public void JRun_DoesNotHardFail_AtHardFloorExactly() {
+        var c = C; // NHard=3 => starCount < 3 fails; exactly 3 is OK
+        var m = GoodRun(frameCount: 10, starsPerFrame: 40);
+        var counts = m.FrameStarCounts.ToList();
+        counts[0] = 3;
+        m.FrameStarCounts = counts;
+        var j = OptimizationObjective.JRun(m, c);
+        Assert.That(j, Is.GreaterThan(0.0));
+    }
+
+    // A run with every sub-score saturated to exactly 1.0 (sharp focus, star-rich, perfect fit). Used to
+    // isolate the weights-normalization invariant: if the weights sum to 1, J must equal 1.0 exactly.
+    private static RunEvaluationMetrics PerfectRun() => new RunEvaluationMetrics {
+        SigmaFocus = 1e-9,   // SFocus -> 1
+        LooStdError = double.NaN,
+        StepSize = 1.0,
+        RSquared = 1.0,      // SFit -> 1 (chi at knee)
+        ReducedChiSquared = 1.0,
+        FrameStarCounts = Enumerable.Repeat(100, 10).ToList() // SStars -> 1
+    };
+
+    [Test]
+    public void JRun_WithoutLabels_UsesThreeWeightsSummingToOne() {
+        var c = C;
+        // With a perfect run (all sub-scores = 1) J must equal 1 exactly => weights normalized to sum 1.
+        var j = OptimizationObjective.JRun(PerfectRun(), c);
+        Assert.That(j, Is.EqualTo(1.0).Within(1e-9));
+    }
+
+    [Test]
+    public void JRun_WithLabels_RenormalizesFourWeightsToSumToOne() {
+        var c = C;
+        // Perfect run including a perfect label score => J = 1 exactly.
+        var j = OptimizationObjective.JRun(PerfectRun(), c, recall: 1.0, precision: 1.0);
+        Assert.That(j, Is.EqualTo(1.0).Within(1e-9));
+    }
+
+    [Test]
+    public void JRun_AddingHighLabelScore_RaisesJ_WhenLabelExceedsDisplacedAverage() {
+        var c = C;
+        // Construct a run whose non-label sub-scores are middling, then add a perfect label term.
+        // sigma chosen so SFocus < 1; counts moderate so SStars < 1; chi raised so SFit < 1.
+        var m = new RunEvaluationMetrics {
+            SigmaFocus = 0.25, // SFocus = 0.5
+            LooStdError = double.NaN,
+            StepSize = 1.0,
+            RSquared = 0.8,
+            ReducedChiSquared = 4.0, // penalty 0.5 => SFit = 0.4
+            FrameStarCounts = Enumerable.Repeat(8, 10).ToList() // SStars: min-term 1.0, median-term 0.4*... => < 1
+        };
+        var withoutLabels = OptimizationObjective.JRun(m, c);
+        var withPerfectLabel = OptimizationObjective.JRun(m, c, recall: 1.0, precision: 1.0);
+        Assert.That(withPerfectLabel, Is.GreaterThan(withoutLabels));
+    }
+
+    [Test]
+    public void JRun_IsClampedToUnitInterval() {
+        var c = C;
+        var m = GoodRun(sigmaFocus: 1e-12, frameCount: 20, starsPerFrame: 10000);
+        var j = OptimizationObjective.JRun(m, c, recall: 1.0, precision: 1.0);
+        Assert.That(j, Is.LessThanOrEqualTo(1.0));
+        Assert.That(j, Is.GreaterThanOrEqualTo(0.0));
+    }
+
+    // ---- JTotal ----
+
+    [Test]
+    public void JTotal_SingleRun_IsIdentity() {
+        var c = C;
+        var j = OptimizationObjective.JTotal(new[] { 0.42 }, c);
+        Assert.That(j, Is.EqualTo(0.42).Within(1e-12));
+    }
+
+    [Test]
+    public void JTotal_TwoRuns_BlendsMeanAndMin_WithBetaOneHalf() {
+        var c = new ObjectiveConstants { Beta = 0.5 };
+        var runs = new[] { 0.8, 0.4 };
+        var mean = 0.6;
+        var min = 0.4;
+        var expected = 0.5 * mean + 0.5 * min; // 0.5
+        var j = OptimizationObjective.JTotal(runs, c);
+        Assert.That(j, Is.EqualTo(expected).Within(1e-12));
+    }
+
+    [Test]
+    public void JTotal_BetaOne_IsMin() {
+        var c = new ObjectiveConstants { Beta = 1.0 };
+        var j = OptimizationObjective.JTotal(new[] { 0.9, 0.3, 0.7 }, c);
+        Assert.That(j, Is.EqualTo(0.3).Within(1e-12));
+    }
+
+    [Test]
+    public void JTotal_BetaZero_IsMean() {
+        var c = new ObjectiveConstants { Beta = 0.0 };
+        var j = OptimizationObjective.JTotal(new[] { 0.9, 0.3, 0.6 }, c);
+        Assert.That(j, Is.EqualTo(0.6).Within(1e-12));
+    }
+
+    // ---- ComputeLabelScores ----
+
+    [Test]
+    public void ComputeLabelScores_RecallOne_WhenMissedPointNearAccepted() {
+        var accepted = new[] { (X: 100.0, Y: 100.0) };
+        var labeledMissed = new[] { (X: 102.0, Y: 101.0) }; // within radius 5
+        var shouldReject = Array.Empty<(double X, double Y)>();
+        var (recall, precision) = OptimizationObjective.ComputeLabelScores(accepted, labeledMissed, shouldReject, radiusPx: 5.0);
+        Assert.Multiple(() => {
+            Assert.That(recall, Is.EqualTo(1.0).Within(1e-12));
+            Assert.That(precision, Is.EqualTo(1.0).Within(1e-12)); // empty shouldReject => 1.0
+        });
+    }
+
+    [Test]
+    public void ComputeLabelScores_RecallZero_WhenMissedPointFar() {
+        var accepted = new[] { (X: 100.0, Y: 100.0) };
+        var labeledMissed = new[] { (X: 200.0, Y: 200.0) }; // outside radius
+        var shouldReject = Array.Empty<(double X, double Y)>();
+        var (recall, _) = OptimizationObjective.ComputeLabelScores(accepted, labeledMissed, shouldReject, radiusPx: 5.0);
+        Assert.That(recall, Is.EqualTo(0.0).Within(1e-12));
+    }
+
+    [Test]
+    public void ComputeLabelScores_PrecisionZero_WhenShouldRejectNearAccepted() {
+        var accepted = new[] { (X: 50.0, Y: 50.0) };
+        var labeledMissed = Array.Empty<(double X, double Y)>();
+        var shouldReject = new[] { (X: 51.0, Y: 50.0) }; // accepted within radius => NOT correctly excluded
+        var (recall, precision) = OptimizationObjective.ComputeLabelScores(accepted, labeledMissed, shouldReject, radiusPx: 5.0);
+        Assert.Multiple(() => {
+            Assert.That(recall, Is.EqualTo(1.0).Within(1e-12)); // empty missed => 1.0
+            Assert.That(precision, Is.EqualTo(0.0).Within(1e-12));
+        });
+    }
+
+    [Test]
+    public void ComputeLabelScores_PrecisionOne_WhenShouldRejectFarFromAccepted() {
+        var accepted = new[] { (X: 50.0, Y: 50.0) };
+        var labeledMissed = Array.Empty<(double X, double Y)>();
+        var shouldReject = new[] { (X: 500.0, Y: 500.0) }; // correctly excluded
+        var (_, precision) = OptimizationObjective.ComputeLabelScores(accepted, labeledMissed, shouldReject, radiusPx: 5.0);
+        Assert.That(precision, Is.EqualTo(1.0).Within(1e-12));
+    }
+
+    [Test]
+    public void ComputeLabelScores_BothEmpty_GiveOnes() {
+        var (recall, precision) = OptimizationObjective.ComputeLabelScores(
+            Array.Empty<(double X, double Y)>(),
+            Array.Empty<(double X, double Y)>(),
+            Array.Empty<(double X, double Y)>(),
+            radiusPx: 5.0);
+        Assert.Multiple(() => {
+            Assert.That(recall, Is.EqualTo(1.0).Within(1e-12));
+            Assert.That(precision, Is.EqualTo(1.0).Within(1e-12));
+        });
+    }
+
+    [Test]
+    public void ComputeLabelScores_FractionalRecallAndPrecision() {
+        var accepted = new[] { (X: 0.0, Y: 0.0), (X: 100.0, Y: 0.0) };
+        // 2 missed: one near accepted, one far => recall 0.5
+        var labeledMissed = new[] { (X: 1.0, Y: 0.0), (X: 999.0, Y: 999.0) };
+        // 2 should-reject: one near accepted (bad), one far (good) => precision 0.5
+        var shouldReject = new[] { (X: 100.5, Y: 0.0), (X: -999.0, Y: -999.0) };
+        var (recall, precision) = OptimizationObjective.ComputeLabelScores(accepted, labeledMissed, shouldReject, radiusPx: 5.0);
+        Assert.Multiple(() => {
+            Assert.That(recall, Is.EqualTo(0.5).Within(1e-12));
+            Assert.That(precision, Is.EqualTo(0.5).Within(1e-12));
+        });
+    }
+
+    // ---- LabelScore ----
+
+    [Test]
+    public void LabelScore_IsHalfRecallPlusHalfPrecision() {
+        var s = OptimizationObjective.LabelScore(recall: 0.6, precision: 0.4);
+        Assert.That(s, Is.EqualTo(0.5).Within(1e-12));
+    }
+
+    // ---- Clamp01 ----
+
+    [Test]
+    public void Clamp01_ClampsToUnitInterval() {
+        Assert.Multiple(() => {
+            Assert.That(OptimizationObjective.Clamp01(-1.0), Is.EqualTo(0.0));
+            Assert.That(OptimizationObjective.Clamp01(0.5), Is.EqualTo(0.5));
+            Assert.That(OptimizationObjective.Clamp01(2.0), Is.EqualTo(1.0));
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationObjectiveTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationObjectiveTests.cs
@@ -281,14 +281,19 @@ public class OptimizationObjectiveTests {
         Assert.That(j, Is.EqualTo(0.6).Within(1e-12));
     }
 
-    // ---- ComputeLabelScores ----
+    // ---- ComputeLabelScores (box-containment: point-in-box of accepted centers) ----
+
+    // A small box CENTERED on (cx,cy) with the given half-extent, so the existing point-style test intents
+    // (an accepted center "inside" / "outside" a label region) map cleanly onto boxes.
+    private static LabelBox Box(double cx, double cy, double half = 5.0) =>
+        new LabelBox(cx - half, cy - half, 2 * half, 2 * half);
 
     [Test]
-    public void ComputeLabelScores_RecallOne_WhenMissedPointNearAccepted() {
+    public void ComputeLabelScores_RecallOne_WhenAcceptedCenterInsideMissedBox() {
         var accepted = new[] { (X: 100.0, Y: 100.0) };
-        var labeledMissed = new[] { (X: 102.0, Y: 101.0) }; // within radius 5
-        var shouldReject = Array.Empty<(double X, double Y)>();
-        var (recall, precision) = OptimizationObjective.ComputeLabelScores(accepted, labeledMissed, shouldReject, radiusPx: 5.0);
+        var labeledMissed = new[] { Box(101.0, 101.0) }; // contains the accepted center
+        var shouldReject = Array.Empty<LabelBox>();
+        var (recall, precision) = OptimizationObjective.ComputeLabelScores(accepted, labeledMissed, shouldReject);
         Assert.Multiple(() => {
             Assert.That(recall, Is.EqualTo(1.0).Within(1e-12));
             Assert.That(precision, Is.EqualTo(1.0).Within(1e-12)); // empty shouldReject => 1.0
@@ -296,20 +301,20 @@ public class OptimizationObjectiveTests {
     }
 
     [Test]
-    public void ComputeLabelScores_RecallZero_WhenMissedPointFar() {
+    public void ComputeLabelScores_RecallZero_WhenNoAcceptedCenterInsideMissedBox() {
         var accepted = new[] { (X: 100.0, Y: 100.0) };
-        var labeledMissed = new[] { (X: 200.0, Y: 200.0) }; // outside radius
-        var shouldReject = Array.Empty<(double X, double Y)>();
-        var (recall, _) = OptimizationObjective.ComputeLabelScores(accepted, labeledMissed, shouldReject, radiusPx: 5.0);
+        var labeledMissed = new[] { Box(200.0, 200.0) }; // no accepted center inside
+        var shouldReject = Array.Empty<LabelBox>();
+        var (recall, _) = OptimizationObjective.ComputeLabelScores(accepted, labeledMissed, shouldReject);
         Assert.That(recall, Is.EqualTo(0.0).Within(1e-12));
     }
 
     [Test]
-    public void ComputeLabelScores_PrecisionZero_WhenShouldRejectNearAccepted() {
+    public void ComputeLabelScores_PrecisionZero_WhenAcceptedCenterInsideShouldRejectBox() {
         var accepted = new[] { (X: 50.0, Y: 50.0) };
-        var labeledMissed = Array.Empty<(double X, double Y)>();
-        var shouldReject = new[] { (X: 51.0, Y: 50.0) }; // accepted within radius => NOT correctly excluded
-        var (recall, precision) = OptimizationObjective.ComputeLabelScores(accepted, labeledMissed, shouldReject, radiusPx: 5.0);
+        var labeledMissed = Array.Empty<LabelBox>();
+        var shouldReject = new[] { Box(51.0, 50.0) }; // accepted center inside => NOT correctly excluded
+        var (recall, precision) = OptimizationObjective.ComputeLabelScores(accepted, labeledMissed, shouldReject);
         Assert.Multiple(() => {
             Assert.That(recall, Is.EqualTo(1.0).Within(1e-12)); // empty missed => 1.0
             Assert.That(precision, Is.EqualTo(0.0).Within(1e-12));
@@ -317,11 +322,11 @@ public class OptimizationObjectiveTests {
     }
 
     [Test]
-    public void ComputeLabelScores_PrecisionOne_WhenShouldRejectFarFromAccepted() {
+    public void ComputeLabelScores_PrecisionOne_WhenNoAcceptedCenterInsideShouldRejectBox() {
         var accepted = new[] { (X: 50.0, Y: 50.0) };
-        var labeledMissed = Array.Empty<(double X, double Y)>();
-        var shouldReject = new[] { (X: 500.0, Y: 500.0) }; // correctly excluded
-        var (_, precision) = OptimizationObjective.ComputeLabelScores(accepted, labeledMissed, shouldReject, radiusPx: 5.0);
+        var labeledMissed = Array.Empty<LabelBox>();
+        var shouldReject = new[] { Box(500.0, 500.0) }; // no accepted center inside => correctly excluded
+        var (_, precision) = OptimizationObjective.ComputeLabelScores(accepted, labeledMissed, shouldReject);
         Assert.That(precision, Is.EqualTo(1.0).Within(1e-12));
     }
 
@@ -329,9 +334,8 @@ public class OptimizationObjectiveTests {
     public void ComputeLabelScores_BothEmpty_GiveOnes() {
         var (recall, precision) = OptimizationObjective.ComputeLabelScores(
             Array.Empty<(double X, double Y)>(),
-            Array.Empty<(double X, double Y)>(),
-            Array.Empty<(double X, double Y)>(),
-            radiusPx: 5.0);
+            Array.Empty<LabelBox>(),
+            Array.Empty<LabelBox>());
         Assert.Multiple(() => {
             Assert.That(recall, Is.EqualTo(1.0).Within(1e-12));
             Assert.That(precision, Is.EqualTo(1.0).Within(1e-12));
@@ -341,11 +345,11 @@ public class OptimizationObjectiveTests {
     [Test]
     public void ComputeLabelScores_FractionalRecallAndPrecision() {
         var accepted = new[] { (X: 0.0, Y: 0.0), (X: 100.0, Y: 0.0) };
-        // 2 missed: one near accepted, one far => recall 0.5
-        var labeledMissed = new[] { (X: 1.0, Y: 0.0), (X: 999.0, Y: 999.0) };
-        // 2 should-reject: one near accepted (bad), one far (good) => precision 0.5
-        var shouldReject = new[] { (X: 100.5, Y: 0.0), (X: -999.0, Y: -999.0) };
-        var (recall, precision) = OptimizationObjective.ComputeLabelScores(accepted, labeledMissed, shouldReject, radiusPx: 5.0);
+        // 2 missed boxes: one contains an accepted center, one does not => recall 0.5
+        var labeledMissed = new[] { Box(1.0, 0.0), Box(999.0, 999.0) };
+        // 2 should-reject boxes: one contains an accepted center (bad), one does not (good) => precision 0.5
+        var shouldReject = new[] { Box(100.5, 0.0), Box(-999.0, -999.0) };
+        var (recall, precision) = OptimizationObjective.ComputeLabelScores(accepted, labeledMissed, shouldReject);
         Assert.Multiple(() => {
             Assert.That(recall, Is.EqualTo(0.5).Within(1e-12));
             Assert.That(precision, Is.EqualTo(0.5).Within(1e-12));

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationRunDiscoveryTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationRunDiscoveryTests.cs
@@ -1,0 +1,135 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using TestApp;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Optimization;
+
+/// <summary>
+/// Unit tests for the pure-logic run discovery of the T6 optimize harness (linked from TestApp), built purely
+/// on directory structure + AF-frame filenames. The key behavior: the single-frame final/initial validation
+/// captures must be EXCLUDED by the >=3-distinct-focuser-positions guard, frameless attempt* folders must be
+/// skipped, and only true sweep folders count as runs.
+/// </summary>
+[TestFixture]
+public class OptimizationRunDiscoveryTests {
+
+    private string tempRoot;
+
+    [SetUp]
+    public void SetUp() {
+        tempRoot = Path.Combine(Path.GetTempPath(), "hf-run-discovery-" + Path.GetRandomFileName());
+        Directory.CreateDirectory(tempRoot);
+    }
+
+    [TearDown]
+    public void TearDown() {
+        if (tempRoot != null && Directory.Exists(tempRoot)) {
+            try {
+                Directory.Delete(tempRoot, recursive: true);
+            } catch {
+                // best-effort cleanup
+            }
+        }
+    }
+
+    private static string FrameName(int index, int focuser) =>
+        $"{index}_Frame{index}_BitDepth16_Bayered0_Focuser{focuser}.fits";
+
+    private static void WriteFrame(string dir, int index, int focuser) {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, FrameName(index, focuser)), "dummy");
+    }
+
+    [Test]
+    public void Discover_ExcludesSingleFrameFinalInitialAndFramelessAttempt() {
+        // setup/attempt01: a real sweep (3 distinct focuser positions) -> the ONLY usable run.
+        var attempt01 = Path.Combine(tempRoot, "setup", "attempt01");
+        WriteFrame(attempt01, 0, 5000);
+        WriteFrame(attempt01, 1, 5100);
+        WriteFrame(attempt01, 2, 5200);
+
+        // setup/final: a single-frame validation capture (1 position) -> excluded by the >=3 guard.
+        WriteFrame(Path.Combine(tempRoot, "setup", "final"), 0, 5050);
+
+        // setup/initial: a single-frame validation capture (1 position) -> excluded by the >=3 guard.
+        WriteFrame(Path.Combine(tempRoot, "setup", "initial"), 0, 5060);
+
+        // setup/attempt02: an attempt folder with NO sweep frames (only artifacts) -> skipped.
+        var attempt02 = Path.Combine(tempRoot, "setup", "attempt02");
+        Directory.CreateDirectory(attempt02);
+        File.WriteAllText(Path.Combine(attempt02, "0_Frame0_star_detection_result.json"), "{}");
+        File.WriteAllText(Path.Combine(attempt02, "0_Frame0_annotated.png"), "img");
+
+        var result = OptimizationRunDiscovery.Discover(tempRoot);
+
+        Assert.That(result.Runs.Select(r => r.RunId), Is.EqualTo(new[] { "setup/attempt01" }),
+            "Only the 3-position attempt01 sweep should be discovered as a run");
+        Assert.That(result.Runs.Single().DistinctPositions, Is.EqualTo(3));
+
+        // attempt02 has no frames -> skipped with the "no sweep frames" reason. final/initial are NOT attempt*
+        // folders, so under the attempt-anchored branch they are simply not candidates (and therefore not even
+        // listed as skipped) — the guarantee under test is that they are NOT discovered as runs.
+        Assert.That(result.Runs.Any(r => r.RunId.Contains("final")), Is.False, "final must not be a run");
+        Assert.That(result.Runs.Any(r => r.RunId.Contains("initial")), Is.False, "initial must not be a run");
+        Assert.That(result.Skipped.Any(s => s.RelativePath == "setup/attempt02" && s.Reason.Contains("no sweep frames")),
+            Is.True, "the frameless attempt02 must be skipped with a 'no sweep frames' reason");
+    }
+
+    [Test]
+    public void Discover_BackCompat_RootItselfIsAnAttemptFolderWithEnoughPositions() {
+        // Pointing --runs directly at an attempt folder (>=3 positions) treats the root as a single run.
+        WriteFrame(tempRoot, 0, 4000);
+        WriteFrame(tempRoot, 1, 4100);
+        WriteFrame(tempRoot, 2, 4200);
+
+        var result = OptimizationRunDiscovery.Discover(tempRoot);
+
+        Assert.That(result.Runs.Count, Is.EqualTo(1));
+        Assert.That(result.Runs.Single().DistinctPositions, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void Discover_FindsAttemptFoldersNestedSeveralLevelsDeep() {
+        // astrodet/AutoFocus_x/attempt01 -> nested 2 levels under root.
+        var nested = Path.Combine(tempRoot, "astrodet", "AutoFocus_x", "attempt01");
+        WriteFrame(nested, 0, 6000);
+        WriteFrame(nested, 1, 6100);
+        WriteFrame(nested, 2, 6200);
+
+        var result = OptimizationRunDiscovery.Discover(tempRoot);
+
+        Assert.That(result.Runs.Select(r => r.RunId), Is.EqualTo(new[] { "astrodet/AutoFocus_x/attempt01" }));
+    }
+
+    [Test]
+    public void Discover_Fallback_NoAttemptFolders_UsesSubfoldersWithEnoughPositions() {
+        // No attempt* folders anywhere; an immediate subfolder with >=3 positions becomes a run, and one with
+        // too few positions is skipped.
+        var good = Path.Combine(tempRoot, "weird-layout");
+        WriteFrame(good, 0, 7000);
+        WriteFrame(good, 1, 7100);
+        WriteFrame(good, 2, 7200);
+
+        var tooFew = Path.Combine(tempRoot, "just-two");
+        WriteFrame(tooFew, 0, 8000);
+        WriteFrame(tooFew, 1, 8100);
+
+        var result = OptimizationRunDiscovery.Discover(tempRoot);
+
+        Assert.That(result.Runs.Select(r => r.RunId), Is.EqualTo(new[] { "weird-layout" }));
+        Assert.That(result.Skipped.Any(s => s.RelativePath == "just-two" && s.Reason.Contains("need >=3")), Is.True);
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizerVariableTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizerVariableTests.cs
@@ -175,8 +175,8 @@ public class OptimizerVariableTests {
                 Assert.That(v.InitialStep, Is.EqualTo(step), $"{name} step");
             });
         }
-        Check(nameof(StarDetectorParams.Sensitivity), OptimizerVariableType.Continuous, 0, 20, 1.0);
-        Check(nameof(StarDetectorParams.StarClippingMultiplier), OptimizerVariableType.Continuous, 0.5, 5, 0.5);
+        Check(nameof(StarDetectorParams.Sensitivity), OptimizerVariableType.Continuous, 0, 50, 1.0);
+        Check(nameof(StarDetectorParams.StarClippingMultiplier), OptimizerVariableType.Continuous, 0.25, 10, 0.5);
         Check(nameof(StarDetectorParams.NoiseClippingMultiplier), OptimizerVariableType.Continuous, 1, 10, 0.5);
         Check(nameof(StarDetectorParams.PeakResponse), OptimizerVariableType.Continuous, 0.1, 1.0, 0.05);
         Check(nameof(StarDetectorParams.MaxDistortion), OptimizerVariableType.Continuous, 0.1, 1.0, 0.1);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizerVariableTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizerVariableTests.cs
@@ -1,0 +1,204 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System.Linq;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Optimization;
+
+[TestFixture]
+public class OptimizerVariableTests {
+
+    // Mirrors the curated-set contract: Write clamps to bounds before storing.
+    private static OptimizerVariable Continuous(double lo, double hi, double step) {
+        OptimizerVariable v = null;
+        v = new OptimizerVariable {
+            Name = "Sensitivity",
+            Type = OptimizerVariableType.Continuous,
+            Lower = lo,
+            Upper = hi,
+            InitialStep = step,
+            Read = p => p.Sensitivity,
+            Write = (p, value) => p.Sensitivity = v.Quantize(value)
+        };
+        return v;
+    }
+
+    [Test]
+    public void Clamp_ClampsToBounds() {
+        var v = Continuous(0, 20, 1.0);
+        Assert.Multiple(() => {
+            Assert.That(v.Clamp(-5.0), Is.EqualTo(0.0));
+            Assert.That(v.Clamp(10.0), Is.EqualTo(10.0));
+            Assert.That(v.Clamp(99.0), Is.EqualTo(20.0));
+        });
+    }
+
+    [Test]
+    public void Quantize_Continuous_IsIdentityThenClamp() {
+        var v = Continuous(0, 20, 1.0);
+        Assert.Multiple(() => {
+            Assert.That(v.Quantize(3.14159), Is.EqualTo(3.14159).Within(1e-12));
+            Assert.That(v.Quantize(25.0), Is.EqualTo(20.0));
+        });
+    }
+
+    [Test]
+    public void Quantize_Integer_RoundsAwayFromZeroThenClamps() {
+        var v = new OptimizerVariable {
+            Name = "StructureLayers",
+            Type = OptimizerVariableType.Integer,
+            Lower = 1,
+            Upper = 8,
+            InitialStep = 1,
+            Read = p => p.StructureLayers,
+            Write = (p, x) => p.StructureLayers = (int)x
+        };
+        Assert.Multiple(() => {
+            Assert.That(v.Quantize(3.5), Is.EqualTo(4.0));     // away from zero
+            Assert.That(v.Quantize(2.5), Is.EqualTo(3.0));     // away from zero (not banker's)
+            Assert.That(v.Quantize(0.4), Is.EqualTo(1.0));     // clamp to lower
+            Assert.That(v.Quantize(100.0), Is.EqualTo(8.0));   // clamp to upper
+        });
+    }
+
+    [Test]
+    public void Quantize_Boolean_ThresholdsAtHalf() {
+        var v = new OptimizerVariable {
+            Name = "HotpixelThresholdingEnabled",
+            Type = OptimizerVariableType.Boolean,
+            Lower = 0,
+            Upper = 1,
+            InitialStep = 1,
+            Read = p => p.HotpixelThresholdingEnabled ? 1.0 : 0.0,
+            Write = (p, x) => p.HotpixelThresholdingEnabled = x >= 0.5
+        };
+        Assert.Multiple(() => {
+            Assert.That(v.Quantize(0.49), Is.EqualTo(0.0));
+            Assert.That(v.Quantize(0.5), Is.EqualTo(1.0));
+            Assert.That(v.Quantize(0.7), Is.EqualTo(1.0));
+        });
+    }
+
+    [Test]
+    public void Write_Continuous_ClampsAndWrites() {
+        var v = Continuous(0, 20, 1.0);
+        var p = new StarDetectorParams();
+        v.Write(p, 99.0);
+        Assert.That(p.Sensitivity, Is.EqualTo(20.0));
+        v.Write(p, -5.0);
+        Assert.That(p.Sensitivity, Is.EqualTo(0.0));
+        v.Write(p, 7.5);
+        Assert.That(p.Sensitivity, Is.EqualTo(7.5));
+    }
+
+    [Test]
+    public void Write_Integer_RoundsAndWritesWholeNumber() {
+        var p = new StarDetectorParams();
+        var v = OptimizerVariable.CreateCuratedSet().Single(x => x.Name == nameof(StarDetectorParams.StructureLayers));
+        v.Write(p, 3.5);
+        Assert.That(p.StructureLayers, Is.EqualTo(4));
+        v.Write(p, 100.0);
+        Assert.That(p.StructureLayers, Is.EqualTo(8)); // upper bound
+        v.Write(p, -10.0);
+        Assert.That(p.StructureLayers, Is.EqualTo(1)); // lower bound
+    }
+
+    [Test]
+    public void Write_Boolean_Thresholds() {
+        var p = new StarDetectorParams();
+        var v = OptimizerVariable.CreateCuratedSet().Single(x => x.Name == nameof(StarDetectorParams.HotpixelThresholdingEnabled));
+        v.Write(p, 0.9);
+        Assert.That(p.HotpixelThresholdingEnabled, Is.True);
+        v.Write(p, 0.1);
+        Assert.That(p.HotpixelThresholdingEnabled, Is.False);
+    }
+
+    [Test]
+    public void Read_Boolean_ReturnsZeroOrOne() {
+        var p = new StarDetectorParams { HotpixelThresholdingEnabled = true };
+        var v = OptimizerVariable.CreateCuratedSet().Single(x => x.Name == nameof(StarDetectorParams.HotpixelThresholdingEnabled));
+        Assert.That(v.Read(p), Is.EqualTo(1.0));
+        p.HotpixelThresholdingEnabled = false;
+        Assert.That(v.Read(p), Is.EqualTo(0.0));
+    }
+
+    // ---- CreateCuratedSet ----
+
+    [Test]
+    public void CreateCuratedSet_HasTwelveDistinctVariables() {
+        var set = OptimizerVariable.CreateCuratedSet();
+        Assert.That(set.Count, Is.EqualTo(12));
+        Assert.That(set.Select(x => x.Name).Distinct().Count(), Is.EqualTo(12));
+    }
+
+    [Test]
+    public void CreateCuratedSet_NamesMatchStarDetectorParamsProperties() {
+        var set = OptimizerVariable.CreateCuratedSet();
+        var expected = new[] {
+            nameof(StarDetectorParams.Sensitivity),
+            nameof(StarDetectorParams.StarClippingMultiplier),
+            nameof(StarDetectorParams.NoiseClippingMultiplier),
+            nameof(StarDetectorParams.PeakResponse),
+            nameof(StarDetectorParams.MaxDistortion),
+            nameof(StarDetectorParams.MinHFR),
+            nameof(StarDetectorParams.StarCenterTolerance),
+            nameof(StarDetectorParams.StructureLayers),
+            nameof(StarDetectorParams.NoiseReductionRadius),
+            nameof(StarDetectorParams.MinimumStarBoundingBoxSize),
+            nameof(StarDetectorParams.HotpixelThresholdingEnabled),
+            nameof(StarDetectorParams.HotpixelThreshold),
+        };
+        Assert.That(set.Select(x => x.Name), Is.EquivalentTo(expected));
+    }
+
+    [Test]
+    public void CreateCuratedSet_BoundsAndStepsMatchSpec() {
+        var set = OptimizerVariable.CreateCuratedSet().ToDictionary(x => x.Name);
+        void Check(string name, OptimizerVariableType type, double lo, double hi, double step) {
+            var v = set[name];
+            Assert.Multiple(() => {
+                Assert.That(v.Type, Is.EqualTo(type), $"{name} type");
+                Assert.That(v.Lower, Is.EqualTo(lo), $"{name} lower");
+                Assert.That(v.Upper, Is.EqualTo(hi), $"{name} upper");
+                Assert.That(v.InitialStep, Is.EqualTo(step), $"{name} step");
+            });
+        }
+        Check(nameof(StarDetectorParams.Sensitivity), OptimizerVariableType.Continuous, 0, 20, 1.0);
+        Check(nameof(StarDetectorParams.StarClippingMultiplier), OptimizerVariableType.Continuous, 0.5, 5, 0.5);
+        Check(nameof(StarDetectorParams.NoiseClippingMultiplier), OptimizerVariableType.Continuous, 1, 10, 0.5);
+        Check(nameof(StarDetectorParams.PeakResponse), OptimizerVariableType.Continuous, 0.1, 1.0, 0.05);
+        Check(nameof(StarDetectorParams.MaxDistortion), OptimizerVariableType.Continuous, 0.1, 1.0, 0.1);
+        Check(nameof(StarDetectorParams.MinHFR), OptimizerVariableType.Continuous, 0.1, 5.0, 0.25);
+        Check(nameof(StarDetectorParams.StarCenterTolerance), OptimizerVariableType.Continuous, 0.05, 1.0, 0.05);
+        Check(nameof(StarDetectorParams.StructureLayers), OptimizerVariableType.Integer, 1, 8, 1);
+        Check(nameof(StarDetectorParams.NoiseReductionRadius), OptimizerVariableType.Integer, 0, 10, 1);
+        Check(nameof(StarDetectorParams.MinimumStarBoundingBoxSize), OptimizerVariableType.Integer, 2, 20, 1);
+        Check(nameof(StarDetectorParams.HotpixelThresholdingEnabled), OptimizerVariableType.Boolean, 0, 1, 1);
+        Check(nameof(StarDetectorParams.HotpixelThreshold), OptimizerVariableType.Continuous, 0.0001, 0.05, 0.001);
+    }
+
+    [Test]
+    public void CreateCuratedSet_ReadWriteRoundTripsThroughParams() {
+        var set = OptimizerVariable.CreateCuratedSet();
+        var p = new StarDetectorParams();
+        foreach (var v in set) {
+            // Write the midpoint, read it back (quantized) and confirm consistency.
+            var mid = (v.Lower + v.Upper) / 2.0;
+            v.Write(p, mid);
+            var read = v.Read(p);
+            Assert.That(read, Is.EqualTo(v.Quantize(mid)).Within(1e-9), $"{v.Name} round-trip");
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationDataCacheTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationDataCacheTests.cs
@@ -1,0 +1,191 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Optimization;
+
+/// <summary>
+/// Verifies the optimizer-side early-context cache in <see cref="RunEvaluationData"/>: it must reuse a built
+/// context across candidate evaluations whose EARLY key is unchanged (rebuilding only when the early key
+/// changes), while producing exactly the same per-frame results as the non-cached delegate path. The cache is
+/// a pure performance optimization — results must be identical.
+/// </summary>
+[TestFixture]
+public class RunEvaluationDataCacheTests {
+
+    private static AlglibAPI NewAlglib() => new AlglibAPI();
+
+    private static RunFitConfig DefaultFitConfig() => new RunFitConfig {
+        StepSize = 100,
+        UseWeights = true,
+        MaxOutlierRejections = 0,
+        RejectionConfidence = 0.0,
+        PreferredModel = null
+    };
+
+    private static List<RunFrame> ThreeFrames() => new List<RunFrame> {
+        new RunFrame { FrameId = "a", FocuserPosition = 9900, Image = 9900 },
+        new RunFrame { FrameId = "b", FocuserPosition = 10000, Image = 10000 },
+        new RunFrame { FrameId = "c", FocuserPosition = 10100, Image = 10100 },
+    };
+
+    // A spy split-detector that counts BuildContext vs GateAndMeasure calls and keys the early context on
+    // NoiseClippingMultiplier only (a stand-in early param), so a change to a "late" param reuses the context.
+    private sealed class SpySplitDetector : RunEvaluationData.ISplitFrameDetector {
+        public int BuildCount;
+        public int GateCount;
+
+        // The "context" carries the frame's focuser position + the early-key value it was built with.
+        private sealed class Ctx : IDisposable {
+            public int Position;
+            public double EarlyValue;
+            public bool Disposed;
+            public void Dispose() { Disposed = true; }
+        }
+
+        public string ComputeEarlyKey(StarDetectorParams p) =>
+            p.NoiseClippingMultiplier.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        public Task<IDisposable> BuildContextAsync(object frameImage, StarDetectorParams p, CancellationToken token) {
+            BuildCount++;
+            return Task.FromResult<IDisposable>(new Ctx { Position = (int)frameImage, EarlyValue = p.NoiseClippingMultiplier });
+        }
+
+        public FrameDetectionResult GateAndMeasure(IDisposable context, StarDetectorParams p) {
+            GateCount++;
+            var ctx = (Ctx)context;
+            // HFR is a clean function of the frame position; star count varies with a LATE param (Sensitivity) so
+            // gating actually changes per candidate, while the early context value must be the one it was built with.
+            var dx = (ctx.Position - 10000) / 8.0;
+            return new FrameDetectionResult {
+                AverageHFR = Math.Sqrt(1.5 * 1.5 + dx * dx),
+                HFRStdDev = 0.05,
+                StarCount = (int)(50 + p.Sensitivity + 100 * ctx.EarlyValue),
+                StarCenters = Array.Empty<(double X, double Y)>()
+            };
+        }
+    }
+
+    [Test]
+    public async Task SplitDetector_LateOnlyChanges_ReuseContextAcrossEvaluations() {
+        var spy = new SpySplitDetector();
+        var data = new RunEvaluationData("cache", ThreeFrames(), spy, NewAlglib(), DefaultFitConfig());
+
+        // First eval: 3 frames => 3 builds + 3 gates.
+        await data.EvaluateAsync(new StarDetectorParams { NoiseClippingMultiplier = 4.0, Sensitivity = 2.0 }, CancellationToken.None);
+        // Second eval changes ONLY a late param (same early key): must reuse the 3 contexts => 0 new builds, 3 gates.
+        await data.EvaluateAsync(new StarDetectorParams { NoiseClippingMultiplier = 4.0, Sensitivity = 9.0 }, CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(spy.BuildCount, Is.EqualTo(3), "early context must be built once per frame and reused across late-only evals");
+            Assert.That(spy.GateCount, Is.EqualTo(6), "gate must run for every (frame, eval): 3 frames × 2 evals");
+        });
+    }
+
+    [Test]
+    public async Task SplitDetector_EarlyParamChange_RebuildsContext() {
+        var spy = new SpySplitDetector();
+        var data = new RunEvaluationData("cache", ThreeFrames(), spy, NewAlglib(), DefaultFitConfig());
+
+        await data.EvaluateAsync(new StarDetectorParams { NoiseClippingMultiplier = 4.0 }, CancellationToken.None);
+        // Changing the EARLY param changes the early key => contexts must be rebuilt.
+        await data.EvaluateAsync(new StarDetectorParams { NoiseClippingMultiplier = 5.0 }, CancellationToken.None);
+
+        Assert.That(spy.BuildCount, Is.EqualTo(6), "an early-param change must rebuild every frame's context");
+    }
+
+    [Test]
+    public async Task SplitDetector_ProducesIdenticalResults_ToNonCachedDelegate() {
+        // The cached split path must give byte-identical per-frame results to a plain monolithic delegate that
+        // calls BuildContext+GateAndMeasure inline with no reuse.
+        var pLate = new StarDetectorParams { NoiseClippingMultiplier = 4.0, Sensitivity = 7.0 };
+
+        var spy = new SpySplitDetector();
+        var cached = new RunEvaluationData("cached", ThreeFrames(), spy, NewAlglib(), DefaultFitConfig());
+        var cachedMetrics = await cached.EvaluateAsync(pLate, CancellationToken.None);
+
+        // Reference: a non-split delegate built from the same detector, no caching.
+        Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> reference =
+            async (image, p, token) => {
+                var refSpy = new SpySplitDetector();
+                var ctx = await refSpy.BuildContextAsync(image, p, token);
+                using (ctx) {
+                    return refSpy.GateAndMeasure(ctx, p);
+                }
+            };
+        var refData = new RunEvaluationData("ref", ThreeFrames(), reference, NewAlglib(), DefaultFitConfig());
+        var refMetrics = await refData.EvaluateAsync(pLate, CancellationToken.None);
+
+        Assert.That(cachedMetrics.FrameStarCounts, Is.EqualTo(refMetrics.FrameStarCounts),
+            "cached split path must produce identical per-frame star counts to the non-cached delegate");
+    }
+
+    [Test]
+    public async Task SplitDetector_DisposesEvictedContextsAtRunEnd() {
+        // Track that contexts get disposed both when superseded (early-key change) AND when the run finishes
+        // (RunEvaluationData.Dispose). This covers the Dispose() cleanup loop the wizard/harness fixes rely on to
+        // release the per-frame source Mats.
+        var disposed = new List<bool>();
+        var spy = new DisposalTrackingSplitDetector(disposed);
+        var data = new RunEvaluationData("dispose", ThreeFrames(), spy, NewAlglib(), DefaultFitConfig());
+
+        await data.EvaluateAsync(new StarDetectorParams { NoiseClippingMultiplier = 4.0 }, CancellationToken.None);
+        await data.EvaluateAsync(new StarDetectorParams { NoiseClippingMultiplier = 5.0 }, CancellationToken.None);
+
+        // After two distinct early keys over 3 frames: 6 contexts were built. The first key's 3 were disposed when
+        // the second key superseded them; the second key's 3 are still cached (alive).
+        Assert.Multiple(() => {
+            Assert.That(disposed.Count, Is.EqualTo(6), "two early keys × 3 frames must have built 6 contexts");
+            Assert.That(disposed.Count(d => d), Is.EqualTo(3),
+                "only the evicted first-key contexts are disposed before run end; the surviving ones are still cached");
+        });
+
+        // Run end: Dispose() must release every surviving cached context too, so ALL created contexts end disposed.
+        data.Dispose();
+        Assert.That(disposed.Count(d => d), Is.EqualTo(6),
+            "Dispose() must release every surviving cached context (the source Mats), so all created contexts are freed");
+
+        // Dispose is idempotent: a second call must not throw or double-dispose anything.
+        Assert.DoesNotThrow(() => data.Dispose());
+        Assert.That(disposed.Count(d => d), Is.EqualTo(6), "idempotent Dispose must not change the disposed count");
+    }
+
+    private sealed class DisposalTrackingSplitDetector : RunEvaluationData.ISplitFrameDetector {
+        private readonly List<bool> disposed;
+        public DisposalTrackingSplitDetector(List<bool> disposed) { this.disposed = disposed; }
+
+        private sealed class Ctx : IDisposable {
+            private readonly List<bool> sink;
+            public Ctx(List<bool> sink) { this.sink = sink; sink.Add(false); Index = sink.Count - 1; }
+            public int Index;
+            public void Dispose() { sink[Index] = true; }
+        }
+
+        public string ComputeEarlyKey(StarDetectorParams p) =>
+            p.NoiseClippingMultiplier.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        public Task<IDisposable> BuildContextAsync(object frameImage, StarDetectorParams p, CancellationToken token) =>
+            Task.FromResult<IDisposable>(new Ctx(disposed));
+
+        public FrameDetectionResult GateAndMeasure(IDisposable context, StarDetectorParams p) =>
+            new FrameDetectionResult { AverageHFR = 2.0, HFRStdDev = 0.05, StarCount = 30, StarCenters = Array.Empty<(double X, double Y)>() };
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationDataCacheTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationDataCacheTests.cs
@@ -50,8 +50,12 @@ public class RunEvaluationDataCacheTests {
     // A spy split-detector that counts BuildContext vs GateAndMeasure calls and keys the early context on
     // NoiseClippingMultiplier only (a stand-in early param), so a change to a "late" param reuses the context.
     private sealed class SpySplitDetector : RunEvaluationData.ISplitFrameDetector {
-        public int BuildCount;
-        public int GateCount;
+        // Frames are detected concurrently within an evaluation, so these counters are bumped from multiple threads;
+        // use Interlocked so the exact-count assertions stay reliable. (Exposed as plain int fields via the readers.)
+        private int buildCount;
+        private int gateCount;
+        public int BuildCount => Volatile.Read(ref buildCount);
+        public int GateCount => Volatile.Read(ref gateCount);
 
         // The "context" carries the frame's focuser position + the early-key value it was built with.
         private sealed class Ctx : IDisposable {
@@ -65,12 +69,12 @@ public class RunEvaluationDataCacheTests {
             p.NoiseClippingMultiplier.ToString(System.Globalization.CultureInfo.InvariantCulture);
 
         public Task<IDisposable> BuildContextAsync(object frameImage, StarDetectorParams p, CancellationToken token) {
-            BuildCount++;
+            Interlocked.Increment(ref buildCount);
             return Task.FromResult<IDisposable>(new Ctx { Position = (int)frameImage, EarlyValue = p.NoiseClippingMultiplier });
         }
 
         public FrameDetectionResult GateAndMeasure(IDisposable context, StarDetectorParams p) {
-            GateCount++;
+            Interlocked.Increment(ref gateCount);
             var ctx = (Ctx)context;
             // HFR is a clean function of the frame position; star count varies with a LATE param (Sensitivity) so
             // gating actually changes per candidate, while the early context value must be the one it was built with.
@@ -169,14 +173,21 @@ public class RunEvaluationDataCacheTests {
     }
 
     private sealed class DisposalTrackingSplitDetector : RunEvaluationData.ISplitFrameDetector {
+        // Frames within one evaluation are now detected concurrently, so multiple Ctx instances are created (and the
+        // backing accounting list mutated) from different threads at once. The list operations are serialized on the
+        // list itself so the per-context bookkeeping stays correct; this is purely test plumbing and does not change
+        // the assertion semantics (it still tracks created-vs-disposed counts).
         private readonly List<bool> disposed;
         public DisposalTrackingSplitDetector(List<bool> disposed) { this.disposed = disposed; }
 
         private sealed class Ctx : IDisposable {
             private readonly List<bool> sink;
-            public Ctx(List<bool> sink) { this.sink = sink; sink.Add(false); Index = sink.Count - 1; }
+            public Ctx(List<bool> sink) {
+                this.sink = sink;
+                lock (sink) { sink.Add(false); Index = sink.Count - 1; }
+            }
             public int Index;
-            public void Dispose() { sink[Index] = true; }
+            public void Dispose() { lock (sink) { sink[Index] = true; } }
         }
 
         public string ComputeEarlyKey(StarDetectorParams p) =>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationDataParallelismTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationDataParallelismTests.cs
@@ -1,0 +1,221 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Optimization;
+
+/// <summary>
+/// Verifies that detecting a run's frames CONCURRENTLY within one evaluation (the optimizer perf change) is
+/// both deterministic (identical metrics every run) and bit-identical to a forced-sequential pass (cap=1).
+/// The frames are assembled by index, not completion order, and pooling is order-independent, so parallelism
+/// cannot change any value the objective consumes.
+/// </summary>
+[TestFixture]
+public class RunEvaluationDataParallelismTests {
+
+    private static AlglibAPI NewAlglib() => new AlglibAPI();
+
+    private static RunFitConfig DefaultFitConfig() => new RunFitConfig {
+        StepSize = 100,
+        UseWeights = true,
+        MaxOutlierRejections = 0,
+        RejectionConfidence = 0.0,
+        PreferredModel = null
+    };
+
+    // A clean symmetric hyperbola hfr(pos) = sqrt(a^2 + ((pos - p0)/b)^2).
+    private const double HyperbolaA = 1.5;
+    private const double HyperbolaB = 8.0;
+    private const int HyperbolaP0 = 10000;
+
+    private static double Hfr(int pos) {
+        var dx = (pos - HyperbolaP0) / HyperbolaB;
+        return Math.Sqrt(HyperbolaA * HyperbolaA + dx * dx);
+    }
+
+    // A multi-frame run where TWO frames share the middle focuser position (so pooling is exercised) and frames
+    // carry distinct HFRs at that shared position to make pooling order-sensitive if it were implemented wrong.
+    // The frame payload is (focuserPosition, perFrameSeed): perFrameSeed shifts the HFR a touch so the two frames
+    // at the shared position differ, and the star count is a deterministic function of the seed.
+    private static List<RunFrame> MixedFrames() {
+        var frames = new List<RunFrame>();
+        // Nine distinct positions, plus a duplicate of the middle position with a different HFR/seed.
+        for (var i = -4; i <= 4; i++) {
+            var pos = HyperbolaP0 + i * 100;
+            frames.Add(new RunFrame { FrameId = $"pos_{pos}_a", FocuserPosition = pos, Image = new int[] { pos, 0 } });
+        }
+        // Two extra frames at the SAME (middle) position with different seeds => pooling must average them.
+        frames.Add(new RunFrame { FrameId = "pos_mid_b", FocuserPosition = HyperbolaP0, Image = new int[] { HyperbolaP0, 1 } });
+        frames.Add(new RunFrame { FrameId = "pos_mid_c", FocuserPosition = HyperbolaP0, Image = new int[] { HyperbolaP0, 2 } });
+        return frames;
+    }
+
+    // A split detector whose build is artificially "slow and jittered" so frame tasks finish out of order, AND
+    // whose per-frame star count / HFR is a pure deterministic function of the frame payload — so the ONLY thing
+    // that could differ across runs is completion-order handling, which the index-ordered assembly must defeat.
+    private sealed class JitteredSplitDetector : RunEvaluationData.ISplitFrameDetector {
+        private sealed class Ctx : IDisposable {
+            public int Position;
+            public int Seed;
+            public void Dispose() { }
+        }
+
+        public string ComputeEarlyKey(StarDetectorParams p) =>
+            p.NoiseClippingMultiplier.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        public async Task<IDisposable> BuildContextAsync(object frameImage, StarDetectorParams p, CancellationToken token) {
+            var payload = (int[])frameImage;
+            // Reverse-ish jitter: later frames sleep less, so completion order scrambles relative to index order.
+            var delay = ((payload[1] + 1) * 7 + (payload[0] % 13)) % 11;
+            await Task.Delay(delay, token).ConfigureAwait(false);
+            return new Ctx { Position = payload[0], Seed = payload[1] };
+        }
+
+        public FrameDetectionResult GateAndMeasure(IDisposable context, StarDetectorParams p) {
+            var ctx = (Ctx)context;
+            // HFR is a clean hyperbola plus a small per-frame seed offset; star count is a deterministic function of
+            // the seed and a LATE param (Sensitivity), so gating varies per candidate but never per completion order.
+            var hfr = Hfr(ctx.Position) + ctx.Seed * 0.01;
+            return new FrameDetectionResult {
+                AverageHFR = hfr,
+                HFRStdDev = 0.05 + ctx.Seed * 0.001,
+                StarCount = 40 + ctx.Seed * 3 + (int)p.Sensitivity,
+                StarCenters = Array.Empty<(double X, double Y)>()
+            };
+        }
+    }
+
+    private static void AssertMetricsEqual(RunEvaluationMetrics expected, RunEvaluationMetrics actual, string because) {
+        Assert.Multiple(() => {
+            Assert.That(actual.FrameStarCounts, Is.EqualTo(expected.FrameStarCounts), $"{because}: FrameStarCounts (in order)");
+            Assert.That(actual.SigmaFocus, Is.EqualTo(expected.SigmaFocus).Within(0.0).Or.NaN, $"{because}: SigmaFocus");
+            Assert.That(actual.LooStdError, Is.EqualTo(expected.LooStdError).Within(0.0).Or.NaN, $"{because}: LooStdError");
+            Assert.That(actual.RSquared, Is.EqualTo(expected.RSquared).Within(0.0), $"{because}: RSquared");
+            Assert.That(actual.ReducedChiSquared, Is.EqualTo(expected.ReducedChiSquared).Within(0.0).Or.NaN, $"{because}: ReducedChiSquared");
+            Assert.That(actual.StepSize, Is.EqualTo(expected.StepSize), $"{because}: StepSize");
+        });
+    }
+
+    [Test]
+    public async Task EvaluateAsync_ParallelFrames_AreDeterministicAcrossRepeatedRuns() {
+        // Run the SAME params many times against a jittered (out-of-completion-order) detector; every run must yield
+        // bit-identical metrics. If completion order leaked into FrameStarCounts or pooling, the jitter would expose it.
+        var p = new StarDetectorParams { NoiseClippingMultiplier = 4.0, Sensitivity = 5.0 };
+
+        RunEvaluationMetrics first = null;
+        for (int run = 0; run < 12; run++) {
+            using var data = new RunEvaluationData("det", MixedFrames(), new JitteredSplitDetector(), NewAlglib(), DefaultFitConfig());
+            var metrics = await data.EvaluateAsync(p, CancellationToken.None);
+            if (first == null) {
+                first = metrics;
+            } else {
+                AssertMetricsEqual(first, metrics, $"run {run} must match run 0");
+            }
+        }
+
+        // Sanity: the duplicated middle position must have pooled (12 frames in, 9 distinct positions out is implied
+        // by a finite, well-formed fit). FrameStarCounts is per-frame => 11 entries (9 + 2 extras).
+        Assert.That(first.FrameStarCounts.Count, Is.EqualTo(11), "one star count per frame, including the two shared-position extras");
+    }
+
+    [Test]
+    public async Task EvaluateAsync_ParallelPath_MatchesForcedSequentialPath() {
+        // The parallel path (default cap) must produce metrics IDENTICAL to a forced-sequential path (cap=1) for the
+        // same synthetic run — proving the concurrency does not change results.
+        var p = new StarDetectorParams { NoiseClippingMultiplier = 4.0, Sensitivity = 7.0 };
+
+        using var sequential = new RunEvaluationData("seq", MixedFrames(), new JitteredSplitDetector(), NewAlglib(), DefaultFitConfig()) {
+            FrameParallelismOverride = 1 // force the sequential path
+        };
+        var seqMetrics = await sequential.EvaluateAsync(p, CancellationToken.None);
+
+        using var parallel = new RunEvaluationData("par", MixedFrames(), new JitteredSplitDetector(), NewAlglib(), DefaultFitConfig()) {
+            FrameParallelismOverride = 8 // force a wide fan-out
+        };
+        var parMetrics = await parallel.EvaluateAsync(p, CancellationToken.None);
+
+        AssertMetricsEqual(seqMetrics, parMetrics, "parallel path must equal the forced-sequential path");
+    }
+
+    [Test]
+    public async Task EvaluateAsync_ParallelPath_MatchesSequential_WithDelegateDetector() {
+        // Same equivalence, but for the monolithic delegate path (no early-context cache) so both code paths are
+        // covered. The delegate returns a deterministic per-frame result; only the loop's concurrency differs.
+        Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> detect = async (image, sp, token) => {
+            var payload = (int[])image;
+            await Task.Delay(((payload[1] + 1) * 5) % 9, token).ConfigureAwait(false); // jitter completion order
+            return new FrameDetectionResult {
+                AverageHFR = Hfr(payload[0]) + payload[1] * 0.01,
+                HFRStdDev = 0.05,
+                StarCount = 40 + payload[1] * 3 + (int)sp.Sensitivity,
+                StarCenters = Array.Empty<(double X, double Y)>()
+            };
+        };
+
+        var p = new StarDetectorParams { Sensitivity = 3.0 };
+
+        var sequential = new RunEvaluationData("seq", MixedFrames(), detect, NewAlglib(), DefaultFitConfig()) {
+            FrameParallelismOverride = 1
+        };
+        var seqMetrics = await sequential.EvaluateAsync(p, CancellationToken.None);
+
+        var parallel = new RunEvaluationData("par", MixedFrames(), detect, NewAlglib(), DefaultFitConfig()) {
+            FrameParallelismOverride = 8
+        };
+        var parMetrics = await parallel.EvaluateAsync(p, CancellationToken.None);
+
+        AssertMetricsEqual(seqMetrics, parMetrics, "delegate parallel path must equal the delegate sequential path");
+    }
+
+    [Test]
+    public void EvaluateAsync_ParallelFrames_HonorCancellation() {
+        // Cancelling mid-evaluation must surface an OperationCanceledException and not hang; a detector that blocks
+        // on the token lets us cancel while frames are in flight.
+        using var cts = new CancellationTokenSource();
+        var detector = new BlockingSplitDetector(cts);
+        using var data = new RunEvaluationData("cancel", MixedFrames(), detector, NewAlglib(), DefaultFitConfig()) {
+            FrameParallelismOverride = 4
+        };
+
+        Assert.CatchAsync<OperationCanceledException>(async () =>
+            await data.EvaluateAsync(new StarDetectorParams { NoiseClippingMultiplier = 4.0 }, cts.Token));
+    }
+
+    // A split detector that cancels the token as soon as the first build starts, then waits on it — so the parallel
+    // loop must propagate the cancellation across all in-flight frames.
+    private sealed class BlockingSplitDetector : RunEvaluationData.ISplitFrameDetector {
+        private readonly CancellationTokenSource cts;
+        public BlockingSplitDetector(CancellationTokenSource cts) { this.cts = cts; }
+
+        private sealed class Ctx : IDisposable { public void Dispose() { } }
+
+        public string ComputeEarlyKey(StarDetectorParams p) => "k";
+
+        public async Task<IDisposable> BuildContextAsync(object frameImage, StarDetectorParams p, CancellationToken token) {
+            cts.Cancel();
+            await Task.Delay(Timeout.Infinite, token).ConfigureAwait(false); // blocks until cancelled
+            return new Ctx();
+        }
+
+        public FrameDetectionResult GateAndMeasure(IDisposable context, StarDetectorParams p) =>
+            new FrameDetectionResult { AverageHFR = 2.0, HFRStdDev = 0.05, StarCount = 30, StarCenters = Array.Empty<(double X, double Y)>() };
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationDataTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationDataTests.cs
@@ -1,0 +1,259 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Optimization;
+
+[TestFixture]
+public class RunEvaluationDataTests {
+
+    private static AlglibAPI NewAlglib() => new AlglibAPI();
+
+    private static RunFitConfig DefaultFitConfig() => new RunFitConfig {
+        StepSize = 100,
+        UseWeights = true,
+        MaxOutlierRejections = 0,
+        RejectionConfidence = 0.0,
+        PreferredModel = null
+    };
+
+    // A clean symmetric hyperbola hfr(pos) = sqrt(a^2 + ((pos - p0)/b)^2).
+    private const double HyperbolaA = 1.5;     // minimum HFR at focus
+    private const double HyperbolaB = 8.0;     // focuser-steps-per-unit; larger b => flatter curve
+    private const int HyperbolaP0 = 10000;     // best-focus position
+
+    private static double Hfr(int pos) {
+        var dx = (pos - HyperbolaP0) / HyperbolaB;
+        return Math.Sqrt(HyperbolaA * HyperbolaA + dx * dx);
+    }
+
+    // Detection delegate that returns a clean hyperbola HFR, a fixed small stdev, and a fixed star count.
+    private static Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> HyperbolaDetect(
+        int starCount = 50, double hfrStdDev = 0.05, IReadOnlyList<(double X, double Y)> centers = null) {
+        return (image, p, token) => {
+            var pos = (int)image; // synthetic frames carry their focuser position as the payload
+            return Task.FromResult(new FrameDetectionResult {
+                AverageHFR = Hfr(pos),
+                HFRStdDev = hfrStdDev,
+                StarCount = starCount,
+                StarCenters = centers ?? Array.Empty<(double X, double Y)>()
+            });
+        };
+    }
+
+    private static List<RunFrame> NineFrames() {
+        // Nine evenly-spaced focuser positions centered on best focus.
+        var frames = new List<RunFrame>();
+        for (var i = -4; i <= 4; i++) {
+            var pos = HyperbolaP0 + i * 100;
+            frames.Add(new RunFrame { FrameId = $"pos_{pos}", FocuserPosition = pos, Image = pos });
+        }
+        return frames;
+    }
+
+    [Test]
+    public async Task EvaluateAsync_FramesAtSamePosition_PoolIntoOneScatterPoint() {
+        // Two frames at the SAME focuser position with different HFRs must pool to one point at the average HFR.
+        Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> detect = (image, p, token) => {
+            // Frame A reports HFR=2.0, frame B reports HFR=4.0 (both at the same position) => pooled mean 3.0.
+            var hfr = ((string)((object[])image)[1]) == "A" ? 2.0 : 4.0;
+            return Task.FromResult(new FrameDetectionResult { AverageHFR = hfr, HFRStdDev = 0.1, StarCount = 30, StarCenters = Array.Empty<(double X, double Y)>() });
+        };
+
+        // Three positions so the fit has enough points; the middle position is sampled twice.
+        var frames = new List<RunFrame> {
+            new RunFrame { FrameId = "p0a", FocuserPosition = 9800, Image = new object[] { 9800, "A" } },
+            new RunFrame { FrameId = "p1a", FocuserPosition = 10000, Image = new object[] { 10000, "A" } },
+            new RunFrame { FrameId = "p1b", FocuserPosition = 10000, Image = new object[] { 10000, "B" } },
+            new RunFrame { FrameId = "p2a", FocuserPosition = 10200, Image = new object[] { 10200, "A" } },
+        };
+
+        var data = new RunEvaluationData("pool", frames, detect, NewAlglib(), DefaultFitConfig());
+        var result = await data.EvaluateAndFitAsync(new StarDetectorParams(), CancellationToken.None);
+
+        Assert.Multiple(() => {
+            // Four frames in, but only THREE distinct focuser positions feeding the fit.
+            Assert.That(result.PooledPointCount, Is.EqualTo(3), "two frames at one position must pool to a single fit point");
+            Assert.That(result.Metrics.FrameStarCounts.Count, Is.EqualTo(4), "FrameStarCounts is per-frame, not per-position");
+            Assert.That(result.PooledHfrAt(10000), Is.EqualTo(3.0).Within(1e-9), "pooled HFR is the mean of the per-frame HFRs at that position");
+        });
+    }
+
+    [Test]
+    public async Task EvaluateAsync_CleanHyperbola_FitsWithHighRSquaredAndFiniteSigma() {
+        var data = new RunEvaluationData("clean", NineFrames(), HyperbolaDetect(), NewAlglib(), DefaultFitConfig());
+        var metrics = await data.EvaluateAsync(new StarDetectorParams(), CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(metrics.RSquared, Is.GreaterThan(0.99), "clean hyperbola fits near-perfectly");
+            Assert.That(double.IsNaN(metrics.SigmaFocus), Is.False, "focus sigma must be finite for a clean fit");
+            Assert.That(metrics.SigmaFocus, Is.GreaterThan(0.0));
+            Assert.That(metrics.StepSize, Is.EqualTo(100.0), "StepSize is taken from the fit config");
+            Assert.That(metrics.FrameStarCounts.Count, Is.EqualTo(9), "one star count per frame");
+            Assert.That(metrics.FrameStarCounts.All(c => c == 50), Is.True);
+            Assert.That(metrics.Recall, Is.Null, "no labels => null label scores");
+            Assert.That(metrics.Precision, Is.Null);
+
+            // The whole point of T3: these metrics score well in T2's objective.
+            var j = OptimizationObjective.JRun(metrics, new ObjectiveConstants());
+            Assert.That(j, Is.GreaterThan(0.7), "a clean star-rich run should score highly");
+        });
+    }
+
+    [Test]
+    public async Task EvaluateAsync_StarvedFrames_HardFailsViaJRun() {
+        // Some frames return fewer than NHard stars => the objective's hard constraint maps J to 0.
+        var c = new ObjectiveConstants();
+        var frames = NineFrames();
+        Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> detect = (image, p, token) => {
+            var pos = (int)image;
+            // Starve the two wings (below NHard); the rest are healthy.
+            var starved = pos <= HyperbolaP0 - 300 || pos >= HyperbolaP0 + 300;
+            return Task.FromResult(new FrameDetectionResult {
+                AverageHFR = Hfr(pos),
+                HFRStdDev = 0.05,
+                StarCount = starved ? 1 : 50,
+                StarCenters = Array.Empty<(double X, double Y)>()
+            });
+        };
+
+        var data = new RunEvaluationData("starved", frames, detect, NewAlglib(), DefaultFitConfig());
+        var metrics = await data.EvaluateAsync(new StarDetectorParams(), CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(metrics.FrameStarCounts.Count(n => n < c.NHard), Is.GreaterThan(c.MaxFramesBelowHardFloor),
+                "the run must contain more starved frames than the allowed floor");
+            Assert.That(OptimizationObjective.JRun(metrics, c), Is.EqualTo(0.0), "starved frames must hard-fail the objective");
+        });
+    }
+
+    [Test]
+    public async Task EvaluateAsync_TooFewPositions_ReturnsNaNSigmaWithoutThrowing() {
+        // Only two distinct positions: too few to fit a hyperbola. Must degrade gracefully (NaN sigma, J=0).
+        var frames = new List<RunFrame> {
+            new RunFrame { FrameId = "a", FocuserPosition = 9900, Image = 9900 },
+            new RunFrame { FrameId = "b", FocuserPosition = 10100, Image = 10100 },
+        };
+        var data = new RunEvaluationData("few", frames, HyperbolaDetect(), NewAlglib(), DefaultFitConfig());
+
+        RunEvaluationMetrics metrics = null;
+        Assert.DoesNotThrowAsync(async () => metrics = await data.EvaluateAsync(new StarDetectorParams(), CancellationToken.None));
+        Assert.Multiple(() => {
+            Assert.That(double.IsNaN(metrics.SigmaFocus), Is.True, "too few points => no fitted sigma");
+            Assert.That(double.IsNaN(metrics.LooStdError), Is.True, "too few points => no LOO fallback either");
+            Assert.That(OptimizationObjective.JRun(metrics, new ObjectiveConstants()), Is.EqualTo(0.0), "unusable focus sigma => hard fail");
+        });
+    }
+
+    [Test]
+    public async Task EvaluateAsync_Labels_ProduceRecallAndPrecision() {
+        // One accepted star at (100,100). Labels: a missed star FAR from any accepted center (not recovered =>
+        // recall 0); a should-reject star also far from accepted centers (correctly excluded => precision 1).
+        var accepted = new List<(double X, double Y)> { (100.0, 100.0) };
+        var detect = HyperbolaDetect(centers: accepted);
+
+        var labels = new List<FrameLabels> {
+            new FrameLabels {
+                FocuserPosition = HyperbolaP0,
+                Missed = new List<(double X, double Y)> { (5000.0, 5000.0) },        // nowhere near accepted => recall 0
+                ShouldReject = new List<(double X, double Y)> { (6000.0, 6000.0) },  // nowhere near accepted => precision 1
+                RadiusPx = 3.0
+            }
+        };
+
+        var data = new RunEvaluationData("labeled", NineFrames(), detect, NewAlglib(), DefaultFitConfig(), labels);
+        var metrics = await data.EvaluateAsync(new StarDetectorParams(), CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(metrics.Recall, Is.Not.Null);
+            Assert.That(metrics.Precision, Is.Not.Null);
+            Assert.That(metrics.Recall.Value, Is.EqualTo(0.0).Within(1e-9), "missed star not recovered => recall 0");
+            Assert.That(metrics.Precision.Value, Is.EqualTo(1.0).Within(1e-9), "should-reject star correctly excluded => precision 1");
+        });
+    }
+
+    [Test]
+    public async Task EvaluateAsync_NoLabels_LeavesRecallPrecisionNull() {
+        var data = new RunEvaluationData("nolabels", NineFrames(), HyperbolaDetect(), NewAlglib(), DefaultFitConfig());
+        var metrics = await data.EvaluateAsync(new StarDetectorParams(), CancellationToken.None);
+        Assert.Multiple(() => {
+            Assert.That(metrics.Recall, Is.Null);
+            Assert.That(metrics.Precision, Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task CreateEvaluator_OverTwoRuns_ReturnsOnePerRunInOrder() {
+        var runA = new RunEvaluationData("A", NineFrames(), HyperbolaDetect(starCount: 40), NewAlglib(), DefaultFitConfig());
+        var runB = new RunEvaluationData("B", NineFrames(), HyperbolaDetect(starCount: 60), NewAlglib(), DefaultFitConfig());
+
+        var evaluator = RunEvaluationData.CreateEvaluator(new[] { runA, runB });
+        var metrics = await evaluator(new StarDetectorParams(), CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(metrics.Count, Is.EqualTo(2), "one metrics per run");
+            Assert.That(metrics[0].FrameStarCounts.All(c => c == 40), Is.True, "first run's frames in order");
+            Assert.That(metrics[1].FrameStarCounts.All(c => c == 60), Is.True, "second run's frames in order");
+        });
+    }
+
+    [Test]
+    public async Task CreateEvaluator_PluggedIntoOptimizer_CompletesAndNeverRegresses() {
+        // The real integration proof: T3's evaluator drives T2's optimizer end-to-end with a real fitter.
+        // Make J depend on Sensitivity so there is something to optimize: star count grows toward an optimum
+        // Sensitivity, which raises S_stars (and thus J) without ever hard-failing.
+        const double optSensitivity = 10.0;
+        Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> detect = (image, p, token) => {
+            var pos = (int)image;
+            // Star count peaks at optSensitivity. The range is chosen to sit in the SENSITIVE band of S_stars
+            // (NFloor=8, NTarget=20): ~22 at the optimum (S_stars ~ 1) sliding toward ~10 at the seed (median
+            // term unsaturated), so J responds monotonically to Sensitivity — and always stays above the hard
+            // floor (NHard=3).
+            var dist = Math.Abs(p.Sensitivity - optSensitivity);
+            var starCount = (int)Math.Max(10, Math.Round(22 - 1.5 * dist));
+            return Task.FromResult(new FrameDetectionResult {
+                AverageHFR = Hfr(pos),
+                HFRStdDev = 0.05,
+                StarCount = starCount,
+                StarCenters = Array.Empty<(double X, double Y)>()
+            });
+        };
+
+        var run = new RunEvaluationData("opt", NineFrames(), detect, NewAlglib(), DefaultFitConfig());
+        var evaluator = RunEvaluationData.CreateEvaluator(new[] { run });
+
+        var seed = new StarDetectorParams { Sensitivity = 2.0, StarClippingMultiplier = 2.0 };
+        var variables = OptimizerVariable.CreateCuratedSet();
+        var settings = new OptimizerSettings { MaxEvaluations = 200, CoarseGridLevels = 4, StepFloorFraction = 0.125 };
+
+        var result = await new StarDetectionOptimizer().OptimizeAsync(seed, variables, evaluator, settings, null, CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(result.BestJ, Is.GreaterThanOrEqualTo(result.SeedJ), "must never regress below seed");
+            Assert.That(result.Evaluations, Is.LessThanOrEqualTo(settings.MaxEvaluations), "must respect the eval budget");
+            Assert.That(result.BestJ, Is.GreaterThan(0.0), "a star-rich, well-fit run must score above zero");
+            // It should have moved Sensitivity toward the star-count optimum.
+            Assert.That(Math.Abs(result.BestParams.Sensitivity - optSensitivity),
+                Is.LessThan(Math.Abs(seed.Sensitivity - optSensitivity)), "Sensitivity should approach the star-count optimum");
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationDataTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationDataTests.cs
@@ -41,6 +41,11 @@ public class RunEvaluationDataTests {
     private const double HyperbolaB = 8.0;     // focuser-steps-per-unit; larger b => flatter curve
     private const int HyperbolaP0 = 10000;     // best-focus position
 
+    // A small label box CENTERED on (cx,cy) (half-extent 3, matching the prior point-radius intent), so an accepted
+    // star whose center is at (or very near) (cx,cy) lies INSIDE the box (recovered), while a far one does not.
+    private static LabelBox Box(double cx, double cy, double half = 3.0) =>
+        new LabelBox(cx - half, cy - half, 2 * half, 2 * half);
+
     private static double Hfr(int pos) {
         var dx = (pos - HyperbolaP0) / HyperbolaB;
         return Math.Sqrt(HyperbolaA * HyperbolaA + dx * dx);
@@ -174,8 +179,8 @@ public class RunEvaluationDataTests {
         var labels = new List<FrameLabels> {
             new FrameLabels {
                 FocuserPosition = HyperbolaP0,
-                Missed = new List<(double X, double Y)> { (5000.0, 5000.0) },        // nowhere near accepted => recall 0
-                ShouldReject = new List<(double X, double Y)> { (6000.0, 6000.0) },  // nowhere near accepted => precision 1
+                Missed = new List<LabelBox> { Box(5000.0, 5000.0) },        // no accepted center inside => recall 0
+                ShouldReject = new List<LabelBox> { Box(6000.0, 6000.0) },  // no accepted center inside => precision 1
                 RadiusPx = 3.0
             }
         };
@@ -202,11 +207,11 @@ public class RunEvaluationDataTests {
         var labels = new List<FrameLabels> {
             new FrameLabels {
                 FocuserPosition = HyperbolaP0,
-                Missed = new List<(double X, double Y)>(),                                   // no false negatives
-                ShouldReject = new List<(double X, double Y)>(),                             // no false positives
-                WronglyRejected = new List<(double X, double Y)> {
-                    (100.0, 100.0),                                                          // covered by an accepted center => recovered
-                    (9000.0, 9000.0)                                                         // nowhere near accepted => not recovered
+                Missed = new List<LabelBox>(),                                   // no false negatives
+                ShouldReject = new List<LabelBox>(),                            // no false positives
+                WronglyRejected = new List<LabelBox> {
+                    Box(100.0, 100.0),                                          // contains an accepted center => recovered
+                    Box(9000.0, 9000.0)                                         // no accepted center inside => not recovered
                 },
                 RadiusPx = 3.0
             }
@@ -232,11 +237,11 @@ public class RunEvaluationDataTests {
         var labels = new List<FrameLabels> {
             new FrameLabels {
                 FocuserPosition = HyperbolaP0,
-                Missed = new List<(double X, double Y)> { (100.0, 100.0) },          // recovered
-                ShouldReject = new List<(double X, double Y)>(),
-                WronglyRejected = new List<(double X, double Y)> {
-                    (300.0, 300.0),                                                  // recovered
-                    (9000.0, 9000.0)                                                 // not recovered
+                Missed = new List<LabelBox> { Box(100.0, 100.0) },          // recovered
+                ShouldReject = new List<LabelBox>(),
+                WronglyRejected = new List<LabelBox> {
+                    Box(300.0, 300.0),                                      // recovered
+                    Box(9000.0, 9000.0)                                     // not recovered
                 },
                 RadiusPx = 3.0
             }
@@ -256,10 +261,10 @@ public class RunEvaluationDataTests {
         var accepted = new List<(double X, double Y)> { (100.0, 100.0) };
         var detect = HyperbolaDetect(centers: accepted);
 
-        FrameLabels MakeLabel(IReadOnlyList<(double X, double Y)> wrongly) => new FrameLabels {
+        FrameLabels MakeLabel(IReadOnlyList<LabelBox> wrongly) => new FrameLabels {
             FocuserPosition = HyperbolaP0,
-            Missed = new List<(double X, double Y)> { (100.0, 100.0), (9000.0, 9000.0) }, // 1 of 2 recovered => 0.5
-            ShouldReject = new List<(double X, double Y)>(),
+            Missed = new List<LabelBox> { Box(100.0, 100.0), Box(9000.0, 9000.0) }, // 1 of 2 recovered => 0.5
+            ShouldReject = new List<LabelBox>(),
             WronglyRejected = wrongly,
             RadiusPx = 3.0
         };
@@ -267,7 +272,7 @@ public class RunEvaluationDataTests {
         var dataNull = new RunEvaluationData("null", NineFrames(), detect, NewAlglib(), DefaultFitConfig(),
             new List<FrameLabels> { MakeLabel(null) });
         var dataEmpty = new RunEvaluationData("empty", NineFrames(), detect, NewAlglib(), DefaultFitConfig(),
-            new List<FrameLabels> { MakeLabel(new List<(double X, double Y)>()) });
+            new List<FrameLabels> { MakeLabel(new List<LabelBox>()) });
 
         var mNull = await dataNull.EvaluateAsync(new StarDetectorParams(), CancellationToken.None);
         var mEmpty = await dataEmpty.EvaluateAsync(new StarDetectorParams(), CancellationToken.None);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationDataTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationDataTests.cs
@@ -192,6 +192,93 @@ public class RunEvaluationDataTests {
     }
 
     [Test]
+    public async Task EvaluateAsync_WronglyRejected_FoldsIntoRecall() {
+        // Two accepted stars. One WronglyRejected target lands ON an accepted center (recovered) and one does NOT
+        // (not recovered) => recall 0.5. Precision stays a function of ShouldReject only (none => 1.0). This proves
+        // the union of Missed ∪ WronglyRejected drives recall.
+        var accepted = new List<(double X, double Y)> { (100.0, 100.0), (200.0, 200.0) };
+        var detect = HyperbolaDetect(centers: accepted);
+
+        var labels = new List<FrameLabels> {
+            new FrameLabels {
+                FocuserPosition = HyperbolaP0,
+                Missed = new List<(double X, double Y)>(),                                   // no false negatives
+                ShouldReject = new List<(double X, double Y)>(),                             // no false positives
+                WronglyRejected = new List<(double X, double Y)> {
+                    (100.0, 100.0),                                                          // covered by an accepted center => recovered
+                    (9000.0, 9000.0)                                                         // nowhere near accepted => not recovered
+                },
+                RadiusPx = 3.0
+            }
+        };
+
+        var data = new RunEvaluationData("wrongly", NineFrames(), detect, NewAlglib(), DefaultFitConfig(), labels);
+        var metrics = await data.EvaluateAsync(new StarDetectorParams(), CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(metrics.Recall, Is.Not.Null);
+            Assert.That(metrics.Recall.Value, Is.EqualTo(0.5).Within(1e-9), "1 of 2 wrongly-rejected targets recovered => recall 0.5");
+            Assert.That(metrics.Precision, Is.Not.Null);
+            Assert.That(metrics.Precision.Value, Is.EqualTo(1.0).Within(1e-9), "no should-reject targets => precision 1");
+        });
+    }
+
+    [Test]
+    public async Task EvaluateAsync_MissedAndWronglyRejected_UnionDrivesRecall() {
+        // Missed (recovered) ∪ WronglyRejected (one recovered, one not) => 2 of 3 recall targets recovered => 2/3.
+        var accepted = new List<(double X, double Y)> { (100.0, 100.0), (300.0, 300.0) };
+        var detect = HyperbolaDetect(centers: accepted);
+
+        var labels = new List<FrameLabels> {
+            new FrameLabels {
+                FocuserPosition = HyperbolaP0,
+                Missed = new List<(double X, double Y)> { (100.0, 100.0) },          // recovered
+                ShouldReject = new List<(double X, double Y)>(),
+                WronglyRejected = new List<(double X, double Y)> {
+                    (300.0, 300.0),                                                  // recovered
+                    (9000.0, 9000.0)                                                 // not recovered
+                },
+                RadiusPx = 3.0
+            }
+        };
+
+        var data = new RunEvaluationData("union", NineFrames(), detect, NewAlglib(), DefaultFitConfig(), labels);
+        var metrics = await data.EvaluateAsync(new StarDetectorParams(), CancellationToken.None);
+
+        Assert.That(metrics.Recall, Is.Not.Null);
+        Assert.That(metrics.Recall.Value, Is.EqualTo(2.0 / 3.0).Within(1e-9), "2 of 3 (missed ∪ wrongly-rejected) recovered");
+    }
+
+    [Test]
+    public async Task EvaluateAsync_MissedOnly_WronglyRejectedNullOrEmpty_RecallUnchanged() {
+        // Bit-identical-behavior guard: with WronglyRejected null AND with it empty, recall must match the
+        // missed-only result exactly (the union fold must not perturb the prior single-list path).
+        var accepted = new List<(double X, double Y)> { (100.0, 100.0) };
+        var detect = HyperbolaDetect(centers: accepted);
+
+        FrameLabels MakeLabel(IReadOnlyList<(double X, double Y)> wrongly) => new FrameLabels {
+            FocuserPosition = HyperbolaP0,
+            Missed = new List<(double X, double Y)> { (100.0, 100.0), (9000.0, 9000.0) }, // 1 of 2 recovered => 0.5
+            ShouldReject = new List<(double X, double Y)>(),
+            WronglyRejected = wrongly,
+            RadiusPx = 3.0
+        };
+
+        var dataNull = new RunEvaluationData("null", NineFrames(), detect, NewAlglib(), DefaultFitConfig(),
+            new List<FrameLabels> { MakeLabel(null) });
+        var dataEmpty = new RunEvaluationData("empty", NineFrames(), detect, NewAlglib(), DefaultFitConfig(),
+            new List<FrameLabels> { MakeLabel(new List<(double X, double Y)>()) });
+
+        var mNull = await dataNull.EvaluateAsync(new StarDetectorParams(), CancellationToken.None);
+        var mEmpty = await dataEmpty.EvaluateAsync(new StarDetectorParams(), CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(mNull.Recall.Value, Is.EqualTo(0.5).Within(1e-12), "null WronglyRejected => missed-only recall");
+            Assert.That(mEmpty.Recall.Value, Is.EqualTo(0.5).Within(1e-12), "empty WronglyRejected => missed-only recall");
+        });
+    }
+
+    [Test]
     public async Task EvaluateAsync_NoLabels_LeavesRecallPrecisionNull() {
         var data = new RunEvaluationData("nolabels", NineFrames(), HyperbolaDetect(), NewAlglib(), DefaultFitConfig());
         var metrics = await data.EvaluateAsync(new StarDetectorParams(), CancellationToken.None);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationLoaderTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationLoaderTests.cs
@@ -1,0 +1,51 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using NINA.Image.Interfaces;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NINA.Profile.Interfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Optimization;
+
+/// <summary>
+/// The wizard-side loader is heavily NINA-coupled (image factory + imaging mediator + real star detection),
+/// so its end-to-end path is exercised in T6 against the user's real AF run folder. Here we only verify it
+/// constructs and rejects null collaborators, so a wiring mistake is caught early.
+/// </summary>
+[TestFixture]
+public class RunEvaluationLoaderTests {
+
+    [Test]
+    public void Constructor_WithAllCollaborators_DoesNotThrow() {
+        Assert.DoesNotThrow(() => new RunEvaluationLoader(
+            Substitute.For<IProfileService>(),
+            Substitute.For<IImageDataFactory>(),
+            Substitute.For<IImagingMediator>(),
+            Substitute.For<IAutoFocusEngine>(),
+            Substitute.For<IHocusFocusStarDetection>()));
+    }
+
+    [Test]
+    public void Constructor_NullCollaborator_Throws() {
+        Assert.Throws<ArgumentNullException>(() => new RunEvaluationLoader(
+            null,
+            Substitute.For<IImageDataFactory>(),
+            Substitute.For<IImagingMediator>(),
+            Substitute.For<IAutoFocusEngine>(),
+            Substitute.For<IHocusFocusStarDetection>()));
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerTests.cs
@@ -1,0 +1,318 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Optimization;
+
+[TestFixture]
+public class StarDetectionOptimizerTests {
+
+    // Two-axis synthetic landscape. J is maximized when (Sensitivity, StarClippingMultiplier) are at
+    // the chosen optimum. We map distance-from-optimum to SigmaFocus so SFocus (and thus J) peaks there.
+    // All other metrics are kept star-rich / well-fit so they never hard-fail.
+    private const double OptSensitivity = 10.0;   // interior of [0, 20]
+    private const double OptStarClip = 2.5;        // interior of [0.5, 5]
+
+    private static RunEvaluationMetrics SyntheticRunFor(StarDetectorParams p) {
+        // Normalized distance (0 at optimum) over the two optimized axes, each scaled by its span.
+        var dSens = (p.Sensitivity - OptSensitivity) / 20.0;
+        var dClip = (p.StarClippingMultiplier - OptStarClip) / 4.5;
+        var dist = Math.Sqrt(dSens * dSens + dClip * dClip);
+        // SigmaFocus grows with distance: small (sharp) at the optimum, larger away.
+        var stepSize = 100.0;
+        var sigmaFocus = stepSize * (0.02 + 1.0 * dist);
+        return new RunEvaluationMetrics {
+            SigmaFocus = sigmaFocus,
+            LooStdError = double.NaN,
+            StepSize = stepSize,
+            RSquared = 0.99,
+            ReducedChiSquared = 1.0,
+            FrameStarCounts = Enumerable.Repeat(50, 10).ToList()
+        };
+    }
+
+    private static Func<StarDetectorParams, CancellationToken, Task<IReadOnlyList<RunEvaluationMetrics>>> SyntheticEvaluator(
+        Action<StarDetectorParams> onCall = null) {
+        return (p, token) => {
+            onCall?.Invoke(p);
+            IReadOnlyList<RunEvaluationMetrics> runs = new[] { SyntheticRunFor(p) };
+            return Task.FromResult(runs);
+        };
+    }
+
+    private static StarDetectorParams Seed() => new StarDetectorParams {
+        Sensitivity = 2.0,
+        StarClippingMultiplier = 2.0,
+    };
+
+    private static OptimizerSettings DefaultSettings() => new OptimizerSettings {
+        MaxEvaluations = 400,
+        CoarseGridLevels = 4,
+        StepFloorFraction = 0.125
+    };
+
+    [Test]
+    public async Task Optimize_MovesTowardOptimum_AndNeverWorseThanSeed() {
+        var optimizer = new StarDetectionOptimizer();
+        var seed = Seed();
+        var variables = OptimizerVariable.CreateCuratedSet();
+        var result = await optimizer.OptimizeAsync(seed, variables, SyntheticEvaluator(), DefaultSettings(), null, CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(result.BestJ, Is.GreaterThanOrEqualTo(result.SeedJ), "best J must never regress below seed");
+            Assert.That(result.Evaluations, Is.LessThanOrEqualTo(DefaultSettings().MaxEvaluations), "must respect budget");
+            // Moved measurably toward the optimum on the two optimized axes.
+            var seedDistSens = Math.Abs(seed.Sensitivity - OptSensitivity);
+            var bestDistSens = Math.Abs(result.BestParams.Sensitivity - OptSensitivity);
+            var seedDistClip = Math.Abs(seed.StarClippingMultiplier - OptStarClip);
+            var bestDistClip = Math.Abs(result.BestParams.StarClippingMultiplier - OptStarClip);
+            Assert.That(bestDistSens + bestDistClip, Is.LessThan(seedDistSens + seedDistClip), "should approach the optimum");
+            Assert.That(result.ImprovedOverSeed, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task Optimize_IsDeterministic() {
+        var variables = OptimizerVariable.CreateCuratedSet();
+        var r1 = await new StarDetectionOptimizer().OptimizeAsync(Seed(), variables, SyntheticEvaluator(), DefaultSettings(), null, CancellationToken.None);
+        var r2 = await new StarDetectionOptimizer().OptimizeAsync(Seed(), variables, SyntheticEvaluator(), DefaultSettings(), null, CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(r1.BestJ, Is.EqualTo(r2.BestJ).Within(0.0));
+            Assert.That(r1.SeedJ, Is.EqualTo(r2.SeedJ).Within(0.0));
+            Assert.That(r1.Evaluations, Is.EqualTo(r2.Evaluations));
+
+            // Every curated variable must read back identically across both runs (not just the two grid axes).
+            foreach (var v in variables) {
+                Assert.That(v.Read(r1.BestParams), Is.EqualTo(v.Read(r2.BestParams)).Within(0.0), $"{v.Name} differs between runs");
+            }
+
+            // ChangedVariables must match in count AND contents (name + seed/best values), in order.
+            Assert.That(r1.ChangedVariables.Count, Is.EqualTo(r2.ChangedVariables.Count), "ChangedVariables count differs");
+            for (var i = 0; i < r1.ChangedVariables.Count; i++) {
+                Assert.That(r1.ChangedVariables[i].Name, Is.EqualTo(r2.ChangedVariables[i].Name), $"ChangedVariables[{i}].Name");
+                Assert.That(r1.ChangedVariables[i].SeedValue, Is.EqualTo(r2.ChangedVariables[i].SeedValue).Within(0.0), $"ChangedVariables[{i}].SeedValue");
+                Assert.That(r1.ChangedVariables[i].BestValue, Is.EqualTo(r2.ChangedVariables[i].BestValue).Within(0.0), $"ChangedVariables[{i}].BestValue");
+            }
+        });
+    }
+
+    [Test]
+    public async Task Optimize_FlatLandscape_KeepsSeedAndReportsNoImprovement() {
+        // Constant J everywhere => no strictly-improving move => result equals seed.
+        Func<StarDetectorParams, CancellationToken, Task<IReadOnlyList<RunEvaluationMetrics>>> flat = (p, token) => {
+            IReadOnlyList<RunEvaluationMetrics> runs = new[] {
+                new RunEvaluationMetrics {
+                    SigmaFocus = 10.0,
+                    LooStdError = double.NaN,
+                    StepSize = 100.0,
+                    RSquared = 0.95,
+                    ReducedChiSquared = 1.0,
+                    FrameStarCounts = Enumerable.Repeat(40, 10).ToList()
+                }
+            };
+            return Task.FromResult(runs);
+        };
+
+        var seed = Seed();
+        var variables = OptimizerVariable.CreateCuratedSet();
+        var result = await new StarDetectionOptimizer().OptimizeAsync(seed, variables, flat, DefaultSettings(), null, CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(result.ImprovedOverSeed, Is.False);
+            Assert.That(result.BestJ, Is.EqualTo(result.SeedJ).Within(0.0));
+            Assert.That(result.BestParams.Sensitivity, Is.EqualTo(seed.Sensitivity).Within(0.0));
+            Assert.That(result.BestParams.StarClippingMultiplier, Is.EqualTo(seed.StarClippingMultiplier).Within(0.0));
+            Assert.That(result.ChangedVariables, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Optimize_NeverEvaluatesSameCacheKeyTwice() {
+        var keysSeen = new List<string>();
+        var locker = new object();
+        Action<StarDetectorParams> onCall = p => {
+            var key = StarDetector.ComputeCacheKey(p);
+            lock (locker) {
+                keysSeen.Add(key);
+            }
+        };
+
+        var variables = OptimizerVariable.CreateCuratedSet();
+        await new StarDetectionOptimizer().OptimizeAsync(Seed(), variables, SyntheticEvaluator(onCall), DefaultSettings(), null, CancellationToken.None);
+
+        Assert.That(keysSeen.Count, Is.EqualTo(keysSeen.Distinct().Count()),
+            "the evaluator must never be invoked twice for the same cache key (revisits hit the memo)");
+    }
+
+    [Test]
+    public async Task Optimize_EvaluationCountMatchesUniqueEvaluatorInvocations() {
+        var invocations = 0;
+        Action<StarDetectorParams> onCall = _ => Interlocked.Increment(ref invocations);
+        var variables = OptimizerVariable.CreateCuratedSet();
+        var result = await new StarDetectionOptimizer().OptimizeAsync(Seed(), variables, SyntheticEvaluator(onCall), DefaultSettings(), null, CancellationToken.None);
+        // Evaluations counts only cache misses; every cache miss is exactly one evaluator invocation.
+        Assert.That(result.Evaluations, Is.EqualTo(invocations));
+    }
+
+    [Test]
+    public async Task Optimize_MultiRun_PrefersBalancedOverLopsided() {
+        // Two runs: run A peaks at low Sensitivity, run B peaks at high Sensitivity. With beta=0.5 the min
+        // term dominates, so the optimizer should settle near the midpoint (balanced) rather than at either
+        // extreme (where one run is great and the other terrible).
+        Func<StarDetectorParams, CancellationToken, Task<IReadOnlyList<RunEvaluationMetrics>>> twoRun = (p, token) => {
+            double step = 100.0;
+            double sens = p.Sensitivity;
+            // Run A sigma minimized at sens=4; Run B minimized at sens=16. Midpoint balances both.
+            double sigmaA = step * (0.02 + Math.Abs(sens - 4.0) / 20.0);
+            double sigmaB = step * (0.02 + Math.Abs(sens - 16.0) / 20.0);
+            RunEvaluationMetrics Make(double sigma) => new RunEvaluationMetrics {
+                SigmaFocus = sigma,
+                LooStdError = double.NaN,
+                StepSize = step,
+                RSquared = 0.99,
+                ReducedChiSquared = 1.0,
+                FrameStarCounts = Enumerable.Repeat(50, 10).ToList()
+            };
+            IReadOnlyList<RunEvaluationMetrics> runs = new[] { Make(sigmaA), Make(sigmaB) };
+            return Task.FromResult(runs);
+        };
+
+        // Seed at an extreme.
+        var seed = new StarDetectorParams { Sensitivity = 2.0, StarClippingMultiplier = 2.5 };
+        var variables = OptimizerVariable.CreateCuratedSet();
+        var settings = new OptimizerSettings { MaxEvaluations = 600, CoarseGridLevels = 5, StepFloorFraction = 0.125 };
+        var result = await new StarDetectionOptimizer().OptimizeAsync(seed, variables, twoRun, settings, null, CancellationToken.None);
+
+        // The balanced optimum is sens=10 (midpoint of 4 and 16). Should land closer to 10 than to either extreme.
+        Assert.That(Math.Abs(result.BestParams.Sensitivity - 10.0), Is.LessThan(3.0),
+            $"expected balanced ~10, got {result.BestParams.Sensitivity}");
+    }
+
+    [Test]
+    public void Optimize_CancellationThrows() {
+        var cts = new CancellationTokenSource();
+        var calls = 0;
+        Func<StarDetectorParams, CancellationToken, Task<IReadOnlyList<RunEvaluationMetrics>>> evalWithCancel = (p, token) => {
+            // Cancel after a couple of evaluations.
+            if (Interlocked.Increment(ref calls) >= 2) {
+                cts.Cancel();
+            }
+            IReadOnlyList<RunEvaluationMetrics> runs = new[] { SyntheticRunFor(p) };
+            return Task.FromResult(runs);
+        };
+
+        var variables = OptimizerVariable.CreateCuratedSet();
+        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await new StarDetectionOptimizer().OptimizeAsync(Seed(), variables, evalWithCancel, DefaultSettings(), null, cts.Token));
+    }
+
+    [Test]
+    public async Task Optimize_RespectsBoundsAndQuantization() {
+        var variables = OptimizerVariable.CreateCuratedSet();
+        var result = await new StarDetectionOptimizer().OptimizeAsync(Seed(), variables, SyntheticEvaluator(), DefaultSettings(), null, CancellationToken.None);
+        var p = result.BestParams;
+
+        Assert.Multiple(() => {
+            // Continuous bounds.
+            Assert.That(p.Sensitivity, Is.InRange(0.0, 20.0));
+            Assert.That(p.StarClippingMultiplier, Is.InRange(0.5, 5.0));
+            Assert.That(p.NoiseClippingMultiplier, Is.InRange(1.0, 10.0));
+            Assert.That(p.PeakResponse, Is.InRange(0.1, 1.0));
+            Assert.That(p.MaxDistortion, Is.InRange(0.1, 1.0));
+            Assert.That(p.MinHFR, Is.InRange(0.1, 5.0));
+            Assert.That(p.StarCenterTolerance, Is.InRange(0.05, 1.0));
+            Assert.That(p.HotpixelThreshold, Is.InRange(0.0001, 0.05));
+            // Integers are whole and bounded.
+            Assert.That(p.StructureLayers, Is.InRange(1, 8));
+            Assert.That(p.NoiseReductionRadius, Is.InRange(0, 10));
+            Assert.That(p.MinimumStarBoundingBoxSize, Is.InRange(2, 20));
+        });
+    }
+
+    [Test]
+    public async Task Optimize_ReportsProgress() {
+        // Use a SYNCHRONOUS IProgress double instead of Progress<T>, which posts to the captured
+        // SynchronizationContext and may not drain deterministically under NUnit.
+        var progress = new SynchronousProgress<OptimizationProgress>();
+        var settings = DefaultSettings();
+        var variables = OptimizerVariable.CreateCuratedSet();
+        var result = await new StarDetectionOptimizer().OptimizeAsync(Seed(), variables, SyntheticEvaluator(), settings, progress, CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(result.Evaluations, Is.GreaterThan(0));
+            Assert.That(progress.Reports, Is.Not.Empty, "at least one progress report must be received");
+            Assert.That(progress.Reports.All(r => r.MaxEvaluations == settings.MaxEvaluations), Is.True,
+                "every report carries the configured MaxEvaluations");
+            Assert.That(progress.Reports.Any(r => !string.IsNullOrEmpty(r.Phase)), Is.True,
+                "at least one report carries a non-empty Phase");
+        });
+    }
+
+    [Test]
+    public async Task Optimize_ChangedVariables_OnlyListsDifferences() {
+        var variables = OptimizerVariable.CreateCuratedSet();
+        var seed = Seed();
+        var result = await new StarDetectionOptimizer().OptimizeAsync(seed, variables, SyntheticEvaluator(), DefaultSettings(), null, CancellationToken.None);
+        foreach (var (name, seedValue, bestValue) in result.ChangedVariables) {
+            Assert.That(seedValue, Is.Not.EqualTo(bestValue), $"{name} listed as changed but values equal");
+        }
+        // Sensitivity should have changed (it moves from 2 toward 10).
+        Assert.That(result.ChangedVariables.Any(cv => cv.Name == nameof(StarDetectorParams.Sensitivity)), Is.True);
+    }
+
+    [Test]
+    [Timeout(30000)]
+    public void Optimize_AllDiscreteVariables_Terminates() {
+        // REGRESSION (BLOCKING): an all-Integer/Boolean variable set used to hang forever. With no continuous
+        // variables, ContinuousStepsBelowFloor returned false, so Phase-B's loop guard
+        // (while !BudgetExhausted && !ContinuousStepsBelowFloor) never exited: once the discrete axes were
+        // exhausted every proposed candidate was a memo hit, Evaluations never advanced, and BudgetExhausted
+        // never tripped. The fix returns true when there are no continuous variables, letting the
+        // no-improving-move logic end the search. The [Timeout] guards against a hang before the fix.
+        var discreteVariables = OptimizerVariable.CreateCuratedSet()
+            .Where(v => v.Type != OptimizerVariableType.Continuous)
+            .ToList();
+        // Sanity: the curated set has at least StructureLayers + HotpixelThresholdingEnabled (no continuous).
+        Assert.That(discreteVariables, Is.Not.Empty);
+        Assert.That(discreteVariables.All(v => v.Type != OptimizerVariableType.Continuous), Is.True);
+
+        var settings = DefaultSettings();
+        var task = new StarDetectionOptimizer().OptimizeAsync(
+            Seed(), discreteVariables, SyntheticEvaluator(), settings, null, CancellationToken.None);
+
+        // Before the fix this never completes; the [Timeout] catches the hang. After the fix it returns.
+        Assert.That(task.Wait(TimeSpan.FromSeconds(30)), Is.True, "OptimizeAsync must terminate for an all-discrete variable set");
+        var result = task.Result;
+        Assert.That(result.Evaluations, Is.LessThanOrEqualTo(settings.MaxEvaluations), "must respect the eval budget");
+    }
+
+    /// <summary>
+    /// A synchronous <see cref="IProgress{T}"/> test double: <see cref="Report"/> appends directly to a list
+    /// on the calling thread, so reports are captured deterministically (unlike <see cref="Progress{T}"/>,
+    /// which posts to the captured SynchronizationContext).
+    /// </summary>
+    private sealed class SynchronousProgress<T> : IProgress<T> {
+        public List<T> Reports { get; } = new List<T>();
+
+        public void Report(T value) => Reports.Add(value);
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerTests.cs
@@ -28,8 +28,8 @@ public class StarDetectionOptimizerTests {
     // Two-axis synthetic landscape. J is maximized when (Sensitivity, StarClippingMultiplier) are at
     // the chosen optimum. We map distance-from-optimum to SigmaFocus so SFocus (and thus J) peaks there.
     // All other metrics are kept star-rich / well-fit so they never hard-fail.
-    private const double OptSensitivity = 10.0;   // interior of [0, 20]
-    private const double OptStarClip = 2.5;        // interior of [0.5, 5]
+    private const double OptSensitivity = 10.0;   // interior of [0, 50]
+    private const double OptStarClip = 2.5;        // interior of [0.25, 10]
 
     private static RunEvaluationMetrics SyntheticRunFor(StarDetectorParams p) {
         // Normalized distance (0 at optimum) over the two optimized axes, each scaled by its span.
@@ -233,8 +233,8 @@ public class StarDetectionOptimizerTests {
 
         Assert.Multiple(() => {
             // Continuous bounds.
-            Assert.That(p.Sensitivity, Is.InRange(0.0, 20.0));
-            Assert.That(p.StarClippingMultiplier, Is.InRange(0.5, 5.0));
+            Assert.That(p.Sensitivity, Is.InRange(0.0, 50.0));
+            Assert.That(p.StarClippingMultiplier, Is.InRange(0.25, 10.0));
             Assert.That(p.NoiseClippingMultiplier, Is.InRange(1.0, 10.0));
             Assert.That(p.PeakResponse, Is.InRange(0.1, 1.0));
             Assert.That(p.MaxDistortion, Is.InRange(0.1, 1.0));

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -1,0 +1,377 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NINA.Profile.Interfaces;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Optimization;
+
+/// <summary>
+/// Unit tests for the wizard VM step machine, the STARHFR/seed guard, the summary model, Apply, cancellation,
+/// and multi-run handling. Everything runs in-memory: a fake <see cref="IRunEvaluationLoader"/> returns a
+/// <see cref="RunEvaluationData"/> built over a synthetic detection delegate (mirroring the T3 tests), and a
+/// substitute <see cref="IStarDetectionOptions"/> records the applied DTO. No UI, no real images.
+/// </summary>
+[TestFixture]
+public class StarDetectionOptimizerWizardVMTests {
+
+    private static AlglibAPI NewAlglib() => new AlglibAPI();
+
+    // A clean symmetric hyperbola hfr(pos) = sqrt(a^2 + ((pos - p0)/b)^2), as in RunEvaluationDataTests.
+    private const double HyperbolaA = 1.5;
+    private const double HyperbolaB = 8.0;
+    private const int HyperbolaP0 = 10000;
+    private const int DefaultStepSize = 100;
+
+    private static double Hfr(int pos) {
+        var dx = (pos - HyperbolaP0) / HyperbolaB;
+        return Math.Sqrt(HyperbolaA * HyperbolaA + dx * dx);
+    }
+
+    private static RunFitConfig DefaultFitConfig() => new RunFitConfig {
+        StepSize = DefaultStepSize,
+        UseWeights = true,
+        MaxOutlierRejections = 0,
+        RejectionConfidence = 0.0,
+        PreferredModel = null
+    };
+
+    private static List<RunFrame> NineFrames() {
+        var frames = new List<RunFrame>();
+        for (var i = -4; i <= 4; i++) {
+            var pos = HyperbolaP0 + i * DefaultStepSize;
+            frames.Add(new RunFrame { FrameId = $"pos_{pos}", FocuserPosition = pos, Image = pos });
+        }
+        return frames;
+    }
+
+    // Detection where star count peaks at a target Sensitivity, so J responds to Sensitivity and the optimizer
+    // has something to improve (mirrors CreateEvaluator_PluggedIntoOptimizer in RunEvaluationDataTests).
+    private static Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> OptimizableDetect(
+        double optSensitivity = 10.0) {
+        return (image, p, token) => {
+            var pos = (int)image;
+            var dist = Math.Abs(p.Sensitivity - optSensitivity);
+            var starCount = (int)Math.Max(10, Math.Round(22 - 1.5 * dist));
+            return Task.FromResult(new FrameDetectionResult {
+                AverageHFR = Hfr(pos),
+                HFRStdDev = 0.05,
+                StarCount = starCount,
+                StarCenters = Array.Empty<(double X, double Y)>()
+            });
+        };
+    }
+
+    private static LoadedRun GoodRun(string id = "good", double optSensitivity = 10.0, int seedSensitivity = 2) {
+        var data = new RunEvaluationData(id, NineFrames(), OptimizableDetect(optSensitivity), NewAlglib(), DefaultFitConfig());
+        var seed = new StarDetectorParams { Sensitivity = seedSensitivity, StarClippingMultiplier = 2.0 };
+        var afOptions = new AutoFocusEngineOptions { AutoFocusStepSize = DefaultStepSize, AutoFocusInitialOffsetSteps = 4 };
+        return new LoadedRun { Data = data, Seed = seed, AfOptions = afOptions };
+    }
+
+    // A degenerate run: only two distinct focuser positions => the fit cannot be determined (NaN sigma), which
+    // is exactly the STARHFR/seed guard condition.
+    private static LoadedRun DegenerateRun(string id = "degenerate") {
+        var frames = new List<RunFrame> {
+            new RunFrame { FrameId = "a", FocuserPosition = 9900, Image = 9900 },
+            new RunFrame { FrameId = "b", FocuserPosition = 10100, Image = 10100 },
+        };
+        var data = new RunEvaluationData(id, frames, OptimizableDetect(), NewAlglib(), DefaultFitConfig());
+        var seed = new StarDetectorParams { Sensitivity = 2.0, StarClippingMultiplier = 2.0 };
+        var afOptions = new AutoFocusEngineOptions { AutoFocusStepSize = DefaultStepSize, AutoFocusInitialOffsetSteps = 4 };
+        return new LoadedRun { Data = data, Seed = seed, AfOptions = afOptions };
+    }
+
+    private static IRunEvaluationLoader LoaderReturning(params LoadedRun[] runs) {
+        var loader = Substitute.For<IRunEvaluationLoader>();
+        var queue = new Queue<LoadedRun>(runs);
+        loader.LoadSavedRunAsync(Arg.Any<string>(), Arg.Any<StarDetectionRegion>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult(queue.Count > 0 ? queue.Dequeue() : runs[runs.Length - 1]));
+        return loader;
+    }
+
+    private static StarDetectionOptimizerWizardVM NewVM(
+        IRunEvaluationLoader loader,
+        IStarDetectionOptions options = null,
+        IProfileService profileService = null) {
+        options ??= Substitute.For<IStarDetectionOptions>();
+        profileService ??= Substitute.For<IProfileService>();
+        return new StarDetectionOptimizerWizardVM(
+            profileService,
+            options,
+            loader,
+            autoFocusEngine: Substitute.For<IAutoFocusEngine>(),
+            folderPicker: () => @"C:\fake\attempt",
+            region: StarDetectionRegion.Full,
+            optimizerSettings: new OptimizerSettings { MaxEvaluations = 200, CoarseGridLevels = 4, StepFloorFraction = 0.125 });
+    }
+
+    [Test]
+    public void InitialState_IsSelectSource() {
+        var vm = NewVM(LoaderReturning(GoodRun()));
+        Assert.Multiple(() => {
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.SelectSource));
+            Assert.That(vm.RunCount, Is.EqualTo(1), "default to a single run");
+            Assert.That(vm.SourceMode, Is.EqualTo(SourceMode.Replay));
+        });
+    }
+
+    [Test]
+    public async Task Start_GoodReplayRun_AdvancesToSummary() {
+        var vm = NewVM(LoaderReturning(GoodRun()));
+        vm.SourcePaths[0] = @"C:\run1";
+
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Summary));
+            Assert.That(vm.ErrorMessage, Is.Null.Or.Empty);
+            Assert.That(vm.Summary, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public async Task Start_DegenerateSeed_SetsErrorAndDoesNotAdvanceToSummary() {
+        var vm = NewVM(LoaderReturning(DegenerateRun()));
+        vm.SourcePaths[0] = @"C:\bad";
+
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.CurrentStep, Is.Not.EqualTo(WizardStep.Summary), "the guard must block the summary");
+            Assert.That(vm.ErrorMessage, Is.Not.Null.And.Not.Empty, "a degenerate seed must surface a user-facing error");
+            Assert.That(vm.Summary, Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task Start_GoodRun_PopulatesSummaryModel() {
+        var vm = NewVM(LoaderReturning(GoodRun()));
+        vm.SourcePaths[0] = @"C:\run1";
+
+        await vm.StartAsync(CancellationToken.None);
+
+        var s = vm.Summary;
+        Assert.Multiple(() => {
+            Assert.That(s, Is.Not.Null);
+            Assert.That(s.BestJ, Is.GreaterThanOrEqualTo(s.SeedJ), "best J must never regress below the seed");
+            Assert.That(s.ChangedParameters, Is.Not.Null);
+            Assert.That(s.ChangedParameters.Count, Is.GreaterThan(0), "an improvable run should change at least one parameter");
+            Assert.That(s.RecommendedStepSize, Is.GreaterThanOrEqualTo(1), "a recommended step size must be produced");
+            Assert.That(double.IsNaN(s.SeedSigmaFocus), Is.False, "seed sigma must be finite for a clean run");
+            Assert.That(double.IsNaN(s.BestSigmaFocus), Is.False, "best sigma must be finite for a clean run");
+        });
+    }
+
+    [Test]
+    public async Task Start_ChangedParametersRow_CarriesSeedAndBestValues() {
+        var vm = NewVM(LoaderReturning(GoodRun()));
+        vm.SourcePaths[0] = @"C:\run1";
+
+        await vm.StartAsync(CancellationToken.None);
+
+        var sensitivityRow = vm.Summary.ChangedParameters
+            .FirstOrDefault(r => r.Name == nameof(StarDetectorParams.Sensitivity));
+        Assert.That(sensitivityRow, Is.Not.Null, "Sensitivity is expected to move toward the star-count optimum");
+        Assert.Multiple(() => {
+            Assert.That(sensitivityRow.SeedValue, Is.EqualTo(2.0).Within(1e-9));
+            Assert.That(Math.Abs(sensitivityRow.OptimizedValue - 10.0),
+                Is.LessThan(Math.Abs(sensitivityRow.SeedValue - 10.0)), "optimized Sensitivity is closer to the optimum");
+        });
+    }
+
+    [Test]
+    public async Task Apply_CallsApplyOptimizedSettingsWithCuratedValuesAndMetadata() {
+        var options = Substitute.For<IStarDetectionOptions>();
+        var vm = NewVM(LoaderReturning(GoodRun()), options);
+        vm.SourcePaths[0] = @"C:\run1";
+        await vm.StartAsync(CancellationToken.None);
+
+        vm.ApplyCommand.Execute(null);
+
+        var dto = options.ReceivedCalls()
+            .Single(c => c.GetMethodInfo().Name == nameof(IStarDetectionOptions.ApplyOptimizedSettings))
+            .GetArguments()[0] as OptimizedStarDetectionSettings;
+        Assert.That(dto, Is.Not.Null);
+
+        var best = vm.Result.BestParams;
+        Assert.Multiple(() => {
+            // Curated values equal result.BestParams (note the DTO uses different property names for some knobs).
+            Assert.That(dto.BrightnessSensitivity, Is.EqualTo(best.Sensitivity).Within(1e-9));
+            Assert.That(dto.StarClippingMultiplier, Is.EqualTo(best.StarClippingMultiplier).Within(1e-9));
+            Assert.That(dto.NoiseClippingMultiplier, Is.EqualTo(best.NoiseClippingMultiplier).Within(1e-9));
+            Assert.That(dto.StarPeakResponse, Is.EqualTo(best.PeakResponse).Within(1e-9));
+            Assert.That(dto.MaxDistortion, Is.EqualTo(best.MaxDistortion).Within(1e-9));
+            Assert.That(dto.MinHFR, Is.EqualTo(best.MinHFR).Within(1e-9));
+            Assert.That(dto.StarCenterTolerance, Is.EqualTo(best.StarCenterTolerance).Within(1e-9));
+            Assert.That(dto.StructureLayers, Is.EqualTo(best.StructureLayers));
+            Assert.That(dto.NoiseReductionRadius, Is.EqualTo(best.NoiseReductionRadius));
+            Assert.That(dto.MinStarBoundingBoxSize, Is.EqualTo(best.MinimumStarBoundingBoxSize));
+            Assert.That(dto.HotpixelThresholdingEnabled, Is.EqualTo(best.HotpixelThresholdingEnabled));
+            Assert.That(dto.HotpixelThreshold, Is.EqualTo(best.HotpixelThreshold).Within(1e-9));
+
+            // Metadata.
+            Assert.That(dto.RunCount, Is.EqualTo(1));
+            Assert.That(dto.BaselineJ, Is.EqualTo(vm.Result.SeedJ).Within(1e-12));
+            Assert.That(dto.FinalJ, Is.EqualTo(vm.Result.BestJ).Within(1e-12));
+            Assert.That(dto.RecommendedStepSize, Is.EqualTo(vm.Summary.RecommendedStepSize));
+            Assert.That(dto.RecommendedOffsetSteps, Is.EqualTo(vm.Summary.RecommendedOffsetSteps));
+        });
+    }
+
+    [Test]
+    public async Task Apply_WhenApplyRecommendedStepSizeTrue_WritesProfileStepSize() {
+        var options = Substitute.For<IStarDetectionOptions>();
+        var profileService = Substitute.For<IProfileService>();
+        var focuserSettings = Substitute.For<IFocuserSettings>();
+        profileService.ActiveProfile.FocuserSettings.Returns(focuserSettings);
+
+        var vm = NewVM(LoaderReturning(GoodRun()), options, profileService);
+        vm.SourcePaths[0] = @"C:\run1";
+        await vm.StartAsync(CancellationToken.None);
+        vm.ApplyRecommendedStepSize = true;
+
+        vm.ApplyCommand.Execute(null);
+
+        focuserSettings.Received(1).AutoFocusStepSize = vm.Summary.RecommendedStepSize;
+        focuserSettings.Received(1).AutoFocusInitialOffsetSteps = vm.Summary.RecommendedOffsetSteps;
+    }
+
+    [Test]
+    public async Task Apply_WhenApplyRecommendedStepSizeFalse_DoesNotWriteProfileStepSize() {
+        var options = Substitute.For<IStarDetectionOptions>();
+        var profileService = Substitute.For<IProfileService>();
+        var focuserSettings = Substitute.For<IFocuserSettings>();
+        profileService.ActiveProfile.FocuserSettings.Returns(focuserSettings);
+
+        var vm = NewVM(LoaderReturning(GoodRun()), options, profileService);
+        vm.SourcePaths[0] = @"C:\run1";
+        await vm.StartAsync(CancellationToken.None);
+        vm.ApplyRecommendedStepSize = false;
+
+        vm.ApplyCommand.Execute(null);
+
+        focuserSettings.DidNotReceiveWithAnyArgs().AutoFocusStepSize = default;
+        focuserSettings.DidNotReceiveWithAnyArgs().AutoFocusInitialOffsetSteps = default;
+        // The optimized settings DTO must still be applied even when the step size is declined.
+        options.Received(1).ApplyOptimizedSettings(Arg.Any<OptimizedStarDetectionSettings>());
+    }
+
+    [Test]
+    public async Task RunCountTwo_LoadsTwoRuns_SummaryReportsRunCountTwo() {
+        var loader = LoaderReturning(GoodRun("a"), GoodRun("b"));
+        var vm = NewVM(loader);
+        vm.RunCount = 2;
+        vm.SourcePaths[0] = @"C:\run1";
+        vm.SourcePaths[1] = @"C:\run2";
+
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Summary));
+            Assert.That(vm.Summary.RunCount, Is.EqualTo(2));
+            loader.Received(2).LoadSavedRunAsync(Arg.Any<string>(), Arg.Any<StarDetectionRegion>(), Arg.Any<CancellationToken>());
+        });
+    }
+
+    [Test]
+    public void RunCount_Setter_ResizesSourcePaths() {
+        var vm = NewVM(LoaderReturning(GoodRun()));
+        vm.RunCount = 3;
+        Assert.That(vm.SourcePaths.Count, Is.EqualTo(3));
+        vm.RunCount = 1;
+        Assert.That(vm.SourcePaths.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Cancel_MidOptimize_LeavesVMReRunnable() {
+        // A detect delegate that blocks until cancellation, so we can cancel mid-optimize deterministically.
+        var gate = new SemaphoreSlim(0);
+        var firstHit = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> blockingDetect = async (image, p, token) => {
+            firstHit.TrySetResult(true);
+            await gate.WaitAsync(token).ConfigureAwait(false); // cancelled => throws OperationCanceledException
+            var pos = (int)image;
+            return new FrameDetectionResult { AverageHFR = Hfr(pos), HFRStdDev = 0.05, StarCount = 20, StarCenters = Array.Empty<(double X, double Y)>() };
+        };
+        var blockingRun = new LoadedRun {
+            Data = new RunEvaluationData("block", NineFrames(), blockingDetect, NewAlglib(), DefaultFitConfig()),
+            Seed = new StarDetectorParams { Sensitivity = 2.0 },
+            AfOptions = new AutoFocusEngineOptions { AutoFocusStepSize = DefaultStepSize, AutoFocusInitialOffsetSteps = 4 }
+        };
+
+        var cts = new CancellationTokenSource();
+        // Start blocks (returns null run on the second StartAsync); first loader hit returns the blocking run.
+        var vm = NewVM(LoaderReturning(blockingRun, GoodRun()));
+        vm.SourcePaths[0] = @"C:\run1";
+
+        var startTask = vm.StartAsync(cts.Token);
+        await firstHit.Task; // we are now inside the blocking evaluator
+        cts.Cancel();
+        Assert.DoesNotThrowAsync(async () => await startTask, "cancellation must not crash the VM");
+
+        Assert.That(vm.CurrentStep, Is.Not.EqualTo(WizardStep.Summary), "a cancelled run does not reach the summary");
+
+        // Re-runnable: a fresh start with a good run completes.
+        var freshCts = new CancellationTokenSource();
+        vm.SourcePaths[0] = @"C:\run2";
+        await vm.StartAsync(freshCts.Token);
+        Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Summary), "the VM must be re-runnable after a cancel");
+    }
+
+    [Test]
+    public async Task Dispose_AfterRun_IsIdempotentAndDoesNotThrow() {
+        // T5 disposes the VM when the wizard window closes; disposing must release the CTS safely and be
+        // callable more than once (window-close + GC finalization paths).
+        var vm = NewVM(LoaderReturning(GoodRun()));
+        vm.SourcePaths[0] = @"C:\run1";
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.DoesNotThrow(() => vm.Dispose());
+            Assert.DoesNotThrow(() => vm.Dispose(), "Dispose must be idempotent");
+        });
+    }
+
+    [Test]
+    public void Dispose_BeforeAnyRun_DoesNotThrow() {
+        // No Start has run yet, so the CTS is still null; Dispose must be null-safe.
+        var vm = NewVM(LoaderReturning(GoodRun()));
+        Assert.DoesNotThrow(() => vm.Dispose());
+    }
+
+    [Test]
+    public async Task Start_MissingSourcePath_SetsErrorAndDoesNotLoad() {
+        var loader = LoaderReturning(GoodRun());
+        var vm = NewVM(loader);
+        // Leave SourcePaths[0] empty.
+        vm.SourcePaths[0] = null;
+
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.ErrorMessage, Is.Not.Null.And.Not.Empty);
+            Assert.That(vm.CurrentStep, Is.Not.EqualTo(WizardStep.Summary));
+            loader.DidNotReceiveWithAnyArgs().LoadSavedRunAsync(default, default, default);
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarReviewTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarReviewTests.cs
@@ -44,6 +44,7 @@ public class StarReviewTests {
         [JsonProperty("radiusPx")] public double? RadiusPx { get; set; }
         [JsonProperty("missed")] public List<T6LabelPoint> Missed { get; set; }
         [JsonProperty("shouldReject")] public List<T6LabelPoint> ShouldReject { get; set; }
+        [JsonProperty("wronglyRejected")] public List<T6LabelPoint> WronglyRejected { get; set; }
     }
 
     private sealed class T6RunLabelFile {
@@ -62,7 +63,8 @@ public class StarReviewTests {
                     FocuserPosition = 5000,
                     RadiusPx = 6.0,
                     Missed = new List<StarReviewLabelPoint> { new StarReviewLabelPoint(123.4, 567.8) },
-                    ShouldReject = new List<StarReviewLabelPoint> { new StarReviewLabelPoint(12.0, 34.0) }
+                    ShouldReject = new List<StarReviewLabelPoint> { new StarReviewLabelPoint(12.0, 34.0) },
+                    WronglyRejected = new List<StarReviewLabelPoint> { new StarReviewLabelPoint(88.0, 90.0) }
                 }
             }
         };
@@ -85,6 +87,9 @@ public class StarReviewTests {
             Assert.That(p.ShouldReject, Has.Count.EqualTo(1));
             Assert.That(p.ShouldReject[0].X, Is.EqualTo(12.0));
             Assert.That(p.ShouldReject[0].Y, Is.EqualTo(34.0));
+            Assert.That(p.WronglyRejected, Has.Count.EqualTo(1));
+            Assert.That(p.WronglyRejected[0].X, Is.EqualTo(88.0));
+            Assert.That(p.WronglyRejected[0].Y, Is.EqualTo(90.0));
         });
     }
 
@@ -97,7 +102,8 @@ public class StarReviewTests {
                 new StarReviewPositionLabels {
                     FocuserPosition = 100,
                     Missed = new List<StarReviewLabelPoint> { new StarReviewLabelPoint(1, 2) },
-                    ShouldReject = new List<StarReviewLabelPoint> { new StarReviewLabelPoint(3, 4) }
+                    ShouldReject = new List<StarReviewLabelPoint> { new StarReviewLabelPoint(3, 4) },
+                    WronglyRejected = new List<StarReviewLabelPoint> { new StarReviewLabelPoint(5, 6) }
                 }
             }
         };
@@ -109,6 +115,7 @@ public class StarReviewTests {
             Assert.That(json, Does.Contain("\"focuserPosition\""));
             Assert.That(json, Does.Contain("\"missed\""));
             Assert.That(json, Does.Contain("\"shouldReject\""));
+            Assert.That(json, Does.Contain("\"wronglyRejected\""));
             Assert.That(json, Does.Contain("\"x\""));
             Assert.That(json, Does.Contain("\"y\""));
         });
@@ -187,6 +194,60 @@ public class StarReviewTests {
         StarReviewLabelStore.PruneEmptyPositions(labels);
         Assert.That(labels.Positions, Has.Count.EqualTo(1));
         Assert.That(labels.Positions[0].FocuserPosition, Is.EqualTo(200));
+    }
+
+    [Test]
+    public void PruneEmptyPositions_KeepsWronglyRejectedOnlyPosition() {
+        var labels = new StarReviewRunLabels { RunId = "r" };
+        var empty = StarReviewLabelStore.GetOrAddPosition(labels, 100);
+        var wronglyOnly = StarReviewLabelStore.GetOrAddPosition(labels, 200);
+        StarReviewLabelStore.TogglePoint(wronglyOnly.WronglyRejected, 7, 8);
+
+        StarReviewLabelStore.PruneEmptyPositions(labels);
+        Assert.That(labels.Positions, Has.Count.EqualTo(1));
+        Assert.That(labels.Positions[0].FocuserPosition, Is.EqualTo(200));
+        Assert.That(labels.Positions[0].WronglyRejected, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void Counts_IncludesWronglyRejected() {
+        var labels = new StarReviewRunLabels { RunId = "r" };
+        var pos = StarReviewLabelStore.GetOrAddPosition(labels, 5000);
+        StarReviewLabelStore.TogglePoint(pos.Missed, 1, 1);
+        StarReviewLabelStore.TogglePoint(pos.Missed, 50, 50);
+        StarReviewLabelStore.TogglePoint(pos.ShouldReject, 100, 100);
+        StarReviewLabelStore.TogglePoint(pos.WronglyRejected, 200, 200);
+        StarReviewLabelStore.TogglePoint(pos.WronglyRejected, 300, 300);
+        StarReviewLabelStore.TogglePoint(pos.WronglyRejected, 400, 400);
+
+        var (missed, shouldReject, wronglyRejected) = StarReviewLabelStore.Counts(labels);
+        Assert.Multiple(() => {
+            Assert.That(missed, Is.EqualTo(2));
+            Assert.That(shouldReject, Is.EqualTo(1));
+            Assert.That(wronglyRejected, Is.EqualTo(3));
+        });
+    }
+
+    [Test]
+    public void WronglyRejectedRoundTrip_ThroughLabelStore_Persists() {
+        var dir = Path.Combine(Path.GetTempPath(), "hf-review-test-" + Guid.NewGuid().ToString("N"));
+        try {
+            var labels = new StarReviewRunLabels { RunId = "attempt01", RadiusPx = 6.0 };
+            var pos = StarReviewLabelStore.GetOrAddPosition(labels, 5000);
+            StarReviewLabelStore.TogglePoint(pos.WronglyRejected, 88, 90);
+            StarReviewLabelStore.Save(dir, labels);
+
+            var reloaded = StarReviewLabelStore.Load(dir, "attempt01", out var err);
+            Assert.That(err, Is.Null);
+            Assert.That(reloaded.Positions, Has.Count.EqualTo(1));
+            Assert.That(reloaded.Positions[0].WronglyRejected, Has.Count.EqualTo(1));
+            Assert.That(reloaded.Positions[0].WronglyRejected[0].X, Is.EqualTo(88.0));
+            Assert.That(reloaded.Positions[0].WronglyRejected[0].Y, Is.EqualTo(90.0));
+        } finally {
+            if (Directory.Exists(dir)) {
+                Directory.Delete(dir, true);
+            }
+        }
     }
 
     // ---- Review queue -------------------------------------------------------------------------------------

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarReviewTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarReviewTests.cs
@@ -1,0 +1,317 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using TestApp.StarReview;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Optimization;
+
+/// <summary>
+/// Unit tests for the pure-logic helpers of the T7 interactive star-review tool (linked from TestApp): the
+/// label store (T6-compatible JSON + toggle/merge), the review-queue selection, and the zoom/pan viewport math.
+/// The WPF window/VM are not testable here and are exercised manually on real data.
+/// </summary>
+[TestFixture]
+public class StarReviewTests {
+
+    // ---- Label JSON shape MUST match T6's --labels reader EXACTLY ------------------------------------------
+
+    // POCOs carrying the SAME [JsonProperty] names/casing as T6's private loader (OptimizationDiagnosticRunner:
+    // RunLabelFile / LabelPosition / LabelPoint). The round-trip test below deserializes a T7-written file
+    // THROUGH these — if T7 ever drifts from T6's shape, this test fails. This is the contract that keeps
+    // `review` -> `optimize --labels` working.
+    private sealed class T6LabelPoint {
+        [JsonProperty("x")] public double X { get; set; }
+        [JsonProperty("y")] public double Y { get; set; }
+    }
+
+    private sealed class T6LabelPosition {
+        [JsonProperty("focuserPosition")] public int FocuserPosition { get; set; }
+        [JsonProperty("radiusPx")] public double? RadiusPx { get; set; }
+        [JsonProperty("missed")] public List<T6LabelPoint> Missed { get; set; }
+        [JsonProperty("shouldReject")] public List<T6LabelPoint> ShouldReject { get; set; }
+    }
+
+    private sealed class T6RunLabelFile {
+        [JsonProperty("runId")] public string RunId { get; set; }
+        [JsonProperty("radiusPx")] public double? RadiusPx { get; set; }
+        [JsonProperty("positions")] public List<T6LabelPosition> Positions { get; set; }
+    }
+
+    [Test]
+    public void WrittenJson_IsReadByT6LoaderShape_RoundTrip() {
+        var labels = new StarReviewRunLabels {
+            RunId = "attempt01",
+            RadiusPx = 6.0,
+            Positions = new List<StarReviewPositionLabels> {
+                new StarReviewPositionLabels {
+                    FocuserPosition = 5000,
+                    RadiusPx = 6.0,
+                    Missed = new List<StarReviewLabelPoint> { new StarReviewLabelPoint(123.4, 567.8) },
+                    ShouldReject = new List<StarReviewLabelPoint> { new StarReviewLabelPoint(12.0, 34.0) }
+                }
+            }
+        };
+
+        var json = StarReviewLabelStore.Serialize(labels);
+
+        // Deserialize through T6's exact attribute shape (this is what T6's loader does).
+        var t6 = JsonConvert.DeserializeObject<T6RunLabelFile>(json);
+
+        Assert.Multiple(() => {
+            Assert.That(t6.RunId, Is.EqualTo("attempt01"));
+            Assert.That(t6.RadiusPx, Is.EqualTo(6.0));
+            Assert.That(t6.Positions, Has.Count.EqualTo(1));
+            var p = t6.Positions[0];
+            Assert.That(p.FocuserPosition, Is.EqualTo(5000));
+            Assert.That(p.RadiusPx, Is.EqualTo(6.0));
+            Assert.That(p.Missed, Has.Count.EqualTo(1));
+            Assert.That(p.Missed[0].X, Is.EqualTo(123.4));
+            Assert.That(p.Missed[0].Y, Is.EqualTo(567.8));
+            Assert.That(p.ShouldReject, Has.Count.EqualTo(1));
+            Assert.That(p.ShouldReject[0].X, Is.EqualTo(12.0));
+            Assert.That(p.ShouldReject[0].Y, Is.EqualTo(34.0));
+        });
+    }
+
+    [Test]
+    public void WrittenJson_UsesExactT6PropertyNames() {
+        var labels = new StarReviewRunLabels {
+            RunId = "r",
+            RadiusPx = 6.0,
+            Positions = new List<StarReviewPositionLabels> {
+                new StarReviewPositionLabels {
+                    FocuserPosition = 100,
+                    Missed = new List<StarReviewLabelPoint> { new StarReviewLabelPoint(1, 2) },
+                    ShouldReject = new List<StarReviewLabelPoint> { new StarReviewLabelPoint(3, 4) }
+                }
+            }
+        };
+        var json = StarReviewLabelStore.Serialize(labels);
+        Assert.Multiple(() => {
+            Assert.That(json, Does.Contain("\"runId\""));
+            Assert.That(json, Does.Contain("\"radiusPx\""));
+            Assert.That(json, Does.Contain("\"positions\""));
+            Assert.That(json, Does.Contain("\"focuserPosition\""));
+            Assert.That(json, Does.Contain("\"missed\""));
+            Assert.That(json, Does.Contain("\"shouldReject\""));
+            Assert.That(json, Does.Contain("\"x\""));
+            Assert.That(json, Does.Contain("\"y\""));
+        });
+    }
+
+    [Test]
+    public void SaveThenLoad_MergesIncrementally() {
+        var dir = Path.Combine(Path.GetTempPath(), "hf-review-test-" + Guid.NewGuid().ToString("N"));
+        try {
+            var labels = new StarReviewRunLabels { RunId = "attempt01", RadiusPx = 6.0 };
+            var pos = StarReviewLabelStore.GetOrAddPosition(labels, 5000);
+            StarReviewLabelStore.TogglePoint(pos.Missed, 10, 20);
+            StarReviewLabelStore.Save(dir, labels);
+
+            // Re-load (a fresh review session), add more, save, reload — prior labels must persist.
+            var reloaded = StarReviewLabelStore.Load(dir, "attempt01", out var err);
+            Assert.That(err, Is.Null);
+            Assert.That(reloaded.Positions, Has.Count.EqualTo(1));
+            Assert.That(reloaded.Positions[0].Missed, Has.Count.EqualTo(1));
+
+            var pos2 = StarReviewLabelStore.GetOrAddPosition(reloaded, 5000);
+            StarReviewLabelStore.TogglePoint(pos2.ShouldReject, 30, 40);
+            StarReviewLabelStore.Save(dir, reloaded);
+
+            var final = StarReviewLabelStore.Load(dir, "attempt01", out _);
+            Assert.That(final.Positions[0].Missed, Has.Count.EqualTo(1));
+            Assert.That(final.Positions[0].ShouldReject, Has.Count.EqualTo(1));
+        } finally {
+            if (Directory.Exists(dir)) {
+                Directory.Delete(dir, true);
+            }
+        }
+    }
+
+    [Test]
+    public void Load_MissingDir_ReturnsEmptyDefault() {
+        var labels = StarReviewLabelStore.Load(@"X:\does\not\exist", "runX", out var err);
+        Assert.Multiple(() => {
+            Assert.That(err, Is.Null);
+            Assert.That(labels.RunId, Is.EqualTo("runX"));
+            Assert.That(labels.Positions, Is.Empty);
+            Assert.That(labels.RadiusPx, Is.EqualTo(StarReviewLabelStore.DefaultRadiusPx));
+        });
+    }
+
+    // ---- Toggle / merge -----------------------------------------------------------------------------------
+
+    [Test]
+    public void TogglePoint_AddsThenRemovesNearbyPoint() {
+        var points = new List<StarReviewLabelPoint>();
+        var added = StarReviewLabelStore.TogglePoint(points, 100, 100);
+        Assert.That(added, Is.True);
+        Assert.That(points, Has.Count.EqualTo(1));
+
+        // A second click within tolerance removes it (undo).
+        var removed = StarReviewLabelStore.TogglePoint(points, 101, 101);
+        Assert.That(removed, Is.False);
+        Assert.That(points, Is.Empty);
+    }
+
+    [Test]
+    public void TogglePoint_FarClickAddsSecondPoint() {
+        var points = new List<StarReviewLabelPoint>();
+        StarReviewLabelStore.TogglePoint(points, 100, 100);
+        StarReviewLabelStore.TogglePoint(points, 500, 500);
+        Assert.That(points, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void PruneEmptyPositions_DropsEmptyButKeepsLabeled() {
+        var labels = new StarReviewRunLabels { RunId = "r" };
+        var empty = StarReviewLabelStore.GetOrAddPosition(labels, 100);
+        var kept = StarReviewLabelStore.GetOrAddPosition(labels, 200);
+        StarReviewLabelStore.TogglePoint(kept.Missed, 1, 1);
+
+        StarReviewLabelStore.PruneEmptyPositions(labels);
+        Assert.That(labels.Positions, Has.Count.EqualTo(1));
+        Assert.That(labels.Positions[0].FocuserPosition, Is.EqualTo(200));
+    }
+
+    // ---- Review queue -------------------------------------------------------------------------------------
+
+    private static List<StarReviewFrame> Frames(params (string run, int pos, int accepted)[] specs) {
+        return specs.Select(s => new StarReviewFrame {
+            RunId = s.run, FocuserPosition = s.pos, FramePath = $"{s.run}_{s.pos}", AcceptedCount = s.accepted
+        }).ToList();
+    }
+
+    [Test]
+    public void Queue_Low_SelectsBelowNReview() {
+        var frames = Frames(("a", 100, 3), ("a", 200, 8), ("a", 300, 20), ("a", 400, 7));
+        StarReviewQueue.MarkExtremes(frames);
+        var q = StarReviewQueue.Build(frames, StarReviewMode.Low);
+        // < 8: 3 and 7 => positions 100 and 400.
+        Assert.That(q.Select(f => f.FocuserPosition), Is.EquivalentTo(new[] { 100, 400 }));
+    }
+
+    [Test]
+    public void Queue_All_SelectsEveryFrame() {
+        var frames = Frames(("a", 100, 3), ("a", 200, 50), ("b", 300, 50));
+        StarReviewQueue.MarkExtremes(frames);
+        var q = StarReviewQueue.Build(frames, StarReviewMode.All);
+        Assert.That(q, Has.Count.EqualTo(3));
+    }
+
+    [Test]
+    public void Queue_Uncertain_AddsDefocusedExtremesToLowSet() {
+        // All star-rich (>= NReview) so Low is empty; Uncertain must still pick each run's min/max position.
+        var frames = Frames(("a", 100, 50), ("a", 200, 50), ("a", 300, 50));
+        StarReviewQueue.MarkExtremes(frames);
+        var low = StarReviewQueue.Build(frames, StarReviewMode.Low);
+        var uncertain = StarReviewQueue.Build(frames, StarReviewMode.Uncertain);
+        Assert.Multiple(() => {
+            Assert.That(low, Is.Empty);
+            Assert.That(uncertain.Select(f => f.FocuserPosition), Is.EquivalentTo(new[] { 100, 300 }));
+        });
+    }
+
+    [Test]
+    public void Queue_OrderedByRunThenPosition() {
+        var frames = Frames(("b", 100, 1), ("a", 300, 1), ("a", 100, 1));
+        StarReviewQueue.MarkExtremes(frames);
+        var q = StarReviewQueue.Build(frames, StarReviewMode.All);
+        Assert.That(q.Select(f => (f.RunId, f.FocuserPosition)),
+            Is.EqualTo(new[] { ("a", 100), ("a", 300), ("b", 100) }).AsCollection);
+    }
+
+    [Test]
+    public void ParseMode_DefaultsToLow_AndRejectsGarbage() {
+        Assert.Multiple(() => {
+            Assert.That(StarReviewQueue.ParseMode(null), Is.EqualTo(StarReviewMode.Low));
+            Assert.That(StarReviewQueue.ParseMode("uncertain"), Is.EqualTo(StarReviewMode.Uncertain));
+            Assert.That(StarReviewQueue.ParseMode("ALL"), Is.EqualTo(StarReviewMode.All));
+            Assert.Throws<ArgumentException>(() => StarReviewQueue.ParseMode("bogus"));
+        });
+    }
+
+    // ---- Viewport (screen <-> image with zoom/pan) --------------------------------------------------------
+
+    [Test]
+    public void Viewport_ScreenImageRoundTrip() {
+        var vp = new StarReviewViewport(2.5, 30, -15);
+        var (sx, sy) = vp.ImageToScreen(100, 200);
+        var (ix, iy) = vp.ScreenToImage(sx, sy);
+        Assert.Multiple(() => {
+            Assert.That(ix, Is.EqualTo(100).Within(1e-9));
+            Assert.That(iy, Is.EqualTo(200).Within(1e-9));
+        });
+    }
+
+    [Test]
+    public void Viewport_ScreenToImage_AppliesScaleAndOffset() {
+        var vp = new StarReviewViewport(2.0, 10, 20);
+        // image (5, 7) -> screen (5*2+10, 7*2+20) = (20, 34).
+        var (ix, iy) = vp.ScreenToImage(20, 34);
+        Assert.Multiple(() => {
+            Assert.That(ix, Is.EqualTo(5).Within(1e-9));
+            Assert.That(iy, Is.EqualTo(7).Within(1e-9));
+        });
+    }
+
+    [Test]
+    public void Viewport_ZoomAt_KeepsAnchorPixelFixed() {
+        var vp = new StarReviewViewport(1.0, 0, 0);
+        // The pixel currently under screen (300, 400) must remain under (300, 400) after zooming in.
+        var (anchorImgX, anchorImgY) = vp.ScreenToImage(300, 400);
+        vp.ZoomAt(3.0, 300, 400);
+        var (sx, sy) = vp.ImageToScreen(anchorImgX, anchorImgY);
+        Assert.Multiple(() => {
+            Assert.That(vp.Scale, Is.EqualTo(3.0).Within(1e-9));
+            Assert.That(sx, Is.EqualTo(300).Within(1e-6));
+            Assert.That(sy, Is.EqualTo(400).Within(1e-6));
+        });
+    }
+
+    [Test]
+    public void Viewport_FitTo_CentersAndScalesDown() {
+        var vp = new StarReviewViewport();
+        // 1000x500 image into an 800x800 viewport: fit = min(0.8, 1.6) = 0.8; image drawn 800x400, centered.
+        vp.FitTo(800, 800, 1000, 500);
+        Assert.Multiple(() => {
+            Assert.That(vp.Scale, Is.EqualTo(0.8).Within(1e-9));
+            Assert.That(vp.OffsetX, Is.EqualTo(0).Within(1e-9));     // 800 - 1000*0.8 = 0
+            Assert.That(vp.OffsetY, Is.EqualTo(200).Within(1e-9));   // (800 - 500*0.8)/2 = 200
+        });
+    }
+
+    [Test]
+    public void Viewport_ClampsScaleToBounds() {
+        var vp = new StarReviewViewport();
+        vp.Set(1000.0, 0, 0);
+        Assert.That(vp.Scale, Is.EqualTo(StarReviewViewport.MaxScale));
+        vp.Set(0.0001, 0, 0);
+        Assert.That(vp.Scale, Is.EqualTo(StarReviewViewport.MinScale));
+    }
+
+    [Test]
+    public void PanBy_TranslatesOffset() {
+        var vp = new StarReviewViewport(1.0, 10, 10);
+        vp.PanBy(5, -3);
+        Assert.Multiple(() => {
+            Assert.That(vp.OffsetX, Is.EqualTo(15));
+            Assert.That(vp.OffsetY, Is.EqualTo(7));
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarReviewTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarReviewTests.cs
@@ -31,12 +31,14 @@ public class StarReviewTests {
     // ---- Label JSON shape MUST match T6's --labels reader EXACTLY ------------------------------------------
 
     // POCOs carrying the SAME [JsonProperty] names/casing as T6's private loader (OptimizationDiagnosticRunner:
-    // RunLabelFile / LabelPosition / LabelPoint). The round-trip test below deserializes a T7-written file
-    // THROUGH these — if T7 ever drifts from T6's shape, this test fails. This is the contract that keeps
-    // `review` -> `optimize --labels` working.
+    // RunLabelFile / LabelPosition / LabelPoint). Each label is now a BOX (x,y,w,h). The round-trip test below
+    // deserializes a T7-written file THROUGH these — if T7 ever drifts from T6's shape, this test fails. This is the
+    // contract that keeps `review` -> `optimize --labels` working.
     private sealed class T6LabelPoint {
         [JsonProperty("x")] public double X { get; set; }
         [JsonProperty("y")] public double Y { get; set; }
+        [JsonProperty("w")] public double? W { get; set; }
+        [JsonProperty("h")] public double? H { get; set; }
     }
 
     private sealed class T6LabelPosition {
@@ -62,9 +64,9 @@ public class StarReviewTests {
                 new StarReviewPositionLabels {
                     FocuserPosition = 5000,
                     RadiusPx = 6.0,
-                    Missed = new List<StarReviewLabelPoint> { new StarReviewLabelPoint(123.4, 567.8) },
-                    ShouldReject = new List<StarReviewLabelPoint> { new StarReviewLabelPoint(12.0, 34.0) },
-                    WronglyRejected = new List<StarReviewLabelPoint> { new StarReviewLabelPoint(88.0, 90.0) }
+                    Missed = new List<StarReviewLabelBox> { new StarReviewLabelBox(123.4, 567.8, 12.0, 14.0) },
+                    ShouldReject = new List<StarReviewLabelBox> { new StarReviewLabelBox(12.0, 34.0, 9.0, 9.0) },
+                    WronglyRejected = new List<StarReviewLabelBox> { new StarReviewLabelBox(88.0, 90.0, 10.0, 8.0) }
                 }
             }
         };
@@ -84,12 +86,18 @@ public class StarReviewTests {
             Assert.That(p.Missed, Has.Count.EqualTo(1));
             Assert.That(p.Missed[0].X, Is.EqualTo(123.4));
             Assert.That(p.Missed[0].Y, Is.EqualTo(567.8));
+            Assert.That(p.Missed[0].W, Is.EqualTo(12.0));
+            Assert.That(p.Missed[0].H, Is.EqualTo(14.0));
             Assert.That(p.ShouldReject, Has.Count.EqualTo(1));
             Assert.That(p.ShouldReject[0].X, Is.EqualTo(12.0));
             Assert.That(p.ShouldReject[0].Y, Is.EqualTo(34.0));
+            Assert.That(p.ShouldReject[0].W, Is.EqualTo(9.0));
+            Assert.That(p.ShouldReject[0].H, Is.EqualTo(9.0));
             Assert.That(p.WronglyRejected, Has.Count.EqualTo(1));
             Assert.That(p.WronglyRejected[0].X, Is.EqualTo(88.0));
             Assert.That(p.WronglyRejected[0].Y, Is.EqualTo(90.0));
+            Assert.That(p.WronglyRejected[0].W, Is.EqualTo(10.0));
+            Assert.That(p.WronglyRejected[0].H, Is.EqualTo(8.0));
         });
     }
 
@@ -101,9 +109,9 @@ public class StarReviewTests {
             Positions = new List<StarReviewPositionLabels> {
                 new StarReviewPositionLabels {
                     FocuserPosition = 100,
-                    Missed = new List<StarReviewLabelPoint> { new StarReviewLabelPoint(1, 2) },
-                    ShouldReject = new List<StarReviewLabelPoint> { new StarReviewLabelPoint(3, 4) },
-                    WronglyRejected = new List<StarReviewLabelPoint> { new StarReviewLabelPoint(5, 6) }
+                    Missed = new List<StarReviewLabelBox> { new StarReviewLabelBox(1, 2, 3, 4) },
+                    ShouldReject = new List<StarReviewLabelBox> { new StarReviewLabelBox(3, 4, 5, 6) },
+                    WronglyRejected = new List<StarReviewLabelBox> { new StarReviewLabelBox(5, 6, 7, 8) }
                 }
             }
         };
@@ -118,7 +126,41 @@ public class StarReviewTests {
             Assert.That(json, Does.Contain("\"wronglyRejected\""));
             Assert.That(json, Does.Contain("\"x\""));
             Assert.That(json, Does.Contain("\"y\""));
+            Assert.That(json, Does.Contain("\"w\""));
+            Assert.That(json, Does.Contain("\"h\""));
         });
+    }
+
+    [Test]
+    public void Load_LegacyPointOnlyFile_BackfillsDefaultBox() {
+        // An older point-only label file (x,y, no w/h). Loading must widen each point to a 2·radiusPx box centered on
+        // the point (so old files keep working under the new box-containment scoring).
+        var dir = Path.Combine(Path.GetTempPath(), "hf-review-test-" + Guid.NewGuid().ToString("N"));
+        try {
+            Directory.CreateDirectory(dir);
+            var legacyJson =
+                "{ \"runId\": \"legacy\", \"radiusPx\": 5.0, \"positions\": [ " +
+                "{ \"focuserPosition\": 5000, \"missed\": [ { \"x\": 100.0, \"y\": 200.0 } ] } ] }";
+            File.WriteAllText(Path.Combine(dir, "legacy.json"), legacyJson);
+
+            var loaded = StarReviewLabelStore.Load(dir, "legacy", out var err);
+            Assert.That(err, Is.Null);
+            Assert.That(loaded.Positions, Has.Count.EqualTo(1));
+            var b = loaded.Positions[0].Missed[0];
+            Assert.Multiple(() => {
+                Assert.That(b.HasSize, Is.True, "legacy point widened to a real box");
+                Assert.That(b.W.Value, Is.EqualTo(10.0).Within(1e-12), "side = 2*radiusPx");
+                Assert.That(b.H.Value, Is.EqualTo(10.0).Within(1e-12));
+                Assert.That(b.X, Is.EqualTo(95.0).Within(1e-12), "centered on the original point => top-left = x - side/2");
+                Assert.That(b.Y, Is.EqualTo(195.0).Within(1e-12));
+                Assert.That(b.CenterX, Is.EqualTo(100.0).Within(1e-12));
+                Assert.That(b.CenterY, Is.EqualTo(200.0).Within(1e-12));
+            });
+        } finally {
+            if (Directory.Exists(dir)) {
+                Directory.Delete(dir, true);
+            }
+        }
     }
 
     [Test]
@@ -127,7 +169,7 @@ public class StarReviewTests {
         try {
             var labels = new StarReviewRunLabels { RunId = "attempt01", RadiusPx = 6.0 };
             var pos = StarReviewLabelStore.GetOrAddPosition(labels, 5000);
-            StarReviewLabelStore.TogglePoint(pos.Missed, 10, 20);
+            StarReviewLabelStore.ToggleBox(pos.Missed, 10, 20, 8, 8);
             StarReviewLabelStore.Save(dir, labels);
 
             // Re-load (a fresh review session), add more, save, reload — prior labels must persist.
@@ -137,7 +179,7 @@ public class StarReviewTests {
             Assert.That(reloaded.Positions[0].Missed, Has.Count.EqualTo(1));
 
             var pos2 = StarReviewLabelStore.GetOrAddPosition(reloaded, 5000);
-            StarReviewLabelStore.TogglePoint(pos2.ShouldReject, 30, 40);
+            StarReviewLabelStore.ToggleBox(pos2.ShouldReject, 30, 40, 8, 8);
             StarReviewLabelStore.Save(dir, reloaded);
 
             var final = StarReviewLabelStore.Load(dir, "attempt01", out _);
@@ -164,24 +206,35 @@ public class StarReviewTests {
     // ---- Toggle / merge -----------------------------------------------------------------------------------
 
     [Test]
-    public void TogglePoint_AddsThenRemovesNearbyPoint() {
-        var points = new List<StarReviewLabelPoint>();
-        var added = StarReviewLabelStore.TogglePoint(points, 100, 100);
+    public void ToggleBox_AddsThenRemovesNearbyBox() {
+        var boxes = new List<StarReviewLabelBox>();
+        var added = StarReviewLabelStore.ToggleBox(boxes, 100, 100, 8, 8); // center (104,104)
         Assert.That(added, Is.True);
-        Assert.That(points, Has.Count.EqualTo(1));
+        Assert.That(boxes, Has.Count.EqualTo(1));
 
-        // A second click within tolerance removes it (undo).
-        var removed = StarReviewLabelStore.TogglePoint(points, 101, 101);
+        // A second toggle whose CENTER is within tolerance of the existing box's center removes it (undo).
+        var removed = StarReviewLabelStore.ToggleBox(boxes, 101, 101, 8, 8); // center (105,105) ~ within tol of (104,104)
         Assert.That(removed, Is.False);
-        Assert.That(points, Is.Empty);
+        Assert.That(boxes, Is.Empty);
     }
 
     [Test]
-    public void TogglePoint_FarClickAddsSecondPoint() {
-        var points = new List<StarReviewLabelPoint>();
-        StarReviewLabelStore.TogglePoint(points, 100, 100);
-        StarReviewLabelStore.TogglePoint(points, 500, 500);
-        Assert.That(points, Has.Count.EqualTo(2));
+    public void ToggleBox_FarClickAddsSecondBox() {
+        var boxes = new List<StarReviewLabelBox>();
+        StarReviewLabelStore.ToggleBox(boxes, 100, 100, 8, 8);
+        StarReviewLabelStore.ToggleBox(boxes, 500, 500, 8, 8);
+        Assert.That(boxes, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void SmallestContainingBoxIndex_PrefersTightestBox() {
+        var boxes = new List<StarReviewLabelBox> {
+            new StarReviewLabelBox(0, 0, 100, 100),   // big box covering the click
+            new StarReviewLabelBox(40, 40, 20, 20)    // tight box also covering it (smaller area)
+        };
+        var idx = StarReviewLabelStore.SmallestContainingBoxIndex(boxes, 50, 50);
+        Assert.That(idx, Is.EqualTo(1));
+        Assert.That(StarReviewLabelStore.SmallestContainingBoxIndex(boxes, 5000, 5000), Is.EqualTo(-1));
     }
 
     [Test]
@@ -189,7 +242,7 @@ public class StarReviewTests {
         var labels = new StarReviewRunLabels { RunId = "r" };
         var empty = StarReviewLabelStore.GetOrAddPosition(labels, 100);
         var kept = StarReviewLabelStore.GetOrAddPosition(labels, 200);
-        StarReviewLabelStore.TogglePoint(kept.Missed, 1, 1);
+        StarReviewLabelStore.ToggleBox(kept.Missed, 1, 1, 4, 4);
 
         StarReviewLabelStore.PruneEmptyPositions(labels);
         Assert.That(labels.Positions, Has.Count.EqualTo(1));
@@ -201,7 +254,7 @@ public class StarReviewTests {
         var labels = new StarReviewRunLabels { RunId = "r" };
         var empty = StarReviewLabelStore.GetOrAddPosition(labels, 100);
         var wronglyOnly = StarReviewLabelStore.GetOrAddPosition(labels, 200);
-        StarReviewLabelStore.TogglePoint(wronglyOnly.WronglyRejected, 7, 8);
+        StarReviewLabelStore.ToggleBox(wronglyOnly.WronglyRejected, 7, 8, 4, 4);
 
         StarReviewLabelStore.PruneEmptyPositions(labels);
         Assert.That(labels.Positions, Has.Count.EqualTo(1));
@@ -213,12 +266,12 @@ public class StarReviewTests {
     public void Counts_IncludesWronglyRejected() {
         var labels = new StarReviewRunLabels { RunId = "r" };
         var pos = StarReviewLabelStore.GetOrAddPosition(labels, 5000);
-        StarReviewLabelStore.TogglePoint(pos.Missed, 1, 1);
-        StarReviewLabelStore.TogglePoint(pos.Missed, 50, 50);
-        StarReviewLabelStore.TogglePoint(pos.ShouldReject, 100, 100);
-        StarReviewLabelStore.TogglePoint(pos.WronglyRejected, 200, 200);
-        StarReviewLabelStore.TogglePoint(pos.WronglyRejected, 300, 300);
-        StarReviewLabelStore.TogglePoint(pos.WronglyRejected, 400, 400);
+        StarReviewLabelStore.ToggleBox(pos.Missed, 1, 1, 4, 4);
+        StarReviewLabelStore.ToggleBox(pos.Missed, 50, 50, 4, 4);
+        StarReviewLabelStore.ToggleBox(pos.ShouldReject, 100, 100, 4, 4);
+        StarReviewLabelStore.ToggleBox(pos.WronglyRejected, 200, 200, 4, 4);
+        StarReviewLabelStore.ToggleBox(pos.WronglyRejected, 300, 300, 4, 4);
+        StarReviewLabelStore.ToggleBox(pos.WronglyRejected, 400, 400, 4, 4);
 
         var (missed, shouldReject, wronglyRejected) = StarReviewLabelStore.Counts(labels);
         Assert.Multiple(() => {
@@ -234,15 +287,20 @@ public class StarReviewTests {
         try {
             var labels = new StarReviewRunLabels { RunId = "attempt01", RadiusPx = 6.0 };
             var pos = StarReviewLabelStore.GetOrAddPosition(labels, 5000);
-            StarReviewLabelStore.TogglePoint(pos.WronglyRejected, 88, 90);
+            StarReviewLabelStore.ToggleBox(pos.WronglyRejected, 88, 90, 10, 8);
             StarReviewLabelStore.Save(dir, labels);
 
             var reloaded = StarReviewLabelStore.Load(dir, "attempt01", out var err);
             Assert.That(err, Is.Null);
             Assert.That(reloaded.Positions, Has.Count.EqualTo(1));
             Assert.That(reloaded.Positions[0].WronglyRejected, Has.Count.EqualTo(1));
-            Assert.That(reloaded.Positions[0].WronglyRejected[0].X, Is.EqualTo(88.0));
-            Assert.That(reloaded.Positions[0].WronglyRejected[0].Y, Is.EqualTo(90.0));
+            var b = reloaded.Positions[0].WronglyRejected[0];
+            Assert.Multiple(() => {
+                Assert.That(b.X, Is.EqualTo(88.0));
+                Assert.That(b.Y, Is.EqualTo(90.0));
+                Assert.That(b.W.Value, Is.EqualTo(10.0));
+                Assert.That(b.H.Value, Is.EqualTo(8.0));
+            });
         } finally {
             if (Directory.Exists(dir)) {
                 Directory.Delete(dir, true);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StepSizeRecommenderTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StepSizeRecommenderTests.cs
@@ -1,0 +1,85 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using OxyPlot.Series;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Optimization;
+
+[TestFixture]
+public class StepSizeRecommenderTests {
+
+    // Symmetric hyperbola hfr(pos) = sqrt(a^2 + ((pos - p0)/b)^2). The offset W where hfr == 2*minHfr (== 2a)
+    // satisfies 4a^2 = a^2 + (W/b)^2 => W = b*sqrt(3)*a. With a=1.5, b=8 => W = 8*sqrt(3)*1.5 ~= 20.78.
+    private const double A = 1.5;
+    private const double B = 8.0;
+    private const int P0 = 10000;
+    private static double ExpectedHalfWidth => B * Math.Sqrt(3.0) * A; // ~20.78
+
+    private static AlglibHyperbolicFitting FitCleanHyperbola() {
+        var alglib = new AlglibAPI();
+        var points = new List<ScatterErrorPoint>();
+        for (var i = -6; i <= 6; i++) {
+            var pos = P0 + i * 100;
+            var dx = (pos - P0) / B;
+            var hfr = Math.Sqrt(A * A + dx * dx);
+            points.Add(new ScatterErrorPoint(pos, hfr, 0, 0.02));
+        }
+        AlglibHyperbolicFitting.SelectBestModel(alglib, points, stepSize: 100, useWeights: true,
+            maxOutlierRejections: 0, rejectionConfidence: 0.0, out var bestFit, out _);
+        return bestFit;
+    }
+
+    [Test]
+    public void Recommend_KnownHalfWidth_GivesAboutWidthOver3Point5() {
+        var fit = FitCleanHyperbola();
+        var rec = StepSizeRecommender.Recommend(fit, currentStepSize: 100);
+
+        var expectedStep = (int)Math.Round(ExpectedHalfWidth / 3.5); // ~6
+        Assert.Multiple(() => {
+            Assert.That(rec.HalfWidth, Is.EqualTo(ExpectedHalfWidth).Within(2.0), "modeled 2x-min-HFR half-width");
+            Assert.That(rec.StepSize, Is.EqualTo(expectedStep).Within(1), "step size ~= round(W / 3.5) so the sweep has ~3-4 points/side");
+            Assert.That(rec.OffsetSteps, Is.EqualTo(4));
+        });
+    }
+
+    [Test]
+    public void Recommend_ClampsToFocuserMaxStep() {
+        var fit = FitCleanHyperbola();
+        var rec = StepSizeRecommender.Recommend(fit, currentStepSize: 100, focuserMaxStep: 2);
+        Assert.That(rec.StepSize, Is.LessThanOrEqualTo(2), "must clamp to the focuser max step");
+        Assert.That(rec.StepSize, Is.GreaterThanOrEqualTo(1), "step size never below 1");
+    }
+
+    [Test]
+    public void Recommend_StepSizeNeverBelowOne() {
+        var fit = FitCleanHyperbola();
+        // Even with a focuserMaxStep of 0/negative the recommender must keep a legal >= 1 step.
+        var rec = StepSizeRecommender.Recommend(fit, currentStepSize: 100, focuserMaxStep: 0);
+        Assert.That(rec.StepSize, Is.GreaterThanOrEqualTo(1));
+    }
+
+    [Test]
+    public void Recommend_NullFit_ReturnsCurrentStepUnchanged() {
+        var rec = StepSizeRecommender.Recommend(null, currentStepSize: 42);
+        Assert.Multiple(() => {
+            Assert.That(rec.StepSize, Is.EqualTo(42), "degenerate (null) fit => keep current step");
+            Assert.That(double.IsNaN(rec.HalfWidth), Is.True);
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/OptimizedStarDetectionSettingsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/OptimizedStarDetectionSettingsTests.cs
@@ -1,5 +1,6 @@
 using System;
 using Newtonsoft.Json;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
 using NUnit.Framework;
 
@@ -65,6 +66,61 @@ public class OptimizedStarDetectionSettingsTests {
             Assert.That(restored.RecommendedOffsetSteps, Is.EqualTo(original.RecommendedOffsetSteps));
             Assert.That(restored.SchemaVersion, Is.EqualTo(original.SchemaVersion));
         });
+    }
+
+    [Test]
+    public void FromParams_MapsCuratedKnobsAndMetadata() {
+        // Distinct, recognizable values so a mis-wired field (esp. the renamed ones) is caught.
+        var p = new StarDetectorParams {
+            Sensitivity = 3.3,
+            StarClippingMultiplier = 2.7,
+            NoiseClippingMultiplier = 5.5,
+            PeakResponse = 0.66,
+            MaxDistortion = 0.42,
+            MinHFR = 1.1,
+            StarCenterTolerance = 0.45,
+            StructureLayers = 7,
+            NoiseReductionRadius = 6,
+            MinimumStarBoundingBoxSize = 8,
+            HotpixelThresholdingEnabled = false,
+            HotpixelThreshold = 0.02
+        };
+
+        var before = DateTime.UtcNow;
+        var dto = OptimizedStarDetectionSettings.FromParams(p, runCount: 5, baselineJ: 0.9, finalJ: 0.4, recommendedStepSize: 25, recommendedOffsetSteps: 6);
+        var after = DateTime.UtcNow;
+
+        Assert.Multiple(() => {
+            // Curated knobs (note the renames: Sensitivity->BrightnessSensitivity, PeakResponse->StarPeakResponse,
+            // MinimumStarBoundingBoxSize->MinStarBoundingBoxSize).
+            Assert.That(dto.BrightnessSensitivity, Is.EqualTo(3.3));
+            Assert.That(dto.StarClippingMultiplier, Is.EqualTo(2.7));
+            Assert.That(dto.NoiseClippingMultiplier, Is.EqualTo(5.5));
+            Assert.That(dto.StarPeakResponse, Is.EqualTo(0.66));
+            Assert.That(dto.MaxDistortion, Is.EqualTo(0.42));
+            Assert.That(dto.MinHFR, Is.EqualTo(1.1));
+            Assert.That(dto.StarCenterTolerance, Is.EqualTo(0.45));
+            Assert.That(dto.StructureLayers, Is.EqualTo(7));
+            Assert.That(dto.NoiseReductionRadius, Is.EqualTo(6));
+            Assert.That(dto.MinStarBoundingBoxSize, Is.EqualTo(8));
+            Assert.That(dto.HotpixelThresholdingEnabled, Is.False);
+            Assert.That(dto.HotpixelThreshold, Is.EqualTo(0.02));
+
+            // Metadata.
+            Assert.That(dto.RunCount, Is.EqualTo(5));
+            Assert.That(dto.BaselineJ, Is.EqualTo(0.9));
+            Assert.That(dto.FinalJ, Is.EqualTo(0.4));
+            Assert.That(dto.RecommendedStepSize, Is.EqualTo(25));
+            Assert.That(dto.RecommendedOffsetSteps, Is.EqualTo(6));
+            Assert.That(dto.SchemaVersion, Is.EqualTo(1));
+            Assert.That(dto.CreatedAtUtc, Is.InRange(before, after));
+            Assert.That(dto.CreatedAtUtc.Kind, Is.EqualTo(DateTimeKind.Utc));
+        });
+    }
+
+    [Test]
+    public void FromParams_NullParams_Throws() {
+        Assert.Throws<ArgumentNullException>(() => OptimizedStarDetectionSettings.FromParams(null, 1, 0.0, 0.0, 1, 1));
     }
 
     [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/OptimizedStarDetectionSettingsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/OptimizedStarDetectionSettingsTests.cs
@@ -1,0 +1,82 @@
+using System;
+using Newtonsoft.Json;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection;
+
+[TestFixture]
+public class OptimizedStarDetectionSettingsTests {
+
+    private static OptimizedStarDetectionSettings Make() {
+        return new OptimizedStarDetectionSettings {
+            BrightnessSensitivity = 3.3,
+            StarClippingMultiplier = 2.7,
+            NoiseClippingMultiplier = 5.5,
+            StarPeakResponse = 0.66,
+            MaxDistortion = 0.42,
+            MinHFR = 1.1,
+            StarCenterTolerance = 0.45,
+            StructureLayers = 7,
+            NoiseReductionRadius = 6,
+            MinStarBoundingBoxSize = 8,
+            HotpixelThresholdingEnabled = false,
+            HotpixelThreshold = 0.02,
+            CreatedAtUtc = new DateTime(2026, 6, 14, 12, 0, 0, DateTimeKind.Utc),
+            RunCount = 5,
+            BaselineJ = 0.9,
+            FinalJ = 0.4,
+            RecommendedStepSize = 25,
+            RecommendedOffsetSteps = 6,
+            SchemaVersion = 1
+        };
+    }
+
+    [Test]
+    public void DefaultSchemaVersion_IsOne() {
+        Assert.That(new OptimizedStarDetectionSettings().SchemaVersion, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void JsonRoundTrip_PreservesAllFields() {
+        var original = Make();
+
+        var json = JsonConvert.SerializeObject(original);
+        var restored = JsonConvert.DeserializeObject<OptimizedStarDetectionSettings>(json);
+
+        Assert.Multiple(() => {
+            Assert.That(restored.BrightnessSensitivity, Is.EqualTo(original.BrightnessSensitivity));
+            Assert.That(restored.StarClippingMultiplier, Is.EqualTo(original.StarClippingMultiplier));
+            Assert.That(restored.NoiseClippingMultiplier, Is.EqualTo(original.NoiseClippingMultiplier));
+            Assert.That(restored.StarPeakResponse, Is.EqualTo(original.StarPeakResponse));
+            Assert.That(restored.MaxDistortion, Is.EqualTo(original.MaxDistortion));
+            Assert.That(restored.MinHFR, Is.EqualTo(original.MinHFR));
+            Assert.That(restored.StarCenterTolerance, Is.EqualTo(original.StarCenterTolerance));
+            Assert.That(restored.StructureLayers, Is.EqualTo(original.StructureLayers));
+            Assert.That(restored.NoiseReductionRadius, Is.EqualTo(original.NoiseReductionRadius));
+            Assert.That(restored.MinStarBoundingBoxSize, Is.EqualTo(original.MinStarBoundingBoxSize));
+            Assert.That(restored.HotpixelThresholdingEnabled, Is.EqualTo(original.HotpixelThresholdingEnabled));
+            Assert.That(restored.HotpixelThreshold, Is.EqualTo(original.HotpixelThreshold));
+            Assert.That(restored.CreatedAtUtc, Is.EqualTo(original.CreatedAtUtc));
+            Assert.That(restored.RunCount, Is.EqualTo(original.RunCount));
+            Assert.That(restored.BaselineJ, Is.EqualTo(original.BaselineJ));
+            Assert.That(restored.FinalJ, Is.EqualTo(original.FinalJ));
+            Assert.That(restored.RecommendedStepSize, Is.EqualTo(original.RecommendedStepSize));
+            Assert.That(restored.RecommendedOffsetSteps, Is.EqualTo(original.RecommendedOffsetSteps));
+            Assert.That(restored.SchemaVersion, Is.EqualTo(original.SchemaVersion));
+        });
+    }
+
+    [Test]
+    public void Clone_ProducesIndependentCopy() {
+        var original = Make();
+        var clone = original.Clone();
+        clone.BrightnessSensitivity = 99.0;
+
+        Assert.Multiple(() => {
+            Assert.That(clone, Is.Not.SameAs(original));
+            Assert.That(original.BrightnessSensitivity, Is.EqualTo(3.3));
+            Assert.That(clone.BrightnessSensitivity, Is.EqualTo(99.0));
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionOptionsTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
 using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
 using NINA.Profile.Interfaces;
 using NSubstitute;
@@ -391,5 +392,215 @@ public class StarDetectionOptionsTests {
     public void Constructor_ThrowsOnNullAccessor() {
         var profile = Substitute.For<IProfileService>();
         Assert.Throws<ArgumentNullException>(() => new StarDetectionOptions(profile, null));
+    }
+
+    // ---- Optimized settings snapshot + "Use Optimized Settings" toggle (T1) ----
+
+    private static OptimizedStarDetectionSettings MakeSnapshot() {
+        // Distinctive curated values, all within each property's valid range.
+        return new OptimizedStarDetectionSettings {
+            BrightnessSensitivity = 3.3,
+            StarClippingMultiplier = 2.7,
+            NoiseClippingMultiplier = 5.5,
+            StarPeakResponse = 0.66,
+            MaxDistortion = 0.42,
+            MinHFR = 1.1,
+            StarCenterTolerance = 0.45,
+            StructureLayers = 7,
+            NoiseReductionRadius = 6,
+            MinStarBoundingBoxSize = 8,
+            HotpixelThresholdingEnabled = false,
+            HotpixelThreshold = 0.02,
+            CreatedAtUtc = new DateTime(2026, 6, 14, 12, 0, 0, DateTimeKind.Utc),
+            RunCount = 5,
+            BaselineJ = 0.9,
+            FinalJ = 0.4,
+            RecommendedStepSize = 25,
+            RecommendedOffsetSteps = 6,
+            SchemaVersion = 1
+        };
+    }
+
+    private static void AssertLiveMatchesSnapshot(IStarDetectionOptions options, OptimizedStarDetectionSettings s) {
+        Assert.Multiple(() => {
+            Assert.That(options.BrightnessSensitivity, Is.EqualTo(s.BrightnessSensitivity));
+            Assert.That(options.StarClippingMultiplier, Is.EqualTo(s.StarClippingMultiplier));
+            Assert.That(options.NoiseClippingMultiplier, Is.EqualTo(s.NoiseClippingMultiplier));
+            Assert.That(options.StarPeakResponse, Is.EqualTo(s.StarPeakResponse));
+            Assert.That(options.MaxDistortion, Is.EqualTo(s.MaxDistortion));
+            Assert.That(options.MinHFR, Is.EqualTo(s.MinHFR));
+            Assert.That(options.StarCenterTolerance, Is.EqualTo(s.StarCenterTolerance));
+            Assert.That(options.StructureLayers, Is.EqualTo(s.StructureLayers));
+            Assert.That(options.NoiseReductionRadius, Is.EqualTo(s.NoiseReductionRadius));
+            Assert.That(options.MinStarBoundingBoxSize, Is.EqualTo(s.MinStarBoundingBoxSize));
+            Assert.That(options.HotpixelThresholdingEnabled, Is.EqualTo(s.HotpixelThresholdingEnabled));
+            Assert.That(options.HotpixelThreshold, Is.EqualTo(s.HotpixelThreshold));
+        });
+    }
+
+    [Test]
+    public void OptimizedSettings_DefaultsToNoneAndOff() {
+        var (options, _, _) = Build();
+        Assert.Multiple(() => {
+            Assert.That(options.HasOptimizedSettings, Is.False);
+            Assert.That(options.UseOptimizedSettings, Is.False);
+            Assert.That(options.GetOptimizedSettings(), Is.Null);
+        });
+    }
+
+    [Test]
+    public void ApplyOptimizedSettings_TurnsOnAndDrivesLiveProperties() {
+        var (options, _, _) = Build();
+        var snapshot = MakeSnapshot();
+
+        options.ApplyOptimizedSettings(snapshot);
+
+        Assert.Multiple(() => {
+            Assert.That(options.HasOptimizedSettings, Is.True);
+            Assert.That(options.UseOptimizedSettings, Is.True);
+            Assert.That(options.UseAdvanced, Is.False);
+        });
+        AssertLiveMatchesSnapshot(options, snapshot);
+    }
+
+    [Test]
+    public void ApplyOptimizedSettings_NullThrows() {
+        var (options, _, _) = Build();
+        Assert.Throws<ArgumentNullException>(() => options.ApplyOptimizedSettings(null));
+    }
+
+    [Test]
+    public void ApplyOptimizedSettings_ReflectedInBuildStarDetectorParams() {
+        var (options, _, _) = Build();
+        var snapshot = MakeSnapshot();
+        options.ApplyOptimizedSettings(snapshot);
+
+        var p = HocusFocusStarDetection.BuildStarDetectorParams(options);
+
+        Assert.Multiple(() => {
+            Assert.That(p.Sensitivity, Is.EqualTo(snapshot.BrightnessSensitivity));
+            Assert.That(p.StarClippingMultiplier, Is.EqualTo(snapshot.StarClippingMultiplier));
+            Assert.That(p.NoiseClippingMultiplier, Is.EqualTo(snapshot.NoiseClippingMultiplier));
+            Assert.That(p.PeakResponse, Is.EqualTo(snapshot.StarPeakResponse));
+            Assert.That(p.MaxDistortion, Is.EqualTo(snapshot.MaxDistortion));
+            Assert.That(p.MinHFR, Is.EqualTo(snapshot.MinHFR));
+            Assert.That(p.StarCenterTolerance, Is.EqualTo(snapshot.StarCenterTolerance));
+            Assert.That(p.StructureLayers, Is.EqualTo(snapshot.StructureLayers));
+            Assert.That(p.NoiseReductionRadius, Is.EqualTo(snapshot.NoiseReductionRadius));
+            Assert.That(p.MinimumStarBoundingBoxSize, Is.EqualTo(snapshot.MinStarBoundingBoxSize));
+            Assert.That(p.HotpixelThresholdingEnabled, Is.EqualTo(snapshot.HotpixelThresholdingEnabled));
+            Assert.That(p.HotpixelThreshold, Is.EqualTo(snapshot.HotpixelThreshold));
+        });
+    }
+
+    [Test]
+    public void ToggleOptimizedSettingsOff_RestoresPresetDerivedValues() {
+        var (options, _, _) = Build();
+        // Establish the preset-derived baseline for a fresh Typical/Typical/Typical config.
+        var (baseline, _, _) = Build();
+
+        // HotpixelThresholdingEnabled is an input toggle that DerivePresetSettings reads (not re-derives), so
+        // use the default (true) here to keep the NoiseReductionRadius derivation aligned with the baseline.
+        var snapshot = MakeSnapshot();
+        snapshot.HotpixelThresholdingEnabled = true;
+        options.ApplyOptimizedSettings(snapshot);
+        options.UseOptimizedSettings = false;
+
+        Assert.Multiple(() => {
+            Assert.That(options.HasOptimizedSettings, Is.True, "snapshot should still be stored when toggled off");
+            Assert.That(options.BrightnessSensitivity, Is.EqualTo(baseline.BrightnessSensitivity));
+            Assert.That(options.StarClippingMultiplier, Is.EqualTo(baseline.StarClippingMultiplier));
+            Assert.That(options.NoiseClippingMultiplier, Is.EqualTo(baseline.NoiseClippingMultiplier));
+            Assert.That(options.StarPeakResponse, Is.EqualTo(baseline.StarPeakResponse));
+            Assert.That(options.MaxDistortion, Is.EqualTo(baseline.MaxDistortion));
+            Assert.That(options.MinHFR, Is.EqualTo(baseline.MinHFR));
+            Assert.That(options.StarCenterTolerance, Is.EqualTo(baseline.StarCenterTolerance));
+            Assert.That(options.StructureLayers, Is.EqualTo(baseline.StructureLayers));
+            Assert.That(options.NoiseReductionRadius, Is.EqualTo(baseline.NoiseReductionRadius));
+            Assert.That(options.MinStarBoundingBoxSize, Is.EqualTo(baseline.MinStarBoundingBoxSize));
+            Assert.That(options.HotpixelThresholdingEnabled, Is.EqualTo(baseline.HotpixelThresholdingEnabled));
+            Assert.That(options.HotpixelThreshold, Is.EqualTo(baseline.HotpixelThreshold));
+        });
+    }
+
+    [Test]
+    public void OptimizedSettings_PersistAndReloadAcrossNewOptionsInstance() {
+        var profile = Substitute.For<IProfileService>();
+        var store = new InMemoryPluginOptionsAccessor();
+        var snapshot = MakeSnapshot();
+
+        var first = new StarDetectionOptions(profile, store);
+        first.ApplyOptimizedSettings(snapshot);
+
+        // A brand new options object over the SAME persisted store must reload the snapshot + toggle.
+        var reloaded = new StarDetectionOptions(profile, store);
+        Assert.Multiple(() => {
+            Assert.That(reloaded.HasOptimizedSettings, Is.True);
+            Assert.That(reloaded.UseOptimizedSettings, Is.True);
+        });
+        AssertLiveMatchesSnapshot(reloaded, snapshot);
+    }
+
+    [Test]
+    public void ResetDefaults_ClearsOptimizedSettings() {
+        var (options, _, _) = Build();
+        var (baseline, _, _) = Build();
+        options.ApplyOptimizedSettings(MakeSnapshot());
+
+        options.ResetDefaults();
+
+        Assert.Multiple(() => {
+            Assert.That(options.HasOptimizedSettings, Is.False);
+            Assert.That(options.UseOptimizedSettings, Is.False);
+            Assert.That(options.GetOptimizedSettings(), Is.Null);
+            // Live values back to preset-derived defaults.
+            Assert.That(options.BrightnessSensitivity, Is.EqualTo(baseline.BrightnessSensitivity));
+            Assert.That(options.MinHFR, Is.EqualTo(baseline.MinHFR));
+            Assert.That(options.StructureLayers, Is.EqualTo(baseline.StructureLayers));
+        });
+    }
+
+    [Test]
+    public void UseOptimizedSettings_DefaultPersistsFalse() {
+        var (options, store, _) = Build();
+        options.UseAdvanced = true; // avoid simple-mode reconfig recursion noise
+        options.UseOptimizedSettings = true;
+        Assert.That(store.Snapshot[nameof(StarDetectionOptions.UseOptimizedSettings)], Is.True);
+    }
+
+    [Test]
+    public void CorruptOptimizedSettingsJson_IsDiscardedAndDoesNotThrow() {
+        // A malformed persisted JSON blob must not break options loading: InitializeOptions runs in the
+        // constructor (and on every ProfileChanged), so a deserialize failure here would otherwise abort
+        // loading entirely. It should be swallowed (logged) and treated as "no snapshot".
+        var profile = Substitute.For<IProfileService>();
+        var store = new InMemoryPluginOptionsAccessor();
+        store.SetValueString("OptimizedSettingsJson", "{ this is not valid json");
+
+        StarDetectionOptions options = null;
+        Assert.DoesNotThrow(() => options = new StarDetectionOptions(profile, store));
+        Assert.Multiple(() => {
+            Assert.That(options.HasOptimizedSettings, Is.False);
+            Assert.That(options.GetOptimizedSettings(), Is.Null);
+        });
+    }
+
+    [Test]
+    public void GetOptimizedSettings_ReturnsDefensiveCopy() {
+        // Mutating the object returned by GetOptimizedSettings() must not change the stored in-memory snapshot,
+        // so a subsequent fetch returns the original curated values.
+        var (options, _, _) = Build();
+        var snapshot = MakeSnapshot();
+        options.ApplyOptimizedSettings(snapshot);
+
+        var fetched = options.GetOptimizedSettings();
+        fetched.BrightnessSensitivity += 100.0;
+        fetched.StructureLayers += 5;
+
+        var refetched = options.GetOptimizedSettings();
+        Assert.Multiple(() => {
+            Assert.That(refetched.BrightnessSensitivity, Is.EqualTo(snapshot.BrightnessSensitivity));
+            Assert.That(refetched.StructureLayers, Is.EqualTo(snapshot.StructureLayers));
+        });
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionOptionsTests.cs
@@ -59,6 +59,7 @@ public class StarDetectionOptionsTests {
         options.StarCenterTolerance = 0.5;
         options.StarPeakResponse = 0.8;
         options.MaxDistortion = 0.4;
+        options.DefocusAwareDistortion = true;
         options.StarBackgroundBoxExpansion = 4;
         options.MinStarBoundingBoxSize = 6;
         options.MinHFR = 1.0;
@@ -90,6 +91,7 @@ public class StarDetectionOptionsTests {
             Assert.That(store.Snapshot["StarCenterTolerance"], Is.EqualTo(0.5));
             Assert.That(store.Snapshot["StarPeakResponse"], Is.EqualTo(0.8));
             Assert.That(store.Snapshot["MaxDistortion"], Is.EqualTo(0.4));
+            Assert.That(store.Snapshot["DefocusAwareDistortion"], Is.True);
             Assert.That(store.Snapshot["StarBackgroundBoxExpansion"], Is.EqualTo(4));
             Assert.That(store.Snapshot["MinStarBoundingBoxSize"], Is.EqualTo(6));
             Assert.That(store.Snapshot["MinHFR"], Is.EqualTo(1.0));
@@ -325,6 +327,7 @@ public class StarDetectionOptionsTests {
     [TestCase(nameof(StarDetectionOptions.HotpixelFiltering), false)]
     [TestCase(nameof(StarDetectionOptions.HotpixelThresholdingEnabled), false)]
     [TestCase(nameof(StarDetectionOptions.UsePSFAbsoluteDeviation), true)]
+    [TestCase(nameof(StarDetectionOptions.DefocusAwareDistortion), true)]
     public void Setter_RaisesPropertyChanged(string propertyName, object newValue) {
         var (options, _, _) = Build();
         var raised = new List<string>();

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionOptionsTests.cs
@@ -60,6 +60,7 @@ public class StarDetectionOptionsTests {
         options.StarPeakResponse = 0.8;
         options.MaxDistortion = 0.4;
         options.DefocusAwareDistortion = true;
+        options.DefocusAwareCentering = true;
         options.StarBackgroundBoxExpansion = 4;
         options.MinStarBoundingBoxSize = 6;
         options.MinHFR = 1.0;
@@ -92,6 +93,7 @@ public class StarDetectionOptionsTests {
             Assert.That(store.Snapshot["StarPeakResponse"], Is.EqualTo(0.8));
             Assert.That(store.Snapshot["MaxDistortion"], Is.EqualTo(0.4));
             Assert.That(store.Snapshot["DefocusAwareDistortion"], Is.True);
+            Assert.That(store.Snapshot["DefocusAwareCentering"], Is.True);
             Assert.That(store.Snapshot["StarBackgroundBoxExpansion"], Is.EqualTo(4));
             Assert.That(store.Snapshot["MinStarBoundingBoxSize"], Is.EqualTo(6));
             Assert.That(store.Snapshot["MinHFR"], Is.EqualTo(1.0));
@@ -328,6 +330,7 @@ public class StarDetectionOptionsTests {
     [TestCase(nameof(StarDetectionOptions.HotpixelThresholdingEnabled), false)]
     [TestCase(nameof(StarDetectionOptions.UsePSFAbsoluteDeviation), true)]
     [TestCase(nameof(StarDetectionOptions.DefocusAwareDistortion), true)]
+    [TestCase(nameof(StarDetectionOptions.DefocusAwareCentering), true)]
     public void Setter_RaisesPropertyChanged(string propertyName, object newValue) {
         var (options, _, _) = Build();
         var raised = new List<string>();

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectorEarlyLateSplitTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectorEarlyLateSplitTests.cs
@@ -89,6 +89,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
                 Mutate(earlyParams, q => q.StarCenterTolerance = 0.15),
                 Mutate(earlyParams, q => q.MinHFR = 2.5),
                 Mutate(earlyParams, q => q.StarClippingMultiplier = 3.0),
+                // Defocus-aware distortion is a late-only gate change: reusing the early context must still match
+                // a fresh full Detect with the flag on.
+                Mutate(earlyParams, q => { q.DefocusAwareDistortion = true; q.DefocusDistortionSizeReference = 15.0; q.DefocusDistortionMinFactor = 0.2; }),
             };
 
             foreach (var lateParams in lateVariants) {
@@ -116,6 +119,10 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
                 Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.MinHFR = 3.0)), Is.EqualTo(baseKey), "MinHFR is late-only");
                 Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.StarCenterTolerance = 0.1)), Is.EqualTo(baseKey), "StarCenterTolerance is late-only");
                 Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.MinimumStarBoundingBoxSize = 9)), Is.EqualTo(baseKey), "MinimumStarBoundingBoxSize is late-only");
+                // The defocus-aware distortion knobs are all late-gate (TooDistorted decision only).
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.DefocusAwareDistortion = true)), Is.EqualTo(baseKey), "DefocusAwareDistortion is late-only");
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => { q.DefocusAwareDistortion = true; q.DefocusDistortionSizeReference = 50.0; })), Is.EqualTo(baseKey), "DefocusDistortionSizeReference is late-only");
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => { q.DefocusAwareDistortion = true; q.DefocusDistortionMinFactor = 0.1; })), Is.EqualTo(baseKey), "DefocusDistortionMinFactor is late-only");
             });
 
             // EARLY changes MUST change the early key.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectorEarlyLateSplitTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectorEarlyLateSplitTests.cs
@@ -92,6 +92,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
                 // Defocus-aware distortion is a late-only gate change: reusing the early context must still match
                 // a fresh full Detect with the flag on.
                 Mutate(earlyParams, q => { q.DefocusAwareDistortion = true; q.DefocusDistortionSizeReference = 15.0; q.DefocusDistortionMinFactor = 0.2; }),
+                // Defocus-aware centering is likewise a late-only gate change (NotCentered decision only).
+                Mutate(earlyParams, q => { q.DefocusAwareCentering = true; q.DefocusDistortionSizeReference = 15.0; q.DefocusCenteringToleranceFactor = 2.5; }),
             };
 
             foreach (var lateParams in lateVariants) {
@@ -123,6 +125,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
                 Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.DefocusAwareDistortion = true)), Is.EqualTo(baseKey), "DefocusAwareDistortion is late-only");
                 Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => { q.DefocusAwareDistortion = true; q.DefocusDistortionSizeReference = 50.0; })), Is.EqualTo(baseKey), "DefocusDistortionSizeReference is late-only");
                 Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => { q.DefocusAwareDistortion = true; q.DefocusDistortionMinFactor = 0.1; })), Is.EqualTo(baseKey), "DefocusDistortionMinFactor is late-only");
+                // The defocus-aware centering knobs are all late-gate (NotCentered decision only).
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.DefocusAwareCentering = true)), Is.EqualTo(baseKey), "DefocusAwareCentering is late-only");
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => { q.DefocusAwareCentering = true; q.DefocusCenteringToleranceFactor = 3.0; })), Is.EqualTo(baseKey), "DefocusCenteringToleranceFactor is late-only");
             });
 
             // EARLY changes MUST change the early key.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectorEarlyLateSplitTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectorEarlyLateSplitTests.cs
@@ -1,0 +1,143 @@
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NUnit.Framework;
+using OpenCvSharp;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
+
+    /// <summary>
+    /// Proves the early/late detection split is bit-identical to the monolithic <c>Detect</c> and that the
+    /// early-context cache is safe to reuse across late-only param changes. These tests guard the optimizer
+    /// speedup refactor: the cache may reuse a <see cref="StarDetector.DetectionContext"/> ONLY when the early
+    /// params match, and reusing one across different LATE params must produce exactly the monolithic result.
+    /// </summary>
+    [TestFixture]
+    public class StarDetectorEarlyLateSplitTests {
+
+        private static StarDetector NewDetector() => new StarDetector(new AlglibAPI());
+
+        // Runs the split path (BuildDetectionContext + GateAndMeasure) on a fresh field.
+        private static async Task<HocusFocusStarDetectorResult> RunSplit(StarDetectorParams p) {
+            var detector = NewDetector();
+            using var field = StarDetectorEquivalence.BuildSmallField();
+            var ctx = await detector.BuildDetectionContext(field, p, null, CancellationToken.None);
+            using (ctx) {
+                return detector.GateAndMeasure(ctx, p, CancellationToken.None);
+            }
+        }
+
+        [Test]
+        public async Task SplitPath_MatchesMonolithicDetect_DefaultParams() {
+            var p = StarDetectorEquivalence.StandardParams();
+
+            using var monoField = StarDetectorEquivalence.BuildSmallField();
+            var monoResult = await NewDetector().Detect(monoField, p, null, CancellationToken.None);
+            var monoSig = StarDetectorEquivalence.Signature(monoResult);
+
+            var splitResult = await RunSplit(p);
+            var splitSig = StarDetectorEquivalence.Signature(splitResult);
+
+            Assert.Multiple(() => {
+                Assert.That(splitSig, Is.EqualTo(monoSig),
+                    "BuildDetectionContext + GateAndMeasure must produce a byte-identical signature to monolithic Detect");
+                Assert.That(splitResult.StructureNoiseSigma, Is.EqualTo(monoResult.StructureNoiseSigma),
+                    "structure-map noise sigma must be identical");
+                Assert.That(splitResult.MeasurementNoiseSigma, Is.EqualTo(monoResult.MeasurementNoiseSigma),
+                    "measurement-image noise sigma must be identical");
+            });
+        }
+
+        [Test]
+        public async Task SplitPath_MatchesMonolithicDetect_WithNoiseReductionAndRoi() {
+            // Exercise the branch where the measurement image differs from the structure-map source (two distinct
+            // noise estimates) AND a non-trivial ROI is in play.
+            var p = StarDetectorEquivalence.StandardParams();
+            p.NoiseReductionRadius = 2;
+            p.StarMeasurementNoiseReductionEnabled = false;
+            p.Region = new StarDetectionRegion(new RatioRect(0.1, 0.1, 0.8, 0.8));
+
+            using var monoField = StarDetectorEquivalence.BuildSmallField();
+            var monoResult = await NewDetector().Detect(monoField, p, null, CancellationToken.None);
+            var monoSig = StarDetectorEquivalence.Signature(monoResult);
+
+            var splitResult = await RunSplit(p);
+            var splitSig = StarDetectorEquivalence.Signature(splitResult);
+
+            Assert.That(splitSig, Is.EqualTo(monoSig),
+                "split path must match monolithic Detect even with noise reduction + ROI offset");
+        }
+
+        [Test]
+        public async Task ReusedContext_AcrossLateParamChanges_MatchesFreshFullDetect() {
+            // Build the early context ONCE from default params, then gate-and-measure with several different LATE
+            // param sets. Each must equal a fresh full Detect with those same params — proving the cached early
+            // context is exact to reuse across late-only changes.
+            var earlyParams = StarDetectorEquivalence.StandardParams();
+            var detector = NewDetector();
+            using var ctxField = StarDetectorEquivalence.BuildSmallField();
+            using var ctx = await detector.BuildDetectionContext(ctxField, earlyParams, null, CancellationToken.None);
+
+            // Each variant changes ONLY late-stage gate params (so the early key is unchanged).
+            var lateVariants = new[] {
+                Mutate(earlyParams, q => q.Sensitivity = 5.0),
+                Mutate(earlyParams, q => q.MinimumStarBoundingBoxSize = 8),
+                Mutate(earlyParams, q => q.MaxDistortion = 0.7),
+                Mutate(earlyParams, q => q.PeakResponse = 0.5),
+                Mutate(earlyParams, q => q.StarCenterTolerance = 0.15),
+                Mutate(earlyParams, q => q.MinHFR = 2.5),
+                Mutate(earlyParams, q => q.StarClippingMultiplier = 3.0),
+            };
+
+            foreach (var lateParams in lateVariants) {
+                var reusedSig = StarDetectorEquivalence.Signature(detector.GateAndMeasure(ctx, lateParams, CancellationToken.None));
+
+                using var freshField = StarDetectorEquivalence.BuildSmallField();
+                var freshSig = StarDetectorEquivalence.Signature(await NewDetector().Detect(freshField, lateParams, null, CancellationToken.None));
+
+                Assert.That(reusedSig, Is.EqualTo(freshSig),
+                    $"reusing the early context with late params {lateParams} must equal a fresh full Detect");
+            }
+        }
+
+        [Test]
+        public void EarlyCacheKey_SameForLateOnlyChanges_DifferentForEarlyChanges() {
+            var baseP = StarDetectorEquivalence.StandardParams();
+            var baseKey = StarDetector.ComputeEarlyCacheKey(baseP);
+
+            // LATE-only changes must NOT change the early key.
+            Assert.Multiple(() => {
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.Sensitivity = 9.0)), Is.EqualTo(baseKey), "Sensitivity is late-only");
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.StarClippingMultiplier = 4.0)), Is.EqualTo(baseKey), "StarClippingMultiplier is late-only");
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.PeakResponse = 0.4)), Is.EqualTo(baseKey), "PeakResponse is late-only");
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.MaxDistortion = 0.9)), Is.EqualTo(baseKey), "MaxDistortion is late-only");
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.MinHFR = 3.0)), Is.EqualTo(baseKey), "MinHFR is late-only");
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.StarCenterTolerance = 0.1)), Is.EqualTo(baseKey), "StarCenterTolerance is late-only");
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.MinimumStarBoundingBoxSize = 9)), Is.EqualTo(baseKey), "MinimumStarBoundingBoxSize is late-only");
+            });
+
+            // EARLY changes MUST change the early key.
+            Assert.Multiple(() => {
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.NoiseClippingMultiplier = 5.0)), Is.Not.EqualTo(baseKey), "NoiseClippingMultiplier is early");
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.StructureLayers = 5)), Is.Not.EqualTo(baseKey), "StructureLayers is early");
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.NoiseReductionRadius = 5)), Is.Not.EqualTo(baseKey), "NoiseReductionRadius is early");
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.HotpixelThresholdingEnabled = false)), Is.Not.EqualTo(baseKey), "HotpixelThresholdingEnabled is early");
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.HotpixelThreshold = 0.5)), Is.Not.EqualTo(baseKey), "HotpixelThreshold is early");
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.HotpixelFiltering = false)), Is.Not.EqualTo(baseKey), "HotpixelFiltering is early");
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.StarMeasurementNoiseReductionEnabled = true)), Is.Not.EqualTo(baseKey), "StarMeasurementNoiseReductionEnabled is early");
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.StructureDilationCount = 1)), Is.Not.EqualTo(baseKey), "StructureDilationCount is early");
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.StructureDilationSize = 5)), Is.Not.EqualTo(baseKey), "StructureDilationSize is early");
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.SaturationThreshold = 0.5)), Is.Not.EqualTo(baseKey), "SaturationThreshold affects an early metric (over-keyed for safety)");
+                Assert.That(StarDetector.ComputeEarlyCacheKey(Mutate(baseP, q => q.Region = new StarDetectionRegion(new RatioRect(0.1, 0.1, 0.5, 0.5)))), Is.Not.EqualTo(baseKey), "Region is early");
+            });
+        }
+
+        private static StarDetectorParams Mutate(StarDetectorParams p, System.Action<StarDetectorParams> mutate) {
+            var clone = p.Clone();
+            mutate(clone);
+            return clone;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectorTests.cs
@@ -155,6 +155,128 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
         }
 
         // -----------------------------------------------------------------------
+        // ComputeEffectiveStarCenterTolerance (defocus-aware NotCentered gate) tests
+        // -----------------------------------------------------------------------
+
+        [Test]
+        public void EffectiveStarCenterTolerance_FlagOff_AlwaysReturnsBaseTolerance_BitIdentical() {
+            // The production gate only calls this helper when DefocusAwareCentering is true; with the flag OFF the
+            // gate uses p.StarCenterTolerance verbatim. To prove the helper itself never tightens/relaxes when its
+            // own preconditions are not met, maxFactor <= 1.0 (which a flag-off path effectively means: no relax)
+            // must return the base tolerance byte-for-byte at every size.
+            Assert.Multiple(() => {
+                foreach (var size in new[] { 1.0, 5.0, 30.0, 60.0, 200.0, 1000.0 }) {
+                    Assert.That(StarDetector.ComputeEffectiveStarCenterTolerance(0.3, size, sizeReference: 30.0, maxFactor: 1.0),
+                        Is.EqualTo(0.3), $"maxFactor 1.0 (no-op) must return base tolerance verbatim at size {size}");
+                }
+            });
+        }
+
+        [Test]
+        public void EffectiveStarCenterTolerance_SmallCandidate_StaysStrict() {
+            // Candidates at or below the size reference keep the strict tolerance (factor clamped to 1.0).
+            Assert.Multiple(() => {
+                Assert.That(StarDetector.ComputeEffectiveStarCenterTolerance(0.3, 5.0, sizeReference: 30.0, maxFactor: 2.0),
+                    Is.EqualTo(0.3).Within(1e-12), "well below the reference ⇒ strict");
+                Assert.That(StarDetector.ComputeEffectiveStarCenterTolerance(0.3, 30.0, sizeReference: 30.0, maxFactor: 2.0),
+                    Is.EqualTo(0.3).Within(1e-12), "exactly at the reference ⇒ strict (factor = 1.0)");
+            });
+        }
+
+        [Test]
+        public void EffectiveStarCenterTolerance_LargeCandidate_RelaxesTowardCeiling() {
+            // Larger candidates get a more permissive (larger) tolerance = base · (candidateSize / sizeReference),
+            // capped at base · maxFactor, then clamped to <= 1.0.
+            Assert.Multiple(() => {
+                // size 45 ⇒ factor 1.5 ⇒ 0.3 * 1.5 = 0.45
+                Assert.That(StarDetector.ComputeEffectiveStarCenterTolerance(0.3, 45.0, sizeReference: 30.0, maxFactor: 2.0),
+                    Is.EqualTo(0.45).Within(1e-12));
+                // size 60 ⇒ raw factor 2.0 = maxFactor ⇒ 0.3 * 2.0 = 0.6
+                Assert.That(StarDetector.ComputeEffectiveStarCenterTolerance(0.3, 60.0, sizeReference: 30.0, maxFactor: 2.0),
+                    Is.EqualTo(0.6).Within(1e-12));
+                // size 1000 ⇒ raw factor 33.3, clamped DOWN to maxFactor 2.0 ⇒ 0.6 (the ceiling)
+                Assert.That(StarDetector.ComputeEffectiveStarCenterTolerance(0.3, 1000.0, sizeReference: 30.0, maxFactor: 2.0),
+                    Is.EqualTo(0.6).Within(1e-12), "very large candidates cap at base · maxFactor");
+            });
+        }
+
+        [Test]
+        public void EffectiveStarCenterTolerance_NeverExceedsOne_ClampedToValidRange() {
+            // The tolerance is a ratio of the bbox; the gate's valid max is 1.0 (sub-box == whole bbox). Even with a
+            // large base tolerance and a large multiplier the effective value must never exceed 1.0.
+            Assert.Multiple(() => {
+                // base 0.8 * factor 2.0 = 1.6 ⇒ clamped to 1.0
+                Assert.That(StarDetector.ComputeEffectiveStarCenterTolerance(0.8, 100.0, sizeReference: 30.0, maxFactor: 2.0),
+                    Is.EqualTo(1.0).Within(1e-12), "1.6 clamped down to the 1.0 ceiling");
+                // base 0.6 * factor 2.0 = 1.2 ⇒ clamped to 1.0
+                Assert.That(StarDetector.ComputeEffectiveStarCenterTolerance(0.6, 60.0, sizeReference: 30.0, maxFactor: 2.0),
+                    Is.EqualTo(1.0).Within(1e-12), "1.2 clamped down to the 1.0 ceiling");
+                // base 0.4 * factor 2.0 = 0.8 ⇒ within range, unchanged
+                Assert.That(StarDetector.ComputeEffectiveStarCenterTolerance(0.4, 60.0, sizeReference: 30.0, maxFactor: 2.0),
+                    Is.EqualTo(0.8).Within(1e-12), "0.8 is in range, not clamped");
+            });
+        }
+
+        [Test]
+        public void EffectiveStarCenterTolerance_DegenerateInputs_FallBackToStrict() {
+            Assert.Multiple(() => {
+                Assert.That(StarDetector.ComputeEffectiveStarCenterTolerance(0.3, 0.0, sizeReference: 30.0, maxFactor: 2.0),
+                    Is.EqualTo(0.3), "zero candidate size ⇒ strict fallback (no relaxation)");
+                Assert.That(StarDetector.ComputeEffectiveStarCenterTolerance(0.3, -3.0, sizeReference: 30.0, maxFactor: 2.0),
+                    Is.EqualTo(0.3), "negative candidate size ⇒ strict fallback");
+                Assert.That(StarDetector.ComputeEffectiveStarCenterTolerance(0.3, 100.0, sizeReference: 0.0, maxFactor: 2.0),
+                    Is.EqualTo(0.3), "zero size reference ⇒ strict fallback");
+                Assert.That(StarDetector.ComputeEffectiveStarCenterTolerance(0.3, 100.0, sizeReference: 30.0, maxFactor: 1.0),
+                    Is.EqualTo(0.3), "maxFactor 1.0 ⇒ no-op (strict)");
+                Assert.That(StarDetector.ComputeEffectiveStarCenterTolerance(0.3, 100.0, sizeReference: 30.0, maxFactor: 0.5),
+                    Is.EqualTo(0.3), "maxFactor < 1.0 must NOT tighten the gate ⇒ strict fallback");
+            });
+        }
+
+        [Test]
+        public void EffectiveStarCenterTolerance_LargeOffCenter_PassesOnButFailsOff_SmallOffCenterFailsBoth() {
+            // Replicates the production NotCentered decision (StarDetector.IsStarCentered): a centroid passes iff it
+            // lies inside the centered acceptance sub-box of size (tolerance · bbox) about the bbox center. Equivalent
+            // 1-D condition for a coordinate at fractional offset f from the bbox-center (f in [0, 0.5], where 0.5 is
+            // the bbox edge): the candidate is centered iff f <= tolerance / 2.
+            //
+            //  - a LARGE off-center centroid (defocused donut: big bbox, centroid pushed toward the ring) passes when
+            //    the relaxed (ON) tolerance is used, fails under the strict (OFF) tolerance;
+            //  - a SMALL off-center centroid (junk) fails under BOTH (strict at small size, no relaxation).
+            const double baseTolerance = 0.3;     // strict acceptance sub-box half-extent = 0.15 of the bbox
+            const double sizeReference = 30.0;
+            const double maxFactor = 2.0;         // ON ceiling: effective tolerance up to 0.6 (half-extent 0.30)
+
+            // A donut centroid offset by 0.20 of the bbox from center: outside the strict 0.15 band, inside the
+            // relaxed 0.30 band (at the large size the factor hits the 2.0 ceiling ⇒ tolerance 0.6 ⇒ band 0.30).
+            const double largeSize = 60.0;
+            const double centroidOffsetFraction = 0.20;
+            bool LargeCentered(bool defocusAware) {
+                var tol = defocusAware
+                    ? StarDetector.ComputeEffectiveStarCenterTolerance(baseTolerance, largeSize, sizeReference, maxFactor)
+                    : baseTolerance;
+                return centroidOffsetFraction <= tol / 2.0;
+            }
+
+            // Small junk at the SAME fractional offset: at/below the size reference the tolerance never relaxes, so it
+            // stays rejected even with the flag ON.
+            const double smallSize = 8.0;
+            bool SmallCentered(bool defocusAware) {
+                var tol = defocusAware
+                    ? StarDetector.ComputeEffectiveStarCenterTolerance(baseTolerance, smallSize, sizeReference, maxFactor)
+                    : baseTolerance;
+                return centroidOffsetFraction <= tol / 2.0;
+            }
+
+            Assert.Multiple(() => {
+                Assert.That(LargeCentered(defocusAware: false), Is.False, "large off-center donut is NotCentered with the flag OFF (legacy)");
+                Assert.That(LargeCentered(defocusAware: true), Is.True, "large off-center donut is admitted with the flag ON");
+                Assert.That(SmallCentered(defocusAware: false), Is.False, "small off-center junk is NotCentered OFF");
+                Assert.That(SmallCentered(defocusAware: true), Is.False, "small off-center junk is STILL NotCentered ON (strict at small size)");
+            });
+        }
+
+        // -----------------------------------------------------------------------
         // ComputeIterativeCentroid tests
         // -----------------------------------------------------------------------
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectorTests.cs
@@ -61,6 +61,100 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
         }
 
         // -----------------------------------------------------------------------
+        // ComputeEffectiveMaxDistortion (defocus-aware distortion gate) tests
+        // -----------------------------------------------------------------------
+
+        private static StarDetectorParams DistortionParams(bool defocusAware, double maxDistortion = 0.5,
+            double sizeReference = 20.0, double minFactor = 0.25) => new StarDetectorParams {
+            MaxDistortion = maxDistortion,
+            DefocusAwareDistortion = defocusAware,
+            DefocusDistortionSizeReference = sizeReference,
+            DefocusDistortionMinFactor = minFactor,
+        };
+
+        [Test]
+        public void EffectiveMaxDistortion_FlagOff_AlwaysReturnsMaxDistortion_BitIdentical() {
+            // With the flag OFF the gate must be byte-for-byte the legacy gate: MaxDistortion exactly, for every
+            // candidate size, regardless of the (ignored) tuning knobs.
+            var p = DistortionParams(defocusAware: false, maxDistortion: 0.5);
+            Assert.Multiple(() => {
+                foreach (var size in new[] { 1.0, 5.0, 20.0, 50.0, 200.0, 1000.0 }) {
+                    Assert.That(StarDetector.ComputeEffectiveMaxDistortion(p, size), Is.EqualTo(0.5),
+                        $"flag OFF must return MaxDistortion verbatim at size {size}");
+                }
+            });
+        }
+
+        [Test]
+        public void EffectiveMaxDistortion_FlagOn_SmallCandidate_StaysStrict() {
+            // Candidates at or below the size reference keep the strict threshold (factor clamped to 1.0).
+            var p = DistortionParams(defocusAware: true, maxDistortion: 0.5, sizeReference: 20.0, minFactor: 0.25);
+            Assert.Multiple(() => {
+                Assert.That(StarDetector.ComputeEffectiveMaxDistortion(p, 5.0), Is.EqualTo(0.5).Within(1e-12),
+                    "well below the reference ⇒ strict");
+                Assert.That(StarDetector.ComputeEffectiveMaxDistortion(p, 20.0), Is.EqualTo(0.5).Within(1e-12),
+                    "exactly at the reference ⇒ strict (factor = 1.0)");
+            });
+        }
+
+        [Test]
+        public void EffectiveMaxDistortion_FlagOn_LargeCandidate_RelaxesTowardFloor() {
+            // Larger candidates get a more permissive threshold = MaxDistortion · (sizeReference / candidateSize),
+            // floored at MinFactor · MaxDistortion.
+            var p = DistortionParams(defocusAware: true, maxDistortion: 0.5, sizeReference: 20.0, minFactor: 0.25);
+            Assert.Multiple(() => {
+                // size 40 ⇒ factor 0.5 ⇒ 0.25
+                Assert.That(StarDetector.ComputeEffectiveMaxDistortion(p, 40.0), Is.EqualTo(0.25).Within(1e-12));
+                // size 25 ⇒ factor 0.8 ⇒ 0.4
+                Assert.That(StarDetector.ComputeEffectiveMaxDistortion(p, 25.0), Is.EqualTo(0.4).Within(1e-12));
+                // size 1000 ⇒ raw factor 0.02, clamped up to minFactor 0.25 ⇒ 0.125
+                Assert.That(StarDetector.ComputeEffectiveMaxDistortion(p, 1000.0), Is.EqualTo(0.5 * 0.25).Within(1e-12),
+                    "very large candidates floor at MinFactor · MaxDistortion");
+            });
+        }
+
+        [Test]
+        public void EffectiveMaxDistortion_LargeLowFill_PassesOnButRejectsOff_SmallLowFillRejectsBoth() {
+            // The core behavioral contract the production gate uses (fillRatio < effectiveMaxDistortion ⇒ reject):
+            //  - a LARGE low-fill candidate (donut) passes when ON, rejects when OFF;
+            //  - a SMALL low-fill candidate rejects in BOTH cases (strict at small size).
+            const double maxDistortion = 0.5;
+            var on = DistortionParams(defocusAware: true, maxDistortion: maxDistortion, sizeReference: 20.0, minFactor: 0.25);
+            var off = DistortionParams(defocusAware: false, maxDistortion: maxDistortion);
+
+            // Donut: bbox max-dim 60px, annulus fills ~30% of the bbox² ⇒ fillRatio 0.30.
+            const double largeSize = 60.0;
+            const double largeFillRatio = 0.30;
+            bool LargeRejected(StarDetectorParams pp) => largeFillRatio < StarDetector.ComputeEffectiveMaxDistortion(pp, largeSize);
+
+            // Small junk: bbox max-dim 8px, same low fill ⇒ should stay rejected even with the relaxed gate.
+            const double smallSize = 8.0;
+            const double smallFillRatio = 0.30;
+            bool SmallRejected(StarDetectorParams pp) => smallFillRatio < StarDetector.ComputeEffectiveMaxDistortion(pp, smallSize);
+
+            Assert.Multiple(() => {
+                Assert.That(LargeRejected(off), Is.True, "large low-fill donut is rejected with the flag OFF (legacy)");
+                Assert.That(LargeRejected(on), Is.False, "large low-fill donut survives with the flag ON");
+                Assert.That(SmallRejected(off), Is.True, "small low-fill junk is rejected OFF");
+                Assert.That(SmallRejected(on), Is.True, "small low-fill junk is STILL rejected ON (strict at small size)");
+            });
+        }
+
+        [Test]
+        public void EffectiveMaxDistortion_DegenerateSizes_FallBackToStrict() {
+            var p = DistortionParams(defocusAware: true, maxDistortion: 0.5, sizeReference: 20.0, minFactor: 0.25);
+            Assert.Multiple(() => {
+                Assert.That(StarDetector.ComputeEffectiveMaxDistortion(p, 0.0), Is.EqualTo(0.5),
+                    "zero candidate size ⇒ strict fallback (no relaxation)");
+                Assert.That(StarDetector.ComputeEffectiveMaxDistortion(p, -3.0), Is.EqualTo(0.5),
+                    "negative candidate size ⇒ strict fallback");
+                var pZeroRef = DistortionParams(defocusAware: true, sizeReference: 0.0);
+                Assert.That(StarDetector.ComputeEffectiveMaxDistortion(pZeroRef, 100.0), Is.EqualTo(0.5),
+                    "zero size reference ⇒ strict fallback");
+            });
+        }
+
+        // -----------------------------------------------------------------------
         // ComputeIterativeCentroid tests
         // -----------------------------------------------------------------------
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/HocusFocusPlugin.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/HocusFocusPlugin.cs
@@ -14,11 +14,14 @@ using NINA.Joko.Plugins.HocusFocus.AutoFocus;
 using NINA.Joko.Plugins.HocusFocus.Properties;
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
 using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
 using NINA.Core.Utility;
+using NINA.Core.Utility.WindowService;
 using NINA.Plugin;
 using NINA.Plugin.Interfaces;
 using NINA.Profile.Interfaces;
 using System.ComponentModel.Composition;
+using System.Windows;
 using System.Windows.Input;
 using NINA.Equipment.Interfaces.Mediator;
 using NINA.Core.Interfaces;
@@ -27,17 +30,32 @@ using NINA.Image.Interfaces;
 using System.Reflection;
 using System.IO;
 using System;
+using System.Linq;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.Utility;
 using System.Threading.Tasks;
 using NINA.WPF.Base.Interfaces.Mediator;
-using NINA.Core.Model;
 using NINA.WPF.Base.Interfaces.ViewModel;
+using NINA.Core.Model;
 using RelayCommand = CommunityToolkit.Mvvm.Input.RelayCommand;
 
 namespace NINA.Joko.Plugins.HocusFocus {
 
     [Export(typeof(IPluginManifest))]
     public class HocusFocusPlugin : PluginBase {
+
+        // Collaborators captured for the on-demand Star Detection Optimization Wizard (T5). The wizard is created
+        // lazily when the user clicks "Optimize Star Detection…", well after MEF composition, so these are safe to
+        // reuse for building its RunEvaluationLoader + detector.
+        private readonly IProfileService profileService;
+        private readonly IFocuserMediator focuserMediator;
+        private readonly IImagingMediator imagingMediator;
+        private readonly IImageDataFactory imageDataFactory;
+        private readonly IPluggableBehaviorSelector<IStarDetection> starDetectionSelector;
+
+        // WindowServiceFactory is not a MEF export (NINA exposes the concrete type with a default ctor only), so it
+        // is instantiated directly here, mirroring RunAberrationInspector.
+        private readonly IWindowServiceFactory windowServiceFactory = new WindowServiceFactory();
 
         [ImportingConstructor]
         public HocusFocusPlugin(
@@ -52,6 +70,11 @@ namespace NINA.Joko.Plugins.HocusFocus {
             IOptionsVM options,
             IPluggableBehaviorSelector<IStarDetection> starDetectionSelector,
             IPluggableBehaviorSelector<IStarAnnotator> starAnnotatorSelector) {
+            this.profileService = profileService;
+            this.focuserMediator = focuserMediator;
+            this.imagingMediator = imagingMediator;
+            this.imageDataFactory = imageDataFactory;
+            this.starDetectionSelector = starDetectionSelector;
             if (Settings.Default.UpdateSettings) {
                 Settings.Default.Upgrade();
                 Settings.Default.UpdateSettings = false;
@@ -109,6 +132,56 @@ namespace NINA.Joko.Plugins.HocusFocus {
             ResetAutoFocusDefaultsCommand = new RelayCommand(AutoFocusOptions.ResetDefaults);
             ChooseIntermediatePathDiagCommand = new RelayCommand(ChooseIntermediatePathDiag);
             ChooseSavePathDiagCommand = new RelayCommand(ChooseSavePathDiag);
+            OptimizeStarDetectionCommand = new RelayCommand(OptimizeStarDetection);
+        }
+
+        /// <summary>
+        /// Builds the Star Detection Optimization Wizard with its real collaborators and shows it as a modal dialog.
+        /// The window resolves the wizard's content from the keyed DataTemplate (exported as a ResourceDictionary by
+        /// StarDetection/Optimization/DataTemplates.xaml). The VM is disposed when the window closes.
+        /// </summary>
+        private void OptimizeStarDetection() {
+            var autoFocusEngine = AutoFocusEngineFactory.Create();
+
+            // Reuse the MEF-composed HocusFocus detector when present (no new manifest import needed). Fall back to a
+            // fresh instance — the loader's detection path (GetStarDetectorParams + Detect) does not use
+            // ImageStatisticsVM, so a null is safe here.
+            var detection = starDetectionSelector?.Behaviors?.OfType<IHocusFocusStarDetection>().FirstOrDefault()
+                ?? new HocusFocusStarDetection(
+                    null,
+                    profileService,
+                    focuserMediator,
+                    StarDetectionOptions,
+                    AlglibAPI);
+
+            var vm = new StarDetectionOptimizerWizardVM(
+                profileService,
+                imageDataFactory,
+                imagingMediator,
+                autoFocusEngine,
+                detection);
+
+            var windowService = windowServiceFactory.Create();
+
+            // The VM's Close button asks the host to dismiss the dialog.
+            void onRequestClose(object s, EventArgs e) {
+                _ = windowService.Close();
+            }
+
+            // Tear down the VM (cancellation-token source) once the window is dismissed. OnClosed fires whether the
+            // user closes the window or the VM's Close command closes it.
+            EventHandler onClosed = null;
+            onClosed = (s, e) => {
+                windowService.OnClosed -= onClosed;
+                vm.RequestClose -= onRequestClose;
+                vm.Dispose();
+            };
+            windowService.OnClosed += onClosed;
+            vm.RequestClose += onRequestClose;
+
+            // NINA's WindowService marshals window creation onto the application dispatcher internally; this is the
+            // standard way NINA plugins show a modal dialog (the content is resolved from the keyed DataTemplate).
+            windowService.ShowDialog(vm, "Optimize Star Detection", ResizeMode.CanResize, WindowStyle.SingleBorderWindow);
         }
 
         private void ChooseIntermediatePathDiag() {
@@ -173,5 +246,7 @@ namespace NINA.Joko.Plugins.HocusFocus {
         public ICommand ChooseIntermediatePathDiagCommand { get; private set; }
 
         public ICommand ChooseSavePathDiagCommand { get; private set; }
+
+        public ICommand OptimizeStarDetectionCommand { get; private set; }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IHocusFocusStarDetection.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IHocusFocusStarDetection.cs
@@ -35,5 +35,41 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         StarDetectorParams GetStarDetectorParams(IRenderedImage image, StarDetectionRegion starDetectionRegion, bool isAutoFocus);
 
         Task<StarDetectionResult> Detect(IRenderedImage image, HocusFocusDetectionParams hocusFocusParams, StarDetectorParams detectorParams, IProgress<ApplicationStatus> progress, CancellationToken token);
+
+        /// <summary>
+        /// EARLY phase of <see cref="Detect(IRenderedImage, HocusFocusDetectionParams, StarDetectorParams, IProgress{ApplicationStatus}, CancellationToken)"/>:
+        /// converts the image + builds the reusable early-stage detection context. Pair with
+        /// <see cref="GateAndMeasure"/>. Lets the optimizer cache the expensive early stage across candidate
+        /// evaluations that change only late-stage params. The returned context owns native resources; dispose it.
+        /// </summary>
+        Task<HocusFocusDetectionContext> BuildDetectionContext(IRenderedImage image, HocusFocusDetectionParams hocusFocusParams, StarDetectorParams detectorParams, IProgress<ApplicationStatus> progress, CancellationToken token);
+
+        /// <summary>
+        /// LATE phase: gates + measures a context built by <see cref="BuildDetectionContext"/> and runs the same
+        /// post-processing (HFR aggregation, etc.) as the monolithic Detect, producing an identical result.
+        /// </summary>
+        StarDetectionResult GateAndMeasure(HocusFocusDetectionContext context, StarDetectorParams detectorParams, CancellationToken token);
+
+        /// <summary>Early cache key over only the early-affecting detection params.</summary>
+        string ComputeEarlyCacheKey(StarDetectorParams detectorParams);
+    }
+
+    /// <summary>
+    /// Opaque, disposable carrier for the early-stage detection of one image: the raw-detector early context plus
+    /// the header data the late stage needs to assemble the final <c>StarDetectionResult</c>. Built by
+    /// <see cref="IHocusFocusStarDetection.BuildDetectionContext"/>, consumed by
+    /// <see cref="IHocusFocusStarDetection.GateAndMeasure"/>, and reused across late-only candidate changes.
+    /// </summary>
+    public sealed class HocusFocusDetectionContext : IDisposable {
+        public StarDetection.StarDetector.DetectionContext DetectorContext { get; set; }
+        public HocusFocusDetectionParams HocusFocusParams { get; set; }
+        public System.Drawing.Size ImageSize { get; set; }
+        public double PixelSize { get; set; }
+        public int FocuserPosition { get; set; }
+
+        public void Dispose() {
+            DetectorContext?.Dispose();
+            DetectorContext = null;
+        }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetectionOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetectionOptions.cs
@@ -92,6 +92,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         double BrightnessSensitivity { get; set; }
         double StarPeakResponse { get; set; }
         double MaxDistortion { get; set; }
+        bool DefocusAwareDistortion { get; set; }
         double StarCenterTolerance { get; set; }
         int StarBackgroundBoxExpansion { get; set; }
         int MinStarBoundingBoxSize { get; set; }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetectionOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetectionOptions.cs
@@ -13,6 +13,7 @@
 using NINA.Core.Utility;
 using NINA.Joko.Plugins.HocusFocus.Converters;
 using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
 using System.ComponentModel;
 
 namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
@@ -111,5 +112,14 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         double SaturationThreshold { get; set; }
         MeasurementAverageEnum MeasurementAverage { get; set; }
         bool PSFPixelIntegration { get; set; }
+
+        // Optimized settings snapshot (Star Detection Optimization Wizard)
+        bool HasOptimizedSettings { get; }
+
+        bool UseOptimizedSettings { get; set; }
+
+        OptimizedStarDetectionSettings GetOptimizedSettings();
+
+        void ApplyOptimizedSettings(OptimizedStarDetectionSettings settings);
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetectionOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetectionOptions.cs
@@ -93,6 +93,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         double StarPeakResponse { get; set; }
         double MaxDistortion { get; set; }
         bool DefocusAwareDistortion { get; set; }
+        bool DefocusAwareCentering { get; set; }
         double StarCenterTolerance { get; set; }
         int StarBackgroundBoxExpansion { get; set; }
         int MinStarBoundingBoxSize { get; set; }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
@@ -355,6 +355,13 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         // This is an internal knob — it is not exposed in the options UI and is not persisted.
         public int MaxStarEvaluationParallelism { get; set; } = 0;
 
+        /// <summary>
+        /// Shallow copy of this parameter bundle. Used by the star-detection optimizer (T2) to materialize
+        /// candidate params from a seed without mutating the seed. <see cref="Region"/> is a shared reference,
+        /// which is safe because the optimizer never mutates the region — it only tunes the scalar knobs.
+        /// </summary>
+        public StarDetectorParams Clone() => (StarDetectorParams)this.MemberwiseClone();
+
         public override string ToString() {
             return $"{{{nameof(HotpixelFiltering)}={HotpixelFiltering.ToString()}, {nameof(NoiseReductionRadius)}={NoiseReductionRadius.ToString()}, {nameof(NoiseClippingMultiplier)}={NoiseClippingMultiplier.ToString()}, {nameof(StarClippingMultiplier)}={StarClippingMultiplier.ToString()}, {nameof(HotpixelFilterRadius)}={HotpixelFilterRadius.ToString()}, {nameof(StructureLayers)}={StructureLayers.ToString()}, {nameof(StructureDilationSize)}={StructureDilationSize.ToString()}, {nameof(StructureDilationCount)}={StructureDilationCount.ToString()}, {nameof(Sensitivity)}={Sensitivity.ToString()}, {nameof(PeakResponse)}={PeakResponse.ToString()}, {nameof(MaxDistortion)}={MaxDistortion.ToString()}, {nameof(StarCenterTolerance)}={StarCenterTolerance.ToString()}, {nameof(BackgroundBoxExpansion)}={BackgroundBoxExpansion.ToString()}, {nameof(MinimumStarBoundingBoxSize)}={MinimumStarBoundingBoxSize.ToString()}, {nameof(MinHFR)}={MinHFR.ToString()}, {nameof(Region)}={Region}, {nameof(AnalysisSamplingSize)}={AnalysisSamplingSize.ToString()}, {nameof(StoreStructureMap)}={StoreStructureMap.ToString()}, {nameof(SaveIntermediateFilesPath)}={SaveIntermediateFilesPath}, {nameof(SaturationThreshold)}={SaturationThreshold.ToString()}, {nameof(ModelPSF)}={ModelPSF.ToString()}, {nameof(PSFFitType)}={PSFFitType.ToString()}, {nameof(UsePSFAbsoluteDeviation)}={UsePSFAbsoluteDeviation.ToString()}, {nameof(PSFGoodnessOfFitThreshold)}={PSFGoodnessOfFitThreshold.ToString()}, {nameof(PSFResolution)}={PSFResolution.ToString()}, {nameof(PSFParallelPartitionSize)}={PSFParallelPartitionSize.ToString()}, {nameof(PixelScale)}={PixelScale.ToString()}, {nameof(ContaminationSensitivity)}={ContaminationSensitivity.ToString()}, {nameof(MaxStarEvaluationParallelism)}={MaxStarEvaluationParallelism.ToString()}}}";
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
@@ -419,6 +419,36 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Like <see cref="ToCanonicalCacheString()"/> but emits ONLY the properties named in
+        /// <paramref name="includedProperties"/> (an explicit ALLOW-list, sorted by name), each formatted with
+        /// <see cref="CultureInfo.InvariantCulture"/>. Used by
+        /// <see cref="StarDetection.StarDetector.ComputeEarlyCacheKey"/> to key a reusable early-stage detection
+        /// context on just the early-affecting params. Because it is an allow-list, a property that is not listed
+        /// is simply absent from the string (its value never contributes), which is exactly what makes a cache
+        /// keyed on this safe to reuse across changes to the omitted (late-only) params.
+        /// </summary>
+        public string ToCanonicalCacheString(ISet<string> includedProperties) {
+            if (includedProperties == null) {
+                throw new ArgumentNullException(nameof(includedProperties));
+            }
+
+            var properties = GetType()
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(prop => prop.CanRead && prop.GetIndexParameters().Length == 0)
+                .Where(prop => includedProperties.Contains(prop.Name))
+                .OrderBy(prop => prop.Name, StringComparer.Ordinal);
+
+            var sb = new StringBuilder();
+            foreach (var prop in properties) {
+                sb.Append(prop.Name);
+                sb.Append('=');
+                sb.Append(FormatCacheValue(GetPropertyValueSafe(prop)));
+                sb.Append('|');
+            }
+            return sb.ToString();
+        }
+
         private object GetPropertyValueSafe(PropertyInfo prop) {
             try {
                 return prop.GetValue(this);
@@ -655,5 +685,22 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
     public interface IStarDetector {
 
         Task<HocusFocusStarDetectorResult> Detect(IRenderedImage image, StarDetectorParams p, IProgress<ApplicationStatus> progress, CancellationToken token);
+
+        /// <summary>
+        /// EARLY phase: builds the reusable early-stage detection context for an image. Pair with
+        /// <see cref="GateAndMeasure"/>. Used by the optimizer to cache + reuse the expensive early stage across
+        /// candidate evaluations that change only late-stage params. The returned context owns its image; dispose it.
+        /// </summary>
+        Task<StarDetection.StarDetector.DetectionContext> BuildDetectionContext(IRenderedImage image, StarDetectorParams p, IProgress<ApplicationStatus> progress, CancellationToken token);
+
+        /// <summary>
+        /// LATE phase: gates + measures a context built by <see cref="BuildDetectionContext"/>, producing the same
+        /// result the monolithic <see cref="Detect"/> would for the full param bundle.
+        /// </summary>
+        HocusFocusStarDetectorResult GateAndMeasure(StarDetection.StarDetector.DetectionContext context, StarDetectorParams p, CancellationToken token);
+
+        /// <summary>Early cache key over only the early-affecting params; see
+        /// <see cref="StarDetection.StarDetector.ComputeEarlyCacheKey"/>.</summary>
+        string ComputeEarlyCacheKey(StarDetectorParams p);
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
@@ -294,6 +294,29 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         // circle has distortion PI/4 which is about 0.8. Smaller values are more distorted
         public double MaxDistortion { get; set; } = 0.5;
 
+        // Opt-in (default OFF for bit-identical detection). When true, the TooDistorted gate's effective
+        // fill-ratio threshold is relaxed for LARGE candidates (proxy for large defocus): at large defocus a
+        // star becomes a donut/annulus (central-obstruction shadow) → large bbox, low fill-ratio → today's
+        // strict MaxDistortion wrongly rejects it as TooDistorted. The effective threshold is
+        //   MaxDistortion * clamp(DefocusDistortionSizeReference / candidateSize, DefocusDistortionMinFactor, 1.0)
+        // where candidateSize = max(bbox.Width, bbox.Height) (the same d the gate already uses). Candidates at or
+        // below the size reference keep the strict MaxDistortion (factor = 1.0); larger candidates get a more
+        // permissive threshold toward the MinFactor floor. See ComputeEffectiveMaxDistortion. LATE-gate param:
+        // it changes only the late TooDistorted decision, so it is excluded from the early cache key.
+        public bool DefocusAwareDistortion { get; set; } = false;
+
+        // The candidate bbox max-dimension (px) at/below which the strict MaxDistortion threshold applies (the
+        // factor is exactly 1.0). Above it the effective threshold relaxes. Only consulted when
+        // DefocusAwareDistortion is true. Default 30 px tuned on the Panos wide-range AF run (Focuser 44396
+        // donuts): at 30 the most-defocused donuts (≈36–49 px bbox) clear the distortion gate while the closest
+        // in-sweep frame's accepted count stays sane (no junk flood); lowering it toward 20 recovers the last
+        // couple of smaller donuts but inflates moderately-defocused frames.
+        public double DefocusDistortionSizeReference { get; set; } = 30.0;
+
+        // The floor multiplier on MaxDistortion for very large candidates (the most permissive the gate ever
+        // becomes). Only consulted when DefocusAwareDistortion is true. Must be in (0, 1].
+        public double DefocusDistortionMinFactor { get; set; } = 0.25;
+
         // Size (as a ratio) of a centered rectangle within the star bounding box that the star center must be in. 1.0 covers the whole region, and 0.0 will fail every star
         public double StarCenterTolerance { get; set; } = 0.3;
 
@@ -363,7 +386,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         public StarDetectorParams Clone() => (StarDetectorParams)this.MemberwiseClone();
 
         public override string ToString() {
-            return $"{{{nameof(HotpixelFiltering)}={HotpixelFiltering.ToString()}, {nameof(NoiseReductionRadius)}={NoiseReductionRadius.ToString()}, {nameof(NoiseClippingMultiplier)}={NoiseClippingMultiplier.ToString()}, {nameof(StarClippingMultiplier)}={StarClippingMultiplier.ToString()}, {nameof(HotpixelFilterRadius)}={HotpixelFilterRadius.ToString()}, {nameof(StructureLayers)}={StructureLayers.ToString()}, {nameof(StructureDilationSize)}={StructureDilationSize.ToString()}, {nameof(StructureDilationCount)}={StructureDilationCount.ToString()}, {nameof(Sensitivity)}={Sensitivity.ToString()}, {nameof(PeakResponse)}={PeakResponse.ToString()}, {nameof(MaxDistortion)}={MaxDistortion.ToString()}, {nameof(StarCenterTolerance)}={StarCenterTolerance.ToString()}, {nameof(BackgroundBoxExpansion)}={BackgroundBoxExpansion.ToString()}, {nameof(MinimumStarBoundingBoxSize)}={MinimumStarBoundingBoxSize.ToString()}, {nameof(MinHFR)}={MinHFR.ToString()}, {nameof(Region)}={Region}, {nameof(AnalysisSamplingSize)}={AnalysisSamplingSize.ToString()}, {nameof(StoreStructureMap)}={StoreStructureMap.ToString()}, {nameof(SaveIntermediateFilesPath)}={SaveIntermediateFilesPath}, {nameof(SaturationThreshold)}={SaturationThreshold.ToString()}, {nameof(ModelPSF)}={ModelPSF.ToString()}, {nameof(PSFFitType)}={PSFFitType.ToString()}, {nameof(UsePSFAbsoluteDeviation)}={UsePSFAbsoluteDeviation.ToString()}, {nameof(PSFGoodnessOfFitThreshold)}={PSFGoodnessOfFitThreshold.ToString()}, {nameof(PSFResolution)}={PSFResolution.ToString()}, {nameof(PSFParallelPartitionSize)}={PSFParallelPartitionSize.ToString()}, {nameof(PixelScale)}={PixelScale.ToString()}, {nameof(ContaminationSensitivity)}={ContaminationSensitivity.ToString()}, {nameof(MaxStarEvaluationParallelism)}={MaxStarEvaluationParallelism.ToString()}}}";
+            return $"{{{nameof(HotpixelFiltering)}={HotpixelFiltering.ToString()}, {nameof(NoiseReductionRadius)}={NoiseReductionRadius.ToString()}, {nameof(NoiseClippingMultiplier)}={NoiseClippingMultiplier.ToString()}, {nameof(StarClippingMultiplier)}={StarClippingMultiplier.ToString()}, {nameof(HotpixelFilterRadius)}={HotpixelFilterRadius.ToString()}, {nameof(StructureLayers)}={StructureLayers.ToString()}, {nameof(StructureDilationSize)}={StructureDilationSize.ToString()}, {nameof(StructureDilationCount)}={StructureDilationCount.ToString()}, {nameof(Sensitivity)}={Sensitivity.ToString()}, {nameof(PeakResponse)}={PeakResponse.ToString()}, {nameof(MaxDistortion)}={MaxDistortion.ToString()}, {nameof(DefocusAwareDistortion)}={DefocusAwareDistortion.ToString()}, {nameof(DefocusDistortionSizeReference)}={DefocusDistortionSizeReference.ToString()}, {nameof(DefocusDistortionMinFactor)}={DefocusDistortionMinFactor.ToString()}, {nameof(StarCenterTolerance)}={StarCenterTolerance.ToString()}, {nameof(BackgroundBoxExpansion)}={BackgroundBoxExpansion.ToString()}, {nameof(MinimumStarBoundingBoxSize)}={MinimumStarBoundingBoxSize.ToString()}, {nameof(MinHFR)}={MinHFR.ToString()}, {nameof(Region)}={Region}, {nameof(AnalysisSamplingSize)}={AnalysisSamplingSize.ToString()}, {nameof(StoreStructureMap)}={StoreStructureMap.ToString()}, {nameof(SaveIntermediateFilesPath)}={SaveIntermediateFilesPath}, {nameof(SaturationThreshold)}={SaturationThreshold.ToString()}, {nameof(ModelPSF)}={ModelPSF.ToString()}, {nameof(PSFFitType)}={PSFFitType.ToString()}, {nameof(UsePSFAbsoluteDeviation)}={UsePSFAbsoluteDeviation.ToString()}, {nameof(PSFGoodnessOfFitThreshold)}={PSFGoodnessOfFitThreshold.ToString()}, {nameof(PSFResolution)}={PSFResolution.ToString()}, {nameof(PSFParallelPartitionSize)}={PSFParallelPartitionSize.ToString()}, {nameof(PixelScale)}={PixelScale.ToString()}, {nameof(ContaminationSensitivity)}={ContaminationSensitivity.ToString()}, {nameof(MaxStarEvaluationParallelism)}={MaxStarEvaluationParallelism.ToString()}}}";
         }
 
         // Properties intentionally EXCLUDED from the detection-result cache key (ToCanonicalCacheString). The

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
@@ -317,6 +317,28 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         // becomes). Only consulted when DefocusAwareDistortion is true. Must be in (0, 1].
         public double DefocusDistortionMinFactor { get; set; } = 0.25;
 
+        // Opt-in (default OFF for bit-identical detection). Companion to DefocusAwareDistortion. When true, the
+        // NotCentered gate's effective StarCenterTolerance is RELAXED (the centered acceptance sub-box grows) for
+        // LARGE candidates (proxy for large defocus): a defocused donut's hollow ring makes its intensity-weighted
+        // centroid wobble away from the bbox center, so today's strict StarCenterTolerance wrongly rejects it as
+        // NotCentered even after the distortion gate admits it. The effective tolerance is
+        //   StarCenterTolerance * clamp(candidateSize / DefocusDistortionSizeReference, 1.0, DefocusCenteringToleranceFactor)
+        // clamped to <= 1.0 (the max valid tolerance, where the sub-box covers the whole bbox). candidateSize =
+        // max(bbox.Width, bbox.Height) and the SAME DefocusDistortionSizeReference defocus proxy is reused.
+        // Candidates at or below the size reference keep the strict tolerance (factor = 1.0); larger candidates get
+        // a larger (more permissive) tolerance toward DefocusCenteringToleranceFactor. See
+        // ComputeEffectiveStarCenterTolerance. LATE-gate param: it changes only the late NotCentered decision, so
+        // it is excluded from the early cache key.
+        public bool DefocusAwareCentering { get; set; } = false;
+
+        // The max multiplier applied to StarCenterTolerance for very large candidates (the most permissive the
+        // NotCentered gate ever becomes). Only consulted when DefocusAwareCentering is true. Must be >= 1.0
+        // (>1 relaxes; 1.0 is a no-op). The resulting effective tolerance is additionally clamped to <= 1.0 so it
+        // never exceeds the whole bbox. Default 2.0 tuned on the Panos wide-range AF run: doubling the centering
+        // sub-box recovers the ring-unstable donut centroids the distortion gate admits, without ballooning
+        // near-focus accepted/NotCentered counts (near-focus candidates stay <= the size reference, so factor 1.0).
+        public double DefocusCenteringToleranceFactor { get; set; } = 2.0;
+
         // Size (as a ratio) of a centered rectangle within the star bounding box that the star center must be in. 1.0 covers the whole region, and 0.0 will fail every star
         public double StarCenterTolerance { get; set; } = 0.3;
 
@@ -386,7 +408,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         public StarDetectorParams Clone() => (StarDetectorParams)this.MemberwiseClone();
 
         public override string ToString() {
-            return $"{{{nameof(HotpixelFiltering)}={HotpixelFiltering.ToString()}, {nameof(NoiseReductionRadius)}={NoiseReductionRadius.ToString()}, {nameof(NoiseClippingMultiplier)}={NoiseClippingMultiplier.ToString()}, {nameof(StarClippingMultiplier)}={StarClippingMultiplier.ToString()}, {nameof(HotpixelFilterRadius)}={HotpixelFilterRadius.ToString()}, {nameof(StructureLayers)}={StructureLayers.ToString()}, {nameof(StructureDilationSize)}={StructureDilationSize.ToString()}, {nameof(StructureDilationCount)}={StructureDilationCount.ToString()}, {nameof(Sensitivity)}={Sensitivity.ToString()}, {nameof(PeakResponse)}={PeakResponse.ToString()}, {nameof(MaxDistortion)}={MaxDistortion.ToString()}, {nameof(DefocusAwareDistortion)}={DefocusAwareDistortion.ToString()}, {nameof(DefocusDistortionSizeReference)}={DefocusDistortionSizeReference.ToString()}, {nameof(DefocusDistortionMinFactor)}={DefocusDistortionMinFactor.ToString()}, {nameof(StarCenterTolerance)}={StarCenterTolerance.ToString()}, {nameof(BackgroundBoxExpansion)}={BackgroundBoxExpansion.ToString()}, {nameof(MinimumStarBoundingBoxSize)}={MinimumStarBoundingBoxSize.ToString()}, {nameof(MinHFR)}={MinHFR.ToString()}, {nameof(Region)}={Region}, {nameof(AnalysisSamplingSize)}={AnalysisSamplingSize.ToString()}, {nameof(StoreStructureMap)}={StoreStructureMap.ToString()}, {nameof(SaveIntermediateFilesPath)}={SaveIntermediateFilesPath}, {nameof(SaturationThreshold)}={SaturationThreshold.ToString()}, {nameof(ModelPSF)}={ModelPSF.ToString()}, {nameof(PSFFitType)}={PSFFitType.ToString()}, {nameof(UsePSFAbsoluteDeviation)}={UsePSFAbsoluteDeviation.ToString()}, {nameof(PSFGoodnessOfFitThreshold)}={PSFGoodnessOfFitThreshold.ToString()}, {nameof(PSFResolution)}={PSFResolution.ToString()}, {nameof(PSFParallelPartitionSize)}={PSFParallelPartitionSize.ToString()}, {nameof(PixelScale)}={PixelScale.ToString()}, {nameof(ContaminationSensitivity)}={ContaminationSensitivity.ToString()}, {nameof(MaxStarEvaluationParallelism)}={MaxStarEvaluationParallelism.ToString()}}}";
+            return $"{{{nameof(HotpixelFiltering)}={HotpixelFiltering.ToString()}, {nameof(NoiseReductionRadius)}={NoiseReductionRadius.ToString()}, {nameof(NoiseClippingMultiplier)}={NoiseClippingMultiplier.ToString()}, {nameof(StarClippingMultiplier)}={StarClippingMultiplier.ToString()}, {nameof(HotpixelFilterRadius)}={HotpixelFilterRadius.ToString()}, {nameof(StructureLayers)}={StructureLayers.ToString()}, {nameof(StructureDilationSize)}={StructureDilationSize.ToString()}, {nameof(StructureDilationCount)}={StructureDilationCount.ToString()}, {nameof(Sensitivity)}={Sensitivity.ToString()}, {nameof(PeakResponse)}={PeakResponse.ToString()}, {nameof(MaxDistortion)}={MaxDistortion.ToString()}, {nameof(DefocusAwareDistortion)}={DefocusAwareDistortion.ToString()}, {nameof(DefocusDistortionSizeReference)}={DefocusDistortionSizeReference.ToString()}, {nameof(DefocusDistortionMinFactor)}={DefocusDistortionMinFactor.ToString()}, {nameof(DefocusAwareCentering)}={DefocusAwareCentering.ToString()}, {nameof(DefocusCenteringToleranceFactor)}={DefocusCenteringToleranceFactor.ToString()}, {nameof(StarCenterTolerance)}={StarCenterTolerance.ToString()}, {nameof(BackgroundBoxExpansion)}={BackgroundBoxExpansion.ToString()}, {nameof(MinimumStarBoundingBoxSize)}={MinimumStarBoundingBoxSize.ToString()}, {nameof(MinHFR)}={MinHFR.ToString()}, {nameof(Region)}={Region}, {nameof(AnalysisSamplingSize)}={AnalysisSamplingSize.ToString()}, {nameof(StoreStructureMap)}={StoreStructureMap.ToString()}, {nameof(SaveIntermediateFilesPath)}={SaveIntermediateFilesPath}, {nameof(SaturationThreshold)}={SaturationThreshold.ToString()}, {nameof(ModelPSF)}={ModelPSF.ToString()}, {nameof(PSFFitType)}={PSFFitType.ToString()}, {nameof(UsePSFAbsoluteDeviation)}={UsePSFAbsoluteDeviation.ToString()}, {nameof(PSFGoodnessOfFitThreshold)}={PSFGoodnessOfFitThreshold.ToString()}, {nameof(PSFResolution)}={PSFResolution.ToString()}, {nameof(PSFParallelPartitionSize)}={PSFParallelPartitionSize.ToString()}, {nameof(PixelScale)}={PixelScale.ToString()}, {nameof(ContaminationSensitivity)}={ContaminationSensitivity.ToString()}, {nameof(MaxStarEvaluationParallelism)}={MaxStarEvaluationParallelism.ToString()}}}";
         }
 
         // Properties intentionally EXCLUDED from the detection-result cache key (ToCanonicalCacheString). The

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Options.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Options.xaml
@@ -125,6 +125,18 @@
                                 <RowDefinition />
                             </Grid.RowDefinitions>
                             <StackPanel Grid.Column="0" Orientation="Vertical">
+                                <Button
+                                    Margin="5,5,5,10"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Command="{Binding OptimizeStarDetectionCommand}"
+                                    ToolTip="{StaticResource OptimizeStarDetection_Tooltip}">
+                                    <TextBlock
+                                        Margin="10,5,10,5"
+                                        Foreground="{StaticResource ButtonForegroundBrush}"
+                                        Text="Optimize Star Detection…"
+                                        TextWrapping="Wrap" />
+                                </Button>
                                 <ContentControl Content="{Binding}" ContentTemplate="{StaticResource HocusFocus_StarDetection_Options}" />
                                 <Button
                                     Margin="5"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
@@ -443,6 +443,7 @@
         is measured on the image actually used for star measurement, so this value is an honest multiple of the real noise and means the same thing regardless of noise-reduction settings. The default of 2 works well; if you find a large number of rejections due to low sensitivity, smaller values increase sensitivity</TextBlock>
     <TextBlock x:Key="StarPeakResponse_Tooltip" Text="The ratio of the star median relative to the star peak. It provides a measure of flatness, since median values close to the peak indicate low dispersion. Consider increasing if too many stars are rejected with &quot;Too Flat&quot;" />
     <TextBlock x:Key="MaxDistortion_Tooltip" Text="The ratio of star pixels to the size of a perfect square bounding box. A perfect circule has a distortion of PI/4, which is approximately 0.7. The default value of 0.5 allows for some distortion and measurement error and should work for most cases." />
+    <TextBlock x:Key="DefocusAwareDistortion_Tooltip" Text="When enabled, the Max Distortion gate is relaxed for large candidates (a proxy for large defocus). At large defocus a star becomes a hollow donut (the central-obstruction shadow), giving a big bounding box with a low pixel fill-ratio that the strict Max Distortion would wrongly reject as too distorted. Small candidates (near focus) keep the strict threshold, so junk is still rejected. Off by default; enable it if you collect autofocus frames far from focus and find defocused donut stars being dropped." />
     <TextBlock x:Key="StarCenterTolerance_Tooltip" Text="Size (as a percentage) of a centered rectangle within the star bounding box that the star center must be in. 1.0 covers the whole region, and 0.0 will fail every star" />
     <TextBlock x:Key="StarBackgroundBoxExpansion_Tooltip" Text="The background is estimated by looking in an area around the star bounding box, increased on each side by this number of pixels. The default value of 3 should work for most cases, but you can consider increasing it if stars are very spare, or even decreasing it if the star field is very crowded with stars less than 3 pixels from one another." />
     <TextBlock x:Key="MinStarBoundingBoxSize_Tooltip" Text="The minimum allowed size (length of either side) of a star candidate's bounding box. Increasing this can be helpful at very high focal lengths if too many small structures are detected" />
@@ -1420,6 +1421,22 @@
                     </Binding.ValidationRules>
                 </Binding>
             </ninactrl:UnitTextBox>
+
+            <TextBlock
+                Grid.Row="22"
+                Grid.Column="0"
+                VerticalAlignment="Center"
+                Text="Defocus-Aware Distortion"
+                ToolTip="{StaticResource DefocusAwareDistortion_Tooltip}" />
+            <CheckBox
+                Grid.Row="22"
+                Grid.Column="1"
+                MinWidth="80"
+                Margin="5,5,0,0"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                IsChecked="{Binding StarDetectionOptions.DefocusAwareDistortion}"
+                ToolTip="{StaticResource DefocusAwareDistortion_Tooltip}" />
 
             <TextBlock
                 Grid.Row="19"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
@@ -482,6 +482,8 @@
     <TextBlock x:Key="SaveIntermediatePath_Tooltip" Text="When Save Intermediate Files is enabled, they are written to this path the next time star detection runs" />
     <TextBlock x:Key="SaveIntermediateFiles_Tooltip" Text="If enabled, every step of star detection emits a debugging file to the intermediate path" />
     <TextBlock x:Key="UseAdvanced_Tooltip" Text="Enables advanced mode with fine-grained control over star detection parameters. Not recommended unless you're an expert" />
+    <TextBlock x:Key="OptimizeStarDetection_Tooltip" Text="Opens the Star Detection Optimization Wizard, which tunes star detection against one or more saved auto-focus runs and (optionally) applies the result as your Simple-Mode settings" />
+    <TextBlock x:Key="UseOptimizedSettings_Tooltip" Text="When enabled, the optimized star-detection settings produced by the optimization wizard drive detection instead of the Noise Level / Pixel Scale / Focus Range presets. Only available in Simple Mode after the wizard has produced and applied a result" />
     <TextBlock x:Key="ModelPSF_Tooltip" Text="Whether to fit PSF models to detected stars. This is required for FWHM and Eccentricity" />
     <TextBlock x:Key="PSFFitType_Tooltip" Text="What type of PSF model to fit. Moffat 0.4 more closely resembles real stars and is the default used by PixInsight" />
     <TextBlock x:Key="PSFResolution_Tooltip" Text="The number of pixels of the width of a nominal square to sample star bounding boxes for the purposes of PSF model fitting. Higher resolution may be more accurate, but takes longer to calculate" />
@@ -915,6 +917,32 @@
                         </DataTrigger>
                     </Style.Triggers>
                 </Style>
+                <!--  Simple-Mode preset rows, hidden once optimized settings are driving detection.  -->
+                <Style x:Key="ShowOnUseSimpleNotOptimized" TargetType="{x:Type RowDefinition}">
+                    <Setter Property="Height" Value="0" />
+                    <Style.Triggers>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding StarDetectionOptions.UseAdvanced}" Value="False" />
+                                <Condition Binding="{Binding StarDetectionOptions.UseOptimizedSettings}" Value="False" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="Height" Value="Auto" />
+                        </MultiDataTrigger>
+                    </Style.Triggers>
+                </Style>
+                <!--  "Use Optimized Settings" toggle: Simple Mode, and only when the wizard has produced a result.  -->
+                <Style x:Key="ShowOnSimpleHasOptimized" TargetType="{x:Type RowDefinition}">
+                    <Setter Property="Height" Value="0" />
+                    <Style.Triggers>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding StarDetectionOptions.UseAdvanced}" Value="False" />
+                                <Condition Binding="{Binding StarDetectionOptions.HasOptimizedSettings}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="Height" Value="Auto" />
+                        </MultiDataTrigger>
+                    </Style.Triggers>
+                </Style>
                 <Style x:Key="ShowOnUseHotpixelThresholding_Advanced" TargetType="{x:Type RowDefinition}">
                     <Setter Property="Height" Value="0" />
                     <Style.Triggers>
@@ -943,10 +971,10 @@
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition />
-                <RowDefinition Style="{StaticResource ShowOnUseSimple}" />
-                <RowDefinition Style="{StaticResource ShowOnUseSimple}" />
-                <RowDefinition Style="{StaticResource ShowOnUseSimple}" />
-                <RowDefinition Style="{StaticResource ShowOnUseSimple}" />
+                <RowDefinition Style="{StaticResource ShowOnUseSimpleNotOptimized}" />
+                <RowDefinition Style="{StaticResource ShowOnUseSimpleNotOptimized}" />
+                <RowDefinition Style="{StaticResource ShowOnUseSimpleNotOptimized}" />
+                <RowDefinition Style="{StaticResource ShowOnSimpleHasOptimized}" />
                 <RowDefinition Style="{StaticResource ShowOnUseSimple}" />
                 <RowDefinition Style="{StaticResource ShowOnUseSimple}" />
                 <RowDefinition />
@@ -1078,6 +1106,37 @@
                     </DataTemplate>
                 </ComboBox.ItemTemplate>
             </ComboBox>
+
+            <!--  Simple-Mode toggle: drive detection from the wizard's optimized settings. Shown only in Simple Mode once optimized settings exist (!UseAdvanced && HasOptimizedSettings).  -->
+            <TextBlock
+                Grid.Row="4"
+                Grid.Column="0"
+                VerticalAlignment="Center"
+                Text="Use Optimized Settings"
+                ToolTip="{StaticResource UseOptimizedSettings_Tooltip}">
+                <TextBlock.Visibility>
+                    <MultiBinding Converter="{StaticResource HF_MultiBooleanToVisibilityCollapsedConverter}">
+                        <Binding Converter="{StaticResource HF_InverseBooleanConverter}" Path="StarDetectionOptions.UseAdvanced" />
+                        <Binding Path="StarDetectionOptions.HasOptimizedSettings" />
+                    </MultiBinding>
+                </TextBlock.Visibility>
+            </TextBlock>
+            <CheckBox
+                Grid.Row="4"
+                Grid.Column="1"
+                MinWidth="80"
+                Margin="5,5,0,0"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                IsChecked="{Binding StarDetectionOptions.UseOptimizedSettings}"
+                ToolTip="{StaticResource UseOptimizedSettings_Tooltip}">
+                <CheckBox.Visibility>
+                    <MultiBinding Converter="{StaticResource HF_MultiBooleanToVisibilityCollapsedConverter}">
+                        <Binding Converter="{StaticResource HF_InverseBooleanConverter}" Path="StarDetectionOptions.UseAdvanced" />
+                        <Binding Path="StarDetectionOptions.HasOptimizedSettings" />
+                    </MultiBinding>
+                </CheckBox.Visibility>
+            </CheckBox>
 
             <TextBlock
                 Grid.Row="7"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
@@ -444,6 +444,7 @@
     <TextBlock x:Key="StarPeakResponse_Tooltip" Text="The ratio of the star median relative to the star peak. It provides a measure of flatness, since median values close to the peak indicate low dispersion. Consider increasing if too many stars are rejected with &quot;Too Flat&quot;" />
     <TextBlock x:Key="MaxDistortion_Tooltip" Text="The ratio of star pixels to the size of a perfect square bounding box. A perfect circule has a distortion of PI/4, which is approximately 0.7. The default value of 0.5 allows for some distortion and measurement error and should work for most cases." />
     <TextBlock x:Key="DefocusAwareDistortion_Tooltip" Text="When enabled, the Max Distortion gate is relaxed for large candidates (a proxy for large defocus). At large defocus a star becomes a hollow donut (the central-obstruction shadow), giving a big bounding box with a low pixel fill-ratio that the strict Max Distortion would wrongly reject as too distorted. Small candidates (near focus) keep the strict threshold, so junk is still rejected. Off by default; enable it if you collect autofocus frames far from focus and find defocused donut stars being dropped." />
+    <TextBlock x:Key="DefocusAwareCentering_Tooltip" Text="Companion to Defocus-Aware Distortion. When enabled, the Star Center Tolerance gate is relaxed for large candidates (a proxy for large defocus). A defocused donut's hollow ring makes its intensity-weighted center wobble away from the bounding-box center, so the strict centering test would wrongly reject it as not centered even after the distortion gate admits it. Small candidates (near focus) keep the strict tolerance, so junk is still rejected. Off by default; enable it together with Defocus-Aware Distortion if defocused donut stars are still being dropped as not centered." />
     <TextBlock x:Key="StarCenterTolerance_Tooltip" Text="Size (as a percentage) of a centered rectangle within the star bounding box that the star center must be in. 1.0 covers the whole region, and 0.0 will fail every star" />
     <TextBlock x:Key="StarBackgroundBoxExpansion_Tooltip" Text="The background is estimated by looking in an area around the star bounding box, increased on each side by this number of pixels. The default value of 3 should work for most cases, but you can consider increasing it if stars are very spare, or even decreasing it if the star field is very crowded with stars less than 3 pixels from one another." />
     <TextBlock x:Key="MinStarBoundingBoxSize_Tooltip" Text="The minimum allowed size (length of either side) of a star candidate's bounding box. Increasing this can be helpful at very high focal lengths if too many small structures are detected" />
@@ -1018,7 +1019,9 @@
                 <RowDefinition />
                 <RowDefinition Style="{StaticResource HideOnSaveIntermediateOff}" />
                 <RowDefinition />
-                <RowDefinition />
+                <!--  41: Defocus-Aware Distortion (advanced-only); 42: Defocus-Aware Centering (advanced-only)  -->
+                <RowDefinition Style="{StaticResource ShowOnUseAdvanced}" />
+                <RowDefinition Style="{StaticResource ShowOnUseAdvanced}" />
             </Grid.RowDefinitions>
             <TextBlock
                 Grid.Row="0"
@@ -1423,13 +1426,13 @@
             </ninactrl:UnitTextBox>
 
             <TextBlock
-                Grid.Row="22"
+                Grid.Row="41"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Defocus-Aware Distortion"
                 ToolTip="{StaticResource DefocusAwareDistortion_Tooltip}" />
             <CheckBox
-                Grid.Row="22"
+                Grid.Row="41"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"
@@ -1437,6 +1440,22 @@
                 VerticalAlignment="Center"
                 IsChecked="{Binding StarDetectionOptions.DefocusAwareDistortion}"
                 ToolTip="{StaticResource DefocusAwareDistortion_Tooltip}" />
+
+            <TextBlock
+                Grid.Row="42"
+                Grid.Column="0"
+                VerticalAlignment="Center"
+                Text="Defocus-Aware Centering"
+                ToolTip="{StaticResource DefocusAwareCentering_Tooltip}" />
+            <CheckBox
+                Grid.Row="42"
+                Grid.Column="1"
+                MinWidth="80"
+                Margin="5,5,0,0"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                IsChecked="{Binding StarDetectionOptions.DefocusAwareCentering}"
+                ToolTip="{StaticResource DefocusAwareCentering_Tooltip}" />
 
             <TextBlock
                 Grid.Row="19"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
@@ -297,10 +297,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                 Sensitivity = options.BrightnessSensitivity,
                 PeakResponse = options.StarPeakResponse,
                 MaxDistortion = options.MaxDistortion,
-                // Opt-in, default OFF. The two numeric tuning knobs (DefocusDistortionSizeReference /
-                // DefocusDistortionMinFactor) are not exposed in the options UI, so they keep the
-                // StarDetectorParams class defaults (20.0 px / 0.25).
+                // Opt-in, default OFF. The numeric tuning knobs (DefocusDistortionSizeReference /
+                // DefocusDistortionMinFactor / DefocusCenteringToleranceFactor) are not exposed in the options UI,
+                // so they keep the StarDetectorParams class defaults (30.0 px / 0.25 / 2.0).
                 DefocusAwareDistortion = options.DefocusAwareDistortion,
+                // Companion opt-in, default OFF. Relaxes the NotCentered gate for large (defocused) candidates,
+                // reusing the same DefocusDistortionSizeReference defocus proxy as the distortion gate.
+                DefocusAwareCentering = options.DefocusAwareCentering,
                 StarCenterTolerance = options.StarCenterTolerance,
                 BackgroundBoxExpansion = options.StarBackgroundBoxExpansion,
                 MinimumStarBoundingBoxSize = options.MinStarBoundingBoxSize,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
@@ -352,11 +352,24 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
         }
 
         public async Task<StarDetectionResult> Detect(IRenderedImage image, HocusFocusDetectionParams hocusFocusParams, StarDetectorParams detectorParams, IProgress<ApplicationStatus> progress, CancellationToken token) {
+            var result = BuildResultHeader(image, hocusFocusParams, detectorParams, out var imageSize, out var _);
+            var starDetectorResult = await this.starDetector.Detect(image, detectorParams, progress, token);
+            if (!string.IsNullOrEmpty(detectorParams.SaveIntermediateFilesPath)) {
+                Notification.ShowInformation("Saved intermediate star detection files");
+                Logger.Info($"Saved intermediate star detection files to {detectorParams.SaveIntermediateFilesPath}");
+            }
+
+            return BuildStarDetectionResult(result, starDetectorResult, hocusFocusParams, detectorParams, imageSize);
+        }
+
+        /// <summary>Builds the pre-populated <see cref="HocusFocusStarDetectionResult"/> header (image geometry,
+        /// pixel size/scale, focuser position, cache key) shared by the monolithic and split detect paths.</summary>
+        private HocusFocusStarDetectionResult BuildResultHeader(IRenderedImage image, HocusFocusDetectionParams hocusFocusParams, StarDetectorParams detectorParams, out Size imageSize, out double pixelSize) {
             var binX = double.IsNaN(image.RawImageData.MetaData.Camera.BinX) ? 1 : image.RawImageData.MetaData.Camera.BinX;
             var metadataPixelSize = double.IsNaN(image.RawImageData.MetaData.Camera.PixelSize) ? 3.76 : image.RawImageData.MetaData.Camera.PixelSize;
-            var pixelSize = metadataPixelSize * Math.Max(binX, 1);
-            var imageSize = new Size(width: image.RawImageData.Properties.Width, height: image.RawImageData.Properties.Height);
-            var result = new HocusFocusStarDetectionResult() {
+            pixelSize = metadataPixelSize * Math.Max(binX, 1);
+            imageSize = new Size(width: image.RawImageData.Properties.Width, height: image.RawImageData.Properties.Height);
+            return new HocusFocusStarDetectionResult() {
                 HocusFocusParams = hocusFocusParams,
                 DetectorParams = detectorParams,
                 ImageSize = imageSize,
@@ -368,12 +381,57 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                 DetectorVersion = StarDetector.StarDetectorVersion,
                 CacheKey = StarDetector.ComputeCacheKey(detectorParams)
             };
-            var starDetectorResult = await this.starDetector.Detect(image, detectorParams, progress, token);
-            if (!string.IsNullOrEmpty(detectorParams.SaveIntermediateFilesPath)) {
-                Notification.ShowInformation("Saved intermediate star detection files");
-                Logger.Info($"Saved intermediate star detection files to {detectorParams.SaveIntermediateFilesPath}");
-            }
+        }
 
+        public string ComputeEarlyCacheKey(StarDetectorParams detectorParams) => StarDetector.ComputeEarlyCacheKey(detectorParams);
+
+        public async Task<HocusFocusDetectionContext> BuildDetectionContext(IRenderedImage image, HocusFocusDetectionParams hocusFocusParams, StarDetectorParams detectorParams, IProgress<ApplicationStatus> progress, CancellationToken token) {
+            // EARLY phase: capture the header inputs (focuser position is read NOW, matching the monolithic path
+            // which reads it before detection) + run the expensive early detector stage into a reusable context.
+            BuildResultHeader(image, hocusFocusParams, detectorParams, out var imageSize, out var pixelSize);
+            var detectorContext = await this.starDetector.BuildDetectionContext(image, detectorParams, progress, token).ConfigureAwait(false);
+            return new HocusFocusDetectionContext {
+                DetectorContext = detectorContext,
+                HocusFocusParams = hocusFocusParams,
+                ImageSize = imageSize,
+                PixelSize = pixelSize,
+                FocuserPosition = focuserMediator.GetInfo().Position
+            };
+        }
+
+        public StarDetectionResult GateAndMeasure(HocusFocusDetectionContext context, StarDetectorParams detectorParams, CancellationToken token) {
+            // LATE phase: re-build the header (deterministic from the carried inputs + current detectorParams) so the
+            // late-param-dependent fields (DetectorParams, Region, CacheKey) reflect the candidate being evaluated,
+            // then gate+measure the cached context and run the identical post-processing.
+            var hocusFocusParams = context.HocusFocusParams;
+            var result = new HocusFocusStarDetectionResult() {
+                HocusFocusParams = hocusFocusParams,
+                DetectorParams = detectorParams,
+                ImageSize = context.ImageSize,
+                Region = detectorParams.Region,
+                FocuserPosition = context.FocuserPosition,
+                PixelSize = context.PixelSize,
+                PixelScale = detectorParams.PixelScale,
+                MeasurementAverage = this.starDetectionOptions.MeasurementAverage,
+                DetectorVersion = StarDetector.StarDetectorVersion,
+                CacheKey = StarDetector.ComputeCacheKey(detectorParams)
+            };
+            var starDetectorResult = this.starDetector.GateAndMeasure(context.DetectorContext, detectorParams, token);
+            return BuildStarDetectionResult(result, starDetectorResult, hocusFocusParams, detectorParams, context.ImageSize);
+        }
+
+        /// <summary>
+        /// The post-detection processing (OutsideROI crop, optional outlier rejection, PSF aggregation, AF-star
+        /// selection, HFR aggregation) shared by the monolithic <see cref="Detect(IRenderedImage, HocusFocusDetectionParams, StarDetectorParams, IProgress{ApplicationStatus}, CancellationToken)"/>
+        /// path AND the optimizer's split path (so they cannot drift). <paramref name="result"/> is the
+        /// pre-populated header; <paramref name="starDetectorResult"/> is the raw detector output to fold in.
+        /// </summary>
+        internal StarDetectionResult BuildStarDetectionResult(
+                HocusFocusStarDetectionResult result,
+                HocusFocusStarDetectorResult starDetectorResult,
+                HocusFocusDetectionParams hocusFocusParams,
+                StarDetectorParams detectorParams,
+                Size imageSize) {
             var starList = starDetectorResult.DetectedStars;
 
             if (!detectorParams.Region.IsFull() && detectorParams.Region.InnerCropBoundary != null) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
@@ -297,6 +297,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                 Sensitivity = options.BrightnessSensitivity,
                 PeakResponse = options.StarPeakResponse,
                 MaxDistortion = options.MaxDistortion,
+                // Opt-in, default OFF. The two numeric tuning knobs (DefocusDistortionSizeReference /
+                // DefocusDistortionMinFactor) are not exposed in the options UI, so they keep the
+                // StarDetectorParams class defaults (20.0 px / 0.25).
+                DefocusAwareDistortion = options.DefocusAwareDistortion,
                 StarCenterTolerance = options.StarCenterTolerance,
                 BackgroundBoxExpansion = options.StarBackgroundBoxExpansion,
                 MinimumStarBoundingBoxSize = options.MinStarBoundingBoxSize,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -1,0 +1,294 @@
+<ResourceDictionary
+    x:Class="NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.DataTemplates"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization"
+    xmlns:ninactrl="clr-namespace:NINA.CustomControlLibrary;assembly=NINA.CustomControlLibrary"
+    xmlns:rules="clr-namespace:NINA.Core.Utility.ValidationRules;assembly=NINA.Core"
+    xmlns:s="clr-namespace:System;assembly=mscorlib"
+    xmlns:util="clr-namespace:NINA.Core.Utility;assembly=NINA.Core">
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="../../Resources/OptionsDataTemplates.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
+    <!--  Tooltips  -->
+    <TextBlock x:Key="SDOpt_SourceMode_Tooltip" Text="Replay optimizes against one or more saved auto-focus runs (recommended). Live triggers a fresh auto-focus that saves its frames, then optimizes against those." />
+    <TextBlock x:Key="SDOpt_RunCount_Tooltip" Text="How many saved auto-focus runs to optimize against together. Using two or three runs balances the settings across them and reduces overfitting to a single night's conditions." />
+    <TextBlock x:Key="SDOpt_ApplyStepSize_Tooltip" Text="Also write the recommended auto-focus step size and offset steps to the active profile when applying. The step size is sized so a sweep lands several measurement points across the focus-sensitive region of the curve." />
+
+    <!--  The wizard window content. Keyed by the VM's full type name so IWindowServiceFactory resolves it.  -->
+    <DataTemplate x:Key="NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.StarDetectionOptimizerWizardVM">
+        <Grid Width="640" MinHeight="420" Margin="10">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <!--  Header  -->
+            <TextBlock
+                Grid.Row="0"
+                Margin="0,0,0,8"
+                FontSize="16"
+                FontWeight="Bold"
+                Text="Star Detection Optimization Wizard" />
+
+            <!--  Body: one panel visible per step  -->
+            <Grid Grid.Row="1">
+
+                <!--  Step 1: Select Source  -->
+                <StackPanel Visibility="{Binding IsSelectSource, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                    <TextBlock
+                        Margin="0,0,0,8"
+                        Text="Choose one or more saved auto-focus runs to tune star detection against. The optimizer re-runs detection on those frames with many parameter combinations and keeps the settings that best pin down focus."
+                        TextWrapping="Wrap" />
+
+                    <StackPanel Margin="0,4" Orientation="Horizontal">
+                        <TextBlock
+                            Width="90"
+                            VerticalAlignment="Center"
+                            Text="Source" />
+                        <ComboBox
+                            Width="160"
+                            ItemsSource="{Binding Source={util:EnumBindingSource {x:Type local:SourceMode}}}"
+                            SelectedItem="{Binding SourceMode}"
+                            ToolTip="{StaticResource SDOpt_SourceMode_Tooltip}">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Converter={StaticResource HF_EnumStaticDescriptionValueConverter}}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+                    </StackPanel>
+
+                    <StackPanel Margin="0,4" Orientation="Horizontal">
+                        <TextBlock
+                            Width="90"
+                            VerticalAlignment="Center"
+                            Text="Number of runs" />
+                        <ninactrl:UnitTextBox
+                            Width="60"
+                            VerticalContentAlignment="Center"
+                            ToolTip="{StaticResource SDOpt_RunCount_Tooltip}">
+                            <ninactrl:UnitTextBox.Text>
+                                <Binding Path="RunCount" UpdateSourceTrigger="PropertyChanged">
+                                    <Binding.ValidationRules>
+                                        <rules:IntRangeRule>
+                                            <rules:IntRangeRule.ValidRange>
+                                                <rules:IntRangeChecker Maximum="5" Minimum="1" />
+                                            </rules:IntRangeRule.ValidRange>
+                                        </rules:IntRangeRule>
+                                    </Binding.ValidationRules>
+                                </Binding>
+                            </ninactrl:UnitTextBox.Text>
+                        </ninactrl:UnitTextBox>
+                    </StackPanel>
+
+                    <!--  One folder picker per run (Replay). AlternationCount surfaces the per-row index as the picker's CommandParameter.  -->
+                    <ItemsControl
+                        Margin="0,8,0,0"
+                        AlternationCount="100"
+                        ItemsSource="{Binding SourcePaths}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="0,2" Orientation="Horizontal">
+                                    <Button
+                                        Width="80"
+                                        Command="{Binding DataContext.BrowseSourceCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                        CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=ContentPresenter}, Path=(ItemsControl.AlternationIndex)}"
+                                        Content="Browse…" />
+                                    <TextBlock
+                                        Width="440"
+                                        Margin="8,0,0,0"
+                                        VerticalAlignment="Center"
+                                        Text="{Binding}"
+                                        TextTrimming="CharacterEllipsis" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!--  Steps 2-3: Acquire / Optimize progress  -->
+                <StackPanel VerticalAlignment="Center">
+                    <StackPanel.Style>
+                        <Style TargetType="StackPanel">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsAcquire}" Value="True">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding IsOptimize}" Value="True">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </StackPanel.Style>
+
+                    <TextBlock
+                        Margin="0,0,0,8"
+                        HorizontalAlignment="Center"
+                        FontWeight="Bold"
+                        Text="{Binding Phase}" />
+                    <ProgressBar
+                        Height="18"
+                        Maximum="{Binding MaxEvaluations}"
+                        Minimum="0"
+                        Value="{Binding Evaluations, Mode=OneWay}" />
+                    <TextBlock Margin="0,4,0,0" HorizontalAlignment="Center">
+                        <Run Text="Evaluations:" />
+                        <Run Text="{Binding Evaluations, Mode=OneWay}" />
+                        <Run Text="/" />
+                        <Run Text="{Binding MaxEvaluations, Mode=OneWay}" />
+                    </TextBlock>
+                    <TextBlock Margin="0,2,0,0" HorizontalAlignment="Center">
+                        <Run Text="Seed J:" />
+                        <Run Text="{Binding ProgressSeedJ, Mode=OneWay, StringFormat=F3}" />
+                        <Run Text="    Best J:" />
+                        <Run Text="{Binding ProgressBestJ, Mode=OneWay, StringFormat=F3}" />
+                    </TextBlock>
+                </StackPanel>
+
+                <!--  Step 4: Summary  -->
+                <ScrollViewer VerticalScrollBarVisibility="Auto" Visibility="{Binding IsSummary, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                    <StackPanel>
+                        <TextBlock
+                            Margin="0,0,0,8"
+                            FontWeight="Bold"
+                            Text="Optimization complete" />
+
+                        <!--  Before / after  -->
+                        <UniformGrid Columns="2" Margin="0,0,0,8">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Width="160" Text="Objective (J): seed → best" />
+                                <TextBlock>
+                                    <Run Text="{Binding Summary.SeedJ, Mode=OneWay, StringFormat=F3}" />
+                                    <Run Text="→" />
+                                    <Run Text="{Binding Summary.BestJ, Mode=OneWay, StringFormat=F3}" />
+                                </TextBlock>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Width="160" Text="σ(focus): seed → best" />
+                                <TextBlock>
+                                    <Run Text="{Binding Summary.SeedSigmaFocus, Mode=OneWay, StringFormat=F2}" />
+                                    <Run Text="→" />
+                                    <Run Text="{Binding Summary.BestSigmaFocus, Mode=OneWay, StringFormat=F2}" />
+                                </TextBlock>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Width="160" Text="Runs optimized" />
+                                <TextBlock Text="{Binding Summary.RunCount, Mode=OneWay}" />
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Width="160" Text="Recommended step size" />
+                                <TextBlock>
+                                    <Run Text="{Binding Summary.RecommendedStepSize, Mode=OneWay}" />
+                                    <Run Text="(was" />
+                                    <Run Text="{Binding Summary.CurrentStepSize, Mode=OneWay}" />
+                                    <Run Text=")" />
+                                </TextBlock>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Width="160" Text="Recommended offset steps" />
+                                <TextBlock Text="{Binding Summary.RecommendedOffsetSteps, Mode=OneWay}" />
+                            </StackPanel>
+                        </UniformGrid>
+
+                        <!--  Changed parameters table  -->
+                        <TextBlock
+                            Margin="0,4,0,4"
+                            FontWeight="Bold"
+                            Text="Changed parameters" />
+                        <DataGrid
+                            AutoGenerateColumns="False"
+                            CanUserAddRows="False"
+                            HeadersVisibility="Column"
+                            IsReadOnly="True"
+                            ItemsSource="{Binding Summary.ChangedParameters}"
+                            MaxHeight="180">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn
+                                    Width="2*"
+                                    Binding="{Binding Name}"
+                                    Header="Parameter" />
+                                <DataGridTextColumn
+                                    Width="*"
+                                    Binding="{Binding SeedValue, StringFormat=F3}"
+                                    Header="Seed" />
+                                <DataGridTextColumn
+                                    Width="*"
+                                    Binding="{Binding OptimizedValue, StringFormat=F3}"
+                                    Header="Optimized" />
+                            </DataGrid.Columns>
+                        </DataGrid>
+
+                        <CheckBox
+                            Margin="0,8,0,0"
+                            Content="Apply recommended auto-focus step size"
+                            IsChecked="{Binding ApplyRecommendedStepSize}"
+                            ToolTip="{StaticResource SDOpt_ApplyStepSize_Tooltip}" />
+                    </StackPanel>
+                </ScrollViewer>
+            </Grid>
+
+            <!--  Error banner  -->
+            <TextBlock
+                Grid.Row="2"
+                Margin="0,8,0,0"
+                Foreground="{StaticResource NotificationErrorBrush}"
+                Text="{Binding ErrorMessage}"
+                TextWrapping="Wrap"
+                Visibility="{Binding HasError, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+
+            <!--  Footer: navigation  -->
+            <StackPanel
+                Grid.Row="3"
+                Margin="0,10,0,0"
+                HorizontalAlignment="Right"
+                Orientation="Horizontal">
+                <Button
+                    Width="90"
+                    Margin="0,0,8,0"
+                    Command="{Binding BackCommand}"
+                    Content="Back"
+                    Visibility="{Binding IsSummary, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                <Button
+                    Width="90"
+                    Margin="0,0,8,0"
+                    Command="{Binding StartCommand}"
+                    Content="Start"
+                    Visibility="{Binding IsSelectSource, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                <Button
+                    Width="90"
+                    Margin="0,0,8,0"
+                    Command="{Binding CancelCommand}"
+                    Content="Cancel">
+                    <Button.Style>
+                        <Style TargetType="Button">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsAcquire}" Value="True">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding IsOptimize}" Value="True">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Style>
+                </Button>
+                <Button
+                    Width="90"
+                    Margin="0,0,8,0"
+                    Command="{Binding ApplyCommand}"
+                    Content="Apply"
+                    Visibility="{Binding IsSummary, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                <Button
+                    Width="90"
+                    Command="{Binding CloseCommand}"
+                    Content="Close" />
+            </StackPanel>
+        </Grid>
+    </DataTemplate>
+</ResourceDictionary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml.cs
@@ -1,0 +1,30 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System.ComponentModel.Composition;
+using System.Windows;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
+
+    /// <summary>
+    /// Interaction logic for DataTemplates.xaml. Exported as a <see cref="ResourceDictionary"/> so NINA's plugin
+    /// resource composition merges it into application resources; this is how the wizard's content DataTemplate
+    /// (keyed by the VM's full type name) becomes discoverable to IWindowServiceFactory when T5 shows the dialog.
+    /// </summary>
+    [Export(typeof(ResourceDictionary))]
+    public partial class DataTemplates : ResourceDictionary {
+
+        public DataTemplates() {
+            InitializeComponent();
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationObjective.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationObjective.cs
@@ -1,0 +1,258 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
+
+    /// <summary>
+    /// All weights and thresholds of the composite optimization objective, in one editable place. Defaults
+    /// come from the Star Detection Optimization Wizard design (the constant names match the design):
+    ///   Wf/Ws/Wc/Wl — sub-score weights (focus / star-count / curve-fit / label);
+    ///   RhoRef      — reference normalized focus σ for S_focus;
+    ///   NFloor/NTarget — star-count knees for S_stars;
+    ///   ChiTau      — reduced-χ² knee for S_fit;
+    ///   NHard / MaxFramesBelowHardFloor — hard constraint on per-frame star count;
+    ///   Beta        — multi-run min/mean blend.
+    /// </summary>
+    public sealed class ObjectiveConstants {
+        public double Wf { get; set; } = 0.55;   // focus weight
+        public double Ws { get; set; } = 0.20;   // star-count weight
+        public double Wc { get; set; } = 0.25;   // curve-fit weight
+        public double Wl { get; set; } = 0.25;   // label weight (only when labels are present)
+
+        public double RhoRef { get; set; } = 0.25;   // S_focus reference ρ = σ/step
+
+        public int NFloor { get; set; } = 8;     // S_stars: nMin knee
+        public int NTarget { get; set; } = 20;   // S_stars: nMedian knee
+
+        // S_fit penalty knee on reduced-χ². reducedχ² runs ≪1 for star-rich fields (over-fit-looking but
+        // benign), so ONLY the high side is penalized — below ChiTau there is no penalty at all.
+        public double ChiTau { get; set; } = 2.0;
+
+        public int NHard { get; set; } = 3;                  // hard floor: frames with starCount < NHard are "bad"
+        public int MaxFramesBelowHardFloor { get; set; } = 0; // more than this many bad frames => J_run = 0
+
+        public double Beta { get; set; } = 0.5;  // J_total = (1-β)·mean + β·min over runs
+    }
+
+    /// <summary>
+    /// Everything <see cref="OptimizationObjective.JRun"/> needs to score a single AF run. This is the contract
+    /// that Task T3 (which actually runs detection, pools frames, and fits the AF curve) fills in. Label
+    /// recall/precision are computed by the evaluator when labels exist (it owns the accepted-star centers),
+    /// so the objective and the search engine remain label-agnostic.
+    /// </summary>
+    public sealed class RunEvaluationMetrics {
+        public double SigmaFocus { get; set; }        // bestFit.MinimumStdError (may be NaN)
+        public double LooStdError { get; set; }       // leave-one-out best-focus std-error fallback (may be NaN)
+        public double StepSize { get; set; }          // AF step size used in the fit (> 0)
+        public double RSquared { get; set; }          // fit R^2
+        public double ReducedChiSquared { get; set; } // fit reduced χ² (NaN => treated as no penalty)
+        public IReadOnlyList<int> FrameStarCounts { get; set; } // accepted star count per frame in the run
+
+        // Label scores for this run, supplied by the evaluator only when labels exist; null otherwise. The
+        // optimizer passes these straight through to JRun, keeping itself label-agnostic.
+        public double? Recall { get; set; }
+        public double? Precision { get; set; }
+    }
+
+    /// <summary>
+    /// The composite objective J (maximized; every sub-score and J ∈ [0, 1]). All methods are pure and static.
+    /// The math mirrors the Star Detection Optimization Wizard design; constants live in
+    /// <see cref="ObjectiveConstants"/>.
+    /// </summary>
+    public static class OptimizationObjective {
+
+        /// <summary>Clamps to the unit interval [0, 1].</summary>
+        public static double Clamp01(double v) {
+            if (double.IsNaN(v)) {
+                return 0.0;
+            }
+            if (v < 0.0) {
+                return 0.0;
+            }
+            if (v > 1.0) {
+                return 1.0;
+            }
+            return v;
+        }
+
+        /// <summary>
+        /// S_focus = 1 / (1 + (ρ / RhoRef)²) where ρ = σ / stepSize. σ is <paramref name="sigmaFocus"/> when
+        /// finite, otherwise the leave-one-out fallback <paramref name="looStdError"/>. If NEITHER is finite,
+        /// returns NaN to signal a hard failure to the caller (JRun maps that to 0). Monotone-decreasing in σ:
+        /// a sharper focus relative to the step size scores higher.
+        /// </summary>
+        public static double SFocus(double sigmaFocus, double looStdError, double stepSize, ObjectiveConstants c) {
+            var sigma = IsFinite(sigmaFocus) ? sigmaFocus : (IsFinite(looStdError) ? looStdError : double.NaN);
+            if (!IsFinite(sigma)) {
+                return double.NaN;
+            }
+            if (!(stepSize > 0.0)) {
+                return double.NaN;
+            }
+            var rho = sigma / stepSize;
+            var ratio = rho / c.RhoRef;
+            return 1.0 / (1.0 + ratio * ratio);
+        }
+
+        /// <summary>
+        /// S_stars = 0.6·clamp01(nMin / NFloor) + 0.4·clamp01(nMedian / NTarget). The minimum carries the
+        /// larger weight so a single starved frame is penalized harder than a merely-thin median.
+        /// </summary>
+        public static double SStars(IReadOnlyList<int> counts, ObjectiveConstants c) {
+            if (counts == null || counts.Count == 0) {
+                return 0.0;
+            }
+            var nMin = counts.Min();
+            var nMed = Median(counts);
+            var minTerm = Clamp01((double)nMin / c.NFloor);
+            var medTerm = Clamp01(nMed / c.NTarget);
+            return 0.6 * minTerm + 0.4 * medTerm;
+        }
+
+        /// <summary>
+        /// S_fit = clamp01(R²) · penalty(reducedχ²). The penalty is 1 when reducedχ² ≤ ChiTau (or NaN — no
+        /// information, no penalty), and otherwise the smooth, monotone-decreasing, (0,1]-valued
+        /// <c>ChiTau / reducedχ²</c> (i.e. only the high side is penalized; equals 1 exactly at the knee).
+        /// </summary>
+        public static double SFit(double rSquared, double reducedChiSquared, ObjectiveConstants c) {
+            var penalty = 1.0;
+            if (IsFinite(reducedChiSquared) && reducedChiSquared > c.ChiTau) {
+                penalty = c.ChiTau / reducedChiSquared; // ∈ (0, 1) above the knee
+                penalty = Clamp01(penalty);
+            }
+            return Clamp01(rSquared) * penalty;
+        }
+
+        /// <summary>S_label = 0.5·recall + 0.5·precision.</summary>
+        public static double LabelScore(double recall, double precision) {
+            return 0.5 * recall + 0.5 * precision;
+        }
+
+        /// <summary>
+        /// Composite score for a single run. Returns 0 (hard fail) when the focus σ is unusable (both
+        /// sigmaFocus and looStdError non-finite) OR when more than <see cref="ObjectiveConstants.MaxFramesBelowHardFloor"/>
+        /// frames have a star count below <see cref="ObjectiveConstants.NHard"/>. Otherwise returns the
+        /// weighted sum of the sub-scores, clamped to [0, 1]. The weights are renormalized to sum to 1: with
+        /// labels they are (Wf, Ws, Wc, Wl); without, (Wf, Ws, Wc).
+        /// </summary>
+        public static double JRun(RunEvaluationMetrics m, ObjectiveConstants c, double? recall = null, double? precision = null) {
+            // Prefer the per-run recall/precision supplied on the metrics (T3 fills these in when labels
+            // exist); fall back to any explicitly passed values.
+            var effRecall = recall ?? m.Recall;
+            var effPrecision = precision ?? m.Precision;
+
+            // Hard constraint: too many starved frames.
+            if (m.FrameStarCounts != null) {
+                var below = m.FrameStarCounts.Count(n => n < c.NHard);
+                if (below > c.MaxFramesBelowHardFloor) {
+                    return 0.0;
+                }
+            }
+
+            var sFocus = SFocus(m.SigmaFocus, m.LooStdError, m.StepSize, c);
+            if (double.IsNaN(sFocus)) {
+                return 0.0; // unusable focus σ => hard fail
+            }
+            var sStars = SStars(m.FrameStarCounts, c);
+            var sFit = SFit(m.RSquared, m.ReducedChiSquared, c);
+
+            double j;
+            if (effRecall.HasValue && effPrecision.HasValue) {
+                var sLabel = LabelScore(effRecall.Value, effPrecision.Value);
+                var wSum = c.Wf + c.Ws + c.Wc + c.Wl;
+                j = (c.Wf * sFocus + c.Ws * sStars + c.Wc * sFit + c.Wl * sLabel) / wSum;
+            } else {
+                var wSum = c.Wf + c.Ws + c.Wc;
+                j = (c.Wf * sFocus + c.Ws * sStars + c.Wc * sFit) / wSum;
+            }
+            return Clamp01(j);
+        }
+
+        /// <summary>
+        /// Aggregates per-run J into a single score: J_total = (1 − β)·mean + β·min. A single run reduces to
+        /// that run's J (mean == min). β = 1 is pure worst-case (min); β = 0 is the average.
+        /// </summary>
+        public static double JTotal(IReadOnlyList<double> perRunJ, ObjectiveConstants c) {
+            if (perRunJ == null || perRunJ.Count == 0) {
+                return 0.0;
+            }
+            var mean = perRunJ.Average();
+            var min = perRunJ.Min();
+            return (1.0 - c.Beta) * mean + c.Beta * min;
+        }
+
+        /// <summary>
+        /// Geometric label scores against the accepted-star centers:
+        ///   recall    = fraction of <paramref name="labeledMissed"/> that have SOME accepted center within
+        ///               <paramref name="radiusPx"/> (Euclidean) — i.e. correctly recovered. Empty => 1.0.
+        ///   precision = fraction of <paramref name="labeledShouldReject"/> that have NO accepted center within
+        ///               radius — i.e. correctly excluded. Empty => 1.0.
+        /// </summary>
+        public static (double recall, double precision) ComputeLabelScores(
+            IReadOnlyList<(double X, double Y)> acceptedCenters,
+            IReadOnlyList<(double X, double Y)> labeledMissed,
+            IReadOnlyList<(double X, double Y)> labeledShouldReject,
+            double radiusPx) {
+            var r2 = radiusPx * radiusPx;
+
+            double recall;
+            if (labeledMissed == null || labeledMissed.Count == 0) {
+                recall = 1.0; // nothing to recover
+            } else {
+                var recovered = labeledMissed.Count(target => HasCenterWithin(acceptedCenters, target, r2));
+                recall = (double)recovered / labeledMissed.Count;
+            }
+
+            double precision;
+            if (labeledShouldReject == null || labeledShouldReject.Count == 0) {
+                precision = 1.0; // nothing that should be rejected
+            } else {
+                var correctlyExcluded = labeledShouldReject.Count(target => !HasCenterWithin(acceptedCenters, target, r2));
+                precision = (double)correctlyExcluded / labeledShouldReject.Count;
+            }
+
+            return (recall, precision);
+        }
+
+        private static bool HasCenterWithin(IReadOnlyList<(double X, double Y)> centers, (double X, double Y) target, double r2) {
+            if (centers == null) {
+                return false;
+            }
+            for (var i = 0; i < centers.Count; i++) {
+                var dx = centers[i].X - target.X;
+                var dy = centers[i].Y - target.Y;
+                if (dx * dx + dy * dy <= r2) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static bool IsFinite(double v) => !double.IsNaN(v) && !double.IsInfinity(v);
+
+        private static double Median(IReadOnlyList<int> counts) {
+            var sorted = counts.OrderBy(x => x).ToArray();
+            var n = sorted.Length;
+            if (n == 0) {
+                return 0.0;
+            }
+            if ((n & 1) == 1) {
+                return sorted[n / 2];
+            }
+            return (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationObjective.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationObjective.cs
@@ -195,24 +195,23 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         }
 
         /// <summary>
-        /// Geometric label scores against the accepted-star centers:
-        ///   recall    = fraction of <paramref name="labeledMissed"/> that have SOME accepted center within
-        ///               <paramref name="radiusPx"/> (Euclidean) — i.e. correctly recovered. Empty => 1.0.
-        ///   precision = fraction of <paramref name="labeledShouldReject"/> that have NO accepted center within
-        ///               radius — i.e. correctly excluded. Empty => 1.0.
+        /// Box-containment label scores against the accepted-star centers:
+        ///   recall    = fraction of <paramref name="labeledMissed"/> boxes that CONTAIN at least one accepted
+        ///               center — i.e. correctly recovered. Empty => 1.0.
+        ///   precision = fraction of <paramref name="labeledShouldReject"/> boxes that contain NO accepted center
+        ///               (the flagged accepted star is now excluded) — i.e. correctly rejected. Empty => 1.0.
+        /// Containment is point-in-box: cx ∈ [X, X+W] && cy ∈ [Y, Y+H] (see <see cref="LabelBox.Contains"/>). The
+        /// box defines the region directly, so no radius is needed.
         /// </summary>
         public static (double recall, double precision) ComputeLabelScores(
             IReadOnlyList<(double X, double Y)> acceptedCenters,
-            IReadOnlyList<(double X, double Y)> labeledMissed,
-            IReadOnlyList<(double X, double Y)> labeledShouldReject,
-            double radiusPx) {
-            var r2 = radiusPx * radiusPx;
-
+            IReadOnlyList<LabelBox> labeledMissed,
+            IReadOnlyList<LabelBox> labeledShouldReject) {
             double recall;
             if (labeledMissed == null || labeledMissed.Count == 0) {
                 recall = 1.0; // nothing to recover
             } else {
-                var recovered = labeledMissed.Count(target => HasCenterWithin(acceptedCenters, target, r2));
+                var recovered = labeledMissed.Count(box => ContainsAnyCenter(acceptedCenters, box));
                 recall = (double)recovered / labeledMissed.Count;
             }
 
@@ -220,21 +219,19 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             if (labeledShouldReject == null || labeledShouldReject.Count == 0) {
                 precision = 1.0; // nothing that should be rejected
             } else {
-                var correctlyExcluded = labeledShouldReject.Count(target => !HasCenterWithin(acceptedCenters, target, r2));
+                var correctlyExcluded = labeledShouldReject.Count(box => !ContainsAnyCenter(acceptedCenters, box));
                 precision = (double)correctlyExcluded / labeledShouldReject.Count;
             }
 
             return (recall, precision);
         }
 
-        private static bool HasCenterWithin(IReadOnlyList<(double X, double Y)> centers, (double X, double Y) target, double r2) {
+        private static bool ContainsAnyCenter(IReadOnlyList<(double X, double Y)> centers, LabelBox box) {
             if (centers == null) {
                 return false;
             }
             for (var i = 0; i < centers.Count; i++) {
-                var dx = centers[i].X - target.X;
-                var dy = centers[i].Y - target.Y;
-                if (dx * dx + dy * dy <= r2) {
+                if (box.Contains(centers[i].X, centers[i].Y)) {
                     return true;
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
@@ -1,0 +1,58 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using Newtonsoft.Json;
+using System;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
+
+    /// <summary>
+    /// Serializable snapshot of the curated star-detection knob values produced by the Star Detection
+    /// Optimization Wizard, plus metadata about the run that produced them. This is a pure data class — it
+    /// holds only the curated subset of <see cref="StarDetectionOptions"/> properties that the optimizer
+    /// tunes; the remaining advanced knobs continue to follow Simple-mode preset defaults when this snapshot
+    /// is applied.
+    /// </summary>
+    [JsonObject(MemberSerialization.OptOut)]
+    public class OptimizedStarDetectionSettings {
+
+        public OptimizedStarDetectionSettings() {
+        }
+
+        // Curated knobs (mirror the matching StarDetectionOptions property names/types)
+        public double BrightnessSensitivity { get; set; }
+        public double StarClippingMultiplier { get; set; }
+        public double NoiseClippingMultiplier { get; set; }
+        public double StarPeakResponse { get; set; }
+        public double MaxDistortion { get; set; }
+        public double MinHFR { get; set; }
+        public double StarCenterTolerance { get; set; }
+        public int StructureLayers { get; set; }
+        public int NoiseReductionRadius { get; set; }
+        public int MinStarBoundingBoxSize { get; set; }
+        public bool HotpixelThresholdingEnabled { get; set; }
+        public double HotpixelThreshold { get; set; }
+
+        // Metadata about the optimization run that produced this snapshot
+        public DateTime CreatedAtUtc { get; set; }
+        public int RunCount { get; set; }
+        public double BaselineJ { get; set; }
+        public double FinalJ { get; set; }
+        public int RecommendedStepSize { get; set; }
+        public int RecommendedOffsetSteps { get; set; }
+        public int SchemaVersion { get; set; } = 1;
+
+        public OptimizedStarDetectionSettings Clone() {
+            return (OptimizedStarDetectionSettings)MemberwiseClone();
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
@@ -11,6 +11,7 @@
 #endregion "copyright"
 
 using Newtonsoft.Json;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using System;
 
 namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
@@ -53,6 +54,43 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
         public OptimizedStarDetectionSettings Clone() {
             return (OptimizedStarDetectionSettings)MemberwiseClone();
+        }
+
+        /// <summary>
+        /// Builds a snapshot DTO from the optimizer's winning <see cref="StarDetectorParams"/> plus the run
+        /// metadata. This is the SINGLE source of truth for the params→DTO mapping (the DTO renames a few knobs:
+        /// Sensitivity→BrightnessSensitivity, PeakResponse→StarPeakResponse, MinimumStarBoundingBoxSize→
+        /// MinStarBoundingBoxSize). Both the in-app wizard (<c>StarDetectionOptimizerWizardVM.Apply</c>) and the
+        /// headless harness (<c>OptimizationDiagnosticRunner</c>) call this so the two paths can never drift.
+        /// <see cref="CreatedAtUtc"/> is stamped with <see cref="DateTime.UtcNow"/> at the call site.
+        /// </summary>
+        public static OptimizedStarDetectionSettings FromParams(
+            StarDetectorParams p, int runCount, double baselineJ, double finalJ, int recommendedStepSize, int recommendedOffsetSteps) {
+            if (p == null) {
+                throw new ArgumentNullException(nameof(p));
+            }
+            return new OptimizedStarDetectionSettings {
+                // Curated knobs — note the DTO renames a few (Sensitivity->BrightnessSensitivity etc.).
+                BrightnessSensitivity = p.Sensitivity,
+                StarClippingMultiplier = p.StarClippingMultiplier,
+                NoiseClippingMultiplier = p.NoiseClippingMultiplier,
+                StarPeakResponse = p.PeakResponse,
+                MaxDistortion = p.MaxDistortion,
+                MinHFR = p.MinHFR,
+                StarCenterTolerance = p.StarCenterTolerance,
+                StructureLayers = p.StructureLayers,
+                NoiseReductionRadius = p.NoiseReductionRadius,
+                MinStarBoundingBoxSize = p.MinimumStarBoundingBoxSize,
+                HotpixelThresholdingEnabled = p.HotpixelThresholdingEnabled,
+                HotpixelThreshold = p.HotpixelThreshold,
+
+                CreatedAtUtc = DateTime.UtcNow,
+                RunCount = runCount,
+                BaselineJ = baselineJ,
+                FinalJ = finalJ,
+                RecommendedStepSize = recommendedStepSize,
+                RecommendedOffsetSteps = recommendedOffsetSteps
+            };
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizerVariable.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizerVariable.cs
@@ -1,0 +1,203 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using System;
+using System.Collections.Generic;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
+
+    /// <summary>
+    /// The domain of a single tunable knob.
+    ///   Continuous — any real value within [Lower, Upper].
+    ///   Integer    — whole values within [Lower, Upper] (the optimizer rounds away from zero).
+    ///   Boolean    — represented as 0/1 with a 0.5 threshold; bounds are always [0, 1].
+    /// </summary>
+    public enum OptimizerVariableType {
+        Continuous,
+        Integer,
+        Boolean
+    }
+
+    /// <summary>
+    /// Descriptor for one star-detection parameter that the optimizer is allowed to tune. Every value flows
+    /// through this descriptor as a <c>double</c> so the search engine (T2) can stay parameter-agnostic: it
+    /// reads the seed value via <see cref="Read"/>, proposes a new double, and writes it back via
+    /// <see cref="Write"/>, which always clamps to [<see cref="Lower"/>, <see cref="Upper"/>] and quantizes
+    /// per <see cref="Type"/> (round Integers, threshold Booleans). The descriptor is pure data + delegates;
+    /// it performs no IO and runs no detection.
+    /// </summary>
+    public sealed class OptimizerVariable {
+        /// <summary>The matching <see cref="StarDetectorParams"/> property name (e.g. "Sensitivity").</summary>
+        public string Name { get; init; }
+
+        public OptimizerVariableType Type { get; init; }
+
+        /// <summary>Inclusive lower bound (for Boolean, 0).</summary>
+        public double Lower { get; init; }
+
+        /// <summary>Inclusive upper bound (for Boolean, 1).</summary>
+        public double Upper { get; init; }
+
+        /// <summary>The initial pattern-search step for this axis (in the variable's own units).</summary>
+        public double InitialStep { get; init; }
+
+        /// <summary>Reads the current value from a params bundle as a double (Boolean -> 0/1).</summary>
+        public Func<StarDetectorParams, double> Read { get; init; }
+
+        /// <summary>
+        /// Writes a value into a params bundle. The incoming double is clamped to [Lower, Upper] and quantized
+        /// per <see cref="Type"/> before being stored, so callers may pass raw proposals freely.
+        /// </summary>
+        public Action<StarDetectorParams, double> Write { get; init; }
+
+        /// <summary>Clamps a raw value to the inclusive bounds.</summary>
+        public double Clamp(double v) {
+            if (v < Lower) {
+                return Lower;
+            }
+            if (v > Upper) {
+                return Upper;
+            }
+            return v;
+        }
+
+        /// <summary>
+        /// Quantizes a raw value to a legal value of this variable's type, then clamps to bounds:
+        ///   Integer  — Math.Round(v, AwayFromZero);
+        ///   Boolean  — v >= 0.5 ? 1 : 0;
+        ///   Continuous — identity.
+        /// </summary>
+        public double Quantize(double v) {
+            switch (Type) {
+                case OptimizerVariableType.Integer:
+                    return Clamp(Math.Round(v, MidpointRounding.AwayFromZero));
+                case OptimizerVariableType.Boolean:
+                    return Clamp(v >= 0.5 ? 1.0 : 0.0);
+                default:
+                    return Clamp(v);
+            }
+        }
+
+        /// <summary>
+        /// The 12 curated tunable variables. Bounds/initial steps follow the validation ranges in
+        /// StarDetectionOptions.cs where a UI range exists; where a range is open-ended the bound is a
+        /// HEURISTIC (pragmatic, easily editable) value — see the named constants below.
+        ///
+        /// Bounds are defined exactly once per variable (in <see cref="Lower"/>/<see cref="Upper"/>); every
+        /// <see cref="Write"/> delegate routes its proposal through that same descriptor's own
+        /// <see cref="Quantize"/>, so there is a single source of truth and the lambdas can never drift from
+        /// the published bounds. The descriptor properties are init-only, so the bounds the lambda quantizes
+        /// against are exactly the ones returned by <see cref="Lower"/>/<see cref="Upper"/>.
+        /// </summary>
+        public static IReadOnlyList<OptimizerVariable> CreateCuratedSet() {
+            // --- Heuristic bounds (no hard UI validation range; chosen pragmatically). Edit here to retune. ---
+            const double SensitivityLower = 0.0;       // heuristic
+            const double SensitivityUpper = 20.0;      // heuristic
+            const double StarClipLower = 0.5;          // heuristic
+            const double StarClipUpper = 5.0;          // heuristic
+            const double NoiseClipLower = 1.0;         // heuristic
+            const double NoiseClipUpper = 10.0;        // heuristic
+            const double MinHFRLower = 0.1;            // heuristic
+            const double MinHFRUpper = 5.0;            // heuristic
+            const double HotpixelThresholdLower = 0.0001; // heuristic
+            const double HotpixelThresholdUpper = 0.05;   // heuristic
+            const int StructureLayersLower = 1;        // heuristic
+            const int StructureLayersUpper = 8;        // heuristic
+            const int NoiseReductionRadiusLower = 0;   // heuristic
+            const int NoiseReductionRadiusUpper = 10;  // heuristic
+            const int MinBoundingBoxLower = 2;         // heuristic
+            const int MinBoundingBoxUpper = 20;        // heuristic
+
+            return new List<OptimizerVariable> {
+                Continuous(nameof(StarDetectorParams.Sensitivity), SensitivityLower, SensitivityUpper, 1.0,
+                    p => p.Sensitivity, (p, v) => p.Sensitivity = v),
+                Continuous(nameof(StarDetectorParams.StarClippingMultiplier), StarClipLower, StarClipUpper, 0.5,
+                    p => p.StarClippingMultiplier, (p, v) => p.StarClippingMultiplier = v),
+                Continuous(nameof(StarDetectorParams.NoiseClippingMultiplier), NoiseClipLower, NoiseClipUpper, 0.5,
+                    p => p.NoiseClippingMultiplier, (p, v) => p.NoiseClippingMultiplier = v),
+                Continuous(nameof(StarDetectorParams.PeakResponse), 0.1, 1.0, 0.05,
+                    p => p.PeakResponse, (p, v) => p.PeakResponse = v),
+                Continuous(nameof(StarDetectorParams.MaxDistortion), 0.1, 1.0, 0.1,
+                    p => p.MaxDistortion, (p, v) => p.MaxDistortion = v),
+                Continuous(nameof(StarDetectorParams.MinHFR), MinHFRLower, MinHFRUpper, 0.25,
+                    p => p.MinHFR, (p, v) => p.MinHFR = v),
+                Continuous(nameof(StarDetectorParams.StarCenterTolerance), 0.05, 1.0, 0.05,
+                    p => p.StarCenterTolerance, (p, v) => p.StarCenterTolerance = v),
+                IntegerVar(nameof(StarDetectorParams.StructureLayers), StructureLayersLower, StructureLayersUpper, 1,
+                    p => p.StructureLayers, (p, v) => p.StructureLayers = v),
+                IntegerVar(nameof(StarDetectorParams.NoiseReductionRadius), NoiseReductionRadiusLower, NoiseReductionRadiusUpper, 1,
+                    p => p.NoiseReductionRadius, (p, v) => p.NoiseReductionRadius = v),
+                IntegerVar(nameof(StarDetectorParams.MinimumStarBoundingBoxSize), MinBoundingBoxLower, MinBoundingBoxUpper, 1,
+                    p => p.MinimumStarBoundingBoxSize, (p, v) => p.MinimumStarBoundingBoxSize = v),
+                BooleanVar(nameof(StarDetectorParams.HotpixelThresholdingEnabled), 1,
+                    p => p.HotpixelThresholdingEnabled, (p, b) => p.HotpixelThresholdingEnabled = b),
+                Continuous(nameof(StarDetectorParams.HotpixelThreshold), HotpixelThresholdLower, HotpixelThresholdUpper, 0.001,
+                    p => p.HotpixelThreshold, (p, v) => p.HotpixelThreshold = v),
+            };
+        }
+
+        /// <summary>
+        /// Builds a Continuous variable whose Write quantizes the proposal through the variable's OWN
+        /// <see cref="Quantize"/> (single source of bounds) before storing it via <paramref name="store"/>.
+        /// </summary>
+        private static OptimizerVariable Continuous(
+            string name, double lower, double upper, double step,
+            Func<StarDetectorParams, double> read, Action<StarDetectorParams, double> store) {
+            OptimizerVariable v = null;
+            v = new OptimizerVariable {
+                Name = name,
+                Type = OptimizerVariableType.Continuous,
+                Lower = lower, Upper = upper, InitialStep = step,
+                Read = read,
+                Write = (p, raw) => store(p, v.Quantize(raw))
+            };
+            return v;
+        }
+
+        /// <summary>
+        /// Builds an Integer variable whose Write quantizes (round-away-from-zero + clamp) the proposal through
+        /// the variable's OWN <see cref="Quantize"/>, then stores the whole-number result as an int.
+        /// </summary>
+        private static OptimizerVariable IntegerVar(
+            string name, int lower, int upper, double step,
+            Func<StarDetectorParams, int> read, Action<StarDetectorParams, int> store) {
+            OptimizerVariable v = null;
+            v = new OptimizerVariable {
+                Name = name,
+                Type = OptimizerVariableType.Integer,
+                Lower = lower, Upper = upper, InitialStep = step,
+                Read = p => read(p),
+                Write = (p, raw) => store(p, (int)v.Quantize(raw))
+            };
+            return v;
+        }
+
+        /// <summary>
+        /// Builds a Boolean variable (bounds [0, 1]) whose Write thresholds the proposal through the variable's
+        /// OWN <see cref="Quantize"/> (>= 0.5) before storing the bool via <paramref name="store"/>.
+        /// </summary>
+        private static OptimizerVariable BooleanVar(
+            string name, double step,
+            Func<StarDetectorParams, bool> read, Action<StarDetectorParams, bool> store) {
+            OptimizerVariable v = null;
+            v = new OptimizerVariable {
+                Name = name,
+                Type = OptimizerVariableType.Boolean,
+                Lower = 0, Upper = 1, InitialStep = step,
+                Read = p => read(p) ? 1.0 : 0.0,
+                Write = (p, raw) => store(p, v.Quantize(raw) >= 0.5)
+            };
+            return v;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizerVariable.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizerVariable.cs
@@ -102,9 +102,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public static IReadOnlyList<OptimizerVariable> CreateCuratedSet() {
             // --- Heuristic bounds (no hard UI validation range; chosen pragmatically). Edit here to retune. ---
             const double SensitivityLower = 0.0;       // heuristic
-            const double SensitivityUpper = 20.0;      // heuristic
-            const double StarClipLower = 0.5;          // heuristic
-            const double StarClipUpper = 5.0;          // heuristic
+            const double SensitivityUpper = 50.0;      // heuristic; widened 20 -> 50 because rich fields pinned the old 20 ceiling
+            const double StarClipLower = 0.25;         // heuristic; widened 0.5 -> 0.25 (a setup pinned the old 0.5 floor)
+            const double StarClipUpper = 10.0;         // heuristic; widened 5 -> 10 because rich fields pinned the old 5 ceiling
             const double NoiseClipLower = 1.0;         // heuristic
             const double NoiseClipUpper = 10.0;        // heuristic
             const double MinHFRLower = 0.1;            // heuristic

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationData.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationData.cs
@@ -60,6 +60,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// <summary>Stars that SHOULD have been rejected (correctly excluded when NO accepted center is within radius).</summary>
         public IReadOnlyList<(double X, double Y)> ShouldReject { get; set; }
 
+        /// <summary>Candidates that WERE detected but a gate rejected, which the user judges should have been KEPT.
+        /// These fold into recall (treated identically to <see cref="Missed"/> — both are recall targets the optimizer
+        /// should recover with an accepted star within radius).</summary>
+        public IReadOnlyList<(double X, double Y)> WronglyRejected { get; set; }
+
         public double RadiusPx { get; set; }
     }
 
@@ -566,7 +571,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     .Where(f => f.FocuserPosition == label.FocuserPosition)
                     .SelectMany(f => f.Detection.StarCenters ?? Array.Empty<(double X, double Y)>())
                     .ToList();
-                var (recall, precision) = OptimizationObjective.ComputeLabelScores(accepted, label.Missed, label.ShouldReject, label.RadiusPx);
+                // Recall targets = explicitly-missed (false negatives) ∪ wrongly-rejected (detected-but-gated stars the
+                // user wants kept). Both want an accepted center within radius, so they share the recall term. The
+                // union is the whole change here; ComputeLabelScores' signature is unchanged. Precision still depends
+                // only on ShouldReject. When neither list has entries the union is empty, so recall stays 1.0 exactly
+                // as before — the unlabeled / missed-only paths are bit-identical.
+                var recallTargets = UnionTargets(label.Missed, label.WronglyRejected);
+                var (recall, precision) = OptimizationObjective.ComputeLabelScores(accepted, recallTargets, label.ShouldReject, label.RadiusPx);
                 recallSum += recall;
                 precisionSum += precision;
                 scored++;
@@ -576,6 +587,30 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 metrics.Recall = recallSum / scored;
                 metrics.Precision = precisionSum / scored;
             }
+        }
+
+        /// <summary>
+        /// Concatenates the two recall-target lists (missed ∪ wrongly-rejected) into a single list. Returns the
+        /// other list as-is when one is null/empty (so the common missed-only / wrongly-only cases allocate nothing
+        /// extra and stay bit-identical to the prior single-list behavior). Returns null only when both are empty.
+        /// </summary>
+        private static IReadOnlyList<(double X, double Y)> UnionTargets(
+            IReadOnlyList<(double X, double Y)> a, IReadOnlyList<(double X, double Y)> b) {
+            var aEmpty = a == null || a.Count == 0;
+            var bEmpty = b == null || b.Count == 0;
+            if (aEmpty && bEmpty) {
+                return a; // null or empty — ComputeLabelScores treats it as recall = 1.0
+            }
+            if (bEmpty) {
+                return a;
+            }
+            if (aEmpty) {
+                return b;
+            }
+            var union = new List<(double X, double Y)>(a.Count + b.Count);
+            union.AddRange(a);
+            union.AddRange(b);
+            return union;
         }
 
         /// <summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationData.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationData.cs
@@ -107,35 +107,150 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
     /// <see cref="object"/>) and detection is an injected delegate, so the same evaluator drives the live wizard
     /// (IRenderedImage) and the offline harness (Mat) unchanged.</para>
     ///
-    /// <para>No per-frame detection cache is kept on purpose: the optimizer already memoizes J at the params
-    /// level (one evaluator call per distinct params via <see cref="StarDetector.ComputeCacheKey"/>), so caching
-    /// per frame here would be redundant and would pin many star lists in memory.</para>
+    /// <para>Optionally, an <see cref="ISplitFrameDetector"/> may be supplied instead of a monolithic detect
+    /// delegate. When it is, the evaluator caches the EXPENSIVE early-stage detection result per (frame, early
+    /// cache key) and reuses it across candidate evaluations that change only late-stage gate params (the bulk of
+    /// a compass search), re-running only the cheap gate+measure step. This is the ~2× optimizer speedup; it is a
+    /// pure performance optimization and produces byte-identical per-frame results to the non-cached path. The
+    /// cache is bounded to ONE context per frame (the current early key), since the search moves the incumbent —
+    /// when a frame's early key changes the prior context is disposed before the new one is built; at 61 MP each
+    /// cached context pins ~244 MB, so keeping only one per frame caps the footprint at one frame-set of source
+    /// Mats. The cache lives for this <see cref="RunEvaluationData"/> instance's lifetime (which in the wizard
+    /// spans seed-guard → optimize → summary, all evaluated against the same instance); <see cref="Dispose"/>
+    /// releases all cached contexts and MUST be called by the owner once the instance is no longer needed.</para>
+    ///
+    /// <para>When only a monolithic delegate is supplied (the legacy path), no per-frame detection cache is kept:
+    /// the optimizer already memoizes J at the params level (one evaluator call per distinct params via
+    /// <see cref="StarDetector.ComputeCacheKey"/>), so star-list caching there would be redundant.</para>
     /// </summary>
-    public sealed class RunEvaluationData {
+    public sealed class RunEvaluationData : IDisposable {
+        /// <summary>
+        /// A split-capable detection façade the evaluator can drive in two phases so it can cache the expensive
+        /// early phase. Implemented by the wizard loader (over <c>HocusFocusStarDetection</c>/<c>StarDetector</c>)
+        /// and the offline harness; the frame payload and the context are opaque to the evaluator.
+        /// </summary>
+        public interface ISplitFrameDetector {
+            /// <summary>A deterministic key over ONLY the early-affecting params (see
+            /// <c>StarDetector.ComputeEarlyCacheKey</c>): two params with the same key yield an identical early
+            /// context, so a cached context may be reused.</summary>
+            string ComputeEarlyKey(StarDetectorParams p);
+
+            /// <summary>Runs the expensive early detection stage for one frame and returns an opaque, disposable
+            /// context. The evaluator owns disposing it.</summary>
+            Task<IDisposable> BuildContextAsync(object frameImage, StarDetectorParams p, CancellationToken token);
+
+            /// <summary>Runs the cheap late (gate + measure) stage against a previously-built context. Pure over
+            /// the context (read-only), so it is safe to call repeatedly with different late params.</summary>
+            FrameDetectionResult GateAndMeasure(IDisposable context, StarDetectorParams p);
+        }
+
         // A hyperbola has 4-5 parameters; fewer than this many distinct positions can never determine a fit.
         private const int MinPositionsForFit = 3;
 
         private readonly IReadOnlyList<RunFrame> frames;
         private readonly Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> detect;
+        private readonly ISplitFrameDetector splitDetector;
         private readonly IAlglibAPI alglibAPI;
         private readonly RunFitConfig fitConfig;
         private readonly IReadOnlyList<FrameLabels> labels;
 
+        // Early-context cache (only used when splitDetector != null). One slot per frame index; each slot holds the
+        // context most recently built for that frame plus the early key it was built under. A candidate whose early
+        // key matches the slot reuses the context; a mismatch disposes the old context and rebuilds. Bounded to one
+        // context per frame by construction (see class doc). Guarded by cacheLock so a (future) concurrent caller
+        // cannot corrupt it — today the evaluator runs frames sequentially, so contention is nil.
+        private readonly CachedContext[] contextCache;
+        private readonly object cacheLock = new object();
+        private bool disposed;
+
+        private sealed class CachedContext {
+            public string EarlyKey;
+            public IDisposable Context;
+        }
+
         public string RunId { get; }
 
+        public RunEvaluationData(
+            string runId,
+            Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> detect,
+            ISplitFrameDetector splitDetector,
+            IReadOnlyList<RunFrame> frames,
+            IAlglibAPI alglibAPI,
+            RunFitConfig fitConfig,
+            IReadOnlyList<FrameLabels> labels) {
+            RunId = runId;
+            this.frames = frames ?? throw new ArgumentNullException(nameof(frames));
+            this.alglibAPI = alglibAPI ?? throw new ArgumentNullException(nameof(alglibAPI));
+            this.fitConfig = fitConfig;
+            this.labels = labels;
+
+            // Exactly one of (detect, splitDetector) must be supplied.
+            if (detect == null && splitDetector == null) {
+                throw new ArgumentNullException(nameof(detect), "either a detect delegate or a split detector is required");
+            }
+            this.detect = detect;
+            this.splitDetector = splitDetector;
+            this.contextCache = splitDetector != null ? new CachedContext[frames.Count] : null;
+        }
+
+        /// <summary>Legacy constructor: a monolithic detect delegate, no early-context cache.</summary>
         public RunEvaluationData(
             string runId,
             IReadOnlyList<RunFrame> frames,
             Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> detect,
             IAlglibAPI alglibAPI,
             RunFitConfig fitConfig,
-            IReadOnlyList<FrameLabels> labels = null) {
-            RunId = runId;
-            this.frames = frames ?? throw new ArgumentNullException(nameof(frames));
-            this.detect = detect ?? throw new ArgumentNullException(nameof(detect));
-            this.alglibAPI = alglibAPI ?? throw new ArgumentNullException(nameof(alglibAPI));
-            this.fitConfig = fitConfig;
-            this.labels = labels;
+            IReadOnlyList<FrameLabels> labels = null)
+            : this(runId, detect ?? throw new ArgumentNullException(nameof(detect)), null, frames, alglibAPI, fitConfig, labels) {
+        }
+
+        /// <summary>Split constructor: caches the expensive early detection per (frame, early key) and reuses it
+        /// across late-only candidate changes (the optimizer speedup). Results are identical to the delegate path.</summary>
+        public RunEvaluationData(
+            string runId,
+            IReadOnlyList<RunFrame> frames,
+            ISplitFrameDetector splitDetector,
+            IAlglibAPI alglibAPI,
+            RunFitConfig fitConfig,
+            IReadOnlyList<FrameLabels> labels = null)
+            : this(runId, null, splitDetector ?? throw new ArgumentNullException(nameof(splitDetector)), frames, alglibAPI, fitConfig, labels) {
+        }
+
+        /// <summary>
+        /// Detects one frame, going through the early-context cache when a split detector was supplied. On a
+        /// late-only param change the cached early context is reused; on an early-key change (or first use) the
+        /// prior context is disposed and a new one is built. Falls back to the monolithic delegate otherwise.
+        /// </summary>
+        private async Task<FrameDetectionResult> DetectFrameAsync(int frameIndex, object frameImage, StarDetectorParams p, CancellationToken token) {
+            if (splitDetector == null) {
+                return await detect(frameImage, p, token).ConfigureAwait(false);
+            }
+
+            var earlyKey = splitDetector.ComputeEarlyKey(p);
+            IDisposable context;
+            IDisposable evicted = null;
+            lock (cacheLock) {
+                var slot = contextCache[frameIndex];
+                if (slot != null && slot.Context != null && slot.EarlyKey == earlyKey) {
+                    context = slot.Context; // reuse
+                } else {
+                    context = null; // must build (below, outside the lock)
+                    evicted = slot?.Context; // dispose the superseded context after building the new one
+                }
+            }
+
+            if (context == null) {
+                // Build outside the lock (BuildContextAsync is the expensive stage). The evaluator runs frames
+                // sequentially today, so there is no risk of two builders racing for the same slot.
+                var built = await splitDetector.BuildContextAsync(frameImage, p, token).ConfigureAwait(false);
+                evicted?.Dispose();
+                lock (cacheLock) {
+                    contextCache[frameIndex] = new CachedContext { EarlyKey = earlyKey, Context = built };
+                }
+                context = built;
+            }
+
+            return splitDetector.GateAndMeasure(context, p);
         }
 
         /// <summary>
@@ -154,12 +269,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// objective hard-fails gracefully.
         /// </summary>
         public async Task<RunEvaluationResult> EvaluateAndFitAsync(StarDetectorParams p, CancellationToken token) {
-            // 1. Detect every frame in a fixed, deterministic order; collect per-frame results.
+            // 1. Detect every frame in a fixed, deterministic order; collect per-frame results. When a split
+            //    detector is in use this goes through the early-context cache (reused across late-only changes),
+            //    which is a pure-perf optimization — the per-frame results are identical to the delegate path.
             var frameStarCounts = new List<int>(frames.Count);
             var perFrame = new List<(int FocuserPosition, FrameDetectionResult Detection)>(frames.Count);
-            foreach (var frame in frames) {
+            for (int i = 0; i < frames.Count; i++) {
                 token.ThrowIfCancellationRequested();
-                var detection = await detect(frame.Image, p, token).ConfigureAwait(false);
+                var frame = frames[i];
+                var detection = await DetectFrameAsync(i, frame.Image, p, token).ConfigureAwait(false);
                 frameStarCounts.Add(detection.StarCount);
                 perFrame.Add((frame.FocuserPosition, detection));
             }
@@ -279,6 +397,26 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// </summary>
         private static double SafeDisplayError(double stdev) {
             return double.IsFinite(stdev) ? Math.Max(0.0, stdev) : 0.0;
+        }
+
+        /// <summary>
+        /// Releases every cached early-detection context (frees the pinned source Mats) held for this instance's
+        /// lifetime. Idempotent. Only the split path holds contexts; the monolithic path keeps none, so Dispose is a
+        /// no-op there.
+        /// </summary>
+        public void Dispose() {
+            lock (cacheLock) {
+                if (disposed) {
+                    return;
+                }
+                disposed = true;
+                if (contextCache != null) {
+                    for (int i = 0; i < contextCache.Length; i++) {
+                        contextCache[i]?.Context?.Dispose();
+                        contextCache[i] = null;
+                    }
+                }
+            }
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationData.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationData.cs
@@ -147,6 +147,32 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         // A hyperbola has 4-5 parameters; fewer than this many distinct positions can never determine a fit.
         private const int MinPositionsForFit = 3;
 
+        // Concurrency cap for the per-frame detect/build+gate loop WITHIN one evaluation. Frames are largely
+        // single-threaded in their expensive early stage (wavelet/binarization), so running a few concurrently
+        // fills idle cores. The cap is deliberately SMALL for two reasons:
+        //   (1) Memory — each in-flight frame holds/builds a ~244 MB early context at 61 MP; the cap bounds peak
+        //       footprint to (cap × one source frame-set), not the whole run at once.
+        //   (2) Oversubscription — the LATE/gate stage already runs an internal Parallel.For over candidates on the
+        //       shared scheduler (≈ ProcessorCount threads). Letting many frames into the gate concurrently would
+        //       multiply that against the frame fan-out, so we keep the frame fan-out to a small fraction of cores.
+        // Default: ProcessorCount/4, floored at 2 and never more than the frame count. On an 8-core box this is 2;
+        // on a 16-core box, 4. A fixed-but-modest value that fills idle cores during the single-threaded early
+        // stage without contending hard with the gate phase or blowing the memory budget.
+        private static int DefaultFrameParallelism(int frameCount) =>
+            Math.Max(1, Math.Min(frameCount, Math.Max(2, Environment.ProcessorCount / 4)));
+
+        // Test/override hook: 1 forces the sequential path (used to prove parallel ≡ sequential); a value > 1 caps
+        // the frame fan-out at that value; <= 0 means "use DefaultFrameParallelism". Not persisted; an in-memory knob
+        // only (settable so tests can force cap=1 to prove the parallel path ≡ the sequential path).
+        public int FrameParallelismOverride { get; set; } = 0;
+
+        /// <summary>The effective frame-detection concurrency cap for this run: the override when set (> 0), else
+        /// <see cref="DefaultFrameParallelism"/>. Always in [1, frameCount].</summary>
+        private int EffectiveFrameParallelism =>
+            FrameParallelismOverride > 0
+                ? Math.Max(1, Math.Min(frames.Count, FrameParallelismOverride))
+                : DefaultFrameParallelism(frames.Count);
+
         private readonly IReadOnlyList<RunFrame> frames;
         private readonly Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> detect;
         private readonly ISplitFrameDetector splitDetector;
@@ -157,8 +183,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         // Early-context cache (only used when splitDetector != null). One slot per frame index; each slot holds the
         // context most recently built for that frame plus the early key it was built under. A candidate whose early
         // key matches the slot reuses the context; a mismatch disposes the old context and rebuilds. Bounded to one
-        // context per frame by construction (see class doc). Guarded by cacheLock so a (future) concurrent caller
-        // cannot corrupt it — today the evaluator runs frames sequentially, so contention is nil.
+        // context per frame by construction (see class doc). Guarded by cacheLock.
+        //
+        // Concurrency: WITHIN one evaluation, frames are detected concurrently (capped — see DefaultFrameParallelism),
+        // so multiple DetectFrameAsync calls may run at once — but each touches its OWN slot (keyed by frame index),
+        // never another frame's. The lock serializes the check-and-claim and the post-build publish so that, even for
+        // the same frame, no two callers build the same slot twice and no built context is leaked. Distinct slots are
+        // independent: two frames building concurrently into different slots never contend except briefly on the lock
+        // (held only around the O(1) slot read/write, not the expensive build). Disposal on eviction/Dispose stays
+        // correct: the superseded context captured under the lock is disposed exactly once, by the claiming caller.
         private readonly CachedContext[] contextCache;
         private readonly object cacheLock = new object();
         private bool disposed;
@@ -166,6 +199,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         private sealed class CachedContext {
             public string EarlyKey;
             public IDisposable Context;
+
+            // Set while a context for EarlyKey is being built (between claim and publish). A concurrent caller that
+            // wants the SAME (slot, key) awaits this instead of starting a second build, so a slot is never built
+            // twice concurrently and no built context is leaked. In normal operation (one task per frame index per
+            // evaluation, sequential evaluations) this is never contended; it makes same-slot concurrency safe by
+            // construction rather than by assumption.
+            public Task<IDisposable> Building;
         }
 
         public string RunId { get; }
@@ -226,31 +266,195 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 return await detect(frameImage, p, token).ConfigureAwait(false);
             }
 
-            var earlyKey = splitDetector.ComputeEarlyKey(p);
-            IDisposable context;
-            IDisposable evicted = null;
-            lock (cacheLock) {
-                var slot = contextCache[frameIndex];
-                if (slot != null && slot.Context != null && slot.EarlyKey == earlyKey) {
-                    context = slot.Context; // reuse
-                } else {
-                    context = null; // must build (below, outside the lock)
-                    evicted = slot?.Context; // dispose the superseded context after building the new one
-                }
-            }
-
-            if (context == null) {
-                // Build outside the lock (BuildContextAsync is the expensive stage). The evaluator runs frames
-                // sequentially today, so there is no risk of two builders racing for the same slot.
-                var built = await splitDetector.BuildContextAsync(frameImage, p, token).ConfigureAwait(false);
-                evicted?.Dispose();
-                lock (cacheLock) {
-                    contextCache[frameIndex] = new CachedContext { EarlyKey = earlyKey, Context = built };
-                }
-                context = built;
-            }
-
+            var context = await GetOrBuildContextAsync(frameIndex, frameImage, p, token).ConfigureAwait(false);
             return splitDetector.GateAndMeasure(context, p);
+        }
+
+        /// <summary>
+        /// Returns the early-detection context for one frame's slot, reusing it when the early key matches and
+        /// (re)building it otherwise. Safe under concurrency: each frame uses its OWN slot (by index) and the lock
+        /// serializes the check/claim/publish so a slot is never built twice concurrently and no built context is
+        /// leaked. The expensive <see cref="ISplitFrameDetector.BuildContextAsync"/> runs OUTSIDE the lock; the lock
+        /// is held only around the O(1) slot inspection and the publish of the build task / built context.
+        /// </summary>
+        private async Task<IDisposable> GetOrBuildContextAsync(int frameIndex, object frameImage, StarDetectorParams p, CancellationToken token) {
+            var earlyKey = splitDetector.ComputeEarlyKey(p);
+
+            // Spin on (claim a build) | (reuse cached) | (await another caller's in-flight build for this key). The
+            // loop only re-iterates when an in-flight build for a DIFFERENT key (or a build we awaited) leaves the
+            // slot not matching ours — which cannot happen within one evaluation (one task per slot), but is handled
+            // for defensiveness so concurrent same-slot callers can never double-build or leak.
+            while (true) {
+                token.ThrowIfCancellationRequested();
+
+                Task<IDisposable> awaitExisting = null;                 // an in-flight build by another caller we should await
+                TaskCompletionSource<IDisposable> ourClaim = null;      // set if WE claimed the slot to build
+                IDisposable evicted = null;                            // a superseded context WE must dispose after building
+
+                lock (cacheLock) {
+                    if (disposed) {
+                        throw new ObjectDisposedException(nameof(RunEvaluationData));
+                    }
+                    var slot = contextCache[frameIndex];
+                    if (slot != null && slot.Context != null && slot.EarlyKey == earlyKey) {
+                        return slot.Context; // reuse the published context
+                    }
+                    if (slot != null && slot.Building != null && slot.EarlyKey == earlyKey) {
+                        awaitExisting = slot.Building; // someone is already building exactly this; await it
+                    } else {
+                        // Claim the slot for OUR build: record the early key + a build task others can await, and
+                        // remember any superseded context so we dispose it after the new one is built.
+                        evicted = slot?.Context;
+                        ourClaim = new TaskCompletionSource<IDisposable>(TaskCreationOptions.RunContinuationsAsynchronously);
+                        contextCache[frameIndex] = new CachedContext { EarlyKey = earlyKey, Context = null, Building = ourClaim.Task };
+                    }
+                }
+
+                if (ourClaim != null) {
+                    // We own the build: run it OUTSIDE the lock and publish the result.
+                    return await RunClaimedBuildAsync(frameIndex, frameImage, p, earlyKey, ourClaim, evicted, token).ConfigureAwait(false);
+                }
+
+                // Await another caller's in-flight build for the same key, then re-check the slot (it should now be
+                // published with our key; if a later eviction changed it we loop and re-claim). Swallow that build's
+                // own exception here — the slot will simply read as un-built and we re-claim on the next iteration.
+                try {
+                    await awaitExisting.ConfigureAwait(false);
+                } catch {
+                    // The owning build failed/cancelled; loop and re-evaluate the slot.
+                }
+            }
+        }
+
+        /// <summary>
+        /// Runs a build we have claimed for <paramref name="frameIndex"/>: builds outside the lock, disposes the
+        /// superseded context, publishes the built context into the slot, and signals waiters via
+        /// <paramref name="tcs"/>. On failure the slot's build marker is cleared so a later caller can retry, and the
+        /// freshly-built context (if any) is disposed so nothing leaks.
+        /// </summary>
+        private async Task<IDisposable> RunClaimedBuildAsync(
+                int frameIndex, object frameImage, StarDetectorParams p, string earlyKey,
+                TaskCompletionSource<IDisposable> tcs, IDisposable evicted, CancellationToken token) {
+            IDisposable built = null;
+            try {
+                built = await splitDetector.BuildContextAsync(frameImage, p, token).ConfigureAwait(false);
+                evicted?.Dispose();
+
+                bool disposeBuilt = false;
+                lock (cacheLock) {
+                    if (disposed) {
+                        // Disposed while we built: don't publish; dispose the orphan after the lock.
+                        disposeBuilt = true;
+                    } else {
+                        contextCache[frameIndex] = new CachedContext { EarlyKey = earlyKey, Context = built, Building = null };
+                    }
+                }
+                if (disposeBuilt) {
+                    built.Dispose();
+                    tcs.TrySetResult(null);
+                    throw new ObjectDisposedException(nameof(RunEvaluationData));
+                }
+
+                tcs.TrySetResult(built);
+                return built;
+            } catch (Exception ex) {
+                // Failed/cancelled build: clear our build marker so the slot can be re-claimed, dispose any orphaned
+                // context, and propagate to both this caller and any waiters.
+                lock (cacheLock) {
+                    var slot = contextCache[frameIndex];
+                    if (slot != null && ReferenceEquals(slot.Building, tcs.Task)) {
+                        contextCache[frameIndex] = null;
+                    }
+                }
+                if (built != null) {
+                    built.Dispose();
+                }
+                tcs.TrySetException(ex);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Detects every frame for one candidate, running up to <see cref="EffectiveFrameParallelism"/> frames
+        /// concurrently and returning their results in a per-INDEX array (result[i] is frame i's detection,
+        /// regardless of completion order). Determinism: results are assigned by frame index, never appended in
+        /// completion order, so the caller sees the identical sequence the old sequential loop produced.
+        /// Cancellation: a linked token source cancels all in-flight frames on request (or when any frame faults);
+        /// the first fault/cancellation is rethrown after all started tasks settle, so no detection is left running.
+        /// </summary>
+        private async Task<FrameDetectionResult[]> DetectAllFramesAsync(StarDetectorParams p, CancellationToken token) {
+            var count = frames.Count;
+            var results = new FrameDetectionResult[count];
+            if (count == 0) {
+                return results;
+            }
+
+            token.ThrowIfCancellationRequested();
+
+            var degree = EffectiveFrameParallelism;
+            if (degree <= 1) {
+                // Forced/derived sequential path: identical ordering and behavior to the original loop. Used by tests
+                // (cap=1) to prove the parallel path produces the same metrics, and on single-frame/single-core runs.
+                for (int i = 0; i < count; i++) {
+                    token.ThrowIfCancellationRequested();
+                    results[i] = await DetectFrameAsync(i, frames[i].Image, p, token).ConfigureAwait(false);
+                }
+                return results;
+            }
+
+            // Bounded fan-out: a SemaphoreSlim caps the number of frames in flight at once; a linked CTS lets us
+            // cancel every in-flight frame the moment one faults or the caller cancels. Each task writes ONLY its own
+            // index, so there is no shared mutable state across tasks beyond the cache (per-slot safe) and the array
+            // (disjoint indices) — no locking needed for the results array.
+            using var throttle = new SemaphoreSlim(degree, degree);
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+            var linkedToken = linkedCts.Token;
+
+            var tasks = new Task[count];
+            try {
+                for (int i = 0; i < count; i++) {
+                    linkedToken.ThrowIfCancellationRequested();
+                    await throttle.WaitAsync(linkedToken).ConfigureAwait(false);
+
+                    var index = i;
+                    tasks[index] = Task.Run(async () => {
+                        try {
+                            results[index] = await DetectFrameAsync(index, frames[index].Image, p, linkedToken).ConfigureAwait(false);
+                        } catch {
+                            // Cancel siblings so the whole evaluation tears down promptly; the original exception is
+                            // surfaced via Task.WhenAll below.
+                            linkedCts.Cancel();
+                            throw;
+                        } finally {
+                            throttle.Release();
+                        }
+                    }, linkedToken);
+                }
+            } catch (OperationCanceledException) {
+                // The acquire loop was cancelled (caller token or a sibling fault). Make sure every already-started
+                // task settles before we surface, so nothing keeps building after we return.
+                linkedCts.Cancel();
+                await WhenAllSafe(tasks).ConfigureAwait(false);
+                throw;
+            }
+
+            await Task.WhenAll(tasks.Where(t => t != null)).ConfigureAwait(false);
+            return results;
+        }
+
+        /// <summary>Awaits all non-null tasks, swallowing their exceptions (used on the cancellation teardown path so
+        /// the in-flight frames finish before we rethrow the originating cancellation/fault).</summary>
+        private static async Task WhenAllSafe(Task[] tasks) {
+            foreach (var t in tasks) {
+                if (t == null) {
+                    continue;
+                }
+                try {
+                    await t.ConfigureAwait(false);
+                } catch {
+                    // Intentionally ignored — teardown path.
+                }
+            }
         }
 
         /// <summary>
@@ -269,17 +473,21 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// objective hard-fails gracefully.
         /// </summary>
         public async Task<RunEvaluationResult> EvaluateAndFitAsync(StarDetectorParams p, CancellationToken token) {
-            // 1. Detect every frame in a fixed, deterministic order; collect per-frame results. When a split
-            //    detector is in use this goes through the early-context cache (reused across late-only changes),
-            //    which is a pure-perf optimization — the per-frame results are identical to the delegate path.
+            // 1. Detect every frame, CONCURRENTLY but capped (see EffectiveFrameParallelism), to fill idle cores
+            //    during the largely single-threaded early stage. Determinism is preserved by assembling results into
+            //    a per-index array (assign by frame index, NOT completion order) and then consuming that array in
+            //    strict ascending-index order below — so every downstream value (pooling, fit, J, labels) is byte-
+            //    identical to the old sequential loop regardless of how the frame tasks interleave. When a split
+            //    detector is in use each frame goes through its own early-context cache slot (reused across late-only
+            //    changes); concurrent builds touch distinct slots, so the cache is unaffected by the parallelism.
+            var detections = await DetectAllFramesAsync(p, token).ConfigureAwait(false);
+
             var frameStarCounts = new List<int>(frames.Count);
             var perFrame = new List<(int FocuserPosition, FrameDetectionResult Detection)>(frames.Count);
             for (int i = 0; i < frames.Count; i++) {
-                token.ThrowIfCancellationRequested();
-                var frame = frames[i];
-                var detection = await DetectFrameAsync(i, frame.Image, p, token).ConfigureAwait(false);
+                var detection = detections[i];
                 frameStarCounts.Add(detection.StarCount);
-                perFrame.Add((frame.FocuserPosition, detection));
+                perFrame.Add((frames[i].FocuserPosition, detection));
             }
 
             // 2. Pool frames sharing a focuser position using the SAME semantics as the AF engine's

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationData.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationData.cs
@@ -48,23 +48,49 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
     }
 
     /// <summary>
+    /// A ground-truth label region in image space: a box (top-left X,Y + W,H). Recall/precision are scored by
+    /// box-containment (an accepted star center lying inside the box), so the box defines the region directly and no
+    /// separate radius is needed. Dependency-light (a plain struct) so the objective stays free of any drawing/UI type.
+    /// </summary>
+    public readonly struct LabelBox {
+        public double X { get; }
+        public double Y { get; }
+        public double W { get; }
+        public double H { get; }
+
+        public LabelBox(double x, double y, double w, double h) {
+            X = x;
+            Y = y;
+            W = w;
+            H = h;
+        }
+
+        /// <summary>True when (cx,cy) lies within this box (inclusive AABB containment).</summary>
+        public bool Contains(double cx, double cy) =>
+            cx >= X && cx <= X + W && cy >= Y && cy <= Y + H;
+    }
+
+    /// <summary>
     /// Optional ground-truth labels for one focuser position, used to score recall/precision. Plumbed now (T3),
-    /// consumed by the labeling workflow (T7); when no labels are supplied the run scores label-agnostically.
+    /// consumed by the labeling workflow (T7); when no labels are supplied the run scores label-agnostically. Each
+    /// label is a BOX; recall/precision use box-containment of accepted-star centers.
     /// </summary>
     public sealed class FrameLabels {
         public int FocuserPosition { get; set; }
 
-        /// <summary>Stars that SHOULD have been detected (recovered when an accepted center lands within radius).</summary>
-        public IReadOnlyList<(double X, double Y)> Missed { get; set; }
+        /// <summary>Stars that SHOULD have been detected (recovered when an accepted center lies inside the box).</summary>
+        public IReadOnlyList<LabelBox> Missed { get; set; }
 
-        /// <summary>Stars that SHOULD have been rejected (correctly excluded when NO accepted center is within radius).</summary>
-        public IReadOnlyList<(double X, double Y)> ShouldReject { get; set; }
+        /// <summary>Stars that SHOULD have been rejected (correctly excluded when NO accepted center lies inside the box).</summary>
+        public IReadOnlyList<LabelBox> ShouldReject { get; set; }
 
         /// <summary>Candidates that WERE detected but a gate rejected, which the user judges should have been KEPT.
         /// These fold into recall (treated identically to <see cref="Missed"/> — both are recall targets the optimizer
-        /// should recover with an accepted star within radius).</summary>
-        public IReadOnlyList<(double X, double Y)> WronglyRejected { get; set; }
+        /// should recover with an accepted star inside the box).</summary>
+        public IReadOnlyList<LabelBox> WronglyRejected { get; set; }
 
+        /// <summary>Legacy default-radius carrier (used only when widening older point-only labels to boxes on load);
+        /// no longer consumed by the box-containment scoring.</summary>
         public double RadiusPx { get; set; }
     }
 
@@ -572,12 +598,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     .SelectMany(f => f.Detection.StarCenters ?? Array.Empty<(double X, double Y)>())
                     .ToList();
                 // Recall targets = explicitly-missed (false negatives) ∪ wrongly-rejected (detected-but-gated stars the
-                // user wants kept). Both want an accepted center within radius, so they share the recall term. The
-                // union is the whole change here; ComputeLabelScores' signature is unchanged. Precision still depends
-                // only on ShouldReject. When neither list has entries the union is empty, so recall stays 1.0 exactly
-                // as before — the unlabeled / missed-only paths are bit-identical.
+                // user wants kept). Both want an accepted center INSIDE the box, so they share the recall term. The
+                // union is folded here; ComputeLabelScores does box-containment. Precision still depends only on
+                // ShouldReject. When neither list has entries the union is empty, so recall stays 1.0 exactly as before
+                // — the unlabeled / missed-only paths are bit-identical.
                 var recallTargets = UnionTargets(label.Missed, label.WronglyRejected);
-                var (recall, precision) = OptimizationObjective.ComputeLabelScores(accepted, recallTargets, label.ShouldReject, label.RadiusPx);
+                var (recall, precision) = OptimizationObjective.ComputeLabelScores(accepted, recallTargets, label.ShouldReject);
                 recallSum += recall;
                 precisionSum += precision;
                 scored++;
@@ -590,12 +616,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         }
 
         /// <summary>
-        /// Concatenates the two recall-target lists (missed ∪ wrongly-rejected) into a single list. Returns the
+        /// Concatenates the two recall-target box lists (missed ∪ wrongly-rejected) into a single list. Returns the
         /// other list as-is when one is null/empty (so the common missed-only / wrongly-only cases allocate nothing
         /// extra and stay bit-identical to the prior single-list behavior). Returns null only when both are empty.
         /// </summary>
-        private static IReadOnlyList<(double X, double Y)> UnionTargets(
-            IReadOnlyList<(double X, double Y)> a, IReadOnlyList<(double X, double Y)> b) {
+        private static IReadOnlyList<LabelBox> UnionTargets(
+            IReadOnlyList<LabelBox> a, IReadOnlyList<LabelBox> b) {
             var aEmpty = a == null || a.Count == 0;
             var bEmpty = b == null || b.Count == 0;
             if (aEmpty && bEmpty) {
@@ -607,7 +633,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             if (aEmpty) {
                 return b;
             }
-            var union = new List<(double X, double Y)>(a.Count + b.Count);
+            var union = new List<LabelBox>(a.Count + b.Count);
             union.AddRange(a);
             union.AddRange(b);
             return union;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationData.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationData.cs
@@ -1,0 +1,284 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NINA.WPF.Base.ViewModel.AutoFocus;
+using OxyPlot.Series;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
+
+    /// <summary>
+    /// A normalized, lightweight per-frame detection result the evaluator's detect delegate returns. It is the
+    /// only thing the evaluator needs from detection (HFR, σ, accepted-star count, and — for labels — the
+    /// accepted-star centers), so the evaluator stays decoupled from the concrete detection result type.
+    /// </summary>
+    public sealed class FrameDetectionResult {
+        public double AverageHFR { get; set; }
+        public double HFRStdDev { get; set; }
+        public int StarCount { get; set; }
+
+        /// <summary>Accepted-star centers (image pixel coords), used only for label recall/precision.</summary>
+        public IReadOnlyList<(double X, double Y)> StarCenters { get; set; }
+    }
+
+    /// <summary>
+    /// One auto-focus frame: a stable id for logging, its focuser position, and an opaque image payload that the
+    /// detect delegate knows how to consume (an <c>IRenderedImage</c> in the wizard, a float <c>Mat</c> in the
+    /// offline harness). Keeping the payload as <see cref="object"/> is what lets the same evaluator serve both.
+    /// </summary>
+    public sealed class RunFrame {
+        public string FrameId { get; set; }
+        public int FocuserPosition { get; set; }
+        public object Image { get; set; }
+    }
+
+    /// <summary>
+    /// Optional ground-truth labels for one focuser position, used to score recall/precision. Plumbed now (T3),
+    /// consumed by the labeling workflow (T7); when no labels are supplied the run scores label-agnostically.
+    /// </summary>
+    public sealed class FrameLabels {
+        public int FocuserPosition { get; set; }
+
+        /// <summary>Stars that SHOULD have been detected (recovered when an accepted center lands within radius).</summary>
+        public IReadOnlyList<(double X, double Y)> Missed { get; set; }
+
+        /// <summary>Stars that SHOULD have been rejected (correctly excluded when NO accepted center is within radius).</summary>
+        public IReadOnlyList<(double X, double Y)> ShouldReject { get; set; }
+
+        public double RadiusPx { get; set; }
+    }
+
+    /// <summary>
+    /// The auto-focus curve-fit configuration for a run, taken from the run's <c>AutoFocusEngineOptions</c> so the
+    /// optimizer's fit matches the AF engine's fit exactly.
+    /// </summary>
+    public struct RunFitConfig {
+        public int StepSize { get; set; }
+        public bool UseWeights { get; set; }
+        public int MaxOutlierRejections { get; set; }
+        public double RejectionConfidence { get; set; }
+
+        /// <summary>The user's preferred model. Currently informational: the evaluator always runs the Hybrid
+        /// "best fit" selection (mirroring the AF engine) regardless, so the winning model competes on merit.</summary>
+        // Reserved: not yet honored — SelectBestModel currently chooses the best model per fit.
+        public HyperbolicFitModel? PreferredModel { get; set; }
+    }
+
+    /// <summary>
+    /// The fitted outcome of evaluating one candidate params bundle against one run: the <see cref="Metrics"/>
+    /// the objective consumes, plus the winning <see cref="BestFit"/> (so the step-size recommender can use it)
+    /// and a couple of pooling diagnostics for tests/diagnostics.
+    /// </summary>
+    public sealed class RunEvaluationResult {
+        public RunEvaluationMetrics Metrics { get; set; }
+        public AlglibHyperbolicFitting BestFit { get; set; }
+
+        /// <summary>Number of DISTINCT focuser positions that fed the fit (frames at the same position are pooled).</summary>
+        public int PooledPointCount { get; set; }
+
+        /// <summary>The pooled (mean) HFR at each distinct focuser position; for assertions/diagnostics.</summary>
+        public IReadOnlyDictionary<int, double> PooledHfrByPosition { get; set; }
+
+        public double PooledHfrAt(int focuserPosition) => PooledHfrByPosition[focuserPosition];
+    }
+
+    /// <summary>
+    /// Holds one auto-focus run as loaded-once frames + an injected detection delegate + the AF fit config, and
+    /// evaluates a candidate <see cref="StarDetectorParams"/> into a <see cref="RunEvaluationMetrics"/> (run
+    /// detection on every frame, pool frames sharing a focuser position, fit the AF curve, read σ(focus)/R²/χ²,
+    /// and — when labels exist — recall/precision).
+    ///
+    /// <para>This type is image-source-agnostic: the frame payload is opaque (<see cref="RunFrame.Image"/> is an
+    /// <see cref="object"/>) and detection is an injected delegate, so the same evaluator drives the live wizard
+    /// (IRenderedImage) and the offline harness (Mat) unchanged.</para>
+    ///
+    /// <para>No per-frame detection cache is kept on purpose: the optimizer already memoizes J at the params
+    /// level (one evaluator call per distinct params via <see cref="StarDetector.ComputeCacheKey"/>), so caching
+    /// per frame here would be redundant and would pin many star lists in memory.</para>
+    /// </summary>
+    public sealed class RunEvaluationData {
+        // A hyperbola has 4-5 parameters; fewer than this many distinct positions can never determine a fit.
+        private const int MinPositionsForFit = 3;
+
+        private readonly IReadOnlyList<RunFrame> frames;
+        private readonly Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> detect;
+        private readonly IAlglibAPI alglibAPI;
+        private readonly RunFitConfig fitConfig;
+        private readonly IReadOnlyList<FrameLabels> labels;
+
+        public string RunId { get; }
+
+        public RunEvaluationData(
+            string runId,
+            IReadOnlyList<RunFrame> frames,
+            Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> detect,
+            IAlglibAPI alglibAPI,
+            RunFitConfig fitConfig,
+            IReadOnlyList<FrameLabels> labels = null) {
+            RunId = runId;
+            this.frames = frames ?? throw new ArgumentNullException(nameof(frames));
+            this.detect = detect ?? throw new ArgumentNullException(nameof(detect));
+            this.alglibAPI = alglibAPI ?? throw new ArgumentNullException(nameof(alglibAPI));
+            this.fitConfig = fitConfig;
+            this.labels = labels;
+        }
+
+        /// <summary>
+        /// Evaluates a candidate params bundle into the metrics the objective consumes. Delegates to
+        /// <see cref="EvaluateAndFitAsync"/> and returns only its <see cref="RunEvaluationResult.Metrics"/>.
+        /// </summary>
+        public async Task<RunEvaluationMetrics> EvaluateAsync(StarDetectorParams p, CancellationToken token) {
+            var result = await EvaluateAndFitAsync(p, token).ConfigureAwait(false);
+            return result.Metrics;
+        }
+
+        /// <summary>
+        /// The full evaluation: detect every frame (deterministic order), pool frames at the same focuser
+        /// position into one scatter point, fit the AF curve, and assemble the metrics (+ keep the winning fit
+        /// for the step-size recommender). Never throws on a degenerate run — too few points produce NaN σ so the
+        /// objective hard-fails gracefully.
+        /// </summary>
+        public async Task<RunEvaluationResult> EvaluateAndFitAsync(StarDetectorParams p, CancellationToken token) {
+            // 1. Detect every frame in a fixed, deterministic order; collect per-frame results.
+            var frameStarCounts = new List<int>(frames.Count);
+            var perFrame = new List<(int FocuserPosition, FrameDetectionResult Detection)>(frames.Count);
+            foreach (var frame in frames) {
+                token.ThrowIfCancellationRequested();
+                var detection = await detect(frame.Image, p, token).ConfigureAwait(false);
+                frameStarCounts.Add(detection.StarCount);
+                perFrame.Add((frame.FocuserPosition, detection));
+            }
+
+            // 2. Pool frames sharing a focuser position using the SAME semantics as the AF engine's
+            //    AverageMeasurement(): mean of the per-frame measures and SEM-pooled σ (RMS of valid per-frame σs
+            //    divided by sqrt(count of contributing frames)). Iterating in ascending focuser position keeps the
+            //    fit input order deterministic.
+            var byPosition = new SortedDictionary<int, List<MeasureAndError>>();
+            foreach (var (pos, detection) in perFrame) {
+                if (!byPosition.TryGetValue(pos, out var measures)) {
+                    measures = new List<MeasureAndError>();
+                    byPosition.Add(pos, measures);
+                }
+                measures.Add(new MeasureAndError { Measure = detection.AverageHFR, Stdev = detection.HFRStdDev });
+            }
+
+            var points = new List<ScatterErrorPoint>(byPosition.Count);
+            var pooledHfr = new Dictionary<int, double>(byPosition.Count);
+            foreach (var kvp in byPosition) {
+                var pooled = kvp.Value.AverageMeasurement();
+                pooledHfr[kvp.Key] = pooled.Measure;
+                points.Add(new ScatterErrorPoint(kvp.Key, pooled.Measure, 0, SafeDisplayError(pooled.Stdev)));
+            }
+
+            // 3. Fit (or degrade gracefully when there are too few distinct positions).
+            var metrics = new RunEvaluationMetrics {
+                SigmaFocus = double.NaN,
+                LooStdError = double.NaN,
+                StepSize = fitConfig.StepSize,
+                RSquared = 0.0,
+                ReducedChiSquared = double.NaN,
+                FrameStarCounts = frameStarCounts
+            };
+            AlglibHyperbolicFitting bestFit = null;
+
+            if (points.Count >= MinPositionsForFit) {
+                var winningModel = AlglibHyperbolicFitting.SelectBestModel(
+                    alglibAPI, points, fitConfig.StepSize, fitConfig.UseWeights,
+                    fitConfig.MaxOutlierRejections, fitConfig.RejectionConfidence,
+                    out bestFit, out _);
+
+                if (bestFit != null) {
+                    metrics.SigmaFocus = bestFit.MinimumStdError;
+                    metrics.RSquared = bestFit.RSquared;
+                    metrics.ReducedChiSquared = bestFit.ReducedChiSquared;
+
+                    // Only pay for the leave-one-out fallback when the parametric σ is unusable (matches the
+                    // objective, which prefers SigmaFocus and only falls back to LooStdError).
+                    if (double.IsNaN(metrics.SigmaFocus) || double.IsInfinity(metrics.SigmaFocus)) {
+                        metrics.LooStdError = AlglibHyperbolicFitting.ComputeLeaveOneOutBestFocusStdError(
+                            alglibAPI, winningModel, points, fitConfig.StepSize, fitConfig.UseWeights);
+                    }
+                }
+            }
+
+            // 4. Labels (only when supplied): recall/precision per labeled position, averaged across them.
+            ApplyLabelScores(metrics, perFrame);
+
+            return new RunEvaluationResult {
+                Metrics = metrics,
+                BestFit = bestFit,
+                PooledPointCount = points.Count,
+                PooledHfrByPosition = pooledHfr
+            };
+        }
+
+        private void ApplyLabelScores(RunEvaluationMetrics metrics, List<(int FocuserPosition, FrameDetectionResult Detection)> perFrame) {
+            if (labels == null || labels.Count == 0) {
+                return;
+            }
+
+            double recallSum = 0.0, precisionSum = 0.0;
+            var scored = 0;
+            foreach (var label in labels) {
+                // Accepted centers at this labeled position: union across every frame sampled there.
+                var accepted = perFrame
+                    .Where(f => f.FocuserPosition == label.FocuserPosition)
+                    .SelectMany(f => f.Detection.StarCenters ?? Array.Empty<(double X, double Y)>())
+                    .ToList();
+                var (recall, precision) = OptimizationObjective.ComputeLabelScores(accepted, label.Missed, label.ShouldReject, label.RadiusPx);
+                recallSum += recall;
+                precisionSum += precision;
+                scored++;
+            }
+
+            if (scored > 0) {
+                metrics.Recall = recallSum / scored;
+                metrics.Precision = precisionSum / scored;
+            }
+        }
+
+        /// <summary>
+        /// Builds the optimizer's evaluator delegate from N runs: evaluates each run in the given (deterministic)
+        /// order and returns one <see cref="RunEvaluationMetrics"/> per run, ready to feed
+        /// <see cref="StarDetectionOptimizer.OptimizeAsync"/>.
+        /// </summary>
+        public static Func<StarDetectorParams, CancellationToken, Task<IReadOnlyList<RunEvaluationMetrics>>> CreateEvaluator(
+            IReadOnlyList<RunEvaluationData> runs) {
+            if (runs == null) {
+                throw new ArgumentNullException(nameof(runs));
+            }
+            return async (p, token) => {
+                var results = new List<RunEvaluationMetrics>(runs.Count);
+                foreach (var run in runs) {
+                    token.ThrowIfCancellationRequested();
+                    results.Add(await run.EvaluateAsync(p, token).ConfigureAwait(false));
+                }
+                return results;
+            };
+        }
+
+        /// <summary>
+        /// σ for the fit's display/weight layer: keep a finite, non-negative value; non-finite σ (NaN/±Inf) and
+        /// negatives map to 0 = "no error bar". Mirrors <c>AutoFocusEngine.SafeDisplayError</c> so the fit inputs
+        /// here are identical to the ones the AF engine produces.
+        /// </summary>
+        private static double SafeDisplayError(double stdev) {
+            return double.IsFinite(stdev) ? Math.Max(0.0, stdev) : 0.0;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationLoader.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationLoader.cs
@@ -135,22 +135,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 PreferredModel = afOptions.HyperbolicFitModel
             };
 
-            Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> detect =
-                async (image, candidateParams, ct) => {
-                    var result = await detection.Detect((IRenderedImage)image, hocusParams, candidateParams, null, ct).ConfigureAwait(false);
-                    var centers = result.StarList == null
-                        ? (IReadOnlyList<(double X, double Y)>)Array.Empty<(double X, double Y)>()
-                        : result.StarList.Select(s => ((double)s.Position.X, (double)s.Position.Y)).ToList();
-                    return new FrameDetectionResult {
-                        AverageHFR = result.AverageHFR,
-                        HFRStdDev = result.HFRStdDev,
-                        StarCount = result.DetectedStars,
-                        StarCenters = centers
-                    };
-                };
+            // Split detector: caches the expensive early detection per (frame, early key) and reuses it across the
+            // many candidate evaluations that change only late-stage gate params (the ~2× optimizer speedup). The
+            // mapping to FrameDetectionResult is identical to the legacy monolithic delegate, so results are
+            // unchanged — only the early stage is skipped on a late-only move.
+            var splitDetector = new HocusFocusSplitFrameDetector(detection, hocusParams);
 
             var runId = attempt.FolderPath ?? attemptFolderPath;
-            var data = new RunEvaluationData(runId, frames, detect, alglibAPI, fitConfig);
+            var data = new RunEvaluationData(runId, frames, splitDetector, alglibAPI, fitConfig);
 
             Logger.Info($"Loaded saved AF run '{runId}' for optimization: {frames.Count} frames, step size {fitConfig.StepSize}");
             return new LoadedRun {
@@ -174,6 +166,41 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
             var prepareParameters = new PrepareImageParameters(autoStretch: autoStretch, detectStars: false);
             return await imagingMediator.PrepareImage(imageData, prepareParameters, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Drives the real HocusFocus detector in two phases so the optimizer can cache the expensive early stage.
+        /// The frame payload is the loaded <see cref="IRenderedImage"/>; the opaque context is a
+        /// <see cref="HocusFocusDetectionContext"/>. The <see cref="FrameDetectionResult"/> mapping is identical to
+        /// the legacy monolithic delegate (HFR, σ, accepted-star count + centers), so results are unchanged.
+        /// </summary>
+        private sealed class HocusFocusSplitFrameDetector : RunEvaluationData.ISplitFrameDetector {
+            private readonly IHocusFocusStarDetection detection;
+            private readonly HocusFocusDetectionParams hocusParams;
+
+            public HocusFocusSplitFrameDetector(IHocusFocusStarDetection detection, HocusFocusDetectionParams hocusParams) {
+                this.detection = detection;
+                this.hocusParams = hocusParams;
+            }
+
+            public string ComputeEarlyKey(StarDetectorParams p) => detection.ComputeEarlyCacheKey(p);
+
+            public async Task<IDisposable> BuildContextAsync(object frameImage, StarDetectorParams p, CancellationToken token) {
+                return await detection.BuildDetectionContext((IRenderedImage)frameImage, hocusParams, p, null, token).ConfigureAwait(false);
+            }
+
+            public FrameDetectionResult GateAndMeasure(IDisposable context, StarDetectorParams p) {
+                var result = detection.GateAndMeasure((HocusFocusDetectionContext)context, p, CancellationToken.None);
+                var centers = result.StarList == null
+                    ? (IReadOnlyList<(double X, double Y)>)Array.Empty<(double X, double Y)>()
+                    : result.StarList.Select(s => ((double)s.Position.X, (double)s.Position.Y)).ToList();
+                return new FrameDetectionResult {
+                    AverageHFR = result.AverageHFR,
+                    HFRStdDev = result.HFRStdDev,
+                    StarCount = result.DetectedStars,
+                    StarCenters = centers
+                };
+            }
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationLoader.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationLoader.cs
@@ -1,0 +1,169 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Enum;
+using NINA.Core.Utility;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Image.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NINA.Profile.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Logger = NINA.Core.Utility.Logger;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
+
+    /// <summary>
+    /// A loaded auto-focus run ready for optimization: the <see cref="Data"/> the optimizer evaluates, the
+    /// <see cref="Seed"/> params the search starts from (the AF-base params for the first frame, carrying
+    /// PixelScale + Region + ModelPSF=false), and the run's <see cref="AfOptions"/> (for the current step size).
+    /// </summary>
+    public sealed class LoadedRun {
+        public RunEvaluationData Data { get; set; }
+        public StarDetectorParams Seed { get; set; }
+        public AutoFocusEngineOptions AfOptions { get; set; }
+    }
+
+    /// <summary>
+    /// Wizard-side loader: turns a saved auto-focus attempt folder into a <see cref="RunEvaluationData"/> the
+    /// optimizer can evaluate. Unlike the pure optimizer (T2) and the image-source-agnostic
+    /// <see cref="RunEvaluationData"/> (T3 core), this is intentionally NINA-coupled — it loads exposures via the
+    /// image-data factory + imaging mediator (mirroring <c>InspectorVM.LoadSavedFile</c>) and runs the real
+    /// HocusFocus star detector. Its end-to-end path is exercised in T6 against a real AF run folder; the unit
+    /// tests cover only construction/argument validation.
+    /// </summary>
+    public sealed class RunEvaluationLoader {
+        private readonly IProfileService profileService;
+        private readonly IImageDataFactory imageDataFactory;
+        private readonly IImagingMediator imagingMediator;
+        private readonly IAutoFocusEngine autoFocusEngine;
+        private readonly IHocusFocusStarDetection detection;
+        private readonly IAlglibAPI alglibAPI;
+
+        public RunEvaluationLoader(
+            IProfileService profileService,
+            IImageDataFactory imageDataFactory,
+            IImagingMediator imagingMediator,
+            IAutoFocusEngine autoFocusEngine,
+            IHocusFocusStarDetection detection,
+            IAlglibAPI alglibAPI = null) {
+            this.profileService = profileService ?? throw new ArgumentNullException(nameof(profileService));
+            this.imageDataFactory = imageDataFactory ?? throw new ArgumentNullException(nameof(imageDataFactory));
+            this.imagingMediator = imagingMediator ?? throw new ArgumentNullException(nameof(imagingMediator));
+            this.autoFocusEngine = autoFocusEngine ?? throw new ArgumentNullException(nameof(autoFocusEngine));
+            this.detection = detection ?? throw new ArgumentNullException(nameof(detection));
+            // The plugin singleton is the production source; allow null here only so the dependency is overridable.
+            this.alglibAPI = alglibAPI ?? HocusFocusPlugin.AlglibAPI;
+        }
+
+        /// <summary>
+        /// Loads the saved attempt at <paramref name="attemptFolderPath"/> into a <see cref="LoadedRun"/>:
+        /// every saved exposure is rendered once (detectStars: false), the AF-base detector params for the first
+        /// image become the optimizer seed, and the detection delegate re-runs the HocusFocus detector with each
+        /// candidate params on the already-loaded frames. The fit config is taken from the run's AF options so the
+        /// optimizer's curve fit matches the AF engine's.
+        /// </summary>
+        public async Task<LoadedRun> LoadSavedRunAsync(string attemptFolderPath, StarDetectionRegion region, CancellationToken token) {
+            if (string.IsNullOrEmpty(attemptFolderPath)) {
+                throw new ArgumentException("attemptFolderPath is required", nameof(attemptFolderPath));
+            }
+            region = region ?? StarDetectionRegion.Full;
+
+            var attempt = autoFocusEngine.LoadSavedAutoFocusAttempt(attemptFolderPath);
+            var afOptions = autoFocusEngine.GetOptions(attempt);
+
+            if (attempt.SavedImages == null || attempt.SavedImages.Count == 0) {
+                throw new InvalidOperationException($"No saved images found in {attemptFolderPath}");
+            }
+
+            // Render every saved exposure once (detectStars: false, mirroring InspectorVM.LoadSavedFile).
+            var frames = new List<RunFrame>(attempt.SavedImages.Count);
+            IRenderedImage firstImage = null;
+            foreach (var savedImage in attempt.SavedImages) {
+                token.ThrowIfCancellationRequested();
+                var rendered = await LoadRenderedImageAsync(savedImage, afOptions, token).ConfigureAwait(false);
+                if (firstImage == null) {
+                    firstImage = rendered;
+                }
+                frames.Add(new RunFrame {
+                    FrameId = savedImage.Path,
+                    FocuserPosition = savedImage.FocuserPosition,
+                    Image = rendered
+                });
+            }
+
+            // Seed = AF-base detector params for the first image (PixelScale + Region + ModelPSF=false). This is
+            // the bundle the optimizer starts from and tunes.
+            var seed = detection.GetStarDetectorParams(firstImage, region, isAutoFocus: true);
+
+            // AF detection params: the auto-focus detection contract (sigma rejections + AF flag). NumberOfAFStars
+            // is left at 0 so detection keeps every accepted star — the optimizer scores on the full accepted set,
+            // not the brightest-N subset the live AF picks for centroiding.
+            var hocusParams = new HocusFocusDetectionParams {
+                IsAutoFocus = true,
+                NumberOfAFStars = 0
+            };
+
+            var fitConfig = new RunFitConfig {
+                StepSize = afOptions.AutoFocusStepSize,
+                UseWeights = afOptions.WeightedHyperbolicFitEnabled,
+                MaxOutlierRejections = afOptions.MaxOutlierRejections,
+                RejectionConfidence = afOptions.OutlierRejectionConfidence,
+                PreferredModel = afOptions.HyperbolicFitModel
+            };
+
+            Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> detect =
+                async (image, candidateParams, ct) => {
+                    var result = await detection.Detect((IRenderedImage)image, hocusParams, candidateParams, null, ct).ConfigureAwait(false);
+                    var centers = result.StarList == null
+                        ? (IReadOnlyList<(double X, double Y)>)Array.Empty<(double X, double Y)>()
+                        : result.StarList.Select(s => ((double)s.Position.X, (double)s.Position.Y)).ToList();
+                    return new FrameDetectionResult {
+                        AverageHFR = result.AverageHFR,
+                        HFRStdDev = result.HFRStdDev,
+                        StarCount = result.DetectedStars,
+                        StarCenters = centers
+                    };
+                };
+
+            var runId = attempt.FolderPath ?? attemptFolderPath;
+            var data = new RunEvaluationData(runId, frames, detect, alglibAPI, fitConfig);
+
+            Logger.Info($"Loaded saved AF run '{runId}' for optimization: {frames.Count} frames, step size {fitConfig.StepSize}");
+            return new LoadedRun {
+                Data = data,
+                Seed = seed,
+                AfOptions = afOptions
+            };
+        }
+
+        private async Task<IRenderedImage> LoadRenderedImageAsync(SavedAutoFocusImage savedImage, AutoFocusEngineOptions afOptions, CancellationToken token) {
+            var imageData = await imageDataFactory.CreateFromFile(
+                savedImage.Path, savedImage.BitDepth, savedImage.IsBayered,
+                profileService.ActiveProfile.CameraSettings.RawConverter, token).ConfigureAwait(false);
+
+            // Auto-stretch unless contrast-detection statistics are in play (mirrors InspectorVM.LoadSavedFile).
+            var autoStretch = true;
+            if (afOptions.AutoFocusMethod == AFMethodEnum.CONTRASTDETECTION
+                && profileService.ActiveProfile.FocuserSettings.ContrastDetectionMethod == ContrastDetectionMethodEnum.Statistics) {
+                autoStretch = false;
+            }
+
+            var prepareParameters = new PrepareImageParameters(autoStretch: autoStretch, detectStars: false);
+            return await imagingMediator.PrepareImage(imageData, prepareParameters, token).ConfigureAwait(false);
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationLoader.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationLoader.cs
@@ -38,6 +38,16 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
     }
 
     /// <summary>
+    /// Loads a saved auto-focus attempt folder into a <see cref="LoadedRun"/> the optimizer can evaluate.
+    /// Extracted so the wizard VM can be unit-tested against a fake loader (the concrete
+    /// <see cref="RunEvaluationLoader"/> is heavily NINA-coupled).
+    /// </summary>
+    public interface IRunEvaluationLoader {
+
+        Task<LoadedRun> LoadSavedRunAsync(string attemptFolderPath, StarDetectionRegion region, CancellationToken token);
+    }
+
+    /// <summary>
     /// Wizard-side loader: turns a saved auto-focus attempt folder into a <see cref="RunEvaluationData"/> the
     /// optimizer can evaluate. Unlike the pure optimizer (T2) and the image-source-agnostic
     /// <see cref="RunEvaluationData"/> (T3 core), this is intentionally NINA-coupled — it loads exposures via the
@@ -45,7 +55,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
     /// HocusFocus star detector. Its end-to-end path is exercised in T6 against a real AF run folder; the unit
     /// tests cover only construction/argument validation.
     /// </summary>
-    public sealed class RunEvaluationLoader {
+    public sealed class RunEvaluationLoader : IRunEvaluationLoader {
         private readonly IProfileService profileService;
         private readonly IImageDataFactory imageDataFactory;
         private readonly IImagingMediator imagingMediator;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizer.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizer.cs
@@ -1,0 +1,396 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
+
+    /// <summary>Tuning knobs for the search engine (not the objective — those live in <see cref="ObjectiveConstants"/>).</summary>
+    public sealed class OptimizerSettings {
+        /// <summary>Hard cap on evaluator invocations (cache misses). The search never exceeds this.</summary>
+        public int MaxEvaluations { get; set; } = 400;
+
+        /// <summary>Number of grid levels per axis in the Phase-A coarse seed (over the 2 highest-impact axes).</summary>
+        public int CoarseGridLevels { get; set; } = 4;
+
+        /// <summary>
+        /// Phase-B stops halving a Continuous variable's step once it drops below InitialStep × this fraction.
+        /// </summary>
+        public double StepFloorFraction { get; set; } = 0.125;
+    }
+
+    /// <summary>Progress payload emitted during <see cref="StarDetectionOptimizer.OptimizeAsync"/>.</summary>
+    public sealed class OptimizationProgress {
+        public int Evaluations { get; set; }
+        public int MaxEvaluations { get; set; }
+        public double BestJ { get; set; }
+        public double SeedJ { get; set; }
+        public string Phase { get; set; }
+    }
+
+    /// <summary>Outcome of an optimization run.</summary>
+    public sealed class OptimizationResult {
+        public StarDetectorParams BestParams { get; set; }
+        public double BestJ { get; set; }
+        public double SeedJ { get; set; }
+        public int Evaluations { get; set; }
+        public bool ImprovedOverSeed { get; set; }
+        public IReadOnlyList<(string Name, double SeedValue, double BestValue)> ChangedVariables { get; set; }
+    }
+
+    /// <summary>
+    /// A pure, derivative-free optimizer over star-detection parameters. It depends only on an INJECTED
+    /// evaluator delegate (params → per-run metrics); it never loads images, runs detection, or touches WPF.
+    /// The search is fully deterministic (no RNG, fixed evaluation order) and memoized on
+    /// <see cref="StarDetector.ComputeCacheKey"/> so revisited points never re-invoke the evaluator.
+    ///
+    /// Strategy:
+    ///   Phase A — a coarse grid over the two highest-impact axes (Sensitivity × StarClippingMultiplier).
+    ///   Phase B — a compass/pattern search: from the incumbent, try ±step on every variable, accept the single
+    ///             best strictly-improving move; when a sweep finds none, halve every Continuous step; stop when
+    ///             all Continuous steps fall below their floor (or the eval budget is exhausted).
+    /// Because the seed is the initial incumbent and only strictly-improving moves are accepted, the result can
+    /// never be worse than the seed.
+    /// </summary>
+    public sealed class StarDetectionOptimizer {
+        private readonly ObjectiveConstants constants;
+
+        public StarDetectionOptimizer(ObjectiveConstants constants = null) {
+            this.constants = constants ?? new ObjectiveConstants();
+        }
+
+        public async Task<OptimizationResult> OptimizeAsync(
+            StarDetectorParams seed,
+            IReadOnlyList<OptimizerVariable> variables,
+            Func<StarDetectorParams, CancellationToken, Task<IReadOnlyList<RunEvaluationMetrics>>> evaluator,
+            OptimizerSettings settings,
+            IProgress<OptimizationProgress> progress,
+            CancellationToken token) {
+            if (seed == null) {
+                throw new ArgumentNullException(nameof(seed));
+            }
+            if (variables == null || variables.Count == 0) {
+                throw new ArgumentException("At least one variable is required", nameof(variables));
+            }
+            if (evaluator == null) {
+                throw new ArgumentNullException(nameof(evaluator));
+            }
+            settings = settings ?? new OptimizerSettings();
+
+            var ctx = new SearchContext(this, seed, variables, evaluator, settings, progress, token);
+
+            // θ0 = read each variable from the seed.
+            var theta0 = new double[variables.Count];
+            for (var i = 0; i < variables.Count; i++) {
+                theta0[i] = variables[i].Quantize(variables[i].Read(seed));
+            }
+
+            // Seed evaluation; this is the initial incumbent and the never-regress floor.
+            var seedJ = await ctx.EvalJ(theta0).ConfigureAwait(false);
+            var bestTheta = (double[])theta0.Clone();
+            var bestJ = seedJ;
+
+            ctx.Report("Seed", bestJ, seedJ);
+
+            // Phase A — coarse grid over the two highest-impact axes.
+            (bestTheta, bestJ) = await ctx.CoarseGrid(bestTheta, bestJ, seedJ).ConfigureAwait(false);
+
+            // Phase B — compass/pattern search.
+            (bestTheta, bestJ) = await ctx.PatternSearch(bestTheta, bestJ, seedJ).ConfigureAwait(false);
+
+            // Materialize the winning params.
+            var bestParams = ctx.Materialize(bestTheta);
+
+            // ChangedVariables: seed vs best, only where they differ.
+            var changed = new List<(string Name, double SeedValue, double BestValue)>();
+            for (var i = 0; i < variables.Count; i++) {
+                if (theta0[i] != bestTheta[i]) {
+                    changed.Add((variables[i].Name, theta0[i], bestTheta[i]));
+                }
+            }
+
+            return new OptimizationResult {
+                BestParams = bestParams,
+                BestJ = bestJ,
+                SeedJ = seedJ,
+                Evaluations = ctx.Evaluations,
+                ImprovedOverSeed = bestJ > seedJ,
+                ChangedVariables = changed
+            };
+        }
+
+        /// <summary>
+        /// Holds all mutable search state (memo, eval counter) plus the immutable inputs, so the search phases
+        /// read as small deterministic methods.
+        /// </summary>
+        private sealed class SearchContext {
+            // Fixed compass directions tried for every variable each sweep: + then −, deterministic order.
+            private static readonly double[] Directions = { +1.0, -1.0 };
+
+            private readonly StarDetectionOptimizer owner;
+            private readonly StarDetectorParams seed;
+            private readonly IReadOnlyList<OptimizerVariable> variables;
+            private readonly Func<StarDetectorParams, CancellationToken, Task<IReadOnlyList<RunEvaluationMetrics>>> evaluator;
+            private readonly OptimizerSettings settings;
+            private readonly IProgress<OptimizationProgress> progress;
+            private readonly CancellationToken token;
+            private readonly Dictionary<string, double> memo = new Dictionary<string, double>(StringComparer.Ordinal);
+
+            public int Evaluations { get; private set; }
+
+            public SearchContext(
+                StarDetectionOptimizer owner,
+                StarDetectorParams seed,
+                IReadOnlyList<OptimizerVariable> variables,
+                Func<StarDetectorParams, CancellationToken, Task<IReadOnlyList<RunEvaluationMetrics>>> evaluator,
+                OptimizerSettings settings,
+                IProgress<OptimizationProgress> progress,
+                CancellationToken token) {
+                this.owner = owner;
+                this.seed = seed;
+                this.variables = variables;
+                this.evaluator = evaluator;
+                this.settings = settings;
+                this.progress = progress;
+                this.token = token;
+            }
+
+            /// <summary>Clones the seed and writes the candidate vector through each variable's Write.</summary>
+            public StarDetectorParams Materialize(double[] theta) {
+                var p = seed.Clone();
+                for (var i = 0; i < variables.Count; i++) {
+                    variables[i].Write(p, theta[i]);
+                }
+                return p;
+            }
+
+            /// <summary>
+            /// Memoized objective. Materializes params, keys on <see cref="StarDetector.ComputeCacheKey"/>, and
+            /// only invokes the evaluator on a cache MISS (incrementing the eval counter then). J is the
+            /// multi-run aggregate <see cref="OptimizationObjective.JTotal"/> over per-run J. Honors cancellation.
+            /// </summary>
+            public async Task<double> EvalJ(double[] theta) {
+                token.ThrowIfCancellationRequested();
+                var p = Materialize(theta);
+                var key = StarDetector.ComputeCacheKey(p);
+                if (memo.TryGetValue(key, out var cached)) {
+                    return cached;
+                }
+
+                var runMetrics = await evaluator(p, token).ConfigureAwait(false);
+                Evaluations++;
+
+                double j;
+                if (runMetrics == null || runMetrics.Count == 0) {
+                    j = 0.0;
+                } else {
+                    var perRunJ = runMetrics
+                        .Select(m => OptimizationObjective.JRun(m, owner.constants))
+                        .ToList();
+                    j = OptimizationObjective.JTotal(perRunJ, owner.constants);
+                }
+
+                memo[key] = j;
+                return j;
+            }
+
+            /// <summary>True once the eval budget is spent. We never start an evaluation past the cap.</summary>
+            public bool BudgetExhausted => Evaluations >= settings.MaxEvaluations;
+
+            public void Report(string phase, double bestJ, double seedJ) {
+                progress?.Report(new OptimizationProgress {
+                    Evaluations = Evaluations,
+                    MaxEvaluations = settings.MaxEvaluations,
+                    BestJ = bestJ,
+                    SeedJ = seedJ,
+                    Phase = phase
+                });
+            }
+
+            /// <summary>
+            /// Phase A. Grid over the two highest-impact axes (Sensitivity × StarClippingMultiplier) with
+            /// CoarseGridLevels evenly-spaced levels each spanning [Lower, Upper]; all other variables held at
+            /// the incumbent. Deterministic iteration order. Keeps the best strictly-improving point.
+            /// </summary>
+            public async Task<(double[] theta, double j)> CoarseGrid(double[] bestTheta, double bestJ, double seedJ) {
+                var axisA = IndexOf(nameof(StarDetectorParams.Sensitivity));
+                var axisB = IndexOf(nameof(StarDetectorParams.StarClippingMultiplier));
+                var levels = Math.Max(2, settings.CoarseGridLevels);
+
+                for (var ia = 0; ia < levels; ia++) {
+                    for (var ib = 0; ib < levels; ib++) {
+                        if (BudgetExhausted) {
+                            return (bestTheta, bestJ);
+                        }
+                        var candidate = (double[])bestTheta.Clone();
+                        if (axisA >= 0) {
+                            candidate[axisA] = variables[axisA].Quantize(GridValue(variables[axisA], ia, levels));
+                        }
+                        if (axisB >= 0) {
+                            candidate[axisB] = variables[axisB].Quantize(GridValue(variables[axisB], ib, levels));
+                        }
+                        var j = await EvalJ(candidate).ConfigureAwait(false);
+                        if (j > bestJ) {
+                            bestJ = j;
+                            bestTheta = candidate;
+                        }
+                    }
+                }
+                Report("CoarseGrid", bestJ, seedJ);
+                return (bestTheta, bestJ);
+            }
+
+            private static double GridValue(OptimizerVariable v, int level, int levels) {
+                // Evenly spaced inclusive of both bounds: level 0 => Lower, level (levels-1) => Upper.
+                var t = (double)level / (levels - 1);
+                return v.Lower + t * (v.Upper - v.Lower);
+            }
+
+            /// <summary>
+            /// Phase B. Compass/pattern search. Each sweep proposes, for every variable, +step and −step
+            /// (Integer: ±max(1, round(step)); Boolean: flip; Continuous: ±step) in a fixed order, evaluates
+            /// all of them, and takes the single best STRICTLY-improving move (ties => no move). A sweep with no
+            /// improving move halves every Continuous step. Stops when all Continuous steps fall below their
+            /// floor (InitialStep × StepFloorFraction) or the budget is exhausted.
+            /// </summary>
+            public async Task<(double[] theta, double j)> PatternSearch(double[] bestTheta, double bestJ, double seedJ) {
+                // Current per-variable step (only Continuous steps shrink).
+                var steps = new double[variables.Count];
+                for (var i = 0; i < variables.Count; i++) {
+                    steps[i] = variables[i].InitialStep;
+                }
+
+                while (!BudgetExhausted && !ContinuousStepsBelowFloor(steps)) {
+                    // Collect all candidate moves in a fixed deterministic order.
+                    double improvedJ = bestJ;
+                    double[] improvedTheta = null;
+
+                    for (var i = 0; i < variables.Count; i++) {
+                        var v = variables[i];
+                        foreach (var direction in Directions) {
+                            if (BudgetExhausted) {
+                                break;
+                            }
+                            var candidate = ProposeMove(bestTheta, i, v, steps[i], direction);
+                            if (candidate == null) {
+                                continue; // move produced no change (e.g. already at bound, or boolean no-op)
+                            }
+                            var j = await EvalJ(candidate).ConfigureAwait(false);
+                            if (j > improvedJ) {
+                                improvedJ = j;
+                                improvedTheta = candidate;
+                            }
+                        }
+                        if (BudgetExhausted) {
+                            break;
+                        }
+                    }
+
+                    if (improvedTheta != null) {
+                        // Accept the single best strictly-improving move and re-sweep from there.
+                        bestTheta = improvedTheta;
+                        bestJ = improvedJ;
+                        Report("PatternSearch", bestJ, seedJ);
+                    } else {
+                        // No improving move: refine the Continuous steps and sweep again.
+                        HalveContinuousSteps(steps);
+                    }
+                }
+                Report("PatternSearch", bestJ, seedJ);
+                return (bestTheta, bestJ);
+            }
+
+            /// <summary>
+            /// Builds a candidate vector for moving variable <paramref name="i"/> by ±step. Returns null when
+            /// the move yields no change after quantization/clamping (so it is not evaluated needlessly).
+            /// </summary>
+            private double[] ProposeMove(double[] theta, int i, OptimizerVariable v, double step, double direction) {
+                double proposed;
+                switch (v.Type) {
+                    case OptimizerVariableType.Boolean:
+                        // Flip; direction is irrelevant for a binary axis, so only +1 produces a move (the −1
+                        // branch will yield the same flipped value and be deduped by the memo, but we still
+                        // suppress it here to keep candidate sets minimal and deterministic).
+                        if (direction < 0) {
+                            return null;
+                        }
+                        proposed = theta[i] >= 0.5 ? 0.0 : 1.0;
+                        break;
+
+                    case OptimizerVariableType.Integer:
+                        var intStep = Math.Max(1.0, Math.Round(step, MidpointRounding.AwayFromZero));
+                        proposed = theta[i] + direction * intStep;
+                        break;
+
+                    default: // Continuous
+                        proposed = theta[i] + direction * step;
+                        break;
+                }
+
+                var quantized = v.Quantize(proposed);
+                if (quantized == theta[i]) {
+                    return null; // no movement
+                }
+                var candidate = (double[])theta.Clone();
+                candidate[i] = quantized;
+                return candidate;
+            }
+
+            private bool ContinuousStepsBelowFloor(double[] steps) {
+                var anyContinuous = false;
+                for (var i = 0; i < variables.Count; i++) {
+                    if (variables[i].Type != OptimizerVariableType.Continuous) {
+                        continue;
+                    }
+                    anyContinuous = true;
+                    var floor = variables[i].InitialStep * settings.StepFloorFraction;
+                    if (steps[i] >= floor) {
+                        return false; // at least one continuous step still above its floor
+                    }
+                }
+                if (!anyContinuous) {
+                    // No continuous variables at all: there is nothing to refine, so treat as "below floor" and
+                    // let the no-improving-move logic end the search. This is the critical guard — without it an
+                    // all-Integer/Boolean variable set loops forever once the discrete axes are exhausted, since
+                    // every proposed candidate is then a memo hit, Evaluations never advances, and
+                    // BudgetExhausted never trips.
+                    return true;
+                }
+                // At least one continuous variable exists and we reached here only because every continuous step
+                // has fallen below its floor — also nothing left to refine.
+                return true;
+            }
+
+            private void HalveContinuousSteps(double[] steps) {
+                for (var i = 0; i < variables.Count; i++) {
+                    if (variables[i].Type == OptimizerVariableType.Continuous) {
+                        steps[i] *= 0.5;
+                    }
+                }
+            }
+
+            private int IndexOf(string name) {
+                for (var i = 0; i < variables.Count; i++) {
+                    if (string.Equals(variables[i].Name, name, StringComparison.Ordinal)) {
+                        return i;
+                    }
+                }
+                return -1;
+            }
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -571,30 +571,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 return;
             }
 
-            var best = Result.BestParams;
-            var dto = new OptimizedStarDetectionSettings {
-                // Curated knobs — note the DTO renames a few (Sensitivity->BrightnessSensitivity etc.).
-                BrightnessSensitivity = best.Sensitivity,
-                StarClippingMultiplier = best.StarClippingMultiplier,
-                NoiseClippingMultiplier = best.NoiseClippingMultiplier,
-                StarPeakResponse = best.PeakResponse,
-                MaxDistortion = best.MaxDistortion,
-                MinHFR = best.MinHFR,
-                StarCenterTolerance = best.StarCenterTolerance,
-                StructureLayers = best.StructureLayers,
-                NoiseReductionRadius = best.NoiseReductionRadius,
-                MinStarBoundingBoxSize = best.MinimumStarBoundingBoxSize,
-                HotpixelThresholdingEnabled = best.HotpixelThresholdingEnabled,
-                HotpixelThreshold = best.HotpixelThreshold,
-
-                // Metadata (DateTime is fine here — this runs in-app, not in the headless harness).
-                CreatedAtUtc = DateTime.UtcNow,
-                RunCount = Summary.RunCount,
-                BaselineJ = Result.SeedJ,
-                FinalJ = Result.BestJ,
-                RecommendedStepSize = Summary.RecommendedStepSize,
-                RecommendedOffsetSteps = Summary.RecommendedOffsetSteps
-            };
+            // Build the snapshot via the shared params->DTO mapping (the single source of truth shared with the
+            // headless harness) so the in-app and offline paths can never drift. CreatedAtUtc is stamped inside.
+            var dto = OptimizedStarDetectionSettings.FromParams(
+                Result.BestParams, Summary.RunCount, Result.SeedJ, Result.BestJ,
+                Summary.RecommendedStepSize, Summary.RecommendedOffsetSteps);
 
             starDetectionOptions.ApplyOptimizedSettings(dto);
             Logger.Info($"Applied optimized star-detection settings (J {Result.SeedJ:F3} -> {Result.BestJ:F3}, {Summary.RunCount} run(s))");

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -339,10 +339,17 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             cts = CancellationTokenSource.CreateLinkedTokenSource(externalToken);
             var token = cts.Token;
 
+            // Each loaded run owns a disposable RunEvaluationData (the cached early-detection contexts pin the
+            // per-frame source Mats — multiple GB at 61 MP). They are consumed through seed-guard → optimize →
+            // summary, then released in the finally so the Mats are freed on success, cancel, AND error (and never
+            // accumulate across re-runs). The summary is built inside the try (step 4) BEFORE this finally runs, so
+            // nothing the summary needs is disposed early.
+            List<LoadedRun> loadedRuns = null;
             try {
-                // 1. Acquire — load every source into a LoadedRun.
+                // 1. Acquire — load every source into a LoadedRun. AcquireAsync disposes its own partial list on an
+                //    early-out/exception, so a null return has already cleaned up.
                 CurrentStep = WizardStep.Acquire;
-                var loadedRuns = await AcquireAsync(token).ConfigureAwait(true);
+                loadedRuns = await AcquireAsync(token).ConfigureAwait(true);
                 if (loadedRuns == null) {
                     return; // ErrorMessage already set, or cancelled
                 }
@@ -369,6 +376,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 ErrorMessage = $"Optimization failed: {ex.Message}";
                 CurrentStep = WizardStep.SelectSource;
             } finally {
+                // Release the cached source Mats. Safe even when AcquireAsync already disposed a partial list
+                // (RunEvaluationData.Dispose is idempotent); harmless when loadedRuns is null.
+                DisposeLoadedRuns(loadedRuns);
                 IsBusy = false;
                 Interlocked.Exchange(ref running, 0);
             }
@@ -376,33 +386,55 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
         /// <summary>Loads each configured source folder into a <see cref="LoadedRun"/>. For Live, runs a fresh AF
         /// attempt first and then loads its saved folder. Sets <see cref="ErrorMessage"/> and returns null on a
-        /// missing/invalid source.</summary>
+        /// missing/invalid source. Each loaded run owns a disposable <see cref="RunEvaluationData"/> (cached source
+        /// Mats); on any early-out (error/cancel) or exception this disposes whatever was loaded so a partial
+        /// acquisition never leaks. On full success the caller (<see cref="StartAsync"/>) owns disposing the list.</summary>
         private async Task<List<LoadedRun>> AcquireAsync(CancellationToken token) {
             var runs = new List<LoadedRun>(RunCount);
-            for (var i = 0; i < RunCount; i++) {
-                token.ThrowIfCancellationRequested();
-                string folder;
-                if (SourceMode == SourceMode.Live) {
-                    folder = await RunLiveAttemptAsync(token).ConfigureAwait(true);
-                    if (string.IsNullOrEmpty(folder)) {
-                        ErrorMessage = "The live auto-focus run did not produce a saved attempt folder.";
-                        CurrentStep = WizardStep.SelectSource;
-                        return null;
+            try {
+                for (var i = 0; i < RunCount; i++) {
+                    token.ThrowIfCancellationRequested();
+                    string folder;
+                    if (SourceMode == SourceMode.Live) {
+                        folder = await RunLiveAttemptAsync(token).ConfigureAwait(true);
+                        if (string.IsNullOrEmpty(folder)) {
+                            ErrorMessage = "The live auto-focus run did not produce a saved attempt folder.";
+                            CurrentStep = WizardStep.SelectSource;
+                            DisposeLoadedRuns(runs);
+                            return null;
+                        }
+                    } else {
+                        folder = i < SourcePaths.Count ? SourcePaths[i] : null;
+                        if (string.IsNullOrEmpty(folder)) {
+                            ErrorMessage = $"Select a saved auto-focus folder for run {i + 1}.";
+                            CurrentStep = WizardStep.SelectSource;
+                            DisposeLoadedRuns(runs);
+                            return null;
+                        }
                     }
-                } else {
-                    folder = i < SourcePaths.Count ? SourcePaths[i] : null;
-                    if (string.IsNullOrEmpty(folder)) {
-                        ErrorMessage = $"Select a saved auto-focus folder for run {i + 1}.";
-                        CurrentStep = WizardStep.SelectSource;
-                        return null;
-                    }
-                }
 
-                Phase = $"Loading run {i + 1} of {RunCount}";
-                var loaded = await loader.LoadSavedRunAsync(folder, region, token).ConfigureAwait(true);
-                runs.Add(loaded);
+                    Phase = $"Loading run {i + 1} of {RunCount}";
+                    var loaded = await loader.LoadSavedRunAsync(folder, region, token).ConfigureAwait(true);
+                    runs.Add(loaded);
+                }
+                return runs;
+            } catch {
+                // Cancellation / loader failure midway: free the runs loaded so far before propagating.
+                DisposeLoadedRuns(runs);
+                throw;
             }
-            return runs;
+        }
+
+        /// <summary>Disposes each loaded run's <see cref="RunEvaluationData"/> (the cached early-detection contexts
+        /// pinning the source Mats). Null-safe and idempotent — <see cref="RunEvaluationData.Dispose"/> guards
+        /// double-dispose, so calling this twice on the same list is harmless.</summary>
+        private static void DisposeLoadedRuns(IReadOnlyList<LoadedRun> runs) {
+            if (runs == null) {
+                return;
+            }
+            foreach (var run in runs) {
+                run?.Data?.Dispose();
+            }
         }
 
         /// <summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -1,0 +1,636 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using CommunityToolkit.Mvvm.Input;
+using NINA.Core.Utility;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Image.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NINA.Profile.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AsyncRelayCommand = CommunityToolkit.Mvvm.Input.AsyncRelayCommand;
+using Logger = NINA.Core.Utility.Logger;
+using RelayCommand = CommunityToolkit.Mvvm.Input.RelayCommand;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
+
+    /// <summary>The wizard's linear steps. The window renders a single panel keyed off <see cref="CurrentStep"/>.</summary>
+    public enum WizardStep {
+        SelectSource,
+        Acquire,
+        Optimize,
+        Summary
+    }
+
+    /// <summary>Where the run frames come from: an already-saved AF attempt (Replay) or a fresh live AF run.</summary>
+    public enum SourceMode {
+        Replay,
+        Live
+    }
+
+    /// <summary>One row of the summary's changed-parameters table (seed vs optimized for a single knob).</summary>
+    public sealed class ChangedParameterRow {
+        public string Name { get; set; }
+        public double SeedValue { get; set; }
+        public double OptimizedValue { get; set; }
+    }
+
+    /// <summary>
+    /// The fully-computed summary shown after a successful optimization: the changed-parameters table, the
+    /// before/after objective and σ(focus), and the recommended AF step size/offset.
+    /// </summary>
+    public sealed class OptimizationSummary {
+        public IReadOnlyList<ChangedParameterRow> ChangedParameters { get; set; }
+        public double SeedJ { get; set; }
+        public double BestJ { get; set; }
+        public double SeedSigmaFocus { get; set; }
+        public double BestSigmaFocus { get; set; }
+        public int RunCount { get; set; }
+        public int RecommendedStepSize { get; set; }
+        public int RecommendedOffsetSteps { get; set; }
+        public int CurrentStepSize { get; set; }
+        public bool ImprovedOverSeed { get; set; }
+    }
+
+    /// <summary>
+    /// ViewModel for the Star Detection Optimization Wizard. It is a plain <see cref="BaseINPC"/> (not a
+    /// DockableVM): T5 instantiates it on demand and shows it in a window via <c>IWindowServiceFactory</c>,
+    /// resolving the content from the keyed DataTemplate. The VM owns the four-step state machine, loads one or
+    /// more saved AF runs through an injected <see cref="IRunEvaluationLoader"/>, validates the seed fit (the
+    /// STARHFR/seed guard), runs the pure <see cref="StarDetectionOptimizer"/> off the UI thread, builds the
+    /// summary, and applies the result to <see cref="IStarDetectionOptions"/> (and optionally the profile's AF
+    /// step size) only when the user clicks Apply.
+    ///
+    /// <para>All optimizer/loader work runs off the captured UI context (via <see cref="Task.Run(Func{Task})"/>);
+    /// progress is marshaled back through <see cref="IProgress{T}"/>, which posts to the captured
+    /// <see cref="SynchronizationContext"/>.</para>
+    /// </summary>
+    public class StarDetectionOptimizerWizardVM : BaseINPC, IDisposable {
+        private readonly IProfileService profileService;
+        private readonly IStarDetectionOptions starDetectionOptions;
+        private readonly IRunEvaluationLoader loader;
+        private readonly IAutoFocusEngine autoFocusEngine;
+        private readonly Func<string> folderPicker;
+        private readonly StarDetectionRegion region;
+        private readonly OptimizerSettings optimizerSettings;
+
+        private CancellationTokenSource cts;
+        private int running; // 0 = idle, 1 = a Start is in flight (guards against double-start)
+        private bool disposed;
+
+        /// <summary>
+        /// MEF/T5 convenience constructor: wires the real collaborators from the plugin singletons + mediators.
+        /// The wizard is not MEF-exported (it is created on demand by T5's launch command), so this just supplies
+        /// production dependencies to the primary constructor.
+        /// </summary>
+        public StarDetectionOptimizerWizardVM(
+            IProfileService profileService,
+            IImageDataFactory imageDataFactory,
+            IImagingMediator imagingMediator,
+            IAutoFocusEngine autoFocusEngine,
+            IHocusFocusStarDetection detection)
+            : this(
+                profileService,
+                HocusFocusPlugin.StarDetectionOptions,
+                new RunEvaluationLoader(profileService, imageDataFactory, imagingMediator, autoFocusEngine, detection),
+                autoFocusEngine,
+                folderPicker: PickFolderViaDialog,
+                // The optimizer's detection mirrors AF detection on the full image; the loader's own default is
+                // StarDetectionRegion.Full as well. See the type doc for why Full is used.
+                region: StarDetectionRegion.Full,
+                optimizerSettings: new OptimizerSettings()) {
+        }
+
+        /// <summary>
+        /// Primary constructor (interfaces only) used by both the convenience constructor and the unit tests.
+        /// </summary>
+        public StarDetectionOptimizerWizardVM(
+            IProfileService profileService,
+            IStarDetectionOptions starDetectionOptions,
+            IRunEvaluationLoader loader,
+            IAutoFocusEngine autoFocusEngine,
+            Func<string> folderPicker,
+            StarDetectionRegion region,
+            OptimizerSettings optimizerSettings) {
+            this.profileService = profileService ?? throw new ArgumentNullException(nameof(profileService));
+            this.starDetectionOptions = starDetectionOptions ?? throw new ArgumentNullException(nameof(starDetectionOptions));
+            this.loader = loader ?? throw new ArgumentNullException(nameof(loader));
+            this.autoFocusEngine = autoFocusEngine;
+            this.folderPicker = folderPicker ?? (() => null);
+            this.region = region ?? StarDetectionRegion.Full;
+            this.optimizerSettings = optimizerSettings ?? new OptimizerSettings();
+
+            sourcePaths = new ObservableCollection<string> { null };
+            applyRecommendedStepSize = true;
+
+            BrowseSourceCommand = new RelayCommand<object>(BrowseSource);
+            StartCommand = new AsyncRelayCommand(() => StartAsync(CancellationToken.None));
+            CancelCommand = new RelayCommand(Cancel);
+            ApplyCommand = new RelayCommand(Apply, () => Summary != null);
+            BackCommand = new RelayCommand(Back, () => CurrentStep == WizardStep.Summary && !IsBusy);
+            CloseCommand = new RelayCommand(() => RequestClose?.Invoke(this, EventArgs.Empty));
+        }
+
+        /// <summary>Raised when the user clicks Close so the host window (T5) can dismiss the dialog.</summary>
+        public event EventHandler RequestClose;
+
+        #region State
+
+        private WizardStep currentStep = WizardStep.SelectSource;
+
+        public WizardStep CurrentStep {
+            get => currentStep;
+            private set {
+                if (currentStep != value) {
+                    currentStep = value;
+                    RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(IsSelectSource));
+                    RaisePropertyChanged(nameof(IsAcquire));
+                    RaisePropertyChanged(nameof(IsOptimize));
+                    RaisePropertyChanged(nameof(IsSummary));
+                    BackCommand.NotifyCanExecuteChanged();
+                }
+            }
+        }
+
+        public bool IsSelectSource => CurrentStep == WizardStep.SelectSource;
+        public bool IsAcquire => CurrentStep == WizardStep.Acquire;
+        public bool IsOptimize => CurrentStep == WizardStep.Optimize;
+        public bool IsSummary => CurrentStep == WizardStep.Summary;
+
+        private SourceMode sourceMode = SourceMode.Replay;
+
+        public SourceMode SourceMode {
+            get => sourceMode;
+            set {
+                if (sourceMode != value) {
+                    sourceMode = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private int runCount = 1;
+
+        public int RunCount {
+            get => runCount;
+            set {
+                var clamped = Math.Max(1, value);
+                if (runCount != clamped) {
+                    runCount = clamped;
+                    ResizeSourcePaths();
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private readonly ObservableCollection<string> sourcePaths;
+
+        /// <summary>One source folder per run (sized to <see cref="RunCount"/>).</summary>
+        public ObservableCollection<string> SourcePaths => sourcePaths;
+
+        private bool isBusy;
+
+        public bool IsBusy {
+            get => isBusy;
+            private set {
+                if (isBusy != value) {
+                    isBusy = value;
+                    RaisePropertyChanged();
+                    StartCommand.NotifyCanExecuteChanged();
+                    BackCommand.NotifyCanExecuteChanged();
+                }
+            }
+        }
+
+        private string errorMessage;
+
+        public string ErrorMessage {
+            get => errorMessage;
+            private set {
+                if (errorMessage != value) {
+                    errorMessage = value;
+                    RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(HasError));
+                }
+            }
+        }
+
+        public bool HasError => !string.IsNullOrEmpty(ErrorMessage);
+
+        #endregion State
+
+        #region Progress
+
+        private int evaluations;
+
+        public int Evaluations {
+            get => evaluations;
+            private set { evaluations = value; RaisePropertyChanged(); }
+        }
+
+        private int maxEvaluations;
+
+        public int MaxEvaluations {
+            get => maxEvaluations;
+            private set { maxEvaluations = value; RaisePropertyChanged(); }
+        }
+
+        private double progressSeedJ;
+
+        public double ProgressSeedJ {
+            get => progressSeedJ;
+            private set { progressSeedJ = value; RaisePropertyChanged(); }
+        }
+
+        private double progressBestJ;
+
+        public double ProgressBestJ {
+            get => progressBestJ;
+            private set { progressBestJ = value; RaisePropertyChanged(); }
+        }
+
+        private string phase;
+
+        public string Phase {
+            get => phase;
+            private set { phase = value; RaisePropertyChanged(); }
+        }
+
+        #endregion Progress
+
+        #region Results
+
+        private OptimizationResult result;
+
+        public OptimizationResult Result {
+            get => result;
+            private set { result = value; RaisePropertyChanged(); }
+        }
+
+        private OptimizationSummary summary;
+
+        public OptimizationSummary Summary {
+            get => summary;
+            private set {
+                summary = value;
+                RaisePropertyChanged();
+                ApplyCommand.NotifyCanExecuteChanged();
+                BackCommand.NotifyCanExecuteChanged();
+            }
+        }
+
+        private bool applyRecommendedStepSize;
+
+        public bool ApplyRecommendedStepSize {
+            get => applyRecommendedStepSize;
+            set {
+                if (applyRecommendedStepSize != value) {
+                    applyRecommendedStepSize = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        #endregion Results
+
+        #region Commands
+
+        public RelayCommand<object> BrowseSourceCommand { get; }
+        public AsyncRelayCommand StartCommand { get; }
+        public RelayCommand CancelCommand { get; }
+        public RelayCommand ApplyCommand { get; }
+        public RelayCommand BackCommand { get; }
+        public RelayCommand CloseCommand { get; }
+
+        #endregion Commands
+
+        /// <summary>
+        /// Runs the full pipeline: acquire (load each run) → seed guard → optimize → summary. Guards against a
+        /// double-start, marshals progress via <see cref="IProgress{T}"/>, and never throws on cancellation —
+        /// a cancelled run leaves the VM idle and re-runnable.
+        /// </summary>
+        public async Task StartAsync(CancellationToken externalToken) {
+            if (Interlocked.CompareExchange(ref running, 1, 0) != 0) {
+                return; // already running
+            }
+
+            ErrorMessage = null;
+            Summary = null;
+            Result = null;
+            IsBusy = true;
+
+            cts?.Dispose();
+            cts = CancellationTokenSource.CreateLinkedTokenSource(externalToken);
+            var token = cts.Token;
+
+            try {
+                // 1. Acquire — load every source into a LoadedRun.
+                CurrentStep = WizardStep.Acquire;
+                var loadedRuns = await AcquireAsync(token).ConfigureAwait(true);
+                if (loadedRuns == null) {
+                    return; // ErrorMessage already set, or cancelled
+                }
+
+                // 2. Seed guard — evaluate the seed once; bail with a clear error on a degenerate run.
+                if (!await SeedFitIsUsableAsync(loadedRuns, token).ConfigureAwait(true)) {
+                    return; // ErrorMessage set by the guard
+                }
+
+                // 3. Optimize — off the UI thread, progress marshaled back. OptimizeAsync always returns a
+                // non-null result; it signals cancellation by throwing OperationCanceledException (caught below).
+                CurrentStep = WizardStep.Optimize;
+                var optimizeResult = await OptimizeAsync(loadedRuns, token).ConfigureAwait(true);
+                Result = optimizeResult;
+
+                // 4. Summary — re-evaluate seed vs best for σ(focus) and recommend a step size.
+                Summary = await BuildSummaryAsync(loadedRuns, optimizeResult, token).ConfigureAwait(true);
+                CurrentStep = WizardStep.Summary;
+            } catch (OperationCanceledException) {
+                Logger.Info("Star detection optimization cancelled");
+                CurrentStep = WizardStep.SelectSource;
+            } catch (Exception ex) {
+                Logger.Error(ex, "Star detection optimization failed");
+                ErrorMessage = $"Optimization failed: {ex.Message}";
+                CurrentStep = WizardStep.SelectSource;
+            } finally {
+                IsBusy = false;
+                Interlocked.Exchange(ref running, 0);
+            }
+        }
+
+        /// <summary>Loads each configured source folder into a <see cref="LoadedRun"/>. For Live, runs a fresh AF
+        /// attempt first and then loads its saved folder. Sets <see cref="ErrorMessage"/> and returns null on a
+        /// missing/invalid source.</summary>
+        private async Task<List<LoadedRun>> AcquireAsync(CancellationToken token) {
+            var runs = new List<LoadedRun>(RunCount);
+            for (var i = 0; i < RunCount; i++) {
+                token.ThrowIfCancellationRequested();
+                string folder;
+                if (SourceMode == SourceMode.Live) {
+                    folder = await RunLiveAttemptAsync(token).ConfigureAwait(true);
+                    if (string.IsNullOrEmpty(folder)) {
+                        ErrorMessage = "The live auto-focus run did not produce a saved attempt folder.";
+                        CurrentStep = WizardStep.SelectSource;
+                        return null;
+                    }
+                } else {
+                    folder = i < SourcePaths.Count ? SourcePaths[i] : null;
+                    if (string.IsNullOrEmpty(folder)) {
+                        ErrorMessage = $"Select a saved auto-focus folder for run {i + 1}.";
+                        CurrentStep = WizardStep.SelectSource;
+                        return null;
+                    }
+                }
+
+                Phase = $"Loading run {i + 1} of {RunCount}";
+                var loaded = await loader.LoadSavedRunAsync(folder, region, token).ConfigureAwait(true);
+                runs.Add(loaded);
+            }
+            return runs;
+        }
+
+        /// <summary>
+        /// Triggers a live auto-focus run that saves its frames, then returns the saved attempt folder so the run
+        /// converges onto the same replay path. Kept minimal — hardware-dependent, manually verified later (T6).
+        /// </summary>
+        private async Task<string> RunLiveAttemptAsync(CancellationToken token) {
+            if (autoFocusEngine == null) {
+                throw new InvalidOperationException("Live mode requires an auto-focus engine.");
+            }
+            Phase = "Running live auto-focus";
+            var options = autoFocusEngine.GetOptions();
+            options.Save = true; // ensure frames land on disk so we can load them like a replay
+            var afResult = await autoFocusEngine.Run(options, null, token, null).ConfigureAwait(true);
+            return afResult?.SaveFolder;
+        }
+
+        /// <summary>
+        /// The STARHFR/seed guard. STARHFR is NINA's "HFR-on-detected-stars" auto-focus method (AFMethodEnum.
+        /// STARHFR), where focus is found by fitting an HFR-vs-position curve — so a usable run needs enough
+        /// frames that actually yielded stars to determine that fit. We evaluate the SEED params once per run and
+        /// require, on at least one run, a finite σ(focus) backed by ≥ 3 distinct focuser positions (the minimum
+        /// a hyperbola can determine; mirrors the AF engine's "< 3 valid points => no fit" rule). When every run
+        /// is degenerate (NaN σ and too few usable positions, i.e. most frames had no stars) we surface a clear
+        /// error and refuse to optimize, so the user is not handed a meaningless result.
+        /// </summary>
+        private async Task<bool> SeedFitIsUsableAsync(IReadOnlyList<LoadedRun> runs, CancellationToken token) {
+            const int MinPositionsForFit = 3;
+            var anyUsable = false;
+            foreach (var run in runs) {
+                token.ThrowIfCancellationRequested();
+                var eval = await run.Data.EvaluateAndFitAsync(run.Seed, token).ConfigureAwait(true);
+                var sigmaFinite = double.IsFinite(eval.Metrics.SigmaFocus);
+                if (sigmaFinite && eval.PooledPointCount >= MinPositionsForFit) {
+                    anyUsable = true;
+                    break;
+                }
+            }
+
+            if (!anyUsable) {
+                ErrorMessage =
+                    "The selected auto-focus run(s) do not produce a usable focus curve at the current settings: " +
+                    "too few focuser positions yielded detectable stars to fit a curve. Pick a run with stars across " +
+                    "most frames, or re-acquire with a longer exposure before optimizing.";
+                CurrentStep = WizardStep.SelectSource;
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>Runs the pure optimizer off the UI thread; progress posts back via <see cref="IProgress{T}"/>.</summary>
+        private async Task<OptimizationResult> OptimizeAsync(IReadOnlyList<LoadedRun> runs, CancellationToken token) {
+            // All runs share the same camera/optics, so the search starts from the first run's seed.
+            var seed = runs[0].Seed;
+            var variables = OptimizerVariable.CreateCuratedSet();
+            var evaluator = RunEvaluationData.CreateEvaluator(runs.Select(r => r.Data).ToList());
+
+            MaxEvaluations = optimizerSettings.MaxEvaluations;
+            var progress = new Progress<OptimizationProgress>(p => {
+                Evaluations = p.Evaluations;
+                MaxEvaluations = p.MaxEvaluations;
+                ProgressBestJ = p.BestJ;
+                ProgressSeedJ = p.SeedJ;
+                Phase = p.Phase;
+            });
+
+            var optimizer = new StarDetectionOptimizer();
+            return await Task.Run(
+                () => optimizer.OptimizeAsync(seed, variables, evaluator, optimizerSettings, progress, token),
+                token).ConfigureAwait(true);
+        }
+
+        /// <summary>
+        /// Builds the summary: the changed-parameters table, before/after J + σ(focus) (re-evaluated at seed and
+        /// best, averaged across runs), and the recommended step size from the representative (first) run's best
+        /// fit, clamped to the focuser's max increment when known.
+        /// </summary>
+        private async Task<OptimizationSummary> BuildSummaryAsync(IReadOnlyList<LoadedRun> runs, OptimizationResult res, CancellationToken token) {
+            var seed = runs[0].Seed;
+            var changed = res.ChangedVariables
+                .Select(c => new ChangedParameterRow { Name = c.Name, SeedValue = c.SeedValue, OptimizedValue = c.BestValue })
+                .ToList();
+
+            // σ(focus) before/after, averaged over the runs (the first run also yields the representative best fit).
+            double seedSigmaSum = 0.0, bestSigmaSum = 0.0;
+            var seedSigmaCount = 0; var bestSigmaCount = 0;
+            AlglibHyperbolicFitting representativeBestFit = null;
+            for (var i = 0; i < runs.Count; i++) {
+                token.ThrowIfCancellationRequested();
+                var seedEval = await runs[i].Data.EvaluateAndFitAsync(seed, token).ConfigureAwait(true);
+                var bestEval = await runs[i].Data.EvaluateAndFitAsync(res.BestParams, token).ConfigureAwait(true);
+                if (double.IsFinite(seedEval.Metrics.SigmaFocus)) { seedSigmaSum += seedEval.Metrics.SigmaFocus; seedSigmaCount++; }
+                if (double.IsFinite(bestEval.Metrics.SigmaFocus)) { bestSigmaSum += bestEval.Metrics.SigmaFocus; bestSigmaCount++; }
+                if (i == 0) {
+                    representativeBestFit = bestEval.BestFit;
+                }
+            }
+
+            var currentStepSize = runs[0].AfOptions?.AutoFocusStepSize ?? DefaultCurrentStepSize;
+            var recommendation = StepSizeRecommender.Recommend(representativeBestFit, currentStepSize, GetFocuserMaxStep());
+
+            return new OptimizationSummary {
+                ChangedParameters = changed,
+                SeedJ = res.SeedJ,
+                BestJ = res.BestJ,
+                SeedSigmaFocus = seedSigmaCount > 0 ? seedSigmaSum / seedSigmaCount : double.NaN,
+                BestSigmaFocus = bestSigmaCount > 0 ? bestSigmaSum / bestSigmaCount : double.NaN,
+                RunCount = runs.Count,
+                RecommendedStepSize = recommendation.StepSize,
+                RecommendedOffsetSteps = recommendation.OffsetSteps,
+                CurrentStepSize = currentStepSize,
+                ImprovedOverSeed = res.ImprovedOverSeed
+            };
+        }
+
+        private const int DefaultCurrentStepSize = 10;
+
+        /// <summary>
+        /// The focuser's max single-move increment, when available, to clamp the recommendation. No reliable
+        /// max-step source is exposed to the wizard, so this returns null (the recommender treats null as
+        /// "no clamp"), keeping the recommendation purely curve-driven.
+        /// </summary>
+        private int? GetFocuserMaxStep() => null;
+
+        /// <summary>
+        /// Applies the result. Builds an <see cref="OptimizedStarDetectionSettings"/> from
+        /// <see cref="OptimizationResult.BestParams"/> + run metadata and hands it to
+        /// <see cref="IStarDetectionOptions.ApplyOptimizedSettings"/>. When <see cref="ApplyRecommendedStepSize"/>
+        /// is set, also writes the recommended AF step size/offset to the active profile. Only ever called by the
+        /// user clicking Apply — never during the search.
+        /// </summary>
+        private void Apply() {
+            if (Result == null || Summary == null) {
+                return;
+            }
+
+            var best = Result.BestParams;
+            var dto = new OptimizedStarDetectionSettings {
+                // Curated knobs — note the DTO renames a few (Sensitivity->BrightnessSensitivity etc.).
+                BrightnessSensitivity = best.Sensitivity,
+                StarClippingMultiplier = best.StarClippingMultiplier,
+                NoiseClippingMultiplier = best.NoiseClippingMultiplier,
+                StarPeakResponse = best.PeakResponse,
+                MaxDistortion = best.MaxDistortion,
+                MinHFR = best.MinHFR,
+                StarCenterTolerance = best.StarCenterTolerance,
+                StructureLayers = best.StructureLayers,
+                NoiseReductionRadius = best.NoiseReductionRadius,
+                MinStarBoundingBoxSize = best.MinimumStarBoundingBoxSize,
+                HotpixelThresholdingEnabled = best.HotpixelThresholdingEnabled,
+                HotpixelThreshold = best.HotpixelThreshold,
+
+                // Metadata (DateTime is fine here — this runs in-app, not in the headless harness).
+                CreatedAtUtc = DateTime.UtcNow,
+                RunCount = Summary.RunCount,
+                BaselineJ = Result.SeedJ,
+                FinalJ = Result.BestJ,
+                RecommendedStepSize = Summary.RecommendedStepSize,
+                RecommendedOffsetSteps = Summary.RecommendedOffsetSteps
+            };
+
+            starDetectionOptions.ApplyOptimizedSettings(dto);
+            Logger.Info($"Applied optimized star-detection settings (J {Result.SeedJ:F3} -> {Result.BestJ:F3}, {Summary.RunCount} run(s))");
+
+            if (ApplyRecommendedStepSize) {
+                var focuserSettings = profileService?.ActiveProfile?.FocuserSettings;
+                if (focuserSettings != null) {
+                    focuserSettings.AutoFocusStepSize = Summary.RecommendedStepSize;
+                    focuserSettings.AutoFocusInitialOffsetSteps = Summary.RecommendedOffsetSteps;
+                    Logger.Info($"Applied recommended AF step size {Summary.RecommendedStepSize}, offset steps {Summary.RecommendedOffsetSteps}");
+                }
+            }
+        }
+
+        private void Cancel() {
+            try {
+                cts?.Cancel();
+            } catch (ObjectDisposedException) {
+            }
+        }
+
+        /// <summary>
+        /// Disposes the current <see cref="CancellationTokenSource"/>. T5's launch command should call this when
+        /// the wizard window closes. Idempotent and null-safe; does not change run-time behavior otherwise.
+        /// </summary>
+        public void Dispose() {
+            if (disposed) {
+                return;
+            }
+            disposed = true;
+            cts?.Dispose();
+            cts = null;
+        }
+
+        private void Back() {
+            if (CurrentStep == WizardStep.Summary && !IsBusy) {
+                CurrentStep = WizardStep.SelectSource;
+            }
+        }
+
+        private void BrowseSource(object parameter) {
+            var index = 0;
+            if (parameter != null && int.TryParse(parameter.ToString(), out var parsed)) {
+                index = parsed;
+            }
+            var picked = folderPicker();
+            if (!string.IsNullOrEmpty(picked) && index >= 0 && index < SourcePaths.Count) {
+                SourcePaths[index] = picked;
+            }
+        }
+
+        private void ResizeSourcePaths() {
+            while (SourcePaths.Count < runCount) {
+                SourcePaths.Add(null);
+            }
+            while (SourcePaths.Count > runCount) {
+                SourcePaths.RemoveAt(SourcePaths.Count - 1);
+            }
+        }
+
+        /// <summary>The production folder picker (WinForms), mirroring InspectorVM's replay picker.</summary>
+        private static string PickFolderViaDialog() {
+            using (var dialog = new System.Windows.Forms.FolderBrowserDialog()) {
+                if (dialog.ShowDialog() != System.Windows.Forms.DialogResult.OK) {
+                    return null;
+                }
+                return dialog.SelectedPath;
+            }
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StepSizeRecommender.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StepSizeRecommender.cs
@@ -1,0 +1,177 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
+
+    /// <summary>
+    /// An auto-focus step-size recommendation derived from a fitted focus curve.
+    /// </summary>
+    public sealed class StepSizeRecommendation {
+        /// <summary>Recommended AF step size (focuser steps), always &gt;= 1.</summary>
+        public int StepSize { get; set; }
+
+        /// <summary>Recommended number of offset steps per side of focus (points per side).</summary>
+        public int OffsetSteps { get; set; }
+
+        /// <summary>
+        /// The modeled focus-sensitive half-width: the offset from best focus at which the fitted HFR reaches
+        /// twice the minimum HFR (averaged over the two sides). <see cref="double.NaN"/> for a degenerate fit.
+        /// </summary>
+        public double HalfWidth { get; set; }
+    }
+
+    /// <summary>
+    /// Recommends an auto-focus step size from a winning hyperbolic fit. The idea: size the step so a focus sweep
+    /// lands ~3-4 measurement points on each side of focus inside the "focus-sensitive" region — the band where
+    /// HFR climbs from its minimum to roughly twice the minimum, which is where the curve carries the most slope
+    /// (and thus the most information). The half-width W of that band is read directly off the fitted model, and
+    /// the step is W / 3.5 (so the band holds ~3-4 points per side).
+    /// </summary>
+    public static class StepSizeRecommender {
+        // Targeted points per side within the focus-sensitive band [x0, x0 + W]: W / PointsPerSide steps.
+        private const double PointsPerSide = 3.5;
+
+        // Default offset steps per side of focus for the recommended sweep.
+        private const int DefaultOffsetSteps = 4;
+
+        // Upper bound on the outward search for the half-width, as a multiple of the fit's sampled X span — a
+        // guard so a near-flat / degenerate fit cannot loop unboundedly.
+        private const double MaxSearchSpanMultiple = 4.0;
+
+        /// <summary>
+        /// Recommends a step size (and offset steps) from <paramref name="bestFit"/>. Returns the
+        /// <paramref name="currentStepSize"/> unchanged (with <see cref="StepSizeRecommendation.HalfWidth"/> NaN)
+        /// for a degenerate fit (null fit, non-finite minimum, or non-positive minimum HFR). When supplied,
+        /// <paramref name="focuserMaxStep"/> clamps the recommendation; the result is never below 1.
+        /// </summary>
+        public static StepSizeRecommendation Recommend(AlglibHyperbolicFitting bestFit, int currentStepSize, int? focuserMaxStep = null) {
+            if (bestFit == null || bestFit.Fitting == null) {
+                return Degenerate(currentStepSize, focuserMaxStep);
+            }
+
+            var x0 = bestFit.Minimum.X;
+            var minHfr = bestFit.Minimum.Y;
+            if (double.IsNaN(x0) || double.IsInfinity(x0) || !(minHfr > 0.0) || double.IsNaN(minHfr) || double.IsInfinity(minHfr)) {
+                return Degenerate(currentStepSize, focuserMaxStep);
+            }
+
+            var fitting = bestFit.Fitting;
+            var target = 2.0 * minHfr;
+
+            // Search outward from x0 in both directions for the offset where HFR == 2*minHfr.
+            var searchSpan = SearchSpan(bestFit);
+            var rightW = FindHalfWidth(fitting, x0, +1.0, target, searchSpan);
+            var leftW = FindHalfWidth(fitting, x0, -1.0, target, searchSpan);
+
+            double halfWidth;
+            if (double.IsNaN(rightW) && double.IsNaN(leftW)) {
+                return Degenerate(currentStepSize, focuserMaxStep);
+            } else if (double.IsNaN(rightW)) {
+                halfWidth = leftW;
+            } else if (double.IsNaN(leftW)) {
+                halfWidth = rightW;
+            } else {
+                halfWidth = 0.5 * (rightW + leftW); // average the two sides (handles asymmetric models)
+            }
+
+            var step = (int)Math.Round(halfWidth / PointsPerSide, MidpointRounding.AwayFromZero);
+            step = ClampStep(step, focuserMaxStep);
+
+            return new StepSizeRecommendation {
+                StepSize = step,
+                OffsetSteps = DefaultOffsetSteps,
+                HalfWidth = halfWidth
+            };
+        }
+
+        private static StepSizeRecommendation Degenerate(int currentStepSize, int? focuserMaxStep) {
+            return new StepSizeRecommendation {
+                StepSize = ClampStep(currentStepSize, focuserMaxStep),
+                OffsetSteps = DefaultOffsetSteps,
+                HalfWidth = double.NaN
+            };
+        }
+
+        private static int ClampStep(int step, int? focuserMaxStep) {
+            if (step < 1) {
+                step = 1;
+            }
+            if (focuserMaxStep.HasValue && focuserMaxStep.Value >= 1 && step > focuserMaxStep.Value) {
+                step = focuserMaxStep.Value;
+            }
+            return step;
+        }
+
+        /// <summary>The sampled-X span of the fit, used to bound the outward half-width search.</summary>
+        private static double SearchSpan(AlglibHyperbolicFitting bestFit) {
+            var span = double.NaN;
+            var inputs = bestFit.Inputs;
+            if (inputs != null && inputs.Length > 0) {
+                double minX = double.PositiveInfinity, maxX = double.NegativeInfinity;
+                foreach (var row in inputs) {
+                    var x = row[0];
+                    if (x < minX) minX = x;
+                    if (x > maxX) maxX = x;
+                }
+                span = maxX - minX;
+            }
+            if (!(span > 0.0)) {
+                // Fall back to a generous absolute span keyed off the step size so the search still terminates.
+                span = Math.Max(1.0, Math.Abs(bestFit.StepSize)) * 100.0;
+            }
+            return span;
+        }
+
+        /// <summary>
+        /// Walks outward from <paramref name="x0"/> in <paramref name="direction"/> until the modeled HFR reaches
+        /// <paramref name="target"/>, then refines by bisection. Returns the offset (a positive magnitude) or NaN
+        /// if the target is not reached within <see cref="MaxSearchSpanMultiple"/> × <paramref name="searchSpan"/>.
+        /// </summary>
+        private static double FindHalfWidth(Func<double, double> fitting, double x0, double direction, double target, double searchSpan) {
+            var maxOffset = MaxSearchSpanMultiple * searchSpan;
+            // Coarse step: 1/256 of the search budget — fine enough to bracket, cheap enough to terminate.
+            var coarse = Math.Max(maxOffset / 256.0, 1e-6);
+
+            double prevOffset = 0.0;
+            for (var offset = coarse; offset <= maxOffset; offset += coarse) {
+                var value = fitting(x0 + direction * offset);
+                if (double.IsNaN(value) || double.IsInfinity(value)) {
+                    return double.NaN;
+                }
+                if (value >= target) {
+                    // Bracketed between prevOffset (below target) and offset (>= target): bisection refine.
+                    return Bisect(fitting, x0, direction, target, prevOffset, offset);
+                }
+                prevOffset = offset;
+            }
+            return double.NaN; // never reached 2*min within the budget (near-flat / degenerate)
+        }
+
+        private static double Bisect(Func<double, double> fitting, double x0, double direction, double target, double lo, double hi) {
+            for (var i = 0; i < 60; i++) {
+                var mid = 0.5 * (lo + hi);
+                var value = fitting(x0 + direction * mid);
+                if (value >= target) {
+                    hi = mid;
+                } else {
+                    lo = mid;
+                }
+                if (hi - lo < 1e-6) {
+                    break;
+                }
+            }
+            return 0.5 * (lo + hi);
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
@@ -204,6 +204,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             brightnessSensitivity = optionsAccessor.GetValueDouble("BrightnessSensitivity", 2.0);
             starPeakResponse = optionsAccessor.GetValueDouble("StarPeakResponse", 0.75);
             maxDistortion = optionsAccessor.GetValueDouble("MaxDistortion", 0.5);
+            defocusAwareDistortion = optionsAccessor.GetValueBoolean("DefocusAwareDistortion", false);
             starCenterTolerance = optionsAccessor.GetValueDouble("StarCenterTolerance", 0.3);
             starBackgroundBoxExpansion = optionsAccessor.GetValueInt32("StarBackgroundBoxExpansion", 3);
             minStarBoundingBoxSize = optionsAccessor.GetValueInt32("MinStarBoundingBoxSize", 5);
@@ -261,6 +262,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             BrightnessSensitivity = 2.0;
             StarPeakResponse = 0.75;
             MaxDistortion = 0.5;
+            DefocusAwareDistortion = false;
             StarCenterTolerance = 0.3;
             StarBackgroundBoxExpansion = 3;
             MinStarBoundingBoxSize = 5;
@@ -568,6 +570,24 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                     }
                     maxDistortion = value;
                     optionsAccessor.SetValueDouble("MaxDistortion", maxDistortion);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool defocusAwareDistortion;
+
+        // Opt-in, Advanced-only. Default OFF so detection stays bit-identical when disabled. When ON, the
+        // TooDistorted gate relaxes its fill-ratio threshold for LARGE candidates (large-defocus donut stars),
+        // recovering donuts that the strict ratio would reject. The two numeric tuning knobs (size reference and
+        // min factor) are kept as detector params with fixed sensible defaults (not exposed in the UI) to limit
+        // the option surface; only this on/off toggle is a persisted option.
+        public bool DefocusAwareDistortion {
+            get => defocusAwareDistortion;
+            set {
+                if (defocusAwareDistortion != value) {
+                    defocusAwareDistortion = value;
+                    optionsAccessor.SetValueBoolean("DefocusAwareDistortion", defocusAwareDistortion);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
@@ -205,6 +205,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             starPeakResponse = optionsAccessor.GetValueDouble("StarPeakResponse", 0.75);
             maxDistortion = optionsAccessor.GetValueDouble("MaxDistortion", 0.5);
             defocusAwareDistortion = optionsAccessor.GetValueBoolean("DefocusAwareDistortion", false);
+            defocusAwareCentering = optionsAccessor.GetValueBoolean("DefocusAwareCentering", false);
             starCenterTolerance = optionsAccessor.GetValueDouble("StarCenterTolerance", 0.3);
             starBackgroundBoxExpansion = optionsAccessor.GetValueInt32("StarBackgroundBoxExpansion", 3);
             minStarBoundingBoxSize = optionsAccessor.GetValueInt32("MinStarBoundingBoxSize", 5);
@@ -263,6 +264,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             StarPeakResponse = 0.75;
             MaxDistortion = 0.5;
             DefocusAwareDistortion = false;
+            DefocusAwareCentering = false;
             StarCenterTolerance = 0.3;
             StarBackgroundBoxExpansion = 3;
             MinStarBoundingBoxSize = 5;
@@ -588,6 +590,26 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                 if (defocusAwareDistortion != value) {
                     defocusAwareDistortion = value;
                     optionsAccessor.SetValueBoolean("DefocusAwareDistortion", defocusAwareDistortion);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool defocusAwareCentering;
+
+        // Opt-in, Advanced-only. Companion to DefocusAwareDistortion. Default OFF so detection stays bit-identical
+        // when disabled. When ON, the NotCentered gate relaxes its StarCenterTolerance (grows the centered
+        // acceptance sub-box) for LARGE candidates (large-defocus donut stars whose hollow ring destabilizes the
+        // centroid), recovering donuts the distortion gate now admits but the strict centering test would reject.
+        // The numeric tuning knob (DefocusCenteringToleranceFactor) and the shared size reference are kept as
+        // detector params with fixed sensible defaults (not exposed in the UI) to limit the option surface; only
+        // this on/off toggle is a persisted option.
+        public bool DefocusAwareCentering {
+            get => defocusAwareCentering;
+            set {
+                if (defocusAwareCentering != value) {
+                    defocusAwareCentering = value;
+                    optionsAccessor.SetValueBoolean("DefocusAwareCentering", defocusAwareCentering);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
@@ -11,6 +11,7 @@
 #endregion "copyright"
 
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
 using NINA.Core.Utility;
 using NINA.Profile;
 using NINA.Profile.Interfaces;
@@ -18,6 +19,7 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Logger = NINA.Core.Utility.Logger;
 
 namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
 
@@ -53,6 +55,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             nameof(Simple_NoiseLevel),
             nameof(Simple_PixelScale),
             nameof(Simple_FocusRange),
+            nameof(UseOptimizedSettings),
         };
 
         private void ConfigureSimpleSettings() {
@@ -60,6 +63,40 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                 return;
             }
 
+            if (UseOptimizedSettings && HasOptimizedSettings) {
+                ApplyOptimizedSnapshotToLiveProperties();
+                return;
+            }
+
+            DerivePresetSettings();
+        }
+
+        // Applies the curated optimized snapshot on top of the Simple-mode preset baseline. The non-curated
+        // advanced knobs (PSF, dilation, etc.) keep their Simple-mode preset defaults; the curated knobs win.
+        // Setting these live properties while in Simple Mode does NOT recurse, because the PropertyChanged
+        // handler only re-runs ConfigureSimpleSettings for properties in SimplePropertyNames (which the curated
+        // knobs are not).
+        private void ApplyOptimizedSnapshotToLiveProperties() {
+            DerivePresetSettings();
+            var s = optimizedSettings;
+            if (s == null) {
+                return;
+            }
+            BrightnessSensitivity = s.BrightnessSensitivity;
+            StarClippingMultiplier = s.StarClippingMultiplier;
+            NoiseClippingMultiplier = s.NoiseClippingMultiplier;
+            StarPeakResponse = s.StarPeakResponse;
+            MaxDistortion = s.MaxDistortion;
+            MinHFR = s.MinHFR;
+            StarCenterTolerance = s.StarCenterTolerance;
+            StructureLayers = s.StructureLayers;
+            NoiseReductionRadius = s.NoiseReductionRadius;
+            MinStarBoundingBoxSize = s.MinStarBoundingBoxSize;
+            HotpixelThresholdingEnabled = s.HotpixelThresholdingEnabled;
+            HotpixelThreshold = s.HotpixelThreshold;
+        }
+
+        private void DerivePresetSettings() {
             HotpixelFiltering = Simple_NoiseLevel != NoiseLevelEnum.None;
             // F4: σ-based knobs are honest multiples of the measured image's σ. The old code measured σ on a
             // blurred copy (~4× understated for white noise) on the Low/Typical path only, so the same knob value
@@ -190,6 +227,16 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             saturationThreshold = optionsAccessor.GetValueDouble(nameof(SaturationThreshold), 0.99d);
             measurementAverage = optionsAccessor.GetValueEnum<MeasurementAverageEnum>(nameof(MeasurementAverage), MeasurementAverageEnum.Median);
             psfPixelIntegration = optionsAccessor.GetValueBoolean(nameof(PSFPixelIntegration), false);
+            useOptimizedSettings = optionsAccessor.GetValueBoolean(nameof(UseOptimizedSettings), false);
+            var optimizedSettingsJson = optionsAccessor.GetValueString(OptimizedSettingsJsonKey, "");
+            optimizedSettings = null;
+            if (!string.IsNullOrEmpty(optimizedSettingsJson)) {
+                try {
+                    optimizedSettings = JsonConvert.DeserializeObject<OptimizedStarDetectionSettings>(optimizedSettingsJson);
+                } catch (Exception ex) {
+                    Logger.Warning($"Discarding corrupt OptimizedSettingsJson: {ex.Message}");
+                }
+            }
             ConfigureSimpleSettings();
         }
 
@@ -234,6 +281,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             SaturationThreshold = 0.99d;
             MeasurementAverage = MeasurementAverageEnum.Median;
             PSFPixelIntegration = false;
+            optimizedSettings = null;
+            optionsAccessor.SetValueString(OptimizedSettingsJsonKey, "");
+            RaisePropertyChanged(nameof(HasOptimizedSettings));
+            UseOptimizedSettings = false;
         }
 
         private bool debugMode;
@@ -776,6 +827,43 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                     RaisePropertyChanged();
                 }
             }
+        }
+
+        // Persisted JSON blob holding the optimized star-detection snapshot (Optimization Wizard, T1).
+        private const string OptimizedSettingsJsonKey = "OptimizedSettingsJson";
+
+        private OptimizedStarDetectionSettings optimizedSettings;
+
+        public bool HasOptimizedSettings => optimizedSettings != null;
+
+        private bool useOptimizedSettings;
+
+        public bool UseOptimizedSettings {
+            get => useOptimizedSettings;
+            set {
+                if (useOptimizedSettings != value) {
+                    useOptimizedSettings = value;
+                    optionsAccessor.SetValueBoolean(nameof(UseOptimizedSettings), useOptimizedSettings);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public OptimizedStarDetectionSettings GetOptimizedSettings() {
+            return optimizedSettings?.Clone();
+        }
+
+        public void ApplyOptimizedSettings(OptimizedStarDetectionSettings settings) {
+            if (settings == null) {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            optimizedSettings = settings.Clone();
+            optionsAccessor.SetValueString(OptimizedSettingsJsonKey, JsonConvert.SerializeObject(settings));
+            RaisePropertyChanged(nameof(HasOptimizedSettings));
+            UseAdvanced = false;
+            UseOptimizedSettings = true; // fires ConfigureSimpleSettings via PropertyChanged
+            ConfigureSimpleSettings(); // ensure applied even if UseOptimizedSettings was already true
+            RaiseAllPropertiesChanged(); // refresh UI bindings for all live advanced props
         }
 
     }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
@@ -1183,6 +1183,45 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             return p.MaxDistortion * factor;
         }
 
+        /// <summary>
+        /// Companion to <see cref="ComputeEffectiveMaxDistortion"/> for the NotCentered gate. Computes the
+        /// effective StarCenterTolerance the centering check uses for a candidate of bbox max-dimension
+        /// <paramref name="candidateSize"/> (= max(bbox.Width, bbox.Height), the SAME defocus proxy the distortion
+        /// gate uses).
+        ///
+        /// When <see cref="StarDetectorParams.DefocusAwareCentering"/> is FALSE this returns
+        /// <see cref="StarDetectorParams.StarCenterTolerance"/> verbatim, so the gate is byte-for-byte the legacy
+        /// gate (default-OFF ⇒ bit-identical detection). When TRUE it returns
+        ///   StarCenterTolerance · clamp(candidateSize / SizeReference, 1.0, ToleranceFactor)
+        /// (additionally clamped so the effective tolerance never exceeds 1.0, where the centered acceptance
+        /// sub-box covers the whole bbox). Candidates at or below the size reference keep the strict tolerance
+        /// (factor 1.0); larger candidates (defocused donuts, whose hollow ring destabilizes the intensity-weighted
+        /// centroid) get a LARGER tolerance → a bigger centered sub-box → the NotCentered gate is MORE permissive,
+        /// admitting off-center donut centroids. Pure + deterministic (no image access) so it is unit-testable in
+        /// isolation. Mirrors the distortion helper's clamp structure (relaxation direction is inverted because a
+        /// LARGER tolerance is more permissive, whereas a SMALLER distortion threshold is more permissive).
+        /// </summary>
+        public static double ComputeEffectiveStarCenterTolerance(double baseTolerance, double candidateSize, double sizeReference, double maxFactor) {
+            // Degenerate inputs can't make the gate permissive; fall back to the strict tolerance. maxFactor < 1
+            // would TIGHTEN the gate, which this helper must never do, so treat it as the 1.0 no-op.
+            if (candidateSize <= 0.0 || sizeReference <= 0.0 || maxFactor <= 1.0) {
+                return baseTolerance;
+            }
+
+            var factor = candidateSize / sizeReference;
+            // clamp to [1.0, maxFactor]: ≤ SizeReference ⇒ ≤ 1 ⇒ strict; larger ⇒ relaxes toward the ceiling.
+            if (factor < 1.0) {
+                factor = 1.0;
+            } else if (factor > maxFactor) {
+                factor = maxFactor;
+            }
+
+            var effective = baseTolerance * factor;
+            // The tolerance is a ratio of the bbox; 1.0 is the max valid value (sub-box == whole bbox). Never
+            // exceed it (a value > 1.0 would place the acceptance band outside the bbox and is meaningless).
+            return effective > 1.0 ? 1.0 : effective;
+        }
+
         private Star EvaluateStarCandidate(Mat srcImage, StarDetectorParams p, Rect starBounds, List<Point> starPoints, double srcImageNoiseSigma, StarDetectorMetrics metrics, ConcurrentBag<ContaminationDiagnosticRecord> diagnosticsBag) {
             // Now we have a potential star bounding box as well as the coordinates of every star pixel. If this is a reliable star,
             // we compute its barycenter and include it.
@@ -1303,8 +1342,16 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
 
         private static bool IsStarCentered(StarCandidate starCandidate, StarDetectorParams p) {
             var box = starCandidate.StarBoundingBox;
-            var centerThresholdBoxWidth = box.Width * p.StarCenterTolerance;
-            var centerThresholdBoxHeight = box.Height * p.StarCenterTolerance;
+            // When DefocusAwareCentering is off the effective tolerance is exactly p.StarCenterTolerance
+            // (bit-identical to the legacy gate). When on, it is relaxed (the centered acceptance sub-box grows)
+            // for large candidates so large-defocus donuts (whose ring destabilizes the centroid) survive — see
+            // ComputeEffectiveStarCenterTolerance. The same effective tolerance drives both the decision and the
+            // NotCentered metrics/bounds tally (the tally happens at the single call site, which honors the return).
+            var effectiveTolerance = p.DefocusAwareCentering
+                ? ComputeEffectiveStarCenterTolerance(p.StarCenterTolerance, Math.Max(box.Width, box.Height), p.DefocusDistortionSizeReference, p.DefocusCenteringToleranceFactor)
+                : p.StarCenterTolerance;
+            var centerThresholdBoxWidth = box.Width * effectiveTolerance;
+            var centerThresholdBoxHeight = box.Height * effectiveTolerance;
             var minX = box.X + (box.Width - centerThresholdBoxWidth) / 2.0;
             var maxX = minX + centerThresholdBoxWidth;
             var minY = box.Y + (box.Height - centerThresholdBoxHeight) / 2.0;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
@@ -366,16 +366,18 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                 stopWatch.RecordEntry("StarAnalysis");
 
                 // Step 9: Fit PSF models
-                var stopwatch = new Stopwatch();
-                stopwatch.Start();
                 if (p.ModelPSF) {
+                    // Time only the PSF step, and only when it actually runs. During optimization/AF (ModelPSF=false,
+                    // the common case) this whole block is skipped, so the per-detection stopwatch + Console.WriteLine
+                    // overhead is eliminated. The remaining timer is TRACE-only (short-circuits unless TRACE is on).
+                    var psfStopwatch = Stopwatch.StartNew();
                     progress?.Report(new ApplicationStatus() { Status = "Modeling PSFs" });
                     await ModelPSF(srcImage, measurementImageNoise.Sigma, stars, p, metrics, token);
 
                     stopWatch.RecordEntry("ModelPSF");
+                    psfStopwatch.Stop();
+                    Logger.Trace($"PSF time: {psfStopwatch.Elapsed}");
                 }
-                stopwatch.Stop();
-                Console.WriteLine($"PSF time: {stopwatch.Elapsed}");
                 MaybeSaveIntermediateStars(stars, p, "09-detected-stars.txt");
 
                 var metricsTrace = $"Star Detection Metrics. Total={metrics.TotalDetected}, Candidates={metrics.StructureCandidates}, TooSmall={metrics.TooSmall}, OnBorder={metrics.OnBorder}, TooDistorted={metrics.TooDistorted}, Degenerate={metrics.Degenerate}, SaturatedMasked={metrics.Saturated}, LowSensitivity={metrics.LowSensitivity}, NotCentered={metrics.NotCentered}, TooFlat={metrics.TooFlat}, HFRAnalysisFailed={metrics.HFRAnalysisFailed}";

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
@@ -87,6 +87,69 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             }
         }
 
+        // The EARLY-stage detection params: everything BuildDetectionContext reads to produce a DetectionContext
+        // (hotpixel filtering, noise reduction, the structure map + wavelet, binarization, candidate flood-fill,
+        // and the early-only metrics). A cached DetectionContext is safe to reuse across GateAndMeasure calls ONLY
+        // when this key matches, so the SAFE failure mode is a spurious recompute, never stale reuse: a param is
+        // included here if it changes the prepared measurement image, the candidate region set, the two noise
+        // sigmas, OR any early metric (HotpixelCount/StructureCandidates/SaturatedPixelCount). When in doubt a
+        // param is INCLUDED (over-keying only costs a recompute). The list is a deliberate ALLOW-list (not a
+        // denylist over all params) precisely so a newly-added late-only param can never silently corrupt reuse —
+        // it would simply be absent here and force a recompute until explicitly classified.
+        //
+        // Notes on a few subtle entries:
+        //  - NoiseClippingMultiplier: sets the K-σ clip AND the binarize threshold ⇒ changes the candidate set.
+        //  - StarMeasurementNoiseReductionEnabled / NoiseReductionRadius / Hotpixel*: drive SrcImagePreparation and
+        //    the structure-map source, and which of the two noise estimates is computed (measurement vs structure).
+        //  - SaturationThreshold: read by EvaluateGlobalMetrics (early) to tally SaturatedPixelCount, so it is early
+        //    even though it is ALSO used by the late saturated-bounds gate (the late use is harmless to over-key).
+        //  - Region: the ROI submat (outer) and the inner-crop clearing both change which candidates are collected.
+        //  - HotpixelFilterRadius: gates the pipeline (only radius 1 supported) and would change filtering if ever
+        //    extended; included for safety.
+        private static readonly HashSet<string> EarlyCacheKeyProperties = new HashSet<string>(StringComparer.Ordinal) {
+            nameof(StarDetectorParams.HotpixelFiltering),
+            nameof(StarDetectorParams.HotpixelThresholdingEnabled),
+            nameof(StarDetectorParams.HotpixelThreshold),
+            nameof(StarDetectorParams.HotpixelFilterRadius),
+            nameof(StarDetectorParams.StarMeasurementNoiseReductionEnabled),
+            nameof(StarDetectorParams.NoiseReductionRadius),
+            nameof(StarDetectorParams.NoiseClippingMultiplier),
+            nameof(StarDetectorParams.StructureLayers),
+            nameof(StarDetectorParams.StructureDilationSize),
+            nameof(StarDetectorParams.StructureDilationCount),
+            nameof(StarDetectorParams.SaturationThreshold),
+            nameof(StarDetectorParams.Region)
+        };
+
+        /// <summary>
+        /// Computes a deterministic, culture-invariant cache key over ONLY the EARLY-stage detection params (plus
+        /// the detector version), for keying a reusable <see cref="DetectionContext"/>. Two parameter bundles that
+        /// produce this same key yield a byte-identical early context (prepared measurement image, candidate
+        /// regions, both noise sigmas, and the early metrics), so a context built under one bundle may be reused by
+        /// <see cref="GateAndMeasure"/> under the other. Built from the same canonical mechanism as
+        /// <see cref="ComputeCacheKey"/> but restricted to <see cref="EarlyCacheKeyProperties"/>. Like
+        /// <see cref="ComputeCacheKey"/>, the safe failure mode is a spurious miss (recompute), never stale reuse.
+        /// </summary>
+        // Instance wrapper so IStarDetector can expose the early-key computation (the canonical logic stays static).
+        string IStarDetector.ComputeEarlyCacheKey(StarDetectorParams p) => ComputeEarlyCacheKey(p);
+
+        public static string ComputeEarlyCacheKey(StarDetectorParams p) {
+            if (p == null) {
+                throw new ArgumentNullException(nameof(p));
+            }
+
+            var canonical = $"early-v{StarDetectorVersion.ToString(System.Globalization.CultureInfo.InvariantCulture)}|{p.ToCanonicalCacheString(EarlyCacheKeyProperties)}";
+            var bytes = Encoding.UTF8.GetBytes(canonical);
+            using (var sha = System.Security.Cryptography.SHA256.Create()) {
+                var hash = sha.ComputeHash(bytes);
+                var sb = new StringBuilder(hash.Length * 2);
+                foreach (var b in hash) {
+                    sb.Append(b.ToString("x2", System.Globalization.CultureInfo.InvariantCulture));
+                }
+                return sb.ToString();
+            }
+        }
+
         private class StarCandidate {
             public Point2d Center;
             public double CenterBrightness;
@@ -151,27 +214,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
         public async Task<HocusFocusStarDetectorResult> Detect(IRenderedImage image, StarDetectorParams p, IProgress<ApplicationStatus> progress, CancellationToken token) {
             var resourceTracker = new ResourcesTracker();
             try {
-                Mat srcImage;
-                var debayeredImage = image as IDebayeredImage;
-                var hotpixelFilteringApplied = false;
-                long? numHotpixels = null;
-                if (debayeredImage != null && p.HotpixelFiltering && p.HotpixelThresholdingEnabled) {
-                    var rawImageDataCopy = new ushort[debayeredImage.RawImageData.Data.FlatArray.Length];
-                    Buffer.BlockCopy(debayeredImage.RawImageData.Data.FlatArray, 0, rawImageDataCopy, 0, debayeredImage.RawImageData.Data.FlatArray.Length * sizeof(ushort));
-
-                    var props = debayeredImage.RawImageData.Properties;
-                    var rawImageData = new RawImageData(rawImageDataCopy, width: props.Width, height: props.Height);
-
-                    var threshold = (ushort)(p.HotpixelThreshold * (1 << props.BitDepth));
-                    numHotpixels = HotpixelFiltering.CFAHotpixelFilter(rawImageData, debayeredImage.BayerPattern, threshold);
-                    var bitmapSource = ImageUtility.CreateSourceFromArray(new ImageArray(rawImageDataCopy), props, PixelFormats.Gray16);
-                    var debayeredImageData = ImageUtility.Debayer(bitmapSource, pf: System.Drawing.Imaging.PixelFormat.Format16bppGrayScale, saveColorChannels: false, saveLumChannel: true, bayerPattern: debayeredImage.BayerPattern);
-                    hotpixelFilteringApplied = true;
-
-                    srcImage = resourceTracker.T(CvImageUtility.ToOpenCVMat(debayeredImageData.Data.Lum, bpp: props.BitDepth, width: props.Width, height: props.Height));
-                } else {
-                    srcImage = resourceTracker.T(CvImageUtility.ToOpenCVMat(image));
-                }
+                var srcImage = resourceTracker.T(PrepareSrcImageFromRenderedImage(image, p, out var hotpixelFilteringApplied, out var numHotpixels));
                 var result = await DetectImpl(srcImage, resourceTracker, p, hotpixelFilteringApplied, progress, token);
                 if (numHotpixels.HasValue) {
                     result.Metrics.HotpixelCount = numHotpixels.Value;
@@ -188,181 +231,389 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             }
         }
 
+        /// <summary>
+        /// Converts an <see cref="IRenderedImage"/> into the float source Mat the pipeline consumes, applying the
+        /// CFA hotpixel filter + debayer when the image is bayered and hotpixel thresholding is on (otherwise a
+        /// plain <c>ToOpenCVMat</c>). This is the EXACT conversion the monolithic <see cref="Detect(IRenderedImage, StarDetectorParams, IProgress{ApplicationStatus}, CancellationToken)"/>
+        /// used to perform inline; it is extracted so the optimizer's split path produces a byte-identical source
+        /// image. The returned Mat is NOT tracked — the caller owns it.
+        /// </summary>
+        private static Mat PrepareSrcImageFromRenderedImage(IRenderedImage image, StarDetectorParams p, out bool hotpixelFilteringApplied, out long? numHotpixels) {
+            var debayeredImage = image as IDebayeredImage;
+            hotpixelFilteringApplied = false;
+            numHotpixels = null;
+            if (debayeredImage != null && p.HotpixelFiltering && p.HotpixelThresholdingEnabled) {
+                var rawImageDataCopy = new ushort[debayeredImage.RawImageData.Data.FlatArray.Length];
+                Buffer.BlockCopy(debayeredImage.RawImageData.Data.FlatArray, 0, rawImageDataCopy, 0, debayeredImage.RawImageData.Data.FlatArray.Length * sizeof(ushort));
+
+                var props = debayeredImage.RawImageData.Properties;
+                var rawImageData = new RawImageData(rawImageDataCopy, width: props.Width, height: props.Height);
+
+                var threshold = (ushort)(p.HotpixelThreshold * (1 << props.BitDepth));
+                numHotpixels = HotpixelFiltering.CFAHotpixelFilter(rawImageData, debayeredImage.BayerPattern, threshold);
+                var bitmapSource = ImageUtility.CreateSourceFromArray(new ImageArray(rawImageDataCopy), props, PixelFormats.Gray16);
+                var debayeredImageData = ImageUtility.Debayer(bitmapSource, pf: System.Drawing.Imaging.PixelFormat.Format16bppGrayScale, saveColorChannels: false, saveLumChannel: true, bayerPattern: debayeredImage.BayerPattern);
+                hotpixelFilteringApplied = true;
+
+                return CvImageUtility.ToOpenCVMat(debayeredImageData.Data.Lum, bpp: props.BitDepth, width: props.Width, height: props.Height);
+            } else {
+                return CvImageUtility.ToOpenCVMat(image);
+            }
+        }
+
+        /// <summary>
+        /// EARLY phase for an <see cref="IRenderedImage"/>: performs the same conversion as
+        /// <see cref="Detect(IRenderedImage, StarDetectorParams, IProgress{ApplicationStatus}, CancellationToken)"/>
+        /// then builds the reusable <see cref="DetectionContext"/> (carrying the CFA hotpixel count when the
+        /// debayered-hotpixel path ran). See <see cref="BuildDetectionContext(Mat, StarDetectorParams, IProgress{ApplicationStatus}, CancellationToken)"/>.
+        /// </summary>
+        public async Task<DetectionContext> BuildDetectionContext(IRenderedImage image, StarDetectorParams p, IProgress<ApplicationStatus> progress, CancellationToken token) {
+            if (p.HotpixelFiltering && p.HotpixelFilterRadius != 1) {
+                throw new NotImplementedException("Only hotpixel filter radius of 1 currently supported");
+            }
+            // PrepareSrcImageFromRenderedImage returns a freshly-allocated, untracked Mat that the context will own;
+            // no extra clone needed (unlike the Mat overload, which clones the caller's Mat).
+            var srcImage = PrepareSrcImageFromRenderedImage(image, p, out var hotpixelFilteringApplied, out var numHotpixels);
+            var ctx = await BuildDetectionContextInternal(srcImage, resourceTracker: null, p, hotpixelFilteringApplied, progress, token);
+            ctx.DebayerHotpixelCount = numHotpixels;
+            return ctx;
+        }
+
+        /// <summary>
+        /// A reusable intermediate produced by <see cref="BuildDetectionContext"/> from ONLY the early-stage
+        /// params (see <see cref="EarlyCacheKeyProperties"/>): the prepared, read-only measurement image, the full
+        /// candidate region set from the flood-fill, both noise sigmas, the ROI offset, the early-only metric
+        /// counters, and the debug data. <see cref="GateAndMeasure"/> consumes it to produce the final result and
+        /// may be called repeatedly with different LATE-stage params, reusing the same context.
+        ///
+        /// <para>Ownership: the context owns <see cref="MeasurementImage"/> and disposes it (<see cref="Dispose"/>).
+        /// The late stage only READS the image, so the same context is safe to reuse across late-only param
+        /// changes. Disposing the context releases the (potentially large, 61 MP ≈ 244 MB) source Mat.</para>
+        /// </summary>
+        public sealed class DetectionContext : IDisposable {
+            internal Mat MeasurementImage;                       // prepared source image, read-only for the late stage
+            internal List<StarCandidateRegion> Candidates;      // ALL flood-fill candidates (no late gate applied)
+            internal double StructureNoiseSigma;                 // K-σ on the noise-reduced structure-map source
+            internal double MeasurementNoiseSigma;              // K-σ on the image actually sampled for measurement
+            internal Rect? RoiRect;                              // ROI offset to add back to outputs (null if full frame)
+            internal DebugData DebugData;
+            // Early-only metric counters captured here so GateAndMeasure can seed a fresh metrics with them. These
+            // are produced by the early pipeline (hotpixel filter) and the candidate flood-fill / global scan.
+            internal long HotpixelCount;
+            internal int StructureCandidates;
+            internal long SaturatedPixelCount;
+
+            // Set on the IRenderedImage debayered-hotpixel path: the CFA hotpixel count to stamp onto the final
+            // metrics (mirrors Detect(IRenderedImage), which overwrites Metrics.HotpixelCount with this value). Null
+            // when that path did not run, in which case the structure-pipeline HotpixelCount above is authoritative.
+            internal long? DebayerHotpixelCount;
+
+            public void Dispose() {
+                MeasurementImage?.Dispose();
+                MeasurementImage = null;
+            }
+        }
+
         private async Task<HocusFocusStarDetectorResult> DetectImpl(Mat srcImage, ResourcesTracker resourceTracker, StarDetectorParams p, bool hotpixelFilterAlreadyApplied, IProgress<ApplicationStatus> progress, CancellationToken token) {
+            // The monolithic detect is now exactly: build the early context, then gate + measure. The split is
+            // value-preserving — the early stage performs the identical pixel work it always did and the late stage
+            // reads it the same way — so output is byte-identical to the pre-split pipeline.
+            var ctx = await BuildDetectionContextInternal(srcImage, resourceTracker, p, hotpixelFilterAlreadyApplied, progress, token);
+            // BuildDetectionContextInternal tracks the prepared image in resourceTracker (caller disposes it via
+            // the tracker in Detect), so do NOT also dispose the context here — that would double-free.
+            return await GateAndMeasureInternal(ctx, p, progress, token);
+        }
+
+        /// <summary>
+        /// EARLY phase: runs the expensive, late-param-independent pipeline (hotpixel filtering, noise reduction,
+        /// structure-map + wavelet, binarization, candidate flood-fill, and both noise estimates) and returns a
+        /// reusable <see cref="DetectionContext"/>. The returned context OWNS its measurement image; dispose the
+        /// context (or call <see cref="GateAndMeasure"/> and dispose afterward) to release it. The result depends
+        /// ONLY on the params named in <see cref="EarlyCacheKeyProperties"/> (see <see cref="ComputeEarlyCacheKey"/>),
+        /// so it is safe to cache + reuse across <see cref="GateAndMeasure"/> calls whose early key matches.
+        /// </summary>
+        public async Task<DetectionContext> BuildDetectionContext(Mat srcImage, StarDetectorParams p, IProgress<ApplicationStatus> progress, CancellationToken token) {
+            if (p.HotpixelFiltering && p.HotpixelFilterRadius != 1) {
+                throw new NotImplementedException("Only hotpixel filter radius of 1 currently supported");
+            }
+            // The public split entry points clone the input so the caller's Mat is never mutated and the context's
+            // image is independently owned (matching the harness's clone-before-Detect discipline). The monolithic
+            // DetectImpl path instead lets BuildDetectionContextInternal mutate the tracker-owned srcImage in place,
+            // exactly as before, so behavior on that path is unchanged.
+            var ctx = await BuildDetectionContextInternal(srcImage.Clone(), resourceTracker: null, p, hotpixelFilterAlreadyApplied: false, progress, token);
+            return ctx;
+        }
+
+        /// <summary>
+        /// LATE phase: gates + measures the cached candidate regions in <paramref name="ctx"/> using the late-stage
+        /// params (Sensitivity, StarClippingMultiplier, PeakResponse, MaxDistortion, MinHFR, StarCenterTolerance,
+        /// MinimumStarBoundingBoxSize, BackgroundBoxExpansion, AnalysisSamplingSize, …) and assembles the final
+        /// <see cref="HocusFocusStarDetectorResult"/> — identical to what the monolithic <c>Detect</c> would have
+        /// produced for the full param bundle. Pure over the context (reads the image, never mutates it), so it may
+        /// be called repeatedly on the same context with different late params.
+        /// </summary>
+        public HocusFocusStarDetectorResult GateAndMeasure(DetectionContext ctx, StarDetectorParams p, CancellationToken token) {
+            // The late stage is synchronous except for the optional PSF fit, which is OFF for every cache user
+            // (AF/optimize set ModelPSF=false). When PSF IS on this blocks on the PSF tasks (Task.Run-based, no
+            // captured sync context), which is acceptable for this non-hot, non-cached usage.
+            return GateAndMeasureInternal(ctx, p, progress: null, token).GetAwaiter().GetResult();
+        }
+
+        private async Task<DetectionContext> BuildDetectionContextInternal(Mat srcImage, ResourcesTracker resourceTracker, StarDetectorParams p, bool hotpixelFilterAlreadyApplied, IProgress<ApplicationStatus> progress, CancellationToken token) {
             if (p.HotpixelFiltering && p.HotpixelFilterRadius != 1) {
                 throw new NotImplementedException("Only hotpixel filter radius of 1 currently supported");
             }
 
-            MaybeSaveIntermediateText(p.ToString(), p, "00-params.txt");
-            var metrics = new StarDetectorMetrics();
-            // Local (not an instance field): DetectImpl runs concurrently on a shared StarDetector during replay,
-            // so a per-call bag is required or concurrent detections would clobber each other's diagnostics. Star
-            // scanning is parallel, hence the thread-safe ConcurrentBag. Null in normal (non-diagnostic) runs.
-            var contaminationDiagnosticsBag = p.CollectContaminationDiagnostics ? new ConcurrentBag<ContaminationDiagnosticRecord>() : null;
-            using (var stopWatch = MultiStopWatch.Measure()) {
-                var debugData = new DebugData();
+            // When a resourceTracker is supplied (the monolithic DetectImpl path) the prepared srcImage and the
+            // scratch Mats are tracked there and freed by the caller. When it is null (the public split path) we
+            // own srcImage directly (handed to the context) and use a local tracker for the transient scratch Mats,
+            // which is disposed before returning so only the context's image survives.
+            var ownsLocalTracker = resourceTracker == null;
+            var scratch = resourceTracker ?? new ResourcesTracker();
 
-                Rect? roiRect = null;
-                if (p.Region.OuterBoundary.Height < 1.0d || p.Region.OuterBoundary.Width < 1.0d) {
-                    roiRect = new Rect(
-                        (int)Math.Floor(srcImage.Cols * p.Region.OuterBoundary.StartX),
-                        (int)Math.Floor(srcImage.Rows * p.Region.OuterBoundary.StartY),
-                        (int)(srcImage.Cols * p.Region.OuterBoundary.Width),
-                        (int)(srcImage.Rows * p.Region.OuterBoundary.Height));
-                    debugData.DetectionROI = roiRect.Value.ToDrawingRectangle();
+            // The Mat destined for the context: it is owned here until the context is successfully constructed, after
+            // which the context owns it. If the early pipeline throws (cancellation, OOM, CollectStarCandidates, …)
+            // before the context exists, this would otherwise be orphaned — it is registered with NEITHER tracker on
+            // the split path, and the ROI-replacement clone is untracked on BOTH paths. So we hold it in a local and
+            // dispose it in the finally when no context was produced.
+            //   - Split path (ownsLocalTracker): we own the incoming srcImage from entry.
+            //   - Monolithic path: the caller owns the incoming srcImage (and tracks it), so we must NOT dispose it
+            //     here — start null and only adopt the ROI-replacement clone we make below.
+            Mat liveOwnedImage = ownsLocalTracker ? srcImage : null;
+            var contextProduced = false;
+            try {
+                MaybeSaveIntermediateText(p.ToString(), p, "00-params.txt");
+                var metrics = new StarDetectorMetrics();
+                using (var stopWatch = MultiStopWatch.Measure()) {
+                    var debugData = new DebugData();
 
-                    var roiImage = srcImage.SubMat(roiRect.Value).Clone();
-                    srcImage.Dispose();
-                    srcImage = roiImage;
-                } else {
-                    debugData.DetectionROI = new System.Drawing.Rectangle(0, 0, srcImage.Width, srcImage.Height);
-                }
-                MaybeSaveIntermediateImage(srcImage, p, "01-source.tif");
+                    Rect? roiRect = null;
+                    if (p.Region.OuterBoundary.Height < 1.0d || p.Region.OuterBoundary.Width < 1.0d) {
+                        roiRect = new Rect(
+                            (int)Math.Floor(srcImage.Cols * p.Region.OuterBoundary.StartX),
+                            (int)Math.Floor(srcImage.Rows * p.Region.OuterBoundary.StartY),
+                            (int)(srcImage.Cols * p.Region.OuterBoundary.Width),
+                            (int)(srcImage.Rows * p.Region.OuterBoundary.Height));
+                        debugData.DetectionROI = roiRect.Value.ToDrawingRectangle();
 
-                if (p.StoreStructureMap) {
-                    debugData.StructureMap = new byte[debugData.DetectionROI.Width * debugData.DetectionROI.Height];
-                }
-
-                stopWatch.RecordEntry("LoadImage");
-
-                // Step 1: Perform initial noise reduction and hotpixel filtering
-                progress?.Report(new ApplicationStatus() { Status = "Noise Reduction" });
-                var hotpixelFilteringApplied = hotpixelFilterAlreadyApplied;
-
-                // Also apply hotpixel filtering if noise reduction will be done to the source image
-                if (p.HotpixelFiltering || (p.NoiseReductionRadius > 0 && p.StarMeasurementNoiseReductionEnabled)) {
-                    // Apply a median box filter in place to the starting image
-                    if (!hotpixelFilterAlreadyApplied) {
-                        metrics.HotpixelCount = ApplyHotpixelFilter(srcImage, p);
+                        var roiImage = srcImage.SubMat(roiRect.Value).Clone();
+                        srcImage.Dispose();
+                        srcImage = roiImage;
+                        // From here srcImage is a clone this method owns (the original was disposed just above). Adopt
+                        // it as the live owned Mat on BOTH paths so a later early-stage throw disposes the ROI clone
+                        // rather than orphaning it — on the monolithic path the caller's original is already gone.
+                        liveOwnedImage = roiImage;
+                    } else {
+                        debugData.DetectionROI = new System.Drawing.Rectangle(0, 0, srcImage.Width, srcImage.Height);
                     }
-                    hotpixelFilteringApplied = true;
-                }
+                    MaybeSaveIntermediateImage(srcImage, p, "01-source.tif");
 
-                var noiseReductionApplied = false;
-                if (p.NoiseReductionRadius > 0 && p.StarMeasurementNoiseReductionEnabled) {
-                    CvImageUtility.ConvolveGaussian(srcImage, srcImage, p.NoiseReductionRadius * 2 + 1);
-                    noiseReductionApplied = true;
-                }
+                    if (p.StoreStructureMap) {
+                        debugData.StructureMap = new byte[debugData.DetectionROI.Width * debugData.DetectionROI.Height];
+                    }
 
-                MaybeSaveIntermediateImage(srcImage, p, "02-src-image-preparation.tif");
-                stopWatch.RecordEntry("SrcImagePreparation");
+                    stopWatch.RecordEntry("LoadImage");
 
-                // Step 2: Prepare for structure detection by performing optional noise reduction
-                progress?.Report(new ApplicationStatus() { Status = "Preparing for Structure Detection" });
+                    // Step 1: Perform initial noise reduction and hotpixel filtering
+                    progress?.Report(new ApplicationStatus() { Status = "Noise Reduction" });
+                    var hotpixelFilteringApplied = hotpixelFilterAlreadyApplied;
 
-                Mat noiseReducedImage = resourceTracker.NewMat();
-                if (hotpixelFilteringApplied || noiseReductionApplied || p.NoiseReductionRadius <= 0) {
-                    // In this case, we've already applied hotpixel filtering, so no need to do it again. The structure map can start from here
-                    srcImage.CopyTo(noiseReducedImage);
-                } else {
-                    srcImage.CopyTo(noiseReducedImage);
-                    metrics.HotpixelCount = ApplyHotpixelFilter(noiseReducedImage, p);
-                }
+                    // Also apply hotpixel filtering if noise reduction will be done to the source image
+                    if (p.HotpixelFiltering || (p.NoiseReductionRadius > 0 && p.StarMeasurementNoiseReductionEnabled)) {
+                        // Apply a median box filter in place to the starting image
+                        if (!hotpixelFilterAlreadyApplied) {
+                            metrics.HotpixelCount = ApplyHotpixelFilter(srcImage, p);
+                        }
+                        hotpixelFilteringApplied = true;
+                    }
 
-                // Step 3: If we haven't yet applied noise reduction and it is configured, do so now
-                if (p.NoiseReductionRadius > 0 && !noiseReductionApplied) {
-                    CvImageUtility.ConvolveGaussian(noiseReducedImage, noiseReducedImage, p.NoiseReductionRadius * 2 + 1);
-                }
+                    var noiseReductionApplied = false;
+                    if (p.NoiseReductionRadius > 0 && p.StarMeasurementNoiseReductionEnabled) {
+                        CvImageUtility.ConvolveGaussian(srcImage, srcImage, p.NoiseReductionRadius * 2 + 1);
+                        noiseReductionApplied = true;
+                    }
 
-                Mat structureMap = resourceTracker.NewMat();
-                noiseReducedImage.CopyTo(structureMap);
-                var noiseReducedNoiseEstimateTask = Task.Run(() => {
-                    var result = CvImageUtility.KappaSigmaNoiseEstimate(noiseReducedImage, clippingMultipler: p.NoiseClippingMultiplier);
-                    var ksigmaTraceStructureMap = $"Structure Map K-Sigma Noise Estimate: {result.Sigma}, Background Mean: {result.BackgroundMean}, NumIterations={result.NumIterations}";
-                    Logger.Trace(ksigmaTraceStructureMap);
-                    MaybeSaveIntermediateText(ksigmaTraceStructureMap, p, "02-ksigma-estimate-noise-reduced.txt");
+                    MaybeSaveIntermediateImage(srcImage, p, "02-src-image-preparation.tif");
+                    stopWatch.RecordEntry("SrcImagePreparation");
 
-                    noiseReducedImage.Dispose();
-                    noiseReducedImage = null;
-                    return result;
-                });
+                    // Step 2: Prepare for structure detection by performing optional noise reduction
+                    progress?.Report(new ApplicationStatus() { Status = "Preparing for Structure Detection" });
 
-                // F4 (σ consistency): thresholds applied to the image actually sampled must use that image's σ.
-                // The estimate above is computed on the (possibly blurred) structure-map source; when a noise
-                // reduction radius is set but measurement noise reduction is off, srcImage was never blurred and
-                // its white-noise σ is ~4x larger. Measure it directly on srcImage (rather than applying an
-                // analytic kernel factor) so correlated real-camera noise and hotpixel filtering are accounted
-                // for automatically. srcImage is read-only from here until this task is awaited (before binarization), so the concurrent read is safe.
-                var measurementImageDiffers = p.NoiseReductionRadius > 0 && !noiseReductionApplied;
-                var measurementNoiseEstimateTask = measurementImageDiffers
-                    ? Task.Run(() => {
-                        var result = CvImageUtility.KappaSigmaNoiseEstimate(srcImage, clippingMultipler: p.NoiseClippingMultiplier);
-                        var ksigmaTraceMeasurement = $"Measurement Image K-Sigma Noise Estimate: {result.Sigma}, Background Mean: {result.BackgroundMean}, NumIterations={result.NumIterations}";
-                        Logger.Trace(ksigmaTraceMeasurement);
-                        MaybeSaveIntermediateText(ksigmaTraceMeasurement, p, "02-ksigma-estimate-measurement.txt");
+                    Mat noiseReducedImage = scratch.NewMat();
+                    if (hotpixelFilteringApplied || noiseReductionApplied || p.NoiseReductionRadius <= 0) {
+                        // In this case, we've already applied hotpixel filtering, so no need to do it again. The structure map can start from here
+                        srcImage.CopyTo(noiseReducedImage);
+                    } else {
+                        srcImage.CopyTo(noiseReducedImage);
+                        metrics.HotpixelCount = ApplyHotpixelFilter(noiseReducedImage, p);
+                    }
+
+                    // Step 3: If we haven't yet applied noise reduction and it is configured, do so now
+                    if (p.NoiseReductionRadius > 0 && !noiseReductionApplied) {
+                        CvImageUtility.ConvolveGaussian(noiseReducedImage, noiseReducedImage, p.NoiseReductionRadius * 2 + 1);
+                    }
+
+                    Mat structureMap = scratch.NewMat();
+                    noiseReducedImage.CopyTo(structureMap);
+                    var noiseReducedNoiseEstimateTask = Task.Run(() => {
+                        var result = CvImageUtility.KappaSigmaNoiseEstimate(noiseReducedImage, clippingMultipler: p.NoiseClippingMultiplier);
+                        var ksigmaTraceStructureMap = $"Structure Map K-Sigma Noise Estimate: {result.Sigma}, Background Mean: {result.BackgroundMean}, NumIterations={result.NumIterations}";
+                        Logger.Trace(ksigmaTraceStructureMap);
+                        MaybeSaveIntermediateText(ksigmaTraceStructureMap, p, "02-ksigma-estimate-noise-reduced.txt");
+
+                        noiseReducedImage.Dispose();
+                        noiseReducedImage = null;
                         return result;
-                    })
-                    : null;
+                    });
 
-                MaybeSaveIntermediateImage(structureMap, p, "03-structure-map-start.tif");
-                stopWatch.RecordEntry("StructureMapPreparation");
+                    // F4 (σ consistency): thresholds applied to the image actually sampled must use that image's σ.
+                    // The estimate above is computed on the (possibly blurred) structure-map source; when a noise
+                    // reduction radius is set but measurement noise reduction is off, srcImage was never blurred and
+                    // its white-noise σ is ~4x larger. Measure it directly on srcImage (rather than applying an
+                    // analytic kernel factor) so correlated real-camera noise and hotpixel filtering are accounted
+                    // for automatically. srcImage is read-only from here until this task is awaited (before binarization), so the concurrent read is safe.
+                    var measurementImageDiffers = p.NoiseReductionRadius > 0 && !noiseReductionApplied;
+                    var measurementNoiseEstimateTask = measurementImageDiffers
+                        ? Task.Run(() => {
+                            var result = CvImageUtility.KappaSigmaNoiseEstimate(srcImage, clippingMultipler: p.NoiseClippingMultiplier);
+                            var ksigmaTraceMeasurement = $"Measurement Image K-Sigma Noise Estimate: {result.Sigma}, Background Mean: {result.BackgroundMean}, NumIterations={result.NumIterations}";
+                            Logger.Trace(ksigmaTraceMeasurement);
+                            MaybeSaveIntermediateText(ksigmaTraceMeasurement, p, "02-ksigma-estimate-measurement.txt");
+                            return result;
+                        })
+                        : null;
 
-                // Step 4: Compute b-spline wavelets to exclude large structures such as nebulae. If the pixel scale is very small or need a wide range for focus, you may need to increase the number of layers
-                //         to keep stars from being excluded
-                using (var residualLayer = ComputeResidualAtrousB3SplineDyadicWaveletLayer(structureMap, p.StructureLayers)) {
-                    MaybeSaveIntermediateImage(residualLayer, p, "04-structure-wavelet-residual.tif");
-                    CvImageUtility.SubtractInPlace(structureMap, residualLayer);
-                }
+                    MaybeSaveIntermediateImage(structureMap, p, "03-structure-map-start.tif");
+                    stopWatch.RecordEntry("StructureMapPreparation");
 
-                MaybeSaveIntermediateImage(structureMap, p, "04-structure-wavelet-subtracted.tif");
-                stopWatch.RecordEntry("WaveletCalculation");
-
-                // Step 5: Excluding large structures can cut off the outsides of large stars, or leave holes when far out of focus. Blurring smooths this out well for structure detection
-                CvImageUtility.ConvolveGaussian(structureMap, structureMap, p.StructureLayers * 2 + 1);
-                MaybeSaveIntermediateImage(structureMap, p, "05-structure-wavelet-blurred.tif");
-                stopWatch.RecordEntry("PostWaveletConvolution");
-
-                // Log histograms produce more accurate results due to clustering in very low ADUs, but are substantially more computationally expensive
-                // The difference doesn't seem worth it based on tests done so far
-                var structureMapStats = CalculateStatistics_Histogram(structureMap, useLogHistogram: false, flags: CvImageStatisticsFlags.Median);
-                stopWatch.RecordEntry("BinarizationStatistics");
-
-                var noiseReducedImageNoise = await noiseReducedNoiseEstimateTask;
-                var measurementImageNoise = measurementNoiseEstimateTask != null
-                    ? await measurementNoiseEstimateTask
-                    : noiseReducedImageNoise;
-                double binarizeThreshold = structureMapStats.Median + p.NoiseClippingMultiplier * noiseReducedImageNoise.Sigma;
-                var binarizeTrace = $"Structure Map Binarization - Median: {structureMapStats.Median}, Threshold: {binarizeThreshold}, Clipping Multiplier: {p.NoiseClippingMultiplier}, Noise Sigma: {noiseReducedImageNoise.Sigma}";
-                Logger.Trace(binarizeTrace);
-                MaybeSaveIntermediateText(structureMapStats.ToString() + Environment.NewLine + binarizeTrace, p, "05-structure-map-statistics.txt");
-
-                if (p.StoreStructureMap) {
-                    UpdateStructureMapDebugData(structureMap, debugData.StructureMap, binarizeThreshold, 1);
-                }
-
-                // Step 6: Boost small structures with a dilation box filter
-                if (p.StructureDilationCount > 0) {
-                    using (var dilationStructure = Cv2.GetStructuringElement(MorphShapes.Ellipse, new Size(p.StructureDilationSize, p.StructureDilationSize))) {
-                        Cv2.MorphologyEx(structureMap, structureMap, MorphTypes.Dilate, dilationStructure, iterations: p.StructureDilationCount, borderType: BorderTypes.Reflect);
+                    // Step 4: Compute b-spline wavelets to exclude large structures such as nebulae. If the pixel scale is very small or need a wide range for focus, you may need to increase the number of layers
+                    //         to keep stars from being excluded
+                    using (var residualLayer = ComputeResidualAtrousB3SplineDyadicWaveletLayer(structureMap, p.StructureLayers)) {
+                        MaybeSaveIntermediateImage(residualLayer, p, "04-structure-wavelet-residual.tif");
+                        CvImageUtility.SubtractInPlace(structureMap, residualLayer);
                     }
-                    stopWatch.RecordEntry("StructureDilation");
-                    MaybeSaveIntermediateImage(structureMap, p, "06-structure-map-dilated.tif");
+
+                    MaybeSaveIntermediateImage(structureMap, p, "04-structure-wavelet-subtracted.tif");
+                    stopWatch.RecordEntry("WaveletCalculation");
+
+                    // Step 5: Excluding large structures can cut off the outsides of large stars, or leave holes when far out of focus. Blurring smooths this out well for structure detection
+                    CvImageUtility.ConvolveGaussian(structureMap, structureMap, p.StructureLayers * 2 + 1);
+                    MaybeSaveIntermediateImage(structureMap, p, "05-structure-wavelet-blurred.tif");
+                    stopWatch.RecordEntry("PostWaveletConvolution");
+
+                    // Log histograms produce more accurate results due to clustering in very low ADUs, but are substantially more computationally expensive
+                    // The difference doesn't seem worth it based on tests done so far
+                    var structureMapStats = CalculateStatistics_Histogram(structureMap, useLogHistogram: false, flags: CvImageStatisticsFlags.Median);
+                    stopWatch.RecordEntry("BinarizationStatistics");
+
+                    var noiseReducedImageNoise = await noiseReducedNoiseEstimateTask;
+                    var measurementImageNoise = measurementNoiseEstimateTask != null
+                        ? await measurementNoiseEstimateTask
+                        : noiseReducedImageNoise;
+                    double binarizeThreshold = structureMapStats.Median + p.NoiseClippingMultiplier * noiseReducedImageNoise.Sigma;
+                    var binarizeTrace = $"Structure Map Binarization - Median: {structureMapStats.Median}, Threshold: {binarizeThreshold}, Clipping Multiplier: {p.NoiseClippingMultiplier}, Noise Sigma: {noiseReducedImageNoise.Sigma}";
+                    Logger.Trace(binarizeTrace);
+                    MaybeSaveIntermediateText(structureMapStats.ToString() + Environment.NewLine + binarizeTrace, p, "05-structure-map-statistics.txt");
+
+                    if (p.StoreStructureMap) {
+                        UpdateStructureMapDebugData(structureMap, debugData.StructureMap, binarizeThreshold, 1);
+                    }
+
+                    // Step 6: Boost small structures with a dilation box filter
+                    if (p.StructureDilationCount > 0) {
+                        using (var dilationStructure = Cv2.GetStructuringElement(MorphShapes.Ellipse, new Size(p.StructureDilationSize, p.StructureDilationSize))) {
+                            Cv2.MorphologyEx(structureMap, structureMap, MorphTypes.Dilate, dilationStructure, iterations: p.StructureDilationCount, borderType: BorderTypes.Reflect);
+                        }
+                        stopWatch.RecordEntry("StructureDilation");
+                        MaybeSaveIntermediateImage(structureMap, p, "06-structure-map-dilated.tif");
+                    }
+
+                    if (p.StoreStructureMap) {
+                        UpdateStructureMapDebugData(structureMap, debugData.StructureMap, binarizeThreshold, 2);
+                    }
+
+                    progress?.Report(new ApplicationStatus() { Status = "Structure Detection" });
+
+                    // Step 7: Binarize foreground structures based on noise estimates
+                    CvImageUtility.Binarize(structureMap, structureMap, binarizeThreshold);
+                    if (p.Region.InnerCropBoundary != null) {
+                        var innerRoiRect = new Rect(
+                            (int)Math.Floor(srcImage.Cols * p.Region.InnerCropBoundary.StartX),
+                            (int)Math.Floor(srcImage.Rows * p.Region.InnerCropBoundary.StartY),
+                            (int)(srcImage.Cols * p.Region.InnerCropBoundary.Width),
+                            (int)(srcImage.Rows * p.Region.InnerCropBoundary.Height));
+                        structureMap.SubMat(innerRoiRect).SetTo(0.0f);
+                        Logger.Info($"Clearing structure map for inner ROI: {p.Region.InnerCropBoundary}");
+                    }
+
+                    stopWatch.RecordEntry("Binarization");
+                    MaybeSaveIntermediateImage(structureMap, p, "07-structure-binarized.tif");
+
+                    // Step 8: Scan the structure map and collect ALL candidate regions (the late size/shape/border
+                    // gates are NOT applied here — they live in GateAndMeasure, so the candidate set depends only on
+                    // the early params). This tallies the early-only metrics: StructureCandidates (per candidate),
+                    // HotpixelCount (already set above), and SaturatedPixelCount (via EvaluateGlobalMetrics).
+                    progress?.Report(new ApplicationStatus() { Status = "Scan and Analyze Stars" });
+                    var candidates = CollectStarCandidates(srcImage, structureMap, p, metrics, token);
+                    stopWatch.RecordEntry("CollectStarCandidates");
+
+                    // srcImage (the prepared measurement image) is never registered with the tracker — it is the
+                    // method parameter, replaced by a fresh Clone()'d ROI submat when an ROI is in play (the old one
+                    // disposed there). So disposing the local tracker in the finally frees only the scratch Mats
+                    // (structureMap; noiseReducedImage is disposed inside its task) and the context's image survives.
+                    var context = new DetectionContext {
+                        MeasurementImage = srcImage,
+                        Candidates = candidates,
+                        StructureNoiseSigma = noiseReducedImageNoise.Sigma,
+                        MeasurementNoiseSigma = measurementImageNoise.Sigma,
+                        RoiRect = roiRect,
+                        DebugData = debugData,
+                        HotpixelCount = metrics.HotpixelCount,
+                        StructureCandidates = metrics.StructureCandidates,
+                        SaturatedPixelCount = metrics.SaturatedPixelCount
+                    };
+                    // The context now owns srcImage; clear the failure-cleanup flag so the finally does NOT dispose it.
+                    contextProduced = true;
+                    return context;
                 }
-
-                if (p.StoreStructureMap) {
-                    UpdateStructureMapDebugData(structureMap, debugData.StructureMap, binarizeThreshold, 2);
+            } finally {
+                if (ownsLocalTracker) {
+                    // Free the transient scratch Mats (structure map, etc). The prepared srcImage was detached above
+                    // and survives on the returned context.
+                    scratch.Dispose();
                 }
-
-                progress?.Report(new ApplicationStatus() { Status = "Structure Detection" });
-
-                // Step 7: Binarize foreground structures based on noise estimates
-                CvImageUtility.Binarize(structureMap, structureMap, binarizeThreshold);
-                if (p.Region.InnerCropBoundary != null) {
-                    var innerRoiRect = new Rect(
-                        (int)Math.Floor(srcImage.Cols * p.Region.InnerCropBoundary.StartX),
-                        (int)Math.Floor(srcImage.Rows * p.Region.InnerCropBoundary.StartY),
-                        (int)(srcImage.Cols * p.Region.InnerCropBoundary.Width),
-                        (int)(srcImage.Rows * p.Region.InnerCropBoundary.Height));
-                    structureMap.SubMat(innerRoiRect).SetTo(0.0f);
-                    Logger.Info($"Clearing structure map for inner ROI: {p.Region.InnerCropBoundary}");
+                if (!contextProduced) {
+                    // The early pipeline threw before the context was constructed: dispose the in-flight source/ROI
+                    // Mat we own so the ~244 MB allocation is not orphaned. On the monolithic no-ROI path
+                    // liveOwnedImage is null (the caller still owns + disposes its input), so this is a no-op there —
+                    // preserving the established contract that the no-ROI Detect path never disposes the caller's Mat.
+                    liveOwnedImage?.Dispose();
                 }
+            }
+        }
 
-                stopWatch.RecordEntry("Binarization");
-                MaybeSaveIntermediateImage(structureMap, p, "07-structure-binarized.tif");
+        private async Task<HocusFocusStarDetectorResult> GateAndMeasureInternal(DetectionContext ctx, StarDetectorParams p, IProgress<ApplicationStatus> progress, CancellationToken token) {
+            var srcImage = ctx.MeasurementImage;
+            var roiRect = ctx.RoiRect;
 
-                // Step 8: Scan structure map for stars
-                progress?.Report(new ApplicationStatus() { Status = "Scan and Analyze Stars" });
-                var stars = ScanStars(srcImage, structureMap, p, measurementImageNoise.Sigma, metrics, contaminationDiagnosticsBag, token);
+            // Seed a fresh metrics with ONLY the early-stage counters carried on the context, then run the late
+            // (gate + measure) stage which fills in every other counter. Starting fresh each call is what makes a
+            // reused context produce the same metrics as a one-shot detect.
+            var metrics = new StarDetectorMetrics {
+                // The debayered-hotpixel path (IRenderedImage) overwrites the structure-pipeline HotpixelCount with
+                // the CFA count, exactly as the monolithic Detect(IRenderedImage) did; otherwise the early
+                // structure-pipeline count is authoritative.
+                HotpixelCount = ctx.DebayerHotpixelCount ?? ctx.HotpixelCount,
+                StructureCandidates = ctx.StructureCandidates,
+                SaturatedPixelCount = ctx.SaturatedPixelCount
+            };
+
+            // Per-call diagnostics bag (thread-safe; the late stage evaluates candidates in parallel). Null in
+            // normal runs (zero overhead).
+            var contaminationDiagnosticsBag = p.CollectContaminationDiagnostics ? new ConcurrentBag<ContaminationDiagnosticRecord>() : null;
+
+            using (var stopWatch = MultiStopWatch.Measure()) {
+                var stars = EvaluateStarCandidates(srcImage, ctx.Candidates, p, ctx.MeasurementNoiseSigma, metrics, contaminationDiagnosticsBag, token);
                 stopWatch.RecordEntry("StarAnalysis");
 
                 // Step 9: Fit PSF models
@@ -372,7 +623,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                     // overhead is eliminated. The remaining timer is TRACE-only (short-circuits unless TRACE is on).
                     var psfStopwatch = Stopwatch.StartNew();
                     progress?.Report(new ApplicationStatus() { Status = "Modeling PSFs" });
-                    await ModelPSF(srcImage, measurementImageNoise.Sigma, stars, p, metrics, token);
+                    await ModelPSF(srcImage, ctx.MeasurementNoiseSigma, stars, p, metrics, token);
 
                     stopWatch.RecordEntry("ModelPSF");
                     psfStopwatch.Stop();
@@ -414,10 +665,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                 return new HocusFocusStarDetectorResult() {
                     DetectedStars = stars,
                     Metrics = metrics,
-                    DebugData = debugData,
+                    DebugData = ctx.DebugData,
                     ContaminationDiagnostics = contaminationDiagnostics,
-                    StructureNoiseSigma = noiseReducedImageNoise.Sigma,
-                    MeasurementNoiseSigma = measurementImageNoise.Sigma
+                    StructureNoiseSigma = ctx.StructureNoiseSigma,
+                    MeasurementNoiseSigma = ctx.MeasurementNoiseSigma
                 };
             }
         }
@@ -751,7 +1002,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
 
         // A candidate star collected by the sequential flood-fill (Stage A) and evaluated in parallel (Stage B).
         // Each candidate owns its OWN point list (no sharing/reuse) so the parallel evaluation is data-race free.
-        private readonly struct StarCandidateRegion {
+        internal readonly struct StarCandidateRegion {
             public readonly Rect Bounds;
             public readonly List<Point> Points;
 
@@ -761,15 +1012,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             }
         }
 
-        private List<Star> ScanStars(Mat srcImage, Mat structureMap, StarDetectorParams p, double srcImageNoiseSigma, StarDetectorMetrics metrics, ConcurrentBag<ContaminationDiagnosticRecord> diagnosticsBag, CancellationToken ct) {
-            // Stage A: sequential flood-fill raster walk. Collects each candidate (bounds + its own point list)
-            // and zeroes the candidate's pixels so it is not re-scanned. EvaluateGlobalMetrics and the per-
-            // candidate StructureCandidates count run here, single-threaded, on the main metrics.
-            var candidates = CollectStarCandidates(srcImage, structureMap, p, metrics, ct);
-
-            // Stage B: evaluate every candidate in parallel. Per-star evaluation is independent (only LOCAL
-            // arrays + read-only image reads), so the only shared mutable state is the metrics (handled via
-            // thread-locals merged afterward) and the (thread-safe, per-DetectImpl) diagnosticsBag.
+        // Stage B: evaluate every collected candidate in parallel and assemble the accepted stars in deterministic
+        // raster order. This is the LATE phase — it applies all size/shape/border/sensitivity gates and measures
+        // each accepted star. It only READS srcImage + the candidate point lists, so it is safe to run repeatedly
+        // against the same cached DetectionContext with different late params.
+        private List<Star> EvaluateStarCandidates(Mat srcImage, List<StarCandidateRegion> candidates, StarDetectorParams p, double srcImageNoiseSigma, StarDetectorMetrics metrics, ConcurrentBag<ContaminationDiagnosticRecord> diagnosticsBag, CancellationToken ct) {
+            // Per-star evaluation is independent (only LOCAL arrays + read-only image reads), so the only shared
+            // mutable state is the metrics (handled via thread-locals merged afterward) and the (thread-safe,
+            // per-call) diagnosticsBag.
             var results = new Star[candidates.Count];
             using var localMetrics = new ThreadLocal<StarDetectorMetrics>(() => new StarDetectorMetrics(), trackAllValues: true);
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
@@ -1149,6 +1149,40 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             return candidates;
         }
 
+        /// <summary>
+        /// Computes the effective fill-ratio threshold the TooDistorted gate compares against for a candidate of
+        /// bbox max-dimension <paramref name="candidateSize"/> (= max(bbox.Width, bbox.Height), the same d the
+        /// gate divides by).
+        ///
+        /// When <see cref="StarDetectorParams.DefocusAwareDistortion"/> is FALSE this returns
+        /// <see cref="StarDetectorParams.MaxDistortion"/> verbatim, so the gate is byte-for-byte the legacy gate
+        /// (default-OFF ⇒ bit-identical detection). When TRUE it returns
+        ///   MaxDistortion · clamp(SizeReference / candidateSize, MinFactor, 1.0)
+        /// so candidates at or below the size reference keep the strict threshold (factor 1.0) and larger
+        /// candidates (defocused donuts, large bbox + low fill-ratio) get a more permissive threshold, floored at
+        /// MinFactor · MaxDistortion. Pure + deterministic (no image access) so it is unit-testable in isolation.
+        /// </summary>
+        public static double ComputeEffectiveMaxDistortion(StarDetectorParams p, double candidateSize) {
+            if (!p.DefocusAwareDistortion) {
+                return p.MaxDistortion;
+            }
+
+            // Degenerate sizes can't make the gate permissive; fall back to the strict threshold.
+            if (candidateSize <= 0.0 || p.DefocusDistortionSizeReference <= 0.0) {
+                return p.MaxDistortion;
+            }
+
+            var factor = p.DefocusDistortionSizeReference / candidateSize;
+            // clamp to [MinFactor, 1.0]: ≤ SizeReference ⇒ ≥ 1 ⇒ strict; larger ⇒ relaxes toward the floor.
+            var minFactor = p.DefocusDistortionMinFactor;
+            if (factor > 1.0) {
+                factor = 1.0;
+            } else if (factor < minFactor) {
+                factor = minFactor;
+            }
+            return p.MaxDistortion * factor;
+        }
+
         private Star EvaluateStarCandidate(Mat srcImage, StarDetectorParams p, Rect starBounds, List<Point> starPoints, double srcImageNoiseSigma, StarDetectorMetrics metrics, ConcurrentBag<ContaminationDiagnosticRecord> diagnosticsBag) {
             // Now we have a potential star bounding box as well as the coordinates of every star pixel. If this is a reliable star,
             // we compute its barycenter and include it.
@@ -1173,9 +1207,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                 return null;
             }
 
-            // Too distorted
+            // Too distorted. The fill-ratio metric is (pixel count) / d², where d is the bbox max dimension; a
+            // perfect disk fills ~PI/4 ≈ 0.79. When DefocusAwareDistortion is off, the effective threshold is
+            // exactly p.MaxDistortion (bit-identical to the legacy gate). When on, it is relaxed for large
+            // candidates so large-defocus donuts (big bbox, low fill-ratio) survive — see
+            // ComputeEffectiveMaxDistortion. The same effective threshold drives both the decision and the
+            // TooDistorted metrics tally.
             double d = Math.Max(starBounds.Width, starBounds.Height);
-            if ((starPoints.Count / d / d) < p.MaxDistortion) {
+            var effectiveMaxDistortion = ComputeEffectiveMaxDistortion(p, d);
+            if ((starPoints.Count / d / d) < effectiveMaxDistortion) {
                 metrics.TooDistortedBounds.Add(starBounds);
                 return null;
             }

--- a/Joko.NINA.Plugins/TestApp/ContaminationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/ContaminationDiagnosticRunner.cs
@@ -149,6 +149,24 @@ namespace TestApp {
                 Console.WriteLine("DefocusAwareDistortion=OFF");
             }
 
+            // Companion defocus-aware CENTERING test switch (relaxes the NotCentered gate for large/defocused
+            // candidates). Shares the size reference with the distortion gate; optional --defocus-center-factor
+            // overrides the max centering-tolerance multiplier.
+            if (DiagnosticUtil.HasFlag(args, "--defocus-centering")) {
+                baseParams.DefocusAwareCentering = true;
+                var sizeRefArg = DiagnosticUtil.GetArg(args, "--defocus-size-ref");
+                if (!string.IsNullOrWhiteSpace(sizeRefArg) && double.TryParse(sizeRefArg, NumberStyles.Float, CultureInfo.InvariantCulture, out var sizeRef)) {
+                    baseParams.DefocusDistortionSizeReference = sizeRef;
+                }
+                var centerFactorArg = DiagnosticUtil.GetArg(args, "--defocus-center-factor");
+                if (!string.IsNullOrWhiteSpace(centerFactorArg) && double.TryParse(centerFactorArg, NumberStyles.Float, CultureInfo.InvariantCulture, out var centerFactor)) {
+                    baseParams.DefocusCenteringToleranceFactor = centerFactor;
+                }
+                Console.WriteLine($"DefocusAwareCentering=ON (SizeReference={baseParams.DefocusDistortionSizeReference.ToString(CultureInfo.InvariantCulture)} px, ToleranceFactor={baseParams.DefocusCenteringToleranceFactor.ToString(CultureInfo.InvariantCulture)})");
+            } else {
+                Console.WriteLine("DefocusAwareCentering=OFF");
+            }
+
             // Load the original image once (CV_32F, normalized [0,1]). Detection mutates its input in place,
             // so each run gets a clone and the original is kept for the annotated background.
             using var srcFloat = await DiagnosticUtil.LoadFloatMat(imagePath, profileService);

--- a/Joko.NINA.Plugins/TestApp/ContaminationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/ContaminationDiagnosticRunner.cs
@@ -131,6 +131,24 @@ namespace TestApp {
                 baseParams.ContaminationSensitivity = sensitivityOverride.Value;
             }
 
+            // Opt-in defocus-aware distortion test switch (for the near-focus precision check). Flips the flag ON
+            // and optionally overrides the two tuning knobs; prints accepted + TooDistorted before/after so the
+            // gate's effect on a single frame is visible without labels.
+            if (DiagnosticUtil.HasFlag(args, "--defocus-distortion")) {
+                baseParams.DefocusAwareDistortion = true;
+                var sizeRefArg = DiagnosticUtil.GetArg(args, "--defocus-size-ref");
+                if (!string.IsNullOrWhiteSpace(sizeRefArg) && double.TryParse(sizeRefArg, NumberStyles.Float, CultureInfo.InvariantCulture, out var sizeRef)) {
+                    baseParams.DefocusDistortionSizeReference = sizeRef;
+                }
+                var minFactorArg = DiagnosticUtil.GetArg(args, "--defocus-min-factor");
+                if (!string.IsNullOrWhiteSpace(minFactorArg) && double.TryParse(minFactorArg, NumberStyles.Float, CultureInfo.InvariantCulture, out var minFactor)) {
+                    baseParams.DefocusDistortionMinFactor = minFactor;
+                }
+                Console.WriteLine($"DefocusAwareDistortion=ON (SizeReference={baseParams.DefocusDistortionSizeReference.ToString(CultureInfo.InvariantCulture)} px, MinFactor={baseParams.DefocusDistortionMinFactor.ToString(CultureInfo.InvariantCulture)})");
+            } else {
+                Console.WriteLine("DefocusAwareDistortion=OFF");
+            }
+
             // Load the original image once (CV_32F, normalized [0,1]). Detection mutates its input in place,
             // so each run gets a clone and the original is kept for the annotated background.
             using var srcFloat = await DiagnosticUtil.LoadFloatMat(imagePath, profileService);
@@ -149,6 +167,7 @@ namespace TestApp {
             int total = result.DetectedStars.Count;
             int suspected = result.Metrics.ContaminationSuspected;
             Console.WriteLine($"Detected {total}, {suspected} contamination-suspected ({Percent(suspected, total)})");
+            Console.WriteLine($"PRECISION-CHECK accepted={total}, TooDistorted={result.Metrics.TooDistorted}, NotCentered={result.Metrics.NotCentered}, TooSmall={result.Metrics.TooSmall}");
 
             var shapes = BuildShapeLookup(result, diagnostics);
             WriteCsv(Path.Combine(outDir, "contamination_stars.csv"), diagnostics, shapes);

--- a/Joko.NINA.Plugins/TestApp/DiagnoseLabelsRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/DiagnoseLabelsRunner.cs
@@ -159,9 +159,31 @@ namespace TestApp {
             var firstFramePath = discovered[0].Frames.FirstOrDefault()?.Path;
             var firstRunFolder = string.IsNullOrEmpty(firstFramePath) ? null : Path.GetDirectoryName(firstFramePath);
             var detectionParams = StarReviewRunner.BuildDetectionParams(starDetectionOptions, activeProfile, useOptimized, optResultsDir, firstRunFolder);
+
+            // Opt-in defocus-aware distortion test switch. Flips DefocusAwareDistortion ON on the freshly built
+            // params (least-invasive: does not touch the profile). Optional --defocus-size-ref / --defocus-min-factor
+            // override the two tuning knobs (otherwise the StarDetectorParams class defaults 20.0 px / 0.25 apply).
+            // This lets a single `--params current` baseline run be re-run with the gate ON to measure the delta.
+            if (DiagnosticUtil.HasFlag(args, "--defocus-distortion")) {
+                detectionParams.DefocusAwareDistortion = true;
+                var sizeRefArg = DiagnosticUtil.GetArg(args, "--defocus-size-ref");
+                if (!string.IsNullOrWhiteSpace(sizeRefArg) && double.TryParse(sizeRefArg, NumberStyles.Float, CultureInfo.InvariantCulture, out var sizeRef)) {
+                    detectionParams.DefocusDistortionSizeReference = sizeRef;
+                }
+                var minFactorArg = DiagnosticUtil.GetArg(args, "--defocus-min-factor");
+                if (!string.IsNullOrWhiteSpace(minFactorArg) && double.TryParse(minFactorArg, NumberStyles.Float, CultureInfo.InvariantCulture, out var minFactor)) {
+                    detectionParams.DefocusDistortionMinFactor = minFactor;
+                }
+            }
+
             Line($"Detection params: Sensitivity={detectionParams.Sensitivity.ToString("G6", CultureInfo.InvariantCulture)}, " +
                 $"StructureLayers={detectionParams.StructureLayers}, MaxDistortion={detectionParams.MaxDistortion.ToString("G6", CultureInfo.InvariantCulture)}, " +
                 $"PixelScale={detectionParams.PixelScale.ToString("G6", CultureInfo.InvariantCulture)}, RejectContaminated={detectionParams.RejectContaminatedStars}");
+            Line($"DefocusAwareDistortion={detectionParams.DefocusAwareDistortion}" +
+                (detectionParams.DefocusAwareDistortion
+                    ? $" (SizeReference={detectionParams.DefocusDistortionSizeReference.ToString("G6", CultureInfo.InvariantCulture)} px, " +
+                      $"MinFactor={detectionParams.DefocusDistortionMinFactor.ToString("G6", CultureInfo.InvariantCulture)})"
+                    : ""));
             Line();
 
             var detector = new StarDetector(new AlglibAPI());
@@ -385,6 +407,9 @@ namespace TestApp {
             Console.Error.WriteLine("  --opt-results (optional) folder holding optimized_settings.json (the optimizer's --out subdir).");
             Console.Error.WriteLine("  --profile-id  (default active) NINA profile id to load.");
             Console.Error.WriteLine("  --out         (default a temp dir) where diagnose_labels.txt is written.");
+            Console.Error.WriteLine("  --defocus-distortion        (opt-in test switch) flips DefocusAwareDistortion ON on the built params.");
+            Console.Error.WriteLine("  --defocus-size-ref <px>     (with --defocus-distortion) override the strict-below size reference (default 20).");
+            Console.Error.WriteLine("  --defocus-min-factor <0..1> (with --defocus-distortion) override the floor multiplier on MaxDistortion (default 0.25).");
         }
 
         // ---- Run / frame discovery (mirrors StarReviewRunner / OptimizationDiagnosticRunner) ----------------

--- a/Joko.NINA.Plugins/TestApp/DiagnoseLabelsRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/DiagnoseLabelsRunner.cs
@@ -176,6 +176,23 @@ namespace TestApp {
                 }
             }
 
+            // Opt-in defocus-aware CENTERING test switch (companion to --defocus-distortion). Flips
+            // DefocusAwareCentering ON on the freshly built params; optional --defocus-center-factor overrides the
+            // max centering-tolerance multiplier (otherwise the StarDetectorParams class default 2.0 applies). The
+            // size reference is SHARED with the distortion gate (DefocusDistortionSizeReference), so --defocus-size-ref
+            // affects both gates. Enable both flags to recover ring-unstable donut centroids the distortion gate admits.
+            if (DiagnosticUtil.HasFlag(args, "--defocus-centering")) {
+                detectionParams.DefocusAwareCentering = true;
+                var sizeRefArg = DiagnosticUtil.GetArg(args, "--defocus-size-ref");
+                if (!string.IsNullOrWhiteSpace(sizeRefArg) && double.TryParse(sizeRefArg, NumberStyles.Float, CultureInfo.InvariantCulture, out var sizeRef)) {
+                    detectionParams.DefocusDistortionSizeReference = sizeRef;
+                }
+                var centerFactorArg = DiagnosticUtil.GetArg(args, "--defocus-center-factor");
+                if (!string.IsNullOrWhiteSpace(centerFactorArg) && double.TryParse(centerFactorArg, NumberStyles.Float, CultureInfo.InvariantCulture, out var centerFactor)) {
+                    detectionParams.DefocusCenteringToleranceFactor = centerFactor;
+                }
+            }
+
             Line($"Detection params: Sensitivity={detectionParams.Sensitivity.ToString("G6", CultureInfo.InvariantCulture)}, " +
                 $"StructureLayers={detectionParams.StructureLayers}, MaxDistortion={detectionParams.MaxDistortion.ToString("G6", CultureInfo.InvariantCulture)}, " +
                 $"PixelScale={detectionParams.PixelScale.ToString("G6", CultureInfo.InvariantCulture)}, RejectContaminated={detectionParams.RejectContaminatedStars}");
@@ -183,6 +200,11 @@ namespace TestApp {
                 (detectionParams.DefocusAwareDistortion
                     ? $" (SizeReference={detectionParams.DefocusDistortionSizeReference.ToString("G6", CultureInfo.InvariantCulture)} px, " +
                       $"MinFactor={detectionParams.DefocusDistortionMinFactor.ToString("G6", CultureInfo.InvariantCulture)})"
+                    : ""));
+            Line($"DefocusAwareCentering={detectionParams.DefocusAwareCentering}" +
+                (detectionParams.DefocusAwareCentering
+                    ? $" (SizeReference={detectionParams.DefocusDistortionSizeReference.ToString("G6", CultureInfo.InvariantCulture)} px, " +
+                      $"ToleranceFactor={detectionParams.DefocusCenteringToleranceFactor.ToString("G6", CultureInfo.InvariantCulture)})"
                     : ""));
             Line();
 
@@ -408,8 +430,10 @@ namespace TestApp {
             Console.Error.WriteLine("  --profile-id  (default active) NINA profile id to load.");
             Console.Error.WriteLine("  --out         (default a temp dir) where diagnose_labels.txt is written.");
             Console.Error.WriteLine("  --defocus-distortion        (opt-in test switch) flips DefocusAwareDistortion ON on the built params.");
-            Console.Error.WriteLine("  --defocus-size-ref <px>     (with --defocus-distortion) override the strict-below size reference (default 20).");
+            Console.Error.WriteLine("  --defocus-centering         (opt-in test switch) flips DefocusAwareCentering ON (relaxes NotCentered for large/defocused candidates).");
+            Console.Error.WriteLine("  --defocus-size-ref <px>     (with either defocus switch) override the strict-below size reference, shared by both gates (default 30).");
             Console.Error.WriteLine("  --defocus-min-factor <0..1> (with --defocus-distortion) override the floor multiplier on MaxDistortion (default 0.25).");
+            Console.Error.WriteLine("  --defocus-center-factor <>=1> (with --defocus-centering) override the max multiplier on StarCenterTolerance (default 2.0).");
         }
 
         // ---- Run / frame discovery (mirrors StarReviewRunner / OptimizationDiagnosticRunner) ----------------

--- a/Joko.NINA.Plugins/TestApp/DiagnoseLabelsRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/DiagnoseLabelsRunner.cs
@@ -1,0 +1,445 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Enum;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NINA.Profile;
+using NINA.Profile.Interfaces;
+using OpenCvSharp;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using TestApp.StarReview;
+using Logger = NINA.Core.Utility.Logger;
+using Rect = OpenCvSharp.Rect;
+
+namespace TestApp {
+
+    /// <summary>
+    /// Headless diagnostic: classify EACH human-labeled review box (missed / shouldReject / wronglyRejected)
+    /// against a fresh detection of the same frame, to determine which detector outcome applies to it:
+    ///
+    /// <list type="bullet">
+    /// <item><b>ACCEPTED</b> — the label box overlaps an accepted star's <c>StarBoundingBox</c> (the detector
+    ///   already keeps it).</item>
+    /// <item><b>REJECTED:&lt;reason&gt;</b> — the label box overlaps a rejected candidate from one of the
+    ///   <c>StarDetectorMetrics.*Bounds</c> lists (TooDistorted / Degenerate / Saturated / LowSensitivity /
+    ///   NotCentered / TooFlat / Contaminated); reports WHICH gate killed it.</item>
+    /// <item><b>NO CANDIDATE (structure gap)</b> — the label box overlaps no accepted star AND no rejected
+    ///   candidate, so the detector never even formed a candidate there: a true structure-detection gap, only
+    ///   fixable by detector-algorithm work (not by loosening a gate).</item>
+    /// </list>
+    ///
+    /// <para>This is purely a READ-ONLY diagnostic: it reuses <see cref="StarReviewRunner"/>'s param construction
+    /// (<c>--params current|optimized</c> + <c>--opt-results</c>/run-folder resolution) and rejected-candidate
+    /// extraction so it sees exactly what the review overlay / optimizer see, never mutating the profile or
+    /// detection logic. It tells us whether the wrongly-rejected donut stars are killed by ONE loosenable gate
+    /// versus being structure gaps.</para>
+    ///
+    /// <para>CLI: <c>TestApp diagnose-labels --runs &lt;folder&gt; --labels &lt;dir&gt; [--params current|optimized]
+    /// [--opt-results &lt;dir&gt;] [--profile-id &lt;guid&gt;] [--out &lt;dir&gt;]</c>.</para>
+    /// </summary>
+    internal static class DiagnoseLabelsRunner {
+
+        // The four classification outcomes for a labeled box.
+        private const string ResultAccepted = "ACCEPTED";
+        private const string ResultNoCandidate = "NO CANDIDATE";
+
+        public static void Run(string[] args) {
+            try {
+                RunImpl(args);
+            } catch (Exception ex) {
+                Console.Error.WriteLine($"ERROR: {ex.Message}");
+                Console.Error.WriteLine(ex.ToString());
+                Logger.Error(ex, "diagnose-labels run failed");
+                Environment.ExitCode = 1;
+            }
+        }
+
+        private static void RunImpl(string[] args) {
+            var runsDir = DiagnosticUtil.GetArg(args, "--runs");
+            if (string.IsNullOrWhiteSpace(runsDir)) {
+                PrintUsage();
+                Environment.ExitCode = 2;
+                return;
+            }
+            if (!Directory.Exists(runsDir)) {
+                throw new DirectoryNotFoundException($"--runs folder not found: {runsDir}");
+            }
+
+            // Default labels dir alongside the runs (mirrors `review`/`optimize`).
+            var labelsDir = DiagnosticUtil.GetArg(args, "--labels");
+            if (string.IsNullOrWhiteSpace(labelsDir)) {
+                labelsDir = Path.Combine(runsDir, "labels");
+            }
+            if (!Directory.Exists(labelsDir)) {
+                throw new DirectoryNotFoundException($"--labels folder not found: {labelsDir}");
+            }
+
+            var profileId = DiagnosticUtil.GetArg(args, "--profile-id");
+
+            var paramsArg = (DiagnosticUtil.GetArg(args, "--params") ?? "current").Trim().ToLowerInvariant();
+            bool useOptimized;
+            switch (paramsArg) {
+                case "current": useOptimized = false; break;
+                case "optimized": useOptimized = true; break;
+                default: throw new ArgumentException($"--params: '{paramsArg}' must be 'current' or 'optimized'");
+            }
+            var optResultsDir = DiagnosticUtil.GetArg(args, "--opt-results");
+
+            var outDir = DiagnosticUtil.GetArg(args, "--out");
+            if (string.IsNullOrWhiteSpace(outDir)) {
+                outDir = Path.Combine(Path.GetTempPath(), "hf-diagnose-labels", DateTime.Now.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture));
+            }
+            Directory.CreateDirectory(outDir);
+
+            Logger.SetLogLevel(LogLevelEnum.TRACE);
+
+            // The real ProfileService.ActiveProfile setter writes to Application.Current.Resources, so a WPF
+            // Application must exist before the profile loads (mirrors the review / contamination runners).
+            if (System.Windows.Application.Current == null) {
+                new System.Windows.Application();
+            }
+
+            var sb = new StringBuilder();
+            void Line(string s = "") {
+                Console.WriteLine(s);
+                sb.AppendLine(s);
+            }
+
+            Line($"Runs root: {runsDir}");
+            Line($"Labels dir: {labelsDir}");
+            Line($"Params: {paramsArg}");
+            Line($"Out dir: {outDir}");
+
+            // Load the user's real profile + star detection options (single source of truth for params + PixelScale).
+            var profileService = new ProfileService();
+            profileService.TryLoad(profileId ?? string.Empty);
+            var activeProfile = profileService.ActiveProfile;
+            if (activeProfile == null) {
+                throw new InvalidOperationException("No active NINA profile could be loaded. Pass --profile-id, or run NINA at least once to create a profile.");
+            }
+            Line($"Profile: {activeProfile.Name} ({activeProfile.Id})");
+
+            var guid = PluginOptionsAccessor.GetAssemblyGuid(typeof(StarDetectionOptions));
+            if (guid == null) {
+                throw new InvalidOperationException("Could not resolve the HocusFocus plugin assembly GUID");
+            }
+            var accessor = new PluginOptionsAccessor(profileService, guid.Value);
+            var starDetectionOptions = new StarDetectionOptions(profileService, accessor);
+
+            var discovered = DiscoverRuns(runsDir);
+            if (discovered.Count == 0) {
+                throw new InvalidOperationException(
+                    $"No AF frames matched the saved-run filename pattern under {runsDir}. Expected files like " +
+                    "'0_Frame1_BitDepth16_Bayered0_Focuser5000.fits' in the folder or an immediate subfolder.");
+            }
+            Line($"Discovered {discovered.Count} run(s):");
+            foreach (var d in discovered) {
+                Line($"  {d.RunId}: {d.Frames.Count} frames");
+            }
+
+            // Build the detection params (current vs optimized) via StarReviewRunner's single source of truth so
+            // this diagnostic sees exactly what the review overlay / optimizer see.
+            var firstFramePath = discovered[0].Frames.FirstOrDefault()?.Path;
+            var firstRunFolder = string.IsNullOrEmpty(firstFramePath) ? null : Path.GetDirectoryName(firstFramePath);
+            var detectionParams = StarReviewRunner.BuildDetectionParams(starDetectionOptions, activeProfile, useOptimized, optResultsDir, firstRunFolder);
+            Line($"Detection params: Sensitivity={detectionParams.Sensitivity.ToString("G6", CultureInfo.InvariantCulture)}, " +
+                $"StructureLayers={detectionParams.StructureLayers}, MaxDistortion={detectionParams.MaxDistortion.ToString("G6", CultureInfo.InvariantCulture)}, " +
+                $"PixelScale={detectionParams.PixelScale.ToString("G6", CultureInfo.InvariantCulture)}, RejectContaminated={detectionParams.RejectContaminatedStars}");
+            Line();
+
+            var detector = new StarDetector(new AlglibAPI());
+
+            // Tally: category -> (result-or-reason -> count). Result key is "ACCEPTED", "NO CANDIDATE", or
+            // "REJECTED:<reason>".
+            var tally = new Dictionary<string, Dictionary<string, int>>(StringComparer.Ordinal);
+            void Tally(string category, string result) {
+                if (!tally.TryGetValue(category, out var byResult)) {
+                    byResult = new Dictionary<string, int>(StringComparer.Ordinal);
+                    tally[category] = byResult;
+                }
+                byResult[result] = byResult.TryGetValue(result, out var c) ? c + 1 : 1;
+            }
+
+            int totalBoxes = 0;
+            foreach (var d in discovered) {
+                // Load labels for this run (reuse the same loader/model the review tool writes + optimizer reads).
+                var labels = StarReviewLabelStore.Load(labelsDir, d.RunId, out var loadError);
+                if (loadError != null) {
+                    Line($"WARNING: {loadError}");
+                    Logger.Warning(loadError);
+                }
+                if (labels?.Positions == null || labels.Positions.Count == 0) {
+                    continue;
+                }
+
+                // Index frames by focuser position so we only detect/process positions that appear in the labels.
+                var framesByPos = d.Frames
+                    .GroupBy(f => f.FocuserPosition)
+                    .ToDictionary(g => g.Key, g => g.First().Path);
+
+                foreach (var pos in labels.Positions.OrderBy(p => p.FocuserPosition)) {
+                    var missed = pos.Missed ?? new List<StarReviewLabelBox>();
+                    var shouldReject = pos.ShouldReject ?? new List<StarReviewLabelBox>();
+                    var wronglyRejected = pos.WronglyRejected ?? new List<StarReviewLabelBox>();
+                    if (missed.Count == 0 && shouldReject.Count == 0 && wronglyRejected.Count == 0) {
+                        continue;
+                    }
+
+                    if (!framesByPos.TryGetValue(pos.FocuserPosition, out var framePath)) {
+                        Line($"WARNING: run '{d.RunId}' label focuser {pos.FocuserPosition} has no matching frame; skipping " +
+                            $"{missed.Count + shouldReject.Count + wronglyRejected.Count} box(es).");
+                        Logger.Warning($"diagnose-labels: no frame for run '{d.RunId}' focuser {pos.FocuserPosition}");
+                        continue;
+                    }
+
+                    // Fresh detection of this frame (Detect mutates its input; clone the loaded Mat).
+                    List<Star> accepted;
+                    List<(string Reason, Rect Bounds)> rejected;
+                    using (var mat = DiagnosticUtil.LoadFloatMat(framePath, profileService).GetAwaiter().GetResult())
+                    using (var clone = mat.Clone()) {
+                        var result = detector.Detect(clone, detectionParams, null, CancellationToken.None).GetAwaiter().GetResult();
+                        accepted = result.DetectedStars ?? new List<Star>();
+                        rejected = StarReviewRunner.ExtractRejected(result);
+                    }
+
+                    Line($"=== run '{d.RunId}' @ focuser {pos.FocuserPosition} ({Path.GetFileName(framePath)}) ===");
+                    Line($"    detection: {accepted.Count} accepted, {rejected.Count} rejected candidate(s)");
+                    Line($"    {"category",-16} {"box(x,y,w,h)",-28} {"result",-26} matched candidate");
+
+                    void Classify(string category, List<StarReviewLabelBox> boxes) {
+                        foreach (var box in boxes) {
+                            totalBoxes++;
+                            var (result, matchDesc) = ClassifyBox(box, accepted, rejected);
+                            Tally(category, result);
+                            Line($"    {category,-16} {FormatBox(box),-28} {result,-26} {matchDesc}");
+                        }
+                    }
+
+                    Classify("missed", missed);
+                    Classify("shouldReject", shouldReject);
+                    Classify("wronglyRejected", wronglyRejected);
+                    Line();
+                }
+            }
+
+            // ---- Summary tally ----
+            Line("================ SUMMARY TALLY ================");
+            Line($"Total labeled boxes classified: {totalBoxes}");
+            if (tally.Count == 0) {
+                Line("(no labeled boxes found in the labels dir for any discovered run)");
+            }
+            foreach (var category in new[] { "missed", "shouldReject", "wronglyRejected" }) {
+                if (!tally.TryGetValue(category, out var byResult)) {
+                    continue;
+                }
+                var total = byResult.Values.Sum();
+                Line($"{category}: {total} box(es)");
+                foreach (var kv in byResult.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key, StringComparer.Ordinal)) {
+                    Line($"    {kv.Value,4}  {kv.Key}");
+                }
+            }
+            // Compact one-line-per-category form (matches the task's example phrasing).
+            Line();
+            foreach (var category in new[] { "missed", "shouldReject", "wronglyRejected" }) {
+                if (!tally.TryGetValue(category, out var byResult)) {
+                    continue;
+                }
+                var parts = byResult.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key, StringComparer.Ordinal)
+                    .Select(kv => $"{kv.Value} {kv.Key}");
+                Line($"{category}: {string.Join(", ", parts)}");
+            }
+
+            var outFile = Path.Combine(outDir, "diagnose_labels.txt");
+            File.WriteAllText(outFile, sb.ToString());
+            Console.WriteLine();
+            Console.WriteLine($"Wrote {outFile}");
+        }
+
+        /// <summary>
+        /// Classifies one label box by BEST overlap. Computes IoU + overlap-area against every accepted star box
+        /// and every rejected-candidate box; the best (highest-overlap) candidate across BOTH pools wins, provided
+        /// a real overlap exists (IoU &gt; 0, i.e. the rectangles intersect). Accepted wins ties at equal IoU (so
+        /// a box straddling an accepted and a rejected candidate is reported as ACCEPTED, the detector's actual
+        /// behavior). With no real overlap in either pool the box is a NO CANDIDATE structure gap.
+        /// </summary>
+        private static (string result, string matchDesc) ClassifyBox(
+            StarReviewLabelBox box, List<Star> accepted, List<(string Reason, Rect Bounds)> rejected) {
+            var labelRect = ToRectD(box);
+
+            // Best accepted overlap.
+            double bestAcceptedIoU = 0.0;
+            Rect bestAcceptedRect = default;
+            bool haveAccepted = false;
+            foreach (var s in accepted) {
+                var iou = IoU(labelRect, s.StarBoundingBox);
+                if (iou > bestAcceptedIoU) {
+                    bestAcceptedIoU = iou;
+                    bestAcceptedRect = s.StarBoundingBox;
+                    haveAccepted = true;
+                }
+            }
+
+            // Best rejected overlap (track the reason too).
+            double bestRejectedIoU = 0.0;
+            Rect bestRejectedRect = default;
+            string bestRejectedReason = null;
+            int rejectedTieCount = 0;
+            foreach (var (reason, bounds) in rejected) {
+                var iou = IoU(labelRect, bounds);
+                if (iou <= 0.0) {
+                    continue;
+                }
+                if (iou > bestRejectedIoU) {
+                    bestRejectedIoU = iou;
+                    bestRejectedRect = bounds;
+                    bestRejectedReason = reason;
+                    rejectedTieCount = 1;
+                } else if (Math.Abs(iou - bestRejectedIoU) < 1e-9 && !string.Equals(reason, bestRejectedReason, StringComparison.Ordinal)) {
+                    // A different-reason candidate ties the best — note the ambiguity.
+                    rejectedTieCount++;
+                }
+            }
+
+            bool acceptedReal = haveAccepted && bestAcceptedIoU > 0.0;
+            bool rejectedReal = bestRejectedReason != null && bestRejectedIoU > 0.0;
+
+            if (!acceptedReal && !rejectedReal) {
+                return (ResultNoCandidate, "(no accepted star, no rejected candidate)");
+            }
+
+            // Accepted wins ties (>= rejected IoU). It reflects the detector's actual outcome at that location.
+            if (acceptedReal && bestAcceptedIoU >= bestRejectedIoU) {
+                var tieNote = rejectedReal ? $" [also overlaps REJECTED:{bestRejectedReason} IoU={bestRejectedIoU:F3}]" : "";
+                return (ResultAccepted, $"accepted box {FormatRect(bestAcceptedRect)} IoU={bestAcceptedIoU:F3}{tieNote}");
+            }
+
+            var ambiguity = rejectedTieCount > 1 ? $" [AMBIGUOUS: {rejectedTieCount} reasons tie at IoU={bestRejectedIoU:F3}]" : "";
+            var acceptedNote = acceptedReal ? $" [also overlaps ACCEPTED IoU={bestAcceptedIoU:F3}]" : "";
+            return ($"REJECTED:{bestRejectedReason}", $"rejected box {FormatRect(bestRejectedRect)} IoU={bestRejectedIoU:F3}{acceptedNote}{ambiguity}");
+        }
+
+        // ---- Geometry helpers ------------------------------------------------------------------------------
+
+        private readonly struct RectD {
+            public readonly double X, Y, W, H;
+
+            public RectD(double x, double y, double w, double h) {
+                X = x; Y = y; W = w; H = h;
+            }
+
+            public double Area => Math.Max(0.0, W) * Math.Max(0.0, H);
+        }
+
+        private static RectD ToRectD(StarReviewLabelBox b) => new RectD(b.X, b.Y, b.W ?? 0.0, b.H ?? 0.0);
+
+        /// <summary>Intersection-over-union between a label box (double) and a detector Rect (int). Zero when they
+        /// do not intersect or either has zero area.</summary>
+        private static double IoU(RectD a, Rect b) {
+            var bd = new RectD(b.X, b.Y, b.Width, b.Height);
+            var ix = Math.Max(a.X, bd.X);
+            var iy = Math.Max(a.Y, bd.Y);
+            var ix2 = Math.Min(a.X + a.W, bd.X + bd.W);
+            var iy2 = Math.Min(a.Y + a.H, bd.Y + bd.H);
+            var iw = ix2 - ix;
+            var ih = iy2 - iy;
+            if (iw <= 0.0 || ih <= 0.0) {
+                return 0.0;
+            }
+            var inter = iw * ih;
+            var union = a.Area + bd.Area - inter;
+            return union <= 0.0 ? 0.0 : inter / union;
+        }
+
+        private static string FormatBox(StarReviewLabelBox b) =>
+            $"({b.X.ToString("F0", CultureInfo.InvariantCulture)},{b.Y.ToString("F0", CultureInfo.InvariantCulture)}," +
+            $"{(b.W ?? 0).ToString("F0", CultureInfo.InvariantCulture)},{(b.H ?? 0).ToString("F0", CultureInfo.InvariantCulture)})";
+
+        private static string FormatRect(Rect r) => $"({r.X},{r.Y},{r.Width},{r.Height})";
+
+        private static void PrintUsage() {
+            Console.Error.WriteLine("Usage: TestApp diagnose-labels --runs <folder> --labels <dir> [--params current|optimized] [--opt-results <dir>] [--profile-id <guid>] [--out <dir>]");
+            Console.Error.WriteLine("  Classifies each human-labeled review box against a fresh detection of the same frame:");
+            Console.Error.WriteLine("    ACCEPTED          - overlaps an accepted star's bounding box");
+            Console.Error.WriteLine("    REJECTED:<reason> - overlaps a rejected candidate (TooDistorted/Degenerate/Saturated/LowSensitivity/NotCentered/TooFlat/Contaminated)");
+            Console.Error.WriteLine("    NO CANDIDATE      - overlaps neither (a structure-detection gap; only fixable by detector-algorithm work)");
+            Console.Error.WriteLine("  --runs        (required) folder of saved AF runs (same discovery as `review`/`optimize`).");
+            Console.Error.WriteLine("  --labels      (default <runs>/labels) folder of label JSON files written by `review`.");
+            Console.Error.WriteLine("  --params      (default current) which detector params to use: 'current' (profile seed) or 'optimized' (snapshot).");
+            Console.Error.WriteLine("  --opt-results (optional) folder holding optimized_settings.json (the optimizer's --out subdir).");
+            Console.Error.WriteLine("  --profile-id  (default active) NINA profile id to load.");
+            Console.Error.WriteLine("  --out         (default a temp dir) where diagnose_labels.txt is written.");
+        }
+
+        // ---- Run / frame discovery (mirrors StarReviewRunner / OptimizationDiagnosticRunner) ----------------
+
+        private sealed class FrameRef {
+            public string Path;
+            public int FocuserPosition;
+        }
+
+        private sealed class DiscoveredRun {
+            public string RunId;
+            public List<FrameRef> Frames;
+        }
+
+        private static List<DiscoveredRun> DiscoverRuns(string runsDir) {
+            var root = new DirectoryInfo(runsDir);
+            var runs = new List<DiscoveredRun>();
+
+            var rootFrames = MatchFrames(root);
+            if (rootFrames.Count > 0) {
+                runs.Add(new DiscoveredRun { RunId = root.Name, Frames = rootFrames });
+                return runs;
+            }
+
+            foreach (var sub in root.EnumerateDirectories().OrderBy(d => d.Name, StringComparer.Ordinal)) {
+                var frames = MatchFrames(sub);
+                if (frames.Count == 0) {
+                    var attempt = sub.EnumerateDirectories("attempt*").FirstOrDefault();
+                    if (attempt != null) {
+                        frames = MatchFrames(attempt);
+                    }
+                }
+                if (frames.Count > 0) {
+                    runs.Add(new DiscoveredRun { RunId = sub.Name, Frames = frames });
+                }
+            }
+            return runs;
+        }
+
+        private static List<FrameRef> MatchFrames(DirectoryInfo dir) {
+            var frames = new List<FrameRef>();
+            if (!dir.Exists) {
+                return frames;
+            }
+            foreach (var file in dir.GetFiles().OrderBy(f => f.Name, StringComparer.Ordinal)) {
+                var match = OptimizationRunDiscovery.ImageFileRegex.Match(Path.GetFileNameWithoutExtension(file.Name));
+                if (!match.Success) {
+                    continue;
+                }
+                if (!int.TryParse(match.Groups["FOCUSER"].Value, out var pos)) {
+                    continue;
+                }
+                frames.Add(new FrameRef { Path = file.FullName, FocuserPosition = pos });
+            }
+            return frames;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/TestApp/DiagnosticUtil.cs
+++ b/Joko.NINA.Plugins/TestApp/DiagnosticUtil.cs
@@ -38,6 +38,16 @@ namespace TestApp {
             return null;
         }
 
+        /// <summary>True when the boolean flag <paramref name="name"/> appears anywhere in <paramref name="args"/>.</summary>
+        public static bool HasFlag(string[] args, string name) {
+            for (int i = 0; i < args.Length; ++i) {
+                if (string.Equals(args[i], name, StringComparison.OrdinalIgnoreCase)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         /// <summary>
         /// Loads an image file as a CV_32F Mat normalized to [0,1]. .tif/.tiff are read directly; .xisf/.fits/.fit
         /// go through NINA's loaders (which need a profile). profileService may be null for .tif-only callers.

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -685,18 +685,20 @@ namespace TestApp {
         /// <summary>
         /// Forward-compatible label JSON shape (T7 writes these; T6 reads them). One file per run, named
         /// "&lt;runId&gt;.json" (the discovered RunId == the run's folder name), or any *.json whose embedded RunId
-        /// matches a discovered run. Shape:
+        /// matches a discovered run. Each label is a BOX (top-left x,y + w,h); recall/precision are scored by
+        /// box-containment of an accepted center. Older point-only files (x,y, no w/h) still load: a missing w/h
+        /// defaults to a 2·radiusPx box centered on the point. Shape:
         /// <code>
         /// {
         ///   "runId": "attempt01",
-        ///   "radiusPx": 6.0,                       // default radius for positions that omit one
+        ///   "radiusPx": 6.0,                       // default radius (legacy point-load box fallback)
         ///   "positions": [
         ///     {
         ///       "focuserPosition": 5000,
         ///       "radiusPx": 6.0,                    // optional per-position override
-        ///       "missed":          [ { "x": 123.4, "y": 567.8 }, ... ],   // false negatives to recover (recall)
-        ///       "shouldReject":    [ { "x": 12.0,  "y": 34.0  }, ... ],   // false positives to exclude (precision)
-        ///       "wronglyRejected": [ { "x": 88.0,  "y": 90.0  }, ... ]    // detected-but-gated candidates to KEEP (folds into recall)
+        ///       "missed":          [ { "x": 123.4, "y": 567.8, "w": 12.0, "h": 12.0 }, ... ],  // false negatives to recover (recall)
+        ///       "shouldReject":    [ { "x": 12.0,  "y": 34.0,  "w": 9.0,  "h": 9.0  }, ... ],  // false positives to exclude (precision)
+        ///       "wronglyRejected": [ { "x": 88.0,  "y": 90.0,  "w": 10.0, "h": 8.0  }, ... ]   // detected-but-gated candidates to KEEP (folds into recall)
         ///     }
         ///   ]
         /// }
@@ -705,6 +707,10 @@ namespace TestApp {
         private sealed class LabelPoint {
             [JsonProperty("x")] public double X { get; set; }
             [JsonProperty("y")] public double Y { get; set; }
+
+            // Nullable so a legacy point-only file (x,y, no w/h) deserializes; back-filled to a 2·radiusPx box below.
+            [JsonProperty("w")] public double? W { get; set; }
+            [JsonProperty("h")] public double? H { get; set; }
         }
 
         private sealed class LabelPosition {
@@ -757,17 +763,39 @@ namespace TestApp {
                 var defaultRadius = lf.RadiusPx ?? DefaultLabelRadiusPx;
                 var frameLabels = new List<FrameLabels>(lf.Positions.Count);
                 foreach (var pos in lf.Positions) {
+                    var radius = pos.RadiusPx ?? defaultRadius;
                     frameLabels.Add(new FrameLabels {
                         FocuserPosition = pos.FocuserPosition,
-                        RadiusPx = pos.RadiusPx ?? defaultRadius,
-                        Missed = (pos.Missed ?? new List<LabelPoint>()).Select(p => (p.X, p.Y)).ToList(),
-                        ShouldReject = (pos.ShouldReject ?? new List<LabelPoint>()).Select(p => (p.X, p.Y)).ToList(),
-                        WronglyRejected = (pos.WronglyRejected ?? new List<LabelPoint>()).Select(p => (p.X, p.Y)).ToList()
+                        RadiusPx = radius,
+                        Missed = ToBoxes(pos.Missed, radius),
+                        ShouldReject = ToBoxes(pos.ShouldReject, radius),
+                        WronglyRejected = ToBoxes(pos.WronglyRejected, radius)
                     });
                 }
                 result[run.RunId] = frameLabels;
             }
             return result;
+        }
+
+        /// <summary>
+        /// Maps parsed label JSON points into the objective's <see cref="LabelBox"/> list. A label with explicit w/h
+        /// is taken as-is (top-left x,y + w,h). A legacy point-only label (no w/h) is widened to a 2·radiusPx box
+        /// CENTERED on its (x,y), matching the T7 writer's legacy back-fill so the two tools agree on old files.
+        /// </summary>
+        private static IReadOnlyList<LabelBox> ToBoxes(List<LabelPoint> points, double radiusPx) {
+            if (points == null || points.Count == 0) {
+                return new List<LabelBox>();
+            }
+            var side = Math.Max(1e-9, 2.0 * radiusPx);
+            var boxes = new List<LabelBox>(points.Count);
+            foreach (var p in points) {
+                if (p.W.HasValue && p.H.HasValue) {
+                    boxes.Add(new LabelBox(p.X, p.Y, p.W.Value, p.H.Value));
+                } else {
+                    boxes.Add(new LabelBox(p.X - side / 2.0, p.Y - side / 2.0, side, side));
+                }
+            }
+            return boxes;
         }
 
         // ---- Hard-floor assertion --------------------------------------------------------------------------

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -167,8 +167,9 @@ namespace TestApp {
                 $"NoiseClippingMultiplier={F(seed.NoiseClippingMultiplier)}, StructureLayers={seed.StructureLayers}, PixelScale={F(seed.PixelScale)}, " +
                 $"MeasurementAverage={starDetectionOptions.MeasurementAverage}");
 
-            // The fixed AF-detection sigma rejections the wizard loader uses (HocusFocusDetectionParams defaults):
-            // high = 4.0, low = 3.0. These feed the MeanOutliers HFR aggregation only.
+            // The fixed AF-detection sigma rejections the wizard's RunEvaluationLoader uses (the
+            // HocusFocusDetectionParams class defaults, NOT the live AF path): high = 4.0, low = 3.0. These feed
+            // the MeanOutliers HFR aggregation only.
             const double highSigmaOutlierRejection = 4.0;
             const double lowSigmaOutlierRejection = 3.0;
 
@@ -379,13 +380,17 @@ namespace TestApp {
             return positions.Count > 1 ? Math.Abs(positions[0] - positions[1]) : 0;
         }
 
-        // ---- Production-matching HFR aggregation ------------------------------------------------------------
+        // ---- HFR aggregation matching the wizard's RunEvaluationLoader -------------------------------------
 
         /// <summary>
         /// Adapts a <see cref="HocusFocusStarDetectorResult"/> (from <see cref="StarDetector.Detect(Mat, StarDetectorParams, IProgress{NINA.Core.Model.ApplicationStatus}, CancellationToken)"/>)
-        /// into the <see cref="FrameDetectionResult"/> the optimizer consumes, REPLICATING the production HFR
-        /// aggregation in <c>HocusFocusStarDetection.Detect</c> so the harness's per-frame HFR/σ match the live AF
-        /// path exactly. The matched production code:
+        /// into the <see cref="FrameDetectionResult"/> the optimizer consumes, REPLICATING the HFR aggregation in
+        /// <c>HocusFocusStarDetection.Detect</c> AS THE WIZARD'S <see cref="RunEvaluationLoader"/> drives it — i.e.
+        /// with NumberOfAFStars=0 (every accepted star is scored, not the brightest-N) and the sigma rejections at
+        /// the <see cref="HocusFocusDetectionParams"/> class defaults (high=4.0/low=3.0). NOTE this is the wizard's
+        /// loader path, NOT the live AF path: live AF uses high=3.0 when Sensitivity=Normal (HocusFocusStarDetection
+        /// line ~269), so the harness deliberately matches RunEvaluationLoader so its per-frame HFR/σ equal what the
+        /// optimizer scores in the wizard. The matched production code:
         ///   - MeanOutliers: first re-filter the star list to HFR ∈ [median − low·MAD, median + high·MAD]
         ///     (HocusFocusDetection.Detect lines ~389-399, sigmas 4.0/3.0 from HocusFocusDetectionParams), then
         ///     AverageHFR = mean, HFRStdDev = sample std-dev (n-1) (lines ~440-442).

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -412,6 +412,13 @@ namespace TestApp {
                 loadedRuns, perRunSeed, perRunBest, objectiveConstants, focuserMaxStep, ctx.LabelsDir, settings, passed, worstFrameCount, worstRunId);
             WriteCsv(Path.Combine(targetDir, "optimize_result.csv"), loadedRuns, perRunSeed, perRunBest);
 
+            // Per-run optimized-settings handoff: write the winning snapshot as optimized_settings.json into BOTH
+            // each focus run's own source folder (so `review --runs <same>` auto-discovers it) and the per-run --out
+            // subdir. Uses the SAME params->DTO mapping the wizard's Apply() uses (OptimizedStarDetectionSettings.
+            // FromParams) so the headless and in-app handoffs can never drift. Each run's recommended step is from
+            // its OWN best fit (StepSizeRecommender, exactly as BuildAggregateRow computes it).
+            WriteOptimizedSettings(targetDir, loadedRuns, perRunBest, result, focuserMaxStep);
+
             await WriteAnnotatedFrames(targetDir, loadedRuns, result.BestParams, ctx.Detector,
                 ctx.MeasurementAverage, ctx.HighSigmaOutlierRejection, ctx.LowSigmaOutlierRejection, ctx.AnnotateAll).ConfigureAwait(false);
 
@@ -424,6 +431,47 @@ namespace TestApp {
                 PerRunBest = perRunBest,
                 LoadedRuns = loadedRuns
             };
+        }
+
+        /// <summary>
+        /// Writes <c>optimized_settings.json</c> (the wizard's <see cref="OptimizedStarDetectionSettings"/> snapshot
+        /// serialized with <see cref="JsonConvert"/>) for every loaded run: one copy into the focus run's own source
+        /// folder (the directory holding its sweep frames — so <c>review --runs &lt;same&gt;</c> auto-discovers it)
+        /// and one into the per-run <paramref name="targetDir"/> (the <c>--out</c> subdir). The curated knob values
+        /// are the optimizer's combined winner (<see cref="OptimizationResult.BestParams"/>); the recommended AF step
+        /// is per-run from that run's OWN best fit. A failed write for one run is logged and skipped — it never aborts
+        /// the batch.
+        /// </summary>
+        private static void WriteOptimizedSettings(
+            string targetDir, List<LoadedHarnessRun> loadedRuns, List<RunEvaluationResult> perRunBest,
+            OptimizationResult result, int? focuserMaxStep) {
+            for (int i = 0; i < loadedRuns.Count; i++) {
+                var run = loadedRuns[i];
+                try {
+                    var rec = StepSizeRecommender.Recommend(perRunBest[i].BestFit, run.StepSize, focuserMaxStep);
+                    var dto = OptimizedStarDetectionSettings.FromParams(
+                        result.BestParams, loadedRuns.Count, result.SeedJ, result.BestJ, rec.StepSize, rec.OffsetSteps);
+                    var json = JsonConvert.SerializeObject(dto);
+
+                    // The run's source folder is the directory holding its frames (each run's frames live together).
+                    var firstFramePath = run.Discovered.Frames.FirstOrDefault()?.Path;
+                    var runFolder = string.IsNullOrEmpty(firstFramePath) ? null : Path.GetDirectoryName(firstFramePath);
+                    if (!string.IsNullOrEmpty(runFolder)) {
+                        var runPath = Path.Combine(runFolder, "optimized_settings.json");
+                        File.WriteAllText(runPath, json);
+                        Console.WriteLine($"  wrote optimized_settings.json to {runPath}");
+                    } else {
+                        Console.Error.WriteLine($"  WARNING: could not resolve source folder for run '{run.Discovered.RunId}'; skipped the in-folder optimized_settings.json");
+                    }
+
+                    // A copy in the per-run --out subdir.
+                    var outPath = Path.Combine(targetDir, "optimized_settings.json");
+                    File.WriteAllText(outPath, json);
+                } catch (Exception ex) {
+                    Console.Error.WriteLine($"  WARNING: failed to write optimized_settings.json for run '{run.Discovered.RunId}': {ex.Message}");
+                    Logger.Error(ex, $"Failed to write optimized_settings.json for run '{run.Discovered.RunId}'");
+                }
+            }
         }
 
         private static void DisposeRuns(List<LoadedHarnessRun> loadedRuns) {
@@ -646,8 +694,9 @@ namespace TestApp {
         ///     {
         ///       "focuserPosition": 5000,
         ///       "radiusPx": 6.0,                    // optional per-position override
-        ///       "missed":       [ { "x": 123.4, "y": 567.8 }, ... ],   // false negatives to recover (recall)
-        ///       "shouldReject": [ { "x": 12.0,  "y": 34.0  }, ... ]    // false positives to exclude (precision)
+        ///       "missed":          [ { "x": 123.4, "y": 567.8 }, ... ],   // false negatives to recover (recall)
+        ///       "shouldReject":    [ { "x": 12.0,  "y": 34.0  }, ... ],   // false positives to exclude (precision)
+        ///       "wronglyRejected": [ { "x": 88.0,  "y": 90.0  }, ... ]    // detected-but-gated candidates to KEEP (folds into recall)
         ///     }
         ///   ]
         /// }
@@ -663,6 +712,7 @@ namespace TestApp {
             [JsonProperty("radiusPx")] public double? RadiusPx { get; set; }
             [JsonProperty("missed")] public List<LabelPoint> Missed { get; set; }
             [JsonProperty("shouldReject")] public List<LabelPoint> ShouldReject { get; set; }
+            [JsonProperty("wronglyRejected")] public List<LabelPoint> WronglyRejected { get; set; }
         }
 
         private sealed class RunLabelFile {
@@ -711,7 +761,8 @@ namespace TestApp {
                         FocuserPosition = pos.FocuserPosition,
                         RadiusPx = pos.RadiusPx ?? defaultRadius,
                         Missed = (pos.Missed ?? new List<LabelPoint>()).Select(p => (p.X, p.Y)).ToList(),
-                        ShouldReject = (pos.ShouldReject ?? new List<LabelPoint>()).Select(p => (p.X, p.Y)).ToList()
+                        ShouldReject = (pos.ShouldReject ?? new List<LabelPoint>()).Select(p => (p.X, p.Y)).ToList(),
+                        WronglyRejected = (pos.WronglyRejected ?? new List<LabelPoint>()).Select(p => (p.X, p.Y)).ToList()
                     });
                 }
                 result[run.RunId] = frameLabels;

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -27,7 +27,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -49,12 +48,8 @@ namespace TestApp {
     /// </summary>
     internal static class OptimizationDiagnosticRunner {
 
-        // Mirrors AutoFocusEngine.IMAGE_FILE_REGEX (private) so the harness stays decoupled from the engine, and
-        // matches FocusSweepDiagnosticRunner's copy. Frames the AF engine writes look like
-        // "0_Frame1_BitDepth16_Bayered0_Focuser5000.fits" (the trailing _HFRxxx is optional).
-        private static readonly Regex ImageFileRegex = new Regex(
-            @"^(?<IMAGE_INDEX>\d+)_Frame(?<FRAME_NUMBER>\d+)_BitDepth(?<BITDEPTH>\d+)_Bayered(?<BAYERED>\d)_Focuser(?<FOCUSER>\d+)(_HFR(?<HFR>(\d+)(\.\d+)?))?$",
-            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        // Run discovery (attempt-anchored, >=3-position guard) lives in the pure, unit-testable
+        // OptimizationRunDiscovery helper. Frame matching uses its ImageFileRegex (kept as the single copy).
 
         public static async Task Run(string[] args) {
             try {
@@ -109,6 +104,12 @@ namespace TestApp {
             }
 
             var labelsDir = DiagnosticUtil.GetArg(args, "--labels");
+
+            // --per-run is a valueless flag: optimize each discovered run INDEPENDENTLY (one optimization, one
+            // evaluator, one output subfolder, one hard-floor assertion per run) instead of jointly. Use this
+            // when --runs points at a bank of DIFFERENT optical setups, where a joint (N>1 balanced) objective
+            // across incompatible cameras/scopes is meaningless.
+            bool perRun = args.Any(a => string.Equals(a, "--per-run", StringComparison.OrdinalIgnoreCase));
 
             // Verbose logging to the NINA log file for offline inspection.
             Logger.SetLogLevel(LogLevelEnum.TRACE);
@@ -173,129 +174,342 @@ namespace TestApp {
             const double highSigmaOutlierRejection = 4.0;
             const double lowSigmaOutlierRejection = 3.0;
 
-            // Discover runs: each immediate subfolder that contains AF frames is one run; if the --runs folder
-            // itself contains AF frames it is treated as a single run (so a single attempt folder works directly).
-            var discovered = DiscoverRuns(runsDir);
-            if (discovered.Count == 0) {
-                throw new InvalidOperationException(
-                    $"No AF frames matched the saved-run filename pattern under {runsDir}. Expected files like " +
-                    "'0_Frame1_BitDepth16_Bayered0_Focuser5000.fits' in the folder or an immediate subfolder.");
+            // Discover runs: attempt-anchored recursive search with the >=3-position guard (excludes the
+            // single-frame final/initial validation captures), with back-compat (--runs is itself an attempt
+            // folder) and a fallback (no attempt* folders anywhere). Pure logic lives in OptimizationRunDiscovery.
+            var discovery = OptimizationRunDiscovery.Discover(runsDir);
+            foreach (var d in discovery.Runs) {
+                Console.WriteLine($"  run '{d.RunId}': {d.Frames.Count} frames, {d.DistinctPositions} focuser position(s)");
+                Logger.Info($"Discovered run '{d.RunId}': {d.Frames.Count} frames, {d.DistinctPositions} focuser position(s)");
             }
-            Console.WriteLine($"Discovered {discovered.Count} run(s):");
-            foreach (var d in discovered) {
-                Console.WriteLine($"  {d.RunId}: {d.Frames.Count} frames, {d.Frames.Select(f => f.FocuserPosition).Distinct().Count()} positions");
+            foreach (var s in discovery.Skipped) {
+                Console.WriteLine($"  skipped '{s.RelativePath}': {s.Reason}");
+                Logger.Info($"Skipped '{s.RelativePath}': {s.Reason}");
+            }
+            Console.WriteLine($"Discovered {discovery.Runs.Count} runs (skipped {discovery.Skipped.Count} folders)");
+            Logger.Info($"Discovered {discovery.Runs.Count} runs (skipped {discovery.Skipped.Count} folders)");
+            if (discovery.Runs.Count == 0) {
+                throw new InvalidOperationException(
+                    $"No usable AF runs (>= {OptimizationRunDiscovery.MinPositionsForFit} focuser positions) were found under {runsDir}. " +
+                    "Expected files like '0_Frame1_BitDepth16_Bayered0_Focuser5000.fits' in an 'attempt*' folder (or directly in --runs).");
             }
 
-            var labelsByRun = LoadLabels(labelsDir, discovered);
+            var labelsByRun = LoadLabels(labelsDir, discovery.Runs);
 
             var alglibAPI = new AlglibAPI();
             var detector = new StarDetector(alglibAPI);
+            var ctx = new RunDetectionContext {
+                ProfileService = profileService,
+                AfOptions = afOptions,
+                AlglibAPI = alglibAPI,
+                Detector = detector,
+                MeasurementAverage = starDetectionOptions.MeasurementAverage,
+                HighSigmaOutlierRejection = highSigmaOutlierRejection,
+                LowSigmaOutlierRejection = lowSigmaOutlierRejection,
+                Seed = seed,
+                Variables = OptimizerVariable.CreateCuratedSet(),
+                MaxEvals = maxEvals,
+                LabelsDir = labelsDir,
+                AnnotateAll = annotateAll
+            };
 
-            // Build a RunEvaluationData per discovered run: load every frame once as a float Mat, wire the harness
-            // detection delegate (StarDetector.Detect(Mat) -> FrameDetectionResult), and infer the fit config.
+            if (perRun) {
+                await RunPerRun(ctx, runsDir, outDir, discovery.Runs, labelsByRun).ConfigureAwait(false);
+            } else {
+                await RunJoint(ctx, runsDir, outDir, discovery.Runs, labelsByRun).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>Shared, run-independent dependencies + tuning settings threaded through the optimize helpers.</summary>
+        private sealed class RunDetectionContext {
+            public ProfileService ProfileService;
+            public AutoFocusOptions AfOptions;
+            public AlglibAPI AlglibAPI;
+            public StarDetector Detector;
+            public MeasurementAverageEnum MeasurementAverage;
+            public double HighSigmaOutlierRejection;
+            public double LowSigmaOutlierRejection;
+            public StarDetectorParams Seed;
+            public IReadOnlyList<OptimizerVariable> Variables;
+            public int? MaxEvals;
+            public string LabelsDir;
+            public bool AnnotateAll;
+        }
+
+        /// <summary>Outcome of optimizing one set of runs (joint or a single per-run), for the aggregate report.</summary>
+        private sealed class RunSetOutcome {
+            public bool HardFloorPassed;
+            public int WorstFrameCount;
+            public string WorstRunId;
+            public OptimizationResult Result;
+            public List<RunEvaluationResult> PerRunSeed;
+            public List<RunEvaluationResult> PerRunBest;
+            public List<LoadedHarnessRun> LoadedRuns;
+        }
+
+        // ---- Joint mode (default): optimize ALL discovered runs together (N=1 reduces; N>1 is the balanced blend).
+
+        private static async Task RunJoint(
+            RunDetectionContext ctx, string runsDir, string outDir,
+            List<OptimizationRunDiscovery.DiscoveredRun> discovered,
+            Dictionary<string, IReadOnlyList<FrameLabels>> labelsByRun) {
             var loadedRuns = new List<LoadedHarnessRun>(discovered.Count);
-            foreach (var d in discovered) {
-                var frames = new List<RunFrame>(d.Frames.Count);
-                foreach (var frame in d.Frames) {
-                    // LoadFloatMat returns a fresh Mat each call; the optimizer detect delegate clones before
-                    // detection (Detect mutates its input), so the cached Mat here is never mutated.
-                    var mat = await DiagnosticUtil.LoadFloatMat(frame.Path, profileService).ConfigureAwait(false);
-                    frames.Add(new RunFrame {
-                        FrameId = frame.Path,
-                        FocuserPosition = frame.FocuserPosition,
-                        Image = mat
-                    });
+            try {
+                foreach (var d in discovered) {
+                    loadedRuns.Add(await PrepareRunAsync(ctx, d, labelsByRun).ConfigureAwait(false));
                 }
 
-                var stepSize = InferStepSize(d.Frames);
-                var fitConfig = new RunFitConfig {
-                    StepSize = stepSize,
-                    UseWeights = afOptions.WeightedHyperbolicFitEnabled,
-                    MaxOutlierRejections = afOptions.MaxOutlierRejections,
-                    RejectionConfidence = afOptions.OutlierRejectionConfidence,
-                    PreferredModel = null
+                Console.WriteLine($"Optimizing JOINTLY over {loadedRuns.Count} run(s) (MaxEvaluations=" +
+                    $"{(ctx.MaxEvals?.ToString(CultureInfo.InvariantCulture) ?? "default")}, {(ctx.LabelsDir != null ? "labeled" : "unlabeled")})...");
+                var outcome = await OptimizeRunSetAsync(ctx, runsDir, outDir, loadedRuns).ConfigureAwait(false);
+                if (!outcome.HardFloorPassed) {
+                    Environment.ExitCode = 3;
+                }
+                Console.WriteLine($"Wrote optimize_summary.txt, optimize_result.csv, and annotated PNG(s) to {outDir}");
+            } finally {
+                DisposeRuns(loadedRuns);
+            }
+        }
+
+        // ---- Per-run mode: optimize each discovered run INDEPENDENTLY, one output subfolder each, plus an
+        //      aggregate_summary.txt at the top level. One bad run is logged and recorded as failed; the batch
+        //      continues.
+
+        private static async Task RunPerRun(
+            RunDetectionContext ctx, string runsDir, string outDir,
+            List<OptimizationRunDiscovery.DiscoveredRun> discovered,
+            Dictionary<string, IReadOnlyList<FrameLabels>> labelsByRun) {
+            var aggregate = new List<AggregateRow>(discovered.Count);
+            bool anyFailure = false;
+            for (int idx = 0; idx < discovered.Count; idx++) {
+                var d = discovered[idx];
+                Console.WriteLine($"[{idx + 1}/{discovered.Count}] optimizing {d.RunId} ...");
+                var subDir = Path.Combine(outDir, OptimizationRunDiscovery.SanitizeForFileName(d.RunId));
+                var loadedRuns = new List<LoadedHarnessRun>(1);
+                try {
+                    loadedRuns.Add(await PrepareRunAsync(ctx, d, labelsByRun).ConfigureAwait(false));
+                    Directory.CreateDirectory(subDir);
+                    var outcome = await OptimizeRunSetAsync(ctx, runsDir, subDir, loadedRuns).ConfigureAwait(false);
+                    if (!outcome.HardFloorPassed) {
+                        anyFailure = true;
+                    }
+                    aggregate.Add(BuildAggregateRow(d.RunId, outcome));
+                    Console.WriteLine($"  -> {d.RunId}: seedJ={F(outcome.Result.SeedJ)} bestJ={F(outcome.Result.BestJ)} " +
+                        $"hard-floor {(outcome.HardFloorPassed ? "PASS" : "FAIL")}; outputs in {subDir}");
+                } catch (Exception ex) {
+                    anyFailure = true;
+                    Console.Error.WriteLine($"  -> {d.RunId}: FAILED to optimize ({ex.Message}); continuing to next run");
+                    Logger.Error(ex, $"Per-run optimization failed for '{d.RunId}'");
+                    aggregate.Add(new AggregateRow {
+                        RunId = d.RunId,
+                        LoadOk = false,
+                        Error = ex.Message
+                    });
+                } finally {
+                    DisposeRuns(loadedRuns);
+                }
+            }
+
+            WriteAggregateSummary(Path.Combine(outDir, "aggregate_summary.txt"), runsDir, ctx, aggregate);
+            Console.WriteLine($"Per-run batch complete: {aggregate.Count(r => r.LoadOk)} optimized, " +
+                $"{aggregate.Count(r => !r.LoadOk)} failed. Wrote aggregate_summary.txt to {outDir}");
+            if (anyFailure) {
+                Environment.ExitCode = 3;
+            }
+        }
+
+        /// <summary>
+        /// Loads a discovered run's frames as float Mats once, wires the harness detection delegate, infers the
+        /// fit config, and builds its <see cref="RunEvaluationData"/>. Caller owns disposing the returned run's
+        /// cached Mats (see <see cref="DisposeRuns"/>).
+        /// </summary>
+        private static async Task<LoadedHarnessRun> PrepareRunAsync(
+            RunDetectionContext ctx, OptimizationRunDiscovery.DiscoveredRun d,
+            Dictionary<string, IReadOnlyList<FrameLabels>> labelsByRun) {
+            var frames = new List<RunFrame>(d.Frames.Count);
+            foreach (var frame in d.Frames) {
+                // LoadFloatMat returns a fresh Mat each call; the optimizer detect delegate clones before
+                // detection (Detect mutates its input), so the cached Mat here is never mutated.
+                var mat = await DiagnosticUtil.LoadFloatMat(frame.Path, ctx.ProfileService).ConfigureAwait(false);
+                frames.Add(new RunFrame {
+                    FrameId = frame.Path,
+                    FocuserPosition = frame.FocuserPosition,
+                    Image = mat
+                });
+            }
+
+            var stepSize = InferStepSize(d.Frames);
+            var fitConfig = new RunFitConfig {
+                StepSize = stepSize,
+                UseWeights = ctx.AfOptions.WeightedHyperbolicFitEnabled,
+                MaxOutlierRejections = ctx.AfOptions.MaxOutlierRejections,
+                RejectionConfidence = ctx.AfOptions.OutlierRejectionConfidence,
+                PreferredModel = null
+            };
+
+            var detector = ctx.Detector;
+            var measurementAverage = ctx.MeasurementAverage;
+            var highSigma = ctx.HighSigmaOutlierRejection;
+            var lowSigma = ctx.LowSigmaOutlierRejection;
+            Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> detect =
+                async (image, candidateParams, ct) => {
+                    // Detect mutates its input in place, so each detection gets a clone of the cached Mat.
+                    using var clone = ((Mat)image).Clone();
+                    var result = await detector.Detect(clone, candidateParams, null, ct).ConfigureAwait(false);
+                    return ToFrameDetectionResult(result, measurementAverage, highSigma, lowSigma);
                 };
 
-                var measurementAverage = starDetectionOptions.MeasurementAverage;
-                Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> detect =
-                    async (image, candidateParams, ct) => {
-                        // Detect mutates its input in place, so each detection gets a clone of the cached Mat.
-                        using var clone = ((Mat)image).Clone();
-                        var result = await detector.Detect(clone, candidateParams, null, ct).ConfigureAwait(false);
-                        return ToFrameDetectionResult(result, measurementAverage, highSigmaOutlierRejection, lowSigmaOutlierRejection);
-                    };
+            var labels = labelsByRun.TryGetValue(d.RunId, out var ls) ? ls : null;
+            var data = new RunEvaluationData(d.RunId, frames, detect, ctx.AlglibAPI, fitConfig, labels);
+            Console.WriteLine($"  {d.RunId}: inferred step size {stepSize}" + (labels != null ? $", {labels.Count} labeled position(s)" : ", unlabeled"));
+            return new LoadedHarnessRun { Discovered = d, Data = data, StepSize = stepSize, Frames = frames };
+        }
 
-                var labels = labelsByRun.TryGetValue(d.RunId, out var ls) ? ls : null;
-                var data = new RunEvaluationData(d.RunId, frames, detect, alglibAPI, fitConfig, labels);
-                loadedRuns.Add(new LoadedHarnessRun { Discovered = d, Data = data, StepSize = stepSize, Frames = frames });
-                Console.WriteLine($"  {d.RunId}: inferred step size {stepSize}" + (labels != null ? $", {labels.Count} labeled position(s)" : ", unlabeled"));
-            }
-
+        /// <summary>
+        /// Optimizes a SET of loaded runs together (1 run = N=1; several = the balanced N>1 blend), evaluates the
+        /// seed + winner against each run, runs the hard-floor assertion, and writes the per-set summary, CSV, and
+        /// annotated PNGs into <paramref name="targetDir"/>. Returns the outcome for the aggregate report.
+        /// </summary>
+        private static async Task<RunSetOutcome> OptimizeRunSetAsync(
+            RunDetectionContext ctx, string runsDir, string targetDir, List<LoadedHarnessRun> loadedRuns) {
             var settings = new OptimizerSettings();
-            if (maxEvals.HasValue) {
-                settings.MaxEvaluations = maxEvals.Value;
+            if (ctx.MaxEvals.HasValue) {
+                settings.MaxEvaluations = ctx.MaxEvals.Value;
             }
 
-            var variables = OptimizerVariable.CreateCuratedSet();
+            var variables = ctx.Variables;
             var optimizer = new StarDetectionOptimizer();
 
-            // Run the optimizer over ALL discovered runs at once (single-run reduces to N=1; N>1 is the balanced
-            // min/mean blend via JTotal). This is the configuration the wizard ships.
             var dataList = loadedRuns.Select(r => r.Data).ToList();
             var evaluator = RunEvaluationData.CreateEvaluator(dataList);
 
             var progress = new Progress<OptimizationProgress>(op =>
                 Console.WriteLine($"  [{op.Phase}] evals={op.Evaluations}/{op.MaxEvaluations} bestJ={F(op.BestJ)} seedJ={F(op.SeedJ)}"));
 
-            Console.WriteLine($"Optimizing over {dataList.Count} run(s) (MaxEvaluations={settings.MaxEvaluations}, {(labelsDir != null ? "labeled" : "unlabeled")})...");
-            var result = await optimizer.OptimizeAsync(seed, variables, evaluator, settings, progress, CancellationToken.None).ConfigureAwait(false);
+            var result = await optimizer.OptimizeAsync(ctx.Seed, variables, evaluator, settings, progress, CancellationToken.None).ConfigureAwait(false);
             Console.WriteLine($"Optimization complete: seedJ={F(result.SeedJ)} -> bestJ={F(result.BestJ)} ({(result.ImprovedOverSeed ? "improved" : "no improvement")}), evals={result.Evaluations}");
 
-            // Evaluate the seed and the winning params against each run, capturing the fit + per-frame counts.
             var perRunSeed = new List<RunEvaluationResult>(loadedRuns.Count);
             var perRunBest = new List<RunEvaluationResult>(loadedRuns.Count);
             foreach (var r in loadedRuns) {
-                perRunSeed.Add(await r.Data.EvaluateAndFitAsync(seed, CancellationToken.None).ConfigureAwait(false));
+                perRunSeed.Add(await r.Data.EvaluateAndFitAsync(ctx.Seed, CancellationToken.None).ConfigureAwait(false));
                 perRunBest.Add(await r.Data.EvaluateAndFitAsync(result.BestParams, CancellationToken.None).ConfigureAwait(false));
             }
 
-            // Hard-floor assertion: every frame (incl. defocused extremes) must keep >= NHard accepted stars under
-            // the winning params. This is the optimizer's hard constraint; a FAIL means the winner starves a frame.
             var objectiveConstants = new ObjectiveConstants();
             var (passed, worstFrameCount, worstRunId) = AssertHardFloor(loadedRuns, perRunBest, objectiveConstants);
             Console.WriteLine(passed
                 ? $"PASS: every frame has >= {objectiveConstants.NHard} stars under optimized params (min observed = {worstFrameCount})"
                 : $"FAIL: at least one frame has < {objectiveConstants.NHard} stars under optimized params (min observed = {worstFrameCount} in run {worstRunId})");
-            if (!passed) {
-                Environment.ExitCode = 3;
-            }
 
-            // Each run's step-size recommendation (from its own winning fit) is written to the summary. The
-            // focuser's max step is unavailable headless, so it is left null — StepSizeRecommender clamps to >= 1.
+            // The focuser's max step is unavailable headless, so it is left null — StepSizeRecommender clamps to >= 1.
             var focuserMaxStep = (int?)null;
 
-            WriteSummary(Path.Combine(outDir, "optimize_summary.txt"), runsDir, seed, result, variables,
-                loadedRuns, perRunSeed, perRunBest, objectiveConstants, focuserMaxStep, labelsDir, settings, passed, worstFrameCount, worstRunId);
-            WriteCsv(Path.Combine(outDir, "optimize_result.csv"), loadedRuns, perRunSeed, perRunBest);
+            WriteSummary(Path.Combine(targetDir, "optimize_summary.txt"), runsDir, ctx.Seed, result, variables,
+                loadedRuns, perRunSeed, perRunBest, objectiveConstants, focuserMaxStep, ctx.LabelsDir, settings, passed, worstFrameCount, worstRunId);
+            WriteCsv(Path.Combine(targetDir, "optimize_result.csv"), loadedRuns, perRunSeed, perRunBest);
 
-            // Annotated PNGs (per --annotate) using the OPTIMIZED params, so a real star with no marker reads as
-            // "missed entirely". Annotate the min/max focuser frame per run by default, or every frame for "all".
-            await WriteAnnotatedFrames(outDir, loadedRuns, result.BestParams, detector,
-                starDetectionOptions.MeasurementAverage, highSigmaOutlierRejection, lowSigmaOutlierRejection, annotateAll).ConfigureAwait(false);
+            await WriteAnnotatedFrames(targetDir, loadedRuns, result.BestParams, ctx.Detector,
+                ctx.MeasurementAverage, ctx.HighSigmaOutlierRejection, ctx.LowSigmaOutlierRejection, ctx.AnnotateAll).ConfigureAwait(false);
 
+            return new RunSetOutcome {
+                HardFloorPassed = passed,
+                WorstFrameCount = worstFrameCount,
+                WorstRunId = worstRunId,
+                Result = result,
+                PerRunSeed = perRunSeed,
+                PerRunBest = perRunBest,
+                LoadedRuns = loadedRuns
+            };
+        }
+
+        private static void DisposeRuns(List<LoadedHarnessRun> loadedRuns) {
             // Release the cached frame Mats (each RunFrame.Image is a Mat the harness loaded once).
             foreach (var r in loadedRuns) {
                 foreach (var rf in r.Frames) {
                     (rf.Image as Mat)?.Dispose();
                 }
             }
+        }
 
-            Console.WriteLine($"Wrote optimize_summary.txt, optimize_result.csv, and annotated PNG(s) to {outDir}");
+        // ---- Per-run aggregate report ----------------------------------------------------------------------
+
+        /// <summary>One scannable row of the cross-setup aggregate report (the --per-run verification deliverable).</summary>
+        private sealed class AggregateRow {
+            public string RunId;
+            public bool LoadOk = true;              // false => the run failed to load/optimize (Error set)
+            public string Error;                    // populated only when LoadOk == false
+            public bool HardFloorPassed;
+            public int WorstFrameCount;
+            public double SeedJ = double.NaN;
+            public double BestJ = double.NaN;
+            public double SeedSigmaFocus = double.NaN;
+            public double BestSigmaFocus = double.NaN;
+            public int RecommendedStep;
+            public string ChangedParams = string.Empty;
+        }
+
+        /// <summary>Builds an aggregate row from a per-run outcome (exactly one run in the set in --per-run mode).</summary>
+        private static AggregateRow BuildAggregateRow(string runId, RunSetOutcome outcome) {
+            var run = outcome.LoadedRuns[0];
+            var seedM = outcome.PerRunSeed[0].Metrics;
+            var bestM = outcome.PerRunBest[0].Metrics;
+            var rec = StepSizeRecommender.Recommend(outcome.PerRunBest[0].BestFit, run.StepSize, null);
+            var changed = outcome.Result.ChangedVariables;
+            return new AggregateRow {
+                RunId = runId,
+                LoadOk = true,
+                HardFloorPassed = outcome.HardFloorPassed,
+                WorstFrameCount = outcome.WorstFrameCount,
+                SeedJ = outcome.Result.SeedJ,
+                BestJ = outcome.Result.BestJ,
+                SeedSigmaFocus = seedM.SigmaFocus,
+                BestSigmaFocus = bestM.SigmaFocus,
+                RecommendedStep = rec.StepSize,
+                ChangedParams = (changed == null || changed.Count == 0)
+                    ? "(none)"
+                    : string.Join("; ", changed.Select(cv => $"{cv.Name}: {F(cv.SeedValue)}->{F(cv.BestValue)}"))
+            };
+        }
+
+        /// <summary>
+        /// Writes the top-level aggregate_summary.txt for --per-run mode: one row per run, easy to scan across
+        /// setups — RunId, load OK/failed, hard-floor PASS/FAIL (with the min star count), seed J -> best J,
+        /// σ_focus seed -> optimized, recommended step, and which curated params changed.
+        /// </summary>
+        private static void WriteAggregateSummary(string path, string runsDir, RunDetectionContext ctx, List<AggregateRow> rows) {
+            var sb = new StringBuilder();
+            sb.AppendLine("=== Star Detection Optimizer — per-run aggregate ===");
+            sb.AppendLine($"Runs root: {runsDir}");
+            sb.AppendLine($"Mode: --per-run (each run optimized independently)");
+            sb.AppendLine($"Labels: {(string.IsNullOrWhiteSpace(ctx.LabelsDir) ? "(none — unlabeled)" : ctx.LabelsDir)}");
+            sb.AppendLine($"MaxEvaluations: {(ctx.MaxEvals?.ToString(CultureInfo.InvariantCulture) ?? "default")}");
+            sb.AppendLine($"Runs: {rows.Count} ({rows.Count(r => r.LoadOk)} optimized, {rows.Count(r => !r.LoadOk)} failed)");
+            sb.AppendLine();
+
+            foreach (var r in rows) {
+                sb.AppendLine($"--- {r.RunId} ---");
+                if (!r.LoadOk) {
+                    sb.AppendLine($"  load        : FAILED ({r.Error})");
+                    sb.AppendLine();
+                    continue;
+                }
+                sb.AppendLine($"  load        : OK");
+                sb.AppendLine($"  hard-floor  : {(r.HardFloorPassed ? "PASS" : "FAIL")} (min stars = {r.WorstFrameCount})");
+                sb.AppendLine($"  J           : {F(r.SeedJ)} -> {F(r.BestJ)}");
+                sb.AppendLine($"  sigma_focus : {F(r.SeedSigmaFocus)} -> {F(r.BestSigmaFocus)}");
+                sb.AppendLine($"  rec. step   : {r.RecommendedStep}");
+                sb.AppendLine($"  changed     : {r.ChangedParams}");
+                sb.AppendLine();
+            }
+
+            File.WriteAllText(path, sb.ToString());
         }
 
         private static void PrintUsage() {
-            Console.Error.WriteLine("Usage: TestApp optimize --runs <folder> [--profile-id <guid>] [--out <dir>] [--max-evals <int>] [--annotate extremes|all] [--labels <dir>]");
-            Console.Error.WriteLine("  --runs       (required) folder of saved AF runs. Each immediate subfolder with AF frames is one run; or the folder itself is a single run.");
+            Console.Error.WriteLine("Usage: TestApp optimize --runs <folder> [--per-run] [--profile-id <guid>] [--out <dir>] [--max-evals <int>] [--annotate extremes|all] [--labels <dir>]");
+            Console.Error.WriteLine("  --runs       (required) folder of saved AF runs. Runs are 'attempt*' folders (recursively, <=4 deep) with >=3 focuser positions; or --runs itself.");
+            Console.Error.WriteLine("  --per-run    (optional) optimize each discovered run INDEPENDENTLY into its own subfolder + an aggregate_summary.txt (use for a multi-setup bank).");
             Console.Error.WriteLine("  --profile-id (default active) NINA profile id to load (settings + PixelScale).");
             Console.Error.WriteLine("  --out        (default %LOCALAPPDATA%\\NINA\\Logs\\hf-diag\\optimize\\<timestamp>) output directory.");
             Console.Error.WriteLine("  --max-evals  (optional) override the optimizer's MaxEvaluations budget.");
@@ -304,78 +518,21 @@ namespace TestApp {
         }
 
         // ---- Run / frame discovery -------------------------------------------------------------------------
-
-        private sealed class FrameRef {
-            public string Path;
-            public int FocuserPosition;
-        }
-
-        private sealed class DiscoveredRun {
-            public string RunId;
-            public List<FrameRef> Frames;
-        }
+        // Attempt-anchored discovery (with the >=3-position guard, back-compat, and fallback) lives in the pure,
+        // unit-testable OptimizationRunDiscovery helper. The runner consumes its DiscoveredRun/FrameRef types.
 
         private sealed class LoadedHarnessRun {
-            public DiscoveredRun Discovered;
+            public OptimizationRunDiscovery.DiscoveredRun Discovered;
             public RunEvaluationData Data;
             public int StepSize;
             public List<RunFrame> Frames; // the loaded-once frame Mats, retained for disposal
         }
 
         /// <summary>
-        /// Discovers runs under <paramref name="runsDir"/>. If the folder itself contains AF frames it is a single
-        /// run; otherwise every immediate subfolder that contains AF frames is treated as a separate run. RunId is
-        /// the folder name (or the runs-dir name for the single-run case). Deterministic (ordinal) order.
-        /// </summary>
-        private static List<DiscoveredRun> DiscoverRuns(string runsDir) {
-            var root = new DirectoryInfo(runsDir);
-            var runs = new List<DiscoveredRun>();
-
-            var rootFrames = MatchFrames(root);
-            if (rootFrames.Count > 0) {
-                runs.Add(new DiscoveredRun { RunId = root.Name, Frames = rootFrames });
-                return runs;
-            }
-
-            foreach (var sub in root.EnumerateDirectories().OrderBy(d => d.Name, StringComparer.Ordinal)) {
-                var frames = MatchFrames(sub);
-                if (frames.Count == 0) {
-                    // Also accept a parent that wraps a single attempt* subfolder (the saved AF layout).
-                    var attempt = sub.EnumerateDirectories("attempt*").FirstOrDefault();
-                    if (attempt != null) {
-                        frames = MatchFrames(attempt);
-                    }
-                }
-                if (frames.Count > 0) {
-                    runs.Add(new DiscoveredRun { RunId = sub.Name, Frames = frames });
-                }
-            }
-            return runs;
-        }
-
-        private static List<FrameRef> MatchFrames(DirectoryInfo dir) {
-            var frames = new List<FrameRef>();
-            if (!dir.Exists) {
-                return frames;
-            }
-            foreach (var file in dir.GetFiles().OrderBy(f => f.Name, StringComparer.Ordinal)) {
-                var m = ImageFileRegex.Match(Path.GetFileNameWithoutExtension(file.Name));
-                if (!m.Success) {
-                    continue;
-                }
-                if (!int.TryParse(m.Groups["FOCUSER"].Value, out var pos)) {
-                    continue;
-                }
-                frames.Add(new FrameRef { Path = file.FullName, FocuserPosition = pos });
-            }
-            return frames;
-        }
-
-        /// <summary>
         /// Infers the AF step size from the frames exactly as <c>AutoFocusEngine.LoadSavedAttemptImpl</c> does:
         /// the absolute difference of the two smallest DISTINCT focuser positions. 0 when fewer than 2 positions.
         /// </summary>
-        private static int InferStepSize(List<FrameRef> frames) {
+        private static int InferStepSize(List<OptimizationRunDiscovery.FrameRef> frames) {
             var positions = frames.Select(f => f.FocuserPosition).Distinct().OrderBy(x => x).Take(2).ToList();
             return positions.Count > 1 ? Math.Abs(positions[0] - positions[1]) : 0;
         }
@@ -476,7 +633,7 @@ namespace TestApp {
 
         private const double DefaultLabelRadiusPx = 6.0;
 
-        private static Dictionary<string, IReadOnlyList<FrameLabels>> LoadLabels(string labelsDir, List<DiscoveredRun> runs) {
+        private static Dictionary<string, IReadOnlyList<FrameLabels>> LoadLabels(string labelsDir, List<OptimizationRunDiscovery.DiscoveredRun> runs) {
             var result = new Dictionary<string, IReadOnlyList<FrameLabels>>(StringComparer.Ordinal);
             if (string.IsNullOrWhiteSpace(labelsDir)) {
                 return result;
@@ -794,12 +951,8 @@ namespace TestApp {
 
         // ---- Small helpers ---------------------------------------------------------------------------------
 
-        private static string SanitizeFileName(string name) {
-            foreach (var c in Path.GetInvalidFileNameChars()) {
-                name = name.Replace(c, '_');
-            }
-            return name;
-        }
+        // RunIds can be nested paths (e.g. "toml999/attempt01"), so delegate to the helper's slash-aware sanitizer.
+        private static string SanitizeFileName(string name) => OptimizationRunDiscovery.SanitizeForFileName(name);
 
         private static string Csv(string s) {
             if (string.IsNullOrEmpty(s)) {

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -328,8 +328,9 @@ namespace TestApp {
 
         /// <summary>
         /// Loads a discovered run's frames as float Mats once, wires the harness detection delegate, infers the
-        /// fit config, and builds its <see cref="RunEvaluationData"/>. Caller owns disposing the returned run's
-        /// cached Mats (see <see cref="DisposeRuns"/>).
+        /// fit config, and builds its <see cref="RunEvaluationData"/>. Caller owns disposing the returned run via
+        /// <see cref="DisposeRuns"/>, which frees BOTH the <see cref="RunEvaluationData"/>'s cached early-detection
+        /// contexts and the loaded-once frame Mats.
         /// </summary>
         private static async Task<LoadedHarnessRun> PrepareRunAsync(
             RunDetectionContext ctx, OptimizationRunDiscovery.DiscoveredRun d,
@@ -355,20 +356,14 @@ namespace TestApp {
                 PreferredModel = null
             };
 
-            var detector = ctx.Detector;
-            var measurementAverage = ctx.MeasurementAverage;
-            var highSigma = ctx.HighSigmaOutlierRejection;
-            var lowSigma = ctx.LowSigmaOutlierRejection;
-            Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> detect =
-                async (image, candidateParams, ct) => {
-                    // Detect mutates its input in place, so each detection gets a clone of the cached Mat.
-                    using var clone = ((Mat)image).Clone();
-                    var result = await detector.Detect(clone, candidateParams, null, ct).ConfigureAwait(false);
-                    return ToFrameDetectionResult(result, measurementAverage, highSigma, lowSigma);
-                };
+            // Split detector: caches the expensive early detection per (frame, early key) and reuses it across the
+            // many candidate evaluations that change only late-stage gate params (the ~2× speedup). The
+            // FrameDetectionResult mapping is the SAME ToFrameDetectionResult the legacy delegate used, so results
+            // are unchanged.
+            var splitDetector = new MatSplitFrameDetector(ctx.Detector, ctx.MeasurementAverage, ctx.HighSigmaOutlierRejection, ctx.LowSigmaOutlierRejection);
 
             var labels = labelsByRun.TryGetValue(d.RunId, out var ls) ? ls : null;
-            var data = new RunEvaluationData(d.RunId, frames, detect, ctx.AlglibAPI, fitConfig, labels);
+            var data = new RunEvaluationData(d.RunId, frames, splitDetector, ctx.AlglibAPI, fitConfig, labels);
             Console.WriteLine($"  {d.RunId}: inferred step size {stepSize}" + (labels != null ? $", {labels.Count} labeled position(s)" : ", unlabeled"));
             return new LoadedHarnessRun { Discovered = d, Data = data, StepSize = stepSize, Frames = frames };
         }
@@ -432,8 +427,11 @@ namespace TestApp {
         }
 
         private static void DisposeRuns(List<LoadedHarnessRun> loadedRuns) {
-            // Release the cached frame Mats (each RunFrame.Image is a Mat the harness loaded once).
             foreach (var r in loadedRuns) {
+                // Release the per-frame cached early-detection contexts the RunEvaluationData pinned (each holds a
+                // ~244 MB source Mat at 61 MP); a long --per-run batch accumulates them otherwise. Idempotent.
+                r.Data?.Dispose();
+                // Release the cached frame Mats (each RunFrame.Image is a Mat the harness loaded once).
                 foreach (var rf in r.Frames) {
                     (rf.Image as Mat)?.Dispose();
                 }
@@ -599,6 +597,39 @@ namespace TestApp {
                 StarCount = stars.Count,
                 StarCenters = centers
             };
+        }
+
+        /// <summary>
+        /// Mat-based split detector for the offline harness: caches the expensive early detection per (frame, early
+        /// key) and reuses it across candidate evaluations that change only late-stage gate params. The context is
+        /// a <see cref="StarDetector.DetectionContext"/>; the result mapping is the SAME
+        /// <see cref="ToFrameDetectionResult"/> the legacy delegate used, so results are byte-identical.
+        /// <see cref="StarDetector.BuildDetectionContext(Mat, StarDetectorParams, IProgress{NINA.Core.Model.ApplicationStatus}, CancellationToken)"/>
+        /// clones the frame Mat internally, so the cached frame Mats are never mutated.
+        /// </summary>
+        private sealed class MatSplitFrameDetector : RunEvaluationData.ISplitFrameDetector {
+            private readonly StarDetector detector;
+            private readonly MeasurementAverageEnum measurementAverage;
+            private readonly double highSigma;
+            private readonly double lowSigma;
+
+            public MatSplitFrameDetector(StarDetector detector, MeasurementAverageEnum measurementAverage, double highSigma, double lowSigma) {
+                this.detector = detector;
+                this.measurementAverage = measurementAverage;
+                this.highSigma = highSigma;
+                this.lowSigma = lowSigma;
+            }
+
+            public string ComputeEarlyKey(StarDetectorParams p) => StarDetector.ComputeEarlyCacheKey(p);
+
+            public async Task<IDisposable> BuildContextAsync(object frameImage, StarDetectorParams p, CancellationToken token) {
+                return await detector.BuildDetectionContext((Mat)frameImage, p, null, token).ConfigureAwait(false);
+            }
+
+            public FrameDetectionResult GateAndMeasure(IDisposable context, StarDetectorParams p) {
+                var result = detector.GateAndMeasure((StarDetector.DetectionContext)context, p, CancellationToken.None);
+                return ToFrameDetectionResult(result, measurementAverage, highSigma, lowSigma);
+            }
         }
 
         // ---- Labels ----------------------------------------------------------------------------------------

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -1,0 +1,816 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using Newtonsoft.Json;
+using NINA.Core.Enum;
+using NINA.Core.Utility;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NINA.Profile;
+using NINA.Profile.Interfaces;
+using OpenCvSharp;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using Logger = NINA.Core.Utility.Logger;
+using Rect = OpenCvSharp.Rect;
+
+namespace TestApp {
+
+    /// <summary>
+    /// Headless dev harness for the Star Detection Optimization wizard's optimizer (T6). Loads one or more saved
+    /// auto-focus runs from disk as float Mats, drives the SAME <see cref="StarDetectionOptimizer"/> the live
+    /// wizard uses (over an injected <see cref="StarDetector.Detect(Mat, StarDetectorParams, IProgress{NINA.Core.Model.ApplicationStatus}, CancellationToken)"/>
+    /// delegate), and writes a summary + CSV + stretched annotated PNGs so the optimizer can be verified offline
+    /// without launching NINA. Mirrors <see cref="ContaminationDiagnosticRunner"/> in structure and conventions.
+    ///
+    /// <para>This is image-source-agnostic by design: the optimizer's <see cref="RunEvaluationData"/> takes an
+    /// opaque image payload and an injected detection delegate, so the offline harness feeds it float Mats while
+    /// the live wizard feeds it <c>IRenderedImage</c>s — the optimizer code is identical in both.</para>
+    /// </summary>
+    internal static class OptimizationDiagnosticRunner {
+
+        // Mirrors AutoFocusEngine.IMAGE_FILE_REGEX (private) so the harness stays decoupled from the engine, and
+        // matches FocusSweepDiagnosticRunner's copy. Frames the AF engine writes look like
+        // "0_Frame1_BitDepth16_Bayered0_Focuser5000.fits" (the trailing _HFRxxx is optional).
+        private static readonly Regex ImageFileRegex = new Regex(
+            @"^(?<IMAGE_INDEX>\d+)_Frame(?<FRAME_NUMBER>\d+)_BitDepth(?<BITDEPTH>\d+)_Bayered(?<BAYERED>\d)_Focuser(?<FOCUSER>\d+)(_HFR(?<HFR>(\d+)(\.\d+)?))?$",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        public static async Task Run(string[] args) {
+            try {
+                await RunImpl(args);
+            } catch (Exception ex) {
+                Console.Error.WriteLine($"ERROR: {ex.Message}");
+                Console.Error.WriteLine(ex.ToString());
+                Logger.Error(ex, "Optimization diagnostic run failed");
+                Environment.ExitCode = 1;
+            }
+        }
+
+        private static async Task RunImpl(string[] args) {
+            var runsDir = DiagnosticUtil.GetArg(args, "--runs");
+            if (string.IsNullOrWhiteSpace(runsDir)) {
+                PrintUsage();
+                Environment.ExitCode = 2;
+                return;
+            }
+            if (!Directory.Exists(runsDir)) {
+                throw new DirectoryNotFoundException($"--runs folder not found: {runsDir}");
+            }
+
+            var profileId = DiagnosticUtil.GetArg(args, "--profile-id");
+            var outDir = DiagnosticUtil.GetArg(args, "--out");
+            if (string.IsNullOrWhiteSpace(outDir)) {
+                var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                outDir = Path.Combine(localAppData, "NINA", "Logs", "hf-diag", "optimize",
+                    DateTime.Now.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture));
+            }
+            Directory.CreateDirectory(outDir);
+
+            int? maxEvals = null;
+            var maxEvalsArg = DiagnosticUtil.GetArg(args, "--max-evals");
+            if (!string.IsNullOrWhiteSpace(maxEvalsArg)) {
+                if (!int.TryParse(maxEvalsArg, NumberStyles.Integer, CultureInfo.InvariantCulture, out var me) || me <= 0) {
+                    throw new ArgumentException($"--max-evals: '{maxEvalsArg}' is not a positive integer");
+                }
+                maxEvals = me;
+            }
+
+            var annotateArg = DiagnosticUtil.GetArg(args, "--annotate");
+            bool annotateAll = false;
+            if (!string.IsNullOrWhiteSpace(annotateArg)) {
+                if (annotateArg.Equals("all", StringComparison.OrdinalIgnoreCase)) {
+                    annotateAll = true;
+                } else if (annotateArg.Equals("extremes", StringComparison.OrdinalIgnoreCase)) {
+                    annotateAll = false;
+                } else {
+                    throw new ArgumentException($"--annotate: '{annotateArg}' must be 'extremes' or 'all'");
+                }
+            }
+
+            var labelsDir = DiagnosticUtil.GetArg(args, "--labels");
+
+            // Verbose logging to the NINA log file for offline inspection.
+            Logger.SetLogLevel(LogLevelEnum.TRACE);
+
+            // The real ProfileService.ActiveProfile setter writes to Application.Current.Resources, so a
+            // (non-running) WPF Application must exist or it NREs (mirrors ContaminationDiagnosticRunner).
+            if (Application.Current == null) {
+                new Application();
+            }
+
+            Console.WriteLine($"Runs root: {runsDir}");
+            Console.WriteLine($"Output: {outDir}");
+
+            // Load the user's real profile + star detection settings (single source of truth for params + PixelScale).
+            var profileService = new ProfileService();
+            profileService.TryLoad(profileId ?? string.Empty);
+            var activeProfile = profileService.ActiveProfile;
+            if (activeProfile == null) {
+                throw new InvalidOperationException("No active NINA profile could be loaded. Pass --profile-id, or run NINA at least once to create a profile.");
+            }
+            Console.WriteLine($"Profile: {activeProfile.Name} ({activeProfile.Id})");
+            Logger.Info($"Loaded profile {activeProfile.Name} ({activeProfile.Id})");
+
+            var guid = PluginOptionsAccessor.GetAssemblyGuid(typeof(StarDetectionOptions));
+            if (guid == null) {
+                throw new InvalidOperationException("Could not resolve the HocusFocus plugin assembly GUID");
+            }
+            var accessor = new PluginOptionsAccessor(profileService, guid.Value);
+            var starDetectionOptions = new StarDetectionOptions(profileService, accessor);
+            var afOptions = new AutoFocusOptions(profileService);
+
+            // PixelScale = arcsec/pixel from the profile (pixel size / focal length) × binning, mirroring
+            // HocusFocusStarDetection.GetStarDetectorParams. Production reads binning from per-frame metadata
+            // (image.RawImageData.MetaData.Camera.BinX, which defaults to 1 when unset); the harness loads raw
+            // float Mats with no NINA metadata, so binning = 1 is used (the same value an unbinned/unset frame
+            // yields in production). PixelScale only feeds PixelScale-dependent detection gates, not the curve fit.
+            const int binning = 1;
+            var pixelScale = MathUtility.ArcsecPerPixel(activeProfile.CameraSettings.PixelSize, activeProfile.TelescopeSettings.FocalLength) * binning;
+            if (double.IsNaN(pixelScale)) {
+                Console.WriteLine("WARNING: PixelScale is NaN (pixel size / focal length not set in the profile). Detection will still run; PixelScale-dependent gates use NaN.");
+                Logger.Warning("PixelScale is NaN; pixel size / focal length not set in the profile");
+            }
+
+            // Seed params = the SAME mapping NINA uses (BuildStarDetectorParams), with the AF overrides
+            // GetStarDetectorParams(..., isAutoFocus:true) applies: ModelPSF=false, no intermediate files, plus
+            // PixelScale and Region=Full. This is exactly the bundle the optimizer starts from and tunes.
+            var seed = HocusFocusStarDetection.BuildStarDetectorParams(starDetectionOptions);
+            seed.PixelScale = pixelScale;
+            seed.Region = StarDetectionRegion.Full;
+            seed.ModelPSF = false;
+            seed.SaveIntermediateFilesPath = string.Empty;
+            // The optimizer scores the full accepted set, so keep contaminated stars only if the profile says to.
+            // Leave RejectContaminatedStars exactly as the profile resolved it (matches production AF).
+
+            Console.WriteLine($"Seed params: Sensitivity={F(seed.Sensitivity)}, StarClippingMultiplier={F(seed.StarClippingMultiplier)}, " +
+                $"NoiseClippingMultiplier={F(seed.NoiseClippingMultiplier)}, StructureLayers={seed.StructureLayers}, PixelScale={F(seed.PixelScale)}, " +
+                $"MeasurementAverage={starDetectionOptions.MeasurementAverage}");
+
+            // The fixed AF-detection sigma rejections the wizard loader uses (HocusFocusDetectionParams defaults):
+            // high = 4.0, low = 3.0. These feed the MeanOutliers HFR aggregation only.
+            const double highSigmaOutlierRejection = 4.0;
+            const double lowSigmaOutlierRejection = 3.0;
+
+            // Discover runs: each immediate subfolder that contains AF frames is one run; if the --runs folder
+            // itself contains AF frames it is treated as a single run (so a single attempt folder works directly).
+            var discovered = DiscoverRuns(runsDir);
+            if (discovered.Count == 0) {
+                throw new InvalidOperationException(
+                    $"No AF frames matched the saved-run filename pattern under {runsDir}. Expected files like " +
+                    "'0_Frame1_BitDepth16_Bayered0_Focuser5000.fits' in the folder or an immediate subfolder.");
+            }
+            Console.WriteLine($"Discovered {discovered.Count} run(s):");
+            foreach (var d in discovered) {
+                Console.WriteLine($"  {d.RunId}: {d.Frames.Count} frames, {d.Frames.Select(f => f.FocuserPosition).Distinct().Count()} positions");
+            }
+
+            var labelsByRun = LoadLabels(labelsDir, discovered);
+
+            var alglibAPI = new AlglibAPI();
+            var detector = new StarDetector(alglibAPI);
+
+            // Build a RunEvaluationData per discovered run: load every frame once as a float Mat, wire the harness
+            // detection delegate (StarDetector.Detect(Mat) -> FrameDetectionResult), and infer the fit config.
+            var loadedRuns = new List<LoadedHarnessRun>(discovered.Count);
+            foreach (var d in discovered) {
+                var frames = new List<RunFrame>(d.Frames.Count);
+                foreach (var frame in d.Frames) {
+                    // LoadFloatMat returns a fresh Mat each call; the optimizer detect delegate clones before
+                    // detection (Detect mutates its input), so the cached Mat here is never mutated.
+                    var mat = await DiagnosticUtil.LoadFloatMat(frame.Path, profileService).ConfigureAwait(false);
+                    frames.Add(new RunFrame {
+                        FrameId = frame.Path,
+                        FocuserPosition = frame.FocuserPosition,
+                        Image = mat
+                    });
+                }
+
+                var stepSize = InferStepSize(d.Frames);
+                var fitConfig = new RunFitConfig {
+                    StepSize = stepSize,
+                    UseWeights = afOptions.WeightedHyperbolicFitEnabled,
+                    MaxOutlierRejections = afOptions.MaxOutlierRejections,
+                    RejectionConfidence = afOptions.OutlierRejectionConfidence,
+                    PreferredModel = null
+                };
+
+                var measurementAverage = starDetectionOptions.MeasurementAverage;
+                Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> detect =
+                    async (image, candidateParams, ct) => {
+                        // Detect mutates its input in place, so each detection gets a clone of the cached Mat.
+                        using var clone = ((Mat)image).Clone();
+                        var result = await detector.Detect(clone, candidateParams, null, ct).ConfigureAwait(false);
+                        return ToFrameDetectionResult(result, measurementAverage, highSigmaOutlierRejection, lowSigmaOutlierRejection);
+                    };
+
+                var labels = labelsByRun.TryGetValue(d.RunId, out var ls) ? ls : null;
+                var data = new RunEvaluationData(d.RunId, frames, detect, alglibAPI, fitConfig, labels);
+                loadedRuns.Add(new LoadedHarnessRun { Discovered = d, Data = data, StepSize = stepSize, Frames = frames });
+                Console.WriteLine($"  {d.RunId}: inferred step size {stepSize}" + (labels != null ? $", {labels.Count} labeled position(s)" : ", unlabeled"));
+            }
+
+            var settings = new OptimizerSettings();
+            if (maxEvals.HasValue) {
+                settings.MaxEvaluations = maxEvals.Value;
+            }
+
+            var variables = OptimizerVariable.CreateCuratedSet();
+            var optimizer = new StarDetectionOptimizer();
+
+            // Run the optimizer over ALL discovered runs at once (single-run reduces to N=1; N>1 is the balanced
+            // min/mean blend via JTotal). This is the configuration the wizard ships.
+            var dataList = loadedRuns.Select(r => r.Data).ToList();
+            var evaluator = RunEvaluationData.CreateEvaluator(dataList);
+
+            var progress = new Progress<OptimizationProgress>(op =>
+                Console.WriteLine($"  [{op.Phase}] evals={op.Evaluations}/{op.MaxEvaluations} bestJ={F(op.BestJ)} seedJ={F(op.SeedJ)}"));
+
+            Console.WriteLine($"Optimizing over {dataList.Count} run(s) (MaxEvaluations={settings.MaxEvaluations}, {(labelsDir != null ? "labeled" : "unlabeled")})...");
+            var result = await optimizer.OptimizeAsync(seed, variables, evaluator, settings, progress, CancellationToken.None).ConfigureAwait(false);
+            Console.WriteLine($"Optimization complete: seedJ={F(result.SeedJ)} -> bestJ={F(result.BestJ)} ({(result.ImprovedOverSeed ? "improved" : "no improvement")}), evals={result.Evaluations}");
+
+            // Evaluate the seed and the winning params against each run, capturing the fit + per-frame counts.
+            var perRunSeed = new List<RunEvaluationResult>(loadedRuns.Count);
+            var perRunBest = new List<RunEvaluationResult>(loadedRuns.Count);
+            foreach (var r in loadedRuns) {
+                perRunSeed.Add(await r.Data.EvaluateAndFitAsync(seed, CancellationToken.None).ConfigureAwait(false));
+                perRunBest.Add(await r.Data.EvaluateAndFitAsync(result.BestParams, CancellationToken.None).ConfigureAwait(false));
+            }
+
+            // Hard-floor assertion: every frame (incl. defocused extremes) must keep >= NHard accepted stars under
+            // the winning params. This is the optimizer's hard constraint; a FAIL means the winner starves a frame.
+            var objectiveConstants = new ObjectiveConstants();
+            var (passed, worstFrameCount, worstRunId) = AssertHardFloor(loadedRuns, perRunBest, objectiveConstants);
+            Console.WriteLine(passed
+                ? $"PASS: every frame has >= {objectiveConstants.NHard} stars under optimized params (min observed = {worstFrameCount})"
+                : $"FAIL: at least one frame has < {objectiveConstants.NHard} stars under optimized params (min observed = {worstFrameCount} in run {worstRunId})");
+            if (!passed) {
+                Environment.ExitCode = 3;
+            }
+
+            // Each run's step-size recommendation (from its own winning fit) is written to the summary. The
+            // focuser's max step is unavailable headless, so it is left null — StepSizeRecommender clamps to >= 1.
+            var focuserMaxStep = (int?)null;
+
+            WriteSummary(Path.Combine(outDir, "optimize_summary.txt"), runsDir, seed, result, variables,
+                loadedRuns, perRunSeed, perRunBest, objectiveConstants, focuserMaxStep, labelsDir, settings, passed, worstFrameCount, worstRunId);
+            WriteCsv(Path.Combine(outDir, "optimize_result.csv"), loadedRuns, perRunSeed, perRunBest);
+
+            // Annotated PNGs (per --annotate) using the OPTIMIZED params, so a real star with no marker reads as
+            // "missed entirely". Annotate the min/max focuser frame per run by default, or every frame for "all".
+            await WriteAnnotatedFrames(outDir, loadedRuns, result.BestParams, detector,
+                starDetectionOptions.MeasurementAverage, highSigmaOutlierRejection, lowSigmaOutlierRejection, annotateAll).ConfigureAwait(false);
+
+            // Release the cached frame Mats (each RunFrame.Image is a Mat the harness loaded once).
+            foreach (var r in loadedRuns) {
+                foreach (var rf in r.Frames) {
+                    (rf.Image as Mat)?.Dispose();
+                }
+            }
+
+            Console.WriteLine($"Wrote optimize_summary.txt, optimize_result.csv, and annotated PNG(s) to {outDir}");
+        }
+
+        private static void PrintUsage() {
+            Console.Error.WriteLine("Usage: TestApp optimize --runs <folder> [--profile-id <guid>] [--out <dir>] [--max-evals <int>] [--annotate extremes|all] [--labels <dir>]");
+            Console.Error.WriteLine("  --runs       (required) folder of saved AF runs. Each immediate subfolder with AF frames is one run; or the folder itself is a single run.");
+            Console.Error.WriteLine("  --profile-id (default active) NINA profile id to load (settings + PixelScale).");
+            Console.Error.WriteLine("  --out        (default %LOCALAPPDATA%\\NINA\\Logs\\hf-diag\\optimize\\<timestamp>) output directory.");
+            Console.Error.WriteLine("  --max-evals  (optional) override the optimizer's MaxEvaluations budget.");
+            Console.Error.WriteLine("  --annotate   (default extremes) annotate only min/max-focuser frames, or 'all' frames.");
+            Console.Error.WriteLine("  --labels     (optional) folder of label JSON files; activates the recall/precision objective term.");
+        }
+
+        // ---- Run / frame discovery -------------------------------------------------------------------------
+
+        private sealed class FrameRef {
+            public string Path;
+            public int FocuserPosition;
+        }
+
+        private sealed class DiscoveredRun {
+            public string RunId;
+            public List<FrameRef> Frames;
+        }
+
+        private sealed class LoadedHarnessRun {
+            public DiscoveredRun Discovered;
+            public RunEvaluationData Data;
+            public int StepSize;
+            public List<RunFrame> Frames; // the loaded-once frame Mats, retained for disposal
+        }
+
+        /// <summary>
+        /// Discovers runs under <paramref name="runsDir"/>. If the folder itself contains AF frames it is a single
+        /// run; otherwise every immediate subfolder that contains AF frames is treated as a separate run. RunId is
+        /// the folder name (or the runs-dir name for the single-run case). Deterministic (ordinal) order.
+        /// </summary>
+        private static List<DiscoveredRun> DiscoverRuns(string runsDir) {
+            var root = new DirectoryInfo(runsDir);
+            var runs = new List<DiscoveredRun>();
+
+            var rootFrames = MatchFrames(root);
+            if (rootFrames.Count > 0) {
+                runs.Add(new DiscoveredRun { RunId = root.Name, Frames = rootFrames });
+                return runs;
+            }
+
+            foreach (var sub in root.EnumerateDirectories().OrderBy(d => d.Name, StringComparer.Ordinal)) {
+                var frames = MatchFrames(sub);
+                if (frames.Count == 0) {
+                    // Also accept a parent that wraps a single attempt* subfolder (the saved AF layout).
+                    var attempt = sub.EnumerateDirectories("attempt*").FirstOrDefault();
+                    if (attempt != null) {
+                        frames = MatchFrames(attempt);
+                    }
+                }
+                if (frames.Count > 0) {
+                    runs.Add(new DiscoveredRun { RunId = sub.Name, Frames = frames });
+                }
+            }
+            return runs;
+        }
+
+        private static List<FrameRef> MatchFrames(DirectoryInfo dir) {
+            var frames = new List<FrameRef>();
+            if (!dir.Exists) {
+                return frames;
+            }
+            foreach (var file in dir.GetFiles().OrderBy(f => f.Name, StringComparer.Ordinal)) {
+                var m = ImageFileRegex.Match(Path.GetFileNameWithoutExtension(file.Name));
+                if (!m.Success) {
+                    continue;
+                }
+                if (!int.TryParse(m.Groups["FOCUSER"].Value, out var pos)) {
+                    continue;
+                }
+                frames.Add(new FrameRef { Path = file.FullName, FocuserPosition = pos });
+            }
+            return frames;
+        }
+
+        /// <summary>
+        /// Infers the AF step size from the frames exactly as <c>AutoFocusEngine.LoadSavedAttemptImpl</c> does:
+        /// the absolute difference of the two smallest DISTINCT focuser positions. 0 when fewer than 2 positions.
+        /// </summary>
+        private static int InferStepSize(List<FrameRef> frames) {
+            var positions = frames.Select(f => f.FocuserPosition).Distinct().OrderBy(x => x).Take(2).ToList();
+            return positions.Count > 1 ? Math.Abs(positions[0] - positions[1]) : 0;
+        }
+
+        // ---- Production-matching HFR aggregation ------------------------------------------------------------
+
+        /// <summary>
+        /// Adapts a <see cref="HocusFocusStarDetectorResult"/> (from <see cref="StarDetector.Detect(Mat, StarDetectorParams, IProgress{NINA.Core.Model.ApplicationStatus}, CancellationToken)"/>)
+        /// into the <see cref="FrameDetectionResult"/> the optimizer consumes, REPLICATING the production HFR
+        /// aggregation in <c>HocusFocusStarDetection.Detect</c> so the harness's per-frame HFR/σ match the live AF
+        /// path exactly. The matched production code:
+        ///   - MeanOutliers: first re-filter the star list to HFR ∈ [median − low·MAD, median + high·MAD]
+        ///     (HocusFocusDetection.Detect lines ~389-399, sigmas 4.0/3.0 from HocusFocusDetectionParams), then
+        ///     AverageHFR = mean, HFRStdDev = sample std-dev (n-1) (lines ~440-442).
+        ///   - Median (default): AverageHFR = median, HFRStdDev = MAD (lines ~446-448).
+        ///   - Both only computed when the surviving list has &gt; 1 star; otherwise AverageHFR/HFRStdDev stay 0.
+        /// StarCount and StarCenters are taken from the SURVIVING accepted set (post outlier-filter for
+        /// MeanOutliers) to match what production counts and centroids.
+        /// </summary>
+        private static FrameDetectionResult ToFrameDetectionResult(
+            HocusFocusStarDetectorResult result, MeasurementAverageEnum measurementAverage,
+            double highSigmaOutlierRejection, double lowSigmaOutlierRejection) {
+            var stars = result.DetectedStars ?? new List<Star>();
+
+            // Production MeanOutliers re-filters the list before averaging (only when count > 1).
+            if (stars.Count > 1 && measurementAverage == MeasurementAverageEnum.MeanOutliers) {
+                var (median, mad) = stars.Select(s => s.HFR).MedianMAD();
+                var hi = median + highSigmaOutlierRejection * mad;
+                var lo = median - lowSigmaOutlierRejection * mad;
+                stars = stars.Where(s => s.HFR <= hi && s.HFR >= lo).ToList();
+            }
+
+            double averageHfr = 0.0;
+            double hfrStdDev = 0.0;
+            if (stars.Count > 1) {
+                if (measurementAverage == MeasurementAverageEnum.MeanOutliers) {
+                    averageHfr = stars.Average(s => s.HFR);
+                    var variance = stars.Sum(s => (s.HFR - averageHfr) * (s.HFR - averageHfr)) / (stars.Count - 1);
+                    hfrStdDev = Math.Sqrt(variance);
+                } else {
+                    var (hfrMedian, hfrMAD) = stars.Select(s => s.HFR).MedianMAD();
+                    averageHfr = hfrMedian;
+                    hfrStdDev = hfrMAD;
+                }
+            }
+
+            var centers = stars.Select(s => (s.Center.X, s.Center.Y)).ToList();
+            return new FrameDetectionResult {
+                AverageHFR = averageHfr,
+                HFRStdDev = hfrStdDev,
+                StarCount = stars.Count,
+                StarCenters = centers
+            };
+        }
+
+        // ---- Labels ----------------------------------------------------------------------------------------
+
+        /// <summary>
+        /// Forward-compatible label JSON shape (T7 writes these; T6 reads them). One file per run, named
+        /// "&lt;runId&gt;.json" (the discovered RunId == the run's folder name), or any *.json whose embedded RunId
+        /// matches a discovered run. Shape:
+        /// <code>
+        /// {
+        ///   "runId": "attempt01",
+        ///   "radiusPx": 6.0,                       // default radius for positions that omit one
+        ///   "positions": [
+        ///     {
+        ///       "focuserPosition": 5000,
+        ///       "radiusPx": 6.0,                    // optional per-position override
+        ///       "missed":       [ { "x": 123.4, "y": 567.8 }, ... ],   // false negatives to recover (recall)
+        ///       "shouldReject": [ { "x": 12.0,  "y": 34.0  }, ... ]    // false positives to exclude (precision)
+        ///     }
+        ///   ]
+        /// }
+        /// </code>
+        /// </summary>
+        private sealed class LabelPoint {
+            [JsonProperty("x")] public double X { get; set; }
+            [JsonProperty("y")] public double Y { get; set; }
+        }
+
+        private sealed class LabelPosition {
+            [JsonProperty("focuserPosition")] public int FocuserPosition { get; set; }
+            [JsonProperty("radiusPx")] public double? RadiusPx { get; set; }
+            [JsonProperty("missed")] public List<LabelPoint> Missed { get; set; }
+            [JsonProperty("shouldReject")] public List<LabelPoint> ShouldReject { get; set; }
+        }
+
+        private sealed class RunLabelFile {
+            [JsonProperty("runId")] public string RunId { get; set; }
+            [JsonProperty("radiusPx")] public double? RadiusPx { get; set; }
+            [JsonProperty("positions")] public List<LabelPosition> Positions { get; set; }
+        }
+
+        private const double DefaultLabelRadiusPx = 6.0;
+
+        private static Dictionary<string, IReadOnlyList<FrameLabels>> LoadLabels(string labelsDir, List<DiscoveredRun> runs) {
+            var result = new Dictionary<string, IReadOnlyList<FrameLabels>>(StringComparer.Ordinal);
+            if (string.IsNullOrWhiteSpace(labelsDir)) {
+                return result;
+            }
+            if (!Directory.Exists(labelsDir)) {
+                throw new DirectoryNotFoundException($"--labels folder not found: {labelsDir}");
+            }
+
+            var byRunId = new Dictionary<string, RunLabelFile>(StringComparer.Ordinal);
+            foreach (var file in Directory.GetFiles(labelsDir, "*.json").OrderBy(f => f, StringComparer.Ordinal)) {
+                RunLabelFile parsed;
+                try {
+                    parsed = JsonConvert.DeserializeObject<RunLabelFile>(File.ReadAllText(file));
+                } catch (Exception ex) {
+                    Console.WriteLine($"WARNING: could not parse label file '{file}': {ex.Message}");
+                    Logger.Warning($"Could not parse label file '{file}': {ex.Message}");
+                    continue;
+                }
+                if (parsed == null) {
+                    continue;
+                }
+                // Prefer the embedded runId; fall back to the filename (without extension).
+                var runId = !string.IsNullOrWhiteSpace(parsed.RunId) ? parsed.RunId : Path.GetFileNameWithoutExtension(file);
+                byRunId[runId] = parsed;
+            }
+
+            foreach (var run in runs) {
+                if (!byRunId.TryGetValue(run.RunId, out var lf) || lf.Positions == null) {
+                    continue;
+                }
+                var defaultRadius = lf.RadiusPx ?? DefaultLabelRadiusPx;
+                var frameLabels = new List<FrameLabels>(lf.Positions.Count);
+                foreach (var pos in lf.Positions) {
+                    frameLabels.Add(new FrameLabels {
+                        FocuserPosition = pos.FocuserPosition,
+                        RadiusPx = pos.RadiusPx ?? defaultRadius,
+                        Missed = (pos.Missed ?? new List<LabelPoint>()).Select(p => (p.X, p.Y)).ToList(),
+                        ShouldReject = (pos.ShouldReject ?? new List<LabelPoint>()).Select(p => (p.X, p.Y)).ToList()
+                    });
+                }
+                result[run.RunId] = frameLabels;
+            }
+            return result;
+        }
+
+        // ---- Hard-floor assertion --------------------------------------------------------------------------
+
+        private static (bool passed, int worstCount, string worstRunId) AssertHardFloor(
+            List<LoadedHarnessRun> runs, List<RunEvaluationResult> perRunBest, ObjectiveConstants c) {
+            bool passed = true;
+            int worst = int.MaxValue;
+            string worstRunId = null;
+            for (int i = 0; i < runs.Count; i++) {
+                var counts = perRunBest[i].Metrics.FrameStarCounts;
+                if (counts == null || counts.Count == 0) {
+                    continue;
+                }
+                var min = counts.Min();
+                if (min < worst) {
+                    worst = min;
+                    worstRunId = runs[i].Discovered.RunId;
+                }
+                if (min < c.NHard) {
+                    passed = false;
+                }
+            }
+            if (worst == int.MaxValue) {
+                worst = 0;
+            }
+            return (passed, worst, worstRunId);
+        }
+
+        // ---- Output: summary + CSV -------------------------------------------------------------------------
+
+        private static void WriteSummary(
+            string path, string runsDir, StarDetectorParams seed, OptimizationResult result,
+            IReadOnlyList<OptimizerVariable> variables, List<LoadedHarnessRun> runs,
+            List<RunEvaluationResult> perRunSeed, List<RunEvaluationResult> perRunBest,
+            ObjectiveConstants c, int? focuserMaxStep, string labelsDir, OptimizerSettings settings,
+            bool passed, int worstFrameCount, string worstRunId) {
+            var sb = new StringBuilder();
+            sb.AppendLine("=== Star Detection Optimizer — headless harness ===");
+            sb.AppendLine($"Runs root: {runsDir}");
+            sb.AppendLine($"Runs: {runs.Count} ({string.Join(", ", runs.Select(r => r.Discovered.RunId))})");
+            sb.AppendLine($"Labels: {(string.IsNullOrWhiteSpace(labelsDir) ? "(none — unlabeled)" : labelsDir)}");
+            sb.AppendLine($"MaxEvaluations: {settings.MaxEvaluations}; evaluator calls: {result.Evaluations}");
+            sb.AppendLine();
+
+            sb.AppendLine("--- Objective ---");
+            sb.AppendLine($"Seed J : {F(result.SeedJ)}");
+            sb.AppendLine($"Best J : {F(result.BestJ)}  ({(result.ImprovedOverSeed ? "improved over seed" : "no improvement over seed")})");
+            sb.AppendLine();
+
+            sb.AppendLine("--- Per-run σ_focus (seed -> optimized) and recommended step size ---");
+            for (int i = 0; i < runs.Count; i++) {
+                var run = runs[i];
+                var seedM = perRunSeed[i].Metrics;
+                var bestM = perRunBest[i].Metrics;
+                var rec = StepSizeRecommender.Recommend(perRunBest[i].BestFit, run.StepSize, focuserMaxStep);
+                sb.AppendLine($"  {run.Discovered.RunId}:");
+                sb.AppendLine($"    σ_focus       : {F(seedM.SigmaFocus)} -> {F(bestM.SigmaFocus)}");
+                sb.AppendLine($"    R²            : {F(seedM.RSquared)} -> {F(bestM.RSquared)}");
+                sb.AppendLine($"    reducedχ²     : {F(seedM.ReducedChiSquared)} -> {F(bestM.ReducedChiSquared)}");
+                sb.AppendLine($"    current step  : {run.StepSize}");
+                sb.AppendLine($"    recommended   : step {rec.StepSize}, offset {rec.OffsetSteps} per side (half-width {F(rec.HalfWidth)})");
+                if (bestM.Recall.HasValue || bestM.Precision.HasValue) {
+                    sb.AppendLine($"    recall/prec   : {F(bestM.Recall ?? double.NaN)} / {F(bestM.Precision ?? double.NaN)}");
+                }
+            }
+            sb.AppendLine();
+
+            sb.AppendLine("--- Curated params (seed -> optimized) ---");
+            // Map changed variables for quick lookup.
+            var changed = result.ChangedVariables?.ToDictionary(cv => cv.Name, cv => cv) ?? new Dictionary<string, (string, double, double)>();
+            foreach (var v in variables) {
+                var seedVal = v.Read(seed);
+                var bestVal = v.Read(result.BestParams);
+                var marker = changed.ContainsKey(v.Name) ? "  *" : "";
+                sb.AppendLine($"  {v.Name,-30} {F(seedVal),14} -> {F(bestVal),-14}{marker}");
+            }
+            sb.AppendLine("  (* = changed by the optimizer)");
+            sb.AppendLine();
+
+            sb.AppendLine($"--- Hard-floor check (every frame must keep >= {c.NHard} stars) ---");
+            sb.AppendLine(passed
+                ? $"  PASS (min observed = {worstFrameCount})"
+                : $"  FAIL (min observed = {worstFrameCount} in run {worstRunId})");
+            sb.AppendLine();
+
+            sb.AppendLine("--- Per-frame star counts (per run, per focuser position: seed -> optimized) ---");
+            for (int i = 0; i < runs.Count; i++) {
+                var run = runs[i];
+                sb.AppendLine($"  {run.Discovered.RunId}:");
+                // Group frames by focuser position; report seed/optimized counts for each.
+                var byPos = BuildPerPositionCounts(run, perRunSeed[i], perRunBest[i]);
+                sb.AppendLine($"    {"focuser",-10} {"seed",6} {"opt",6}");
+                foreach (var kvp in byPos) {
+                    sb.AppendLine($"    {kvp.Key,-10} {kvp.Value.seed,6} {kvp.Value.opt,6}");
+                }
+            }
+
+            File.WriteAllText(path, sb.ToString());
+        }
+
+        /// <summary>
+        /// Builds a focuser-position -> (seed count, optimized count) map for one run. FrameStarCounts is in the
+        /// SAME order RunEvaluationData iterates its frames (the order they were added), so it aligns 1:1 with the
+        /// run's frame list; multiple frames at one position are summed (matches how the V-curve pools positions).
+        /// </summary>
+        private static SortedDictionary<int, (int seed, int opt)> BuildPerPositionCounts(
+            LoadedHarnessRun run, RunEvaluationResult seedResult, RunEvaluationResult bestResult) {
+            var byPos = new SortedDictionary<int, (int seed, int opt)>();
+            var frames = run.Discovered.Frames;
+            var seedCounts = seedResult.Metrics.FrameStarCounts;
+            var bestCounts = bestResult.Metrics.FrameStarCounts;
+            for (int i = 0; i < frames.Count; i++) {
+                var pos = frames[i].FocuserPosition;
+                var s = (seedCounts != null && i < seedCounts.Count) ? seedCounts[i] : 0;
+                var o = (bestCounts != null && i < bestCounts.Count) ? bestCounts[i] : 0;
+                if (byPos.TryGetValue(pos, out var cur)) {
+                    byPos[pos] = (cur.seed + s, cur.opt + o);
+                } else {
+                    byPos[pos] = (s, o);
+                }
+            }
+            return byPos;
+        }
+
+        private static void WriteCsv(
+            string path, List<LoadedHarnessRun> runs, List<RunEvaluationResult> perRunSeed, List<RunEvaluationResult> perRunBest) {
+            var sb = new StringBuilder();
+            sb.AppendLine("run,focuserPosition,seedStarCount,optimizedStarCount,frameIndex,framePath");
+            for (int i = 0; i < runs.Count; i++) {
+                var run = runs[i];
+                var frames = run.Discovered.Frames;
+                var seedCounts = perRunSeed[i].Metrics.FrameStarCounts;
+                var bestCounts = perRunBest[i].Metrics.FrameStarCounts;
+                for (int j = 0; j < frames.Count; j++) {
+                    var s = (seedCounts != null && j < seedCounts.Count) ? seedCounts[j] : 0;
+                    var o = (bestCounts != null && j < bestCounts.Count) ? bestCounts[j] : 0;
+                    sb.AppendLine(string.Join(",",
+                        Csv(run.Discovered.RunId), frames[j].FocuserPosition, s, o, j, Csv(frames[j].Path)));
+                }
+            }
+            File.WriteAllText(path, sb.ToString());
+        }
+
+        // ---- Output: annotated PNGs ------------------------------------------------------------------------
+
+        /// <summary>
+        /// Color key for rejected candidates (BGR for OpenCV). Accepted stars are GREEN with their HFR; a real
+        /// star with NO marker at all is "missed entirely" — the whole point of drawing every rejection reason.
+        /// </summary>
+        private static readonly Scalar AcceptedColor = new Scalar(0, 255, 0);          // green
+        private static readonly (string Reason, Scalar Color)[] RejectionLegend = {
+            ("TooDistorted",   new Scalar(0, 255, 255)),   // yellow
+            ("Degenerate",     new Scalar(0, 165, 255)),   // orange
+            ("Saturated",      new Scalar(0, 0, 255)),     // red
+            ("LowSensitivity", new Scalar(255, 255, 0)),   // cyan
+            ("NotCentered",    new Scalar(255, 0, 255)),   // magenta
+            ("TooFlat",        new Scalar(255, 0, 0)),     // blue
+            ("Contaminated",   new Scalar(128, 0, 128)),   // purple
+        };
+
+        private static async Task WriteAnnotatedFrames(
+            string outDir, List<LoadedHarnessRun> runs, StarDetectorParams optimizedParams, StarDetector detector,
+            MeasurementAverageEnum measurementAverage, double highSigma, double lowSigma, bool annotateAll) {
+            foreach (var run in runs) {
+                var frames = run.Frames;
+                if (frames.Count == 0) {
+                    continue;
+                }
+                List<RunFrame> toAnnotate;
+                if (annotateAll) {
+                    toAnnotate = frames;
+                } else {
+                    // The two most-defocused extremes = min and max focuser position.
+                    var minPos = frames.OrderBy(f => f.FocuserPosition).First();
+                    var maxPos = frames.OrderByDescending(f => f.FocuserPosition).First();
+                    toAnnotate = ReferenceEquals(minPos, maxPos)
+                        ? new List<RunFrame> { minPos }
+                        : new List<RunFrame> { minPos, maxPos };
+                }
+
+                foreach (var frame in toAnnotate) {
+                    // Reuse the already-loaded float Mat (it is never mutated — detection always clones it). This
+                    // also sidesteps re-loading .xisf/.fits, which would need the profile again.
+                    var srcFloat = (Mat)frame.Image;
+                    using var detectClone = srcFloat.Clone();
+                    var result = await detector.Detect(detectClone, optimizedParams, null, CancellationToken.None).ConfigureAwait(false);
+
+                    var fileName = $"{SanitizeFileName(run.Discovered.RunId)}_Focuser{frame.FocuserPosition}_optimized.png";
+                    var outPath = Path.Combine(outDir, fileName);
+                    WriteAnnotated(outPath, srcFloat, result, measurementAverage, highSigma, lowSigma);
+                    Console.WriteLine($"  annotated {outPath} ({result.DetectedStars.Count} accepted)");
+                }
+            }
+        }
+
+        private static void WriteAnnotated(
+            string path, Mat srcFloat, HocusFocusStarDetectorResult result,
+            MeasurementAverageEnum measurementAverage, double highSigma, double lowSigma) {
+            using var bgr = BuildStretchedBgr(srcFloat);
+
+            // Rejected candidates first (so accepted markers draw on top): one color per reason.
+            var metrics = result.Metrics;
+            DrawRects(bgr, metrics?.TooDistortedBounds, RejectionLegend[0].Color);
+            DrawRects(bgr, metrics?.DegenerateBounds, RejectionLegend[1].Color);
+            DrawRects(bgr, metrics?.SaturatedBounds, RejectionLegend[2].Color);
+            DrawRects(bgr, metrics?.LowSensitivityBounds, RejectionLegend[3].Color);
+            DrawRects(bgr, metrics?.NotCenteredBounds, RejectionLegend[4].Color);
+            DrawRects(bgr, metrics?.TooFlatBounds, RejectionLegend[5].Color);
+            DrawRects(bgr, metrics?.ContaminatedBounds, RejectionLegend[6].Color);
+
+            // Accepted stars: green circle + HFR text. We mirror the production accepted set (post outlier-filter
+            // for MeanOutliers) so the markers match the counts the optimizer scored.
+            var accepted = (result.DetectedStars ?? new List<Star>());
+            if (accepted.Count > 1 && measurementAverage == MeasurementAverageEnum.MeanOutliers) {
+                var (median, mad) = accepted.Select(s => s.HFR).MedianMAD();
+                var hi = median + highSigma * mad;
+                var lo = median - lowSigma * mad;
+                accepted = accepted.Where(s => s.HFR <= hi && s.HFR >= lo).ToList();
+            }
+            foreach (var s in accepted) {
+                var center = new OpenCvSharp.Point((int)Math.Round(s.Center.X), (int)Math.Round(s.Center.Y));
+                Cv2.Circle(bgr, center, 8, AcceptedColor, 1, LineTypes.AntiAlias);
+                Cv2.PutText(bgr, s.HFR.ToString("0.0", CultureInfo.InvariantCulture),
+                    new OpenCvSharp.Point(center.X + 9, center.Y - 9), HersheyFonts.HersheySimplex, 0.35, AcceptedColor, 1, LineTypes.AntiAlias);
+            }
+
+            DrawLegend(bgr, accepted.Count);
+            Cv2.ImWrite(path, bgr);
+        }
+
+        private static void DrawRects(Mat bgr, List<Rect> rects, Scalar color) {
+            if (rects == null) {
+                return;
+            }
+            foreach (var r in rects) {
+                Cv2.Rectangle(bgr, r, color, 1, LineTypes.AntiAlias);
+            }
+        }
+
+        /// <summary>Draws a small color key (top-left) so the rejection reasons are readable on the image itself.</summary>
+        private static void DrawLegend(Mat bgr, int acceptedCount) {
+            int x = 8, y = 18, dy = 16;
+            Cv2.PutText(bgr, $"accepted ({acceptedCount})", new OpenCvSharp.Point(x, y), HersheyFonts.HersheySimplex, 0.4, AcceptedColor, 1, LineTypes.AntiAlias);
+            y += dy;
+            foreach (var (reason, color) in RejectionLegend) {
+                Cv2.PutText(bgr, reason, new OpenCvSharp.Point(x, y), HersheyFonts.HersheySimplex, 0.4, color, 1, LineTypes.AntiAlias);
+                y += dy;
+            }
+        }
+
+        // MTF-stretched BGR background for the annotated image (copied from ContaminationDiagnosticRunner so the
+        // two harnesses stay self-contained and identical in appearance).
+        private static Mat BuildStretchedBgr(Mat srcFloat) {
+            using var src16 = new Mat();
+            srcFloat.ConvertTo(src16, MatType.CV_16U, ushort.MaxValue);
+            using var stretched16 = new Mat();
+            try {
+                var stats = CvImageUtility.CalculateStatistics_Histogram(src16);
+                using var lut = CvImageUtility.CreateMTFLookup(stats);
+                CvImageUtility.ApplyLUT(src16, lut, stretched16);
+            } catch (Exception ex) {
+                Logger.Warning($"MTF stretch failed ({ex.Message}); falling back to linear normalization for the annotated image");
+                Cv2.Normalize(src16, stretched16, 0, ushort.MaxValue, NormTypes.MinMax);
+            }
+            using var stretched8 = new Mat();
+            stretched16.ConvertTo(stretched8, MatType.CV_8U, 1.0 / 256.0);
+            var bgr = new Mat();
+            Cv2.CvtColor(stretched8, bgr, ColorConversionCodes.GRAY2BGR);
+            return bgr;
+        }
+
+        // ---- Small helpers ---------------------------------------------------------------------------------
+
+        private static string SanitizeFileName(string name) {
+            foreach (var c in Path.GetInvalidFileNameChars()) {
+                name = name.Replace(c, '_');
+            }
+            return name;
+        }
+
+        private static string Csv(string s) {
+            if (string.IsNullOrEmpty(s)) {
+                return string.Empty;
+            }
+            if (s.Contains(',') || s.Contains('"') || s.Contains('\n')) {
+                return "\"" + s.Replace("\"", "\"\"") + "\"";
+            }
+            return s;
+        }
+
+        private static string F(double v) {
+            if (double.IsNaN(v)) {
+                return "NaN";
+            }
+            return v.ToString("G6", CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -111,8 +111,16 @@ namespace TestApp {
             // across incompatible cameras/scopes is meaningless.
             bool perRun = args.Any(a => string.Equals(a, "--per-run", StringComparison.OrdinalIgnoreCase));
 
-            // Verbose logging to the NINA log file for offline inspection.
-            Logger.SetLogLevel(LogLevelEnum.TRACE);
+            // --verbose is a valueless flag that restores TRACE logging for offline inspection. By default the
+            // optimize harness runs at INFO so the detector's thousands of per-detection Logger.Trace stage-timing
+            // lines (LoadImage/SrcImagePreparation/WaveletCalculation/...) short-circuit instead of serializing to
+            // disk every detection — pure wall-clock overhead during a run of thousands of detections. This is a
+            // logging-only change: detection inputs, params, gates, and results are untouched.
+            bool verbose = args.Any(a => string.Equals(a, "--verbose", StringComparison.OrdinalIgnoreCase));
+            Logger.SetLogLevel(verbose ? LogLevelEnum.TRACE : LogLevelEnum.INFO);
+            if (verbose) {
+                Console.WriteLine("Verbose logging enabled (TRACE).");
+            }
 
             // The real ProfileService.ActiveProfile setter writes to Application.Current.Resources, so a
             // (non-running) WPF Application must exist or it NREs (mirrors ContaminationDiagnosticRunner).
@@ -507,7 +515,7 @@ namespace TestApp {
         }
 
         private static void PrintUsage() {
-            Console.Error.WriteLine("Usage: TestApp optimize --runs <folder> [--per-run] [--profile-id <guid>] [--out <dir>] [--max-evals <int>] [--annotate extremes|all] [--labels <dir>]");
+            Console.Error.WriteLine("Usage: TestApp optimize --runs <folder> [--per-run] [--profile-id <guid>] [--out <dir>] [--max-evals <int>] [--annotate extremes|all] [--labels <dir>] [--verbose]");
             Console.Error.WriteLine("  --runs       (required) folder of saved AF runs. Runs are 'attempt*' folders (recursively, <=4 deep) with >=3 focuser positions; or --runs itself.");
             Console.Error.WriteLine("  --per-run    (optional) optimize each discovered run INDEPENDENTLY into its own subfolder + an aggregate_summary.txt (use for a multi-setup bank).");
             Console.Error.WriteLine("  --profile-id (default active) NINA profile id to load (settings + PixelScale).");
@@ -515,6 +523,7 @@ namespace TestApp {
             Console.Error.WriteLine("  --max-evals  (optional) override the optimizer's MaxEvaluations budget.");
             Console.Error.WriteLine("  --annotate   (default extremes) annotate only min/max-focuser frames, or 'all' frames.");
             Console.Error.WriteLine("  --labels     (optional) folder of label JSON files; activates the recall/precision objective term.");
+            Console.Error.WriteLine("  --verbose    (optional) restore TRACE logging (default INFO). Slower: serializes per-detection stage timings to the NINA log.");
         }
 
         // ---- Run / frame discovery -------------------------------------------------------------------------

--- a/Joko.NINA.Plugins/TestApp/OptimizationRunDiscovery.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationRunDiscovery.cs
@@ -1,0 +1,242 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace TestApp {
+
+    /// <summary>
+    /// Pure (no NINA / no image-load coupling) run discovery for the optimize harness. Operates purely on
+    /// directory structure + AF-frame filenames so it is unit-testable against a temp directory tree.
+    ///
+    /// <para>Real AF save folders look like <c>&lt;setup&gt;/attempt01/&lt;sweep frames&gt;</c> with sibling
+    /// single-frame validation captures (<c>&lt;setup&gt;/final/&lt;1 frame&gt;</c>,
+    /// <c>&lt;setup&gt;/initial/&lt;1 frame&gt;</c>) that are NOT runs (1 focuser position each → can't fit →
+    /// σ_focus NaN → corrupts the joint objective). Runs can also be nested 1–3 levels under the root, and some
+    /// <c>attempt*</c> folders contain ZERO sweep frames (only annotation / result-JSON artifacts) and must be
+    /// skipped. The >= 3 distinct-focuser-positions guard (mirroring
+    /// <c>RunEvaluationData.MinPositionsForFit = 3</c>) is the key filter that excludes final/initial.</para>
+    /// </summary>
+    internal static class OptimizationRunDiscovery {
+
+        /// <summary>Mirror of <c>RunEvaluationData.MinPositionsForFit</c>: the minimum distinct focuser
+        /// positions a folder needs before it can be fit (and therefore counted as a usable run).</summary>
+        public const int MinPositionsForFit = 3;
+
+        /// <summary>How deep below the runs root to search for <c>attempt*</c> folders.</summary>
+        public const int DefaultMaxDepth = 4;
+
+        /// <summary>An AF sweep frame the AF engine writes, e.g.
+        /// "0_Frame1_BitDepth16_Bayered0_Focuser5000.fits" (the trailing _HFRxxx is optional).</summary>
+        public static readonly Regex ImageFileRegex = new Regex(
+            @"^(?<IMAGE_INDEX>\d+)_Frame(?<FRAME_NUMBER>\d+)_BitDepth(?<BITDEPTH>\d+)_Bayered(?<BAYERED>\d)_Focuser(?<FOCUSER>\d+)(_HFR(?<HFR>(\d+)(\.\d+)?))?$",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex AttemptDirRegex = new Regex(@"^attempt\d+$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly HashSet<string> FrameExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
+            ".fits", ".fit", ".xisf"
+        };
+
+        public sealed class FrameRef {
+            public string Path;
+            public int FocuserPosition;
+        }
+
+        public sealed class DiscoveredRun {
+            /// <summary>Readable path relative to the runs root (e.g. "toml999/attempt01"), forward-slashed.</summary>
+            public string RunId;
+
+            public List<FrameRef> Frames;
+
+            public int DistinctPositions => Frames.Select(f => f.FocuserPosition).Distinct().Count();
+        }
+
+        public sealed class SkippedFolder {
+            /// <summary>Readable path relative to the runs root, forward-slashed.</summary>
+            public string RelativePath;
+
+            public string Reason;
+        }
+
+        public sealed class DiscoveryResult {
+            public List<DiscoveredRun> Runs = new List<DiscoveredRun>();
+            public List<SkippedFolder> Skipped = new List<SkippedFolder>();
+        }
+
+        /// <summary>
+        /// Discovers usable runs under <paramref name="runsDir"/>. Algorithm:
+        /// <list type="number">
+        /// <item>Back-compat: if the runs root itself directly holds AF sweep frames (>= 3 distinct positions),
+        ///   the root is a single run (so pointing directly at an attempt folder works). If it has frames but
+        ///   too few positions, it is recorded as skipped (not silently dropped).</item>
+        /// <item>Otherwise, recursively search to <paramref name="maxDepth"/> for directories whose name matches
+        ///   <c>attempt\d+</c> (case-insensitive). Each is a candidate: it becomes a run iff it has >= 3 distinct
+        ///   focuser positions, else it is skipped with a reason (no sweep frames / too few positions).</item>
+        /// <item>Fallback: if NO <c>attempt*</c> folders are found anywhere, treat each immediate subfolder with
+        ///   >= 3 distinct positions as a run (unusual layouts); subfolders with frames but too few positions are
+        ///   skipped.</item>
+        /// </list>
+        /// Runs are returned in ordinal RunId order (deterministic). RunId / RelativePath are forward-slashed
+        /// paths relative to the runs root.
+        /// </summary>
+        public static DiscoveryResult Discover(string runsDir, int minPositions = MinPositionsForFit, int maxDepth = DefaultMaxDepth) {
+            var result = new DiscoveryResult();
+            var root = new DirectoryInfo(runsDir);
+            if (!root.Exists) {
+                return result;
+            }
+
+            // 1) Back-compat: the runs root itself directly holds AF sweep frames.
+            var rootFrames = MatchFrames(root);
+            if (rootFrames.Count > 0) {
+                if (DistinctPositions(rootFrames) >= minPositions) {
+                    result.Runs.Add(new DiscoveredRun { RunId = root.Name, Frames = rootFrames });
+                } else {
+                    result.Skipped.Add(new SkippedFolder {
+                        RelativePath = root.Name,
+                        Reason = $"only {DistinctPositions(rootFrames)} focuser position(s) (need >={minPositions})"
+                    });
+                }
+                Finalize(result);
+                return result;
+            }
+
+            // 2) Recursive attempt* search.
+            var attemptDirs = new List<DirectoryInfo>();
+            CollectAttemptDirs(root, root, 0, maxDepth, attemptDirs);
+            if (attemptDirs.Count > 0) {
+                foreach (var dir in attemptDirs) {
+                    var rel = RelativePath(root, dir);
+                    var frames = MatchFrames(dir);
+                    if (frames.Count == 0) {
+                        result.Skipped.Add(new SkippedFolder { RelativePath = rel, Reason = "no sweep frames" });
+                        continue;
+                    }
+                    var positions = DistinctPositions(frames);
+                    if (positions < minPositions) {
+                        result.Skipped.Add(new SkippedFolder {
+                            RelativePath = rel,
+                            Reason = $"only {positions} focuser position(s) (need >={minPositions})"
+                        });
+                        continue;
+                    }
+                    result.Runs.Add(new DiscoveredRun { RunId = rel, Frames = frames });
+                }
+                Finalize(result);
+                return result;
+            }
+
+            // 3) Fallback: no attempt* folders anywhere — treat each immediate subfolder with enough positions
+            //    as a run.
+            foreach (var sub in root.EnumerateDirectories()) {
+                var rel = RelativePath(root, sub);
+                var frames = MatchFrames(sub);
+                if (frames.Count == 0) {
+                    continue; // no frames at all is not a notable skip in fallback mode
+                }
+                var positions = DistinctPositions(frames);
+                if (positions < minPositions) {
+                    result.Skipped.Add(new SkippedFolder {
+                        RelativePath = rel,
+                        Reason = $"only {positions} focuser position(s) (need >={minPositions})"
+                    });
+                    continue;
+                }
+                result.Runs.Add(new DiscoveredRun { RunId = rel, Frames = frames });
+            }
+            Finalize(result);
+            return result;
+        }
+
+        private static void Finalize(DiscoveryResult result) {
+            result.Runs = result.Runs.OrderBy(r => r.RunId, StringComparer.Ordinal).ToList();
+            result.Skipped = result.Skipped.OrderBy(s => s.RelativePath, StringComparer.Ordinal).ToList();
+        }
+
+        /// <summary>Recursively collects directories named "attempt\d+" up to <paramref name="maxDepth"/> levels
+        /// below the root. Depth 0 == the root's immediate children.</summary>
+        private static void CollectAttemptDirs(DirectoryInfo root, DirectoryInfo current, int depth, int maxDepth, List<DirectoryInfo> sink) {
+            if (depth > maxDepth) {
+                return;
+            }
+            IEnumerable<DirectoryInfo> children;
+            try {
+                children = current.EnumerateDirectories();
+            } catch {
+                return; // unreadable directory — skip the subtree
+            }
+            foreach (var child in children) {
+                if (AttemptDirRegex.IsMatch(child.Name)) {
+                    sink.Add(child);
+                    // Do not descend into an attempt folder — its contents are frames, not nested runs.
+                    continue;
+                }
+                CollectAttemptDirs(root, child, depth + 1, maxDepth, sink);
+            }
+        }
+
+        private static List<FrameRef> MatchFrames(DirectoryInfo dir) {
+            var frames = new List<FrameRef>();
+            if (!dir.Exists) {
+                return frames;
+            }
+            FileInfo[] files;
+            try {
+                files = dir.GetFiles();
+            } catch {
+                return frames;
+            }
+            foreach (var file in files.OrderBy(f => f.Name, StringComparer.Ordinal)) {
+                if (!FrameExtensions.Contains(file.Extension)) {
+                    continue;
+                }
+                var m = ImageFileRegex.Match(Path.GetFileNameWithoutExtension(file.Name));
+                if (!m.Success) {
+                    continue;
+                }
+                if (!int.TryParse(m.Groups["FOCUSER"].Value, out var pos)) {
+                    continue;
+                }
+                frames.Add(new FrameRef { Path = file.FullName, FocuserPosition = pos });
+            }
+            return frames;
+        }
+
+        private static int DistinctPositions(List<FrameRef> frames) => frames.Select(f => f.FocuserPosition).Distinct().Count();
+
+        /// <summary>Forward-slashed path of <paramref name="dir"/> relative to <paramref name="root"/>.</summary>
+        private static string RelativePath(DirectoryInfo root, DirectoryInfo dir) {
+            var rel = Path.GetRelativePath(root.FullName, dir.FullName);
+            if (string.IsNullOrEmpty(rel) || rel == ".") {
+                return dir.Name;
+            }
+            return rel.Replace(Path.DirectorySeparatorChar, '/').Replace(Path.AltDirectorySeparatorChar, '/');
+        }
+
+        /// <summary>Sanitizes a RunId for use as a filename / folder-name prefix (slashes → underscores too).</summary>
+        public static string SanitizeForFileName(string name) {
+            if (string.IsNullOrEmpty(name)) {
+                return name;
+            }
+            name = name.Replace('/', '_').Replace('\\', '_');
+            foreach (var c in Path.GetInvalidFileNameChars()) {
+                name = name.Replace(c, '_');
+            }
+            return name;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/TestApp/Program.cs
+++ b/Joko.NINA.Plugins/TestApp/Program.cs
@@ -121,6 +121,12 @@ namespace TestApp {
                 return;
             }
 
+            // Headless star-detection optimizer harness: `TestApp optimize --runs <dir> ...`
+            if (args.Length > 0 && args[0].Equals("optimize", StringComparison.OrdinalIgnoreCase)) {
+                await OptimizationDiagnosticRunner.Run(args);
+                return;
+            }
+
             // Headless contamination diagnostic mode: `TestApp contamination --image <path> ...` (or any
             // invocation that passes --image). Otherwise fall through to the existing WPF GUI.
             bool diagnosticMode = args.Length > 0 &&

--- a/Joko.NINA.Plugins/TestApp/Program.cs
+++ b/Joko.NINA.Plugins/TestApp/Program.cs
@@ -127,8 +127,10 @@ namespace TestApp {
                 return;
             }
 
-            // Interactive two-pass star-review labeling tool: `TestApp review --runs <dir> ...`. This opens a WPF
-            // window (ShowDialog) and so must run on this STA thread (Main is [STAThread]); it is synchronous.
+            // Interactive two-pass star-review labeling tool: `TestApp review --runs <dir> ...`. The runner does its
+            // async loading/detection on this thread, then constructs and shows the WPF window on a dedicated STA
+            // thread it creates internally — so it is correct regardless of this thread's apartment (an async Main
+            // can resume off the [STAThread] main thread after an await, which would otherwise crash window ctor).
             if (args.Length > 0 && args[0].Equals("review", StringComparison.OrdinalIgnoreCase)) {
                 StarReview.StarReviewRunner.Run(args);
                 return;

--- a/Joko.NINA.Plugins/TestApp/Program.cs
+++ b/Joko.NINA.Plugins/TestApp/Program.cs
@@ -127,6 +127,14 @@ namespace TestApp {
                 return;
             }
 
+            // Headless label-classification diagnostic: `TestApp diagnose-labels --runs <dir> --labels <dir> ...`.
+            // Classifies each human-labeled review box (missed/shouldReject/wronglyRejected) against a fresh
+            // detection: ACCEPTED / REJECTED:<reason> / NO CANDIDATE (structure gap).
+            if (args.Length > 0 && args[0].Equals("diagnose-labels", StringComparison.OrdinalIgnoreCase)) {
+                DiagnoseLabelsRunner.Run(args);
+                return;
+            }
+
             // Interactive two-pass star-review labeling tool: `TestApp review --runs <dir> ...`. The runner does its
             // async loading/detection on this thread, then constructs and shows the WPF window on a dedicated STA
             // thread it creates internally — so it is correct regardless of this thread's apartment (an async Main

--- a/Joko.NINA.Plugins/TestApp/Program.cs
+++ b/Joko.NINA.Plugins/TestApp/Program.cs
@@ -127,6 +127,13 @@ namespace TestApp {
                 return;
             }
 
+            // Interactive two-pass star-review labeling tool: `TestApp review --runs <dir> ...`. This opens a WPF
+            // window (ShowDialog) and so must run on this STA thread (Main is [STAThread]); it is synchronous.
+            if (args.Length > 0 && args[0].Equals("review", StringComparison.OrdinalIgnoreCase)) {
+                StarReview.StarReviewRunner.Run(args);
+                return;
+            }
+
             // Headless contamination diagnostic mode: `TestApp contamination --image <path> ...` (or any
             // invocation that passes --image). Otherwise fall through to the existing WPF GUI.
             bool diagnosticMode = args.Length > 0 &&

--- a/Joko.NINA.Plugins/TestApp/StarReview/StarReviewLabels.cs
+++ b/Joko.NINA.Plugins/TestApp/StarReview/StarReviewLabels.cs
@@ -1,0 +1,266 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+
+namespace TestApp.StarReview {
+
+    /// <summary>
+    /// The on-disk label JSON model, shaped EXACTLY as the T6 optimizer harness
+    /// (<c>OptimizationDiagnosticRunner</c>) reads it via <c>--labels</c>: one file per run, named
+    /// "&lt;runId&gt;.json", with the property names/casing below (matching T6's <c>[JsonProperty]</c> names).
+    /// T7 (the interactive review tool) WRITES these; T6 READS them back to activate the recall/precision
+    /// objective term — so the two property-name sets must stay identical. The round-trip is covered by a unit
+    /// test that deserializes a T7-written file through a POCO carrying T6's exact attributes.
+    /// <code>
+    /// {
+    ///   "runId": "attempt01",
+    ///   "radiusPx": 6.0,                          // default radius for positions that omit one
+    ///   "positions": [
+    ///     {
+    ///       "focuserPosition": 5000,
+    ///       "radiusPx": 6.0,                       // optional per-position override
+    ///       "missed":       [ { "x": 123.4, "y": 567.8 } ],  // false negatives to recover (recall)
+    ///       "shouldReject": [ { "x": 12.0,  "y": 34.0  } ]   // false positives to exclude (precision)
+    ///     }
+    ///   ]
+    /// }
+    /// </code>
+    /// </summary>
+    public sealed class StarReviewLabelPoint {
+        [JsonProperty("x")] public double X { get; set; }
+        [JsonProperty("y")] public double Y { get; set; }
+
+        public StarReviewLabelPoint() { }
+
+        public StarReviewLabelPoint(double x, double y) {
+            X = x;
+            Y = y;
+        }
+    }
+
+    public sealed class StarReviewPositionLabels {
+        [JsonProperty("focuserPosition")] public int FocuserPosition { get; set; }
+        [JsonProperty("radiusPx")] public double? RadiusPx { get; set; }
+        [JsonProperty("missed")] public List<StarReviewLabelPoint> Missed { get; set; } = new List<StarReviewLabelPoint>();
+        [JsonProperty("shouldReject")] public List<StarReviewLabelPoint> ShouldReject { get; set; } = new List<StarReviewLabelPoint>();
+    }
+
+    public sealed class StarReviewRunLabels {
+        [JsonProperty("runId")] public string RunId { get; set; }
+        [JsonProperty("radiusPx")] public double? RadiusPx { get; set; }
+        [JsonProperty("positions")] public List<StarReviewPositionLabels> Positions { get; set; } = new List<StarReviewPositionLabels>();
+    }
+
+    /// <summary>
+    /// Load/merge/save helpers for the per-run label files. All file shaping (one file per run, ordinal-sorted,
+    /// indented JSON, T6-compatible serializer settings) and all merge/dedupe logic live here so they are pure
+    /// (no UI/IO mixed with decisions) and unit-testable.
+    /// </summary>
+    public static class StarReviewLabelStore {
+        public const double DefaultRadiusPx = 6.0;
+
+        // Two label points are "the same" (so a toggle removes rather than re-adds) when within this many pixels.
+        // Independent of the scoring radius; this is purely a UI hit-test for the undo-on-click behavior.
+        public const double SamePointTolerancePx = 4.0;
+
+        // T6 reads with default Newtonsoft settings (JsonConvert.DeserializeObject). Serialize indented and skip
+        // nulls so an empty per-position radius override is simply absent (T6 falls back to the file default).
+        private static readonly JsonSerializerSettings SerializerSettings = new JsonSerializerSettings {
+            Formatting = Formatting.Indented,
+            NullValueHandling = NullValueHandling.Ignore
+        };
+
+        public static string FileNameFor(string runId) => SanitizeFileName(runId) + ".json";
+
+        /// <summary>
+        /// Loads the label file for <paramref name="runId"/> from <paramref name="labelsDir"/> if it exists,
+        /// otherwise returns an empty <see cref="StarReviewRunLabels"/> with the default radius. The lookup
+        /// prefers the "&lt;runId&gt;.json" filename, then falls back to any *.json whose embedded runId matches
+        /// (mirroring T6's resolution order). Never throws on a missing dir/file; a corrupt file logs to the
+        /// caller via the returned <paramref name="error"/>.
+        /// </summary>
+        public static StarReviewRunLabels Load(string labelsDir, string runId, out string error) {
+            error = null;
+            var fresh = new StarReviewRunLabels { RunId = runId, RadiusPx = DefaultRadiusPx };
+            if (string.IsNullOrWhiteSpace(labelsDir) || !Directory.Exists(labelsDir)) {
+                return fresh;
+            }
+
+            // 1. Exact filename match.
+            var direct = Path.Combine(labelsDir, FileNameFor(runId));
+            if (File.Exists(direct)) {
+                var parsed = TryParse(direct, out error);
+                if (parsed != null) {
+                    parsed.RunId = runId; // canonicalize
+                    Normalize(parsed);
+                    return parsed;
+                }
+                return fresh;
+            }
+
+            // 2. Embedded-runId match across all *.json (ordinal order for determinism).
+            foreach (var file in Directory.GetFiles(labelsDir, "*.json").OrderBy(f => f, StringComparer.Ordinal)) {
+                var parsed = TryParse(file, out var perFileError);
+                if (parsed == null) {
+                    if (error == null) {
+                        error = perFileError;
+                    }
+                    continue;
+                }
+                var embedded = !string.IsNullOrWhiteSpace(parsed.RunId) ? parsed.RunId : Path.GetFileNameWithoutExtension(file);
+                if (string.Equals(embedded, runId, StringComparison.Ordinal)) {
+                    parsed.RunId = runId;
+                    Normalize(parsed);
+                    return parsed;
+                }
+            }
+            return fresh;
+        }
+
+        /// <summary>Saves <paramref name="labels"/> to "&lt;runId&gt;.json" in <paramref name="labelsDir"/>
+        /// (created if needed), ordinal-sorted by focuser position, indented, T6-compatible.</summary>
+        public static string Save(string labelsDir, StarReviewRunLabels labels) {
+            if (labels == null) {
+                throw new ArgumentNullException(nameof(labels));
+            }
+            Directory.CreateDirectory(labelsDir);
+            Normalize(labels);
+            var path = Path.Combine(labelsDir, FileNameFor(labels.RunId));
+            File.WriteAllText(path, Serialize(labels));
+            return path;
+        }
+
+        /// <summary>Pure serializer (no IO) — exposed so a unit test can assert the produced JSON shape.</summary>
+        public static string Serialize(StarReviewRunLabels labels) {
+            Normalize(labels);
+            return JsonConvert.SerializeObject(labels, SerializerSettings);
+        }
+
+        /// <summary>
+        /// Returns the per-position label bucket for <paramref name="focuserPosition"/>, creating it (with the
+        /// run's default radius) and appending it in sorted order when absent. Mutates and returns from
+        /// <paramref name="labels"/> so the caller's edits land in the persisted model.
+        /// </summary>
+        public static StarReviewPositionLabels GetOrAddPosition(StarReviewRunLabels labels, int focuserPosition) {
+            var existing = labels.Positions.FirstOrDefault(p => p.FocuserPosition == focuserPosition);
+            if (existing != null) {
+                return existing;
+            }
+            var added = new StarReviewPositionLabels {
+                FocuserPosition = focuserPosition,
+                RadiusPx = labels.RadiusPx ?? DefaultRadiusPx
+            };
+            labels.Positions.Add(added);
+            labels.Positions.Sort((a, b) => a.FocuserPosition.CompareTo(b.FocuserPosition));
+            return added;
+        }
+
+        /// <summary>
+        /// Toggles a label point at (x,y): removes an existing point in <paramref name="points"/> within
+        /// <see cref="SamePointTolerancePx"/>, otherwise adds a new one. Returns true if a point was ADDED, false
+        /// if one was removed. Pure list mutation — used for the click-to-add / click-again-to-undo UX.
+        /// </summary>
+        public static bool TogglePoint(List<StarReviewLabelPoint> points, double x, double y) {
+            var idx = NearestPointIndexWithin(points, x, y, SamePointTolerancePx);
+            if (idx >= 0) {
+                points.RemoveAt(idx);
+                return false;
+            }
+            points.Add(new StarReviewLabelPoint(x, y));
+            return true;
+        }
+
+        /// <summary>
+        /// Index of the point in <paramref name="points"/> nearest to (x,y) within <paramref name="tolerancePx"/>,
+        /// or -1 if none. Pure helper (used by the toggle hit-test and unit-tested directly).
+        /// </summary>
+        public static int NearestPointIndexWithin(List<StarReviewLabelPoint> points, double x, double y, double tolerancePx) {
+            if (points == null || points.Count == 0) {
+                return -1;
+            }
+            var tol2 = tolerancePx * tolerancePx;
+            var bestIdx = -1;
+            var bestD2 = double.MaxValue;
+            for (var i = 0; i < points.Count; i++) {
+                var dx = points[i].X - x;
+                var dy = points[i].Y - y;
+                var d2 = dx * dx + dy * dy;
+                if (d2 <= tol2 && d2 < bestD2) {
+                    bestD2 = d2;
+                    bestIdx = i;
+                }
+            }
+            return bestIdx;
+        }
+
+        /// <summary>Total missed + should-reject counts across all positions, for a quick summary line.</summary>
+        public static (int missed, int shouldReject) Counts(StarReviewRunLabels labels) {
+            if (labels?.Positions == null) {
+                return (0, 0);
+            }
+            var missed = labels.Positions.Sum(p => p.Missed?.Count ?? 0);
+            var reject = labels.Positions.Sum(p => p.ShouldReject?.Count ?? 0);
+            return (missed, reject);
+        }
+
+        /// <summary>
+        /// Drops positions that carry no labels at all, so re-saving after an inadvertent navigate-through does not
+        /// litter the file with empty buckets. Keeps the file minimal and stable across re-runs.
+        /// </summary>
+        public static void PruneEmptyPositions(StarReviewRunLabels labels) {
+            if (labels?.Positions == null) {
+                return;
+            }
+            labels.Positions.RemoveAll(p => (p.Missed == null || p.Missed.Count == 0)
+                                            && (p.ShouldReject == null || p.ShouldReject.Count == 0));
+        }
+
+        private static StarReviewRunLabels TryParse(string path, out string error) {
+            error = null;
+            try {
+                var parsed = JsonConvert.DeserializeObject<StarReviewRunLabels>(File.ReadAllText(path));
+                if (parsed == null) {
+                    return new StarReviewRunLabels { RunId = Path.GetFileNameWithoutExtension(path), RadiusPx = DefaultRadiusPx };
+                }
+                return parsed;
+            } catch (Exception ex) {
+                error = $"Could not parse label file '{path}': {ex.Message}";
+                return null;
+            }
+        }
+
+        private static void Normalize(StarReviewRunLabels labels) {
+            labels.Positions ??= new List<StarReviewPositionLabels>();
+            foreach (var p in labels.Positions) {
+                p.Missed ??= new List<StarReviewLabelPoint>();
+                p.ShouldReject ??= new List<StarReviewLabelPoint>();
+            }
+            labels.Positions.Sort((a, b) => a.FocuserPosition.CompareTo(b.FocuserPosition));
+        }
+
+        private static string SanitizeFileName(string name) {
+            if (string.IsNullOrEmpty(name)) {
+                return "run";
+            }
+            foreach (var c in Path.GetInvalidFileNameChars()) {
+                name = name.Replace(c, '_');
+            }
+            return name;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/TestApp/StarReview/StarReviewLabels.cs
+++ b/Joko.NINA.Plugins/TestApp/StarReview/StarReviewLabels.cs
@@ -26,43 +26,67 @@ namespace TestApp.StarReview {
     /// T7 (the interactive review tool) WRITES these; T6 READS them back to activate the recall/precision
     /// objective term — so the two property-name sets must stay identical. The round-trip is covered by a unit
     /// test that deserializes a T7-written file through a POCO carrying T6's exact attributes.
+    ///
+    /// <para>Each label is a BOX in image-space (top-left <c>x</c>,<c>y</c> + <c>w</c>,<c>h</c>): missed is a
+    /// rubber-band box the user drags; should-reject / wrongly-rejected record the actual detector bounding box of
+    /// the clicked star. Recall/precision are scored by box-containment (an accepted center inside the box). Older
+    /// point-only files (with just <c>x</c>,<c>y</c>) still load: a missing <c>w</c>/<c>h</c> defaults to a small
+    /// 2·radiusPx box centered on the point (see <see cref="StarReviewLabelStore.Normalize"/>).</para>
     /// <code>
     /// {
     ///   "runId": "attempt01",
-    ///   "radiusPx": 6.0,                          // default radius for positions that omit one
+    ///   "radiusPx": 6.0,                          // default radius (legacy point-load box fallback)
     ///   "positions": [
     ///     {
     ///       "focuserPosition": 5000,
     ///       "radiusPx": 6.0,                       // optional per-position override
-    ///       "missed":          [ { "x": 123.4, "y": 567.8 } ],  // false negatives to recover (recall)
-    ///       "shouldReject":    [ { "x": 12.0,  "y": 34.0  } ],  // false positives to exclude (precision)
-    ///       "wronglyRejected": [ { "x": 88.0,  "y": 90.0  } ]   // detected-but-gated candidates that should be KEPT (folds into recall)
+    ///       "missed":          [ { "x": 123.4, "y": 567.8, "w": 12.0, "h": 12.0 } ],  // false negatives to recover (recall)
+    ///       "shouldReject":    [ { "x": 12.0,  "y": 34.0,  "w": 9.0,  "h": 9.0  } ],  // false positives to exclude (precision)
+    ///       "wronglyRejected": [ { "x": 88.0,  "y": 90.0,  "w": 10.0, "h": 8.0  } ]   // detected-but-gated candidates that should be KEPT (folds into recall)
     ///     }
     ///   ]
     /// }
     /// </code>
     /// </summary>
-    public sealed class StarReviewLabelPoint {
+    public sealed class StarReviewLabelBox {
         [JsonProperty("x")] public double X { get; set; }
         [JsonProperty("y")] public double Y { get; set; }
 
-        public StarReviewLabelPoint() { }
+        // Nullable so a legacy point-only file (x,y but no w,h) round-trips through deserialization and can be
+        // back-filled with a default box in Normalize. Once filled they always serialize.
+        [JsonProperty("w")] public double? W { get; set; }
+        [JsonProperty("h")] public double? H { get; set; }
 
-        public StarReviewLabelPoint(double x, double y) {
+        public StarReviewLabelBox() { }
+
+        public StarReviewLabelBox(double x, double y, double w, double h) {
             X = x;
             Y = y;
+            W = w;
+            H = h;
         }
+
+        /// <summary>True when this label already carries both dimensions (i.e. is a real box, not a legacy point).</summary>
+        [JsonIgnore]
+        public bool HasSize => W.HasValue && H.HasValue;
+
+        /// <summary>Center of the box (used by the precision/recall containment helpers and the toggle hit-test).</summary>
+        [JsonIgnore]
+        public double CenterX => X + (W ?? 0.0) / 2.0;
+
+        [JsonIgnore]
+        public double CenterY => Y + (H ?? 0.0) / 2.0;
     }
 
     public sealed class StarReviewPositionLabels {
         [JsonProperty("focuserPosition")] public int FocuserPosition { get; set; }
         [JsonProperty("radiusPx")] public double? RadiusPx { get; set; }
-        [JsonProperty("missed")] public List<StarReviewLabelPoint> Missed { get; set; } = new List<StarReviewLabelPoint>();
-        [JsonProperty("shouldReject")] public List<StarReviewLabelPoint> ShouldReject { get; set; } = new List<StarReviewLabelPoint>();
+        [JsonProperty("missed")] public List<StarReviewLabelBox> Missed { get; set; } = new List<StarReviewLabelBox>();
+        [JsonProperty("shouldReject")] public List<StarReviewLabelBox> ShouldReject { get; set; } = new List<StarReviewLabelBox>();
 
         /// <summary>Detected-but-gate-rejected candidates the user judges should have been KEPT. Folds into recall
-        /// (union with <see cref="Missed"/>) on the optimizer side — every wrongly-rejected point is a recall target.</summary>
-        [JsonProperty("wronglyRejected")] public List<StarReviewLabelPoint> WronglyRejected { get; set; } = new List<StarReviewLabelPoint>();
+        /// (union with <see cref="Missed"/>) on the optimizer side — every wrongly-rejected box is a recall target.</summary>
+        [JsonProperty("wronglyRejected")] public List<StarReviewLabelBox> WronglyRejected { get; set; } = new List<StarReviewLabelBox>();
     }
 
     public sealed class StarReviewRunLabels {
@@ -79,8 +103,8 @@ namespace TestApp.StarReview {
     public static class StarReviewLabelStore {
         public const double DefaultRadiusPx = 6.0;
 
-        // Two label points are "the same" (so a toggle removes rather than re-adds) when within this many pixels.
-        // Independent of the scoring radius; this is purely a UI hit-test for the undo-on-click behavior.
+        // Two label boxes are "the same" (so a toggle removes rather than re-adds) when their CENTERS are within this
+        // many pixels. Independent of the scoring radius; this is purely a UI hit-test for the undo-on-click behavior.
         public const double SamePointTolerancePx = 4.0;
 
         // T6 reads with default Newtonsoft settings (JsonConvert.DeserializeObject). Serialize indented and skip
@@ -176,37 +200,68 @@ namespace TestApp.StarReview {
         }
 
         /// <summary>
-        /// Toggles a label point at (x,y): removes an existing point in <paramref name="points"/> within
-        /// <see cref="SamePointTolerancePx"/>, otherwise adds a new one. Returns true if a point was ADDED, false
-        /// if one was removed. Pure list mutation — used for the click-to-add / click-again-to-undo UX.
+        /// Toggles a label box: removes an existing box in <paramref name="boxes"/> whose CENTER is within
+        /// <see cref="SamePointTolerancePx"/> of (<paramref name="x"/>,<paramref name="y"/>,<paramref name="w"/>,
+        /// <paramref name="h"/>)'s center, otherwise adds <paramref name="x"/>,<paramref name="y"/>,<paramref name="w"/>,
+        /// <paramref name="h"/> as a new box. Returns true if a box was ADDED, false if one was removed. Pure list
+        /// mutation — used for the click/drag-to-add / click-again-to-undo UX.
         /// </summary>
-        public static bool TogglePoint(List<StarReviewLabelPoint> points, double x, double y) {
-            var idx = NearestPointIndexWithin(points, x, y, SamePointTolerancePx);
+        public static bool ToggleBox(List<StarReviewLabelBox> boxes, double x, double y, double w, double h) {
+            var cx = x + w / 2.0;
+            var cy = y + h / 2.0;
+            var idx = NearestBoxIndexWithin(boxes, cx, cy, SamePointTolerancePx);
             if (idx >= 0) {
-                points.RemoveAt(idx);
+                boxes.RemoveAt(idx);
                 return false;
             }
-            points.Add(new StarReviewLabelPoint(x, y));
+            boxes.Add(new StarReviewLabelBox(x, y, w, h));
             return true;
         }
 
         /// <summary>
-        /// Index of the point in <paramref name="points"/> nearest to (x,y) within <paramref name="tolerancePx"/>,
-        /// or -1 if none. Pure helper (used by the toggle hit-test and unit-tested directly).
+        /// Index of the box in <paramref name="boxes"/> whose CENTER is nearest to (cx,cy) within
+        /// <paramref name="tolerancePx"/>, or -1 if none. Pure helper (used by the toggle hit-test and unit-tested directly).
         /// </summary>
-        public static int NearestPointIndexWithin(List<StarReviewLabelPoint> points, double x, double y, double tolerancePx) {
-            if (points == null || points.Count == 0) {
+        public static int NearestBoxIndexWithin(List<StarReviewLabelBox> boxes, double cx, double cy, double tolerancePx) {
+            if (boxes == null || boxes.Count == 0) {
                 return -1;
             }
             var tol2 = tolerancePx * tolerancePx;
             var bestIdx = -1;
             var bestD2 = double.MaxValue;
-            for (var i = 0; i < points.Count; i++) {
-                var dx = points[i].X - x;
-                var dy = points[i].Y - y;
+            for (var i = 0; i < boxes.Count; i++) {
+                var dx = boxes[i].CenterX - cx;
+                var dy = boxes[i].CenterY - cy;
                 var d2 = dx * dx + dy * dy;
                 if (d2 <= tol2 && d2 < bestD2) {
                     bestD2 = d2;
+                    bestIdx = i;
+                }
+            }
+            return bestIdx;
+        }
+
+        /// <summary>
+        /// Index of the SMALLEST-area box in <paramref name="boxes"/> that CONTAINS (x,y) (AABB containment), or -1 if
+        /// none. Pure helper — used by the should-reject/wrongly-rejected undo hit-test where a click lands inside an
+        /// already-labeled box rather than near its center.
+        /// </summary>
+        public static int SmallestContainingBoxIndex(List<StarReviewLabelBox> boxes, double x, double y) {
+            if (boxes == null || boxes.Count == 0) {
+                return -1;
+            }
+            var bestIdx = -1;
+            var bestArea = double.MaxValue;
+            for (var i = 0; i < boxes.Count; i++) {
+                var b = boxes[i];
+                var w = b.W ?? 0.0;
+                var h = b.H ?? 0.0;
+                if (x < b.X || y < b.Y || x > b.X + w || y > b.Y + h) {
+                    continue;
+                }
+                var area = w * h;
+                if (area < bestArea) {
+                    bestArea = area;
                     bestIdx = i;
                 }
             }
@@ -253,12 +308,40 @@ namespace TestApp.StarReview {
 
         private static void Normalize(StarReviewRunLabels labels) {
             labels.Positions ??= new List<StarReviewPositionLabels>();
+            var fileRadius = labels.RadiusPx ?? DefaultRadiusPx;
             foreach (var p in labels.Positions) {
-                p.Missed ??= new List<StarReviewLabelPoint>();
-                p.ShouldReject ??= new List<StarReviewLabelPoint>();
-                p.WronglyRejected ??= new List<StarReviewLabelPoint>();
+                p.Missed ??= new List<StarReviewLabelBox>();
+                p.ShouldReject ??= new List<StarReviewLabelBox>();
+                p.WronglyRejected ??= new List<StarReviewLabelBox>();
+
+                // Legacy tolerance: a label loaded from an older point-only file carries x,y but no w,h. Back-fill it
+                // with a small box of side 2·radiusPx CENTERED on the original point (so x,y becomes the box top-left)
+                // — old files keep loading and immediately participate in box-containment scoring.
+                var radius = p.RadiusPx ?? fileRadius;
+                BackfillLegacyBoxes(p.Missed, radius);
+                BackfillLegacyBoxes(p.ShouldReject, radius);
+                BackfillLegacyBoxes(p.WronglyRejected, radius);
             }
             labels.Positions.Sort((a, b) => a.FocuserPosition.CompareTo(b.FocuserPosition));
+        }
+
+        /// <summary>Back-fills any legacy point-only label (no w/h) in <paramref name="boxes"/> with a 2·radiusPx box
+        /// centered on its (x,y), rewriting x,y to the box top-left so it serializes as a real box thereafter.</summary>
+        private static void BackfillLegacyBoxes(List<StarReviewLabelBox> boxes, double radiusPx) {
+            if (boxes == null) {
+                return;
+            }
+            var side = Math.Max(1e-9, 2.0 * radiusPx);
+            foreach (var b in boxes) {
+                if (b.HasSize) {
+                    continue;
+                }
+                // The legacy x,y is the point center; convert to top-left + size.
+                b.X -= side / 2.0;
+                b.Y -= side / 2.0;
+                b.W = side;
+                b.H = side;
+            }
         }
 
         private static string SanitizeFileName(string name) {

--- a/Joko.NINA.Plugins/TestApp/StarReview/StarReviewLabels.cs
+++ b/Joko.NINA.Plugins/TestApp/StarReview/StarReviewLabels.cs
@@ -34,8 +34,9 @@ namespace TestApp.StarReview {
     ///     {
     ///       "focuserPosition": 5000,
     ///       "radiusPx": 6.0,                       // optional per-position override
-    ///       "missed":       [ { "x": 123.4, "y": 567.8 } ],  // false negatives to recover (recall)
-    ///       "shouldReject": [ { "x": 12.0,  "y": 34.0  } ]   // false positives to exclude (precision)
+    ///       "missed":          [ { "x": 123.4, "y": 567.8 } ],  // false negatives to recover (recall)
+    ///       "shouldReject":    [ { "x": 12.0,  "y": 34.0  } ],  // false positives to exclude (precision)
+    ///       "wronglyRejected": [ { "x": 88.0,  "y": 90.0  } ]   // detected-but-gated candidates that should be KEPT (folds into recall)
     ///     }
     ///   ]
     /// }
@@ -58,6 +59,10 @@ namespace TestApp.StarReview {
         [JsonProperty("radiusPx")] public double? RadiusPx { get; set; }
         [JsonProperty("missed")] public List<StarReviewLabelPoint> Missed { get; set; } = new List<StarReviewLabelPoint>();
         [JsonProperty("shouldReject")] public List<StarReviewLabelPoint> ShouldReject { get; set; } = new List<StarReviewLabelPoint>();
+
+        /// <summary>Detected-but-gate-rejected candidates the user judges should have been KEPT. Folds into recall
+        /// (union with <see cref="Missed"/>) on the optimizer side — every wrongly-rejected point is a recall target.</summary>
+        [JsonProperty("wronglyRejected")] public List<StarReviewLabelPoint> WronglyRejected { get; set; } = new List<StarReviewLabelPoint>();
     }
 
     public sealed class StarReviewRunLabels {
@@ -208,14 +213,15 @@ namespace TestApp.StarReview {
             return bestIdx;
         }
 
-        /// <summary>Total missed + should-reject counts across all positions, for a quick summary line.</summary>
-        public static (int missed, int shouldReject) Counts(StarReviewRunLabels labels) {
+        /// <summary>Total missed + should-reject + wrongly-rejected counts across all positions, for a summary line.</summary>
+        public static (int missed, int shouldReject, int wronglyRejected) Counts(StarReviewRunLabels labels) {
             if (labels?.Positions == null) {
-                return (0, 0);
+                return (0, 0, 0);
             }
             var missed = labels.Positions.Sum(p => p.Missed?.Count ?? 0);
             var reject = labels.Positions.Sum(p => p.ShouldReject?.Count ?? 0);
-            return (missed, reject);
+            var wronglyRejected = labels.Positions.Sum(p => p.WronglyRejected?.Count ?? 0);
+            return (missed, reject, wronglyRejected);
         }
 
         /// <summary>
@@ -227,7 +233,8 @@ namespace TestApp.StarReview {
                 return;
             }
             labels.Positions.RemoveAll(p => (p.Missed == null || p.Missed.Count == 0)
-                                            && (p.ShouldReject == null || p.ShouldReject.Count == 0));
+                                            && (p.ShouldReject == null || p.ShouldReject.Count == 0)
+                                            && (p.WronglyRejected == null || p.WronglyRejected.Count == 0));
         }
 
         private static StarReviewRunLabels TryParse(string path, out string error) {
@@ -249,6 +256,7 @@ namespace TestApp.StarReview {
             foreach (var p in labels.Positions) {
                 p.Missed ??= new List<StarReviewLabelPoint>();
                 p.ShouldReject ??= new List<StarReviewLabelPoint>();
+                p.WronglyRejected ??= new List<StarReviewLabelPoint>();
             }
             labels.Positions.Sort((a, b) => a.FocuserPosition.CompareTo(b.FocuserPosition));
         }

--- a/Joko.NINA.Plugins/TestApp/StarReview/StarReviewQueue.cs
+++ b/Joko.NINA.Plugins/TestApp/StarReview/StarReviewQueue.cs
@@ -1,0 +1,136 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TestApp.StarReview {
+
+    /// <summary>Which frames the review window should surface.</summary>
+    public enum StarReviewMode {
+        /// <summary>Frames whose accepted-star count is below the review threshold (the ones worth labeling).</summary>
+        Low,
+
+        /// <summary>Frames the optimizer can least trust: the low ones PLUS each run's most-defocused extremes.</summary>
+        Uncertain,
+
+        /// <summary>Every frame.</summary>
+        All
+    }
+
+    /// <summary>
+    /// A single reviewable frame in the queue: its run, focuser position, the on-disk frame path, and the
+    /// accepted-star count under the chosen params (used for the Low/Uncertain selection and shown in the UI).
+    /// </summary>
+    public sealed class StarReviewFrame {
+        public string RunId { get; set; }
+        public int FocuserPosition { get; set; }
+        public string FramePath { get; set; }
+        public int AcceptedCount { get; set; }
+
+        /// <summary>True when this frame is one of its run's min/max focuser-position extremes.</summary>
+        public bool IsExtreme { get; set; }
+    }
+
+    /// <summary>
+    /// Pure queue-selection logic (no IO/UI): given every frame with its accepted-star count, picks which frames
+    /// the reviewer should see for a given <see cref="StarReviewMode"/>. Kept separate so it is unit-testable.
+    /// </summary>
+    public static class StarReviewQueue {
+
+        /// <summary>
+        /// N_review — the accepted-star count at/under which a frame is "low" and worth a human look. Tied to the
+        /// objective's <c>NFloor</c> star-count knee (8): frames with fewer than the floor are exactly the ones the
+        /// star-count sub-score penalizes, so they are the ones a reviewer most wants to correct. A frame AT or
+        /// ABOVE the floor is already scoring well on star count and rarely needs labels.
+        /// </summary>
+        public const int NReview = 8;
+
+        /// <summary>
+        /// Builds the review queue from <paramref name="allFrames"/> (which must already carry per-frame
+        /// AcceptedCount and IsExtreme) for the given <paramref name="mode"/>:
+        /// <list type="bullet">
+        ///   <item><b>Low</b>: AcceptedCount &lt; <see cref="NReview"/>.</item>
+        ///   <item><b>Uncertain</b>: the Low set UNION each run's most-defocused extremes (min/max focuser
+        ///     position). There is no cheap per-frame optimizer "uncertainty" signal available offline, so this is
+        ///     the documented stand-in: starved frames plus the defocused extremes are exactly where the optimizer
+        ///     is most likely to be wrong (the hard floor lives at the extremes).</item>
+        ///   <item><b>All</b>: every frame.</item>
+        /// </list>
+        /// Output order is deterministic: by run id (ordinal), then by focuser position.
+        /// </summary>
+        public static List<StarReviewFrame> Build(IReadOnlyList<StarReviewFrame> allFrames, StarReviewMode mode) {
+            if (allFrames == null) {
+                throw new ArgumentNullException(nameof(allFrames));
+            }
+
+            IEnumerable<StarReviewFrame> selected;
+            switch (mode) {
+                case StarReviewMode.All:
+                    selected = allFrames;
+                    break;
+
+                case StarReviewMode.Low:
+                    selected = allFrames.Where(f => f.AcceptedCount < NReview);
+                    break;
+
+                case StarReviewMode.Uncertain:
+                    selected = allFrames.Where(f => f.AcceptedCount < NReview || f.IsExtreme);
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unknown review mode");
+            }
+
+            return selected
+                .OrderBy(f => f.RunId, StringComparer.Ordinal)
+                .ThenBy(f => f.FocuserPosition)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Marks the min/max focuser-position frame of each run as an extreme (in place), so
+        /// <see cref="StarReviewMode.Uncertain"/> can include them. A run with a single distinct position has that
+        /// one frame as its (sole) extreme.
+        /// </summary>
+        public static void MarkExtremes(IReadOnlyList<StarReviewFrame> allFrames) {
+            if (allFrames == null) {
+                return;
+            }
+            foreach (var byRun in allFrames.GroupBy(f => f.RunId, StringComparer.Ordinal)) {
+                var positions = byRun.Select(f => f.FocuserPosition).ToList();
+                if (positions.Count == 0) {
+                    continue;
+                }
+                var min = positions.Min();
+                var max = positions.Max();
+                foreach (var f in byRun) {
+                    f.IsExtreme = f.FocuserPosition == min || f.FocuserPosition == max;
+                }
+            }
+        }
+
+        public static StarReviewMode ParseMode(string s) {
+            if (string.IsNullOrWhiteSpace(s)) {
+                return StarReviewMode.Low;
+            }
+            switch (s.Trim().ToLowerInvariant()) {
+                case "low": return StarReviewMode.Low;
+                case "uncertain": return StarReviewMode.Uncertain;
+                case "all": return StarReviewMode.All;
+                default:
+                    throw new ArgumentException($"--review: '{s}' must be 'low', 'uncertain', or 'all'");
+            }
+        }
+    }
+}

--- a/Joko.NINA.Plugins/TestApp/StarReview/StarReviewRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/StarReview/StarReviewRunner.cs
@@ -28,6 +28,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Threading;
 using Logger = NINA.Core.Utility.Logger;
 using Rect = OpenCvSharp.Rect;
 
@@ -181,23 +182,70 @@ namespace TestApp.StarReview {
                 labelsByRun[runId] = labels;
             }
 
-            // Build the per-frame review payloads in queue order, joining each to its detection + run labels.
-            var window = new StarReviewWindow();
-            var vm = new StarReviewVM(
-                queue.Select(q => detections[(q.RunId, q.FocuserPosition)]).ToList(),
-                labelsByRun,
-                labelsDir,
-                profileService);
-            window.DataContext = vm;
-            vm.AttachWindow(window);
+            // Build the per-frame review payloads in queue order, joining each to its detection + run labels. All
+            // of the above (discovery, Mat loads, detection) is plain off-UI work; only the WPF VM + window below
+            // require an STA thread, so they are constructed and shown on a dedicated one (see ShowReviewWindowSta).
+            var reviewFrames = queue.Select(q => detections[(q.RunId, q.FocuserPosition)]).ToList();
 
             Console.WriteLine("Opening review window. Mark Missed (false negatives) and Should-Reject (false positives), then Save.");
-            window.ShowDialog();
+            ShowReviewWindowSta(reviewFrames, labelsByRun, labelsDir, profileService);
 
-            // The VM saves on navigate + on close; do a final flush for safety.
-            vm.SaveAll();
             Console.WriteLine($"Labels written to {labelsDir}");
             Console.WriteLine($"Next: TestApp optimize --runs \"{runsDir}\" --labels \"{labelsDir}\"");
+        }
+
+        /// <summary>
+        /// Constructs the WPF <see cref="StarReviewVM"/> + <see cref="StarReviewWindow"/> and runs the modal dialog
+        /// on a dedicated STA thread, then joins it. This is required because <see cref="RunImpl"/> performs async
+        /// loading/detection (via blocking <c>GetAwaiter().GetResult()</c> calls and an async <c>Main</c>) before
+        /// reaching the UI; after any await the runner is no longer guaranteed to be on the process's [STAThread]
+        /// main thread, and a WPF <see cref="Window"/> can only be created on an STA thread. Creating a fresh STA
+        /// thread here makes window construction correct regardless of the caller's apartment.
+        ///
+        /// <para>Every WPF object (VM, window, the property-changed notifications, and the BitmapSource the VM builds
+        /// off-thread and then marshals back) is created/touched on THIS thread. A
+        /// <see cref="DispatcherSynchronizationContext"/> is installed first so the VM's <c>ConfigureAwait(true)</c>
+        /// image-load continuation posts back onto this thread's dispatcher (pumped by <c>ShowDialog</c>) rather than
+        /// onto an arbitrary thread-pool thread. Any exception is captured and rethrown on the calling thread so the
+        /// runner's catch/logging (and the process exit code) still report failures.</para>
+        /// </summary>
+        private static void ShowReviewWindowSta(
+            List<FrameReview> reviewFrames,
+            Dictionary<string, StarReviewRunLabels> labelsByRun,
+            string labelsDir,
+            IProfileService profileService) {
+            Exception uiError = null;
+            var thread = new Thread(() => {
+                try {
+                    // A WPF Application already exists (created on the runner thread so the profile load could write
+                    // to Application.Current.Resources); only one Application may exist per process, so do NOT make a
+                    // second one. Instead install a dispatcher SynchronizationContext on THIS STA thread so awaited
+                    // continuations (the VM's image-load) resume here and are pumped by ShowDialog.
+                    SynchronizationContext.SetSynchronizationContext(
+                        new DispatcherSynchronizationContext(Dispatcher.CurrentDispatcher));
+
+                    var vm = new StarReviewVM(reviewFrames, labelsByRun, labelsDir, profileService);
+                    var window = new StarReviewWindow();
+                    window.DataContext = vm;
+                    vm.AttachWindow(window);
+
+                    window.ShowDialog();
+
+                    // The VM saves on navigate + on close; do a final flush for safety (on this UI thread).
+                    vm.SaveAll();
+                } catch (Exception ex) {
+                    uiError = ex;
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.IsBackground = false;
+            thread.Start();
+            thread.Join();
+
+            if (uiError != null) {
+                // Surface to RunImpl's caller (Run) so existing error logging + exit code 1 still apply.
+                throw uiError;
+            }
         }
 
         private static void PrintUsage() {

--- a/Joko.NINA.Plugins/TestApp/StarReview/StarReviewRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/StarReview/StarReviewRunner.cs
@@ -286,7 +286,7 @@ namespace TestApp.StarReview {
         /// silently rewrite the user's on-disk settings. So both branches READ from the options and build the
         /// params locally instead.</para>
         /// </summary>
-        private static StarDetectorParams BuildDetectionParams(
+        internal static StarDetectorParams BuildDetectionParams(
             StarDetectionOptions options, IProfile activeProfile, bool useOptimized, string optResultsDir, string runFolder) {
             // "current" = the detector exactly as the profile is currently configured (read-only and honest:
             // whatever UseOptimizedSettings / Simple / Advanced state the profile is already in, we report it
@@ -414,7 +414,7 @@ namespace TestApp.StarReview {
         /// flat list of (reason, rect) tuples, using the SAME reason set as T6's annotated PNG so the colors line
         /// up between the two tools.
         /// </summary>
-        private static List<(string Reason, Rect Bounds)> ExtractRejected(HocusFocusStarDetectorResult result) {
+        internal static List<(string Reason, Rect Bounds)> ExtractRejected(HocusFocusStarDetectorResult result) {
             var list = new List<(string, Rect)>();
             var m = result.Metrics;
             if (m == null) {

--- a/Joko.NINA.Plugins/TestApp/StarReview/StarReviewRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/StarReview/StarReviewRunner.cs
@@ -1,0 +1,368 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Enum;
+using NINA.Core.Utility;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NINA.Profile;
+using NINA.Profile.Interfaces;
+using OpenCvSharp;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using Logger = NINA.Core.Utility.Logger;
+using Rect = OpenCvSharp.Rect;
+
+namespace TestApp.StarReview {
+
+    /// <summary>
+    /// CLI + setup for the interactive two-pass star "review" labeling tool (T7). Mirrors the headless T6
+    /// <c>OptimizationDiagnosticRunner</c> for run/frame discovery, profile + seed-param construction, and the
+    /// float-Mat load path, but instead of optimizing it launches a WPF window where a human marks false
+    /// negatives ("missed") and false positives ("should-reject"), then writes labels in the EXACT JSON shape
+    /// T6's <c>--labels</c> reader consumes. The loop is: <c>optimize</c> → <c>review --labels L</c> →
+    /// <c>optimize --labels L</c>; this tool only produces labels.
+    /// </summary>
+    internal static class StarReviewRunner {
+
+        // Same saved-frame filename pattern as T6 / the AF engine: "0_Frame1_BitDepth16_Bayered0_Focuser5000.fits".
+        private static readonly Regex ImageFileRegex = new Regex(
+            @"^(?<IMAGE_INDEX>\d+)_Frame(?<FRAME_NUMBER>\d+)_BitDepth(?<BITDEPTH>\d+)_Bayered(?<BAYERED>\d)_Focuser(?<FOCUSER>\d+)(_HFR(?<HFR>(\d+)(\.\d+)?))?$",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        public static void Run(string[] args) {
+            try {
+                RunImpl(args);
+            } catch (Exception ex) {
+                Console.Error.WriteLine($"ERROR: {ex.Message}");
+                Console.Error.WriteLine(ex.ToString());
+                Logger.Error(ex, "Star review run failed");
+                Environment.ExitCode = 1;
+            }
+        }
+
+        private static void RunImpl(string[] args) {
+            var runsDir = DiagnosticUtil.GetArg(args, "--runs");
+            if (string.IsNullOrWhiteSpace(runsDir)) {
+                PrintUsage();
+                Environment.ExitCode = 2;
+                return;
+            }
+            if (!Directory.Exists(runsDir)) {
+                throw new DirectoryNotFoundException($"--runs folder not found: {runsDir}");
+            }
+
+            var profileId = DiagnosticUtil.GetArg(args, "--profile-id");
+
+            // Default labels dir alongside the runs so the same path feeds `optimize --labels`.
+            var labelsDir = DiagnosticUtil.GetArg(args, "--labels");
+            if (string.IsNullOrWhiteSpace(labelsDir)) {
+                labelsDir = Path.Combine(runsDir, "labels");
+            }
+
+            var paramsArg = (DiagnosticUtil.GetArg(args, "--params") ?? "current").Trim().ToLowerInvariant();
+            bool useOptimized;
+            switch (paramsArg) {
+                case "current": useOptimized = false; break;
+                case "optimized": useOptimized = true; break;
+                default: throw new ArgumentException($"--params: '{paramsArg}' must be 'current' or 'optimized'");
+            }
+
+            var mode = StarReviewQueue.ParseMode(DiagnosticUtil.GetArg(args, "--review"));
+
+            Logger.SetLogLevel(LogLevelEnum.TRACE);
+
+            // The real ProfileService.ActiveProfile setter writes to Application.Current.Resources, so a WPF
+            // Application must exist before the profile loads (mirrors T6 / the contamination runner).
+            if (Application.Current == null) {
+                new Application();
+            }
+
+            Console.WriteLine($"Runs root: {runsDir}");
+            Console.WriteLine($"Labels dir: {labelsDir}");
+            Console.WriteLine($"Params: {paramsArg}; review queue: {mode}");
+
+            // Load the user's real profile + star detection options (single source of truth for params + PixelScale).
+            var profileService = new ProfileService();
+            profileService.TryLoad(profileId ?? string.Empty);
+            var activeProfile = profileService.ActiveProfile;
+            if (activeProfile == null) {
+                throw new InvalidOperationException("No active NINA profile could be loaded. Pass --profile-id, or run NINA at least once to create a profile.");
+            }
+            Console.WriteLine($"Profile: {activeProfile.Name} ({activeProfile.Id})");
+
+            var guid = PluginOptionsAccessor.GetAssemblyGuid(typeof(StarDetectionOptions));
+            if (guid == null) {
+                throw new InvalidOperationException("Could not resolve the HocusFocus plugin assembly GUID");
+            }
+            var accessor = new PluginOptionsAccessor(profileService, guid.Value);
+            var starDetectionOptions = new StarDetectionOptions(profileService, accessor);
+
+            var detectionParams = BuildDetectionParams(starDetectionOptions, activeProfile, useOptimized);
+            Console.WriteLine($"Seed params: Sensitivity={detectionParams.Sensitivity.ToString("G6", CultureInfo.InvariantCulture)}, " +
+                $"StructureLayers={detectionParams.StructureLayers}, PixelScale={detectionParams.PixelScale.ToString("G6", CultureInfo.InvariantCulture)}");
+
+            var discovered = DiscoverRuns(runsDir);
+            if (discovered.Count == 0) {
+                throw new InvalidOperationException(
+                    $"No AF frames matched the saved-run filename pattern under {runsDir}. Expected files like " +
+                    "'0_Frame1_BitDepth16_Bayered0_Focuser5000.fits' in the folder or an immediate subfolder.");
+            }
+            Console.WriteLine($"Discovered {discovered.Count} run(s):");
+            foreach (var d in discovered) {
+                Console.WriteLine($"  {d.RunId}: {d.Frames.Count} frames");
+            }
+
+            // Detect every frame once (off the UI thread — this is still the CLI thread) to get accepted counts +
+            // the accepted/rejected overlay, then assemble the review queue. Detection is heavy; doing it up front
+            // keeps the window responsive and lets the queue selection use real counts.
+            var detector = new StarDetector(new AlglibAPI());
+            var allFrames = new List<StarReviewFrame>();
+            var detections = new Dictionary<(string runId, int focuser), FrameReview>();
+
+            foreach (var d in discovered) {
+                foreach (var frame in d.Frames) {
+                    using var mat = LoadFloatMatSync(frame.Path, profileService);
+                    using var clone = mat.Clone(); // Detect mutates its input in place.
+                    var result = detector.Detect(clone, detectionParams, null, CancellationToken.None).GetAwaiter().GetResult();
+                    var accepted = result.DetectedStars ?? new List<Star>();
+                    var review = new FrameReview {
+                        RunId = d.RunId,
+                        FocuserPosition = frame.FocuserPosition,
+                        FramePath = frame.Path,
+                        AcceptedCenters = accepted.Select(s => (s.Center.X, s.Center.Y, s.HFR)).ToList(),
+                        Rejected = ExtractRejected(result),
+                    };
+                    detections[(d.RunId, frame.FocuserPosition)] = review;
+                    allFrames.Add(new StarReviewFrame {
+                        RunId = d.RunId,
+                        FocuserPosition = frame.FocuserPosition,
+                        FramePath = frame.Path,
+                        AcceptedCount = accepted.Count
+                    });
+                    Console.WriteLine($"  {d.RunId} @ {frame.FocuserPosition}: {accepted.Count} accepted");
+                }
+            }
+
+            StarReviewQueue.MarkExtremes(allFrames);
+            var queue = StarReviewQueue.Build(allFrames, mode);
+            if (queue.Count == 0) {
+                Console.WriteLine($"Review queue is empty for mode '{mode}' (N_review = {StarReviewQueue.NReview}). Try --review all.");
+                return;
+            }
+            Console.WriteLine($"Review queue: {queue.Count} frame(s) (N_review = {StarReviewQueue.NReview})");
+
+            // Load existing labels per run (incrementally — re-running merges/extends prior labels).
+            var labelsByRun = new Dictionary<string, StarReviewRunLabels>(StringComparer.Ordinal);
+            foreach (var runId in queue.Select(q => q.RunId).Distinct(StringComparer.Ordinal)) {
+                var labels = StarReviewLabelStore.Load(labelsDir, runId, out var loadError);
+                if (loadError != null) {
+                    Console.WriteLine($"WARNING: {loadError}");
+                    Logger.Warning(loadError);
+                }
+                labelsByRun[runId] = labels;
+            }
+
+            // Build the per-frame review payloads in queue order, joining each to its detection + run labels.
+            var window = new StarReviewWindow();
+            var vm = new StarReviewVM(
+                queue.Select(q => detections[(q.RunId, q.FocuserPosition)]).ToList(),
+                labelsByRun,
+                labelsDir,
+                profileService);
+            window.DataContext = vm;
+            vm.AttachWindow(window);
+
+            Console.WriteLine("Opening review window. Mark Missed (false negatives) and Should-Reject (false positives), then Save.");
+            window.ShowDialog();
+
+            // The VM saves on navigate + on close; do a final flush for safety.
+            vm.SaveAll();
+            Console.WriteLine($"Labels written to {labelsDir}");
+            Console.WriteLine($"Next: TestApp optimize --runs \"{runsDir}\" --labels \"{labelsDir}\"");
+        }
+
+        private static void PrintUsage() {
+            Console.Error.WriteLine("Usage: TestApp review --runs <folder> [--labels <dir>] [--params current|optimized] [--review low|uncertain|all] [--profile-id <guid>]");
+            Console.Error.WriteLine("  --runs       (required) folder of saved AF runs (same discovery as `optimize`).");
+            Console.Error.WriteLine("  --labels     (default <runs>/labels) where label JSON is read/written; feeds `optimize --labels`.");
+            Console.Error.WriteLine("  --params     (default current) which detector params drive the overlay: 'current' = profile/preset seed, 'optimized' = the saved optimized snapshot.");
+            Console.Error.WriteLine("  --review     (default low) which frames to queue: 'low' (< N_review accepted), 'uncertain' (low + defocused extremes), or 'all'.");
+            Console.Error.WriteLine("  --profile-id (default active) NINA profile id to load.");
+        }
+
+        // ---- Params construction (current vs optimized) ----------------------------------------------------
+
+        /// <summary>
+        /// Builds the <see cref="StarDetectorParams"/> for the overlay. <paramref name="useOptimized"/> selects
+        /// between the profile-as-configured seed ("current") and the saved optimized snapshot ("optimized").
+        /// Mirrors T6's seed assembly (BuildStarDetectorParams + PixelScale + Region.Full + ModelPSF=false).
+        ///
+        /// <para>This is STRICTLY READ-ONLY with respect to the live <paramref name="options"/>: like the headless
+        /// T6 optimizer, the review tool never calls a setter on the persisted <see cref="StarDetectionOptions"/>
+        /// (and never touches the underlying options accessor). That matters because the review window is
+        /// long-lived and NINA auto-saves the active profile on a debounced timer — mutating the options here (as
+        /// the old <c>ApplyOptimizedSettings(...)</c> / <c>UseOptimizedSettings = false</c> path did) would
+        /// silently rewrite the user's on-disk settings. So both branches READ from the options and build the
+        /// params locally instead.</para>
+        /// </summary>
+        private static StarDetectorParams BuildDetectionParams(StarDetectionOptions options, IProfile activeProfile, bool useOptimized) {
+            // "current" = the detector exactly as the profile is currently configured (read-only and honest:
+            // whatever UseOptimizedSettings / Simple / Advanced state the profile is already in, we report it
+            // unchanged rather than toggling anything).
+            var p = BuildBaseParams(options, activeProfile);
+            if (!useOptimized) {
+                return p;
+            }
+
+            var snapshot = options.GetOptimizedSettings();
+            if (snapshot == null) {
+                Console.WriteLine("WARNING: --params optimized requested but the profile has no saved optimized snapshot; falling back to current.");
+                Logger.Warning("--params optimized requested but no optimized snapshot exists; using current params");
+                return p;
+            }
+
+            // Overlay the 12 curated snapshot knobs LOCALLY onto the base params (no ApplyOptimizedSettings, which
+            // would persist through the options accessor). Mapping mirrors HocusFocusStarDetection.BuildStarDetectorParams
+            // (snapshot field names match the matching StarDetectionOptions property names) and T1/T4.
+            p.Sensitivity = snapshot.BrightnessSensitivity;
+            p.StarClippingMultiplier = snapshot.StarClippingMultiplier;
+            p.NoiseClippingMultiplier = snapshot.NoiseClippingMultiplier;
+            p.PeakResponse = snapshot.StarPeakResponse;
+            p.MaxDistortion = snapshot.MaxDistortion;
+            p.MinHFR = snapshot.MinHFR;
+            p.StarCenterTolerance = snapshot.StarCenterTolerance;
+            p.StructureLayers = snapshot.StructureLayers;
+            p.NoiseReductionRadius = snapshot.NoiseReductionRadius;
+            p.MinimumStarBoundingBoxSize = snapshot.MinStarBoundingBoxSize;
+            p.HotpixelThresholdingEnabled = snapshot.HotpixelThresholdingEnabled;
+            p.HotpixelThreshold = snapshot.HotpixelThreshold;
+            return p;
+        }
+
+        /// <summary>
+        /// Builds the base detection params from the live options (READ-ONLY) plus the AF overrides T6's seed
+        /// applies (PixelScale from the profile × binning=1 for raw Mats, Region=Full, ModelPSF=false, no
+        /// intermediate-save path), so "current" here matches T6's seed exactly. Never writes to the options.
+        /// </summary>
+        private static StarDetectorParams BuildBaseParams(StarDetectionOptions options, IProfile activeProfile) {
+            var p = HocusFocusStarDetection.BuildStarDetectorParams(options);
+
+            const int binning = 1;
+            var pixelScale = MathUtility.ArcsecPerPixel(activeProfile.CameraSettings.PixelSize, activeProfile.TelescopeSettings.FocalLength) * binning;
+            p.PixelScale = pixelScale;
+            p.Region = StarDetectionRegion.Full;
+            p.ModelPSF = false;
+            p.SaveIntermediateFilesPath = string.Empty;
+            return p;
+        }
+
+        // ---- Rejected-candidate overlay extraction ---------------------------------------------------------
+
+        /// <summary>
+        /// Flattens the per-reason rejection bounds from <see cref="HocusFocusStarDetectorResult.Metrics"/> into a
+        /// flat list of (reason, rect) tuples, using the SAME reason set as T6's annotated PNG so the colors line
+        /// up between the two tools.
+        /// </summary>
+        private static List<(string Reason, Rect Bounds)> ExtractRejected(HocusFocusStarDetectorResult result) {
+            var list = new List<(string, Rect)>();
+            var m = result.Metrics;
+            if (m == null) {
+                return list;
+            }
+            void Add(string reason, List<Rect> rects) {
+                if (rects == null) {
+                    return;
+                }
+                foreach (var r in rects) {
+                    list.Add((reason, r));
+                }
+            }
+            Add("TooDistorted", m.TooDistortedBounds);
+            Add("Degenerate", m.DegenerateBounds);
+            Add("Saturated", m.SaturatedBounds);
+            Add("LowSensitivity", m.LowSensitivityBounds);
+            Add("NotCentered", m.NotCenteredBounds);
+            Add("TooFlat", m.TooFlatBounds);
+            Add("Contaminated", m.ContaminatedBounds);
+            return list;
+        }
+
+        private static Mat LoadFloatMatSync(string path, IProfileService profileService) {
+            return DiagnosticUtil.LoadFloatMat(path, profileService).GetAwaiter().GetResult();
+        }
+
+        // ---- Run / frame discovery (mirrors T6 OptimizationDiagnosticRunner) -------------------------------
+
+        private sealed class FrameRef {
+            public string Path;
+            public int FocuserPosition;
+        }
+
+        private sealed class DiscoveredRun {
+            public string RunId;
+            public List<FrameRef> Frames;
+        }
+
+        private static List<DiscoveredRun> DiscoverRuns(string runsDir) {
+            var root = new DirectoryInfo(runsDir);
+            var runs = new List<DiscoveredRun>();
+
+            var rootFrames = MatchFrames(root);
+            if (rootFrames.Count > 0) {
+                runs.Add(new DiscoveredRun { RunId = root.Name, Frames = rootFrames });
+                return runs;
+            }
+
+            foreach (var sub in root.EnumerateDirectories().OrderBy(d => d.Name, StringComparer.Ordinal)) {
+                var frames = MatchFrames(sub);
+                if (frames.Count == 0) {
+                    var attempt = sub.EnumerateDirectories("attempt*").FirstOrDefault();
+                    if (attempt != null) {
+                        frames = MatchFrames(attempt);
+                    }
+                }
+                if (frames.Count > 0) {
+                    runs.Add(new DiscoveredRun { RunId = sub.Name, Frames = frames });
+                }
+            }
+            return runs;
+        }
+
+        private static List<FrameRef> MatchFrames(DirectoryInfo dir) {
+            var frames = new List<FrameRef>();
+            if (!dir.Exists) {
+                return frames;
+            }
+            foreach (var file in dir.GetFiles().OrderBy(f => f.Name, StringComparer.Ordinal)) {
+                var match = ImageFileRegex.Match(Path.GetFileNameWithoutExtension(file.Name));
+                if (!match.Success) {
+                    continue;
+                }
+                if (!int.TryParse(match.Groups["FOCUSER"].Value, out var pos)) {
+                    continue;
+                }
+                frames.Add(new FrameRef { Path = file.FullName, FocuserPosition = pos });
+            }
+            return frames;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/TestApp/StarReview/StarReviewRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/StarReview/StarReviewRunner.cs
@@ -159,7 +159,9 @@ namespace TestApp.StarReview {
                         RunId = d.RunId,
                         FocuserPosition = frame.FocuserPosition,
                         FramePath = frame.Path,
-                        AcceptedCenters = accepted.Select(s => (s.Center.X, s.Center.Y, s.HFR)).ToList(),
+                        // Capture each accepted star's REAL StarBoundingBox so the overlay draws actual-size boxes and
+                        // the should-reject click records the actual bounds.
+                        Accepted = accepted.Select(s => (s.Center.X, s.Center.Y, s.HFR, s.StarBoundingBox)).ToList(),
                         Rejected = ExtractRejected(result),
                     };
                     detections[(d.RunId, frame.FocuserPosition)] = review;

--- a/Joko.NINA.Plugins/TestApp/StarReview/StarReviewRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/StarReview/StarReviewRunner.cs
@@ -10,6 +10,7 @@
 
 #endregion "copyright"
 
+using Newtonsoft.Json;
 using NINA.Core.Enum;
 using NINA.Core.Utility;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
@@ -87,6 +88,10 @@ namespace TestApp.StarReview {
                 default: throw new ArgumentException($"--params: '{paramsArg}' must be 'current' or 'optimized'");
             }
 
+            // Optional explicit folder holding an optimized_settings.json (the optimizer's --out subdir). When
+            // omitted, --params optimized auto-discovers <runFolder>/optimized_settings.json, then the profile.
+            var optResultsDir = DiagnosticUtil.GetArg(args, "--opt-results");
+
             var mode = StarReviewQueue.ParseMode(DiagnosticUtil.GetArg(args, "--review"));
 
             Logger.SetLogLevel(LogLevelEnum.TRACE);
@@ -117,10 +122,6 @@ namespace TestApp.StarReview {
             var accessor = new PluginOptionsAccessor(profileService, guid.Value);
             var starDetectionOptions = new StarDetectionOptions(profileService, accessor);
 
-            var detectionParams = BuildDetectionParams(starDetectionOptions, activeProfile, useOptimized);
-            Console.WriteLine($"Seed params: Sensitivity={detectionParams.Sensitivity.ToString("G6", CultureInfo.InvariantCulture)}, " +
-                $"StructureLayers={detectionParams.StructureLayers}, PixelScale={detectionParams.PixelScale.ToString("G6", CultureInfo.InvariantCulture)}");
-
             var discovered = DiscoverRuns(runsDir);
             if (discovered.Count == 0) {
                 throw new InvalidOperationException(
@@ -131,6 +132,15 @@ namespace TestApp.StarReview {
             foreach (var d in discovered) {
                 Console.WriteLine($"  {d.RunId}: {d.Frames.Count} frames");
             }
+
+            // The first discovered run's source folder (the directory holding its frames) is where the optimizer
+            // writes optimized_settings.json — used by the --params optimized auto-discovery path.
+            var firstFramePath = discovered[0].Frames.FirstOrDefault()?.Path;
+            var firstRunFolder = string.IsNullOrEmpty(firstFramePath) ? null : Path.GetDirectoryName(firstFramePath);
+
+            var detectionParams = BuildDetectionParams(starDetectionOptions, activeProfile, useOptimized, optResultsDir, firstRunFolder);
+            Console.WriteLine($"Seed params: Sensitivity={detectionParams.Sensitivity.ToString("G6", CultureInfo.InvariantCulture)}, " +
+                $"StructureLayers={detectionParams.StructureLayers}, PixelScale={detectionParams.PixelScale.ToString("G6", CultureInfo.InvariantCulture)}");
 
             // Detect every frame once (off the UI thread — this is still the CLI thread) to get accepted counts +
             // the accepted/rejected overlay, then assemble the review queue. Detection is heavy; doing it up front
@@ -249,12 +259,14 @@ namespace TestApp.StarReview {
         }
 
         private static void PrintUsage() {
-            Console.Error.WriteLine("Usage: TestApp review --runs <folder> [--labels <dir>] [--params current|optimized] [--review low|uncertain|all] [--profile-id <guid>]");
-            Console.Error.WriteLine("  --runs       (required) folder of saved AF runs (same discovery as `optimize`).");
-            Console.Error.WriteLine("  --labels     (default <runs>/labels) where label JSON is read/written; feeds `optimize --labels`.");
-            Console.Error.WriteLine("  --params     (default current) which detector params drive the overlay: 'current' = profile/preset seed, 'optimized' = the saved optimized snapshot.");
-            Console.Error.WriteLine("  --review     (default low) which frames to queue: 'low' (< N_review accepted), 'uncertain' (low + defocused extremes), or 'all'.");
-            Console.Error.WriteLine("  --profile-id (default active) NINA profile id to load.");
+            Console.Error.WriteLine("Usage: TestApp review --runs <folder> [--labels <dir>] [--params current|optimized] [--opt-results <dir>] [--review low|uncertain|all] [--profile-id <guid>]");
+            Console.Error.WriteLine("  --runs        (required) folder of saved AF runs (same discovery as `optimize`).");
+            Console.Error.WriteLine("  --labels      (default <runs>/labels) where label JSON is read/written; feeds `optimize --labels`.");
+            Console.Error.WriteLine("  --params      (default current) which detector params drive the overlay: 'current' = profile/preset seed, 'optimized' = an optimized snapshot.");
+            Console.Error.WriteLine("  --opt-results (optional) folder holding optimized_settings.json (the optimizer's --out subdir). With --params optimized,");
+            Console.Error.WriteLine("                resolution order is: this folder, then <runFolder>/optimized_settings.json, then the profile snapshot, then current.");
+            Console.Error.WriteLine("  --review      (default low) which frames to queue: 'low' (< N_review accepted), 'uncertain' (low + defocused extremes), or 'all'.");
+            Console.Error.WriteLine("  --profile-id  (default active) NINA profile id to load.");
         }
 
         // ---- Params construction (current vs optimized) ----------------------------------------------------
@@ -272,7 +284,8 @@ namespace TestApp.StarReview {
         /// silently rewrite the user's on-disk settings. So both branches READ from the options and build the
         /// params locally instead.</para>
         /// </summary>
-        private static StarDetectorParams BuildDetectionParams(StarDetectionOptions options, IProfile activeProfile, bool useOptimized) {
+        private static StarDetectorParams BuildDetectionParams(
+            StarDetectionOptions options, IProfile activeProfile, bool useOptimized, string optResultsDir, string runFolder) {
             // "current" = the detector exactly as the profile is currently configured (read-only and honest:
             // whatever UseOptimizedSettings / Simple / Advanced state the profile is already in, we report it
             // unchanged rather than toggling anything).
@@ -281,16 +294,86 @@ namespace TestApp.StarReview {
                 return p;
             }
 
-            var snapshot = options.GetOptimizedSettings();
+            // Resolve the optimized snapshot in priority order:
+            //   (a) explicit --opt-results <dir>/optimized_settings.json,
+            //   (b) auto: <runFolder>/optimized_settings.json (the focus run's own folder, where the optimizer wrote it),
+            //   (c) the profile's saved snapshot (options.GetOptimizedSettings()),
+            //   (d) fall back to "current" with a warning.
+            var snapshot = ResolveOptimizedSnapshot(options, optResultsDir, runFolder, out var source);
             if (snapshot == null) {
-                Console.WriteLine("WARNING: --params optimized requested but the profile has no saved optimized snapshot; falling back to current.");
+                Console.WriteLine("WARNING: --params optimized requested but no optimized snapshot was found " +
+                    "(--opt-results, <runFolder>/optimized_settings.json, or the profile); falling back to current.");
                 Logger.Warning("--params optimized requested but no optimized snapshot exists; using current params");
                 return p;
             }
+            Console.WriteLine($"Optimized snapshot source: {source}");
 
-            // Overlay the 12 curated snapshot knobs LOCALLY onto the base params (no ApplyOptimizedSettings, which
-            // would persist through the options accessor). Mapping mirrors HocusFocusStarDetection.BuildStarDetectorParams
-            // (snapshot field names match the matching StarDetectionOptions property names) and T1/T4.
+            OverlaySnapshot(p, snapshot);
+            return p;
+        }
+
+        /// <summary>
+        /// Resolves the optimized snapshot to overlay for --params optimized, in priority order: an explicit
+        /// --opt-results folder, then the focus run's own folder (auto-discovery), then the profile snapshot. Returns
+        /// null when none is found (caller falls back to "current"). File loads are tolerant — a missing/corrupt file
+        /// logs a warning and the resolution continues to the next source. STRICTLY READ-ONLY on the options.
+        /// </summary>
+        private static OptimizedStarDetectionSettings ResolveOptimizedSnapshot(
+            StarDetectionOptions options, string optResultsDir, string runFolder, out string source) {
+            // (a) Explicit --opt-results directory.
+            if (!string.IsNullOrWhiteSpace(optResultsDir)) {
+                var explicitPath = Path.Combine(optResultsDir, "optimized_settings.json");
+                var loaded = TryLoadSnapshot(explicitPath);
+                if (loaded != null) {
+                    source = $"--opt-results ({explicitPath})";
+                    return loaded;
+                }
+                Console.WriteLine($"WARNING: --opt-results given but no usable optimized_settings.json at {explicitPath}; trying other sources.");
+            }
+
+            // (b) Auto-discovery in the focus run's own folder.
+            if (!string.IsNullOrWhiteSpace(runFolder)) {
+                var autoPath = Path.Combine(runFolder, "optimized_settings.json");
+                var loaded = TryLoadSnapshot(autoPath);
+                if (loaded != null) {
+                    source = $"auto ({autoPath})";
+                    return loaded;
+                }
+            }
+
+            // (c) The profile's saved snapshot.
+            var profileSnapshot = options.GetOptimizedSettings();
+            if (profileSnapshot != null) {
+                source = "profile (GetOptimizedSettings)";
+                return profileSnapshot;
+            }
+
+            source = "(none)";
+            return null;
+        }
+
+        /// <summary>Loads an <see cref="OptimizedStarDetectionSettings"/> from a JSON file, or null if it is missing
+        /// or unparseable (a corrupt file logs a warning and is treated as absent).</summary>
+        private static OptimizedStarDetectionSettings TryLoadSnapshot(string path) {
+            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) {
+                return null;
+            }
+            try {
+                return JsonConvert.DeserializeObject<OptimizedStarDetectionSettings>(File.ReadAllText(path));
+            } catch (Exception ex) {
+                Console.WriteLine($"WARNING: could not parse optimized snapshot '{path}': {ex.Message}");
+                Logger.Warning($"Could not parse optimized snapshot '{path}': {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Overlays the 12 curated snapshot knobs onto <paramref name="p"/> LOCALLY (no ApplyOptimizedSettings, which
+        /// would persist through the options accessor). Shared by the file (--opt-results / auto) and profile paths so
+        /// the mapping lives in one place. Mapping mirrors HocusFocusStarDetection.BuildStarDetectorParams (snapshot
+        /// field names match the matching StarDetectionOptions property names) and OptimizedStarDetectionSettings.FromParams.
+        /// </summary>
+        private static void OverlaySnapshot(StarDetectorParams p, OptimizedStarDetectionSettings snapshot) {
             p.Sensitivity = snapshot.BrightnessSensitivity;
             p.StarClippingMultiplier = snapshot.StarClippingMultiplier;
             p.NoiseClippingMultiplier = snapshot.NoiseClippingMultiplier;
@@ -303,7 +386,6 @@ namespace TestApp.StarReview {
             p.MinimumStarBoundingBoxSize = snapshot.MinStarBoundingBoxSize;
             p.HotpixelThresholdingEnabled = snapshot.HotpixelThresholdingEnabled;
             p.HotpixelThreshold = snapshot.HotpixelThreshold;
-            return p;
         }
 
         /// <summary>

--- a/Joko.NINA.Plugins/TestApp/StarReview/StarReviewVM.cs
+++ b/Joko.NINA.Plugins/TestApp/StarReview/StarReviewVM.cs
@@ -61,7 +61,8 @@ namespace TestApp.StarReview {
 
     public enum LabelPass {
         Missed,
-        ShouldReject
+        ShouldReject,
+        WronglyRejected
     }
 
     /// <summary>
@@ -107,6 +108,7 @@ namespace TestApp.StarReview {
             SaveCommand = new RelayCommand(SaveAll);
             MarkMissedCommand = new RelayCommand(() => Pass = LabelPass.Missed);
             MarkShouldRejectCommand = new RelayCommand(() => Pass = LabelPass.ShouldReject);
+            MarkWronglyRejectedCommand = new RelayCommand(() => Pass = LabelPass.WronglyRejected);
             FitCommand = new RelayCommand(RequestFit);
 
             CurrentIndex = 0;
@@ -160,11 +162,28 @@ namespace TestApp.StarReview {
 
         public StarReviewViewport Viewport { get; }
 
+        // All markers live inside a canvas whose RenderTransform scales everything (including stroke width). At
+        // fit-to-window zoom (Scale ~0.1-0.3) a hardcoded stroke would scale down to nothing, so bind thickness
+        // INVERSELY to the current scale to keep on-screen stroke width roughly constant. Clamp to MinScale so the
+        // thickness never blows up at extreme zoom-out.
+        public double MarkerStrokeThickness => 1.5 / Math.Max(StarReviewViewport.MinScale, Viewport.Scale);
+
+        // Slightly heavier for the three user-applied label markers so they read above the detector overlay.
+        public double LabelStrokeThickness => 2.5 / Math.Max(StarReviewViewport.MinScale, Viewport.Scale);
+
+        /// <summary>Raises the zoom-dependent marker-thickness bindings. The view calls this after any viewport change
+        /// (wheel-zoom, fit, pan) so the stroke widths track the current scale.</summary>
+        public void NotifyViewportChanged() {
+            RaisePropertyChanged(nameof(MarkerStrokeThickness));
+            RaisePropertyChanged(nameof(LabelStrokeThickness));
+        }
+
         // Markers in IMAGE pixel coords; the view applies the viewport transform to place them.
         public ObservableCollection<AcceptedMarker> AcceptedMarkers { get; } = new();
         public ObservableCollection<RejectedMarker> RejectedMarkers { get; } = new();
         public ObservableCollection<StarReviewLabelPoint> MissedMarkers { get; } = new();
         public ObservableCollection<StarReviewLabelPoint> ShouldRejectMarkers { get; } = new();
+        public ObservableCollection<StarReviewLabelPoint> WronglyRejectedMarkers { get; } = new();
 
         private LabelPass pass = LabelPass.Missed;
         public LabelPass Pass {
@@ -175,6 +194,7 @@ namespace TestApp.StarReview {
                     RaisePropertyChanged();
                     RaisePropertyChanged(nameof(IsMissedPass));
                     RaisePropertyChanged(nameof(IsShouldRejectPass));
+                    RaisePropertyChanged(nameof(IsWronglyRejectedPass));
                     RaisePropertyChanged(nameof(PassLabel));
                 }
             }
@@ -182,7 +202,17 @@ namespace TestApp.StarReview {
 
         public bool IsMissedPass => Pass == LabelPass.Missed;
         public bool IsShouldRejectPass => Pass == LabelPass.ShouldReject;
-        public string PassLabel => Pass == LabelPass.Missed ? "Marking: MISSED (false negatives)" : "Marking: SHOULD-REJECT (false positives)";
+        public bool IsWronglyRejectedPass => Pass == LabelPass.WronglyRejected;
+        public string PassLabel {
+            get {
+                switch (Pass) {
+                    case LabelPass.Missed: return "Marking: MISSED (false negatives)";
+                    case LabelPass.ShouldReject: return "Marking: SHOULD-REJECT (false positives)";
+                    case LabelPass.WronglyRejected: return "Marking: WRONGLY-REJECTED (click inside a rejected box to keep it)";
+                    default: return "Marking";
+                }
+            }
+        }
 
         private double radiusPx = StarReviewLabelStore.DefaultRadiusPx;
         public double RadiusPx {
@@ -199,11 +229,13 @@ namespace TestApp.StarReview {
         public string CountsLabel {
             get {
                 var labels = CurrentRunLabels;
-                var (missed, reject) = StarReviewLabelStore.Counts(labels);
+                var (missed, reject, wrongly) = StarReviewLabelStore.Counts(labels);
                 var pos = CurrentPositionLabels;
                 var posMissed = pos?.Missed?.Count ?? 0;
                 var posReject = pos?.ShouldReject?.Count ?? 0;
-                return $"this frame: {posMissed} missed, {posReject} should-reject | run total: {missed} missed, {reject} should-reject";
+                var posWrongly = pos?.WronglyRejected?.Count ?? 0;
+                return $"this frame: {posMissed} missed, {posReject} should-reject, {posWrongly} wrongly-rejected | " +
+                       $"run total: {missed} missed, {reject} should-reject, {wrongly} wrongly-rejected";
             }
         }
 
@@ -212,6 +244,7 @@ namespace TestApp.StarReview {
         public RelayCommand SaveCommand { get; }
         public RelayCommand MarkMissedCommand { get; }
         public RelayCommand MarkShouldRejectCommand { get; }
+        public RelayCommand MarkWronglyRejectedCommand { get; }
         public RelayCommand FitCommand { get; }
 
         /// <summary>Raised when the VM wants the view to re-fit the image (initial load / Fit button).</summary>
@@ -320,6 +353,24 @@ namespace TestApp.StarReview {
             if (run == null) {
                 return;
             }
+
+            // WRONGLY-REJECTED is a CONSTRAINED pass: the user must click INSIDE a displayed rejected-candidate box.
+            // A hit toggles a point at that box's CENTER (not the raw click), so the recorded recall target lands on
+            // the candidate the detector already found. A click outside every rejected box is a no-op.
+            if (Pass == LabelPass.WronglyRejected) {
+                var hit = HitTestRejected(imageX, imageY);
+                if (hit == null) {
+                    return;
+                }
+                var posWr = StarReviewLabelStore.GetOrAddPosition(run, Current.FocuserPosition);
+                if (posWr.RadiusPx == null) {
+                    posWr.RadiusPx = RadiusPx;
+                }
+                StarReviewLabelStore.TogglePoint(posWr.WronglyRejected, hit.Value.cx, hit.Value.cy);
+                RefreshLabelMarkers();
+                return;
+            }
+
             var pos = StarReviewLabelStore.GetOrAddPosition(run, Current.FocuserPosition);
             if (pos.RadiusPx == null) {
                 pos.RadiusPx = RadiusPx;
@@ -329,9 +380,31 @@ namespace TestApp.StarReview {
             RefreshLabelMarkers();
         }
 
+        /// <summary>
+        /// Returns the CENTER of the rejected-candidate box (in image coords) containing the click, or null if the
+        /// click is outside every rejected box. AABB containment; on overlap the smallest-area box wins (so a click
+        /// in a region of nested boxes selects the tightest candidate). Pure geometry over <see cref="FrameReview.Rejected"/>.
+        /// </summary>
+        private (double cx, double cy)? HitTestRejected(double imageX, double imageY) {
+            (double cx, double cy)? best = null;
+            var bestArea = double.MaxValue;
+            foreach (var (_, b) in Current.Rejected) {
+                if (imageX < b.X || imageY < b.Y || imageX > b.X + b.Width || imageY > b.Y + b.Height) {
+                    continue;
+                }
+                var area = (double)b.Width * b.Height;
+                if (area < bestArea) {
+                    bestArea = area;
+                    best = (b.X + b.Width / 2.0, b.Y + b.Height / 2.0);
+                }
+            }
+            return best;
+        }
+
         private void RefreshLabelMarkers() {
             MissedMarkers.Clear();
             ShouldRejectMarkers.Clear();
+            WronglyRejectedMarkers.Clear();
             var pos = CurrentPositionLabels;
             if (pos != null) {
                 foreach (var p in pos.Missed) {
@@ -339,6 +412,11 @@ namespace TestApp.StarReview {
                 }
                 foreach (var p in pos.ShouldReject) {
                     ShouldRejectMarkers.Add(p);
+                }
+                if (pos.WronglyRejected != null) {
+                    foreach (var p in pos.WronglyRejected) {
+                        WronglyRejectedMarkers.Add(p);
+                    }
                 }
             }
             RaisePropertyChanged(nameof(CountsLabel));

--- a/Joko.NINA.Plugins/TestApp/StarReview/StarReviewVM.cs
+++ b/Joko.NINA.Plugins/TestApp/StarReview/StarReviewVM.cs
@@ -1,0 +1,386 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Utility;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NINA.Profile.Interfaces;
+using OpenCvSharp;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using Logger = NINA.Core.Utility.Logger;
+using RelayCommand = CommunityToolkit.Mvvm.Input.RelayCommand;
+using Rect = OpenCvSharp.Rect;
+using Window = System.Windows.Window;
+
+namespace TestApp.StarReview {
+
+    /// <summary>
+    /// The pre-computed detection result + paths for one reviewable frame. AcceptedCenters carry HFR for the
+    /// overlay label; Rejected carries the per-reason bounding boxes so the reviewer sees what the detector did.
+    /// </summary>
+    internal sealed class FrameReview {
+        public string RunId { get; set; }
+        public int FocuserPosition { get; set; }
+        public string FramePath { get; set; }
+        public List<(double X, double Y, double HFR)> AcceptedCenters { get; set; } = new();
+        public List<(string Reason, Rect Bounds)> Rejected { get; set; } = new();
+    }
+
+    /// <summary>A drawable accepted-star marker in image-pixel coords.</summary>
+    public sealed class AcceptedMarker {
+        public double X { get; set; }
+        public double Y { get; set; }
+        public double HFR { get; set; }
+    }
+
+    /// <summary>A drawable rejected-candidate box in image-pixel coords, colored by reason.</summary>
+    public sealed class RejectedMarker {
+        public double X { get; set; }
+        public double Y { get; set; }
+        public double Width { get; set; }
+        public double Height { get; set; }
+        public string Reason { get; set; }
+        public Color Color { get; set; }
+    }
+
+    public enum LabelPass {
+        Missed,
+        ShouldReject
+    }
+
+    /// <summary>
+    /// ViewModel for the interactive review window. Holds the queue of frames, the per-run labels, the zoom/pan
+    /// viewport, and the current labeling pass. All detection was done up front by <see cref="StarReviewRunner"/>;
+    /// this VM only renders overlays and edits/persists labels. The screen↔image pixel mapping is delegated to
+    /// the unit-tested <see cref="StarReviewViewport"/>; the label add/remove/merge logic to the unit-tested
+    /// <see cref="StarReviewLabelStore"/>.
+    /// </summary>
+    public class StarReviewVM : BaseINPC {
+        private readonly IReadOnlyList<FrameReview> queue;
+        private readonly Dictionary<string, StarReviewRunLabels> labelsByRun;
+        private readonly string labelsDir;
+        private readonly IProfileService profileService;
+
+        // Per-reason overlay colors, matching T6's annotated-PNG legend (RGB here; BGR there).
+        private static readonly Dictionary<string, Color> ReasonColors = new(StringComparer.Ordinal) {
+            { "TooDistorted",   Color.FromRgb(255, 255, 0) },   // yellow
+            { "Degenerate",     Color.FromRgb(255, 165, 0) },   // orange
+            { "Saturated",      Color.FromRgb(255, 0, 0) },     // red
+            { "LowSensitivity", Color.FromRgb(0, 255, 255) },   // cyan
+            { "NotCentered",    Color.FromRgb(255, 0, 255) },   // magenta
+            { "TooFlat",        Color.FromRgb(0, 0, 255) },     // blue
+            { "Contaminated",   Color.FromRgb(128, 0, 128) },   // purple
+        };
+
+        private Window window;
+
+        internal StarReviewVM(
+            IReadOnlyList<FrameReview> queue,
+            Dictionary<string, StarReviewRunLabels> labelsByRun,
+            string labelsDir,
+            IProfileService profileService) {
+            this.queue = queue ?? throw new ArgumentNullException(nameof(queue));
+            this.labelsByRun = labelsByRun ?? throw new ArgumentNullException(nameof(labelsByRun));
+            this.labelsDir = labelsDir ?? throw new ArgumentNullException(nameof(labelsDir));
+            this.profileService = profileService;
+
+            Viewport = new StarReviewViewport();
+
+            NextCommand = new RelayCommand(Next, () => CurrentIndex < queue.Count - 1);
+            PrevCommand = new RelayCommand(Prev, () => CurrentIndex > 0);
+            SaveCommand = new RelayCommand(SaveAll);
+            MarkMissedCommand = new RelayCommand(() => Pass = LabelPass.Missed);
+            MarkShouldRejectCommand = new RelayCommand(() => Pass = LabelPass.ShouldReject);
+            FitCommand = new RelayCommand(RequestFit);
+
+            CurrentIndex = 0;
+            LoadCurrent();
+        }
+
+        internal void AttachWindow(Window w) {
+            window = w;
+            if (window != null) {
+                window.Closing += (_, __) => SaveAll();
+            }
+        }
+
+        // ---- Navigation / current frame --------------------------------------------------------------------
+
+        private int currentIndex;
+        public int CurrentIndex {
+            get => currentIndex;
+            private set {
+                if (currentIndex != value) {
+                    currentIndex = value;
+                    RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(PositionLabel));
+                }
+            }
+        }
+
+        public int QueueCount => queue.Count;
+
+        public string PositionLabel => $"{CurrentIndex + 1} / {queue.Count}";
+
+        private string frameHeader;
+        public string FrameHeader {
+            get => frameHeader;
+            private set { frameHeader = value; RaisePropertyChanged(); }
+        }
+
+        private BitmapSource frameImage;
+        public BitmapSource FrameImage {
+            get => frameImage;
+            private set {
+                frameImage = value;
+                RaisePropertyChanged();
+                RaisePropertyChanged(nameof(ImageWidth));
+                RaisePropertyChanged(nameof(ImageHeight));
+            }
+        }
+
+        public double ImageWidth => frameImage?.PixelWidth ?? 0;
+        public double ImageHeight => frameImage?.PixelHeight ?? 0;
+
+        public StarReviewViewport Viewport { get; }
+
+        // Markers in IMAGE pixel coords; the view applies the viewport transform to place them.
+        public ObservableCollection<AcceptedMarker> AcceptedMarkers { get; } = new();
+        public ObservableCollection<RejectedMarker> RejectedMarkers { get; } = new();
+        public ObservableCollection<StarReviewLabelPoint> MissedMarkers { get; } = new();
+        public ObservableCollection<StarReviewLabelPoint> ShouldRejectMarkers { get; } = new();
+
+        private LabelPass pass = LabelPass.Missed;
+        public LabelPass Pass {
+            get => pass;
+            set {
+                if (pass != value) {
+                    pass = value;
+                    RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(IsMissedPass));
+                    RaisePropertyChanged(nameof(IsShouldRejectPass));
+                    RaisePropertyChanged(nameof(PassLabel));
+                }
+            }
+        }
+
+        public bool IsMissedPass => Pass == LabelPass.Missed;
+        public bool IsShouldRejectPass => Pass == LabelPass.ShouldReject;
+        public string PassLabel => Pass == LabelPass.Missed ? "Marking: MISSED (false negatives)" : "Marking: SHOULD-REJECT (false positives)";
+
+        private double radiusPx = StarReviewLabelStore.DefaultRadiusPx;
+        public double RadiusPx {
+            get => radiusPx;
+            set {
+                if (Math.Abs(radiusPx - value) > 1e-9 && value > 0) {
+                    radiusPx = value;
+                    RaisePropertyChanged();
+                    PersistRadiusToCurrentPosition();
+                }
+            }
+        }
+
+        public string CountsLabel {
+            get {
+                var labels = CurrentRunLabels;
+                var (missed, reject) = StarReviewLabelStore.Counts(labels);
+                var pos = CurrentPositionLabels;
+                var posMissed = pos?.Missed?.Count ?? 0;
+                var posReject = pos?.ShouldReject?.Count ?? 0;
+                return $"this frame: {posMissed} missed, {posReject} should-reject | run total: {missed} missed, {reject} should-reject";
+            }
+        }
+
+        public RelayCommand NextCommand { get; }
+        public RelayCommand PrevCommand { get; }
+        public RelayCommand SaveCommand { get; }
+        public RelayCommand MarkMissedCommand { get; }
+        public RelayCommand MarkShouldRejectCommand { get; }
+        public RelayCommand FitCommand { get; }
+
+        /// <summary>Raised when the VM wants the view to re-fit the image (initial load / Fit button).</summary>
+        public event EventHandler FitRequested;
+
+        private FrameReview Current => queue[CurrentIndex];
+
+        private StarReviewRunLabels CurrentRunLabels =>
+            labelsByRun.TryGetValue(Current.RunId, out var l) ? l : null;
+
+        private StarReviewPositionLabels CurrentPositionLabels {
+            get {
+                var run = CurrentRunLabels;
+                return run?.Positions.FirstOrDefault(p => p.FocuserPosition == Current.FocuserPosition);
+            }
+        }
+
+        private void Next() {
+            if (CurrentIndex < queue.Count - 1) {
+                SaveCurrentRun();
+                CurrentIndex++;
+                LoadCurrent();
+            }
+        }
+
+        private void Prev() {
+            if (CurrentIndex > 0) {
+                SaveCurrentRun();
+                CurrentIndex--;
+                LoadCurrent();
+            }
+        }
+
+        private void RequestFit() => FitRequested?.Invoke(this, EventArgs.Empty);
+
+        private void LoadCurrent() {
+            var f = Current;
+            FrameHeader = $"{f.RunId}  @ focuser {f.FocuserPosition}  |  {f.AcceptedCenters.Count} accepted";
+
+            // Build the MTF-stretched background image (off-thread, then marshal to the UI).
+            FrameImage = null;
+            _ = LoadImageAsync(f.FramePath);
+
+            // Overlays in image coords.
+            AcceptedMarkers.Clear();
+            foreach (var (x, y, hfr) in f.AcceptedCenters) {
+                AcceptedMarkers.Add(new AcceptedMarker { X = x, Y = y, HFR = hfr });
+            }
+            RejectedMarkers.Clear();
+            foreach (var (reason, b) in f.Rejected) {
+                var color = ReasonColors.TryGetValue(reason, out var c) ? c : Colors.Gray;
+                RejectedMarkers.Add(new RejectedMarker {
+                    X = b.X, Y = b.Y, Width = b.Width, Height = b.Height, Reason = reason, Color = color
+                });
+            }
+
+            // The radius shown defaults to the run default unless this position already overrode it.
+            var run = CurrentRunLabels;
+            var pos = CurrentPositionLabels;
+            radiusPx = pos?.RadiusPx ?? run?.RadiusPx ?? StarReviewLabelStore.DefaultRadiusPx;
+            RaisePropertyChanged(nameof(RadiusPx));
+
+            RefreshLabelMarkers();
+
+            NextCommand.NotifyCanExecuteChanged();
+            PrevCommand.NotifyCanExecuteChanged();
+        }
+
+        private async Task LoadImageAsync(string path) {
+            try {
+                var bmp = await Task.Run(() => BuildStretchedBitmap(path)).ConfigureAwait(true);
+                FrameImage = bmp;
+                RequestFit();
+            } catch (Exception ex) {
+                Logger.Error(ex, $"Failed to load/stretch frame {path}");
+                Console.Error.WriteLine($"Failed to load frame {path}: {ex.Message}");
+            }
+        }
+
+        private BitmapSource BuildStretchedBitmap(string path) {
+            using var srcFloat = DiagnosticUtil.LoadFloatMat(path, profileService).GetAwaiter().GetResult();
+            using var src16 = new Mat();
+            srcFloat.ConvertTo(src16, MatType.CV_16U, ushort.MaxValue);
+            using var stretched16 = new Mat();
+            try {
+                var stats = CvImageUtility.CalculateStatistics_Histogram(src16);
+                using var lut = CvImageUtility.CreateMTFLookup(stats);
+                CvImageUtility.ApplyLUT(src16, lut, stretched16);
+            } catch (Exception ex) {
+                Logger.Warning($"MTF stretch failed ({ex.Message}); falling back to linear normalization");
+                Cv2.Normalize(src16, stretched16, 0, ushort.MaxValue, NormTypes.MinMax);
+            }
+            var bmp = Program.ToBitmapSource(stretched16, PixelFormats.Gray16);
+            return bmp;
+        }
+
+        // ---- Labeling (delegates to the pure store) --------------------------------------------------------
+
+        /// <summary>
+        /// Adds-or-removes a label of the current pass at image pixel (imageX, imageY). Called by the view after
+        /// it maps the click through <see cref="StarReviewViewport.ScreenToImage"/>. Toggling near an existing
+        /// point of the same pass removes it.
+        /// </summary>
+        public void ToggleLabelAt(double imageX, double imageY) {
+            var run = CurrentRunLabels;
+            if (run == null) {
+                return;
+            }
+            var pos = StarReviewLabelStore.GetOrAddPosition(run, Current.FocuserPosition);
+            if (pos.RadiusPx == null) {
+                pos.RadiusPx = RadiusPx;
+            }
+            var list = Pass == LabelPass.Missed ? pos.Missed : pos.ShouldReject;
+            StarReviewLabelStore.TogglePoint(list, imageX, imageY);
+            RefreshLabelMarkers();
+        }
+
+        private void RefreshLabelMarkers() {
+            MissedMarkers.Clear();
+            ShouldRejectMarkers.Clear();
+            var pos = CurrentPositionLabels;
+            if (pos != null) {
+                foreach (var p in pos.Missed) {
+                    MissedMarkers.Add(p);
+                }
+                foreach (var p in pos.ShouldReject) {
+                    ShouldRejectMarkers.Add(p);
+                }
+            }
+            RaisePropertyChanged(nameof(CountsLabel));
+        }
+
+        private void PersistRadiusToCurrentPosition() {
+            var run = CurrentRunLabels;
+            if (run == null) {
+                return;
+            }
+            var pos = StarReviewLabelStore.GetOrAddPosition(run, Current.FocuserPosition);
+            pos.RadiusPx = RadiusPx;
+        }
+
+        // ---- Persistence -----------------------------------------------------------------------------------
+
+        private void SaveCurrentRun() {
+            var run = CurrentRunLabels;
+            if (run == null) {
+                return;
+            }
+            try {
+                StarReviewLabelStore.PruneEmptyPositions(run);
+                var path = StarReviewLabelStore.Save(labelsDir, run);
+                Logger.Info($"Saved labels for run '{run.RunId}' to {path}");
+            } catch (Exception ex) {
+                Logger.Error(ex, $"Failed to save labels for run '{run.RunId}'");
+                Console.Error.WriteLine($"Failed to save labels for run '{run.RunId}': {ex.Message}");
+            }
+        }
+
+        /// <summary>Saves every run's labels (save-on-close / Save button / final flush from the runner).</summary>
+        public void SaveAll() {
+            foreach (var run in labelsByRun.Values) {
+                try {
+                    StarReviewLabelStore.PruneEmptyPositions(run);
+                    StarReviewLabelStore.Save(labelsDir, run);
+                } catch (Exception ex) {
+                    Logger.Error(ex, $"Failed to save labels for run '{run.RunId}'");
+                }
+            }
+            RaisePropertyChanged(nameof(CountsLabel));
+        }
+    }
+}

--- a/Joko.NINA.Plugins/TestApp/StarReview/StarReviewVM.cs
+++ b/Joko.NINA.Plugins/TestApp/StarReview/StarReviewVM.cs
@@ -31,22 +31,36 @@ using Window = System.Windows.Window;
 namespace TestApp.StarReview {
 
     /// <summary>
-    /// The pre-computed detection result + paths for one reviewable frame. AcceptedCenters carry HFR for the
-    /// overlay label; Rejected carries the per-reason bounding boxes so the reviewer sees what the detector did.
+    /// The pre-computed detection result + paths for one reviewable frame. Accepted carry the detector's actual
+    /// <c>StarBoundingBox</c> (so the overlay draws real-size boxes) + HFR + center; Rejected carries the per-reason
+    /// bounding boxes so the reviewer sees what the detector did.
     /// </summary>
     internal sealed class FrameReview {
         public string RunId { get; set; }
         public int FocuserPosition { get; set; }
         public string FramePath { get; set; }
-        public List<(double X, double Y, double HFR)> AcceptedCenters { get; set; } = new();
+
+        /// <summary>Accepted stars: the detector's real bounding box + its center (used for click hit-tests, the
+        /// should-reject label box, and the overlay) + HFR.</summary>
+        public List<(double CX, double CY, double HFR, Rect Bounds)> Accepted { get; set; } = new();
         public List<(string Reason, Rect Bounds)> Rejected { get; set; } = new();
     }
 
-    /// <summary>A drawable accepted-star marker in image-pixel coords.</summary>
+    /// <summary>A drawable accepted-star marker (the detector's real bounding box) in image-pixel coords.</summary>
     public sealed class AcceptedMarker {
         public double X { get; set; }
         public double Y { get; set; }
+        public double Width { get; set; }
+        public double Height { get; set; }
         public double HFR { get; set; }
+    }
+
+    /// <summary>A drawable user-label box in image-pixel coords (top-left X,Y + W,H).</summary>
+    public sealed class LabelBoxMarker {
+        public double X { get; set; }
+        public double Y { get; set; }
+        public double Width { get; set; }
+        public double Height { get; set; }
     }
 
     /// <summary>A drawable rejected-candidate box in image-pixel coords, colored by reason.</summary>
@@ -181,9 +195,9 @@ namespace TestApp.StarReview {
         // Markers in IMAGE pixel coords; the view applies the viewport transform to place them.
         public ObservableCollection<AcceptedMarker> AcceptedMarkers { get; } = new();
         public ObservableCollection<RejectedMarker> RejectedMarkers { get; } = new();
-        public ObservableCollection<StarReviewLabelPoint> MissedMarkers { get; } = new();
-        public ObservableCollection<StarReviewLabelPoint> ShouldRejectMarkers { get; } = new();
-        public ObservableCollection<StarReviewLabelPoint> WronglyRejectedMarkers { get; } = new();
+        public ObservableCollection<LabelBoxMarker> MissedMarkers { get; } = new();
+        public ObservableCollection<LabelBoxMarker> ShouldRejectMarkers { get; } = new();
+        public ObservableCollection<LabelBoxMarker> WronglyRejectedMarkers { get; } = new();
 
         private LabelPass pass = LabelPass.Missed;
         public LabelPass Pass {
@@ -206,9 +220,9 @@ namespace TestApp.StarReview {
         public string PassLabel {
             get {
                 switch (Pass) {
-                    case LabelPass.Missed: return "Marking: MISSED (false negatives)";
-                    case LabelPass.ShouldReject: return "Marking: SHOULD-REJECT (false positives)";
-                    case LabelPass.WronglyRejected: return "Marking: WRONGLY-REJECTED (click inside a rejected box to keep it)";
+                    case LabelPass.Missed: return "Marking: MISSED — drag a box around a star the detector missed (false negatives)";
+                    case LabelPass.ShouldReject: return "Marking: SHOULD-REJECT — click an ACCEPTED (green) box to flag it (false positives)";
+                    case LabelPass.WronglyRejected: return "Marking: WRONGLY-REJECTED — click a REJECTED box to keep it (folds into recall)";
                     default: return "Marking";
                 }
             }
@@ -282,16 +296,16 @@ namespace TestApp.StarReview {
 
         private void LoadCurrent() {
             var f = Current;
-            FrameHeader = $"{f.RunId}  @ focuser {f.FocuserPosition}  |  {f.AcceptedCenters.Count} accepted";
+            FrameHeader = $"{f.RunId}  @ focuser {f.FocuserPosition}  |  {f.Accepted.Count} accepted";
 
             // Build the MTF-stretched background image (off-thread, then marshal to the UI).
             FrameImage = null;
             _ = LoadImageAsync(f.FramePath);
 
-            // Overlays in image coords.
+            // Overlays in image coords — accepted stars draw the detector's REAL bounding box (top-left + size).
             AcceptedMarkers.Clear();
-            foreach (var (x, y, hfr) in f.AcceptedCenters) {
-                AcceptedMarkers.Add(new AcceptedMarker { X = x, Y = y, HFR = hfr });
+            foreach (var (_, _, hfr, b) in f.Accepted) {
+                AcceptedMarkers.Add(new AcceptedMarker { X = b.X, Y = b.Y, Width = b.Width, Height = b.Height, HFR = hfr });
             }
             RejectedMarkers.Clear();
             foreach (var (reason, b) in f.Rejected) {
@@ -344,58 +358,93 @@ namespace TestApp.StarReview {
         // ---- Labeling (delegates to the pure store) --------------------------------------------------------
 
         /// <summary>
-        /// Adds-or-removes a label of the current pass at image pixel (imageX, imageY). Called by the view after
-        /// it maps the click through <see cref="StarReviewViewport.ScreenToImage"/>. Toggling near an existing
-        /// point of the same pass removes it.
+        /// MISSED pass: adds (or toggles off) a user-drawn box. The view calls this on mouse-up of a rubber-band
+        /// drag (or a small click). (<paramref name="imageX"/>,<paramref name="imageY"/>) is the top-left and
+        /// (<paramref name="width"/>,<paramref name="height"/>) the size, already normalized to W,H ≥ 0 by the view.
+        /// A degenerate drag (below a few px — effectively a click) is widened to a small default box of side
+        /// 2·RadiusPx centered on the click, so a plain click still drops a usable region. Toggling near an existing
+        /// missed box's center removes it.
         /// </summary>
-        public void ToggleLabelAt(double imageX, double imageY) {
+        public void AddMissedBox(double imageX, double imageY, double width, double height) {
             var run = CurrentRunLabels;
             if (run == null) {
                 return;
             }
+            const double minDragPx = 3.0;
+            if (width < minDragPx || height < minDragPx) {
+                // Effectively a click: drop a small default box centered on the click point.
+                var side = 2.0 * RadiusPx;
+                var cx = imageX + width / 2.0;
+                var cy = imageY + height / 2.0;
+                imageX = cx - side / 2.0;
+                imageY = cy - side / 2.0;
+                width = side;
+                height = side;
+            }
+            var pos = StarReviewLabelStore.GetOrAddPosition(run, Current.FocuserPosition);
+            if (pos.RadiusPx == null) {
+                pos.RadiusPx = RadiusPx;
+            }
+            StarReviewLabelStore.ToggleBox(pos.Missed, imageX, imageY, width, height);
+            RefreshLabelMarkers();
+        }
 
-            // WRONGLY-REJECTED is a CONSTRAINED pass: the user must click INSIDE a displayed rejected-candidate box.
-            // A hit toggles a point at that box's CENTER (not the raw click), so the recorded recall target lands on
-            // the candidate the detector already found. A click outside every rejected box is a no-op.
-            if (Pass == LabelPass.WronglyRejected) {
-                var hit = HitTestRejected(imageX, imageY);
-                if (hit == null) {
-                    return;
-                }
-                var posWr = StarReviewLabelStore.GetOrAddPosition(run, Current.FocuserPosition);
-                if (posWr.RadiusPx == null) {
-                    posWr.RadiusPx = RadiusPx;
-                }
-                StarReviewLabelStore.TogglePoint(posWr.WronglyRejected, hit.Value.cx, hit.Value.cy);
-                RefreshLabelMarkers();
+        /// <summary>
+        /// SHOULD-REJECT / WRONGLY-REJECTED pass: a click that hit-tests the detector's ACCEPTED (should-reject) or
+        /// REJECTED (wrongly-rejected) boxes and toggles THAT star's actual bounding box into the label list. The
+        /// view calls this after mapping the click through <see cref="StarReviewViewport.ScreenToImage"/>. A click
+        /// outside every candidate box is a no-op (the MISSED pass is handled by <see cref="AddMissedBox"/> instead).
+        /// On overlap the smallest-area box wins. Clicking an already-labeled star again removes it.
+        /// </summary>
+        public void ToggleLabelAt(double imageX, double imageY) {
+            var run = CurrentRunLabels;
+            if (run == null || Pass == LabelPass.Missed) {
                 return;
+            }
+
+            // Hit-test the relevant detector boxes (accepted for should-reject, rejected for wrongly-rejected).
+            var hit = Pass == LabelPass.ShouldReject
+                ? HitTestBoxes(Current.Accepted.Select(a => a.Bounds), imageX, imageY)
+                : HitTestBoxes(Current.Rejected.Select(r => r.Bounds), imageX, imageY);
+            if (hit == null) {
+                return; // click outside every candidate box: no-op
             }
 
             var pos = StarReviewLabelStore.GetOrAddPosition(run, Current.FocuserPosition);
             if (pos.RadiusPx == null) {
                 pos.RadiusPx = RadiusPx;
             }
-            var list = Pass == LabelPass.Missed ? pos.Missed : pos.ShouldReject;
-            StarReviewLabelStore.TogglePoint(list, imageX, imageY);
+            var list = Pass == LabelPass.ShouldReject ? pos.ShouldReject : pos.WronglyRejected;
+
+            // Toggle semantics: if a label already covers this star (its center matches the hit box's center within
+            // tolerance), remove it; otherwise record the star's ACTUAL bounding box.
+            var b = hit.Value;
+            var existing = StarReviewLabelStore.NearestBoxIndexWithin(
+                list, b.X + b.Width / 2.0, b.Y + b.Height / 2.0, StarReviewLabelStore.SamePointTolerancePx);
+            if (existing >= 0) {
+                list.RemoveAt(existing);
+            } else {
+                list.Add(new StarReviewLabelBox(b.X, b.Y, b.Width, b.Height));
+            }
             RefreshLabelMarkers();
         }
 
         /// <summary>
-        /// Returns the CENTER of the rejected-candidate box (in image coords) containing the click, or null if the
-        /// click is outside every rejected box. AABB containment; on overlap the smallest-area box wins (so a click
-        /// in a region of nested boxes selects the tightest candidate). Pure geometry over <see cref="FrameReview.Rejected"/>.
+        /// Returns the SMALLEST-area box (in image coords) from <paramref name="boxes"/> that contains the click, or
+        /// null if the click is outside every box. AABB containment; on overlap the smallest-area box wins (so a
+        /// click in a region of nested boxes selects the tightest candidate). Pure geometry.
         /// </summary>
-        private (double cx, double cy)? HitTestRejected(double imageX, double imageY) {
-            (double cx, double cy)? best = null;
+        private static Rect? HitTestBoxes(IEnumerable<Rect> boxes, double imageX, double imageY) {
+            Rect? best = null;
             var bestArea = double.MaxValue;
-            foreach (var (_, b) in Current.Rejected) {
+            foreach (var b in boxes) {
                 if (imageX < b.X || imageY < b.Y || imageX > b.X + b.Width || imageY > b.Y + b.Height) {
                     continue;
                 }
                 var area = (double)b.Width * b.Height;
                 if (area < bestArea) {
                     bestArea = area;
-                    best = (b.X + b.Width / 2.0, b.Y + b.Height / 2.0);
+                    best = b;
                 }
             }
             return best;
@@ -408,18 +457,28 @@ namespace TestApp.StarReview {
             var pos = CurrentPositionLabels;
             if (pos != null) {
                 foreach (var p in pos.Missed) {
-                    MissedMarkers.Add(p);
+                    MissedMarkers.Add(ToBoxMarker(p));
                 }
                 foreach (var p in pos.ShouldReject) {
-                    ShouldRejectMarkers.Add(p);
+                    ShouldRejectMarkers.Add(ToBoxMarker(p));
                 }
                 if (pos.WronglyRejected != null) {
                     foreach (var p in pos.WronglyRejected) {
-                        WronglyRejectedMarkers.Add(p);
+                        WronglyRejectedMarkers.Add(ToBoxMarker(p));
                     }
                 }
             }
             RaisePropertyChanged(nameof(CountsLabel));
+        }
+
+        /// <summary>Maps a stored label box to a drawable marker. A legacy label that somehow still lacks W/H is drawn
+        /// as a small 2·RadiusPx box centered on its (x,y) (Normalize back-fills on load, so this is belt-and-suspenders).</summary>
+        private LabelBoxMarker ToBoxMarker(StarReviewLabelBox b) {
+            if (b.HasSize) {
+                return new LabelBoxMarker { X = b.X, Y = b.Y, Width = b.W.Value, Height = b.H.Value };
+            }
+            var side = 2.0 * RadiusPx;
+            return new LabelBoxMarker { X = b.X - side / 2.0, Y = b.Y - side / 2.0, Width = side, Height = side };
         }
 
         private void PersistRadiusToCurrentPosition() {

--- a/Joko.NINA.Plugins/TestApp/StarReview/StarReviewViewport.cs
+++ b/Joko.NINA.Plugins/TestApp/StarReview/StarReviewViewport.cs
@@ -1,0 +1,107 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+
+namespace TestApp.StarReview {
+
+    /// <summary>
+    /// Pure zoom/pan viewport math for the review window, factored out of the WPF code so the screen↔image pixel
+    /// mapping (the load-bearing part of the click-to-label UX) is unit-testable. The model is a simple uniform
+    /// scale + translation: a point at image pixel (ix, iy) is drawn at screen (ix·Scale + OffsetX, iy·Scale +
+    /// OffsetY); the inverse maps a mouse click back to an image pixel. Scale and Offset are exactly what the
+    /// rendering layer applies (a ScaleTransform + TranslateTransform on the overlay/Image), so the two stay in
+    /// lockstep.
+    /// </summary>
+    public sealed class StarReviewViewport {
+        public const double MinScale = 0.05;
+        public const double MaxScale = 40.0;
+
+        public double Scale { get; private set; } = 1.0;
+        public double OffsetX { get; private set; }
+        public double OffsetY { get; private set; }
+
+        public StarReviewViewport() { }
+
+        public StarReviewViewport(double scale, double offsetX, double offsetY) {
+            Scale = ClampScale(scale);
+            OffsetX = offsetX;
+            OffsetY = offsetY;
+        }
+
+        /// <summary>Image pixel -> screen point.</summary>
+        public (double X, double Y) ImageToScreen(double imageX, double imageY) {
+            return (imageX * Scale + OffsetX, imageY * Scale + OffsetY);
+        }
+
+        /// <summary>Screen point -> image pixel (the inverse of <see cref="ImageToScreen"/>).</summary>
+        public (double X, double Y) ScreenToImage(double screenX, double screenY) {
+            return ((screenX - OffsetX) / Scale, (screenY - OffsetY) / Scale);
+        }
+
+        /// <summary>
+        /// Sizes and centers the image so it fits within a viewport of (<paramref name="viewportWidth"/> ×
+        /// <paramref name="viewportHeight"/>): scale = min(vw/iw, vh/ih) (never up-scaling past 1:1), then centered.
+        /// </summary>
+        public void FitTo(double viewportWidth, double viewportHeight, double imageWidth, double imageHeight) {
+            if (imageWidth <= 0 || imageHeight <= 0 || viewportWidth <= 0 || viewportHeight <= 0) {
+                Scale = 1.0;
+                OffsetX = 0;
+                OffsetY = 0;
+                return;
+            }
+            var fit = Math.Min(viewportWidth / imageWidth, viewportHeight / imageHeight);
+            Scale = ClampScale(Math.Min(fit, 1.0));
+            OffsetX = (viewportWidth - imageWidth * Scale) / 2.0;
+            OffsetY = (viewportHeight - imageHeight * Scale) / 2.0;
+        }
+
+        /// <summary>
+        /// Zooms by <paramref name="factor"/> keeping the image point currently under the screen anchor
+        /// (<paramref name="anchorScreenX"/>, <paramref name="anchorScreenY"/>) fixed — i.e. the pixel under the
+        /// cursor stays under the cursor. This is the wheel-zoom behavior users expect.
+        /// </summary>
+        public void ZoomAt(double factor, double anchorScreenX, double anchorScreenY) {
+            var (imgX, imgY) = ScreenToImage(anchorScreenX, anchorScreenY);
+            var newScale = ClampScale(Scale * factor);
+            // Solve for the offset that keeps (imgX, imgY) under the anchor at the new scale.
+            OffsetX = anchorScreenX - imgX * newScale;
+            OffsetY = anchorScreenY - imgY * newScale;
+            Scale = newScale;
+        }
+
+        /// <summary>Pans by a screen-space delta (drag).</summary>
+        public void PanBy(double dxScreen, double dyScreen) {
+            OffsetX += dxScreen;
+            OffsetY += dyScreen;
+        }
+
+        public void Set(double scale, double offsetX, double offsetY) {
+            Scale = ClampScale(scale);
+            OffsetX = offsetX;
+            OffsetY = offsetY;
+        }
+
+        public static double ClampScale(double s) {
+            if (double.IsNaN(s) || s <= 0) {
+                return 1.0;
+            }
+            if (s < MinScale) {
+                return MinScale;
+            }
+            if (s > MaxScale) {
+                return MaxScale;
+            }
+            return s;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/TestApp/StarReview/StarReviewWindow.xaml
+++ b/Joko.NINA.Plugins/TestApp/StarReview/StarReviewWindow.xaml
@@ -48,6 +48,12 @@
                 Content="Mark Should-Reject (2)"
                 IsChecked="{Binding IsShouldRejectPass, Mode=OneWay}"
                 Command="{Binding MarkShouldRejectCommand}" />
+            <ToggleButton
+                Margin="4,0"
+                Padding="10,4"
+                Content="Mark Wrongly-Rejected (3)"
+                IsChecked="{Binding IsWronglyRejectedPass, Mode=OneWay}"
+                Command="{Binding MarkWronglyRejectedCommand}" />
             <TextBlock Margin="16,0,4,0" Text="Radius px:" />
             <TextBox Width="50" VerticalContentAlignment="Center"
                      Text="{Binding RadiusPx, UpdateSourceTrigger=PropertyChanged, StringFormat=0.#}" />
@@ -95,7 +101,8 @@
                     </ItemsControl.ItemContainerStyle>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Rectangle Width="{Binding Width}" Height="{Binding Height}" StrokeThickness="0.6">
+                            <Rectangle Width="{Binding Width}" Height="{Binding Height}"
+                                       StrokeThickness="{Binding DataContext.MarkerStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}">
                                 <Rectangle.Stroke>
                                     <SolidColorBrush Color="{Binding Color}" />
                                 </Rectangle.Stroke>
@@ -118,7 +125,8 @@
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Ellipse Width="9" Height="9" Margin="-4.5,-4.5,0,0"
-                                     Stroke="#FF00FF00" StrokeThickness="0.7" />
+                                     Stroke="#FF00FF00"
+                                     StrokeThickness="{Binding DataContext.MarkerStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
@@ -137,7 +145,8 @@
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Ellipse Width="13" Height="13" Margin="-6.5,-6.5,0,0"
-                                     Stroke="#FF00E5FF" StrokeThickness="1.2" />
+                                     Stroke="#FF00E5FF"
+                                     StrokeThickness="{Binding DataContext.LabelStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
@@ -156,7 +165,34 @@
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Rectangle Width="13" Height="13" Margin="-6.5,-6.5,0,0"
-                                       Stroke="#FFFF8C00" StrokeThickness="1.2" />
+                                       Stroke="#FFFF8C00"
+                                       StrokeThickness="{Binding DataContext.LabelStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <!-- User: wrongly-rejected (detected-but-gated, should be KEPT) — bright-green diamond (a rotated
+                     square) so it reads distinctly as "should-have-been-accepted". -->
+                <ItemsControl ItemsSource="{Binding WronglyRejectedMarkers}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemContainerStyle>
+                        <Style TargetType="ContentPresenter">
+                            <Setter Property="Canvas.Left" Value="{Binding X}" />
+                            <Setter Property="Canvas.Top" Value="{Binding Y}" />
+                        </Style>
+                    </ItemsControl.ItemContainerStyle>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Rectangle Width="14" Height="14" Margin="-7,-7,0,0"
+                                       Stroke="#FF39FF14"
+                                       StrokeThickness="{Binding DataContext.LabelStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                       RenderTransformOrigin="0.5,0.5">
+                                <Rectangle.RenderTransform>
+                                    <RotateTransform Angle="45" />
+                                </Rectangle.RenderTransform>
+                            </Rectangle>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
@@ -171,6 +207,6 @@
 
         <!-- Legend / help -->
         <TextBlock Grid.Row="4" Margin="0,4,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
-                   Text="Green = accepted. Boxes = rejected-by-reason (yellow TooDistorted, orange Degenerate, red Saturated, cyan LowSensitivity, magenta NotCentered, blue TooFlat, purple Contaminated). Cyan ring = your MISSED. Orange box = your SHOULD-REJECT. Left-click to add/toggle the current pass at that pixel. Right-drag to pan, wheel to zoom." />
+                   Text="Green = accepted. Boxes = rejected-by-reason (yellow TooDistorted, orange Degenerate, red Saturated, cyan LowSensitivity, magenta NotCentered, blue TooFlat, purple Contaminated). Cyan ring = your MISSED. Orange box = your SHOULD-REJECT. Bright-green diamond = your WRONGLY-REJECTED (folds into recall). Left-click to add/toggle the current pass at that pixel; for Wrongly-Rejected, click INSIDE a rejected box to keep it. Right-drag to pan, wheel to zoom." />
     </Grid>
 </Window>

--- a/Joko.NINA.Plugins/TestApp/StarReview/StarReviewWindow.xaml
+++ b/Joko.NINA.Plugins/TestApp/StarReview/StarReviewWindow.xaml
@@ -70,6 +70,7 @@
                     Background="Transparent"
                     MouseWheel="ViewportCanvas_MouseWheel"
                     MouseLeftButtonDown="ViewportCanvas_MouseLeftButtonDown"
+                    MouseLeftButtonUp="ViewportCanvas_MouseLeftButtonUp"
                     MouseRightButtonDown="ViewportCanvas_MouseRightButtonDown"
                     MouseRightButtonUp="ViewportCanvas_MouseRightButtonUp"
                     MouseMove="ViewportCanvas_MouseMove"
@@ -111,7 +112,7 @@
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
 
-                <!-- Accepted stars (green circles). -->
+                <!-- Accepted stars — the detector's REAL bounding box (green). -->
                 <ItemsControl ItemsSource="{Binding AcceptedMarkers}">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
@@ -124,14 +125,14 @@
                     </ItemsControl.ItemContainerStyle>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Ellipse Width="9" Height="9" Margin="-4.5,-4.5,0,0"
-                                     Stroke="#FF00FF00"
-                                     StrokeThickness="{Binding DataContext.MarkerStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                            <Rectangle Width="{Binding Width}" Height="{Binding Height}"
+                                       Stroke="#FF00FF00"
+                                       StrokeThickness="{Binding DataContext.MarkerStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
 
-                <!-- User: missed (false negatives) — bright cyan crosshair-ish ring. -->
+                <!-- User: missed (false negatives) — cyan box (the user's drag region). -->
                 <ItemsControl ItemsSource="{Binding MissedMarkers}">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
@@ -144,14 +145,14 @@
                     </ItemsControl.ItemContainerStyle>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Ellipse Width="13" Height="13" Margin="-6.5,-6.5,0,0"
-                                     Stroke="#FF00E5FF"
-                                     StrokeThickness="{Binding DataContext.LabelStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                            <Rectangle Width="{Binding Width}" Height="{Binding Height}"
+                                       Stroke="#FF00E5FF"
+                                       StrokeThickness="{Binding DataContext.LabelStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
 
-                <!-- User: should-reject (false positives) — orange X-style ring. -->
+                <!-- User: should-reject (false positives) — orange box (the accepted star's actual bounds). -->
                 <ItemsControl ItemsSource="{Binding ShouldRejectMarkers}">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
@@ -164,15 +165,15 @@
                     </ItemsControl.ItemContainerStyle>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Rectangle Width="13" Height="13" Margin="-6.5,-6.5,0,0"
+                            <Rectangle Width="{Binding Width}" Height="{Binding Height}"
                                        Stroke="#FFFF8C00"
                                        StrokeThickness="{Binding DataContext.LabelStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
 
-                <!-- User: wrongly-rejected (detected-but-gated, should be KEPT) — bright-green diamond (a rotated
-                     square) so it reads distinctly as "should-have-been-accepted". -->
+                <!-- User: wrongly-rejected (detected-but-gated, should be KEPT) — bright-green box (the rejected
+                     candidate's actual bounds). -->
                 <ItemsControl ItemsSource="{Binding WronglyRejectedMarkers}">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
@@ -185,17 +186,21 @@
                     </ItemsControl.ItemContainerStyle>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Rectangle Width="14" Height="14" Margin="-7,-7,0,0"
+                            <Rectangle Width="{Binding Width}" Height="{Binding Height}"
                                        Stroke="#FF39FF14"
-                                       StrokeThickness="{Binding DataContext.LabelStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
-                                       RenderTransformOrigin="0.5,0.5">
-                                <Rectangle.RenderTransform>
-                                    <RotateTransform Angle="45" />
-                                </Rectangle.RenderTransform>
-                            </Rectangle>
+                                       StrokeThickness="{Binding DataContext.LabelStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
+
+                <!-- Live rubber-band rectangle while dragging a MISSED box (placed/sized in code-behind in image
+                     coords; shares the canvas transform so it tracks the cursor under zoom/pan). -->
+                <Rectangle x:Name="DragRect"
+                           Visibility="Collapsed"
+                           Stroke="#FF00E5FF"
+                           StrokeDashArray="3 2"
+                           StrokeThickness="{Binding LabelStrokeThickness}"
+                           IsHitTestVisible="False" />
             </Canvas>
         </Border>
 
@@ -207,6 +212,6 @@
 
         <!-- Legend / help -->
         <TextBlock Grid.Row="4" Margin="0,4,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
-                   Text="Green = accepted. Boxes = rejected-by-reason (yellow TooDistorted, orange Degenerate, red Saturated, cyan LowSensitivity, magenta NotCentered, blue TooFlat, purple Contaminated). Cyan ring = your MISSED. Orange box = your SHOULD-REJECT. Bright-green diamond = your WRONGLY-REJECTED (folds into recall). Left-click to add/toggle the current pass at that pixel; for Wrongly-Rejected, click INSIDE a rejected box to keep it. Right-drag to pan, wheel to zoom." />
+                   Text="Green box = accepted (real detector bounds). Reason boxes = rejected (yellow TooDistorted, orange Degenerate, red Saturated, cyan LowSensitivity, magenta NotCentered, blue TooFlat, purple Contaminated). Cyan box = your MISSED. Orange box = your SHOULD-REJECT. Bright-green box = your WRONGLY-REJECTED (folds into recall). Missed (1): LEFT-DRAG a box around a missed star (a tiny drag drops a small default box). Should-Reject (2): LEFT-CLICK an accepted green box. Wrongly-Rejected (3): LEFT-CLICK a rejected box to keep it. Click an existing label again to remove it. Right-drag to pan, wheel to zoom." />
     </Grid>
 </Window>

--- a/Joko.NINA.Plugins/TestApp/StarReview/StarReviewWindow.xaml
+++ b/Joko.NINA.Plugins/TestApp/StarReview/StarReviewWindow.xaml
@@ -1,0 +1,176 @@
+<Window
+    x:Class="TestApp.StarReview.StarReviewWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:TestApp.StarReview"
+    Title="Star Detection Review — label missed / should-reject"
+    Width="1280"
+    Height="900"
+    Background="#FF1E2125">
+    <Window.Resources>
+        <SolidColorBrush x:Key="Fg" Color="White" />
+        <Style TargetType="Button">
+            <Setter Property="Margin" Value="4,0" />
+            <Setter Property="Padding" Value="10,4" />
+        </Style>
+        <Style TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{StaticResource Fg}" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+    </Window.Resources>
+
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <DockPanel Grid.Row="0" LastChildFill="False" Margin="0,0,0,6">
+            <TextBlock DockPanel.Dock="Left" FontWeight="SemiBold" Text="{Binding FrameHeader}" />
+            <TextBlock DockPanel.Dock="Right" Text="{Binding PositionLabel}" />
+        </DockPanel>
+
+        <!-- Toolbar: pass toggle, radius, navigation, save -->
+        <WrapPanel Grid.Row="1" Margin="0,0,0,6">
+            <ToggleButton
+                Margin="4,0"
+                Padding="10,4"
+                Content="Mark Missed (1)"
+                IsChecked="{Binding IsMissedPass, Mode=OneWay}"
+                Command="{Binding MarkMissedCommand}" />
+            <ToggleButton
+                Margin="4,0"
+                Padding="10,4"
+                Content="Mark Should-Reject (2)"
+                IsChecked="{Binding IsShouldRejectPass, Mode=OneWay}"
+                Command="{Binding MarkShouldRejectCommand}" />
+            <TextBlock Margin="16,0,4,0" Text="Radius px:" />
+            <TextBox Width="50" VerticalContentAlignment="Center"
+                     Text="{Binding RadiusPx, UpdateSourceTrigger=PropertyChanged, StringFormat=0.#}" />
+            <Button Content="Fit" Command="{Binding FitCommand}" Margin="16,0,4,0" />
+            <Button Content="◀ Prev" Command="{Binding PrevCommand}" />
+            <Button Content="Next ▶" Command="{Binding NextCommand}" />
+            <Button Content="Save" Command="{Binding SaveCommand}" Margin="16,0,4,0" />
+        </WrapPanel>
+
+        <!-- Image + overlays. The Image and all marker layers share one transform (zoom/pan) so markers stay
+             pinned to image pixels. Mouse events are handled in code-behind against the viewport. -->
+        <Border Grid.Row="2" ClipToBounds="True" Background="Black" BorderBrush="#FF3F4958" BorderThickness="1">
+            <Canvas x:Name="ViewportCanvas"
+                    Background="Transparent"
+                    MouseWheel="ViewportCanvas_MouseWheel"
+                    MouseLeftButtonDown="ViewportCanvas_MouseLeftButtonDown"
+                    MouseRightButtonDown="ViewportCanvas_MouseRightButtonDown"
+                    MouseRightButtonUp="ViewportCanvas_MouseRightButtonUp"
+                    MouseMove="ViewportCanvas_MouseMove"
+                    SizeChanged="ViewportCanvas_SizeChanged">
+                <Canvas.RenderTransform>
+                    <TransformGroup>
+                        <ScaleTransform x:Name="ContentScale" ScaleX="1" ScaleY="1" />
+                        <TranslateTransform x:Name="ContentTranslate" X="0" Y="0" />
+                    </TransformGroup>
+                </Canvas.RenderTransform>
+
+                <!-- Background frame (image-pixel coords; the canvas transform handles zoom/pan). -->
+                <Image x:Name="FrameImageControl"
+                       Source="{Binding FrameImage}"
+                       Canvas.Left="0" Canvas.Top="0"
+                       Stretch="None"
+                       RenderOptions.BitmapScalingMode="NearestNeighbor" />
+
+                <!-- Rejected candidate boxes (per-reason color). -->
+                <ItemsControl ItemsSource="{Binding RejectedMarkers}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemContainerStyle>
+                        <Style TargetType="ContentPresenter">
+                            <Setter Property="Canvas.Left" Value="{Binding X}" />
+                            <Setter Property="Canvas.Top" Value="{Binding Y}" />
+                        </Style>
+                    </ItemsControl.ItemContainerStyle>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Rectangle Width="{Binding Width}" Height="{Binding Height}" StrokeThickness="0.6">
+                                <Rectangle.Stroke>
+                                    <SolidColorBrush Color="{Binding Color}" />
+                                </Rectangle.Stroke>
+                            </Rectangle>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <!-- Accepted stars (green circles). -->
+                <ItemsControl ItemsSource="{Binding AcceptedMarkers}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemContainerStyle>
+                        <Style TargetType="ContentPresenter">
+                            <Setter Property="Canvas.Left" Value="{Binding X}" />
+                            <Setter Property="Canvas.Top" Value="{Binding Y}" />
+                        </Style>
+                    </ItemsControl.ItemContainerStyle>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Ellipse Width="9" Height="9" Margin="-4.5,-4.5,0,0"
+                                     Stroke="#FF00FF00" StrokeThickness="0.7" />
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <!-- User: missed (false negatives) — bright cyan crosshair-ish ring. -->
+                <ItemsControl ItemsSource="{Binding MissedMarkers}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemContainerStyle>
+                        <Style TargetType="ContentPresenter">
+                            <Setter Property="Canvas.Left" Value="{Binding X}" />
+                            <Setter Property="Canvas.Top" Value="{Binding Y}" />
+                        </Style>
+                    </ItemsControl.ItemContainerStyle>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Ellipse Width="13" Height="13" Margin="-6.5,-6.5,0,0"
+                                     Stroke="#FF00E5FF" StrokeThickness="1.2" />
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <!-- User: should-reject (false positives) — orange X-style ring. -->
+                <ItemsControl ItemsSource="{Binding ShouldRejectMarkers}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemContainerStyle>
+                        <Style TargetType="ContentPresenter">
+                            <Setter Property="Canvas.Left" Value="{Binding X}" />
+                            <Setter Property="Canvas.Top" Value="{Binding Y}" />
+                        </Style>
+                    </ItemsControl.ItemContainerStyle>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Rectangle Width="13" Height="13" Margin="-6.5,-6.5,0,0"
+                                       Stroke="#FFFF8C00" StrokeThickness="1.2" />
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </Canvas>
+        </Border>
+
+        <!-- Pass + counts -->
+        <DockPanel Grid.Row="3" LastChildFill="False" Margin="0,6,0,0">
+            <TextBlock DockPanel.Dock="Left" FontWeight="SemiBold" Text="{Binding PassLabel}" />
+            <TextBlock DockPanel.Dock="Right" Text="{Binding CountsLabel}" />
+        </DockPanel>
+
+        <!-- Legend / help -->
+        <TextBlock Grid.Row="4" Margin="0,4,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
+                   Text="Green = accepted. Boxes = rejected-by-reason (yellow TooDistorted, orange Degenerate, red Saturated, cyan LowSensitivity, magenta NotCentered, blue TooFlat, purple Contaminated). Cyan ring = your MISSED. Orange box = your SHOULD-REJECT. Left-click to add/toggle the current pass at that pixel. Right-drag to pan, wheel to zoom." />
+    </Grid>
+</Window>

--- a/Joko.NINA.Plugins/TestApp/StarReview/StarReviewWindow.xaml.cs
+++ b/Joko.NINA.Plugins/TestApp/StarReview/StarReviewWindow.xaml.cs
@@ -55,6 +55,11 @@ namespace TestApp.StarReview {
                     vm.Pass = LabelPass.ShouldReject;
                     e.Handled = true;
                     break;
+                case Key.D3:
+                case Key.NumPad3:
+                    vm.Pass = LabelPass.WronglyRejected;
+                    e.Handled = true;
+                    break;
                 case Key.Left:
                     if (vm.PrevCommand.CanExecute(null)) {
                         vm.PrevCommand.Execute(null);
@@ -92,6 +97,9 @@ namespace TestApp.StarReview {
             ContentScale.ScaleY = vm.Viewport.Scale;
             ContentTranslate.X = vm.Viewport.OffsetX;
             ContentTranslate.Y = vm.Viewport.OffsetY;
+            // Markers scale with the canvas transform, so refresh the zoom-inverse stroke thickness after any
+            // viewport change (this covers wheel-zoom, fit, and pan since all route through ApplyViewport).
+            vm.NotifyViewportChanged();
         }
 
         // The canvas RenderTransform maps image space -> screen space, so a mouse position taken relative to the

--- a/Joko.NINA.Plugins/TestApp/StarReview/StarReviewWindow.xaml.cs
+++ b/Joko.NINA.Plugins/TestApp/StarReview/StarReviewWindow.xaml.cs
@@ -24,6 +24,11 @@ namespace TestApp.StarReview {
         private System.Windows.Point lastPanScreen;
         private bool hasFitOnce;
 
+        // Rubber-band drag state for the MISSED pass (image-space). dragging is set on left-button-down in the Missed
+        // pass; dragStart is the down point and the live DragRect tracks the cursor until button-up finalizes the box.
+        private bool dragging;
+        private System.Windows.Point dragStartImage;
+
         public StarReviewWindow() {
             InitializeComponent();
             DataContextChanged += OnDataContextChanged;
@@ -129,7 +134,52 @@ namespace TestApp.StarReview {
             }
             var screen = ScreenPoint(e);
             var (imgX, imgY) = vm.Viewport.ScreenToImage(screen.X, screen.Y);
-            // Ignore clicks outside the image bounds.
+            // Ignore presses outside the image bounds.
+            if (imgX < 0 || imgY < 0 || imgX > vm.ImageWidth || imgY > vm.ImageHeight) {
+                return;
+            }
+
+            // MISSED pass: begin a rubber-band drag (the box is finalized on button-up). Other passes are click-based
+            // (hit-test an accepted/rejected box on button-up) so the user can see what they are about to label.
+            if (vm.Pass == LabelPass.Missed) {
+                dragging = true;
+                dragStartImage = new System.Windows.Point(imgX, imgY);
+                // Start a zero-size rect anchored at the down point (in image coords; the canvas transform scales it).
+                System.Windows.Controls.Canvas.SetLeft(DragRect, imgX);
+                System.Windows.Controls.Canvas.SetTop(DragRect, imgY);
+                DragRect.Width = 0;
+                DragRect.Height = 0;
+                DragRect.Visibility = Visibility.Visible;
+                ViewportCanvas.CaptureMouse();
+            }
+            e.Handled = true;
+        }
+
+        private void ViewportCanvas_MouseLeftButtonUp(object sender, MouseButtonEventArgs e) {
+            var vm = Vm;
+            if (vm == null) {
+                return;
+            }
+            var screen = ScreenPoint(e);
+            var (imgX, imgY) = vm.Viewport.ScreenToImage(screen.X, screen.Y);
+
+            if (dragging) {
+                dragging = false;
+                DragRect.Visibility = Visibility.Collapsed;
+                ViewportCanvas.ReleaseMouseCapture();
+                // Normalize so W,H >= 0 regardless of drag direction. AddMissedBox widens a tiny drag (effectively a
+                // click) to a small default box itself.
+                var x = Math.Min(dragStartImage.X, imgX);
+                var y = Math.Min(dragStartImage.Y, imgY);
+                var w = Math.Abs(imgX - dragStartImage.X);
+                var h = Math.Abs(imgY - dragStartImage.Y);
+                vm.AddMissedBox(x, y, w, h);
+                e.Handled = true;
+                return;
+            }
+
+            // Click-based passes (should-reject / wrongly-rejected): hit-test the detector boxes. Ignore clicks
+            // outside the image bounds.
             if (imgX < 0 || imgY < 0 || imgX > vm.ImageWidth || imgY > vm.ImageHeight) {
                 return;
             }
@@ -151,11 +201,25 @@ namespace TestApp.StarReview {
         }
 
         private void ViewportCanvas_MouseMove(object sender, MouseEventArgs e) {
-            if (!panning) {
-                return;
-            }
             var vm = Vm;
             if (vm == null) {
+                return;
+            }
+
+            // Update the live rubber-band while dragging a MISSED box (image-space; the canvas transform scales it).
+            if (dragging) {
+                var screenNow = ScreenPoint(e);
+                var (imgX, imgY) = vm.Viewport.ScreenToImage(screenNow.X, screenNow.Y);
+                var x = Math.Min(dragStartImage.X, imgX);
+                var y = Math.Min(dragStartImage.Y, imgY);
+                System.Windows.Controls.Canvas.SetLeft(DragRect, x);
+                System.Windows.Controls.Canvas.SetTop(DragRect, y);
+                DragRect.Width = Math.Abs(imgX - dragStartImage.X);
+                DragRect.Height = Math.Abs(imgY - dragStartImage.Y);
+                return;
+            }
+
+            if (!panning) {
                 return;
             }
             var screen = ScreenPoint(e);

--- a/Joko.NINA.Plugins/TestApp/StarReview/StarReviewWindow.xaml.cs
+++ b/Joko.NINA.Plugins/TestApp/StarReview/StarReviewWindow.xaml.cs
@@ -1,0 +1,173 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Windows;
+using System.Windows.Input;
+
+namespace TestApp.StarReview {
+
+    public partial class StarReviewWindow : Window {
+
+        private StarReviewVM Vm => DataContext as StarReviewVM;
+
+        private bool panning;
+        private System.Windows.Point lastPanScreen;
+        private bool hasFitOnce;
+
+        public StarReviewWindow() {
+            InitializeComponent();
+            DataContextChanged += OnDataContextChanged;
+            KeyDown += OnKeyDown;
+        }
+
+        private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e) {
+            if (e.OldValue is StarReviewVM oldVm) {
+                oldVm.FitRequested -= OnFitRequested;
+            }
+            if (e.NewValue is StarReviewVM newVm) {
+                newVm.FitRequested += OnFitRequested;
+            }
+        }
+
+        private void OnKeyDown(object sender, KeyEventArgs e) {
+            var vm = Vm;
+            if (vm == null) {
+                return;
+            }
+            switch (e.Key) {
+                case Key.D1:
+                case Key.NumPad1:
+                    vm.Pass = LabelPass.Missed;
+                    e.Handled = true;
+                    break;
+                case Key.D2:
+                case Key.NumPad2:
+                    vm.Pass = LabelPass.ShouldReject;
+                    e.Handled = true;
+                    break;
+                case Key.Left:
+                    if (vm.PrevCommand.CanExecute(null)) {
+                        vm.PrevCommand.Execute(null);
+                    }
+                    e.Handled = true;
+                    break;
+                case Key.Right:
+                    if (vm.NextCommand.CanExecute(null)) {
+                        vm.NextCommand.Execute(null);
+                    }
+                    e.Handled = true;
+                    break;
+                case Key.F:
+                    OnFitRequested(this, EventArgs.Empty);
+                    e.Handled = true;
+                    break;
+            }
+        }
+
+        private void OnFitRequested(object sender, EventArgs e) {
+            var vm = Vm;
+            if (vm == null || ViewportCanvas.ActualWidth <= 0 || vm.ImageWidth <= 0) {
+                return;
+            }
+            vm.Viewport.FitTo(ViewportCanvas.ActualWidth, ViewportCanvas.ActualHeight, vm.ImageWidth, vm.ImageHeight);
+            ApplyViewport();
+        }
+
+        private void ApplyViewport() {
+            var vm = Vm;
+            if (vm == null) {
+                return;
+            }
+            ContentScale.ScaleX = vm.Viewport.Scale;
+            ContentScale.ScaleY = vm.Viewport.Scale;
+            ContentTranslate.X = vm.Viewport.OffsetX;
+            ContentTranslate.Y = vm.Viewport.OffsetY;
+        }
+
+        // The canvas RenderTransform maps image space -> screen space, so a mouse position taken relative to the
+        // canvas's PARENT (the Border) is in screen space; convert to image space via the viewport. We read the
+        // pointer relative to the Border (the untransformed container) to get true screen coords.
+        private System.Windows.Point ScreenPoint(MouseEventArgs e) {
+            var parent = (UIElement)ViewportCanvas.Parent;
+            return e.GetPosition(parent);
+        }
+
+        private void ViewportCanvas_MouseWheel(object sender, MouseWheelEventArgs e) {
+            var vm = Vm;
+            if (vm == null) {
+                return;
+            }
+            var anchor = ScreenPoint(e);
+            var factor = e.Delta > 0 ? 1.2 : 1.0 / 1.2;
+            vm.Viewport.ZoomAt(factor, anchor.X, anchor.Y);
+            ApplyViewport();
+            e.Handled = true;
+        }
+
+        private void ViewportCanvas_MouseLeftButtonDown(object sender, MouseButtonEventArgs e) {
+            var vm = Vm;
+            if (vm == null) {
+                return;
+            }
+            var screen = ScreenPoint(e);
+            var (imgX, imgY) = vm.Viewport.ScreenToImage(screen.X, screen.Y);
+            // Ignore clicks outside the image bounds.
+            if (imgX < 0 || imgY < 0 || imgX > vm.ImageWidth || imgY > vm.ImageHeight) {
+                return;
+            }
+            vm.ToggleLabelAt(imgX, imgY);
+            e.Handled = true;
+        }
+
+        private void ViewportCanvas_MouseRightButtonDown(object sender, MouseButtonEventArgs e) {
+            panning = true;
+            lastPanScreen = ScreenPoint(e);
+            ViewportCanvas.CaptureMouse();
+            e.Handled = true;
+        }
+
+        private void ViewportCanvas_MouseRightButtonUp(object sender, MouseButtonEventArgs e) {
+            panning = false;
+            ViewportCanvas.ReleaseMouseCapture();
+            e.Handled = true;
+        }
+
+        private void ViewportCanvas_MouseMove(object sender, MouseEventArgs e) {
+            if (!panning) {
+                return;
+            }
+            var vm = Vm;
+            if (vm == null) {
+                return;
+            }
+            var screen = ScreenPoint(e);
+            var dx = screen.X - lastPanScreen.X;
+            var dy = screen.Y - lastPanScreen.Y;
+            lastPanScreen = screen;
+            vm.Viewport.PanBy(dx, dy);
+            ApplyViewport();
+        }
+
+        private void ViewportCanvas_SizeChanged(object sender, SizeChangedEventArgs e) {
+            // Re-fit only on the first meaningful size (initial layout); afterwards keep the user's zoom/pan so a
+            // window resize doesn't blow away the current view.
+            if (hasFitOnce) {
+                return;
+            }
+            if (ViewportCanvas.ActualWidth > 0 && Vm?.ImageWidth > 0) {
+                hasFitOnce = true;
+                OnFitRequested(this, EventArgs.Empty);
+            }
+        }
+    }
+}

--- a/docs/star-detection-optimization-wizard-design.md
+++ b/docs/star-detection-optimization-wizard-design.md
@@ -1,6 +1,6 @@
 # Star Detection Optimization Wizard — Design
 
-**Status:** Approved (ready to implement)
+**Status:** Implemented (branch `ghilios/star-detection-optimization-wizard`)
 **Implementation plan:** `plans/star-detection-optimization-wizard-plan.md`
 
 ## Context
@@ -202,6 +202,15 @@ defocused extremes (`n_min ≥ N_hard`). Outputs: `optimize_summary.txt` (baseli
 `optimize_result.csv`, and a **stretched annotated PNG per frame** (accepted = green + HFR;
 rejected = color-coded by reason from `*Bounds`; **a real star with no marker = missed
 entirely**).
+
+> **As implemented:** run discovery is **attempt-anchored** — it finds `attempt<NN>` folders
+> (recursively, ≤4 deep) with ≥3 distinct focuser positions and skips the single-frame
+> `final`/`initial` validation captures (pure logic in `OptimizationRunDiscovery`). A
+> **`--per-run`** flag optimizes each discovered run independently into its own subfolder plus a
+> top-level `aggregate_summary.txt`, for verifying across many *different* optical setups in one
+> command (the default joint objective only applies within a single setup). Scoring deliberately
+> uses the **full accepted-star set** (NumberOfAFStars=0, no brightest-N trim) — both for
+> objective stability and so the same detection is useful for whole-frame sensor modeling.
 
 ### B. Interactive two-pass `review` (dev tool only)
 

--- a/docs/star-detection-optimization-wizard-design.md
+++ b/docs/star-detection-optimization-wizard-design.md
@@ -2,6 +2,8 @@
 
 **Status:** Implemented (branch `ghilios/star-detection-optimization-wizard`)
 **Implementation plan:** `plans/star-detection-optimization-wizard-plan.md`
+**Empirical record:** `docs/star-detection-optimization-wizard-results.md`
+**Performance analysis:** `docs/star-detection-optimizer-performance-design.md`
 
 ## Context
 
@@ -232,3 +234,91 @@ star activates the recall term, pressuring the structure axes (`StructureLayers`
 `NoiseReductionRadius`, `NoiseClippingMultiplier`, `MinStarBoundingBoxSize`) to recover it. If
 settings alone can't, the labels prove it's detector-algorithm work (e.g. multi-scale /
 large-structure handling) — the point where the author may ask for help.
+
+---
+
+## Performance (implemented)
+
+The optimizer evaluates the same frames hundreds of times; detection compute (a full-frame
+wavelet + binarization-statistics + gate/measure pass) dominates wall-clock. Two changes shipped
+(full analysis in `docs/star-detection-optimizer-performance-design.md`):
+
+- **Early/late split + per-frame early-context cache.** `StarDetector.DetectImpl` was split into a
+  cacheable **EARLY** phase (`BuildDetectionContext`: hotpixel filter, structure-map prep, à-trous
+  wavelet, binarization, candidate collection — ~78% of a detection, depends only on the 5 early
+  params) and a cheap **LATE** phase (`GateAndMeasure`: per-candidate gate + measure — ~22%, the 7
+  late-only gate params). `RunEvaluationData` caches the early `DetectionContext` per
+  (frame, early-key) and reuses it across candidates that change only late-stage gates — i.e. the
+  bulk of a compass search. The split is value-preserving: detection output is **bit-identical**.
+  The cache is bounded to one context per frame (the current early key), disposed when a frame's
+  early key changes (at 61 MP a context is ~244 MB).
+- **Bounded parallel per-frame detection within an eval.** Frames in one evaluation now detect
+  concurrently (`RunEvaluationData`, degree ≈ `max(2, ProcessorCount/4)`), with results assembled
+  by frame index and pooled by focuser position, so the fit is order-independent and deterministic.
+
+**Both apply to the in-NINA wizard for live AND replay data sources.** Both paths converge on
+`RunEvaluationLoader` → `RunEvaluationData` → `HocusFocusSplitFrameDetector` (the offline harness
+uses an equivalent `MatSplitFrameDetector`); the caching + parallelism live in `RunEvaluationData`,
+so they benefit every source. The interface boundary is `RunEvaluationData.ISplitFrameDetector`
+(`ComputeEarlyKey` / `BuildContextAsync` / `GateAndMeasure`).
+
+Live-AF capture and the inspector keep the **monolithic** `Detect` (they detect each image once, so
+there is nothing for the cache to amortize).
+
+**Measured (`optimize --per-run`, bit-identical detection):** CWhite 61 MP **19m51s → 1m30s = 13.2×**;
+Panos **7m02s → 44s = 9.6×** (at `--max-evals 24`). Net **~10–13×**.
+
+The earlier logging "quick win" (gating the per-detection PSF-time `Console.WriteLine` behind
+`ModelPSF`, defaulting the harness to INFO) is correct and result-neutral but gave **no measurable
+speedup** — NINA's `Logger` is buffered and detection compute swamps it.
+
+## Cross-setup verification
+
+Ran `optimize --per-run` over a **14-run bank (11 distinct setups)**. The Workshop
+`sensitivity_example1/2` and `standard_example2` runs are copies of fmeschia / Linwood / CWhite, so
+identical results across builds also served as a bonus **bit-identity** check.
+
+- **All 14 PASS the hard floor** (every frame ≥ 3 stars, including defocused extremes; lowest
+  observed min = 5).
+- **σ_focus improved on all 14** (≈ 1.2× to 21×).
+- **Seed Sensitivity (1.6) is too sensitive** — the optimizer raised it on 12/14.
+- **Very star-rich fields pinned the curated bounds**, so they were widened: Sensitivity `20 → 50`,
+  StarClipping `[0.5, 5] → [0.25, 10]`. A re-verify showed the widening is roughly **a wash** — the
+  real limiter is the **fixed coarse-grid resolution** over the range, not the bound endpoints
+  (logged as a follow-up).
+
+Full table in `docs/star-detection-optimization-wizard-results.md`.
+
+## Defocus-aware detector gates (opt-in, default OFF)
+
+The interactive label loop (`review` → `diagnose-labels`) diagnosed the user's bloated/donut
+defocused stars: **9/9 flagged misses were rejected by the `MaxDistortion` gate** (`TooDistorted`,
+exact match), and **4/5 dim misses were structure-detection gaps** (`NO CANDIDATE` — never formed a
+candidate). Two opt-in, default-off, size-scaled (size = defocus proxy) gate relaxations were added:
+
+- **`DefocusAwareDistortion`** — for candidates larger than `DefocusDistortionSizeReference`
+  (default **30 px**), relaxes the distortion gate by
+  `MaxDistortion × clamp(sizeRef/size, DefocusDistortionMinFactor (0.25), 1)`.
+- **`DefocusAwareCentering`** — companion; relaxes the centering gate by
+  `StarCenterTolerance × clamp(size/sizeRef, 1, DefocusCenteringToleranceFactor (2.0))`, capped at
+  the max valid tolerance. (Recovering ring-unstable donut centroids whose centers drift.)
+
+At the safe production default (sizeRef=30) these recover **8/9** donuts; at **sizeRef=20** they
+recover **9/9** — with **zero near-focus cost** from the centering gate. Both default **OFF**, which
+returns `MaxDistortion` / `StarCenterTolerance` verbatim, keeping detection **bit-identical**.
+
+---
+
+## Follow-ups
+
+- **Expose `DefocusDistortionSizeReference` as a tunable** (currently param-only / harness switch) to
+  reach 9/9 in the UI.
+- **Add the defocus-aware gates to the optimizer's curated set ONLY after a precision /
+  false-positive penalty is in the objective** — without it the optimizer cranks recall and floods
+  near-focus frames with spurious detections.
+- **Structure-detection improvement for dim missed stars** (the 4/5 `NO CANDIDATE` structure gaps —
+  detector-algorithm work, not a gate tweak).
+- **Coarse-grid-resolution vs bound-range tuning** — the cross-setup re-verify showed bound widening
+  is ~a wash; the limiter is grid resolution over the (now wider) range.
+- (cosmetic) In joint mode, the out-dir `optimized_settings.json` copy reflects the **last** run's
+  recommended step rather than a joint value.

--- a/docs/star-detection-optimization-wizard-design.md
+++ b/docs/star-detection-optimization-wizard-design.md
@@ -1,0 +1,225 @@
+# Star Detection Optimization Wizard — Design
+
+**Status:** Approved (ready to implement)
+**Implementation plan:** `plans/star-detection-optimization-wizard-plan.md`
+
+## Context
+
+HocusFocus exposes ~30 star-detection options. Tuning them well for a given optical train +
+camera + sky is expert work, and the payoff that matters is **autofocus reliability**:
+cleaner star measurements → a tighter HFR-vs-focuser curve → a more repeatable best-focus
+position. Today users guess at these knobs.
+
+This feature adds a **wizard** that automatically optimizes the star-detection options (and
+recommends an autofocus step size) for the user's setup by running or replaying autofocus
+sweeps and searching for the settings that produce the most reliable focus curve. The
+optimized settings are saved **separately** and toggled with a single Simple-Mode option that
+only appears once the wizard has succeeded.
+
+## Goals
+
+- One-click wizard launch from the top of the Star Detection options page.
+- Optimize over a replayed saved AF run **or** a live run; choose **N runs** (default 1);
+  balance a single setting across all N when N>1.
+- Recommend an autofocus step size giving ~3–4 points per side of the optimum.
+- Save optimized settings separately; expose a Simple-Mode toggle (hidden until a successful
+  run); conclude with a summary of every changed parameter.
+- A `TestApp` dev harness to verify the optimizer on real saved runs and to capture human
+  ground truth on hard frames (dim/large defocused stars).
+
+## Non-goals
+
+- No changes to the autofocus engine (`CurveFittingResult.Calculate` stays private; we use the
+  public `AlglibHyperbolicFitting.SelectBestModel`).
+- The interactive two-pass review is a **TestApp dev tool only**, not shipped in the wizard.
+- PSF-fit params are not tuned (PSF modeling is off during AF).
+
+## Locked design decisions
+
+- **Presentation:** a real **separate modal window** via NINA's `IWindowServiceFactory` (new
+  pattern — no true window exists in the plugin today; the tilt-adapter "calibration wizard"
+  is an `IDockableVM` dock panel and its only popup is the WinForms folder-picker on replay).
+- **Objective:** a **composite score** blending focus-position uncertainty, usable star count,
+  and curve consistency (+ optional human-label recall/precision); weights are tunable.
+- **Step size:** **recommend, and apply on confirm** (write the profile only on Apply).
+- **Scope:** optimized settings apply to **all** star detection (AF + inspector + sequence).
+- **Toggle placement:** "Use Optimized Settings" is a **Simple-Mode-only** toggle, visible
+  only after a successful run. When on, the three Simple presets (Noise Level / Pixel Scale /
+  Focus Range) are hidden, and switching to **Advanced Mode** reveals the optimized values in
+  the normal advanced controls (they are written into the live properties).
+
+---
+
+## Optimization Methodology (point 6 — the deliverable for review)
+
+### Why this is *not* a clean convex problem
+
+The "convex non-linear optimization over several variables" intuition is the right spirit, but
+honestly:
+
+- **Mixed-integer + boolean**, not continuous. Continuous (`BrightnessSensitivity`,
+  `StarClippingMultiplier`, `NoiseClippingMultiplier`, `MinHFR`, `StarPeakResponse`,
+  `MaxDistortion`), integer (`StructureLayers`, `NoiseReductionRadius`,
+  `MinStarBoundingBoxSize`, dilation), boolean (`HotpixelThresholdingEnabled`).
+- **Noisy / non-smooth objective.** Detection *counts* stars crossing thresholds, so the
+  objective is piecewise-constant with jumps as stars enter/leave the accepted set. Gradients
+  are undefined; a smooth solver (alglib `minbleic`, Nelder–Mead) would chase quantization
+  noise.
+- **Not provably unimodal globally** (a "few bright stars" basin vs. a "many faint stars"
+  basin).
+
+What *is* exploitable: each axis is approximately unimodal over its sensible range, the
+dimensionality is low, and evaluation is cheap and cacheable → a **bounded, derivative-free
+coordinate / pattern search** is the right tool (coordinate descent on near-monotone axes,
+with a coarse seed to escape a bad starting basin).
+
+### Objective J(θ) — composite, maximized, ∈ [0, 1]
+
+Per candidate θ evaluated on one run:
+
+1. Build `StarDetectorParams` = AF-base params (`BuildStarDetectorParams`, `ModelPSF=false`,
+   Region/PixelScale set — exactly what `GetStarDetectorParams(..., isAutoFocus:true)`
+   produces) with θ's curated values.
+2. For each saved frame run the **detection delegate** (wizard:
+   `IHocusFocusStarDetection.Detect`; harness: `StarDetector.Detect(Mat)`) → `AverageHFR`,
+   `HFRStdDev`, `DetectedStars` (mirrors `AutoFocusEngine.cs:631`).
+3. Pool frames at the same focuser position into `ScatterErrorPoint(focuserPos, pooledHFR, 0,
+   pooledStdev)` (mirrors `AutoFocusEngine.cs:734`).
+4. Fit with the user's actual AF fit settings (`engine.GetOptions(savedAttempt)`):
+   `AlglibHyperbolicFitting.SelectBestModel(alglibAPI, points, stepSize, weighted,
+   maxOutlierRejections, rejectionConfidence, out bestFit, out _)` →
+   `σ_focus = bestFit.MinimumStdError`, `R²`, `reducedχ²`, fallback
+   `ComputeLeaveOneOutBestFocusStdError(...)`.
+
+Sub-scores (each ∈ [0,1], higher better):
+
+- **S_focus:** `ρ = σ_focus/stepSize`; `S_focus = 1/(1 + (ρ/ρ_ref)²)`, `ρ_ref=0.25`. NaN
+  σ_focus → fall back to LOO std; both NaN → **hard fail** `J_run=0`.
+- **S_stars:** `n_min` = min star count over frames (curve weakest at defocused extremes),
+  `n_med` = median; `S_stars = 0.6·clamp(n_min/N_floor) + 0.4·clamp(n_med/N_target)`,
+  `N_floor=8`, `N_target=20`.
+- **S_fit:** `clamp(R²)·penalty(reducedχ²)`; `penalty=1` for `reducedχ² ≤ τ`, decays above
+  (reducedχ² runs ≪1 for star-rich fields, so penalize only the high side).
+
+Composite (unlabeled frame): `J_run = w_f·S_focus + w_s·S_stars + w_c·S_fit`, defaults
+**w_f=0.55, w_s=0.20, w_c=0.25** (one named constants block). Hard-constraint violation
+(NaN focus, or `n_min < N_hard=3` on more than k frames) forces `J_run=0`.
+
+### Optional human-label terms — recall / precision
+
+When a frame has labels from the interactive harness, add a fourth sub-score (turns the count
+proxy into measured precision/recall against ground truth — decisive for dim/large defocused
+stars):
+
+- **Recall** = fraction of labeled **missed** stars now covered by an accepted star within
+  `R` px. **Precision** = fraction of labeled **should-reject** stars now excluded.
+- `S_label = 0.5·recall + 0.5·precision`; labeled-frame composite
+  `J_run = w_f·S_focus + w_s·S_stars + w_c·S_fit + w_l·S_label`, weights rescaled to sum to 1
+  (default `w_l=0.25`). `R` defaults to ~max(2 px, star-size-derived), stored with labels.
+  Recall is weighted (not a hard fail) to stay feasible; a strong-penalty mode is available.
+
+### Multi-run balancing (point 5)
+
+`J_total = (1−β)·mean_r(J_run,r) + β·min_r(J_run,r)`, `β=0.5`. The `min` term enforces balance
+— θ must be good on average **and** not bad on any single run.
+
+### Search algorithm (derivative-free, bounded, deterministic)
+
+- Variables: curated set, each `{type, lower, upper, initialStep}`.
+- **Seed at today's settings** θ0 and record `J(θ0)` — never silently regress below today.
+- **Phase A — coarse seed:** 3–5-level grid over the 2 highest-impact axes
+  (`BrightnessSensitivity` × `StarClippingMultiplier`), others at θ0; take the best.
+- **Phase B — compass/pattern search:** ±step per variable (integer steps for ints, flip for
+  bools), accept best improving move; on a no-improvement sweep, halve continuous steps until
+  the step floor.
+- **Caching:** memoize detection by `(frameId, StarDetector.ComputeCacheKey(θParams))`.
+- **Determinism:** detection + `SelectBestModel` are deterministic; fix evaluation order; cap
+  total evals (~400) with progress + cancel.
+
+### Curated variables and exclusions
+
+**Optimized:** `BrightnessSensitivity`, `StarClippingMultiplier`, `NoiseClippingMultiplier`,
+`StarPeakResponse`, `MaxDistortion`, `MinHFR`, `StarCenterTolerance` (continuous);
+`StructureLayers`, `NoiseReductionRadius`, `MinStarBoundingBoxSize` (integer);
+`HotpixelThresholdingEnabled` (+ `HotpixelThreshold`). Bounds from the validation ranges in
+`StarDetectionOptions.cs`.
+
+**Excluded (reason):** all PSF params (PSF off during AF — can't be tuned from AF data, follow
+Simple-mode defaults); `SaturationThreshold` + contamination (safety / separate concern);
+debug/intermediate-save flags, parallelism knobs, `PixelSampleSize` (not quality knobs).
+
+**Transfer caveat:** AF frames are defocused, so params (esp. `StructureLayers`) could skew
+large for sharp in-focus stars. Mitigation: the objective spans the whole sweep (incl.
+near-focus frames), biasing toward settings that work in both regimes; the summary surfaces
+every change and the toggle makes it reversible.
+
+### Step-size recommendation (point 7)
+
+Derived (not part of θ). From the winning fit, estimate the focus-sensitive half-width `W`
+(offset from the minimum where modeled HFR ≈ 2× the minimum HFR); then
+`recommendedStepSize ≈ round(W/3.5)` (~3–4 points/side), `recommendedOffsetSteps ≈ 4`,
+clamped to focuser limits. **Limitation:** a replay can't re-sample at a new spacing — this is
+a recommendation for future runs; written to `profile.FocuserSettings.AutoFocusStepSize` /
+`AutoFocusInitialOffsetSteps` only on Apply.
+
+---
+
+## Persistence & Toggle (point 2)
+
+Mental model: in **Simple Mode** the live advanced properties are *driven* by a single source
+— normally the 3 presets via `ConfigureSimpleSettings()`; "Use Optimized Settings" makes that
+source the **optimized snapshot** instead.
+
+- Snapshot stored separately as one JSON string key in `StarDetectionOptions` (never
+  overwrites the presets). `HasOptimizedSettings` is derived = "a snapshot exists".
+- `UseOptimizedSettings` (persisted bool, default false) added to `SimplePropertyNames`. In
+  `ConfigureSimpleSettings()` (runs only in Simple Mode), **before** preset derivation:
+  `if (UseOptimizedSettings && HasOptimizedSettings) { ApplyOptimizedSnapshotToLiveProperties(); return; }`.
+  Off → existing preset derivation runs.
+- Because optimized values land in the **live** properties, `BuildStarDetectorParams` needs
+  **no overlay**; Advanced Mode shows them in normal controls.
+- UI: toggle shown only when `!UseAdvanced && HasOptimizedSettings`; when on, the 3 preset rows
+  collapse. `ApplyOptimizedSettings(snapshot)` stores it, sets `UseAdvanced=false` +
+  `UseOptimizedSettings=true`, re-runs `ConfigureSimpleSettings()`. `ResetDefaults` clears it.
+
+---
+
+## Verification harness (`TestApp`) — two tools
+
+TestApp already loads the real NINA profile, builds params via `BuildStarDetectorParams`, and
+has headless subcommands + a WPF GUI path. Reuse `DiagnosticUtil.LoadFloatMat`,
+`ProfileService.TryLoad`, `StarDetector.Detect`, and the MTF stretch
+(`CvImageUtility.CreateMTFLookup`/`ApplyLUT`). Accepted stars from `StarList`; rejected
+candidates from `StarDetectorMetrics.*Bounds` (populated every run — no flag needed).
+
+### A. Headless `optimize`
+
+`TestApp optimize --runs <folder> [--profile-id] [--out] [--max-evals] [--annotate
+extremes|all] [--labels <dir>]`. Loads each run's frames as float `Mat`s, drives the **same**
+`StarDetectionOptimizer` (single + N>1 balanced), asserts valid stars on every frame incl.
+defocused extremes (`n_min ≥ N_hard`). Outputs: `optimize_summary.txt` (baseline vs optimized
+`J`, `σ_focus`, recommended step size, param old→new, per-frame star-count table),
+`optimize_result.csv`, and a **stretched annotated PNG per frame** (accepted = green + HFR;
+rejected = color-coded by reason from `*Bounds`; **a real star with no marker = missed
+entirely**).
+
+### B. Interactive two-pass `review` (dev tool only)
+
+`TestApp review --runs <folder> [--labels <dir>] [--params optimized|current] [--review
+low|uncertain|all]`. New `Program.cs` branch shows `StarReview/StarReviewWindow` (+ VM). Frames
+are queued only when accepted count `< N_review` **or** the optimizer flags uncertainty.
+MTF-stretched, zoom/pan display with a `Canvas` overlay (accepted + rejected-by-reason).
+Two passes (mode toggle; click→pixel via `e.GetPosition(canvas) ÷ scale`): **Mark Missed**
+(false negatives) and **Mark Should-Reject** (false positives). Labels persist to JSON
+(`runId` + focuser position, missed/should-reject points, `R`), reloaded incrementally, and
+consumed by `optimize --labels <dir>` to activate the recall/precision term. Loop:
+`optimize` → `review --labels L` → `optimize --labels L`.
+
+### Dim/large/out-of-focus star recall
+
+Long-focal-length rigs often miss faint, bloated donut stars *entirely* (not even a structure
+candidate) — a structure-detection gap the count proxy barely penalizes. A user-marked missed
+star activates the recall term, pressuring the structure axes (`StructureLayers`,
+`NoiseReductionRadius`, `NoiseClippingMultiplier`, `MinStarBoundingBoxSize`) to recover it. If
+settings alone can't, the labels prove it's detector-algorithm work (e.g. multi-scale /
+large-structure handling) — the point where the author may ask for help.

--- a/docs/star-detection-optimization-wizard-results.md
+++ b/docs/star-detection-optimization-wizard-results.md
@@ -1,0 +1,74 @@
+# Star Detection Optimization Wizard — Empirical Results
+
+Concise record of the verification runs for the optimization wizard. Design: see
+`docs/star-detection-optimization-wizard-design.md`. Performance analysis:
+`docs/star-detection-optimizer-performance-design.md`.
+
+All runs used the offline harness `TestApp optimize --per-run`, which drives the **same**
+`StarDetectionOptimizer` as the in-NINA wizard, against real saved AF sweeps loaded from the user's
+NINA profile.
+
+## Cross-setup verification (14-run bank)
+
+`optimize --per-run` over a **14-run bank spanning 11 distinct optical setups**. Three runs are
+deliberate copies — Workshop `sensitivity_example1`, `sensitivity_example2`, and `standard_example2`
+are copies of the **fmeschia**, **Linwood**, and **CWhite** setups — so they double as a
+**bit-identity check** (identical inputs → identical results across builds = detection unchanged by
+the perf refactor).
+
+### Outcome (summary; per-run detail in the harness `aggregate_summary.txt`)
+
+| Metric | Result across all 14 runs |
+|---|---|
+| Hard floor (every frame ≥ 3 stars, incl. defocused extremes) | **14/14 PASS** (lowest observed min = **5**) |
+| σ_focus (focus-position uncertainty) | **improved on all 14** (≈ **1.2× to 21×** tighter) |
+| Seed Sensitivity 1.6 raised by the optimizer | **12/14** (the seed is too sensitive) |
+
+### Findings
+
+- **The seed Sensitivity (1.6) is too sensitive.** The optimizer raised it on 12 of 14 runs.
+- **Very star-rich fields pinned the curated bounds**, so they were widened:
+  - `Sensitivity` upper bound `20 → 50`
+  - `StarClipping` bounds `[0.5, 5] → [0.25, 10]`
+- **Bound widening is roughly a wash.** A re-verify after widening showed little net change — the
+  real limiter is the **fixed coarse-grid resolution** over the (now wider) range, not the bound
+  endpoints. Logged as a follow-up (coarse-grid-resolution vs bound-range tuning).
+
+## Panos label diagnosis + defocus-aware-gate recovery
+
+The Panos setup (long focal length) misses bloated/donut defocused stars. The interactive label loop
+(`review --labels` → `diagnose-labels`) attributed each flagged miss to a specific cause:
+
+| Flagged misses | Cause (from `diagnose-labels`) |
+|---|---|
+| **9 of 9 donut stars** | **REJECTED: TooDistorted** — killed by the `MaxDistortion` gate (exact match) |
+| **4 of 5 dim misses** | **NO CANDIDATE** — structure-detection gaps (no candidate ever formed) |
+
+### Recovery via the opt-in defocus-aware gates (default OFF)
+
+The two size-scaled (size = defocus proxy) gate relaxations recover the distortion-gated donuts:
+
+| `DefocusDistortionSizeReference` | Donuts recovered | Near-focus cost (centering gate) |
+|---|---|---|
+| **30 px** (safe production default) | **8 / 9** | **zero** |
+| 20 px (harness `--defocus-size-ref 20`) | **9 / 9** | zero |
+
+`DefocusAwareCentering` additionally recovers ring-unstable donut centroids whose centers drift. The
+4/5 `NO CANDIDATE` dim misses are **not** fixable by gate relaxation — they need
+structure-detection-algorithm work (follow-up).
+
+Both gates are **opt-in, default OFF**; off returns `MaxDistortion` / `StarCenterTolerance` verbatim,
+so detection stays **bit-identical**.
+
+## Performance (before → after)
+
+Early/late split + per-frame early-context cache + bounded parallel per-frame detection.
+**Detection bit-identical** (confirmed, including the cross-setup copy-run check).
+
+| Setup | Before | After | Speedup | Notes |
+|---|---|---|---|---|
+| CWhite | 19m 51s | 1m 30s | **13.2×** | 61 MP |
+| Panos | 7m 02s | 44s | **9.6×** | `--max-evals 24` |
+
+Net **~10–13×**. The earlier logging quick-win is result-neutral but gave **no measurable speedup**
+(NINA `Logger` is buffered; detection compute dominates).

--- a/docs/star-detection-optimizer-performance-design.md
+++ b/docs/star-detection-optimizer-performance-design.md
@@ -1,6 +1,15 @@
 # Star Detection Optimizer — Performance Investigation & Speedup Design
 
-Status: investigation / design (read-only analysis; no code changed).
+Status: **Implemented.** The §3 early/late split + per-frame early-context cache (#4) AND the §4
+bounded parallel per-frame detection (#5) both shipped and were measured: **~10–13× faster,
+detection bit-identical** (CWhite 61 MP 19m51s → 1m30s = 13.2×; Panos 7m02s → 44s = 9.6× at
+`--max-evals 24`). Both apply to the in-NINA wizard for **live AND replay** sources (both converge
+on `RunEvaluationLoader` → `RunEvaluationData` → `HocusFocusSplitFrameDetector`; the offline harness
+uses an equivalent `MatSplitFrameDetector`). The §7 logging quick-win shipped too but is
+**result-neutral with no measurable speedup** (NINA `Logger` is buffered; detection compute
+dominates). The wizard per-eval convert-reuse (#1) remains DEFERRED (see §7). The analysis below is
+retained as the rationale; the "ranked recommendations" reflect what shipped vs. what is left.
+
 Scope: the Star Detection Optimization wizard and its offline harness (`TestApp optimize`).
 Goal: explain where wall-clock time goes and lay out the highest-leverage speedups, separating
 safe "pure performance" wins (must stay bit-identical) from larger refactors.
@@ -60,10 +69,12 @@ completed runs predicts **1626** — the small delta is annotated frames / a par
   (`PrepareImage`, detectStars:false) into `RunFrame.Image` (an `IRenderedImage`). The detect delegate
   (lines 138–150) re-detects the already-rendered frame.
 
-`RunEvaluationData` is documented to deliberately keep **no per-frame detection cache** (class doc,
-RunEvaluationData.cs:100–113): "the optimizer already memoizes J at the params level… caching per frame here
-would be redundant and would pin many star lists in memory." That reasoning is sound for *star-list* caching
-but it conflated star-list reuse with **early-stage image reuse** — see §3, the real opportunity.
+`RunEvaluationData` originally kept **no per-frame detection cache** (the original class doc reasoned: "the
+optimizer already memoizes J at the params level… caching per frame here would be redundant and would pin
+many star lists in memory"). That reasoning was sound for *star-list* caching but conflated star-list reuse
+with **early-stage image reuse** — see §3, the real opportunity. **As shipped**, `RunEvaluationData` now
+caches the **early `DetectionContext`** (not the star list) per (frame, early-key), which is exactly the
+reuse the original note missed; star lists are still not cached.
 
 ### Redundant per-detection allocations / copies
 
@@ -130,20 +141,25 @@ Two important nuances that make the win even larger or require care:
   part of the early-cache key. Note Phase-A's coarse grid sweeps Sensitivity (LATE) × StarClippingMultiplier
   (LATE) — **all 16 Phase-A points share one early result**, a clean 16→1 early-stage win.
 
-### Proposed split
+### Proposed split — **SHIPPED**
 
-Refactor `DetectImpl` into two phases with an intermediate, reusable artifact:
+Refactored `DetectImpl` into two phases with an intermediate, reusable artifact (the names below are
+the ones that shipped):
 
-- `BuildDetectionContext(srcImage, earlyParams) → DetectionContext` = {hotpixel-filtered source Mat,
-  candidate `StarCandidateRegion[]`, measurementNoiseSigma, structureNoiseSigma, ROI offset}. Contains
-  everything produced up to and including `CollectStarCandidates` (Stages 1–8 flood-fill). Pure function of
-  the EARLY params + image.
-- `GateAndMeasure(context, lateParams) → HocusFocusStarDetectorResult` = Stage-B `EvaluateStarCandidate`
-  over the cached regions (the cheap 22%).
+- `StarDetector.BuildDetectionContext(srcImage, earlyParams) → DetectionContext` = {hotpixel-filtered
+  source Mat, candidate regions, measurementNoiseSigma, structureNoiseSigma, ROI offset, early-only
+  metric counters}. Contains everything produced up to and including candidate collection. Pure
+  function of the EARLY params + image.
+- `StarDetector.GateAndMeasure(context, lateParams) → result` = the per-candidate `EvaluateStarCandidate`
+  pass over the cached regions (the cheap 22%).
 
-Then `RunEvaluationData`/the detect delegate caches `DetectionContext` per (frame, early-key). On a
-late-only move the early 78% is skipped. The cache key for the context is the EARLY subset of
-`ToCanonicalCacheString` (or a dedicated early-only canonical string).
+`RunEvaluationData` caches the `DetectionContext` per (frame, early-key) and reuses it across
+candidates that change only late-stage gates; on a late-only move the early 78% is skipped. The early
+key is computed by `ComputeEarlyKey` over the EARLY-only param subset. The boundary is the
+`RunEvaluationData.ISplitFrameDetector` interface (`ComputeEarlyKey` / `BuildContextAsync` /
+`GateAndMeasure`), implemented by `HocusFocusSplitFrameDetector` (wizard) and `MatSplitFrameDetector`
+(harness). Cache is bounded to one context per frame; a frame's prior context is disposed when its
+early key changes.
 
 **Architecture allows it.** Today the boundary is already clean: `CollectStarCandidates` (sequential
 flood-fill, produces independent per-candidate point lists) is followed by a parallel `EvaluateStarCandidate`
@@ -176,12 +192,11 @@ Current concurrency:
   PatternSearch.
 
 Options:
-- **(a) Parallel frame detection within an eval** — frames are independent; detect them concurrently
-  (`Task.WhenAll` over frames, bounded). Caveat: each 61 MP detection already saturates cores via the inner
-  `Parallel.For`, so naive nesting oversubscribes; the win is real only for the *early* (single-threaded)
-  stages or when frames are small. Best combined with §3 (early stage parallelized across frames). Order
-  must be re-sorted before the fit to preserve determinism (the code already pools by position into a
-  `SortedDictionary`, so frame order does not affect the fit result — safe).
+- **(a) Parallel frame detection within an eval — SHIPPED.** Frames are independent; they detect
+  concurrently in `RunEvaluationData` with a bounded degree (≈ `max(2, ProcessorCount/4)`) chosen so
+  the inner per-star `Parallel.For` is not oversubscribed. Results are assembled by frame index and
+  pooled by focuser position (`SortedDictionary`), so the fit is order-independent and deterministic.
+  Combined with §3 the early (single-threaded) stages parallelize across frames.
 - **(b) Parallel candidate evaluation** — Phase-A's 16 grid points are independent; within a Phase-B sweep
   the ±step candidates are independent (the sweep evaluates all, then picks the best). These could be a
   bounded-parallel batch. Caveats: (i) memory at 61 MP (each concurrent detection clones a ~244 MB Mat +
@@ -213,37 +228,52 @@ Options:
 - **Gate the `Console.WriteLine("PSF time")`** behind `ModelPSF`/a debug flag (§2.3). Trivial.
 - **Don't force TRACE during optimize** (§2.4) — or at least not the per-detection traces — in the wizard.
 
-## 6. Ranked recommendations
+## 6. Ranked recommendations (status)
 
 Safe quick wins (pure performance; keep results bit-identical):
 1. **Wizard: pre-convert frames to float Mats once** and use the Mat `Detect` overload (skip per-eval
-   debayer/ToOpenCVMat). High impact in the wizard, low effort, bit-identical when hotpixel params unchanged.
-   (StarDetector.cs:151–189 vs the harness pattern in OptimizationDiagnosticRunner.PrepareRunAsync.)
-2. **Lower the default `MaxEvaluations`** (400 → ~80–120) and/or add a no-improvement early stop. High impact,
-   trivial effort, search-quality tradeoff only. (StarDetectionOptimizer.cs:25.)
-3. **Gate the PSF-time `Console.WriteLine`** and avoid forcing TRACE per-detection in the wizard. Low impact,
-   trivial effort.
+   debayer/ToOpenCVMat). **DEFERRED** — folded into #4 (the convert path keys on the hotpixel params,
+   which the optimizer tunes; only the early/late refactor makes the mono-vs-bayered split safe). See §7.
+2. **Lower the default `MaxEvaluations`** (400 → ~80–120) and/or add a no-improvement early stop. Not
+   shipped on this branch (search-quality tuning, orthogonal to the per-eval cost win). (StarDetectionOptimizer.cs:25.)
+3. **Gate the PSF-time `Console.WriteLine`** and avoid forcing TRACE per-detection in the harness.
+   **SHIPPED** — result-neutral, but **no measurable speedup** (Logger is buffered). See §7.
 
 Larger refactors (bigger impact, must preserve bit-identical results):
-4. **Split `DetectImpl` into BuildDetectionContext (early) + GateAndMeasure (late), cache the early context
-   per (frame, early-key).** Highest structural impact (~2× alone; more with Phase-A reuse). Medium-high
-   effort + careful early/late param partition (encode the §3 table as the cache key; treat the cached Mat as
-   read-only). This is the change the T3 "no per-frame cache" note did not consider.
-5. **Parallelize frame detection within an eval** (bounded), ideally after #4 so the early stage parallelizes
-   across frames without oversubscribing the inner per-star `Parallel.For`. Medium effort; determinism safe
-   (fit pools by position).
-6. **Parallelize independent candidate evaluations** (Phase-A grid, Phase-B sweep) with a thread-safe memo and
-   a memory cap. Medium-high effort; determinism safe on values but needs the concurrent-memo + memory care.
-7. **Search on a downsampled/ROI image, confirm full-frame at the winner.** Medium effort; search-heuristic
-   tradeoff, final params validated full-frame.
+4. **Split `DetectImpl` into BuildDetectionContext (early) + GateAndMeasure (late), cache the early
+   context per (frame, early-key).** **SHIPPED** — `RunEvaluationData` caches the context per
+   (frame, early-key) behind the `ISplitFrameDetector` boundary; detection is bit-identical. This is
+   the change the T3 "no per-frame cache" note did not consider. (Main driver of the measured ~10–13×.)
+5. **Parallelize frame detection within an eval** (bounded). **SHIPPED** — `RunEvaluationData` detects
+   frames concurrently at degree ≈ `max(2, ProcessorCount/4)`, assembling by index and pooling by
+   position; determinism safe.
+6. **Parallelize independent candidate evaluations** (Phase-A grid, Phase-B sweep). Not shipped
+   (would need a concurrent memo + memory cap). Optional future win.
+7. **Search on a downsampled/ROI image, confirm full-frame at the winner.** Not shipped (search
+   heuristic). Optional future win.
 
 Anything touching detection math (the §3 split, parallelism) must be proven result-identical (the existing
-`ComputeCacheKey`/equivalence-signature discipline applies). Items 1–3 and 5–7's framing are pure scheduling/
-IO and do not change detection output; item 4 changes structure but must produce the same stars/values.
+`ComputeCacheKey`/equivalence-signature discipline applies). The shipped #4 changes structure but produces
+the same stars/values (verified bit-identical, incl. the cross-setup copy-run check); #5's framing is pure
+scheduling and does not change detection output.
 
-## 7. Implementation note — quick-wins pass (logging done; wizard convert-reuse DEFERRED)
+## 7. Implementation note — what shipped
 
-Implemented (pure logging/scheduling, bit-identical — no detection input/param/gate/result touched):
+Implemented (the big wins; detection **bit-identical**, measured **~10–13×**):
+- **#4 early/late split + per-frame early-context cache.** `StarDetector.DetectImpl` split into
+  `BuildDetectionContext` (early, ~78%) + `GateAndMeasure` (late, ~22%); `RunEvaluationData` caches the
+  early `DetectionContext` per (frame, early-key) and reuses it across late-only candidate moves, behind
+  the `ISplitFrameDetector` boundary (`HocusFocusSplitFrameDetector` wizard / `MatSplitFrameDetector`
+  harness). Applies to live AND replay (both converge on `RunEvaluationLoader` → `RunEvaluationData` →
+  the split detector). Cache bounded to one context per frame.
+- **#5 bounded parallel per-frame detection within an eval.** `RunEvaluationData` detects frames
+  concurrently at degree ≈ `max(2, ProcessorCount/4)`, assembled by index, pooled by focuser position;
+  fit is order-independent (deterministic).
+- **Measured:** CWhite 61 MP **19m51s → 1m30s = 13.2×**; Panos **7m02s → 44s = 9.6×** (`--max-evals 24`).
+  Verified bit-identical, including the cross-setup copy-run (identical-results) check.
+
+Implemented (pure logging/scheduling, bit-identical — **but no measurable speedup**: NINA `Logger` is
+buffered and detection compute dominates, so this is a correctness/cleanup change, not a perf win):
 - **#3 PSF-time write + per-detection TRACE.** `StarDetector.cs` no longer does a `Console.WriteLine("PSF
   time…")` on every detection: the whole PSF block (incl. the timer) is now inside `if (p.ModelPSF)` and the
   timing line is `Logger.Trace`. During AF/optimize (`ModelPSF=false`, always) that block is skipped entirely.
@@ -252,6 +282,15 @@ Implemented (pure logging/scheduling, bit-identical — no detection input/param
   detection `Logger.Trace` stage-timing lines short-circuit (no disk serialization) on the common path. The
   `contamination` runner is unchanged. The wizard does not call `SetLogLevel`, so it already respects the
   user's configured level — nothing to fix there.
+
+### Related: defocus-aware detector gates (opt-in, default OFF)
+
+Separate from performance, the same branch added two opt-in, default-off, size-scaled gate relaxations
+(`DefocusAwareDistortion`, `DefocusAwareCentering`) that recover bloated/donut defocused stars rejected by
+the `MaxDistortion` / centering gates. Default-OFF returns the gates verbatim, so they keep detection
+**bit-identical** and do not affect any of the perf measurements above. See
+`docs/star-detection-optimization-wizard-design.md` (and the results doc) for the diagnosis and recovery
+rates.
 
 DEFERRED — #1 wizard per-eval IRenderedImage→Mat convert-reuse (needs the §3 refactor, not a quick win):
 The §2.2/§5/§6.1 framing ("bit-identical *when hotpixel params unchanged*") is the catch. The curated

--- a/docs/star-detection-optimizer-performance-design.md
+++ b/docs/star-detection-optimizer-performance-design.md
@@ -1,0 +1,271 @@
+# Star Detection Optimizer — Performance Investigation & Speedup Design
+
+Status: investigation / design (read-only analysis; no code changed).
+Scope: the Star Detection Optimization wizard and its offline harness (`TestApp optimize`).
+Goal: explain where wall-clock time goes and lay out the highest-leverage speedups, separating
+safe "pure performance" wins (must stay bit-identical) from larger refactors.
+
+## 1. Time budget — where the wall-clock goes
+
+A single optimization run does:
+
+```
+wall ≈ (distinct evaluator calls) × (frames per run) × (per-frame Detect)   [+ small fixed overhead]
+```
+
+- **Distinct evaluator calls** = the optimizer's cache MISSES (`StarDetectionOptimizer.SearchContext.EvalJ`
+  memoizes J on `StarDetector.ComputeCacheKey`, so revisited points are free). Bounded by
+  `OptimizerSettings.MaxEvaluations`. Harness runs used `--max-evals 24`; the **wizard default is 400**
+  (`OptimizerSettings.MaxEvaluations = 400`, StarDetectionOptimizer.cs:25).
+- **Frames per run** = number of saved AF exposures (observed bank: 7–10 frames/run).
+- **Per-frame Detect** = one `StarDetector.DetectImpl` pass over a full-resolution float Mat.
+
+There is also a fixed tail per optimization: the seed + best are re-evaluated against every run for the
+summary (`OptimizeRunSetAsync` perRunSeed/perRunBest; wizard `BuildSummaryAsync` lines 495–496) = +2×frames
+detections, plus 1–2 annotated detections. So total detections ≈ `(MaxEvals + 2) × frames + ~2`.
+
+### Per-detection stage split (measured, real bank `run.log`)
+
+These are real TRACE lines (`StarDetector.cs|DetectImpl`), a large sensor (~5 s/frame; the file's frames are
+bigger than the 4656×3520 example in the brief):
+
+| Stage | Typical | Share | Depends on (params) |
+|---|---|---|---|
+| LoadImage | ~0.0 s | ~0% | (ROI submat only) |
+| SrcImagePreparation | 0.31–0.52 s | ~6% | HotpixelFiltering, HotpixelThresholdingEnabled, HotpixelThreshold, NoiseReductionRadius, StarMeasurementNoiseReductionEnabled |
+| StructureMapPreparation | 0.35–0.51 s | ~7% | NoiseReductionRadius, (hotpixel\*) — copies + 2nd Gaussian + launches K-σ noise tasks |
+| **WaveletCalculation** | **2.1–2.5 s** | **~44%** | **StructureLayers** (à-trous B3-spline, `numLayers` separable filter passes; kernel widens per layer) |
+| PostWaveletConvolution | 0.15–0.17 s | ~3% | StructureLayers (Gaussian of radius `StructureLayers·2+1`) |
+| **BinarizationStatistics** | **0.9–1.2 s** | **~21%** | (histogram median of structure map; param-independent) + awaits the K-σ noise tasks (NoiseClippingMultiplier) |
+| Binarization | ~0.02 s | <1% | NoiseClippingMultiplier (threshold), Region.InnerCrop |
+| **StarAnalysis** | **0.9–1.3 s** | **~22%** | gate params: Sensitivity, StarClippingMultiplier, PeakResponse, MaxDistortion, MinHFR, StarCenterTolerance, MinimumStarBoundingBoxSize, BackgroundBoxExpansion, AnalysisSamplingSize |
+| Elapsed | 4.8–6.0 s | 100% | |
+
+**61 MP vs mid-sensor:** every stage is ≈ linear in pixel count (full-frame OpenCV filters + raster
+scans + per-pixel noise estimate). A 24 MP frame ≈ 1.4 s (brief's figure); a 61 MP frame ≈ 5–6 s. So the
+24-eval, 7-frame Panos run = (24+2)×7 + 2 ≈ 184 detections × ~5 s ≈ **~15 min** (matches the observed
+~20 min at 61 MP with overhead). At the wizard default 400 evals it would be **~16×** that.
+
+Cross-check: the bank `--per-run` batch logged **1659** detections; summing `(24+2)×frames+2` over the 7
+completed runs predicts **1626** — the small delta is annotated frames / a partial run. The model holds.
+
+## 2. File I/O — definitive
+
+**Files are loaded ONCE per run and held in memory; they are NOT re-read per evaluation.** Both paths:
+
+- **Harness** (`OptimizationDiagnosticRunner.PrepareRunAsync`, lines 330–339): each frame is loaded once via
+  `DiagnosticUtil.LoadFloatMat` into `RunFrame.Image` (a `Mat`) and cached; `DisposeRuns` frees them at the
+  end. The detect delegate (lines 354–360) does **not** touch disk.
+- **Wizard** (`RunEvaluationLoader.LoadSavedRunAsync`, lines 103–116): each saved exposure is rendered once
+  (`PrepareImage`, detectStars:false) into `RunFrame.Image` (an `IRenderedImage`). The detect delegate
+  (lines 138–150) re-detects the already-rendered frame.
+
+`RunEvaluationData` is documented to deliberately keep **no per-frame detection cache** (class doc,
+RunEvaluationData.cs:100–113): "the optimizer already memoizes J at the params level… caching per frame here
+would be redundant and would pin many star lists in memory." That reasoning is sound for *star-list* caching
+but it conflated star-list reuse with **early-stage image reuse** — see §3, the real opportunity.
+
+### Redundant per-detection allocations / copies
+
+1. **Mat clone per detection (both paths).**
+   - Harness: `using var clone = ((Mat)image).Clone();` before every `Detect` (line 357) because
+     `DetectImpl` mutates its input in place (ROI submat, hotpixel filter, Gaussian). At 61 MP a CV_32F clone
+     is ~244 MB memcpy — small vs the 5 s detect, but non-trivial and repeated `MaxEvals×frames` times.
+   - This clone is **unavoidable as long as `DetectImpl` mutates `srcImage`**; it is the price of the
+     in-place pipeline.
+2. **Wizard path re-runs the IRenderedImage→Mat conversion every eval.** `starDetector.Detect(image, …)`
+   (the `IRenderedImage` overload, StarDetector.cs:151–189) re-does, per candidate: a full `ushort[]` copy,
+   CFA hotpixel filter, **debayer**, and `ToOpenCVMat` — *before* `DetectImpl` even starts. The harness avoids
+   this by pre-converting to a float Mat once. This is pure wasted work in the wizard (the conversion output is
+   identical across candidates **unless** the candidate changes `HotpixelThreshold`/`HotpixelThresholdingEnabled`
+   — and only when `HotpixelFiltering && HotpixelThresholdingEnabled` and the image is debayered).
+3. **`Console.WriteLine($"PSF time: …")` runs on every detection even when `ModelPSF=false`**
+   (StarDetector.cs:378). Harmless per call, but 1659× to a console is measurable; trivially gated.
+4. **Verbose TRACE logging.** The optimizer forces `LogLevel = TRACE` (harness) and `DetectImpl` emits
+   several `Logger.Trace` lines + K-σ traces per detection. Per detection the logging is small relative to
+   ~5 s, but across `MaxEvals×frames` detections it is real I/O; it is *not* the bottleneck (the stage timers
+   bound it), but production/wizard runs should not be at TRACE.
+
+## 3. The reuse opportunity (the big one): split Detect into "build candidates" + "gate/measure"
+
+### Param → stage dependency map (for the 12 curated optimizer variables)
+
+| Variable | Type | Affects EARLY (image→structure map→candidate regions) | Affects LATE (StarAnalysis gating/measure) |
+|---|---|---|---|
+| Sensitivity | Continuous | no | **yes** (EvaluateStarCandidate sensitivity gate) |
+| StarClippingMultiplier | Continuous | no | **yes** (clip margin in ComputeStarParameters + MeasureStar) |
+| PeakResponse | Continuous | no | **yes** (TooFlat gate + NormalizedBrightness) |
+| MaxDistortion | Continuous | no | **yes** (distortion gate) |
+| MinHFR | Continuous | no | **yes** (HFR floor) |
+| StarCenterTolerance | Continuous | no | **yes** (IsStarCentered) |
+| MinimumStarBoundingBoxSize | Integer | no | **yes** (TooSmall gate) |
+| NoiseClippingMultiplier | Continuous | **yes** (binarize threshold → which structure pixels survive → candidate regions; also K-σ) | no (only via the σ baked into candidates) |
+| StructureLayers | Integer | **yes** (wavelet layers + post-wavelet blur radius) | no |
+| NoiseReductionRadius | Integer | **yes** (Gaussian on structure-map source; SrcImagePreparation) | no |
+| HotpixelThresholdingEnabled | Boolean | **yes** (hotpixel filter mode) | no |
+| HotpixelThreshold | Continuous | **yes** (hotpixel filter threshold) | no |
+
+So of the 12 variables, **7 are LATE-only** (Sensitivity, StarClippingMultiplier, PeakResponse,
+MaxDistortion, MinHFR, StarCenterTolerance, MinimumStarBoundingBoxSize) and **5 are EARLY** (NoiseClipping,
+StructureLayers, NoiseReductionRadius, Hotpixel×2). The expensive stages — Wavelet (44%) +
+BinarizationStatistics (21%) + SrcImagePrep/StructureMapPrep (13%) ≈ **78% of per-detection time** — depend
+ONLY on the 5 EARLY variables. StarAnalysis (~22%) depends on the 7 LATE variables.
+
+### Why this matters for the search
+
+Phase B (compass/pattern search) perturbs **one variable at a time** (`ProposeMove`). Every move that
+perturbs a LATE-only variable reuses the *identical* hotpixel-filtered source image, structure map,
+candidate regions, and noise σ — only the per-candidate gating/measurement changes. With 7 LATE vs 5 EARLY
+variables and the search spending most of its budget in Phase B compass moves, **a large majority of
+evaluations change only late-stage gates.** Caching the early result keyed on the EARLY-subset would let
+those evals skip ~78% of the work.
+
+Two important nuances that make the win even larger or require care:
+- **`StarClippingMultiplier` is LATE but reaches into `ComputeStarParameters`/`MeasureStar`** (the clip
+  margin), which today live inside the parallel candidate-evaluation stage — so it is correctly LATE: the
+  candidate *regions* (flood-fill on the binarized structure map) do not depend on it.
+- **`NoiseClippingMultiplier` is the one subtle EARLY var**: it sets the binarize threshold AND the K-σ
+  clipping. It changes which pixels enter the structure map → the candidate region set. So a cache keyed only
+  on {StructureLayers, NoiseReductionRadius, Hotpixel×2} would be wrong if NoiseClipping changed; it must be
+  part of the early-cache key. Note Phase-A's coarse grid sweeps Sensitivity (LATE) × StarClippingMultiplier
+  (LATE) — **all 16 Phase-A points share one early result**, a clean 16→1 early-stage win.
+
+### Proposed split
+
+Refactor `DetectImpl` into two phases with an intermediate, reusable artifact:
+
+- `BuildDetectionContext(srcImage, earlyParams) → DetectionContext` = {hotpixel-filtered source Mat,
+  candidate `StarCandidateRegion[]`, measurementNoiseSigma, structureNoiseSigma, ROI offset}. Contains
+  everything produced up to and including `CollectStarCandidates` (Stages 1–8 flood-fill). Pure function of
+  the EARLY params + image.
+- `GateAndMeasure(context, lateParams) → HocusFocusStarDetectorResult` = Stage-B `EvaluateStarCandidate`
+  over the cached regions (the cheap 22%).
+
+Then `RunEvaluationData`/the detect delegate caches `DetectionContext` per (frame, early-key). On a
+late-only move the early 78% is skipped. The cache key for the context is the EARLY subset of
+`ToCanonicalCacheString` (or a dedicated early-only canonical string).
+
+**Architecture allows it.** Today the boundary is already clean: `CollectStarCandidates` (sequential
+flood-fill, produces independent per-candidate point lists) is followed by a parallel `EvaluateStarCandidate`
+pass; the late stage only *reads* the source image + regions. The clone-on-mutate concern (§2.1) means the
+cached context's source Mat must be treated as read-only by the late stage — it already is
+(`EvaluateStarCandidate`/`ComputeStarParameters`/`MeasureStar` only read `srcImage`).
+
+**Risk / determinism:** the refactor must keep results **bit-identical**. The split is value-preserving only
+if the early/late param partition is exactly correct — the table above must be encoded as the cache key, and
+any param not provably late-only must stay in the early key (same "safe failure mode = spurious miss"
+discipline as `ComputeCacheKey`). Memory: one cached source Mat + region lists per frame per distinct early-key
+(at 61 MP, ~244 MB per cached source) — must bound the cache (e.g. keep only the current early-key's contexts,
+i.e. one set of frame contexts at a time, since the compass search moves the incumbent).
+
+**Estimated speedup:** if ~⅔ of evals are late-only and the early stage is 78% of a detection, late-only evals
+cost ~0.22× → overall detect time ≈ ⅓·1.0 + ⅔·0.22 ≈ **0.48×**, i.e. ~2× faster, before any parallelism.
+Combined with Phase-A's 16→1 early reuse the practical win is larger.
+
+## 4. Parallelism opportunities
+
+Current concurrency:
+- **Within a detection:** `ScanStars` evaluates candidates with `Parallel.For` governed by
+  `MaxStarEvaluationParallelism` (default 0 ⇒ `Environment.ProcessorCount`), StarDetector.cs:774. The two
+  K-σ noise estimates run on `Task.Run` concurrently with the structure-map prep. PSF fit is parallel but
+  **off** during AF/optimize (`ModelPSF=false`). So the *late* stage already uses all cores; the *early*
+  stage (wavelet/binarization-stats) is largely single-threaded OpenCV calls.
+- **Across frames within an eval:** SEQUENTIAL — `RunEvaluationData.EvaluateAndFitAsync` lines 160–165 detect
+  frames in a `foreach` "deterministic order". 7–10 frames done one at a time.
+- **Across candidates:** SEQUENTIAL — `EvalJ` is awaited one candidate at a time in both CoarseGrid and
+  PatternSearch.
+
+Options:
+- **(a) Parallel frame detection within an eval** — frames are independent; detect them concurrently
+  (`Task.WhenAll` over frames, bounded). Caveat: each 61 MP detection already saturates cores via the inner
+  `Parallel.For`, so naive nesting oversubscribes; the win is real only for the *early* (single-threaded)
+  stages or when frames are small. Best combined with §3 (early stage parallelized across frames). Order
+  must be re-sorted before the fit to preserve determinism (the code already pools by position into a
+  `SortedDictionary`, so frame order does not affect the fit result — safe).
+- **(b) Parallel candidate evaluation** — Phase-A's 16 grid points are independent; within a Phase-B sweep
+  the ±step candidates are independent (the sweep evaluates all, then picks the best). These could be a
+  bounded-parallel batch. Caveats: (i) memory at 61 MP (each concurrent detection clones a ~244 MB Mat +
+  buffers); (ii) the memo is a plain `Dictionary` (not thread-safe) — concurrent `EvalJ` needs a concurrent
+  memo or a gather-then-insert; (iii) determinism — results must be identical regardless of completion order
+  (the "take best strictly-improving, ties⇒no move" rule is order-independent on values, so as long as J is
+  deterministic per-candidate, parallel evaluation is safe).
+- **Determinism guard:** detection itself must remain deterministic under parallelism — it already sorts
+  bounds by (Y,X) and assembles stars in index order (`ScanStars`), so per-candidate J is reproducible.
+
+## 5. Other wins
+
+- **Lower the wizard default budget.** 400 is very high for a 12-var compass search seeded by a 16-point
+  grid; the harness improved J meaningfully at 24. Estimate the natural stopping point: Phase B halves
+  continuous steps from InitialStep down to InitialStep×0.125 = **3 halvings**; with 7 continuous + integer/
+  boolean axes a typical search converges in well under 100 evals. A default of ~80–120 (or an
+  early-stop on "no improvement across a full sweep after step-floor") would cut wall-clock several-fold with
+  little quality loss. (Pure tuning; no result-correctness risk — only changes how long the search runs.)
+- **Early-stop the compass search** when a full sweep yields no strictly-improving move AND continuous steps
+  are at floor — the loop already terminates there; the lever is the budget cap and the floor fraction.
+- **Downsample / region for the search, full pass at the end.** Run the search on a center ROI or a binned
+  image (fast, ~linear speedup), then do ONE full-frame confirm at the winning params. Risk: changes results
+  during the search (acceptable — it is a search heuristic) but the final applied params are validated full-
+  frame. Region plumbing already exists (`StarDetectionRegion`, `p.Region`).
+- **Skip the per-detection IRenderedImage→Mat re-conversion in the wizard** (see §2.2): pre-convert each
+  frame to a float Mat once (as the harness does) and feed the Mat `Detect` overload, re-doing the CFA
+  hotpixel/debayer step only when a candidate changes the hotpixel params. Pure perf; bit-identical when the
+  hotpixel params are unchanged.
+- **Gate the `Console.WriteLine("PSF time")`** behind `ModelPSF`/a debug flag (§2.3). Trivial.
+- **Don't force TRACE during optimize** (§2.4) — or at least not the per-detection traces — in the wizard.
+
+## 6. Ranked recommendations
+
+Safe quick wins (pure performance; keep results bit-identical):
+1. **Wizard: pre-convert frames to float Mats once** and use the Mat `Detect` overload (skip per-eval
+   debayer/ToOpenCVMat). High impact in the wizard, low effort, bit-identical when hotpixel params unchanged.
+   (StarDetector.cs:151–189 vs the harness pattern in OptimizationDiagnosticRunner.PrepareRunAsync.)
+2. **Lower the default `MaxEvaluations`** (400 → ~80–120) and/or add a no-improvement early stop. High impact,
+   trivial effort, search-quality tradeoff only. (StarDetectionOptimizer.cs:25.)
+3. **Gate the PSF-time `Console.WriteLine`** and avoid forcing TRACE per-detection in the wizard. Low impact,
+   trivial effort.
+
+Larger refactors (bigger impact, must preserve bit-identical results):
+4. **Split `DetectImpl` into BuildDetectionContext (early) + GateAndMeasure (late), cache the early context
+   per (frame, early-key).** Highest structural impact (~2× alone; more with Phase-A reuse). Medium-high
+   effort + careful early/late param partition (encode the §3 table as the cache key; treat the cached Mat as
+   read-only). This is the change the T3 "no per-frame cache" note did not consider.
+5. **Parallelize frame detection within an eval** (bounded), ideally after #4 so the early stage parallelizes
+   across frames without oversubscribing the inner per-star `Parallel.For`. Medium effort; determinism safe
+   (fit pools by position).
+6. **Parallelize independent candidate evaluations** (Phase-A grid, Phase-B sweep) with a thread-safe memo and
+   a memory cap. Medium-high effort; determinism safe on values but needs the concurrent-memo + memory care.
+7. **Search on a downsampled/ROI image, confirm full-frame at the winner.** Medium effort; search-heuristic
+   tradeoff, final params validated full-frame.
+
+Anything touching detection math (the §3 split, parallelism) must be proven result-identical (the existing
+`ComputeCacheKey`/equivalence-signature discipline applies). Items 1–3 and 5–7's framing are pure scheduling/
+IO and do not change detection output; item 4 changes structure but must produce the same stars/values.
+
+## 7. Implementation note — quick-wins pass (logging done; wizard convert-reuse DEFERRED)
+
+Implemented (pure logging/scheduling, bit-identical — no detection input/param/gate/result touched):
+- **#3 PSF-time write + per-detection TRACE.** `StarDetector.cs` no longer does a `Console.WriteLine("PSF
+  time…")` on every detection: the whole PSF block (incl. the timer) is now inside `if (p.ModelPSF)` and the
+  timing line is `Logger.Trace`. During AF/optimize (`ModelPSF=false`, always) that block is skipped entirely.
+  The `optimize` harness (`OptimizationDiagnosticRunner.cs`) now defaults to `LogLevelEnum.INFO` instead of
+  forcing `TRACE`, with an opt-in `--verbose` flag that restores `TRACE`; this makes the detector's per-
+  detection `Logger.Trace` stage-timing lines short-circuit (no disk serialization) on the common path. The
+  `contamination` runner is unchanged. The wizard does not call `SetLogLevel`, so it already respects the
+  user's configured level — nothing to fix there.
+
+DEFERRED — #1 wizard per-eval IRenderedImage→Mat convert-reuse (needs the §3 refactor, not a quick win):
+The §2.2/§5/§6.1 framing ("bit-identical *when hotpixel params unchanged*") is the catch. The curated
+optimizer variable set (`OptimizerVariable.CreateCuratedSet`) **tunes `HotpixelThresholdingEnabled` and
+`HotpixelThreshold`** (and `NoiseReductionRadius`). For **bayered (`IDebayeredImage`) frames**, those two are
+exactly the params that drive the per-eval conversion branch in `StarDetector.Detect(IRenderedImage)` (the
+CFA-hotpixel-filter + debayer + `ToOpenCVMat` path, lines ~158–171): changing them changes the converted
+pixels, so a convert-once cache would change results across candidates. A cache keyed on exactly
+`(HotpixelFiltering, HotpixelThresholdingEnabled, HotpixelThreshold)` would be *correct* but would essentially
+never hit (the optimizer perturbs those keys), yielding no real speedup while adding cache-correctness risk.
+The genuinely safe win — convert-once for **mono** AF frames, where the `IDebayeredImage` branch is dead and
+the conversion is always the param-independent `ToOpenCVMat(image)` — requires the loader to reliably split
+the mono vs. bayered path. That is structural and belongs with the early/late-stage refactor (§3/#4), which
+already has to make the cached source Mat read-only and key it on the EARLY params (which include the hotpixel
+params). Per the "bit-identical safety beats the speedup" rule, this is left to that refactor. The harness
+(`OptimizationDiagnosticRunner.PrepareRunAsync`) already pre-converts each frame to a float Mat once and clones
+per eval, so it pays no per-eval conversion cost regardless.

--- a/plans/star-detection-followups-plan.md
+++ b/plans/star-detection-followups-plan.md
@@ -1,0 +1,72 @@
+# Star Detection Optimization — Follow-ups Plan
+
+**Context / rationale:** `docs/star-detection-optimization-wizard-design.md` ("Follow-ups" section) and
+`docs/star-detection-optimization-wizard-results.md` (cross-setup + Panos donut diagnosis). These are the
+deferred items from the wizard branch (PR #55: `ghilios/star-detection-optimization-wizard`).
+
+**Branch:** create `ghilios/star-detection-followups` **off `ghilios/star-detection-optimization-wizard`**
+(the follow-ups depend on the wizard/perf/defocus-gate code, which is in PR #55, not yet on `develop`). Once
+PR #55 merges, rebase onto `develop`. Never push `develop`; PR to merge.
+**Commit identity:** `George Hilios <322725+ghilios@users.noreply.github.com>` (author + committer), per CLAUDE.md.
+**After each task:** `cmd.exe /c "dotnet build Joko.NINA.Plugins\Joko.NINA.Plugins.sln -c Debug --nologo"`
+(+ `TestApp\TestApp.csproj`) and `dotnet test ... -c Debug`; fix root causes before continuing.
+CLAUDE.md rules apply (options need UI + tooltips; new `StarDetectorMetrics` fields need the metrics panel).
+The user will supply the AF-runs folder `D:\Autofocus Bank` for verification items (F2/F3/F4).
+
+The two defocus-aware gates and the harnesses already exist (see CLAUDE.md "Star Detection Optimizer
+harnesses" + the `DefocusAware*` options). Build on them; keep new detector behavior **opt-in / default-OFF**
+so detection stays bit-identical when disabled.
+
+---
+
+## F1 — Expose the distortion size reference as a tunable (quick; → 9/9 donut recovery)
+Surface `StarDetectorParams.DefocusDistortionSizeReference` (and consider `DefocusDistortionMinFactor`,
+`DefocusCenteringToleranceFactor`) as **Advanced** `StarDetectionOptions` (UnitTextBox + DoubleRangeRule +
+tooltip per CLAUDE.md), wire through `BuildStarDetectorParams` + `ResetDefaults`, default unchanged (30 / 0.25
+/ 2.0). **Verify:** persistence round-trip test; with the gates ON and a lower size-ref, `TestApp diagnose-labels`
+on Panos 44396 recovers 9/9 (it already does at `--defocus-size-ref 20`).
+
+## F2 — Precision validation of the relaxed gates (verification; informs F3)
+Confirm the *new* accepts the distortion relaxation admits on moderately-defocused frames are real stars, not
+junk. Use `review`/`diagnose-labels` (`--defocus-distortion --defocus-centering`) on Panos 40396/42396 (and a
+2nd setup) to label false positives; quantify the near-focus false-positive rate vs the donut recall gain.
+Decide a safe default size-ref. **Deliverable:** a short results note appended to
+`docs/star-detection-optimization-wizard-results.md`. (Needs the AF-runs folder + interactive review.)
+**Checkpoint with the user before F3.**
+
+## F3 — Optimizer integration of the defocus gates, guarded by a precision penalty
+Add the gate flags (and possibly the size-ref) to the optimizer's curated set **only after** wiring a
+**precision / false-positive penalty** into `OptimizationObjective` (else the search cranks recall and floods
+near-focus). Likely a near-focus junk proxy (e.g. fraction of accepted stars that are large + low-fill on the
+near-focus frames, or a per-frame star-count-stability term). **Verify:** the labeled `optimize --labels` loop
+on Panos now improves recall *without* tanking precision; unlabeled path stays bit-identical (default-OFF
+gates); re-run the 14-run bank to confirm no regression. **Checkpoint before this objective change.**
+
+## F4 — Structure-detection for dim "no-candidate" misses (research)
+4/5 of the flagged Panos misses were true structure gaps (the detector never forms a candidate). Investigate
+multi-scale / large-structure / sensitivity handling for dim, bloated defocused stars (e.g. `StructureLayers`
+/ wavelet behavior at large defocus). Prototype opt-in/default-OFF; verify via `diagnose-labels` that
+previously NO-CANDIDATE boxes become candidates without exploding the candidate count near focus. Exploratory
+— scope a spike first.
+
+## F5 — Cosmetic: joint-mode `optimized_settings.json` out-dir copy
+In joint mode the `--out` copy of `optimized_settings.json` reflects the *last* run's recommended step (the
+per-run source-folder copies are correct). Either write the joint winner's representative step, or omit the
+out-dir copy in joint mode. Small fix in `OptimizationDiagnosticRunner`.
+
+## F6 — Coarse-grid resolution vs bound range (optimizer tuning)
+Widening the curated bounds (Sensitivity 20→50, StarClipping→[0.25,10]) was ~a wash because the fixed
+`CoarseGridLevels=4` coarsens over a wider range. Consider scaling grid levels with the variable range, or a
+finer compass step on the two high-impact axes. **Verify:** re-run the bound-pinned setups (CWhite, mccomiskey,
+muggsie, timmer) and confirm J/σ_focus improve vs the current wide-bounds result, deterministically.
+
+---
+
+## Order & checkpoints
+F1 → F5 → F2 (verification, **checkpoint**) → F3 (**checkpoint before the objective change**) → F6 → F4 (spike).
+F1/F5 are quick + independent; F2 gates F3; F4 is exploratory and can be deferred or split to its own PR.
+
+## Global verification
+Full `dotnet test` green; `TestApp optimize`/`review`/`diagnose-labels` exercised on `D:\Autofocus Bank`;
+all new detector behavior default-OFF ⇒ bit-identical when disabled (diff star counts + J vs committed
+baselines for any setup). PR to `develop` (or to the wizard branch if PR #55 is still open).

--- a/plans/star-detection-optimization-wizard-plan.md
+++ b/plans/star-detection-optimization-wizard-plan.md
@@ -1,0 +1,118 @@
+# Star Detection Optimization Wizard — Implementation Plan
+
+**Design / methodology:** `docs/star-detection-optimization-wizard-design.md` (read first).
+**Branch:** `ghilios/star-detection-optimization-wizard` (never push `develop`; PR to merge).
+**Commit identity:** `George Hilios <322725+ghilios@users.noreply.github.com>` (author +
+committer), per `CLAUDE.md`.
+
+This plan is decomposed into independently-reviewable tasks for subagent-driven execution.
+Each task lists its files, the existing code to reuse, and its own verification gate. Build
+after every task; run `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`
+and fix root causes before moving on.
+
+## Architecture
+
+### New files (plugin, under `Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/`)
+
+| File | Responsibility |
+|---|---|
+| `OptimizerVariable.cs` | Descriptor per tunable knob: name, get/set on `StarDetectorParams`, type (continuous/int/bool), bounds, initial step. |
+| `OptimizationObjective.cs` | Composite `J_run` (S_focus/S_stars/S_fit + optional label recall/precision) from a fit + metrics + labels; tunable-constants block; multi-run `J_total`. |
+| `OptimizedStarDetectionSettings.cs` | Serializable DTO snapshot (curated values) + metadata (date, #runs, baseline/final J, recommended step size/offset). |
+| `RunEvaluationData.cs` | Loaded-once per-run frames (focuser pos + image) + the matching detection delegate. Wizard: `IRenderedImage`; harness: float `Mat`. |
+| `StarDetectionOptimizer.cs` | Search engine: coarse seed + compass/pattern search, caching, multi-run aggregation. Depends only on a **detection delegate** `Func<frame, StarDetectorParams, CancellationToken, Task<HocusFocusStarDetectionResult>>`, `IAlglibAPI`, AF fit options. No WPF/mediator deps. |
+| `StarDetectionOptimizerWizardVM.cs` | Wizard VM (`BaseINPC`, not `DockableVM`), enum step state, async commands, progress, cancel, summary, Apply. Dual MEF/test constructors. |
+| `DataTemplates.xaml` (+ `.xaml.cs`) | Window content template, key `NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.StarDetectionOptimizerWizardVM`; data-source / acquire / optimize / summary panels. |
+
+### Modified files (plugin)
+
+| File | Change |
+|---|---|
+| `Interfaces/IStarDetectionOptions.cs` | Add `bool HasOptimizedSettings { get; }`, `bool UseOptimizedSettings { get; set; }`, `OptimizedStarDetectionSettings GetOptimizedSettings()`, `void ApplyOptimizedSettings(OptimizedStarDetectionSettings)`. |
+| `StarDetection/StarDetectionOptions.cs` | Persist snapshot as JSON string + `UseOptimizedSettings` bool (`HasOptimizedSettings` derived); load in `InitializeOptions`, clear in `ResetDefaults`; add `UseOptimizedSettings` to `SimplePropertyNames`; `ConfigureSimpleSettings()` optimized branch (before preset derivation); `ApplyOptimizedSettings()` per design. |
+| `StarDetection/HocusFocusStarDetection.cs` | **No change** to `BuildStarDetectorParams` (reads live properties). |
+| `Resources/OptionsDataTemplates.xaml` | Top-of-page "Optimize Star Detection…" button; Simple-Mode "Use Optimized Settings" checkbox (visible only when `HasOptimizedSettings`); collapse the 3 preset rows when `UseOptimizedSettings`; tooltips. |
+| `HocusFocusPlugin.cs` | `OptimizeStarDetectionCommand` (`RelayCommand`) builds the wizard VM and shows it via `IWindowServiceFactory`. |
+
+### New files (TestApp)
+
+| File | Responsibility |
+|---|---|
+| `TestApp/OptimizationDiagnosticRunner.cs` | Headless `optimize` subcommand (mirrors `ContaminationDiagnosticRunner.cs`); harness detection delegate via `StarDetector.Detect(Mat)`; reports + annotated PNGs. |
+| `TestApp/StarReview/StarReviewRunner.cs` | `review` arg parse, load runs, build review queue, persist labels, optional re-optimize. |
+| `TestApp/StarReview/StarReviewWindow.xaml(.cs)`, `StarReviewVM.cs`, `StarReviewLabels.cs` | Interactive two-pass click UI + label model. |
+| `TestApp/Program.cs` (modify) | Add `optimize` and `review` dispatch branches. |
+
+### Reuse (do not reinvent)
+
+- `AlglibHyperbolicFitting.SelectBestModel` / `ComputeLeaveOneOutBestFocusStdError`.
+- `HocusFocusStarDetection.BuildStarDetectorParams` / `GetStarDetectorParams` / `ToHocusFocusParams`; `IHocusFocusStarDetection.Detect`.
+- `IAutoFocusEngine.LoadSavedAutoFocusAttempt` / `GetOptions(savedAttempt)` / `Run`; `AutoFocusEngineFactory`.
+- Wizard image load like `InspectorVM.LoadSavedFile` (`imageDataFactory.CreateFromFile` + `imagingMediator.PrepareImage`).
+- `ScatterErrorPoint`, `MeasureAndError`, `SafeDisplayError`.
+- TestApp: `DiagnosticUtil.LoadFloatMat`, `ProfileService`, `StarDetector.Detect(Mat,…)`, `CvImageUtility` MTF stretch + `BuildStretchedBgr` pattern, `StarDetector.ComputeCacheKey`.
+- `ProgressFactory.Create`, `AsyncRelayCommand`, `CancellationTokenSource`, `PluginOptionsAccessor`.
+
+---
+
+## Task breakdown (ordered; note dependencies)
+
+**T1 — Options model & toggle** (no deps). `OptimizedStarDetectionSettings.cs`; modify
+`IStarDetectionOptions.cs` + `StarDetectionOptions.cs` per design (snapshot persistence,
+`ConfigureSimpleSettings` optimized branch, `ApplyOptimizedSettings`, `SimplePropertyNames`,
+`ResetDefaults`). **Verify (tests):** toggle off → preset-derived live values; on → snapshot
+values (and `BuildStarDetectorParams` reflects them); JSON round-trip; `HasOptimizedSettings`
+false→true; `ResetDefaults` clears; on→off restores presets.
+
+**T2 — Optimizer core** (no deps; pure). `OptimizerVariable.cs`, `OptimizationObjective.cs`,
+`StarDetectionOptimizer.cs` with the detection-delegate abstraction. **Verify (tests):**
+objective monotonicity + hard-fails; pattern search reaches a synthetic optimum within budget,
+never worse than seed, deterministic; multi-run β behavior; label recall/precision terms shift
+θ and keep weights summing to 1.
+
+**T3 — Run evaluation + fit + step size** (deps T2). `RunEvaluationData.cs`; wizard-side
+loader (saved attempt → frames); per-frame detect → pool → `ScatterErrorPoint` → `SelectBestModel`
+→ σ_focus/R²/reducedχ²; step-size/offset recommendation. **Verify:** synthetic fit of known
+width → ~3–4 points/side; a real saved run loads and scores end-to-end (exercised by T6).
+
+**T4 — Wizard VM + window** (deps T1–T3). `StarDetectionOptimizerWizardVM.cs`,
+`Optimization/DataTemplates.xaml(.cs)`; step flow (data source / acquire / optimize / summary),
+STARHFR guard, live progress + cancel, summary table, Apply → `ApplyOptimizedSettings` +
+profile step-size write on confirm. **Verify:** unit-test the VM step transitions / summary
+model; manual window smoke later.
+
+**T5 — Options UI + launch** (deps T1, T4). `Resources/OptionsDataTemplates.xaml` button +
+toggle + preset hiding + tooltips; `HocusFocusPlugin.cs` `OptimizeStarDetectionCommand` via
+`IWindowServiceFactory`. **Verify:** builds; manual smoke in NINA later.
+
+**T6 — TestApp headless `optimize`** (deps T2, T3). `OptimizationDiagnosticRunner.cs` +
+`Program.cs` branch; harness delegate via `StarDetector.Detect(Mat)`; summary/CSV + stretched
+annotated PNGs. **Verify:** run on a real folder of AF runs; `n_min ≥ N_hard`; inspect PNGs.
+
+**T7 — TestApp interactive `review`** (deps T6). `StarReview/*` + `Program.cs` branch; two-pass
+clicking, selective queue, JSON labels; `optimize --labels` consumes them. **Verify:** label a
+frame, confirm JSON persists and re-`optimize --labels` activates the recall/precision term.
+
+**T8 — Docs, CLAUDE.md, PR** (deps all). Ensure `docs/` design is current; document `optimize`
++ `review` in `CLAUDE.md` by the contamination-runner section; final full build + tests; open
+PR to `develop`.
+
+---
+
+## Global verification
+
+1. `cmd.exe /c "dotnet build Joko.NINA.Plugins\Joko.NINA.Plugins.sln -c Debug --nologo"` and
+   `... TestApp\TestApp.csproj ...` — both clean.
+2. `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo` — all green.
+3. **Harness** `TestApp optimize --runs <folder>` on the user-supplied AF runs: completes,
+   valid stars on every frame incl. defocused extremes; review annotated PNGs for misses.
+4. **Interactive** `TestApp review --runs <folder>`: low-count/uncertain frames queued; pass 1
+   (missed) + pass 2 (should-reject); labels persist; re-`optimize --labels` recovers flagged
+   misses (or makes the gap explicit).
+5. NINA: Star Detection options shows the button; toggle absent until a run. Wizard (separate
+   window) replays N=1 → summary (changed params, before/after σ_focus, recommended step).
+   Apply → Simple Mode + toggle on + presets hidden; Advanced Mode shows optimized values;
+   snapshot persists across reload/profile switch; step size/offset written. Toggle off/on
+   reverts/reapplies. N=2 → single balanced setting (cross-check harness combined result).
+
+> The user will supply a path to a folder of several autofocus runs for steps 3–4.


### PR DESCRIPTION
## Summary

Adds a **Star Detection Optimization Wizard** that auto-tunes the star-detection options (and recommends an AF step size) for a user's optical train by replaying or running autofocus sweeps and searching for the settings that produce the most reliable HFR-vs-focuser curve. Optimized settings are saved separately and toggled with a single Simple-Mode option. Along the way this branch also delivers a large **optimizer performance** improvement, two opt-in **defocus-aware detector gates**, and a `TestApp` dev-tool suite for verification.

Design/methodology: `docs/star-detection-optimization-wizard-design.md`; perf: `docs/star-detection-optimizer-performance-design.md`; empirical results: `docs/star-detection-optimization-wizard-results.md`.

## What's included

**Wizard (the feature):** optimized-settings snapshot + Simple-Mode "Use Optimized Settings" toggle; pure derivative-free optimizer (curated variables, composite objective S_focus/S_stars/S_fit + optional label recall/precision, coarse-seed + compass/pattern search, memoized & deterministic); AF run-evaluation (detect → pool → `AlglibHyperbolicFitting.SelectBestModel` → σ_focus/R²/χ²) with byte-identical pooling to the AF engine; step-size recommendation; wizard VM + modal window via `IWindowServiceFactory`; options-page launch button. `BuildStarDetectorParams` is unchanged — optimized values land in the live properties.

**Performance (~10–13×, bit-identical detection):** detection split into a cacheable EARLY context (hotpixel/structure-map/wavelet/binarization/candidate-collection) + a LATE gate/measure phase; the optimizer's `RunEvaluationData` caches the early context per (frame, early-key) and reuses it across candidates that change only late-stage gates, plus bounded parallel per-frame detection. Both apply to the in-NINA wizard for **live and replay** data sources. Measured: CWhite 61MP 19m51s→1m30s (13.2×), Panos 7m02s→44s (9.6×) at `--max-evals 24`, with per-frame star counts and J byte-identical to baseline.

**Defocus-aware detector gates (opt-in, default OFF → bit-identical when off):** size-scaled relaxations of the `MaxDistortion` and `NotCentered` gates so bloated/donut defocused stars survive while near-focus junk is still rejected. Recover 8/9 human-flagged donut stars on a real run at the safe default (9/9 with a tighter size reference), with zero near-focus cost from the centering gate.

**TestApp dev tooling:** headless `optimize` (attempt-anchored run discovery, `--per-run`, writes `optimized_settings.json` per run); interactive two-pass `review` (box-based 3-category labels — missed/should-reject/wrongly-rejected — drag-box for missed, actual-size detector boxes, zoom-invariant markers; runs on a dedicated STA thread); `diagnose-labels` (classifies each labeled box as accepted / rejected-by-reason / structure-gap). Loop: `optimize` → `review --labels` → `optimize --labels`.

## Verification

- Full suite: **1117 tests pass, 0 failed**; solution + TestApp build clean.
- Each task: TDD + two-stage review (spec then quality); the production-touching perf work also got adversarial concurrency/bit-identity review. All blocking findings fixed and re-verified.
- Cross-setup: ran `optimize --per-run` over a 14-run bank (11 distinct setups). All PASS the hard floor (≥3 stars on every frame incl. defocused extremes); σ_focus improved in every setup (≈1.2–21×).
- Detection result-identity confirmed against real data for the caching + parallel refactors (J, σ_focus, and per-frame star counts byte-identical). All opt-in detector gates default OFF, preserving existing behavior.

## Documented follow-ups (not in this PR)

- Expose `DefocusDistortionSizeReference` as a tunable (reaches 9/9 donut recovery for long-FL rigs).
- Add the defocus-aware gates to the optimizer's curated set only behind a precision/false-positive penalty.
- Structure-detection improvement for dim "no-candidate" missed stars (4/5 of the flagged misses were true structure gaps).
- Coarse-grid-resolution vs bound-range tuning (widening the curated bounds was ~a wash because the fixed 4-level coarse grid coarsens over a wider range).

## Notes

- Commit identity is `George Hilios <322725+ghilios@users.noreply.github.com>` throughout.
- History is linear and interdependent (perf builds on the wizard; gates build on perf), so it's one PR rather than split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
