### PR TITLE
Star review panel interactions: undo/redo, scrollbars, right-click delete (PR3/3)

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarReviewTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarReviewTests.cs
@@ -620,4 +620,24 @@ public class StarReviewTests {
             Assert.That(rejected, Has.Count.EqualTo(3));
         });
     }
+
+    // ---- Legend (starry-hopper item 13) -----------------------------------------------------------------
+
+    [Test]
+    public void LegendEntries_CoverAcceptedRejectedAndUserLabels_WithPlainCaptions() {
+        var queue = new List<FrameReview> { new FrameReview { RunId = "r", FocuserPosition = 1000 } };
+        var vm = new StarReviewVM(queue, new Dictionary<string, StarReviewRunLabels>(StringComparer.Ordinal), string.Empty);
+
+        var legend = vm.LegendEntries;
+        Assert.Multiple(() => {
+            // 1 accepted + 7 rejection reasons + 3 user-label types.
+            Assert.That(legend, Has.Count.EqualTo(11));
+            Assert.That(legend.Count(e => e.Dashed), Is.EqualTo(3), "the three user-label types are dashed");
+            Assert.That(legend.Any(e => e.Caption == "Accepted star" && !e.Dashed), Is.True);
+            Assert.That(legend.All(e => e.Brush != null), Is.True);
+            // Plain-language captions — raw gate enum names must not leak through.
+            Assert.That(legend.Any(e => e.Caption.Contains("TooDistorted")), Is.False);
+            Assert.That(legend.Any(e => e.Caption == "Rejected: Too distorted"), Is.True);
+        });
+    }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarReviewTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarReviewTests.cs
@@ -495,6 +495,48 @@ public class StarReviewTests {
         });
     }
 
+    // ---- Bounded pan (starry-hopper item 11) ------------------------------------------------------------
+
+    [Test]
+    public void ClampToBounds_LargerThanViewport_KeepsImageCoveringViewport() {
+        // image 200x200 at scale 1 => content 200 > viewport 100 => offset must stay in [-100, 0].
+        var vp = new StarReviewViewport(1.0, 0, 0);
+        vp.PanBy(500, 500); // over-pan toward positive
+        vp.ClampToBounds(100, 100, 200, 200);
+        Assert.Multiple(() => {
+            Assert.That(vp.OffsetX, Is.EqualTo(0).Within(1e-9));
+            Assert.That(vp.OffsetY, Is.EqualTo(0).Within(1e-9));
+        });
+
+        vp.PanBy(-1000, -1000); // over-pan toward negative
+        vp.ClampToBounds(100, 100, 200, 200);
+        Assert.Multiple(() => {
+            Assert.That(vp.OffsetX, Is.EqualTo(-100).Within(1e-9));
+            Assert.That(vp.OffsetY, Is.EqualTo(-100).Within(1e-9));
+        });
+    }
+
+    [Test]
+    public void ClampToBounds_SmallerThanViewport_CentersAxis() {
+        // content 100 < viewport 200 => the axis is centered at (200-100)/2 = 50, regardless of prior offset.
+        var vp = new StarReviewViewport(1.0, 999, -999);
+        vp.ClampToBounds(200, 200, 100, 100);
+        Assert.Multiple(() => {
+            Assert.That(vp.OffsetX, Is.EqualTo(50).Within(1e-9));
+            Assert.That(vp.OffsetY, Is.EqualTo(50).Within(1e-9));
+        });
+    }
+
+    [Test]
+    public void ClampToBounds_NonPositiveDims_NoOp() {
+        var vp = new StarReviewViewport(1.0, 33, 44);
+        vp.ClampToBounds(0, 0, 100, 100);
+        Assert.Multiple(() => {
+            Assert.That(vp.OffsetX, Is.EqualTo(33).Within(1e-9));
+            Assert.That(vp.OffsetY, Is.EqualTo(44).Within(1e-9));
+        });
+    }
+
     // ---- Combined hit-test + categorize (mode-less click routing) -----------------------------------------
     //
     // The view (StarReviewControl) decides click-vs-drag and the VM infers the label category from the SAME pure
@@ -638,6 +680,99 @@ public class StarReviewTests {
             // Plain-language captions — raw gate enum names must not leak through.
             Assert.That(legend.Any(e => e.Caption.Contains("TooDistorted")), Is.False);
             Assert.That(legend.Any(e => e.Caption == "Rejected: Too distorted"), Is.True);
+        });
+    }
+
+    // ---- Undo/redo + right-click delete (starry-hopper items 9/17) --------------------------------------
+
+    private static FrameReview FrameWithBoxes(string runId = "r", int pos = 1000) {
+        var f = new FrameReview { RunId = runId, FocuserPosition = pos };
+        f.Accepted.Add((110, 110, 2.0, new Rect(100, 100, 20, 20))); // accepted box
+        f.Rejected.Add(("TooDistorted", new Rect(300, 300, 20, 20))); // rejected box
+        return f;
+    }
+
+    private static StarReviewVM ReviewVM(out Dictionary<string, StarReviewRunLabels> labels, params FrameReview[] frames) {
+        labels = new Dictionary<string, StarReviewRunLabels>(StringComparer.Ordinal);
+        foreach (var rid in frames.Select(f => f.RunId).Distinct(StringComparer.Ordinal)) {
+            labels[rid] = new StarReviewRunLabels { RunId = rid, RadiusPx = 6.0 };
+        }
+        return new StarReviewVM(frames, labels, string.Empty);
+    }
+
+    private static (int missed, int reject, int wrongly) Counts(Dictionary<string, StarReviewRunLabels> labels, string runId, int pos) {
+        var p = labels[runId].Positions.FirstOrDefault(x => x.FocuserPosition == pos);
+        return (p?.Missed?.Count ?? 0, p?.ShouldReject?.Count ?? 0, p?.WronglyRejected?.Count ?? 0);
+    }
+
+    [Test]
+    public void Undo_Redo_MissedBox() {
+        var vm = ReviewVM(out var labels, FrameWithBoxes());
+        vm.AddMissedBox(500, 500, 20, 20);
+        Assert.That(Counts(labels, "r", 1000).missed, Is.EqualTo(1));
+
+        Assert.That(vm.UndoCommand.CanExecute(null), Is.True);
+        vm.UndoCommand.Execute(null);
+        Assert.That(Counts(labels, "r", 1000).missed, Is.EqualTo(0), "undo removes the added missed box");
+
+        Assert.That(vm.RedoCommand.CanExecute(null), Is.True);
+        vm.RedoCommand.Execute(null);
+        Assert.That(Counts(labels, "r", 1000).missed, Is.EqualTo(1), "redo re-adds it");
+    }
+
+    [Test]
+    public void Undo_RestoresToggledLabel() {
+        var vm = ReviewVM(out var labels, FrameWithBoxes());
+        vm.ToggleLabelAt(110, 110); // inside the accepted box => should-reject
+        Assert.That(Counts(labels, "r", 1000).reject, Is.EqualTo(1));
+        vm.UndoCommand.Execute(null);
+        Assert.That(Counts(labels, "r", 1000).reject, Is.EqualTo(0), "undo removes the should-reject label");
+    }
+
+    [Test]
+    public void RemoveLabelAt_DeletesLabel_AndUndoRestoresIt() {
+        var vm = ReviewVM(out var labels, FrameWithBoxes());
+        vm.AddMissedBox(500, 500, 20, 20); // center (510,510)
+        Assert.That(Counts(labels, "r", 1000).missed, Is.EqualTo(1));
+
+        var removed = vm.RemoveLabelAt(510, 510);
+        Assert.That(removed, Is.True);
+        Assert.That(Counts(labels, "r", 1000).missed, Is.EqualTo(0), "right-click removed the label");
+
+        vm.UndoCommand.Execute(null);
+        Assert.That(Counts(labels, "r", 1000).missed, Is.EqualTo(1), "undo restores a right-click deletion");
+    }
+
+    [Test]
+    public void RemoveLabelAt_OutsideEveryLabel_IsNoOp() {
+        var vm = ReviewVM(out _, FrameWithBoxes());
+        vm.AddMissedBox(500, 500, 20, 20);
+        Assert.That(vm.RemoveLabelAt(10, 10), Is.False);
+    }
+
+    [Test]
+    public void NewEdit_ClearsRedoStack() {
+        var vm = ReviewVM(out _, FrameWithBoxes());
+        vm.AddMissedBox(500, 500, 20, 20);
+        vm.UndoCommand.Execute(null);
+        Assert.That(vm.RedoCommand.CanExecute(null), Is.True, "precondition: a redo is available");
+
+        vm.AddMissedBox(600, 600, 20, 20); // a fresh edit forks history
+        Assert.That(vm.RedoCommand.CanExecute(null), Is.False, "a new edit clears the redo stack");
+    }
+
+    [Test]
+    public void Undo_NavigatesToTheEditedFrame() {
+        var vm = ReviewVM(out var labels, FrameWithBoxes("r", 1000), FrameWithBoxes("r", 2000));
+        // Label on frame 0, move to frame 1, then undo — it must jump back to frame 0 so the change is visible.
+        vm.AddMissedBox(500, 500, 20, 20);
+        vm.NextCommand.Execute(null);
+        Assert.That(vm.CurrentIndex, Is.EqualTo(1));
+
+        vm.UndoCommand.Execute(null);
+        Assert.Multiple(() => {
+            Assert.That(vm.CurrentIndex, Is.EqualTo(0), "undo navigates back to the edited frame");
+            Assert.That(Counts(labels, "r", 1000).missed, Is.EqualTo(0));
         });
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -30,7 +30,7 @@
                     <Setter Property="MinHeight" Value="420" />
                     <Style.Triggers>
                         <DataTrigger Binding="{Binding IsReview}" Value="True">
-                            <Setter Property="Width" Value="980" />
+                            <Setter Property="Width" Value="1120" />
                             <Setter Property="MinHeight" Value="720" />
                         </DataTrigger>
                     </Style.Triggers>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -212,7 +212,10 @@
                                     </Style>
                                 </Rectangle.Style>
                             </Rectangle>
-                            <TextBlock Width="190" VerticalAlignment="Center" Text="{Binding Caption}" TextWrapping="Wrap" />
+                            <!-- Explicit Foreground: the control's implicit white-TextBlock style does not reach
+                                 TextBlocks generated inside this ItemTemplate, so they'd render dark-on-dark. -->
+                            <TextBlock Width="190" VerticalAlignment="Center" Foreground="{StaticResource Fg}"
+                                       Text="{Binding Caption}" TextWrapping="Wrap" />
                         </StackPanel>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -16,22 +16,25 @@
     </UserControl.Resources>
 
     <Grid Margin="10">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <!-- Header -->
-        <DockPanel Grid.Row="0" LastChildFill="False" Margin="0,0,0,6">
+        <DockPanel Grid.Row="0" Grid.Column="0" LastChildFill="False" Margin="0,0,0,6">
             <TextBlock DockPanel.Dock="Left" FontWeight="SemiBold" Text="{Binding FrameHeader}" />
             <TextBlock DockPanel.Dock="Right" Text="{Binding PositionLabel}" />
         </DockPanel>
 
-        <!-- Toolbar: radius, navigation, save (labeling is mode-less — the category is inferred from what is clicked). -->
-        <WrapPanel Grid.Row="1" Margin="0,0,0,6">
+        <!-- Toolbar: navigation (labeling is mode-less — the category is inferred from what is clicked). -->
+        <WrapPanel Grid.Row="1" Grid.Column="0" Margin="0,0,0,6">
             <TextBlock Margin="0,0,4,0" Text="Radius px:" />
             <TextBox Width="50" VerticalContentAlignment="Center"
                      Text="{Binding RadiusPx, UpdateSourceTrigger=PropertyChanged, StringFormat=0.#}" />
@@ -42,7 +45,7 @@
 
         <!-- Image + overlays. The Image and all marker layers share one transform (zoom/pan) so markers stay
              pinned to image pixels. Mouse events are handled in code-behind against the viewport. -->
-        <Border Grid.Row="2" ClipToBounds="True" Background="Black" BorderBrush="#FF3F4958" BorderThickness="1">
+        <Border Grid.Row="2" Grid.Column="0" ClipToBounds="True" Background="Black" BorderBrush="#FF3F4958" BorderThickness="1">
             <Canvas x:Name="ViewportCanvas"
                     Background="Transparent"
                     MouseWheel="ViewportCanvas_MouseWheel"
@@ -103,7 +106,7 @@
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Rectangle Width="{Binding Width}" Height="{Binding Height}"
-                                       Stroke="#FF00FF00"
+                                       Stroke="{Binding DataContext.AcceptedBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                        StrokeThickness="{Binding DataContext.MarkerStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
@@ -123,7 +126,7 @@
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Rectangle Width="{Binding Width}" Height="{Binding Height}"
-                                       Stroke="#FF00E5FF"
+                                       Stroke="{Binding DataContext.MissedBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                        StrokeDashArray="3 2"
                                        StrokeThickness="{Binding DataContext.LabelStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
                         </DataTemplate>
@@ -144,7 +147,7 @@
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Rectangle Width="{Binding Width}" Height="{Binding Height}"
-                                       Stroke="#FFFF8C00"
+                                       Stroke="{Binding DataContext.ShouldRejectBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                        StrokeDashArray="3 2"
                                        StrokeThickness="{Binding DataContext.LabelStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
                         </DataTemplate>
@@ -166,7 +169,7 @@
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Rectangle Width="{Binding Width}" Height="{Binding Height}"
-                                       Stroke="#FF39FF14"
+                                       Stroke="{Binding DataContext.WronglyRejectedBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                        StrokeDashArray="3 2"
                                        StrokeThickness="{Binding DataContext.LabelStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
                         </DataTemplate>
@@ -177,21 +180,43 @@
                      coords; shares the canvas transform so it tracks the cursor under zoom/pan). -->
                 <Rectangle x:Name="DragRect"
                            Visibility="Collapsed"
-                           Stroke="#FF00E5FF"
+                           Stroke="{Binding MissedBrush}"
                            StrokeDashArray="3 2"
                            StrokeThickness="{Binding LabelStrokeThickness}"
                            IsHitTestVisible="False" />
             </Canvas>
         </Border>
 
-        <!-- Mode-less interaction help + counts -->
-        <DockPanel Grid.Row="3" LastChildFill="False" Margin="0,6,0,0">
-            <TextBlock DockPanel.Dock="Left" FontWeight="SemiBold" Text="{Binding HelpText}" />
-            <TextBlock DockPanel.Dock="Right" Text="{Binding CountsLabel}" />
-        </DockPanel>
+        <!-- Concise, wrapping interaction instructions (the color key now lives in the legend panel at right) + counts. -->
+        <StackPanel Grid.Row="3" Grid.Column="0" Margin="0,6,0,0">
+            <TextBlock Foreground="#FFB0B6BD" Text="{Binding HelpText}" TextWrapping="Wrap" />
+            <TextBlock Margin="0,4,0,0" Foreground="#FFB0B6BD" Text="{Binding CountsLabel}" />
+        </StackPanel>
 
-        <!-- Legend / help -->
-        <TextBlock Grid.Row="4" Margin="0,4,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
-                   Text="SOLID detector boxes: green = accepted (real detector bounds); reason boxes = rejected (yellow TooDistorted, orange Degenerate, red Saturated, cyan LowSensitivity, magenta NotCentered, blue TooFlat, purple Contaminated). DASHED user labels: cyan = MISSED, orange = SHOULD-REJECT, bright-green = WRONGLY-REJECTED (folds into recall). Mode-less: LEFT-CLICK an accepted green box to flag a false positive; LEFT-CLICK a rejected box to keep it; LEFT-DRAG a box over blank space to mark a missed star (a tiny drag drops a small default box). Click an existing label again to remove it. Right-drag to pan, wheel to zoom." />
+        <!-- Color legend (right column), generated from the VM's single color source so it tracks the overlays. -->
+        <StackPanel Grid.Row="0" Grid.RowSpan="4" Grid.Column="1" Width="230" Margin="12,0,0,0">
+            <TextBlock FontWeight="Bold" Margin="0,0,0,6" Text="Legend" />
+            <ItemsControl ItemsSource="{Binding LegendEntries}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Margin="0,2" Orientation="Horizontal">
+                            <Rectangle Width="20" Height="12" Margin="0,0,8,0" VerticalAlignment="Center"
+                                       Fill="Transparent" Stroke="{Binding Brush}" StrokeThickness="2">
+                                <Rectangle.Style>
+                                    <Style TargetType="Rectangle">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Dashed}" Value="True">
+                                                <Setter Property="StrokeDashArray" Value="3 2" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Rectangle.Style>
+                            </Rectangle>
+                            <TextBlock Width="190" VerticalAlignment="Center" Text="{Binding Caption}" TextWrapping="Wrap" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </StackPanel>
     </Grid>
 </UserControl>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -33,19 +33,29 @@
             <TextBlock DockPanel.Dock="Right" Text="{Binding PositionLabel}" />
         </DockPanel>
 
-        <!-- Toolbar: navigation (labeling is mode-less — the category is inferred from what is clicked). -->
+        <!-- Toolbar: navigation + undo/redo (labeling is mode-less — the category is inferred from what is clicked). -->
         <WrapPanel Grid.Row="1" Grid.Column="0" Margin="0,0,0,6">
-            <TextBlock Margin="0,0,4,0" Text="Radius px:" />
-            <TextBox Width="50" VerticalContentAlignment="Center"
-                     Text="{Binding RadiusPx, UpdateSourceTrigger=PropertyChanged, StringFormat=0.#}" />
-            <Button Content="Fit" Command="{Binding FitCommand}" Margin="16,0,4,0" />
+            <Button Content="Fit" Command="{Binding FitCommand}" Margin="0,0,4,0" />
             <Button Content="◀ Prev" Command="{Binding PrevCommand}" />
             <Button Content="Next ▶" Command="{Binding NextCommand}" />
+            <Button Content="Undo" Command="{Binding UndoCommand}" Margin="16,0,4,0" />
+            <Button Content="Redo" Command="{Binding RedoCommand}" />
         </WrapPanel>
+
+        <!-- Image + scrollbars: the image Border sits at (0,0); scrollbars appear only when zoomed beyond fit. -->
+        <Grid Grid.Row="2" Grid.Column="0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
 
         <!-- Image + overlays. The Image and all marker layers share one transform (zoom/pan) so markers stay
              pinned to image pixels. Mouse events are handled in code-behind against the viewport. -->
-        <Border Grid.Row="2" Grid.Column="0" ClipToBounds="True" Background="Black" BorderBrush="#FF3F4958" BorderThickness="1">
+        <Border Grid.Row="0" Grid.Column="0" ClipToBounds="True" Background="Black" BorderBrush="#FF3F4958" BorderThickness="1">
             <Canvas x:Name="ViewportCanvas"
                     Background="Transparent"
                     MouseWheel="ViewportCanvas_MouseWheel"
@@ -186,6 +196,13 @@
                            IsHitTestVisible="False" />
             </Canvas>
         </Border>
+
+            <!-- Scrollbars: driven from code-behind (UpdateScrollBars); the Scroll handlers map value -> viewport offset. -->
+            <ScrollBar x:Name="VScroll" Grid.Row="0" Grid.Column="1" Orientation="Vertical"
+                       Visibility="Collapsed" Scroll="VScroll_Scroll" />
+            <ScrollBar x:Name="HScroll" Grid.Row="1" Grid.Column="0" Orientation="Horizontal"
+                       Visibility="Collapsed" Scroll="HScroll_Scroll" />
+        </Grid>
 
         <!-- Concise, wrapping interaction instructions (the color key now lives in the legend panel at right) + counts. -->
         <StackPanel Grid.Row="3" Grid.Column="0" Margin="0,6,0,0">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml.cs
@@ -27,9 +27,18 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
         private StarReviewVM Vm => DataContext as StarReviewVM;
 
+        // Minimum drag (image px for left, screen px for right) below which a press+release counts as a click, not a
+        // drag — so a blank left-click creates no missed box and a right-click deletes a label instead of panning.
+        private const double MinDragPx = 3.0;
+
         private bool panning;
         private System.Windows.Point lastPanScreen;
         private bool hasFitOnce;
+
+        // Right-button: distinguish a right-CLICK (delete the label under the cursor) from a right-DRAG (pan).
+        // rightMoved flips true once the pointer moves past MinDragPx while the right button is held.
+        private bool rightMoved;
+        private System.Windows.Point rightDownScreen;
 
         // Left-button interaction state (image-space). pressArmed is set on a valid left-button-down inside the image
         // and consumed on button-up (so a press that started outside the image, or after the VM went away, is ignored).
@@ -77,6 +86,18 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
                     OnFitRequested(this, EventArgs.Empty);
                     e.Handled = true;
                     break;
+                case Key.Z:
+                    if ((Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control && vm.UndoCommand.CanExecute(null)) {
+                        vm.UndoCommand.Execute(null);
+                        e.Handled = true;
+                    }
+                    break;
+                case Key.Y:
+                    if ((Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control && vm.RedoCommand.CanExecute(null)) {
+                        vm.RedoCommand.Execute(null);
+                        e.Handled = true;
+                    }
+                    break;
             }
         }
 
@@ -94,13 +115,69 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             if (vm == null) {
                 return;
             }
+            // Keep the image within the viewport (bounded pan; centered when smaller than the viewport).
+            vm.Viewport.ClampToBounds(ViewportCanvas.ActualWidth, ViewportCanvas.ActualHeight, vm.ImageWidth, vm.ImageHeight);
             ContentScale.ScaleX = vm.Viewport.Scale;
             ContentScale.ScaleY = vm.Viewport.Scale;
             ContentTranslate.X = vm.Viewport.OffsetX;
             ContentTranslate.Y = vm.Viewport.OffsetY;
+            UpdateScrollBars();
             // Markers scale with the canvas transform, so refresh the zoom-inverse stroke thickness after any
             // viewport change (this covers wheel-zoom, fit, and pan since all route through ApplyViewport).
             vm.NotifyViewportChanged();
+        }
+
+        private bool suppressScrollEvents;
+
+        /// <summary>Reflects the current viewport into the two scrollbars (shown only when the scaled image exceeds
+        /// the viewport on that axis). Scroll position on each axis is -Offset; the scrollable extent is
+        /// image·Scale - viewport.</summary>
+        private void UpdateScrollBars() {
+            var vm = Vm;
+            if (vm == null) {
+                return;
+            }
+            suppressScrollEvents = true;
+            try {
+                UpdateScrollBar(HScroll, ViewportCanvas.ActualWidth, vm.ImageWidth * vm.Viewport.Scale, -vm.Viewport.OffsetX);
+                UpdateScrollBar(VScroll, ViewportCanvas.ActualHeight, vm.ImageHeight * vm.Viewport.Scale, -vm.Viewport.OffsetY);
+            } finally {
+                suppressScrollEvents = false;
+            }
+        }
+
+        private static void UpdateScrollBar(System.Windows.Controls.Primitives.ScrollBar bar, double viewport, double content, double scrollPos) {
+            var scrollable = content - viewport;
+            if (scrollable > 0.5 && viewport > 0) {
+                bar.Visibility = Visibility.Visible;
+                bar.Minimum = 0;
+                bar.Maximum = scrollable;
+                bar.ViewportSize = viewport; // proportional thumb
+                bar.LargeChange = viewport * 0.9;
+                bar.SmallChange = Math.Max(1.0, viewport * 0.1);
+                bar.Value = Math.Min(Math.Max(scrollPos, 0.0), scrollable);
+            } else {
+                bar.Visibility = Visibility.Collapsed;
+                bar.Value = 0;
+            }
+        }
+
+        private void HScroll_Scroll(object sender, System.Windows.Controls.Primitives.ScrollEventArgs e) {
+            var vm = Vm;
+            if (vm == null || suppressScrollEvents) {
+                return;
+            }
+            vm.Viewport.Set(vm.Viewport.Scale, -e.NewValue, vm.Viewport.OffsetY);
+            ApplyViewport();
+        }
+
+        private void VScroll_Scroll(object sender, System.Windows.Controls.Primitives.ScrollEventArgs e) {
+            var vm = Vm;
+            if (vm == null || suppressScrollEvents) {
+                return;
+            }
+            vm.Viewport.Set(vm.Viewport.Scale, vm.Viewport.OffsetX, -e.NewValue);
+            ApplyViewport();
         }
 
         // The canvas RenderTransform maps image space -> screen space, so a mouse position taken relative to the
@@ -172,13 +249,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             if (dragging) {
                 dragging = false;
                 DragRect.Visibility = Visibility.Collapsed;
-                // Normalize so W,H >= 0 regardless of drag direction. AddMissedBox widens a tiny drag (effectively a
-                // click on blank space) to a small default box itself.
+                // Normalize so W,H >= 0 regardless of drag direction.
                 var x = Math.Min(dragStartImage.X, imgX);
                 var y = Math.Min(dragStartImage.Y, imgY);
                 var w = Math.Abs(imgX - dragStartImage.X);
                 var h = Math.Abs(imgY - dragStartImage.Y);
-                vm.AddMissedBox(x, y, w, h);
+                // A plain click on blank space (a negligible drag) must NOT create a box — only a real drag does.
+                if (w >= MinDragPx && h >= MinDragPx) {
+                    vm.AddMissedBox(x, y, w, h);
+                }
                 e.Handled = true;
                 return;
             }
@@ -191,7 +270,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
         private void ViewportCanvas_MouseRightButtonDown(object sender, MouseButtonEventArgs e) {
             panning = true;
-            lastPanScreen = ScreenPoint(e);
+            rightMoved = false;
+            rightDownScreen = ScreenPoint(e);
+            lastPanScreen = rightDownScreen;
             ViewportCanvas.CaptureMouse();
             e.Handled = true;
         }
@@ -200,6 +281,21 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             panning = false;
             ViewportCanvas.ReleaseMouseCapture();
             e.Handled = true;
+
+            // A right-CLICK (no meaningful drag) deletes the label under the cursor; a right-DRAG was a pan.
+            if (rightMoved) {
+                return;
+            }
+            var vm = Vm;
+            if (vm == null) {
+                return;
+            }
+            var screen = ScreenPoint(e);
+            var (imgX, imgY) = vm.Viewport.ScreenToImage(screen.X, screen.Y);
+            if (imgX < 0 || imgY < 0 || imgX > vm.ImageWidth || imgY > vm.ImageHeight) {
+                return;
+            }
+            vm.RemoveLabelAt(imgX, imgY);
         }
 
         private void ViewportCanvas_MouseMove(object sender, MouseEventArgs e) {
@@ -225,6 +321,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
                 return;
             }
             var screen = ScreenPoint(e);
+            // Once the right-button pointer travels past the threshold it's a pan, not a click-to-delete.
+            if (!rightMoved &&
+                (Math.Abs(screen.X - rightDownScreen.X) > MinDragPx || Math.Abs(screen.Y - rightDownScreen.Y) > MinDragPx)) {
+                rightMoved = true;
+            }
             var dx = screen.X - lastPanScreen.X;
             var dy = screen.Y - lastPanScreen.Y;
             lastPanScreen = screen;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
@@ -171,6 +171,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             PrevCommand = new RelayCommand(Prev, () => CurrentIndex > 0);
             SaveCommand = new RelayCommand(SaveAll);
             FitCommand = new RelayCommand(RequestFit);
+            UndoCommand = new RelayCommand(Undo, () => undoStack.Count > 0);
+            RedoCommand = new RelayCommand(Redo, () => redoStack.Count > 0);
 
             CurrentIndex = 0;
             LoadCurrent();
@@ -262,19 +264,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         /// legend panel to the right).</summary>
         public string HelpText =>
             "Left-drag over a missed star to mark it. Click an accepted box to flag a false positive, or a " +
-            "rejected box to keep it. Click a label again to remove it. Wheel to zoom, right-drag to pan.";
-
-        private double radiusPx = StarReviewLabelStore.DefaultRadiusPx;
-        public double RadiusPx {
-            get => radiusPx;
-            set {
-                if (Math.Abs(radiusPx - value) > 1e-9 && value > 0) {
-                    radiusPx = value;
-                    RaisePropertyChanged();
-                    PersistRadiusToCurrentPosition();
-                }
-            }
-        }
+            "rejected box to keep it. Right-click a label (or click it again) to remove it. Ctrl+Z / Ctrl+Y to " +
+            "undo / redo. Wheel to zoom, right-drag to pan.";
 
         public string CountsLabel {
             get {
@@ -293,6 +284,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         public RelayCommand PrevCommand { get; }
         public RelayCommand SaveCommand { get; }
         public RelayCommand FitCommand { get; }
+        public RelayCommand UndoCommand { get; }
+        public RelayCommand RedoCommand { get; }
 
         /// <summary>Raised when the VM wants the view to re-fit the image (initial load / Fit button).</summary>
         public event EventHandler FitRequested;
@@ -309,9 +302,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             }
         }
 
+        // Navigation no longer writes to disk: labels live in-memory (labelsByRun) and are flushed only by SaveAll
+        // (the wizard's Accept/Re-optimize, or the TestApp host's save-on-close), so a Cancel discards them.
         private void Next() {
             if (CurrentIndex < queue.Count - 1) {
-                SaveCurrentRun();
                 CurrentIndex++;
                 LoadCurrent();
             }
@@ -319,7 +313,6 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
         private void Prev() {
             if (CurrentIndex > 0) {
-                SaveCurrentRun();
                 CurrentIndex--;
                 LoadCurrent();
             }
@@ -348,12 +341,6 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
                 });
             }
 
-            // The radius shown defaults to the run default unless this position already overrode it.
-            var run = CurrentRunLabels;
-            var pos = CurrentPositionLabels;
-            radiusPx = pos?.RadiusPx ?? run?.RadiusPx ?? StarReviewLabelStore.DefaultRadiusPx;
-            RaisePropertyChanged(nameof(RadiusPx));
-
             RefreshLabelMarkers();
 
             NextCommand.NotifyCanExecuteChanged();
@@ -378,34 +365,29 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         // ---- Labeling (delegates to the pure store) --------------------------------------------------------
 
         /// <summary>
-        /// MISSED pass: adds (or toggles off) a user-drawn box. The view calls this on mouse-up of a rubber-band
-        /// drag (or a small click). (<paramref name="imageX"/>,<paramref name="imageY"/>) is the top-left and
-        /// (<paramref name="width"/>,<paramref name="height"/>) the size, already normalized to W,H ≥ 0 by the view.
-        /// A degenerate drag (below a few px — effectively a click) is widened to a small default box of side
-        /// 2·RadiusPx centered on the click, so a plain click still drops a usable region. Toggling near an existing
-        /// missed box's center removes it.
+        /// MISSED pass: adds a user-drawn box over a missed star (or toggles one off if the drag lands on an
+        /// existing missed box's center). The view calls this on mouse-up of a rubber-band drag with the box
+        /// already normalized to W,H ≥ 0; the view does NOT call it for a plain click on blank space (no
+        /// click-to-create — that drops stray boxes). Recorded as an undoable edit.
         /// </summary>
         public void AddMissedBox(double imageX, double imageY, double width, double height) {
             var run = CurrentRunLabels;
             if (run == null) {
                 return;
             }
-            const double minDragPx = 3.0;
-            if (width < minDragPx || height < minDragPx) {
-                // Effectively a click: drop a small default box centered on the click point.
-                var side = 2.0 * RadiusPx;
-                var cx = imageX + width / 2.0;
-                var cy = imageY + height / 2.0;
-                imageX = cx - side / 2.0;
-                imageY = cy - side / 2.0;
-                width = side;
-                height = side;
-            }
             var pos = StarReviewLabelStore.GetOrAddPosition(run, Current.FocuserPosition);
-            if (pos.RadiusPx == null) {
-                pos.RadiusPx = RadiusPx;
+            var cx = imageX + width / 2.0;
+            var cy = imageY + height / 2.0;
+            var idx = StarReviewLabelStore.NearestBoxIndexWithin(pos.Missed, cx, cy, StarReviewLabelStore.SamePointTolerancePx);
+            if (idx >= 0) {
+                var removed = pos.Missed[idx];
+                pos.Missed.RemoveAt(idx);
+                RecordEdit(run.RunId, Current.FocuserPosition, LabelKind.Missed, removed, wasAdd: false);
+            } else {
+                var box = new StarReviewLabelBox(imageX, imageY, width, height);
+                pos.Missed.Add(box);
+                RecordEdit(run.RunId, Current.FocuserPosition, LabelKind.Missed, box, wasAdd: true);
             }
-            StarReviewLabelStore.ToggleBox(pos.Missed, imageX, imageY, width, height);
             RefreshLabelMarkers();
         }
 
@@ -431,21 +413,68 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             }
 
             var pos = StarReviewLabelStore.GetOrAddPosition(run, Current.FocuserPosition);
-            if (pos.RadiusPx == null) {
-                pos.RadiusPx = RadiusPx;
-            }
+            var kind = category == HitCategory.Accepted ? LabelKind.ShouldReject : LabelKind.WronglyRejected;
             var list = category == HitCategory.Accepted ? pos.ShouldReject : pos.WronglyRejected;
 
             // Toggle semantics: if a label already covers this star (its center matches the hit box's center within
-            // tolerance), remove it; otherwise record the star's ACTUAL bounding box.
+            // tolerance), remove it; otherwise record the star's ACTUAL bounding box. Either way it's an undoable edit.
             var existing = StarReviewLabelStore.NearestBoxIndexWithin(
                 list, hit.X + hit.Width / 2.0, hit.Y + hit.Height / 2.0, StarReviewLabelStore.SamePointTolerancePx);
             if (existing >= 0) {
+                var removed = list[existing];
                 list.RemoveAt(existing);
+                RecordEdit(run.RunId, Current.FocuserPosition, kind, removed, wasAdd: false);
             } else {
-                list.Add(new StarReviewLabelBox(hit.X, hit.Y, hit.Width, hit.Height));
+                var box = new StarReviewLabelBox(hit.X, hit.Y, hit.Width, hit.Height);
+                list.Add(box);
+                RecordEdit(run.RunId, Current.FocuserPosition, kind, box, wasAdd: true);
             }
             RefreshLabelMarkers();
+        }
+
+        /// <summary>
+        /// Right-click delete: removes the smallest USER-LABEL box (missed / should-reject / wrongly-rejected)
+        /// containing (<paramref name="imageX"/>,<paramref name="imageY"/>), across all three lists. Returns true
+        /// if a label was removed (recorded as an undoable edit), false when the click was outside every label.
+        /// The view calls this on a right-CLICK (a right-drag pans instead).
+        /// </summary>
+        public bool RemoveLabelAt(double imageX, double imageY) {
+            var run = CurrentRunLabels;
+            var pos = CurrentPositionLabels;
+            if (run == null || pos == null) {
+                return false;
+            }
+
+            LabelKind bestKind = default;
+            List<StarReviewLabelBox> bestList = null;
+            var bestIdx = -1;
+            var bestArea = double.MaxValue;
+            foreach (var (kind, list) in new[] {
+                         (LabelKind.Missed, pos.Missed),
+                         (LabelKind.ShouldReject, pos.ShouldReject),
+                         (LabelKind.WronglyRejected, pos.WronglyRejected) }) {
+                var idx = StarReviewLabelStore.SmallestContainingBoxIndex(list, imageX, imageY);
+                if (idx < 0) {
+                    continue;
+                }
+                var b = list[idx];
+                var area = (b.W ?? 0.0) * (b.H ?? 0.0);
+                if (area < bestArea) {
+                    bestArea = area;
+                    bestKind = kind;
+                    bestList = list;
+                    bestIdx = idx;
+                }
+            }
+
+            if (bestList == null) {
+                return false;
+            }
+            var removed = bestList[bestIdx];
+            bestList.RemoveAt(bestIdx);
+            RecordEdit(run.RunId, pos.FocuserPosition, bestKind, removed, wasAdd: false);
+            RefreshLabelMarkers();
+            return true;
         }
 
         /// <summary>
@@ -522,44 +551,112 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         }
 
         /// <summary>Maps a stored label box to a drawable marker. A legacy label that somehow still lacks W/H is drawn
-        /// as a small 2·RadiusPx box centered on its (x,y) (Normalize back-fills on load, so this is belt-and-suspenders).</summary>
-        private LabelBoxMarker ToBoxMarker(StarReviewLabelBox b) {
+        /// as a small default box centered on its (x,y) (Normalize back-fills on load, so this is belt-and-suspenders).</summary>
+        private static LabelBoxMarker ToBoxMarker(StarReviewLabelBox b) {
             if (b.HasSize) {
                 return new LabelBoxMarker { X = b.X, Y = b.Y, Width = b.W.Value, Height = b.H.Value };
             }
-            var side = 2.0 * RadiusPx;
+            var side = 2.0 * StarReviewLabelStore.DefaultRadiusPx;
             return new LabelBoxMarker { X = b.X - side / 2.0, Y = b.Y - side / 2.0, Width = side, Height = side };
         }
 
-        private void PersistRadiusToCurrentPosition() {
-            var run = CurrentRunLabels;
-            if (run == null) {
+        // ---- Undo / redo -----------------------------------------------------------------------------------
+
+        private enum LabelKind { Missed, ShouldReject, WronglyRejected }
+
+        /// <summary>One undoable label edit: the box that was added or removed, in a specific run/position/list.</summary>
+        private sealed class LabelEdit {
+            public string RunId;
+            public int FocuserPosition;
+            public LabelKind Kind;
+            public StarReviewLabelBox Box;
+            public bool WasAdd; // true: the edit ADDED Box (undo removes it); false: it REMOVED Box (undo re-adds).
+        }
+
+        private readonly Stack<LabelEdit> undoStack = new();
+        private readonly Stack<LabelEdit> redoStack = new();
+
+        /// <summary>Records a label mutation for undo and clears the redo stack (a new edit forks the history).</summary>
+        private void RecordEdit(string runId, int focuserPosition, LabelKind kind, StarReviewLabelBox box, bool wasAdd) {
+            undoStack.Push(new LabelEdit { RunId = runId, FocuserPosition = focuserPosition, Kind = kind, Box = box, WasAdd = wasAdd });
+            redoStack.Clear();
+            RaiseUndoRedo();
+        }
+
+        private void Undo() {
+            if (undoStack.Count == 0) {
                 return;
             }
-            var pos = StarReviewLabelStore.GetOrAddPosition(run, Current.FocuserPosition);
-            pos.RadiusPx = RadiusPx;
+            var edit = undoStack.Pop();
+            ApplyEdit(edit, forward: false);
+            redoStack.Push(edit);
+            NavigateTo(edit.RunId, edit.FocuserPosition);
+            RefreshLabelMarkers();
+            RaiseUndoRedo();
+        }
+
+        private void Redo() {
+            if (redoStack.Count == 0) {
+                return;
+            }
+            var edit = redoStack.Pop();
+            ApplyEdit(edit, forward: true);
+            undoStack.Push(edit);
+            NavigateTo(edit.RunId, edit.FocuserPosition);
+            RefreshLabelMarkers();
+            RaiseUndoRedo();
+        }
+
+        /// <summary>Applies an edit in the forward (redo / original) or inverse (undo) direction to the in-memory
+        /// label model. Add/remove are matched by box-center tolerance so a re-applied add doesn't duplicate.</summary>
+        private void ApplyEdit(LabelEdit e, bool forward) {
+            if (!labelsByRun.TryGetValue(e.RunId, out var run) || run == null) {
+                return;
+            }
+            var pos = StarReviewLabelStore.GetOrAddPosition(run, e.FocuserPosition);
+            var list = ListFor(pos, e.Kind);
+            var doAdd = e.WasAdd ? forward : !forward;
+            if (doAdd) {
+                if (StarReviewLabelStore.NearestBoxIndexWithin(list, e.Box.CenterX, e.Box.CenterY, StarReviewLabelStore.SamePointTolerancePx) < 0) {
+                    list.Add(e.Box);
+                }
+            } else {
+                var idx = StarReviewLabelStore.NearestBoxIndexWithin(list, e.Box.CenterX, e.Box.CenterY, StarReviewLabelStore.SamePointTolerancePx);
+                if (idx >= 0) {
+                    list.RemoveAt(idx);
+                }
+            }
+        }
+
+        private static List<StarReviewLabelBox> ListFor(StarReviewPositionLabels pos, LabelKind kind) => kind switch {
+            LabelKind.Missed => pos.Missed,
+            LabelKind.ShouldReject => pos.ShouldReject,
+            _ => pos.WronglyRejected
+        };
+
+        /// <summary>Moves the current frame to the one matching (runId, focuserPosition) so an undone/redone edit is
+        /// visible. No-op if it is already current or not in the queue.</summary>
+        private void NavigateTo(string runId, int focuserPosition) {
+            if (Current.RunId == runId && Current.FocuserPosition == focuserPosition) {
+                return;
+            }
+            for (var i = 0; i < queue.Count; i++) {
+                if (queue[i].RunId == runId && queue[i].FocuserPosition == focuserPosition) {
+                    CurrentIndex = i;
+                    LoadCurrent();
+                    return;
+                }
+            }
+        }
+
+        private void RaiseUndoRedo() {
+            UndoCommand.NotifyCanExecuteChanged();
+            RedoCommand.NotifyCanExecuteChanged();
         }
 
         // ---- Persistence -----------------------------------------------------------------------------------
 
-        private void SaveCurrentRun() {
-            var run = CurrentRunLabels;
-            if (run == null) {
-                return;
-            }
-            try {
-                StarReviewLabelStore.PruneEmptyPositions(run);
-                var path = StarReviewLabelStore.Save(labelsDir, run);
-                if (path != null) {
-                    Logger.Info($"Saved labels for run '{run.RunId}' to {path}");
-                }
-            } catch (Exception ex) {
-                Logger.Error(ex, $"Failed to save labels for run '{run.RunId}'");
-                Console.Error.WriteLine($"Failed to save labels for run '{run.RunId}': {ex.Message}");
-            }
-        }
-
-        /// <summary>Saves every run's labels (save-on-close / Save button / final flush from the runner).</summary>
+        /// <summary>Saves every run's labels (save-on-close / final flush from the wizard or the TestApp host).</summary>
         public void SaveAll() {
             foreach (var run in labelsByRun.Values) {
                 try {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
@@ -75,6 +75,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         public Color Color { get; set; }
     }
 
+    /// <summary>One row of the on-screen color legend: a swatch brush, a plain-language caption, and whether the
+    /// swatch is drawn dashed (user labels) or solid (detector boxes).</summary>
+    public sealed class StarReviewLegendEntry {
+        public Brush Brush { get; set; }
+        public string Caption { get; set; }
+        public bool Dashed { get; set; }
+    }
+
     /// <summary>The kind of detector box (if any) found under a click point by <see cref="StarReviewVM.HitTestCandidate(IEnumerable{Rect}, IEnumerable{Rect}, double, double)"/>.</summary>
     public enum HitCategory {
         /// <summary>No detector box (accepted or rejected) contains the click.</summary>
@@ -112,6 +120,42 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             { "Contaminated",   Color.FromRgb(128, 0, 128) },   // purple
         };
 
+        // Plain-language captions for the rejection reasons, shown in the legend instead of the raw enum names.
+        private static readonly Dictionary<string, string> ReasonCaptions = new(StringComparer.Ordinal) {
+            { "TooDistorted",   "Too distorted" },
+            { "Degenerate",     "Degenerate shape" },
+            { "Saturated",      "Saturated" },
+            { "LowSensitivity", "Below sensitivity" },
+            { "NotCentered",    "Off-center" },
+            { "TooFlat",        "Too flat" },
+            { "Contaminated",   "Contaminated" },
+        };
+
+        // Fixed marker colors (the detector ACCEPTED box + the three user-label boxes). Centralized here so the
+        // overlays AND the legend draw from one source and can't drift. Frozen brushes are safe to share/bind.
+        private static readonly Color AcceptedColor = Color.FromRgb(0x00, 0xFF, 0x00);        // green
+        private static readonly Color MissedColor = Color.FromRgb(0x00, 0xE5, 0xFF);          // cyan
+        private static readonly Color ShouldRejectColor = Color.FromRgb(0xFF, 0x8C, 0x00);    // orange
+        private static readonly Color WronglyRejectedColor = Color.FromRgb(0x39, 0xFF, 0x14); // bright green
+
+        /// <summary>Detector ACCEPTED-box stroke (green). Bound by the accepted-marker overlay and the legend.</summary>
+        public Brush AcceptedBrush { get; } = FrozenBrush(AcceptedColor);
+
+        /// <summary>User "missed" label stroke (cyan, dashed).</summary>
+        public Brush MissedBrush { get; } = FrozenBrush(MissedColor);
+
+        /// <summary>User "should-reject" label stroke (orange, dashed).</summary>
+        public Brush ShouldRejectBrush { get; } = FrozenBrush(ShouldRejectColor);
+
+        /// <summary>User "wrongly-rejected / keep" label stroke (bright green, dashed).</summary>
+        public Brush WronglyRejectedBrush { get; } = FrozenBrush(WronglyRejectedColor);
+
+        private static SolidColorBrush FrozenBrush(Color c) {
+            var b = new SolidColorBrush(c);
+            b.Freeze();
+            return b;
+        }
+
         public StarReviewVM(
             IReadOnlyList<FrameReview> queue,
             Dictionary<string, StarReviewRunLabels> labelsByRun,
@@ -121,6 +165,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             this.labelsDir = labelsDir ?? throw new ArgumentNullException(nameof(labelsDir));
 
             Viewport = new StarReviewViewport();
+            LegendEntries = BuildLegend();
 
             NextCommand = new RelayCommand(Next, () => CurrentIndex < queue.Count - 1);
             PrevCommand = new RelayCommand(Prev, () => CurrentIndex > 0);
@@ -194,9 +239,30 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         public ObservableCollection<LabelBoxMarker> ShouldRejectMarkers { get; } = new();
         public ObservableCollection<LabelBoxMarker> WronglyRejectedMarkers { get; } = new();
 
-        /// <summary>Static, mode-less interaction help line shown under the image (no pass selection any more).</summary>
+        /// <summary>The on-screen color legend (swatch + plain-language caption), built once. Detector boxes are
+        /// drawn solid, the three user-label types dashed — matching the overlays. Generated from the same color
+        /// source as the markers so the two can't drift.</summary>
+        public IReadOnlyList<StarReviewLegendEntry> LegendEntries { get; }
+
+        private IReadOnlyList<StarReviewLegendEntry> BuildLegend() {
+            var entries = new List<StarReviewLegendEntry> {
+                new() { Brush = AcceptedBrush, Caption = "Accepted star", Dashed = false }
+            };
+            foreach (var kv in ReasonColors) {
+                var caption = ReasonCaptions.TryGetValue(kv.Key, out var c) ? c : kv.Key;
+                entries.Add(new StarReviewLegendEntry { Brush = FrozenBrush(kv.Value), Caption = "Rejected: " + caption, Dashed = false });
+            }
+            entries.Add(new StarReviewLegendEntry { Brush = MissedBrush, Caption = "Missed (you marked)", Dashed = true });
+            entries.Add(new StarReviewLegendEntry { Brush = ShouldRejectBrush, Caption = "Should reject (you marked)", Dashed = true });
+            entries.Add(new StarReviewLegendEntry { Brush = WronglyRejectedBrush, Caption = "Keep / wrongly rejected (you marked)", Dashed = true });
+            return entries;
+        }
+
+        /// <summary>Concise, wrapping interaction help shown under the image (the color key now lives in the
+        /// legend panel to the right).</summary>
         public string HelpText =>
-            "Click a green box to flag a false positive · click a rejected box to keep it · drag a box over a missed star · click a label again to remove it";
+            "Left-drag over a missed star to mark it. Click an accepted box to flag a false positive, or a " +
+            "rejected box to keep it. Click a label again to remove it. Wheel to zoom, right-drag to pan.";
 
         private double radiusPx = StarReviewLabelStore.DefaultRadiusPx;
         public double RadiusPx {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewViewport.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewViewport.cs
@@ -85,6 +85,32 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             OffsetY += dyScreen;
         }
 
+        /// <summary>
+        /// Clamps the offsets so the (scaled) image can't be dragged past the viewport edges: when the scaled
+        /// image is larger than the viewport on an axis, the offset is kept within [viewport - content, 0] so the
+        /// image always covers the viewport; when it is smaller, that axis is centered. Idempotent — safe to call
+        /// after every Pan/Zoom/Fit. Pure (no UI) so it is unit-tested. The current scrollable extent on each axis
+        /// is <c>max(0, image·Scale - viewport)</c>; the scroll position is <c>-Offset</c>.
+        /// </summary>
+        public void ClampToBounds(double viewportWidth, double viewportHeight, double imageWidth, double imageHeight) {
+            if (viewportWidth <= 0 || viewportHeight <= 0 || imageWidth <= 0 || imageHeight <= 0) {
+                return;
+            }
+            OffsetX = ClampAxis(OffsetX, viewportWidth, imageWidth * Scale);
+            OffsetY = ClampAxis(OffsetY, viewportHeight, imageHeight * Scale);
+        }
+
+        private static double ClampAxis(double offset, double viewport, double content) {
+            if (content <= viewport) {
+                // Scaled image smaller than the viewport on this axis: center it.
+                return (viewport - content) / 2.0;
+            }
+            // Larger than the viewport: keep it covering the viewport (offset in [viewport - content, 0]).
+            var min = viewport - content; // negative
+            const double max = 0.0;
+            return Math.Min(max, Math.Max(min, offset));
+        }
+
         public void Set(double scale, double offsetX, double offsetY) {
             Scale = ClampScale(scale);
             OffsetX = offsetX;


### PR DESCRIPTION
Third and final themed PR for the wizard/labeling UX feedback ("starry-hopper"). Covers the **review-panel interactions**.

> **Stacked on #58** (base = `ghilios/sdopt-review-layout`, which is stacked on #57). Will retarget to `develop` as the chain merges. Review the [last commit](../../commits/ghilios/sdopt-review-interactions) for the PR3-only diff.

## Changes (feedback items in parentheses)
- **(9) Undo / redo.** Every label mutation — missed-drag, accepted/rejected click, and the new right-click delete — is recorded as an undoable edit. Added **Undo/Redo** toolbar buttons and **Ctrl+Z / Ctrl+Y**. Undo navigates back to the edited frame so the change is visible; a fresh edit clears the redo stack.
- **(10) Drag-only missed boxes.** Removed the **"Radius px"** input; a plain click on blank space no longer drops a box — only a real drag creates a missed box. `DefaultRadiusPx` is kept solely for legacy point-file back-fill.
- **(17) Right-click delete.** A right-**click** on a user label removes the smallest label containing the point (across all three lists); a right-**drag** still pans. The deletion is undoable.
- **(11) Scrollbars + bounded pan.** New `StarReviewViewport.ClampToBounds` keeps the scaled image covering the viewport (centered when smaller than the viewport); horizontal/vertical scrollbars appear only when zoomed beyond fit and drive the viewport offset.
- **Label persistence:** frame navigation no longer auto-saves to disk (labels stay in-memory), completing the item-15 policy — labels persist on Accept / Re-optimize and are discarded on Cancel.

## Tests
- New unit tests: `ClampToBounds` (over-pan clamping, small-image centering, no-op on zero dims); undo/redo of missed boxes and toggled labels; right-click delete + undo restore; redo cleared on a new edit; cross-frame undo navigation.
- Full suite green: **1208 passed, 0 failed**.

## Notes
- Item 11 was the riskiest; the bounded-pan math lives in the unit-tested `StarReviewViewport`, and the transform-based rendering / hit-test are unchanged.
- The shared `StarReviewControl` is used by both the in-NINA wizard and the standalone `TestApp review` dev tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)