### PR TITLE
docs: fix raw LaTeX in acceptance-gates display math

### DIFF
--- a/documentation/docs/settings/acceptance-gates.md
+++ b/documentation/docs/settings/acceptance-gates.md
@@ -180,15 +180,20 @@ A single opt-in toggle that relaxes **both** the Max Distortion and Star Center 
 **How the relaxation works.** The candidate size used as the defocus proxy is \(d = \max(\text{box width}, \text{box height})\). Candidates at or below the **Defocus Size Reference** keep the strict thresholds; larger candidates are relaxed progressively:
 
 - Distortion: the effective fill-ratio threshold is
-\[
-\text{MaxDistortion} \times \operatorname{clamp}\!\left(\frac{\text{SizeReference}}{d},\ \text{MinFactor},\ 1.0\right),
-\]
-so a bigger donut needs to fill proportionally less of its box, floored at `MinFactor × MaxDistortion`.
+
+    \[
+    \text{MaxDistortion} \times \operatorname{clamp}\!\left(\frac{\text{SizeReference}}{d},\ \text{MinFactor},\ 1.0\right),
+    \]
+
+    so a bigger donut needs to fill proportionally less of its box, floored at `MinFactor × MaxDistortion`.
+
 - Centering: the effective tolerance is
-\[
-\text{StarCenterTolerance} \times \operatorname{clamp}\!\left(\frac{d}{\text{SizeReference}},\ 1.0,\ \text{ToleranceFactor}\right),
-\]
-additionally capped at 1.0 (the sub-box covering the whole bounding box), so a bigger donut gets a larger centered acceptance region.
+
+    \[
+    \text{StarCenterTolerance} \times \operatorname{clamp}\!\left(\frac{d}{\text{SizeReference}},\ 1.0,\ \text{ToleranceFactor}\right),
+    \]
+
+    additionally capped at 1.0 (the sub-box covering the whole bounding box), so a bigger donut gets a larger centered acceptance region.
 
 Because near-focus candidates stay at or below the size reference, they keep the strict thresholds and junk is still rejected. Stars admitted only by the relaxation are flagged internally so the optimizer can discourage over-relaxing into false positives.
 


### PR DESCRIPTION
## Problem

On the published docs site, the two **Defocus-Aware Gates** formulas on the *Star Acceptance Gates* page rendered as raw, mangled TeX instead of equations — e.g.:

> Distortion: the effective fill-ratio threshold is [ \text{MaxDistortion} \times \operatorname{clamp}!\left(\frac{\text{SizeReference}}{d},\ \text{MinFactor},\ 1.0\right), ] so a bigger donut …

## Root cause

This is **not** a doc-generation / MathJax bug — the MkDocs Material + `pymdownx.arithmatex` (generic) + MathJax setup is correct (inline `\(...\)` math one line above the broken block renders fine).

The two `\[ ... \]` display blocks were placed on the line **immediately after a list-item line, with no blank line**. Python-Markdown treats that as lazy paragraph continuation of the bullet, so arithmatex's *block* processor never fires. The math then falls through to ordinary inline Markdown, which unescapes ASCII punctuation:

- `\[` → `[`, `\]` → `]`
- `\!` → `!`  (the stray `clamp}!\left` in the output)
- `\frac` / `\text` / `\times` survive (those letters aren't escapable)

## Fix

Give each formula a blank line and 4-space list-item indentation so it parses as a standalone block inside the `<li>`. arithmatex now emits `<div class="arithmatex">\[…\]</div>` with backslashes and `\!` intact, and the bullet list structure is preserved.

## Verification

- Local `mkdocs build`: both formulas now wrapped in `arithmatex` divs; `<ul>`/`<li>` structure intact.
- Whole-site sweep: no mangled `clamp}!` / bare-bracket text outside `arithmatex` anywhere; 274 math elements render cleanly.
- Source scan of every `.md`: these two were the only occurrences of the anti-pattern (display math glued to a non-blank line); zero remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)