### PR TITLE
Star detection wizard: AF-curve chart, variant toggle, determinate progress

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationDataTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationDataTests.cs
@@ -348,4 +348,57 @@ public class RunEvaluationDataTests {
                 Is.LessThan(Math.Abs(seed.Sensitivity - optSensitivity)), "Sensitivity should approach the star-count optimum");
         });
     }
+
+    [Test]
+    public async Task EvaluateAndFitAsync_ExposesPooledScatterPoints_WithHfrAndErrorBars() {
+        // The wizard plots the curve from these points; one per distinct focuser position, Y = pooled HFR, ErrorY =
+        // the (display-safe) per-frame stdev. Surfaced from the same pooling that feeds the fit (zero extra cost).
+        const double stdev = 0.07;
+        var data = new RunEvaluationData("curve", NineFrames(), HyperbolaDetect(hfrStdDev: stdev), NewAlglib(), DefaultFitConfig());
+
+        var result = await data.EvaluateAndFitAsync(new StarDetectorParams(), CancellationToken.None);
+
+        Assert.That(result.Points, Is.Not.Null);
+        Assert.That(result.Points.Count, Is.EqualTo(9), "one scatter point per distinct focuser position");
+        var ordered = result.Points.OrderBy(p => p.X).ToList();
+        Assert.Multiple(() => {
+            Assert.That(ordered[0].X, Is.EqualTo(HyperbolaP0 - 400).Within(1e-9));
+            Assert.That(ordered.Select(p => p.Y), Is.EqualTo(ordered.Select(p => Hfr((int)p.X))).Within(1e-9).AsCollection,
+                "each point's Y is the pooled HFR for its position");
+            Assert.That(ordered.All(p => Math.Abs(p.ErrorY - stdev) < 1e-9), Is.True, "ErrorY carries the per-position stdev");
+        });
+    }
+
+    [Test]
+    public async Task EvaluateAndFitAsync_FrameProgress_ReportsEveryFrame_AndMetricsAreIdentical() {
+        // The optional per-frame progress (used by the seed-guard) must report once per frame, AND the metrics must be
+        // byte-identical to the no-progress overload (proving the optimizer hot path, which passes no progress, is
+        // unaffected). Force the sequential path so the report order is deterministic.
+        var data = new RunEvaluationData("clean", NineFrames(), HyperbolaDetect(), NewAlglib(), DefaultFitConfig()) {
+            FrameParallelismOverride = 1
+        };
+        var p = new StarDetectorParams();
+
+        var reports = new List<RunLoadProgress>();
+        var progress = new ImmediateProgress<RunLoadProgress>(reports.Add);
+        var withProgress = await data.EvaluateAndFitAsync(p, progress, CancellationToken.None);
+        var withoutProgress = await data.EvaluateAndFitAsync(p, CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(reports.Count, Is.EqualTo(9), "one progress report per frame");
+            Assert.That(reports[^1].Current, Is.EqualTo(9));
+            Assert.That(reports[^1].Total, Is.EqualTo(9));
+            Assert.That(withProgress.Metrics.SigmaFocus, Is.EqualTo(withoutProgress.Metrics.SigmaFocus).Within(1e-12),
+                "progress must not change the computed metrics");
+            Assert.That(withProgress.Metrics.RSquared, Is.EqualTo(withoutProgress.Metrics.RSquared).Within(1e-12));
+            Assert.That(withProgress.PooledPointCount, Is.EqualTo(withoutProgress.PooledPointCount));
+        });
+    }
+
+    // Synchronous IProgress so reports are captured on the calling thread (no SynchronizationContext marshaling).
+    private sealed class ImmediateProgress<T> : IProgress<T> {
+        private readonly Action<T> onReport;
+        public ImmediateProgress(Action<T> onReport) => this.onReport = onReport;
+        public void Report(T value) => onReport(value);
+    }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -110,6 +110,9 @@ public class StarDetectionOptimizerWizardVMTests {
         // The labels-overload (used by the re-optimize path) delegates to the same source so re-loads keep working.
         loader.LoadSavedRunAsync(Arg.Any<string>(), Arg.Any<StarDetectionRegion>(), Arg.Any<IReadOnlyList<FrameLabels>>(), Arg.Any<CancellationToken>())
             .Returns(_ => Task.FromResult(queue.Count > 0 ? queue.Dequeue() : runs[runs.Length - 1]));
+        // The progress-bearing overload is the one the VM actually calls (acquire + re-load); feed it the same queue.
+        loader.LoadSavedRunAsync(Arg.Any<string>(), Arg.Any<StarDetectionRegion>(), Arg.Any<IReadOnlyList<FrameLabels>>(), Arg.Any<IProgress<RunLoadProgress>>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult(queue.Count > 0 ? queue.Dequeue() : runs[runs.Length - 1]));
         return loader;
     }
 
@@ -145,14 +148,21 @@ public class StarDetectionOptimizerWizardVMTests {
             };
         }
 
-        public Task<LoadedRun> LoadSavedRunAsync(string attemptFolderPath, StarDetectionRegion region, CancellationToken token) {
-            NoLabelCalls++;
-            return Task.FromResult(Make(attemptFolderPath, null));
-        }
+        public Task<LoadedRun> LoadSavedRunAsync(string attemptFolderPath, StarDetectionRegion region, CancellationToken token) =>
+            LoadSavedRunAsync(attemptFolderPath, region, labels: null, progress: null, token);
 
-        public Task<LoadedRun> LoadSavedRunAsync(string attemptFolderPath, StarDetectionRegion region, IReadOnlyList<FrameLabels> labels, CancellationToken token) {
-            LabelOverloadCalls++;
-            LabelsByFolder[attemptFolderPath] = labels;
+        public Task<LoadedRun> LoadSavedRunAsync(string attemptFolderPath, StarDetectionRegion region, IReadOnlyList<FrameLabels> labels, CancellationToken token) =>
+            LoadSavedRunAsync(attemptFolderPath, region, labels, progress: null, token);
+
+        // The progress overload is the one the VM calls; it is the single recorder so the existing counters/labels
+        // assertions keep their meaning (labels present => the labels overload; null => the no-label overload).
+        public Task<LoadedRun> LoadSavedRunAsync(string attemptFolderPath, StarDetectionRegion region, IReadOnlyList<FrameLabels> labels, IProgress<RunLoadProgress> progress, CancellationToken token) {
+            if (labels != null) {
+                LabelOverloadCalls++;
+                LabelsByFolder[attemptFolderPath] = labels;
+            } else {
+                NoLabelCalls++;
+            }
             return Task.FromResult(Make(attemptFolderPath, labels));
         }
     }
@@ -161,7 +171,7 @@ public class StarDetectionOptimizerWizardVMTests {
         IRunEvaluationLoader loader,
         IStarDetectionOptions options = null,
         IProfileService profileService = null,
-        Func<IReadOnlyList<FrameReviewDescriptor>, StarDetectorParams, CancellationToken, Task<List<FrameReview>>> frameReviewBuilder = null,
+        Func<IReadOnlyList<FrameReviewDescriptor>, StarDetectorParams, IProgress<RunLoadProgress>, CancellationToken, Task<List<FrameReview>>> frameReviewBuilder = null,
         Func<bool> isCameraConnected = null,
         Func<bool> isFocuserConnected = null) {
         options ??= Substitute.For<IStarDetectionOptions>();
@@ -190,7 +200,7 @@ public class StarDetectionOptimizerWizardVMTests {
         public IReadOnlyList<FrameReviewDescriptor> LastDescriptors { get; private set; }
 
         public Task<List<FrameReview>> Build(
-            IReadOnlyList<FrameReviewDescriptor> descriptors, StarDetectorParams p, CancellationToken token) {
+            IReadOnlyList<FrameReviewDescriptor> descriptors, StarDetectorParams p, IProgress<RunLoadProgress> progress, CancellationToken token) {
             Invocations++;
             LastParams = p;
             LastDescriptors = descriptors;
@@ -452,7 +462,7 @@ public class StarDetectionOptimizerWizardVMTests {
         Assert.Multiple(() => {
             Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Summary));
             Assert.That(vm.Summary.RunCount, Is.EqualTo(2));
-            loader.Received(2).LoadSavedRunAsync(Arg.Any<string>(), Arg.Any<StarDetectionRegion>(), Arg.Any<CancellationToken>());
+            loader.Received(2).LoadSavedRunAsync(Arg.Any<string>(), Arg.Any<StarDetectionRegion>(), Arg.Any<IReadOnlyList<FrameLabels>>(), Arg.Any<IProgress<RunLoadProgress>>(), Arg.Any<CancellationToken>());
         });
     }
 
@@ -574,12 +584,17 @@ public class StarDetectionOptimizerWizardVMTests {
 
     [Test]
     public async Task Accept_AfterReview_StillApplies() {
-        // Accept must apply whether or not the user visited Review, and it is reachable from the Review step too.
+        // Accept must apply whether or not the user visited Review. Accept is NOT offered on the Review step itself
+        // (CanExecute is false there) — the user returns to the results page first, then Accepts.
         var options = Substitute.For<IStarDetectionOptions>();
         var vm = NewVM(LoaderReturning(GoodRun()), options, frameReviewBuilder: new FakeReviewBuilder().Build);
         vm.SourcePaths[0] = @"C:\run1";
         await vm.StartAsync(CancellationToken.None);
         await vm.ReviewCommand.ExecuteAsync(null);
+
+        Assert.That(vm.AcceptCommand.CanExecute(null), Is.False, "Accept must be disabled on the Review (labeling) step");
+
+        vm.BackToSummaryCommand.Execute(null);
 
         var closeRaised = false;
         vm.RequestClose += (s, e) => closeRaised = true;
@@ -588,7 +603,7 @@ public class StarDetectionOptimizerWizardVMTests {
 
         Assert.Multiple(() => {
             options.Received(1).ApplyOptimizedSettings(Arg.Any<OptimizedStarDetectionSettings>());
-            Assert.That(closeRaised, Is.True, "Accept from Review must still close the wizard");
+            Assert.That(closeRaised, Is.True, "Accept from the results page must close the wizard");
         });
     }
 
@@ -644,8 +659,8 @@ public class StarDetectionOptimizerWizardVMTests {
     public async Task EnterReview_WhenBuilderThrows_SetsErrorAndStaysOnSummary() {
         // If the review build fails, the VM must surface the error, stay on Summary, and NOT construct a ReviewVM —
         // the user can still Accept or retry. (Matches EnterReviewAsync's catch-all error path.)
-        Func<IReadOnlyList<FrameReviewDescriptor>, StarDetectorParams, CancellationToken, Task<List<FrameReview>>> throwingBuilder =
-            (descriptors, p, token) => throw new InvalidOperationException("boom while detecting");
+        Func<IReadOnlyList<FrameReviewDescriptor>, StarDetectorParams, IProgress<RunLoadProgress>, CancellationToken, Task<List<FrameReview>>> throwingBuilder =
+            (descriptors, p, progress, token) => throw new InvalidOperationException("boom while detecting");
         var vm = NewVM(LoaderReturning(GoodRun()), frameReviewBuilder: throwingBuilder);
         vm.SourcePaths[0] = @"C:\run1";
         await vm.StartAsync(CancellationToken.None);
@@ -894,6 +909,157 @@ public class StarDetectionOptimizerWizardVMTests {
             Assert.That(vm.ErrorMessage, Is.Not.Null.And.Not.Empty);
             Assert.That(vm.CurrentStep, Is.Not.EqualTo(WizardStep.Summary));
             loader.DidNotReceiveWithAnyArgs().LoadSavedRunAsync(default, default, default);
+        });
+    }
+
+    // ---- Variant model + curve display (curve toggle) ---------------------------------------------------
+
+    [Test]
+    public async Task Start_Optimized_RetainsCurrentAndOptimizedVariants_DefaultsToOptimized() {
+        var vm = NewVM(LoaderReturning(GoodRun()));
+        vm.SourcePaths[0] = @"C:\run1";
+
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.HasCurrent, Is.True);
+            Assert.That(vm.HasOptimized, Is.True);
+            Assert.That(vm.HasFeedback, Is.False, "no feedback until a re-optimize");
+            Assert.That(vm.SelectedVariant, Is.EqualTo(OptimizationVariant.Optimized), "default shows the improvement");
+            Assert.That(vm.HasSelectedCurve, Is.True);
+            Assert.That(vm.SelectedCurve.Points.Count, Is.EqualTo(9), "a curve point per pooled focuser position");
+            Assert.That(vm.SelectedCurve.Fit, Is.Not.Null, "the optimized curve carries a fit");
+            Assert.That(vm.AcceptCommand.CanExecute(null), Is.True, "the optimized variant is acceptable");
+        });
+    }
+
+    [Test]
+    public async Task SelectingCurrentVariant_SwitchesCurveAndSummary_AndDisablesAccept() {
+        var vm = NewVM(LoaderReturning(GoodRun()));
+        vm.SourcePaths[0] = @"C:\run1";
+        await vm.StartAsync(CancellationToken.None);
+        Assert.That(vm.Summary.ChangedParameters.Count, Is.GreaterThan(0), "precondition: optimized changed parameters");
+
+        vm.SelectedVariant = OptimizationVariant.Current;
+
+        Assert.Multiple(() => {
+            Assert.That(vm.SelectedCurve.Label, Is.EqualTo("Current"));
+            Assert.That(vm.Summary.ChangedParameters, Is.Empty, "the current variant has no changes");
+            Assert.That(vm.AcceptCommand.CanExecute(null), Is.False, "Current is the baseline and cannot be accepted");
+        });
+    }
+
+    [Test]
+    public async Task Start_UseCurrentSettings_HasOnlyCurrentVariant_AcceptDisabled() {
+        var vm = NewVM(LoaderReturning(GoodRun()), frameReviewBuilder: new FakeReviewBuilder().Build);
+        vm.SourcePaths[0] = @"C:\run1";
+        vm.OptimizeMode = WizardOptimizeMode.UseCurrentSettings;
+
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.HasCurrent, Is.True);
+            Assert.That(vm.HasOptimized, Is.False, "review-only produces no optimized variant");
+            Assert.That(vm.SelectedVariant, Is.EqualTo(OptimizationVariant.Current));
+            Assert.That(vm.HasSelectedCurve, Is.True, "the current curve is still plotted");
+            Assert.That(vm.AcceptCommand.CanExecute(null), Is.False, "nothing changed to accept in review-only");
+            Assert.That(vm.ReviewCommand.CanExecute(null), Is.True, "review-only still allows labeling → feedback");
+        });
+    }
+
+    [Test]
+    public async Task ReOptimize_PreservesOptimizedVariant_AndReplacesFeedback() {
+        // Requirement: the FIRST optimized variant is preserved across re-optimizes; only the LATEST feedback persists.
+        var loader = new RecordingLoader();
+        var vm = NewVM(loader, frameReviewBuilder: new FakeReviewBuilder().Build);
+        vm.SourcePaths[0] = @"C:\reopt-run";
+        await vm.StartAsync(CancellationToken.None);
+
+        vm.SelectedVariant = OptimizationVariant.Optimized;
+        var optimizedRef = vm.Result;
+        Assert.That(optimizedRef, Is.Not.Null);
+
+        // First feedback round.
+        await vm.ReviewCommand.ExecuteAsync(null);
+        vm.ReviewVM.AddMissedBox(150.0, 175.0, 18.0, 18.0);
+        vm.BackToSummaryCommand.Execute(null);
+        await vm.ReOptimizeCommand.ExecuteAsync(null);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.SelectedVariant, Is.EqualTo(OptimizationVariant.Feedback), "the newest result is shown");
+            Assert.That(vm.HasOptimized, Is.True);
+            Assert.That(vm.HasFeedback, Is.True);
+        });
+        vm.SelectedVariant = OptimizationVariant.Optimized;
+        Assert.That(vm.Result, Is.SameAs(optimizedRef), "the first optimized variant is preserved");
+        vm.SelectedVariant = OptimizationVariant.Feedback;
+        var feedbackRef1 = vm.Result;
+
+        // Second feedback round.
+        await vm.ReviewCommand.ExecuteAsync(null);
+        vm.ReviewVM.AddMissedBox(160.0, 185.0, 18.0, 18.0);
+        vm.BackToSummaryCommand.Execute(null);
+        await vm.ReOptimizeCommand.ExecuteAsync(null);
+
+        vm.SelectedVariant = OptimizationVariant.Optimized;
+        Assert.That(vm.Result, Is.SameAs(optimizedRef), "optimized still preserved after a second re-optimize");
+        vm.SelectedVariant = OptimizationVariant.Feedback;
+        Assert.That(vm.Result, Is.Not.SameAs(feedbackRef1), "only the latest feedback is retained");
+    }
+
+    [Test]
+    public async Task Accept_FeedbackVariantSelected_AppliesFeedbackResult() {
+        var options = Substitute.For<IStarDetectionOptions>();
+        var vm = NewVM(new RecordingLoader(), options, frameReviewBuilder: new FakeReviewBuilder().Build);
+        vm.SourcePaths[0] = @"C:\reopt-run";
+        await vm.StartAsync(CancellationToken.None);
+        await vm.ReviewCommand.ExecuteAsync(null);
+        vm.ReviewVM.AddMissedBox(150.0, 175.0, 18.0, 18.0);
+        vm.BackToSummaryCommand.Execute(null);
+        await vm.ReOptimizeCommand.ExecuteAsync(null);
+        Assert.That(vm.SelectedVariant, Is.EqualTo(OptimizationVariant.Feedback));
+
+        var feedbackBest = vm.Result.BestParams; // Feedback selected
+        vm.AcceptCommand.Execute(null);
+
+        var dto = options.ReceivedCalls()
+            .Single(c => c.GetMethodInfo().Name == nameof(IStarDetectionOptions.ApplyOptimizedSettings))
+            .GetArguments()[0] as OptimizedStarDetectionSettings;
+        Assert.That(dto, Is.Not.Null);
+        Assert.That(dto.BrightnessSensitivity, Is.EqualTo(feedbackBest.Sensitivity).Within(1e-9),
+            "Accept applies the SELECTED (feedback) variant's BestParams");
+    }
+
+    [Test]
+    public async Task ReOptimize_FeedbackSummary_CarriesOptimizedBaselineComparison() {
+        var vm = NewVM(new RecordingLoader(), frameReviewBuilder: new FakeReviewBuilder().Build);
+        vm.SourcePaths[0] = @"C:\reopt-run";
+        await vm.StartAsync(CancellationToken.None);
+        await vm.ReviewCommand.ExecuteAsync(null);
+        vm.ReviewVM.AddMissedBox(150.0, 175.0, 18.0, 18.0);
+        vm.BackToSummaryCommand.Execute(null);
+        await vm.ReOptimizeCommand.ExecuteAsync(null);
+
+        Assert.That(vm.SelectedVariant, Is.EqualTo(OptimizationVariant.Feedback));
+        Assert.Multiple(() => {
+            Assert.That(vm.Summary.HasFeedbackComparison, Is.True, "the feedback summary compares against the optimized baseline");
+            Assert.That(vm.Summary.PriorSigmaFocus, Is.Not.Null);
+            Assert.That(vm.Summary.FeedbackVsOptimizedText, Is.Not.Empty);
+        });
+    }
+
+    [Test]
+    public void FeedbackVsOptimizedText_ReportsTighterPercentVsOptimizedBaseline() {
+        var s = new OptimizationSummary { BestSigmaFocus = 1.80, PriorSigmaFocus = 2.00 };
+        Assert.Multiple(() => {
+            Assert.That(s.HasFeedbackComparison, Is.True);
+            Assert.That(s.FeedbackVsOptimizedText, Does.Contain("2.00").And.Contains("1.80").And.Contains("tighter"));
+        });
+
+        var noPrior = new OptimizationSummary { BestSigmaFocus = 1.80 };
+        Assert.Multiple(() => {
+            Assert.That(noPrior.HasFeedbackComparison, Is.False);
+            Assert.That(noPrior.FeedbackVsOptimizedText, Is.Empty);
         });
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -1062,4 +1062,40 @@ public class StarDetectionOptimizerWizardVMTests {
             Assert.That(noPrior.FeedbackVsOptimizedText, Is.Empty);
         });
     }
+
+    [Test]
+    public async Task StarCountChanges_PresentForFeedbackVariant_AndReoptimizePromptReplaced() {
+        var vm = NewVM(new RecordingLoader(), frameReviewBuilder: new FakeReviewBuilder().Build);
+        vm.SourcePaths[0] = @"C:\reopt-run";
+        await vm.StartAsync(CancellationToken.None);
+
+        // Just optimized (Optimized selected): no feedback comparison, no labels → no re-run prompt.
+        Assert.Multiple(() => {
+            Assert.That(vm.StarCountChanges, Is.Empty);
+            Assert.That(vm.HasStarCountChanges, Is.False);
+            Assert.That(vm.ShowReoptimizePrompt, Is.False, "no labels yet");
+        });
+
+        // Label, return to summary: the re-run prompt appears (labeled, but no feedback run yet).
+        await vm.ReviewCommand.ExecuteAsync(null);
+        vm.ReviewVM.AddMissedBox(150.0, 175.0, 18.0, 18.0);
+        vm.BackToSummaryCommand.Execute(null);
+        Assert.That(vm.ShowReoptimizePrompt, Is.True, "labeled but not re-optimized → prompt to re-run");
+
+        // Re-optimize: now on the feedback variant — the prompt is replaced by the star-count comparison.
+        await vm.ReOptimizeCommand.ExecuteAsync(null);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.SelectedVariant, Is.EqualTo(OptimizationVariant.Feedback));
+            Assert.That(vm.ShowReoptimizePrompt, Is.False, "after a feedback run the prompt is gone");
+            Assert.That(vm.HasStarCountChanges, Is.True);
+            Assert.That(vm.StarCountChanges.Count, Is.EqualTo(9), "one cell per distinct focuser position");
+            Assert.That(vm.StarCountChanges.All(c => c.Delta == c.FeedbackCount - c.BaselineCount), Is.True);
+            Assert.That(vm.StarCountChangeBaselineLabel, Is.EqualTo("optimized"));
+        });
+
+        // Toggling away from Feedback hides the comparison.
+        vm.SelectedVariant = OptimizationVariant.Optimized;
+        Assert.That(vm.HasStarCountChanges, Is.False, "the comparison only shows on the feedback variant");
+    }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarReviewTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarReviewTests.cs
@@ -579,6 +579,23 @@ public class StarReviewTests {
     }
 
     [Test]
+    public void Viewport_WheelZoomOut_StopsAtStartingFit() {
+        var vp = new StarReviewViewport();
+        // 1000x500 image into 800x800: fit = 0.8, which becomes the zoom-out floor.
+        vp.FitTo(800, 800, 1000, 500);
+        Assert.That(vp.ZoomOutFloor, Is.EqualTo(0.8).Within(1e-9));
+
+        // Wheel zoom-out far past the fit must clamp AT the fit (so the image never shrinks inside the viewport,
+        // which would show black on all four edges).
+        vp.ZoomAt(0.001, 400, 400);
+        Assert.That(vp.Scale, Is.EqualTo(0.8).Within(1e-9), "zoom-out is clamped to the starting fit");
+
+        // Zooming back in still works normally.
+        vp.ZoomAt(10.0, 400, 400);
+        Assert.That(vp.Scale, Is.EqualTo(8.0).Within(1e-9));
+    }
+
+    [Test]
     public void PanBy_TranslatesOffset() {
         var vp = new StarReviewViewport(1.0, 10, 10);
         vp.PanBy(5, -3);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -334,7 +334,7 @@
                                 <DataGridTextColumn
                                     Width="*"
                                     Binding="{Binding SeedValue, StringFormat=F3}"
-                                    Header="Seed" />
+                                    Header="Current" />
                                 <DataGridTextColumn
                                     Width="*"
                                     Binding="{Binding OptimizedValue, StringFormat=F3}"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -286,10 +286,6 @@
                             <TextBlock Width="200" Text="vs optimized (no feedback)" />
                             <TextBlock Text="{Binding Summary.FeedbackVsOptimizedText, Mode=OneWay}" />
                         </StackPanel>
-                        <StackPanel Orientation="Horizontal" Margin="0,2">
-                            <TextBlock Width="200" Text="Runs optimized" />
-                            <TextBlock Text="{Binding Summary.RunCount, Mode=OneWay}" />
-                        </StackPanel>
 
                         <!--  Auto-focus block: the recommended step size / offset steps PLUS the toggle that applies
                               them on Accept, grouped so the toggle's purpose is obvious.  -->

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -361,21 +361,64 @@
                             BorderBrush="{StaticResource BorderBrush}"
                             BorderThickness="1"
                             CornerRadius="3"
-                            Visibility="{Binding HasLabels, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                            Visibility="{Binding ShowFeedbackPanel, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
                             <StackPanel>
-                                <TextBlock
-                                    FontWeight="Bold"
-                                    Text="You labeled stars in Review" />
-                                <TextBlock
-                                    Margin="0,4,0,8"
-                                    Text="Re-run the optimization using the feedback you just made. The optimizer will try to recover the stars you marked as missed or wrongly-rejected and exclude the ones you marked should-reject, then bring you back to an updated summary."
-                                    TextWrapping="Wrap" />
-                                <Button
-                                    Width="220"
-                                    HorizontalAlignment="Left"
-                                    Command="{Binding ReOptimizeCommand}"
-                                    Content="Optimize with feedback"
-                                    ToolTip="{StaticResource SDOpt_ReOptimize_Tooltip}" />
+                                <!--  Before a feedback run exists: prompt to re-run with the labels just made. Once a
+                                      feedback result exists this is replaced by the star-count comparison below
+                                      (re-optimize stays reachable from the Review page footer).  -->
+                                <StackPanel Visibility="{Binding ShowReoptimizePrompt, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                                    <TextBlock
+                                        FontWeight="Bold"
+                                        Text="You labeled stars in Review" />
+                                    <TextBlock
+                                        Margin="0,4,0,8"
+                                        Text="Re-run the optimization using the feedback you just made. The optimizer will try to recover the stars you marked as missed or wrongly-rejected and exclude the ones you marked should-reject, then bring you back to an updated summary."
+                                        TextWrapping="Wrap" />
+                                    <Button
+                                        Width="220"
+                                        HorizontalAlignment="Left"
+                                        Command="{Binding ReOptimizeCommand}"
+                                        Content="Optimize with feedback"
+                                        ToolTip="{StaticResource SDOpt_ReOptimize_Tooltip}" />
+                                </StackPanel>
+
+                                <!--  When viewing the feedback variant: the accepted-star-count change per frame
+                                      (baseline → with feedback), as a wrapping horizontal list of per-position cells.  -->
+                                <StackPanel Visibility="{Binding HasStarCountChanges, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                                    <TextBlock Margin="0,0,0,4" FontWeight="Bold">
+                                        <Run Text="Star count change per frame (" /><Run Text="{Binding StarCountChangeBaselineLabel, Mode=OneWay}" /><Run Text=" → with feedback)" />
+                                    </TextBlock>
+                                    <ItemsControl ItemsSource="{Binding StarCountChanges}">
+                                        <ItemsControl.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <WrapPanel Orientation="Horizontal" />
+                                            </ItemsPanelTemplate>
+                                        </ItemsControl.ItemsPanel>
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <Border
+                                                    Margin="0,0,6,6"
+                                                    Padding="6,3"
+                                                    BorderBrush="{StaticResource BorderBrush}"
+                                                    BorderThickness="1"
+                                                    CornerRadius="3">
+                                                    <StackPanel>
+                                                        <TextBlock
+                                                            HorizontalAlignment="Center"
+                                                            FontSize="10"
+                                                            Foreground="{StaticResource SecondaryBrush}"
+                                                            Text="{Binding FocuserPosition}" />
+                                                        <TextBlock HorizontalAlignment="Center" Text="{Binding CountsText}" />
+                                                        <TextBlock
+                                                            HorizontalAlignment="Center"
+                                                            FontWeight="Bold"
+                                                            Text="{Binding DeltaText}" />
+                                                    </StackPanel>
+                                                </Border>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </StackPanel>
 
                                 <!--  Transparent label→gate breakdown produced by the last feedback run. Each row's
                                       ToString() renders "Param old → new  recovers N/M Gate, admits ~K unlabeled".  -->

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="clr-namespace:NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization"
     xmlns:ninactrl="clr-namespace:NINA.CustomControlLibrary;assembly=NINA.CustomControlLibrary"
+    xmlns:oxy="clr-namespace:OxyPlot.Wpf;assembly=OxyPlot.Contrib.Wpf"
     xmlns:review="clr-namespace:NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review"
     xmlns:rules="clr-namespace:NINA.Core.Utility.ValidationRules;assembly=NINA.Core"
     xmlns:s="clr-namespace:System;assembly=mscorlib"
@@ -20,6 +21,70 @@
     <TextBlock x:Key="SDOpt_ApplyStepSize_Tooltip" Text="When checked, clicking Accept also writes the recommended auto-focus step size and offset steps to the active profile (they appear in the Changed parameters list above). The step size is sized so a sweep lands several measurement points across the focus-sensitive region of the curve. Disabled when the recommendation already matches your current settings (nothing to apply)." />
     <TextBlock x:Key="SDOpt_Review_Tooltip" Text="Optional: review the optimized detector boxes over every loaded frame and label any missed, falsely-accepted, or wrongly-rejected stars. The labels are saved next to the run and can drive a future re-optimization. Reviewing is not required — you can Accept directly." />
     <TextBlock x:Key="SDOpt_ReOptimize_Tooltip" Text="Re-run the optimization using the labels you just made in Review. Your missed / wrongly-rejected stars steer the optimizer to recover them (recall), and your should-reject stars steer it to exclude them (precision). The runs are re-read from disk and the search re-runs, landing on an updated summary you can review again or accept." />
+    <TextBlock x:Key="SDOpt_Variant_Tooltip" Text="Switch the chart and the summary below between your current settings, the optimized settings, and (after Optimize with feedback) the feedback-optimized settings. Accept applies whichever variant is shown (Current can't be accepted — it's your baseline)." />
+
+    <!--  Auto-focus curve chart for ONE settings variant. The Summary panel hosts this via a ContentControl bound to
+          SelectedCurve, so toggling the variant rebuilds the plot from a fresh OptimizationCurve instance (a robust
+          OxyPlot re-render without InvalidatePlot). Bindings are relative to the OptimizationCurve. Mirrors the AF
+          chart in AutoFocus/DataTemplates.xaml: ScatterErrorSeries (points + HFR error bars), a FunctionAnnotation for
+          the fitted curve, and a PointAnnotation diamond at the curve minimum (best focus). The default tracker shows
+          the per-point readout on hover/click.  -->
+    <DataTemplate DataType="{x:Type local:OptimizationCurve}">
+        <oxy:Plot
+            MinHeight="240"
+            Background="{StaticResource BackgroundBrush}"
+            PlotAreaBackground="{StaticResource BackgroundBrush}"
+            PlotAreaBorderColor="{Binding Path=Color, Source={StaticResource BorderBrush}}"
+            TextColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}">
+            <oxy:Plot.Axes>
+                <oxy:LinearAxis
+                    AxislineColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
+                    IsPanEnabled="False"
+                    IsZoomEnabled="False"
+                    MajorGridlineColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}, Converter={StaticResource SetAlphaToColorConverter}, ConverterParameter=60}"
+                    MajorGridlineStyle="LongDash"
+                    MaximumPadding="0.1"
+                    MinimumPadding="0.1"
+                    Position="Left"
+                    TextColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
+                    TicklineColor="{Binding Path=Color, Source={StaticResource SecondaryBrush}}"
+                    Title="HFR" />
+                <oxy:LinearAxis
+                    AxislineColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
+                    IsPanEnabled="False"
+                    IsZoomEnabled="False"
+                    MajorGridlineColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}, Converter={StaticResource SetAlphaToColorConverter}, ConverterParameter=60}"
+                    MajorGridlineStyle="LongDash"
+                    MaximumPadding="0.1"
+                    MinimumPadding="0.1"
+                    Position="Bottom"
+                    TextColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
+                    TicklineColor="{Binding Path=Color, Source={StaticResource SecondaryBrush}}"
+                    Title="Focuser position" />
+            </oxy:Plot.Axes>
+            <oxy:Plot.Series>
+                <oxy:ScatterErrorSeries
+                    ErrorBarColor="{Binding Path=Color, Source={StaticResource NotificationErrorBrush}}"
+                    ErrorBarStopWidth="2"
+                    ErrorBarStrokeThickness="2"
+                    ItemsSource="{Binding Points}"
+                    MarkerFill="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
+                    MarkerType="Circle"
+                    TrackerFormatString="Focuser: {2:0}, HFR: {4:0.000}" />
+            </oxy:Plot.Series>
+            <oxy:Plot.Annotations>
+                <oxy:FunctionAnnotation
+                    Color="{Binding Path=Color, Source={StaticResource SecondaryBrush}}"
+                    Equation="{Binding Fitting}" />
+                <oxy:PointAnnotation
+                    Fill="{Binding Path=Color, Source={StaticResource NotificationErrorBrush}}"
+                    Shape="Diamond"
+                    Stroke="{Binding Path=Color, Source={StaticResource NotificationErrorBrush}}"
+                    X="{Binding Minimum.X}"
+                    Y="{Binding Minimum.Y}" />
+            </oxy:Plot.Annotations>
+        </oxy:Plot>
+    </DataTemplate>
 
     <!--  The wizard window content. Implicit DataType template so the WindowService's ContentPresenter resolves it by VM type.  -->
     <DataTemplate DataType="{x:Type local:StarDetectionOptimizerWizardVM}">
@@ -31,6 +96,13 @@
                     <Setter Property="Width" Value="640" />
                     <Setter Property="MinHeight" Value="420" />
                     <Style.Triggers>
+                        <!--  Wider on the results page so the auto-focus curve chart has room…  -->
+                        <DataTrigger Binding="{Binding IsSummary}" Value="True">
+                            <Setter Property="Width" Value="820" />
+                            <Setter Property="MinHeight" Value="560" />
+                        </DataTrigger>
+                        <!--  …and widest for the Review step (embeds the full interactive image viewer). Listed last
+                              so it wins; the two are mutually exclusive anyway.  -->
                         <DataTrigger Binding="{Binding IsReview}" Value="True">
                             <Setter Property="Width" Value="1120" />
                             <Setter Property="MinHeight" Value="720" />
@@ -57,7 +129,7 @@
             <Grid Grid.Row="1">
 
                 <!--  Step 1: Select Source  -->
-                <StackPanel Visibility="{Binding IsSelectSource, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                <StackPanel Visibility="{Binding ShowSelectSource, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
                     <TextBlock
                         Margin="0,0,0,8"
                         Text="Choose one or more saved auto-focus runs to tune star detection against. The optimizer re-runs detection on those frames with many parameter combinations and keeps the settings that best pin down focus."
@@ -128,22 +200,11 @@
                     </ItemsControl>
                 </StackPanel>
 
-                <!--  Steps 2-3: Acquire / Optimize progress  -->
-                <StackPanel VerticalAlignment="Center">
-                    <StackPanel.Style>
-                        <Style TargetType="StackPanel">
-                            <Setter Property="Visibility" Value="Collapsed" />
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding IsAcquire}" Value="True">
-                                    <Setter Property="Visibility" Value="Visible" />
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding IsOptimize}" Value="True">
-                                    <Setter Property="Visibility" Value="Visible" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </StackPanel.Style>
-
+                <!--  Determinate progress: shown whenever the wizard is busy (loading frames / analyzing frames /
+                      optimizing / building the review). The bar marches (indeterminate) for phases with no known
+                      total yet, and shows a "N / M" count otherwise.  -->
+                <StackPanel VerticalAlignment="Center"
+                            Visibility="{Binding ShowProgress, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
                     <TextBlock
                         Margin="0,0,0,8"
                         HorizontalAlignment="Center"
@@ -151,28 +212,66 @@
                         Text="{Binding Phase}" />
                     <ProgressBar
                         Height="18"
-                        Maximum="{Binding MaxEvaluations}"
+                        IsIndeterminate="{Binding IsProgressIndeterminate}"
+                        Maximum="{Binding ProgressTotal}"
                         Minimum="0"
-                        Value="{Binding Evaluations, Mode=OneWay}" />
-                    <TextBlock Margin="0,4,0,0" HorizontalAlignment="Center">
-                        <Run Text="Combinations tried:" />
-                        <Run Text="{Binding Evaluations, Mode=OneWay}" />
-                        <Run Text="/" />
-                        <Run Text="{Binding MaxEvaluations, Mode=OneWay}" />
-                    </TextBlock>
+                        Value="{Binding ProgressCurrent, Mode=OneWay}" />
+                    <TextBlock
+                        Margin="0,4,0,0"
+                        HorizontalAlignment="Center"
+                        Text="{Binding ProgressCountText}"
+                        Visibility="{Binding HasProgressCount, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                     <TextBlock
                         Margin="0,2,0,0"
                         HorizontalAlignment="Center"
-                        Text="{Binding ProgressImprovementText}" />
+                        Text="{Binding ProgressImprovementText}"
+                        Visibility="{Binding IsOptimizing, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                 </StackPanel>
 
-                <!--  Step 4: Summary  -->
-                <ScrollViewer VerticalScrollBarVisibility="Auto" Visibility="{Binding IsSummary, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                <!--  Step 4: Summary (the results page)  -->
+                <ScrollViewer VerticalScrollBarVisibility="Auto" Visibility="{Binding ShowSummary, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
                     <StackPanel>
                         <TextBlock
                             Margin="0,0,0,8"
                             FontWeight="Bold"
                             Text="Optimization complete" />
+
+                        <!--  Variant toggle: switch the chart + summary between Current / Optimized / Optimized (with
+                              feedback). Hidden when only the current curve exists (review-only).  -->
+                        <StackPanel
+                            Margin="0,0,0,6"
+                            Orientation="Horizontal"
+                            Visibility="{Binding HasOptimized, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                            <RadioButton
+                                VerticalAlignment="Center"
+                                Content="Current"
+                                GroupName="Variant"
+                                IsChecked="{Binding IsCurrentVariant}"
+                                ToolTip="{StaticResource SDOpt_Variant_Tooltip}" />
+                            <RadioButton
+                                Margin="12,0,0,0"
+                                VerticalAlignment="Center"
+                                Content="Optimized"
+                                GroupName="Variant"
+                                IsChecked="{Binding IsOptimizedVariant}"
+                                ToolTip="{StaticResource SDOpt_Variant_Tooltip}" />
+                            <RadioButton
+                                Margin="12,0,0,0"
+                                VerticalAlignment="Center"
+                                Content="Optimized (with feedback)"
+                                GroupName="Variant"
+                                IsChecked="{Binding IsFeedbackVariant}"
+                                ToolTip="{StaticResource SDOpt_Variant_Tooltip}"
+                                Visibility="{Binding HasFeedback, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                        </StackPanel>
+
+                        <!--  Auto-focus curve for the selected variant (rebuilt on toggle via the ContentControl).  -->
+                        <Border
+                            Height="260"
+                            Margin="0,0,0,8"
+                            Visibility="{Binding HasSelectedCurve, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                            <ContentControl Content="{Binding SelectedCurve}" />
+                        </Border>
 
                         <!--  Before / after — plain language, no jargon "J" (the abstract objective stays in logs).
                               Every row is "[label Width=200][value]" with uniform spacing so the values line up in a
@@ -180,6 +279,12 @@
                         <StackPanel Orientation="Horizontal" Margin="0,2">
                             <TextBlock Width="200" Text="Focus precision (σ, lower is better)" />
                             <TextBlock Text="{Binding Summary.SigmaText, Mode=OneWay}" />
+                        </StackPanel>
+                        <!--  Feedback variant only: how much the feedback round tightened σ over the plain optimization.  -->
+                        <StackPanel Orientation="Horizontal" Margin="0,2"
+                                    Visibility="{Binding Summary.HasFeedbackComparison, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                            <TextBlock Width="200" Text="vs optimized (no feedback)" />
+                            <TextBlock Text="{Binding Summary.FeedbackVsOptimizedText, Mode=OneWay}" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Margin="0,2">
                             <TextBlock Width="200" Text="Runs optimized" />
@@ -243,7 +348,7 @@
 
                         <TextBlock
                             Margin="0,8,0,0"
-                            Text="Optionally review the optimized detector boxes on your frames and label any mistakes, then Accept to apply these settings (they become your active star-detection settings), or Cancel to discard."
+                            Text="Toggle between your current, optimized, and feedback-optimized curves above. Optionally review the detector boxes on your frames and label any mistakes, then Accept to apply the selected variant (it becomes your active star-detection settings), or Close to discard."
                             TextWrapping="Wrap" />
 
                         <!--  Re-optimize with feedback: shown only after the user labeled mistakes in Review. Re-reads
@@ -298,7 +403,7 @@
                       params. Fills the body when IsReview; its DataContext is the lazily-built StarReviewVM.  -->
                 <review:StarReviewControl
                     DataContext="{Binding ReviewVM}"
-                    Visibility="{Binding DataContext.IsReview, RelativeSource={RelativeSource AncestorType=Grid}, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                    Visibility="{Binding DataContext.ShowReview, RelativeSource={RelativeSource AncestorType=Grid}, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
             </Grid>
 
             <!--  Error banner  -->
@@ -310,105 +415,88 @@
                 TextWrapping="Wrap"
                 Visibility="{Binding HasError, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
 
-            <!--  Footer: navigation  -->
+            <!--  Footer: navigation. Exactly one step's buttons show at a time; while busy only Cancel shows.  -->
             <StackPanel
                 Grid.Row="3"
                 Margin="0,10,0,0"
                 HorizontalAlignment="Right"
                 Orientation="Horizontal">
+
+                <!--  Busy (loading / analyzing / optimizing / building review): only Cancel.  -->
                 <Button
                     Width="90"
                     Margin="0,0,8,0"
-                    Command="{Binding BackCommand}"
-                    Content="Back"
-                    Visibility="{Binding IsSummary, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
-                <!--  Review → Summary  -->
-                <Button
-                    Width="120"
-                    Margin="0,0,8,0"
-                    Command="{Binding BackToSummaryCommand}"
-                    Content="Back to summary"
-                    Visibility="{Binding IsReview, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
-                <!--  Review → re-optimize with the labels just made (enabled once anything is labeled). Accept is
-                      intentionally NOT offered here: finalize from the Summary step.  -->
-                <Button
-                    Width="180"
-                    Margin="0,0,8,0"
-                    Command="{Binding ReOptimizeCommand}"
-                    Content="Optimize with feedback"
-                    ToolTip="{StaticResource SDOpt_ReOptimize_Tooltip}"
-                    Visibility="{Binding IsReview, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                    Command="{Binding CancelCommand}"
+                    Content="Cancel"
+                    Visibility="{Binding ShowProgress, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+
+                <!--  SelectSource: Start (Close is the shared button below).  -->
                 <Button
                     Width="90"
                     Margin="0,0,8,0"
                     Command="{Binding StartCommand}"
                     Content="Start"
-                    Visibility="{Binding IsSelectSource, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                    Visibility="{Binding ShowSelectSource, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+
+                <!--  Summary (results) page: Back, Review, Accept. Accept is always shown but disabled (via CanAccept)
+                      on Current / in review-only / while a run is in progress — there is then nothing to apply.  -->
                 <Button
                     Width="90"
                     Margin="0,0,8,0"
-                    Command="{Binding CancelCommand}"
-                    Content="Cancel">
-                    <Button.Style>
-                        <!--  BasedOn the theme's implicit Button style so Cancel matches the other footer buttons'
-                              font/look (a style without BasedOn would drop the NINA default style).  -->
-                        <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
-                            <Setter Property="Visibility" Value="Collapsed" />
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding IsAcquire}" Value="True">
-                                    <Setter Property="Visibility" Value="Visible" />
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding IsOptimize}" Value="True">
-                                    <Setter Property="Visibility" Value="Visible" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </Button.Style>
-                </Button>
-                <!--  Summary → Review (optional). Hidden once reviewing.  -->
+                    Command="{Binding BackCommand}"
+                    Content="Back"
+                    Visibility="{Binding ShowSummary, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                 <Button
                     Width="120"
                     Margin="0,0,8,0"
                     Command="{Binding ReviewCommand}"
                     Content="Review frames"
                     ToolTip="{StaticResource SDOpt_Review_Tooltip}"
-                    Visibility="{Binding IsSummary, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
-                <!--  Accept = apply + select + close. Offered on Summary only — the Review step finalizes by going
-                      Back to summary (or Optimize with feedback) first.  -->
+                    Visibility="{Binding ShowSummary, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                 <Button
                     Width="90"
                     Margin="0,0,8,0"
                     Command="{Binding AcceptCommand}"
                     Content="Accept"
-                    Visibility="{Binding IsSummary, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
-                <!--  Summary/Review "Cancel" = discard (close without applying); reuses the close path, no options mutation.  -->
+                    Visibility="{Binding ShowSummary, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+
+                <!--  Review (labeling) page: Back to summary + Optimize with feedback (enabled once anything is
+                      labeled). Accept/Cancel are intentionally NOT offered here — finalize from the results page.  -->
+                <Button
+                    Width="120"
+                    Margin="0,0,8,0"
+                    Command="{Binding BackToSummaryCommand}"
+                    Content="Back to summary"
+                    Visibility="{Binding ShowReview, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                <Button
+                    Width="180"
+                    Margin="0,0,8,0"
+                    Command="{Binding ReOptimizeCommand}"
+                    Content="Optimize with feedback"
+                    ToolTip="{StaticResource SDOpt_ReOptimize_Tooltip}"
+                    Visibility="{Binding ShowReview, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+
+                <!--  Close: on SelectSource (generic) and on the Summary results page (discard without applying).  -->
                 <Button
                     Width="90"
-                    Margin="0,0,8,0"
                     Command="{Binding CloseCommand}"
-                    Content="Cancel">
+                    Content="Close">
                     <Button.Style>
-                        <!--  BasedOn the theme's implicit Button style so Cancel matches the other footer buttons'
+                        <!--  BasedOn the theme's implicit Button style so Close matches the other footer buttons'
                               font/look (a style without BasedOn would drop the NINA default style).  -->
                         <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
                             <Setter Property="Visibility" Value="Collapsed" />
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding IsSummary}" Value="True">
+                                <DataTrigger Binding="{Binding ShowSelectSource}" Value="True">
                                     <Setter Property="Visibility" Value="Visible" />
                                 </DataTrigger>
-                                <DataTrigger Binding="{Binding IsReview}" Value="True">
+                                <DataTrigger Binding="{Binding ShowSummary}" Value="True">
                                     <Setter Property="Visibility" Value="Visible" />
                                 </DataTrigger>
                             </Style.Triggers>
                         </Style>
                     </Button.Style>
                 </Button>
-                <!--  Generic Close for non-Summary steps (SelectSource); hidden on Summary/Review where Accept/Cancel decide.  -->
-                <Button
-                    Width="90"
-                    Command="{Binding CloseCommand}"
-                    Content="Close"
-                    Visibility="{Binding IsSelectSource, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
             </StackPanel>
         </Grid>
     </DataTemplate>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationCurve.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationCurve.cs
@@ -1,0 +1,75 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using OxyPlot;
+using OxyPlot.Series;
+using System;
+using System.Collections.Generic;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
+
+    /// <summary>
+    /// Which settings variant the results page is currently showing / would Accept:
+    /// <list type="bullet">
+    /// <item><see cref="Current"/> — the user's current (seed) settings; shown for comparison, never accepted.</item>
+    /// <item><see cref="Optimized"/> — the first optimization pass (preserved across re-optimizes).</item>
+    /// <item><see cref="Feedback"/> — the latest re-optimization that used the user's review labels (replaced each round).</item>
+    /// </list>
+    /// </summary>
+    public enum OptimizationVariant {
+        Current,
+        Optimized,
+        Feedback
+    }
+
+    /// <summary>
+    /// One auto-focus curve to plot on the results page: the pooled scatter points (with error bars), the winning
+    /// hyperbolic fit (which carries the smooth curve function + the optimum point), and a short label. Holds ONLY
+    /// Mat-free POCOs (<see cref="ScatterErrorPoint"/> structs + an <see cref="AlglibHyperbolicFitting"/> whose
+    /// <c>Fitting</c> closure captures only a <c>double[]</c> solution), so it safely survives disposal of the
+    /// in-memory run data. The pass-through members let the XAML chart bind without null-walking into <see cref="Fit"/>.
+    /// </summary>
+    public sealed class OptimizationCurve {
+        public string Label { get; set; }
+        public IReadOnlyList<ScatterErrorPoint> Points { get; set; }
+        public AlglibHyperbolicFitting Fit { get; set; }
+
+        /// <summary>The fitted curve function (focuser position → HFR) for the chart's FunctionAnnotation.</summary>
+        public Func<double, double> Fitting => Fit?.Fitting;
+
+        /// <summary>The fitted curve minimum (best-focus position + HFR) for the chart's optimum marker.</summary>
+        public DataPoint Minimum => Fit?.Minimum ?? default;
+
+        public double MinimumStdError => Fit?.MinimumStdError ?? double.NaN;
+        public double RSquared => Fit?.RSquared ?? double.NaN;
+        public double ReducedChiSquared => Fit?.ReducedChiSquared ?? double.NaN;
+        public double LeaveOneOutStdError => Fit?.LeaveOneOutStdError ?? double.NaN;
+
+        /// <summary>True when there is a real fit and at least one scatter point to plot.</summary>
+        public bool HasFit => Fit != null && Points != null && Points.Count > 0;
+    }
+
+    /// <summary>
+    /// Determinate progress for the wizard's long-running per-item phases (loading frames from disk, building the
+    /// per-frame early-detection contexts during the seed-guard, and detecting frames for review). Both fields are
+    /// 1-based running counts: <see cref="Current"/> items done out of <see cref="Total"/>.
+    /// </summary>
+    public readonly struct RunLoadProgress {
+        public int Current { get; }
+        public int Total { get; }
+
+        public RunLoadProgress(int current, int total) {
+            Current = current;
+            Total = total;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationCurve.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationCurve.cs
@@ -43,6 +43,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public IReadOnlyList<ScatterErrorPoint> Points { get; set; }
         public AlglibHyperbolicFitting Fit { get; set; }
 
+        /// <summary>Accepted star count per frame for this variant's params (parallel to
+        /// <see cref="FrameFocuserPositions"/>), from the representative run's evaluation. Used to show the
+        /// per-frame star-count change between the optimized and feedback variants.</summary>
+        public IReadOnlyList<int> FrameStarCounts { get; set; }
+
+        /// <summary>Focuser position per frame, parallel to <see cref="FrameStarCounts"/>.</summary>
+        public IReadOnlyList<int> FrameFocuserPositions { get; set; }
+
         /// <summary>The fitted curve function (focuser position → HFR) for the chart's FunctionAnnotation.</summary>
         public Func<double, double> Fitting => Fit?.Fitting;
 
@@ -56,6 +64,26 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
         /// <summary>True when there is a real fit and at least one scatter point to plot.</summary>
         public bool HasFit => Fit != null && Points != null && Points.Count > 0;
+    }
+
+    /// <summary>
+    /// One frame's accepted-star-count change between a baseline variant (optimized, or current when there was no
+    /// optimization pass) and the feedback-optimized variant, at a given focuser position. Shown as a compact
+    /// horizontal list when the user is comparing the feedback variant.
+    /// </summary>
+    public sealed class FrameStarCountChange {
+        public int FocuserPosition { get; set; }
+        public int BaselineCount { get; set; }
+        public int FeedbackCount { get; set; }
+
+        /// <summary>Feedback minus baseline (positive = more stars accepted with feedback).</summary>
+        public int Delta => FeedbackCount - BaselineCount;
+
+        /// <summary>"{baseline}→{feedback}" accepted-star counts.</summary>
+        public string CountsText => $"{BaselineCount}→{FeedbackCount}";
+
+        /// <summary>Signed delta, e.g. "+3" / "-2" / "0".</summary>
+        public string DeltaText => Delta > 0 ? $"+{Delta}" : Delta.ToString();
     }
 
     /// <summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewBuilder.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewBuilder.cs
@@ -67,12 +67,16 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         /// <param name="detector">The star detector (constructed by the caller with its AlglibAPI).</param>
         /// <param name="floatMatLoader">Profile-aware (or .tif-direct) loader producing a CV_32F [0,1] Mat for a path.</param>
         /// <param name="token">Cancellation token honored between frames and during detection.</param>
+        /// <param name="progress">Optional determinate per-frame progress (each detected frame), used by the wizard's
+        /// "Detecting frames for review" bar. Null (the default) reports nothing — byte-identical to the old behavior,
+        /// so TestApp and other callers are unaffected.</param>
         public static async Task<List<FrameReview>> BuildAsync(
             IEnumerable<FrameReviewDescriptor> descriptors,
             StarDetectorParams detectorParams,
             StarDetector detector,
             Func<string, Task<Mat>> floatMatLoader,
-            CancellationToken token) {
+            CancellationToken token,
+            IProgress<RunLoadProgress> progress = null) {
             if (descriptors == null) {
                 throw new ArgumentNullException(nameof(descriptors));
             }
@@ -86,10 +90,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
                 throw new ArgumentNullException(nameof(floatMatLoader));
             }
 
-            var reviews = new List<FrameReview>();
-            foreach (var d in descriptors) {
+            // Materialize so we know the total up-front for determinate progress.
+            var descriptorList = descriptors as IReadOnlyList<FrameReviewDescriptor> ?? descriptors.ToList();
+            var reviews = new List<FrameReview>(descriptorList.Count);
+            for (var i = 0; i < descriptorList.Count; i++) {
                 token.ThrowIfCancellationRequested();
-                reviews.Add(await BuildOneAsync(d, detectorParams, detector, floatMatLoader, token).ConfigureAwait(false));
+                reviews.Add(await BuildOneAsync(descriptorList[i], detectorParams, detector, floatMatLoader, token).ConfigureAwait(false));
+                progress?.Report(new RunLoadProgress(i + 1, descriptorList.Count));
             }
             return reviews;
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -435,11 +435,11 @@
             <Separator Margin="0,12,0,0" />
             <TextBlock FontWeight="Bold" Margin="0,8,0,3" Text="How to label" />
             <TextBlock Foreground="#FFB0B6BD" TextWrapping="Wrap"
-                       Text="• Flag rejected stars sparingly — fewer is better." />
+                       Text="• Flag rejected stars sparingly. Fewer is better." />
             <TextBlock Margin="0,3,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
                        Text="• Zoom into different regions and step through every frame; focus on stars accepted near focus but rejected far from it." />
             <TextBlock Margin="0,3,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
-                       Text="• If a flagged star has no HFR, unflag it — not enough signal." />
+                       Text="• If a flagged star has no HFR, unflag it. There isn't enough signal to measure." />
             <TextBlock Margin="0,3,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
                        Text="• Prefer flagging rejected stars. If large, defocused stars aren't detected at all, draw a box around them." />
 
@@ -448,7 +448,7 @@
             <Separator Margin="0,12,0,0" />
             <TextBlock FontWeight="Bold" Margin="0,8,0,3" Text="What this changes" />
             <TextBlock Foreground="#FFB0B6BD" TextWrapping="Wrap"
-                       Text="Labeling stars and re-optimizing recovers more stars — especially large, defocused ones — so detected star counts go up. But it relaxes the detection gates, which makes the auto-focus curve noisier and worsens focus precision. Use this to get more stars for aberration inspection, not to improve auto-focus." />
+                       Text="Labeling stars and re-optimizing recovers more stars, especially large defocused ones, so detected star counts go up. The cost is looser detection gates, so the auto-focus curve gets noisier and focus precision drops. This is useful for aberration inspection, where more stars help. It will not improve auto-focus." />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -442,6 +442,13 @@
                        Text="• If a flagged star has no HFR, unflag it — not enough signal." />
             <TextBlock Margin="0,3,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
                        Text="• Prefer flagging rejected stars. If large, defocused stars aren't detected at all, draw a box around them." />
+
+            <!-- Trade-off note: relaxing the gates via labels recovers more (often defocused) stars, raising the
+                 detected count, but it degrades the detection the auto-focus curve depends on. -->
+            <Separator Margin="0,12,0,0" />
+            <TextBlock FontWeight="Bold" Margin="0,8,0,3" Text="What this changes" />
+            <TextBlock Foreground="#FFB0B6BD" TextWrapping="Wrap"
+                       Text="Labeling stars and re-optimizing recovers more stars — especially large, defocused ones — so detected star counts go up. But it relaxes the detection gates, which makes the auto-focus curve noisier and worsens focus precision. Use this to get more stars for aberration inspection, not to improve auto-focus." />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewViewport.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewViewport.cs
@@ -30,6 +30,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         public double OffsetX { get; private set; }
         public double OffsetY { get; private set; }
 
+        // The wheel-zoom-out floor: the user can't zoom out smaller than the starting fit (below it the image would
+        // shrink inside the viewport and show black on all four edges). Set by FitTo to the fitted scale; until then
+        // it is the absolute MinScale so a viewport used without fitting (e.g. in unit tests) behaves as before.
+        private double zoomOutFloor = MinScale;
+
+        /// <summary>The current zoom-out floor (the starting-fit scale once <see cref="FitTo"/> has run).</summary>
+        public double ZoomOutFloor => zoomOutFloor;
+
         public StarReviewViewport() { }
 
         public StarReviewViewport(double scale, double offsetX, double offsetY) {
@@ -57,12 +65,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
                 Scale = 1.0;
                 OffsetX = 0;
                 OffsetY = 0;
+                zoomOutFloor = MinScale;
                 return;
             }
             var fit = Math.Min(viewportWidth / imageWidth, viewportHeight / imageHeight);
             Scale = ClampScale(Math.Min(fit, 1.0));
             OffsetX = (viewportWidth - imageWidth * Scale) / 2.0;
             OffsetY = (viewportHeight - imageHeight * Scale) / 2.0;
+            // The fitted scale becomes the zoom-out floor so the user can't zoom out into a 4-edge black border.
+            zoomOutFloor = Scale;
         }
 
         /// <summary>
@@ -72,11 +83,25 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         /// </summary>
         public void ZoomAt(double factor, double anchorScreenX, double anchorScreenY) {
             var (imgX, imgY) = ScreenToImage(anchorScreenX, anchorScreenY);
-            var newScale = ClampScale(Scale * factor);
+            // Clamp to the zoom-out floor (the starting fit) so wheel-zoom can't shrink the image below the viewport
+            // fit; the upper bound stays the absolute MaxScale.
+            var newScale = ClampToZoomOutFloor(Scale * factor);
             // Solve for the offset that keeps (imgX, imgY) under the anchor at the new scale.
             OffsetX = anchorScreenX - imgX * newScale;
             OffsetY = anchorScreenY - imgY * newScale;
             Scale = newScale;
+        }
+
+        /// <summary>Clamps a scale to [<see cref="zoomOutFloor"/>, <see cref="MaxScale"/>] (the wheel-zoom range),
+        /// guarding non-finite/non-positive input.</summary>
+        private double ClampToZoomOutFloor(double s) {
+            if (double.IsNaN(s) || s <= 0) {
+                return zoomOutFloor;
+            }
+            if (s < zoomOutFloor) {
+                return zoomOutFloor;
+            }
+            return s > MaxScale ? MaxScale : s;
         }
 
         /// <summary>Pans by a screen-space delta (drag).</summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationData.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationData.cs
@@ -131,6 +131,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// <summary>The pooled (mean) HFR at each distinct focuser position; for assertions/diagnostics.</summary>
         public IReadOnlyDictionary<int, double> PooledHfrByPosition { get; set; }
 
+        /// <summary>The pooled per-position scatter points the fit was computed from (X = focuser position,
+        /// Y = pooled mean HFR, ErrorY = pooled stdev via <see cref="SafeDisplayError"/>). Mat-free and cheap;
+        /// exposed so the wizard can plot the auto-focus curve without re-detecting. Empty when there were too
+        /// few positions to pool.</summary>
+        public IReadOnlyList<ScatterErrorPoint> Points { get; set; }
+
         public double PooledHfrAt(int focuserPosition) => PooledHfrByPosition[focuserPosition];
     }
 
@@ -261,6 +267,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         }
 
         public string RunId { get; }
+
+        /// <summary>The number of frames in this run (used by the wizard to set determinate "Analyzing frames"
+        /// progress totals before the first evaluation builds the per-frame early contexts).</summary>
+        public int FrameCount => frames.Count;
 
         /// <summary>
         /// A lightweight, Mat-free description of this run's frames for the interactive review step: each frame's
@@ -448,7 +458,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// Cancellation: a linked token source cancels all in-flight frames on request (or when any frame faults);
         /// the first fault/cancellation is rethrown after all started tasks settle, so no detection is left running.
         /// </summary>
-        private async Task<FrameDetectionResult[]> DetectAllFramesAsync(StarDetectorParams p, CancellationToken token) {
+        private async Task<FrameDetectionResult[]> DetectAllFramesAsync(StarDetectorParams p, IProgress<RunLoadProgress> frameProgress, CancellationToken token) {
             var count = frames.Count;
             var results = new FrameDetectionResult[count];
             if (count == 0) {
@@ -457,6 +467,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
             token.ThrowIfCancellationRequested();
 
+            // Determinate progress for the (optional) reporter: count frames as their detection completes. Interlocked
+            // so the parallel path (frames complete out of order) reports a monotonic running count safely.
+            var completed = 0;
+            void ReportFrameDone() {
+                if (frameProgress != null) {
+                    frameProgress.Report(new RunLoadProgress(System.Threading.Interlocked.Increment(ref completed), count));
+                }
+            }
+
             var degree = EffectiveFrameParallelism;
             if (degree <= 1) {
                 // Forced/derived sequential path: identical ordering and behavior to the original loop. Used by tests
@@ -464,6 +483,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 for (int i = 0; i < count; i++) {
                     token.ThrowIfCancellationRequested();
                     results[i] = await DetectFrameAsync(i, frames[i].Image, p, token).ConfigureAwait(false);
+                    ReportFrameDone();
                 }
                 return results;
             }
@@ -486,6 +506,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     tasks[index] = Task.Run(async () => {
                         try {
                             results[index] = await DetectFrameAsync(index, frames[index].Image, p, linkedToken).ConfigureAwait(false);
+                            ReportFrameDone();
                         } catch {
                             // Cancel siblings so the whole evaluation tears down promptly; the original exception is
                             // surfaced via Task.WhenAll below.
@@ -538,7 +559,17 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// for the step-size recommender). Never throws on a degenerate run — too few points produce NaN σ so the
         /// objective hard-fails gracefully.
         /// </summary>
-        public async Task<RunEvaluationResult> EvaluateAndFitAsync(StarDetectorParams p, CancellationToken token) {
+        public Task<RunEvaluationResult> EvaluateAndFitAsync(StarDetectorParams p, CancellationToken token) =>
+            EvaluateAndFitAsync(p, frameProgress: null, token);
+
+        /// <summary>
+        /// Overload that reports determinate per-frame progress as each frame's detection completes (used by the
+        /// wizard's seed-guard, where the first evaluation builds every frame's expensive early context — the long
+        /// initial wait). <paramref name="frameProgress"/> is OPTIONAL: the optimizer hot path
+        /// (<see cref="EvaluateAsync"/> → the 2-arg overload) passes none, so its evaluation behavior and metrics
+        /// are byte-identical to before.
+        /// </summary>
+        public async Task<RunEvaluationResult> EvaluateAndFitAsync(StarDetectorParams p, IProgress<RunLoadProgress> frameProgress, CancellationToken token) {
             // 1. Detect every frame, CONCURRENTLY but capped (see EffectiveFrameParallelism), to fill idle cores
             //    during the largely single-threaded early stage. Determinism is preserved by assembling results into
             //    a per-index array (assign by frame index, NOT completion order) and then consuming that array in
@@ -546,7 +577,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             //    identical to the old sequential loop regardless of how the frame tasks interleave. When a split
             //    detector is in use each frame goes through its own early-context cache slot (reused across late-only
             //    changes); concurrent builds touch distinct slots, so the cache is unaffected by the parallelism.
-            var detections = await DetectAllFramesAsync(p, token).ConfigureAwait(false);
+            var detections = await DetectAllFramesAsync(p, frameProgress, token).ConfigureAwait(false);
 
             var frameStarCounts = new List<int>(frames.Count);
             var frameRelaxationAdmittedCounts = new List<int>(frames.Count);
@@ -629,7 +660,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 Metrics = metrics,
                 BestFit = bestFit,
                 PooledPointCount = points.Count,
-                PooledHfrByPosition = pooledHfr
+                PooledHfrByPosition = pooledHfr,
+                Points = points
             };
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationLoader.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationLoader.cs
@@ -54,6 +54,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// user just made.
         /// </summary>
         Task<LoadedRun> LoadSavedRunAsync(string attemptFolderPath, StarDetectionRegion region, IReadOnlyList<FrameLabels> labels, CancellationToken token);
+
+        /// <summary>
+        /// As the labels overload, but reports determinate per-frame loading progress (each rendered exposure) via
+        /// <paramref name="progress"/> so the wizard's progress bar advances during the long initial disk-render
+        /// phase instead of sitting idle. The other overloads delegate here with <c>progress: null</c>; passing
+        /// <c>null</c> progress is identical to them.
+        /// </summary>
+        Task<LoadedRun> LoadSavedRunAsync(string attemptFolderPath, StarDetectionRegion region, IReadOnlyList<FrameLabels> labels, IProgress<RunLoadProgress> progress, CancellationToken token);
     }
 
     /// <summary>
@@ -96,10 +104,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// optimizer's curve fit matches the AF engine's.
         /// </summary>
         public Task<LoadedRun> LoadSavedRunAsync(string attemptFolderPath, StarDetectionRegion region, CancellationToken token) =>
-            LoadSavedRunAsync(attemptFolderPath, region, labels: null, token);
+            LoadSavedRunAsync(attemptFolderPath, region, labels: null, progress: null, token);
 
         /// <inheritdoc />
-        public async Task<LoadedRun> LoadSavedRunAsync(string attemptFolderPath, StarDetectionRegion region, IReadOnlyList<FrameLabels> labels, CancellationToken token) {
+        public Task<LoadedRun> LoadSavedRunAsync(string attemptFolderPath, StarDetectionRegion region, IReadOnlyList<FrameLabels> labels, CancellationToken token) =>
+            LoadSavedRunAsync(attemptFolderPath, region, labels, progress: null, token);
+
+        /// <inheritdoc />
+        public async Task<LoadedRun> LoadSavedRunAsync(string attemptFolderPath, StarDetectionRegion region, IReadOnlyList<FrameLabels> labels, IProgress<RunLoadProgress> progress, CancellationToken token) {
             if (string.IsNullOrEmpty(attemptFolderPath)) {
                 throw new ArgumentException("attemptFolderPath is required", nameof(attemptFolderPath));
             }
@@ -112,9 +124,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 throw new InvalidOperationException($"No saved images found in {attemptFolderPath}");
             }
 
-            // Render every saved exposure once (detectStars: false, mirroring InspectorVM.LoadSavedFile).
+            // Render every saved exposure once (detectStars: false, mirroring InspectorVM.LoadSavedFile). Report
+            // determinate per-frame progress so the wizard's bar advances during this long disk-render phase.
             var frames = new List<RunFrame>(attempt.SavedImages.Count);
             IRenderedImage firstImage = null;
+            var totalImages = attempt.SavedImages.Count;
+            var loadedCount = 0;
             foreach (var savedImage in attempt.SavedImages) {
                 token.ThrowIfCancellationRequested();
                 var rendered = await LoadRenderedImageAsync(savedImage, afOptions, token).ConfigureAwait(false);
@@ -126,6 +141,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     FocuserPosition = savedImage.FocuserPosition,
                     Image = rendered
                 });
+                progress?.Report(new RunLoadProgress(++loadedCount, totalImages));
             }
 
             // Seed = AF-base detector params for the first image (PixelScale + Region + ModelPSF=false). This is

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -90,6 +90,18 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public int CurrentOffsetSteps { get; set; }
         public bool ImprovedOverSeed { get; set; }
 
+        /// <summary>For the feedback variant only: σ(focus) of the optimized-WITHOUT-feedback result, so the
+        /// results header can show how much the feedback round tightened focus relative to the plain optimization.
+        /// Null for the current/optimized summaries.</summary>
+        public double? PriorSigmaFocus { get; set; }
+
+        /// <summary>For the feedback variant only: the optimized-without-feedback objective (J) baseline.</summary>
+        public double? PriorBestJ { get; set; }
+
+        /// <summary>True when this summary carries an optimized-without-feedback baseline to compare against
+        /// (i.e. it is the feedback summary produced after an initial optimization).</summary>
+        public bool HasFeedbackComparison => PriorSigmaFocus.HasValue;
+
         /// <summary>True when the recommended AF step size and/or offset steps differ from the current profile
         /// values — i.e. there is actually something to apply. Drives whether the "apply AF step size" toggle is
         /// enabled and whether the AF rows appear in the changed-parameters list.</summary>
@@ -117,6 +129,29 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 if (double.IsFinite(SeedSigmaFocus) && double.IsFinite(BestSigmaFocus)
                     && SeedSigmaFocus > 1e-9 && BestSigmaFocus < SeedSigmaFocus) {
                     var pct = (SeedSigmaFocus - BestSigmaFocus) / SeedSigmaFocus * 100.0;
+                    return $"{baseText}  (~{pct:F0}% tighter)";
+                }
+                return baseText;
+            }
+        }
+
+        /// <summary>Feedback-vs-optimized focus-precision readout for the results header: "{optimized} → {feedback}"
+        /// with a "(~N% tighter)" suffix when the feedback round improved σ over the plain optimization. Empty when
+        /// there is no optimized-without-feedback baseline (so the row is hidden for non-feedback variants).</summary>
+        public string FeedbackVsOptimizedText {
+            get {
+                if (!PriorSigmaFocus.HasValue) {
+                    return string.Empty;
+                }
+                var prior = PriorSigmaFocus.Value;
+                if (double.IsFinite(prior) && double.IsFinite(BestSigmaFocus)
+                    && Math.Abs(prior - BestSigmaFocus) < 0.005) {
+                    return $"{BestSigmaFocus:F2} (unchanged)";
+                }
+                var baseText = $"{prior:F2} → {BestSigmaFocus:F2}";
+                if (double.IsFinite(prior) && double.IsFinite(BestSigmaFocus)
+                    && prior > 1e-9 && BestSigmaFocus < prior) {
+                    var pct = (prior - BestSigmaFocus) / prior * 100.0;
                     return $"{baseText}  (~{pct:F0}% tighter)";
                 }
                 return baseText;
@@ -170,7 +205,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         // per-frame FrameReviews the StarReviewVM renders. Production wires FrameReviewBuilder over a real
         // StarDetector + a profile-aware disk loader; the unit tests inject a fake so the step-flow can be exercised
         // without real images.
-        private readonly Func<IReadOnlyList<FrameReviewDescriptor>, StarDetectorParams, CancellationToken, Task<List<FrameReview>>> frameReviewBuilder;
+        private readonly Func<IReadOnlyList<FrameReviewDescriptor>, StarDetectorParams, IProgress<RunLoadProgress>, CancellationToken, Task<List<FrameReview>>> frameReviewBuilder;
 
         // Connection probes for the Live source's pre-flight check (Start verifies the camera + focuser are
         // connected before triggering a live auto-focus). Injected as delegates so the VM stays mediator-free and
@@ -249,7 +284,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             Func<string> folderPicker,
             StarDetectionRegion region,
             OptimizerSettings optimizerSettings,
-            Func<IReadOnlyList<FrameReviewDescriptor>, StarDetectorParams, CancellationToken, Task<List<FrameReview>>> frameReviewBuilder = null,
+            Func<IReadOnlyList<FrameReviewDescriptor>, StarDetectorParams, IProgress<RunLoadProgress>, CancellationToken, Task<List<FrameReview>>> frameReviewBuilder = null,
             Func<bool> isCameraConnected = null,
             Func<bool> isFocuserConnected = null) {
             this.profileService = profileService ?? throw new ArgumentNullException(nameof(profileService));
@@ -269,7 +304,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             BrowseSourceCommand = new RelayCommand<object>(BrowseSource);
             StartCommand = new AsyncRelayCommand(() => StartAsync(CancellationToken.None), CanStart);
             CancelCommand = new RelayCommand(Cancel);
-            AcceptCommand = new RelayCommand(Accept, () => Summary != null && !IsBusy);
+            AcceptCommand = new RelayCommand(Accept, CanAccept);
             BackCommand = new RelayCommand(Back, () => CurrentStep == WizardStep.Summary && !IsBusy);
             CloseCommand = new RelayCommand(() => RequestClose?.Invoke(this, EventArgs.Empty));
             ReviewCommand = new AsyncRelayCommand(EnterReviewAsync, CanEnterReview);
@@ -299,9 +334,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     RaisePropertyChanged(nameof(IsOptimize));
                     RaisePropertyChanged(nameof(IsSummary));
                     RaisePropertyChanged(nameof(IsReview));
+                    RaiseStepVisibilityChanged();
                     BackCommand.NotifyCanExecuteChanged();
                     ReviewCommand.NotifyCanExecuteChanged();
                     BackToSummaryCommand.NotifyCanExecuteChanged();
+                    AcceptCommand.NotifyCanExecuteChanged();
                 }
             }
         }
@@ -311,6 +348,20 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public bool IsOptimize => CurrentStep == WizardStep.Optimize;
         public bool IsSummary => CurrentStep == WizardStep.Summary;
         public bool IsReview => CurrentStep == WizardStep.Review;
+
+        // Body-panel visibility: exactly one panel shows. While the wizard is busy (loading / analyzing / optimizing
+        // / building the review) the determinate progress panel takes over, so the content panels hide on !IsBusy.
+        public bool ShowSelectSource => IsSelectSource && !IsBusy;
+        public bool ShowProgress => IsBusy;
+        public bool ShowSummary => IsSummary && !IsBusy;
+        public bool ShowReview => IsReview && !IsBusy;
+
+        private void RaiseStepVisibilityChanged() {
+            RaisePropertyChanged(nameof(ShowSelectSource));
+            RaisePropertyChanged(nameof(ShowProgress));
+            RaisePropertyChanged(nameof(ShowSummary));
+            RaisePropertyChanged(nameof(ShowReview));
+        }
 
         private WizardOptimizeMode optimizeMode = WizardOptimizeMode.Optimize;
 
@@ -384,6 +435,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 if (isBusy != value) {
                     isBusy = value;
                     RaisePropertyChanged();
+                    RaiseStepVisibilityChanged();
                     StartCommand.NotifyCanExecuteChanged();
                     AcceptCommand.NotifyCanExecuteChanged();
                     BackCommand.NotifyCanExecuteChanged();
@@ -413,18 +465,53 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
         #region Progress
 
-        private int evaluations;
+        private int progressCurrent;
 
-        public int Evaluations {
-            get => evaluations;
-            private set { evaluations = value; RaisePropertyChanged(); }
+        /// <summary>Determinate progress numerator: items done in the current phase (frames loaded / frames
+        /// analyzed / combinations tried / frames detected for review).</summary>
+        public int ProgressCurrent {
+            get => progressCurrent;
+            private set { progressCurrent = value; RaisePropertyChanged(); RaisePropertyChanged(nameof(ProgressCountText)); }
         }
 
-        private int maxEvaluations;
+        private int progressTotal;
 
-        public int MaxEvaluations {
-            get => maxEvaluations;
-            private set { maxEvaluations = value; RaisePropertyChanged(); }
+        /// <summary>Determinate progress denominator: total items in the current phase. 0 = no determinate count
+        /// (an indeterminate phase), which hides the count text.</summary>
+        public int ProgressTotal {
+            get => progressTotal;
+            private set {
+                progressTotal = value;
+                RaisePropertyChanged();
+                RaisePropertyChanged(nameof(ProgressCountText));
+                RaisePropertyChanged(nameof(HasProgressCount));
+                RaisePropertyChanged(nameof(IsProgressIndeterminate));
+            }
+        }
+
+        public bool HasProgressCount => progressTotal > 0;
+
+        /// <summary>True when the current phase has no determinate count yet (e.g. the live AF run, or before the
+        /// frame count is known) — the progress bar shows its marching animation instead of a static empty bar.</summary>
+        public bool IsProgressIndeterminate => progressTotal <= 0;
+
+        /// <summary>The "N / M" count line shown under the progress bar; empty when there is no determinate total.</summary>
+        public string ProgressCountText => progressTotal > 0 ? $"{progressCurrent} / {progressTotal}" : string.Empty;
+
+        private bool isOptimizing;
+
+        /// <summary>True only while the parameter search is running, so the live improvement readout (which is
+        /// meaningless during loading/analysis) is shown only then.</summary>
+        public bool IsOptimizing {
+            get => isOptimizing;
+            private set { isOptimizing = value; RaisePropertyChanged(); }
+        }
+
+        /// <summary>Sets the descriptive phase heading + the determinate count in one shot (raising once each).</summary>
+        private void SetProgress(string phase, int current, int total) {
+            Phase = phase;
+            ProgressCurrent = current;
+            ProgressTotal = total;
         }
 
         private double progressSeedJ;
@@ -462,30 +549,118 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
         #region Results
 
-        private OptimizationResult result;
+        // Retained per-variant state. Each variant has its own result + summary + curve so the user can toggle the
+        // chart/summary between them and Accept either the first optimization or the latest feedback round. "Current"
+        // is the seed (shown for comparison, never Accepted). "Optimized" is the first optimization pass and is
+        // PRESERVED across re-optimizes. "Feedback" is the latest re-optimization that used review labels and is
+        // REPLACED each round (so at most three variants ever exist).
+        private OptimizationResult currentResult, optimizedResult, feedbackResult;
+        private OptimizationSummary currentSummary, optimizedSummary, feedbackSummary;
+        private OptimizationCurve currentCurve, optimizedCurve, feedbackCurve;
+        private OptimizationVariant selectedVariant = OptimizationVariant.Current;
 
-        public OptimizationResult Result {
-            get => result;
-            private set { result = value; RaisePropertyChanged(); }
+        private OptimizationResult SelectedResult => selectedVariant switch {
+            OptimizationVariant.Feedback => feedbackResult,
+            OptimizationVariant.Optimized => optimizedResult,
+            _ => currentResult
+        };
+
+        private OptimizationSummary SelectedSummary => selectedVariant switch {
+            OptimizationVariant.Feedback => feedbackSummary,
+            OptimizationVariant.Optimized => optimizedSummary,
+            _ => currentSummary
+        };
+
+        /// <summary>The optimization result for the selected variant. A computed pass-through so existing bindings,
+        /// <see cref="Apply"/>, and tests that read <c>Result</c> follow the variant toggle automatically.</summary>
+        public OptimizationResult Result => SelectedResult;
+
+        /// <summary>The summary for the selected variant (pass-through; drives the changed-params table + header).</summary>
+        public OptimizationSummary Summary => SelectedSummary;
+
+        /// <summary>Which settings variant the results page shows / would Accept. Selecting an available variant
+        /// refreshes the chart, the summary text, and the Accept affordance.</summary>
+        public OptimizationVariant SelectedVariant {
+            get => selectedVariant;
+            set {
+                if (selectedVariant != value && IsVariantAvailable(value)) {
+                    selectedVariant = value;
+                    RaiseSelectedVariantDependents();
+                }
+            }
         }
 
-        private OptimizationSummary summary;
+        /// <summary>The auto-focus curve plotted for the selected variant.</summary>
+        public OptimizationCurve SelectedCurve => selectedVariant switch {
+            OptimizationVariant.Feedback => feedbackCurve,
+            OptimizationVariant.Optimized => optimizedCurve,
+            _ => currentCurve
+        };
 
-        public OptimizationSummary Summary {
-            get => summary;
-            private set {
-                summary = value;
-                // A fresh summary: default the toggle to match whether there is anything to apply — ON when the AF
-                // recommendation actually differs from the profile (the user opts OUT rather than in), and OFF
-                // (plus disabled via CanApplyRecommendedStepSize) when nothing changed.
-                applyRecommendedStepSize = CanApplyRecommendedStepSize;
-                RaisePropertyChanged();
-                RaisePropertyChanged(nameof(ApplyRecommendedStepSize));
-                RaisePropertyChanged(nameof(CanApplyRecommendedStepSize));
-                RaisePropertyChanged(nameof(ChangedParametersDisplay));
-                AcceptCommand.NotifyCanExecuteChanged();
-                BackCommand.NotifyCanExecuteChanged();
-            }
+        public bool HasSelectedCurve => SelectedCurve?.HasFit == true;
+        public string SelectedVariantLabel => SelectedCurve?.Label;
+
+        public bool HasCurrent => currentCurve != null;
+        public bool HasOptimized => optimizedResult != null;
+        public bool HasFeedback => feedbackResult != null;
+
+        private bool IsVariantAvailable(OptimizationVariant v) => v switch {
+            OptimizationVariant.Feedback => HasFeedback,
+            OptimizationVariant.Optimized => HasOptimized,
+            _ => HasCurrent
+        };
+
+        // Variant toggle radio-button helpers (mirror IsOptimizeMode/IsUseCurrentMode).
+        public bool IsCurrentVariant {
+            get => selectedVariant == OptimizationVariant.Current;
+            set { if (value) { SelectedVariant = OptimizationVariant.Current; } }
+        }
+
+        public bool IsOptimizedVariant {
+            get => selectedVariant == OptimizationVariant.Optimized;
+            set { if (value) { SelectedVariant = OptimizationVariant.Optimized; } }
+        }
+
+        public bool IsFeedbackVariant {
+            get => selectedVariant == OptimizationVariant.Feedback;
+            set { if (value) { SelectedVariant = OptimizationVariant.Feedback; } }
+        }
+
+        /// <summary>
+        /// Re-raises every property that depends on which variant is selected (and re-derives the AF step-size toggle
+        /// default from the selected summary). Called after the variants are (re)populated and whenever the selection
+        /// changes — it is where the old <c>Summary</c> setter's batch of notifications now lives.
+        /// </summary>
+        private void RaiseSelectedVariantDependents() {
+            // Default the AF step-size toggle to match whether the SELECTED summary actually changes the AF settings
+            // (opt-out when there is something to apply; off + disabled when nothing changed).
+            applyRecommendedStepSize = CanApplyRecommendedStepSize;
+            RaisePropertyChanged(nameof(SelectedVariant));
+            RaisePropertyChanged(nameof(IsCurrentVariant));
+            RaisePropertyChanged(nameof(IsOptimizedVariant));
+            RaisePropertyChanged(nameof(IsFeedbackVariant));
+            RaisePropertyChanged(nameof(Result));
+            RaisePropertyChanged(nameof(Summary));
+            RaisePropertyChanged(nameof(SelectedCurve));
+            RaisePropertyChanged(nameof(HasSelectedCurve));
+            RaisePropertyChanged(nameof(SelectedVariantLabel));
+            RaisePropertyChanged(nameof(HasCurrent));
+            RaisePropertyChanged(nameof(HasOptimized));
+            RaisePropertyChanged(nameof(HasFeedback));
+            RaisePropertyChanged(nameof(ApplyRecommendedStepSize));
+            RaisePropertyChanged(nameof(CanApplyRecommendedStepSize));
+            RaisePropertyChanged(nameof(ChangedParametersDisplay));
+            AcceptCommand.NotifyCanExecuteChanged();
+            BackCommand.NotifyCanExecuteChanged();
+        }
+
+        /// <summary>Resets all retained variants (called at the top of a fresh Start).</summary>
+        private void ResetVariants() {
+            currentResult = optimizedResult = feedbackResult = null;
+            currentSummary = optimizedSummary = feedbackSummary = null;
+            currentCurve = optimizedCurve = feedbackCurve = null;
+            selectedVariant = OptimizationVariant.Current;
+            RaiseSelectedVariantDependents();
         }
 
         private bool applyRecommendedStepSize;
@@ -677,15 +852,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 Interlocked.Exchange(ref running, 0);
                 return;
             }
-            Summary = null;
-            Result = null;
+            ResetVariants();
             // Clear stale progress so a re-run after a cancel/complete doesn't briefly show the previous run's
             // evaluation count / phase / improvement before the first progress callback overwrites them.
-            Evaluations = 0;
-            MaxEvaluations = 0;
+            SetProgress(null, 0, 0);
             ProgressSeedJ = 0;
             ProgressBestJ = 0;
-            Phase = null;
             // A fresh run invalidates any prior review snapshot/labels (they belonged to the previous result).
             if (ReviewVM != null) {
                 ReviewVM.PropertyChanged -= OnReviewLabelsChanged;
@@ -734,8 +906,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 // In "Use current settings" mode the optimization pass is skipped entirely: BestParams = the seed
                 // (current settings), so the Summary shows no changes and the user can go straight to Review.
                 OptimizationResult optimizeResult;
+                bool optimized;
                 if (OptimizeMode == WizardOptimizeMode.UseCurrentSettings) {
-                    Phase = "Using current settings (no optimization)";
+                    SetProgress("Using current settings (no optimization)", 0, 0);
                     optimizeResult = new OptimizationResult {
                         BestParams = loadedRuns[0].Seed,
                         SeedJ = 0.0,
@@ -744,14 +917,39 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                         ImprovedOverSeed = false,
                         ChangedVariables = new List<(string Name, double SeedValue, double BestValue)>()
                     };
+                    optimized = false;
                 } else {
                     CurrentStep = WizardStep.Optimize;
                     optimizeResult = await OptimizeAsync(loadedRuns, token).ConfigureAwait(true);
+                    optimized = true;
                 }
-                Result = optimizeResult;
 
-                // 4. Summary — re-evaluate seed vs best for σ(focus) and recommend a step size.
-                Summary = await BuildSummaryAsync(loadedRuns, optimizeResult, token).ConfigureAwait(true);
+                // 4. Summary + curves — re-evaluate seed vs best for σ(focus), recommend a step size, and capture the
+                //    AF curves to plot (seed = "Current", best = "Optimized"). Done here while loadedRuns is alive,
+                //    before the finally disposes the source Mats; the captured curves hold only Mat-free POCOs.
+                var built = await BuildSummaryAsync(loadedRuns, optimizeResult, token).ConfigureAwait(true);
+
+                // The Current (seed) variant always exists — for the comparison curve and the baseline summary.
+                currentResult = new OptimizationResult {
+                    BestParams = loadedRuns[0].Seed,
+                    SeedJ = optimizeResult.SeedJ,
+                    BestJ = optimizeResult.SeedJ,
+                    Evaluations = 0,
+                    ImprovedOverSeed = false,
+                    ChangedVariables = new List<(string Name, double SeedValue, double BestValue)>()
+                };
+                currentSummary = BuildCurrentSummary(built.Summary);
+                currentCurve = built.CurrentCurve;
+
+                if (optimized) {
+                    optimizedResult = optimizeResult;
+                    optimizedSummary = built.Summary;
+                    optimizedCurve = built.OptimizedCurve;
+                    selectedVariant = OptimizationVariant.Optimized; // default to showing the improvement
+                } else {
+                    selectedVariant = OptimizationVariant.Current; // review-only: only the current curve exists
+                }
+                RaiseSelectedVariantDependents();
 
                 // Snapshot the Mat-free frame descriptors + the labels dir for the optional Review step NOW, while
                 // loadedRuns is still alive — the finally below disposes the in-memory source Mats, so the Review
@@ -804,8 +1002,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                         }
                     }
 
-                    Phase = $"Loading run {i + 1} of {RunCount}";
-                    var loaded = await loader.LoadSavedRunAsync(folder, region, token).ConfigureAwait(true);
+                    var runIndex = i;
+                    SetProgress($"Loading run {runIndex + 1} of {RunCount}", 0, 0);
+                    var loadProgress = new Progress<RunLoadProgress>(rp =>
+                        SetProgress($"Loading frames (run {runIndex + 1} of {RunCount})", rp.Current, rp.Total));
+                    var loaded = await loader.LoadSavedRunAsync(folder, region, null, loadProgress, token).ConfigureAwait(true);
                     runs.Add(loaded);
                     // Record the actual folder loaded (in load order) so the re-optimize path can re-read it from disk
                     // after the source Mats are disposed. Snapshotted in SnapshotReviewInputs on full success.
@@ -860,12 +1061,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// </summary>
         private async Task<bool> SeedFitIsUsableAsync(IReadOnlyList<LoadedRun> runs, CancellationToken token) {
             const int MinPositionsForFit = 3;
+            // Evaluate the seed on every run WITH determinate "Analyzing frames" progress. This first pass also builds
+            // each frame's expensive early-detection context (the long initial wait), so reporting it here is what
+            // makes the bar advance instead of sitting on a static count; the optimizer then reuses the warmed contexts.
+            var results = await AnalyzeWithProgressAsync(runs, r => r.Seed, token).ConfigureAwait(true);
             var anyUsable = false;
-            foreach (var run in runs) {
-                token.ThrowIfCancellationRequested();
-                var eval = await run.Data.EvaluateAndFitAsync(run.Seed, token).ConfigureAwait(true);
-                var sigmaFinite = double.IsFinite(eval.Metrics.SigmaFocus);
-                if (sigmaFinite && eval.PooledPointCount >= MinPositionsForFit) {
+            foreach (var eval in results) {
+                if (double.IsFinite(eval.Metrics.SigmaFocus) && eval.PooledPointCount >= MinPositionsForFit) {
                     anyUsable = true;
                     break;
                 }
@@ -882,6 +1084,28 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             return true;
         }
 
+        /// <summary>
+        /// Evaluates <paramref name="paramsSelector"/>'s params on each run while reporting determinate
+        /// "Analyzing frames (run i of N)" progress as each frame's detection completes. Used to surface — and warm —
+        /// the expensive first-evaluation early-context build so the progress bar moves during the long initial wait.
+        /// Returns the per-run results (the seed-guard reads them; the re-optimize warm-up discards them, the call
+        /// having only primed the cache).
+        /// </summary>
+        private async Task<List<RunEvaluationResult>> AnalyzeWithProgressAsync(
+            IReadOnlyList<LoadedRun> runs, Func<LoadedRun, StarDetectorParams> paramsSelector, CancellationToken token) {
+            var results = new List<RunEvaluationResult>(runs.Count);
+            for (var i = 0; i < runs.Count; i++) {
+                token.ThrowIfCancellationRequested();
+                var runIndex = i;
+                var run = runs[i];
+                var label = $"Analyzing frames (run {runIndex + 1} of {runs.Count})";
+                SetProgress(label, 0, run.Data.FrameCount);
+                var frameProgress = new Progress<RunLoadProgress>(rp => SetProgress(label, rp.Current, rp.Total));
+                results.Add(await run.Data.EvaluateAndFitAsync(paramsSelector(run), frameProgress, token).ConfigureAwait(true));
+            }
+            return results;
+        }
+
         /// <summary>Runs the pure optimizer off the UI thread; progress posts back via <see cref="IProgress{T}"/>.
         /// When <paramref name="seedOverride"/>/<paramref name="variablesOverride"/> are supplied (the warm-start
         /// "Optimize with feedback" path), the search starts from the analytic recommendation and explores only the
@@ -893,19 +1117,24 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             var variables = variablesOverride ?? OptimizerVariable.CreateCuratedSet();
             var evaluator = RunEvaluationData.CreateEvaluator(runs.Select(r => r.Data).ToList());
 
-            MaxEvaluations = optimizerSettings.MaxEvaluations;
+            ProgressTotal = optimizerSettings.MaxEvaluations;
             var progress = new Progress<OptimizationProgress>(p => {
-                Evaluations = p.Evaluations;
-                MaxEvaluations = p.MaxEvaluations;
+                ProgressCurrent = p.Evaluations;
+                ProgressTotal = p.MaxEvaluations;
                 ProgressBestJ = p.BestJ;
                 ProgressSeedJ = p.SeedJ;
                 Phase = FriendlyPhase(p.Phase);
             });
 
             var optimizer = new StarDetectionOptimizer();
-            return await Task.Run(
-                () => optimizer.OptimizeAsync(seed, variables, evaluator, optimizerSettings, progress, token),
-                token).ConfigureAwait(true);
+            IsOptimizing = true;
+            try {
+                return await Task.Run(
+                    () => optimizer.OptimizeAsync(seed, variables, evaluator, optimizerSettings, progress, token),
+                    token).ConfigureAwait(true);
+            } finally {
+                IsOptimizing = false;
+            }
         }
 
         /// <summary>Maps the optimizer's internal phase identifiers ("Seed"/"CoarseGrid"/"PatternSearch", which
@@ -922,16 +1151,19 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// best, averaged across runs), and the recommended step size from the representative (first) run's best
         /// fit, clamped to the focuser's max increment when known.
         /// </summary>
-        private async Task<OptimizationSummary> BuildSummaryAsync(IReadOnlyList<LoadedRun> runs, OptimizationResult res, CancellationToken token) {
+        private async Task<(OptimizationSummary Summary, OptimizationCurve CurrentCurve, OptimizationCurve OptimizedCurve)>
+            BuildSummaryAsync(IReadOnlyList<LoadedRun> runs, OptimizationResult res, CancellationToken token) {
             var seed = runs[0].Seed;
             var changed = res.ChangedVariables
                 .Select(c => new ChangedParameterRow { Name = c.Name, SeedValue = c.SeedValue, OptimizedValue = c.BestValue })
                 .ToList();
 
-            // σ(focus) before/after, averaged over the runs (the first run also yields the representative best fit).
+            // σ(focus) before/after, averaged over the runs (the first run also yields the representative best fit
+            // AND the curves we plot — seed = "Current", best = "Optimized"; both carry the scatter points + fit).
             double seedSigmaSum = 0.0, bestSigmaSum = 0.0;
             var seedSigmaCount = 0; var bestSigmaCount = 0;
             AlglibHyperbolicFitting representativeBestFit = null;
+            OptimizationCurve currentCurveLocal = null, optimizedCurveLocal = null;
             for (var i = 0; i < runs.Count; i++) {
                 token.ThrowIfCancellationRequested();
                 var seedEval = await runs[i].Data.EvaluateAndFitAsync(seed, token).ConfigureAwait(true);
@@ -940,6 +1172,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 if (double.IsFinite(bestEval.Metrics.SigmaFocus)) { bestSigmaSum += bestEval.Metrics.SigmaFocus; bestSigmaCount++; }
                 if (i == 0) {
                     representativeBestFit = bestEval.BestFit;
+                    currentCurveLocal = new OptimizationCurve { Label = "Current", Points = seedEval.Points, Fit = seedEval.BestFit };
+                    optimizedCurveLocal = new OptimizationCurve { Label = "Optimized", Points = bestEval.Points, Fit = bestEval.BestFit };
                 }
             }
 
@@ -947,7 +1181,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             var currentOffsetSteps = runs[0].AfOptions?.AutoFocusInitialOffsetSteps ?? DefaultCurrentOffsetSteps;
             var recommendation = StepSizeRecommender.Recommend(representativeBestFit, currentStepSize, GetFocuserMaxStep());
 
-            return new OptimizationSummary {
+            var summary = new OptimizationSummary {
                 ChangedParameters = changed,
                 SeedJ = res.SeedJ,
                 BestJ = res.BestJ,
@@ -959,6 +1193,29 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 CurrentStepSize = currentStepSize,
                 CurrentOffsetSteps = currentOffsetSteps,
                 ImprovedOverSeed = res.ImprovedOverSeed
+            };
+            return (summary, currentCurveLocal, optimizedCurveLocal);
+        }
+
+        /// <summary>
+        /// Builds the "Current" variant's summary from the optimized run's summary: nothing changed, so the
+        /// changed-parameters table is empty, J/σ collapse to the seed baseline, and the AF recommendation equals the
+        /// current profile values (so the apply-step-size toggle is disabled). Used so toggling to "Current" shows a
+        /// truthful "no changes" summary alongside the current curve.
+        /// </summary>
+        private static OptimizationSummary BuildCurrentSummary(OptimizationSummary optimized) {
+            return new OptimizationSummary {
+                ChangedParameters = Array.Empty<ChangedParameterRow>(),
+                SeedJ = optimized.SeedJ,
+                BestJ = optimized.SeedJ,
+                SeedSigmaFocus = optimized.SeedSigmaFocus,
+                BestSigmaFocus = optimized.SeedSigmaFocus,
+                RunCount = optimized.RunCount,
+                RecommendedStepSize = optimized.CurrentStepSize,
+                RecommendedOffsetSteps = optimized.CurrentOffsetSteps,
+                CurrentStepSize = optimized.CurrentStepSize,
+                CurrentOffsetSteps = optimized.CurrentOffsetSteps,
+                ImprovedOverSeed = false
             };
         }
 
@@ -980,9 +1237,16 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// applying (it never mutates options) — though it still flushes labels, since those are user work product,
         /// not a settings mutation. Reachable from Summary AND Review.
         /// </summary>
+        /// <summary>Accept is enabled only on the finished Summary view, when the VM is idle, and when a non-Current
+        /// variant (something there is actually to apply) is selected. This keeps Accept disabled while the Start /
+        /// SelectSource view or a run-in-progress is showing, and in review-only (Current selected).</summary>
+        private bool CanAccept() =>
+            !IsBusy && IsSummary && selectedVariant != OptimizationVariant.Current
+            && SelectedResult != null && SelectedSummary != null;
+
         private void Accept() {
             PersistReviewLabels();
-            Apply();
+            Apply(SelectedResult, SelectedSummary);
             RequestClose?.Invoke(this, EventArgs.Empty);
         }
 
@@ -993,26 +1257,26 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// is set, also writes the recommended AF step size/offset to the active profile. Only ever called via
         /// <see cref="Accept"/> when the user accepts the summary — never during the search.
         /// </summary>
-        private void Apply() {
-            if (Result == null || Summary == null) {
+        private void Apply(OptimizationResult result, OptimizationSummary summary) {
+            if (result == null || summary == null) {
                 return;
             }
 
             // Build the snapshot via the shared params->DTO mapping (the single source of truth shared with the
             // headless harness) so the in-app and offline paths can never drift. CreatedAtUtc is stamped inside.
             var dto = OptimizedStarDetectionSettings.FromParams(
-                Result.BestParams, Summary.RunCount, Result.SeedJ, Result.BestJ,
-                Summary.RecommendedStepSize, Summary.RecommendedOffsetSteps);
+                result.BestParams, summary.RunCount, result.SeedJ, result.BestJ,
+                summary.RecommendedStepSize, summary.RecommendedOffsetSteps);
 
             starDetectionOptions.ApplyOptimizedSettings(dto);
-            Logger.Info($"Applied optimized star-detection settings (J {Result.SeedJ:F3} -> {Result.BestJ:F3}, {Summary.RunCount} run(s))");
+            Logger.Info($"Applied optimized star-detection settings (J {result.SeedJ:F3} -> {result.BestJ:F3}, {summary.RunCount} run(s))");
 
             if (ApplyRecommendedStepSize) {
                 var focuserSettings = profileService?.ActiveProfile?.FocuserSettings;
                 if (focuserSettings != null) {
-                    focuserSettings.AutoFocusStepSize = Summary.RecommendedStepSize;
-                    focuserSettings.AutoFocusInitialOffsetSteps = Summary.RecommendedOffsetSteps;
-                    Logger.Info($"Applied recommended AF step size {Summary.RecommendedStepSize}, offset steps {Summary.RecommendedOffsetSteps}");
+                    focuserSettings.AutoFocusStepSize = summary.RecommendedStepSize;
+                    focuserSettings.AutoFocusInitialOffsetSteps = summary.RecommendedOffsetSteps;
+                    Logger.Info($"Applied recommended AF step size {summary.RecommendedStepSize}, offset steps {summary.RecommendedOffsetSteps}");
                 }
             }
         }
@@ -1079,13 +1343,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
             ErrorMessage = null;
             IsBusy = true;
-            Phase = "Detecting frames for review";
+            SetProgress("Detecting frames for review", 0, descriptors.Count);
             try {
                 // Detect every frame at the optimized params, off the UI thread. The production builder seam wraps the
                 // shared FrameReviewBuilder in a Task.Run, so the whole build (disk load + detection) runs on the
                 // threadpool and never stutters the UI thread; we just await the result here. The resulting
                 // FrameReviews carry frozen overlays + a disk-backed image provider.
-                var reviews = await frameReviewBuilder(descriptors, bestParams, cts?.Token ?? CancellationToken.None).ConfigureAwait(true);
+                var reviewProgress = new Progress<RunLoadProgress>(rp => SetProgress("Detecting frames for review", rp.Current, rp.Total));
+                var reviews = await frameReviewBuilder(descriptors, bestParams, reviewProgress, cts?.Token ?? CancellationToken.None).ConfigureAwait(true);
                 if (reviews == null || reviews.Count == 0) {
                     ErrorMessage = "No frames could be prepared for review.";
                     return;
@@ -1244,11 +1509,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
             ErrorMessage = null;
             // Clear stale progress so the re-optimize doesn't briefly show the prior run's numbers.
-            Evaluations = 0;
-            MaxEvaluations = 0;
+            SetProgress(null, 0, 0);
             ProgressSeedJ = 0;
             ProgressBestJ = 0;
-            Phase = null;
             IsBusy = true;
 
             cts?.Dispose();
@@ -1261,7 +1524,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 reloaded = new List<LoadedRun>(reoptimizeRunFolders.Count);
                 for (var i = 0; i < reoptimizeRunFolders.Count; i++) {
                     token.ThrowIfCancellationRequested();
-                    Phase = $"Re-loading run {i + 1} of {reoptimizeRunFolders.Count}";
+                    var runIndex = i;
+                    SetProgress($"Re-loading run {runIndex + 1} of {reoptimizeRunFolders.Count}", 0, 0);
                     var folder = reoptimizeRunFolders[i];
 
                     // The RunId was recorded during the first acquire (it is a deterministic function of the folder),
@@ -1273,7 +1537,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     // Passing null frameLabels is byte-identical to the no-label load (the loader's no-label overload
                     // delegates to this one with labels: null), so a label-less run is loaded the same as before.
                     var frameLabels = LabelConverter.ToFrameLabels(runLabels);
-                    var loaded = await loader.LoadSavedRunAsync(folder, region, frameLabels, token).ConfigureAwait(true);
+                    var loadProgress = new Progress<RunLoadProgress>(rp =>
+                        SetProgress($"Loading frames (run {runIndex + 1} of {reoptimizeRunFolders.Count})", rp.Current, rp.Total));
+                    var loaded = await loader.LoadSavedRunAsync(folder, region, frameLabels, loadProgress, token).ConfigureAwait(true);
                     reloaded.Add(loaded);
                 }
 
@@ -1292,10 +1558,28 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                         OptimizerVariable.CreateCuratedSet(), reviewParams, feedback.Recommended);
                 }
 
+                // Warm + report the per-frame early contexts for the params the optimizer will start from (re-optimize
+                // skips the seed-guard, so this is the parity warm-up that makes the bar move during the initial build).
+                await AnalyzeWithProgressAsync(reloaded, _ => seedOverride ?? reloaded[0].Seed, token).ConfigureAwait(true);
+
                 // Re-run the optimize + summary pipeline over the labeled runs (warm-started when we have a recommendation).
                 var optimizeResult = await OptimizeAsync(reloaded, token, seedOverride, variablesOverride).ConfigureAwait(true);
-                Result = optimizeResult;
-                Summary = await BuildSummaryAsync(reloaded, optimizeResult, token).ConfigureAwait(true);
+                var built = await BuildSummaryAsync(reloaded, optimizeResult, token).ConfigureAwait(true);
+
+                // Retain as the FEEDBACK variant. This REPLACES any prior feedback and leaves the first Optimized
+                // variant (and Current) untouched, so only the latest feedback persists while the original optimization
+                // stays available to compare/accept. Carry the optimized-without-feedback σ/J baseline so the header
+                // can show how much the feedback round improved over the plain optimization.
+                feedbackResult = optimizeResult;
+                feedbackSummary = built.Summary;
+                feedbackSummary.PriorSigmaFocus = optimizedSummary?.BestSigmaFocus;
+                feedbackSummary.PriorBestJ = optimizedResult?.BestJ;
+                feedbackCurve = built.OptimizedCurve;
+                if (feedbackCurve != null) {
+                    feedbackCurve.Label = "Optimized (with feedback)";
+                }
+                selectedVariant = OptimizationVariant.Feedback;
+                RaiseSelectedVariantDependents();
 
                 // Re-snapshot the review inputs from the RE-LOADED runs (mirroring StartAsync step 4) so the user can
                 // enter Review again before this finally disposes the freshly-loaded source Mats. The same folders we
@@ -1381,18 +1665,19 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// normalized float Mat; .tif direct). Mirrors the TestApp <c>review</c> path so detection + overlay
         /// extraction + the MTF-stretch image provider are byte-identical between the offline tool and the wizard.
         /// </summary>
-        private static Func<IReadOnlyList<FrameReviewDescriptor>, StarDetectorParams, CancellationToken, Task<List<FrameReview>>>
+        private static Func<IReadOnlyList<FrameReviewDescriptor>, StarDetectorParams, IProgress<RunLoadProgress>, CancellationToken, Task<List<FrameReview>>>
             BuildProductionReviewBuilder(IProfileService profileService, IImageDataFactory imageDataFactory) {
-            return (descriptors, p, token) => {
+            return (descriptors, p, progress, token) => {
                 var detector = new StarDetector(HocusFocusPlugin.AlglibAPI);
                 // Hop to the threadpool so the WHOLE build (disk load + detection) runs off the captured UI context.
                 // FrameReviewBuilder.BuildAsync awaits its work, so without this hop its synchronous prologue (and any
-                // continuation that resumes on the UI SynchronizationContext) could stutter the UI thread.
+                // continuation that resumes on the UI SynchronizationContext) could stutter the UI thread. Progress
+                // is posted via the IProgress the VM created on the UI context, so per-frame reports marshal back.
                 return Task.Run(
                     () => FrameReviewBuilder.BuildAsync(
                         descriptors, p, detector,
                         path => LoadFloatMatFromDisk(path, profileService, imageDataFactory),
-                        token),
+                        token, progress),
                     token);
             };
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -610,6 +610,63 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             _ => HasCurrent
         };
 
+        /// <summary>The accepted-star-count change per focuser position between the baseline (optimized, or current
+        /// when no optimization pass ran) and the feedback variant. Non-empty ONLY while the feedback variant is
+        /// selected (i.e. when the user is comparing optimized vs optimized-with-feedback). Summed per position so it
+        /// lines up with the curve points.</summary>
+        public IReadOnlyList<FrameStarCountChange> StarCountChanges {
+            get {
+                if (selectedVariant != OptimizationVariant.Feedback) {
+                    return Array.Empty<FrameStarCountChange>();
+                }
+                return BuildStarCountChanges(optimizedCurve ?? currentCurve, feedbackCurve);
+            }
+        }
+
+        public bool HasStarCountChanges => StarCountChanges.Count > 0;
+
+        /// <summary>Whether the star-count comparison baseline is the optimized run ("optimized") or — in the
+        /// review-only → feedback path — the current settings ("current"). Drives the section heading.</summary>
+        public string StarCountChangeBaselineLabel => HasOptimized ? "optimized" : "current";
+
+        /// <summary>Shows the "you labeled stars — re-run optimization" prompt: only when the user has labels that
+        /// have not yet been turned into a feedback result. Once a feedback variant exists, the prompt is replaced by
+        /// the star-count comparison (re-optimize stays reachable from the Review page).</summary>
+        public bool ShowReoptimizePrompt => HasLabels && !HasFeedback;
+
+        /// <summary>Whether the feedback panel (the bordered box on the results page) has anything to show: the
+        /// re-run prompt, the star-count comparison, or the label→gate breakdown.</summary>
+        public bool ShowFeedbackPanel => ShowReoptimizePrompt || HasStarCountChanges || HasRecommendation;
+
+        /// <summary>Builds the per-position accepted-star-count change between two variants' representative-run frames
+        /// (positions match because both detect the SAME frames). Returns empty when either side lacks counts.</summary>
+        private static IReadOnlyList<FrameStarCountChange> BuildStarCountChanges(OptimizationCurve baseline, OptimizationCurve feedback) {
+            if (baseline?.FrameStarCounts == null || baseline.FrameFocuserPositions == null
+                || feedback?.FrameStarCounts == null || feedback.FrameFocuserPositions == null) {
+                return Array.Empty<FrameStarCountChange>();
+            }
+            var baseByPos = SumStarCountsByPosition(baseline.FrameFocuserPositions, baseline.FrameStarCounts);
+            var fbByPos = SumStarCountsByPosition(feedback.FrameFocuserPositions, feedback.FrameStarCounts);
+            var result = new List<FrameStarCountChange>();
+            foreach (var pos in baseByPos.Keys.Union(fbByPos.Keys).OrderBy(p => p)) {
+                result.Add(new FrameStarCountChange {
+                    FocuserPosition = pos,
+                    BaselineCount = baseByPos.TryGetValue(pos, out var b) ? b : 0,
+                    FeedbackCount = fbByPos.TryGetValue(pos, out var f) ? f : 0
+                });
+            }
+            return result;
+        }
+
+        private static Dictionary<int, int> SumStarCountsByPosition(IReadOnlyList<int> positions, IReadOnlyList<int> counts) {
+            var d = new Dictionary<int, int>();
+            var n = Math.Min(positions.Count, counts.Count);
+            for (var i = 0; i < n; i++) {
+                d[positions[i]] = (d.TryGetValue(positions[i], out var c) ? c : 0) + counts[i];
+            }
+            return d;
+        }
+
         // Variant toggle radio-button helpers (mirror IsOptimizeMode/IsUseCurrentMode).
         public bool IsCurrentVariant {
             get => selectedVariant == OptimizationVariant.Current;
@@ -650,6 +707,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             RaisePropertyChanged(nameof(ApplyRecommendedStepSize));
             RaisePropertyChanged(nameof(CanApplyRecommendedStepSize));
             RaisePropertyChanged(nameof(ChangedParametersDisplay));
+            RaisePropertyChanged(nameof(StarCountChanges));
+            RaisePropertyChanged(nameof(HasStarCountChanges));
+            RaisePropertyChanged(nameof(StarCountChangeBaselineLabel));
+            RaisePropertyChanged(nameof(ShowReoptimizePrompt));
+            RaisePropertyChanged(nameof(ShowFeedbackPanel));
             AcceptCommand.NotifyCanExecuteChanged();
             BackCommand.NotifyCanExecuteChanged();
         }
@@ -874,6 +936,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             reviewParams = null;
             Recommendation = null;
             RaisePropertyChanged(nameof(HasLabels));
+            RaisePropertyChanged(nameof(ShowReoptimizePrompt));
+            RaisePropertyChanged(nameof(ShowFeedbackPanel));
             ReOptimizeCommand.NotifyCanExecuteChanged();
             IsBusy = true;
 
@@ -1172,8 +1236,16 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 if (double.IsFinite(bestEval.Metrics.SigmaFocus)) { bestSigmaSum += bestEval.Metrics.SigmaFocus; bestSigmaCount++; }
                 if (i == 0) {
                     representativeBestFit = bestEval.BestFit;
-                    currentCurveLocal = new OptimizationCurve { Label = "Current", Points = seedEval.Points, Fit = seedEval.BestFit };
-                    optimizedCurveLocal = new OptimizationCurve { Label = "Optimized", Points = bestEval.Points, Fit = bestEval.BestFit };
+                    currentCurveLocal = new OptimizationCurve {
+                        Label = "Current", Points = seedEval.Points, Fit = seedEval.BestFit,
+                        FrameStarCounts = seedEval.Metrics.FrameStarCounts,
+                        FrameFocuserPositions = seedEval.Metrics.FrameFocuserPositions
+                    };
+                    optimizedCurveLocal = new OptimizationCurve {
+                        Label = "Optimized", Points = bestEval.Points, Fit = bestEval.BestFit,
+                        FrameStarCounts = bestEval.Metrics.FrameStarCounts,
+                        FrameFocuserPositions = bestEval.Metrics.FrameFocuserPositions
+                    };
                 }
             }
 
@@ -1371,6 +1443,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 }
                 capturedLabels = labelsByRun;
                 RaisePropertyChanged(nameof(HasLabels));
+                RaisePropertyChanged(nameof(ShowReoptimizePrompt));
+                RaisePropertyChanged(nameof(ShowFeedbackPanel));
                 ReOptimizeCommand.NotifyCanExecuteChanged();
 
                 // Replace any prior review (drop its label-change subscription first to avoid a dangling handler).
@@ -1408,6 +1482,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         private void OnReviewLabelsChanged(object sender, PropertyChangedEventArgs e) {
             if (e.PropertyName == nameof(StarReviewVM.CountsLabel)) {
                 RaisePropertyChanged(nameof(HasLabels));
+                RaisePropertyChanged(nameof(ShowReoptimizePrompt));
+                RaisePropertyChanged(nameof(ShowFeedbackPanel));
                 ReOptimizeCommand.NotifyCanExecuteChanged();
             }
         }
@@ -1424,6 +1500,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 RaisePropertyChanged();
                 RaisePropertyChanged(nameof(HasRecommendation));
                 RaisePropertyChanged(nameof(RecommendationRows));
+                RaisePropertyChanged(nameof(ShowFeedbackPanel));
             }
         }
 
@@ -1653,6 +1730,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 // labels dir it was constructed with). SaveAll also refreshes its in-memory counts.
                 ReviewVM.SaveAll();
                 RaisePropertyChanged(nameof(HasLabels));
+                RaisePropertyChanged(nameof(ShowReoptimizePrompt));
+                RaisePropertyChanged(nameof(ShowFeedbackPanel));
                 ReOptimizeCommand.NotifyCanExecuteChanged();
             } catch (Exception ex) {
                 Logger.Error(ex, "Failed to persist review labels");


### PR DESCRIPTION
## Summary

Reworks the Star Detection Optimization Wizard's results flow to (1) visualize the auto-focus curve, (2) let the user compare/accept distinct settings variants, and (3) show real progress during the long startup instead of "Combinations tried 0/0".

### Auto-focus curve chart (results page)
- OxyPlot chart of HFR vs focuser position with per-point error bars, an optimum-point diamond at the curve minimum, and a hover tracker — mirroring the existing AF chart pattern.
- A **Current / Optimized / Optimized (with feedback)** toggle selects which curve is shown; the selection also drives the summary text and the changed-parameters table.
- Hosted in a `ContentControl` bound to `SelectedCurve` (with an `OptimizationCurve` DataTemplate) so toggling rebuilds the plot from a fresh instance — sidesteps OxyPlot.Wpf's bound-collection-swap refresh quirk.
- `RunEvaluationResult.Points` surfaces the pooled `ScatterErrorPoint`s, captured in `BuildSummaryAsync` from the seed/best evals already performed there — **zero extra detection**.

### Retained variants + Accept
- Replaces the single `Result`/`Summary` (which were overwritten on re-optimize) with retained **Current / Optimized / Feedback** variants. `Result`/`Summary` are now pass-throughs of the selected variant. The first **Optimized** variant is preserved across re-optimizes; **Feedback** is replaced each round (≤3 variants).
- Single **Accept** applies the *selected* variant; disabled on Current, in review-only, and while Start/a run is in progress.
- The feedback summary header adds a "vs optimized (no feedback)" σ row (`PriorSigmaFocus` / `FeedbackVsOptimizedText`).

### Footer / page roles
- **Review (labeling) page**: no Accept/Cancel — only **Back to summary** and **Optimize with feedback** (enabled when labels exist).
- **Results page**: Back / Review / Accept / Close.

### Determinate progress
- Unified `ProgressLabel` + `ProgressCurrent`/`ProgressTotal` model replaces the hardcoded "Combinations tried", covering frame **loading**, the seed-guard **early-context build** (the long initial wait), and **review detection**. The progress panel shows whenever the wizard is busy, so the **review-only** path shows progress too.
- Plumbing is additive: a progress-bearing `IRunEvaluationLoader` overload, an optional `IProgress` on `EvaluateAndFitAsync`/`DetectAllFramesAsync` and `FrameReviewBuilder.BuildAsync` (default `null`). The optimizer hot path passes no progress and stays **byte-identical**.

## Testing
- `dotnet build` (plugin + TestApp): clean. `dotnet test`: **1267 passed, 0 failed**.
- New tests: curve-point surfacing; metrics identical with/without frame progress (hot-path proof); variant defaults/availability per case; Accept applies the selected variant; optimized-preserved / feedback-replaced across two re-optimizes; CanAccept per case; feedback-vs-optimized formatter.
- Not covered by unit tests (needs a manual NINA pass): live WPF rendering — chart re-render on toggle, tracker tooltip, and window sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)