### PR TITLE
docs: rig-derived starting points, per-knob feedback signals, terminology glosses

### DIFF
--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -2,8 +2,8 @@
 
 **Hocus Focus** is a plugin for [NINA](https://nighttime-imaging.eu/) (Nighttime Imaging 'N' Astronomy)
 that provides improved **star detection**, customizable **star annotation**, a concurrent
-**autofocus** engine, and a **tilt / aberration inspector** that measures backfocus and sensor-tilt
-errors. It fits PSF models to stars for more accurate HFR, eccentricity, and FWHM measurements; lets
+**autofocus** engine, and a **tilt / aberration inspector** that measures backfocus (the spacing
+between the corrector/flattener and the sensor) and sensor-tilt errors. It fits PSF models to stars for more accurate HFR, eccentricity, and FWHM measurements; lets
 you swap in just the star detector or just the annotator without taking both; and builds a full sensor
 tilt-and-curvature model so you can quantify and correct aberrations across the field.
 

--- a/documentation/docs/optimization/index.md
+++ b/documentation/docs/optimization/index.md
@@ -38,8 +38,9 @@ The high-level loop is simple:
    recommended autofocus step size is offered alongside them.
 
 Optionally, you can label a handful of hard frames (missed stars, false positives) to add a
-**recall/precision** term to the score — decisive for dim or bloated, out-of-focus "donut" stars that
-the raw star count barely reflects.
+**recall/precision** term to the score (recall = the fraction of real stars recovered; precision = the
+fraction of accepted detections that are real) — decisive for dim or bloated, out-of-focus "donut"
+stars that the raw star count barely reflects.
 
 ![Staged compass/pattern search trajectory on a 2D objective surface](../assets/figures/compass-search.png){ width=620 }
 

--- a/documentation/docs/overview/index.md
+++ b/documentation/docs/overview/index.md
@@ -1,6 +1,6 @@
 # Overview & Features
 
-Hocus Focus is a plugin for [NINA](https://nighttime-imaging.eu/) that, in the words of its own description, provides **"Improved Star Detection, Star Annotation, Auto Focus, and Tilt Correction for NINA."** It replaces or augments NINA's built-in star handling and auto-focus routines with a more accurate star detector, a fully customizable annotator, a concurrent auto-focus engine, and an aberration inspector that measures backfocus and sensor-tilt errors.
+Hocus Focus is a plugin for [NINA](https://nighttime-imaging.eu/) that, in the words of its own description, provides **"Improved Star Detection, Star Annotation, Auto Focus, and Tilt Correction for NINA."** It replaces or augments NINA's built-in star handling and auto-focus routines with a more accurate star detector, a fully customizable annotator, a concurrent auto-focus engine, and an aberration inspector that measures backfocus (the spacing between the corrector/flattener and the sensor) and sensor-tilt errors.
 
 The plugin is deliberately modular. Per its documentation, you "can use the new Star Detector or Annotator without requiring both" — keep whichever pieces you like and leave the rest on NINA's defaults. The features are wired in under **Options → Imaging → Image Options**, where installing the plugin adds **Star Annotator** and **Auto Focus** dropdowns; select **"Hocus Focus"** in those to turn the features on.
 

--- a/documentation/docs/overview/star-detection.md
+++ b/documentation/docs/overview/star-detection.md
@@ -13,7 +13,8 @@ A naive "threshold and count blobs" detector is fooled by the things real astrop
 and galaxy gradients, hot pixels, sensor noise, saturated cores, diffraction spikes, close double stars, and
 heavily defocused donuts. Hocus Focus addresses these head-on:
 
-- **Large-scale structure is removed before detection** with a B-spline wavelet residual, so nebulosity and
+- **Large-scale structure is removed before detection** with an à-trous B3-spline wavelet (a multi-scale
+  smoothing that separates star-sized structure from large-scale background) residual, so nebulosity and
   sky gradients do not drown faint stars or create spurious blobs.
 - **The background is modeled as a tilted plane per star**, not a single number, so a one-sided gradient
   under a star no longer biases its centroid, flux, or HFR.
@@ -21,7 +22,7 @@ heavily defocused donuts. Hocus Focus addresses these head-on:
   measurement annulus is flagged and (by default) removed, instead of quietly corrupting the HFR.
 - **Multiple independent acceptance gates** reject clipped, distorted, off-center, flat, dim, and
   contaminated candidates, each tracked as a named rejection count you can inspect.
-- **Aggregation is robust** — median and MAD, plus an explicit outlier pass — so a handful of bad
+- **Aggregation is robust** — median and median absolute deviation (MAD), plus an explicit outlier pass — so a handful of bad
   measurements cannot drag the reported focus metric around.
 
 Nearly every stage is tunable. This page walks the pipeline in execution order; the
@@ -62,7 +63,7 @@ so it helps most on noisy, short, or high-gain subs and can hurt on already-clea
 ### 4. Wavelet structure detection (remove large-scale structures)
 
 This is the heart of what makes the detector robust to nebulae and gradients. The detector computes an
-à-trous B-spline wavelet residual over a configurable number of layers and **subtracts it**, which removes
+à-trous B3-spline wavelet residual over a configurable number of layers and **subtracts it**, which removes
 structures larger than the stars while keeping the stars themselves. A short Gaussian smoothing then heals
 the holes that subtracting large scales can punch in the middle of big or out-of-focus stars.
 
@@ -80,7 +81,7 @@ donut stars survive the subtraction. See [Structure Detection](../settings/struc
 
 The smoothed structure map is thresholded into foreground (star) vs. background. The threshold is the
 structure map's median plus a **noise-clipping multiplier** times an estimated noise sigma, where the sigma
-comes from a kappa-sigma noise estimate on the noise-reduced image:
+comes from a Kappa-Sigma (an iterative clip-at-k·σ robust noise estimate) noise estimate on the noise-reduced image:
 
 \[
 T = \text{median} + k_\sigma \cdot \sigma_{\text{noise}}

--- a/documentation/docs/overview/tilt-aberration-inspector.md
+++ b/documentation/docs/overview/tilt-aberration-inspector.md
@@ -3,7 +3,7 @@
 The **Aberration Inspector** is a dockable panel that drives an auto-focus run (or a single snapshot)
 and turns the result into a quantitative picture of how your sensor sits in the optical train. It
 answers the questions a single center-of-frame focus number cannot: *Is one corner sharper than the
-other? Is the field bowed? Is my back-focus distance right?* And, when paired with a tilt-adapter
+other? Is the field bowed? Is my backfocus (the spacing between the corrector/flattener and the sensor) distance right?* And, when paired with a tilt-adapter
 calibration, it translates those numbers into concrete screw-turn guidance.
 
 ## Sensor tilt, in one paragraph
@@ -13,7 +13,7 @@ is reached at a *different* focuser position on each side of the frame: stars on
 while the opposite edge is bloated, no matter where you park the focuser. That asymmetry is **tilt**.
 A separate but related defect, **field curvature**, is when the best-focus surface is not flat but
 bowl- or dome-shaped, so the corners and the center focus at different positions even with zero tilt.
-The inspector measures both, plus the axial **back-focus** offset between the center and the corners.
+The inspector measures both, plus the axial **backfocus** offset between the center and the corners.
 
 ![Sensor tilt and field-curvature best-focus offset map](../assets/figures/tilt-heatmap.png){ width=620 }
 

--- a/documentation/docs/settings/acceptance-gates.md
+++ b/documentation/docs/settings/acceptance-gates.md
@@ -57,7 +57,7 @@ A candidate is accepted only when its normalized brightness divided by the measu
 *Sensitivity is the star's brightness above background relative to the noise; a dim star with low \((s-b)/n\) is rejected.*
 
 !!! tip "When to adjust"
-    Lower it (toward 1) if too many real but faint stars are reported as **Low Sensitivity** and your autofocus runs are starved for stars. Raise it on noisy data where spurious faint blobs are slipping through. It can hurt by flooding detection with noise clumps if set too low, or by discarding usable faint stars near focus if set too high. Leave it at the default for typical data.
+    Lower it (toward 1) if too many real but faint stars are reported as **Low Sensitivity** (watch the **Low Sensitivity** count in the [Star Detection Results panel](index.md#reading-the-results-the-star-detection-results-panel)) and your autofocus runs are starved for stars. Raise it on noisy data where spurious faint blobs are slipping through. It can hurt by flooding detection with noise clumps if set too low, or by discarding usable faint stars near focus if set too high. Leave it at the default for typical data.
 
 ## Star Peak Response
 
@@ -79,7 +79,7 @@ The option is shown as a percentage (default 75%), so a candidate fails when its
 *A genuine star has a median far below its peak; a flat blob's median sits close to the peak and is rejected.*
 
 !!! tip "When to adjust"
-    Increase it if legitimate stars — often slightly defocused or undersampled ones — are wrongly rejected as **Too Flat**. Leave it at the default for in-focus data. Setting it too high weakens the gate and lets diffuse, non-stellar structure through.
+    Increase it if legitimate stars — often slightly defocused or undersampled ones — are wrongly rejected as **Too Flat** (check the **Too Flat** count in the [Star Detection Results panel](index.md#reading-the-results-the-star-detection-results-panel)). Leave it at the default for in-focus data. Setting it too high weakens the gate and lets diffuse, non-stellar structure through.
 
 ## Max Distortion
 
@@ -101,7 +101,7 @@ This is a **fill ratio**: the number of structure pixels divided by \(d^2\), whe
 *Fill ratio is pixel count over the square box area; a compact star passes while a stringy shape fails.*
 
 !!! tip "When to adjust"
-    Lower it if real stars with elongation — from tilt, coma, field curvature, or tracking error — are being rejected as **Too Distorted**. Raise it toward the \(\pi/4\) ideal only on excellent optics where you want to suppress trails and spikes aggressively; that risks discarding stars in the corners of a tilted or curved field. For heavily **defocused** frames, prefer the [Defocus-Aware Gates](#defocus-aware-gates) below over simply lowering this value, since that keeps near-focus frames strict.
+    Lower it if real stars with elongation — from tilt, coma, field curvature, or tracking error — are being rejected as **Too Distorted** (watch the **Too Distorted** count in the [Star Detection Results panel](index.md#reading-the-results-the-star-detection-results-panel)). Raise it toward the \(\pi/4\) ideal only on excellent optics where you want to suppress trails and spikes aggressively; that risks discarding stars in the corners of a tilted or curved field. For heavily **defocused** frames, prefer the [Defocus-Aware Gates](#defocus-aware-gates) below over simply lowering this value, since that keeps near-focus frames strict.
 
 ## Star Center Tolerance
 
@@ -117,7 +117,7 @@ The gate defines a centered sub-rectangle within the bounding box and requires t
 *The centroid must fall inside the centered acceptance sub-box; an off-center centroid is rejected.*
 
 !!! tip "When to adjust"
-    Raise it (toward 50%) if well-formed stars are rejected as **Not Centered**, which is common with asymmetric aberration or undersampled centroids. Leave the default for typical fields. Setting it too high lets genuinely off-center blends and double stars through. As with distortion, for far-from-focus donut stars the [Defocus-Aware Gates](#defocus-aware-gates) relax this automatically for large candidates only.
+    Raise it (toward 50%) if well-formed stars are rejected as **Not Centered** (track the **Not Centered** count in the [Star Detection Results panel](index.md#reading-the-results-the-star-detection-results-panel)), which is common with asymmetric aberration or undersampled centroids. Leave the default for typical fields. Setting it too high lets genuinely off-center blends and double stars through. As with distortion, for far-from-focus donut stars the [Defocus-Aware Gates](#defocus-aware-gates) relax this automatically for large candidates only.
 
 ## Min Bounding Box Size
 
@@ -132,8 +132,11 @@ This is the first gate applied. It removes tiny detections — single hot pixels
 ![Candidate boxes compared against the minimum-size threshold](../assets/figures/gate-min-size.png){ width=620 }
 *Candidates smaller than the minimum box size on either side are rejected as Too Small.*
 
+!!! tip "Starting point"
+    From your rig: `MinStarBoundingBoxSize ≈ max(3, round(2–3 × FWHM_px))`, where `FWHM_px = FWHM_arcsec / pixelScale` ([reasoning](../analysis/heuristic-defaults.md)). This is just a starting point the Simple presets and the optimizer refine.
+
 !!! tip "When to adjust"
-    Increase it at very long focal lengths, where the plate scale spreads real stars over many pixels and small structures are almost always artifacts. Lower it for wide-field, undersampled rigs where genuine stars occupy only a few pixels — too high a value there will silently drop real stars. The Simple-mode presets already nudge this down for wide-field and up for long focal length.
+    Increase it at very long focal lengths, where the plate scale spreads real stars over many pixels and small structures are almost always artifacts. Lower it for wide-field, undersampled rigs where genuine stars occupy only a few pixels — too high a value there will silently drop real stars (and inflate the **Too Small** count in the [Star Detection Results panel](index.md#reading-the-results-the-star-detection-results-panel)). The Simple-mode presets already nudge this down for wide-field and up for long focal length.
 
 ## Min HFR
 
@@ -143,7 +146,7 @@ Rejects candidates whose measured Half-Flux Radius is at or below this floor —
 
 A star's HFR is the radius enclosing half its total flux (see [Star detection](../overview/star-detection.md)). An impossibly small HFR indicates a point-like artifact — a residual hot pixel or single-pixel spike — rather than a focused star, which always has a finite, optics-limited width. The gate runs late, after HFR has actually been measured, and rejects when \(\text{HFR} \le \text{MinHFR}\).
 
-**Default:** 1.2 px — **Range:** > 0 (must be non-negative; the UI requires greater than zero)
+**Default:** 1.2 px — **Range:** > 0 (the model accepts 0, but the UI requires a value greater than zero)
 
 !!! tip "When to adjust"
     Leave it at the default for almost all setups. Lower it only if you are extremely undersampled and confident your real stars measure below 1.2 px. Raising it discards the sharpest stars and is rarely useful. The default of 1.2 is an honest-HFR floor calibrated to the current measurement pipeline; the older 1.5 floor was tuned against noise-inflated faint-star HFRs and is no longer appropriate.

--- a/documentation/docs/settings/advanced-debug.md
+++ b/documentation/docs/settings/advanced-debug.md
@@ -85,7 +85,9 @@ applied to the measurement image, not just the structure map.
 
     Bump to **High** for a noisy sensor or very high f-ratio where faint stars are being missed in noise.
     Leave at **Typical** for most CMOS rigs. **None** is for already-clean data; over-blurring (High on a
-    clean image) can merge close stars and slightly inflate HFR.
+    clean image) can merge close stars and slightly inflate HFR. To tell whether a change is helping,
+    re-detect and watch **Total detected** rise without the spurious/**Structure candidates** counts
+    ballooning in the [Star Detection Results panel](index.md#reading-the-results-the-star-detection-results-panel).
 
 ### Pixel Scale
 

--- a/documentation/docs/settings/contamination.md
+++ b/documentation/docs/settings/contamination.md
@@ -76,7 +76,9 @@ per star, not assumed globally.
 
     - **Lower it (e.g. 3–4)** when you image dense fields, clusters, or galaxy/nebula regions
       where close pairs are common and you want HFR and PSF statistics scrubbed of every
-      contaminated star. More stars get flagged.
+      contaminated star. More stars get flagged — watch the **Contaminated** rejection count in
+      the [Star Detection Results panel](index.md#reading-the-results-the-star-detection-results-panel)
+      climb as you lower it (or, with rejection off, the contaminated annotation count).
     - **Leave it at 5** for typical wide-to-medium fields. This is the validated default and
       balances rejecting genuine contaminants against keeping good stars.
     - **Raise it (e.g. 8–12)** in sparse fields if you find the test is flagging real,
@@ -106,7 +108,11 @@ tools, which keep flagged stars so they can be analyzed.
 !!! tip "When to adjust"
 
     - **Leave it on** for normal autofocus and HFR work. Removing contaminated stars keeps
-      the focus curve and PSF statistics clean, which is the whole point of the test.
+      the focus curve and PSF statistics clean, which is the whole point of the test; with
+      reject on, the count appears under **Contaminated** in the
+      [Star Detection Results panel](index.md#reading-the-results-the-star-detection-results-panel),
+      whereas with reject off the same stars stay accepted and show only the flagged/contaminated
+      annotation.
     - **Turn it off** when you want to *see* which stars are suspect rather than lose them —
       for example while diagnosing why a frame is short on stars, or when feeding frames to
       the review/diagnostic tooling. It is also the safe choice in very sparse fields where

--- a/documentation/docs/settings/preprocessing.md
+++ b/documentation/docs/settings/preprocessing.md
@@ -19,7 +19,7 @@ A key idea runs through all of these: Hocus Focus keeps **two images**. A *struc
 | Noise Reduction Radius (`NoiseReductionRadius`) | 3 | ≥ 0 (UI requires > 0) | Half-size of the Gaussian blur applied for noise reduction |
 | Noise Clipping Multiplier (`NoiseClippingMultiplier`) | 4.0 | ≥ 0 (UI requires > 0) | σ multiplier for the structure-map binarization floor (candidate finding) |
 | Star Clipping Multiplier (`StarClippingMultiplier`) | 2.0 | ≥ 0 (UI requires > 0) | σ multiplier for the per-star measurement-pixel inclusion gate |
-| Pixel Sample Size (`PixelSampleSize`) | 1.0 (100%) | (0, 1]; UI 25%–100% | Sub-pixel sampling granularity for center/HFR measurement |
+| Pixel Sample Size (`PixelSampleSize`) | 1.0 (100%) | setter (0, 1]; UI floor 25% (25%–100%) | Sub-pixel sampling granularity for center/HFR measurement |
 
 ![Noisy star field before and after a Gaussian blur](../assets/figures/noise-reduction.png){ width=620 }
 *Noise reduction blurs the image so that per-pixel noise does not fragment a star or produce spurious candidates. By default this blur is applied only to the structure-detection image.*
@@ -37,7 +37,7 @@ A key idea runs through all of these: Hocus Focus keeps **two images**. A *struc
 The radius is a *half-size*: the convolution kernel spans roughly twice the radius, with the Gaussian σ chosen automatically to match. A larger radius merges more neighboring pixels, which smooths away noise but also softens faint, closely-spaced, or small stars. Because a blur would smear hot pixels into their neighbors, enabling noise reduction implies hot-pixel filtering runs first (see [Hot Pixels & Saturation](hotpixel-saturation.md)).
 
 !!! tip "When this helps"
-    Raise it for **low-SNR** subframes (short exposures, fast focus sweeps, or a noisy sensor) where single-pixel noise is fragmenting stars or producing spurious candidates. Leave it at the default for typical data. **It can hurt** when the field is tightly packed or the rig is undersampled — over-blurring merges adjacent stars and erases the smallest ones.
+    Raise it for **low-SNR** subframes (short exposures, fast focus sweeps, or a noisy sensor) where single-pixel noise is fragmenting stars or producing spurious candidates. Leave it at the default for typical data. **It can hurt** when the field is tightly packed or the rig is undersampled — over-blurring merges adjacent stars and erases the smallest ones. **Feedback:** in the [Star Detection Results panel](index.md#reading-the-results-the-star-detection-results-panel), a good move raises **Total detected** while the **Structure candidates** count falls toward it (fewer spurious candidates are formed only to be rejected).
 
 ## Noise Reduced Star Measurement
 
@@ -95,7 +95,7 @@ Where the Noise Clipping Multiplier decides *which structures become candidates*
 above the local background is used as an **inclusion gate**: pixels at or below \(b + \tau\) are excluded from the centroid, flux, and HFR sum. Because \(\sigma_{\text{measurement}}\) is measured on the image actually sampled, the multiplier is an honest multiple of the real noise — the same value means the same thing whether or not noise reduction is on.
 
 !!! tip "When this helps"
-    **Lower it** when many obviously-real dim stars are being thrown out as degenerate (their wings sink below the gate, leaving too few pixels to measure). **Raise it** if faint star measurements look noise-inflated and you want a stricter, cleaner pixel set. Setting it too low lets background noise leak into the flux sum and biases HFR; too high starves faint stars of pixels.
+    **Lower it** when many obviously-real dim stars are being thrown out as degenerate (their wings sink below the gate, leaving too few pixels to measure). **Raise it** if faint star measurements look noise-inflated and you want a stricter, cleaner pixel set. Setting it too low lets background noise leak into the flux sum and biases HFR; too high starves faint stars of pixels. **Feedback:** watch the **Degenerate** rejection count in the [Star Detection Results panel](index.md#reading-the-results-the-star-detection-results-panel) — lowering this should bring it down as starved stars recover enough pixels to measure.
 
 !!! note
     The two multipliers are independent knobs for two different stages. If faint stars are missing entirely, the Noise Clipping Multiplier (candidate finding) and [Brightness Sensitivity](structure-detection.md) are usually the levers; if faint stars are *found* but rejected as degenerate, the Star Clipping Multiplier is the one to relax.
@@ -117,6 +117,9 @@ This value is the spacing of the sampling grid, in pixels, that Hocus Focus walk
 
 !!! tip "When this helps"
     Leave it at **1.0** if you are correctly sampled or oversampled — finer sampling buys nothing there and only costs time. Lower it (toward **0.5** or below) for **undersampled** rigs — wide-field setups with large pixels and short focal lengths — where stars span only a few pixels; the Wide-field pixel-scale preset sets it to 0.5 for you. Going below the default on a well-sampled rig wastes computation without improving accuracy.
+
+!!! tip "Starting point"
+    From your rig's FWHM in pixels (\(\text{FWHM}_{px} = \text{FWHM}_{arcsec} / \text{pixelScale}\)): use **1.0** if \(\text{FWHM}_{px} \gtrsim 3\), ramp toward **0.5** as \(\text{FWHM}_{px} \to 1.5\), and go below 0.5 if \(\text{FWHM}_{px} < 1\). This is just a starting point the optimizer and Simple presets refine — see [Heuristic Defaults](../analysis/heuristic-defaults.md).
 
 !!! warning
     Finer sub-pixel sampling improves accuracy but does not create resolution that the optics did not capture. For a severely undersampled rig, also consider enabling [PSF pixel integration](psf-modeling.md), which reduces PSF bias at very small FWHM.

--- a/documentation/docs/settings/psf-modeling.md
+++ b/documentation/docs/settings/psf-modeling.md
@@ -42,7 +42,7 @@ When this is on, each accepted star is fit and the results populate the star's F
 *Eccentricity measures how elongated a star is: a round star (left) has eccentricity near 0, while an elongated one (right) — from tilt, trailing, or astigmatism — has high eccentricity. This shape comes only from the fitted PSF.*
 
 !!! tip "When this helps"
-    Leave it **on** for aberration inspection, tilt analysis, eccentricity maps, and any workflow that reads FWHM/eccentricity. Turn it **off** only when you need the lightest, fastest detection and care solely about star counts and HFR. (Auto-focus runs already disable PSF modeling internally for speed, so this switch primarily affects detection-driven analysis panels.)
+    Leave it **on** for aberration inspection, tilt analysis, eccentricity maps, and any workflow that reads FWHM/eccentricity. Turn it **off** only when you need the lightest, fastest detection and care solely about star counts and HFR (the cost is per-star fit time, which grows on dense fields). (Auto-focus runs already disable PSF modeling internally for speed, so this switch primarily affects detection-driven analysis panels.)
 
 ## PSF Type
 
@@ -106,7 +106,7 @@ Computes the model value for each pixel as the integral over the pixel's area ra
 Point-sampling the model at \( (i, j) \) ignores how the profile varies across a pixel. On **undersampled** rigs — where a star spans only a couple of pixels — that approximation biases the fitted sigma. Integrating the model over each pixel area \([i-0.5, i+0.5]\times[j-0.5, j+0.5]\) removes most of that bias.
 
 !!! tip "When this helps"
-    Turn it **on** for undersampled setups (short focal length / large pixels, FWHM around 1.5 px), where it cuts sigma error from roughly 8% to under 5%. **Leave it off** for well-sampled rigs — the extra cost buys nothing there.
+    Turn it **on** for undersampled setups (short focal length / large pixels, FWHM around 1.5 px), where it cuts sigma error from roughly 8% to under 5%. **Leave it off** for well-sampled rigs — the extra cost buys nothing there. To judge it, compare reported FWHM/σ stability before and after, and watch the **PSFFitFailed** count in the [Star Detection Results panel](index.md#reading-the-results-the-star-detection-results-panel) for any change in fit rejections.
 
 ## PSF MAD Fitting
 
@@ -119,7 +119,7 @@ Experimental fitting mode that minimizes absolute deviation instead of squared r
 Fitting to minimize absolute deviation downweights outlier pixels (a hot pixel, a cosmic-ray hit, a nearby star's flux) relative to a least-squares fit, at a modest extra computational cost. The internal note describes it as "more robust to noise and outlier pixels."
 
 !!! tip "When this helps"
-    Try it on **noisy frames** or fields with frequent outlier pixels where ordinary fits are being pulled around, and when you want behavior closer to PixInsight's PSF logic. Because it is experimental and slower, **leave it off** by default and enable it deliberately when robustness matters more than speed.
+    Try it on **noisy frames** or fields with frequent outlier pixels where ordinary fits are being pulled around, and when you want behavior closer to PixInsight's PSF logic. To gauge the effect, compare reported FWHM/σ stability before and after and watch the **PSFFitFailed** count in the [Star Detection Results panel](index.md#reading-the-results-the-star-detection-results-panel) for any shift in fit rejections. Because it is experimental and slower, **leave it off** by default and enable it deliberately when robustness matters more than speed.
 
 ## PSF Parallel Size
 

--- a/documentation/docs/settings/structure-detection.md
+++ b/documentation/docs/settings/structure-detection.md
@@ -35,7 +35,10 @@ Sets how much large-scale structure the wavelet removes — and therefore the la
 In `BuildStarDetectorParams` this maps straight to `StarDetectorParams.StructureLayers`, which is also the layer count used for the post-subtraction blur, so it has a second, smaller effect on how holes in large stars are smoothed over.
 
 !!! tip "When to adjust"
-    **Raise it** when real stars are missing entirely because they are large on the sensor — long focal lengths, big pixels, or frames taken well away from focus, where stars spread over many pixels and get swept up with the background. The Simple-mode presets already do this for you: *Wide Range* focus and *Long Focal Length* each add a layer, while *Wide Field* pixel scale removes one. **Leave it at the default** for typical sampling near focus. **Lowering it can hurt** by erasing genuine large stars; raising it too far **lets nebulosity and gradients leak in** as false candidates, since less background is removed.
+    **Raise it** when real stars are missing entirely because they are large on the sensor — long focal lengths, big pixels, or frames taken well away from focus, where stars spread over many pixels and get swept up with the background. The Simple-mode presets already do this for you: *Wide Range* focus and *Long Focal Length* each add a layer, while *Wide Field* pixel scale removes one. **Leave it at the default** for typical sampling near focus. **Lowering it can hurt** by erasing genuine large stars; raising it too far **lets nebulosity and gradients leak in** as false candidates, since less background is removed. As you adjust, watch the **Total detected** count in the [Star Detection Results panel](index.md#reading-the-results-the-star-detection-results-panel) and confirm real stars stop being missing entirely.
+
+!!! tip "Starting point"
+    Pick \(L\) so \(2^{L}\) is a few × your star size in pixels: \(L \approx \mathrm{clamp}(\mathrm{round}(\log_2(3\text{–}4 \times \mathrm{FWHM\_px})),\ 1,\ 8)\), where \(\mathrm{FWHM\_px} = \mathrm{FWHM\_arcsec} / \mathrm{pixelScale}\) is known from your rig (see [Heuristic defaults](../analysis/heuristic-defaults.md)). This is just a starting point the optimizer and Simple presets refine.
 
 ## Defocus-Aware Structure
 
@@ -77,7 +80,7 @@ The diameter of the morphological filter used to grow candidate blobs in the str
 Internally this is the diameter of an elliptical structuring element passed to OpenCV's morphological dilation. It has **no effect** unless **Structure Dilation Iterations** is at least 1 — dilation only runs when the iteration count is positive.
 
 !!! tip "When to adjust"
-    **Increase it** (together with at least one iteration) when bounding boxes are clipping the outsides of stars — most likely at very high focal lengths where a star's wings extend beyond the binarized core. **Leave it at the default** otherwise. **It can hurt** in crowded fields: larger dilation merges nearby stars into a single blob, producing oversized boxes or lost separations.
+    **Increase it** (together with at least one iteration) when bounding boxes are clipping the outsides of stars — most likely at very high focal lengths where a star's wings extend beyond the binarized core. **Leave it at the default** otherwise. **It can hurt** in crowded fields: larger dilation merges nearby stars into a single blob, producing oversized boxes or lost separations — watch for the **Total detected** count in the [Star Detection Results panel](index.md#reading-the-results-the-star-detection-results-panel) dropping as neighbors merge.
 
 ## Structure Dilation Iterations
 


### PR DESCRIPTION
Second documentation pass addressing the **deferred** findings from the review (`review/docs-review.md`), in a separate branch from the first fix pass (#65).

## What changed (11 files, +47/−28)
- **F3 — rig-derived starting points** added on the settings pages where the reader actually tunes (previously stranded on the analysis page):
  - Structure Layers: pick L so `2^L` ≈ a few × `FWHM_px`
  - Min Star Bounding Box Size: `≈ max(3, round(2–3 × FWHM_px))`
  - Pixel Sample Size: `1.0` if `FWHM_px ≳ 3`, ramp toward `0.5` near 1.5 px
  - with `FWHM_px = FWHM_arcsec / pixel scale` and a link to the Heuristic Defaults reasoning.
- **F4 — per-knob feedback signals**: each "When to adjust" now names the **exact** count to watch in the **Star Detection Results panel** and links it — Distortion→Too Distorted, Centering→Not Centered, Peak Response→Too Flat, Sensitivity→Low Sensitivity, Min Box→Too Small, Star Clipping→Degenerate, Contamination→Contaminated, Noise Reduction→Total detected / Structure candidates, PSF→PSFFitFailed.
- **Terminology glosses on first use** + consistent naming: `backfocus` (one word), `à-trous B3-spline wavelet`, `Kappa-Sigma`, `MAD` (median absolute deviation), recall/precision.
- **Nits:** Pixel Sample Size table notes the 25% UI floor; Min HFR range wording.

This completes the actionable items from the review. `mkdocs build --strict` passes; all new panel links resolve to the existing anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)