### PR TITLE
Fix star-review box placement; resolve bundled ScottPlot under NINA 3.3.0

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarReviewTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarReviewTests.cs
@@ -369,6 +369,99 @@ public class StarReviewTests {
         }
     }
 
+    // ---- Accepted-star overlay: centroid crosshair hidden by default; the box stays the detector's bounds -----
+
+    [Test]
+    public void AcceptedOverlay_CentroidCrosshairsHiddenByDefault_BoxStillRendered() {
+        // The centroid crosshair is a dev-only overlay (ShowCentroidMarkers, off by default) so the labeler isn't
+        // cluttered. With it off, no centroid markers are populated, while the accepted box is still drawn at the
+        // detector's StarBoundingBox (top-left + size).
+        var box = new Rect(100, 100, 20, 20);
+        var review = new FrameReview {
+            RunId = "run1",
+            FocuserPosition = 5000,
+            FramePath = "frame.fits",
+            ImageProvider = null, // no UI/image needed: markers populate synchronously in the ctor's LoadCurrent
+            Accepted = new List<(double, double, double, Rect)> { (103.0, 117.0, 2.34, box) },
+        };
+        var labelsByRun = new Dictionary<string, StarReviewRunLabels> {
+            { "run1", new StarReviewRunLabels { RunId = "run1" } }
+        };
+
+        var vm = new StarReviewVM(new[] { review }, labelsByRun, labelsDir: string.Empty);
+
+        Assert.Multiple(() => {
+            // Crosshair overlay hidden by default → no centroid markers.
+            Assert.That(vm.CentroidMarkers, Is.Empty);
+            // The accepted box is still the detector's StarBoundingBox (top-left + size), not recentered.
+            Assert.That(vm.AcceptedMarkers, Has.Count.EqualTo(1));
+            Assert.That(vm.AcceptedMarkers[0].X, Is.EqualTo(box.X));
+            Assert.That(vm.AcceptedMarkers[0].Y, Is.EqualTo(box.Y));
+            Assert.That(vm.AcceptedMarkers[0].Width, Is.EqualTo(box.Width));
+            Assert.That(vm.AcceptedMarkers[0].Height, Is.EqualTo(box.Height));
+        });
+    }
+
+    // The reported "box is off" bug: the green ACCEPTED box renders OFFSET from its star. The box Rectangle lives
+    // in a Grid alongside the (wider) HFR TextBlock; with no explicit alignment the Rectangle defaults to Stretch,
+    // which WPF resolves to CENTER for a fixed-size child — so when the HFR label is larger than a small box, the
+    // Rectangle is displaced from the box's true top-left. Detection is fine (the accepted-star centering gate
+    // guarantees Center is inside StarBoundingBox); this is purely a XAML layout bug. With no image loaded the
+    // viewport stays Scale=1/Offset=0 (identity overlay transform), so the rendered Rectangle top-left, in
+    // ViewportCanvas coords, must equal the box's image coords.
+    [Test]
+    [Apartment(System.Threading.ApartmentState.STA)]
+    public void AcceptedBox_RendersAtBoundingBoxOrigin_NotDisplacedByHfrLabel() {
+        var box = new Rect(100, 100, 10, 10); // small box, smaller than the "3.56" HFR label's layout size
+        var review = new FrameReview {
+            RunId = "run1", FocuserPosition = 5000, FramePath = "f.fits",
+            ImageProvider = null, // no image: viewport stays identity (Scale=1, Offset=0)
+            Accepted = new List<(double, double, double, Rect)> { (104.0, 108.0, 3.56, box) },
+        };
+        var labelsByRun = new Dictionary<string, StarReviewRunLabels> { { "run1", new StarReviewRunLabels { RunId = "run1" } } };
+        var vm = new StarReviewVM(new[] { review }, labelsByRun, string.Empty);
+
+        var control = new StarReviewControl { DataContext = vm };
+        control.Measure(new System.Windows.Size(1000, 800));
+        control.Arrange(new System.Windows.Rect(0, 0, 1000, 800));
+        control.UpdateLayout();
+
+        var viewportCanvas = VisualDescendants<System.Windows.Controls.Canvas>(control)
+            .FirstOrDefault(c => c.Name == "ViewportCanvas");
+        Assert.That(viewportCanvas, Is.Not.Null, "ViewportCanvas not found in the visual tree");
+
+        // The only 10x10 Rectangle is the accepted box (rejected/should-reject/missed lists are empty; legend
+        // swatches are 20x12; the rubber-band DragRect is collapsed/zero-size).
+        var rect = VisualDescendants<System.Windows.Shapes.Rectangle>(viewportCanvas)
+            .FirstOrDefault(r => Math.Abs(r.Width - box.Width) < 0.01 && Math.Abs(r.Height - box.Height) < 0.01);
+        Assert.That(rect, Is.Not.Null, "accepted box Rectangle not realized in the overlay");
+
+        var topLeft = rect.TransformToAncestor(viewportCanvas).Transform(new System.Windows.Point(0, 0));
+        Assert.Multiple(() => {
+            Assert.That(topLeft.X, Is.EqualTo(box.X).Within(0.5),
+                "accepted box X displaced from StarBoundingBox.X by the HFR-label Grid layout");
+            Assert.That(topLeft.Y, Is.EqualTo(box.Y).Within(0.5),
+                "accepted box Y displaced from StarBoundingBox.Y by the HFR-label Grid layout");
+        });
+    }
+
+    private static IEnumerable<T> VisualDescendants<T>(System.Windows.DependencyObject root)
+        where T : System.Windows.DependencyObject {
+        if (root == null) {
+            yield break;
+        }
+        var count = System.Windows.Media.VisualTreeHelper.GetChildrenCount(root);
+        for (var i = 0; i < count; i++) {
+            var child = System.Windows.Media.VisualTreeHelper.GetChild(root, i);
+            if (child is T match) {
+                yield return match;
+            }
+            foreach (var d in VisualDescendants<T>(child)) {
+                yield return d;
+            }
+        }
+    }
+
     // ---- Review queue -------------------------------------------------------------------------------------
 
     private static List<StarReviewFrame> Frames(params (string run, int pos, int accepted)[] specs) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/BundledAssemblyResolverTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/BundledAssemblyResolverTests.cs
@@ -1,0 +1,78 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.IO;
+using NUnit.Framework;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Utility;
+
+[TestFixture]
+public class BundledAssemblyResolverTests {
+
+    private const string PluginDir = @"C:\Users\me\AppData\Local\NINA\Plugins\3.0.0\Hocus Focus";
+
+    [Test]
+    public void ResolveBundledAssemblyPath_BundledAssembly_ReturnsDllPathInPluginDir() {
+        // The exact failing request from the NINA log: ScottPlot.WPF with culture + public key token, no Version.
+        const string request = "ScottPlot.WPF, Culture=neutral, PublicKeyToken=e53b06131e34a3aa";
+        var expected = Path.Combine(PluginDir, "ScottPlot.WPF.dll");
+
+        var path = BundledAssemblyResolver.ResolveBundledAssemblyPath(PluginDir, request, p => p == expected);
+
+        Assert.That(path, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ResolveBundledAssemblyPath_FullySpecifiedName_UsesSimpleNamePlusDll() {
+        const string request = "ScottPlot, Version=4.1.59.0, Culture=neutral, PublicKeyToken=e53b06131e34a3aa";
+        var expected = Path.Combine(PluginDir, "ScottPlot.dll");
+
+        var path = BundledAssemblyResolver.ResolveBundledAssemblyPath(PluginDir, request, p => p == expected);
+
+        Assert.That(path, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ResolveBundledAssemblyPath_NotBundled_ReturnsNull() {
+        // A framework/NINA-provided assembly that is NOT in the plugin folder must defer (null) to default resolution.
+        var path = BundledAssemblyResolver.ResolveBundledAssemblyPath(
+            PluginDir, "System.Drawing.Common, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51", _ => false);
+
+        Assert.That(path, Is.Null);
+    }
+
+    [Test]
+    public void ResolveBundledAssemblyPath_ResourceSatelliteAssembly_DefersWhenAbsent() {
+        // Satellite resource probes (e.g. "ScottPlot.WPF.resources") must not resolve to the main DLL.
+        var probed = (string)null;
+        var path = BundledAssemblyResolver.ResolveBundledAssemblyPath(
+            PluginDir, "ScottPlot.WPF.resources, Culture=de, PublicKeyToken=e53b06131e34a3aa",
+            p => { probed = p; return false; });
+
+        Assert.Multiple(() => {
+            Assert.That(path, Is.Null);
+            Assert.That(probed, Is.EqualTo(Path.Combine(PluginDir, "ScottPlot.WPF.resources.dll")));
+        });
+    }
+
+    [Test]
+    public void ResolveBundledAssemblyPath_GarbledOrEmptyInputs_ReturnNull() {
+        Assert.Multiple(() => {
+            Assert.That(BundledAssemblyResolver.ResolveBundledAssemblyPath(PluginDir, "", p => true), Is.Null);
+            Assert.That(BundledAssemblyResolver.ResolveBundledAssemblyPath(PluginDir, null, p => true), Is.Null);
+            Assert.That(BundledAssemblyResolver.ResolveBundledAssemblyPath("", "ScottPlot.WPF", p => true), Is.Null);
+            Assert.That(BundledAssemblyResolver.ResolveBundledAssemblyPath(PluginDir, "ScottPlot.WPF", null), Is.Null);
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/HocusFocusPlugin.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/HocusFocusPlugin.cs
@@ -58,6 +58,16 @@ namespace NINA.Joko.Plugins.HocusFocus {
         // is instantiated directly here, mirroring RunAberrationInspector.
         private readonly IWindowServiceFactory windowServiceFactory = new WindowServiceFactory();
 
+        static HocusFocusPlugin() {
+            // NINA does not ship ScottPlot, so the plugin's bundled ScottPlot(.WPF) DLLs live only in the plugin
+            // folder — which is not on the default assembly probing path. WPF/BAML loads a view's xmlns assemblies on
+            // demand, and without this resolver that load fails (FileNotFoundException -> XamlParseException), so views
+            // with ScottPlot charts (e.g. the Star Detection Optimization Wizard) fail to render — the window just
+            // flashes. Registering here (static ctor: runs the moment the plugin type is first touched at MEF
+            // discovery, before any view is shown) makes those bundled-dependency loads resolve from the plugin folder.
+            BundledAssemblyResolver.Register(Path.GetDirectoryName(Assembly.GetAssembly(typeof(HocusFocusPlugin))?.Location));
+        }
+
         [ImportingConstructor]
         public HocusFocusPlugin(
             IProfileService profileService,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -199,7 +199,12 @@
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Grid>
+                                <!-- Pin the box to the Grid's top-left. Without this, the Rectangle's default
+                                     Stretch alignment (resolved to Center for a fixed-size child) lets the wider
+                                     HFR TextBlock sibling enlarge the Grid and push the box off its true
+                                     (StarBoundingBox.X, StarBoundingBox.Y) origin. -->
                                 <Rectangle Width="{Binding Width}" Height="{Binding Height}"
+                                           HorizontalAlignment="Left" VerticalAlignment="Top"
                                            Stroke="{Binding DataContext.AcceptedBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                            StrokeThickness="{Binding DataContext.MarkerStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
                                 <!-- HFR label: anchored at the box top-left, kept a constant on-screen size by the
@@ -223,6 +228,45 @@
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
 
+                <!-- Accepted-star measured centroid (the detector's flux-weighted Center) — a small green crosshair
+                     drawn ON TOP of the box so the marker tracks the actual star even when the structure bounding
+                     box above is larger than / off-center from the bright core. Placed at the centroid in image
+                     coords; kept a constant on-screen size by the inverse-zoom MarkerTextScale (like the HFR text).
+                     The Canvas root lets the crosshair's geometry origin (0,0) render exactly at the container
+                     point — a Canvas does not offset its children by their geometry bounds. -->
+                <ItemsControl ItemsSource="{Binding CentroidMarkers}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemContainerStyle>
+                        <Style TargetType="ContentPresenter">
+                            <Setter Property="Canvas.Left" Value="{Binding X}" />
+                            <Setter Property="Canvas.Top" Value="{Binding Y}" />
+                        </Style>
+                    </ItemsControl.ItemContainerStyle>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Canvas>
+                                <Path Stroke="{Binding DataContext.AcceptedBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                      StrokeThickness="1.5" IsHitTestVisible="False">
+                                    <Path.Data>
+                                        <GeometryGroup>
+                                            <LineGeometry StartPoint="-5,0" EndPoint="5,0" />
+                                            <LineGeometry StartPoint="0,-5" EndPoint="0,5" />
+                                        </GeometryGroup>
+                                    </Path.Data>
+                                    <!-- Inverse-zoom scale about the geometry origin (0,0) keeps the crosshair a
+                                         constant ~10 px on screen and centered on the measured Center. -->
+                                    <Path.RenderTransform>
+                                        <ScaleTransform ScaleX="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                        ScaleY="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                    </Path.RenderTransform>
+                                </Path>
+                            </Canvas>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
                 <!-- User: missed (false negatives) — cyan box (the user's drag region). -->
                 <ItemsControl ItemsSource="{Binding MissedMarkers}">
                     <ItemsControl.ItemsPanel>
@@ -238,6 +282,7 @@
                         <DataTemplate>
                             <Grid>
                                 <Rectangle Width="{Binding Width}" Height="{Binding Height}"
+                                           HorizontalAlignment="Left" VerticalAlignment="Top"
                                            Stroke="{Binding DataContext.MissedBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                            StrokeDashArray="3 2"
                                            StrokeThickness="{Binding DataContext.LabelStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
@@ -299,6 +344,7 @@
                         <DataTemplate>
                             <Grid>
                                 <Rectangle Width="{Binding Width}" Height="{Binding Height}"
+                                           HorizontalAlignment="Left" VerticalAlignment="Top"
                                            Stroke="{Binding DataContext.WronglyRejectedBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                            StrokeDashArray="3 2"
                                            StrokeThickness="{Binding DataContext.LabelStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
@@ -64,6 +64,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         public string HfrText { get; set; }
     }
 
+    /// <summary>The detector's measured star position (the flux-weighted <c>Center</c>) for an accepted star, in
+    /// image-pixel coords. Drawn as a small crosshair ON TOP of the green box so the marker tracks the actual star
+    /// even when the structure bounding box (drawn verbatim from <c>StarBoundingBox</c>) is larger than, or
+    /// off-center from, the bright core — which is what makes some boxes look "off" from their star.</summary>
+    public sealed class CentroidMarker {
+        public double X { get; set; }
+        public double Y { get; set; }
+    }
+
     /// <summary>A drawable user-label box in image-pixel coords (top-left X,Y + W,H).</summary>
     public sealed class LabelBoxMarker {
         public double X { get; set; }
@@ -283,6 +292,20 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
         // Markers in IMAGE pixel coords; the view applies the viewport transform to place them.
         public ObservableCollection<AcceptedMarker> AcceptedMarkers { get; } = new();
+
+        // Dev/diagnostic switch — intentionally NOT a UI toggle, to keep the labeler uncluttered. When true, each
+        // accepted star also gets a small crosshair drawn at the detector's measured Center (populated into the
+        // CentroidMarkers collection below and rendered by the centroid ItemsControl in StarReviewControl.xaml).
+        // Hidden by default; flip to true in code to surface the crosshairs — handy when diagnosing box-vs-centroid
+        // placement, since the structure bounding box and the flux-weighted centroid are computed independently and
+        // can legitimately differ for asymmetric stars.
+        private static readonly bool ShowCentroidMarkers = false;
+
+        /// <summary>Per-accepted-star measured-centroid markers (the detector's <c>Center</c>), in image-pixel
+        /// coords. Drawn as a small crosshair on top of the green box so the marker reflects where the detector
+        /// actually measured the star, independent of the structure bounding box the box layer draws. Populated only
+        /// when <see cref="ShowCentroidMarkers"/> is enabled (off by default).</summary>
+        public ObservableCollection<CentroidMarker> CentroidMarkers { get; } = new();
         public ObservableCollection<RejectedMarker> RejectedMarkers { get; } = new();
         public ObservableCollection<LabelBoxMarker> MissedMarkers { get; } = new();
         public ObservableCollection<LabelBoxMarker> ShouldRejectMarkers { get; } = new();
@@ -379,9 +402,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             _ = LoadImageAsync(f, fitView);
 
             // Overlays in image coords — accepted stars draw the detector's REAL bounding box (top-left + size).
+            // The measured-Center crosshair is a dev-only overlay, hidden by default (see ShowCentroidMarkers).
             AcceptedMarkers.Clear();
-            foreach (var (_, _, hfr, b) in f.Accepted) {
+            CentroidMarkers.Clear();
+            foreach (var (cx, cy, hfr, b) in f.Accepted) {
                 AcceptedMarkers.Add(new AcceptedMarker { X = b.X, Y = b.Y, Width = b.Width, Height = b.Height, HFR = hfr, HfrText = FormatHfr(hfr) });
+                if (ShowCentroidMarkers) {
+                    CentroidMarkers.Add(new CentroidMarker { X = cx, Y = cy });
+                }
             }
             RejectedMarkers.Clear();
             foreach (var (reason, b) in f.Rejected) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/BundledAssemblyResolver.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/BundledAssemblyResolver.cs
@@ -1,0 +1,96 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+
+namespace NINA.Joko.Plugins.HocusFocus.Utility {
+
+    /// <summary>
+    /// Resolves the plugin's BUNDLED dependency assemblies (e.g. ScottPlot.WPF, ScottPlot) from the plugin's own
+    /// directory.
+    ///
+    /// <para>NINA does not ship ScottPlot (it ships OxyPlot), so those DLLs only exist in the plugin folder — which
+    /// is NOT on the default assembly probing path. WPF/BAML resolves a XAML view's xmlns assemblies on demand via
+    /// <see cref="Assembly.Load(AssemblyName)"/>; for the bundled DLLs that load fails with a
+    /// <see cref="FileNotFoundException"/>, surfacing as a <c>XamlParseException</c> that prevents the view from
+    /// rendering (observed on NINA 3.3.0: the Star Detection Optimization Wizard window "just flashes" because its
+    /// ScottPlot chart view cannot be parsed). Registering this <see cref="AppDomain.AssemblyResolve"/> handler makes
+    /// those on-demand loads succeed by loading the requested assembly from the plugin directory.</para>
+    /// </summary>
+    public static class BundledAssemblyResolver {
+        private static int registered;
+
+        /// <summary>
+        /// Registers the <see cref="AppDomain.AssemblyResolve"/> handler exactly once for the given plugin directory.
+        /// Safe to call multiple times (subsequent calls are no-ops). Call this from plugin bootstrap, before any
+        /// view that references a bundled assembly is shown.
+        /// </summary>
+        public static void Register(string pluginDirectory) {
+            if (string.IsNullOrEmpty(pluginDirectory)) {
+                return;
+            }
+            if (Interlocked.Exchange(ref registered, 1) != 0) {
+                return;
+            }
+            AppDomain.CurrentDomain.AssemblyResolve += (sender, args) => Resolve(pluginDirectory, args.Name);
+        }
+
+        private static Assembly Resolve(string pluginDirectory, string assemblyFullName) {
+            var simpleName = SafeSimpleName(assemblyFullName);
+            if (simpleName == null) {
+                return null;
+            }
+            // Reuse an already-loaded assembly of the same simple name (avoids duplicate loads and recursion).
+            var alreadyLoaded = AppDomain.CurrentDomain.GetAssemblies()
+                .FirstOrDefault(a => !a.IsDynamic && string.Equals(a.GetName().Name, simpleName, StringComparison.OrdinalIgnoreCase));
+            if (alreadyLoaded != null) {
+                return alreadyLoaded;
+            }
+            var path = ResolveBundledAssemblyPath(pluginDirectory, assemblyFullName, File.Exists);
+            return path != null ? Assembly.LoadFrom(path) : null;
+        }
+
+        /// <summary>
+        /// Pure mapping from an assembly request to a bundled DLL path under <paramref name="pluginDirectory"/>, or
+        /// <c>null</c> when the assembly is not bundled there (so resolution defers to NINA / the runtime). Split out
+        /// from <see cref="Resolve"/> so the name-parsing + path logic is unit-testable without touching the AppDomain.
+        /// </summary>
+        public static string ResolveBundledAssemblyPath(string pluginDirectory, string assemblyFullName, Func<string, bool> fileExists) {
+            if (string.IsNullOrEmpty(pluginDirectory) || fileExists == null) {
+                return null;
+            }
+            var simpleName = SafeSimpleName(assemblyFullName);
+            if (simpleName == null) {
+                return null;
+            }
+            var candidate = Path.Combine(pluginDirectory, simpleName + ".dll");
+            return fileExists(candidate) ? candidate : null;
+        }
+
+        /// <summary>Extracts the simple name from an assembly full name, or null if it is empty/unparseable.</summary>
+        private static string SafeSimpleName(string assemblyFullName) {
+            if (string.IsNullOrEmpty(assemblyFullName)) {
+                return null;
+            }
+            try {
+                var name = new AssemblyName(assemblyFullName).Name;
+                return string.IsNullOrEmpty(name) ? null : name;
+            } catch {
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Three fixes to the Star Detection Optimization Wizard / review labeler:

1. **Accepted-star boxes drawn offset from their stars.** The box `Rectangle` shared a `Grid` with the (wider) HFR `TextBlock`; its default `Stretch` alignment (which WPF resolves to *Center* for a fixed-size child) displaced the box from `StarBoundingBox`'s top-left whenever the label was larger than a small box. Pinning the `Rectangle` `Left`/`Top` in the accepted / missed / wrongly-rejected templates draws boxes at their true coordinates.

2. **Optional measured-`Center` crosshair overlay** (`CentroidMarker` + a centroid `ItemsControl`), gated behind a dev-only `ShowCentroidMarkers` switch — off by default, intentionally **not** a UI toggle. Useful for diagnosing box-vs-centroid placement, since the structure bounding box and the flux-weighted centroid are computed independently and can legitimately differ for asymmetric stars.

3. **Wizard window failed to render on NINA 3.3.0 (it "just flashed").** NINA 3.3.0 no longer ships ScottPlot, and the plugin's bundled `ScottPlot.WPF` lives only in the plugin folder, which is not on the default assembly probe path — so WPF/BAML's on-demand `Assembly.Load("ScottPlot.WPF")` (triggered while parsing the wizard's chart view) threw `FileNotFoundException`, surfacing as a `XamlParseException` that stopped the window from rendering. New `BundledAssemblyResolver` (registered in `HocusFocusPlugin`'s static constructor) loads the plugin's bundled dependency DLLs from the plugin directory.

## Testing

- STA WPF layout test asserting accepted boxes render at the `StarBoundingBox` origin (reproduces the offset before the alignment fix, passes after).
- `BundledAssemblyResolver` path-resolution tests, including the exact failing assembly request from the NINA log (satellite-resource and not-bundled cases defer correctly).
- Updated review test for the default-hidden crosshair (box still rendered at its detector bounds).
- Full suite green: **1258 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
