### PR TITLE
Star detection: opt-in defocused/donut recovery (regression-safe optimizer)

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationObjectiveTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationObjectiveTests.cs
@@ -247,6 +247,79 @@ public class OptimizationObjectiveTests {
         Assert.That(j, Is.GreaterThanOrEqualTo(0.0));
     }
 
+    // ---- SExtreme (F5 extreme-frame donut-recall term) ----
+
+    // Metrics with explicit per-frame focuser positions and star counts (everything else neutral for J).
+    private static RunEvaluationMetrics RunWithCounts(int[] positions, int[] counts) => new RunEvaluationMetrics {
+        SigmaFocus = 0.05,
+        LooStdError = double.NaN,
+        StepSize = 100,
+        RSquared = 0.99,
+        ReducedChiSquared = 1.0,
+        FrameStarCounts = counts,
+        FrameFocuserPositions = positions,
+        BestFocusPosition = positions[positions.Length / 2]
+    };
+
+    [Test]
+    public void SExtreme_GateOff_ReturnsNull() {
+        // Default constants leave the term OFF ⇒ the objective is bit-identical (no extreme term).
+        var m = RunWithCounts(new[] { 5000, 5100, 5200 }, new[] { 10, 40, 30 });
+        Assert.That(OptimizationObjective.SExtreme(m, C), Is.Null);
+    }
+
+    [Test]
+    public void SExtreme_NoPositions_OrSingleDistinctPosition_ReturnsNull() {
+        var c = new ObjectiveConstants { EnableExtremeRecall = true };
+        var noPos = new RunEvaluationMetrics { FrameStarCounts = new[] { 10, 20 }, FrameFocuserPositions = null };
+        var oneDistinct = RunWithCounts(new[] { 5000, 5000, 5000 }, new[] { 10, 40, 30 });
+        Assert.Multiple(() => {
+            Assert.That(OptimizationObjective.SExtreme(noPos, c), Is.Null, "no positions ⇒ not applicable");
+            Assert.That(OptimizationObjective.SExtreme(oneDistinct, c), Is.Null, "single distinct position ⇒ no extremes");
+        });
+    }
+
+    [Test]
+    public void SExtreme_IsClampedMeanOfExtremeFrameCounts() {
+        var c = new ObjectiveConstants { EnableExtremeRecall = true, ExtremeTarget = 20 };
+        // Extremes are the min (5000 ⇒ 10 stars) and max (5200 ⇒ 30 stars) positions; mid frame is ignored.
+        // mean(10, 30) = 20 ⇒ 20/20 = 1.0.
+        var atTarget = RunWithCounts(new[] { 5000, 5100, 5200 }, new[] { 10, 999, 30 });
+        // mean(5, 5) = 5 ⇒ 5/20 = 0.25.
+        var quarter = RunWithCounts(new[] { 5000, 5100, 5200 }, new[] { 5, 999, 5 });
+        Assert.Multiple(() => {
+            Assert.That(OptimizationObjective.SExtreme(atTarget, c).Value, Is.EqualTo(1.0).Within(1e-12));
+            Assert.That(OptimizationObjective.SExtreme(quarter, c).Value, Is.EqualTo(0.25).Within(1e-12));
+        });
+    }
+
+    [Test]
+    public void SExtreme_SaturatesAtTarget() {
+        var c = new ObjectiveConstants { EnableExtremeRecall = true, ExtremeTarget = 20 };
+        var rich = RunWithCounts(new[] { 5000, 5100, 5200 }, new[] { 60, 5, 80 });
+        Assert.That(OptimizationObjective.SExtreme(rich, c).Value, Is.EqualTo(1.0), "capped at the target (no junk incentive past it)");
+    }
+
+    [Test]
+    public void JRun_ExtremeRecallOn_BitIdentical_ToOffWhenExtremesAtTarget() {
+        // When SExtreme = 1 (extremes at target), folding We·1 in and adding We to wSum leaves a perfect run at 1.0,
+        // matching the gate-off result — proving the renormalization is exact.
+        var on = new ObjectiveConstants { EnableExtremeRecall = true, ExtremeTarget = 8 };
+        var m = RunWithCounts(new[] { 5000, 5100, 5200 }, new[] { 100, 100, 100 });
+        m.SigmaFocus = 1e-9; m.RSquared = 1.0; m.ReducedChiSquared = 1.0;
+        Assert.That(OptimizationObjective.JRun(m, on), Is.EqualTo(1.0).Within(1e-9));
+    }
+
+    [Test]
+    public void JRun_ExtremeRecallOn_RewardsRicherExtremes() {
+        var c = new ObjectiveConstants { EnableExtremeRecall = true, ExtremeTarget = 30 };
+        // Same focus/fit/median; only the EXTREME-frame counts differ. The mid frames keep nMin/median identical
+        // so S_stars is matched, isolating the extreme term's effect.
+        var poor = RunWithCounts(new[] { 5000, 5100, 5200 }, new[] { 8, 50, 8 });
+        var rich = RunWithCounts(new[] { 5000, 5100, 5200 }, new[] { 28, 50, 28 });
+        Assert.That(OptimizationObjective.JRun(rich, c), Is.GreaterThan(OptimizationObjective.JRun(poor, c)));
+    }
+
     // ---- SDefocusPrecision (F3 label-free precision penalty) ----
 
     // GoodRun augmented with the per-frame plumbing the near-focus signal needs: a focuser-position axis centered

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizerVariableTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizerVariableTests.cs
@@ -137,16 +137,20 @@ public class OptimizerVariableTests {
     // ---- CreateCuratedSet ----
 
     [Test]
-    public void CreateCuratedSet_HasFourteenDistinctVariables() {
-        var set = OptimizerVariable.CreateCuratedSet();
-        Assert.That(set.Count, Is.EqualTo(14));
-        Assert.That(set.Select(x => x.Name).Distinct().Count(), Is.EqualTo(14));
+    public void CreateCuratedSet_Default_Has14_OptIn_Adds4DefocusKnobs() {
+        var def = OptimizerVariable.CreateCuratedSet();
+        var opt = OptimizerVariable.CreateCuratedSet(defocusRecovery: true);
+        Assert.Multiple(() => {
+            Assert.That(def.Count, Is.EqualTo(14), "default (no opt-in) == baseline dimensionality");
+            Assert.That(def.Select(x => x.Name).Distinct().Count(), Is.EqualTo(14));
+            Assert.That(opt.Count, Is.EqualTo(18), "opt-in adds the 4 defocus-knob variables");
+            Assert.That(opt.Select(x => x.Name).Distinct().Count(), Is.EqualTo(18));
+        });
     }
 
     [Test]
-    public void CreateCuratedSet_NamesMatchStarDetectorParamsProperties() {
-        var set = OptimizerVariable.CreateCuratedSet();
-        var expected = new[] {
+    public void CreateCuratedSet_DefaultNamesAreBaseline_OptInAddsDefocusKnobs() {
+        var baseNames = new[] {
             nameof(StarDetectorParams.Sensitivity),
             nameof(StarDetectorParams.StarClippingMultiplier),
             nameof(StarDetectorParams.NoiseClippingMultiplier),
@@ -159,15 +163,23 @@ public class OptimizerVariableTests {
             nameof(StarDetectorParams.MinimumStarBoundingBoxSize),
             nameof(StarDetectorParams.HotpixelThresholdingEnabled),
             nameof(StarDetectorParams.HotpixelThreshold),
-            // Synthetic combined switch (drives DefocusAwareDistortion + DefocusAwareCentering together).
-            OptimizerVariable.DefocusAwareGatesName,
-            // Synthetic integer knob (drives DefocusAwareStructure + StructureLayerBoost together).
-            OptimizerVariable.DefocusAwareStructureName,
+            OptimizerVariable.DefocusAwareGatesName,      // pre-change / baseline
+            OptimizerVariable.DefocusAwareStructureName,  // pre-change / baseline
         };
-        Assert.That(set.Select(x => x.Name), Is.EquivalentTo(expected));
+        var knobNames = new[] {
+            nameof(StarDetectorParams.DefocusDistortionSizeReference),
+            nameof(StarDetectorParams.DefocusMaxElongation),
+            nameof(StarDetectorParams.DefocusDistortionMinFactor),
+            nameof(StarDetectorParams.DefocusCenteringToleranceFactor),
+        };
+        Assert.Multiple(() => {
+            Assert.That(OptimizerVariable.CreateCuratedSet().Select(x => x.Name), Is.EquivalentTo(baseNames));
+            Assert.That(OptimizerVariable.CreateCuratedSet(defocusRecovery: true).Select(x => x.Name),
+                Is.EquivalentTo(baseNames.Concat(knobNames)));
+        });
     }
 
-    // ---- DefocusAwareGates combined switch (F3) ----
+    // ---- DefocusAwareGates combined switch ----
 
     [Test]
     public void CreateCuratedSet_IncludesDefocusAwareGates_AsBoolean() {
@@ -180,24 +192,39 @@ public class OptimizerVariableTests {
     }
 
     [Test]
-    public void DefocusAwareGates_WritingTrue_SetsBothFlags() {
+    public void DefocusAwareGates_DefaultSet_WritingTrue_SetsDistortionAndCentering_NotRoundness() {
+        // Baseline behavior: the default (non-opt-in) gates switch must NOT enable the roundness rescue.
         var v = OptimizerVariable.CreateCuratedSet().Single(x => x.Name == OptimizerVariable.DefocusAwareGatesName);
-        var p = new StarDetectorParams { DefocusAwareDistortion = false, DefocusAwareCentering = false };
+        var p = new StarDetectorParams { DefocusAwareDistortion = false, DefocusAwareCentering = false, DefocusRoundnessAdmission = false };
         v.Write(p, 1.0);
         Assert.Multiple(() => {
             Assert.That(p.DefocusAwareDistortion, Is.True);
             Assert.That(p.DefocusAwareCentering, Is.True);
+            Assert.That(p.DefocusRoundnessAdmission, Is.False, "roundness is opt-in only");
         });
     }
 
     [Test]
-    public void DefocusAwareGates_WritingFalse_ClearsBothFlags() {
-        var v = OptimizerVariable.CreateCuratedSet().Single(x => x.Name == OptimizerVariable.DefocusAwareGatesName);
-        var p = new StarDetectorParams { DefocusAwareDistortion = true, DefocusAwareCentering = true };
+    public void DefocusAwareGates_OptInSet_WritingTrue_SetsAllThreeFlags() {
+        var v = OptimizerVariable.CreateCuratedSet(defocusRecovery: true).Single(x => x.Name == OptimizerVariable.DefocusAwareGatesName);
+        var p = new StarDetectorParams { DefocusAwareDistortion = false, DefocusAwareCentering = false, DefocusRoundnessAdmission = false };
+        v.Write(p, 1.0);
+        Assert.Multiple(() => {
+            Assert.That(p.DefocusAwareDistortion, Is.True);
+            Assert.That(p.DefocusAwareCentering, Is.True);
+            Assert.That(p.DefocusRoundnessAdmission, Is.True);
+        });
+    }
+
+    [Test]
+    public void DefocusAwareGates_OptInSet_WritingFalse_ClearsAllThreeFlags() {
+        var v = OptimizerVariable.CreateCuratedSet(defocusRecovery: true).Single(x => x.Name == OptimizerVariable.DefocusAwareGatesName);
+        var p = new StarDetectorParams { DefocusAwareDistortion = true, DefocusAwareCentering = true, DefocusRoundnessAdmission = true };
         v.Write(p, 0.0);
         Assert.Multiple(() => {
             Assert.That(p.DefocusAwareDistortion, Is.False);
             Assert.That(p.DefocusAwareCentering, Is.False);
+            Assert.That(p.DefocusRoundnessAdmission, Is.False);
         });
     }
 
@@ -214,7 +241,8 @@ public class OptimizerVariableTests {
 
     [Test]
     public void CreateCuratedSet_BoundsAndStepsMatchSpec() {
-        var set = OptimizerVariable.CreateCuratedSet().ToDictionary(x => x.Name);
+        // Use the opt-in (superset) so all 18 variables' bounds/steps are covered in one place.
+        var set = OptimizerVariable.CreateCuratedSet(defocusRecovery: true).ToDictionary(x => x.Name);
         void Check(string name, OptimizerVariableType type, double lo, double hi, double step) {
             var v = set[name];
             Assert.Multiple(() => {
@@ -236,6 +264,10 @@ public class OptimizerVariableTests {
         Check(nameof(StarDetectorParams.MinimumStarBoundingBoxSize), OptimizerVariableType.Integer, 2, 20, 1);
         Check(nameof(StarDetectorParams.HotpixelThresholdingEnabled), OptimizerVariableType.Boolean, 0, 1, 1);
         Check(nameof(StarDetectorParams.HotpixelThreshold), OptimizerVariableType.Continuous, 0.0001, 0.05, 0.001);
+        Check(nameof(StarDetectorParams.DefocusDistortionSizeReference), OptimizerVariableType.Continuous, 15.0, 60.0, 5.0);
+        Check(nameof(StarDetectorParams.DefocusMaxElongation), OptimizerVariableType.Continuous, 1.0, 4.0, 0.25);
+        Check(nameof(StarDetectorParams.DefocusDistortionMinFactor), OptimizerVariableType.Continuous, 0.1, 1.0, 0.05);
+        Check(nameof(StarDetectorParams.DefocusCenteringToleranceFactor), OptimizerVariableType.Continuous, 1.0, 4.0, 0.25);
     }
 
     [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -35,6 +35,23 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Optimization;
 [TestFixture]
 public class StarDetectionOptimizerWizardVMTests {
 
+    // Regression guard for the defocus-recovery toggle → objective wiring. A pre-release build once shipped with
+    // this disconnected, so enabling "Recover defocused / donut stars" silently ran the BASELINE objective (which
+    // is rewarded for culling faint extreme-defocus donuts to tighten the curve) instead of the extreme-recall
+    // regime. The toggle MUST drive ObjectiveConstants.EnableExtremeRecall; OFF must stay bit-identical to baseline.
+    [Test]
+    public void BuildOptimizerObjective_TogglesExtremeRecallWithDefocusRecovery() {
+        var on = StarDetectionOptimizerWizardVM.BuildOptimizerObjective(defocusRecovery: true);
+        var off = StarDetectionOptimizerWizardVM.BuildOptimizerObjective(defocusRecovery: false);
+        Assert.Multiple(() => {
+            Assert.That(on.EnableExtremeRecall, Is.True, "Defocus recovery ON must enable the extreme-recall term");
+            Assert.That(off.EnableExtremeRecall, Is.False, "Defocus recovery OFF must keep the baseline objective");
+            // OFF must equal a default ObjectiveConstants (bit-identical baseline): only the flag may differ.
+            Assert.That(off.We, Is.EqualTo(new ObjectiveConstants().We));
+            Assert.That(off.ExtremeTarget, Is.EqualTo(new ObjectiveConstants().ExtremeTarget));
+        });
+    }
+
     private static AlglibAPI NewAlglib() => new AlglibAPI();
 
     // A clean symmetric hyperbola hfr(pos) = sqrt(a^2 + ((pos - p0)/b)^2), as in RunEvaluationDataTests.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/OptimizedStarDetectionSettingsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/OptimizedStarDetectionSettingsTests.cs
@@ -23,19 +23,55 @@ public class OptimizedStarDetectionSettingsTests {
             MinStarBoundingBoxSize = 8,
             HotpixelThresholdingEnabled = false,
             HotpixelThreshold = 0.02,
+            DefocusAwareGates = false,
+            DefocusDistortionSizeReference = 22.0,
+            DefocusDistortionMinFactor = 0.4,
+            DefocusCenteringToleranceFactor = 2.5,
+            DefocusMaxElongation = 1.7,
+            DefocusAwareStructure = true,
+            StructureLayerBoost = 3,
             CreatedAtUtc = new DateTime(2026, 6, 14, 12, 0, 0, DateTimeKind.Utc),
             RunCount = 5,
             BaselineJ = 0.9,
             FinalJ = 0.4,
             RecommendedStepSize = 25,
             RecommendedOffsetSteps = 6,
-            SchemaVersion = 1
+            SchemaVersion = 2
         };
     }
 
     [Test]
-    public void DefaultSchemaVersion_IsOne() {
-        Assert.That(new OptimizedStarDetectionSettings().SchemaVersion, Is.EqualTo(1));
+    public void DefaultSchemaVersion_IsTwo() {
+        Assert.That(new OptimizedStarDetectionSettings().SchemaVersion, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void DefaultDefocusFields_MatchOptionDefaults() {
+        // A snapshot that predates the defocus fields (SchemaVersion 1 JSON) deserializes with these defaults,
+        // so applying it yields gates-ON with the default knobs rather than zeros (an invalid 0 px size reference).
+        var d = new OptimizedStarDetectionSettings();
+        Assert.Multiple(() => {
+            Assert.That(d.DefocusAwareGates, Is.False);
+            Assert.That(d.DefocusDistortionSizeReference, Is.EqualTo(30.0));
+            Assert.That(d.DefocusDistortionMinFactor, Is.EqualTo(0.25));
+            Assert.That(d.DefocusCenteringToleranceFactor, Is.EqualTo(2.0));
+            Assert.That(d.DefocusMaxElongation, Is.EqualTo(2.0));
+            Assert.That(d.DefocusAwareStructure, Is.False);
+            Assert.That(d.StructureLayerBoost, Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void OldSchemaJson_WithoutDefocusFields_DeserializesToDefaults() {
+        // Simulate a v1 snapshot: JSON with the curated knobs but NO defocus keys.
+        const string v1Json = "{\"BrightnessSensitivity\":3.3,\"MaxDistortion\":0.42,\"SchemaVersion\":1}";
+        var restored = JsonConvert.DeserializeObject<OptimizedStarDetectionSettings>(v1Json);
+        Assert.Multiple(() => {
+            Assert.That(restored.SchemaVersion, Is.EqualTo(1), "preserves the stored version");
+            Assert.That(restored.DefocusAwareGates, Is.False, "missing defocus keys fall back to the baseline default (off)");
+            Assert.That(restored.DefocusDistortionSizeReference, Is.EqualTo(30.0));
+            Assert.That(restored.DefocusMaxElongation, Is.EqualTo(2.0));
+        });
     }
 
     [Test]
@@ -58,6 +94,13 @@ public class OptimizedStarDetectionSettingsTests {
             Assert.That(restored.MinStarBoundingBoxSize, Is.EqualTo(original.MinStarBoundingBoxSize));
             Assert.That(restored.HotpixelThresholdingEnabled, Is.EqualTo(original.HotpixelThresholdingEnabled));
             Assert.That(restored.HotpixelThreshold, Is.EqualTo(original.HotpixelThreshold));
+            Assert.That(restored.DefocusAwareGates, Is.EqualTo(original.DefocusAwareGates));
+            Assert.That(restored.DefocusDistortionSizeReference, Is.EqualTo(original.DefocusDistortionSizeReference));
+            Assert.That(restored.DefocusDistortionMinFactor, Is.EqualTo(original.DefocusDistortionMinFactor));
+            Assert.That(restored.DefocusCenteringToleranceFactor, Is.EqualTo(original.DefocusCenteringToleranceFactor));
+            Assert.That(restored.DefocusMaxElongation, Is.EqualTo(original.DefocusMaxElongation));
+            Assert.That(restored.DefocusAwareStructure, Is.EqualTo(original.DefocusAwareStructure));
+            Assert.That(restored.StructureLayerBoost, Is.EqualTo(original.StructureLayerBoost));
             Assert.That(restored.CreatedAtUtc, Is.EqualTo(original.CreatedAtUtc));
             Assert.That(restored.RunCount, Is.EqualTo(original.RunCount));
             Assert.That(restored.BaselineJ, Is.EqualTo(original.BaselineJ));
@@ -83,7 +126,17 @@ public class OptimizedStarDetectionSettingsTests {
             NoiseReductionRadius = 6,
             MinimumStarBoundingBoxSize = 8,
             HotpixelThresholdingEnabled = false,
-            HotpixelThreshold = 0.02
+            HotpixelThreshold = 0.02,
+            // Defocus-aware family: the three gate flags move in lockstep, so DefocusAwareGates mirrors distortion.
+            DefocusAwareDistortion = true,
+            DefocusAwareCentering = true,
+            DefocusRoundnessAdmission = true,
+            DefocusDistortionSizeReference = 22.0,
+            DefocusDistortionMinFactor = 0.4,
+            DefocusCenteringToleranceFactor = 2.5,
+            DefocusMaxElongation = 1.7,
+            DefocusAwareStructure = true,
+            StructureLayerBoost = 3
         };
 
         var before = DateTime.UtcNow;
@@ -106,13 +159,22 @@ public class OptimizedStarDetectionSettingsTests {
             Assert.That(dto.HotpixelThresholdingEnabled, Is.False);
             Assert.That(dto.HotpixelThreshold, Is.EqualTo(0.02));
 
+            // Defocus-aware family (single gates flag mirrors the distortion flag).
+            Assert.That(dto.DefocusAwareGates, Is.True);
+            Assert.That(dto.DefocusDistortionSizeReference, Is.EqualTo(22.0));
+            Assert.That(dto.DefocusDistortionMinFactor, Is.EqualTo(0.4));
+            Assert.That(dto.DefocusCenteringToleranceFactor, Is.EqualTo(2.5));
+            Assert.That(dto.DefocusMaxElongation, Is.EqualTo(1.7));
+            Assert.That(dto.DefocusAwareStructure, Is.True);
+            Assert.That(dto.StructureLayerBoost, Is.EqualTo(3));
+
             // Metadata.
             Assert.That(dto.RunCount, Is.EqualTo(5));
             Assert.That(dto.BaselineJ, Is.EqualTo(0.9));
             Assert.That(dto.FinalJ, Is.EqualTo(0.4));
             Assert.That(dto.RecommendedStepSize, Is.EqualTo(25));
             Assert.That(dto.RecommendedOffsetSteps, Is.EqualTo(6));
-            Assert.That(dto.SchemaVersion, Is.EqualTo(1));
+            Assert.That(dto.SchemaVersion, Is.EqualTo(2));
             Assert.That(dto.CreatedAtUtc, Is.InRange(before, after));
             Assert.That(dto.CreatedAtUtc.Kind, Is.EqualTo(DateTimeKind.Utc));
         });

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionOptionsTests.cs
@@ -59,10 +59,11 @@ public class StarDetectionOptionsTests {
         options.StarCenterTolerance = 0.5;
         options.StarPeakResponse = 0.8;
         options.MaxDistortion = 0.4;
-        options.DefocusAwareGates = true;
+        options.DefocusAwareGates = true; // differs from the default (false) so the setter persists it
         options.DefocusDistortionSizeReference = 25.0;
         options.DefocusDistortionMinFactor = 0.3;
         options.DefocusCenteringToleranceFactor = 2.5;
+        options.DefocusMaxElongation = 3.0;
         options.StarBackgroundBoxExpansion = 4;
         options.MinStarBoundingBoxSize = 6;
         options.MinHFR = 1.0;
@@ -98,6 +99,7 @@ public class StarDetectionOptionsTests {
             Assert.That(store.Snapshot["DefocusDistortionSizeReference"], Is.EqualTo(25.0));
             Assert.That(store.Snapshot["DefocusDistortionMinFactor"], Is.EqualTo(0.3));
             Assert.That(store.Snapshot["DefocusCenteringToleranceFactor"], Is.EqualTo(2.5));
+            Assert.That(store.Snapshot["DefocusMaxElongation"], Is.EqualTo(3.0));
             Assert.That(store.Snapshot["StarBackgroundBoxExpansion"], Is.EqualTo(4));
             Assert.That(store.Snapshot["MinStarBoundingBoxSize"], Is.EqualTo(6));
             Assert.That(store.Snapshot["MinHFR"], Is.EqualTo(1.0));
@@ -275,19 +277,21 @@ public class StarDetectionOptionsTests {
 
     [Test]
     public void DefocusAwareGates_DefaultsOff() {
+        // Default OFF (baseline): the gates trade AF-curve tightness for donut recall, so they are opt-in via the
+        // optimization wizard's defocus-recovery toggle (see donut-defocus-detection-analysis-design.md).
         var (options, _, _) = Build();
         Assert.That(options.DefocusAwareGates, Is.False);
     }
 
     [Test]
     public void DefocusTunables_DefaultToParamDefaults() {
-        // Defaults must equal the StarDetectorParams class defaults so detection stays bit-identical when the
-        // gates are off and unchanged when first turned on.
+        // Defaults must equal the StarDetectorParams class defaults so the knobs are unchanged from the detector.
         var (options, _, _) = Build();
         Assert.Multiple(() => {
             Assert.That(options.DefocusDistortionSizeReference, Is.EqualTo(30.0));
             Assert.That(options.DefocusDistortionMinFactor, Is.EqualTo(0.25));
             Assert.That(options.DefocusCenteringToleranceFactor, Is.EqualTo(2.0));
+            Assert.That(options.DefocusMaxElongation, Is.EqualTo(2.0));
         });
     }
 
@@ -322,10 +326,11 @@ public class StarDetectionOptionsTests {
     public void ResetDefaults_RestoresDefocusGateDefaults() {
         var (options, _, _) = Build();
         options.UseAdvanced = true;
-        options.DefocusAwareGates = true;
+        options.DefocusAwareGates = true; // differs from the default (false)
         options.DefocusDistortionSizeReference = 25.0;
         options.DefocusDistortionMinFactor = 0.3;
         options.DefocusCenteringToleranceFactor = 2.5;
+        options.DefocusMaxElongation = 3.0;
 
         options.ResetDefaults();
 
@@ -334,38 +339,44 @@ public class StarDetectionOptionsTests {
             Assert.That(options.DefocusDistortionSizeReference, Is.EqualTo(30.0));
             Assert.That(options.DefocusDistortionMinFactor, Is.EqualTo(0.25));
             Assert.That(options.DefocusCenteringToleranceFactor, Is.EqualTo(2.0));
+            Assert.That(options.DefocusMaxElongation, Is.EqualTo(2.0));
         });
     }
 
     [Test]
     public void DefocusGates_RoundTripThroughBuildStarDetectorParams() {
-        // The single DefocusAwareGates toggle must drive BOTH detector-param flags, and the three numeric knobs
-        // must flow through unchanged.
+        // The single DefocusAwareGates toggle must drive ALL THREE detector-param flags (distortion, centering,
+        // roundness rescue), and the numeric knobs must flow through unchanged.
         var (options, _, _) = Build();
         options.UseAdvanced = true;
         options.DefocusAwareGates = true;
         options.DefocusDistortionSizeReference = 22.0;
         options.DefocusDistortionMinFactor = 0.4;
         options.DefocusCenteringToleranceFactor = 3.0;
+        options.DefocusMaxElongation = 1.8;
 
         var p = HocusFocusStarDetection.BuildStarDetectorParams(options);
 
         Assert.Multiple(() => {
             Assert.That(p.DefocusAwareDistortion, Is.True);
             Assert.That(p.DefocusAwareCentering, Is.True);
+            Assert.That(p.DefocusRoundnessAdmission, Is.True);
             Assert.That(p.DefocusDistortionSizeReference, Is.EqualTo(22.0));
             Assert.That(p.DefocusDistortionMinFactor, Is.EqualTo(0.4));
             Assert.That(p.DefocusCenteringToleranceFactor, Is.EqualTo(3.0));
+            Assert.That(p.DefocusMaxElongation, Is.EqualTo(1.8));
         });
     }
 
     [Test]
-    public void DefocusGatesOff_BothDetectorFlagsOff() {
+    public void DefocusGatesOff_AllThreeDetectorFlagsOff() {
         var (options, _, _) = Build();
+        // DefocusAwareGates defaults OFF, so a fresh options object yields all three detector flags off.
         var p = HocusFocusStarDetection.BuildStarDetectorParams(options);
         Assert.Multiple(() => {
             Assert.That(p.DefocusAwareDistortion, Is.False);
             Assert.That(p.DefocusAwareCentering, Is.False);
+            Assert.That(p.DefocusRoundnessAdmission, Is.False);
         });
     }
 
@@ -433,6 +444,7 @@ public class StarDetectionOptionsTests {
     [TestCase(nameof(StarDetectionOptions.DefocusDistortionSizeReference), 25.0)]
     [TestCase(nameof(StarDetectionOptions.DefocusDistortionMinFactor), 0.3)]
     [TestCase(nameof(StarDetectionOptions.DefocusCenteringToleranceFactor), 2.5)]
+    [TestCase(nameof(StarDetectionOptions.DefocusMaxElongation), 3.0)]
     public void Setter_RaisesPropertyChanged(string propertyName, object newValue) {
         var (options, _, _) = Build();
         var raised = new List<string>();
@@ -519,13 +531,22 @@ public class StarDetectionOptionsTests {
             MinStarBoundingBoxSize = 8,
             HotpixelThresholdingEnabled = false,
             HotpixelThreshold = 0.02,
+            // Defocus-aware family — non-default numeric values (defaults are 30/0.25/2.0/2.0, structure off/0) so
+            // the apply test proves these are actually driven from the snapshot, not coincidentally the defaults.
+            DefocusAwareGates = true,
+            DefocusDistortionSizeReference = 22.0,
+            DefocusDistortionMinFactor = 0.4,
+            DefocusCenteringToleranceFactor = 2.5,
+            DefocusMaxElongation = 1.7,
+            DefocusAwareStructure = true,
+            StructureLayerBoost = 3,
             CreatedAtUtc = new DateTime(2026, 6, 14, 12, 0, 0, DateTimeKind.Utc),
             RunCount = 5,
             BaselineJ = 0.9,
             FinalJ = 0.4,
             RecommendedStepSize = 25,
             RecommendedOffsetSteps = 6,
-            SchemaVersion = 1
+            SchemaVersion = 2
         };
     }
 
@@ -543,6 +564,13 @@ public class StarDetectionOptionsTests {
             Assert.That(options.MinStarBoundingBoxSize, Is.EqualTo(s.MinStarBoundingBoxSize));
             Assert.That(options.HotpixelThresholdingEnabled, Is.EqualTo(s.HotpixelThresholdingEnabled));
             Assert.That(options.HotpixelThreshold, Is.EqualTo(s.HotpixelThreshold));
+            Assert.That(options.DefocusAwareGates, Is.EqualTo(s.DefocusAwareGates));
+            Assert.That(options.DefocusDistortionSizeReference, Is.EqualTo(s.DefocusDistortionSizeReference));
+            Assert.That(options.DefocusDistortionMinFactor, Is.EqualTo(s.DefocusDistortionMinFactor));
+            Assert.That(options.DefocusCenteringToleranceFactor, Is.EqualTo(s.DefocusCenteringToleranceFactor));
+            Assert.That(options.DefocusMaxElongation, Is.EqualTo(s.DefocusMaxElongation));
+            Assert.That(options.DefocusAwareStructure, Is.EqualTo(s.DefocusAwareStructure));
+            Assert.That(options.StructureLayerBoost, Is.EqualTo(s.StructureLayerBoost));
         });
     }
 
@@ -598,6 +626,16 @@ public class StarDetectionOptionsTests {
             Assert.That(p.MinimumStarBoundingBoxSize, Is.EqualTo(snapshot.MinStarBoundingBoxSize));
             Assert.That(p.HotpixelThresholdingEnabled, Is.EqualTo(snapshot.HotpixelThresholdingEnabled));
             Assert.That(p.HotpixelThreshold, Is.EqualTo(snapshot.HotpixelThreshold));
+            // Defocus-aware family: the single gates flag drives all three detector flags; knobs flow through.
+            Assert.That(p.DefocusAwareDistortion, Is.EqualTo(snapshot.DefocusAwareGates));
+            Assert.That(p.DefocusAwareCentering, Is.EqualTo(snapshot.DefocusAwareGates));
+            Assert.That(p.DefocusRoundnessAdmission, Is.EqualTo(snapshot.DefocusAwareGates));
+            Assert.That(p.DefocusDistortionSizeReference, Is.EqualTo(snapshot.DefocusDistortionSizeReference));
+            Assert.That(p.DefocusDistortionMinFactor, Is.EqualTo(snapshot.DefocusDistortionMinFactor));
+            Assert.That(p.DefocusCenteringToleranceFactor, Is.EqualTo(snapshot.DefocusCenteringToleranceFactor));
+            Assert.That(p.DefocusMaxElongation, Is.EqualTo(snapshot.DefocusMaxElongation));
+            Assert.That(p.DefocusAwareStructure, Is.EqualTo(snapshot.DefocusAwareStructure));
+            Assert.That(p.StructureLayerBoost, Is.EqualTo(snapshot.StructureLayerBoost));
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectorTests.cs
@@ -156,6 +156,74 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
         }
 
         // -----------------------------------------------------------------------
+        // ComputeCandidateElongation (roundness-rescue discriminator) tests
+        // -----------------------------------------------------------------------
+
+        // Build a filled rectangle footprint (w x h) of integer pixel coordinates.
+        private static List<CvPoint> FilledRect(int w, int h) {
+            var pts = new List<CvPoint>(w * h);
+            for (int y = 0; y < h; ++y) {
+                for (int x = 0; x < w; ++x) {
+                    pts.Add(new CvPoint(x, y));
+                }
+            }
+            return pts;
+        }
+
+        [Test]
+        public void Elongation_FilledSquare_IsNearOne() {
+            // A symmetric (square) footprint has equal coordinate variances ⇒ elongation ≈ 1.
+            var e = StarDetector.ComputeCandidateElongation(FilledRect(21, 21));
+            Assert.That(e, Is.EqualTo(1.0).Within(1e-9));
+        }
+
+        [Test]
+        public void Elongation_Streak_MatchesAspectRatio() {
+            // For a filled w x h rectangle the coordinate-covariance eigenvalues are the per-axis variances,
+            // so elongation = sqrt(varMajor / varMinor) = (longer side / shorter side) for uniform fills.
+            // A 60x20 streak ⇒ 3:1. Allow a small tolerance for the discrete uniform variance ratio.
+            var e = StarDetector.ComputeCandidateElongation(FilledRect(60, 20));
+            Assert.That(e, Is.EqualTo(3.0).Within(0.05));
+        }
+
+        [Test]
+        public void Elongation_DonutRing_IsNearOne_AndPassesTypicalCap() {
+            // A hollow ring (donut) of outer radius ~20 px, inner radius ~9 px is radially symmetric ⇒ elongation ≈ 1,
+            // so it clears the default DefocusMaxElongation = 2.0 cap (admitted), unlike an elongated streak.
+            var pts = new List<CvPoint>();
+            const double rOut = 20.0, rIn = 9.0;
+            for (int y = -22; y <= 22; ++y) {
+                for (int x = -22; x <= 22; ++x) {
+                    var r = Math.Sqrt(x * x + y * y);
+                    if (r >= rIn && r <= rOut) {
+                        pts.Add(new CvPoint(x + 30, y + 30));
+                    }
+                }
+            }
+            var e = StarDetector.ComputeCandidateElongation(pts);
+            Assert.Multiple(() => {
+                Assert.That(e, Is.EqualTo(1.0).Within(0.05), "a symmetric ring is round");
+                Assert.That(e, Is.LessThanOrEqualTo(2.0), "round donut clears the default elongation cap");
+            });
+        }
+
+        [Test]
+        public void Elongation_DegenerateFootprints_ReturnInfinity() {
+            Assert.Multiple(() => {
+                Assert.That(StarDetector.ComputeCandidateElongation(null), Is.EqualTo(double.PositiveInfinity));
+                Assert.That(StarDetector.ComputeCandidateElongation(new List<CvPoint>()), Is.EqualTo(double.PositiveInfinity));
+                Assert.That(StarDetector.ComputeCandidateElongation(new List<CvPoint> { new CvPoint(5, 5) }),
+                    Is.EqualTo(double.PositiveInfinity), "single pixel ⇒ infinite (never rescued)");
+                // A perfectly collinear set has zero minor-axis variance ⇒ infinite elongation (a line is not round).
+                var line = new List<CvPoint>();
+                for (int x = 0; x < 10; ++x) {
+                    line.Add(new CvPoint(x, 3));
+                }
+                Assert.That(StarDetector.ComputeCandidateElongation(line), Is.EqualTo(double.PositiveInfinity));
+            });
+        }
+
+        // -----------------------------------------------------------------------
         // ComputeEffectiveStarCenterTolerance (defocus-aware NotCentered gate) tests
         // -----------------------------------------------------------------------
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetectionOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetectionOptions.cs
@@ -98,6 +98,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         double DefocusDistortionSizeReference { get; set; }
         double DefocusDistortionMinFactor { get; set; }
         double DefocusCenteringToleranceFactor { get; set; }
+        double DefocusMaxElongation { get; set; }
         double StarCenterTolerance { get; set; }
         int StarBackgroundBoxExpansion { get; set; }
         int MinStarBoundingBoxSize { get; set; }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
@@ -359,6 +359,25 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         // near-focus accepted/NotCentered counts (near-focus candidates stay <= the size reference, so factor 1.0).
         public double DefocusCenteringToleranceFactor { get; set; } = 2.0;
 
+        // Opt-in (default OFF for bit-identical detection). Roundness-rescue for the TooDistorted gate: fill-ratio
+        // is a POOR donut discriminator (a real donut ring and an irregular junk blob can share the same ~0.47
+        // fill), so relaxing the fill-ratio alone admits junk too. When true, a LARGE candidate
+        // (candidateSize = max(bbox.Width, bbox.Height) > DefocusDistortionSizeReference) that the (possibly
+        // relaxed) fill-ratio gate would reject is RESCUED — admitted — iff it is sufficiently ROUND, i.e. its
+        // pixel-coordinate elongation (√(λmax/λmin) of the unweighted covariance) is <= DefocusMaxElongation. A
+        // complete donut ring is radially symmetric (elongation ≈ 1); streaks, diffraction-spike fragments, and
+        // partial arcs are elongated and stay rejected. Rescued admissions set Star.RelaxationAdmitted (so the
+        // objective's near-focus precision penalty still accounts for them). LATE-gate param: it changes only the
+        // late TooDistorted decision, so it is excluded from the early cache key. Mapped from
+        // StarDetectionOptions.DefocusAwareGates in BuildStarDetectorParams (rides the same single toggle).
+        public bool DefocusRoundnessAdmission { get; set; } = false;
+
+        // The maximum pixel-coordinate elongation (√(λmax/λmin) of the candidate's unweighted coordinate
+        // covariance; 1.0 = perfectly round, larger = more elongated) for a large low-fill candidate to be
+        // rescued by DefocusRoundnessAdmission. Only consulted when DefocusRoundnessAdmission is true. Default 2.0
+        // (admits up to ~2:1 roundish donuts; rejects clearly elongated streaks/spike-fragments).
+        public double DefocusMaxElongation { get; set; } = 2.0;
+
         // Size (as a ratio) of a centered rectangle within the star bounding box that the star center must be in. 1.0 covers the whole region, and 0.0 will fail every star
         public double StarCenterTolerance { get; set; } = 0.3;
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
@@ -447,6 +447,7 @@
     <TextBlock x:Key="DefocusDistortionSizeReference_Tooltip" Text="Tuning knob for the Defocus-Aware Gates (only used while they are enabled). The candidate bounding-box size (in pixels, the larger of width/height) at or below which the strict gate thresholds still apply; larger candidates get the relaxed thresholds. Shared by both the distortion and centering relaxations. Lower it to relax smaller stars; raise it to keep more of the strict behavior. Default 30." />
     <TextBlock x:Key="DefocusDistortionMinFactor_Tooltip" Text="Tuning knob for the Defocus-Aware Gates (only used while they are enabled). The floor multiplier applied to Max Distortion for very large (very defocused) candidates — the most permissive the distortion gate ever becomes. Must be greater than 0 and at most 1. Smaller values accept more heavily-distorted donuts. Default 0.25." />
     <TextBlock x:Key="DefocusCenteringToleranceFactor_Tooltip" Text="Tuning knob for the Defocus-Aware Gates (only used while they are enabled). The maximum multiplier applied to Star Center Tolerance for very large (very defocused) candidates — the most permissive the centering gate ever becomes. Must be at least 1 (1 is a no-op; larger values relax centering further). Default 2." />
+    <TextBlock x:Key="DefocusMaxElongation_Tooltip" Text="Tuning knob for the Defocus-Aware Gates (only used while they are enabled). A large, low-fill candidate that the distortion gate would reject is rescued — kept as a star — only if it is round enough, i.e. its elongation (1.0 = perfectly round; larger = more stretched) is at or below this value. A complete out-of-focus donut ring is round (~1), while streaks, diffraction-spike fragments, and partial arcs are elongated and stay rejected. Lower it to be stricter (admit only very round donuts); raise it to admit more oval shapes. Must be at least 1. Default 2 (about 2:1)." />
     <TextBlock x:Key="DefocusAwareStructure_Tooltip" Text="When enabled, large/donut (heavily defocused) stars are kept during structure detection so they form candidates instead of being erased. The wavelet step that removes large-scale background structure (nebulae, gradients) can also erase a big out-of-focus donut entirely, so it never even becomes a candidate to evaluate. This option makes that removal coarser (by Structure Layer Boost extra layers) so large stars survive. Off by default (detection is unchanged); enable it together with a Structure Layer Boost above 0 if heavily-defocused stars are missing entirely (not just rejected). EARLY-stage setting." />
     <TextBlock x:Key="StructureLayerBoost_Tooltip" Text="Only used while Defocus-Aware Structure is enabled. The number of extra wavelet layers added when removing large-scale structure, making the removal coarser so larger defocused donuts survive and form candidates. 0 means no change (identical to the feature being off). Raise it (1–6) if very out-of-focus stars never appear; raising it too far can let nebulosity/background structure leak in as false candidates. Default 0." />
     <TextBlock x:Key="StarCenterTolerance_Tooltip" Text="Size (as a percentage) of a centered rectangle within the star bounding box that the star center must be in. 1.0 covers the whole region, and 0.0 will fail every star" />
@@ -489,7 +490,7 @@
     <TextBlock x:Key="SaveIntermediateFiles_Tooltip" Text="If enabled, every step of star detection emits a debugging file to the intermediate path" />
     <TextBlock x:Key="UseAdvanced_Tooltip" Text="Enables advanced mode with fine-grained control over star detection parameters. Not recommended unless you're an expert" />
     <TextBlock x:Key="OptimizeStarDetection_Tooltip" Text="Opens the Star Detection Optimization Wizard, which tunes star detection against one or more saved auto-focus runs and (optionally) applies the result as your Simple-Mode settings" />
-    <TextBlock x:Key="UseOptimizedSettings_Tooltip" Text="When enabled, the optimized star-detection settings produced by the optimization wizard drive detection instead of the Noise Level / Pixel Scale / Focus Range presets. Only available in Simple Mode after the wizard has produced and applied a result" />
+    <TextBlock x:Key="UseOptimizedSettings_Tooltip" Text="When enabled, the optimized star-detection settings produced by the optimization wizard drive detection instead of the Noise Level / Pixel Scale / Focus Range presets. Shown in Simple Mode; it stays disabled until the optimization wizard has produced and applied a result for this profile." />
     <TextBlock x:Key="ModelPSF_Tooltip" Text="Whether to fit PSF models to detected stars. This is required for FWHM and Eccentricity" />
     <TextBlock x:Key="PSFFitType_Tooltip" Text="What type of PSF model to fit. Moffat 0.4 more closely resembles real stars and is the default used by PixInsight" />
     <TextBlock x:Key="PSFResolution_Tooltip" Text="The number of pixels of the width of a nominal square to sample star bounding boxes for the purposes of PSF model fitting. Higher resolution may be more accurate, but takes longer to calculate" />
@@ -975,19 +976,6 @@
                         </MultiDataTrigger>
                     </Style.Triggers>
                 </Style>
-                <!--  "Use Optimized Settings" toggle: Simple Mode, and only when the wizard has produced a result.  -->
-                <Style x:Key="ShowOnSimpleHasOptimized" TargetType="{x:Type RowDefinition}">
-                    <Setter Property="Height" Value="0" />
-                    <Style.Triggers>
-                        <MultiDataTrigger>
-                            <MultiDataTrigger.Conditions>
-                                <Condition Binding="{Binding StarDetectionOptions.UseAdvanced}" Value="False" />
-                                <Condition Binding="{Binding StarDetectionOptions.HasOptimizedSettings}" Value="True" />
-                            </MultiDataTrigger.Conditions>
-                            <Setter Property="Height" Value="Auto" />
-                        </MultiDataTrigger>
-                    </Style.Triggers>
-                </Style>
                 <Style x:Key="ShowOnUseHotpixelThresholding_Advanced" TargetType="{x:Type RowDefinition}">
                     <Setter Property="Height" Value="0" />
                     <Style.Triggers>
@@ -1019,10 +1007,10 @@
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition />
-                <!--  Row 1: "Use Optimized Settings" toggle (Simple + HasOptimized) — placed ABOVE the
+                <!--  Row 1: "Use Optimized Settings" toggle (Simple Mode; disabled-not-hidden until HasOptimized) — placed ABOVE the
                       Noise Level / Pixel Scale / Focus Range presets it replaces. Rows 2-4: those presets,
                       shown only when NOT using the optimized settings.  -->
-                <RowDefinition Style="{StaticResource ShowOnSimpleHasOptimized}" />
+                <RowDefinition Style="{StaticResource ShowOnUseSimple}" />
                 <RowDefinition Style="{StaticResource ShowOnUseSimpleNotOptimized}" />
                 <RowDefinition Style="{StaticResource ShowOnUseSimpleNotOptimized}" />
                 <RowDefinition Style="{StaticResource ShowOnUseSimpleNotOptimized}" />
@@ -1068,13 +1056,14 @@
                 <RowDefinition />
                 <RowDefinition Style="{StaticResource HideOnSaveIntermediateOff}" />
                 <RowDefinition />
-                <!--  41: Defocus-Aware Gates toggle (advanced-only); 42-44: its three numeric tuning knobs
+                <!--  41: Defocus-Aware Gates toggle (advanced-only); 42-45: its four numeric tuning knobs
                       (advanced-only AND only when the gates toggle is on).  -->
                 <RowDefinition Style="{StaticResource ShowOnUseAdvanced}" />
                 <RowDefinition Style="{StaticResource ShowOnUseAdvancedAndDefocusGates}" />
                 <RowDefinition Style="{StaticResource ShowOnUseAdvancedAndDefocusGates}" />
                 <RowDefinition Style="{StaticResource ShowOnUseAdvancedAndDefocusGates}" />
-                <!--  45: Defocus-Aware Structure toggle (advanced-only); 46: its layer-boost knob (advanced-only).  -->
+                <RowDefinition Style="{StaticResource ShowOnUseAdvancedAndDefocusGates}" />
+                <!--  46: Defocus-Aware Structure toggle (advanced-only); 47: its layer-boost knob (advanced-only).  -->
                 <RowDefinition Style="{StaticResource ShowOnUseAdvanced}" />
                 <RowDefinition Style="{StaticResource ShowOnUseAdvanced}" />
             </Grid.RowDefinitions>
@@ -1166,20 +1155,17 @@
                 </ComboBox.ItemTemplate>
             </ComboBox>
 
-            <!--  Simple-Mode toggle: drive detection from the wizard's optimized settings. Shown only in Simple Mode once optimized settings exist (!UseAdvanced && HasOptimizedSettings). Placed ABOVE the presets it replaces.  -->
+            <!--  Simple-Mode toggle: drive detection from the wizard's optimized settings. Visible throughout Simple
+                  Mode (!UseAdvanced); DISABLED (not hidden) until the wizard has produced a result (HasOptimizedSettings),
+                  so users can see the option exists. Placed ABOVE the presets it replaces.  -->
             <TextBlock
                 Grid.Row="1"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Use Optimized Settings"
-                ToolTip="{StaticResource UseOptimizedSettings_Tooltip}">
-                <TextBlock.Visibility>
-                    <MultiBinding Converter="{StaticResource HF_MultiBooleanToVisibilityCollapsedConverter}">
-                        <Binding Converter="{StaticResource HF_InverseBooleanConverter}" Path="StarDetectionOptions.UseAdvanced" />
-                        <Binding Path="StarDetectionOptions.HasOptimizedSettings" />
-                    </MultiBinding>
-                </TextBlock.Visibility>
-            </TextBlock>
+                IsEnabled="{Binding StarDetectionOptions.HasOptimizedSettings}"
+                ToolTip="{StaticResource UseOptimizedSettings_Tooltip}"
+                Visibility="{Binding StarDetectionOptions.UseAdvanced, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}" />
             <CheckBox
                 Grid.Row="1"
                 Grid.Column="1"
@@ -1188,14 +1174,9 @@
                 HorizontalAlignment="Left"
                 VerticalAlignment="Center"
                 IsChecked="{Binding StarDetectionOptions.UseOptimizedSettings}"
-                ToolTip="{StaticResource UseOptimizedSettings_Tooltip}">
-                <CheckBox.Visibility>
-                    <MultiBinding Converter="{StaticResource HF_MultiBooleanToVisibilityCollapsedConverter}">
-                        <Binding Converter="{StaticResource HF_InverseBooleanConverter}" Path="StarDetectionOptions.UseAdvanced" />
-                        <Binding Path="StarDetectionOptions.HasOptimizedSettings" />
-                    </MultiBinding>
-                </CheckBox.Visibility>
-            </CheckBox>
+                IsEnabled="{Binding StarDetectionOptions.HasOptimizedSettings}"
+                ToolTip="{StaticResource UseOptimizedSettings_Tooltip}"
+                Visibility="{Binding StarDetectionOptions.UseAdvanced, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}" />
 
             <TextBlock
                 Grid.Row="7"
@@ -1582,10 +1563,37 @@
                 Grid.Row="45"
                 Grid.Column="0"
                 VerticalAlignment="Center"
+                Text="Defocus Max Elongation"
+                ToolTip="{StaticResource DefocusMaxElongation_Tooltip}" />
+            <ninactrl:UnitTextBox
+                Grid.Row="45"
+                Grid.Column="1"
+                MinWidth="80"
+                Margin="5,5,0,0"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                ToolTip="{StaticResource DefocusMaxElongation_Tooltip}">
+                <Binding
+                    Path="StarDetectionOptions.DefocusMaxElongation"
+                    UpdateSourceTrigger="LostFocus">
+                    <Binding.ValidationRules>
+                        <rules:DoubleRangeRule>
+                            <rules:DoubleRangeRule.ValidRange>
+                                <rules:DoubleRangeChecker Maximum="10.0" Minimum="1.0" />
+                            </rules:DoubleRangeRule.ValidRange>
+                        </rules:DoubleRangeRule>
+                    </Binding.ValidationRules>
+                </Binding>
+            </ninactrl:UnitTextBox>
+
+            <TextBlock
+                Grid.Row="46"
+                Grid.Column="0"
+                VerticalAlignment="Center"
                 Text="Defocus-Aware Structure"
                 ToolTip="{StaticResource DefocusAwareStructure_Tooltip}" />
             <CheckBox
-                Grid.Row="45"
+                Grid.Row="46"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"
@@ -1595,13 +1603,13 @@
                 ToolTip="{StaticResource DefocusAwareStructure_Tooltip}" />
 
             <TextBlock
-                Grid.Row="46"
+                Grid.Row="47"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Structure Layer Boost"
                 ToolTip="{StaticResource StructureLayerBoost_Tooltip}" />
             <ninactrl:UnitTextBox
-                Grid.Row="46"
+                Grid.Row="47"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
@@ -306,6 +306,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                 // --defocus-distortion / --defocus-centering switches can toggle them separately.
                 DefocusAwareDistortion = options.DefocusAwareGates,
                 DefocusAwareCentering = options.DefocusAwareGates,
+                // Roundness-rescue for the TooDistorted gate rides the same single toggle: a large low-fill
+                // candidate the (relaxed) fill-ratio would reject is admitted iff it is round (donut ring), so
+                // fill-ratio relaxation no longer admits elongated junk/spike fragments along with real donuts.
+                DefocusRoundnessAdmission = options.DefocusAwareGates,
+                DefocusMaxElongation = options.DefocusMaxElongation,
                 // Numeric tuning knobs (Advanced options); only take effect while the gates are ON.
                 DefocusDistortionSizeReference = options.DefocusDistortionSizeReference,
                 DefocusDistortionMinFactor = options.DefocusDistortionMinFactor,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -17,11 +17,11 @@
     <TextBlock x:Key="SDOpt_SourceMode_Tooltip" Text="Replay optimizes against one or more saved auto-focus runs (recommended). Live triggers a fresh auto-focus that saves its frames, then optimizes against those." />
     <TextBlock x:Key="SDOpt_OptimizeMode_Tooltip" Text="Optimize runs the parameter search and recommends improved settings. Use current settings skips the search entirely and jumps straight to a summary built from your current settings, so you can review (and label) today's detection without an optimization pass. Either way, after reviewing you can still run Optimize with feedback to recover the stars you labeled." />
     <TextBlock x:Key="SDOpt_FeedbackBreakdown_Tooltip" Text="How your labels map to the detector's gates: each row is the gate that rejected the stars you marked, and the setting change that would recover them — bounded so it doesn't admit too many unlabeled candidates (precision). Optimize with feedback starts the optimizer from these recommendations." />
-    <TextBlock x:Key="SDOpt_RunCount_Tooltip" Text="How many saved auto-focus runs to optimize against together. Using two or three runs balances the settings across them and reduces overfitting to a single night's conditions." />
     <TextBlock x:Key="SDOpt_ApplyStepSize_Tooltip" Text="When checked, clicking Accept also writes the recommended auto-focus step size and offset steps to the active profile (they appear in the Changed parameters list above). The step size is sized so a sweep lands several measurement points across the focus-sensitive region of the curve. Disabled when the recommendation already matches your current settings (nothing to apply)." />
     <TextBlock x:Key="SDOpt_Review_Tooltip" Text="Optional: review the optimized detector boxes over every loaded frame and label any missed, falsely-accepted, or wrongly-rejected stars. The labels are saved next to the run and can drive a future re-optimization. Reviewing is not required — you can Accept directly." />
     <TextBlock x:Key="SDOpt_ReOptimize_Tooltip" Text="Re-run the optimization using the labels you just made in Review. Your missed / wrongly-rejected stars steer the optimizer to recover them (recall), and your should-reject stars steer it to exclude them (precision). The runs are re-read from disk and the search re-runs, landing on an updated summary you can review again or accept." />
     <TextBlock x:Key="SDOpt_Variant_Tooltip" Text="Switch the chart and the summary below between your current settings, the optimized settings, and (after Optimize with feedback) the feedback-optimized settings. Accept applies whichever variant is shown (Current can't be accepted — it's your baseline)." />
+    <TextBlock x:Key="SDOpt_DefocusRecovery_Tooltip" Text="Off by default. When enabled, the optimizer also searches the defocus-aware gates (a roundness-based rescue plus four tuning knobs) and rewards detecting faint 'donut' stars at the far ends of the focus sweep. This recovers heavily out-of-focus stars — useful for the Aberration Inspector's image alignment and for donut-heavy setups — but it trades away some auto-focus-curve tightness, so leave it off unless you specifically need defocused-star recall. With it off, the optimization is identical to the standard search." />
 
     <!--  Auto-focus curve chart for ONE settings variant. The Summary panel hosts this via a ContentControl bound to
           SelectedCurve, so toggling the variant rebuilds the plot from a fresh OptimizationCurve instance (a robust
@@ -171,6 +171,25 @@
                             GroupName="OptimizeMode"
                             IsChecked="{Binding IsUseCurrentMode}"
                             ToolTip="{StaticResource SDOpt_OptimizeMode_Tooltip}" />
+                    </StackPanel>
+
+                    <!--  Opt-in: search the defocus-aware gates + reward extreme-defocus donut recall. OFF by default
+                          (baseline search, no AF-curve fit regression). Only meaningful while actually optimizing.  -->
+                    <StackPanel
+                        Margin="0,4"
+                        Orientation="Horizontal"
+                        Visibility="{Binding IsOptimizeMode, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                        <CheckBox
+                            VerticalAlignment="Center"
+                            IsChecked="{Binding DefocusRecovery}"
+                            ToolTip="{StaticResource SDOpt_DefocusRecovery_Tooltip}" />
+                        <TextBlock
+                            MaxWidth="420"
+                            Margin="6,0,0,0"
+                            VerticalAlignment="Center"
+                            TextWrapping="Wrap"
+                            Text="Recover defocused / donut stars — enable when your stars form large donuts when out of focus (helps the Aberration Inspector align frames). Trades a little focus-curve tightness; leave off otherwise."
+                            ToolTip="{StaticResource SDOpt_DefocusRecovery_Tooltip}" />
                     </StackPanel>
 
                     <!--  Single saved-run folder picker (Saved Auto-Focus only). Optimizing against one run at a time

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationObjective.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationObjective.cs
@@ -78,6 +78,29 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         // stars before the run-level relaxed-fraction fallback may apply any penalty.
         public int MinFramesForPenalty { get; set; } = 3;
         public int MinAcceptedForPenalty { get; set; } = 1;
+
+        // ── F5: extreme-frame donut-recall term (SExtreme) ─────────────────────────────────────────────────
+        // The optimizer otherwise has NO incentive to keep faint donuts at the sweep EXTREMES: S_stars saturates
+        // its nMin knee at NFloor (8), so 10 vs 30 stars on the most-defocused frame score identically, and a
+        // cleaner focus curve / higher label precision actively reward REJECTING those donuts. This additive term
+        // rewards star recall on the min/max focuser-position frames so the search keeps (and the defocus-aware
+        // gates earn their place recovering) extreme-defocus donuts. OFF by default so the raw objective stays
+        // bit-identical for existing tests; the production StarDetectionOptimizer constructs constants with it ON.
+        public bool EnableExtremeRecall { get; set; } = false;
+
+        // Additive weight of SExtreme in the JRun weighted sum (folded into wSum alongside Wf/Ws/Wc[/Wl]). Only
+        // included when EnableExtremeRecall is on AND the run has >= 2 distinct focuser positions (so extremes
+        // exist). 0.30 makes it strong enough to push back on the focus/precision terms' incentive to cull faint
+        // extreme donuts (Wf = 0.55 dominates otherwise) without overriding a genuinely bad curve.
+        public double We { get; set; } = 0.30;
+
+        // Star count on an extreme frame at/above which SExtreme saturates to 1.0. SExtreme is the clamped mean,
+        // over the min- and max-focuser-position frames, of (extremeFrameStarCount / ExtremeTarget). Set near the
+        // achievable extreme-frame recall on a rich field so the term keeps a gradient across the operating range
+        // (a too-low target saturates and stops rewarding additional recovery); capping the reward at the target
+        // means there is no incentive to inflate extreme counts with junk past it. 50 tuned on the mufti AF run
+        // (achievable extreme recall ≈ 66 with the defocus-aware gates on); revisit across the AF bank.
+        public int ExtremeTarget { get; set; } = 50;
     }
 
     /// <summary>
@@ -191,6 +214,37 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         }
 
         /// <summary>
+        /// S_extreme ∈ [0, 1]: the clamped mean, over the two EXTREME frames (lowest and highest focuser
+        /// position — the most defocused), of <c>extremeStarCount / ExtremeTarget</c>. Rewards donut recall at the
+        /// sweep boundaries, which S_stars (saturating at NFloor) and the focus/label terms do not. Returns
+        /// <c>null</c> when the term is not applicable — gate off, no per-frame data, mismatched lengths, or fewer
+        /// than 2 distinct focuser positions (no extremes) — so <see cref="JRun"/> omits it and keeps the existing
+        /// weighting/renormalization unchanged.
+        /// </summary>
+        public static double? SExtreme(RunEvaluationMetrics m, ObjectiveConstants c) {
+            if (m == null || !c.EnableExtremeRecall || c.ExtremeTarget <= 0) {
+                return null;
+            }
+            var positions = m.FrameFocuserPositions;
+            var counts = m.FrameStarCounts;
+            if (positions == null || counts == null || positions.Count != counts.Count || positions.Count == 0) {
+                return null;
+            }
+
+            int minPos = positions[0], maxPos = positions[0], minIdx = 0, maxIdx = 0;
+            for (var i = 1; i < positions.Count; i++) {
+                if (positions[i] < minPos) { minPos = positions[i]; minIdx = i; }
+                if (positions[i] > maxPos) { maxPos = positions[i]; maxIdx = i; }
+            }
+            if (minPos == maxPos) {
+                return null; // fewer than 2 distinct positions ⇒ no extremes
+            }
+
+            var meanExtreme = 0.5 * (counts[minIdx] + counts[maxIdx]);
+            return Clamp01(meanExtreme / c.ExtremeTarget);
+        }
+
+        /// <summary>
         /// Composite score for a single run. Returns 0 (hard fail) when the focus σ is unusable (both
         /// sigmaFocus and looStdError non-finite) OR when more than <see cref="ObjectiveConstants.MaxFramesBelowHardFloor"/>
         /// frames have a star count below <see cref="ObjectiveConstants.NHard"/>. Otherwise returns the
@@ -218,15 +272,23 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             var sStars = SStars(m.FrameStarCounts, c);
             var sFit = SFit(m.RSquared, m.ReducedChiSquared, c);
 
-            double j;
+            // F5: extreme-frame donut-recall term. Additive (a first-class objective term, like S_label), folded
+            // into the weighted sum and renormalized into wSum. Included ONLY when applicable (gate on, >= 2
+            // distinct focuser positions); otherwise sExtreme is null and the term — and its weight — are omitted,
+            // so the existing (Wf, Ws, Wc[, Wl]) weighting is exactly preserved.
+            var sExtreme = SExtreme(m, c);
+
+            double weighted = c.Wf * sFocus + c.Ws * sStars + c.Wc * sFit;
+            double wSum = c.Wf + c.Ws + c.Wc;
             if (effRecall.HasValue && effPrecision.HasValue) {
-                var sLabel = LabelScore(effRecall.Value, effPrecision.Value);
-                var wSum = c.Wf + c.Ws + c.Wc + c.Wl;
-                j = (c.Wf * sFocus + c.Ws * sStars + c.Wc * sFit + c.Wl * sLabel) / wSum;
-            } else {
-                var wSum = c.Wf + c.Ws + c.Wc;
-                j = (c.Wf * sFocus + c.Ws * sStars + c.Wc * sFit) / wSum;
+                weighted += c.Wl * LabelScore(effRecall.Value, effPrecision.Value);
+                wSum += c.Wl;
             }
+            if (sExtreme.HasValue) {
+                weighted += c.We * sExtreme.Value;
+                wSum += c.We;
+            }
+            double j = weighted / wSum;
 
             // F3: MULTIPLICATIVE label-free precision penalty. NOT an additive Wd weight (that would change the
             // baseline). SDefocusPrecision returns exactly 1.0 when there is no relaxation data or zero relaxation

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
@@ -43,6 +43,19 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public bool HotpixelThresholdingEnabled { get; set; }
         public double HotpixelThreshold { get; set; }
 
+        // Defocus-aware family (set only when the wizard's defocus-recovery opt-in produced this snapshot). Defaults
+        // MATCH StarDetectionOptions so a snapshot that predates these fields (SchemaVersion 1, no defocus keys in
+        // its JSON) deserializes to the BASELINE defaults — gates OFF with the default knobs — rather than zeros
+        // (which would, e.g., set an invalid 0 px size reference). DefocusAwareGates is a single flag because the
+        // optimizer moves the three detector flags (distortion/centering/roundness) in lockstep.
+        public bool DefocusAwareGates { get; set; } = false;
+        public double DefocusDistortionSizeReference { get; set; } = 30.0;
+        public double DefocusDistortionMinFactor { get; set; } = 0.25;
+        public double DefocusCenteringToleranceFactor { get; set; } = 2.0;
+        public double DefocusMaxElongation { get; set; } = 2.0;
+        public bool DefocusAwareStructure { get; set; } = false;
+        public int StructureLayerBoost { get; set; } = 0;
+
         // Metadata about the optimization run that produced this snapshot
         public DateTime CreatedAtUtc { get; set; }
         public int RunCount { get; set; }
@@ -50,7 +63,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public double FinalJ { get; set; }
         public int RecommendedStepSize { get; set; }
         public int RecommendedOffsetSteps { get; set; }
-        public int SchemaVersion { get; set; } = 1;
+        public int SchemaVersion { get; set; } = 2; // 2 adds the defocus-aware family
 
         public OptimizedStarDetectionSettings Clone() {
             return (OptimizedStarDetectionSettings)MemberwiseClone();
@@ -83,6 +96,16 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 MinStarBoundingBoxSize = p.MinimumStarBoundingBoxSize,
                 HotpixelThresholdingEnabled = p.HotpixelThresholdingEnabled,
                 HotpixelThreshold = p.HotpixelThreshold,
+
+                // Defocus-aware family. The three gate flags move in lockstep (the optimizer's combined switch),
+                // so the single DefocusAwareGates mirrors p.DefocusAwareDistortion.
+                DefocusAwareGates = p.DefocusAwareDistortion,
+                DefocusDistortionSizeReference = p.DefocusDistortionSizeReference,
+                DefocusDistortionMinFactor = p.DefocusDistortionMinFactor,
+                DefocusCenteringToleranceFactor = p.DefocusCenteringToleranceFactor,
+                DefocusMaxElongation = p.DefocusMaxElongation,
+                DefocusAwareStructure = p.DefocusAwareStructure,
+                StructureLayerBoost = p.StructureLayerBoost,
 
                 CreatedAtUtc = DateTime.UtcNow,
                 RunCount = runCount,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizerVariable.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizerVariable.cs
@@ -92,7 +92,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         }
 
         /// <summary>
-        /// The 13 curated tunable variables. Bounds/initial steps follow the validation ranges in
+        /// The curated tunable variables. Bounds/initial steps follow the validation ranges in
         /// StarDetectionOptions.cs where a UI range exists; where a range is open-ended the bound is a
         /// HEURISTIC (pragmatic, easily editable) value — see the named constants below.
         ///
@@ -102,7 +102,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// the published bounds. The descriptor properties are init-only, so the bounds the lambda quantizes
         /// against are exactly the ones returned by <see cref="Lower"/>/<see cref="Upper"/>.
         /// </summary>
-        public static IReadOnlyList<OptimizerVariable> CreateCuratedSet() {
+        public static IReadOnlyList<OptimizerVariable> CreateCuratedSet(bool defocusRecovery = false) {
             // --- Heuristic bounds (no hard UI validation range; chosen pragmatically). Edit here to retune. ---
             const double SensitivityLower = 0.0;       // heuristic
             const double SensitivityUpper = 50.0;      // heuristic; widened 20 -> 50 because rich fields pinned the old 20 ceiling
@@ -120,8 +120,24 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             const int NoiseReductionRadiusUpper = 10;  // heuristic
             const int MinBoundingBoxLower = 2;         // heuristic
             const int MinBoundingBoxUpper = 20;        // heuristic
+            const double DefocusSizeRefLower = 15.0;   // heuristic; bbox max-dim (px) above which the defocus gates relax
+            const double DefocusSizeRefUpper = 60.0;   // heuristic
+            const double DefocusMaxElongationLower = 1.0; // heuristic; 1.0 = admit only perfectly-round donuts
+            const double DefocusMaxElongationUpper = 4.0; // heuristic; up to ~4:1 elongation admitted
+            const double DefocusMinFactorLower = 0.1;  // heuristic; floor multiplier on MaxDistortion (most permissive)
+            const double DefocusMinFactorUpper = 1.0;  // heuristic; 1.0 = no distortion relaxation
+            const double DefocusCenterFactorLower = 1.0; // heuristic; 1.0 = no centering relaxation
+            const double DefocusCenterFactorUpper = 4.0; // heuristic; max centering-tolerance multiplier
 
-            return new List<OptimizerVariable> {
+            // The defocus-aware gates switch. In the BASELINE (default) set it drives distortion + centering only —
+            // exactly the pre-existing behavior. Under the defocus-recovery OPT-IN it ALSO drives the roundness
+            // rescue, and the 4 numeric defocus knobs below are added. Keeping the default set == baseline is what
+            // guarantees no AF-curve fit regression for users who don't opt into donut recovery.
+            Action<StarDetectorParams, bool> gatesWrite = defocusRecovery
+                ? (p, en) => { p.DefocusAwareDistortion = en; p.DefocusAwareCentering = en; p.DefocusRoundnessAdmission = en; }
+                : (p, en) => { p.DefocusAwareDistortion = en; p.DefocusAwareCentering = en; };
+
+            var set = new List<OptimizerVariable> {
                 Continuous(nameof(StarDetectorParams.Sensitivity), SensitivityLower, SensitivityUpper, 1.0,
                     p => p.Sensitivity, (p, v) => p.Sensitivity = v),
                 Continuous(nameof(StarDetectorParams.StarClippingMultiplier), StarClipLower, StarClipUpper, 0.5,
@@ -146,21 +162,32 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     p => p.HotpixelThresholdingEnabled, (p, b) => p.HotpixelThresholdingEnabled = b),
                 Continuous(nameof(StarDetectorParams.HotpixelThreshold), HotpixelThresholdLower, HotpixelThresholdUpper, 0.001,
                     p => p.HotpixelThreshold, (p, v) => p.HotpixelThreshold = v),
-                // F3: a single combined switch that flips BOTH defocus-aware gates together, so the optimizer can
-                // explore the defocus relaxation (recovering large/donut defocused stars) as one knob. The Name is
-                // a SYNTHETIC alias (not a StarDetectorParams property): Read reports the distortion flag (the two
-                // are written in lockstep), Write sets distortion AND centering to the same value. The seed reads
-                // the current params (both OFF by default), so the baseline is unchanged; the search may flip it on.
-                // Size-reference tuning is intentionally NOT exposed as a variable for now — only this flag.
-                BooleanVar(DefocusAwareGatesName, 1,
-                    p => p.DefocusAwareDistortion,
-                    (p, en) => { p.DefocusAwareDistortion = en; p.DefocusAwareCentering = en; }),
-                // Defocus-aware STRUCTURE detection as a single integer knob (EARLY): 0 ⇒ OFF (bit-identical
-                // baseline), >0 ⇒ enable DefocusAwareStructure with that many extra wavelet layers, recovering
-                // large/donut defocused stars that never form a candidate. The seed reads the effective boost (0
-                // when the flag is off), so the baseline J is unchanged; the search may raise it.
+                // Combined defocus-aware-gates switch (a SYNTHETIC alias; Read reports the distortion flag, Write
+                // drives the flags in lockstep). Present in BOTH sets — it was curated pre-change, so keeping it is
+                // part of the baseline. The roundness coupling differs by mode (see gatesWrite above).
+                BooleanVar(DefocusAwareGatesName, 1, p => p.DefocusAwareDistortion, gatesWrite),
+                // Defocus-aware STRUCTURE integer knob (EARLY): 0 ⇒ OFF (bit-identical), >0 ⇒ extra wavelet layers.
+                // Also pre-change / baseline, so kept in both sets.
                 StructureBoostVar(),
             };
+
+            if (defocusRecovery) {
+                // OPT-IN ONLY: the LATE gate-tuning knobs. They are excluded from the default set because adding 4
+                // extra search dimensions on a fixed eval budget measurably dilutes convergence and regresses the
+                // AF-curve fit across the bank. They only take effect while the gates are ON. SizeReference = the
+                // bbox max-dim (px) above which a candidate gets the relaxed gates + roundness rescue; MaxElongation
+                // = the roundness cap; MinFactor = the floor multiplier on MaxDistortion; CenteringToleranceFactor =
+                // how far the NotCentered tolerance grows. All LATE (not in the early cache key) so they reuse context.
+                set.Add(Continuous(nameof(StarDetectorParams.DefocusDistortionSizeReference), DefocusSizeRefLower, DefocusSizeRefUpper, 5.0,
+                    p => p.DefocusDistortionSizeReference, (p, v) => p.DefocusDistortionSizeReference = v));
+                set.Add(Continuous(nameof(StarDetectorParams.DefocusMaxElongation), DefocusMaxElongationLower, DefocusMaxElongationUpper, 0.25,
+                    p => p.DefocusMaxElongation, (p, v) => p.DefocusMaxElongation = v));
+                set.Add(Continuous(nameof(StarDetectorParams.DefocusDistortionMinFactor), DefocusMinFactorLower, DefocusMinFactorUpper, 0.05,
+                    p => p.DefocusDistortionMinFactor, (p, v) => p.DefocusDistortionMinFactor = v));
+                set.Add(Continuous(nameof(StarDetectorParams.DefocusCenteringToleranceFactor), DefocusCenterFactorLower, DefocusCenterFactorUpper, 0.25,
+                    p => p.DefocusCenteringToleranceFactor, (p, v) => p.DefocusCenteringToleranceFactor = v));
+            }
+            return set;
         }
 
         /// <summary>Synthetic curated-set variable name for the combined defocus-aware-gates switch. It is NOT a

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizer.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizer.cs
@@ -75,6 +75,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         private readonly ObjectiveConstants constants;
 
         public StarDetectionOptimizer(ObjectiveConstants constants = null) {
+            // Default == baseline (extreme-recall term OFF) so the optimizer does not trade AF-curve fit for star
+            // count unless the caller opts in. The defocus-recovery opt-in passes an ObjectiveConstants with
+            // EnableExtremeRecall = true to actively keep faint donuts at the sweep extremes.
             this.constants = constants ?? new ObjectiveConstants();
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -744,6 +744,24 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// checkbox binds its IsEnabled here so an unchanged recommendation can't be "applied".</summary>
         public bool CanApplyRecommendedStepSize => Summary?.StepSizeOrOffsetChanged ?? false;
 
+        private bool defocusRecovery;
+
+        /// <summary>Opt-in (default OFF): when set BEFORE running Optimize, the optimizer explores the full
+        /// defocused/donut-recovery package — the roundness rescue, the 4 defocus-gate tuning knobs, and the
+        /// extreme-frame donut-recall objective term. This recovers donut stars at the sweep extremes (e.g. for
+        /// the aberration inspector) at the cost of some AF-curve tightness, so it is OFF by default. With it off
+        /// the optimization is identical to the baseline search (no fit regression). Bound to the
+        /// "Recover defocused / donut stars" checkbox on the optimize screen.</summary>
+        public bool DefocusRecovery {
+            get => defocusRecovery;
+            set {
+                if (defocusRecovery != value) {
+                    defocusRecovery = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
         /// <summary>The changed-parameters rows shown on the summary: the optimized detector params, plus — only
         /// when <see cref="ApplyRecommendedStepSize"/> is on — the AF step size / offset-steps rows so the user
         /// sees the AF settings that Accept will also write. Recomputed when the toggle or the summary changes.</summary>
@@ -876,7 +894,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             for (var i = 0; i < RunCount; i++) {
                 var path = i < SourcePaths.Count ? SourcePaths[i] : null;
                 if (string.IsNullOrWhiteSpace(path)) {
-                    ErrorMessage = $"Select a saved auto-focus folder for run {i + 1}.";
+                    ErrorMessage = "Select a saved auto-focus folder.";
                     return false;
                 }
                 if (!normalized.Add(NormalizePath(path))) {
@@ -1059,17 +1077,16 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     } else {
                         folder = i < SourcePaths.Count ? SourcePaths[i] : null;
                         if (string.IsNullOrEmpty(folder)) {
-                            ErrorMessage = $"Select a saved auto-focus folder for run {i + 1}.";
+                            ErrorMessage = "Select a saved auto-focus folder.";
                             CurrentStep = WizardStep.SelectSource;
                             DisposeLoadedRuns(runs);
                             return null;
                         }
                     }
 
-                    var runIndex = i;
-                    SetProgress($"Loading run {runIndex + 1} of {RunCount}", 0, 0);
+                    SetProgress("Loading run", 0, 0);
                     var loadProgress = new Progress<RunLoadProgress>(rp =>
-                        SetProgress($"Loading frames (run {runIndex + 1} of {RunCount})", rp.Current, rp.Total));
+                        SetProgress("Loading frames", rp.Current, rp.Total));
                     var loaded = await loader.LoadSavedRunAsync(folder, region, null, loadProgress, token).ConfigureAwait(true);
                     runs.Add(loaded);
                     // Record the actual folder loaded (in load order) so the re-optimize path can re-read it from disk
@@ -1160,9 +1177,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             var results = new List<RunEvaluationResult>(runs.Count);
             for (var i = 0; i < runs.Count; i++) {
                 token.ThrowIfCancellationRequested();
-                var runIndex = i;
                 var run = runs[i];
-                var label = $"Analyzing frames (run {runIndex + 1} of {runs.Count})";
+                var label = "Analyzing frames";
                 SetProgress(label, 0, run.Data.FrameCount);
                 var frameProgress = new Progress<RunLoadProgress>(rp => SetProgress(label, rp.Current, rp.Total));
                 results.Add(await run.Data.EvaluateAndFitAsync(paramsSelector(run), frameProgress, token).ConfigureAwait(true));
@@ -1178,7 +1194,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             StarDetectorParams seedOverride = null, IReadOnlyList<OptimizerVariable> variablesOverride = null) {
             // All runs share the same camera/optics, so the search starts from the first run's seed (or the override).
             var seed = seedOverride ?? runs[0].Seed;
-            var variables = variablesOverride ?? OptimizerVariable.CreateCuratedSet();
+            var variables = variablesOverride ?? OptimizerVariable.CreateCuratedSet(DefocusRecovery);
             var evaluator = RunEvaluationData.CreateEvaluator(runs.Select(r => r.Data).ToList());
 
             ProgressTotal = optimizerSettings.MaxEvaluations;
@@ -1190,7 +1206,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 Phase = FriendlyPhase(p.Phase);
             });
 
-            var optimizer = new StarDetectionOptimizer();
+            // Opt-in only: enable the extreme-frame donut-recall objective term when the user selected defocus
+            // recovery. Default == baseline objective (no fit-vs-stars trade).
+            var optimizer = new StarDetectionOptimizer(
+                DefocusRecovery ? new ObjectiveConstants { EnableExtremeRecall = true } : null);
             IsOptimizing = true;
             try {
                 return await Task.Run(
@@ -1601,8 +1620,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 reloaded = new List<LoadedRun>(reoptimizeRunFolders.Count);
                 for (var i = 0; i < reoptimizeRunFolders.Count; i++) {
                     token.ThrowIfCancellationRequested();
-                    var runIndex = i;
-                    SetProgress($"Re-loading run {runIndex + 1} of {reoptimizeRunFolders.Count}", 0, 0);
+                    SetProgress("Re-loading run", 0, 0);
                     var folder = reoptimizeRunFolders[i];
 
                     // The RunId was recorded during the first acquire (it is a deterministic function of the folder),
@@ -1615,7 +1633,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     // delegates to this one with labels: null), so a label-less run is loaded the same as before.
                     var frameLabels = LabelConverter.ToFrameLabels(runLabels);
                     var loadProgress = new Progress<RunLoadProgress>(rp =>
-                        SetProgress($"Loading frames (run {runIndex + 1} of {reoptimizeRunFolders.Count})", rp.Current, rp.Total));
+                        SetProgress("Loading frames", rp.Current, rp.Total));
                     var loaded = await loader.LoadSavedRunAsync(folder, region, frameLabels, loadProgress, token).ConfigureAwait(true);
                     reloaded.Add(loaded);
                 }
@@ -1632,7 +1650,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 if (feedback != null) {
                     seedOverride = feedback.Recommended;
                     variablesOverride = OptimizerVariable.CreateWarmStartSet(
-                        OptimizerVariable.CreateCuratedSet(), reviewParams, feedback.Recommended);
+                        OptimizerVariable.CreateCuratedSet(DefocusRecovery), reviewParams, feedback.Recommended);
                 }
 
                 // Warm + report the per-frame early contexts for the params the optimizer will start from (re-optimize

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -1208,8 +1208,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
             // Opt-in only: enable the extreme-frame donut-recall objective term when the user selected defocus
             // recovery. Default == baseline objective (no fit-vs-stars trade).
-            var optimizer = new StarDetectionOptimizer(
-                DefocusRecovery ? new ObjectiveConstants { EnableExtremeRecall = true } : null);
+            var optimizer = new StarDetectionOptimizer(BuildOptimizerObjective(DefocusRecovery));
             IsOptimizing = true;
             try {
                 return await Task.Run(
@@ -1219,6 +1218,18 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 IsOptimizing = false;
             }
         }
+
+        /// <summary>
+        /// Selects the objective constants for the search from the defocus-recovery toggle: ON also turns on the
+        /// extreme-frame donut-recall term (<see cref="ObjectiveConstants.EnableExtremeRecall"/>), which — paired
+        /// with the recovery curated variables from <see cref="OptimizerVariable.CreateCuratedSet"/> — is what makes
+        /// the optimizer recover defocused/donut stars at the sweep extremes instead of culling them for a cleaner
+        /// curve; OFF is the baseline objective (bit-identical, since every field but the flag is already its
+        /// default). Extracted as a testable static so the toggle→objective wiring is locked by a unit test: a
+        /// pre-release build once shipped with this disconnected, so a recovery run silently ran the baseline regime.
+        /// </summary>
+        internal static ObjectiveConstants BuildOptimizerObjective(bool defocusRecovery) =>
+            new ObjectiveConstants { EnableExtremeRecall = defocusRecovery };
 
         /// <summary>Maps the optimizer's internal phase identifiers ("Seed"/"CoarseGrid"/"PatternSearch", which
         /// stay as-is in logs and tests) to plain language for the progress display.</summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
@@ -94,6 +94,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             MinStarBoundingBoxSize = s.MinStarBoundingBoxSize;
             HotpixelThresholdingEnabled = s.HotpixelThresholdingEnabled;
             HotpixelThreshold = s.HotpixelThreshold;
+            // Defocus-aware family (the optimizer tunes these too). A single DefocusAwareGates flag drives the
+            // three detector flags via BuildStarDetectorParams; the numeric knobs and the structure pair follow.
+            DefocusAwareGates = s.DefocusAwareGates;
+            DefocusDistortionSizeReference = s.DefocusDistortionSizeReference;
+            DefocusDistortionMinFactor = s.DefocusDistortionMinFactor;
+            DefocusCenteringToleranceFactor = s.DefocusCenteringToleranceFactor;
+            DefocusMaxElongation = s.DefocusMaxElongation;
+            DefocusAwareStructure = s.DefocusAwareStructure;
+            StructureLayerBoost = s.StructureLayerBoost;
         }
 
         private void DerivePresetSettings() {
@@ -170,6 +179,16 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             PSFResolution = 10;
             PSFFitThreshold = 0.9;
             HotpixelThreshold = 0.001d;
+            // Defocus-aware family: not preset-scaled, so reset to the defaults here. This keeps them consistent
+            // with the other curated knobs when "Use Optimized Settings" is toggled OFF or a preset changes (the
+            // snapshot apply runs DerivePresetSettings first, then overrides these with the optimized values).
+            DefocusAwareGates = false;
+            DefocusDistortionSizeReference = 30.0;
+            DefocusDistortionMinFactor = 0.25;
+            DefocusCenteringToleranceFactor = 2.0;
+            DefocusMaxElongation = 2.0;
+            DefocusAwareStructure = false;
+            StructureLayerBoost = 0;
         }
 
         private void StarDetectionOptions_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e) {
@@ -206,10 +225,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             brightnessSensitivity = optionsAccessor.GetValueDouble("BrightnessSensitivity", 2.0);
             starPeakResponse = optionsAccessor.GetValueDouble("StarPeakResponse", 0.75);
             maxDistortion = optionsAccessor.GetValueDouble("MaxDistortion", 0.5);
+            // Default OFF (baseline): the defocus-aware gates + roundness rescue trade AF-curve tightness for
+            // donut recall (a measured fit regression across the AF bank), so they are opt-in. They are turned on
+            // only via the optimization wizard's "Recover defocused/donut stars" opt-in (and written to the profile
+            // when that result is accepted). Default-OFF keeps detection bit-identical to baseline.
             defocusAwareGates = optionsAccessor.GetValueBoolean("DefocusAwareGates", false);
             defocusDistortionSizeReference = optionsAccessor.GetValueDouble("DefocusDistortionSizeReference", 30.0);
             defocusDistortionMinFactor = optionsAccessor.GetValueDouble("DefocusDistortionMinFactor", 0.25);
             defocusCenteringToleranceFactor = optionsAccessor.GetValueDouble("DefocusCenteringToleranceFactor", 2.0);
+            defocusMaxElongation = optionsAccessor.GetValueDouble("DefocusMaxElongation", 2.0);
             starCenterTolerance = optionsAccessor.GetValueDouble("StarCenterTolerance", 0.3);
             starBackgroundBoxExpansion = optionsAccessor.GetValueInt32("StarBackgroundBoxExpansion", 3);
             minStarBoundingBoxSize = optionsAccessor.GetValueInt32("MinStarBoundingBoxSize", 5);
@@ -273,6 +297,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             DefocusDistortionSizeReference = 30.0;
             DefocusDistortionMinFactor = 0.25;
             DefocusCenteringToleranceFactor = 2.0;
+            DefocusMaxElongation = 2.0;
             StarCenterTolerance = 0.3;
             StarBackgroundBoxExpansion = 3;
             MinStarBoundingBoxSize = 5;
@@ -658,6 +683,27 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                     }
                     defocusCenteringToleranceFactor = value;
                     optionsAccessor.SetValueDouble("DefocusCenteringToleranceFactor", defocusCenteringToleranceFactor);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private double defocusMaxElongation;
+
+        // Advanced-only tuning knob for the defocus-aware gates (only consulted while DefocusAwareGates is ON). The
+        // maximum pixel-coordinate elongation (1.0 = perfectly round; larger = more elongated) for a large low-fill
+        // candidate to be RESCUED by the roundness gate, i.e. admitted as a donut even though its fill-ratio is
+        // below the (relaxed) distortion threshold. Complete donut rings score ~1; streaks / diffraction-spike
+        // fragments / partial arcs score higher and stay rejected. Must be >= 1.0. Default 2.0 (~2:1).
+        public double DefocusMaxElongation {
+            get => defocusMaxElongation;
+            set {
+                if (defocusMaxElongation != value) {
+                    if (value < 1.0 || value > 10.0) {
+                        throw new ArgumentException("DefocusMaxElongation must be within [1, 10]", "DefocusMaxElongation");
+                    }
+                    defocusMaxElongation = value;
+                    optionsAccessor.SetValueDouble("DefocusMaxElongation", defocusMaxElongation);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
@@ -1193,6 +1193,54 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
         }
 
         /// <summary>
+        /// Pixel-coordinate elongation of a candidate footprint: √(λmax / λmin) of the UNWEIGHTED 2×2 covariance
+        /// of the candidate's pixel coordinates. Equals 1.0 for a radially-symmetric footprint (a round, complete
+        /// donut ring or a filled disk) and grows with elongation (≈ the major/minor axis ratio of the equivalent
+        /// ellipse): streaks, diffraction-spike fragments, and partial donut arcs score &gt; 1. Used by the
+        /// roundness-rescue path of the TooDistorted gate to admit round low-fill donuts while still rejecting
+        /// elongated junk. Pure + deterministic (operates only on the coordinate list), so it is unit-testable in
+        /// isolation. Returns <see cref="double.PositiveInfinity"/> for degenerate footprints (&lt; 2 points, or a
+        /// perfectly collinear/zero-area set) so such candidates are never rescued.
+        /// </summary>
+        public static double ComputeCandidateElongation(IReadOnlyList<Point> starPoints) {
+            if (starPoints == null || starPoints.Count < 2) {
+                return double.PositiveInfinity;
+            }
+
+            double cx = 0.0, cy = 0.0;
+            for (var i = 0; i < starPoints.Count; ++i) {
+                cx += starPoints[i].X;
+                cy += starPoints[i].Y;
+            }
+            var n = starPoints.Count;
+            cx /= n;
+            cy /= n;
+
+            double sxx = 0.0, sxy = 0.0, syy = 0.0;
+            for (var i = 0; i < starPoints.Count; ++i) {
+                var dx = starPoints[i].X - cx;
+                var dy = starPoints[i].Y - cy;
+                sxx += dx * dx;
+                sxy += dx * dy;
+                syy += dy * dy;
+            }
+            sxx /= n;
+            sxy /= n;
+            syy /= n;
+
+            // Eigenvalues of the symmetric 2×2 covariance [[sxx, sxy], [sxy, syy]].
+            var trace = sxx + syy;
+            var diff = sxx - syy;
+            var disc = Math.Sqrt(diff * diff + 4.0 * sxy * sxy);
+            var lambdaMax = 0.5 * (trace + disc);
+            var lambdaMin = 0.5 * (trace - disc);
+            if (lambdaMin <= 0.0 || lambdaMax <= 0.0) {
+                return double.PositiveInfinity;
+            }
+            return Math.Sqrt(lambdaMax / lambdaMin);
+        }
+
+        /// <summary>
         /// Computes the effective fill-ratio threshold the TooDistorted gate compares against for a candidate of
         /// bbox max-dimension <paramref name="candidateSize"/> (= max(bbox.Width, bbox.Height), the same d the
         /// gate divides by).
@@ -1351,11 +1399,22 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             var fillRatio = starPoints.Count / d / d;
             var effectiveMaxDistortion = ComputeEffectiveMaxDistortion(p, d);
             if (fillRatio < effectiveMaxDistortion) {
-                metrics.TooDistortedBounds.Add(starBounds);
-                if (rejectedBag != null) {
-                    RecordRejection(rejectedBag, starBounds, RejectionGate.TooDistorted, fillRatio, effectiveMaxDistortion, bboxCenterX, bboxCenterY);
+                // Roundness rescue (opt-in, default OFF ⇒ bit-identical): fill-ratio cannot tell a real donut ring
+                // from an irregular junk blob (both ~0.47), so before rejecting a LARGE low-fill candidate, admit it
+                // iff it is sufficiently ROUND — a complete donut ring is radially symmetric (elongation ≈ 1) while
+                // streaks / spike fragments / partial arcs are elongated. Admission is marked as a relaxation so the
+                // objective's near-focus precision penalty still accounts for it.
+                var roundnessRescued = p.DefocusRoundnessAdmission
+                    && d > p.DefocusDistortionSizeReference
+                    && ComputeCandidateElongation(starPoints) <= p.DefocusMaxElongation;
+                if (!roundnessRescued) {
+                    metrics.TooDistortedBounds.Add(starBounds);
+                    if (rejectedBag != null) {
+                        RecordRejection(rejectedBag, starBounds, RejectionGate.TooDistorted, fillRatio, effectiveMaxDistortion, bboxCenterX, bboxCenterY);
+                    }
+                    return null;
                 }
-                return null;
+                relaxationAdmitted = true;
             }
             // The accept/reject decision above uses the effective threshold ONLY. Separately (informational), note
             // whether the verbatim STRICT threshold would have rejected this candidate — i.e. it survives only

--- a/Joko.NINA.Plugins/TestApp/DiagnoseLabelsRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/DiagnoseLabelsRunner.cs
@@ -215,6 +215,17 @@ namespace TestApp {
                 detectionParams.StructureLayerBoost = boost;
             }
 
+            // Opt-in ROUNDNESS-rescue test switch (companion to --defocus-distortion). Flips DefocusRoundnessAdmission
+            // ON so a large low-fill candidate the (relaxed) distortion gate would reject is admitted iff it is round
+            // (a complete donut ring). --defocus-max-elongation overrides the elongation cap (default 2.0).
+            if (DiagnosticUtil.HasFlag(args, "--defocus-roundness")) {
+                detectionParams.DefocusRoundnessAdmission = true;
+                var elongArg = DiagnosticUtil.GetArg(args, "--defocus-max-elongation");
+                if (!string.IsNullOrWhiteSpace(elongArg) && double.TryParse(elongArg, NumberStyles.Float, CultureInfo.InvariantCulture, out var elong)) {
+                    detectionParams.DefocusMaxElongation = elong;
+                }
+            }
+
             // Optional StructureLayers override (diagnostic only): pins the nominal StructureLayers independent of
             // the profile so the structure-boost mechanism can be A/B-tested against a controlled baseline (e.g.
             // the factory default 4 where the donuts are NO-CANDIDATE) rather than against a drifted/optimized

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -106,6 +106,12 @@ namespace TestApp {
 
             var labelsDir = DiagnosticUtil.GetArg(args, "--labels");
 
+            // Defocus-recovery OPT-IN (default OFF = baseline, no AF-curve fit regression). When set, the optimizer
+            // explores the full donut package: the 4 defocus-knob search variables are added, the gates switch also
+            // drives the roundness rescue, and the extreme-frame donut-recall objective term is enabled. Mirrors the
+            // wizard's "Recover defocused/donut stars" checkbox.
+            var defocusRecovery = DiagnosticUtil.HasFlag(args, "--defocus-recovery");
+
             // --per-run is a valueless flag: optimize each discovered run INDEPENDENTLY (one optimization, one
             // evaluator, one output subfolder, one hard-floor assertion per run) instead of jointly. Use this
             // when --runs points at a bank of DIFFERENT optical setups, where a joint (N>1 balanced) objective
@@ -216,11 +222,15 @@ namespace TestApp {
                 HighSigmaOutlierRejection = highSigmaOutlierRejection,
                 LowSigmaOutlierRejection = lowSigmaOutlierRejection,
                 Seed = seed,
-                Variables = OptimizerVariable.CreateCuratedSet(),
+                Variables = OptimizerVariable.CreateCuratedSet(defocusRecovery),
                 MaxEvals = maxEvals,
                 LabelsDir = labelsDir,
-                AnnotateAll = annotateAll
+                AnnotateAll = annotateAll,
+                ExtremeRecall = defocusRecovery
             };
+            Console.WriteLine(defocusRecovery
+                ? "  Defocus-recovery OPT-IN: donut package enabled (roundness + 4 defocus knobs + extreme-recall term)"
+                : "  Defocus recovery OFF (default): baseline search — no AF-curve fit regression");
 
             if (perRun) {
                 await RunPerRun(ctx, runsDir, outDir, discovery.Runs, labelsByRun).ConfigureAwait(false);
@@ -240,6 +250,7 @@ namespace TestApp {
             public double LowSigmaOutlierRejection;
             public StarDetectorParams Seed;
             public IReadOnlyList<OptimizerVariable> Variables;
+            public bool ExtremeRecall = true;
             public int? MaxEvals;
             public string LabelsDir;
             public bool AnnotateAll;
@@ -382,7 +393,8 @@ namespace TestApp {
             }
 
             var variables = ctx.Variables;
-            var optimizer = new StarDetectionOptimizer();
+            // Opt-in only: pass EnableExtremeRecall=true; otherwise null ⇒ default ctor == baseline (term OFF).
+            var optimizer = new StarDetectionOptimizer(ctx.ExtremeRecall ? new ObjectiveConstants { EnableExtremeRecall = true } : null);
 
             var dataList = loadedRuns.Select(r => r.Data).ToList();
             var evaluator = RunEvaluationData.CreateEvaluator(dataList);

--- a/Joko.NINA.Plugins/TestApp/StarReview/StarReviewRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/StarReview/StarReviewRunner.cs
@@ -369,10 +369,11 @@ namespace TestApp.StarReview {
         }
 
         /// <summary>
-        /// Overlays the 12 curated snapshot knobs onto <paramref name="p"/> LOCALLY (no ApplyOptimizedSettings, which
+        /// Overlays the curated snapshot knobs onto <paramref name="p"/> LOCALLY (no ApplyOptimizedSettings, which
         /// would persist through the options accessor). Shared by the file (--opt-results / auto) and profile paths so
         /// the mapping lives in one place. Mapping mirrors HocusFocusStarDetection.BuildStarDetectorParams (snapshot
-        /// field names match the matching StarDetectionOptions property names) and OptimizedStarDetectionSettings.FromParams.
+        /// field names match the matching StarDetectionOptions property names) and OptimizedStarDetectionSettings.FromParams,
+        /// including the defocus-aware family (the single DefocusAwareGates flag drives all three detector flags).
         /// </summary>
         private static void OverlaySnapshot(StarDetectorParams p, OptimizedStarDetectionSettings snapshot) {
             p.Sensitivity = snapshot.BrightnessSensitivity;
@@ -387,6 +388,16 @@ namespace TestApp.StarReview {
             p.MinimumStarBoundingBoxSize = snapshot.MinStarBoundingBoxSize;
             p.HotpixelThresholdingEnabled = snapshot.HotpixelThresholdingEnabled;
             p.HotpixelThreshold = snapshot.HotpixelThreshold;
+            // Defocus-aware family — the single gates flag drives distortion + centering + roundness in lockstep.
+            p.DefocusAwareDistortion = snapshot.DefocusAwareGates;
+            p.DefocusAwareCentering = snapshot.DefocusAwareGates;
+            p.DefocusRoundnessAdmission = snapshot.DefocusAwareGates;
+            p.DefocusDistortionSizeReference = snapshot.DefocusDistortionSizeReference;
+            p.DefocusDistortionMinFactor = snapshot.DefocusDistortionMinFactor;
+            p.DefocusCenteringToleranceFactor = snapshot.DefocusCenteringToleranceFactor;
+            p.DefocusMaxElongation = snapshot.DefocusMaxElongation;
+            p.DefocusAwareStructure = snapshot.DefocusAwareStructure;
+            p.StructureLayerBoost = snapshot.StructureLayerBoost;
         }
 
         /// <summary>

--- a/docs/donut-defocus-detection-analysis-design.md
+++ b/docs/donut-defocus-detection-analysis-design.md
@@ -215,3 +215,24 @@ larger-HFR stars) is fundamentally in tension with curve tightness — every don
 to baseline on all 16 runs** (σ_focus + bestJ match to <5e-4) ⇒ **zero fit regression** unless the user opts in. The
 earlier 16/16 "differs" was entirely because the active test profile already had `DefocusAwareGates: true` +
 `UseOptimizedSettings` + a donut snapshot (i.e. already in the opt-in state). 1283 tests pass.
+
+### 7. Post-merge follow-up — "a recovery run looked unchanged" (stale WIP build + regression guard)
+
+A live-wizard run on the mufti AF folder, **with the Defocus Recovery toggle on**, came back looking like baseline —
+donuts still missed at the sweep extremes. Root-caused by reproducing the *exact* path with `TestApp optimize`:
+
+- **The two regimes are qualitatively opposite, both scoring J≈0.985.** Baseline (extreme-recall OFF) drives
+  σ_focus 12.4→**0.005** with `DefocusAwareGates 0→0` and extremes **8→7 / 10→11** (it is *rewarded* for culling
+  faint donuts to tighten the curve). Recovery (`--defocus-recovery`) drives `DefocusAwareGates 0→1`, σ_focus 12.4→4.6
+  and extremes **8→73 / 10→46**. So a "donuts-missed" result is the *baseline* regime — i.e. recovery did not engage.
+- **Why it didn't engage:** the wizard run executed **~3.5 min before the finalized commit** (`703c67e`, 18:29:55)
+  on a pre-release plugin build (loaded DLL predated the commit) in which the toggle→objective wiring was not yet
+  connected. The committed code wires `DefocusRecovery` into **both** `CreateCuratedSet(...)` *and*
+  `EnableExtremeRecall`; rebuilding from HEAD and re-running reproduces the recovery regime. The seed itself was
+  identical in both paths (same profile, gates-off; per-frame seed counts 8/59/406/680/335/42/10 matched exactly), so
+  this was **not** a seed-basin/coordinate-descent issue — the optimizer flips the gates on from a gates-off seed
+  unaided (proven by the TestApp `--defocus-recovery` run).
+- **Regression guard added:** the optimizer-objective selection is extracted to a testable static
+  `StarDetectionOptimizerWizardVM.BuildOptimizerObjective(bool defocusRecovery)` (bit-identical: OFF == default
+  `ObjectiveConstants`), locked by a unit test asserting the toggle drives `EnableExtremeRecall`. This closes the gap
+  that let a disconnected build ship unnoticed (there was no test on the toggle→objective wiring).

--- a/docs/donut-defocus-detection-analysis-design.md
+++ b/docs/donut-defocus-detection-analysis-design.md
@@ -1,0 +1,217 @@
+# Donut / defocused-star detection — root-cause analysis (mufti AF run)
+
+**Data:** `D:\Autofocus Bank\mufti\AutoFocus_20260607_030642-20260615T214722Z-3-001\attempt01`
+— 7-frame focuser sweep 2325→2925 (step 100), best focus ≈ 2625, central-obstruction scope
+(produces donut/annular stars off-focus). Sensor 9576×6388. Existing user labels in `attempt01/labels`.
+
+**Harness:** `TestApp diagnose-labels` + `optimize` (Debug build), active profile **"AA1600MM Copy"**
+(Sensitivity 1.6, StructureLayers 5, MaxDistortion 0.5, PixelScale 1.616). All read-only on the profile.
+
+> ⚠️ **Profile caveat:** the harness loads the *developer's* active profile, not mufti's rig. Gate geometry
+> (distortion/centering/size) is pixel-based so the diagnosis holds; PixelScale only scales HFR-arcsec / the AF
+> curve. A first diagnose-labels run accidentally used a *stale different* profile (Sens 2 / SL 4 / PixScale
+> 1.127) and gave a much worse baseline — discard it; the numbers below are the consistent "AA1600MM Copy" run.
+
+---
+
+## Quantified baseline (current settings, per frame)
+
+| Focuser | Defocus | Candidates | **Accepted** | TooSmall | **TooDistorted** | %TooDist |
+|---|---|---|---|---|---|---|
+| 2625 (focus) | 0 | 1006 | **733** | 161 | 39 | 4% |
+| 2525 | −1 | 774 | 485 | 129 | 120 | 16% |
+| 2725 | +1 | 747 | 428 | 191 | 90 | 12% |
+| 2425 | −2 | 490 | 116 | 163 | 174 | 36% |
+| 2825 | +2 | 465 | 97 | 192 | 163 | 35% |
+| 2325 | −3 (extreme) | 395 | **35** | 182 | 162 | 41% |
+| 2925 | +3 (extreme) | 327 | **26** | 144 | 145 | 44% |
+
+As defocus grows, **TooDistorted** explodes (4% → ~42%) and **TooSmall** stays huge (~40%), while the **candidate
+count itself collapses** (1006 → ~330). At the extremes only ~26–35 of ~330–400 candidates survive.
+
+## Label-box attribution (ground truth, current settings)
+
+- **wronglyRejected (missed real donuts), 6 boxes:** 4 already **ACCEPTED**; 1 **Contaminated**; 1 **TooFlat**
+  (the 55px object — actually a *saturated bright star with diffraction spikes*, not a clean donut).
+- **shouldReject (false positives), 8 boxes:** 6 now **rejected** (5 TooDistorted, 1 TooSmall), 2 still accepted.
+- The missed donuts that *do* form a candidate fail TooDistorted by a hair: fill-ratios **0.466–0.491 vs 0.5**.
+  They are single candidates (IoU ≈ 0.9), **not** fragmented — so for moderate defocus this is a *gate-threshold*
+  problem, not a candidate-formation gap.
+
+## Why "even the optimized settings" miss donuts (the crux)
+
+A labeled `optimize` run (J 0.887 → 0.924) made the extremes **worse**, not better:
+
+| | 2325 | 2425 | 2525 | 2625 | 2725 | 2825 | 2925 |
+|---|---|---|---|---|---|---|---|
+| seed (current) | 35 | 116 | 485 | 733 | 428 | 97 | 26 |
+| **optimized** | **15** | 68 | 214 | 361 | 184 | 62 | **10** |
+
+It got there by making detection **stricter**: **Sensitivity 1.6 → 15.2**, StarClippingMultiplier 2 → 1.5,
+PeakResponse 0.75 → 0.8, **MaxDistortion 0.5 → 0.55 (tighter!)**, and **DefocusAwareGates left OFF**. That
+**halves** every frame and hammers the extremes (26→10, 35→15) — but improves σ_focus (9.6 → 6.8), R² (0.986 →
+0.992), and label **precision = 1.0** (recall only 0.556).
+
+**Root cause:** the optimizer objective rewards a *clean focus curve* + label *precision*; faint extreme donuts
+add curve noise, so the optimizer is **incentivized to reject them**. Donut recall and curve-cleanliness are in
+direct tension, and the precision-heavy label set (8 shouldReject vs 6 wronglyRejected) pushes toward strictness.
+The optimizer is doing its job — its job just doesn't include extreme-donut recall.
+
+## Three real loss mechanisms (off-focus)
+
+1. **Gate rejection (dominant, settings-addressable):** donut forms one candidate, dies at **TooDistorted**
+   (fill ≈ 0.47 vs 0.5), **Sensitivity**, or occasionally **TooFlat** (saturated) / **Contaminated**.
+2. **Structure fragmentation + faintness (secondary):** at extremes, rims fragment into sub-threshold
+   **TooSmall** pieces and faint donuts never exceed the binarize threshold (candidate count collapses).
+3. **Bright-star spikes/halo accepted as stars (the "parts of defocused stars" FP):** a saturated star's
+   diffraction-spike knots get **green-accepted** as separate stars; its flat core is TooFlat-rejected.
+
+`fill-ratio` is a **poor donut discriminator** — a real donut (~0.47) and a junk blob (~0.47) are
+indistinguishable to it, which is why relaxing it admits junk and tightening it kills donuts.
+
+---
+
+## Recommendations
+
+### A. Settings (the bulk of the recovery) — *opposite* to what the optimizer chose
+- **Keep Sensitivity low** (~1.5–2.5; the optimizer's 15 is curve-optimal but donut-hostile).
+- **Enable DefocusAwareGates** (DefocusAwareDistortion + DefocusAwareCentering).
+- **Lower DefocusDistortionSizeReference 30 → ~20** so 20–30px donuts get relaxed (default 30 misses them).
+- Consider **MaxDistortion ≈ 0.4** and/or **DefocusAwareStructure** boost ≈ 2 for the extreme fragmentation.
+- Consider **RejectContaminatedStars OFF** for AF (recovers the 1 contaminated donut; minor).
+- The saturated bright star (TooFlat) is *correctly* down-weighted — saturated cores shouldn't anchor HFR.
+
+*Confirmed lever:* enabling defocus-distortion with size-ref 20 moved 4/6 labeled donuts → ACCEPTED.
+
+### B. Code changes (genuine, but re-prioritized vs. the original rim-bridging plan)
+1. **Optimizer objective** — highest leverage. It does not value extreme-donut recall; that is *why* optimized
+   settings fail. Options: add an extreme-frame star-count/recall term, weight extreme frames, or capture
+   extreme-frame `wronglyRejected` labels. Without this, any detector change is undone by the next optimize run.
+2. **Roundness / radial-symmetry admission for large candidates** — replace/augment the fill-ratio relaxation
+   so donuts (round, symmetric) are admitted while junk (irregular) is not. More robust than relaxing fill-ratio.
+3. **Re-tune DefocusDistortionSizeReference default** (30 → ~20) and ship DefocusAwareGates ON-by-default for AF.
+4. **Structure-stage rim bridging** (the original plan) — helps the extreme TooSmall fragmentation, but it is a
+   *secondary* win and near-focus-risky; pursue only after 1–3.
+
+**Bottom line:** primarily a **settings + optimizer-objective** problem, not a candidate-formation bug. The
+moderate-defocus donuts already detect under sane (low-Sensitivity, defocus-aware) settings; the optimizer
+actively tunes those away. A detector-algorithm change is optional and, if pursued, should target the
+fill-ratio→roundness discriminator and the objective, not rim-bridging first.
+
+---
+
+## Implementation (approved: gate + objective) — branch `ghilios/donut-defocus-detection`
+
+### 1. Detector: roundness-rescue admission (LATE gate)
+- `IStarDetector.cs` `StarDetectorParams`: add `DefocusRoundnessAdmission` (bool, default false) +
+  `DefocusMaxElongation` (double, default 2.0). **Not** in `EarlyCacheKeyProperties` (late-only, like
+  `DefocusAwareDistortion`).
+- `StarDetector.cs` TooDistorted gate (~1353): when `fillRatio < effectiveMaxDistortion`, before rejecting,
+  apply a **roundness rescue** — if `DefocusRoundnessAdmission` AND `d > DefocusDistortionSizeReference` AND
+  `ComputeCandidateElongation(starPoints) ≤ DefocusMaxElongation`, admit (set `relaxationAdmitted = true`)
+  instead of rejecting. Off ⇒ no rescue ⇒ bit-identical. New helper `ComputeCandidateElongation` =
+  √(λmax/λmin) of the unweighted pixel-coordinate covariance (≈1 for a round/complete donut ring, large for
+  streaks / spike fragments / partial arcs).
+- `HocusFocusStarDetection.BuildStarDetectorParams`: `DefocusRoundnessAdmission = options.DefocusAwareGates`,
+  `DefocusMaxElongation = options.DefocusMaxElongation`.
+
+### 2. Optimizer objective: extreme-frame donut-recall term
+- `OptimizationObjective.ObjectiveConstants`: add `EnableExtremeRecall` (bool, **default false** so existing
+  objective tests stay bit-identical), `We` (0.20), `ExtremeTarget` (20).
+- `SExtreme(m,c)` = `clamp01(meanExtremeCount / ExtremeTarget)` over the **min & max focuser-position** frames;
+  in `JRun`, when enabled AND ≥2 distinct positions, fold `We·SExtreme` into the weighted sum (conditional
+  include like `Wl`, renormalized into `wSum`). Reward is capped at target (no incentive to pump junk past it);
+  roundness gate + label precision + SDefocusPrecision bound the precision risk.
+- `StarDetectionOptimizer` default constants enable it (`EnableExtremeRecall = true`) so the wizard/TestApp use
+  it while the objective unit tests (raw `new ObjectiveConstants()`) remain bit-identical.
+
+### 2b. Optimizer coverage of the defocus-aware knobs (curated variable set)
+`OptimizerVariable.CreateCuratedSet` now exposes the **entire** defocus-aware family so the optimizer fine-tunes
+it, not just flips it on:
+- `DefocusAwareGates` — Boolean on/off; its Write drives `DefocusAwareDistortion` + `DefocusAwareCentering` +
+  `DefocusRoundnessAdmission` together (one knob enables the whole feature, incl. roundness rescue).
+- `DefocusDistortionSizeReference` — Continuous [15, 60] px, step 5.
+- `DefocusMaxElongation` — Continuous [1.0, 4.0], step 0.25.
+- `DefocusDistortionMinFactor` — Continuous [0.1, 1.0], step 0.05.
+- `DefocusCenteringToleranceFactor` — Continuous [1.0, 4.0], step 0.25.
+- `DefocusAwareStructure`/`StructureLayerBoost` — Integer boost [0, 4] (already curated).
+All four numeric knobs are **LATE** params (gate-only; not in `EarlyCacheKeyProperties`), so exploring them
+reuses the cached early detection context — no perf regression. They are inert no-ops while the gates are OFF.
+The **objective** constants (`EnableExtremeRecall`, `We`, `ExtremeTarget`) are NOT searched — they shape the
+objective itself (set in `StarDetectionOptimizer`), not detector params the search tunes.
+
+### 3. Options / UI / defaults
+- `DefocusAwareGates` default **false → true** (ship defocus-aware on for AF; roundness + SDefocusPrecision
+  guard precision). Keep `DefocusDistortionSizeReference` default **30** (don't regress the Panos tuning);
+  recommend 20 in the per-setup recipe.
+- New Advanced option `DefocusMaxElongation` (double, default 2.0, range [1,10]): UnitTextBox + DoubleRangeRule
+  + tooltip in `OptionsDataTemplates.xaml`; plus a CheckBox already exists for `DefocusAwareGates`.
+- TestApp `diagnose-labels`: add `--defocus-roundness` / `--defocus-max-elongation` switches to validate.
+
+### 4. Tests (NUnit) + validation
+- Unit: `ComputeCandidateElongation` (disk≈1, 3:1 streak≈3, ring≈1, degenerate), roundness-rescue OFF path
+  bit-identical, `SExtreme` math + `JRun` extreme-term include/renorm, optimizer enables the term.
+- Validate on the mufti run: `diagnose-labels`/`optimize` before/after — labeled donuts → ACCEPTED, extreme
+  counts recover, near-focus precision not regressed. Deliver the concrete per-setup settings recipe.
+
+### 5. Validation results (mufti run, "AA1600MM Copy" profile)
+
+**Detector fix (default-on gates + roundness) — seed extreme recall roughly doubled:**
+
+| Extreme frame | before fix | after fix (seed) |
+|---|---|---|
+| 2325 | 35 | **68** |
+| 2925 | 26 | **66** |
+
+Visual: recovered donuts are real rings; the bright-star **diffraction-spike fragments are correctly rejected**
+(elongated ⇒ fail the roundness cap). Remaining misses at the extreme are **faint, sub-30px** donuts — an SNR
+floor below the roundness size gate, not recoverable without admitting noise (honest limitation).
+
+**Objective fix (extreme-recall term, We=0.30 / ExtremeTarget=50) — the optimizer now PRESERVES donuts:**
+
+| Optimized extreme recall | 2325 | 2925 | Sensitivity chosen |
+|---|---|---|---|
+| old objective | 15 | 10 | 1.6 → **18** (culls donuts) |
+| + both fixes, untuned term | 45 | 28 | → 18 |
+| + tuned term (final) | **54** | **50** | 1.6 → **0** (keeps donuts) |
+
+The term **flips the optimizer's incentive**: instead of raising Sensitivity to cull faint extreme stars for a
+cleaner curve, it lowers Sensitivity to keep them (J 0.915→0.947; σ still improves 8.9→…; label precision 1.0).
+
+**Labels under the new optimized settings** (`diagnose-labels --params optimized`): all **8/8 false-positive
+fragments rejected** (was 6/8), **4/6 missed donuts ACCEPTED**; the 2 residual are the saturated diffraction
+star (TooFlat — correct) and one Contaminated donut.
+
+### Per-setup settings recipe (delivered)
+- **DefocusAwareGates: ON** (now the default) — drives distortion + centering relaxation + roundness rescue.
+- **DefocusMaxElongation: 2.0** (default); lower for stricter roundness.
+- **DefocusDistortionSizeReference: 30** (default); lower toward **20** to catch 20–30px donuts (costs some
+  moderate-frame admissions — validate per setup).
+- **Sensitivity: keep low (1.5–2.5)** for donut recall; do NOT adopt the high Sensitivity the *old* optimizer
+  recommended (that is what was culling donuts).
+- **DefocusAwareStructure: ON + boost 2** only if faint donuts never form candidates (NO-CANDIDATE).
+- Optionally **RejectContaminatedStars OFF** for AF to recover contamination-flagged donuts.
+- `ExtremeTarget=50 / We=0.30` are first-cut objective constants tuned on this run; revisit across the AF bank.
+
+### 6. Bank regression sweep → opt-in redesign (the donut features trade AF-curve fit)
+
+A full A/B over **16 bank runs** (baseline = HEAD worktree vs. the new fields; identical 400-eval budget; deterministic
+optimizer) showed the donut fields, default-on, **regressed AF-curve fit on 11/16 runs** (some 2–3×: Panos σ 3.96→10.2,
+fmeschia 2.0→6.2, mccomiskey 0.58→1.46 with R² 0.997→0.985). Attribution (via `--no-extreme-recall` / `--legacy-curated`
+isolation runs): the 4 new curated variables (search-space dilution on a fixed budget) ≈4 runs; the detection
+default-on + roundness + round-trip seed ≈6 runs; the extreme-recall term ≈1 run. **Donut recall (more, fainter,
+larger-HFR stars) is fundamentally in tension with curve tightness — every donut-favoring *default* trades some fit.**
+
+**Resolution — the whole defocus/donut package is OPT-IN, gated on the optimizer screen:**
+- `DefocusAwareGates` option default reverted to **OFF** (baseline live detection + optimizer seed); DTO default OFF.
+- `OptimizerVariable.CreateCuratedSet(defocusRecovery=false)`: default = the **14-var baseline** set (the gates switch
+  drives distortion+centering only, **no** roundness, **no** 4 knobs — `DefocusAwareGates`/`DefocusAwareStructure` were
+  curated pre-change so they stay); opt-in (`true`) adds the roundness coupling + the 4 defocus knobs (18 vars).
+- Extreme-recall term: `StarDetectionOptimizer` default OFF; the opt-in passes `EnableExtremeRecall=true`.
+- Wizard: a **"Recover defocused / donut stars"** checkbox (`DefocusRecovery`, default off) on the optimize screen
+  threads through to the curated set + objective; TestApp mirrors it with `--defocus-recovery`.
+
+**Verification (definitive):** with a baseline-state profile (gates OFF), the new default optimizer is **bit-identical
+to baseline on all 16 runs** (σ_focus + bestJ match to <5e-4) ⇒ **zero fit regression** unless the user opts in. The
+earlier 16/16 "differs" was entirely because the active test profile already had `DefocusAwareGates: true` +
+`UseOptimizedSettings` + a donut snapshot (i.e. already in the opt-in state). 1283 tests pass.

--- a/plans/donut-recovery-completion-plan.md
+++ b/plans/donut-recovery-completion-plan.md
@@ -1,0 +1,113 @@
+# Donut recovery — completion plan (rim-bridging + TooFlat/Contamination relaxation)
+
+**Status:** ready to execute (user approved "Both"). Branch: continue on `ghilios/donut-defocus-detection` (PR #66)
+or a fresh `ghilios/donut-recovery-completion` off `develop` — decide at start. **Clear context (`/clear`) before executing.**
+
+## Why (evidence)
+
+`diagnose-labels --params optimized` on the mufti run (profile 4cf31cda), recovery engaged, attributes the labels:
+- Real donuts still missed die at **TooFlat** (1) and **Contaminated** (2) — gates recovery does NOT relax. The big
+  `(55×57)` donut: `StarMedian ≥ PeakResponse·Peak` at `StarDetector.cs:1479` (flat 0.957 > 0.8); optimizer raised
+  PeakResponse 0.75→0.8, so the search moves away from flat donuts.
+- 5/8 flagged **bright rim fragments** (7–11 px) still accepted — small/round/bright pass the ordinary gates; only a
+  structural merge can fix this.
+
+See `docs/donut-defocus-detection-analysis-design.md §8` for the full attribution table + design rationale.
+
+## Invariants (do not violate)
+
+- **Default OFF ⇒ bit-identical.** Every new feature is gated; with the defocus-recovery opt-in OFF, detection and the
+  optimizer must be byte-for-byte unchanged (the bank-sweep regression check is the gate). All knobs default to the
+  no-op value.
+- **All new feature work is opt-in under the existing "Recover defocused / donut stars" toggle** (`DefocusRecovery` /
+  `StarDetectionOptions.DefocusAwareGates` → `BuildStarDetectorParams`). No new top-level default-on behavior.
+- TestApp harnesses stay **read-only on the profile**. Specs in `docs/`, plans in `plans/`. Commit only when asked;
+  author/committer `322725+ghilios@users.noreply.github.com`.
+- TDD: write the failing test first for each unit (per `superpowers:test-driven-development`).
+
+---
+
+## Part A — Defocus-aware TooFlat relaxation (recall; smallest, do first)
+
+1. **Params** (`Interfaces/IStarDetector.cs`): add `StarDetectorParams.DefocusAwareFlatness` (bool, default false) and
+   `DefocusFlatnessToleranceFactor` (double, default 1.0 = no relaxation). LATE params (not in `EarlyCacheKeyProperties`).
+2. **Helper** (`StarDetector.cs`, beside `ComputeEffectiveMaxDistortion:1256`): `ComputeEffectivePeakResponse(p, d)` —
+   when `!DefocusAwareFlatness` return `p.PeakResponse` (strict); else for large candidates (size `d` >
+   `DefocusDistortionSizeReference`) raise the allowed median/peak ratio toward 1.0 by the tolerance factor (size-scaled,
+   same shape as the distortion helper). A perfectly flat disk ⇒ median≈peak, so the relaxed bar admits hollow donuts.
+3. **Gate** (`StarDetector.cs:1479`): replace `p.PeakResponse` with the effective value; when a star passes ONLY due to
+   the relaxed bar, set `relaxationAdmitted = true` (mirror the distortion gate at `:1417/1424`) so `SDefocusPrecision`
+   can penalize near-focus abuse.
+4. **Options** (`StarDetectionOptions.cs` + `IStarDetectionOptions.cs`): `DefocusFlatnessToleranceFactor` option (the
+   bool couples to `DefocusAwareGates` in `BuildStarDetectorParams`, like the other defocus gates). Reset in
+   `ResetDefaults`/`DerivePresetSettings`.
+5. **BuildStarDetectorParams** (`HocusFocusStarDetection.cs`): map `DefocusAwareFlatness = options.DefocusAwareGates`,
+   `DefocusFlatnessToleranceFactor = options.DefocusFlatnessToleranceFactor`.
+6. **UI** (`Resources/OptionsDataTemplates.xaml`): Advanced `UnitTextBox` + `DoubleRangeRule` + tooltip.
+7. **Optimizer** (`OptimizerVariable.CreateCuratedSet`, opt-in branch): add `DefocusFlatnessToleranceFactor` Continuous
+   var (e.g. [1.0, 3.0] step 0.25). Couple the gate bool onto `gatesWrite` (opt-in) like roundness.
+8. **Tests:** effective-peak-response math (OFF == strict, ON relaxes only large); gate admits a synthetic flat donut
+   only when ON; OFF-path bit-identical. `OptimizerVariableTests` count bump.
+
+## Part B — Defocus-aware Contamination exemption (recall)
+
+1. **Params:** `StarDetectorParams.DefocusAwareContamination` (bool, default false). LATE.
+2. **Gate** (`StarDetector.cs`, the `RejectContaminatedStars` rejection path fed by `ComputeGradientContamination:819`):
+   when `DefocusAwareContamination` and the candidate is large (size > `DefocusDistortionSizeReference`), do NOT reject
+   on contamination — keep the star, still set `StarContaminationSuspected` for display, and set `relaxationAdmitted`.
+   (Rationale: a defocused donut's structured rim trips the one-sided-excess test; size-gating limits the exemption to
+   genuinely defocused blobs.)
+3. **Options / BuildStarDetectorParams / curated set:** couple `DefocusAwareContamination = options.DefocusAwareGates`
+   (no separate numeric knob — it's a pure exemption; the size threshold reuses `DefocusDistortionSizeReference`). No new
+   UI control needed beyond the existing recovery toggle, but document it in the toggle tooltip.
+4. **Tests:** a synthetic large contaminated donut is kept when ON and rejected when OFF; OFF-path bit-identical.
+
+## Part C — Structure-stage rim-bridging (recall + fragment precision; biggest)
+
+1. **Params:** `StarDetectorParams.DefocusRimBridging` (bool, default false) — **EARLY** (add to
+   `EarlyCacheKeyProperties`; a move rebuilds the early context). Kernel radius derived from
+   `DefocusDistortionSizeReference` (reuse; no new knob initially). Optionally a small integer `RimBridgingRadius`
+   override later if needed.
+2. **Closing step** (`StarDetector.cs`, between `Binarize:556` and `CollectStarCandidates:575`): when `DefocusRimBridging`,
+   apply OpenCV morphological **closing** (`Cv2.MorphologyEx`, `MorphTypes.Close`, elliptical kernel radius r) to the
+   binary `structureMap` in place. Guard: `if (!p.DefocusRimBridging) { /* unchanged */ }` ⇒ bit-identical. Dispose the
+   kernel Mat.
+3. **Metric:** `StarDetectorMetrics.RimBridged` (count of candidates whose bounding box exceeds the pre-close
+   fragment scale, or simpler: log that bridging ran) — if added, **show it in the metrics panel** (`AutoFocus/DataTemplates.xaml`).
+4. **Optimizer:** add `DefocusRimBridging` as a curated **EARLY** boolean in the opt-in set (like `DefocusAwareStructure`).
+5. **Precision validation (REQUIRED before keeping it):** on the mufti sweep, confirm closing (a) merges the bright
+   fragments at 2725 into their parent donut (the 5 `shouldReject` boxes stop being separately accepted) and recovers
+   fragmented donuts, AND (b) does NOT merge genuine close pairs on the **near-focus** frame 2625 — star count + σ_focus
+   at 2625 must not degrade. If over-merge appears, size-gate the closing (only close where local connected-component
+   area already exceeds a defocus-size threshold) or fall back to the post-`CollectStarCandidates` **annulus-merge**
+   (group small candidates on a common ring) per the original analysis fallback.
+6. **Tests:** closing OFF ⇒ structure map identical (bit-identical detection); a synthetic donut (bright ring, dark hole)
+   forms ONE candidate with closing ON vs. multiple arcs with it OFF.
+
+## Part D — Verification (end-to-end, the acceptance gate)
+
+1. **Label-level (mufti, profile 4cf31cda):** `optimize --runs <mufti> --defocus-recovery` then
+   `diagnose-labels --params optimized --opt-results <out>`. PASS = the 3 gate-rejected donuts (TooFlat + 2 Contaminated)
+   → ACCEPTED, and the 5 fragment `shouldReject` boxes → no longer ACCEPTED. Capture before/after table.
+2. **Visual:** annotated 2325 / 2725 PNGs — fragments subsumed (no green on rim pieces), donuts recovered, the bright
+   corner star handled. Render downscaled + corner crops (ImageMagick) to inspect.
+3. **Bank regression (the hard gate):** `optimize --runs "D:\Autofocus Bank" --per-run` with the recovery opt-in OFF
+   must be **bit-identical** to current `develop` (σ_focus + bestJ match < 5e-4 on all 16 runs). With opt-in ON, report
+   the per-run fit trade so the doc records it (§6 precedent).
+4. **Full suite:** `dotnet test ... -c Debug` green; every OFF-path bit-identity test passes.
+5. Update `docs/donut-defocus-detection-analysis-design.md §8` with the before/after numbers; refresh
+   `docs/star-detection-optimization-wizard-results.md` if the curated-var count changes.
+
+## Sequencing
+
+A → B (cheap LATE-gate relaxations; recover the labeled donuts, verify) → C (rim-bridging; precision + structural recall,
+with its own precision-validation gate) → D (bank + suite). Land A/B first so there is a verified recall win even if C's
+over-merge guard needs iteration. Keep each part a separate commit.
+
+## Open risks
+
+- **Rim-bridging over-merge near focus** — the main risk; mitigated by opt-in + size-gating + the 2625 validation gate +
+  `SDefocusPrecision`. Annulus-merge is the fallback if closing is too blunt.
+- **Curated-set dilution** — each new opt-in variable adds a search dimension on a fixed 400-eval budget (§6 cost ≈4
+  runs from 4 vars). Keep new knobs minimal (TooFlat factor + bridging bool; contamination is a coupled exemption, no knob).
+- **Profile mismatch** — harnesses load the dev profile, not mufti's; gate geometry is pixel-based so attribution holds.


### PR DESCRIPTION
## Summary

Recover heavily-defocused **donut** stars (for donut-heavy setups and the Aberration Inspector's alignment) **without regressing AF-curve fit** — the whole defocus package is gated behind an explicit opt-in.

### Detector
- **Roundness rescue** in the `TooDistorted` gate: a large low-fill candidate is admitted iff it is round (elongation = √(λmax/λmin) of the pixel-coordinate covariance ≤ `DefocusMaxElongation`), so real donut rings pass while streaks / diffraction-spike fragments don't. New `StarDetectorParams.DefocusRoundnessAdmission` + `DefocusMaxElongation` (LATE gate params; default off ⇒ bit-identical detection).

### Optimizer
- **Extreme-frame donut-recall** objective term (`SExtreme`) so the search can keep faint donuts at the sweep extremes instead of tuning them away.
- The four defocus-gate knobs are exposed as curated optimizer variables.

### Opt-in gating (no fit regression by default)
A full A/B over **16 AF-bank runs** showed the donut features, default-on, regress AF-curve fit on **11/16 runs** (donut recall trades curve tightness). So the package is now **opt-in**:
- `DefocusAwareGates` option default reverted to **off**.
- `CreateCuratedSet(defocusRecovery)`: default = **14-var baseline** set (gates drive distortion+centering only, no roundness, no knobs); opt-in = 18 vars + roundness.
- Extreme-recall term off in the `StarDetectionOptimizer` default; on only under opt-in.
- Wizard adds a **"Recover defocused / donut stars"** checkbox on the optimize screen; TestApp adds `--defocus-recovery`.

**Verified:** the default path is **bit-identical to baseline on all 16 runs** (σ_focus + bestJ to <5e-4 ⇒ zero regression); the opt-in recovers donuts (mufti extremes **7→74, 11→50**) at the expected curve-tightness cost.

### Snapshot round-trip
`OptimizedStarDetectionSettings` now carries the defocus-aware family, so the optimizer's choices survive Apply/serialize and are visible/editable in Advanced mode; old snapshots default to baseline (off). `SchemaVersion` 1→2.

### Also
- Documented the **Aberration Inspector** interaction (it shares these detection settings; its triangle alignment needs star-rich frames, so AF-optimized sparse settings can fail alignment on defocused extremes).
- Wizard UX cleanups: removed "(run X of Y)" progress text, the `RunCount` tooltip, the per-run folder error text; "Use Optimized Settings" is now **disabled-not-hidden** in Simple mode.

Analysis + full verification: `docs/donut-defocus-detection-analysis-design.md`. **1283 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)