### PR TITLE
Star detection optimizer wizard: options UI + wizard flow UX (PR1/3)

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationSummaryTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationSummaryTests.cs
@@ -1,0 +1,85 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Optimization;
+
+/// <summary>
+/// Unit tests for the pure, de-jargoned summary formatting + improvement math on <see cref="OptimizationSummary"/>
+/// (starry-hopper items 5/8): the before→after / "(unchanged)" recommendation text, the σ "tighter" readout, and
+/// the higher-is-better improvement percentage.
+/// </summary>
+[TestFixture]
+public class OptimizationSummaryTests {
+
+    [Test]
+    public void FormatRecommendation_Changed_UsesArrow() {
+        Assert.That(OptimizationSummary.FormatRecommendation(150, 105), Is.EqualTo("150 → 105"));
+    }
+
+    [Test]
+    public void FormatRecommendation_Unchanged_SaysSo() {
+        Assert.That(OptimizationSummary.FormatRecommendation(105, 105), Is.EqualTo("105 (unchanged)"));
+    }
+
+    [Test]
+    public void StepSizeText_AndOffsetStepsText_FollowRecommendationFormat() {
+        var changed = new OptimizationSummary { CurrentStepSize = 150, RecommendedStepSize = 105, CurrentOffsetSteps = 4, RecommendedOffsetSteps = 4 };
+        Assert.Multiple(() => {
+            Assert.That(changed.StepSizeText, Is.EqualTo("150 → 105"));
+            Assert.That(changed.OffsetStepsText, Is.EqualTo("4 (unchanged)"));
+        });
+    }
+
+    [Test]
+    public void StepSizeOrOffsetChanged_TrueWhenEitherDiffers() {
+        Assert.Multiple(() => {
+            Assert.That(new OptimizationSummary { CurrentStepSize = 150, RecommendedStepSize = 105, CurrentOffsetSteps = 4, RecommendedOffsetSteps = 4 }.StepSizeOrOffsetChanged, Is.True);
+            Assert.That(new OptimizationSummary { CurrentStepSize = 100, RecommendedStepSize = 100, CurrentOffsetSteps = 4, RecommendedOffsetSteps = 5 }.StepSizeOrOffsetChanged, Is.True);
+            Assert.That(new OptimizationSummary { CurrentStepSize = 100, RecommendedStepSize = 100, CurrentOffsetSteps = 4, RecommendedOffsetSteps = 4 }.StepSizeOrOffsetChanged, Is.False);
+        });
+    }
+
+    [Test]
+    public void SigmaText_ShowsTighterPercent_WhenImproved() {
+        var s = new OptimizationSummary { SeedSigmaFocus = 2.0, BestSigmaFocus = 1.0 };
+        Assert.That(s.SigmaText, Does.Contain("2.00 → 1.00").And.Contain("50% tighter"));
+    }
+
+    [Test]
+    public void SigmaText_NoTighterSuffix_WhenNotImprovedOrNonFinite() {
+        Assert.Multiple(() => {
+            Assert.That(new OptimizationSummary { SeedSigmaFocus = 1.0, BestSigmaFocus = 1.0 }.SigmaText, Is.EqualTo("1.00 → 1.00"));
+            Assert.That(new OptimizationSummary { SeedSigmaFocus = double.NaN, BestSigmaFocus = 1.0 }.SigmaText, Does.Not.Contain("tighter"));
+        });
+    }
+
+    [Test]
+    public void PercentBetter_HigherIsBetter_ClampedAndGuarded() {
+        Assert.Multiple(() => {
+            Assert.That(OptimizationSummary.PercentBetter(1.0, 1.5), Is.EqualTo(50.0).Within(1e-9), "higher best => positive %");
+            Assert.That(OptimizationSummary.PercentBetter(2.0, 1.0), Is.EqualTo(0.0), "a lower 'best' clamps to 0 (no improvement)");
+            Assert.That(OptimizationSummary.PercentBetter(1.0, 1.0), Is.EqualTo(0.0));
+            Assert.That(OptimizationSummary.PercentBetter(0.0, 5.0), Is.EqualTo(0.0), "near-zero baseline guarded");
+            Assert.That(OptimizationSummary.PercentBetter(double.NaN, 1.0), Is.EqualTo(0.0));
+            Assert.That(OptimizationSummary.PercentBetter(1.0, double.PositiveInfinity), Is.EqualTo(0.0));
+        });
+    }
+
+    [Test]
+    public void ImprovementPercent_UsesObjectiveScore() {
+        var s = new OptimizationSummary { SeedJ = 1.0, BestJ = 1.2 };
+        Assert.That(s.ImprovementPercent, Is.EqualTo(20.0).Within(1e-9));
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationSummaryTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationSummaryTests.cs
@@ -58,10 +58,20 @@ public class OptimizationSummaryTests {
     }
 
     [Test]
-    public void SigmaText_NoTighterSuffix_WhenNotImprovedOrNonFinite() {
+    public void SigmaText_Unchanged_SaysUnchanged() {
+        // σ effectively the same before/after (at the F2 precision shown) reads "2.20 (unchanged)", not "2.20 → 2.20".
         Assert.Multiple(() => {
-            Assert.That(new OptimizationSummary { SeedSigmaFocus = 1.0, BestSigmaFocus = 1.0 }.SigmaText, Is.EqualTo("1.00 → 1.00"));
-            Assert.That(new OptimizationSummary { SeedSigmaFocus = double.NaN, BestSigmaFocus = 1.0 }.SigmaText, Does.Not.Contain("tighter"));
+            Assert.That(new OptimizationSummary { SeedSigmaFocus = 2.20, BestSigmaFocus = 2.20 }.SigmaText, Is.EqualTo("2.20 (unchanged)"));
+            Assert.That(new OptimizationSummary { SeedSigmaFocus = 2.201, BestSigmaFocus = 2.203 }.SigmaText, Is.EqualTo("2.20 (unchanged)"));
+        });
+    }
+
+    [Test]
+    public void SigmaText_NonFinite_FallsBackToBaseText_NoTighterOrUnchanged() {
+        var s = new OptimizationSummary { SeedSigmaFocus = double.NaN, BestSigmaFocus = 1.0 }.SigmaText;
+        Assert.Multiple(() => {
+            Assert.That(s, Does.Not.Contain("tighter"));
+            Assert.That(s, Does.Not.Contain("unchanged"));
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -161,7 +161,9 @@ public class StarDetectionOptimizerWizardVMTests {
         IRunEvaluationLoader loader,
         IStarDetectionOptions options = null,
         IProfileService profileService = null,
-        Func<IReadOnlyList<FrameReviewDescriptor>, StarDetectorParams, CancellationToken, Task<List<FrameReview>>> frameReviewBuilder = null) {
+        Func<IReadOnlyList<FrameReviewDescriptor>, StarDetectorParams, CancellationToken, Task<List<FrameReview>>> frameReviewBuilder = null,
+        Func<bool> isCameraConnected = null,
+        Func<bool> isFocuserConnected = null) {
         options ??= Substitute.For<IStarDetectionOptions>();
         profileService ??= Substitute.For<IProfileService>();
         return new StarDetectionOptimizerWizardVM(
@@ -172,7 +174,9 @@ public class StarDetectionOptimizerWizardVMTests {
             folderPicker: () => @"C:\fake\attempt",
             region: StarDetectionRegion.Full,
             optimizerSettings: new OptimizerSettings { MaxEvaluations = 200, CoarseGridLevels = 4, StepFloorFraction = 0.125 },
-            frameReviewBuilder: frameReviewBuilder);
+            frameReviewBuilder: frameReviewBuilder,
+            isCameraConnected: isCameraConnected,
+            isFocuserConnected: isFocuserConnected);
     }
 
     // An HONEST fake review builder: it maps EACH supplied descriptor to one FrameReview (so the ReviewVM's queue
@@ -754,6 +758,70 @@ public class StarDetectionOptimizerWizardVMTests {
     }
 
     // ---- Source mode + summary UX (starry-hopper PR1) ---------------------------------------------------
+
+    // ---- Start validation (starry-hopper) ---------------------------------------------------------------
+
+    [Test]
+    public void CanStart_SavedMode_DisabledUntilEveryRunHasAPath() {
+        var vm = NewVM(LoaderReturning(GoodRun("a"), GoodRun("b")));
+        vm.RunCount = 2;
+        Assert.That(vm.StartCommand.CanExecute(null), Is.False, "no paths yet");
+        vm.SourcePaths[0] = @"C:\run1";
+        Assert.That(vm.StartCommand.CanExecute(null), Is.False, "only one of two paths set");
+        vm.SourcePaths[1] = @"C:\run2";
+        Assert.That(vm.StartCommand.CanExecute(null), Is.True, "both paths set");
+    }
+
+    [Test]
+    public void CanStart_LiveMode_EnabledEvenWithoutPaths() {
+        var vm = NewVM(LoaderReturning(GoodRun()));
+        vm.SourcePaths[0] = null;
+        vm.SourceMode = SourceMode.Live;
+        Assert.That(vm.StartCommand.CanExecute(null), Is.True, "Live needs no source paths");
+    }
+
+    [Test]
+    public async Task Start_SavedMode_DuplicatePaths_SetsErrorAndDoesNotLoad() {
+        var loader = LoaderReturning(GoodRun("a"), GoodRun("b"));
+        var vm = NewVM(loader);
+        vm.RunCount = 2;
+        vm.SourcePaths[0] = @"C:\same\run";
+        vm.SourcePaths[1] = @"C:\same\run";
+
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.ErrorMessage, Does.Contain("different"));
+            Assert.That(vm.CurrentStep, Is.Not.EqualTo(WizardStep.Summary));
+            loader.DidNotReceiveWithAnyArgs().LoadSavedRunAsync(default, default, default);
+        });
+    }
+
+    [Test]
+    public async Task Start_LiveMode_CameraDisconnected_SetsError() {
+        var vm = NewVM(LoaderReturning(GoodRun()), isCameraConnected: () => false, isFocuserConnected: () => true);
+        vm.SourceMode = SourceMode.Live;
+
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.ErrorMessage, Does.Contain("camera").IgnoreCase);
+            Assert.That(vm.CurrentStep, Is.Not.EqualTo(WizardStep.Summary));
+        });
+    }
+
+    [Test]
+    public async Task Start_LiveMode_FocuserDisconnected_SetsError() {
+        var vm = NewVM(LoaderReturning(GoodRun()), isCameraConnected: () => true, isFocuserConnected: () => false);
+        vm.SourceMode = SourceMode.Live;
+
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.ErrorMessage, Does.Contain("focuser").IgnoreCase);
+            Assert.That(vm.CurrentStep, Is.Not.EqualTo(WizardStep.Summary));
+        });
+    }
 
     [Test]
     public void IsReplay_TracksSourceMode() {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -753,6 +753,46 @@ public class StarDetectionOptimizerWizardVMTests {
         Assert.That(vm.ReviewVM, Is.Not.Null);
     }
 
+    // ---- Source mode + summary UX (starry-hopper PR1) ---------------------------------------------------
+
+    [Test]
+    public void IsReplay_TracksSourceMode() {
+        var vm = NewVM(LoaderReturning(GoodRun()));
+        Assert.That(vm.IsReplay, Is.True, "default source is Saved Auto-Focus (Replay)");
+        vm.SourceMode = SourceMode.Live;
+        Assert.That(vm.IsReplay, Is.False, "Live mode hides the runs/browse inputs");
+        vm.SourceMode = SourceMode.Replay;
+        Assert.That(vm.IsReplay, Is.True);
+    }
+
+    [Test]
+    public async Task CanApplyRecommendedStepSize_MatchesSummaryChange() {
+        var vm = NewVM(LoaderReturning(GoodRun()));
+        vm.SourcePaths[0] = @"C:\run1";
+        await vm.StartAsync(CancellationToken.None);
+        Assert.That(vm.CanApplyRecommendedStepSize, Is.EqualTo(vm.Summary.StepSizeOrOffsetChanged));
+    }
+
+    [Test]
+    public async Task ChangedParametersDisplay_IncludesAfRows_OnlyWhenToggleOnAndChanged() {
+        var vm = NewVM(LoaderReturning(GoodRun()));
+        vm.SourcePaths[0] = @"C:\run1";
+        await vm.StartAsync(CancellationToken.None);
+
+        var s = vm.Summary;
+        var baseCount = s.ChangedParameters.Count;
+        var afRows = (s.RecommendedStepSize != s.CurrentStepSize ? 1 : 0)
+                   + (s.RecommendedOffsetSteps != s.CurrentOffsetSteps ? 1 : 0);
+
+        vm.ApplyRecommendedStepSize = false;
+        Assert.That(vm.ChangedParametersDisplay.Count, Is.EqualTo(baseCount), "AF rows hidden when the toggle is off");
+
+        vm.ApplyRecommendedStepSize = true;
+        var expected = vm.CanApplyRecommendedStepSize ? baseCount + afRows : baseCount;
+        Assert.That(vm.ChangedParametersDisplay.Count, Is.EqualTo(expected),
+            "AF rows appear only when the toggle is on AND the recommendation actually changed");
+    }
+
     [Test]
     public async Task Start_MissingSourcePath_SetsErrorAndDoesNotLoad() {
         var loader = LoaderReturning(GoodRun());

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarReviewTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarReviewTests.cs
@@ -166,6 +166,64 @@ public class StarReviewTests {
         }
     }
 
+    // ---- Cleaner label filenames (starry-hopper item 16) ------------------------------------------------
+
+    [Test]
+    public void FileNameFor_PathLikeRunId_UsesLastTwoSegments() {
+        Assert.Multiple(() => {
+            Assert.That(StarReviewLabelStore.FileNameFor(@"E:\WorkshopData\Data\autofocus\sensitivity_example1\attempt01"),
+                Is.EqualTo("sensitivity_example1_attempt01.json"));
+            Assert.That(StarReviewLabelStore.FileNameFor("/home/me/run5/attempt02"),
+                Is.EqualTo("run5_attempt02.json"));
+        });
+    }
+
+    [Test]
+    public void FileNameFor_SingleSegment_IsUnchanged() {
+        // Back-compat: a bare runId (as the unit tests and the offline discovery use) keeps its simple name.
+        Assert.That(StarReviewLabelStore.FileNameFor("attempt01"), Is.EqualTo("attempt01.json"));
+    }
+
+    [Test]
+    public void FileNameFor_EmptyOrInvalid_FallsBackAndSanitizes() {
+        Assert.Multiple(() => {
+            Assert.That(StarReviewLabelStore.FileNameFor(null), Is.EqualTo("run.json"));
+            Assert.That(StarReviewLabelStore.FileNameFor("   "), Is.EqualTo("run.json"));
+            // Invalid filename characters in the derived stem are sanitized away (ordinal char scan — Does.Contain
+            // is culture-aware and mis-handles control chars).
+            var name = StarReviewLabelStore.FileNameFor(@"C:\a:b\c*d");
+            Assert.That(name, Does.EndWith(".json"));
+            Assert.That(name.IndexOfAny(Path.GetInvalidFileNameChars()), Is.LessThan(0),
+                "no invalid filename characters survive sanitization");
+        });
+    }
+
+    [Test]
+    public void SaveThenLoad_PathLikeRunId_RoundTripsViaCleanFilename() {
+        var dir = Path.Combine(Path.GetTempPath(), "hf-review-test-" + Guid.NewGuid().ToString("N"));
+        try {
+            var runId = @"E:\WorkshopData\sensitivity_example1\attempt01";
+            var labels = new StarReviewRunLabels { RunId = runId, RadiusPx = 6.0 };
+            var pos = StarReviewLabelStore.GetOrAddPosition(labels, 5000);
+            StarReviewLabelStore.ToggleBox(pos.Missed, 10, 20, 8, 8);
+
+            var savedPath = StarReviewLabelStore.Save(dir, labels);
+            Assert.That(Path.GetFileName(savedPath), Is.EqualTo("sensitivity_example1_attempt01.json"),
+                "the on-disk file uses the clean run-derived name");
+
+            var reloaded = StarReviewLabelStore.Load(dir, runId, out var err);
+            Assert.Multiple(() => {
+                Assert.That(err, Is.Null);
+                Assert.That(reloaded.Positions, Has.Count.EqualTo(1), "the clean filename round-trips through Load");
+                Assert.That(reloaded.Positions[0].Missed, Has.Count.EqualTo(1));
+            });
+        } finally {
+            if (Directory.Exists(dir)) {
+                Directory.Delete(dir, true);
+            }
+        }
+    }
+
     [Test]
     public void SaveThenLoad_MergesIncrementally() {
         var dir = Path.Combine(Path.GetTempPath(), "hf-review-test-" + Guid.NewGuid().ToString("N"));

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/HocusFocusPlugin.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/HocusFocusPlugin.cs
@@ -48,6 +48,7 @@ namespace NINA.Joko.Plugins.HocusFocus {
         // lazily when the user clicks "Optimize Star Detection…", well after MEF composition, so these are safe to
         // reuse for building its RunEvaluationLoader + detector.
         private readonly IProfileService profileService;
+        private readonly ICameraMediator cameraMediator;
         private readonly IFocuserMediator focuserMediator;
         private readonly IImagingMediator imagingMediator;
         private readonly IImageDataFactory imageDataFactory;
@@ -71,6 +72,7 @@ namespace NINA.Joko.Plugins.HocusFocus {
             IPluggableBehaviorSelector<IStarDetection> starDetectionSelector,
             IPluggableBehaviorSelector<IStarAnnotator> starAnnotatorSelector) {
             this.profileService = profileService;
+            this.cameraMediator = cameraMediator;
             this.focuserMediator = focuserMediator;
             this.imagingMediator = imagingMediator;
             this.imageDataFactory = imageDataFactory;
@@ -159,6 +161,8 @@ namespace NINA.Joko.Plugins.HocusFocus {
                 profileService,
                 imageDataFactory,
                 imagingMediator,
+                cameraMediator,
+                focuserMediator,
                 autoFocusEngine,
                 detection);
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Options.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Options.xaml
@@ -124,7 +124,9 @@
                                 <RowDefinition />
                                 <RowDefinition />
                             </Grid.RowDefinitions>
-                            <StackPanel Grid.Column="0" Orientation="Vertical">
+                            <!--  HorizontalAlignment=Left so the panel hugs the options content; the button then
+                                  centers OVER the options block rather than over the whole window.  -->
+                            <StackPanel Grid.Column="0" HorizontalAlignment="Left" Orientation="Vertical">
                                 <Button
                                     Margin="5,5,5,10"
                                     HorizontalAlignment="Center"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Options.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Options.xaml
@@ -124,33 +124,48 @@
                                 <RowDefinition />
                                 <RowDefinition />
                             </Grid.RowDefinitions>
-                            <!--  HorizontalAlignment=Left so the panel hugs the options content; the button then
-                                  centers OVER the options block rather than over the whole window.  -->
-                            <StackPanel Grid.Column="0" HorizontalAlignment="Left" Orientation="Vertical">
-                                <Button
-                                    Margin="5,5,5,10"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    Command="{Binding OptimizeStarDetectionCommand}"
-                                    ToolTip="{StaticResource OptimizeStarDetection_Tooltip}">
-                                    <TextBlock
-                                        Margin="10,5,10,5"
-                                        Foreground="{StaticResource ButtonForegroundBrush}"
-                                        Text="Optimize Star Detection"
-                                        TextWrapping="Wrap" />
-                                </Button>
+                            <!--  IsSharedSizeScope so the button rows below can share the options grid's label/value
+                                  column widths and center over exactly that area (not the wider padded grid).  -->
+                            <StackPanel Grid.Column="0" Grid.IsSharedSizeScope="True" HorizontalAlignment="Left" Orientation="Vertical">
+                                <!--  Optimize button centered over the label (col0) + value (col1) area.  -->
+                                <Grid Margin="5,5,5,10">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="HF_SDCol0" />
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="HF_SDCol1" />
+                                    </Grid.ColumnDefinitions>
+                                    <Button
+                                        Grid.Column="0"
+                                        Grid.ColumnSpan="2"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        Command="{Binding OptimizeStarDetectionCommand}"
+                                        ToolTip="{StaticResource OptimizeStarDetection_Tooltip}">
+                                        <TextBlock
+                                            Margin="10,5,10,5"
+                                            Foreground="{StaticResource ButtonForegroundBrush}"
+                                            Text="Optimize Star Detection"
+                                            TextWrapping="Wrap" />
+                                    </Button>
+                                </Grid>
                                 <ContentControl Content="{Binding}" ContentTemplate="{StaticResource HocusFocus_StarDetection_Options}" />
-                                <Button
-                                    Margin="5"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    Command="{Binding ResetStarDetectionDefaultsCommand}">
-                                    <TextBlock
-                                        Margin="10,5,10,5"
-                                        Foreground="{StaticResource ButtonForegroundBrush}"
-                                        Text="Reset Defaults"
-                                        TextWrapping="Wrap" />
-                                </Button>
+                                <Grid Margin="5">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="HF_SDCol0" />
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="HF_SDCol1" />
+                                    </Grid.ColumnDefinitions>
+                                    <Button
+                                        Grid.Column="0"
+                                        Grid.ColumnSpan="2"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        Command="{Binding ResetStarDetectionDefaultsCommand}">
+                                        <TextBlock
+                                            Margin="10,5,10,5"
+                                            Foreground="{StaticResource ButtonForegroundBrush}"
+                                            Text="Reset Defaults"
+                                            TextWrapping="Wrap" />
+                                    </Button>
+                                </Grid>
                             </StackPanel>
                         </Grid>
                     </TabItem.Content>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Options.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Options.xaml
@@ -124,48 +124,22 @@
                                 <RowDefinition />
                                 <RowDefinition />
                             </Grid.RowDefinitions>
-                            <!--  IsSharedSizeScope so the button rows below can share the options grid's label/value
-                                  column widths and center over exactly that area (not the wider padded grid).  -->
-                            <StackPanel Grid.Column="0" Grid.IsSharedSizeScope="True" HorizontalAlignment="Left" Orientation="Vertical">
-                                <!--  Optimize button centered over the label (col0) + value (col1) area.  -->
-                                <Grid Margin="5,5,5,10">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto" SharedSizeGroup="HF_SDCol0" />
-                                        <ColumnDefinition Width="Auto" SharedSizeGroup="HF_SDCol1" />
-                                    </Grid.ColumnDefinitions>
-                                    <Button
-                                        Grid.Column="0"
-                                        Grid.ColumnSpan="2"
-                                        HorizontalAlignment="Center"
-                                        VerticalAlignment="Center"
-                                        Command="{Binding OptimizeStarDetectionCommand}"
-                                        ToolTip="{StaticResource OptimizeStarDetection_Tooltip}">
-                                        <TextBlock
-                                            Margin="10,5,10,5"
-                                            Foreground="{StaticResource ButtonForegroundBrush}"
-                                            Text="Optimize Star Detection"
-                                            TextWrapping="Wrap" />
-                                    </Button>
-                                </Grid>
+                            <!--  The "Optimize Star Detection" button now lives INSIDE the options ContentControl
+                                  (HocusFocus_StarDetection_Options) so it centers over the settings' label/value
+                                  columns. Only "Reset Defaults" stays host-side (the dock VM has no reset command).  -->
+                            <StackPanel Grid.Column="0" HorizontalAlignment="Left" Orientation="Vertical">
                                 <ContentControl Content="{Binding}" ContentTemplate="{StaticResource HocusFocus_StarDetection_Options}" />
-                                <Grid Margin="5">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto" SharedSizeGroup="HF_SDCol0" />
-                                        <ColumnDefinition Width="Auto" SharedSizeGroup="HF_SDCol1" />
-                                    </Grid.ColumnDefinitions>
-                                    <Button
-                                        Grid.Column="0"
-                                        Grid.ColumnSpan="2"
-                                        HorizontalAlignment="Center"
-                                        VerticalAlignment="Center"
-                                        Command="{Binding ResetStarDetectionDefaultsCommand}">
-                                        <TextBlock
-                                            Margin="10,5,10,5"
-                                            Foreground="{StaticResource ButtonForegroundBrush}"
-                                            Text="Reset Defaults"
-                                            TextWrapping="Wrap" />
-                                    </Button>
-                                </Grid>
+                                <Button
+                                    Margin="5"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Command="{Binding ResetStarDetectionDefaultsCommand}">
+                                    <TextBlock
+                                        Margin="10,5,10,5"
+                                        Foreground="{StaticResource ButtonForegroundBrush}"
+                                        Text="Reset Defaults"
+                                        TextWrapping="Wrap" />
+                                </Button>
                             </StackPanel>
                         </Grid>
                     </TabItem.Content>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
@@ -982,17 +982,23 @@
                     </Style.Triggers>
                 </Style>
             </Grid.Resources>
+            <!--  col0 (labels) + col1 (values) carry shared-size groups so the "Optimize Star Detection" /
+                  "Reset Defaults" buttons (hosted outside this grid) can center over exactly the label+value
+                  area — NOT the wider grid, whose col2 (Advanced path browse) and Advanced rows pad the width.  -->
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" SharedSizeGroup="HF_SDCol0" />
+                <ColumnDefinition Width="Auto" SharedSizeGroup="HF_SDCol1" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition />
-                <RowDefinition Style="{StaticResource ShowOnUseSimpleNotOptimized}" />
-                <RowDefinition Style="{StaticResource ShowOnUseSimpleNotOptimized}" />
-                <RowDefinition Style="{StaticResource ShowOnUseSimpleNotOptimized}" />
+                <!--  Row 1: "Use Optimized Settings" toggle (Simple + HasOptimized) — placed ABOVE the
+                      Noise Level / Pixel Scale / Focus Range presets it replaces. Rows 2-4: those presets,
+                      shown only when NOT using the optimized settings.  -->
                 <RowDefinition Style="{StaticResource ShowOnSimpleHasOptimized}" />
+                <RowDefinition Style="{StaticResource ShowOnUseSimpleNotOptimized}" />
+                <RowDefinition Style="{StaticResource ShowOnUseSimpleNotOptimized}" />
+                <RowDefinition Style="{StaticResource ShowOnUseSimpleNotOptimized}" />
                 <RowDefinition Style="{StaticResource ShowOnUseSimple}" />
                 <RowDefinition Style="{StaticResource ShowOnUseSimple}" />
                 <RowDefinition />
@@ -1059,14 +1065,14 @@
                 ToolTip="{StaticResource UseAdvanced_Tooltip}" />
 
             <TextBlock
-                Grid.Row="1"
+                Grid.Row="2"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Noise Level"
                 ToolTip="{StaticResource SimpleNoiseLevel_Tooltip}" />
             <ComboBox
                 Name="PART_NoiseLevelEnumList"
-                Grid.Row="1"
+                Grid.Row="2"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"
@@ -1083,14 +1089,14 @@
             </ComboBox>
 
             <TextBlock
-                Grid.Row="2"
+                Grid.Row="3"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Pixel Scale"
                 ToolTip="{StaticResource SimplePixelScale_Tooltip}" />
             <ComboBox
                 Name="PART_PixelScaleEnumList"
-                Grid.Row="2"
+                Grid.Row="3"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"
@@ -1107,14 +1113,14 @@
             </ComboBox>
 
             <TextBlock
-                Grid.Row="3"
+                Grid.Row="4"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Focus Range"
                 ToolTip="{StaticResource SimpleFocusRange_Tooltip}" />
             <ComboBox
                 Name="PART_FocusRangeEnumList"
-                Grid.Row="3"
+                Grid.Row="4"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"
@@ -1130,9 +1136,9 @@
                 </ComboBox.ItemTemplate>
             </ComboBox>
 
-            <!--  Simple-Mode toggle: drive detection from the wizard's optimized settings. Shown only in Simple Mode once optimized settings exist (!UseAdvanced && HasOptimizedSettings).  -->
+            <!--  Simple-Mode toggle: drive detection from the wizard's optimized settings. Shown only in Simple Mode once optimized settings exist (!UseAdvanced && HasOptimizedSettings). Placed ABOVE the presets it replaces.  -->
             <TextBlock
-                Grid.Row="4"
+                Grid.Row="1"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Use Optimized Settings"
@@ -1145,7 +1151,7 @@
                 </TextBlock.Visibility>
             </TextBlock>
             <CheckBox
-                Grid.Row="4"
+                Grid.Row="1"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
@@ -899,6 +899,31 @@
         </Grid>
     </DataTemplate>
     <DataTemplate x:Key="HocusFocus_StarDetection_Options">
+        <!--  IsSharedSizeScope so the Optimize button can share the options grid's label (col0) + value (col1)
+              column widths and center over EXACTLY that area. The button lives in the SAME template as the grid
+              (not in the host outside the ContentControl), so the shared-size groups reliably link — centering a
+              host-side button across the ContentControl boundary did not work.  -->
+        <StackPanel Grid.IsSharedSizeScope="True">
+            <!--  Optimize Star Detection — centered over the label+value columns (excludes the Advanced browse col).  -->
+            <Grid Margin="5,5,5,10" HorizontalAlignment="Left">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" SharedSizeGroup="HF_SDCol0" />
+                    <ColumnDefinition Width="Auto" SharedSizeGroup="HF_SDCol1" />
+                </Grid.ColumnDefinitions>
+                <Button
+                    Grid.Column="0"
+                    Grid.ColumnSpan="2"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Command="{Binding OptimizeStarDetectionCommand}"
+                    ToolTip="{StaticResource OptimizeStarDetection_Tooltip}">
+                    <TextBlock
+                        Margin="10,5,10,5"
+                        Foreground="{StaticResource ButtonForegroundBrush}"
+                        Text="Optimize Star Detection"
+                        TextWrapping="Wrap" />
+                </Button>
+            </Grid>
         <Grid
             Margin="5"
             VerticalAlignment="Top"
@@ -2001,6 +2026,7 @@
                 IsChecked="{Binding StarDetectionOptions.SaveIntermediateImages}"
                 ToolTip="{StaticResource SaveIntermediateFiles_Tooltip}" />
         </Grid>
+        </StackPanel>
     </DataTemplate>
     <DataTemplate x:Key="HocusFocus_StarAnnotator_Options">
         <Grid Margin="5" VerticalAlignment="Top">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
@@ -913,6 +913,20 @@
                         </DataTrigger>
                     </Style.Triggers>
                 </Style>
+                <!--  Defocus tuning knobs: advanced-mode AND the Defocus-Aware Gates toggle must both be on (the
+                      knobs are meaningless when the gates are off).  -->
+                <Style x:Key="ShowOnUseAdvancedAndDefocusGates" TargetType="{x:Type RowDefinition}">
+                    <Setter Property="Height" Value="0" />
+                    <Style.Triggers>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding StarDetectionOptions.UseAdvanced}" Value="True" />
+                                <Condition Binding="{Binding StarDetectionOptions.DefocusAwareGates}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="Height" Value="Auto" />
+                        </MultiDataTrigger>
+                    </Style.Triggers>
+                </Style>
                 <Style x:Key="ShowOnUseSimple" TargetType="{x:Type RowDefinition}">
                     <Setter Property="Height" Value="0" />
                     <Style.Triggers>
@@ -1021,11 +1035,12 @@
                 <RowDefinition />
                 <RowDefinition Style="{StaticResource HideOnSaveIntermediateOff}" />
                 <RowDefinition />
-                <!--  41: Defocus-Aware Gates toggle (advanced-only); 42-44: its three numeric tuning knobs (advanced-only)  -->
+                <!--  41: Defocus-Aware Gates toggle (advanced-only); 42-44: its three numeric tuning knobs
+                      (advanced-only AND only when the gates toggle is on).  -->
                 <RowDefinition Style="{StaticResource ShowOnUseAdvanced}" />
-                <RowDefinition Style="{StaticResource ShowOnUseAdvanced}" />
-                <RowDefinition Style="{StaticResource ShowOnUseAdvanced}" />
-                <RowDefinition Style="{StaticResource ShowOnUseAdvanced}" />
+                <RowDefinition Style="{StaticResource ShowOnUseAdvancedAndDefocusGates}" />
+                <RowDefinition Style="{StaticResource ShowOnUseAdvancedAndDefocusGates}" />
+                <RowDefinition Style="{StaticResource ShowOnUseAdvancedAndDefocusGates}" />
             </Grid.RowDefinitions>
             <TextBlock
                 Grid.Row="0"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/DataTemplates.xaml
@@ -42,30 +42,9 @@
 
     <DataTemplate x:Key="NINA.Joko.Plugins.HocusFocus.StarDetection.StarDetectionOptionsVM_Dockable">
         <ScrollViewer VerticalScrollBarVisibility="Auto">
-            <!--  IsSharedSizeScope + Left so the Optimize button centers over the options' label/value columns
-                  (shared-size groups) rather than over the whole dock or the wider padded grid.  -->
-            <StackPanel Grid.IsSharedSizeScope="True" HorizontalAlignment="Left" Orientation="Vertical">
-                <Grid Margin="5,5,5,10">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" SharedSizeGroup="HF_SDCol0" />
-                        <ColumnDefinition Width="Auto" SharedSizeGroup="HF_SDCol1" />
-                    </Grid.ColumnDefinitions>
-                    <Button
-                        Grid.Column="0"
-                        Grid.ColumnSpan="2"
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center"
-                        Command="{Binding OptimizeStarDetectionCommand}"
-                        ToolTip="{StaticResource OptimizeStarDetection_Tooltip}">
-                        <TextBlock
-                            Margin="10,5,10,5"
-                            Foreground="{StaticResource ButtonForegroundBrush}"
-                            Text="Optimize Star Detection"
-                            TextWrapping="Wrap" />
-                    </Button>
-                </Grid>
-                <ContentControl Content="{Binding}" ContentTemplate="{StaticResource HocusFocus_StarDetection_Options}" />
-            </StackPanel>
+            <!--  The "Optimize Star Detection" button now lives inside the options ContentControl
+                  (HocusFocus_StarDetection_Options), centered over the settings' label/value columns.  -->
+            <ContentControl Content="{Binding}" ContentTemplate="{StaticResource HocusFocus_StarDetection_Options}" />
         </ScrollViewer>
     </DataTemplate>
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/DataTemplates.xaml
@@ -42,21 +42,28 @@
 
     <DataTemplate x:Key="NINA.Joko.Plugins.HocusFocus.StarDetection.StarDetectionOptionsVM_Dockable">
         <ScrollViewer VerticalScrollBarVisibility="Auto">
-            <!--  HorizontalAlignment=Left so the panel hugs the options content; the button then centers OVER the
-                  options block rather than over the whole dock.  -->
-            <StackPanel HorizontalAlignment="Left" Orientation="Vertical">
-                <Button
-                    Margin="5,5,5,10"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Center"
-                    Command="{Binding OptimizeStarDetectionCommand}"
-                    ToolTip="{StaticResource OptimizeStarDetection_Tooltip}">
-                    <TextBlock
-                        Margin="10,5,10,5"
-                        Foreground="{StaticResource ButtonForegroundBrush}"
-                        Text="Optimize Star Detection"
-                        TextWrapping="Wrap" />
-                </Button>
+            <!--  IsSharedSizeScope + Left so the Optimize button centers over the options' label/value columns
+                  (shared-size groups) rather than over the whole dock or the wider padded grid.  -->
+            <StackPanel Grid.IsSharedSizeScope="True" HorizontalAlignment="Left" Orientation="Vertical">
+                <Grid Margin="5,5,5,10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="HF_SDCol0" />
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="HF_SDCol1" />
+                    </Grid.ColumnDefinitions>
+                    <Button
+                        Grid.Column="0"
+                        Grid.ColumnSpan="2"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Command="{Binding OptimizeStarDetectionCommand}"
+                        ToolTip="{StaticResource OptimizeStarDetection_Tooltip}">
+                        <TextBlock
+                            Margin="10,5,10,5"
+                            Foreground="{StaticResource ButtonForegroundBrush}"
+                            Text="Optimize Star Detection"
+                            TextWrapping="Wrap" />
+                    </Button>
+                </Grid>
                 <ContentControl Content="{Binding}" ContentTemplate="{StaticResource HocusFocus_StarDetection_Options}" />
             </StackPanel>
         </ScrollViewer>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/DataTemplates.xaml
@@ -42,7 +42,9 @@
 
     <DataTemplate x:Key="NINA.Joko.Plugins.HocusFocus.StarDetection.StarDetectionOptionsVM_Dockable">
         <ScrollViewer VerticalScrollBarVisibility="Auto">
-            <StackPanel Orientation="Vertical">
+            <!--  HorizontalAlignment=Left so the panel hugs the options content; the button then centers OVER the
+                  options block rather than over the whole dock.  -->
+            <StackPanel HorizontalAlignment="Left" Orientation="Vertical">
                 <Button
                     Margin="5,5,5,10"
                     HorizontalAlignment="Center"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -181,20 +181,28 @@
                             <TextBlock Margin="0,0,8,0" Text="Focus precision (σ, lower is better):" />
                             <TextBlock FontWeight="SemiBold" Text="{Binding Summary.SigmaText, Mode=OneWay}" />
                         </StackPanel>
-                        <UniformGrid Columns="2" Margin="0,0,0,8">
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock Width="160" Text="Runs optimized" />
-                                <TextBlock Text="{Binding Summary.RunCount, Mode=OneWay}" />
-                            </StackPanel>
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock Width="160" Text="Recommended step size" />
-                                <TextBlock Text="{Binding Summary.StepSizeText, Mode=OneWay}" />
-                            </StackPanel>
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock Width="160" Text="Recommended offset steps" />
-                                <TextBlock Text="{Binding Summary.OffsetStepsText, Mode=OneWay}" />
-                            </StackPanel>
-                        </UniformGrid>
+                        <StackPanel Margin="0,0,0,8" Orientation="Horizontal">
+                            <TextBlock Width="200" Text="Runs optimized" />
+                            <TextBlock Text="{Binding Summary.RunCount, Mode=OneWay}" />
+                        </StackPanel>
+
+                        <!--  Auto-focus block: the recommended step size / offset steps PLUS the toggle that applies
+                              them on Accept, grouped so the toggle's purpose is obvious.  -->
+                        <TextBlock Margin="0,4,0,2" FontWeight="Bold" Text="Auto-focus settings" />
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Width="200" Text="Recommended step size" />
+                            <TextBlock Text="{Binding Summary.StepSizeText, Mode=OneWay}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Width="200" Text="Recommended offset steps" />
+                            <TextBlock Text="{Binding Summary.OffsetStepsText, Mode=OneWay}" />
+                        </StackPanel>
+                        <CheckBox
+                            Margin="0,6,0,8"
+                            Content="Apply these auto-focus settings to my profile when I click Accept"
+                            IsChecked="{Binding ApplyRecommendedStepSize}"
+                            IsEnabled="{Binding CanApplyRecommendedStepSize}"
+                            ToolTip="{StaticResource SDOpt_ApplyStepSize_Tooltip}" />
 
                         <!--  Changed parameters table  -->
                         <TextBlock
@@ -223,13 +231,6 @@
                                     Header="Optimized" />
                             </DataGrid.Columns>
                         </DataGrid>
-
-                        <CheckBox
-                            Margin="0,8,0,0"
-                            Content="Also update auto-focus step size &amp; offset steps on Accept"
-                            IsChecked="{Binding ApplyRecommendedStepSize}"
-                            IsEnabled="{Binding CanApplyRecommendedStepSize}"
-                            ToolTip="{StaticResource SDOpt_ApplyStepSize_Tooltip}" />
 
                         <TextBlock
                             Margin="0,8,0,0"
@@ -322,7 +323,9 @@
                     Command="{Binding CancelCommand}"
                     Content="Cancel">
                     <Button.Style>
-                        <Style TargetType="Button">
+                        <!--  BasedOn the theme's implicit Button style so Cancel matches the other footer buttons'
+                              font/look (a style without BasedOn would drop the NINA default style).  -->
+                        <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
                             <Setter Property="Visibility" Value="Collapsed" />
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding IsAcquire}" Value="True">
@@ -358,7 +361,9 @@
                     Command="{Binding CloseCommand}"
                     Content="Cancel">
                     <Button.Style>
-                        <Style TargetType="Button">
+                        <!--  BasedOn the theme's implicit Button style so Cancel matches the other footer buttons'
+                              font/look (a style without BasedOn would drop the NINA default style).  -->
+                        <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
                             <Setter Property="Visibility" Value="Collapsed" />
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding IsSummary}" Value="True">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -176,33 +176,43 @@
                             Text="Optimization complete" />
 
                         <!--  Before / after — plain language, no jargon "J" (the abstract objective stays in logs).
-                              The focus-precision headline is full-width so the "% tighter" suffix has room.  -->
-                        <StackPanel Margin="0,0,0,6" Orientation="Horizontal">
-                            <TextBlock Margin="0,0,8,0" Text="Focus precision (σ, lower is better):" />
-                            <TextBlock FontWeight="SemiBold" Text="{Binding Summary.SigmaText, Mode=OneWay}" />
+                              Every row is "[label Width=200][value]" with uniform spacing so the values line up in a
+                              column and the row gaps match across the whole summary.  -->
+                        <StackPanel Orientation="Horizontal" Margin="0,2">
+                            <TextBlock Width="200" Text="Focus precision (σ, lower is better)" />
+                            <TextBlock Text="{Binding Summary.SigmaText, Mode=OneWay}" />
                         </StackPanel>
-                        <StackPanel Margin="0,0,0,8" Orientation="Horizontal">
+                        <StackPanel Orientation="Horizontal" Margin="0,2">
                             <TextBlock Width="200" Text="Runs optimized" />
                             <TextBlock Text="{Binding Summary.RunCount, Mode=OneWay}" />
                         </StackPanel>
 
                         <!--  Auto-focus block: the recommended step size / offset steps PLUS the toggle that applies
                               them on Accept, grouped so the toggle's purpose is obvious.  -->
-                        <TextBlock Margin="0,4,0,2" FontWeight="Bold" Text="Auto-focus settings" />
-                        <StackPanel Orientation="Horizontal">
+                        <TextBlock Margin="0,8,0,2" FontWeight="Bold" Text="Auto-focus settings" />
+                        <StackPanel Orientation="Horizontal" Margin="0,2">
                             <TextBlock Width="200" Text="Recommended step size" />
                             <TextBlock Text="{Binding Summary.StepSizeText, Mode=OneWay}" />
                         </StackPanel>
-                        <StackPanel Orientation="Horizontal">
+                        <StackPanel Orientation="Horizontal" Margin="0,2">
                             <TextBlock Width="200" Text="Recommended offset steps" />
                             <TextBlock Text="{Binding Summary.OffsetStepsText, Mode=OneWay}" />
                         </StackPanel>
-                        <CheckBox
-                            Margin="0,6,0,8"
-                            Content="Apply these auto-focus settings to my profile when I click Accept"
-                            IsChecked="{Binding ApplyRecommendedStepSize}"
-                            IsEnabled="{Binding CanApplyRecommendedStepSize}"
-                            ToolTip="{StaticResource SDOpt_ApplyStepSize_Tooltip}" />
+                        <!--  Separate TextBlock label (NINA's CheckBox style doesn't render Content as a visible
+                              label — every other checkbox in the plugin uses this label-beside-box pattern).  -->
+                        <StackPanel Orientation="Horizontal" Margin="0,4,0,8">
+                            <CheckBox
+                                VerticalAlignment="Center"
+                                IsChecked="{Binding ApplyRecommendedStepSize}"
+                                IsEnabled="{Binding CanApplyRecommendedStepSize}"
+                                ToolTip="{StaticResource SDOpt_ApplyStepSize_Tooltip}" />
+                            <TextBlock
+                                Margin="6,0,0,0"
+                                VerticalAlignment="Center"
+                                IsEnabled="{Binding CanApplyRecommendedStepSize}"
+                                Text="Apply these auto-focus settings to my profile when I click Accept"
+                                ToolTip="{StaticResource SDOpt_ApplyStepSize_Tooltip}" />
+                        </StackPanel>
 
                         <!--  Changed parameters table  -->
                         <TextBlock

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -15,7 +15,7 @@
     <!--  Tooltips  -->
     <TextBlock x:Key="SDOpt_SourceMode_Tooltip" Text="Replay optimizes against one or more saved auto-focus runs (recommended). Live triggers a fresh auto-focus that saves its frames, then optimizes against those." />
     <TextBlock x:Key="SDOpt_RunCount_Tooltip" Text="How many saved auto-focus runs to optimize against together. Using two or three runs balances the settings across them and reduces overfitting to a single night's conditions." />
-    <TextBlock x:Key="SDOpt_ApplyStepSize_Tooltip" Text="Also write the recommended auto-focus step size and offset steps to the active profile when applying. The step size is sized so a sweep lands several measurement points across the focus-sensitive region of the curve." />
+    <TextBlock x:Key="SDOpt_ApplyStepSize_Tooltip" Text="When checked, clicking Accept also writes the recommended auto-focus step size and offset steps to the active profile (they appear in the Changed parameters list above). The step size is sized so a sweep lands several measurement points across the focus-sensitive region of the curve. Disabled when the recommendation already matches your current settings (nothing to apply)." />
     <TextBlock x:Key="SDOpt_Review_Tooltip" Text="Optional: review the optimized detector boxes over every loaded frame and label any missed, falsely-accepted, or wrongly-rejected stars. The labels are saved next to the run and can drive a future re-optimization. Reviewing is not required — you can Accept directly." />
     <TextBlock x:Key="SDOpt_ReOptimize_Tooltip" Text="Re-run the optimization using the labels you just made in Review. Your missed / wrongly-rejected stars steer the optimizer to recover them (recall), and your should-reject stars steer it to exclude them (precision). The runs are re-read from disk and the search re-runs, landing on an updated summary you can review again or accept." />
 
@@ -79,7 +79,8 @@
                         </ComboBox>
                     </StackPanel>
 
-                    <StackPanel Margin="0,4" Orientation="Horizontal">
+                    <StackPanel Margin="0,4" Orientation="Horizontal"
+                                Visibility="{Binding IsReplay, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
                         <TextBlock
                             Width="90"
                             VerticalAlignment="Center"
@@ -102,11 +103,12 @@
                         </ninactrl:UnitTextBox>
                     </StackPanel>
 
-                    <!--  One folder picker per run (Replay). AlternationCount surfaces the per-row index as the picker's CommandParameter.  -->
+                    <!--  One folder picker per run (Saved Auto-Focus only). AlternationCount surfaces the per-row index as the picker's CommandParameter.  -->
                     <ItemsControl
                         Margin="0,8,0,0"
                         AlternationCount="100"
-                        ItemsSource="{Binding SourcePaths}">
+                        ItemsSource="{Binding SourcePaths}"
+                        Visibility="{Binding IsReplay, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Margin="0,2" Orientation="Horizontal">
@@ -154,17 +156,15 @@
                         Minimum="0"
                         Value="{Binding Evaluations, Mode=OneWay}" />
                     <TextBlock Margin="0,4,0,0" HorizontalAlignment="Center">
-                        <Run Text="Evaluations:" />
+                        <Run Text="Combinations tried:" />
                         <Run Text="{Binding Evaluations, Mode=OneWay}" />
                         <Run Text="/" />
                         <Run Text="{Binding MaxEvaluations, Mode=OneWay}" />
                     </TextBlock>
-                    <TextBlock Margin="0,2,0,0" HorizontalAlignment="Center">
-                        <Run Text="Seed J:" />
-                        <Run Text="{Binding ProgressSeedJ, Mode=OneWay, StringFormat=F3}" />
-                        <Run Text="    Best J:" />
-                        <Run Text="{Binding ProgressBestJ, Mode=OneWay, StringFormat=F3}" />
-                    </TextBlock>
+                    <TextBlock
+                        Margin="0,2,0,0"
+                        HorizontalAlignment="Center"
+                        Text="{Binding ProgressImprovementText}" />
                 </StackPanel>
 
                 <!--  Step 4: Summary  -->
@@ -175,40 +175,24 @@
                             FontWeight="Bold"
                             Text="Optimization complete" />
 
-                        <!--  Before / after  -->
+                        <!--  Before / after — plain language, no jargon "J" (the abstract objective stays in logs).
+                              The focus-precision headline is full-width so the "% tighter" suffix has room.  -->
+                        <StackPanel Margin="0,0,0,6" Orientation="Horizontal">
+                            <TextBlock Margin="0,0,8,0" Text="Focus precision (σ, lower is better):" />
+                            <TextBlock FontWeight="SemiBold" Text="{Binding Summary.SigmaText, Mode=OneWay}" />
+                        </StackPanel>
                         <UniformGrid Columns="2" Margin="0,0,0,8">
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock Width="160" Text="Objective (J): seed → best" />
-                                <TextBlock>
-                                    <Run Text="{Binding Summary.SeedJ, Mode=OneWay, StringFormat=F3}" />
-                                    <Run Text="→" />
-                                    <Run Text="{Binding Summary.BestJ, Mode=OneWay, StringFormat=F3}" />
-                                </TextBlock>
-                            </StackPanel>
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock Width="160" Text="σ(focus): seed → best" />
-                                <TextBlock>
-                                    <Run Text="{Binding Summary.SeedSigmaFocus, Mode=OneWay, StringFormat=F2}" />
-                                    <Run Text="→" />
-                                    <Run Text="{Binding Summary.BestSigmaFocus, Mode=OneWay, StringFormat=F2}" />
-                                </TextBlock>
-                            </StackPanel>
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Width="160" Text="Runs optimized" />
                                 <TextBlock Text="{Binding Summary.RunCount, Mode=OneWay}" />
                             </StackPanel>
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Width="160" Text="Recommended step size" />
-                                <TextBlock>
-                                    <Run Text="{Binding Summary.RecommendedStepSize, Mode=OneWay}" />
-                                    <Run Text="(was" />
-                                    <Run Text="{Binding Summary.CurrentStepSize, Mode=OneWay}" />
-                                    <Run Text=")" />
-                                </TextBlock>
+                                <TextBlock Text="{Binding Summary.StepSizeText, Mode=OneWay}" />
                             </StackPanel>
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Width="160" Text="Recommended offset steps" />
-                                <TextBlock Text="{Binding Summary.RecommendedOffsetSteps, Mode=OneWay}" />
+                                <TextBlock Text="{Binding Summary.OffsetStepsText, Mode=OneWay}" />
                             </StackPanel>
                         </UniformGrid>
 
@@ -222,7 +206,7 @@
                             CanUserAddRows="False"
                             HeadersVisibility="Column"
                             IsReadOnly="True"
-                            ItemsSource="{Binding Summary.ChangedParameters}"
+                            ItemsSource="{Binding ChangedParametersDisplay}"
                             MaxHeight="180">
                             <DataGrid.Columns>
                                 <DataGridTextColumn
@@ -242,8 +226,9 @@
 
                         <CheckBox
                             Margin="0,8,0,0"
-                            Content="Apply recommended auto-focus step size"
+                            Content="Also update auto-focus step size &amp; offset steps on Accept"
                             IsChecked="{Binding ApplyRecommendedStepSize}"
+                            IsEnabled="{Binding CanApplyRecommendedStepSize}"
                             ToolTip="{StaticResource SDOpt_ApplyStepSize_Tooltip}" />
 
                         <TextBlock
@@ -274,7 +259,7 @@
                                     Width="220"
                                     HorizontalAlignment="Left"
                                     Command="{Binding ReOptimizeCommand}"
-                                    Content="Re-optimize with my feedback"
+                                    Content="Optimize with feedback"
                                     ToolTip="{StaticResource SDOpt_ReOptimize_Tooltip}" />
                             </StackPanel>
                         </Border>
@@ -316,6 +301,15 @@
                     Command="{Binding BackToSummaryCommand}"
                     Content="Back to summary"
                     Visibility="{Binding IsReview, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                <!--  Review → re-optimize with the labels just made (enabled once anything is labeled). Accept is
+                      intentionally NOT offered here: finalize from the Summary step.  -->
+                <Button
+                    Width="180"
+                    Margin="0,0,8,0"
+                    Command="{Binding ReOptimizeCommand}"
+                    Content="Optimize with feedback"
+                    ToolTip="{StaticResource SDOpt_ReOptimize_Tooltip}"
+                    Visibility="{Binding IsReview, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                 <Button
                     Width="90"
                     Margin="0,0,8,0"
@@ -349,26 +343,14 @@
                     Content="Review frames"
                     ToolTip="{StaticResource SDOpt_Review_Tooltip}"
                     Visibility="{Binding IsSummary, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
-                <!--  Accept = apply + select + close. Reachable from Summary AND Review (skip-review still works).  -->
+                <!--  Accept = apply + select + close. Offered on Summary only — the Review step finalizes by going
+                      Back to summary (or Optimize with feedback) first.  -->
                 <Button
                     Width="90"
                     Margin="0,0,8,0"
                     Command="{Binding AcceptCommand}"
-                    Content="Accept">
-                    <Button.Style>
-                        <Style TargetType="Button">
-                            <Setter Property="Visibility" Value="Collapsed" />
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding IsSummary}" Value="True">
-                                    <Setter Property="Visibility" Value="Visible" />
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding IsReview}" Value="True">
-                                    <Setter Property="Visibility" Value="Visible" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </Button.Style>
-                </Button>
+                    Content="Accept"
+                    Visibility="{Binding IsSummary, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                 <!--  Summary/Review "Cancel" = discard (close without applying); reuses the close path, no options mutation.  -->
                 <Button
                     Width="90"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -38,7 +38,6 @@
             <Button Content="Fit" Command="{Binding FitCommand}" Margin="16,0,4,0" />
             <Button Content="◀ Prev" Command="{Binding PrevCommand}" />
             <Button Content="Next ▶" Command="{Binding NextCommand}" />
-            <Button Content="Save" Command="{Binding SaveCommand}" Margin="16,0,4,0" />
         </WrapPanel>
 
         <!-- Image + overlays. The Image and all marker layers share one transform (zoom/pan) so markers stay

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewLabels.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewLabels.cs
@@ -114,7 +114,31 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             NullValueHandling = NullValueHandling.Ignore
         };
 
-        public static string FileNameFor(string runId) => SanitizeFileName(runId) + ".json";
+        public static string FileNameFor(string runId) => CleanRunFileStem(runId) + ".json";
+
+        /// <summary>
+        /// Derives a clean, human-readable, collision-resistant file stem from a <paramref name="runId"/> that is
+        /// typically an absolute run-folder path: the last one or two path segments joined with '_' (e.g.
+        /// "sensitivity_example1_attempt01"), sanitized of invalid filename characters. Falls back to the whole
+        /// sanitized id, then to "run". The embedded <c>runId</c> inside the file remains authoritative for
+        /// matching (both the plugin's <see cref="Load"/> embedded-scan and the offline harness match on it), so
+        /// this is purely cosmetic — old sanitized-absolute-path files still load via the embedded scan.
+        /// </summary>
+        public static string CleanRunFileStem(string runId) {
+            if (string.IsNullOrWhiteSpace(runId)) {
+                return "run";
+            }
+            var segments = runId.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);
+            string stem;
+            if (segments.Length >= 2) {
+                stem = segments[segments.Length - 2] + "_" + segments[segments.Length - 1];
+            } else if (segments.Length == 1) {
+                stem = segments[0];
+            } else {
+                stem = runId;
+            }
+            return SanitizeFileName(stem);
+        }
 
         /// <summary>
         /// Loads the label file for <paramref name="runId"/> from <paramref name="labelsDir"/> if it exists,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -24,6 +24,7 @@ using OpenCvSharp;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -46,9 +47,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         Review
     }
 
-    /// <summary>Where the run frames come from: an already-saved AF attempt (Replay) or a fresh live AF run.</summary>
+    /// <summary>Where the run frames come from: an already-saved AF attempt (Replay) or a fresh live AF run.
+    /// The <see cref="DescriptionAttribute"/> text is what the wizard ComboBox shows (via the enum-description
+    /// converter) — plain language, not the raw enum names.</summary>
     public enum SourceMode {
+        [Description("Saved Auto-Focus")]
         Replay,
+
+        [Description("Live Auto-Focus")]
         Live
     }
 
@@ -73,7 +79,55 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public int RecommendedStepSize { get; set; }
         public int RecommendedOffsetSteps { get; set; }
         public int CurrentStepSize { get; set; }
+        public int CurrentOffsetSteps { get; set; }
         public bool ImprovedOverSeed { get; set; }
+
+        /// <summary>True when the recommended AF step size and/or offset steps differ from the current profile
+        /// values — i.e. there is actually something to apply. Drives whether the "apply AF step size" toggle is
+        /// enabled and whether the AF rows appear in the changed-parameters list.</summary>
+        public bool StepSizeOrOffsetChanged =>
+            RecommendedStepSize != CurrentStepSize || RecommendedOffsetSteps != CurrentOffsetSteps;
+
+        /// <summary>Plain-language step-size readout: "{current} → {recommended}" when changed, else
+        /// "{recommended} (unchanged)".</summary>
+        public string StepSizeText => FormatRecommendation(CurrentStepSize, RecommendedStepSize);
+
+        /// <summary>Plain-language offset-steps readout (same before→after / "(unchanged)" convention).</summary>
+        public string OffsetStepsText => FormatRecommendation(CurrentOffsetSteps, RecommendedOffsetSteps);
+
+        /// <summary>Focus-precision readout: "{seed} → {best}" with a "(~N% tighter)" suffix when σ improved
+        /// (σ is the focus-curve sigma — lower is tighter/better).</summary>
+        public string SigmaText {
+            get {
+                var baseText = $"{SeedSigmaFocus:F2} → {BestSigmaFocus:F2}";
+                if (double.IsFinite(SeedSigmaFocus) && double.IsFinite(BestSigmaFocus)
+                    && SeedSigmaFocus > 1e-9 && BestSigmaFocus < SeedSigmaFocus) {
+                    var pct = (SeedSigmaFocus - BestSigmaFocus) / SeedSigmaFocus * 100.0;
+                    return $"{baseText}  (~{pct:F0}% tighter)";
+                }
+                return baseText;
+            }
+        }
+
+        /// <summary>How much the objective improved over the seed, as a non-negative percentage (the objective
+        /// is a score where higher is better, and best never regresses below the seed).</summary>
+        public double ImprovementPercent => PercentBetter(SeedJ, BestJ);
+
+        /// <summary>"{current} → {recommended}" when the two differ, else "{recommended} (unchanged)". Pure
+        /// formatter — unit-tested.</summary>
+        public static string FormatRecommendation(int current, int recommended) =>
+            current == recommended ? $"{recommended} (unchanged)" : $"{current} → {recommended}";
+
+        /// <summary>Percent improvement of <paramref name="improved"/> over <paramref name="baseline"/> for a
+        /// higher-is-better score, clamped at 0 and guarded against non-finite / near-zero baselines. Pure —
+        /// unit-tested.</summary>
+        public static double PercentBetter(double baseline, double improved) {
+            if (!double.IsFinite(baseline) || !double.IsFinite(improved) || Math.Abs(baseline) < 1e-12) {
+                return 0.0;
+            }
+            var pct = (improved - baseline) / Math.Abs(baseline) * 100.0;
+            return pct > 0.0 ? pct : 0.0;
+        }
     }
 
     /// <summary>
@@ -227,9 +281,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 if (sourceMode != value) {
                     sourceMode = value;
                     RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(IsReplay));
                 }
             }
         }
+
+        /// <summary>True for the "Saved Auto-Focus" (replay) source. The Number-of-runs input and the per-run
+        /// folder pickers are only meaningful here, so the wizard binds their visibility to this.</summary>
+        public bool IsReplay => SourceMode == SourceMode.Replay;
 
         private int runCount = 1;
 
@@ -305,14 +364,24 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
         public double ProgressSeedJ {
             get => progressSeedJ;
-            private set { progressSeedJ = value; RaisePropertyChanged(); }
+            private set { progressSeedJ = value; RaisePropertyChanged(); RaisePropertyChanged(nameof(ProgressImprovementText)); }
         }
 
         private double progressBestJ;
 
         public double ProgressBestJ {
             get => progressBestJ;
-            private set { progressBestJ = value; RaisePropertyChanged(); }
+            private set { progressBestJ = value; RaisePropertyChanged(); RaisePropertyChanged(nameof(ProgressImprovementText)); }
+        }
+
+        /// <summary>Live, plain-language improvement readout shown during the search (no jargon "J"): how much
+        /// better the best result found so far is than the user's current settings. Computed from the objective
+        /// score but never labeled as such.</summary>
+        public string ProgressImprovementText {
+            get {
+                var pct = OptimizationSummary.PercentBetter(progressSeedJ, progressBestJ);
+                return pct > 0.0 ? $"Detection improved ~{pct:F0}% so far" : "Searching for a better fit…";
+            }
         }
 
         private string phase;
@@ -339,7 +408,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             get => summary;
             private set {
                 summary = value;
+                // A fresh summary: if nothing in the AF recommendation actually changed, there is nothing to
+                // apply, so disable + clear the toggle.
+                if (!CanApplyRecommendedStepSize) {
+                    applyRecommendedStepSize = false;
+                }
                 RaisePropertyChanged();
+                RaisePropertyChanged(nameof(ApplyRecommendedStepSize));
+                RaisePropertyChanged(nameof(CanApplyRecommendedStepSize));
+                RaisePropertyChanged(nameof(ChangedParametersDisplay));
                 AcceptCommand.NotifyCanExecuteChanged();
                 BackCommand.NotifyCanExecuteChanged();
             }
@@ -353,7 +430,43 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 if (applyRecommendedStepSize != value) {
                     applyRecommendedStepSize = value;
                     RaisePropertyChanged();
+                    // The AF rows in the changed-parameters list appear only while this is on.
+                    RaisePropertyChanged(nameof(ChangedParametersDisplay));
                 }
+            }
+        }
+
+        /// <summary>Whether the "apply recommended AF step size" toggle is meaningful — true only when the
+        /// recommended step size and/or offset steps actually differ from the current profile values. The
+        /// checkbox binds its IsEnabled here so an unchanged recommendation can't be "applied".</summary>
+        public bool CanApplyRecommendedStepSize => Summary?.StepSizeOrOffsetChanged ?? false;
+
+        /// <summary>The changed-parameters rows shown on the summary: the optimized detector params, plus — only
+        /// when <see cref="ApplyRecommendedStepSize"/> is on — the AF step size / offset-steps rows so the user
+        /// sees the AF settings that Accept will also write. Recomputed when the toggle or the summary changes.</summary>
+        public IReadOnlyList<ChangedParameterRow> ChangedParametersDisplay {
+            get {
+                if (Summary?.ChangedParameters == null) {
+                    return Array.Empty<ChangedParameterRow>();
+                }
+                var rows = new List<ChangedParameterRow>(Summary.ChangedParameters);
+                if (ApplyRecommendedStepSize && CanApplyRecommendedStepSize) {
+                    if (Summary.RecommendedStepSize != Summary.CurrentStepSize) {
+                        rows.Add(new ChangedParameterRow {
+                            Name = "Auto-focus step size",
+                            SeedValue = Summary.CurrentStepSize,
+                            OptimizedValue = Summary.RecommendedStepSize
+                        });
+                    }
+                    if (Summary.RecommendedOffsetSteps != Summary.CurrentOffsetSteps) {
+                        rows.Add(new ChangedParameterRow {
+                            Name = "Auto-focus offset steps",
+                            SeedValue = Summary.CurrentOffsetSteps,
+                            OptimizedValue = Summary.RecommendedOffsetSteps
+                        });
+                    }
+                }
+                return rows;
             }
         }
 
@@ -430,6 +543,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             Summary = null;
             Result = null;
             // A fresh run invalidates any prior review snapshot/labels (they belonged to the previous result).
+            if (ReviewVM != null) {
+                ReviewVM.PropertyChanged -= OnReviewLabelsChanged;
+            }
             ReviewVM = null;
             reviewDescriptors = null;
             reviewLabelsDir = null;
@@ -617,7 +733,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 MaxEvaluations = p.MaxEvaluations;
                 ProgressBestJ = p.BestJ;
                 ProgressSeedJ = p.SeedJ;
-                Phase = p.Phase;
+                Phase = FriendlyPhase(p.Phase);
             });
 
             var optimizer = new StarDetectionOptimizer();
@@ -625,6 +741,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 () => optimizer.OptimizeAsync(seed, variables, evaluator, optimizerSettings, progress, token),
                 token).ConfigureAwait(true);
         }
+
+        /// <summary>Maps the optimizer's internal phase identifiers ("Seed"/"CoarseGrid"/"PatternSearch", which
+        /// stay as-is in logs and tests) to plain language for the progress display.</summary>
+        private static string FriendlyPhase(string phase) => phase switch {
+            "Seed" => "Checking your current settings",
+            "CoarseGrid" => "Searching settings (coarse pass)",
+            "PatternSearch" => "Refining settings",
+            _ => phase
+        };
 
         /// <summary>
         /// Builds the summary: the changed-parameters table, before/after J + σ(focus) (re-evaluated at seed and
@@ -653,6 +778,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             }
 
             var currentStepSize = runs[0].AfOptions?.AutoFocusStepSize ?? DefaultCurrentStepSize;
+            var currentOffsetSteps = runs[0].AfOptions?.AutoFocusInitialOffsetSteps ?? DefaultCurrentOffsetSteps;
             var recommendation = StepSizeRecommender.Recommend(representativeBestFit, currentStepSize, GetFocuserMaxStep());
 
             return new OptimizationSummary {
@@ -665,11 +791,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 RecommendedStepSize = recommendation.StepSize,
                 RecommendedOffsetSteps = recommendation.OffsetSteps,
                 CurrentStepSize = currentStepSize,
+                CurrentOffsetSteps = currentOffsetSteps,
                 ImprovedOverSeed = res.ImprovedOverSeed
             };
         }
 
         private const int DefaultCurrentStepSize = 10;
+        private const int DefaultCurrentOffsetSteps = 4;
 
         /// <summary>
         /// The focuser's max single-move increment, when available, to clamp the recommendation. No reliable
@@ -811,7 +939,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 RaisePropertyChanged(nameof(HasLabels));
                 ReOptimizeCommand.NotifyCanExecuteChanged();
 
+                // Replace any prior review (drop its label-change subscription first to avoid a dangling handler).
+                if (ReviewVM != null) {
+                    ReviewVM.PropertyChanged -= OnReviewLabelsChanged;
+                }
                 ReviewVM = new StarReviewVM(reviews, labelsByRun, labelsDir ?? string.Empty);
+                // Surface label edits live: the "Optimize with feedback" button enables as soon as the user labels
+                // anything (the StarReviewVM raises CountsLabel on every add/remove).
+                ReviewVM.PropertyChanged += OnReviewLabelsChanged;
                 CurrentStep = WizardStep.Review;
             } catch (OperationCanceledException) {
                 Logger.Info("Star detection review build cancelled");
@@ -823,14 +958,24 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             }
         }
 
-        /// <summary>Review → Summary: persists labels and returns to the Summary step (Accept/Cancel remain the
-        /// terminal decisions and are reachable from either step).</summary>
+        /// <summary>Review → Summary: returns to the Summary step WITHOUT writing labels to disk — labels are
+        /// kept in-memory (<see cref="capturedLabels"/>) and only flushed to disk when the user Accepts or
+        /// re-optimizes (their work product is preserved either way). Accept/Cancel remain the terminal
+        /// decisions, reachable from the Summary step.</summary>
         private void BackToSummary() {
             if (CurrentStep != WizardStep.Review || IsBusy) {
                 return;
             }
-            PersistReviewLabels();
             CurrentStep = WizardStep.Summary;
+        }
+
+        /// <summary>Re-raises the label-dependent UI state when the in-progress review's labels change, so the
+        /// "Optimize with feedback" affordance enables/disables live as the user labels.</summary>
+        private void OnReviewLabelsChanged(object sender, PropertyChangedEventArgs e) {
+            if (e.PropertyName == nameof(StarReviewVM.CountsLabel)) {
+                RaisePropertyChanged(nameof(HasLabels));
+                ReOptimizeCommand.NotifyCanExecuteChanged();
+            }
         }
 
         /// <summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -164,6 +164,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         // without real images.
         private readonly Func<IReadOnlyList<FrameReviewDescriptor>, StarDetectorParams, CancellationToken, Task<List<FrameReview>>> frameReviewBuilder;
 
+        // Connection probes for the Live source's pre-flight check (Start verifies the camera + focuser are
+        // connected before triggering a live auto-focus). Injected as delegates so the VM stays mediator-free and
+        // unit-testable; production wires them to the camera/focuser mediators, tests pass a stub. Default to
+        // "connected" when not supplied so the existing tests are unaffected.
+        private readonly Func<bool> isCameraConnected;
+        private readonly Func<bool> isFocuserConnected;
+
         // Snapshotted at the end of a successful run (BEFORE loadedRuns is disposed): the Mat-free per-frame
         // descriptors for every loaded run, the labels dir each run's labels persist to, and the in-memory label
         // models the review edits. These survive disposal so the Review step can detect from disk afterward.
@@ -195,6 +202,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             IProfileService profileService,
             IImageDataFactory imageDataFactory,
             IImagingMediator imagingMediator,
+            ICameraMediator cameraMediator,
+            IFocuserMediator focuserMediator,
             IAutoFocusEngine autoFocusEngine,
             IHocusFocusStarDetection detection)
             : this(
@@ -210,7 +219,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 // Production review builder: the SHARED FrameReviewBuilder over a real StarDetector + a profile-aware
                 // disk loader (mirrors the TestApp `review` path; single source of truth). Built lazily so the
                 // detector/loader only allocate when the user actually enters Review.
-                frameReviewBuilder: BuildProductionReviewBuilder(profileService, imageDataFactory)) {
+                frameReviewBuilder: BuildProductionReviewBuilder(profileService, imageDataFactory),
+                // Live pre-flight: probe the camera/focuser mediators for the connection check on Start.
+                isCameraConnected: () => cameraMediator?.GetInfo()?.Connected == true,
+                isFocuserConnected: () => focuserMediator?.GetInfo()?.Connected == true) {
         }
 
         /// <summary>
@@ -224,7 +236,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             Func<string> folderPicker,
             StarDetectionRegion region,
             OptimizerSettings optimizerSettings,
-            Func<IReadOnlyList<FrameReviewDescriptor>, StarDetectorParams, CancellationToken, Task<List<FrameReview>>> frameReviewBuilder = null) {
+            Func<IReadOnlyList<FrameReviewDescriptor>, StarDetectorParams, CancellationToken, Task<List<FrameReview>>> frameReviewBuilder = null,
+            Func<bool> isCameraConnected = null,
+            Func<bool> isFocuserConnected = null) {
             this.profileService = profileService ?? throw new ArgumentNullException(nameof(profileService));
             this.starDetectionOptions = starDetectionOptions ?? throw new ArgumentNullException(nameof(starDetectionOptions));
             this.loader = loader ?? throw new ArgumentNullException(nameof(loader));
@@ -233,12 +247,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             this.region = region ?? StarDetectionRegion.Full;
             this.optimizerSettings = optimizerSettings ?? new OptimizerSettings();
             this.frameReviewBuilder = frameReviewBuilder;
+            this.isCameraConnected = isCameraConnected ?? (() => true);
+            this.isFocuserConnected = isFocuserConnected ?? (() => true);
 
             sourcePaths = new ObservableCollection<string> { null };
             applyRecommendedStepSize = true;
 
             BrowseSourceCommand = new RelayCommand<object>(BrowseSource);
-            StartCommand = new AsyncRelayCommand(() => StartAsync(CancellationToken.None));
+            StartCommand = new AsyncRelayCommand(() => StartAsync(CancellationToken.None), CanStart);
             CancelCommand = new RelayCommand(Cancel);
             AcceptCommand = new RelayCommand(Accept, () => Summary != null && !IsBusy);
             BackCommand = new RelayCommand(Back, () => CurrentStep == WizardStep.Summary && !IsBusy);
@@ -246,6 +262,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             ReviewCommand = new AsyncRelayCommand(EnterReviewAsync, CanEnterReview);
             BackToSummaryCommand = new RelayCommand(BackToSummary, () => CurrentStep == WizardStep.Review && !IsBusy);
             ReOptimizeCommand = new AsyncRelayCommand(() => ReOptimizeWithLabelsAsync(CancellationToken.None), () => HasLabels && !IsBusy);
+
+            // Start enables/disables as the per-run paths are filled in (Saved Auto-Focus), so re-evaluate its
+            // CanExecute whenever a path is set or the run count changes.
+            sourcePaths.CollectionChanged += (_, __) => StartCommand.NotifyCanExecuteChanged();
         }
 
         /// <summary>Raised when the user clicks Close so the host window (T5) can dismiss the dialog.</summary>
@@ -288,6 +308,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     sourceMode = value;
                     RaisePropertyChanged();
                     RaisePropertyChanged(nameof(IsReplay));
+                    // Live needs no paths (Start enabled); Saved disables Start until paths are filled.
+                    StartCommand.NotifyCanExecuteChanged();
                 }
             }
         }
@@ -536,6 +558,71 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         #endregion Commands
 
         /// <summary>
+        /// CanExecute for Start. Live is always startable (the camera/focuser connection is checked on Start with a
+        /// clear error). Saved Auto-Focus stays disabled until EVERY run has a (non-empty) folder picked — the
+        /// distinctness check happens on Start so the user gets an explanatory error rather than a silently-disabled
+        /// button. Always disabled while a run is in flight.
+        /// </summary>
+        private bool CanStart() {
+            if (IsBusy) {
+                return false;
+            }
+            if (SourceMode == SourceMode.Live) {
+                return true;
+            }
+            for (var i = 0; i < RunCount; i++) {
+                if (string.IsNullOrWhiteSpace(i < SourcePaths.Count ? SourcePaths[i] : null)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Pre-flight source validation run when Start is clicked. Live: the camera AND focuser must be connected.
+        /// Saved Auto-Focus: every run needs a folder (Start is already disabled until then; re-checked here as a
+        /// safety net) and the folders must be DISTINCT (optimizing the same run twice is almost certainly a
+        /// mistake). Sets <see cref="ErrorMessage"/> and returns false on failure.
+        /// </summary>
+        private bool ValidateSourceBeforeStart() {
+            if (SourceMode == SourceMode.Live) {
+                if (!isCameraConnected()) {
+                    ErrorMessage = "Connect a camera before running a live auto-focus optimization.";
+                    return false;
+                }
+                if (!isFocuserConnected()) {
+                    ErrorMessage = "Connect a focuser before running a live auto-focus optimization.";
+                    return false;
+                }
+                return true;
+            }
+
+            var normalized = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (var i = 0; i < RunCount; i++) {
+                var path = i < SourcePaths.Count ? SourcePaths[i] : null;
+                if (string.IsNullOrWhiteSpace(path)) {
+                    ErrorMessage = $"Select a saved auto-focus folder for run {i + 1}.";
+                    return false;
+                }
+                if (!normalized.Add(NormalizePath(path))) {
+                    ErrorMessage = "Each run must use a different saved auto-focus folder.";
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>Normalizes a folder path for distinctness comparison (full path, trailing separators trimmed);
+        /// falls back to the trimmed input when the path can't be expanded.</summary>
+        private static string NormalizePath(string path) {
+            try {
+                return Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            } catch {
+                return path?.Trim() ?? string.Empty;
+            }
+        }
+
+        /// <summary>
         /// Runs the full pipeline: acquire (load each run) → seed guard → optimize → summary. Guards against a
         /// double-start, marshals progress via <see cref="IProgress{T}"/>, and never throws on cancellation —
         /// a cancelled run leaves the VM idle and re-runnable.
@@ -546,6 +633,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             }
 
             ErrorMessage = null;
+            // Pre-flight validation: Live needs the camera + focuser connected; Saved needs a distinct, non-empty
+            // folder per run. On failure, surface the error and stay on SelectSource without starting a run.
+            if (!ValidateSourceBeforeStart()) {
+                Interlocked.Exchange(ref running, 0);
+                return;
+            }
             Summary = null;
             Result = null;
             // Clear stale progress so a re-run after a cancel/complete doesn't briefly show the previous run's

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -99,6 +99,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// (σ is the focus-curve sigma — lower is tighter/better).</summary>
         public string SigmaText {
             get {
+                // "2.20 (unchanged)" when σ is effectively the same before/after (compared at the F2 precision
+                // shown), else "{seed} → {best}" with a "(~N% tighter)" suffix when it improved.
+                if (double.IsFinite(SeedSigmaFocus) && double.IsFinite(BestSigmaFocus)
+                    && Math.Abs(SeedSigmaFocus - BestSigmaFocus) < 0.005) {
+                    return $"{BestSigmaFocus:F2} (unchanged)";
+                }
                 var baseText = $"{SeedSigmaFocus:F2} → {BestSigmaFocus:F2}";
                 if (double.IsFinite(SeedSigmaFocus) && double.IsFinite(BestSigmaFocus)
                     && SeedSigmaFocus > 1e-9 && BestSigmaFocus < SeedSigmaFocus) {
@@ -542,6 +548,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             ErrorMessage = null;
             Summary = null;
             Result = null;
+            // Clear stale progress so a re-run after a cancel/complete doesn't briefly show the previous run's
+            // evaluation count / phase / improvement before the first progress callback overwrites them.
+            Evaluations = 0;
+            MaxEvaluations = 0;
+            ProgressSeedJ = 0;
+            ProgressBestJ = 0;
+            Phase = null;
             // A fresh run invalidates any prior review snapshot/labels (they belonged to the previous result).
             if (ReviewVM != null) {
                 ReviewVM.PropertyChanged -= OnReviewLabelsChanged;
@@ -1012,6 +1025,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             var labelsByFolderIndex = BuildPositionalLabelFallback(reoptimizeRunFolders, labelsByRunId);
 
             ErrorMessage = null;
+            // Clear stale progress so the re-optimize doesn't briefly show the prior run's numbers.
+            Evaluations = 0;
+            MaxEvaluations = 0;
+            ProgressSeedJ = 0;
+            ProgressBestJ = 0;
+            Phase = null;
             IsBusy = true;
 
             cts?.Dispose();


### PR DESCRIPTION
First of three themed PRs addressing the round of wizard/labeling UX feedback ("starry-hopper"). This one covers the **options UI + wizard flow**; the review-panel layout (PR2) and review interactions — undo/redo, scrollbars, right-click delete (PR3) — follow separately.

## Changes (feedback items in parentheses)
- **(1)** The three Defocus tuning knobs show only when **Advanced mode AND Defocus-Aware Gates** are both on (new `ShowOnUseAdvancedAndDefocusGates` row style); the gates toggle stays advanced-only.
- **(2)** "Optimize Star Detection" button now centers **over the options block** (the container hugs the options) instead of over the whole window/dock — fixed on both the Options page and the Imaging-tab dock.
- **(3)** Source mode renamed **"Replay" → "Saved Auto-Focus"** and **"Live" → "Live Auto-Focus"** (enum `[Description]`); **Number of runs** and the per-run folder pickers appear only for the Saved Auto-Focus source.
- **(4)** No Browse pickers in Live mode.
- **(5)** De-jargoned progress/summary: plain phase names ("Refining settings"…), **"Combinations tried"** instead of "Evaluations", the abstract **"J" removed from the UI** (kept in logs), a live **"Detection improved ~N%"** readout, and a focus-precision **σ before→after with "(~N% tighter)"**.
- **(6/7)** Clarified the AF step-size toggle (answers "what does the On/Off do"): it now lists the AF step size/offset rows in the **Changed parameters** list when on, is **disabled when nothing changed**, and applies them on Accept.
- **(8)** Recommended step size & offset steps render as **"before → after"** or **"N (unchanged)"**.
- **(14)** The **Review screen no longer offers Accept** — its footer is **Back to summary · Optimize with feedback · Cancel**; Accept stays on the Summary step. (The re-optimize-with-labels pipeline already existed; this surfaces it correctly.)
- **(15)** Removed the manual **Save** button; labels persist on **Accept** and on **Re-optimize**, and are **discarded on Cancel** (Back-to-summary keeps them in memory). The standalone TestApp review tool still saves on window close.
- **(16)** Label files use a **clean run-derived name** (last 1–2 path segments) instead of the sanitized absolute path; the embedded `runId` stays authoritative, so old files and the offline `optimize --labels` harness still match.

## Tests
- New unit tests for the pure logic: summary formatters + improvement %, `IsReplay`, `CanApplyRecommendedStepSize`, `ChangedParametersDisplay` AF-row gating, and the clean filename derivation.
- Full suite green: **1198 passed, 0 failed**.

## Notes
- Detection math is untouched — these are UI/flow/persistence changes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)