### PR TITLE
Star review panel: right-side color legend + concise instructions (replaces #58)

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarReviewTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarReviewTests.cs
@@ -620,4 +620,24 @@ public class StarReviewTests {
             Assert.That(rejected, Has.Count.EqualTo(3));
         });
     }
+
+    // ---- Legend (starry-hopper item 13) -----------------------------------------------------------------
+
+    [Test]
+    public void LegendEntries_CoverAcceptedRejectedAndUserLabels_WithPlainCaptions() {
+        var queue = new List<FrameReview> { new FrameReview { RunId = "r", FocuserPosition = 1000 } };
+        var vm = new StarReviewVM(queue, new Dictionary<string, StarReviewRunLabels>(StringComparer.Ordinal), string.Empty);
+
+        var legend = vm.LegendEntries;
+        Assert.Multiple(() => {
+            // 1 accepted + 7 rejection reasons + 3 user-label types.
+            Assert.That(legend, Has.Count.EqualTo(11));
+            Assert.That(legend.Count(e => e.Dashed), Is.EqualTo(3), "the three user-label types are dashed");
+            Assert.That(legend.Any(e => e.Caption == "Accepted star" && !e.Dashed), Is.True);
+            Assert.That(legend.All(e => e.Brush != null), Is.True);
+            // Plain-language captions — raw gate enum names must not leak through.
+            Assert.That(legend.Any(e => e.Caption.Contains("TooDistorted")), Is.False);
+            Assert.That(legend.Any(e => e.Caption == "Rejected: Too distorted"), Is.True);
+        });
+    }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -30,7 +30,7 @@
                     <Setter Property="MinHeight" Value="420" />
                     <Style.Triggers>
                         <DataTrigger Binding="{Binding IsReview}" Value="True">
-                            <Setter Property="Width" Value="980" />
+                            <Setter Property="Width" Value="1120" />
                             <Setter Property="MinHeight" Value="720" />
                         </DataTrigger>
                     </Style.Triggers>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -212,7 +212,10 @@
                                     </Style>
                                 </Rectangle.Style>
                             </Rectangle>
-                            <TextBlock Width="190" VerticalAlignment="Center" Text="{Binding Caption}" TextWrapping="Wrap" />
+                            <!-- Explicit Foreground: the control's implicit white-TextBlock style does not reach
+                                 TextBlocks generated inside this ItemTemplate, so they'd render dark-on-dark. -->
+                            <TextBlock Width="190" VerticalAlignment="Center" Foreground="{StaticResource Fg}"
+                                       Text="{Binding Caption}" TextWrapping="Wrap" />
                         </StackPanel>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -16,22 +16,25 @@
     </UserControl.Resources>
 
     <Grid Margin="10">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <!-- Header -->
-        <DockPanel Grid.Row="0" LastChildFill="False" Margin="0,0,0,6">
+        <DockPanel Grid.Row="0" Grid.Column="0" LastChildFill="False" Margin="0,0,0,6">
             <TextBlock DockPanel.Dock="Left" FontWeight="SemiBold" Text="{Binding FrameHeader}" />
             <TextBlock DockPanel.Dock="Right" Text="{Binding PositionLabel}" />
         </DockPanel>
 
-        <!-- Toolbar: radius, navigation, save (labeling is mode-less — the category is inferred from what is clicked). -->
-        <WrapPanel Grid.Row="1" Margin="0,0,0,6">
+        <!-- Toolbar: navigation (labeling is mode-less — the category is inferred from what is clicked). -->
+        <WrapPanel Grid.Row="1" Grid.Column="0" Margin="0,0,0,6">
             <TextBlock Margin="0,0,4,0" Text="Radius px:" />
             <TextBox Width="50" VerticalContentAlignment="Center"
                      Text="{Binding RadiusPx, UpdateSourceTrigger=PropertyChanged, StringFormat=0.#}" />
@@ -42,7 +45,7 @@
 
         <!-- Image + overlays. The Image and all marker layers share one transform (zoom/pan) so markers stay
              pinned to image pixels. Mouse events are handled in code-behind against the viewport. -->
-        <Border Grid.Row="2" ClipToBounds="True" Background="Black" BorderBrush="#FF3F4958" BorderThickness="1">
+        <Border Grid.Row="2" Grid.Column="0" ClipToBounds="True" Background="Black" BorderBrush="#FF3F4958" BorderThickness="1">
             <Canvas x:Name="ViewportCanvas"
                     Background="Transparent"
                     MouseWheel="ViewportCanvas_MouseWheel"
@@ -103,7 +106,7 @@
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Rectangle Width="{Binding Width}" Height="{Binding Height}"
-                                       Stroke="#FF00FF00"
+                                       Stroke="{Binding DataContext.AcceptedBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                        StrokeThickness="{Binding DataContext.MarkerStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
@@ -123,7 +126,7 @@
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Rectangle Width="{Binding Width}" Height="{Binding Height}"
-                                       Stroke="#FF00E5FF"
+                                       Stroke="{Binding DataContext.MissedBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                        StrokeDashArray="3 2"
                                        StrokeThickness="{Binding DataContext.LabelStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
                         </DataTemplate>
@@ -144,7 +147,7 @@
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Rectangle Width="{Binding Width}" Height="{Binding Height}"
-                                       Stroke="#FFFF8C00"
+                                       Stroke="{Binding DataContext.ShouldRejectBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                        StrokeDashArray="3 2"
                                        StrokeThickness="{Binding DataContext.LabelStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
                         </DataTemplate>
@@ -166,7 +169,7 @@
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Rectangle Width="{Binding Width}" Height="{Binding Height}"
-                                       Stroke="#FF39FF14"
+                                       Stroke="{Binding DataContext.WronglyRejectedBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                        StrokeDashArray="3 2"
                                        StrokeThickness="{Binding DataContext.LabelStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
                         </DataTemplate>
@@ -177,21 +180,43 @@
                      coords; shares the canvas transform so it tracks the cursor under zoom/pan). -->
                 <Rectangle x:Name="DragRect"
                            Visibility="Collapsed"
-                           Stroke="#FF00E5FF"
+                           Stroke="{Binding MissedBrush}"
                            StrokeDashArray="3 2"
                            StrokeThickness="{Binding LabelStrokeThickness}"
                            IsHitTestVisible="False" />
             </Canvas>
         </Border>
 
-        <!-- Mode-less interaction help + counts -->
-        <DockPanel Grid.Row="3" LastChildFill="False" Margin="0,6,0,0">
-            <TextBlock DockPanel.Dock="Left" FontWeight="SemiBold" Text="{Binding HelpText}" />
-            <TextBlock DockPanel.Dock="Right" Text="{Binding CountsLabel}" />
-        </DockPanel>
+        <!-- Concise, wrapping interaction instructions (the color key now lives in the legend panel at right) + counts. -->
+        <StackPanel Grid.Row="3" Grid.Column="0" Margin="0,6,0,0">
+            <TextBlock Foreground="#FFB0B6BD" Text="{Binding HelpText}" TextWrapping="Wrap" />
+            <TextBlock Margin="0,4,0,0" Foreground="#FFB0B6BD" Text="{Binding CountsLabel}" />
+        </StackPanel>
 
-        <!-- Legend / help -->
-        <TextBlock Grid.Row="4" Margin="0,4,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
-                   Text="SOLID detector boxes: green = accepted (real detector bounds); reason boxes = rejected (yellow TooDistorted, orange Degenerate, red Saturated, cyan LowSensitivity, magenta NotCentered, blue TooFlat, purple Contaminated). DASHED user labels: cyan = MISSED, orange = SHOULD-REJECT, bright-green = WRONGLY-REJECTED (folds into recall). Mode-less: LEFT-CLICK an accepted green box to flag a false positive; LEFT-CLICK a rejected box to keep it; LEFT-DRAG a box over blank space to mark a missed star (a tiny drag drops a small default box). Click an existing label again to remove it. Right-drag to pan, wheel to zoom." />
+        <!-- Color legend (right column), generated from the VM's single color source so it tracks the overlays. -->
+        <StackPanel Grid.Row="0" Grid.RowSpan="4" Grid.Column="1" Width="230" Margin="12,0,0,0">
+            <TextBlock FontWeight="Bold" Margin="0,0,0,6" Text="Legend" />
+            <ItemsControl ItemsSource="{Binding LegendEntries}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Margin="0,2" Orientation="Horizontal">
+                            <Rectangle Width="20" Height="12" Margin="0,0,8,0" VerticalAlignment="Center"
+                                       Fill="Transparent" Stroke="{Binding Brush}" StrokeThickness="2">
+                                <Rectangle.Style>
+                                    <Style TargetType="Rectangle">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Dashed}" Value="True">
+                                                <Setter Property="StrokeDashArray" Value="3 2" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Rectangle.Style>
+                            </Rectangle>
+                            <TextBlock Width="190" VerticalAlignment="Center" Text="{Binding Caption}" TextWrapping="Wrap" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </StackPanel>
     </Grid>
 </UserControl>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
@@ -75,6 +75,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         public Color Color { get; set; }
     }
 
+    /// <summary>One row of the on-screen color legend: a swatch brush, a plain-language caption, and whether the
+    /// swatch is drawn dashed (user labels) or solid (detector boxes).</summary>
+    public sealed class StarReviewLegendEntry {
+        public Brush Brush { get; set; }
+        public string Caption { get; set; }
+        public bool Dashed { get; set; }
+    }
+
     /// <summary>The kind of detector box (if any) found under a click point by <see cref="StarReviewVM.HitTestCandidate(IEnumerable{Rect}, IEnumerable{Rect}, double, double)"/>.</summary>
     public enum HitCategory {
         /// <summary>No detector box (accepted or rejected) contains the click.</summary>
@@ -112,6 +120,42 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             { "Contaminated",   Color.FromRgb(128, 0, 128) },   // purple
         };
 
+        // Plain-language captions for the rejection reasons, shown in the legend instead of the raw enum names.
+        private static readonly Dictionary<string, string> ReasonCaptions = new(StringComparer.Ordinal) {
+            { "TooDistorted",   "Too distorted" },
+            { "Degenerate",     "Degenerate shape" },
+            { "Saturated",      "Saturated" },
+            { "LowSensitivity", "Below sensitivity" },
+            { "NotCentered",    "Off-center" },
+            { "TooFlat",        "Too flat" },
+            { "Contaminated",   "Contaminated" },
+        };
+
+        // Fixed marker colors (the detector ACCEPTED box + the three user-label boxes). Centralized here so the
+        // overlays AND the legend draw from one source and can't drift. Frozen brushes are safe to share/bind.
+        private static readonly Color AcceptedColor = Color.FromRgb(0x00, 0xFF, 0x00);        // green
+        private static readonly Color MissedColor = Color.FromRgb(0x00, 0xE5, 0xFF);          // cyan
+        private static readonly Color ShouldRejectColor = Color.FromRgb(0xFF, 0x8C, 0x00);    // orange
+        private static readonly Color WronglyRejectedColor = Color.FromRgb(0x39, 0xFF, 0x14); // bright green
+
+        /// <summary>Detector ACCEPTED-box stroke (green). Bound by the accepted-marker overlay and the legend.</summary>
+        public Brush AcceptedBrush { get; } = FrozenBrush(AcceptedColor);
+
+        /// <summary>User "missed" label stroke (cyan, dashed).</summary>
+        public Brush MissedBrush { get; } = FrozenBrush(MissedColor);
+
+        /// <summary>User "should-reject" label stroke (orange, dashed).</summary>
+        public Brush ShouldRejectBrush { get; } = FrozenBrush(ShouldRejectColor);
+
+        /// <summary>User "wrongly-rejected / keep" label stroke (bright green, dashed).</summary>
+        public Brush WronglyRejectedBrush { get; } = FrozenBrush(WronglyRejectedColor);
+
+        private static SolidColorBrush FrozenBrush(Color c) {
+            var b = new SolidColorBrush(c);
+            b.Freeze();
+            return b;
+        }
+
         public StarReviewVM(
             IReadOnlyList<FrameReview> queue,
             Dictionary<string, StarReviewRunLabels> labelsByRun,
@@ -121,6 +165,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             this.labelsDir = labelsDir ?? throw new ArgumentNullException(nameof(labelsDir));
 
             Viewport = new StarReviewViewport();
+            LegendEntries = BuildLegend();
 
             NextCommand = new RelayCommand(Next, () => CurrentIndex < queue.Count - 1);
             PrevCommand = new RelayCommand(Prev, () => CurrentIndex > 0);
@@ -194,9 +239,30 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         public ObservableCollection<LabelBoxMarker> ShouldRejectMarkers { get; } = new();
         public ObservableCollection<LabelBoxMarker> WronglyRejectedMarkers { get; } = new();
 
-        /// <summary>Static, mode-less interaction help line shown under the image (no pass selection any more).</summary>
+        /// <summary>The on-screen color legend (swatch + plain-language caption), built once. Detector boxes are
+        /// drawn solid, the three user-label types dashed — matching the overlays. Generated from the same color
+        /// source as the markers so the two can't drift.</summary>
+        public IReadOnlyList<StarReviewLegendEntry> LegendEntries { get; }
+
+        private IReadOnlyList<StarReviewLegendEntry> BuildLegend() {
+            var entries = new List<StarReviewLegendEntry> {
+                new() { Brush = AcceptedBrush, Caption = "Accepted star", Dashed = false }
+            };
+            foreach (var kv in ReasonColors) {
+                var caption = ReasonCaptions.TryGetValue(kv.Key, out var c) ? c : kv.Key;
+                entries.Add(new StarReviewLegendEntry { Brush = FrozenBrush(kv.Value), Caption = "Rejected: " + caption, Dashed = false });
+            }
+            entries.Add(new StarReviewLegendEntry { Brush = MissedBrush, Caption = "Missed (you marked)", Dashed = true });
+            entries.Add(new StarReviewLegendEntry { Brush = ShouldRejectBrush, Caption = "Should reject (you marked)", Dashed = true });
+            entries.Add(new StarReviewLegendEntry { Brush = WronglyRejectedBrush, Caption = "Keep / wrongly rejected (you marked)", Dashed = true });
+            return entries;
+        }
+
+        /// <summary>Concise, wrapping interaction help shown under the image (the color key now lives in the
+        /// legend panel to the right).</summary>
         public string HelpText =>
-            "Click a green box to flag a false positive · click a rejected box to keep it · drag a box over a missed star · click a label again to remove it";
+            "Left-drag over a missed star to mark it. Click an accepted box to flag a false positive, or a " +
+            "rejected box to keep it. Click a label again to remove it. Wheel to zoom, right-drag to pan.";
 
         private double radiusPx = StarReviewLabelStore.DefaultRadiusPx;
         public double RadiusPx {


### PR DESCRIPTION
Recreated from #58, which GitHub auto-closed when its stacked base branch (#57) was deleted on merge — it couldn't be reopened (deleted base branch). Same commits, now based on `develop`.

Review-panel layout: color legend moved to a right-hand panel generated from the VM's single color source; concise wrapping bottom instructions; widened Review window; legend caption foreground fixed (was dark-on-dark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)