### PR TITLE
Optimize with feedback: direct label→gate recommender + warm-started optimizer

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/DefocusAwareStructureTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/DefocusAwareStructureTests.cs
@@ -1,0 +1,50 @@
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
+
+    /// <summary>
+    /// Phase 5: the opt-in, default-OFF defocus-aware structure-detection setting (DefocusAwareStructure +
+    /// StructureLayerBoost). When OFF, candidate formation must be bit-identical regardless of the boost value;
+    /// when ON, the coarser wavelet residual must still detect the field (and is a genuine EARLY param).
+    /// </summary>
+    [TestFixture]
+    public class DefocusAwareStructureTests {
+
+        [Test]
+        public async Task FlagOff_IgnoresBoost_BitIdentical() {
+            var pOff0 = StarDetectorEquivalence.StandardParams();
+            var pOff7 = StarDetectorEquivalence.StandardParams();
+            pOff7.StructureLayerBoost = 7; // boost set, but flag OFF ⇒ must be ignored
+
+            using var f1 = StarDetectorEquivalence.BuildSmallField();
+            var r1 = await StarDetectorEquivalence.RunDetect(f1, pOff0);
+
+            using var f2 = StarDetectorEquivalence.BuildSmallField();
+            var r2 = await StarDetectorEquivalence.RunDetect(f2, pOff7);
+
+            Assert.That(StarDetectorEquivalence.Signature(r2), Is.EqualTo(StarDetectorEquivalence.Signature(r1)),
+                "With DefocusAwareStructure OFF, StructureLayerBoost must not change detection at all.");
+        }
+
+        [Test]
+        public async Task FlagOn_DetectsField_AndIsAnEarlyParam() {
+            var pOn = StarDetectorEquivalence.StandardParams();
+            pOn.DefocusAwareStructure = true;
+            pOn.StructureLayerBoost = 2;
+
+            using var field = StarDetectorEquivalence.BuildSmallField();
+            var result = await StarDetectorEquivalence.RunDetect(field, pOn);
+
+            Assert.Multiple(() => {
+                Assert.That(result.DetectedStars, Is.Not.Null);
+                Assert.That(result.DetectedStars.Count, Is.GreaterThan(0), "coarser residual must still detect the star field");
+                // The setting changes candidate formation, so it must participate in the EARLY cache key.
+                Assert.That(StarDetector.IsEarlyCacheKeyParameter(nameof(StarDetectorParams.DefocusAwareStructure)), Is.True);
+                Assert.That(StarDetector.IsEarlyCacheKeyParameter(nameof(StarDetectorParams.StructureLayerBoost)), Is.True);
+            });
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/BoxMatcherTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/BoxMatcherTests.cs
@@ -1,0 +1,96 @@
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using Rect = OpenCvSharp.Rect;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Optimization {
+
+    [TestFixture]
+    public class BoxMatcherTests {
+
+        private static RejectedCandidateRecord Rec(string gate, int x, int y, int w, int h,
+            double measured = double.NaN, double thr = double.NaN) =>
+            new RejectedCandidateRecord {
+                Gate = gate,
+                Bounds = new Rect(x, y, w, h),
+                MeasuredValue = measured,
+                ThresholdValue = thr,
+                CandidateSize = Math.Max(w, h),
+                CenterX = x + w / 2.0,
+                CenterY = y + h / 2.0
+            };
+
+        [Test]
+        public void IoU_IdenticalRects_IsOne() {
+            Assert.That(BoxMatcher.IoU(new RectD(10, 10, 20, 20), new RectD(10, 10, 20, 20)), Is.EqualTo(1.0).Within(1e-9));
+        }
+
+        [Test]
+        public void IoU_Disjoint_IsZero() {
+            Assert.That(BoxMatcher.IoU(new RectD(0, 0, 10, 10), new RectD(100, 100, 10, 10)), Is.EqualTo(0.0));
+        }
+
+        [Test]
+        public void Classify_OverlapsRejectedOnly_ReportsGateAndMeasuredValue() {
+            var label = new RectD(100, 100, 20, 20);
+            var rejected = new List<RejectedCandidateRecord> {
+                Rec(RejectionGate.LowSensitivity, 100, 100, 20, 20, measured: 1.3, thr: 2.0)
+            };
+            var m = BoxMatcher.Classify(label, new List<Rect>(), rejected);
+            Assert.Multiple(() => {
+                Assert.That(m.Kind, Is.EqualTo(BoxClassification.Rejected));
+                Assert.That(m.Gate, Is.EqualTo(RejectionGate.LowSensitivity));
+                Assert.That(m.Rejected.MeasuredValue, Is.EqualTo(1.3));
+            });
+        }
+
+        [Test]
+        public void Classify_TooLowHFR_AttributedNotNoCandidate() {
+            // The regression this whole side channel fixes: a TooLowHFR rejection has no metrics *Bounds list, but
+            // it IS in the records pool, so it must classify as REJECTED:TooLowHFR rather than NO CANDIDATE.
+            var label = new RectD(50, 50, 12, 12);
+            var rejected = new List<RejectedCandidateRecord> {
+                Rec(RejectionGate.TooLowHFR, 50, 50, 12, 12, measured: 0.9, thr: 1.2)
+            };
+            var m = BoxMatcher.Classify(label, new List<Rect>(), rejected);
+            Assert.Multiple(() => {
+                Assert.That(m.Kind, Is.EqualTo(BoxClassification.Rejected));
+                Assert.That(m.Gate, Is.EqualTo(RejectionGate.TooLowHFR));
+            });
+        }
+
+        [Test]
+        public void Classify_OverlapsAcceptedOnly_IsAccepted() {
+            var label = new RectD(200, 200, 16, 16);
+            var accepted = new List<Rect> { new Rect(200, 200, 16, 16) };
+            var m = BoxMatcher.Classify(label, accepted, new List<RejectedCandidateRecord>());
+            Assert.That(m.Kind, Is.EqualTo(BoxClassification.Accepted));
+        }
+
+        [Test]
+        public void Classify_OverlapsNeither_IsNoCandidate() {
+            var label = new RectD(10, 10, 8, 8);
+            var accepted = new List<Rect> { new Rect(500, 500, 16, 16) };
+            var rejected = new List<RejectedCandidateRecord> { Rec(RejectionGate.LowSensitivity, 600, 600, 10, 10) };
+            var m = BoxMatcher.Classify(label, accepted, rejected);
+            Assert.That(m.Kind, Is.EqualTo(BoxClassification.NoCandidate));
+        }
+
+        [Test]
+        public void Classify_AcceptedWinsTie() {
+            // Same box overlaps an accepted star and a rejected candidate at equal IoU → accepted wins (detector's
+            // actual outcome), but the rejected candidate is still reported for the tie note.
+            var label = new RectD(300, 300, 20, 20);
+            var accepted = new List<Rect> { new Rect(300, 300, 20, 20) };
+            var rejected = new List<RejectedCandidateRecord> { Rec(RejectionGate.TooDistorted, 300, 300, 20, 20) };
+            var m = BoxMatcher.Classify(label, accepted, rejected);
+            Assert.Multiple(() => {
+                Assert.That(m.Kind, Is.EqualTo(BoxClassification.Accepted));
+                Assert.That(m.Rejected, Is.Not.Null, "the tied rejected candidate is still surfaced for the note");
+                Assert.That(m.AcceptedIoU, Is.EqualTo(m.RejectedIoU).Within(1e-9));
+            });
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/GateRecommenderTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/GateRecommenderTests.cs
@@ -1,0 +1,148 @@
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Optimization {
+
+    [TestFixture]
+    public class GateRecommenderTests {
+
+        private static AnalyzedRejection R(string gate, double measured, bool recall, double size = 10, bool sr = false, int pos = 5000) =>
+            new AnalyzedRejection {
+                Gate = gate,
+                MeasuredValue = measured,
+                ThresholdValue = 2.0,
+                CandidateSize = size,
+                FocuserPosition = pos,
+                IsRecallTarget = recall,
+                InShouldRejectBox = sr
+            };
+
+        private static LabelGateAnalysis Analysis(IEnumerable<AnalyzedRejection> recs, int noCandidate = 0, int totalRecall = -1) {
+            var list = recs.ToList();
+            var noCand = Enumerable.Range(0, noCandidate).Select(_ => new NoCandidateTarget()).ToList();
+            return new LabelGateAnalysis {
+                Rejections = list,
+                NoCandidate = noCand,
+                NoCandidateCount = noCandidate,
+                TotalRecallTargets = totalRecall >= 0 ? totalRecall : list.Count(r => r.IsRecallTarget) + noCandidate
+            };
+        }
+
+        private static StarDetectorParams CurrentParams() => new StarDetectorParams {
+            Sensitivity = 2.0, MinHFR = 1.2, MaxDistortion = 0.5, PeakResponse = 0.75,
+            StarCenterTolerance = 0.3, MinimumStarBoundingBoxSize = 5
+        };
+
+        [Test]
+        public void LowSensitivity_AdmitsAllLabeled_WithinBudget() {
+            var a = Analysis(new[] {
+                R(RejectionGate.LowSensitivity, 1.1, recall: true),
+                R(RejectionGate.LowSensitivity, 1.3, recall: true),
+                R(RejectionGate.LowSensitivity, 1.5, recall: true),
+                R(RejectionGate.LowSensitivity, 1.4, recall: false),
+                R(RejectionGate.LowSensitivity, 1.6, recall: false),
+            });
+            var rec = GateRecommender.Recommend(a, CurrentParams());
+            var row = rec.Rows.Single(r => r.Gate == RejectionGate.LowSensitivity);
+            Assert.Multiple(() => {
+                Assert.That(row.Applied, Is.True);
+                Assert.That(row.Recovered, Is.EqualTo(3));
+                Assert.That(row.NewValue.Value, Is.LessThan(1.1), "Sensitivity must drop below the faintest labeled star's ratio to admit it");
+                Assert.That(rec.Recommended.Sensitivity, Is.EqualTo(row.NewValue.Value));
+                Assert.That(row.WeightedPrecisionCost, Is.EqualTo(2.0), "both unlabeled candidates (1.4, 1.6) are newly admitted");
+            });
+        }
+
+        [Test]
+        public void LowSensitivity_ShouldRejectLabel_VetoesFurtherLoosening() {
+            var a = Analysis(new[] {
+                R(RejectionGate.LowSensitivity, 1.5, recall: true),
+                R(RejectionGate.LowSensitivity, 1.1, recall: true),
+                R(RejectionGate.LowSensitivity, 1.3, recall: false, sr: true), // user said: reject this one
+            });
+            var rec = GateRecommender.Recommend(a, CurrentParams());
+            var row = rec.Rows.Single(r => r.Gate == RejectionGate.LowSensitivity);
+            Assert.Multiple(() => {
+                Assert.That(row.Recovered, Is.EqualTo(1), "only the 1.5 target is recoverable without re-admitting the should-reject at 1.3");
+                Assert.That(rec.Recommended.Sensitivity, Is.GreaterThanOrEqualTo(1.3), "must not drop below the should-reject star's ratio");
+            });
+        }
+
+        [Test]
+        public void LowSensitivity_DenseUnlabeled_BacksOffOnCostEffectiveness() {
+            var recs = new List<AnalyzedRejection> {
+                R(RejectionGate.LowSensitivity, 1.9, recall: true),
+                R(RejectionGate.LowSensitivity, 1.5, recall: true),
+            };
+            recs.AddRange(Enumerable.Range(0, 10).Select(_ => R(RejectionGate.LowSensitivity, 1.6, recall: false)));
+            var rec = GateRecommender.Recommend(Analysis(recs), CurrentParams());
+            var row = rec.Rows.Single(r => r.Gate == RejectionGate.LowSensitivity);
+            Assert.That(row.Recovered, Is.EqualTo(1),
+                "admitting the 1.5 target would flood in 10 unlabeled candidates (cost 10 > 2*2), so back off to just the 1.9 target");
+        }
+
+        [Test]
+        public void TooFlat_RaisesPeakResponse() {
+            var a = Analysis(new[] {
+                R(RejectionGate.TooFlat, 0.80, recall: true),
+                R(RejectionGate.TooFlat, 0.85, recall: true),
+            });
+            var rec = GateRecommender.Recommend(a, CurrentParams());
+            var row = rec.Rows.Single(r => r.Gate == RejectionGate.TooFlat);
+            Assert.Multiple(() => {
+                Assert.That(row.Recovered, Is.EqualTo(2));
+                Assert.That(rec.Recommended.PeakResponse, Is.GreaterThan(0.85), "PeakResponse must rise above the flattest labeled ratio");
+                Assert.That(rec.Recommended.PeakResponse, Is.LessThanOrEqualTo(1.0));
+            });
+        }
+
+        [Test]
+        public void TooDistorted_LargeTargets_RecommendsDefocusAwareGates() {
+            var a = Analysis(new[] {
+                R(RejectionGate.TooDistorted, 0.30, recall: true, size: 50),
+                R(RejectionGate.TooDistorted, 0.35, recall: true, size: 45),
+            });
+            var rec = GateRecommender.Recommend(a, CurrentParams());
+            Assert.Multiple(() => {
+                Assert.That(rec.RecommendDefocusAwareGates, Is.True);
+                Assert.That(rec.Recommended.DefocusAwareDistortion, Is.True);
+                Assert.That(rec.Recommended.MaxDistortion, Is.EqualTo(0.5), "the global MaxDistortion is left alone for large/defocused targets");
+            });
+        }
+
+        [Test]
+        public void TooDistorted_SmallTargets_LowersMaxDistortion() {
+            var a = Analysis(new[] {
+                R(RejectionGate.TooDistorted, 0.30, recall: true, size: 12),
+                R(RejectionGate.TooDistorted, 0.35, recall: true, size: 14),
+            });
+            var rec = GateRecommender.Recommend(a, CurrentParams());
+            Assert.Multiple(() => {
+                Assert.That(rec.RecommendDefocusAwareGates, Is.False);
+                Assert.That(rec.Recommended.MaxDistortion, Is.LessThan(0.30), "lower MaxDistortion to admit the small distorted stars");
+            });
+        }
+
+        [Test]
+        public void NonInvertibleGate_IsReportedNotApplied() {
+            var a = Analysis(new[] { R(RejectionGate.Degenerate, double.NaN, recall: true) });
+            var rec = GateRecommender.Recommend(a, CurrentParams());
+            var row = rec.Rows.Single(r => r.Gate == RejectionGate.Degenerate);
+            Assert.Multiple(() => {
+                Assert.That(row.Applied, Is.False);
+                Assert.That(row.Note, Does.Contain("not recoverable"));
+                Assert.That(rec.Recommended.Sensitivity, Is.EqualTo(2.0), "no scalar gate touched");
+            });
+        }
+
+        [Test]
+        public void ManyNoCandidate_RecommendsStructureRecovery() {
+            var a = Analysis(new[] { R(RejectionGate.LowSensitivity, 1.5, recall: true) }, noCandidate: 5, totalRecall: 10);
+            var rec = GateRecommender.Recommend(a, CurrentParams());
+            Assert.That(rec.RecommendStructureRecovery, Is.True);
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/LabelGateAnalyzerTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/LabelGateAnalyzerTests.cs
@@ -1,0 +1,113 @@
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Rect = OpenCvSharp.Rect;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Optimization {
+
+    [TestFixture]
+    public class LabelGateAnalyzerTests {
+
+        private static RejectedCandidateRecord Rec(string gate, int x, int y, int w, int h,
+            double measured = double.NaN, double thr = double.NaN) =>
+            new RejectedCandidateRecord {
+                Gate = gate,
+                Bounds = new Rect(x, y, w, h),
+                MeasuredValue = measured,
+                ThresholdValue = thr,
+                CandidateSize = Math.Max(w, h),
+                CenterX = x + w / 2.0,
+                CenterY = y + h / 2.0
+            };
+
+        [Test]
+        public void Analyze_RecallBoxOverRejected_BucketsByGateAndMarksTarget() {
+            var rej = Rec(RejectionGate.LowSensitivity, 100, 100, 20, 20, measured: 1.3, thr: 2.0);
+            var frame = new FrameDetectionForAnalysis {
+                FocuserPosition = 5000,
+                Rejected = new List<RejectedCandidateRecord> { rej },
+                RecallBoxes = new List<RectD> { new RectD(100, 100, 20, 20) }
+            };
+
+            var a = LabelGateAnalyzer.Analyze(new[] { frame });
+
+            Assert.Multiple(() => {
+                Assert.That(a.TotalRecallTargets, Is.EqualTo(1));
+                Assert.That(a.AlreadyRecovered, Is.EqualTo(0));
+                Assert.That(a.NoCandidateCount, Is.EqualTo(0));
+                var targets = a.RecallTargets(RejectionGate.LowSensitivity);
+                Assert.That(targets, Has.Count.EqualTo(1));
+                Assert.That(targets[0].MeasuredValue, Is.EqualTo(1.3));
+                Assert.That(targets[0].FocuserPosition, Is.EqualTo(5000));
+                Assert.That(a.RecallTargetCountByGate[RejectionGate.LowSensitivity], Is.EqualTo(1));
+            });
+        }
+
+        [Test]
+        public void Analyze_RecallBoxOverAccepted_CountsAlreadyRecovered() {
+            var frame = new FrameDetectionForAnalysis {
+                FocuserPosition = 5000,
+                AcceptedBounds = new List<Rect> { new Rect(200, 200, 16, 16) },
+                RecallBoxes = new List<RectD> { new RectD(200, 200, 16, 16) }
+            };
+            var a = LabelGateAnalyzer.Analyze(new[] { frame });
+            Assert.Multiple(() => {
+                Assert.That(a.AlreadyRecovered, Is.EqualTo(1));
+                Assert.That(a.NoCandidateCount, Is.EqualTo(0));
+                Assert.That(a.Rejections, Is.Empty);
+            });
+        }
+
+        [Test]
+        public void Analyze_RecallBoxOverNothing_IsNoCandidate() {
+            var frame = new FrameDetectionForAnalysis {
+                FocuserPosition = 5000,
+                RecallBoxes = new List<RectD> { new RectD(10, 10, 8, 8) }
+            };
+            var a = LabelGateAnalyzer.Analyze(new[] { frame });
+            Assert.Multiple(() => {
+                Assert.That(a.NoCandidateCount, Is.EqualTo(1));
+                Assert.That(a.NoCandidate[0].FocuserPosition, Is.EqualTo(5000));
+            });
+        }
+
+        [Test]
+        public void Analyze_UnlabeledRejection_IsNotRecallTarget() {
+            // A rejected candidate that no label box overlaps is the precision-proxy "unlabeled" pool.
+            var rej = Rec(RejectionGate.LowSensitivity, 800, 800, 10, 10, measured: 1.1, thr: 2.0);
+            var frame = new FrameDetectionForAnalysis {
+                FocuserPosition = 4000,
+                Rejected = new List<RejectedCandidateRecord> { rej },
+                RecallBoxes = new List<RectD>() // no labels here
+            };
+            var a = LabelGateAnalyzer.Analyze(new[] { frame });
+            Assert.Multiple(() => {
+                Assert.That(a.RecallTargets(RejectionGate.LowSensitivity), Is.Empty);
+                Assert.That(a.Unlabeled(RejectionGate.LowSensitivity), Has.Count.EqualTo(1));
+                Assert.That(a.Unlabeled(RejectionGate.LowSensitivity)[0].IsRecallTarget, Is.False);
+            });
+        }
+
+        [Test]
+        public void Analyze_ShouldRejectBox_TagsContainmentAndViolation() {
+            var rejInside = Rec(RejectionGate.LowSensitivity, 300, 300, 10, 10);     // center 305,305 inside SR box
+            var frame = new FrameDetectionForAnalysis {
+                FocuserPosition = 4500,
+                AcceptedCenters = new List<(double, double)> { (302, 302) },          // accepted inside SR box → violated
+                Rejected = new List<RejectedCandidateRecord> { rejInside },
+                ShouldRejectBoxes = new List<RectD> { new RectD(290, 290, 30, 30) }
+            };
+            var a = LabelGateAnalyzer.Analyze(new[] { frame });
+            Assert.Multiple(() => {
+                Assert.That(a.ShouldReject, Has.Count.EqualTo(1));
+                Assert.That(a.ShouldReject[0].CurrentlyViolated, Is.True, "an accepted star inside the should-reject box is a present false positive");
+                var unlabeled = a.Rejections.Single();
+                Assert.That(unlabeled.InShouldRejectBox, Is.True, "a rejected candidate whose center is inside the should-reject box is flagged so loosening can't re-admit it");
+            });
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/LabelRunIdMatchTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/LabelRunIdMatchTests.cs
@@ -1,0 +1,74 @@
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review;
+using NUnit.Framework;
+using System.IO;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Optimization {
+
+    /// <summary>
+    /// G3: the wizard saves labels keyed by the ABSOLUTE run path, but offline discovery keys a run by its
+    /// relative/leaf folder name. <see cref="StarReviewLabelStore.Load"/> must still match them (trailing-segment
+    /// fallback) so wizard labels load against a path-relocated copy of the run, while exact matches keep working.
+    /// </summary>
+    [TestFixture]
+    public class LabelRunIdMatchTests {
+
+        private static string WriteLabel(string dir, string fileName, string embeddedRunId) {
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, fileName);
+            File.WriteAllText(path,
+                "{\"runId\":\"" + embeddedRunId.Replace("\\", "\\\\") + "\",\"radiusPx\":6.0,\"positions\":[" +
+                "{\"focuserPosition\":5000,\"wronglyRejected\":[{\"x\":10,\"y\":20,\"w\":8,\"h\":8}]}]}");
+            return path;
+        }
+
+        [Test]
+        public void Load_AbsolutePathEmbeddedRunId_MatchesLeafRunId() {
+            var dir = Path.Combine(Path.GetTempPath(), "hf-g3-" + System.Guid.NewGuid().ToString("N"));
+            try {
+                // Mimics the wizard: filename + embedded runId are the sanitized absolute path.
+                WriteLabel(dir, "E__WorkshopData_sensitivity_example1_attempt01.json", @"E:\WorkshopData\sensitivity_example1\attempt01");
+
+                // Offline discovery hands us the leaf runId.
+                var labels = StarReviewLabelStore.Load(dir, "attempt01", out var error);
+
+                Assert.Multiple(() => {
+                    Assert.That(error, Is.Null);
+                    Assert.That(labels.Positions, Has.Count.EqualTo(1));
+                    Assert.That(labels.Positions[0].FocuserPosition, Is.EqualTo(5000));
+                    Assert.That(labels.Positions[0].WronglyRejected, Has.Count.EqualTo(1));
+                });
+            } finally {
+                if (Directory.Exists(dir)) {
+                    Directory.Delete(dir, recursive: true);
+                }
+            }
+        }
+
+        [Test]
+        public void Load_ExactFilenameMatch_StillWins() {
+            var dir = Path.Combine(Path.GetTempPath(), "hf-g3-" + System.Guid.NewGuid().ToString("N"));
+            try {
+                WriteLabel(dir, "attempt01.json", "attempt01");
+                var labels = StarReviewLabelStore.Load(dir, "attempt01", out var error);
+                Assert.Multiple(() => {
+                    Assert.That(error, Is.Null);
+                    Assert.That(labels.Positions, Has.Count.EqualTo(1));
+                });
+            } finally {
+                if (Directory.Exists(dir)) {
+                    Directory.Delete(dir, recursive: true);
+                }
+            }
+        }
+
+        [Test]
+        public void LastSegment_HandlesBothSeparators() {
+            Assert.Multiple(() => {
+                Assert.That(StarReviewLabelStore.LastSegment(@"E:\a\b\attempt01"), Is.EqualTo("attempt01"));
+                Assert.That(StarReviewLabelStore.LastSegment("toml999/attempt01"), Is.EqualTo("attempt01"));
+                Assert.That(StarReviewLabelStore.LastSegment("attempt01"), Is.EqualTo("attempt01"));
+                Assert.That(StarReviewLabelStore.LastSegment(""), Is.Null);
+            });
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizerVariableTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizerVariableTests.cs
@@ -137,10 +137,10 @@ public class OptimizerVariableTests {
     // ---- CreateCuratedSet ----
 
     [Test]
-    public void CreateCuratedSet_HasThirteenDistinctVariables() {
+    public void CreateCuratedSet_HasFourteenDistinctVariables() {
         var set = OptimizerVariable.CreateCuratedSet();
-        Assert.That(set.Count, Is.EqualTo(13));
-        Assert.That(set.Select(x => x.Name).Distinct().Count(), Is.EqualTo(13));
+        Assert.That(set.Count, Is.EqualTo(14));
+        Assert.That(set.Select(x => x.Name).Distinct().Count(), Is.EqualTo(14));
     }
 
     [Test]
@@ -161,6 +161,8 @@ public class OptimizerVariableTests {
             nameof(StarDetectorParams.HotpixelThreshold),
             // Synthetic combined switch (drives DefocusAwareDistortion + DefocusAwareCentering together).
             OptimizerVariable.DefocusAwareGatesName,
+            // Synthetic integer knob (drives DefocusAwareStructure + StructureLayerBoost together).
+            OptimizerVariable.DefocusAwareStructureName,
         };
         Assert.That(set.Select(x => x.Name), Is.EquivalentTo(expected));
     }
@@ -247,5 +249,53 @@ public class OptimizerVariableTests {
             var read = v.Read(p);
             Assert.That(read, Is.EqualTo(v.Quantize(mid)).Within(1e-9), $"{v.Name} round-trip");
         }
+    }
+
+    // ---- Warm-start set (Phase 4) ------------------------------------------------------------------------
+
+    [Test]
+    public void WarmStartSet_MovedAxis_GetsNarrowBandAroundRecommended() {
+        var before = new StarDetectorParams { Sensitivity = 16.0 };
+        var after = new StarDetectorParams { Sensitivity = 3.5 };
+        var ws = OptimizerVariable.CreateWarmStartSet(OptimizerVariable.CreateCuratedSet(), before, after);
+
+        var sens = ws.SingleOrDefault(v => v.Name == nameof(StarDetectorParams.Sensitivity));
+        Assert.That(sens, Is.Not.Null, "a moved axis must be present in the warm-start set");
+        Assert.Multiple(() => {
+            // Sensitivity step is 1.0; default bandSteps = 3 ⇒ [3.5-3, 3.5+3] = [0.5, 6.5], clamped to [0,50].
+            Assert.That(sens.Lower, Is.EqualTo(0.5).Within(1e-9));
+            Assert.That(sens.Upper, Is.EqualTo(6.5).Within(1e-9));
+            // The new Write re-quantizes through the band so the optimizer cannot escape it.
+            var p = new StarDetectorParams();
+            sens.Write(p, 100.0);
+            Assert.That(p.Sensitivity, Is.EqualTo(6.5).Within(1e-9));
+        });
+    }
+
+    [Test]
+    public void WarmStartSet_UnmovedNonDefocusAxis_IsOmitted() {
+        var before = new StarDetectorParams { Sensitivity = 16.0, MaxDistortion = 0.5 };
+        var after = new StarDetectorParams { Sensitivity = 3.5, MaxDistortion = 0.5 }; // MaxDistortion unchanged
+        var ws = OptimizerVariable.CreateWarmStartSet(OptimizerVariable.CreateCuratedSet(), before, after);
+        Assert.That(ws.Any(v => v.Name == nameof(StarDetectorParams.MaxDistortion)), Is.False,
+            "an unmoved, non-defocus axis is pinned by omission (the seed carries its value)");
+    }
+
+    [Test]
+    public void WarmStartSet_DefocusToggles_AlwaysLiveAtFullRange() {
+        // Nothing moved — but the defocus-aware toggles must still be explorable.
+        var before = new StarDetectorParams();
+        var after = new StarDetectorParams();
+        var ws = OptimizerVariable.CreateWarmStartSet(OptimizerVariable.CreateCuratedSet(), before, after);
+
+        var gates = ws.SingleOrDefault(v => v.Name == OptimizerVariable.DefocusAwareGatesName);
+        var structure = ws.SingleOrDefault(v => v.Name == OptimizerVariable.DefocusAwareStructureName);
+        Assert.Multiple(() => {
+            Assert.That(gates, Is.Not.Null, "DefocusAwareGates must always stay live");
+            Assert.That(structure, Is.Not.Null, "DefocusAwareStructure must always stay live");
+            Assert.That(gates.Lower, Is.EqualTo(0));
+            Assert.That(gates.Upper, Is.EqualTo(1));
+            Assert.That(structure.Upper, Is.EqualTo(4), "structure boost keeps its full [0,4] range");
+        });
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerTests.cs
@@ -323,6 +323,8 @@ public class StarDetectionOptimizerTests {
             nameof(StarDetectorParams.NoiseReductionRadius),
             nameof(StarDetectorParams.HotpixelThresholdingEnabled),
             nameof(StarDetectorParams.HotpixelThreshold),
+            // Synthetic defocus-aware-structure knob — named for the EARLY cache-key property it drives.
+            OptimizerVariable.DefocusAwareStructureName,
         };
 
         Assert.Multiple(() => {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -246,6 +246,26 @@ public class StarDetectionOptimizerWizardVMTests {
     }
 
     [Test]
+    public async Task Start_UseCurrentSettings_SkipsOptimization_AndReviewIsEnterable() {
+        // The "Use current settings" toggle must skip the optimization pass entirely: Result.BestParams are the
+        // seed (Sensitivity unchanged at 2, not driven toward the optimizable 10), zero evaluations, and the user
+        // can still go to Review to validate/label today's detection.
+        var vm = NewVM(LoaderReturning(GoodRun()), frameReviewBuilder: new FakeReviewBuilder().Build);
+        vm.SourcePaths[0] = @"C:\run1";
+        vm.OptimizeMode = WizardOptimizeMode.UseCurrentSettings;
+
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Summary));
+            Assert.That(vm.Result, Is.Not.Null);
+            Assert.That(vm.Result.Evaluations, Is.EqualTo(0), "no optimization pass ran");
+            Assert.That(vm.Result.BestParams.Sensitivity, Is.EqualTo(2.0), "BestParams are the current/seed settings");
+            Assert.That(vm.ReviewCommand.CanExecute(null), Is.True, "Review must be reachable to validate current settings");
+        });
+    }
+
+    [Test]
     public async Task Start_DegenerateSeed_SetsErrorAndDoesNotAdvanceToSummary() {
         var vm = NewVM(LoaderReturning(DegenerateRun()));
         vm.SourcePaths[0] = @"C:\bad";

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarReviewTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarReviewTests.cs
@@ -705,6 +705,64 @@ public class StarReviewTests {
         return (p?.Missed?.Count ?? 0, p?.ShouldReject?.Count ?? 0, p?.WronglyRejected?.Count ?? 0);
     }
 
+    // ---- Move/resize of drawn (missed) boxes ----------------------------------------------------------
+
+    [Test]
+    public void HitTestMissedBox_DetectsInsideEdgesAndCorners() {
+        var vm = ReviewVM(out _, FrameWithBoxes());
+        vm.AddMissedBox(200, 200, 40, 40); // box edges at x=200/240, y=200/240
+        Assert.Multiple(() => {
+            Assert.That(vm.HitTestMissedBox(220, 220, 5).Handle, Is.EqualTo(BoxHandle.Inside));
+            Assert.That(vm.HitTestMissedBox(200, 220, 5).Handle, Is.EqualTo(BoxHandle.Left));
+            Assert.That(vm.HitTestMissedBox(220, 240, 5).Handle, Is.EqualTo(BoxHandle.Bottom));
+            Assert.That(vm.HitTestMissedBox(200, 200, 5).Handle, Is.EqualTo(BoxHandle.TopLeft));
+            Assert.That(vm.HitTestMissedBox(240, 240, 5).Handle, Is.EqualTo(BoxHandle.BottomRight));
+            Assert.That(vm.HitTestMissedBox(100, 100, 5).Index, Is.EqualTo(-1), "a point far from every box misses");
+        });
+    }
+
+    [Test]
+    public void MissedBoxEdit_Move_ShiftsBox_AndIsUndoable() {
+        var vm = ReviewVM(out var labels, FrameWithBoxes());
+        vm.AddMissedBox(200, 200, 40, 40);
+        var (idx, handle) = vm.HitTestMissedBox(220, 220, 5); // Inside → move
+        vm.BeginMissedBoxEdit(idx, handle, 220, 220);
+        vm.UpdateMissedBoxEdit(230, 215); // drag +10, -5
+        vm.EndMissedBoxEdit();
+        var b = labels["r"].Positions[0].Missed[0];
+        Assert.Multiple(() => {
+            Assert.That(b.X, Is.EqualTo(210));
+            Assert.That(b.Y, Is.EqualTo(195));
+            Assert.That(b.W, Is.EqualTo(40));
+            Assert.That(b.H, Is.EqualTo(40));
+        });
+
+        vm.UndoCommand.Execute(null);
+        var u = labels["r"].Positions[0].Missed[0];
+        Assert.Multiple(() => {
+            Assert.That(u.X, Is.EqualTo(200), "undo restores the original position");
+            Assert.That(u.Y, Is.EqualTo(200));
+        });
+    }
+
+    [Test]
+    public void MissedBoxEdit_ResizeBottomRight_KeepsTopLeftFixed() {
+        var vm = ReviewVM(out var labels, FrameWithBoxes());
+        vm.AddMissedBox(200, 200, 40, 40);
+        var (idx, handle) = vm.HitTestMissedBox(240, 240, 5);
+        Assert.That(handle, Is.EqualTo(BoxHandle.BottomRight));
+        vm.BeginMissedBoxEdit(idx, handle, 240, 240);
+        vm.UpdateMissedBoxEdit(260, 250); // drag the BR corner out
+        vm.EndMissedBoxEdit();
+        var b = labels["r"].Positions[0].Missed[0];
+        Assert.Multiple(() => {
+            Assert.That(b.X, Is.EqualTo(200), "the opposite (top-left) corner stays put");
+            Assert.That(b.Y, Is.EqualTo(200));
+            Assert.That(b.W, Is.EqualTo(60));
+            Assert.That(b.H, Is.EqualTo(50));
+        });
+    }
+
     [Test]
     public void Undo_Redo_MissedBox() {
         var vm = ReviewVM(out var labels, FrameWithBoxes());

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/RejectedCandidateDiagnosticsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/RejectedCandidateDiagnosticsTests.cs
@@ -1,0 +1,115 @@
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NUnit.Framework;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
+
+    /// <summary>
+    /// Phase 1 of the "Optimize with feedback" work: the per-rejected-candidate diagnostics side channel
+    /// (<see cref="StarDetectorParams.CollectRejectedCandidateDiagnostics"/> →
+    /// <see cref="HocusFocusStarDetectorResult.RejectedCandidates"/>).
+    ///
+    /// Guards three properties:
+    ///  1. <b>Bit-identical when OFF/ON</b> — turning the flag on must not change ANY detected star or metric
+    ///     (the records are emitted after the reject decision is already made), and the flag must be excluded
+    ///     from the detection cache key.
+    ///  2. <b>Complete</b> — every rejected candidate produces exactly one record (records.Count == rejected),
+    ///     including the counter-only gates (TooSmall/TooLowHFR) that have no metrics *Bounds list.
+    ///  3. <b>Invertible</b> — each scalar gate's recorded MeasuredValue lies on the reject side of its
+    ///     ThresholdValue, so the recommender can solve for the threshold that recovers the star.
+    /// </summary>
+    [TestFixture]
+    public class RejectedCandidateDiagnosticsTests {
+
+        [Test]
+        public async Task Diagnostics_OffVsOn_DetectionBitIdentical() {
+            var pOff = StarDetectorEquivalence.StandardParams();
+            var pOn = StarDetectorEquivalence.StandardParams();
+            pOn.CollectRejectedCandidateDiagnostics = true;
+
+            using var field1 = StarDetectorEquivalence.BuildSmallField();
+            var resultOff = await StarDetectorEquivalence.RunDetect(field1, pOff);
+
+            using var field2 = StarDetectorEquivalence.BuildSmallField();
+            var resultOn = await StarDetectorEquivalence.RunDetect(field2, pOn);
+
+            Assert.Multiple(() => {
+                Assert.That(StarDetectorEquivalence.Signature(resultOn), Is.EqualTo(StarDetectorEquivalence.Signature(resultOff)),
+                    "Enabling rejected-candidate diagnostics must not change any detected star or metric.");
+                Assert.That(resultOff.RejectedCandidates, Is.Null, "OFF ⇒ the side-channel list is null (zero overhead).");
+                Assert.That(resultOn.RejectedCandidates, Is.Not.Null, "ON ⇒ the side-channel list is populated.");
+            });
+        }
+
+        [Test]
+        public void Diagnostics_FlagExcludedFromCacheKey() {
+            var pOff = StarDetectorEquivalence.StandardParams();
+            var pOn = StarDetectorEquivalence.StandardParams();
+            pOn.CollectRejectedCandidateDiagnostics = true;
+
+            // The flag is a pure side channel — it must NOT change the canonical cache string, else the
+            // optimizer's early-context cache could treat diagnostics-on and -off as different detections.
+            Assert.That(pOn.ToCanonicalCacheString(), Is.EqualTo(pOff.ToCanonicalCacheString()),
+                "CollectRejectedCandidateDiagnostics must be excluded from the detection cache key.");
+        }
+
+        [Test]
+        public async Task Diagnostics_RecordsAccountForEveryRejection() {
+            var p = StarDetectorEquivalence.StandardParams();
+            p.CollectRejectedCandidateDiagnostics = true;
+
+            using var field = StarDetectorEquivalence.BuildSmallField();
+            var result = await StarDetectorEquivalence.RunDetect(field, p);
+
+            var m = result.Metrics;
+            var rejected = m.StructureCandidates - m.TotalDetected;
+            var records = result.RejectedCandidates;
+
+            Assert.Multiple(() => {
+                // One record per rejected candidate (ModelPSF is off in StandardParams, so the only ways a
+                // candidate leaves the accepted set are the gates, each of which now emits exactly one record).
+                Assert.That(records.Count, Is.EqualTo(rejected),
+                    "Every rejected candidate must produce exactly one diagnostics record.");
+
+                // Per-gate record counts agree with the metrics tallies (including counter-only gates).
+                int RecordCount(string gate) => records.Count(r => r.Gate == gate);
+                Assert.That(RecordCount(RejectionGate.TooSmall), Is.EqualTo(m.TooSmall), "TooSmall");
+                Assert.That(RecordCount(RejectionGate.OnBorder), Is.EqualTo(m.OnBorder), "OnBorder");
+                Assert.That(RecordCount(RejectionGate.TooDistorted), Is.EqualTo(m.TooDistorted), "TooDistorted");
+                Assert.That(RecordCount(RejectionGate.Degenerate), Is.EqualTo(m.Degenerate), "Degenerate");
+                Assert.That(RecordCount(RejectionGate.LowSensitivity), Is.EqualTo(m.LowSensitivity), "LowSensitivity");
+                Assert.That(RecordCount(RejectionGate.NotCentered), Is.EqualTo(m.NotCentered), "NotCentered");
+                Assert.That(RecordCount(RejectionGate.TooFlat), Is.EqualTo(m.TooFlat), "TooFlat");
+                Assert.That(RecordCount(RejectionGate.TooLowHFR), Is.EqualTo(m.TooLowHFR), "TooLowHFR");
+                Assert.That(RecordCount(RejectionGate.HFRAnalysisFailed), Is.EqualTo(m.HFRAnalysisFailed), "HFRAnalysisFailed");
+                // ContaminatedBounds counts all flagged; with RejectContaminatedStars=true (the default) all are rejected.
+                Assert.That(RecordCount(RejectionGate.Contaminated), Is.EqualTo(m.ContaminationSuspected), "Contaminated");
+            });
+        }
+
+        [Test]
+        public async Task Diagnostics_InvertsLowSensitivity() {
+            // Crank the sensitivity threshold so every otherwise-valid bright candidate fails the LowSensitivity
+            // gate. Each such record must carry the candidate's measured sensitivity ON the reject side of the
+            // threshold (measured <= threshold), which is exactly what the recommender inverts.
+            var p = StarDetectorEquivalence.StandardParams();
+            p.CollectRejectedCandidateDiagnostics = true;
+            p.Sensitivity = 1000.0;
+
+            using var field = StarDetectorEquivalence.BuildSmallField();
+            var result = await StarDetectorEquivalence.RunDetect(field, p);
+
+            var lowSens = result.RejectedCandidates.Where(r => r.Gate == RejectionGate.LowSensitivity).ToList();
+            Assert.That(lowSens, Is.Not.Empty, "An extreme Sensitivity threshold must produce LowSensitivity rejections.");
+            Assert.Multiple(() => {
+                foreach (var r in lowSens) {
+                    Assert.That(r.ThresholdValue, Is.EqualTo(1000.0), "threshold echoes the effective gate value");
+                    Assert.That(r.MeasuredValue, Is.LessThanOrEqualTo(r.ThresholdValue),
+                        "the measured sensitivity must be on the reject side of the threshold");
+                    Assert.That(r.CandidateSize, Is.GreaterThan(0.0), "candidate size (defocus proxy) is recorded");
+                }
+            });
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/RejectedCandidateDiagnosticsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/RejectedCandidateDiagnosticsTests.cs
@@ -89,6 +89,24 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
         }
 
         [Test]
+        public async Task Diagnostics_MeasuresHfr_ForRejectedCandidates() {
+            // Reject every (real, bright) candidate via an extreme Sensitivity. Because these are rejected AFTER
+            // ComputeStarParameters, the detector measures their HFR on-demand for the review's HFR display — so the
+            // LowSensitivity records must carry a finite, positive HFR (not the NaN of pre-parameter gates).
+            var p = StarDetectorEquivalence.StandardParams();
+            p.CollectRejectedCandidateDiagnostics = true;
+            p.Sensitivity = 1000.0;
+
+            using var field = StarDetectorEquivalence.BuildSmallField();
+            var result = await StarDetectorEquivalence.RunDetect(field, p);
+
+            var lowSens = result.RejectedCandidates.Where(r => r.Gate == RejectionGate.LowSensitivity).ToList();
+            Assert.That(lowSens, Is.Not.Empty);
+            Assert.That(lowSens.Count(r => !double.IsNaN(r.Hfr) && r.Hfr > 0.0), Is.GreaterThan(0),
+                "rejected candidates with a centroid must get an on-demand HFR measurement for the review display");
+        }
+
+        [Test]
         public async Task Diagnostics_InvertsLowSensitivity() {
             // Crank the sensitivity threshold so every otherwise-valid bright candidate fails the LowSensitivity
             // gate. Each such record must carry the candidate's measured sensitivity ON the reject side of the

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetectionOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetectionOptions.cs
@@ -89,6 +89,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         double ContaminationSensitivity { get; set; }
         bool RejectContaminatedStars { get; set; }
         int StructureLayers { get; set; }
+        bool DefocusAwareStructure { get; set; }
+        int StructureLayerBoost { get; set; }
         double BrightnessSensitivity { get; set; }
         double StarPeakResponse { get; set; }
         double MaxDistortion { get; set; }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
@@ -789,6 +789,12 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         public double CandidateSize { get; set; }              // max(W,H) — the defocus/size proxy
         public double CenterX { get; set; }                    // candidate centroid or bbox center (ROI applied)
         public double CenterY { get; set; }
+
+        // Half-flux radius of the rejected candidate, when measurable (NaN for candidates rejected before a
+        // centroid/parameters exist — TooSmall/OnBorder/TooDistorted/Degenerate/HFRAnalysisFailed). For the gates
+        // that reject AFTER ComputeStarParameters (LowSensitivity/NotCentered/TooFlat) the detector measures HFR
+        // on-demand (diagnostics path only); for TooLowHFR/Contaminated the already-measured HFR is carried.
+        public double Hfr { get; set; } = double.NaN;
     }
 
     public class HocusFocusStarDetectorResult {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
@@ -267,12 +267,32 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         // production NINA runs incur zero extra allocations or math. Excluded from ToString().
         public bool CollectContaminationDiagnostics { get; set; } = false;
 
+        // Diagnostics opt-in. When true, the detector records a RejectedCandidateRecord for every candidate that a
+        // late gate rejects — the gate name PLUS the scalar it compared against its threshold (sensitivity ratio,
+        // fill-ratio, HFR, etc.) — into HocusFocusStarDetectorResult.RejectedCandidates. This is what the
+        // label-driven gate recommender inverts ("how far must threshold X move to recover these labeled stars").
+        // Off by default ⇒ the bag is null and not one allocation/branch-with-work runs on the production path, so
+        // detection stays bit-identical. Excluded from the cache key (output-neutral side channel).
+        public bool CollectRejectedCandidateDiagnostics { get; set; } = false;
+
         // Half size of a median box filter, used for hotpixel removal if HotpixelFiltering is enabled. Only 1 is supported for now, since OpenCV has native support for
         // a median box filter but not a general circular one
         public int HotpixelFilterRadius { get; set; } = 1;
 
         // Number of wavelet layers for structure detection
         public int StructureLayers { get; set; } = 4;
+
+        // Defocus-aware structure detection (opt-in, default OFF). When true, the à-trous wavelet residual that is
+        // subtracted to remove large-scale structure is computed at StructureLayers + StructureLayerBoost layers,
+        // so the residual is COARSER and large/donut (heavily defocused) stars survive the subtraction and form
+        // candidates instead of being erased. The post-wavelet blur stays keyed to StructureLayers. When OFF the
+        // effective layer count is exactly StructureLayers, so candidate formation is bit-identical. EARLY param
+        // (changes candidate formation): listed in StarDetector.EarlyCacheKeyProperties.
+        public bool DefocusAwareStructure { get; set; } = false;
+
+        // Extra wavelet layers added to StructureLayers for the residual-subtraction step when
+        // DefocusAwareStructure is on. 0 ⇒ no change even if the flag is on. Ignored entirely when the flag is OFF.
+        public int StructureLayerBoost { get; set; } = 0;
 
         // Size of the circle used to dilate the structure map
         public int StructureDilationSize { get; set; } = 3;
@@ -424,6 +444,12 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
             // HocusFocusStarDetectorResult.ContaminationDiagnostics list; the production contamination decision
             // and every detected-star value are unaffected (already excluded from ToString() for the same reason).
             nameof(CollectContaminationDiagnostics),
+
+            // Diagnostics only: when true the detector fills the side-channel
+            // HocusFocusStarDetectorResult.RejectedCandidates list. The accept/reject decision and every
+            // detected-star value are unaffected — the records are emitted at the same gate sites that already
+            // run, after the reject decision is made — so this is output-neutral.
+            nameof(CollectRejectedCandidateDiagnostics),
 
             // Debug/intermediate-output only: stashes the structure map into DebugData for inspection. Does not
             // change which stars are detected or any measured value.
@@ -728,6 +754,43 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         public int ResidualTrippingSector { get; set; } = -1;          // first sector that tripped, else -1
     }
 
+    /// <summary>
+    /// Canonical gate names used by <see cref="RejectedCandidateRecord.Gate"/>. Centralized so the detector, the
+    /// label analyzer, and the recommender all agree on the spelling (these strings are matched, not enum-typed,
+    /// because they also flow through the human-readable diagnostics text and the review overlay legend).
+    /// </summary>
+    public static class RejectionGate {
+        public const string TooSmall = "TooSmall";
+        public const string OnBorder = "OnBorder";
+        public const string TooDistorted = "TooDistorted";
+        public const string Degenerate = "Degenerate";
+        public const string LowSensitivity = "LowSensitivity";
+        public const string NotCentered = "NotCentered";
+        public const string TooFlat = "TooFlat";
+        public const string HFRAnalysisFailed = "HFRAnalysisFailed";
+        public const string TooLowHFR = "TooLowHFR";
+        public const string Contaminated = "Contaminated";
+    }
+
+    /// <summary>
+    /// Per-rejected-candidate diagnostics, captured only when
+    /// <see cref="StarDetectorParams.CollectRejectedCandidateDiagnostics"/> is enabled. One record is produced for
+    /// EVERY candidate a late gate rejects (unlike the metrics <c>*Bounds</c> lists, which only exist for seven of
+    /// the gates), so the label-driven recommender can attribute a labeled "wrongly-rejected" star to the exact
+    /// gate that killed it and invert that gate's threshold. <see cref="MeasuredValue"/> is the scalar the gate
+    /// compared against <see cref="ThresholdValue"/>; both are <see cref="double.NaN"/> for the non-scalar gates
+    /// (OnBorder/Degenerate/HFRAnalysisFailed), which can only be flagged, not threshold-recovered.
+    /// </summary>
+    public sealed class RejectedCandidateRecord {
+        public Rect Bounds { get; set; }                       // candidate bbox (ROI offset applied, like *Bounds)
+        public string Gate { get; set; }                       // one of RejectionGate.*
+        public double MeasuredValue { get; set; } = double.NaN; // the per-candidate scalar the gate compared
+        public double ThresholdValue { get; set; } = double.NaN;// the effective threshold it compared against
+        public double CandidateSize { get; set; }              // max(W,H) — the defocus/size proxy
+        public double CenterX { get; set; }                    // candidate centroid or bbox center (ROI applied)
+        public double CenterY { get; set; }
+    }
+
     public class HocusFocusStarDetectorResult {
         public List<Star> DetectedStars { get; set; }
         public StarDetectorMetrics Metrics { get; set; }
@@ -744,6 +807,10 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
 
         // Populated only when StarDetectorParams.CollectContaminationDiagnostics is true; otherwise null.
         public List<ContaminationDiagnosticRecord> ContaminationDiagnostics { get; set; } = null;
+
+        // Populated only when StarDetectorParams.CollectRejectedCandidateDiagnostics is true; otherwise null.
+        // One entry per rejected candidate (ROI offset applied, sorted by (Y, X) for determinism).
+        public List<RejectedCandidateRecord> RejectedCandidates { get; set; } = null;
     }
 
     public interface IStarDetector {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
@@ -447,6 +447,8 @@
     <TextBlock x:Key="DefocusDistortionSizeReference_Tooltip" Text="Tuning knob for the Defocus-Aware Gates (only used while they are enabled). The candidate bounding-box size (in pixels, the larger of width/height) at or below which the strict gate thresholds still apply; larger candidates get the relaxed thresholds. Shared by both the distortion and centering relaxations. Lower it to relax smaller stars; raise it to keep more of the strict behavior. Default 30." />
     <TextBlock x:Key="DefocusDistortionMinFactor_Tooltip" Text="Tuning knob for the Defocus-Aware Gates (only used while they are enabled). The floor multiplier applied to Max Distortion for very large (very defocused) candidates — the most permissive the distortion gate ever becomes. Must be greater than 0 and at most 1. Smaller values accept more heavily-distorted donuts. Default 0.25." />
     <TextBlock x:Key="DefocusCenteringToleranceFactor_Tooltip" Text="Tuning knob for the Defocus-Aware Gates (only used while they are enabled). The maximum multiplier applied to Star Center Tolerance for very large (very defocused) candidates — the most permissive the centering gate ever becomes. Must be at least 1 (1 is a no-op; larger values relax centering further). Default 2." />
+    <TextBlock x:Key="DefocusAwareStructure_Tooltip" Text="When enabled, large/donut (heavily defocused) stars are kept during structure detection so they form candidates instead of being erased. The wavelet step that removes large-scale background structure (nebulae, gradients) can also erase a big out-of-focus donut entirely, so it never even becomes a candidate to evaluate. This option makes that removal coarser (by Structure Layer Boost extra layers) so large stars survive. Off by default (detection is unchanged); enable it together with a Structure Layer Boost above 0 if heavily-defocused stars are missing entirely (not just rejected). EARLY-stage setting." />
+    <TextBlock x:Key="StructureLayerBoost_Tooltip" Text="Only used while Defocus-Aware Structure is enabled. The number of extra wavelet layers added when removing large-scale structure, making the removal coarser so larger defocused donuts survive and form candidates. 0 means no change (identical to the feature being off). Raise it (1–6) if very out-of-focus stars never appear; raising it too far can let nebulosity/background structure leak in as false candidates. Default 0." />
     <TextBlock x:Key="StarCenterTolerance_Tooltip" Text="Size (as a percentage) of a centered rectangle within the star bounding box that the star center must be in. 1.0 covers the whole region, and 0.0 will fail every star" />
     <TextBlock x:Key="StarBackgroundBoxExpansion_Tooltip" Text="The background is estimated by looking in an area around the star bounding box, increased on each side by this number of pixels. The default value of 3 should work for most cases, but you can consider increasing it if stars are very spare, or even decreasing it if the star field is very crowded with stars less than 3 pixels from one another." />
     <TextBlock x:Key="MinStarBoundingBoxSize_Tooltip" Text="The minimum allowed size (length of either side) of a star candidate's bounding box. Increasing this can be helpful at very high focal lengths if too many small structures are detected" />
@@ -1072,6 +1074,9 @@
                 <RowDefinition Style="{StaticResource ShowOnUseAdvancedAndDefocusGates}" />
                 <RowDefinition Style="{StaticResource ShowOnUseAdvancedAndDefocusGates}" />
                 <RowDefinition Style="{StaticResource ShowOnUseAdvancedAndDefocusGates}" />
+                <!--  45: Defocus-Aware Structure toggle (advanced-only); 46: its layer-boost knob (advanced-only).  -->
+                <RowDefinition Style="{StaticResource ShowOnUseAdvanced}" />
+                <RowDefinition Style="{StaticResource ShowOnUseAdvanced}" />
             </Grid.RowDefinitions>
             <TextBlock
                 Grid.Row="0"
@@ -1567,6 +1572,49 @@
                         <rules:DoubleRangeRule>
                             <rules:DoubleRangeRule.ValidRange>
                                 <rules:DoubleRangeChecker Maximum="10.0" Minimum="1.0" />
+                            </rules:DoubleRangeRule.ValidRange>
+                        </rules:DoubleRangeRule>
+                    </Binding.ValidationRules>
+                </Binding>
+            </ninactrl:UnitTextBox>
+
+            <TextBlock
+                Grid.Row="45"
+                Grid.Column="0"
+                VerticalAlignment="Center"
+                Text="Defocus-Aware Structure"
+                ToolTip="{StaticResource DefocusAwareStructure_Tooltip}" />
+            <CheckBox
+                Grid.Row="45"
+                Grid.Column="1"
+                MinWidth="80"
+                Margin="5,5,0,0"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                IsChecked="{Binding StarDetectionOptions.DefocusAwareStructure}"
+                ToolTip="{StaticResource DefocusAwareStructure_Tooltip}" />
+
+            <TextBlock
+                Grid.Row="46"
+                Grid.Column="0"
+                VerticalAlignment="Center"
+                Text="Structure Layer Boost"
+                ToolTip="{StaticResource StructureLayerBoost_Tooltip}" />
+            <ninactrl:UnitTextBox
+                Grid.Row="46"
+                Grid.Column="1"
+                MinWidth="80"
+                Margin="5,5,0,0"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                ToolTip="{StaticResource StructureLayerBoost_Tooltip}">
+                <Binding
+                    Path="StarDetectionOptions.StructureLayerBoost"
+                    UpdateSourceTrigger="LostFocus">
+                    <Binding.ValidationRules>
+                        <rules:DoubleRangeRule>
+                            <rules:DoubleRangeRule.ValidRange>
+                                <rules:DoubleRangeChecker Maximum="6" Minimum="0" />
                             </rules:DoubleRangeRule.ValidRange>
                         </rules:DoubleRangeRule>
                     </Binding.ValidationRules>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
@@ -294,6 +294,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                 ContaminationSensitivity = options.ContaminationSensitivity,
                 RejectContaminatedStars = options.RejectContaminatedStars,
                 StructureLayers = options.StructureLayers,
+                DefocusAwareStructure = options.DefocusAwareStructure,
+                StructureLayerBoost = options.StructureLayerBoost,
                 Sensitivity = options.BrightnessSensitivity,
                 PeakResponse = options.StarPeakResponse,
                 MaxDistortion = options.MaxDistortion,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -14,6 +14,8 @@
 
     <!--  Tooltips  -->
     <TextBlock x:Key="SDOpt_SourceMode_Tooltip" Text="Replay optimizes against one or more saved auto-focus runs (recommended). Live triggers a fresh auto-focus that saves its frames, then optimizes against those." />
+    <TextBlock x:Key="SDOpt_OptimizeMode_Tooltip" Text="Optimize runs the parameter search and recommends improved settings. Use current settings skips the search entirely and jumps straight to a summary built from your current settings, so you can review (and label) today's detection without an optimization pass. Either way, after reviewing you can still run Optimize with feedback to recover the stars you labeled." />
+    <TextBlock x:Key="SDOpt_FeedbackBreakdown_Tooltip" Text="How your labels map to the detector's gates: each row is the gate that rejected the stars you marked, and the setting change that would recover them — bounded so it doesn't admit too many unlabeled candidates (precision). Optimize with feedback starts the optimizer from these recommendations." />
     <TextBlock x:Key="SDOpt_RunCount_Tooltip" Text="How many saved auto-focus runs to optimize against together. Using two or three runs balances the settings across them and reduces overfitting to a single night's conditions." />
     <TextBlock x:Key="SDOpt_ApplyStepSize_Tooltip" Text="When checked, clicking Accept also writes the recommended auto-focus step size and offset steps to the active profile (they appear in the Changed parameters list above). The step size is sized so a sweep lands several measurement points across the focus-sensitive region of the curve. Disabled when the recommendation already matches your current settings (nothing to apply)." />
     <TextBlock x:Key="SDOpt_Review_Tooltip" Text="Optional: review the optimized detector boxes over every loaded frame and label any missed, falsely-accepted, or wrongly-rejected stars. The labels are saved next to the run and can drive a future re-optimization. Reviewing is not required — you can Accept directly." />
@@ -77,6 +79,26 @@
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
                         </ComboBox>
+                    </StackPanel>
+
+                    <StackPanel Margin="0,4" Orientation="Horizontal">
+                        <TextBlock
+                            Width="90"
+                            VerticalAlignment="Center"
+                            Text="Mode" />
+                        <RadioButton
+                            Margin="0,0,14,0"
+                            VerticalAlignment="Center"
+                            Content="Optimize"
+                            GroupName="OptimizeMode"
+                            IsChecked="{Binding IsOptimizeMode}"
+                            ToolTip="{StaticResource SDOpt_OptimizeMode_Tooltip}" />
+                        <RadioButton
+                            VerticalAlignment="Center"
+                            Content="Use current settings"
+                            GroupName="OptimizeMode"
+                            IsChecked="{Binding IsUseCurrentMode}"
+                            ToolTip="{StaticResource SDOpt_OptimizeMode_Tooltip}" />
                     </StackPanel>
 
                     <StackPanel Margin="0,4" Orientation="Horizontal"
@@ -272,6 +294,24 @@
                                     Command="{Binding ReOptimizeCommand}"
                                     Content="Optimize with feedback"
                                     ToolTip="{StaticResource SDOpt_ReOptimize_Tooltip}" />
+
+                                <!--  Transparent label→gate breakdown produced by the last feedback run. Each row's
+                                      ToString() renders "Param old → new  recovers N/M Gate, admits ~K unlabeled".  -->
+                                <TextBlock
+                                    Margin="0,10,0,2"
+                                    FontWeight="Bold"
+                                    Text="How your labels map to settings"
+                                    ToolTip="{StaticResource SDOpt_FeedbackBreakdown_Tooltip}"
+                                    Visibility="{Binding HasRecommendation, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                <ItemsControl
+                                    ItemsSource="{Binding RecommendationRows}"
+                                    Visibility="{Binding HasRecommendation, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Margin="0,1" Text="{Binding}" TextWrapping="Wrap" />
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
                             </StackPanel>
                         </Border>
                     </StackPanel>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -101,31 +101,8 @@
                             ToolTip="{StaticResource SDOpt_OptimizeMode_Tooltip}" />
                     </StackPanel>
 
-                    <StackPanel Margin="0,4" Orientation="Horizontal"
-                                Visibility="{Binding IsReplay, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
-                        <TextBlock
-                            Width="90"
-                            VerticalAlignment="Center"
-                            Text="Number of runs" />
-                        <ninactrl:UnitTextBox
-                            Width="60"
-                            VerticalContentAlignment="Center"
-                            ToolTip="{StaticResource SDOpt_RunCount_Tooltip}">
-                            <ninactrl:UnitTextBox.Text>
-                                <Binding Path="RunCount" UpdateSourceTrigger="PropertyChanged">
-                                    <Binding.ValidationRules>
-                                        <rules:IntRangeRule>
-                                            <rules:IntRangeRule.ValidRange>
-                                                <rules:IntRangeChecker Maximum="5" Minimum="1" />
-                                            </rules:IntRangeRule.ValidRange>
-                                        </rules:IntRangeRule>
-                                    </Binding.ValidationRules>
-                                </Binding>
-                            </ninactrl:UnitTextBox.Text>
-                        </ninactrl:UnitTextBox>
-                    </StackPanel>
-
-                    <!--  One folder picker per run (Saved Auto-Focus only). AlternationCount surfaces the per-row index as the picker's CommandParameter.  -->
+                    <!--  Single saved-run folder picker (Saved Auto-Focus only). Optimizing against one run at a time
+                          keeps the recommendation interpretable; the multi-run selector was removed.  -->
                     <ItemsControl
                         Margin="0,8,0,0"
                         AlternationCount="100"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/GateRecommender.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/GateRecommender.cs
@@ -1,0 +1,315 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
+
+    /// <summary>Whether loosening a gate means LOWERING its threshold (admit iff measured &gt; threshold — e.g.
+    /// Sensitivity, MinHFR, MaxDistortion) or RAISING it (admit iff measured &lt; threshold — e.g. PeakResponse,
+    /// StarCenterTolerance).</summary>
+    public enum GateDirection { LowerToAdmit, RaiseToAdmit }
+
+    public sealed class RecommenderConfig {
+        /// <summary>Cost-effectiveness ceiling: extend a gate's recovery only while the (near-focus-weighted)
+        /// count of newly-admitted UNLABELED candidates stays ≤ this many per recovered labeled star. Bounds the
+        /// precision cost in the absence of explicit should-reject labels.</summary>
+        public double MaxUnlabeledPerRecovered { get; set; } = 2.0;
+
+        public double NearFocusWindowSteps { get; set; } = 1.5;
+        public double NearFocusWeight { get; set; } = 3.0;
+        public double? BestFocusPosition { get; set; } = null;
+        public double StepSize { get; set; } = 0.0;
+
+        /// <summary>Candidates whose size exceeds this (px) are "defocused"; for the distortion/centering gates the
+        /// recommender then prefers the defocus-aware relaxation over a global threshold change. Matches the
+        /// detector default <see cref="StarDetectorParams.DefocusDistortionSizeReference"/>.</summary>
+        public double DefocusSizeReference { get; set; } = 30.0;
+
+        /// <summary>Recommend structure-gap recovery (Phase 5) when NO-CANDIDATE boxes are at least this fraction
+        /// of all recall targets.</summary>
+        public double NoCandidateRecommendFraction { get; set; } = 0.15;
+    }
+
+    public sealed class RecommendationRow {
+        public string Gate { get; set; }
+        public string ParamDisplayName { get; set; }
+        public double? OldValue { get; set; }
+        public double? NewValue { get; set; }
+        public int Recovered { get; set; }
+        public int Total { get; set; }
+        public double WeightedPrecisionCost { get; set; }
+        public bool Applied { get; set; }
+        public string Note { get; set; }
+
+        public override string ToString() {
+            var inv = CultureInfo.InvariantCulture;
+            if (OldValue.HasValue && NewValue.HasValue) {
+                return $"{ParamDisplayName} {OldValue.Value.ToString("G4", inv)} → {NewValue.Value.ToString("G4", inv)}  " +
+                       $"recovers {Recovered}/{Total} {Gate}, admits ~{WeightedPrecisionCost.ToString("G3", inv)} unlabeled" +
+                       (string.IsNullOrEmpty(Note) ? "" : $" ({Note})");
+            }
+            return $"{Gate}: {Recovered}/{Total} — {Note}";
+        }
+    }
+
+    public sealed class GateRecommendation {
+        public StarDetectorParams Recommended { get; set; }
+        public List<RecommendationRow> Rows { get; set; } = new List<RecommendationRow>();
+        public bool RecommendStructureRecovery { get; set; }
+        public bool RecommendDefocusAwareGates { get; set; }
+        public double EstimatedWeightedPrecisionCost { get; set; }
+        public int TotalRecovered { get; set; }
+        public int TotalRecallTargets { get; set; }
+        public int NoCandidateCount { get; set; }
+    }
+
+    /// <summary>
+    /// Turns a <see cref="LabelGateAnalysis"/> into concrete detector setting changes: per gate, it inverts the
+    /// gate from the measured-value distribution of the labeled "wrongly-rejected" stars to find the threshold
+    /// that recovers as many as possible, bounded by a precision proxy (the near-focus-weighted count of
+    /// currently-rejected UNLABELED candidates the change would newly admit, plus a hard veto on re-admitting any
+    /// should-reject candidate). Pure and deterministic — fully unit-testable without images.
+    /// </summary>
+    public static class GateRecommender {
+
+        // gate → (display name, direction). Gates absent here are non-invertible (flag only).
+        private static readonly Dictionary<string, (string Display, GateDirection Dir)> GateMap =
+            new Dictionary<string, (string, GateDirection)>(StringComparer.Ordinal) {
+                { RejectionGate.LowSensitivity, ("BrightnessSensitivity", GateDirection.LowerToAdmit) },
+                { RejectionGate.TooLowHFR, ("MinHFR", GateDirection.LowerToAdmit) },
+                { RejectionGate.TooDistorted, ("MaxDistortion", GateDirection.LowerToAdmit) },
+                { RejectionGate.TooSmall, ("MinStarBoundingBoxSize", GateDirection.LowerToAdmit) },
+                { RejectionGate.TooFlat, ("StarPeakResponse", GateDirection.RaiseToAdmit) },
+                { RejectionGate.NotCentered, ("StarCenterTolerance", GateDirection.RaiseToAdmit) },
+            };
+
+        public static GateRecommendation Recommend(LabelGateAnalysis analysis, StarDetectorParams current, RecommenderConfig config = null) {
+            config = config ?? new RecommenderConfig();
+            var rec = new GateRecommendation {
+                Recommended = current.Clone(),
+                TotalRecallTargets = analysis.TotalRecallTargets,
+                NoCandidateCount = analysis.NoCandidateCount
+            };
+
+            // Process gates in descending recall-target count (fix the biggest buckets first).
+            var gatesByImpact = analysis.RecallTargetCountByGate
+                .OrderByDescending(kv => kv.Value)
+                .Select(kv => kv.Key)
+                .ToList();
+
+            foreach (var gate in gatesByImpact) {
+                var labeled = analysis.RecallTargets(gate);
+                if (labeled.Count == 0) {
+                    continue;
+                }
+
+                if (!GateMap.TryGetValue(gate, out var map)) {
+                    // Non-invertible gate (Degenerate / OnBorder / HFRAnalysisFailed / Contaminated handled below).
+                    if (gate == RejectionGate.Contaminated) {
+                        rec.Rows.Add(new RecommendationRow {
+                            Gate = gate, Total = labeled.Count, Recovered = 0, Applied = false,
+                            Note = "contaminated — consider turning RejectContaminatedStars off or raising ContaminationSensitivity"
+                        });
+                    } else {
+                        rec.Rows.Add(new RecommendationRow {
+                            Gate = gate, Total = labeled.Count, Recovered = 0, Applied = false,
+                            Note = "not recoverable by a threshold (needs detector-algorithm work)"
+                        });
+                    }
+                    continue;
+                }
+
+                // Defocus-aware lever: for distortion/centering, if the labeled targets are large (defocused),
+                // recommend the defocus-aware relaxation instead of a global threshold change that would hurt
+                // precision on small near-focus stars.
+                bool defocusGate = gate == RejectionGate.TooDistorted || gate == RejectionGate.NotCentered;
+                if (defocusGate) {
+                    var medianSize = Median(labeled.Select(t => t.CandidateSize).ToList());
+                    if (medianSize > config.DefocusSizeReference) {
+                        rec.RecommendDefocusAwareGates = true;
+                        rec.Recommended.DefocusAwareDistortion = true;
+                        rec.Recommended.DefocusAwareCentering = true;
+                        rec.Rows.Add(new RecommendationRow {
+                            Gate = gate, Total = labeled.Count, Recovered = labeled.Count, Applied = true,
+                            ParamDisplayName = "DefocusAwareGates", OldValue = 0, NewValue = 1,
+                            Note = $"targets are large (median size {medianSize:G3}px > {config.DefocusSizeReference:G3}) — enable defocus-aware relaxation"
+                        });
+                        continue;
+                    }
+                }
+
+                var unlabeled = analysis.Unlabeled(gate)
+                    .Select(u => (m: u.MeasuredValue, w: Weight(u.FocuserPosition, config), sr: u.InShouldRejectBox))
+                    .Where(u => !double.IsNaN(u.m))
+                    .ToList();
+                var labeledMeasured = labeled.Select(t => t.MeasuredValue).Where(v => !double.IsNaN(v)).ToList();
+                if (labeledMeasured.Count == 0) {
+                    continue; // measured values unavailable (non-scalar) — can't invert
+                }
+
+                var current_threshold = ReadThreshold(current, gate);
+                var sol = Solve(labeledMeasured, unlabeled, map.Dir, config.MaxUnlabeledPerRecovered);
+                if (sol.Recovered <= 0) {
+                    rec.Rows.Add(new RecommendationRow {
+                        Gate = gate, ParamDisplayName = map.Display, Total = labeled.Count, Recovered = 0, Applied = false,
+                        OldValue = current_threshold, WeightedPrecisionCost = 0,
+                        Note = "blocked by should-reject labels / precision budget"
+                    });
+                    continue;
+                }
+
+                var newThreshold = ClampThreshold(gate, sol.Threshold);
+                ApplyThreshold(rec.Recommended, gate, newThreshold);
+                rec.TotalRecovered += sol.Recovered;
+                rec.EstimatedWeightedPrecisionCost += sol.Cost;
+                rec.Rows.Add(new RecommendationRow {
+                    Gate = gate, ParamDisplayName = map.Display, Total = labeled.Count, Recovered = sol.Recovered,
+                    OldValue = current_threshold, NewValue = newThreshold, WeightedPrecisionCost = sol.Cost, Applied = true
+                });
+            }
+
+            // NO-CANDIDATE structure gaps → recommend structure recovery (Phase 5) when material.
+            if (analysis.TotalRecallTargets > 0 &&
+                analysis.NoCandidateCount >= config.NoCandidateRecommendFraction * analysis.TotalRecallTargets &&
+                analysis.NoCandidateCount > 0) {
+                rec.RecommendStructureRecovery = true;
+                rec.Rows.Add(new RecommendationRow {
+                    Gate = "NoCandidate", Total = analysis.NoCandidateCount, Recovered = 0, Applied = false,
+                    Note = "stars never formed a candidate (likely large defocused donuts) — enable Defocus-Aware Structure Detection"
+                });
+            }
+
+            return rec;
+        }
+
+        private struct GateSolution {
+            public double Threshold;
+            public int Recovered;
+            public double Cost;
+        }
+
+        /// <summary>
+        /// Chooses the threshold that admits the largest prefix of labeled targets (ordered by ease of admission)
+        /// whose cumulative weighted unlabeled-admit count stays ≤ R · recovered, while never re-admitting a
+        /// should-reject candidate. Returns the most aggressive feasible, cost-effective threshold.
+        /// </summary>
+        private static GateSolution Solve(List<double> labeled, List<(double m, double w, bool sr)> unlabeled, GateDirection dir, double r) {
+            // Order labeled by ease: LowerToAdmit admits the largest measured with the least lowering; RaiseToAdmit
+            // admits the smallest measured with the least raising.
+            var byEase = dir == GateDirection.LowerToAdmit
+                ? labeled.OrderByDescending(x => x).ToList()
+                : labeled.OrderBy(x => x).ToList();
+
+            // Should-reject hard bound. LowerToAdmit: T must stay ≥ max(sr measured) to exclude them; RaiseToAdmit:
+            // T must stay ≤ min(sr measured).
+            double? srBound = null;
+            var srMeasured = unlabeled.Where(u => u.sr).Select(u => u.m).ToList();
+            if (srMeasured.Count > 0) {
+                srBound = dir == GateDirection.LowerToAdmit ? srMeasured.Max() : srMeasured.Min();
+            }
+
+            var best = new GateSolution { Threshold = double.NaN, Recovered = 0, Cost = 0 };
+            for (var j = 1; j <= byEase.Count; j++) {
+                var v = byEase[j - 1];
+                var t = dir == GateDirection.LowerToAdmit ? JustBelow(v) : JustAbove(v);
+
+                // Should-reject veto.
+                if (srBound.HasValue) {
+                    if (dir == GateDirection.LowerToAdmit && t < srBound.Value) break;
+                    if (dir == GateDirection.RaiseToAdmit && t > srBound.Value) break;
+                }
+
+                var cost = WeightedCost(unlabeled, dir, t);
+                if (cost <= r * j) {
+                    best = new GateSolution { Threshold = t, Recovered = j, Cost = cost };
+                } else {
+                    break; // admitting more labeled exceeds the cost-effectiveness ceiling
+                }
+            }
+            return best;
+        }
+
+        private static double WeightedCost(List<(double m, double w, bool sr)> unlabeled, GateDirection dir, double t) {
+            double cost = 0;
+            foreach (var u in unlabeled) {
+                if (u.sr) {
+                    continue; // excluded by the should-reject bound; not a precision "cost" (it's a hard veto)
+                }
+                bool admitted = dir == GateDirection.LowerToAdmit ? u.m > t : u.m < t;
+                if (admitted) {
+                    cost += u.w;
+                }
+            }
+            return cost;
+        }
+
+        private static double Weight(int focuserPosition, RecommenderConfig c) {
+            if (c.StepSize <= 0 || !c.BestFocusPosition.HasValue) {
+                return 1.0;
+            }
+            var window = c.NearFocusWindowSteps * c.StepSize;
+            return Math.Abs(focuserPosition - c.BestFocusPosition.Value) <= window ? c.NearFocusWeight : 1.0;
+        }
+
+        private static double JustBelow(double v) => v - Math.Max(1e-9, Math.Abs(v) * 1e-6);
+        private static double JustAbove(double v) => v + Math.Max(1e-9, Math.Abs(v) * 1e-6);
+
+        private static double Median(List<double> values) {
+            if (values.Count == 0) {
+                return 0.0;
+            }
+            var sorted = values.OrderBy(x => x).ToList();
+            var mid = sorted.Count / 2;
+            return sorted.Count % 2 == 1 ? sorted[mid] : 0.5 * (sorted[mid - 1] + sorted[mid]);
+        }
+
+        private static double ReadThreshold(StarDetectorParams p, string gate) {
+            switch (gate) {
+                case RejectionGate.LowSensitivity: return p.Sensitivity;
+                case RejectionGate.TooLowHFR: return p.MinHFR;
+                case RejectionGate.TooDistorted: return p.MaxDistortion;
+                case RejectionGate.TooSmall: return p.MinimumStarBoundingBoxSize;
+                case RejectionGate.TooFlat: return p.PeakResponse;
+                case RejectionGate.NotCentered: return p.StarCenterTolerance;
+                default: return double.NaN;
+            }
+        }
+
+        private static double ClampThreshold(string gate, double t) {
+            switch (gate) {
+                case RejectionGate.LowSensitivity: return Math.Max(0.0, t);
+                case RejectionGate.TooLowHFR: return Math.Max(0.0, t);
+                case RejectionGate.TooDistorted: return Math.Min(1.0, Math.Max(0.01, t));
+                case RejectionGate.TooSmall: return Math.Max(2.0, Math.Floor(t));
+                case RejectionGate.TooFlat: return Math.Min(1.0, Math.Max(0.0, t));
+                case RejectionGate.NotCentered: return Math.Min(1.0, Math.Max(0.0, t));
+                default: return t;
+            }
+        }
+
+        private static void ApplyThreshold(StarDetectorParams p, string gate, double t) {
+            switch (gate) {
+                case RejectionGate.LowSensitivity: p.Sensitivity = t; break;
+                case RejectionGate.TooLowHFR: p.MinHFR = t; break;
+                case RejectionGate.TooDistorted: p.MaxDistortion = t; break;
+                case RejectionGate.TooSmall: p.MinimumStarBoundingBoxSize = (int)Math.Round(t); break;
+                case RejectionGate.TooFlat: p.PeakResponse = t; break;
+                case RejectionGate.NotCentered: p.StarCenterTolerance = t; break;
+            }
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/LabelGateAnalyzer.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/LabelGateAnalyzer.cs
@@ -1,0 +1,196 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review;
+using System.Collections.Generic;
+using System.Linq;
+using Rect = OpenCvSharp.Rect;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
+
+    /// <summary>One frame's detection + the user's labels for that focuser position, the input to the analyzer.
+    /// The caller (wizard or TestApp) detects each frame with
+    /// <see cref="StarDetectorParams.CollectRejectedCandidateDiagnostics"/> on, then fills this in.</summary>
+    public sealed class FrameDetectionForAnalysis {
+        public int FocuserPosition { get; set; }
+        public IReadOnlyList<Rect> AcceptedBounds { get; set; } = new List<Rect>();
+        public IReadOnlyList<(double X, double Y)> AcceptedCenters { get; set; } = new List<(double, double)>();
+        public IReadOnlyList<RejectedCandidateRecord> Rejected { get; set; } = new List<RejectedCandidateRecord>();
+
+        /// <summary>Recall targets = union of "missed" and "wrongly-rejected" boxes (both are stars the user wants kept).</summary>
+        public IReadOnlyList<RectD> RecallBoxes { get; set; } = new List<RectD>();
+
+        /// <summary>Precision targets = "should-reject" boxes (accepted stars inside them are false positives).</summary>
+        public IReadOnlyList<RectD> ShouldRejectBoxes { get; set; } = new List<RectD>();
+    }
+
+    /// <summary>A single rejected candidate, enriched with its labeling/precision context. The recommender groups
+    /// these by <see cref="Gate"/> and inverts the gate from the <see cref="MeasuredValue"/> distribution.</summary>
+    public sealed class AnalyzedRejection {
+        public string Gate { get; set; }
+        public double MeasuredValue { get; set; }
+        public double ThresholdValue { get; set; }
+        public double CandidateSize { get; set; }
+        public int FocuserPosition { get; set; }
+        public RectD Bounds { get; set; }
+
+        /// <summary>True when this rejected candidate overlaps a recall (missed/wrongly-rejected) box — i.e. the
+        /// user wants it recovered. False candidates are the "unlabeled" pool used to bound the precision cost.</summary>
+        public bool IsRecallTarget { get; set; }
+
+        /// <summary>True when this candidate's center lies inside a should-reject box — admitting it (by loosening
+        /// the gate) is an explicit precision violation the recommender must never do.</summary>
+        public bool InShouldRejectBox { get; set; }
+    }
+
+    public sealed class NoCandidateTarget {
+        public int FocuserPosition { get; set; }
+        public RectD Box { get; set; }
+    }
+
+    public sealed class ShouldRejectTarget {
+        public int FocuserPosition { get; set; }
+        public RectD Box { get; set; }
+
+        /// <summary>True when an accepted star currently falls inside this should-reject box (a present false positive).</summary>
+        public bool CurrentlyViolated { get; set; }
+    }
+
+    /// <summary>
+    /// Result of analyzing a run's labels against a fresh detection: every rejected candidate enriched with its
+    /// recall/precision context, the NO-CANDIDATE structure gaps, and the should-reject precision targets. Pure
+    /// data — the <see cref="GateRecommender"/> consumes it to derive setting changes.
+    /// </summary>
+    public sealed class LabelGateAnalysis {
+        public IReadOnlyList<AnalyzedRejection> Rejections { get; set; } = new List<AnalyzedRejection>();
+        public IReadOnlyList<NoCandidateTarget> NoCandidate { get; set; } = new List<NoCandidateTarget>();
+        public IReadOnlyList<ShouldRejectTarget> ShouldReject { get; set; } = new List<ShouldRejectTarget>();
+
+        public int TotalRecallTargets { get; set; }
+        public int AlreadyRecovered { get; set; }
+        public int NoCandidateCount { get; set; }
+
+        /// <summary>Distinct labeled focuser positions, ascending.</summary>
+        public IReadOnlyList<int> FocuserPositions { get; set; } = new List<int>();
+
+        /// <summary>Recall targets attributed to each gate (only gates that killed ≥1 recall target).</summary>
+        public IReadOnlyDictionary<string, int> RecallTargetCountByGate =>
+            Rejections.Where(r => r.IsRecallTarget)
+                      .GroupBy(r => r.Gate)
+                      .ToDictionary(g => g.Key, g => g.Count());
+
+        /// <summary>The labeled recall targets killed by <paramref name="gate"/>.</summary>
+        public IReadOnlyList<AnalyzedRejection> RecallTargets(string gate) =>
+            Rejections.Where(r => r.IsRecallTarget && r.Gate == gate).ToList();
+
+        /// <summary>The unlabeled rejected candidates of <paramref name="gate"/> (the precision proxy pool).</summary>
+        public IReadOnlyList<AnalyzedRejection> Unlabeled(string gate) =>
+            Rejections.Where(r => !r.IsRecallTarget && r.Gate == gate).ToList();
+    }
+
+    /// <summary>
+    /// Attributes each labeled "wrongly-rejected"/"missed" star to the exact gate that killed it (or flags it as a
+    /// NO-CANDIDATE structure gap), and collects the unlabeled rejected candidates as the precision proxy. Shared
+    /// by the in-wizard "Optimize with feedback" flow and the offline <c>recommend</c> harness; pure (image-free)
+    /// so it is fully unit-testable — the caller does the detection and fills <see cref="FrameDetectionForAnalysis"/>.
+    /// </summary>
+    public static class LabelGateAnalyzer {
+
+        public static LabelGateAnalysis Analyze(IReadOnlyList<FrameDetectionForAnalysis> frames) {
+            var rejections = new List<AnalyzedRejection>();
+            var noCandidate = new List<NoCandidateTarget>();
+            var shouldRejectTargets = new List<ShouldRejectTarget>();
+            int totalRecall = 0, alreadyRecovered = 0;
+
+            foreach (var frame in frames ?? new List<FrameDetectionForAnalysis>()) {
+                var rejected = frame.Rejected ?? new List<RejectedCandidateRecord>();
+
+                // Wrap every rejected candidate; tag should-reject membership by center containment.
+                var wrapped = new List<AnalyzedRejection>(rejected.Count);
+                foreach (var rec in rejected) {
+                    var inShouldReject = (frame.ShouldRejectBoxes ?? new List<RectD>())
+                        .Any(b => Contains(b, rec.CenterX, rec.CenterY));
+                    wrapped.Add(new AnalyzedRejection {
+                        Gate = rec.Gate,
+                        MeasuredValue = rec.MeasuredValue,
+                        ThresholdValue = rec.ThresholdValue,
+                        CandidateSize = rec.CandidateSize,
+                        FocuserPosition = frame.FocuserPosition,
+                        Bounds = RectD.FromRect(rec.Bounds),
+                        IsRecallTarget = false,
+                        InShouldRejectBox = inShouldReject
+                    });
+                }
+
+                // Classify each recall box: accepted ⇒ already recovered; rejected ⇒ mark the matched candidate as
+                // a recall target; neither ⇒ NO CANDIDATE structure gap.
+                foreach (var box in frame.RecallBoxes ?? new List<RectD>()) {
+                    totalRecall++;
+                    var match = BoxMatcher.Classify(box, frame.AcceptedBounds, rejected);
+                    if (match.Kind == BoxClassification.Accepted) {
+                        alreadyRecovered++;
+                    } else if (match.Kind == BoxClassification.Rejected) {
+                        // Mark the wrapped record that corresponds to the matched rejected candidate.
+                        var idx = IndexOfMatch(rejected, match.Rejected);
+                        if (idx >= 0) {
+                            wrapped[idx].IsRecallTarget = true;
+                        }
+                    } else {
+                        noCandidate.Add(new NoCandidateTarget { FocuserPosition = frame.FocuserPosition, Box = box });
+                    }
+                }
+
+                rejections.AddRange(wrapped);
+
+                // Should-reject precision targets: flag those currently violated (an accepted center inside).
+                foreach (var box in frame.ShouldRejectBoxes ?? new List<RectD>()) {
+                    var violated = (frame.AcceptedCenters ?? new List<(double, double)>())
+                        .Any(c => Contains(box, c.X, c.Y));
+                    shouldRejectTargets.Add(new ShouldRejectTarget {
+                        FocuserPosition = frame.FocuserPosition,
+                        Box = box,
+                        CurrentlyViolated = violated
+                    });
+                }
+            }
+
+            return new LabelGateAnalysis {
+                Rejections = rejections,
+                NoCandidate = noCandidate,
+                ShouldReject = shouldRejectTargets,
+                TotalRecallTargets = totalRecall,
+                AlreadyRecovered = alreadyRecovered,
+                NoCandidateCount = noCandidate.Count,
+                FocuserPositions = (frames ?? new List<FrameDetectionForAnalysis>())
+                    .Select(f => f.FocuserPosition).Distinct().OrderBy(x => x).ToList()
+            };
+        }
+
+        private static bool Contains(RectD box, double x, double y) =>
+            x >= box.X && x <= box.X + box.W && y >= box.Y && y <= box.Y + box.H;
+
+        // Reference-identity index of the matched record within the frame's rejected list (the wrapped list is
+        // built 1:1 in the same order, so the index aligns).
+        private static int IndexOfMatch(IReadOnlyList<RejectedCandidateRecord> rejected, RejectedCandidateRecord match) {
+            if (match == null) {
+                return -1;
+            }
+            for (var i = 0; i < rejected.Count; i++) {
+                if (ReferenceEquals(rejected[i], match)) {
+                    return i;
+                }
+            }
+            return -1;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizerVariable.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizerVariable.cs
@@ -155,6 +155,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 BooleanVar(DefocusAwareGatesName, 1,
                     p => p.DefocusAwareDistortion,
                     (p, en) => { p.DefocusAwareDistortion = en; p.DefocusAwareCentering = en; }),
+                // Defocus-aware STRUCTURE detection as a single integer knob (EARLY): 0 ⇒ OFF (bit-identical
+                // baseline), >0 ⇒ enable DefocusAwareStructure with that many extra wavelet layers, recovering
+                // large/donut defocused stars that never form a candidate. The seed reads the effective boost (0
+                // when the flag is off), so the baseline J is unchanged; the search may raise it.
+                StructureBoostVar(),
             };
         }
 
@@ -162,6 +167,78 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// <see cref="StarDetectorParams"/> property name (the variable drives two properties at once), so it is a
         /// named constant rather than a <c>nameof</c>.</summary>
         public const string DefocusAwareGatesName = "DefocusAwareGates";
+
+        /// <summary>Synthetic curated-set variable name for the defocus-aware-structure integer knob. Matches the
+        /// EARLY cache-key property <c>DefocusAwareStructure</c> so the optimizer stages it as an early axis, but
+        /// the variable's Write drives BOTH <see cref="StarDetectorParams.DefocusAwareStructure"/> and
+        /// <see cref="StarDetectorParams.StructureLayerBoost"/>.</summary>
+        public const string DefocusAwareStructureName = nameof(StarDetectorParams.DefocusAwareStructure);
+
+        /// <summary>
+        /// Builds a WARM-START variable set from the curated set and a recommendation (before → after params): for
+        /// each curated axis the recommender MOVED, a copy with a tight band ([recommended ± bandSteps·step] clamped
+        /// to the original bounds) so the optimizer refines near the analytic point without wandering; axes the
+        /// recommender did NOT move are OMITTED (pinned by omission — the warm-start SEED carries their value),
+        /// EXCEPT the defocus-aware toggles (<see cref="DefocusAwareGatesName"/> / <see cref="DefocusAwareStructureName"/>),
+        /// which are always kept live at full range so the optimizer can enable them if needed (guarded by the
+        /// objective's near-focus precision penalty). The caller passes <paramref name="after"/> as the optimizer seed.
+        /// </summary>
+        public static IReadOnlyList<OptimizerVariable> CreateWarmStartSet(
+            IReadOnlyList<OptimizerVariable> baseSet, StarDetectorParams before, StarDetectorParams after, int bandSteps = 3) {
+            var result = new List<OptimizerVariable>();
+            foreach (var v in baseSet) {
+                var beforeVal = v.Read(before);
+                var afterVal = v.Read(after);
+                var moved = Math.Abs(beforeVal - afterVal) > 1e-9;
+                var isDefocusToggle = v.Name == DefocusAwareGatesName || v.Name == DefocusAwareStructureName;
+                if (moved) {
+                    var half = bandSteps * v.InitialStep;
+                    var lo = Math.Max(v.Lower, afterVal - half);
+                    var hi = Math.Min(v.Upper, afterVal + half);
+                    if (hi <= lo) {
+                        hi = Math.Min(v.Upper, lo + Math.Max(v.InitialStep, 1e-9));
+                    }
+                    result.Add(WithBounds(v, lo, hi));
+                } else if (isDefocusToggle) {
+                    result.Add(v); // always explorable, full range
+                }
+                // else: omit — the seed (after) carries the unchanged value.
+            }
+            return result;
+        }
+
+        /// <summary>Copies <paramref name="baseVar"/> with new [<paramref name="lower"/>, <paramref name="upper"/>]
+        /// bounds. The new Write re-quantizes through the NEW bounds (so the optimizer cannot escape the band),
+        /// then delegates to the original Write (a no-op clamp + the real store, since the new band ⊂ original).</summary>
+        private static OptimizerVariable WithBounds(OptimizerVariable baseVar, double lower, double upper) {
+            OptimizerVariable v = null;
+            v = new OptimizerVariable {
+                Name = baseVar.Name,
+                Type = baseVar.Type,
+                Lower = lower, Upper = upper, InitialStep = baseVar.InitialStep,
+                Read = baseVar.Read,
+                Write = (p, raw) => baseVar.Write(p, v.Quantize(raw))
+            };
+            return v;
+        }
+
+        /// <summary>Builds the synthetic defocus-aware-structure variable: an Integer boost in [0, 4] that drives
+        /// the flag (boost &gt; 0) and the layer count together. 0 reproduces the bit-identical baseline.</summary>
+        private static OptimizerVariable StructureBoostVar() {
+            OptimizerVariable v = null;
+            v = new OptimizerVariable {
+                Name = DefocusAwareStructureName,
+                Type = OptimizerVariableType.Integer,
+                Lower = 0, Upper = 4, InitialStep = 1,
+                Read = p => p.DefocusAwareStructure ? p.StructureLayerBoost : 0,
+                Write = (p, raw) => {
+                    var boost = (int)v.Quantize(raw);
+                    p.StructureLayerBoost = boost;
+                    p.DefocusAwareStructure = boost > 0;
+                }
+            };
+            return v;
+        }
 
         /// <summary>
         /// Builds a Continuous variable whose Write quantizes the proposal through the variable's OWN

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/BoxMatcher.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/BoxMatcher.cs
@@ -1,0 +1,157 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using System;
+using System.Collections.Generic;
+using Rect = OpenCvSharp.Rect;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
+
+    /// <summary>A double-precision axis-aligned rectangle (label boxes carry fractional coordinates).</summary>
+    public readonly struct RectD {
+        public readonly double X, Y, W, H;
+
+        public RectD(double x, double y, double w, double h) {
+            X = x; Y = y; W = w; H = h;
+        }
+
+        public double Area => Math.Max(0.0, W) * Math.Max(0.0, H);
+
+        public static RectD FromRect(Rect r) => new RectD(r.X, r.Y, r.Width, r.Height);
+    }
+
+    /// <summary>How a label box relates to a fresh detection of its frame.</summary>
+    public enum BoxClassification {
+        /// <summary>Overlaps an accepted star — already detected (a recall target here is already recovered).</summary>
+        Accepted,
+
+        /// <summary>Overlaps a rejected candidate — a gate killed it (recoverable by tuning that gate).</summary>
+        Rejected,
+
+        /// <summary>Overlaps neither — no candidate ever formed there (a structure-detection gap).</summary>
+        NoCandidate
+    }
+
+    public sealed class BoxMatchResult {
+        public BoxClassification Kind { get; set; }
+        public double AcceptedIoU { get; set; }
+        public Rect AcceptedBounds { get; set; }
+        public double RejectedIoU { get; set; }
+
+        /// <summary>The best-overlapping rejected candidate (set whenever any rejected candidate overlaps, even if
+        /// <see cref="Kind"/> is <see cref="BoxClassification.Accepted"/> on a tie). Null when none overlaps.</summary>
+        public RejectedCandidateRecord Rejected { get; set; }
+
+        /// <summary>Number of DISTINCT gates that tie for the best rejected overlap (&gt;1 = ambiguous attribution).</summary>
+        public int RejectedTieCount { get; set; }
+
+        public string Gate => Rejected?.Gate;
+    }
+
+    /// <summary>
+    /// Shared label-box → detection matcher used by the diagnose-labels harness, the in-wizard label analyzer,
+    /// and the recommender, so all three agree on attribution by construction. A box is classified by BEST
+    /// overlap (IoU) across the accepted-star pool and the rejected-candidate pool; accepted wins ties (it
+    /// reflects the detector's actual outcome at that location). With no real overlap in either pool the box is a
+    /// NO-CANDIDATE structure gap. This is the plugin-side home of the logic that previously lived only in
+    /// TestApp's DiagnoseLabelsRunner.
+    /// </summary>
+    public static class BoxMatcher {
+
+        /// <summary>Intersection-over-union of two double rectangles. Zero when disjoint or either has zero area.</summary>
+        public static double IoU(RectD a, RectD b) {
+            var ix = Math.Max(a.X, b.X);
+            var iy = Math.Max(a.Y, b.Y);
+            var ix2 = Math.Min(a.X + a.W, b.X + b.W);
+            var iy2 = Math.Min(a.Y + a.H, b.Y + b.H);
+            var iw = ix2 - ix;
+            var ih = iy2 - iy;
+            if (iw <= 0.0 || ih <= 0.0) {
+                return 0.0;
+            }
+            var inter = iw * ih;
+            var union = a.Area + b.Area - inter;
+            return union <= 0.0 ? 0.0 : inter / union;
+        }
+
+        public static double IoU(RectD a, Rect b) => IoU(a, RectD.FromRect(b));
+
+        /// <summary>
+        /// Classifies <paramref name="labelBox"/> against the accepted and rejected candidate pools of a single
+        /// frame's detection. <paramref name="rejected"/> are the rich per-gate records
+        /// (<see cref="HocusFocusStarDetectorResult.RejectedCandidates"/>), so the gate that killed a
+        /// wrongly-rejected star — including the counter-only gates (TooLowHFR/TooSmall) that have no metrics
+        /// <c>*Bounds</c> list and so previously mis-classified as NO CANDIDATE — is reported.
+        /// </summary>
+        public static BoxMatchResult Classify(
+            RectD labelBox,
+            IReadOnlyList<Rect> acceptedBounds,
+            IReadOnlyList<RejectedCandidateRecord> rejected) {
+
+            double bestAcceptedIoU = 0.0;
+            Rect bestAcceptedRect = default;
+            bool haveAccepted = false;
+            if (acceptedBounds != null) {
+                foreach (var b in acceptedBounds) {
+                    var iou = IoU(labelBox, b);
+                    if (iou > bestAcceptedIoU) {
+                        bestAcceptedIoU = iou;
+                        bestAcceptedRect = b;
+                        haveAccepted = true;
+                    }
+                }
+            }
+
+            double bestRejectedIoU = 0.0;
+            RejectedCandidateRecord bestRejected = null;
+            int tieCount = 0;
+            if (rejected != null) {
+                foreach (var rec in rejected) {
+                    var iou = IoU(labelBox, rec.Bounds);
+                    if (iou <= 0.0) {
+                        continue;
+                    }
+                    if (iou > bestRejectedIoU) {
+                        bestRejectedIoU = iou;
+                        bestRejected = rec;
+                        tieCount = 1;
+                    } else if (Math.Abs(iou - bestRejectedIoU) < 1e-9 && bestRejected != null
+                               && !string.Equals(rec.Gate, bestRejected.Gate, StringComparison.Ordinal)) {
+                        tieCount++;
+                    }
+                }
+            }
+
+            bool acceptedReal = haveAccepted && bestAcceptedIoU > 0.0;
+            bool rejectedReal = bestRejected != null && bestRejectedIoU > 0.0;
+
+            var result = new BoxMatchResult {
+                AcceptedIoU = bestAcceptedIoU,
+                AcceptedBounds = bestAcceptedRect,
+                RejectedIoU = bestRejectedIoU,
+                Rejected = bestRejected,
+                RejectedTieCount = tieCount
+            };
+
+            if (!acceptedReal && !rejectedReal) {
+                result.Kind = BoxClassification.NoCandidate;
+            } else if (acceptedReal && bestAcceptedIoU >= bestRejectedIoU) {
+                // Accepted wins ties — reflects the detector's actual outcome at that location.
+                result.Kind = BoxClassification.Accepted;
+            } else {
+                result.Kind = BoxClassification.Rejected;
+            }
+            return result;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewBuilder.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewBuilder.cs
@@ -100,10 +100,17 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             StarDetector detector,
             Func<string, Task<Mat>> floatMatLoader,
             CancellationToken token) {
+            // Collect the rich per-rejected-candidate records so the in-wizard "Optimize with feedback" analyzer can
+            // attribute each labeled star to the gate that killed it. The flag is a bit-identical side channel
+            // (excluded from the cache key), so the accepted/rejected overlays are unchanged. Clone so the caller's
+            // params are not mutated.
+            var diagParams = detectorParams.Clone();
+            diagParams.CollectRejectedCandidateDiagnostics = true;
+
             HocusFocusStarDetectorResult result;
             using (var mat = await floatMatLoader(d.FramePath).ConfigureAwait(false))
             using (var clone = mat.Clone()) { // Detect mutates its input in place.
-                result = await detector.Detect(clone, detectorParams, null, token).ConfigureAwait(false);
+                result = await detector.Detect(clone, diagParams, null, token).ConfigureAwait(false);
             }
 
             var accepted = result.DetectedStars ?? new List<Star>();
@@ -122,6 +129,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
                 // should-reject click records the actual bounds.
                 Accepted = accepted.Select(s => (s.Center.X, s.Center.Y, s.HFR, s.StarBoundingBox)).ToList(),
                 Rejected = ExtractRejected(result),
+                RejectedCandidates = result.RejectedCandidates ?? new List<RejectedCandidateRecord>(),
             };
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -32,6 +32,8 @@
         <DockPanel Grid.Row="0" Grid.Column="0" LastChildFill="False" Margin="0,0,0,6">
             <TextBlock DockPanel.Dock="Left" FontWeight="SemiBold" Text="{Binding FrameHeader}" />
             <TextBlock DockPanel.Dock="Right" Text="{Binding PositionLabel}" />
+            <!-- Sensor (image-pixel) coordinates under the cursor, for describing a region precisely. -->
+            <TextBlock DockPanel.Dock="Right" Margin="0,0,16,0" MinWidth="120" Foreground="#FFB0B6BD" Text="{Binding CursorPositionText}" />
         </DockPanel>
 
         <!-- Toolbar: navigation + undo/redo (labeling is mode-less — the category is inferred from what is clicked). -->
@@ -65,6 +67,7 @@
                     MouseRightButtonDown="ViewportCanvas_MouseRightButtonDown"
                     MouseRightButtonUp="ViewportCanvas_MouseRightButtonUp"
                     MouseMove="ViewportCanvas_MouseMove"
+                    MouseLeave="ViewportCanvas_MouseLeave"
                     SizeChanged="ViewportCanvas_SizeChanged">
                 <Canvas.RenderTransform>
                     <TransformGroup>
@@ -293,11 +296,33 @@
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
 
-            <!-- HFR display toggle lives under the legend (toolbar space is tight). -->
+            <!-- HFR display toggle lives under the legend (toolbar space is tight). Keep NINA's toggle look, but
+                 NINA renders the On/Off state text with PrimaryBrush (NOT the inherited Foreground); on this dark
+                 panel the default "Off" label is too dark. Lighten PrimaryBrush — scoped to this checkbox via its
+                 own resource dictionary (DynamicResource lookups resolve here first) — so the state text is legible. -->
             <Separator Margin="0,10,0,8" />
-            <CheckBox Content="Show HFR" IsChecked="{Binding ShowHfr}" Foreground="{StaticResource Fg}" />
+            <CheckBox Content="Show HFR" IsChecked="{Binding ShowHfr}" Foreground="{StaticResource Fg}">
+                <CheckBox.Resources>
+                    <SolidColorBrush x:Key="PrimaryBrush" Color="#FFD8DCE0" />
+                    <SolidColorBrush x:Key="ButtonForegroundBrush" Color="#FFD8DCE0" />
+                    <SolidColorBrush x:Key="ButtonForegroundDisabledBrush" Color="#FFA9B0B8" />
+                    <SolidColorBrush x:Key="SecondaryBrush" Color="#FFD8DCE0" />
+                </CheckBox.Resources>
+            </CheckBox>
             <TextBlock Margin="0,4,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
                        Text="Label each detected star with its HFR, above the box." />
+
+            <!-- Divider between the HFR section and the labeling guidance. -->
+            <Separator Margin="0,12,0,0" />
+            <TextBlock FontWeight="Bold" Margin="0,8,0,3" Text="How to label" />
+            <TextBlock Foreground="#FFB0B6BD" TextWrapping="Wrap"
+                       Text="• Flag rejected stars sparingly — fewer is better." />
+            <TextBlock Margin="0,3,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
+                       Text="• Zoom into different regions and step through every frame; focus on stars accepted near focus but rejected far from it." />
+            <TextBlock Margin="0,3,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
+                       Text="• If a flagged star has no HFR, unflag it — not enough signal." />
+            <TextBlock Margin="0,3,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
+                       Text="• Prefer flagging rejected stars. If large, defocused stars aren't detected at all, draw a box around them." />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -6,6 +6,85 @@
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVis" />
         <SolidColorBrush x:Key="Fg" Color="White" />
+
+        <!-- NINA's default toggle (StandardCheckBox) hard-codes the OFF label to {StaticResource PrimaryBrush},
+             which is too dark on this panel and CANNOT be overridden from the consumer (StaticResource is baked
+             into NINA's parsed style). So we keep NINA's exact toggle look but re-template it locally, pointing
+             ONLY the OFF text at a light brush; the remaining theme brushes use DynamicResource so the switch
+             still matches the active theme. (Template copied from NINA.WPF.Base Resources/Styles/CheckBox.xaml.) -->
+        <SolidColorBrush x:Key="HF_ToggleOffText" Color="#FFD8DCE0" />
+        <Style x:Key="HF_ReviewToggle" TargetType="{x:Type CheckBox}">
+            <Setter Property="Focusable" Value="False" />
+            <Setter Property="Width" Value="65" />
+            <Setter Property="Height" Value="25" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="CheckBox">
+                        <Grid>
+                            <Border
+                                x:Name="SwitchTrack"
+                                Background="Transparent"
+                                BorderBrush="{DynamicResource BorderBrush}"
+                                BorderThickness="1"
+                                CornerRadius="12.5" />
+                            <Grid>
+                                <TextBlock
+                                    x:Name="OnText"
+                                    Margin="8,0,0,0"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    FontWeight="Bold"
+                                    Foreground="{StaticResource HF_ToggleOffText}"
+                                    Text="ON"
+                                    Visibility="Collapsed" />
+                                <TextBlock
+                                    x:Name="OffText"
+                                    Margin="0,0,8,0"
+                                    HorizontalAlignment="Right"
+                                    VerticalAlignment="Center"
+                                    Foreground="{StaticResource HF_ToggleOffText}"
+                                    Text="OFF"
+                                    Visibility="Visible" />
+                            </Grid>
+                            <Ellipse
+                                x:Name="SwitchThumb"
+                                Width="21"
+                                Height="21"
+                                Margin="2"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                Fill="{DynamicResource SecondaryBackgroundBrush}"
+                                RenderTransformOrigin="0.5,0.5">
+                                <Ellipse.RenderTransform>
+                                    <TranslateTransform x:Name="ThumbTransform" />
+                                </Ellipse.RenderTransform>
+                            </Ellipse>
+                        </Grid>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsChecked" Value="True">
+                                <Setter TargetName="SwitchTrack" Property="Background" Value="{DynamicResource TertiaryBackgroundBrush}" />
+                                <Setter TargetName="SwitchThumb" Property="HorizontalAlignment" Value="Right" />
+                                <Setter TargetName="OnText" Property="Visibility" Value="Visible" />
+                                <Setter TargetName="OffText" Property="Visibility" Value="Collapsed" />
+                            </Trigger>
+                            <Trigger Property="IsChecked" Value="False">
+                                <Setter TargetName="SwitchTrack" Property="Background" Value="Transparent" />
+                                <Setter TargetName="SwitchThumb" Property="HorizontalAlignment" Value="Left" />
+                                <Setter TargetName="OnText" Property="Visibility" Value="Collapsed" />
+                                <Setter TargetName="OffText" Property="Visibility" Value="Visible" />
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="SwitchTrack" Property="Opacity" Value="0.4" />
+                                <Setter TargetName="SwitchThumb" Property="Opacity" Value="0.4" />
+                                <Setter TargetName="OnText" Property="Opacity" Value="0.4" />
+                                <Setter TargetName="OffText" Property="Opacity" Value="0.4" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
         <Style TargetType="Button">
             <Setter Property="Margin" Value="4,0" />
             <Setter Property="Padding" Value="10,4" />
@@ -296,19 +375,13 @@
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
 
-            <!-- HFR display toggle lives under the legend (toolbar space is tight). Keep NINA's toggle look, but
-                 NINA renders the On/Off state text with PrimaryBrush (NOT the inherited Foreground); on this dark
-                 panel the default "Off" label is too dark. Lighten PrimaryBrush — scoped to this checkbox via its
-                 own resource dictionary (DynamicResource lookups resolve here first) — so the state text is legible. -->
+            <!-- HFR display toggle lives under the legend (toolbar space is tight). Uses HF_ReviewToggle — NINA's
+                 toggle look with a legible OFF label (see the style comment in UserControl.Resources). -->
             <Separator Margin="0,10,0,8" />
-            <CheckBox Content="Show HFR" IsChecked="{Binding ShowHfr}" Foreground="{StaticResource Fg}">
-                <CheckBox.Resources>
-                    <SolidColorBrush x:Key="PrimaryBrush" Color="#FFD8DCE0" />
-                    <SolidColorBrush x:Key="ButtonForegroundBrush" Color="#FFD8DCE0" />
-                    <SolidColorBrush x:Key="ButtonForegroundDisabledBrush" Color="#FFA9B0B8" />
-                    <SolidColorBrush x:Key="SecondaryBrush" Color="#FFD8DCE0" />
-                </CheckBox.Resources>
-            </CheckBox>
+            <StackPanel Orientation="Horizontal">
+                <CheckBox Style="{StaticResource HF_ReviewToggle}" IsChecked="{Binding ShowHfr}" VerticalAlignment="Center" />
+                <TextBlock Margin="8,0,0,0" VerticalAlignment="Center" Text="Show HFR" />
+            </StackPanel>
             <TextBlock Margin="0,4,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
                        Text="Label each detected star with its HFR, above the box." />
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -297,7 +297,7 @@
             <Separator Margin="0,10,0,8" />
             <CheckBox Content="Show HFR" IsChecked="{Binding ShowHfr}" Foreground="{StaticResource Fg}" />
             <TextBlock Margin="0,4,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
-                       Text="Label each accepted star — and any star you marked as wrongly-rejected — with its measured half-flux radius (HFR), drawn just above the box. Missed boxes show — (no detected star there to measure)." />
+                       Text="Label each detected star with its HFR, above the box." />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Background="#FF1E2125">
     <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis" />
         <SolidColorBrush x:Key="Fg" Color="White" />
         <Style TargetType="Button">
             <Setter Property="Margin" Value="4,0" />
@@ -115,9 +116,27 @@
                     </ItemsControl.ItemContainerStyle>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Rectangle Width="{Binding Width}" Height="{Binding Height}"
-                                       Stroke="{Binding DataContext.AcceptedBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
-                                       StrokeThickness="{Binding DataContext.MarkerStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                            <Grid>
+                                <Rectangle Width="{Binding Width}" Height="{Binding Height}"
+                                           Stroke="{Binding DataContext.AcceptedBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                           StrokeThickness="{Binding DataContext.MarkerStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                <!-- HFR label: anchored at the box top-left, kept a constant on-screen size by the
+                                     inverse-zoom ScaleTransform, then lifted up one text-height so it sits just ABOVE
+                                     the box with no overlap. -->
+                                <TextBlock Text="{Binding HfrText}"
+                                           HorizontalAlignment="Left" VerticalAlignment="Top"
+                                           FontSize="10" Foreground="White" Background="#B0000000" Padding="2,0"
+                                           IsHitTestVisible="False" RenderTransformOrigin="0,0"
+                                           Visibility="{Binding DataContext.ShowHfr, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}">
+                                    <TextBlock.RenderTransform>
+                                        <TransformGroup>
+                                            <ScaleTransform ScaleX="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                            ScaleY="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                            <TranslateTransform Y="{Binding DataContext.HfrLabelOffset, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                        </TransformGroup>
+                                    </TextBlock.RenderTransform>
+                                </TextBlock>
+                            </Grid>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
@@ -135,10 +154,28 @@
                     </ItemsControl.ItemContainerStyle>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Rectangle Width="{Binding Width}" Height="{Binding Height}"
-                                       Stroke="{Binding DataContext.MissedBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
-                                       StrokeDashArray="3 2"
-                                       StrokeThickness="{Binding DataContext.LabelStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                            <Grid>
+                                <Rectangle Width="{Binding Width}" Height="{Binding Height}"
+                                           Stroke="{Binding DataContext.MissedBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                           StrokeDashArray="3 2"
+                                           StrokeThickness="{Binding DataContext.LabelStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                <!-- HFR label: anchored at the box top-left, kept a constant on-screen size by the
+                                     inverse-zoom ScaleTransform, then lifted up one text-height so it sits just ABOVE
+                                     the box with no overlap. -->
+                                <TextBlock Text="{Binding HfrText}"
+                                           HorizontalAlignment="Left" VerticalAlignment="Top"
+                                           FontSize="10" Foreground="White" Background="#B0000000" Padding="2,0"
+                                           IsHitTestVisible="False" RenderTransformOrigin="0,0"
+                                           Visibility="{Binding DataContext.ShowHfr, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}">
+                                    <TextBlock.RenderTransform>
+                                        <TransformGroup>
+                                            <ScaleTransform ScaleX="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                            ScaleY="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                            <TranslateTransform Y="{Binding DataContext.HfrLabelOffset, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                        </TransformGroup>
+                                    </TextBlock.RenderTransform>
+                                </TextBlock>
+                            </Grid>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
@@ -178,10 +215,28 @@
                     </ItemsControl.ItemContainerStyle>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Rectangle Width="{Binding Width}" Height="{Binding Height}"
-                                       Stroke="{Binding DataContext.WronglyRejectedBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
-                                       StrokeDashArray="3 2"
-                                       StrokeThickness="{Binding DataContext.LabelStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                            <Grid>
+                                <Rectangle Width="{Binding Width}" Height="{Binding Height}"
+                                           Stroke="{Binding DataContext.WronglyRejectedBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                           StrokeDashArray="3 2"
+                                           StrokeThickness="{Binding DataContext.LabelStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                <!-- HFR label: anchored at the box top-left, kept a constant on-screen size by the
+                                     inverse-zoom ScaleTransform, then lifted up one text-height so it sits just ABOVE
+                                     the box with no overlap. -->
+                                <TextBlock Text="{Binding HfrText}"
+                                           HorizontalAlignment="Left" VerticalAlignment="Top"
+                                           FontSize="10" Foreground="White" Background="#B0000000" Padding="2,0"
+                                           IsHitTestVisible="False" RenderTransformOrigin="0,0"
+                                           Visibility="{Binding DataContext.ShowHfr, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}">
+                                    <TextBlock.RenderTransform>
+                                        <TransformGroup>
+                                            <ScaleTransform ScaleX="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                            ScaleY="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                            <TranslateTransform Y="{Binding DataContext.HfrLabelOffset, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                        </TransformGroup>
+                                    </TextBlock.RenderTransform>
+                                </TextBlock>
+                            </Grid>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
@@ -237,6 +292,12 @@
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
+
+            <!-- HFR display toggle lives under the legend (toolbar space is tight). -->
+            <Separator Margin="0,10,0,8" />
+            <CheckBox Content="Show HFR" IsChecked="{Binding ShowHfr}" Foreground="{StaticResource Fg}" />
+            <TextBlock Margin="0,4,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
+                       Text="Label each accepted star — and any star you marked as wrongly-rejected — with its measured half-flux radius (HFR), drawn just above the box. Missed boxes show — (no detected star there to measure)." />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml.cs
@@ -49,6 +49,23 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         private bool dragging;
         private System.Windows.Point dragStartImage;
 
+        // Drawn-box (missed) move/resize: editingBox is set while a grabbed box is being moved/resized. EdgeHandlePx
+        // is the on-screen grab margin around an edge/corner (converted to image pixels via the current zoom).
+        private bool editingBox;
+        private const double EdgeHandlePx = 7.0;
+
+        private static Cursor CursorForHandle(BoxHandle handle) => handle switch {
+            BoxHandle.Inside => Cursors.SizeAll,
+            BoxHandle.Left or BoxHandle.Right => Cursors.SizeWE,
+            BoxHandle.Top or BoxHandle.Bottom => Cursors.SizeNS,
+            BoxHandle.TopLeft or BoxHandle.BottomRight => Cursors.SizeNWSE,
+            BoxHandle.TopRight or BoxHandle.BottomLeft => Cursors.SizeNESW,
+            _ => Cursors.Arrow
+        };
+
+        // Image-pixel grab margin at the current zoom (so the handles are a constant on-screen size).
+        private double EdgeHandleImagePx => EdgeHandlePx / Math.Max(StarReviewViewport.MinScale, Vm?.Viewport.Scale ?? 1.0);
+
         public StarReviewControl() {
             InitializeComponent();
             DataContextChanged += OnDataContextChanged;
@@ -224,6 +241,17 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
                 return;
             }
 
+            // Editing a DRAWN (missed) box takes priority over labeling: a press on an edge/corner resizes it, a
+            // press inside moves it. Only when the press misses every drawn box do we fall through to labeling.
+            var (editIdx, editHandle) = vm.HitTestMissedBox(imgX, imgY, EdgeHandleImagePx);
+            if (editIdx >= 0 && editHandle != BoxHandle.None) {
+                editingBox = true;
+                vm.BeginMissedBoxEdit(editIdx, editHandle, imgX, imgY);
+                ViewportCanvas.CaptureMouse();
+                e.Handled = true;
+                return;
+            }
+
             // Mode-less routing: a press over a detector box (accepted or rejected) is a CLICK — on button-up it
             // toggles the inferred label. A press over BLANK space begins a MISSED rubber-band drag (finalized on
             // button-up). Disambiguating on the press keeps a click on a star from dropping a stray missed box.
@@ -247,6 +275,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         private void ViewportCanvas_MouseLeftButtonUp(object sender, MouseButtonEventArgs e) {
             var vm = Vm;
             if (vm == null) {
+                return;
+            }
+            // Finish an in-progress drawn-box move/resize (commits one undoable edit if the geometry changed).
+            if (editingBox) {
+                editingBox = false;
+                ViewportCanvas.ReleaseMouseCapture();
+                vm.EndMissedBoxEdit();
+                e.Handled = true;
                 return;
             }
             if (!pressArmed) {
@@ -316,6 +352,20 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
                 return;
             }
 
+            // Sensor-coordinate readout: show the image pixel under the cursor (cleared when off the image), so a
+            // region can be described precisely. Runs on every move, independent of the drag/pan gestures below.
+            var cursor = ScreenPoint(e);
+            var (cursorX, cursorY) = vm.Viewport.ScreenToImage(cursor.X, cursor.Y);
+            vm.CursorPositionText = (cursorX >= 0 && cursorY >= 0 && cursorX <= vm.ImageWidth && cursorY <= vm.ImageHeight)
+                ? $"x: {cursorX:F0}, y: {cursorY:F0}"
+                : null;
+
+            // An active move/resize of a drawn box owns the gesture.
+            if (editingBox) {
+                vm.UpdateMissedBoxEdit(cursorX, cursorY);
+                return;
+            }
+
             // Update the live rubber-band while dragging a MISSED box (image-space; the canvas transform scales it).
             if (dragging) {
                 var screenNow = ScreenPoint(e);
@@ -330,6 +380,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             }
 
             if (!panning) {
+                // Hover feedback: over a drawn (missed) box show the move cursor inside and resize cursors on the
+                // edges/corners; otherwise the default arrow.
+                var (hoverIdx, hoverHandle) = vm.HitTestMissedBox(cursorX, cursorY, EdgeHandleImagePx);
+                ViewportCanvas.Cursor = hoverIdx >= 0 ? CursorForHandle(hoverHandle) : null;
                 return;
             }
             var screen = ScreenPoint(e);
@@ -343,6 +397,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             lastPanScreen = screen;
             vm.Viewport.PanBy(dx, dy);
             ApplyViewport();
+        }
+
+        private void ViewportCanvas_MouseLeave(object sender, MouseEventArgs e) {
+            if (Vm != null) {
+                Vm.CursorPositionText = null;
+            }
         }
 
         private void ViewportCanvas_SizeChanged(object sender, SizeChangedEventArgs e) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml.cs
@@ -106,6 +106,18 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             if (vm == null || ViewportCanvas.ActualWidth <= 0 || vm.ImageWidth <= 0) {
                 return;
             }
+            // A fitted image always ends with the scrollbars HIDDEN, and their disappearance widens/heightens the
+            // canvas. If we measured now (while still zoomed in, scrollbars visible) the fit would be computed
+            // against the smaller, scrollbar-occupied viewport and the image would land off-center until a second
+            // Fit click. So collapse the scrollbars and force a synchronous layout pass FIRST, then measure the
+            // final (scrollbar-free) viewport. (ApplyViewport's UpdateScrollBars keeps them hidden since the fitted
+            // image is smaller than the viewport, so there is no flip-back.)
+            HScroll.Visibility = Visibility.Collapsed;
+            VScroll.Visibility = Visibility.Collapsed;
+            ViewportCanvas.UpdateLayout();
+            if (ViewportCanvas.ActualWidth <= 0 || ViewportCanvas.ActualHeight <= 0) {
+                return;
+            }
             vm.Viewport.FitTo(ViewportCanvas.ActualWidth, ViewportCanvas.ActualHeight, vm.ImageWidth, vm.ImageHeight);
             ApplyViewport();
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewLabels.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewLabels.cs
@@ -182,7 +182,37 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
                     return parsed;
                 }
             }
+
+            // 3. Trailing-segment fallback (G3): the wizard writes the embedded runId as the ABSOLUTE run path, but
+            //    offline discovery keys a run by its relative path / leaf folder (e.g. "attempt01"). Match when the
+            //    last path segment agrees, so wizard-saved labels load against a path-relocated copy of the run
+            //    without manual renaming. Exact / embedded matches above always take priority.
+            var runLeaf = LastSegment(runId);
+            if (!string.IsNullOrEmpty(runLeaf)) {
+                foreach (var file in Directory.GetFiles(labelsDir, "*.json").OrderBy(f => f, StringComparer.Ordinal)) {
+                    var parsed = TryParse(file, out _);
+                    if (parsed == null) {
+                        continue;
+                    }
+                    var embedded = !string.IsNullOrWhiteSpace(parsed.RunId) ? parsed.RunId : Path.GetFileNameWithoutExtension(file);
+                    if (string.Equals(LastSegment(embedded), runLeaf, StringComparison.OrdinalIgnoreCase)) {
+                        parsed.RunId = runId;
+                        Normalize(parsed);
+                        return parsed;
+                    }
+                }
+            }
             return fresh;
+        }
+
+        /// <summary>Last non-empty path segment of <paramref name="id"/>, splitting on both separators (the wizard
+        /// embeds Windows absolute paths; offline runIds are forward-slashed relative paths).</summary>
+        public static string LastSegment(string id) {
+            if (string.IsNullOrWhiteSpace(id)) {
+                return null;
+            }
+            var segments = id.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);
+            return segments.Length > 0 ? segments[segments.Length - 1] : null;
         }
 
         /// <summary>Saves <paramref name="labels"/> to "&lt;runId&gt;.json" in <paramref name="labelsDir"/>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
@@ -75,6 +75,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         public string HfrText { get; set; }
     }
 
+    /// <summary>Which part of a drawn (missed) box is under the cursor: an edge or corner (resize), the interior
+    /// (move), or nothing. Drives both the move/resize gesture and the cursor shown while hovering.</summary>
+    public enum BoxHandle { None, Inside, Left, Right, Top, Bottom, TopLeft, TopRight, BottomLeft, BottomRight }
+
     /// <summary>A drawable rejected-candidate box in image-pixel coords, colored by reason.</summary>
     public sealed class RejectedMarker {
         public double X { get; set; }
@@ -206,6 +210,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
         public string PositionLabel => $"{CurrentIndex + 1} / {queue.Count}";
 
+        private string cursorPositionText;
+
+        /// <summary>The image (sensor) pixel coordinates under the mouse cursor, shown in the header so a region can
+        /// be described precisely. Null/empty when the cursor is off the image. Updated by the control on mouse move.</summary>
+        public string CursorPositionText {
+            get => cursorPositionText;
+            set { if (cursorPositionText != value) { cursorPositionText = value; RaisePropertyChanged(); } }
+        }
+
         private string frameHeader;
         public string FrameHeader {
             get => frameHeader;
@@ -296,8 +309,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         /// legend panel to the right).</summary>
         public string HelpText =>
             "Left-drag over a missed star to mark it. Click an accepted box to flag a false positive, or a " +
-            "rejected box to keep it. Right-click a label (or click it again) to remove it. Ctrl+Z / Ctrl+Y to " +
-            "undo / redo. Wheel to zoom, right-drag to pan.";
+            "rejected box to keep it. Drag inside a box you drew to move it, or its edges/corners to resize. " +
+            "Right-click a label (or click it again) to remove it. Ctrl+Z / Ctrl+Y to undo / redo. Wheel to zoom, " +
+            "right-drag to pan.";
 
         public string CountsLabel {
             get {
@@ -426,6 +440,124 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
                 RecordEdit(run.RunId, Current.FocuserPosition, LabelKind.Missed, box, wasAdd: true);
             }
             RefreshLabelMarkers();
+        }
+
+        // ---- Move / resize of drawn (missed) boxes ---------------------------------------------------------
+
+        // In-progress edit state (valid between BeginMissedBoxEdit and EndMissedBoxEdit).
+        private int editBoxIndex = -1;
+        private BoxHandle editHandle = BoxHandle.None;
+        private StarReviewLabelBox editBox;
+        private double editStartX, editStartY, editStartW, editStartH; // geometry at grab (undo baseline + move base)
+        private double editGrabX, editGrabY;                            // cursor image point at grab (move delta base)
+
+        /// <summary>True while a move/resize gesture is active (the view routes mouse events to UpdateMissedBoxEdit).</summary>
+        public bool IsEditingBox => editBoxIndex >= 0;
+
+        /// <summary>Finds the drawn (missed) box under (<paramref name="px"/>,<paramref name="py"/>): its index and the
+        /// handle (edge/corner = resize, interior = move) within <paramref name="edgePx"/> image pixels of an edge.
+        /// Smallest box wins on overlap. Returns (-1, None) when no missed box is under the point. Pure query — drives
+        /// both the gesture routing and the hover cursor.</summary>
+        public (int Index, BoxHandle Handle) HitTestMissedBox(double px, double py, double edgePx) {
+            var pos = CurrentPositionLabels;
+            if (pos?.Missed == null || pos.Missed.Count == 0) {
+                return (-1, BoxHandle.None);
+            }
+            var bestIdx = -1;
+            var bestHandle = BoxHandle.None;
+            var bestArea = double.MaxValue;
+            for (var i = 0; i < pos.Missed.Count; i++) {
+                var b = pos.Missed[i];
+                double x = b.X, y = b.Y, w = b.W ?? 0.0, h = b.H ?? 0.0;
+                if (px < x - edgePx || px > x + w + edgePx || py < y - edgePx || py > y + h + edgePx) {
+                    continue;
+                }
+                bool nearL = Math.Abs(px - x) <= edgePx, nearR = Math.Abs(px - (x + w)) <= edgePx;
+                bool nearT = Math.Abs(py - y) <= edgePx, nearB = Math.Abs(py - (y + h)) <= edgePx;
+                BoxHandle handle =
+                    nearL && nearT ? BoxHandle.TopLeft :
+                    nearR && nearT ? BoxHandle.TopRight :
+                    nearL && nearB ? BoxHandle.BottomLeft :
+                    nearR && nearB ? BoxHandle.BottomRight :
+                    nearL ? BoxHandle.Left :
+                    nearR ? BoxHandle.Right :
+                    nearT ? BoxHandle.Top :
+                    nearB ? BoxHandle.Bottom :
+                    BoxHandle.Inside;
+                var area = w * h;
+                if (area < bestArea) {
+                    bestArea = area;
+                    bestIdx = i;
+                    bestHandle = handle;
+                }
+            }
+            return (bestIdx, bestHandle);
+        }
+
+        /// <summary>Begins a move (Inside) or resize (edge/corner) of the missed box at <paramref name="index"/>,
+        /// anchored at the cursor image point. Captures the starting geometry for the live update and the undo.</summary>
+        public void BeginMissedBoxEdit(int index, BoxHandle handle, double grabX, double grabY) {
+            var pos = CurrentPositionLabels;
+            if (pos?.Missed == null || index < 0 || index >= pos.Missed.Count || handle == BoxHandle.None) {
+                editBoxIndex = -1;
+                return;
+            }
+            editBoxIndex = index;
+            editHandle = handle;
+            editBox = pos.Missed[index];
+            editStartX = editBox.X;
+            editStartY = editBox.Y;
+            editStartW = editBox.W ?? 0.0;
+            editStartH = editBox.H ?? 0.0;
+            editGrabX = grabX;
+            editGrabY = grabY;
+        }
+
+        /// <summary>Live-updates the in-progress move/resize to the current cursor image point and refreshes the
+        /// overlay. No-op when no edit is active.</summary>
+        public void UpdateMissedBoxEdit(double cursorX, double cursorY) {
+            if (editBoxIndex < 0 || editBox == null) {
+                return;
+            }
+            double x1 = editStartX, y1 = editStartY, x2 = editStartX + editStartW, y2 = editStartY + editStartH;
+            if (editHandle == BoxHandle.Inside) {
+                var dx = cursorX - editGrabX;
+                var dy = cursorY - editGrabY;
+                x1 += dx; x2 += dx; y1 += dy; y2 += dy;
+            } else {
+                if (editHandle is BoxHandle.Left or BoxHandle.TopLeft or BoxHandle.BottomLeft) x1 = cursorX;
+                if (editHandle is BoxHandle.Right or BoxHandle.TopRight or BoxHandle.BottomRight) x2 = cursorX;
+                if (editHandle is BoxHandle.Top or BoxHandle.TopLeft or BoxHandle.TopRight) y1 = cursorY;
+                if (editHandle is BoxHandle.Bottom or BoxHandle.BottomLeft or BoxHandle.BottomRight) y2 = cursorY;
+            }
+            editBox.X = Math.Min(x1, x2);
+            editBox.Y = Math.Min(y1, y2);
+            editBox.W = Math.Abs(x2 - x1);
+            editBox.H = Math.Abs(y2 - y1);
+            RefreshLabelMarkers();
+        }
+
+        /// <summary>Finishes the in-progress move/resize: records it as one undoable edit when the geometry actually
+        /// changed (a press that didn't move is dropped), then clears the edit state.</summary>
+        public void EndMissedBoxEdit() {
+            if (editBoxIndex < 0 || editBox == null) {
+                editBoxIndex = -1;
+                return;
+            }
+            var changed = Math.Abs(editBox.X - editStartX) > 1e-6 || Math.Abs(editBox.Y - editStartY) > 1e-6
+                || Math.Abs((editBox.W ?? 0.0) - editStartW) > 1e-6 || Math.Abs((editBox.H ?? 0.0) - editStartH) > 1e-6;
+            if (changed) {
+                undoStack.Push(new LabelEdit {
+                    RunId = Current.RunId, FocuserPosition = Current.FocuserPosition, Kind = LabelKind.Missed,
+                    Box = editBox, IsModify = true,
+                    OldX = editStartX, OldY = editStartY, OldW = editStartW, OldH = editStartH,
+                    NewX = editBox.X, NewY = editBox.Y, NewW = editBox.W ?? 0.0, NewH = editBox.H ?? 0.0
+                });
+                redoStack.Clear();
+                RaiseUndoRedo();
+            }
+            editBoxIndex = -1;
+            editBox = null;
         }
 
         /// <summary>
@@ -624,13 +756,20 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
         private enum LabelKind { Missed, ShouldReject, WronglyRejected }
 
-        /// <summary>One undoable label edit: the box that was added or removed, in a specific run/position/list.</summary>
+        /// <summary>One undoable label edit: a box added/removed, OR (when <see cref="IsModify"/>) a box moved/resized
+        /// in a specific run/position/list.</summary>
         private sealed class LabelEdit {
             public string RunId;
             public int FocuserPosition;
             public LabelKind Kind;
             public StarReviewLabelBox Box;
             public bool WasAdd; // true: the edit ADDED Box (undo removes it); false: it REMOVED Box (undo re-adds).
+
+            // Move/resize: when true, the edit changed Box's geometry (the Box stays in the list). Undo restores the
+            // Old* geometry, redo restores the New*.
+            public bool IsModify;
+            public double OldX, OldY, OldW, OldH;
+            public double NewX, NewY, NewW, NewH;
         }
 
         private readonly Stack<LabelEdit> undoStack = new();
@@ -675,6 +814,27 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             }
             var pos = StarReviewLabelStore.GetOrAddPosition(run, e.FocuserPosition);
             var list = ListFor(pos, e.Kind);
+
+            if (e.IsModify) {
+                // The Box reference persists in the list across a move/resize; set its geometry to the target. If the
+                // reference is somehow gone, match by the box's CURRENT (pre-this-step) center.
+                var box = list.Contains(e.Box) ? e.Box : null;
+                if (box == null) {
+                    var (curCx, curCy) = forward
+                        ? (e.OldX + e.OldW / 2.0, e.OldY + e.OldH / 2.0)
+                        : (e.NewX + e.NewW / 2.0, e.NewY + e.NewH / 2.0);
+                    var hit = StarReviewLabelStore.NearestBoxIndexWithin(list, curCx, curCy, StarReviewLabelStore.SamePointTolerancePx);
+                    box = hit >= 0 ? list[hit] : null;
+                }
+                if (box != null) {
+                    box.X = forward ? e.NewX : e.OldX;
+                    box.Y = forward ? e.NewY : e.OldY;
+                    box.W = forward ? e.NewW : e.OldW;
+                    box.H = forward ? e.NewH : e.OldH;
+                }
+                return;
+            }
+
             var doAdd = e.WasAdd ? forward : !forward;
             if (doAdd) {
                 if (StarReviewLabelStore.NearestBoxIndexWithin(list, e.Box.CenterX, e.Box.CenterY, StarReviewLabelStore.SamePointTolerancePx) < 0) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
@@ -259,7 +259,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         // out to a constant ≈15 px on screen (one FontSize-10 line + a 1 px gap) at any zoom.
         public double HfrLabelOffset => -15.0 * MarkerTextScale;
 
-        private bool showHfr;
+        // Default ON — HFR is the primary signal the labeler uses to judge whether a flagged star has enough
+        // signal to keep, so it should be visible the moment Review opens.
+        private bool showHfr = true;
 
         /// <summary>Toggle: when on, every accepted star (and every labeled wrongly-rejected / missed box) shows its
         /// HFR on the overlay. Bound to a checkbox in the toolbar.</summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
@@ -46,6 +46,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         /// should-reject label box, and the overlay) + HFR.</summary>
         public List<(double CX, double CY, double HFR, Rect Bounds)> Accepted { get; set; } = new();
         public List<(string Reason, Rect Bounds)> Rejected { get; set; } = new();
+
+        /// <summary>Rich per-rejected-candidate records (gate + measured value) for the "Optimize with feedback"
+        /// analyzer. Populated by the production builder; may be empty for hosts that don't enable diagnostics.</summary>
+        public List<Interfaces.RejectedCandidateRecord> RejectedCandidates { get; set; } = new();
     }
 
     /// <summary>A drawable accepted-star marker (the detector's real bounding box) in image-pixel coords.</summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
@@ -59,6 +59,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         public double Width { get; set; }
         public double Height { get; set; }
         public double HFR { get; set; }
+
+        /// <summary>Preformatted HFR for the optional on-overlay HFR label ("2.34", or "—" when unavailable).</summary>
+        public string HfrText { get; set; }
     }
 
     /// <summary>A drawable user-label box in image-pixel coords (top-left X,Y + W,H).</summary>
@@ -67,6 +70,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         public double Y { get; set; }
         public double Width { get; set; }
         public double Height { get; set; }
+
+        /// <summary>Preformatted HFR for the optional on-overlay HFR label ("2.34", or "—" when unavailable).</summary>
+        public string HfrText { get; set; }
     }
 
     /// <summary>A drawable rejected-candidate box in image-pixel coords, colored by reason.</summary>
@@ -179,7 +185,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             RedoCommand = new RelayCommand(Redo, () => redoStack.Count > 0);
 
             CurrentIndex = 0;
-            LoadCurrent();
+            LoadCurrent(fitView: true);
         }
 
         // ---- Navigation / current frame --------------------------------------------------------------------
@@ -231,12 +237,34 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         // Slightly heavier for the three user-applied label markers so they read above the detector overlay.
         public double LabelStrokeThickness => 2.5 / Math.Max(StarReviewViewport.MinScale, Viewport.Scale);
 
-        /// <summary>Raises the zoom-dependent marker-thickness bindings. The view calls this after any viewport change
-        /// (wheel-zoom, fit, pan) so the stroke widths track the current scale.</summary>
+        // Inverse-zoom scale for the on-overlay HFR text so it stays a roughly constant on-screen size (the text
+        // lives inside the zoomed canvas, like the markers). Clamped to MinScale so it can't blow up when zoomed out.
+        public double MarkerTextScale => 1.0 / Math.Max(StarReviewViewport.MinScale, Viewport.Scale);
+
+        // Vertical translate (image-space, applied AFTER the inverse-zoom scale) that lifts the HFR label up by one
+        // text-height so it sits just ABOVE the detection box with no overlap. -15·MarkerTextScale image-units works
+        // out to a constant ≈15 px on screen (one FontSize-10 line + a 1 px gap) at any zoom.
+        public double HfrLabelOffset => -15.0 * MarkerTextScale;
+
+        private bool showHfr;
+
+        /// <summary>Toggle: when on, every accepted star (and every labeled wrongly-rejected / missed box) shows its
+        /// HFR on the overlay. Bound to a checkbox in the toolbar.</summary>
+        public bool ShowHfr {
+            get => showHfr;
+            set { if (showHfr != value) { showHfr = value; RaisePropertyChanged(); } }
+        }
+
+        /// <summary>Raises the zoom-dependent marker-thickness/text bindings. The view calls this after any viewport
+        /// change (wheel-zoom, fit, pan) so the stroke widths + HFR text size track the current scale.</summary>
         public void NotifyViewportChanged() {
             RaisePropertyChanged(nameof(MarkerStrokeThickness));
             RaisePropertyChanged(nameof(LabelStrokeThickness));
+            RaisePropertyChanged(nameof(MarkerTextScale));
+            RaisePropertyChanged(nameof(HfrLabelOffset));
         }
+
+        private static string FormatHfr(double hfr) => double.IsNaN(hfr) || hfr <= 0.0 ? "—" : hfr.ToString("F2");
 
         // Markers in IMAGE pixel coords; the view applies the viewport transform to place them.
         public ObservableCollection<AcceptedMarker> AcceptedMarkers { get; } = new();
@@ -311,31 +339,33 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         private void Next() {
             if (CurrentIndex < queue.Count - 1) {
                 CurrentIndex++;
-                LoadCurrent();
+                // Keep the current zoom/pan when stepping frames so the same region of interest stays in view as
+                // the user rotates through the sweep (all frames in a run share the same dimensions).
+                LoadCurrent(fitView: false);
             }
         }
 
         private void Prev() {
             if (CurrentIndex > 0) {
                 CurrentIndex--;
-                LoadCurrent();
+                LoadCurrent(fitView: false);
             }
         }
 
         private void RequestFit() => FitRequested?.Invoke(this, EventArgs.Empty);
 
-        private void LoadCurrent() {
+        private void LoadCurrent(bool fitView) {
             var f = Current;
             FrameHeader = $"{f.RunId}  @ focuser {f.FocuserPosition}  |  {f.Accepted.Count} accepted";
 
             // Build the MTF-stretched background image (via the host-supplied provider, then marshal to the UI).
             FrameImage = null;
-            _ = LoadImageAsync(f);
+            _ = LoadImageAsync(f, fitView);
 
             // Overlays in image coords — accepted stars draw the detector's REAL bounding box (top-left + size).
             AcceptedMarkers.Clear();
             foreach (var (_, _, hfr, b) in f.Accepted) {
-                AcceptedMarkers.Add(new AcceptedMarker { X = b.X, Y = b.Y, Width = b.Width, Height = b.Height, HFR = hfr });
+                AcceptedMarkers.Add(new AcceptedMarker { X = b.X, Y = b.Y, Width = b.Width, Height = b.Height, HFR = hfr, HfrText = FormatHfr(hfr) });
             }
             RejectedMarkers.Clear();
             foreach (var (reason, b) in f.Rejected) {
@@ -351,7 +381,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             PrevCommand.NotifyCanExecuteChanged();
         }
 
-        private async Task LoadImageAsync(FrameReview f) {
+        private async Task LoadImageAsync(FrameReview f, bool fitView) {
             var provider = f.ImageProvider;
             if (provider == null) {
                 return;
@@ -359,7 +389,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             try {
                 var bmp = await provider().ConfigureAwait(true);
                 FrameImage = bmp;
-                RequestFit();
+                // Only re-fit on the initial load / Fit button; navigating frames preserves the current viewport.
+                if (fitView) {
+                    RequestFit();
+                }
             } catch (Exception ex) {
                 Logger.Error(ex, $"Failed to load/stretch frame {f.FramePath}");
                 Console.Error.WriteLine($"Failed to load frame {f.FramePath}: {ex.Message}");
@@ -539,29 +572,52 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             WronglyRejectedMarkers.Clear();
             var pos = CurrentPositionLabels;
             if (pos != null) {
+                // Missed boxes were drawn where the detector found no candidate, so there is no measured HFR to show.
                 foreach (var p in pos.Missed) {
-                    MissedMarkers.Add(ToBoxMarker(p));
+                    MissedMarkers.Add(ToBoxMarker(p, "—"));
                 }
                 foreach (var p in pos.ShouldReject) {
-                    ShouldRejectMarkers.Add(ToBoxMarker(p));
+                    ShouldRejectMarkers.Add(ToBoxMarker(p, null));
                 }
                 if (pos.WronglyRejected != null) {
+                    // A wrongly-rejected label is the bbox of a rejected candidate; show that candidate's HFR.
                     foreach (var p in pos.WronglyRejected) {
-                        WronglyRejectedMarkers.Add(ToBoxMarker(p));
+                        WronglyRejectedMarkers.Add(ToBoxMarker(p, HfrTextForRejectedLabel(p)));
                     }
                 }
             }
             RaisePropertyChanged(nameof(CountsLabel));
         }
 
-        /// <summary>Maps a stored label box to a drawable marker. A legacy label that somehow still lacks W/H is drawn
-        /// as a small default box centered on its (x,y) (Normalize back-fills on load, so this is belt-and-suspenders).</summary>
-        private static LabelBoxMarker ToBoxMarker(StarReviewLabelBox b) {
+        /// <summary>HFR text for a wrongly-rejected label: the HFR of the best-overlapping rejected candidate of the
+        /// current frame (measured in the diagnostics detection pass), or "—" when none overlaps / HFR unavailable.</summary>
+        private string HfrTextForRejectedLabel(StarReviewLabelBox b) {
+            var records = Current.RejectedCandidates;
+            if (records == null || records.Count == 0) {
+                return "—";
+            }
+            var labelRect = new RectD(b.X, b.Y, b.W ?? 0.0, b.H ?? 0.0);
+            double bestIoU = 0.0;
+            double bestHfr = double.NaN;
+            foreach (var r in records) {
+                var iou = BoxMatcher.IoU(labelRect, r.Bounds);
+                if (iou > bestIoU) {
+                    bestIoU = iou;
+                    bestHfr = r.Hfr;
+                }
+            }
+            return bestIoU > 0.0 ? FormatHfr(bestHfr) : "—";
+        }
+
+        /// <summary>Maps a stored label box to a drawable marker (optionally carrying preformatted HFR text). A legacy
+        /// label that somehow still lacks W/H is drawn as a small default box centered on its (x,y) (Normalize
+        /// back-fills on load, so this is belt-and-suspenders).</summary>
+        private static LabelBoxMarker ToBoxMarker(StarReviewLabelBox b, string hfrText) {
             if (b.HasSize) {
-                return new LabelBoxMarker { X = b.X, Y = b.Y, Width = b.W.Value, Height = b.H.Value };
+                return new LabelBoxMarker { X = b.X, Y = b.Y, Width = b.W.Value, Height = b.H.Value, HfrText = hfrText };
             }
             var side = 2.0 * StarReviewLabelStore.DefaultRadiusPx;
-            return new LabelBoxMarker { X = b.X - side / 2.0, Y = b.Y - side / 2.0, Width = side, Height = side };
+            return new LabelBoxMarker { X = b.X - side / 2.0, Y = b.Y - side / 2.0, Width = side, Height = side, HfrText = hfrText };
         }
 
         // ---- Undo / redo -----------------------------------------------------------------------------------
@@ -647,7 +703,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             for (var i = 0; i < queue.Count; i++) {
                 if (queue[i].RunId == runId && queue[i].FocuserPosition == focuserPosition) {
                     CurrentIndex = i;
-                    LoadCurrent();
+                    // Preserve the viewport when jumping to show an undone/redone edit (consistent with Next/Prev).
+                    LoadCurrent(fitView: false);
                     return;
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -475,11 +475,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             get => summary;
             private set {
                 summary = value;
-                // A fresh summary: if nothing in the AF recommendation actually changed, there is nothing to
-                // apply, so disable + clear the toggle.
-                if (!CanApplyRecommendedStepSize) {
-                    applyRecommendedStepSize = false;
-                }
+                // A fresh summary: default the toggle to match whether there is anything to apply — ON when the AF
+                // recommendation actually differs from the profile (the user opts OUT rather than in), and OFF
+                // (plus disabled via CanApplyRecommendedStepSize) when nothing changed.
+                applyRecommendedStepSize = CanApplyRecommendedStepSize;
                 RaisePropertyChanged();
                 RaisePropertyChanged(nameof(ApplyRecommendedStepSize));
                 RaisePropertyChanged(nameof(CanApplyRecommendedStepSize));

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -47,6 +47,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         Review
     }
 
+    /// <summary>What the Start button does: run the optimization pass (default), or skip it and jump straight to a
+    /// Summary built from the CURRENT settings so the user can validate (and label against) today's detection without
+    /// an optimization run. Either way the Review → "Optimize with feedback" loop stays available.</summary>
+    public enum WizardOptimizeMode {
+        Optimize,
+        UseCurrentSettings
+    }
+
     /// <summary>Where the run frames come from: an already-saved AF attempt (Replay) or a fresh live AF run.
     /// The <see cref="DescriptionAttribute"/> text is what the wizard ComboBox shows (via the enum-description
     /// converter) — plain language, not the raw enum names.</summary>
@@ -177,6 +185,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         private IReadOnlyList<FrameReviewDescriptor> reviewDescriptors;
         private string reviewLabelsDir;
 
+        // The frames detected for the LAST Review build + the params they were detected at. The "Optimize with
+        // feedback" analyzer reuses these (plus the live capturedLabels) to attribute labels to gates — no re-detect.
+        private IReadOnlyList<FrameReview> reviewFrames;
+        private StarDetectorParams reviewParams;
+
         // The actual source folders loaded during the current run, in load order (Replay = the SourcePaths entry,
         // Live = the saved attempt folder). Captured in AcquireAsync and snapshotted alongside the review descriptors
         // so the re-optimize-with-labels path can RE-LOAD from disk after StartAsync's finally disposed the in-memory
@@ -298,6 +311,32 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public bool IsOptimize => CurrentStep == WizardStep.Optimize;
         public bool IsSummary => CurrentStep == WizardStep.Summary;
         public bool IsReview => CurrentStep == WizardStep.Review;
+
+        private WizardOptimizeMode optimizeMode = WizardOptimizeMode.Optimize;
+
+        /// <summary>Optimize (run the search) vs. Use current settings (skip optimization, go straight to a Summary
+        /// built from today's params). Bound by two radio buttons on the SelectSource step.</summary>
+        public WizardOptimizeMode OptimizeMode {
+            get => optimizeMode;
+            set {
+                if (optimizeMode != value) {
+                    optimizeMode = value;
+                    RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(IsOptimizeMode));
+                    RaisePropertyChanged(nameof(IsUseCurrentMode));
+                }
+            }
+        }
+
+        public bool IsOptimizeMode {
+            get => OptimizeMode == WizardOptimizeMode.Optimize;
+            set { if (value) { OptimizeMode = WizardOptimizeMode.Optimize; } }
+        }
+
+        public bool IsUseCurrentMode {
+            get => OptimizeMode == WizardOptimizeMode.UseCurrentSettings;
+            set { if (value) { OptimizeMode = WizardOptimizeMode.UseCurrentSettings; } }
+        }
 
         private SourceMode sourceMode = SourceMode.Replay;
 
@@ -660,6 +699,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             loadedRunFolders.Clear();
             loadedRunIds.Clear();
             capturedLabels = null;
+            reviewFrames = null;
+            reviewParams = null;
+            Recommendation = null;
             RaisePropertyChanged(nameof(HasLabels));
             ReOptimizeCommand.NotifyCanExecuteChanged();
             IsBusy = true;
@@ -690,8 +732,23 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
                 // 3. Optimize — off the UI thread, progress marshaled back. OptimizeAsync always returns a
                 // non-null result; it signals cancellation by throwing OperationCanceledException (caught below).
-                CurrentStep = WizardStep.Optimize;
-                var optimizeResult = await OptimizeAsync(loadedRuns, token).ConfigureAwait(true);
+                // In "Use current settings" mode the optimization pass is skipped entirely: BestParams = the seed
+                // (current settings), so the Summary shows no changes and the user can go straight to Review.
+                OptimizationResult optimizeResult;
+                if (OptimizeMode == WizardOptimizeMode.UseCurrentSettings) {
+                    Phase = "Using current settings (no optimization)";
+                    optimizeResult = new OptimizationResult {
+                        BestParams = loadedRuns[0].Seed,
+                        SeedJ = 0.0,
+                        BestJ = 0.0,
+                        Evaluations = 0,
+                        ImprovedOverSeed = false,
+                        ChangedVariables = new List<(string Name, double SeedValue, double BestValue)>()
+                    };
+                } else {
+                    CurrentStep = WizardStep.Optimize;
+                    optimizeResult = await OptimizeAsync(loadedRuns, token).ConfigureAwait(true);
+                }
                 Result = optimizeResult;
 
                 // 4. Summary — re-evaluate seed vs best for σ(focus) and recommend a step size.
@@ -826,11 +883,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             return true;
         }
 
-        /// <summary>Runs the pure optimizer off the UI thread; progress posts back via <see cref="IProgress{T}"/>.</summary>
-        private async Task<OptimizationResult> OptimizeAsync(IReadOnlyList<LoadedRun> runs, CancellationToken token) {
-            // All runs share the same camera/optics, so the search starts from the first run's seed.
-            var seed = runs[0].Seed;
-            var variables = OptimizerVariable.CreateCuratedSet();
+        /// <summary>Runs the pure optimizer off the UI thread; progress posts back via <see cref="IProgress{T}"/>.
+        /// When <paramref name="seedOverride"/>/<paramref name="variablesOverride"/> are supplied (the warm-start
+        /// "Optimize with feedback" path), the search starts from the analytic recommendation and explores only the
+        /// narrowed/curated axes it produced; otherwise it uses the first run's seed and the full curated set.</summary>
+        private async Task<OptimizationResult> OptimizeAsync(IReadOnlyList<LoadedRun> runs, CancellationToken token,
+            StarDetectorParams seedOverride = null, IReadOnlyList<OptimizerVariable> variablesOverride = null) {
+            // All runs share the same camera/optics, so the search starts from the first run's seed (or the override).
+            var seed = seedOverride ?? runs[0].Seed;
+            var variables = variablesOverride ?? OptimizerVariable.CreateCuratedSet();
             var evaluator = RunEvaluationData.CreateEvaluator(runs.Select(r => r.Data).ToList());
 
             MaxEvaluations = optimizerSettings.MaxEvaluations;
@@ -1030,6 +1091,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     ErrorMessage = "No frames could be prepared for review.";
                     return;
                 }
+                // Keep the detected frames + the params they were detected at for the feedback analyzer.
+                reviewFrames = reviews;
+                reviewParams = bestParams;
 
                 // Load any existing labels for each involved run so a re-review merges/extends prior work, exactly as
                 // the TestApp `review` tool does. Kept in-memory on the VM (capturedLabels) for the re-optimize seam.
@@ -1082,6 +1146,68 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 RaisePropertyChanged(nameof(HasLabels));
                 ReOptimizeCommand.NotifyCanExecuteChanged();
             }
+        }
+
+        private GateRecommendation recommendation;
+
+        /// <summary>The transparent label→gate analysis produced by the last "Optimize with feedback": which gate
+        /// rejected each labeled star, and the recommended threshold changes (precision-bounded). Bound by the
+        /// Summary's feedback breakdown. Null until the user runs feedback.</summary>
+        public GateRecommendation Recommendation {
+            get => recommendation;
+            private set {
+                recommendation = value;
+                RaisePropertyChanged();
+                RaisePropertyChanged(nameof(HasRecommendation));
+                RaisePropertyChanged(nameof(RecommendationRows));
+            }
+        }
+
+        public bool HasRecommendation => recommendation != null && recommendation.Rows.Count > 0;
+
+        public IReadOnlyList<RecommendationRow> RecommendationRows => recommendation?.Rows ?? new List<RecommendationRow>();
+
+        /// <summary>
+        /// Builds the direct label→gate analysis from the LAST review's detected frames (which carry the rich
+        /// rejected-candidate records) and the live captured labels, then runs the recommender. Returns null when no
+        /// review/labels are available (the caller then falls back to the plain label objective). No re-detection —
+        /// it reuses what the Review step already computed at the reviewed params.
+        /// </summary>
+        private GateRecommendation ComputeFeedbackRecommendation() {
+            if (reviewFrames == null || reviewParams == null || capturedLabels == null) {
+                return null;
+            }
+
+            RectD ToRectD(StarReviewLabelBox b) => new RectD(b.X, b.Y, b.W ?? 0.0, b.H ?? 0.0);
+
+            var frames = new List<FrameDetectionForAnalysis>(reviewFrames.Count);
+            foreach (var fr in reviewFrames) {
+                StarReviewPositionLabels pos = null;
+                if (fr.RunId != null && capturedLabels.TryGetValue(fr.RunId, out var runLabels)) {
+                    pos = runLabels?.Positions?.FirstOrDefault(p => p.FocuserPosition == fr.FocuserPosition);
+                }
+                var recall = new List<RectD>();
+                var shouldReject = new List<RectD>();
+                if (pos != null) {
+                    foreach (var b in (pos.Missed ?? new List<StarReviewLabelBox>()).Concat(pos.WronglyRejected ?? new List<StarReviewLabelBox>())) {
+                        recall.Add(ToRectD(b));
+                    }
+                    foreach (var b in pos.ShouldReject ?? new List<StarReviewLabelBox>()) {
+                        shouldReject.Add(ToRectD(b));
+                    }
+                }
+                frames.Add(new FrameDetectionForAnalysis {
+                    FocuserPosition = fr.FocuserPosition,
+                    AcceptedBounds = fr.Accepted.Select(a => a.Bounds).ToList(),
+                    AcceptedCenters = fr.Accepted.Select(a => (a.CX, a.CY)).ToList(),
+                    Rejected = fr.RejectedCandidates ?? new List<RejectedCandidateRecord>(),
+                    RecallBoxes = recall,
+                    ShouldRejectBoxes = shouldReject
+                });
+            }
+
+            var analysis = LabelGateAnalyzer.Analyze(frames);
+            return GateRecommender.Recommend(analysis, reviewParams, new RecommenderConfig());
         }
 
         /// <summary>
@@ -1152,8 +1278,23 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     reloaded.Add(loaded);
                 }
 
-                // Re-run the same optimize + summary pipeline over the labeled runs.
-                var optimizeResult = await OptimizeAsync(reloaded, token).ConfigureAwait(true);
+                // Direct label→gate analysis (the transparent step): attribute each labeled star to the gate that
+                // killed it and recommend precision-bounded threshold changes. Then WARM-START the optimizer from
+                // that recommendation (seed + narrowed/curated axes) so it balances the analytic point against
+                // focus-curve quality. If no review/labels are available, recommendation is null and the optimizer
+                // runs as before (the plain label objective term still applies).
+                var feedback = ComputeFeedbackRecommendation();
+                Recommendation = feedback;
+                StarDetectorParams seedOverride = null;
+                IReadOnlyList<OptimizerVariable> variablesOverride = null;
+                if (feedback != null) {
+                    seedOverride = feedback.Recommended;
+                    variablesOverride = OptimizerVariable.CreateWarmStartSet(
+                        OptimizerVariable.CreateCuratedSet(), reviewParams, feedback.Recommended);
+                }
+
+                // Re-run the optimize + summary pipeline over the labeled runs (warm-started when we have a recommendation).
+                var optimizeResult = await OptimizeAsync(reloaded, token, seedOverride, variablesOverride).ConfigureAwait(true);
                 Result = optimizeResult;
                 Summary = await BuildSummaryAsync(reloaded, optimizeResult, token).ConfigureAwait(true);
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
@@ -201,6 +201,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             contaminationSensitivity = optionsAccessor.GetValueDouble("ContaminationSensitivity", 5.0);
             rejectContaminatedStars = optionsAccessor.GetValueBoolean("RejectContaminatedStars", true);
             structureLayers = optionsAccessor.GetValueInt32("StructureLayers", 4);
+            defocusAwareStructure = optionsAccessor.GetValueBoolean("DefocusAwareStructure", false);
+            structureLayerBoost = optionsAccessor.GetValueInt32("StructureLayerBoost", 0);
             brightnessSensitivity = optionsAccessor.GetValueDouble("BrightnessSensitivity", 2.0);
             starPeakResponse = optionsAccessor.GetValueDouble("StarPeakResponse", 0.75);
             maxDistortion = optionsAccessor.GetValueDouble("MaxDistortion", 0.5);
@@ -262,6 +264,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             ContaminationSensitivity = 5.0;
             RejectContaminatedStars = true;
             StructureLayers = 4;
+            DefocusAwareStructure = false;
+            StructureLayerBoost = 0;
             BrightnessSensitivity = 2.0;
             StarPeakResponse = 0.75;
             MaxDistortion = 0.5;
@@ -654,6 +658,41 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                     }
                     defocusCenteringToleranceFactor = value;
                     optionsAccessor.SetValueDouble("DefocusCenteringToleranceFactor", defocusCenteringToleranceFactor);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool defocusAwareStructure;
+
+        // Defocus-aware structure detection (opt-in, default OFF). When ON, the wavelet residual that removes
+        // large-scale structure is computed at StructureLayers + StructureLayerBoost layers so large/donut
+        // (heavily defocused) stars survive and form candidates. Default-OFF ⇒ candidate formation bit-identical.
+        public bool DefocusAwareStructure {
+            get => defocusAwareStructure;
+            set {
+                if (defocusAwareStructure != value) {
+                    defocusAwareStructure = value;
+                    optionsAccessor.SetValueBoolean("DefocusAwareStructure", defocusAwareStructure);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private int structureLayerBoost;
+
+        // Advanced-only knob (only consulted while DefocusAwareStructure is ON): extra wavelet layers added to
+        // StructureLayers for the residual-subtraction step. Higher ⇒ coarser residual ⇒ larger donuts survive.
+        // Must be within [0, 6]. Default 0.
+        public int StructureLayerBoost {
+            get => structureLayerBoost;
+            set {
+                if (structureLayerBoost != value) {
+                    if (value < 0 || value > 6) {
+                        throw new ArgumentException("StructureLayerBoost must be within [0, 6]", "StructureLayerBoost");
+                    }
+                    structureLayerBoost = value;
+                    optionsAccessor.SetValueInt32("StructureLayerBoost", structureLayerBoost);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
@@ -1267,8 +1267,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
 
         // Emits a RejectedCandidateRecord into the (thread-safe) bag, guarded by the caller's null check. centerX/Y
         // are pre-ROI image coords (the ROI offset is applied once during materialization in GateAndMeasureInternal,
-        // mirroring the metrics *Bounds lists). measured/threshold are NaN for the non-scalar gates.
-        private static void RecordRejection(ConcurrentBag<RejectedCandidateRecord> bag, Rect bounds, string gate, double measured, double threshold, double centerX, double centerY) {
+        // mirroring the metrics *Bounds lists). measured/threshold are NaN for the non-scalar gates; hfr is NaN when
+        // the candidate was rejected before HFR could be measured.
+        private static void RecordRejection(ConcurrentBag<RejectedCandidateRecord> bag, Rect bounds, string gate, double measured, double threshold, double centerX, double centerY, double hfr = double.NaN) {
             bag.Add(new RejectedCandidateRecord {
                 Bounds = bounds,
                 Gate = gate,
@@ -1276,8 +1277,28 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                 ThresholdValue = threshold,
                 CandidateSize = Math.Max(bounds.Width, bounds.Height),
                 CenterX = centerX,
-                CenterY = centerY
+                CenterY = centerY,
+                Hfr = hfr
             });
+        }
+
+        // Measures the HFR of a candidate that a gate rejected BEFORE the normal MeasureStar step (LowSensitivity/
+        // NotCentered/TooFlat), so the review's HFR display can show it. Mirrors the accept-path Star construction +
+        // MeasureStar; returns NaN if the measurement fails. Called only on the diagnostics path (rejectedBag != null).
+        private double TryMeasureRejectedHfr(Mat srcImage, StarCandidate starCandidate, Rect starBounds, StarDetectorParams p, double srcImageNoiseSigma) {
+            try {
+                var probe = new Star() {
+                    Center = starCandidate.Center,
+                    Background = starCandidate.Background,
+                    BackgroundPlane = starCandidate.BackgroundPlane,
+                    MeanBrightness = starCandidate.PixelCount > 0 ? starCandidate.TotalFlux / starCandidate.PixelCount : 0.0,
+                    StarBoundingBox = starBounds,
+                    PeakBrightness = starCandidate.Peak
+                };
+                return MeasureStar(srcImage, probe, p, srcImageNoiseSigma) ? probe.HFR : double.NaN;
+            } catch {
+                return double.NaN;
+            }
         }
 
         private Star EvaluateStarCandidate(Mat srcImage, StarDetectorParams p, Rect starBounds, List<Point> starPoints, double srcImageNoiseSigma, StarDetectorMetrics metrics, ConcurrentBag<ContaminationDiagnosticRecord> diagnosticsBag, ConcurrentBag<RejectedCandidateRecord> rejectedBag) {
@@ -1363,7 +1384,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             if (sensitivity <= p.Sensitivity) {
                 metrics.LowSensitivityBounds.Add(starBounds);
                 if (rejectedBag != null) {
-                    RecordRejection(rejectedBag, starBounds, RejectionGate.LowSensitivity, sensitivity, p.Sensitivity, starCandidate.Center.X, starCandidate.Center.Y);
+                    RecordRejection(rejectedBag, starBounds, RejectionGate.LowSensitivity, sensitivity, p.Sensitivity, starCandidate.Center.X, starCandidate.Center.Y,
+                        TryMeasureRejectedHfr(srcImage, starCandidate, starBounds, p, srcImageNoiseSigma));
                 }
                 return null;
             }
@@ -1384,7 +1406,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                         : p.StarCenterTolerance;
                     var ncOffX = ncBox.Width > 0 ? Math.Abs(starCandidate.Center.X - (ncBox.X + ncBox.Width / 2.0)) / (ncBox.Width / 2.0) : 0.0;
                     var ncOffY = ncBox.Height > 0 ? Math.Abs(starCandidate.Center.Y - (ncBox.Y + ncBox.Height / 2.0)) / (ncBox.Height / 2.0) : 0.0;
-                    RecordRejection(rejectedBag, starBounds, RejectionGate.NotCentered, Math.Max(ncOffX, ncOffY), ncEffTol, starCandidate.Center.X, starCandidate.Center.Y);
+                    RecordRejection(rejectedBag, starBounds, RejectionGate.NotCentered, Math.Max(ncOffX, ncOffY), ncEffTol, starCandidate.Center.X, starCandidate.Center.Y,
+                        TryMeasureRejectedHfr(srcImage, starCandidate, starBounds, p, srcImageNoiseSigma));
                 }
                 return null;
             }
@@ -1398,7 +1421,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                 metrics.TooFlatBounds.Add(starBounds);
                 if (rejectedBag != null) {
                     var flatRatio = starCandidate.Peak != 0.0 ? starCandidate.StarMedian / starCandidate.Peak : double.NaN;
-                    RecordRejection(rejectedBag, starBounds, RejectionGate.TooFlat, flatRatio, p.PeakResponse, starCandidate.Center.X, starCandidate.Center.Y);
+                    RecordRejection(rejectedBag, starBounds, RejectionGate.TooFlat, flatRatio, p.PeakResponse, starCandidate.Center.X, starCandidate.Center.Y,
+                        TryMeasureRejectedHfr(srcImage, starCandidate, starBounds, p, srcImageNoiseSigma));
                 }
                 return null;
             }
@@ -1431,7 +1455,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             if (star.HFR <= p.MinHFR) {
                 ++metrics.TooLowHFR;
                 if (rejectedBag != null) {
-                    RecordRejection(rejectedBag, starBounds, RejectionGate.TooLowHFR, star.HFR, p.MinHFR, star.Center.X, star.Center.Y);
+                    RecordRejection(rejectedBag, starBounds, RejectionGate.TooLowHFR, star.HFR, p.MinHFR, star.Center.X, star.Center.Y, star.HFR);
                 }
                 return null;
             }
@@ -1445,7 +1469,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                 // contaminants. Disabled (flag-only) when RejectContaminatedStars is off (e.g. diagnostics).
                 if (p.RejectContaminatedStars) {
                     if (rejectedBag != null) {
-                        RecordRejection(rejectedBag, starBounds, RejectionGate.Contaminated, double.NaN, p.ContaminationSensitivity, star.Center.X, star.Center.Y);
+                        RecordRejection(rejectedBag, starBounds, RejectionGate.Contaminated, double.NaN, p.ContaminationSensitivity, star.Center.X, star.Center.Y, star.HFR);
                     }
                     return null;
                 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
@@ -115,6 +115,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             nameof(StarDetectorParams.NoiseReductionRadius),
             nameof(StarDetectorParams.NoiseClippingMultiplier),
             nameof(StarDetectorParams.StructureLayers),
+            nameof(StarDetectorParams.DefocusAwareStructure),
+            nameof(StarDetectorParams.StructureLayerBoost),
             nameof(StarDetectorParams.StructureDilationSize),
             nameof(StarDetectorParams.StructureDilationCount),
             nameof(StarDetectorParams.SaturationThreshold),
@@ -498,7 +500,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
 
                     // Step 4: Compute b-spline wavelets to exclude large structures such as nebulae. If the pixel scale is very small or need a wide range for focus, you may need to increase the number of layers
                     //         to keep stars from being excluded
-                    using (var residualLayer = ComputeResidualAtrousB3SplineDyadicWaveletLayer(structureMap, p.StructureLayers)) {
+                    // Defocus-aware structure (opt-in): use a COARSER residual (more layers) so large/donut defocused
+                    // stars survive the subtraction. When OFF, effectiveStructureLayers == p.StructureLayers exactly,
+                    // so candidate formation is bit-identical.
+                    var effectiveStructureLayers = p.DefocusAwareStructure
+                        ? Math.Max(1, p.StructureLayers + p.StructureLayerBoost)
+                        : p.StructureLayers;
+                    using (var residualLayer = ComputeResidualAtrousB3SplineDyadicWaveletLayer(structureMap, effectiveStructureLayers)) {
                         MaybeSaveIntermediateImage(residualLayer, p, "04-structure-wavelet-residual.tif");
                         CvImageUtility.SubtractInPlace(structureMap, residualLayer);
                     }
@@ -618,12 +626,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                 SaturatedPixelCount = ctx.SaturatedPixelCount
             };
 
-            // Per-call diagnostics bag (thread-safe; the late stage evaluates candidates in parallel). Null in
+            // Per-call diagnostics bags (thread-safe; the late stage evaluates candidates in parallel). Null in
             // normal runs (zero overhead).
             var contaminationDiagnosticsBag = p.CollectContaminationDiagnostics ? new ConcurrentBag<ContaminationDiagnosticRecord>() : null;
+            var rejectedCandidatesBag = p.CollectRejectedCandidateDiagnostics ? new ConcurrentBag<RejectedCandidateRecord>() : null;
 
             using (var stopWatch = MultiStopWatch.Measure()) {
-                var stars = EvaluateStarCandidates(srcImage, ctx.Candidates, p, ctx.MeasurementNoiseSigma, metrics, contaminationDiagnosticsBag, token);
+                var stars = EvaluateStarCandidates(srcImage, ctx.Candidates, p, ctx.MeasurementNoiseSigma, metrics, contaminationDiagnosticsBag, rejectedCandidatesBag, token);
                 stopWatch.RecordEntry("StarAnalysis");
 
                 // Step 9: Fit PSF models
@@ -672,11 +681,28 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                     Logger.Trace($"Collected {contaminationDiagnostics.Count} contamination diagnostic records ({contaminationDiagnostics.Count(r => r.ContaminationSuspected)} suspected)");
                 }
 
+                // Materialize the (parallel-collected) rejected-candidate diagnostics with the same ROI offset and
+                // deterministic (Y, X) ordering as the metrics *Bounds lists, so the recommender sees a stable set.
+                List<RejectedCandidateRecord> rejectedCandidates = null;
+                if (rejectedCandidatesBag != null) {
+                    rejectedCandidates = rejectedCandidatesBag.ToList();
+                    if (roiRect.HasValue) {
+                        foreach (var rec in rejectedCandidates) {
+                            rec.Bounds = new Rect(rec.Bounds.Location + new Point(roiRect.Value.Left, roiRect.Value.Top), rec.Bounds.Size);
+                            rec.CenterX += roiRect.Value.Left;
+                            rec.CenterY += roiRect.Value.Top;
+                        }
+                    }
+                    rejectedCandidates = rejectedCandidates.OrderBy(r => r.Bounds.Y).ThenBy(r => r.Bounds.X).ToList();
+                    Logger.Trace($"Collected {rejectedCandidates.Count} rejected-candidate diagnostic records");
+                }
+
                 return new HocusFocusStarDetectorResult() {
                     DetectedStars = stars,
                     Metrics = metrics,
                     DebugData = ctx.DebugData,
                     ContaminationDiagnostics = contaminationDiagnostics,
+                    RejectedCandidates = rejectedCandidates,
                     StructureNoiseSigma = ctx.StructureNoiseSigma,
                     MeasurementNoiseSigma = ctx.MeasurementNoiseSigma
                 };
@@ -1026,16 +1052,16 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
         // raster order. This is the LATE phase — it applies all size/shape/border/sensitivity gates and measures
         // each accepted star. It only READS srcImage + the candidate point lists, so it is safe to run repeatedly
         // against the same cached DetectionContext with different late params.
-        private List<Star> EvaluateStarCandidates(Mat srcImage, List<StarCandidateRegion> candidates, StarDetectorParams p, double srcImageNoiseSigma, StarDetectorMetrics metrics, ConcurrentBag<ContaminationDiagnosticRecord> diagnosticsBag, CancellationToken ct) {
+        private List<Star> EvaluateStarCandidates(Mat srcImage, List<StarCandidateRegion> candidates, StarDetectorParams p, double srcImageNoiseSigma, StarDetectorMetrics metrics, ConcurrentBag<ContaminationDiagnosticRecord> diagnosticsBag, ConcurrentBag<RejectedCandidateRecord> rejectedBag, CancellationToken ct) {
             // Per-star evaluation is independent (only LOCAL arrays + read-only image reads), so the only shared
             // mutable state is the metrics (handled via thread-locals merged afterward) and the (thread-safe,
-            // per-call) diagnosticsBag.
+            // per-call) diagnosticsBag / rejectedBag.
             var results = new Star[candidates.Count];
             using var localMetrics = new ThreadLocal<StarDetectorMetrics>(() => new StarDetectorMetrics(), trackAllValues: true);
 
             Parallel.For(0, candidates.Count, ParallelExecution.CreateOptions(p.MaxStarEvaluationParallelism, ct), i => {
                 ct.ThrowIfCancellationRequested();
-                results[i] = EvaluateStarCandidate(srcImage, p, candidates[i].Bounds, candidates[i].Points, srcImageNoiseSigma, localMetrics.Value, diagnosticsBag);
+                results[i] = EvaluateStarCandidate(srcImage, p, candidates[i].Bounds, candidates[i].Points, srcImageNoiseSigma, localMetrics.Value, diagnosticsBag, rejectedBag);
             });
 
             // Fold each per-thread metrics instance into the main metrics (additive — see Merge), then sort the
@@ -1239,7 +1265,22 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             return effective > 1.0 ? 1.0 : effective;
         }
 
-        private Star EvaluateStarCandidate(Mat srcImage, StarDetectorParams p, Rect starBounds, List<Point> starPoints, double srcImageNoiseSigma, StarDetectorMetrics metrics, ConcurrentBag<ContaminationDiagnosticRecord> diagnosticsBag) {
+        // Emits a RejectedCandidateRecord into the (thread-safe) bag, guarded by the caller's null check. centerX/Y
+        // are pre-ROI image coords (the ROI offset is applied once during materialization in GateAndMeasureInternal,
+        // mirroring the metrics *Bounds lists). measured/threshold are NaN for the non-scalar gates.
+        private static void RecordRejection(ConcurrentBag<RejectedCandidateRecord> bag, Rect bounds, string gate, double measured, double threshold, double centerX, double centerY) {
+            bag.Add(new RejectedCandidateRecord {
+                Bounds = bounds,
+                Gate = gate,
+                MeasuredValue = measured,
+                ThresholdValue = threshold,
+                CandidateSize = Math.Max(bounds.Width, bounds.Height),
+                CenterX = centerX,
+                CenterY = centerY
+            });
+        }
+
+        private Star EvaluateStarCandidate(Mat srcImage, StarDetectorParams p, Rect starBounds, List<Point> starPoints, double srcImageNoiseSigma, StarDetectorMetrics metrics, ConcurrentBag<ContaminationDiagnosticRecord> diagnosticsBag, ConcurrentBag<RejectedCandidateRecord> rejectedBag) {
             // Now we have a potential star bounding box as well as the coordinates of every star pixel. If this is a reliable star,
             // we compute its barycenter and include it.
             //
@@ -1257,15 +1298,25 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             // this can never flip — detection stays bit-identical.
             bool relaxationAdmitted = false;
 
+            // Pre-measurement candidate center (bbox center); refined to the measured centroid once available.
+            var bboxCenterX = starBounds.X + starBounds.Width / 2.0;
+            var bboxCenterY = starBounds.Y + starBounds.Height / 2.0;
+
             // Too small
             if (starBounds.Width < p.MinimumStarBoundingBoxSize || starBounds.Height < p.MinimumStarBoundingBoxSize) {
                 ++metrics.TooSmall;
+                if (rejectedBag != null) {
+                    RecordRejection(rejectedBag, starBounds, RejectionGate.TooSmall, Math.Min(starBounds.Width, starBounds.Height), p.MinimumStarBoundingBoxSize, bboxCenterX, bboxCenterY);
+                }
                 return null;
             }
 
             // Touching the border
             if (starBounds.X == 0 || starBounds.Y == 0 || starBounds.Right == srcImage.Width || starBounds.Bottom == srcImage.Height) {
                 ++metrics.OnBorder;
+                if (rejectedBag != null) {
+                    RecordRejection(rejectedBag, starBounds, RejectionGate.OnBorder, double.NaN, double.NaN, bboxCenterX, bboxCenterY);
+                }
                 return null;
             }
 
@@ -1280,6 +1331,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             var effectiveMaxDistortion = ComputeEffectiveMaxDistortion(p, d);
             if (fillRatio < effectiveMaxDistortion) {
                 metrics.TooDistortedBounds.Add(starBounds);
+                if (rejectedBag != null) {
+                    RecordRejection(rejectedBag, starBounds, RejectionGate.TooDistorted, fillRatio, effectiveMaxDistortion, bboxCenterX, bboxCenterY);
+                }
                 return null;
             }
             // The accept/reject decision above uses the effective threshold ONLY. Separately (informational), note
@@ -1293,6 +1347,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             var starCandidate = ComputeStarParameters(srcImage, starBounds, p, srcImageNoiseSigma, starPoints);
             if (starCandidate == null) {
                 metrics.DegenerateBounds.Add(starBounds);
+                if (rejectedBag != null) {
+                    RecordRejection(rejectedBag, starBounds, RejectionGate.Degenerate, double.NaN, double.NaN, bboxCenterX, bboxCenterY);
+                }
                 return null;
             }
 
@@ -1305,6 +1362,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             var sensitivity = starCandidate.NormalizedBrightness / srcImageNoiseSigma;
             if (sensitivity <= p.Sensitivity) {
                 metrics.LowSensitivityBounds.Add(starBounds);
+                if (rejectedBag != null) {
+                    RecordRejection(rejectedBag, starBounds, RejectionGate.LowSensitivity, sensitivity, p.Sensitivity, starCandidate.Center.X, starCandidate.Center.Y);
+                }
                 return null;
             }
 
@@ -1314,6 +1374,18 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             var centered = IsStarCentered(starCandidate, p, out var centeredStrict);
             if (!centered) {
                 metrics.NotCenteredBounds.Add(starBounds);
+                if (rejectedBag != null) {
+                    // Normalized centroid offset: max over axes of |centroid - bbox center| / (bbox half-extent).
+                    // The gate accepts iff this is <= the effective tolerance, so it inverts monotonically in
+                    // StarCenterTolerance (raise the tolerance to >= the offset to recover the star).
+                    var ncBox = starCandidate.StarBoundingBox;
+                    var ncEffTol = p.DefocusAwareCentering
+                        ? ComputeEffectiveStarCenterTolerance(p.StarCenterTolerance, Math.Max(ncBox.Width, ncBox.Height), p.DefocusDistortionSizeReference, p.DefocusCenteringToleranceFactor)
+                        : p.StarCenterTolerance;
+                    var ncOffX = ncBox.Width > 0 ? Math.Abs(starCandidate.Center.X - (ncBox.X + ncBox.Width / 2.0)) / (ncBox.Width / 2.0) : 0.0;
+                    var ncOffY = ncBox.Height > 0 ? Math.Abs(starCandidate.Center.Y - (ncBox.Y + ncBox.Height / 2.0)) / (ncBox.Height / 2.0) : 0.0;
+                    RecordRejection(rejectedBag, starBounds, RejectionGate.NotCentered, Math.Max(ncOffX, ncOffY), ncEffTol, starCandidate.Center.X, starCandidate.Center.Y);
+                }
                 return null;
             }
             if (!centeredStrict) {
@@ -1324,6 +1396,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             // HocusFocusStarDetection.GetStarDetectorParams (accuracy analysis F1).
             if (starCandidate.StarMedian >= (p.PeakResponse * starCandidate.Peak)) {
                 metrics.TooFlatBounds.Add(starBounds);
+                if (rejectedBag != null) {
+                    var flatRatio = starCandidate.Peak != 0.0 ? starCandidate.StarMedian / starCandidate.Peak : double.NaN;
+                    RecordRejection(rejectedBag, starBounds, RejectionGate.TooFlat, flatRatio, p.PeakResponse, starCandidate.Center.X, starCandidate.Center.Y);
+                }
                 return null;
             }
 
@@ -1345,12 +1421,18 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             // Measure HFR, and discard if we couldn't calculate it
             if (!MeasureStar(srcImage, star, p, srcImageNoiseSigma)) {
                 ++metrics.HFRAnalysisFailed;
+                if (rejectedBag != null) {
+                    RecordRejection(rejectedBag, starBounds, RejectionGate.HFRAnalysisFailed, double.NaN, double.NaN, star.Center.X, star.Center.Y);
+                }
                 return null;
             }
 
             // HFR below minimum threshold
             if (star.HFR <= p.MinHFR) {
                 ++metrics.TooLowHFR;
+                if (rejectedBag != null) {
+                    RecordRejection(rejectedBag, starBounds, RejectionGate.TooLowHFR, star.HFR, p.MinHFR, star.Center.X, star.Center.Y);
+                }
                 return null;
             }
 
@@ -1362,6 +1444,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                 // Quality gate: reject contaminated stars so HFR/PSF statistics stay clean of one-sided
                 // contaminants. Disabled (flag-only) when RejectContaminatedStars is off (e.g. diagnostics).
                 if (p.RejectContaminatedStars) {
+                    if (rejectedBag != null) {
+                        RecordRejection(rejectedBag, starBounds, RejectionGate.Contaminated, double.NaN, p.ContaminationSensitivity, star.Center.X, star.Center.Y);
+                    }
                     return null;
                 }
             }

--- a/Joko.NINA.Plugins/TestApp/DiagnoseLabelsRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/DiagnoseLabelsRunner.cs
@@ -161,6 +161,11 @@ namespace TestApp {
             var firstRunFolder = string.IsNullOrEmpty(firstFramePath) ? null : Path.GetDirectoryName(firstFramePath);
             var detectionParams = StarReviewRunner.BuildDetectionParams(starDetectionOptions, activeProfile, useOptimized, optResultsDir, firstRunFolder);
 
+            // Enable the per-rejected-candidate diagnostics so the gate that killed each labeled star — INCLUDING
+            // the counter-only gates (TooLowHFR/TooSmall/HFRAnalysisFailed) that have no metrics *Bounds list and
+            // therefore used to mis-classify as NO CANDIDATE — is attributable from result.RejectedCandidates.
+            detectionParams.CollectRejectedCandidateDiagnostics = true;
+
             // Opt-in defocus-aware distortion test switch. Flips DefocusAwareDistortion ON on the freshly built
             // params (least-invasive: does not touch the profile). Optional --defocus-size-ref / --defocus-min-factor
             // override the two tuning knobs (otherwise the StarDetectorParams class defaults 20.0 px / 0.25 apply).
@@ -254,24 +259,26 @@ namespace TestApp {
                         continue;
                     }
 
-                    // Fresh detection of this frame (Detect mutates its input; clone the loaded Mat).
+                    // Fresh detection of this frame (Detect mutates its input; clone the loaded Mat). Uses the rich
+                    // per-rejected-candidate records (gate + measured value), so the counter-only gates are attributed.
                     List<Star> accepted;
-                    List<(string Reason, Rect Bounds)> rejected;
+                    IReadOnlyList<RejectedCandidateRecord> rejectedRecords;
                     using (var mat = DiagnosticUtil.LoadFloatMat(framePath, profileService).GetAwaiter().GetResult())
                     using (var clone = mat.Clone()) {
                         var result = detector.Detect(clone, detectionParams, null, CancellationToken.None).GetAwaiter().GetResult();
                         accepted = result.DetectedStars ?? new List<Star>();
-                        rejected = StarReviewRunner.ExtractRejected(result);
+                        rejectedRecords = result.RejectedCandidates ?? new List<RejectedCandidateRecord>();
                     }
+                    var acceptedBounds = accepted.Select(s => s.StarBoundingBox).ToList();
 
                     Line($"=== run '{d.RunId}' @ focuser {pos.FocuserPosition} ({Path.GetFileName(framePath)}) ===");
-                    Line($"    detection: {accepted.Count} accepted, {rejected.Count} rejected candidate(s)");
+                    Line($"    detection: {accepted.Count} accepted, {rejectedRecords.Count} rejected candidate(s)");
                     Line($"    {"category",-16} {"box(x,y,w,h)",-28} {"result",-26} matched candidate");
 
                     void Classify(string category, List<StarReviewLabelBox> boxes) {
                         foreach (var box in boxes) {
                             totalBoxes++;
-                            var (result, matchDesc) = ClassifyBox(box, accepted, rejected);
+                            var (result, matchDesc) = ClassifyLabelBox(box, acceptedBounds, rejectedRecords);
                             Tally(category, result);
                             Line($"    {category,-16} {FormatBox(box),-28} {result,-26} {matchDesc}");
                         }
@@ -318,99 +325,38 @@ namespace TestApp {
         }
 
         /// <summary>
-        /// Classifies one label box by BEST overlap. Computes IoU + overlap-area against every accepted star box
-        /// and every rejected-candidate box; the best (highest-overlap) candidate across BOTH pools wins, provided
-        /// a real overlap exists (IoU &gt; 0, i.e. the rectangles intersect). Accepted wins ties at equal IoU (so
-        /// a box straddling an accepted and a rejected candidate is reported as ACCEPTED, the detector's actual
-        /// behavior). With no real overlap in either pool the box is a NO CANDIDATE structure gap.
+        /// Classifies one label box via the shared <see cref="BoxMatcher"/> (so this harness, the in-wizard
+        /// analyzer, and the recommender agree by construction), then formats the human-readable result line. The
+        /// rejected pool is the rich per-candidate records, so the gate AND the measured value it failed are
+        /// reported, and the counter-only gates (TooLowHFR/TooSmall/HFRAnalysisFailed) are no longer mis-reported
+        /// as NO CANDIDATE.
         /// </summary>
-        private static (string result, string matchDesc) ClassifyBox(
-            StarReviewLabelBox box, List<Star> accepted, List<(string Reason, Rect Bounds)> rejected) {
-            var labelRect = ToRectD(box);
-
-            // Best accepted overlap.
-            double bestAcceptedIoU = 0.0;
-            Rect bestAcceptedRect = default;
-            bool haveAccepted = false;
-            foreach (var s in accepted) {
-                var iou = IoU(labelRect, s.StarBoundingBox);
-                if (iou > bestAcceptedIoU) {
-                    bestAcceptedIoU = iou;
-                    bestAcceptedRect = s.StarBoundingBox;
-                    haveAccepted = true;
-                }
+        private static (string result, string matchDesc) ClassifyLabelBox(
+            StarReviewLabelBox box, IReadOnlyList<Rect> acceptedBounds, IReadOnlyList<RejectedCandidateRecord> rejected) {
+            var m = BoxMatcher.Classify(ToRectD(box), acceptedBounds, rejected);
+            switch (m.Kind) {
+                case BoxClassification.Accepted: {
+                        var tieNote = m.Rejected != null && m.RejectedIoU > 0.0
+                            ? $" [also overlaps REJECTED:{m.Gate} IoU={m.RejectedIoU:F3}]" : "";
+                        return (ResultAccepted, $"accepted box {FormatRect(m.AcceptedBounds)} IoU={m.AcceptedIoU:F3}{tieNote}");
+                    }
+                case BoxClassification.Rejected: {
+                        var measured = double.IsNaN(m.Rejected.MeasuredValue)
+                            ? ""
+                            : $" measured={m.Rejected.MeasuredValue.ToString("G4", CultureInfo.InvariantCulture)} thr={m.Rejected.ThresholdValue.ToString("G4", CultureInfo.InvariantCulture)}";
+                        var acceptedNote = m.AcceptedIoU > 0.0 ? $" [also overlaps ACCEPTED IoU={m.AcceptedIoU:F3}]" : "";
+                        var ambiguity = m.RejectedTieCount > 1 ? $" [AMBIGUOUS: {m.RejectedTieCount} reasons tie at IoU={m.RejectedIoU:F3}]" : "";
+                        return ($"REJECTED:{m.Gate}", $"rejected box {FormatRect(m.Rejected.Bounds)} IoU={m.RejectedIoU:F3}{measured}{acceptedNote}{ambiguity}");
+                    }
+                default:
+                    return (ResultNoCandidate, "(no accepted star, no rejected candidate)");
             }
-
-            // Best rejected overlap (track the reason too).
-            double bestRejectedIoU = 0.0;
-            Rect bestRejectedRect = default;
-            string bestRejectedReason = null;
-            int rejectedTieCount = 0;
-            foreach (var (reason, bounds) in rejected) {
-                var iou = IoU(labelRect, bounds);
-                if (iou <= 0.0) {
-                    continue;
-                }
-                if (iou > bestRejectedIoU) {
-                    bestRejectedIoU = iou;
-                    bestRejectedRect = bounds;
-                    bestRejectedReason = reason;
-                    rejectedTieCount = 1;
-                } else if (Math.Abs(iou - bestRejectedIoU) < 1e-9 && !string.Equals(reason, bestRejectedReason, StringComparison.Ordinal)) {
-                    // A different-reason candidate ties the best — note the ambiguity.
-                    rejectedTieCount++;
-                }
-            }
-
-            bool acceptedReal = haveAccepted && bestAcceptedIoU > 0.0;
-            bool rejectedReal = bestRejectedReason != null && bestRejectedIoU > 0.0;
-
-            if (!acceptedReal && !rejectedReal) {
-                return (ResultNoCandidate, "(no accepted star, no rejected candidate)");
-            }
-
-            // Accepted wins ties (>= rejected IoU). It reflects the detector's actual outcome at that location.
-            if (acceptedReal && bestAcceptedIoU >= bestRejectedIoU) {
-                var tieNote = rejectedReal ? $" [also overlaps REJECTED:{bestRejectedReason} IoU={bestRejectedIoU:F3}]" : "";
-                return (ResultAccepted, $"accepted box {FormatRect(bestAcceptedRect)} IoU={bestAcceptedIoU:F3}{tieNote}");
-            }
-
-            var ambiguity = rejectedTieCount > 1 ? $" [AMBIGUOUS: {rejectedTieCount} reasons tie at IoU={bestRejectedIoU:F3}]" : "";
-            var acceptedNote = acceptedReal ? $" [also overlaps ACCEPTED IoU={bestAcceptedIoU:F3}]" : "";
-            return ($"REJECTED:{bestRejectedReason}", $"rejected box {FormatRect(bestRejectedRect)} IoU={bestRejectedIoU:F3}{acceptedNote}{ambiguity}");
         }
 
         // ---- Geometry helpers ------------------------------------------------------------------------------
-
-        private readonly struct RectD {
-            public readonly double X, Y, W, H;
-
-            public RectD(double x, double y, double w, double h) {
-                X = x; Y = y; W = w; H = h;
-            }
-
-            public double Area => Math.Max(0.0, W) * Math.Max(0.0, H);
-        }
+        // RectD + IoU + the BEST-overlap classification now live in the shared plugin BoxMatcher.
 
         private static RectD ToRectD(StarReviewLabelBox b) => new RectD(b.X, b.Y, b.W ?? 0.0, b.H ?? 0.0);
-
-        /// <summary>Intersection-over-union between a label box (double) and a detector Rect (int). Zero when they
-        /// do not intersect or either has zero area.</summary>
-        private static double IoU(RectD a, Rect b) {
-            var bd = new RectD(b.X, b.Y, b.Width, b.Height);
-            var ix = Math.Max(a.X, bd.X);
-            var iy = Math.Max(a.Y, bd.Y);
-            var ix2 = Math.Min(a.X + a.W, bd.X + bd.W);
-            var iy2 = Math.Min(a.Y + a.H, bd.Y + bd.H);
-            var iw = ix2 - ix;
-            var ih = iy2 - iy;
-            if (iw <= 0.0 || ih <= 0.0) {
-                return 0.0;
-            }
-            var inter = iw * ih;
-            var union = a.Area + bd.Area - inter;
-            return union <= 0.0 ? 0.0 : inter / union;
-        }
 
         private static string FormatBox(StarReviewLabelBox b) =>
             $"({b.X.ToString("F0", CultureInfo.InvariantCulture)},{b.Y.ToString("F0", CultureInfo.InvariantCulture)}," +
@@ -422,7 +368,7 @@ namespace TestApp {
             Console.Error.WriteLine("Usage: TestApp diagnose-labels --runs <folder> --labels <dir> [--params current|optimized] [--opt-results <dir>] [--profile-id <guid>] [--out <dir>]");
             Console.Error.WriteLine("  Classifies each human-labeled review box against a fresh detection of the same frame:");
             Console.Error.WriteLine("    ACCEPTED          - overlaps an accepted star's bounding box");
-            Console.Error.WriteLine("    REJECTED:<reason> - overlaps a rejected candidate (TooDistorted/Degenerate/Saturated/LowSensitivity/NotCentered/TooFlat/Contaminated)");
+            Console.Error.WriteLine("    REJECTED:<reason> - overlaps a rejected candidate (TooSmall/OnBorder/TooDistorted/Degenerate/LowSensitivity/NotCentered/TooFlat/HFRAnalysisFailed/TooLowHFR/Contaminated), with the measured value vs threshold");
             Console.Error.WriteLine("    NO CANDIDATE      - overlaps neither (a structure-detection gap; only fixable by detector-algorithm work)");
             Console.Error.WriteLine("  --runs        (required) folder of saved AF runs (same discovery as `review`/`optimize`).");
             Console.Error.WriteLine("  --labels      (default <runs>/labels) folder of label JSON files written by `review`.");

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -17,6 +17,7 @@ using NINA.Joko.Plugins.HocusFocus.AutoFocus;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.StarDetection;
 using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review;
 using NINA.Joko.Plugins.HocusFocus.Utility;
 using NINA.Profile;
 using NINA.Profile.Interfaces;
@@ -780,7 +781,16 @@ namespace TestApp {
             }
 
             foreach (var run in runs) {
-                if (!byRunId.TryGetValue(run.RunId, out var lf) || lf.Positions == null) {
+                if (!byRunId.TryGetValue(run.RunId, out var lf)) {
+                    // G3 trailing-segment fallback: wizard label files embed the ABSOLUTE run path as runId, while
+                    // discovery keys a run by its relative/leaf path — match on the last path segment so wizard
+                    // labels load against a path-relocated copy of the run.
+                    var leaf = StarReviewLabelStore.LastSegment(run.RunId);
+                    if (!string.IsNullOrEmpty(leaf)) {
+                        lf = byRunId.FirstOrDefault(kv => string.Equals(StarReviewLabelStore.LastSegment(kv.Key), leaf, StringComparison.OrdinalIgnoreCase)).Value;
+                    }
+                }
+                if (lf?.Positions == null) {
                     continue;
                 }
                 var defaultRadius = lf.RadiusPx ?? DefaultLabelRadiusPx;

--- a/Joko.NINA.Plugins/TestApp/Program.cs
+++ b/Joko.NINA.Plugins/TestApp/Program.cs
@@ -136,6 +136,14 @@ namespace TestApp {
                 return;
             }
 
+            // Headless label-driven gate RECOMMENDER: `TestApp recommend --runs <dir> --labels <dir> ...`. Runs the
+            // analyzer + recommender the in-wizard "Optimize with feedback" uses, printing the per-gate breakdown
+            // and the recommended threshold changes (precision-bounded) without launching NINA.
+            if (args.Length > 0 && args[0].Equals("recommend", StringComparison.OrdinalIgnoreCase)) {
+                RecommendRunner.Run(args);
+                return;
+            }
+
             // Interactive two-pass star-review labeling tool: `TestApp review --runs <dir> ...`. The runner does its
             // async loading/detection on this thread, then constructs and shows the WPF window on a dedicated STA
             // thread it creates internally — so it is correct regardless of this thread's apartment (an async Main

--- a/Joko.NINA.Plugins/TestApp/RecommendRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/RecommendRunner.cs
@@ -1,0 +1,254 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Enum;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NINA.Profile;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using TestApp.StarReview;
+using Logger = NINA.Core.Utility.Logger;
+using Rect = OpenCvSharp.Rect;
+
+namespace TestApp {
+
+    /// <summary>
+    /// Headless driver for the label-driven gate RECOMMENDER (the "Optimize with feedback" direct analysis). Runs
+    /// the same <see cref="LabelGateAnalyzer"/> + <see cref="GateRecommender"/> the in-wizard flow uses: it detects
+    /// each labeled frame (with per-rejected-candidate diagnostics on), attributes every labeled wrongly-rejected
+    /// star to the exact gate that killed it, then recommends the threshold changes that recover the most labels
+    /// within a precision budget — so the example can be validated without launching NINA.
+    ///
+    /// <para>CLI: <c>TestApp recommend --runs &lt;folder&gt; [--labels &lt;dir&gt;] [--params current|optimized]
+    /// [--opt-results &lt;dir&gt;] [--profile-id &lt;guid&gt;] [--out &lt;dir&gt;] [--precision-budget &lt;n&gt;]</c></para>
+    /// </summary>
+    internal static class RecommendRunner {
+
+        public static void Run(string[] args) {
+            try {
+                RunImpl(args);
+            } catch (Exception ex) {
+                Console.Error.WriteLine($"ERROR: {ex.Message}");
+                Console.Error.WriteLine(ex.ToString());
+                Logger.Error(ex, "recommend run failed");
+                Environment.ExitCode = 1;
+            }
+        }
+
+        private static void RunImpl(string[] args) {
+            var runsDir = DiagnosticUtil.GetArg(args, "--runs");
+            if (string.IsNullOrWhiteSpace(runsDir)) {
+                PrintUsage();
+                Environment.ExitCode = 2;
+                return;
+            }
+            if (!Directory.Exists(runsDir)) {
+                throw new DirectoryNotFoundException($"--runs folder not found: {runsDir}");
+            }
+
+            var labelsDir = DiagnosticUtil.GetArg(args, "--labels");
+            if (string.IsNullOrWhiteSpace(labelsDir)) {
+                labelsDir = Path.Combine(runsDir, "labels");
+            }
+            if (!Directory.Exists(labelsDir)) {
+                throw new DirectoryNotFoundException($"--labels folder not found: {labelsDir}");
+            }
+
+            var profileId = DiagnosticUtil.GetArg(args, "--profile-id");
+            var paramsArg = (DiagnosticUtil.GetArg(args, "--params") ?? "current").Trim().ToLowerInvariant();
+            bool useOptimized;
+            switch (paramsArg) {
+                case "current": useOptimized = false; break;
+                case "optimized": useOptimized = true; break;
+                default: throw new ArgumentException($"--params: '{paramsArg}' must be 'current' or 'optimized'");
+            }
+            var optResultsDir = DiagnosticUtil.GetArg(args, "--opt-results");
+
+            var budget = 2.0;
+            var budgetArg = DiagnosticUtil.GetArg(args, "--precision-budget");
+            if (!string.IsNullOrWhiteSpace(budgetArg) && double.TryParse(budgetArg, NumberStyles.Float, CultureInfo.InvariantCulture, out var b)) {
+                budget = b;
+            }
+
+            var outDir = DiagnosticUtil.GetArg(args, "--out");
+            if (string.IsNullOrWhiteSpace(outDir)) {
+                outDir = Path.Combine(Path.GetTempPath(), "hf-recommend", DateTime.Now.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture));
+            }
+            Directory.CreateDirectory(outDir);
+
+            Logger.SetLogLevel(LogLevelEnum.INFO);
+            if (System.Windows.Application.Current == null) {
+                new System.Windows.Application();
+            }
+
+            var sb = new System.Text.StringBuilder();
+            void Line(string s = "") {
+                Console.WriteLine(s);
+                sb.AppendLine(s);
+            }
+
+            Line($"Runs root: {runsDir}");
+            Line($"Labels dir: {labelsDir}");
+            Line($"Params: {paramsArg};  precision budget (max unlabeled per recovered): {budget.ToString("G3", CultureInfo.InvariantCulture)}");
+
+            var profileService = new ProfileService();
+            profileService.TryLoad(profileId ?? string.Empty);
+            var activeProfile = profileService.ActiveProfile;
+            if (activeProfile == null) {
+                throw new InvalidOperationException("No active NINA profile could be loaded. Pass --profile-id, or run NINA at least once.");
+            }
+            Line($"Profile: {activeProfile.Name} ({activeProfile.Id})");
+
+            var guid = PluginOptionsAccessor.GetAssemblyGuid(typeof(StarDetectionOptions));
+            if (guid == null) {
+                throw new InvalidOperationException("Could not resolve the HocusFocus plugin assembly GUID");
+            }
+            var accessor = new PluginOptionsAccessor(profileService, guid.Value);
+            var starDetectionOptions = new StarDetectionOptions(profileService, accessor);
+
+            var discovery = OptimizationRunDiscovery.Discover(runsDir);
+            if (discovery.Runs.Count == 0) {
+                throw new InvalidOperationException($"No AF runs (≥3 focuser positions) discovered under {runsDir}.");
+            }
+
+            var firstFramePath = discovery.Runs[0].Frames.FirstOrDefault()?.Path;
+            var firstRunFolder = string.IsNullOrEmpty(firstFramePath) ? null : Path.GetDirectoryName(firstFramePath);
+            var detectionParams = StarReviewRunner.BuildDetectionParams(starDetectionOptions, activeProfile, useOptimized, optResultsDir, firstRunFolder);
+            detectionParams.CollectRejectedCandidateDiagnostics = true;
+            Line($"Detection params: Sensitivity={detectionParams.Sensitivity.ToString("G6", CultureInfo.InvariantCulture)}, " +
+                $"MinHFR={detectionParams.MinHFR.ToString("G4", CultureInfo.InvariantCulture)}, " +
+                $"MaxDistortion={detectionParams.MaxDistortion.ToString("G4", CultureInfo.InvariantCulture)}, " +
+                $"StructureLayers={detectionParams.StructureLayers}, MinBBox={detectionParams.MinimumStarBoundingBoxSize}");
+            Line();
+
+            var detector = new StarDetector(new AlglibAPI());
+            var frames = new List<FrameDetectionForAnalysis>();
+
+            foreach (var run in discovery.Runs) {
+                var labels = StarReviewLabelStore.Load(labelsDir, run.RunId, out var loadError);
+                if (loadError != null) {
+                    Line($"WARNING: {loadError}");
+                }
+                if (labels?.Positions == null || labels.Positions.Count == 0) {
+                    Line($"(run '{run.RunId}': no labels matched — skipping)");
+                    continue;
+                }
+
+                var framesByPos = run.Frames
+                    .GroupBy(f => f.FocuserPosition)
+                    .ToDictionary(g => g.Key, g => g.First().Path);
+
+                foreach (var pos in labels.Positions.OrderBy(p => p.FocuserPosition)) {
+                    var recall = (pos.Missed ?? new List<StarReviewLabelBox>())
+                        .Concat(pos.WronglyRejected ?? new List<StarReviewLabelBox>()).ToList();
+                    var shouldReject = pos.ShouldReject ?? new List<StarReviewLabelBox>();
+                    if (recall.Count == 0 && shouldReject.Count == 0) {
+                        continue;
+                    }
+                    if (!framesByPos.TryGetValue(pos.FocuserPosition, out var framePath)) {
+                        Line($"WARNING: run '{run.RunId}' focuser {pos.FocuserPosition} has no frame; skipping its labels.");
+                        continue;
+                    }
+
+                    List<Star> accepted;
+                    IReadOnlyList<RejectedCandidateRecord> rejected;
+                    using (var mat = DiagnosticUtil.LoadFloatMat(framePath, profileService).GetAwaiter().GetResult())
+                    using (var clone = mat.Clone()) {
+                        var result = detector.Detect(clone, detectionParams, null, CancellationToken.None).GetAwaiter().GetResult();
+                        accepted = result.DetectedStars ?? new List<Star>();
+                        rejected = result.RejectedCandidates ?? new List<RejectedCandidateRecord>();
+                    }
+
+                    frames.Add(new FrameDetectionForAnalysis {
+                        FocuserPosition = pos.FocuserPosition,
+                        AcceptedBounds = accepted.Select(s => s.StarBoundingBox).ToList(),
+                        AcceptedCenters = accepted.Select(s => ((double)s.Center.X, (double)s.Center.Y)).ToList(),
+                        Rejected = rejected,
+                        RecallBoxes = recall.Select(ToRectD).ToList(),
+                        ShouldRejectBoxes = shouldReject.Select(ToRectD).ToList()
+                    });
+                }
+            }
+
+            if (frames.Count == 0) {
+                Line("No labeled frames could be detected — nothing to recommend.");
+                File.WriteAllText(Path.Combine(outDir, "recommend.txt"), sb.ToString());
+                return;
+            }
+
+            var analysis = LabelGateAnalyzer.Analyze(frames);
+            var config = new RecommenderConfig { MaxUnlabeledPerRecovered = budget };
+            var rec = GateRecommender.Recommend(analysis, detectionParams, config);
+
+            // ---- Report ----
+            Line("================ LABEL → GATE ATTRIBUTION ================");
+            Line($"Labeled frames: {frames.Count};  recall targets: {analysis.TotalRecallTargets} " +
+                $"(already accepted: {analysis.AlreadyRecovered}, NO-CANDIDATE: {analysis.NoCandidateCount})");
+            foreach (var kv in analysis.RecallTargetCountByGate.OrderByDescending(kv => kv.Value)) {
+                Line($"    {kv.Value,5}  {kv.Key}");
+            }
+            if (analysis.ShouldReject.Count > 0) {
+                Line($"    should-reject labels: {analysis.ShouldReject.Count} (currently violated: {analysis.ShouldReject.Count(s => s.CurrentlyViolated)})");
+            }
+            Line();
+
+            Line("================ RECOMMENDED SETTINGS ================");
+            foreach (var row in rec.Rows) {
+                Line($"    {row}");
+            }
+            Line();
+            Line($"Total recovered: {rec.TotalRecovered}/{rec.TotalRecallTargets};  " +
+                $"estimated weighted precision cost: {rec.EstimatedWeightedPrecisionCost.ToString("G3", CultureInfo.InvariantCulture)}");
+            if (rec.RecommendDefocusAwareGates) {
+                Line("    → recommends ENABLING Defocus-Aware Gates (distortion/centering relaxation).");
+            }
+            if (rec.RecommendStructureRecovery) {
+                Line("    → recommends ENABLING Defocus-Aware Structure Detection (NO-CANDIDATE donuts).");
+            }
+            Line();
+
+            Line("================ PARAMS (current → recommended) ================");
+            void P(string name, double cur, double next, string fmt = "G4") {
+                var marker = Math.Abs(cur - next) > 1e-9 ? " *" : "";
+                Line($"    {name,-26} {cur.ToString(fmt, CultureInfo.InvariantCulture),12} → {next.ToString(fmt, CultureInfo.InvariantCulture),-12}{marker}");
+            }
+            P("BrightnessSensitivity", detectionParams.Sensitivity, rec.Recommended.Sensitivity);
+            P("MinHFR", detectionParams.MinHFR, rec.Recommended.MinHFR);
+            P("MaxDistortion", detectionParams.MaxDistortion, rec.Recommended.MaxDistortion);
+            P("StarPeakResponse", detectionParams.PeakResponse, rec.Recommended.PeakResponse);
+            P("StarCenterTolerance", detectionParams.StarCenterTolerance, rec.Recommended.StarCenterTolerance);
+            P("MinStarBoundingBoxSize", detectionParams.MinimumStarBoundingBoxSize, rec.Recommended.MinimumStarBoundingBoxSize, "G3");
+            Line($"    {"DefocusAwareGates",-26} {detectionParams.DefocusAwareDistortion,12} → {rec.Recommended.DefocusAwareDistortion,-12}");
+
+            var outFile = Path.Combine(outDir, "recommend.txt");
+            File.WriteAllText(outFile, sb.ToString());
+            Console.WriteLine();
+            Console.WriteLine($"Wrote {outFile}");
+        }
+
+        private static RectD ToRectD(StarReviewLabelBox b) => new RectD(b.X, b.Y, b.W ?? 0.0, b.H ?? 0.0);
+
+        private static void PrintUsage() {
+            Console.Error.WriteLine("Usage: TestApp recommend --runs <folder> [--labels <dir>] [--params current|optimized] [--opt-results <dir>] [--profile-id <guid>] [--out <dir>] [--precision-budget <n>]");
+            Console.Error.WriteLine("  Attributes each labeled wrongly-rejected star to the gate that killed it, then recommends the");
+            Console.Error.WriteLine("  threshold changes that recover the most labels within a precision budget (default 2.0 unlabeled/recovered).");
+        }
+    }
+}

--- a/plans/optimize-with-feedback-plan.md
+++ b/plans/optimize-with-feedback-plan.md
@@ -1,0 +1,335 @@
+# Optimize With Feedback — Direct Label→Settings Recommender (+ Warm-Started Optimizer)
+
+> **Repo convention note (CLAUDE.md):** implementation plans live in the repo `plans/` folder. On execution,
+> copy this file to `plans/optimize-with-feedback-plan.md` and work from there. (This copy lives in the
+> Claude plan-mode dir because that was the only writable path during planning.)
+> **`/clear` before executing.** Branch `ghilios/optimize-with-feedback` off `develop`; PR to merge (never push
+> `develop`). Commit identity `George Hilios <322725+ghilios@users.noreply.github.com>` (author + committer).
+
+## Context
+
+The Star Detection Optimization Wizard already has a **Review → label → "Optimize with feedback"** loop: the
+user labels `missed` (false negatives), `shouldReject` (false positives), and `wronglyRejected` (detected but
+gated-out) stars, then re-runs the optimizer. **But the feedback path today just throws those labels into the
+black-box `StarDetectionOptimizer` as one weighted objective term (`Wl=0.25`, recall/precision by box
+containment).** It never *directly analyzes* which gate is failing which labeled star, so it can't tell the user
+"BrightnessSensitivity is rejecting these 21 stars; lower it to 1.1 to recover them," and it has no transparent
+notion of "improve recall without hurting precision much."
+
+The user wants the feedback step to **directly analyze the labels** to recommend concrete settings that recover
+as many labeled stars as possible, improving recall while bounding the precision cost — and to know whether the
+current gates even have the flexibility to do it.
+
+**Empirical anchor (must be solvable):** run `E:\WorkshopData\Data\autofocus\sensitivity_example1\attempt01`
+(9 `.xisf`, focuser 3809–5009), labels at `…\attempt01\labels\E__WorkshopData_…_attempt01.json` — **168 boxes
+across 7 positions, ALL `wronglyRejected`** (no `missed`, no `shouldReject`). A `wronglyRejected` box means a
+candidate *formed* there and a **gate killed it** ⇒ every one is recoverable by gate tuning (not a structure
+gap). Folder name + faint/small boxes ⇒ the **LowSensitivity** gate (`BrightnessSensitivity` 2.0) is the prime
+suspect, with a secondary **TooLowHFR** (`MinHFR` 1.2) bucket.
+
+## Locked decisions (from the user)
+
+1. **Analyzer primary + warm-start optimizer.** The direct gate analyzer computes recommended settings from the
+   labels and shows a per-gate breakdown; that recommendation then **seeds and bounds** the existing
+   `StarDetectionOptimizer` so AF focus-curve quality isn't wrecked while recovering stars.
+2. **Include NO-CANDIDATE structure-gap recovery.** Add a NEW opt-in, default-OFF *defocus-aware
+   structure-detection* setting so stars that never form a candidate (large/donut defocus) can be recovered.
+   Bit-identical when OFF.
+3. **Precision guard = unlabeled-admit proxy + should-reject when present.** Precision cost of a setting change =
+   count of currently-rejected **unlabeled** candidates it would newly admit (near-focus-weighted); AND
+   hard-honor `shouldReject` labels when they exist.
+4. **Optimize-vs-validate toggle.** The wizard offers a choice: **Optimize** (run the optimization pass, current
+   behavior) OR **Use current settings** — skip optimization entirely and jump straight to Review against the
+   current/seed params, so the user can validate (and label against) today's settings without an optimization
+   pass. Labeling + "Optimize with feedback" stay available from that Review either way.
+
+## Architecture facts that constrain the design (verified)
+
+- **Gates discard the measured value.** `StarDetector.EvaluateStarCandidate` (StarDetector.cs:1242–1379)
+  computes each gate's scalar as a local and discards it on `return null`. We must capture it. Per-gate scalars:
+  TooSmall `min(W,H)` vs `MinimumStarBoundingBoxSize`; TooDistorted `fillRatio=points/d²` vs
+  `effectiveMaxDistortion`; LowSensitivity `NormalizedBrightness/srcImageNoiseSigma` vs `Sensitivity`; TooFlat
+  `StarMedian/Peak` vs `PeakResponse`; TooLowHFR `star.HFR` vs `MinHFR`; NotCentered → normalized centroid
+  offset vs effective tolerance; OnBorder/Degenerate/HFRAnalysisFailed → **non-scalar** (flag only);
+  Contaminated → `ContaminationSensitivity`.
+- **Counter-only gates have no bbox list.** `StarDetectorMetrics` carries `*Bounds` lists only for TooDistorted,
+  Degenerate, Saturated, LowSensitivity, NotCentered, TooFlat, Contaminated. TooSmall/TooLowHFR/HFRAnalysisFailed
+  are counter-only, so `FrameReviewBuilder.ExtractRejected` never emits them and `diagnose-labels` mis-reports a
+  TooLowHFR star as **NO CANDIDATE**. The new diagnostics fix this attribution bug.
+- **Diagnostics side-channel pattern already exists.** `CollectContaminationDiagnostics` (default false) is in
+  `CacheKeyExcludedProperties` (IStarDetector.cs:418/426) and threads a `ConcurrentBag<…>` (StarDetector.cs:623,
+  null when off) → **zero overhead / bit-identical when off**. Mirror this exactly.
+- **Cache-key machinery:** `EarlyCacheKeyProperties` + `IsEarlyCacheKeyParameter` (StarDetector.cs:109/144) gate
+  the optimizer's early-context cache; any new param that changes candidate *formation* must be added there.
+  `ToCanonicalCacheString` reflects over public props minus `CacheKeyExcludedProperties`.
+- **Optimizer needs no core change.** `StarDetectionOptimizer.OptimizeAsync(seed, variables, evaluator, …)`
+  already takes the seed + variable set; only the wizard caller (StarDetectionOptimizerWizardVM.cs:830, which
+  hardcodes `runs[0].Seed` + `CreateCuratedSet()`) must inject a warm-start seed + bounded variables.
+- **Shared seams:** `FrameReviewBuilder.ExtractRejected` is the single rejected-box source (TestApp delegates to
+  it). `ClassifyBox`/`IoU`/`RectD` currently live ONLY in TestApp `DiagnoseLabelsRunner.cs` — factor them into
+  shared plugin code so wizard + TestApp + analyzer agree.
+- **Defocus *gates* already exist** (DefocusAwareDistortion/Centering etc.) and are LATE. The new
+  structure-detection setting (decision 2) is genuinely new and **EARLY**.
+
+---
+
+## Implementation
+
+Ship in slices; each new behavior is **opt-in / default-OFF ⇒ detection star counts AND objective `J`
+bit-identical when disabled** (unit-test against an independent re-impl). Run
+`dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug` after each.
+
+### Phase 0 — Validation pass on the user's example (do FIRST, before building anything new)
+
+The user wants the concrete decided settings for `sensitivity_example1\attempt01` to review directly. Produce
+them up front with the **existing** tools (they already match this run's absolute-path runId, so labels load):
+
+1. Build TestApp: `cmd.exe /c "dotnet build Joko.NINA.Plugins\TestApp\TestApp.csproj -c Debug --nologo"`.
+2. **Attribution:** `TestApp diagnose-labels --runs E:\WorkshopData\Data\autofocus\sensitivity_example1\attempt01
+   --params current` → confirms which gates reject the 168 `wronglyRejected` boxes (expected: LowSensitivity
+   dominant; a TooLowHFR subset that currently mislabels as NO CANDIDATE — note this as the bug Phase 1 fixes).
+3. **Concrete settings:** `TestApp optimize --runs …\attempt01 --labels …\attempt01\labels --out <dir>` → writes
+   `optimized_settings.json` + `optimize_summary.txt` with the old→new curated-param deltas. This is the
+   black-box recommendation available TODAY; report the changed params (esp. `BrightnessSensitivity`, `MinHFR`)
+   and the recall/star-count change to the user.
+4. **Report + optionally apply:** tell the user the decided settings and the seed→best `J` / star-count delta.
+   On request, set them in the active NINA profile via the Star Detection options (or hand them the JSON) and
+   list exactly which option values changed. **Read-only on the profile unless the user says to apply.**
+
+This grounds the design in real numbers and lets the user review before the new analytical recommender lands;
+Phases 1–3 then replace the black-box step with the transparent per-gate recommender (more interpretable, same
+or better recovery), and Phase 5 adds structure-gap recovery.
+
+**Phase 0 RESULTS (executed 2026-06-15 on the example):**
+- **Label loading hit the G3 runId-mismatch bug.** The wizard saved the file as
+  `E__WorkshopData_..._attempt01.json` with embedded `runId` = the absolute path, but offline discovery (pointing
+  `--runs` at the attempt folder) assigns `RunId="attempt01"`. `diagnose-labels` (uses
+  `StarReviewLabelStore.Load`, exact-filename path) matched once the file was copied to `attempt01.json`; but
+  `optimize`'s OWN loader (`OptimizationDiagnosticRunner.LoadLabels`) keys by the **embedded** runId, so it also
+  needed the embedded `runId` rewritten to `attempt01`. **In-wizard re-optimize is unaffected (in-memory
+  labels)**, but this confirms G3 must be fixed for the offline harnesses and any path-relocated run. Workaround
+  used: temp `C:\temp\hf-labels-fix\attempt01.json` with `runId":"attempt01"`.
+- **Gate attribution (`diagnose-labels --params current`, 132 boxes):** **111 LowSensitivity (84%) + 21
+  TooDistorted (16%), 0 NO-CANDIDATE, 0 already-accepted.** Everything is gate-fixable — the current gates DO
+  have the flexibility; no structure-detection gap in this example (so Phase 5 isn't exercised here).
+- **Current profile is badly mis-tuned:** `BrightnessSensitivity=16.17` (vs default 2.0), `MaxDistortion=0.6125`,
+  `StructureLayers=5`, `MinStarBoundingBoxSize=6`, `MinHFR=1.5`, `StarClippingMultiplier=0.3125`. The extreme
+  sensitivity is why ~84% of labels are LowSensitivity rejections; detection finds only 11–53 stars/frame.
+- **The 21 TooDistorted are SMALL and near-focus (4409/4559)** — NOT large defocused donuts. So the defocus-aware
+  *gate* (relaxes only large candidates) would NOT recover them; lowering `MaxDistortion` does. This validates the
+  recommender's size-gated branch (don't recommend `DefocusAwareGates` for small TooDistorted).
+- **Black-box `optimize --labels`:** **Seed J 0.898 → Best J 0.988, recall 0.943 / precision 1.0**, star counts
+  ~2–3× (3809: 11→42, 4259: 53→102, 5009: 16→42), hard-floor PASS. Changed params: `BrightnessSensitivity
+  16.17→0`, `MaxDistortion 0.6125→0.5875`, `StructureLayers 5→6`, `StarClippingMultiplier 0.3125→0.375`,
+  `MinStarBoundingBoxSize 6→7`, `HotpixelThreshold 0.001375→0.000875`; `DefocusAwareGates` stayed OFF (correct).
+- **KEY INSIGHT validating the whole design:** the optimizer drove `BrightnessSensitivity` to **0** (the floor) —
+  because with recall-only labels and **no should-reject labels, precision is unconstrained**, so nothing stops
+  it admitting noise. This is exactly the failure the transparent recommender's **unlabeled-admit precision
+  proxy** (decision 3) prevents: it will lower `BrightnessSensitivity` only to the level that recovers the
+  *labeled* stars (≈ the min sensitivity among the 111 labeled boxes, exposed by Phase 1's measured values) and
+  report the precision cost, instead of collapsing to 0. Sensitivity=0 should NOT be applied to the profile as-is.
+
+### Phase 0.5 — G3 stable run key (fold-in; fixes offline label matching)
+
+Wizard-saved labels are keyed by the sanitized **absolute** run path (filename + embedded `runId`), but offline
+discovery (`OptimizationRunDiscovery`) assigns `RunId` = relative path / folder name (e.g. `attempt01`), so
+`optimize`/`diagnose-labels`/`recommend --labels` don't match wizard labels without manual renaming (proven in
+Phase 0). Fix: pick a **stable run identity** consistent between the wizard loader (`RunEvaluationLoader` runId
+derivation) and `OptimizationRunDiscovery`, and make the label loaders match on it robustly.
+- **Approach:** keep the label JSON shape compatible (existing files must still load). Make
+  `StarReviewLabelStore.Load` and `OptimizationDiagnosticRunner.LoadLabels` ALSO match when the discovered RunId
+  equals the **last path segment(s)** of an embedded absolute-path runId (so `attempt01` matches an embedded
+  `…\attempt01`), in addition to exact-match. Prefer a relative-to-runs-root or trailing-segment key.
+- **Files:** `Review/StarReviewLabels.cs` (`FileNameFor`/`CleanRunFileStem`/`Load` embedded-scan), `RunEvaluationLoader.cs`
+  (runId derivation), `OptimizationRunDiscovery.cs` (offline runId), `OptimizationDiagnosticRunner.LoadLabels` +
+  the new `RecommendRunner`. **Tests:** a wizard-written absolute-path file loads against a discovered
+  `attempt01` run; legacy exact-match still works.
+
+### Phase 1 — Per-rejected-candidate measured-value exposure (foundation)
+
+- **New type** `RejectedCandidateRecord` in `Interfaces/IStarDetector.cs` (next to `ContaminationDiagnosticRecord`):
+  `Rect Bounds; string Gate; double MeasuredValue; double ThresholdValue; double CandidateSize; double CenterX, CenterY;`.
+- **New param** `StarDetectorParams.CollectRejectedCandidateDiagnostics` (default false); **add to
+  `CacheKeyExcludedProperties`** (output-neutral, like the contamination flag).
+- **Populate in `EvaluateStarCandidate`**: thread a `ConcurrentBag<RejectedCandidateRecord> rejectedBag`
+  (created in `GateAndMeasureInternal`/`EvaluateStarCandidates` only when the flag is on, exactly like
+  `contaminationDiagnosticsBag` at StarDetector.cs:623) → at *every* `return null` gate add a record guarded by
+  `if (p.CollectRejectedCandidateDiagnostics && rejectedBag != null)`, **including the counter-only gates**
+  (TooSmall/TooLowHFR/HFRAnalysisFailed) and the non-scalar ones (record `NaN`). For NotCentered record the
+  normalized offset `max(|cx−bx|/(W/2), |cy−by|/(H/2))`.
+- **Surface** `HocusFocusStarDetectorResult.RejectedCandidates` (null unless flag on), materialized in
+  `GateAndMeasureInternal` with the same ROI-offset (`+= offset`) + deterministic (Y,X) sort as the existing
+  bounds. **Do not** change `StarDetectorMetrics` (records are a parallel side-channel) so all existing readers
+  and equivalence/signature tests are untouched.
+- **Tests:** `RejectedCandidateDiagnosticsTests` — detect a real frame OFF vs ON → identical `DetectedStars` +
+  every metrics counter; ON → every rejected candidate has a record whose `(MeasuredValue, ThresholdValue)`
+  inverts the gate correctly; confirm the flag is in `CacheKeyExcludedProperties` (no key change).
+
+### Phase 2 — Shared matcher + `LabelGateAnalyzer`
+
+- **New** `StarDetection/Optimization/Review/BoxMatcher.cs` (plugin): `RectD`, `IoU`, generalized `ClassifyBox`
+  that now also consults `RejectedCandidateRecord` (so it reports gate + measured value, and TooLowHFR boxes are
+  attributed instead of NO CANDIDATE). Refactor `DiagnoseLabelsRunner` to call it (delete the TestApp copies),
+  mirroring how `StarReviewRunner.ExtractRejected` delegates to `FrameReviewBuilder.ExtractRejected`.
+- **New** `StarDetection/Optimization/LabelGateAnalyzer.cs` (plugin; detector + float-mat loader seam, like
+  `FrameReviewBuilder`). Per labeled position: re-detect once with `CollectRejectedCandidateDiagnostics=true`;
+  classify each recall-target box (Missed ∪ WronglyRejected): accepted → **AlreadyRecovered**, rejected-record →
+  bucket `(gate, MeasuredValue, CandidateSize)`, neither → **NoCandidate**; match `ShouldReject` boxes to
+  accepted stars. Output `LabelGateAnalysis { GateBucket[] Buckets; RecallTarget[] NoCandidate;
+  ShouldRejectTarget[] ShouldReject; int AlreadyRecovered, TotalRecallTargets; }`.
+- **Tests:** `BoxMatcherTests` + `LabelGateAnalyzerTests` over synthetic accepted/rejected lists; assert the
+  TooLowHFR-attributed-not-NO-CANDIDATE case; accepted wins IoU ties.
+
+### Phase 3 — `GateRecommender` (the direct analysis)
+
+- **New** `StarDetection/Optimization/GateRecommender.cs` (pure, deterministic, image-free → fully unit-testable).
+- **Per-gate inversion (monotone):** from a bucket's measured-value distribution, the threshold to admit `j`
+  targets is an order statistic (e.g. LowSensitivity: `Sensitivity = nextBelow(sort(sensitivities)[j-1])`).
+  Directions: Sensitivity↓, MinHFR↓, MaxDistortion↓, MinimumStarBoundingBoxSize↓, PeakResponse↑,
+  StarCenterTolerance↑. **Non-invertible:** Degenerate/OnBorder/HFRAnalysisFailed → "not recoverable by a
+  threshold; needs detector work" (route to Phase 5). Contaminated → suggest `RejectContaminatedStars=false` /
+  raise `ContaminationSensitivity` only if that bucket dominates.
+- **Defocus-aware gates as a recovery lever** (TooDistorted / NotCentered buckets): when the rejected targets are
+  **large** (`CandidateSize > DefocusDistortionSizeReference`, i.e. defocused), prefer **enabling
+  `DefocusAwareGates`** (the existing LATE distortion+centering relaxation, already a synthetic curated optimizer
+  variable) over globally lowering `MaxDistortion` / raising `StarCenterTolerance` — the global loosening hurts
+  precision on small near-focus stars, whereas the defocus-aware relaxation only fires for large candidates and
+  is guarded by the `SDefocusPrecision` near-focus penalty. Emit a row recommending the toggle, and (see Phase 4)
+  always leave it in the optimizer's search space so the optimizer can confirm/enable it even when the analytic
+  pass didn't pick it.
+- **Precision cost** of a proposed threshold = count of currently-rejected **UNLABELED** candidates of that gate
+  on the admit side of the new threshold, **near-focus-weighted** (reuse the `NearFocusWindowSteps·stepSize`
+  window from `OptimizationObjective.SDefocusPrecision`); **plus** a hard reject of any move that would re-admit a
+  `ShouldReject` target.
+- **Greedy coordinate selection** across gates by recovered-per-precision-cost, within a precision budget,
+  re-attributing remaining targets after each pick (no double-spend). Output `GateRecommendation {
+  StarDetectorParams RecommendedParams; RecommendationRow[] Rows; bool RecommendStructureRecovery;
+  double EstimatedPrecisionCost; }`; rows read e.g. `"BrightnessSensitivity 2.0 → 1.10  recovers 21/23, admits
+  ~7 unlabeled (≈1.2 near-focus)"`.
+- **Tests:** `GateRecommenderTests` — synthetic buckets with known measured arrays → exact order-statistic
+  threshold, exact recovered counts, exact unlabeled-admit cost, near-focus weighting, and `ShouldReject`
+  hard-honor; cover every monotone direction.
+
+### Phase 4 — Warm-start integration (no optimizer-core change)
+
+- **New** `OptimizerVariable.CreateWarmStartSet(baseSet, recommendation)`: for each curated variable the
+  recommender *moved*, narrow `[Lower, Upper]` to a tight band around the recommended value (recommended ± a few
+  `InitialStep`s, clamped) keeping `InitialStep`; **omit** unimplicated variables from the set entirely (the seed
+  already carries their value — pin by omission, NOT by `InitialStep=0`, to dodge the `ContinuousStepsBelowFloor`
+  edge case).
+- **Always-live defocus-aware toggles** (user requirement): the defocus-aware axes — the existing
+  `DefocusAwareGates` (distortion+centering relaxation) and the new `DefocusAwareStructure` (Phase 5) — are
+  **never pinned off** by the warm-start set. They stay in the optimizer's search space at full range so the
+  optimizer can enable them **if needed** even when the analytic recommender didn't implicate them; the
+  `SDefocusPrecision` near-focus penalty keeps them honest (objective bit-identical when no star is
+  relaxation-admitted). If the recommender *did* pick a defocus-aware toggle, seed it ON; otherwise seed at the
+  current value but keep it tunable. This is an explicit exception to the "omit unimplicated" rule above.
+- **Wizard caller** (`StarDetectionOptimizerWizardVM`): make `OptimizeAsync` accept an injected seed + variable
+  set; the new feedback flow passes `recommendation.RecommendedParams` as seed and the warm-start variable set.
+  The existing label objective term (`Wl`) stays active so the search balances the analytic point against σ.
+- **Tests:** `OptimizerVariableTests` additions — bounds narrowed around moved params, unimplicated omitted,
+  `Read`/`Write` preserved; seeded optimize never regresses below the recommended-seed `J`.
+
+### Phase 5 — New defocus-aware structure-detection setting (decision 2; EARLY, opt-in)
+
+- **Mechanism (minimal, reuses the proven path):** add EARLY params `bool DefocusAwareStructure` (default false)
+  + `int StructureLayerBoost` (default 0). When ON, compute the à-trous B3-spline residual at
+  `StructureLayers + StructureLayerBoost` layers (StarDetector.cs ~499–510,
+  `ComputeResidualAtrousB3SplineDyadicWaveletLayer` then `SubtractInPlace`) so large/donut structures survive the
+  residual subtraction and form candidates; blur kernel stays keyed to the original `StructureLayers` (tune). The
+  boost is applied **only inside `if (p.DefocusAwareStructure)`**, else the call is byte-for-byte the current one.
+- **Cache key:** add both new params to **`EarlyCacheKeyProperties`** (they change formation → must invalidate
+  the early context). When OFF, effective layers == `StructureLayers` ⇒ detected stars identical (the key string
+  gains two stable tokens, which is fine).
+- **Exposure:** `StarDetectionOptions.DefocusAwareStructure` + `StructureLayerBoost` (+ `IStarDetectionOptions`),
+  full options pattern (accessor get/set in setters, `InitializeOptions`, `ResetDefaults`, validation, GUID via
+  `typeof(AutoFocusOptions)`); map in `BuildStarDetectorParams`; UI CheckBox + UnitTextBox + `_Tooltip`
+  TextBlocks in `Resources/OptionsDataTemplates.xaml`; new EARLY synthetic curated variable
+  `DefocusAwareStructure` in `OptimizerVariable.CreateCuratedSet()`.
+- **Recommender hook:** when `NoCandidate` is non-trivial and its `CandidateSize`/defocus distribution skews
+  large, set `RecommendStructureRecovery = true` and emit a row; warm-start un-pins the `DefocusAwareStructure`
+  axis so the optimizer can confirm it helps without hurting σ.
+- **Tests:** `DefocusAwareStructureTests` — OFF vs independent re-impl that never reads the flag → identical
+  `DetectedStars`/metrics; confirm it IS in `EarlyCacheKeyProperties`. (This is the exploratory part; if a clean
+  bit-identical mechanism proves hard, scope it to its own PR but keep the recommender's NoCandidate flagging.)
+
+### Phase 6 — In-wizard UI + offline harness
+
+- **Optimize-vs-validate toggle** (decision 4): on the SelectSource/Optimize step add a mode selector
+  (Optimize | Use current settings). "Use current settings" sets `BestParams = seed` (current detector params
+  from the active profile), skips the `OptimizeAsync` call, builds the Summary as a no-op delta ("no optimization
+  run — current settings"), and enables jumping straight to Review. Flow becomes `SelectSource → Acquire →
+  [Optimize?] → Summary → Review`; from that Review the user labels and can still run "Optimize with feedback".
+  Implement as a `WizardOptimizeMode` enum + a guarded branch in the start/optimize path; the snapshot/review/
+  re-loop machinery is unchanged (it already operates off `BestParams`).
+- **Wizard** (`StarDetectionOptimizerWizardVM` + `DataTemplates.xaml`): the "Optimize with feedback" button now
+  runs `OptimizeWithFeedbackAsync` = **analyze** (`LabelGateAnalyzer` + `GateRecommender`, off-UI, reusing the
+  busy/phase indicators) → **show breakdown** (bind `FeedbackAnalysis`/`Recommendation`: per-gate rows
+  recovered/total + threshold change + est. new admits, NoCandidate count + structure suggestion) in the feedback
+  `Border` (DataTemplates.xaml:253–276) → **warm-start optimize** (Phase 4) → updated Summary. Keep the existing
+  Accept / Review / re-loop flow; reuse the already-snapshotted `reviewDescriptors`/`reviewLabelsDir`/captured
+  labels (survive Mat disposal). Add `SDOpt_OptimizeWithFeedback_Tooltip`.
+- **TestApp** new subcommand `recommend` (new `TestApp/RecommendRunner.cs`, dispatched in `Program.cs` next to
+  `diagnose-labels`): args mirror `diagnose-labels` (`--runs --labels --params --opt-results --profile-id --out`)
+  plus `--precision-budget` and `--structure-recovery on|off`; builds `currentParams` via the same
+  source-of-truth as `diagnose-labels` with `CollectRejectedCandidateDiagnostics=true`, runs the shared
+  analyzer + recommender, prints the per-gate breakdown + recommended delta + total weighted precision cost +
+  NoCandidate/structure recommendation, writes `recommend.txt`. (Optional `--then-optimize` chains the
+  warm-started optimize for end-to-end validation.)
+
+---
+
+## Files to create / modify
+
+**Create:** `StarDetection/Optimization/Review/BoxMatcher.cs`, `StarDetection/Optimization/LabelGateAnalyzer.cs`,
+`StarDetection/Optimization/GateRecommender.cs`, `TestApp/RecommendRunner.cs`; tests
+`GateRecommenderTests.cs`, `LabelGateAnalyzerTests.cs`, `BoxMatcherTests.cs`,
+`RejectedCandidateDiagnosticsTests.cs`, `DefocusAwareStructureTests.cs`.
+
+**Modify:** `Interfaces/IStarDetector.cs` (`RejectedCandidateRecord`; new params; `CacheKeyExcludedProperties`;
+`HocusFocusStarDetectorResult.RejectedCandidates`) · `StarDetection/StarDetector.cs` (`EarlyCacheKeyProperties`;
+rejected-bag plumbing + per-gate records; wavelet boost; `GateAndMeasureInternal` materialize) ·
+`StarDetection/HocusFocusStarDetection.cs` (`BuildStarDetectorParams` maps new options) ·
+`StarDetection/StarDetectionOptions.cs` + `Interfaces/IStarDetectionOptions.cs` (two new options) ·
+`StarDetection/Optimization/OptimizerVariable.cs` (`CreateWarmStartSet` + EARLY `DefocusAwareStructure` variable) ·
+`StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs` (`OptimizeWithFeedbackAsync`, injected seed/vars,
+bindings) · `StarDetection/Optimization/DataTemplates.xaml` (breakdown UI) ·
+`Resources/OptionsDataTemplates.xaml` (controls + tooltips) · `TestApp/DiagnoseLabelsRunner.cs` (use `BoxMatcher`)
++ `TestApp/Program.cs` (dispatch `recommend`).
+
+## Verification (end-to-end, on the user's example)
+
+Build: `cmd.exe /c "dotnet build Joko.NINA.Plugins\TestApp\TestApp.csproj -c Debug --nologo"`. Run folder
+`E:\WorkshopData\Data\autofocus\sensitivity_example1\attempt01` (labels in its `labels\`).
+
+1. **Attribution** (proves the TooLowHFR fix): `TestApp diagnose-labels --runs …\attempt01 --params current`
+   → `wronglyRejected` dominated by `REJECTED:LowSensitivity` with a secondary `REJECTED:TooLowHFR` bucket
+   (previously NO CANDIDATE).
+2. **Recommend:** `TestApp recommend --runs …\attempt01 --params current` → dominant gate LowSensitivity;
+   `BrightnessSensitivity` 2.0 → ~1.1 recovering the bulk of the 168; a small `MinHFR` drop for the TooLowHFR
+   subset; **near-focus-weighted precision cost small** (these stars recur across positions, so few new
+   *unlabeled* admits); `NoCandidate ≈ 0` ⇒ structure-recovery NOT recommended — the expected signature.
+3. **End-to-end:** `TestApp recommend --then-optimize …` (or `TestApp optimize --runs … --labels …`) → accepted
+   counts up at labeled positions while σ(focus) is not materially worse (precision held).
+4. **In NINA:** (a) **Use current settings** mode → wizard skips optimization → Review shows current detection to
+   validate/label without an optimization pass; (b) run the wizard with **Optimize** → Review → "Optimize with
+   feedback" → confirm the breakdown renders, the recommendation applies, Summary updates, Accept persists.
+
+Full `dotnet test … -c Debug` green; every default-OFF path bit-identical (independent-reimpl tests).
+
+## Risks & bit-identicality guards
+
+- **New EARLY structure param is the biggest risk:** must be in `EarlyCacheKeyProperties` AND default-OFF AND
+  bit-identical-OFF (independent re-impl). Missing the early-key entry → stale early-context reuse → wrong stars.
+  If a clean mechanism is hard, split Phase 5 into its own PR but keep the NoCandidate flagging.
+- **Diagnostics flag must not affect detection or the cache key** — keep it in `CacheKeyExcludedProperties`,
+  side-channel only, guarded adds; independent-reimpl OFF test.
+- **Recommender correctness depends on a complete record set** — every `return null` path must emit a record
+  (the per-gate table is the checklist; the diagnostics test asserts it).
+- **Non-monotone gates** (Degenerate/OnBorder/HFRAnalysisFailed) → non-recoverable (flag); bound
+  NotCentered/`StarCenterTolerance` at curated limits to avoid junk admits.
+- **Precision proxy applies even with zero `shouldReject`** (this example) — the unlabeled-admit proxy is the
+  primary signal; `shouldReject` is an additional hard constraint only when present.
+- **Warm-start pinning** by omission, not `InitialStep=0` — **except** the defocus-aware toggles
+  (`DefocusAwareGates`, `DefocusAwareStructure`), which are always kept live in the optimizer's search space so it
+  can enable them if needed (guarded by `SDefocusPrecision`).


### PR DESCRIPTION
## What

Replaces the optimization wizard's black-box "Optimize with feedback" with a **transparent, deterministic analysis** of the user's review labels: it attributes each labeled wrongly-rejected star to the exact gate that killed it, recommends the precision-bounded threshold changes that recover the most labels, then **warm-starts** the optimizer from that recommendation.

## Phases (all new detector behavior is opt-in / default-OFF ⇒ detection + objective bit-identical when disabled)

- **Phase 1** — `RejectedCandidateRecord` side channel (`CollectRejectedCandidateDiagnostics`, excluded from the cache key): per-gate measured value at every reject site, including the counter-only gates (TooLowHFR/TooSmall/HFRAnalysisFailed).
- **Phase 2** — shared `BoxMatcher` + `LabelGateAnalyzer`; `diagnose-labels` refactored to use them (fixes the TooLowHFR → "NO CANDIDATE" mis-attribution).
- **Phase 3** — `GateRecommender`: per-gate inversion (order statistics) + precision proxy (near-focus-weighted unlabeled-admit count) + should-reject hard veto; defocus-aware-gates lever for large distortion/centering rejections.
- **Phase 4** — `OptimizerVariable.CreateWarmStartSet` (narrow moved axes, omit unmoved, keep defocus toggles live); wizard `OptimizeAsync` accepts seed/variable overrides.
- **Phase 5** — opt-in `DefocusAwareStructure` + `StructureLayerBoost` (EARLY): coarsen the wavelet residual so large/donut defocused stars survive and form candidates. Options + UI + curated optimizer variable.
- **Phase 6** — wizard **Optimize vs "Use current settings"** toggle (skip the search → straight to Review), `OptimizeWithFeedbackAsync` (analyze → breakdown → warm-start), and the per-gate breakdown in the Summary.
- **G3** — label loaders match the wizard's absolute-path runId by trailing path segment, so wizard-saved labels load in the offline tools.
- **TestApp `recommend`** — headless harness mirroring the in-wizard analysis.

## Validation

On the user's `sensitivity_example1` run (profile mis-tuned at `BrightnessSensitivity=16.17`): 132 wrongly-rejected = **111 LowSensitivity + 21 TooDistorted, 0 NO-CANDIDATE**. The recommender → **`BrightnessSensitivity` 16.17 → 3.48** (recovers all 111, "just enough" — vs the black-box optimizer's reckless `0`), and transparently declines the 21 small near-focus TooDistorted to stay within the precision budget.

Full suite green: **1247 tests** (golden detection baseline unchanged; default-OFF paths verified bit-identical via independent re-impl). Not yet verified live in NINA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)