### PR TITLE
Star-detection follow-ups r2: G2 validation, optimizer cache instrumentation, perf-doc sync

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationData.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationData.cs
@@ -233,6 +233,21 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         private readonly object cacheLock = new object();
         private bool disposed;
 
+        // Cache instrumentation (split path only). ContextBuilds = expensive early-stage rebuilds actually run;
+        // ContextReuses = late-only moves served from a cached context (the cheap path). The build:reuse ratio is the
+        // direct measure of early-context cache health — it quantifies how much of the per-frame early cost the
+        // staged search (T14) / context cache avoids. Updated with Interlocked so the concurrent per-frame loop is safe.
+        private long contextBuilds;
+        private long contextReuses;
+
+        /// <summary>Number of expensive early-stage <see cref="ISplitFrameDetector.BuildContextAsync"/> calls that
+        /// actually ran (cache misses). Zero on the legacy monolithic path.</summary>
+        public long ContextBuilds => System.Threading.Interlocked.Read(ref contextBuilds);
+
+        /// <summary>Number of frame detections served by reusing an already-built early context (cache hits) — the
+        /// cheap late-only path. Zero on the legacy monolithic path.</summary>
+        public long ContextReuses => System.Threading.Interlocked.Read(ref contextReuses);
+
         private sealed class CachedContext {
             public string EarlyKey;
             public IDisposable Context;
@@ -346,6 +361,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     }
                     var slot = contextCache[frameIndex];
                     if (slot != null && slot.Context != null && slot.EarlyKey == earlyKey) {
+                        System.Threading.Interlocked.Increment(ref contextReuses);
                         return slot.Context; // reuse the published context
                     }
                     if (slot != null && slot.Building != null && slot.EarlyKey == earlyKey) {
@@ -387,6 +403,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             IDisposable built = null;
             try {
                 built = await splitDetector.BuildContextAsync(frameImage, p, token).ConfigureAwait(false);
+                System.Threading.Interlocked.Increment(ref contextBuilds);
                 evicted?.Dispose();
 
                 bool disposeBuilt = false;

--- a/Joko.NINA.Plugins/TestApp/DiagnoseLabelsRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/DiagnoseLabelsRunner.cs
@@ -199,6 +199,31 @@ namespace TestApp {
                 }
             }
 
+            // Opt-in defocus-aware STRUCTURE test switch (the EARLY-stage candidate-formation relaxation, distinct
+            // from the two LATE gates above). Flips DefocusAwareStructure ON and sets StructureLayerBoost so the
+            // wavelet residual that removes large-scale structure is computed at StructureLayers + boost EXTRA
+            // layers (coarser), letting large/donut defocused stars survive and form candidates instead of being
+            // erased entirely (the NO-CANDIDATE structure gap). --structure-boost defaults to 2 when the flag is
+            // present (0 ⇒ no change even with the flag on, useful as an explicit bit-identical control).
+            if (DiagnosticUtil.HasFlag(args, "--defocus-structure")) {
+                detectionParams.DefocusAwareStructure = true;
+                var boost = 2;
+                var boostArg = DiagnosticUtil.GetArg(args, "--structure-boost");
+                if (!string.IsNullOrWhiteSpace(boostArg) && int.TryParse(boostArg, NumberStyles.Integer, CultureInfo.InvariantCulture, out var b) && b >= 0) {
+                    boost = b;
+                }
+                detectionParams.StructureLayerBoost = boost;
+            }
+
+            // Optional StructureLayers override (diagnostic only): pins the nominal StructureLayers independent of
+            // the profile so the structure-boost mechanism can be A/B-tested against a controlled baseline (e.g.
+            // the factory default 4 where the donuts are NO-CANDIDATE) rather than against a drifted/optimized
+            // profile. Read-only on the profile, like the defocus switches.
+            var structureLayersArg = DiagnosticUtil.GetArg(args, "--structure-layers");
+            if (!string.IsNullOrWhiteSpace(structureLayersArg) && int.TryParse(structureLayersArg, NumberStyles.Integer, CultureInfo.InvariantCulture, out var sl) && sl >= 1) {
+                detectionParams.StructureLayers = sl;
+            }
+
             Line($"Detection params: Sensitivity={detectionParams.Sensitivity.ToString("G6", CultureInfo.InvariantCulture)}, " +
                 $"StructureLayers={detectionParams.StructureLayers}, MaxDistortion={detectionParams.MaxDistortion.ToString("G6", CultureInfo.InvariantCulture)}, " +
                 $"PixelScale={detectionParams.PixelScale.ToString("G6", CultureInfo.InvariantCulture)}, RejectContaminated={detectionParams.RejectContaminatedStars}");
@@ -212,6 +237,8 @@ namespace TestApp {
                     ? $" (SizeReference={detectionParams.DefocusDistortionSizeReference.ToString("G6", CultureInfo.InvariantCulture)} px, " +
                       $"ToleranceFactor={detectionParams.DefocusCenteringToleranceFactor.ToString("G6", CultureInfo.InvariantCulture)})"
                     : ""));
+            Line($"DefocusAwareStructure={detectionParams.DefocusAwareStructure}" +
+                (detectionParams.DefocusAwareStructure ? $" (StructureLayerBoost={detectionParams.StructureLayerBoost}, effective layers={detectionParams.StructureLayers + detectionParams.StructureLayerBoost})" : ""));
             Line();
 
             var detector = new StarDetector(new AlglibAPI());
@@ -381,6 +408,9 @@ namespace TestApp {
             Console.Error.WriteLine("  --defocus-size-ref <px>     (with either defocus switch) override the strict-below size reference, shared by both gates (default 30).");
             Console.Error.WriteLine("  --defocus-min-factor <0..1> (with --defocus-distortion) override the floor multiplier on MaxDistortion (default 0.25).");
             Console.Error.WriteLine("  --defocus-center-factor <>=1> (with --defocus-centering) override the max multiplier on StarCenterTolerance (default 2.0).");
+            Console.Error.WriteLine("  --defocus-structure         (opt-in test switch) flips DefocusAwareStructure ON (EARLY-stage: coarser large-structure removal so donut/defocused stars form candidates).");
+            Console.Error.WriteLine("  --structure-boost <0..6>    (with --defocus-structure) extra wavelet layers for large-structure removal (default 2; 0 ⇒ bit-identical control).");
+            Console.Error.WriteLine("  --structure-layers <n>      (diagnostic) override nominal StructureLayers (e.g. 4 for the factory baseline), independent of the profile.");
         }
 
         // ---- Run / frame discovery (mirrors StarReviewRunner / OptimizationDiagnosticRunner) ----------------

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -390,8 +390,19 @@ namespace TestApp {
             var progress = new Progress<OptimizationProgress>(op =>
                 Console.WriteLine($"  [{op.Phase}] evals={op.Evaluations}/{op.MaxEvaluations} bestJ={F(op.BestJ)} seedJ={F(op.SeedJ)}"));
 
+            var sw = System.Diagnostics.Stopwatch.StartNew();
             var result = await optimizer.OptimizeAsync(ctx.Seed, variables, evaluator, settings, progress, CancellationToken.None).ConfigureAwait(false);
+            sw.Stop();
             Console.WriteLine($"Optimization complete: seedJ={F(result.SeedJ)} -> bestJ={F(result.BestJ)} ({(result.ImprovedOverSeed ? "improved" : "no improvement")}), evals={result.Evaluations}");
+
+            // Cache-health + wall-clock readout (the early-context build:reuse ratio is the direct measure of how much
+            // per-frame early work the staged search / context cache avoids; see the performance-design doc).
+            var builds = dataList.Sum(d => d.ContextBuilds);
+            var reuses = dataList.Sum(d => d.ContextReuses);
+            var totalDetections = builds + reuses;
+            var reusePct = totalDetections > 0 ? 100.0 * reuses / totalDetections : 0.0;
+            Console.WriteLine($"Optimize phase: {sw.Elapsed.TotalSeconds.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)} s wall, " +
+                $"early-context builds={builds}, reuses={reuses} ({reusePct.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)}% reuse of {totalDetections} frame detections)");
 
             var perRunSeed = new List<RunEvaluationResult>(loadedRuns.Count);
             var perRunBest = new List<RunEvaluationResult>(loadedRuns.Count);

--- a/docs/star-detection-optimization-wizard-results.md
+++ b/docs/star-detection-optimization-wizard-results.md
@@ -201,3 +201,75 @@ low-moderate risk (trajectory changes; verify quality-neutral). **(B)** bounded 
 so an early probe doesn't evict the incumbent → **~2×**, bit-identical results, but ~6.6 GB peak at 61 MP (needs
 a memory guard). **(C)** early-stop early-axis probing after K non-improving sweeps → **~2–4×**, low-moderate risk.
 A captures most of the win with the least memory risk; A+B is best.
+
+> **Update (T14 — implemented):** option **(A)** shipped in commit `a765c9a` as the staged Phase-B compass
+> search (LATE axes refined first with the early context pinned, then a bounded EARLY stage). The headline ~6.7×
+> matches the projected ~5–10×. See `docs/star-detection-optimizer-performance-design.md` for the design write-up.
+
+## G2 — Structure-boost validation (`DefocusAwareStructure` / `StructureLayerBoost`, follow-up T13)
+
+The defocus-aware **structure** relaxation (the EARLY-stage candidate-formation knob, distinct from the two LATE
+`DefocusAwareGates`) shipped in PR #61 but had **never been A/B-tested on data** — F2/F3 had recorded the 4/5
+missed Panos boxes as an undifferentiated "`NO CANDIDATE` structure gap." This closes that out. The
+`DefocusAwareStructure` flag computes the large-structure wavelet residual at `StructureLayers + StructureLayerBoost`
+**extra** layers (coarser removal), so a heavily-defocused donut survives the subtraction and forms a candidate
+instead of being erased. Tested via two new **`diagnose-labels`** switches (`--defocus-structure` / `--structure-boost`,
+plus a diagnostic `--structure-layers` override) on **Panos** `attempt01` (labeled near-focus frame @ **32396** and
+donut frame @ **44396**). The profile (`AA1600MM`) has since drifted to *post-optimization* settings
+(`Sensitivity`=15.67, `StructureLayers`=5 — the F3 path), so the baseline `StructureLayers` is pinned to the factory
+**4** (where the gap is open) to isolate the mechanism.
+
+| Config (SL=4 baseline + flag) | near-focus @32396 acc/rej | donut @44396 acc/rej | missed `NO CANDIDATE` |
+|---|---|---|---|
+| baseline (flag OFF) | 182 / 778 | 0 / 240 | **4** / 5 |
+| `DefocusAwareStructure` ON, **boost 0** (control) | 182 / 778 | 0 / 240 | 4 / 5 |
+| `DefocusAwareStructure` ON, **boost 1** (eff. 5) | 202 / 803 | 0 / 333 | **2** / 5 |
+| `DefocusAwareStructure` ON, **boost 2** (eff. 6) | 197 / 821 | 1 / 435 | 2 / 5 |
+| `DefocusAwareStructure` ON, **boost 3** (eff. 7) | 204 / 811 | 1 / 450 | 2 / 5 |
+| (cross-check) `StructureLayers`=5 global, flag OFF | 204 / 679 | 0 / 259 | 2 / 5 |
+
+### Findings
+
+- **Bit-identical OFF — proven, not just asserted.** `DefocusAwareStructure=ON` with **boost 0** is *byte-identical*
+  to the flag OFF (182/778, 0/240, same 4 `NO CANDIDATE`): `Math.Max(1, StructureLayers + 0) == StructureLayers`, so
+  the wavelet depth is unchanged. Default-OFF detection is unaffected.
+- **The mechanism works — it recovers the structure-gap *donuts*.** boost 1 drops `NO CANDIDATE` from **4 → 2**: the
+  two recovered boxes are exactly the **large donuts** at @44396 (label boxes **47×50** and **47×43** px) — they go
+  from forming no candidate to forming one. The two *unrecoverable* boxes are the faint **near-focus** stars at @32396
+  (12×12 px): a **sensitivity floor**, not a structure erasure — coarser large-structure removal can't and shouldn't
+  resurrect them. (So the F2/F3 "4/5 structure gap" was really **2 structure-recoverable donuts + 2 faint-star floor**.)
+- **Recovery is necessary but not sufficient for end-to-end recall.** The recovered donut forms only a **thin ring
+  fragment** (measured 3–4 px vs the `TooSmall` threshold 6), so it is admitted as a candidate but then re-rejected
+  (`TooSmall`), and the donut-frame ACCEPTED count stays 0–1. Structure boost is **complementary** to the gates: it
+  moves a star from "no candidate at all" into the gate pipeline, where `DefocusAwareGates` (+ a lower `TooSmall`/
+  `Sensitivity`) would have to finish the job. On its own it adds no accepted stars on Panos.
+- **boost 1 is the sweet spot; higher adds churn, not recall.** boost 2/3 recover **no additional** donuts (still 2
+  `NO CANDIDATE`) while inflating the donut-frame candidate pool (333 → 435 → 450) and perturbing the near-focus
+  frame more — i.e. more work, more junk to backstop, no extra real stars.
+- **Near-focus cost is modest, not a flood.** Turning the flag on is a *global* depth change (not per-star), so
+  near-focus is **not** bit-identical when ON: @32396 accepted moves 182 → 202 (+11%) and rejected 778 → 803. That
+  is a real but contained change (the other gates backstop the extra candidates), nowhere near a flood. This is why
+  the flag is correctly **opt-in / default-OFF**.
+- **Relation to the optimizer's global path.** Raising `StructureLayers` to 5 *globally* (the F3 optimizer path, now
+  baked into the profile) reaches the same `2/5 NO CANDIDATE` for the donut frame, because the residual is computed at
+  5 layers either way; the only difference is the post-wavelet blur radius (boost keeps it at the nominal 4 ⇒ a few
+  more small candidates: 803 vs 679 near-focus rejected). So `StructureLayerBoost` is **not** a more-targeted relaxation
+  than `StructureLayers↑` — both are global — it just decouples the residual depth from the blur radius.
+
+**Recommendation.** Keep **default-OFF** (correct as shipped). For users whose heavily-defocused frames *lose donut
+stars entirely* (not merely reject them), `DefocusAwareStructure` + `StructureLayerBoost`=**1** is the effective
+setting — it reopens the structure gap for large donuts — but it should be paired with `DefocusAwareGates` and a
+modestly lower `TooSmall`/`Sensitivity` to carry the recovered fragments through to ACCEPTED; boost > 1 is not worth
+it. The remaining faint near-focus `NO CANDIDATE` misses are a sensitivity floor, outside this feature's reach. The
+new `diagnose-labels --defocus-structure/--structure-boost/--structure-layers` switches make this re-runnable on any
+labeled setup.
+
+### Still open (G1 — precision penalty, deferred)
+
+The `SDefocusPrecision` near-focus precision penalty (F3) and its constants remain **exercised only by unit tests** —
+no `should-reject` (false-positive) labels exist yet, on Panos or any setup, so the penalty has never *bitten* on real
+data and its constants (`NearFocusWindowSteps`=1.5, `DefocusPrecisionThreshold`=0.20, `DefocusPrecisionStrength`=0.5,
+`DefocusPrecisionMinFactor`=0.5) are untuned-against-data. Closing this needs a near-focus-heavy setup labeled with
+`should-reject` boxes (click an **accepted** star in `TestApp review` or the in-wizard review); then
+`optimize --labels` should show the labeled loop improves recall *without* tanking precision and the penalty bites
+when relaxation admits near-focus junk. Deferred to a future session pending those labels.

--- a/docs/star-detection-optimizer-performance-design.md
+++ b/docs/star-detection-optimizer-performance-design.md
@@ -10,6 +10,15 @@ uses an equivalent `MatSplitFrameDetector`). The §7 logging quick-win shipped t
 dominates). The wizard per-eval convert-reuse (#1) remains DEFERRED (see §7). The analysis below is
 retained as the rationale; the "ranked recommendations" reflect what shipped vs. what is left.
 
+> **Important caveat — the 10–13× is conditional on the search staying late-only (see §8).** The single-context
+> per-frame cache holds **one** early context per frame, so an *early-axis* compass probe both rebuilds for the
+> probe **and evicts the incumbent**. With the original single-loop Phase B re-probing all 5 early axes every sweep,
+> ~46% of detections were forced full rebuilds on big sensors and runtime ballooned to ~25× the headline. **This was
+> fixed (T14, commit `a765c9a`) by staging Phase B late→early** so late refinement runs entirely on cache hits and
+> early axes are probed in one bounded, latched stage — restoring near-100% cache reuse (measured 99.3% on muggsie,
+> 150 evals). §8 documents the diagnosis, the fix, and why the further-headroom options (multi-context LRU / early-axis
+> early-stop) are now largely moot.
+
 Scope: the Star Detection Optimization wizard and its offline harness (`TestApp optimize`).
 Goal: explain where wall-clock time goes and lay out the highest-leverage speedups, separating
 safe "pure performance" wins (must stay bit-identical) from larger refactors.
@@ -308,3 +317,76 @@ already has to make the cached source Mat read-only and key it on the EARLY para
 params). Per the "bit-identical safety beats the speedup" rule, this is left to that refactor. The harness
 (`OptimizationDiagnosticRunner.PrepareRunAsync`) already pre-converts each frame to a float Mat once and clones
 per eval, so it pays no per-eval conversion cost regardless.
+
+## 8. Cache-thrashing caveat, the staged Phase-B fix (T14), and what headroom remains (G5)
+
+The §3/§7 single-context-per-frame cache delivers the headline 10–13× **only while the compass search stays on
+late-only moves**. Each EARLY-axis probe (one of the 5 wavelet/structure params) both rebuilds the per-frame
+context for the probe **and evicts the incumbent's context**, so with the original un-staged Phase B — which
+re-probed all 5 early axes on *every* sweep — ~46% of detections on a big sensor were forced full early rebuilds
+(~1.65 s/frame vs ~53 ms for a late gate), ballooning runtime to ~25× the headline. (Full diagnosis: the results
+doc, *Cache-health investigation (T12b)*.)
+
+### The fix that shipped — T14 staged Phase B (option A)
+
+`StarDetectionOptimizer.PatternSearch` now **stages** the compass (commit `a765c9a`). The curated axes are
+partitioned — via the single source of truth `StarDetector.IsEarlyCacheKeyParameter` — into LATE (cache-hit-cheap)
+and EARLY (rebuild+evict). Each round refines the LATE axes to their step floor *first*, with the early params
+pinned (so every late probe is a per-frame cache hit), then runs **one** bounded EARLY stage; the early stage is
+**latched off** (`earlyExhausted`) once it stops paying off, so the 5 early axes are not re-probed indefinitely.
+The search stays deterministic and never-regress (staging changes visit order, not the reachable set).
+
+**Measured (this session, instrumented — `RunEvaluationData.ContextBuilds`/`ContextReuses`, `--max-evals 150`):**
+
+| Run | early-context builds | reuses | reuse % | wall |
+|---|---|---|---|---|
+| muggsie (9 frames, already-good seed) | **9** (= 1/frame, the floor) | 1341 | **99.3%** | 17.9 s |
+| toml999 (9 frames, already-good) | **9** | 1341 | 99.3% | 40.1 s |
+| Panos (9 frames, *labeled*, seed J=0 ⇒ heavy early-axis recall search) | 343 | 707 | 67.3% | 324 s |
+
+So on a normal/unlabeled run T14 drives builds to the **irreducible minimum** (one per frame for the seed) — the
+pre-T14 46%-rebuild thrash is gone. Builds only reappear when the objective genuinely *needs* early-axis search
+(the labeled Panos recall-recovery case explores `StructureLayers`/`NoiseClipping`), and even there 2/3 of
+detections are cache hits.
+
+### Why options B and C are now largely moot
+
+The T12b note ranked three scoped fixes. **A (staged Phase B) shipped and captured the win.** The other two were
+*alternatives* to A, and stacking them on top now buys little:
+
+- **(B) bounded multi-context LRU per frame** — would only save the *re-build of the incumbent's* early context on
+  an early→late transition. At 99.3% reuse there is nothing to save on normal runs; on Panos it could reclaim a
+  fraction of the 343 builds (most of which are genuinely-new early keys the search must build regardless), at the
+  cost of the ~6.6 GB-at-61 MP memory-budget machinery. Poor value post-T14.
+- **(C) early-stop early-axis probing** — T14's `earlyExhausted` latch already *is* an early-axis early-stop
+  (it trips when an early stage yields zero gain).
+
+### A convergence early-stop was investigated and rejected (G5)
+
+Post-T14 the residual wall-clock is **not** cache thrash; it is the search spending its eval budget where the
+per-move gains have gone small. The natural next lever is a *convergence early-stop* — stop (or latch the early
+axes off) once a round/stage improves J by ≤ some tolerance, generalizing `earlyExhausted` from "zero gain" to
+"≤ tolerance gain". It was prototyped (opt-in, default 0 ⇒ bit-identical) and **measured against the bank, where it
+produced no benefit at any tested tolerance, so it was not shipped.** The reason is structural: on these runs the
+optimizer **never converges before the eval budget** — it keeps finding strictly-improving (if marginal) moves, so
+no round or early-stage gain ever falls to ≤ tolerance before the cap. Two illustrative measurements:
+
+| Run | `--max-evals` | tol = 0 | tol = 0.001 | tol = 0.005 |
+|---|---|---|---|---|
+| Panos (labeled, heavy early search) | 150 | 315 s / 343 builds / J 0.928964 | 311 s / 343 builds (identical) | 315 s / 343 builds (identical) |
+| muggsie (wizard-default budget) | 400 | 129 s / 522 builds / J 0.998677 | 127 s / 522 builds (identical) | — (≤ 0.0001 also identical) |
+
+(An *early prototype* that instead trimmed the cheap LATE halving tail actively **back-fired** — breaking the late
+stage hands control to the EXPENSIVE early stage more often, ballooning muggsie to 113 s / 585 builds — confirming
+the late tail is cache-cheap and must not be trimmed.) **Conclusion: T14 already captured the optimizer-perf win;
+the only further lever that *would* cut wall-clock is lowering the eval budget (§5/§6.2) — e.g. muggsie is 129 s at
+400 evals vs 17.9 s at 150 evals for a J cost of only 0.0023 — but that is a search-quality default decision, left
+to the user, not a bit-identical perf change.**
+
+### What G5 *did* ship — cache instrumentation
+
+`RunEvaluationData` now exposes `ContextBuilds` / `ContextReuses` (Interlocked counters over the early-context
+cache), and the `optimize` runner prints a per-run readout: `Optimize phase: … s wall, early-context builds=…,
+reuses=… (… % reuse of … frame detections)`. This is what made the analysis above measurable and is a permanent
+**cache-health regression guard** — if a future change reintroduces early-context thrash, the reuse % drops
+visibly (a healthy normal run is ~99% reuse; the pre-T14 thrash was ~54%).

--- a/plans/star-detection-followups-2-plan.md
+++ b/plans/star-detection-followups-2-plan.md
@@ -1,0 +1,144 @@
+# Star Detection Optimizer — Follow-ups (Round 2) Plan
+
+**Context.** PR #56 (`ghilios/star-detection-followups`) is merged to `develop` (merge `60dc0ba`). It shipped the
+9 wizard/labeling feedback items + F1/F2/F3/F5, a ~6.7× optimizer speedup (staged Phase-B search), and reverted
+F6 (a verified wash). This round captures everything **deferred or left unvalidated** by that PR. Empirical
+record: `docs/star-detection-optimization-wizard-results.md` (F2/F3/F6 + cache-health notes). Round-1 plan:
+`plans/star-detection-followups-plan.md` (with its "Execution status (final)" section).
+
+**Branch:** create `ghilios/<topic>` off `develop` per item (or one branch for the A-items, which are coupled).
+Never push `develop` directly; PR to merge. **Commit identity:** `George Hilios
+<322725+ghilios@users.noreply.github.com>` (author + committer), per CLAUDE.md.
+**After each task:** `cmd.exe /c "dotnet build Joko.NINA.Plugins\Joko.NINA.Plugins.sln -c Debug --nologo"` +
+`dotnet test ... -c Debug`; fix root causes. New detector behavior stays **opt-in / default-OFF ⇒ detection
+star counts AND objective `J` bit-identical when disabled** (unit-test against an independent re-impl, as F3 did).
+
+**Tooling already in place.** `TestApp` harnesses (`optimize` / `review` / `diagnose-labels`) drive the same
+optimizer the wizard uses; AF-runs bank at `D:\Autofocus Bank` (attempt-anchored; **Panos** has ground-truth
+labels at `Panos\labels`; the user's live NINA profile copies live on `E:\WorkshopData\...`). Build TestApp:
+`cmd.exe /c "dotnet build Joko.NINA.Plugins\TestApp\TestApp.csproj -c Debug --nologo"`; exe at
+`./Joko.NINA.Plugins/TestApp/bin/Debug/net8.0-windows7.0/TestApp.exe`.
+
+> **Known facts to carry in (from PR #56's empirical work):**
+> - The defocus gate (`DefocusAwareGates`) is now a curated optimizer variable, BUT on Panos the optimizer
+>   recovered recall via `Sensitivity`↓ + `StructureLayers`↑ and **left the gate OFF** — so the gate's real
+>   utility and the F3 precision penalty (`SDefocusPrecision`) are **unit-tested only, never triggered on data**.
+> - Panos labels are all `wrongly-rejected` (recall); there are **no `should-reject` (precision) labels** yet,
+>   so the precision side of the objective is unexercised.
+> - 4/5 flagged Panos donut misses are **NO CANDIDATE** structure gaps (no candidate forms) — not fixable by
+>   any gate; needs detector-algorithm work.
+> - **Wizard-saved labels are keyed by the sanitized ABSOLUTE run path** (e.g.
+>   `E__WorkshopData_..._attempt01.json` under `<attemptFolder>\labels\`), so offline `optimize --labels`
+>   against a different-path copy of the same run **will not auto-match** them (the in-wizard re-optimize is
+>   fine — it uses in-memory labels). See G3.
+
+---
+
+## Priority A — quality work that changes detection/optimization (do these together; they share data needs)
+
+### G1 — Precision validation + penalty tuning with `should-reject` labels (closes out F3)
+F3's `SDefocusPrecision` near-focus penalty + the `DefocusAwareGates` curated variable are merged but **never
+exercised on real data** (gate not selected on Panos; no `should-reject` labels exist). Goal: prove the
+gate+penalty do something useful, and tune the constants against data.
+- **Data:** label `should-reject` (false positives) on a near-focus-heavy setup (and/or a setup where the
+  defocus relaxation IS the cleanest path to donuts) — e.g. open `TestApp review` (mode-less: click an
+  **accepted** star to flag should-reject) or the in-wizard review, on a 2nd setup beyond Panos.
+- **Verify:** `optimize --labels` shows the labeled loop improves recall *without tanking precision*; confirm
+  the penalty actually bites when relaxation admits near-focus junk; the unlabeled path stays bit-identical.
+- **Tune:** `OptimizationObjective.ObjectiveConstants.{NearFocusWindowSteps (1.5), DefocusPrecisionThreshold
+  (0.20), DefocusPrecisionStrength (0.5), DefocusPrecisionMinFactor (0.5)}` — conservative defaults today.
+- **Files:** `OptimizationObjective.cs`, `RunEvaluationData.cs` (per-frame relaxed counts/positions), the
+  `review`/`diagnose-labels` harnesses. **Deliverable:** results note appended to the results doc.
+
+### G2 — Structure-detection for NO-CANDIDATE dim/donut misses (F4 + #5)
+The unsolved core: ~4/5 flagged Panos donut misses never form a candidate (donut flux removed by the à-trous
+wavelet residual subtraction). Investigate a **defocus-aware `StructureLayers` increase** (#5: more/larger
+wavelet scales survive larger structures; `StructureLayers` is an early-cache param + sets the post-wavelet
+blur radius) and/or multi-scale handling. **Prototype opt-in / default-OFF.**
+- **Verify:** `diagnose-labels` on Panos shows previously `NO CANDIDATE` boxes become candidates **without**
+  exploding the near-focus candidate count; default-OFF stays bit-identical.
+- **Files:** `StarDetector.cs` (wavelet/candidate path ~`ComputeResidualAtrousB3SplineDyadicWaveletLayer`,
+  `CollectStarCandidates`, the early cache-key allow-list), `CvImageUtility.cs` (B3-spline filters). Exploratory
+  — scope a spike first; likely its own PR. Pairs naturally with G1 (both want labeled Panos/2nd-setup data).
+
+---
+
+## Priority B — UX polish (small, surfaced by real use)
+
+### G3 — Wizard label-save UX: surface the path + stable run key
+Two sub-items found when labels were hard to locate after a real review:
+1. **Surface the save location in the wizard** (the path is only in the NINA log today). After review/save,
+   show "Labels saved to …" (ideally an open-folder affordance) in the Review/Summary step.
+2. **Use a stable, non-absolute run key + cleaner filename.** Today `StarReviewLabelStore.FileNameFor` sanitizes
+   the **absolute** run path → `E__WorkshopData_..._attempt01.json`, so offline `optimize --labels` against a
+   different-path copy won't match (the embedded `runId` is the absolute path too). Pick a stable run identity
+   (relative-to-runs-root, or a short hash, consistent between the wizard loader and `OptimizationRunDiscovery`)
+   so the wizard's labels and the offline harness agree.
+- **Files:** `StarDetectionOptimizerWizardVM.cs` (`DeriveLabelsDir`, the review-step VM/XAML), `Review/
+  StarReviewLabels.cs` (`FileNameFor`/`Save`/`Load`), `RunEvaluationLoader.cs` (runId derivation),
+  `OptimizationRunDiscovery.cs` (offline runId). **Keep the label JSON shape compatible** with existing files.
+
+---
+
+## Priority C — verify shipped-but-unconfirmed behavior (verification, fix only if off)
+
+### G4 — Live-NINA verification of the bits not exercised in PR #56's manual pass
+Confirmed already: #6 (wizard renders), #7 (embedded review), #9 (Accept applies). **Still unconfirmed:**
+- **#8 re-optimize loop** — run review → "Re-optimize with my feedback" → updated Summary → Accept, end to end.
+- **#3 imaging-pane button** — confirm the launch button appears + works from the *Imaging-tab* Star Detection
+  Options dock (not just the Options page).
+- **#1/#2 in the standalone `TestApp review`** dev tool (mode-less click + dashed markers; same shared control).
+- **Wizard "Live" source mode** — running a fresh AF sweep instead of replay is hardware-dependent and was built
+  "minimal, manually verified later"; never exercised. (`StarDetectionOptimizerWizardVM.RunLiveAttemptAsync`.)
+Fix anything that's off; otherwise just check the boxes.
+
+---
+
+## Priority D — optional
+
+### G5 — Optimizer perf: remaining headroom (only if optimize is still too slow on the biggest sensors)
+T14 (staged search) got ~6.7×. Further levers documented in the cache-health note: **Option B** (bounded
+multi-context LRU per frame — ~2×, bit-identical, but ~6.6 GB peak at 61 MP → needs a memory-budget guard);
+**Option C** (early-stop early-axis probing). Also: the staged search's early-stop is a one-way latch (a
+deliberate speed/quality trade) and its trajectory differs slightly from pre-T14 — revisit if quality matters.
+**Files:** `StarDetectionOptimizer.cs` (staged `PatternSearch`), `RunEvaluationData.cs` (the per-frame context
+cache), `StarDetector.cs` (`BuildDetectionContext`).
+
+### G6 — Doc sync (minor)
+`docs/star-detection-optimizer-performance-design.md` still describes the original 10–13× cache story; add the
+staged-search fix + the early-probe-thrash caveat (the results doc + CLAUDE.md are already current).
+
+---
+
+## Suggested order & checkpoints
+**G1 + G2 together** (one branch, or G1 first then G2) — the substantive next PR; both need labeled data, and
+G1 should checkpoint before any objective-constant change ships. → **G3** (quick UX win, own PR) → **G4**
+(verification, fold fixes into whichever PR is open) → **G5/G6** as time permits. Global: full `dotnet test`
+green; default-OFF ⇒ bit-identical; PR each to `develop`.
+
+---
+
+## Execution status (2026-06-16, branch `ghilios/sd-followups2-g2-g6`)
+
+**Key correction:** most of this plan's *code* had already shipped in PR #61 (`8e5124c`) + T14 (`a765c9a`),
+which landed after the plan was written — verified against the code, not assumed. This session (user-selected
+scope: G2 validation, G6 doc sync, G5 perf; G1 deferred) did:
+
+- **G2 — DONE (validation).** The `DefocusAwareStructure`/`StructureLayerBoost` mechanism was already coded; this
+  session validated it on Panos via new `diagnose-labels --defocus-structure/--structure-boost/--structure-layers`
+  switches. Result: boost=1 recovers the 2 large NO-CANDIDATE *donuts* → candidates (then `TooSmall` fragments);
+  the 2 remaining NO-CANDIDATE boxes are a **faint near-focus floor** (not structure-erased); bit-identical OFF
+  proven (boost=0 ≡ baseline); boost=1 is the sweet spot; default-OFF correct. Complementary to gates, not
+  sufficient alone. Written up in `docs/star-detection-optimization-wizard-results.md` (§ "G2 — Structure-boost
+  validation").
+- **G5 — partial (instrumentation shipped; B/C + early-stop rejected on evidence).** Added cache instrumentation
+  (`RunEvaluationData.ContextBuilds/ContextReuses` + `optimize` runner readout). Measured: T14 already drives
+  normal runs to **99.3% reuse / 9 builds (the floor)** ⇒ **Options B and C are moot**. A convergence early-stop
+  was prototyped + unit-tested but measured **no benefit** on any bank run/budget/tolerance (the runs never
+  converge before the eval budget) ⇒ **reverted, not shipped**. The only further lever is lowering the eval
+  budget (a quality default decision, left to the user). See `docs/star-detection-optimizer-performance-design.md`
+  § 8.
+- **G6 — DONE.** `performance-design.md` § 8 + Status caveat: T12b cache-thrash → T14 staged-search fix → measured
+  reuse → B/C moot → early-stop rejected → instrumentation.
+- **G1 — DEFERRED** (needs `should-reject`/false-positive labels that don't exist; documented in the results doc).
+- **G3 part-1 (wizard "Labels saved to…" surface) and G4 (live-NINA verification)** — not selected this session.


### PR DESCRIPTION
Round-2 follow-ups (`plans/star-detection-followups-2-plan.md`). **Most of the plan's code had already shipped in PR #61 (`8e5124c`) + T14 (`a765c9a`)**, which landed after the plan was written, so the real remaining work was validation, instrumentation, and docs. Detection and the objective stay **bit-identical** — this is dev-tooling + instrumentation + docs only.

## G2 — validate the already-shipped `DefocusAwareStructure` / `StructureLayerBoost`
Added `diagnose-labels --defocus-structure / --structure-boost / --structure-layers` switches (dev-tool only, profile read-only, mirroring the existing defocus-gate switches) and ran a controlled A/B on Panos:
- `StructureLayerBoost=1` recovers the **2 large NO-CANDIDATE donuts** (47 px label boxes) into candidates (then `TooSmall` fragments). So the F2/F3 "4/5 missed = structure gap" is really **2 structure-recoverable donuts + 2 faint near-focus-floor stars** (12 px, not structure-erased).
- **Bit-identical OFF proven** empirically: `--structure-boost 0` ≡ flag-OFF baseline (182/778, 0/240, 4 NO-CANDIDATE).
- `boost>1` recovers no more donuts and adds churn ⇒ **boost=1 is the sweet spot**; structure boost is complementary to the gates, not sufficient alone (the recovered donut is a thin ring fragment). **Default-OFF is correct.**
- Results: `docs/star-detection-optimization-wizard-results.md` § "G2 — Structure-boost validation".

## G5 — optimizer perf headroom (measured, then evidence-based call)
- Added early-context cache instrumentation: `RunEvaluationData.ContextBuilds` / `ContextReuses` + an `optimize` runner readout (`… s wall, early-context builds=…, reuses=… (… % reuse)`).
- Measurement shows **T14's staged search already drives normal runs to 99.3 % reuse / 9 builds (the per-frame floor)** ⇒ the T12b **Options B (multi-context LRU) and C (early-axis early-stop) are moot**.
- A convergence early-stop was prototyped + unit-tested but **measured no benefit on any bank run / budget / tolerance** (these runs never converge before the eval budget — they keep finding marginal strictly-improving moves), so it was **reverted, not shipped**. Only the validated instrumentation lands here.

## G6 — doc sync
`docs/star-detection-optimizer-performance-design.md` § 8 + Status caveat: T12b cache-thrash → T14 staged-Phase-B fix → measured reuse → why B/C/early-stop add nothing further.

## Deferred / not in scope
- **G1** (precision-penalty validation/tuning): needs `should-reject`/false-positive labels that don't exist yet — documented in the results doc.
- **G3 part-1** (wizard "Labels saved to…" surface) and **G4** (live-NINA verification): not selected this session.

## Before/after runtime (optimizer perf, for context)
| Optimization | Run | Before | After | Speedup |
|---|---|---|---|---|
| early/late split + parallel detect (shipped earlier) | CWhite 61 MP, 24 evals | 19m51s | 1m30s | 13.2× |
| | Panos, 24 evals | 7m02s | 44s | 9.6× |
| T14 staged Phase-B (re-measured here) | muggsie, 150 evals | 143s | 17.9s | 8.0× (builds 621→9, reuse 54%→99.3%) |

## Testing
`dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug` → **1251 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)