### PR TITLE
Optimize from default seed; show improvement vs current settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -665,10 +665,15 @@ flag is false the detector fills no per-sector residual arrays and skips the dia
 
 The Star Detection Optimization Wizard ships with `TestApp` subcommands that drive the **same**
 `StarDetectionOptimizer` the live wizard uses, so the optimizer can be exercised/tuned offline. They load the
-user's real NINA profile and build the seed via `BuildStarDetectorParams` plus the AF overrides (`ModelPSF=false`,
-`Region=Full`, `SaveIntermediateFilesPath=""`, `PixelScale` from the profile × binning=1 for raw Mats). All are
-**read-only with respect to the profile/options** (they never call a settings setter or touch the options
-accessor — NINA auto-saves the active profile, so mutating options would silently rewrite the user's settings).
+user's real NINA profile and, mirroring the wizard, build two param bundles (each with the AF overrides
+`ModelPSF=false`, `Region=Full`, `SaveIntermediateFilesPath=""`, `PixelScale` from the profile × binning=1 for raw
+Mats): the optimizer **seed** = fully-default params (`BuildDefaultStarDetectorParams`, the wizard's
+`LoadedRun.Seed`), and the **baseline** = the user's current settings (`BuildStarDetectorParams`, the wizard's
+`LoadedRun.Baseline`). The search starts from the default seed; improvement (J, σ_focus, curated-param deltas, the
+`optimized_settings.json` `BaselineJ`) is reported **vs the current-settings baseline** — exactly the wizard's
+"vs current" display. All are **read-only with respect to the profile/options** (they never call a settings setter
+or touch the options accessor — NINA auto-saves the active profile, so mutating options would silently rewrite the
+user's settings).
 
 > **Perf:** detection is split into a cacheable EARLY context (`BuildDetectionContext`) + a cheap LATE
 > `GateAndMeasure`; `RunEvaluationData` caches the early context per (frame, early-key) and reuses it across

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationLoaderTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationLoaderTests.cs
@@ -48,4 +48,18 @@ public class RunEvaluationLoaderTests {
             Substitute.For<IAutoFocusEngine>(),
             Substitute.For<IHocusFocusStarDetection>()));
     }
+
+    [Test]
+    public void LoadedRun_Baseline_FallsBackToSeed_WhenNotSet() {
+        var seed = new StarDetectorParams { Sensitivity = 3.0 };
+        var run = new LoadedRun { Seed = seed };
+        Assert.That(run.Baseline, Is.SameAs(seed), "Baseline defaults to Seed when not provided");
+
+        var baseline = new StarDetectorParams { Sensitivity = 9.0 };
+        run.Baseline = baseline;
+        Assert.Multiple(() => {
+            Assert.That(run.Baseline, Is.SameAs(baseline), "an explicitly set Baseline is independent of Seed");
+            Assert.That(run.Seed, Is.SameAs(seed), "setting Baseline does not change Seed");
+        });
+    }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -89,6 +89,19 @@ public class StarDetectionOptimizerWizardVMTests {
         return new LoadedRun { Data = data, Seed = seed, AfOptions = afOptions };
     }
 
+    // A run whose optimizer SEED (default) and displayed BASELINE (current settings) differ, so a test can prove
+    // the optimizer starts from Seed while the summary's "before" column reflects Baseline.
+    private static LoadedRun SeedBaselineSplitRun(
+        string id = "split", double optSensitivity = 10.0, int seedSensitivity = 2, int baselineSensitivity = 8) {
+        var data = new RunEvaluationData(id, NineFrames(), OptimizableDetect(optSensitivity), NewAlglib(), DefaultFitConfig());
+        return new LoadedRun {
+            Data = data,
+            Seed = new StarDetectorParams { Sensitivity = seedSensitivity, StarClippingMultiplier = 2.0 },
+            Baseline = new StarDetectorParams { Sensitivity = baselineSensitivity, StarClippingMultiplier = 2.0 },
+            AfOptions = new AutoFocusEngineOptions { AutoFocusStepSize = DefaultStepSize, AutoFocusInitialOffsetSteps = 4 }
+        };
+    }
+
     // A degenerate run: only two distinct focuser positions => the fit cannot be determined (NaN sigma), which
     // is exactly the STARHFR/seed guard condition.
     private static LoadedRun DegenerateRun(string id = "degenerate") {
@@ -322,6 +335,35 @@ public class StarDetectionOptimizerWizardVMTests {
             Assert.That(sensitivityRow.SeedValue, Is.EqualTo(2.0).Within(1e-9));
             Assert.That(Math.Abs(sensitivityRow.OptimizedValue - 10.0),
                 Is.LessThan(Math.Abs(sensitivityRow.SeedValue - 10.0)), "optimized Sensitivity is closer to the optimum");
+        });
+    }
+
+    [Test]
+    public async Task Start_OptimizerStartsFromSeed_ButSummaryBaselineIsCurrentSettings() {
+        // The optimizer must start from the (default) Seed, while the displayed improvement/changed-parameters
+        // "before" column must reflect the user's CURRENT settings (Baseline). Seed.Sensitivity=2 (default),
+        // Baseline.Sensitivity=8 (current); both optimize toward 10.
+        var vm = NewVM(LoaderReturning(SeedBaselineSplitRun()));
+        vm.SourcePaths[0] = @"C:\run1";
+
+        await vm.StartAsync(CancellationToken.None);
+
+        // The optimizer's own record (Result.ChangedVariables) starts from the Seed (2).
+        var rawSensitivity = vm.Result.ChangedVariables
+            .FirstOrDefault(c => c.Name == nameof(StarDetectorParams.Sensitivity));
+        Assert.That(rawSensitivity.Name, Is.EqualTo(nameof(StarDetectorParams.Sensitivity)),
+            "the optimizer changed Sensitivity from its seed");
+        Assert.That(rawSensitivity.SeedValue, Is.EqualTo(2.0).Within(1e-9), "the optimizer started from the default Seed (2)");
+
+        // The displayed summary's "before" column reflects the current-settings Baseline (8).
+        var displayedSensitivity = vm.Summary.ChangedParameters
+            .FirstOrDefault(r => r.Name == nameof(StarDetectorParams.Sensitivity));
+        Assert.That(displayedSensitivity, Is.Not.Null, "the summary shows the Sensitivity change vs current settings");
+        Assert.Multiple(() => {
+            Assert.That(displayedSensitivity.SeedValue, Is.EqualTo(8.0).Within(1e-9),
+                "the summary 'before' value is the user's current setting (8), not the default seed (2)");
+            Assert.That(Math.Abs(displayedSensitivity.OptimizedValue - 10.0),
+                Is.LessThan(Math.Abs(8.0 - 10.0)), "optimized Sensitivity is closer to the optimum than current");
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionOptionsTests.cs
@@ -370,6 +370,58 @@ public class StarDetectionOptionsTests {
     }
 
     [Test]
+    public void BuildDefaultStarDetectorParams_MatchesResetDefaultsBuild() {
+        // The optimizer's "fully-default" seed must equal what BuildStarDetectorParams produces from a freshly
+        // reset options object — for EVERY option-derived field. If a default ever changes in only one place
+        // (ResetDefaults or BuildDefaultStarDetectorParams), this test fails loudly.
+        var (options, _, _) = Build();
+        options.ResetDefaults();
+        var fromOptions = HocusFocusStarDetection.BuildStarDetectorParams(options);
+        var fromDefault = HocusFocusStarDetection.BuildDefaultStarDetectorParams();
+
+        Assert.Multiple(() => {
+            Assert.That(fromDefault.ModelPSF, Is.EqualTo(fromOptions.ModelPSF));
+            Assert.That(fromDefault.StarMeasurementNoiseReductionEnabled, Is.EqualTo(fromOptions.StarMeasurementNoiseReductionEnabled));
+            Assert.That(fromDefault.PSFFitType, Is.EqualTo(fromOptions.PSFFitType));
+            Assert.That(fromDefault.HotpixelFiltering, Is.EqualTo(fromOptions.HotpixelFiltering));
+            Assert.That(fromDefault.HotpixelThresholdingEnabled, Is.EqualTo(fromOptions.HotpixelThresholdingEnabled));
+            Assert.That(fromDefault.NoiseReductionRadius, Is.EqualTo(fromOptions.NoiseReductionRadius));
+            Assert.That(fromDefault.NoiseClippingMultiplier, Is.EqualTo(fromOptions.NoiseClippingMultiplier));
+            Assert.That(fromDefault.StarClippingMultiplier, Is.EqualTo(fromOptions.StarClippingMultiplier));
+            Assert.That(fromDefault.ContaminationSensitivity, Is.EqualTo(fromOptions.ContaminationSensitivity));
+            Assert.That(fromDefault.RejectContaminatedStars, Is.EqualTo(fromOptions.RejectContaminatedStars));
+            Assert.That(fromDefault.StructureLayers, Is.EqualTo(fromOptions.StructureLayers));
+            Assert.That(fromDefault.DefocusAwareStructure, Is.EqualTo(fromOptions.DefocusAwareStructure));
+            Assert.That(fromDefault.StructureLayerBoost, Is.EqualTo(fromOptions.StructureLayerBoost));
+            Assert.That(fromDefault.Sensitivity, Is.EqualTo(fromOptions.Sensitivity));
+            Assert.That(fromDefault.PeakResponse, Is.EqualTo(fromOptions.PeakResponse));
+            Assert.That(fromDefault.MaxDistortion, Is.EqualTo(fromOptions.MaxDistortion));
+            Assert.That(fromDefault.DefocusAwareDistortion, Is.EqualTo(fromOptions.DefocusAwareDistortion));
+            Assert.That(fromDefault.DefocusAwareCentering, Is.EqualTo(fromOptions.DefocusAwareCentering));
+            Assert.That(fromDefault.DefocusDistortionSizeReference, Is.EqualTo(fromOptions.DefocusDistortionSizeReference));
+            Assert.That(fromDefault.DefocusDistortionMinFactor, Is.EqualTo(fromOptions.DefocusDistortionMinFactor));
+            Assert.That(fromDefault.DefocusCenteringToleranceFactor, Is.EqualTo(fromOptions.DefocusCenteringToleranceFactor));
+            Assert.That(fromDefault.StarCenterTolerance, Is.EqualTo(fromOptions.StarCenterTolerance));
+            Assert.That(fromDefault.BackgroundBoxExpansion, Is.EqualTo(fromOptions.BackgroundBoxExpansion));
+            Assert.That(fromDefault.MinimumStarBoundingBoxSize, Is.EqualTo(fromOptions.MinimumStarBoundingBoxSize));
+            Assert.That(fromDefault.MinHFR, Is.EqualTo(fromOptions.MinHFR));
+            Assert.That(fromDefault.StructureDilationSize, Is.EqualTo(fromOptions.StructureDilationSize));
+            Assert.That(fromDefault.StructureDilationCount, Is.EqualTo(fromOptions.StructureDilationCount));
+            Assert.That(fromDefault.AnalysisSamplingSize, Is.EqualTo(fromOptions.AnalysisSamplingSize));
+            Assert.That(fromDefault.StoreStructureMap, Is.EqualTo(fromOptions.StoreStructureMap));
+            Assert.That(fromDefault.SaveIntermediateFilesPath, Is.EqualTo(fromOptions.SaveIntermediateFilesPath));
+            Assert.That(fromDefault.PSFParallelPartitionSize, Is.EqualTo(fromOptions.PSFParallelPartitionSize));
+            Assert.That(fromDefault.PSFResolution, Is.EqualTo(fromOptions.PSFResolution));
+            Assert.That(fromDefault.PSFGoodnessOfFitThreshold, Is.EqualTo(fromOptions.PSFGoodnessOfFitThreshold));
+            Assert.That(fromDefault.UsePSFAbsoluteDeviation, Is.EqualTo(fromOptions.UsePSFAbsoluteDeviation));
+            Assert.That(fromDefault.HotpixelThreshold, Is.EqualTo(fromOptions.HotpixelThreshold));
+            Assert.That(fromDefault.SaturationThreshold, Is.EqualTo(fromOptions.SaturationThreshold));
+            Assert.That(fromDefault.PSFPixelIntegration, Is.EqualTo(fromOptions.PSFPixelIntegration));
+            Assert.That(fromDefault.MaxStarEvaluationParallelism, Is.EqualTo(fromOptions.MaxStarEvaluationParallelism));
+        });
+    }
+
+    [Test]
     public void PixelSampleSize_RejectsOutOfRange() {
         var (options, _, _) = Build();
         options.UseAdvanced = true;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IHocusFocusStarDetection.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IHocusFocusStarDetection.cs
@@ -34,6 +34,10 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
 
         StarDetectorParams GetStarDetectorParams(IRenderedImage image, StarDetectionRegion starDetectionRegion, bool isAutoFocus);
 
+        /// <summary>The Optimization Wizard's seed: fully-default detector params with the same image-context +
+        /// auto-focus overrides as <see cref="GetStarDetectorParams"/>. Read-only with respect to options.</summary>
+        StarDetectorParams GetDefaultStarDetectorParams(IRenderedImage image, StarDetectionRegion starDetectionRegion, bool isAutoFocus);
+
         Task<StarDetectionResult> Detect(IRenderedImage image, HocusFocusDetectionParams hocusFocusParams, StarDetectorParams detectorParams, IProgress<ApplicationStatus> progress, CancellationToken token);
 
         /// <summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
@@ -385,6 +385,36 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
         }
 
         public StarDetectorParams GetStarDetectorParams(IRenderedImage image, StarDetectionRegion starDetectionRegion, bool isAutoFocus) {
+            var detectorParams = BuildStarDetectorParams(starDetectionOptions);
+            ApplyDetectionImageContext(detectorParams, image, starDetectionRegion, isAutoFocus);
+            if (!isAutoFocus) {
+                // Only save intermediate images for 1 detection. Doing this again should require the user to pick it again.
+                starDetectionOptions.SaveIntermediateImages = false;
+            }
+            return detectorParams;
+        }
+
+        /// <summary>
+        /// The Optimization Wizard's seed: the fully-default detector params (<see cref="BuildDefaultStarDetectorParams"/>)
+        /// with the SAME image-dependent fields + auto-focus overrides as <see cref="GetStarDetectorParams"/> layered on
+        /// (PixelScale, Region, ModelPSF=false, SaveIntermediateFilesPath=""). Read-only with respect to options — it
+        /// never touches <c>starDetectionOptions</c>. <paramref name="isAutoFocus"/> is expected to be true for the
+        /// wizard's replay path.
+        /// </summary>
+        public StarDetectorParams GetDefaultStarDetectorParams(IRenderedImage image, StarDetectionRegion starDetectionRegion, bool isAutoFocus) {
+            var detectorParams = BuildDefaultStarDetectorParams();
+            ApplyDetectionImageContext(detectorParams, image, starDetectionRegion, isAutoFocus);
+            return detectorParams;
+        }
+
+        /// <summary>
+        /// Layers the image-dependent fields (PixelScale from the profile × binning, Region) and the auto-focus
+        /// overrides (ModelPSF=false, no intermediate-file save) onto an already-built params bundle. Pure with
+        /// respect to options — shared by <see cref="GetStarDetectorParams"/> and
+        /// <see cref="GetDefaultStarDetectorParams"/> so the two can never diverge in how they compute pixel scale or
+        /// apply the AF overrides.
+        /// </summary>
+        private void ApplyDetectionImageContext(StarDetectorParams detectorParams, IRenderedImage image, StarDetectionRegion starDetectionRegion, bool isAutoFocus) {
             var binning = Math.Max(image.RawImageData.MetaData.Camera.BinX, 1);
             var pixelScale = MathUtility.ArcsecPerPixel(profileService.ActiveProfile.CameraSettings.PixelSize, profileService.ActiveProfile.TelescopeSettings.FocalLength) * binning;
             if (double.IsNaN(pixelScale)) {
@@ -395,11 +425,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                 Logger.Warning("Pixel Scale is NaN. Make sure pixel size and focal length are set in Options.");
             }
 
-            var detectorParams = BuildStarDetectorParams(starDetectionOptions);
             detectorParams.PixelScale = pixelScale;
             detectorParams.Region = starDetectionRegion;
 
-            // For AutoFocus, don't save intermediate data or model PSFs
+            // For AutoFocus, don't save intermediate data or model PSFs.
             if (isAutoFocus) {
                 detectorParams.SaveIntermediateFilesPath = string.Empty;
                 detectorParams.ModelPSF = false;
@@ -409,11 +438,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                 // PeakResponse is also reused in the sensitivity (NormalizedBrightness) calc so loosening it has side
                 // effects. Revisit with a real defocus dataset (TestApp focus-sweep) if AF star counts drop at sweep
                 // extremes.
-            } else {
-                // Only save intermediate images for 1 detection. Doing this again should require the user to pick it again
-                starDetectionOptions.SaveIntermediateImages = false;
             }
-            return detectorParams;
         }
 
         public async Task<StarDetectionResult> Detect(IRenderedImage image, HocusFocusDetectionParams hocusFocusParams, StarDetectorParams detectorParams, IProgress<ApplicationStatus> progress, CancellationToken token) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
@@ -332,6 +332,58 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             };
         }
 
+        /// <summary>
+        /// The "fully-default" detector params — the analogue of <see cref="BuildStarDetectorParams"/> for an
+        /// options object at <c>StarDetectionOptions.ResetDefaults()</c>. Every option-derived field is at its
+        /// documented default. Used as the Optimization Wizard's seed so the search starts from a clean,
+        /// reproducible point regardless of the user's current settings. Image-dependent fields (PixelScale,
+        /// Region) and the auto-focus overrides are layered on by <see cref="GetDefaultStarDetectorParams"/>.
+        /// The literals here are kept in lockstep with ResetDefaults by
+        /// StarDetectionOptionsTests.BuildDefaultStarDetectorParams_MatchesResetDefaultsBuild.
+        /// </summary>
+        internal static StarDetectorParams BuildDefaultStarDetectorParams() {
+            return new StarDetectorParams() {
+                ModelPSF = true,
+                StarMeasurementNoiseReductionEnabled = false,
+                PSFFitType = StarDetectorPSFFitType.Moffat_40,
+                HotpixelFiltering = true,
+                HotpixelThresholdingEnabled = true,
+                NoiseReductionRadius = 3,
+                NoiseClippingMultiplier = 4.0,
+                StarClippingMultiplier = 2.0,
+                ContaminationSensitivity = 5.0,
+                RejectContaminatedStars = true,
+                StructureLayers = 4,
+                DefocusAwareStructure = false,
+                StructureLayerBoost = 0,
+                Sensitivity = 2.0,
+                PeakResponse = 0.75,
+                MaxDistortion = 0.5,
+                DefocusAwareDistortion = false,
+                DefocusAwareCentering = false,
+                DefocusDistortionSizeReference = 30.0,
+                DefocusDistortionMinFactor = 0.25,
+                DefocusCenteringToleranceFactor = 2.0,
+                StarCenterTolerance = 0.3,
+                BackgroundBoxExpansion = 3,
+                MinimumStarBoundingBoxSize = 5,
+                MinHFR = 1.2,
+                StructureDilationSize = 3,
+                StructureDilationCount = 0,
+                AnalysisSamplingSize = 1.0f,
+                StoreStructureMap = false,
+                SaveIntermediateFilesPath = string.Empty,
+                PSFParallelPartitionSize = 100,
+                PSFResolution = 10,
+                PSFGoodnessOfFitThreshold = 0.9,
+                UsePSFAbsoluteDeviation = false,
+                HotpixelThreshold = 0.001d,
+                SaturationThreshold = 0.99d,
+                PSFPixelIntegration = false,
+                MaxStarEvaluationParallelism = 0
+            };
+        }
+
         public StarDetectorParams GetStarDetectorParams(IRenderedImage image, StarDetectionRegion starDetectionRegion, bool isAutoFocus) {
             var binning = Math.Max(image.RawImageData.MetaData.Camera.BinX, 1);
             var pixelScale = MathUtility.ArcsecPerPixel(profileService.ActiveProfile.CameraSettings.PixelSize, profileService.ActiveProfile.TelescopeSettings.FocalLength) * binning;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationLoader.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationLoader.cs
@@ -33,7 +33,22 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
     /// </summary>
     public sealed class LoadedRun {
         public RunEvaluationData Data { get; set; }
+
+        /// <summary>The params the optimizer starts its search from. In production this is the fully-DEFAULT
+        /// detector params (see <see cref="IHocusFocusStarDetection.GetDefaultStarDetectorParams"/>), carrying
+        /// PixelScale + Region + ModelPSF=false.</summary>
         public StarDetectorParams Seed { get; set; }
+
+        private StarDetectorParams baseline;
+
+        /// <summary>The user's CURRENT settings — the displayed "before" baseline (σ, cost J, the "Current" curve,
+        /// and the changed-parameters before-column). Defaults to <see cref="Seed"/> when not separately provided,
+        /// so a caller/test that sets only <see cref="Seed"/> keeps the legacy "the seed is the baseline" behavior.</summary>
+        public StarDetectorParams Baseline {
+            get => baseline ?? Seed;
+            set => baseline = value;
+        }
+
         public AutoFocusEngineOptions AfOptions { get; set; }
     }
 
@@ -144,9 +159,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 progress?.Report(new RunLoadProgress(++loadedCount, totalImages));
             }
 
-            // Seed = AF-base detector params for the first image (PixelScale + Region + ModelPSF=false). This is
-            // the bundle the optimizer starts from and tunes.
-            var seed = detection.GetStarDetectorParams(firstImage, region, isAutoFocus: true);
+            // Seed = fully-DEFAULT AF-base detector params for the first image (PixelScale + Region + ModelPSF=false):
+            // the optimizer starts its search from a clean, reproducible default regardless of the user's current
+            // settings. Baseline = the user's CURRENT settings, kept for the displayed "before" comparison (σ, cost J,
+            // the "Current" curve). Both carry the same image context; neither writes to options.
+            var seed = detection.GetDefaultStarDetectorParams(firstImage, region, isAutoFocus: true);
+            var baseline = detection.GetStarDetectorParams(firstImage, region, isAutoFocus: true);
 
             // AF detection params: the auto-focus detection contract (sigma rejections + AF flag). NumberOfAFStars
             // is left at 0 so detection keeps every accepted star — the optimizer scores on the full accepted set,
@@ -177,6 +195,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             return new LoadedRun {
                 Data = data,
                 Seed = seed,
+                Baseline = baseline,
                 AfOptions = afOptions
             };
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -241,6 +241,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         private int running; // 0 = idle, 1 = a Start is in flight (guards against double-start)
         private bool disposed;
 
+        // The objective the optimizer uses by default (StarDetectionOptimizer ctor defaults to new ObjectiveConstants()).
+        // The wizard computes the current-settings baseline J with the SAME constants so it is comparable to BestJ.
+        private readonly ObjectiveConstants objectiveConstants = new ObjectiveConstants();
+
+        // J of the user's CURRENT settings (Baseline), evaluated on the loaded runs. The displayed "before" for the
+        // improvement readouts (summary SeedJ + live ProgressSeedJ). Set in StartAsync (and the re-optimize path)
+        // before the optimize + summary steps.
+        private double currentBaselineJ;
+
         /// <summary>
         /// MEF/T5 convenience constructor: wires the real collaborators from the plugin singletons + mediators.
         /// The wizard is not MEF-exported (it is created on demand by T5's launch command), so this just supplies
@@ -960,10 +969,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     return; // ErrorMessage already set, or cancelled
                 }
 
-                // 2. Seed guard — evaluate the seed once; bail with a clear error on a degenerate run.
+                // 2. Seed guard — evaluate the current settings once; bail with a clear error on a degenerate run.
                 if (!await SeedFitIsUsableAsync(loadedRuns, token).ConfigureAwait(true)) {
                     return; // ErrorMessage set by the guard
                 }
+
+                // 2b. Baseline J = the user's CURRENT settings' objective, the displayed "before" for improvement.
+                //     Computed once here (cheap: the guard just warmed the current-settings contexts).
+                currentBaselineJ = await ComputeBaselineJAsync(loadedRuns, token).ConfigureAwait(true);
+                ProgressSeedJ = currentBaselineJ;
 
                 // 3. Optimize — off the UI thread, progress marshaled back. OptimizeAsync always returns a
                 // non-null result; it signals cancellation by throwing OperationCanceledException (caught below).
@@ -974,9 +988,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 if (OptimizeMode == WizardOptimizeMode.UseCurrentSettings) {
                     SetProgress("Using current settings (no optimization)", 0, 0);
                     optimizeResult = new OptimizationResult {
-                        BestParams = loadedRuns[0].Seed,
-                        SeedJ = 0.0,
-                        BestJ = 0.0,
+                        BestParams = loadedRuns[0].Baseline,
+                        SeedJ = currentBaselineJ,
+                        BestJ = currentBaselineJ,
                         Evaluations = 0,
                         ImprovedOverSeed = false,
                         ChangedVariables = new List<(string Name, double SeedValue, double BestValue)>()
@@ -984,6 +998,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     optimized = false;
                 } else {
                     CurrentStep = WizardStep.Optimize;
+                    // Warm the DEFAULT-seed early contexts (the optimizer starts here) so the bar moves during the
+                    // first build instead of sitting on the optimizer's seed evaluation.
+                    await AnalyzeWithProgressAsync(loadedRuns, r => r.Seed, token).ConfigureAwait(true);
                     optimizeResult = await OptimizeAsync(loadedRuns, token).ConfigureAwait(true);
                     optimized = true;
                 }
@@ -995,9 +1012,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
                 // The Current (seed) variant always exists — for the comparison curve and the baseline summary.
                 currentResult = new OptimizationResult {
-                    BestParams = loadedRuns[0].Seed,
-                    SeedJ = optimizeResult.SeedJ,
-                    BestJ = optimizeResult.SeedJ,
+                    BestParams = loadedRuns[0].Baseline,
+                    SeedJ = currentBaselineJ,
+                    BestJ = currentBaselineJ,
                     Evaluations = 0,
                     ImprovedOverSeed = false,
                     ChangedVariables = new List<(string Name, double SeedValue, double BestValue)>()
@@ -1128,7 +1145,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // Evaluate the seed on every run WITH determinate "Analyzing frames" progress. This first pass also builds
             // each frame's expensive early-detection context (the long initial wait), so reporting it here is what
             // makes the bar advance instead of sitting on a static count; the optimizer then reuses the warmed contexts.
-            var results = await AnalyzeWithProgressAsync(runs, r => r.Seed, token).ConfigureAwait(true);
+            var results = await AnalyzeWithProgressAsync(runs, r => r.Baseline, token).ConfigureAwait(true);
             var anyUsable = false;
             foreach (var eval in results) {
                 if (double.IsFinite(eval.Metrics.SigmaFocus) && eval.PooledPointCount >= MinPositionsForFit) {
@@ -1170,6 +1187,26 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             return results;
         }
 
+        /// <summary>
+        /// Computes the objective J of the user's CURRENT settings (<see cref="LoadedRun.Baseline"/>) on the loaded
+        /// runs, using the same <see cref="ObjectiveConstants"/> and JRun/JTotal aggregation the optimizer uses, so the
+        /// value is directly comparable to <see cref="OptimizationResult.BestJ"/>. This is the displayed "before"
+        /// baseline for the improvement readouts. Cheap after the seed guard warmed the early-detection contexts (the
+        /// late stage re-runs against the warmed cache).
+        /// </summary>
+        private async Task<double> ComputeBaselineJAsync(IReadOnlyList<LoadedRun> runs, CancellationToken token) {
+            // Use a SINGLE current-settings bundle (runs[0].Baseline) across every run, exactly as the optimizer's
+            // evaluator applies one StarDetectorParams across all runs — so this J is directly comparable to BestJ.
+            var baseline = runs[0].Baseline;
+            var perRunJ = new List<double>(runs.Count);
+            for (var i = 0; i < runs.Count; i++) {
+                token.ThrowIfCancellationRequested();
+                var eval = await runs[i].Data.EvaluateAndFitAsync(baseline, token).ConfigureAwait(true);
+                perRunJ.Add(OptimizationObjective.JRun(eval.Metrics, objectiveConstants));
+            }
+            return OptimizationObjective.JTotal(perRunJ, objectiveConstants);
+        }
+
         /// <summary>Runs the pure optimizer off the UI thread; progress posts back via <see cref="IProgress{T}"/>.
         /// When <paramref name="seedOverride"/>/<paramref name="variablesOverride"/> are supplied (the warm-start
         /// "Optimize with feedback" path), the search starts from the analytic recommendation and explores only the
@@ -1186,7 +1223,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 ProgressCurrent = p.Evaluations;
                 ProgressTotal = p.MaxEvaluations;
                 ProgressBestJ = p.BestJ;
-                ProgressSeedJ = p.SeedJ;
+                // The displayed baseline is the user's CURRENT settings (currentBaselineJ), not the optimizer's
+                // default seed J (p.SeedJ), so the live "improved ~X%" reads vs current and matches the summary.
+                ProgressSeedJ = currentBaselineJ;
                 Phase = FriendlyPhase(p.Phase);
             });
 
@@ -1211,35 +1250,45 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         };
 
         /// <summary>
-        /// Builds the summary: the changed-parameters table, before/after J + σ(focus) (re-evaluated at seed and
-        /// best, averaged across runs), and the recommended step size from the representative (first) run's best
+        /// Builds the summary: the changed-parameters table, before/after J + σ(focus) (re-evaluated at the current
+        /// settings (baseline) and best, averaged across runs), and the recommended step size from the representative (first) run's best
         /// fit, clamped to the focuser's max increment when known.
         /// </summary>
         private async Task<(OptimizationSummary Summary, OptimizationCurve CurrentCurve, OptimizationCurve OptimizedCurve)>
             BuildSummaryAsync(IReadOnlyList<LoadedRun> runs, OptimizationResult res, CancellationToken token) {
-            var seed = runs[0].Seed;
-            var changed = res.ChangedVariables
-                .Select(c => new ChangedParameterRow { Name = c.Name, SeedValue = c.SeedValue, OptimizedValue = c.BestValue })
-                .ToList();
+            // The displayed "before" is the user's CURRENT settings (Baseline), NOT the optimizer's default seed.
+            var baseline = runs[0].Baseline;
+
+            // Changed-parameters table = current (Baseline) -> optimized (BestParams) over the curated knobs, so it is
+            // exactly the diff the user would accept onto their live settings (consistent with the σ/J improvement,
+            // which is also measured vs current). This intentionally replaces res.ChangedVariables (default -> best).
+            var changed = new List<ChangedParameterRow>();
+            foreach (var v in OptimizerVariable.CreateCuratedSet()) {
+                var before = v.Read(baseline);
+                var after = v.Read(res.BestParams);
+                if (Math.Abs(before - after) > 1e-9) {
+                    changed.Add(new ChangedParameterRow { Name = v.Name, SeedValue = before, OptimizedValue = after });
+                }
+            }
 
             // σ(focus) before/after, averaged over the runs (the first run also yields the representative best fit
-            // AND the curves we plot — seed = "Current", best = "Optimized"; both carry the scatter points + fit).
-            double seedSigmaSum = 0.0, bestSigmaSum = 0.0;
-            var seedSigmaCount = 0; var bestSigmaCount = 0;
+            // AND the curves we plot — baseline = "Current", best = "Optimized"; both carry the scatter points + fit).
+            double baselineSigmaSum = 0.0, bestSigmaSum = 0.0;
+            var baselineSigmaCount = 0; var bestSigmaCount = 0;
             AlglibHyperbolicFitting representativeBestFit = null;
             OptimizationCurve currentCurveLocal = null, optimizedCurveLocal = null;
             for (var i = 0; i < runs.Count; i++) {
                 token.ThrowIfCancellationRequested();
-                var seedEval = await runs[i].Data.EvaluateAndFitAsync(seed, token).ConfigureAwait(true);
+                var baselineEval = await runs[i].Data.EvaluateAndFitAsync(baseline, token).ConfigureAwait(true);
                 var bestEval = await runs[i].Data.EvaluateAndFitAsync(res.BestParams, token).ConfigureAwait(true);
-                if (double.IsFinite(seedEval.Metrics.SigmaFocus)) { seedSigmaSum += seedEval.Metrics.SigmaFocus; seedSigmaCount++; }
+                if (double.IsFinite(baselineEval.Metrics.SigmaFocus)) { baselineSigmaSum += baselineEval.Metrics.SigmaFocus; baselineSigmaCount++; }
                 if (double.IsFinite(bestEval.Metrics.SigmaFocus)) { bestSigmaSum += bestEval.Metrics.SigmaFocus; bestSigmaCount++; }
                 if (i == 0) {
                     representativeBestFit = bestEval.BestFit;
                     currentCurveLocal = new OptimizationCurve {
-                        Label = "Current", Points = seedEval.Points, Fit = seedEval.BestFit,
-                        FrameStarCounts = seedEval.Metrics.FrameStarCounts,
-                        FrameFocuserPositions = seedEval.Metrics.FrameFocuserPositions
+                        Label = "Current", Points = baselineEval.Points, Fit = baselineEval.BestFit,
+                        FrameStarCounts = baselineEval.Metrics.FrameStarCounts,
+                        FrameFocuserPositions = baselineEval.Metrics.FrameFocuserPositions
                     };
                     optimizedCurveLocal = new OptimizationCurve {
                         Label = "Optimized", Points = bestEval.Points, Fit = bestEval.BestFit,
@@ -1255,9 +1304,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
             var summary = new OptimizationSummary {
                 ChangedParameters = changed,
-                SeedJ = res.SeedJ,
+                SeedJ = currentBaselineJ,
                 BestJ = res.BestJ,
-                SeedSigmaFocus = seedSigmaCount > 0 ? seedSigmaSum / seedSigmaCount : double.NaN,
+                SeedSigmaFocus = baselineSigmaCount > 0 ? baselineSigmaSum / baselineSigmaCount : double.NaN,
                 BestSigmaFocus = bestSigmaCount > 0 ? bestSigmaSum / bestSigmaCount : double.NaN,
                 RunCount = runs.Count,
                 RecommendedStepSize = recommendation.StepSize,
@@ -1336,12 +1385,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
             // Build the snapshot via the shared params->DTO mapping (the single source of truth shared with the
             // headless harness) so the in-app and offline paths can never drift. CreatedAtUtc is stamped inside.
+            // Record the displayed (vs current-settings) before/after J in the snapshot + log, so the persisted record
+            // matches the improvement the user saw. summary.SeedJ is the current-settings baseline J; summary.BestJ is
+            // the optimizer's best (== result.BestJ).
             var dto = OptimizedStarDetectionSettings.FromParams(
-                result.BestParams, summary.RunCount, result.SeedJ, result.BestJ,
+                result.BestParams, summary.RunCount, summary.SeedJ, summary.BestJ,
                 summary.RecommendedStepSize, summary.RecommendedOffsetSteps);
 
             starDetectionOptions.ApplyOptimizedSettings(dto);
-            Logger.Info($"Applied optimized star-detection settings (J {result.SeedJ:F3} -> {result.BestJ:F3}, {summary.RunCount} run(s))");
+            Logger.Info($"Applied optimized star-detection settings (J {summary.SeedJ:F3} -> {summary.BestJ:F3}, {summary.RunCount} run(s))");
 
             if (ApplyRecommendedStepSize) {
                 var focuserSettings = profileService?.ActiveProfile?.FocuserSettings;
@@ -1638,6 +1690,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 // Warm + report the per-frame early contexts for the params the optimizer will start from (re-optimize
                 // skips the seed-guard, so this is the parity warm-up that makes the bar move during the initial build).
                 await AnalyzeWithProgressAsync(reloaded, _ => seedOverride ?? reloaded[0].Seed, token).ConfigureAwait(true);
+
+                // Baseline J for the reloaded runs (current settings) — the displayed "before" for the feedback summary,
+                // keeping the improvement measured vs the user's current settings on this path too.
+                currentBaselineJ = await ComputeBaselineJAsync(reloaded, token).ConfigureAwait(true);
 
                 // Re-run the optimize + summary pipeline over the labeled runs (warm-started when we have a recommendation).
                 var optimizeResult = await OptimizeAsync(reloaded, token, seedOverride, variablesOverride).ConfigureAwait(true);

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -162,19 +162,27 @@ namespace TestApp {
                 Logger.Warning("PixelScale is NaN; pixel size / focal length not set in the profile");
             }
 
-            // Seed params = the SAME mapping NINA uses (BuildStarDetectorParams), with the AF overrides
-            // GetStarDetectorParams(..., isAutoFocus:true) applies: ModelPSF=false, no intermediate files, plus
-            // PixelScale and Region=Full. This is exactly the bundle the optimizer starts from and tunes.
-            var seed = HocusFocusStarDetection.BuildStarDetectorParams(starDetectionOptions);
-            seed.PixelScale = pixelScale;
-            seed.Region = StarDetectionRegion.Full;
-            seed.ModelPSF = false;
-            seed.SaveIntermediateFilesPath = string.Empty;
-            // The optimizer scores the full accepted set, so keep contaminated stars only if the profile says to.
-            // Leave RejectContaminatedStars exactly as the profile resolved it (matches production AF).
+            // Mirror the wizard's seed/baseline split (optimizer default seed + current-settings baseline):
+            //  - Seed = fully-DEFAULT params (BuildDefaultStarDetectorParams) — the bundle the optimizer STARTS from,
+            //    exactly like the wizard's LoadedRun.Seed, so the headless search reproduces the live result.
+            //  - Baseline = the user's CURRENT settings (BuildStarDetectorParams) — the "before" that improvement is
+            //    measured against (σ, J, curated-param deltas), exactly like the wizard's LoadedRun.Baseline.
+            // Both carry the same AF image-context overrides GetStarDetectorParams / GetDefaultStarDetectorParams apply
+            // (PixelScale, Region=Full, ModelPSF=false, no intermediate files). Neither writes to the profile.
+            StarDetectorParams ApplyAfContext(StarDetectorParams p) {
+                p.PixelScale = pixelScale;
+                p.Region = StarDetectionRegion.Full;
+                p.ModelPSF = false;
+                p.SaveIntermediateFilesPath = string.Empty;
+                return p;
+            }
+            var seed = ApplyAfContext(HocusFocusStarDetection.BuildDefaultStarDetectorParams());
+            var baseline = ApplyAfContext(HocusFocusStarDetection.BuildStarDetectorParams(starDetectionOptions));
 
-            Console.WriteLine($"Seed params: Sensitivity={F(seed.Sensitivity)}, StarClippingMultiplier={F(seed.StarClippingMultiplier)}, " +
-                $"NoiseClippingMultiplier={F(seed.NoiseClippingMultiplier)}, StructureLayers={seed.StructureLayers}, PixelScale={F(seed.PixelScale)}, " +
+            Console.WriteLine($"Default seed params: Sensitivity={F(seed.Sensitivity)}, StarClippingMultiplier={F(seed.StarClippingMultiplier)}, " +
+                $"NoiseClippingMultiplier={F(seed.NoiseClippingMultiplier)}, StructureLayers={seed.StructureLayers}, PixelScale={F(seed.PixelScale)}");
+            Console.WriteLine($"Current (baseline) params: Sensitivity={F(baseline.Sensitivity)}, StarClippingMultiplier={F(baseline.StarClippingMultiplier)}, " +
+                $"NoiseClippingMultiplier={F(baseline.NoiseClippingMultiplier)}, StructureLayers={baseline.StructureLayers}, " +
                 $"MeasurementAverage={starDetectionOptions.MeasurementAverage}");
 
             // The fixed AF-detection sigma rejections the wizard's RunEvaluationLoader uses (the
@@ -216,6 +224,7 @@ namespace TestApp {
                 HighSigmaOutlierRejection = highSigmaOutlierRejection,
                 LowSigmaOutlierRejection = lowSigmaOutlierRejection,
                 Seed = seed,
+                Baseline = baseline,
                 Variables = OptimizerVariable.CreateCuratedSet(),
                 MaxEvals = maxEvals,
                 LabelsDir = labelsDir,
@@ -238,7 +247,8 @@ namespace TestApp {
             public MeasurementAverageEnum MeasurementAverage;
             public double HighSigmaOutlierRejection;
             public double LowSigmaOutlierRejection;
-            public StarDetectorParams Seed;
+            public StarDetectorParams Seed;       // optimizer start = fully-default params (wizard's LoadedRun.Seed)
+            public StarDetectorParams Baseline;    // current settings = displayed "before" (wizard's LoadedRun.Baseline)
             public IReadOnlyList<OptimizerVariable> Variables;
             public int? MaxEvals;
             public string LabelsDir;
@@ -251,7 +261,8 @@ namespace TestApp {
             public int WorstFrameCount;
             public string WorstRunId;
             public OptimizationResult Result;
-            public List<RunEvaluationResult> PerRunSeed;
+            public double BaselineJ = double.NaN;   // J of the user's CURRENT settings (the displayed "before")
+            public List<RunEvaluationResult> PerRunBaseline;   // per-run eval of CURRENT settings (the "before" columns)
             public List<RunEvaluationResult> PerRunBest;
             public List<LoadedHarnessRun> LoadedRuns;
         }
@@ -302,7 +313,7 @@ namespace TestApp {
                     if (!outcome.HardFloorPassed) {
                         anyFailure = true;
                     }
-                    aggregate.Add(BuildAggregateRow(d.RunId, outcome));
+                    aggregate.Add(BuildAggregateRow(d.RunId, ctx, outcome));
                     Console.WriteLine($"  -> {d.RunId}: seedJ={F(outcome.Result.SeedJ)} bestJ={F(outcome.Result.BestJ)} " +
                         $"hard-floor {(outcome.HardFloorPassed ? "PASS" : "FAIL")}; outputs in {subDir}");
                 } catch (Exception ex) {
@@ -404,14 +415,20 @@ namespace TestApp {
             Console.WriteLine($"Optimize phase: {sw.Elapsed.TotalSeconds.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)} s wall, " +
                 $"early-context builds={builds}, reuses={reuses} ({reusePct.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)}% reuse of {totalDetections} frame detections)");
 
-            var perRunSeed = new List<RunEvaluationResult>(loadedRuns.Count);
+            // "Before" = the user's CURRENT settings (ctx.Baseline) — the wizard's displayed baseline, NOT the default
+            // seed the optimizer started from. perRunBaseline feeds every before-column; baselineJ (the SAME JTotal
+            // the optimizer uses, over the single baseline bundle across runs) is the reported "before J", mirroring
+            // the wizard's currentBaselineJ so the headless improvement equals the live wizard's.
+            var perRunBaseline = new List<RunEvaluationResult>(loadedRuns.Count);
             var perRunBest = new List<RunEvaluationResult>(loadedRuns.Count);
             foreach (var r in loadedRuns) {
-                perRunSeed.Add(await r.Data.EvaluateAndFitAsync(ctx.Seed, CancellationToken.None).ConfigureAwait(false));
+                perRunBaseline.Add(await r.Data.EvaluateAndFitAsync(ctx.Baseline, CancellationToken.None).ConfigureAwait(false));
                 perRunBest.Add(await r.Data.EvaluateAndFitAsync(result.BestParams, CancellationToken.None).ConfigureAwait(false));
             }
 
             var objectiveConstants = new ObjectiveConstants();
+            var baselineJ = OptimizationObjective.JTotal(
+                perRunBaseline.Select(pr => OptimizationObjective.JRun(pr.Metrics, objectiveConstants)).ToList(), objectiveConstants);
             var (passed, worstFrameCount, worstRunId) = AssertHardFloor(loadedRuns, perRunBest, objectiveConstants);
             Console.WriteLine(passed
                 ? $"PASS: every frame has >= {objectiveConstants.NHard} stars under optimized params (min observed = {worstFrameCount})"
@@ -420,9 +437,9 @@ namespace TestApp {
             // The focuser's max step is unavailable headless, so it is left null — StepSizeRecommender clamps to >= 1.
             var focuserMaxStep = (int?)null;
 
-            WriteSummary(Path.Combine(targetDir, "optimize_summary.txt"), runsDir, ctx.Seed, result, variables,
-                loadedRuns, perRunSeed, perRunBest, objectiveConstants, focuserMaxStep, ctx.LabelsDir, settings, passed, worstFrameCount, worstRunId);
-            WriteCsv(Path.Combine(targetDir, "optimize_result.csv"), loadedRuns, perRunSeed, perRunBest);
+            WriteSummary(Path.Combine(targetDir, "optimize_summary.txt"), runsDir, ctx.Baseline, baselineJ, result, variables,
+                loadedRuns, perRunBaseline, perRunBest, objectiveConstants, focuserMaxStep, ctx.LabelsDir, settings, passed, worstFrameCount, worstRunId);
+            WriteCsv(Path.Combine(targetDir, "optimize_result.csv"), loadedRuns, perRunBaseline, perRunBest);
 
             // Optimized-settings handoff: write the winning snapshot as optimized_settings.json into each focus run's
             // own source folder (so `review --runs <same>` auto-discovers it) plus a single copy in the --out dir.
@@ -430,7 +447,7 @@ namespace TestApp {
             // so the headless and in-app handoffs can never drift. The source-folder copies each carry that run's OWN
             // recommended step (StepSizeRecommender, exactly as BuildAggregateRow computes it); the single --out copy
             // uses the representative (first) run's step in joint mode (see WriteOptimizedSettings).
-            WriteOptimizedSettings(targetDir, loadedRuns, perRunBest, result, focuserMaxStep);
+            WriteOptimizedSettings(targetDir, loadedRuns, perRunBest, result, baselineJ, focuserMaxStep);
 
             await WriteAnnotatedFrames(targetDir, loadedRuns, result.BestParams, ctx.Detector,
                 ctx.MeasurementAverage, ctx.HighSigmaOutlierRejection, ctx.LowSigmaOutlierRejection, ctx.AnnotateAll).ConfigureAwait(false);
@@ -440,7 +457,8 @@ namespace TestApp {
                 WorstFrameCount = worstFrameCount,
                 WorstRunId = worstRunId,
                 Result = result,
-                PerRunSeed = perRunSeed,
+                BaselineJ = baselineJ,
+                PerRunBaseline = perRunBaseline,
                 PerRunBest = perRunBest,
                 LoadedRuns = loadedRuns
             };
@@ -461,14 +479,14 @@ namespace TestApp {
         /// </summary>
         private static void WriteOptimizedSettings(
             string targetDir, List<LoadedHarnessRun> loadedRuns, List<RunEvaluationResult> perRunBest,
-            OptimizationResult result, int? focuserMaxStep) {
+            OptimizationResult result, double baselineJ, int? focuserMaxStep) {
             // Per-run source-folder copies: each run's frame directory gets the winner snapshot with its OWN step.
             for (int i = 0; i < loadedRuns.Count; i++) {
                 var run = loadedRuns[i];
                 try {
                     var rec = StepSizeRecommender.Recommend(perRunBest[i].BestFit, run.StepSize, focuserMaxStep);
                     var dto = OptimizedStarDetectionSettings.FromParams(
-                        result.BestParams, loadedRuns.Count, result.SeedJ, result.BestJ, rec.StepSize, rec.OffsetSteps);
+                        result.BestParams, loadedRuns.Count, baselineJ, result.BestJ, rec.StepSize, rec.OffsetSteps);
                     var json = JsonConvert.SerializeObject(dto);
 
                     // The run's source folder is the directory holding its frames (each run's frames live together).
@@ -495,7 +513,7 @@ namespace TestApp {
                 try {
                     var rec = StepSizeRecommender.Recommend(perRunBest[0].BestFit, representative.StepSize, focuserMaxStep);
                     var dto = OptimizedStarDetectionSettings.FromParams(
-                        result.BestParams, loadedRuns.Count, result.SeedJ, result.BestJ, rec.StepSize, rec.OffsetSteps);
+                        result.BestParams, loadedRuns.Count, baselineJ, result.BestJ, rec.StepSize, rec.OffsetSteps);
                     var json = JsonConvert.SerializeObject(dto);
                     var outPath = Path.Combine(targetDir, "optimized_settings.json");
                     File.WriteAllText(outPath, json);
@@ -527,34 +545,41 @@ namespace TestApp {
             public string Error;                    // populated only when LoadOk == false
             public bool HardFloorPassed;
             public int WorstFrameCount;
-            public double SeedJ = double.NaN;
+            public double BaselineJ = double.NaN;       // J of the user's CURRENT settings (the "before")
             public double BestJ = double.NaN;
-            public double SeedSigmaFocus = double.NaN;
+            public double BaselineSigmaFocus = double.NaN;   // σ_focus of the CURRENT settings (the "before")
             public double BestSigmaFocus = double.NaN;
             public int RecommendedStep;
             public string ChangedParams = string.Empty;
         }
 
-        /// <summary>Builds an aggregate row from a per-run outcome (exactly one run in the set in --per-run mode).</summary>
-        private static AggregateRow BuildAggregateRow(string runId, RunSetOutcome outcome) {
+        /// <summary>Builds an aggregate row from a per-run outcome (exactly one run in the set in --per-run mode).
+        /// J / σ_focus / changed-params are reported vs the user's CURRENT settings (ctx.Baseline), mirroring the
+        /// wizard — NOT vs the default seed the optimizer started from.</summary>
+        private static AggregateRow BuildAggregateRow(string runId, RunDetectionContext ctx, RunSetOutcome outcome) {
             var run = outcome.LoadedRuns[0];
-            var seedM = outcome.PerRunSeed[0].Metrics;
+            var baselineM = outcome.PerRunBaseline[0].Metrics;
             var bestM = outcome.PerRunBest[0].Metrics;
             var rec = StepSizeRecommender.Recommend(outcome.PerRunBest[0].BestFit, run.StepSize, null);
-            var changed = outcome.Result.ChangedVariables;
+            // Changed curated params = current (Baseline) -> optimized (BestParams), exactly the diff the wizard shows
+            // (and would apply), not the optimizer's default-seed -> optimized deltas.
+            var changed = ctx.Variables
+                .Select(v => (v.Name, Cur: v.Read(ctx.Baseline), Best: v.Read(outcome.Result.BestParams)))
+                .Where(t => Math.Abs(t.Cur - t.Best) > 1e-9)
+                .ToList();
             return new AggregateRow {
                 RunId = runId,
                 LoadOk = true,
                 HardFloorPassed = outcome.HardFloorPassed,
                 WorstFrameCount = outcome.WorstFrameCount,
-                SeedJ = outcome.Result.SeedJ,
+                BaselineJ = outcome.BaselineJ,
                 BestJ = outcome.Result.BestJ,
-                SeedSigmaFocus = seedM.SigmaFocus,
+                BaselineSigmaFocus = baselineM.SigmaFocus,
                 BestSigmaFocus = bestM.SigmaFocus,
                 RecommendedStep = rec.StepSize,
-                ChangedParams = (changed == null || changed.Count == 0)
+                ChangedParams = changed.Count == 0
                     ? "(none)"
-                    : string.Join("; ", changed.Select(cv => $"{cv.Name}: {F(cv.SeedValue)}->{F(cv.BestValue)}"))
+                    : string.Join("; ", changed.Select(t => $"{t.Name}: {F(t.Cur)}->{F(t.Best)}"))
             };
         }
 
@@ -582,8 +607,8 @@ namespace TestApp {
                 }
                 sb.AppendLine($"  load        : OK");
                 sb.AppendLine($"  hard-floor  : {(r.HardFloorPassed ? "PASS" : "FAIL")} (min stars = {r.WorstFrameCount})");
-                sb.AppendLine($"  J           : {F(r.SeedJ)} -> {F(r.BestJ)}");
-                sb.AppendLine($"  sigma_focus : {F(r.SeedSigmaFocus)} -> {F(r.BestSigmaFocus)}");
+                sb.AppendLine($"  J           : {F(r.BaselineJ)} -> {F(r.BestJ)}  (current -> optimized)");
+                sb.AppendLine($"  sigma_focus : {F(r.BaselineSigmaFocus)} -> {F(r.BestSigmaFocus)}  (current -> optimized)");
                 sb.AppendLine($"  rec. step   : {r.RecommendedStep}");
                 sb.AppendLine($"  changed     : {r.ChangedParams}");
                 sb.AppendLine();
@@ -872,9 +897,9 @@ namespace TestApp {
         // ---- Output: summary + CSV -------------------------------------------------------------------------
 
         private static void WriteSummary(
-            string path, string runsDir, StarDetectorParams seed, OptimizationResult result,
+            string path, string runsDir, StarDetectorParams baseline, double baselineJ, OptimizationResult result,
             IReadOnlyList<OptimizerVariable> variables, List<LoadedHarnessRun> runs,
-            List<RunEvaluationResult> perRunSeed, List<RunEvaluationResult> perRunBest,
+            List<RunEvaluationResult> perRunBaseline, List<RunEvaluationResult> perRunBest,
             ObjectiveConstants c, int? focuserMaxStep, string labelsDir, OptimizerSettings settings,
             bool passed, int worstFrameCount, string worstRunId) {
             var sb = new StringBuilder();
@@ -883,23 +908,24 @@ namespace TestApp {
             sb.AppendLine($"Runs: {runs.Count} ({string.Join(", ", runs.Select(r => r.Discovered.RunId))})");
             sb.AppendLine($"Labels: {(string.IsNullOrWhiteSpace(labelsDir) ? "(none — unlabeled)" : labelsDir)}");
             sb.AppendLine($"MaxEvaluations: {settings.MaxEvaluations}; evaluator calls: {result.Evaluations}");
+            sb.AppendLine("Optimizer seed: fully-default params; improvement is measured vs the user's CURRENT settings (matches the wizard).");
             sb.AppendLine();
 
-            sb.AppendLine("--- Objective ---");
-            sb.AppendLine($"Seed J : {F(result.SeedJ)}");
-            sb.AppendLine($"Best J : {F(result.BestJ)}  ({(result.ImprovedOverSeed ? "improved over seed" : "no improvement over seed")})");
+            sb.AppendLine("--- Objective (current settings -> optimized) ---");
+            sb.AppendLine($"Current J : {F(baselineJ)}");
+            sb.AppendLine($"Best J    : {F(result.BestJ)}  ({(result.BestJ > baselineJ ? "improved over current" : "no improvement over current")})");
             sb.AppendLine();
 
-            sb.AppendLine("--- Per-run σ_focus (seed -> optimized) and recommended step size ---");
+            sb.AppendLine("--- Per-run σ_focus (current -> optimized) and recommended step size ---");
             for (int i = 0; i < runs.Count; i++) {
                 var run = runs[i];
-                var seedM = perRunSeed[i].Metrics;
+                var baselineM = perRunBaseline[i].Metrics;
                 var bestM = perRunBest[i].Metrics;
                 var rec = StepSizeRecommender.Recommend(perRunBest[i].BestFit, run.StepSize, focuserMaxStep);
                 sb.AppendLine($"  {run.Discovered.RunId}:");
-                sb.AppendLine($"    σ_focus       : {F(seedM.SigmaFocus)} -> {F(bestM.SigmaFocus)}");
-                sb.AppendLine($"    R²            : {F(seedM.RSquared)} -> {F(bestM.RSquared)}");
-                sb.AppendLine($"    reducedχ²     : {F(seedM.ReducedChiSquared)} -> {F(bestM.ReducedChiSquared)}");
+                sb.AppendLine($"    σ_focus       : {F(baselineM.SigmaFocus)} -> {F(bestM.SigmaFocus)}");
+                sb.AppendLine($"    R²            : {F(baselineM.RSquared)} -> {F(bestM.RSquared)}");
+                sb.AppendLine($"    reducedχ²     : {F(baselineM.ReducedChiSquared)} -> {F(bestM.ReducedChiSquared)}");
                 sb.AppendLine($"    current step  : {run.StepSize}");
                 sb.AppendLine($"    recommended   : step {rec.StepSize}, offset {rec.OffsetSteps} per side (half-width {F(rec.HalfWidth)})");
                 if (bestM.Recall.HasValue || bestM.Precision.HasValue) {
@@ -908,16 +934,14 @@ namespace TestApp {
             }
             sb.AppendLine();
 
-            sb.AppendLine("--- Curated params (seed -> optimized) ---");
-            // Map changed variables for quick lookup.
-            var changed = result.ChangedVariables?.ToDictionary(cv => cv.Name, cv => cv) ?? new Dictionary<string, (string, double, double)>();
+            sb.AppendLine("--- Curated params (current -> optimized) ---");
             foreach (var v in variables) {
-                var seedVal = v.Read(seed);
+                var currentVal = v.Read(baseline);
                 var bestVal = v.Read(result.BestParams);
-                var marker = changed.ContainsKey(v.Name) ? "  *" : "";
-                sb.AppendLine($"  {v.Name,-30} {F(seedVal),14} -> {F(bestVal),-14}{marker}");
+                var marker = Math.Abs(currentVal - bestVal) > 1e-9 ? "  *" : "";
+                sb.AppendLine($"  {v.Name,-30} {F(currentVal),14} -> {F(bestVal),-14}{marker}");
             }
-            sb.AppendLine("  (* = changed by the optimizer)");
+            sb.AppendLine("  (* = differs from your current settings)");
             sb.AppendLine();
 
             sb.AppendLine($"--- Hard-floor check (every frame must keep >= {c.NHard} stars) ---");
@@ -926,15 +950,15 @@ namespace TestApp {
                 : $"  FAIL (min observed = {worstFrameCount} in run {worstRunId})");
             sb.AppendLine();
 
-            sb.AppendLine("--- Per-frame star counts (per run, per focuser position: seed -> optimized) ---");
+            sb.AppendLine("--- Per-frame star counts (per run, per focuser position: current -> optimized) ---");
             for (int i = 0; i < runs.Count; i++) {
                 var run = runs[i];
                 sb.AppendLine($"  {run.Discovered.RunId}:");
-                // Group frames by focuser position; report seed/optimized counts for each.
-                var byPos = BuildPerPositionCounts(run, perRunSeed[i], perRunBest[i]);
-                sb.AppendLine($"    {"focuser",-10} {"seed",6} {"opt",6}");
+                // Group frames by focuser position; report current/optimized counts for each.
+                var byPos = BuildPerPositionCounts(run, perRunBaseline[i], perRunBest[i]);
+                sb.AppendLine($"    {"focuser",-10} {"current",7} {"opt",6}");
                 foreach (var kvp in byPos) {
-                    sb.AppendLine($"    {kvp.Key,-10} {kvp.Value.seed,6} {kvp.Value.opt,6}");
+                    sb.AppendLine($"    {kvp.Key,-10} {kvp.Value.current,7} {kvp.Value.opt,6}");
                 }
             }
 
@@ -942,22 +966,22 @@ namespace TestApp {
         }
 
         /// <summary>
-        /// Builds a focuser-position -> (seed count, optimized count) map for one run. FrameStarCounts is in the
+        /// Builds a focuser-position -> (current count, optimized count) map for one run. FrameStarCounts is in the
         /// SAME order RunEvaluationData iterates its frames (the order they were added), so it aligns 1:1 with the
         /// run's frame list; multiple frames at one position are summed (matches how the V-curve pools positions).
         /// </summary>
-        private static SortedDictionary<int, (int seed, int opt)> BuildPerPositionCounts(
-            LoadedHarnessRun run, RunEvaluationResult seedResult, RunEvaluationResult bestResult) {
-            var byPos = new SortedDictionary<int, (int seed, int opt)>();
+        private static SortedDictionary<int, (int current, int opt)> BuildPerPositionCounts(
+            LoadedHarnessRun run, RunEvaluationResult baselineResult, RunEvaluationResult bestResult) {
+            var byPos = new SortedDictionary<int, (int current, int opt)>();
             var frames = run.Discovered.Frames;
-            var seedCounts = seedResult.Metrics.FrameStarCounts;
+            var baselineCounts = baselineResult.Metrics.FrameStarCounts;
             var bestCounts = bestResult.Metrics.FrameStarCounts;
             for (int i = 0; i < frames.Count; i++) {
                 var pos = frames[i].FocuserPosition;
-                var s = (seedCounts != null && i < seedCounts.Count) ? seedCounts[i] : 0;
+                var s = (baselineCounts != null && i < baselineCounts.Count) ? baselineCounts[i] : 0;
                 var o = (bestCounts != null && i < bestCounts.Count) ? bestCounts[i] : 0;
                 if (byPos.TryGetValue(pos, out var cur)) {
-                    byPos[pos] = (cur.seed + s, cur.opt + o);
+                    byPos[pos] = (cur.current + s, cur.opt + o);
                 } else {
                     byPos[pos] = (s, o);
                 }
@@ -966,16 +990,16 @@ namespace TestApp {
         }
 
         private static void WriteCsv(
-            string path, List<LoadedHarnessRun> runs, List<RunEvaluationResult> perRunSeed, List<RunEvaluationResult> perRunBest) {
+            string path, List<LoadedHarnessRun> runs, List<RunEvaluationResult> perRunBaseline, List<RunEvaluationResult> perRunBest) {
             var sb = new StringBuilder();
-            sb.AppendLine("run,focuserPosition,seedStarCount,optimizedStarCount,frameIndex,framePath");
+            sb.AppendLine("run,focuserPosition,currentStarCount,optimizedStarCount,frameIndex,framePath");
             for (int i = 0; i < runs.Count; i++) {
                 var run = runs[i];
                 var frames = run.Discovered.Frames;
-                var seedCounts = perRunSeed[i].Metrics.FrameStarCounts;
+                var baselineCounts = perRunBaseline[i].Metrics.FrameStarCounts;
                 var bestCounts = perRunBest[i].Metrics.FrameStarCounts;
                 for (int j = 0; j < frames.Count; j++) {
-                    var s = (seedCounts != null && j < seedCounts.Count) ? seedCounts[j] : 0;
+                    var s = (baselineCounts != null && j < baselineCounts.Count) ? baselineCounts[j] : 0;
                     var o = (bestCounts != null && j < bestCounts.Count) ? bestCounts[j] : 0;
                     sb.AppendLine(string.Join(",",
                         Csv(run.Discovered.RunId), frames[j].FocuserPosition, s, o, j, Csv(frames[j].Path)));

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -314,7 +314,7 @@ namespace TestApp {
                         anyFailure = true;
                     }
                     aggregate.Add(BuildAggregateRow(d.RunId, ctx, outcome));
-                    Console.WriteLine($"  -> {d.RunId}: seedJ={F(outcome.Result.SeedJ)} bestJ={F(outcome.Result.BestJ)} " +
+                    Console.WriteLine($"  -> {d.RunId}: currentJ={F(outcome.BaselineJ)} bestJ={F(outcome.Result.BestJ)} " +
                         $"hard-floor {(outcome.HardFloorPassed ? "PASS" : "FAIL")}; outputs in {subDir}");
                 } catch (Exception ex) {
                     anyFailure = true;
@@ -397,38 +397,47 @@ namespace TestApp {
 
             var dataList = loadedRuns.Select(r => r.Data).ToList();
             var evaluator = RunEvaluationData.CreateEvaluator(dataList);
+            var objectiveConstants = new ObjectiveConstants();
+
+            // "Before" = the user's CURRENT settings (ctx.Baseline) — the wizard's displayed baseline, NOT the default
+            // seed the optimizer started from. Evaluate it FIRST so baselineJ (the SAME JTotal the optimizer uses, over
+            // the single baseline bundle across runs) is available to the progress + completion lines, keeping every
+            // console/report number "vs current" — consistent with the final summary and the live wizard.
+            var perRunBaseline = new List<RunEvaluationResult>(loadedRuns.Count);
+            foreach (var r in loadedRuns) {
+                perRunBaseline.Add(await r.Data.EvaluateAndFitAsync(ctx.Baseline, CancellationToken.None).ConfigureAwait(false));
+            }
+            var baselineJ = OptimizationObjective.JTotal(
+                perRunBaseline.Select(pr => OptimizationObjective.JRun(pr.Metrics, objectiveConstants)).ToList(), objectiveConstants);
+            Console.WriteLine($"Current settings J: {F(baselineJ)}");
 
             var progress = new Progress<OptimizationProgress>(op =>
-                Console.WriteLine($"  [{op.Phase}] evals={op.Evaluations}/{op.MaxEvaluations} bestJ={F(op.BestJ)} seedJ={F(op.SeedJ)}"));
+                Console.WriteLine($"  [{op.Phase}] evals={op.Evaluations}/{op.MaxEvaluations} bestJ={F(op.BestJ)} currentJ={F(baselineJ)}"));
+
+            // Snapshot the cache counters so the readout below measures the OPTIMIZE phase only (the baseline eval above
+            // already warmed some early contexts; counting its builds would understate the optimizer's own reuse).
+            var buildsBefore = dataList.Sum(d => d.ContextBuilds);
+            var reusesBefore = dataList.Sum(d => d.ContextReuses);
 
             var sw = System.Diagnostics.Stopwatch.StartNew();
             var result = await optimizer.OptimizeAsync(ctx.Seed, variables, evaluator, settings, progress, CancellationToken.None).ConfigureAwait(false);
             sw.Stop();
-            Console.WriteLine($"Optimization complete: seedJ={F(result.SeedJ)} -> bestJ={F(result.BestJ)} ({(result.ImprovedOverSeed ? "improved" : "no improvement")}), evals={result.Evaluations}");
+            Console.WriteLine($"Optimization complete: currentJ={F(baselineJ)} -> bestJ={F(result.BestJ)} ({(result.BestJ > baselineJ ? "improved over current" : "no improvement over current")}), evals={result.Evaluations}");
 
             // Cache-health + wall-clock readout (the early-context build:reuse ratio is the direct measure of how much
             // per-frame early work the staged search / context cache avoids; see the performance-design doc).
-            var builds = dataList.Sum(d => d.ContextBuilds);
-            var reuses = dataList.Sum(d => d.ContextReuses);
+            var builds = dataList.Sum(d => d.ContextBuilds) - buildsBefore;
+            var reuses = dataList.Sum(d => d.ContextReuses) - reusesBefore;
             var totalDetections = builds + reuses;
             var reusePct = totalDetections > 0 ? 100.0 * reuses / totalDetections : 0.0;
             Console.WriteLine($"Optimize phase: {sw.Elapsed.TotalSeconds.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)} s wall, " +
                 $"early-context builds={builds}, reuses={reuses} ({reusePct.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)}% reuse of {totalDetections} frame detections)");
 
-            // "Before" = the user's CURRENT settings (ctx.Baseline) — the wizard's displayed baseline, NOT the default
-            // seed the optimizer started from. perRunBaseline feeds every before-column; baselineJ (the SAME JTotal
-            // the optimizer uses, over the single baseline bundle across runs) is the reported "before J", mirroring
-            // the wizard's currentBaselineJ so the headless improvement equals the live wizard's.
-            var perRunBaseline = new List<RunEvaluationResult>(loadedRuns.Count);
+            // Evaluate the winner per run (the current-settings baseline was already evaluated above).
             var perRunBest = new List<RunEvaluationResult>(loadedRuns.Count);
             foreach (var r in loadedRuns) {
-                perRunBaseline.Add(await r.Data.EvaluateAndFitAsync(ctx.Baseline, CancellationToken.None).ConfigureAwait(false));
                 perRunBest.Add(await r.Data.EvaluateAndFitAsync(result.BestParams, CancellationToken.None).ConfigureAwait(false));
             }
-
-            var objectiveConstants = new ObjectiveConstants();
-            var baselineJ = OptimizationObjective.JTotal(
-                perRunBaseline.Select(pr => OptimizationObjective.JRun(pr.Metrics, objectiveConstants)).ToList(), objectiveConstants);
             var (passed, worstFrameCount, worstRunId) = AssertHardFloor(loadedRuns, perRunBest, objectiveConstants);
             Console.WriteLine(passed
                 ? $"PASS: every frame has >= {objectiveConstants.NHard} stars under optimized params (min observed = {worstFrameCount})"

--- a/docs/optimizer-default-seed-baseline-design.md
+++ b/docs/optimizer-default-seed-baseline-design.md
@@ -1,0 +1,161 @@
+# Star Detection Optimizer: Default Seed + Current-Settings Baseline — Design
+
+## Summary
+
+Change the Star Detection Optimization Wizard so that **optimization always starts from a
+fully-default set of star-detection parameters**, instead of from the user's current settings, while
+**still measuring and displaying improvement against the user's current settings**. The user's current
+settings are never written to disk during the run, so if the user does not accept the result their
+settings are unchanged — "revert on reject" is automatic.
+
+This is a behavior change in the wizard only. The pure optimizer engine, the objective function, the
+detector, and the persisted-settings format are unchanged.
+
+## Motivation
+
+Today the optimizer is *seeded from the user's current settings*
+(`RunEvaluationLoader.LoadSavedRunAsync` builds `LoadedRun.Seed` from
+`detection.GetStarDetectorParams(...)`, i.e. `BuildStarDetectorParams(liveOptions)`). Two consequences:
+
+1. The search is biased by whatever the user currently has. A poorly-tuned (or previously
+   hand-edited) starting point can trap the derivative-free search near a local optimum, and results
+   are not reproducible run-to-run as the user's settings drift.
+2. Because the seed *is* the baseline, the "before → after" improvement the wizard shows is implicitly
+   current → optimized.
+
+We want (1) a clean, reproducible **default** starting point, while keeping (2) a meaningful
+improvement comparison against **what the user actually runs today**. These two goals pull the single
+"seed" object in two directions, so the design splits it.
+
+## Design
+
+### Decouple the optimizer seed from the displayed baseline
+
+`LoadedRun` currently carries one param bundle, `Seed`, used for *both* the optimizer's starting point
+*and* the displayed "Current" baseline. Split it:
+
+| Bundle | Value | Used for |
+|---|---|---|
+| **`Seed`** (semantics changed) | **fully-default** detection params, with image-context fields preserved (PixelScale, Region, `ModelPSF=false`, `SaveIntermediateFilesPath=""`, parallelism) | the optimizer's starting point |
+| **`Baseline`** (new) | the user's **current** settings — exactly what `Seed` was constructed from today | seed-fit guard, the "Current" curve/variant, and the **before** numbers (σ, cost J) for the improvement display |
+
+"Fully reset" means *all* option-derived detection fields are at their defaults — not just the curated
+knobs the optimizer tunes — so the fixed (non-tuned) parameters the search holds constant are also at
+default, making the optimization fully reproducible regardless of the user's current configuration.
+
+### No live-options mutation (chosen mechanism)
+
+The wizard does **not** write defaults into the live `StarDetectionOptions`. The default seed is built
+in memory; the user's current settings are captured in memory as `Baseline`. NINA auto-saves the
+active profile, so writing defaults to live options would persist immediately and risk losing the
+user's settings if the app closed mid-run. Keeping everything in memory means:
+
+- **"Save the settings before optimization"** = the in-memory `Baseline` bundle (plus its evaluated σ
+  and J).
+- **"Revert if not accepted"** = automatic. `Apply()` (→ `IStarDetectionOptions.ApplyOptimizedSettings`)
+  remains the *only* code path that mutates options, and it only runs on **Accept**. Reject / cancel /
+  close leaves the live options exactly as they were — a stronger guarantee than an explicit
+  save-and-restore, with no crash window.
+
+### Building the default seed
+
+Add to `HocusFocusStarDetection` (the documented options→params source of truth):
+
+- `internal static StarDetectorParams BuildDefaultStarDetectorParams()` — returns a `StarDetectorParams`
+  whose option-derived detection fields are all at their defaults (the `StarDetectorParams`
+  field-initializer defaults), the analogue of `BuildStarDetectorParams(options)` for a
+  freshly-reset options object.
+- `StarDetectorParams GetDefaultStarDetectorParams(IRenderedImage image, StarDetectionRegion region,
+  bool isAutoFocus)` — layers the same image-context overrides that `GetStarDetectorParams` applies
+  (PixelScale from the profile × binning, Region, and for auto-focus `ModelPSF=false` +
+  `SaveIntermediateFilesPath=""`). The image-context layering is shared with `GetStarDetectorParams`
+  (extract a small private helper) so the two cannot drift.
+
+**Drift guard:** a unit test asserts `BuildDefaultStarDetectorParams()` equals
+`BuildStarDetectorParams(options)` field-by-field (for every option-derived field) where `options` is a
+`StarDetectionOptions` at `ResetDefaults()`. This is feasible and isolated using the existing
+`InMemoryPluginOptionsAccessor` test double (it never touches a real profile). The test ties the two
+default sources together so a future change to either `ResetDefaults()` or the `StarDetectorParams`
+defaults that breaks the equivalence fails loudly.
+
+### Computing the current-settings baseline (σ and cost J)
+
+The objective the optimizer uses is `OptimizationObjective.JRun` / `JTotal` with
+`new ObjectiveConstants()` (the optimizer's default). The wizard computes the baseline the same way so
+the numbers are comparable to the optimizer's `BestJ`:
+
+```
+baselineJ = JTotal( perRunBaselineMetrics.Select(m => JRun(m, constants)), constants )
+```
+
+where `perRunBaselineMetrics` comes from evaluating each run's `Baseline` params. The seed-fit guard
+already evaluates a param bundle per run with determinate progress; it evaluates `Baseline` (preserving
+its "usable at your current settings" semantics) and its results feed `baselineJ` and the before-σ — no
+extra full pass purely for the baseline. The default `Seed` contexts are additionally warmed so the
+optimizer's first evaluation is smooth (when the user's current settings already equal the defaults,
+this warm pass is all cache hits).
+
+### Wizard changes (`StarDetectionOptimizerWizardVM`)
+
+- **Seed-fit guard** (`SeedFitIsUsableAsync`): evaluate `r.Baseline` (was `r.Seed`). Capture results to
+  compute `baselineJ`.
+- **Live progress**: set `ProgressSeedJ = baselineJ` (constant for the run) instead of the optimizer's
+  `p.SeedJ` (which is now the default seed's J). The live "Detection improved ~X% so far" then reads
+  vs current and matches the final summary.
+- **`BuildSummaryAsync`**: evaluate `runs[i].Baseline` for the before-σ and the **Current** curve;
+  set `SeedJ = baselineJ` (not `res.SeedJ`); keep `BestJ = res.BestJ`. Compute the changed-parameters
+  table as **current → optimized**: for each curated `OptimizerVariable`, compare its value read from
+  `Baseline` vs from `res.BestParams`, listing only knobs that differ from the user's current value.
+  (This is the exact diff the user accepts onto their live settings, and is consistent with the σ/J
+  improvement being measured vs current. It replaces today's `res.ChangedVariables`, which is
+  default → optimized.)
+- **"Current" variant** (`currentResult`): `BestParams = runs[0].Baseline`; `SeedJ = BestJ = baselineJ`.
+  `BuildCurrentSummary` already collapses to the summary's seed σ/J, which are now the current-settings
+  values, so it needs no further change.
+
+### Scope
+
+- The default-seed change applies to the **initial** optimization pass.
+- The **feedback re-optimize** path is unchanged: it intentionally warm-starts from the analytic
+  recommendation (`feedback.Recommended`); that is the whole point of the feedback round. Its
+  improvement is still reported against the user's current settings (the baseline carries through), and
+  it additionally reports how much the feedback round improved over the plain optimization, as today.
+- **"Use current settings" mode** continues to short-circuit the optimization, using `Baseline`
+  (current settings) as `BestParams` so the summary shows "no changes".
+
+## Behavioral consequence (intended)
+
+Today the optimizer never returns a result worse than its seed, and the seed is the current settings,
+so an accepted result was always at least as good as the user's current settings. Starting from
+**default**, the optimized result can be **worse than the user's current settings** — if those settings
+were already well-tuned and a search from default did not beat them within the evaluation budget.
+
+This is surfaced honestly: the improvement readouts show σ/J "unchanged" (improvements are clamped to
+non-negative) or a visibly worse before→after. The safety net is exactly the requested one: the user
+**rejects**, and because nothing was written, their current settings remain in force. **Accept** stays
+disabled on the "Current" variant (there is nothing to apply — current is already active), so the path
+to "keep my current settings" is simply closing the wizard.
+
+No automatic "don't apply if worse than current" guard is included; the honest comparison plus reject
+is the agreed UX. (A future enhancement could make the optimizer also consider the current settings as
+a final candidate, guaranteeing accept ≥ current, but that partially re-biases toward current and is
+out of scope here.)
+
+## Testing
+
+- **Drift-guard unit test**: `BuildDefaultStarDetectorParams()` ≡ `BuildStarDetectorParams(resetOptions)`
+  for all option-derived fields (via `InMemoryPluginOptionsAccessor`).
+- **Wizard unit tests**: the displayed before-σ and `SeedJ` derive from `Baseline`, not the default
+  `Seed`; the changed-parameters table reflects current → optimized; the "Current" variant uses
+  `Baseline`. Use the existing fake `IRunEvaluationLoader` / `LoadedRun` test seams.
+- Full suite green: `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`.
+- Manual (later, in NINA): run the wizard with non-default current settings; confirm the search starts
+  from default, the improvement is shown vs current, rejecting leaves the live options unchanged, and
+  accepting applies the optimized snapshot.
+
+## Out of scope
+
+- Any change to the pure optimizer engine, objective weights, detector, or persisted-settings DTO.
+- Mutating / restoring live `StarDetectionOptions` (explicitly avoided per the chosen mechanism).
+- The feedback re-optimize warm-start strategy.
+- An auto-guard against accepting a worse-than-current result.

--- a/plans/optimizer-default-seed-baseline-plan.md
+++ b/plans/optimizer-default-seed-baseline-plan.md
@@ -1,0 +1,1002 @@
+# Optimizer Default Seed + Current-Settings Baseline — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Star Detection Optimization Wizard start optimization from a fully-default star-detection seed while measuring/displaying improvement against the user's current settings; never mutate live options, so rejecting leaves current settings untouched.
+
+**Architecture:** Split the single `LoadedRun.Seed` (today both the optimizer start *and* the displayed baseline) into `Seed` (fully-default params → optimizer start) and `Baseline` (current settings → before-σ/J, "Current" curve, changed-params before-column). The wizard computes a `currentBaselineJ` from the `Baseline` and uses it for the displayed improvement; the optimizer still starts from `Seed`. No `StarDetectionOptions` writes occur until Accept (`ApplyOptimizedSettings`), so reject/cancel/close is automatically a no-op revert.
+
+**Tech Stack:** C# / .NET 8 (WPF class library), NUnit 4 + NSubstitute, CommunityToolkit.Mvvm. Build: `dotnet`; tests via `dotnet test`.
+
+**Reference spec:** `docs/optimizer-default-seed-baseline-design.md`
+
+**Conventions:**
+- Commit author/committer email MUST be `322725+ghilios@users.noreply.github.com` (see CLAUDE.md). Use:
+  ```bash
+  GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+    git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" -m "<msg>"
+  ```
+- Full test command (run from solution root `/mnt/c/Users/ghili/src/nina.plugins`):
+  ```bash
+  dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo
+  ```
+- To run a single test class quickly, add `--filter "FullyQualifiedName~<ClassName>"`.
+- Work on branch `ghilios/optimizer-default-seed-baseline` (already created).
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs` | Modify | Add `BuildDefaultStarDetectorParams()` + `GetDefaultStarDetectorParams(...)`; extract shared `ApplyDetectionImageContext(...)` |
+| `Joko.NINA.Plugins.HocusFocus/Interfaces/IHocusFocusStarDetection.cs` | Modify | Declare `GetDefaultStarDetectorParams(...)` on the interface |
+| `Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationLoader.cs` | Modify | `LoadedRun.Baseline` (falls back to `Seed`); loader sets `Seed`=default, `Baseline`=current |
+| `Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs` | Modify | Decouple baseline from seed: `currentBaselineJ`, guard→Baseline, progress/summary/changed-params/currentResult/UseCurrentSettings/Apply |
+| `Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionOptionsTests.cs` | Modify | Drift-guard test for `BuildDefaultStarDetectorParams()` |
+| `Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationLoaderTests.cs` | Modify | `LoadedRun.Baseline` fallback unit test |
+| `Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs` | Modify | New decoupling test (optimizer uses Seed; display uses Baseline) |
+
+---
+
+## Task 1: Default star-detector params (`BuildDefaultStarDetectorParams`)
+
+**Files:**
+- Modify: `Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs` (add method next to `BuildStarDetectorParams`, ~line 333)
+- Test: `Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionOptionsTests.cs` (add a test reusing the existing `Build()` helper)
+
+- [ ] **Step 1: Write the failing drift-guard test**
+
+Add this test to `StarDetectionOptionsTests.cs` (anywhere inside the `StarDetectionOptionsTests` class, e.g. after `DefocusGatesOff_BothDetectorFlagsOff` near line 370). It reuses the file's existing `Build()` helper and asserts the hand-written default params match a `ResetDefaults()`-ed options build field-for-field, so the two default sources can never drift.
+
+```csharp
+    [Test]
+    public void BuildDefaultStarDetectorParams_MatchesResetDefaultsBuild() {
+        // The optimizer's "fully-default" seed must equal what BuildStarDetectorParams produces from a freshly
+        // reset options object — for EVERY option-derived field. If a default ever changes in only one place
+        // (ResetDefaults or BuildDefaultStarDetectorParams), this test fails loudly.
+        var (options, _, _) = Build();
+        options.ResetDefaults();
+        var fromOptions = HocusFocusStarDetection.BuildStarDetectorParams(options);
+        var fromDefault = HocusFocusStarDetection.BuildDefaultStarDetectorParams();
+
+        Assert.Multiple(() => {
+            Assert.That(fromDefault.ModelPSF, Is.EqualTo(fromOptions.ModelPSF));
+            Assert.That(fromDefault.StarMeasurementNoiseReductionEnabled, Is.EqualTo(fromOptions.StarMeasurementNoiseReductionEnabled));
+            Assert.That(fromDefault.PSFFitType, Is.EqualTo(fromOptions.PSFFitType));
+            Assert.That(fromDefault.HotpixelFiltering, Is.EqualTo(fromOptions.HotpixelFiltering));
+            Assert.That(fromDefault.HotpixelThresholdingEnabled, Is.EqualTo(fromOptions.HotpixelThresholdingEnabled));
+            Assert.That(fromDefault.NoiseReductionRadius, Is.EqualTo(fromOptions.NoiseReductionRadius));
+            Assert.That(fromDefault.NoiseClippingMultiplier, Is.EqualTo(fromOptions.NoiseClippingMultiplier));
+            Assert.That(fromDefault.StarClippingMultiplier, Is.EqualTo(fromOptions.StarClippingMultiplier));
+            Assert.That(fromDefault.ContaminationSensitivity, Is.EqualTo(fromOptions.ContaminationSensitivity));
+            Assert.That(fromDefault.RejectContaminatedStars, Is.EqualTo(fromOptions.RejectContaminatedStars));
+            Assert.That(fromDefault.StructureLayers, Is.EqualTo(fromOptions.StructureLayers));
+            Assert.That(fromDefault.DefocusAwareStructure, Is.EqualTo(fromOptions.DefocusAwareStructure));
+            Assert.That(fromDefault.StructureLayerBoost, Is.EqualTo(fromOptions.StructureLayerBoost));
+            Assert.That(fromDefault.Sensitivity, Is.EqualTo(fromOptions.Sensitivity));
+            Assert.That(fromDefault.PeakResponse, Is.EqualTo(fromOptions.PeakResponse));
+            Assert.That(fromDefault.MaxDistortion, Is.EqualTo(fromOptions.MaxDistortion));
+            Assert.That(fromDefault.DefocusAwareDistortion, Is.EqualTo(fromOptions.DefocusAwareDistortion));
+            Assert.That(fromDefault.DefocusAwareCentering, Is.EqualTo(fromOptions.DefocusAwareCentering));
+            Assert.That(fromDefault.DefocusDistortionSizeReference, Is.EqualTo(fromOptions.DefocusDistortionSizeReference));
+            Assert.That(fromDefault.DefocusDistortionMinFactor, Is.EqualTo(fromOptions.DefocusDistortionMinFactor));
+            Assert.That(fromDefault.DefocusCenteringToleranceFactor, Is.EqualTo(fromOptions.DefocusCenteringToleranceFactor));
+            Assert.That(fromDefault.StarCenterTolerance, Is.EqualTo(fromOptions.StarCenterTolerance));
+            Assert.That(fromDefault.BackgroundBoxExpansion, Is.EqualTo(fromOptions.BackgroundBoxExpansion));
+            Assert.That(fromDefault.MinimumStarBoundingBoxSize, Is.EqualTo(fromOptions.MinimumStarBoundingBoxSize));
+            Assert.That(fromDefault.MinHFR, Is.EqualTo(fromOptions.MinHFR));
+            Assert.That(fromDefault.StructureDilationSize, Is.EqualTo(fromOptions.StructureDilationSize));
+            Assert.That(fromDefault.StructureDilationCount, Is.EqualTo(fromOptions.StructureDilationCount));
+            Assert.That(fromDefault.AnalysisSamplingSize, Is.EqualTo(fromOptions.AnalysisSamplingSize));
+            Assert.That(fromDefault.StoreStructureMap, Is.EqualTo(fromOptions.StoreStructureMap));
+            Assert.That(fromDefault.SaveIntermediateFilesPath, Is.EqualTo(fromOptions.SaveIntermediateFilesPath));
+            Assert.That(fromDefault.PSFParallelPartitionSize, Is.EqualTo(fromOptions.PSFParallelPartitionSize));
+            Assert.That(fromDefault.PSFResolution, Is.EqualTo(fromOptions.PSFResolution));
+            Assert.That(fromDefault.PSFGoodnessOfFitThreshold, Is.EqualTo(fromOptions.PSFGoodnessOfFitThreshold));
+            Assert.That(fromDefault.UsePSFAbsoluteDeviation, Is.EqualTo(fromOptions.UsePSFAbsoluteDeviation));
+            Assert.That(fromDefault.HotpixelThreshold, Is.EqualTo(fromOptions.HotpixelThreshold));
+            Assert.That(fromDefault.SaturationThreshold, Is.EqualTo(fromOptions.SaturationThreshold));
+            Assert.That(fromDefault.PSFPixelIntegration, Is.EqualTo(fromOptions.PSFPixelIntegration));
+            Assert.That(fromDefault.MaxStarEvaluationParallelism, Is.EqualTo(fromOptions.MaxStarEvaluationParallelism));
+        });
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails (does not compile yet)**
+
+Run:
+```bash
+dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~StarDetectionOptionsTests.BuildDefaultStarDetectorParams_MatchesResetDefaultsBuild"
+```
+Expected: BUILD FAILS — `HocusFocusStarDetection` does not contain `BuildDefaultStarDetectorParams`.
+
+- [ ] **Step 3: Implement `BuildDefaultStarDetectorParams()`**
+
+In `HocusFocusStarDetection.cs`, immediately after the closing brace of `BuildStarDetectorParams` (currently line 333), add the method below. It mirrors `BuildStarDetectorParams` exactly, substituting each option read with the literal default from `StarDetectionOptions.ResetDefaults()`. (The Step-1 test guards these literals against `ResetDefaults`.)
+
+```csharp
+        /// <summary>
+        /// The "fully-default" detector params — the analogue of <see cref="BuildStarDetectorParams"/> for an
+        /// options object at <c>StarDetectionOptions.ResetDefaults()</c>. Every option-derived field is at its
+        /// documented default. Used as the Optimization Wizard's seed so the search starts from a clean,
+        /// reproducible point regardless of the user's current settings. Image-dependent fields (PixelScale,
+        /// Region) and the auto-focus overrides are layered on by <see cref="GetDefaultStarDetectorParams"/>.
+        /// The literals here are kept in lockstep with ResetDefaults by
+        /// StarDetectionOptionsTests.BuildDefaultStarDetectorParams_MatchesResetDefaultsBuild.
+        /// </summary>
+        internal static StarDetectorParams BuildDefaultStarDetectorParams() {
+            return new StarDetectorParams() {
+                ModelPSF = true,
+                StarMeasurementNoiseReductionEnabled = false,
+                PSFFitType = StarDetectorPSFFitType.Moffat_40,
+                HotpixelFiltering = true,
+                HotpixelThresholdingEnabled = true,
+                NoiseReductionRadius = 3,
+                NoiseClippingMultiplier = 4.0,
+                StarClippingMultiplier = 2.0,
+                ContaminationSensitivity = 5.0,
+                RejectContaminatedStars = true,
+                StructureLayers = 4,
+                DefocusAwareStructure = false,
+                StructureLayerBoost = 0,
+                Sensitivity = 2.0,
+                PeakResponse = 0.75,
+                MaxDistortion = 0.5,
+                DefocusAwareDistortion = false,
+                DefocusAwareCentering = false,
+                DefocusDistortionSizeReference = 30.0,
+                DefocusDistortionMinFactor = 0.25,
+                DefocusCenteringToleranceFactor = 2.0,
+                StarCenterTolerance = 0.3,
+                BackgroundBoxExpansion = 3,
+                MinimumStarBoundingBoxSize = 5,
+                MinHFR = 1.2,
+                StructureDilationSize = 3,
+                StructureDilationCount = 0,
+                AnalysisSamplingSize = 1.0f,
+                StoreStructureMap = false,
+                SaveIntermediateFilesPath = string.Empty,
+                PSFParallelPartitionSize = 100,
+                PSFResolution = 10,
+                PSFGoodnessOfFitThreshold = 0.9,
+                UsePSFAbsoluteDeviation = false,
+                HotpixelThreshold = 0.001d,
+                SaturationThreshold = 0.99d,
+                PSFPixelIntegration = false,
+                MaxStarEvaluationParallelism = 0
+            };
+        }
+```
+
+Note: `StarDetectorPSFFitType` is already in scope in this file (used by `BuildStarDetectorParams`). If the build reports it unresolved, confirm the existing `using` for the `StarDetector` enums is present (it is — `BuildStarDetectorParams` references `options.PSFFitType` of that type).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+```bash
+dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~StarDetectionOptionsTests.BuildDefaultStarDetectorParams_MatchesResetDefaultsBuild"
+```
+Expected: PASS. If any field assertion fails, the literal in `BuildDefaultStarDetectorParams` disagrees with `ResetDefaults` — fix that single literal to match `ResetDefaults` and re-run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionOptionsTests.cs
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "feat: add BuildDefaultStarDetectorParams with ResetDefaults drift guard
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Default seed with image context (`GetDefaultStarDetectorParams`)
+
+**Files:**
+- Modify: `Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs:335-365` (`GetStarDetectorParams` — extract shared helper, add default variant)
+- Modify: `Joko.NINA.Plugins.HocusFocus/Interfaces/IHocusFocusStarDetection.cs:35` (declare the new method)
+
+There is no clean unit-test seam for the image-context layering (it needs a real `IRenderedImage` + profile pixel scale). It is verified by: (a) the shared helper means the default variant uses the *same* image-context code as the production `GetStarDetectorParams` (already covered by existing detection tests), and (b) the full build + suite at the end. Tracked via Step 4 build check.
+
+- [ ] **Step 1: Extract the shared image-context helper and refactor `GetStarDetectorParams`**
+
+Replace the current `GetStarDetectorParams` (lines 335-365) with the refactor below. Behavior of `GetStarDetectorParams` is unchanged — the pixel-scale calc, Region, AF overrides, and the non-AF `SaveIntermediateImages = false` side effect are preserved exactly; only the pure image-context layering is extracted so the default variant can reuse it.
+
+Old:
+```csharp
+        public StarDetectorParams GetStarDetectorParams(IRenderedImage image, StarDetectionRegion starDetectionRegion, bool isAutoFocus) {
+            var binning = Math.Max(image.RawImageData.MetaData.Camera.BinX, 1);
+            var pixelScale = MathUtility.ArcsecPerPixel(profileService.ActiveProfile.CameraSettings.PixelSize, profileService.ActiveProfile.TelescopeSettings.FocalLength) * binning;
+            if (double.IsNaN(pixelScale)) {
+                if (!pixelScaleWarningShown) {
+                    pixelScaleWarningShown = true;
+                    Notification.ShowWarning("Pixel Scale is NaN. Make sure pixel size and focal length are set in Options.");
+                }
+                Logger.Warning("Pixel Scale is NaN. Make sure pixel size and focal length are set in Options.");
+            }
+
+            var detectorParams = BuildStarDetectorParams(starDetectionOptions);
+            detectorParams.PixelScale = pixelScale;
+            detectorParams.Region = starDetectionRegion;
+
+            // For AutoFocus, don't save intermediate data or model PSFs
+            if (isAutoFocus) {
+                detectorParams.SaveIntermediateFilesPath = string.Empty;
+                detectorParams.ModelPSF = false;
+                // Design decision (accuracy analysis F1): the TooFlat gate (StarDetector rejects candidates whose
+                // median >= PeakResponse*peak) is intentionally left ACTIVE during AutoFocus. It can reject bright,
+                // heavily-defocused flat-top/donut stars, but relaxing it here risks admitting flat noise blobs, and
+                // PeakResponse is also reused in the sensitivity (NormalizedBrightness) calc so loosening it has side
+                // effects. Revisit with a real defocus dataset (TestApp focus-sweep) if AF star counts drop at sweep
+                // extremes.
+            } else {
+                // Only save intermediate images for 1 detection. Doing this again should require the user to pick it again
+                starDetectionOptions.SaveIntermediateImages = false;
+            }
+            return detectorParams;
+        }
+```
+
+New:
+```csharp
+        public StarDetectorParams GetStarDetectorParams(IRenderedImage image, StarDetectionRegion starDetectionRegion, bool isAutoFocus) {
+            var detectorParams = BuildStarDetectorParams(starDetectionOptions);
+            ApplyDetectionImageContext(detectorParams, image, starDetectionRegion, isAutoFocus);
+            if (!isAutoFocus) {
+                // Only save intermediate images for 1 detection. Doing this again should require the user to pick it again.
+                starDetectionOptions.SaveIntermediateImages = false;
+            }
+            return detectorParams;
+        }
+
+        /// <summary>
+        /// The Optimization Wizard's seed: the fully-default detector params (<see cref="BuildDefaultStarDetectorParams"/>)
+        /// with the SAME image-dependent fields + auto-focus overrides as <see cref="GetStarDetectorParams"/> layered on
+        /// (PixelScale, Region, ModelPSF=false, SaveIntermediateFilesPath=""). Read-only with respect to options — it
+        /// never touches <c>starDetectionOptions</c>. <paramref name="isAutoFocus"/> is expected to be true for the
+        /// wizard's replay path.
+        /// </summary>
+        public StarDetectorParams GetDefaultStarDetectorParams(IRenderedImage image, StarDetectionRegion starDetectionRegion, bool isAutoFocus) {
+            var detectorParams = BuildDefaultStarDetectorParams();
+            ApplyDetectionImageContext(detectorParams, image, starDetectionRegion, isAutoFocus);
+            return detectorParams;
+        }
+
+        /// <summary>
+        /// Layers the image-dependent fields (PixelScale from the profile × binning, Region) and the auto-focus
+        /// overrides (ModelPSF=false, no intermediate-file save) onto an already-built params bundle. Pure with
+        /// respect to options — shared by <see cref="GetStarDetectorParams"/> and
+        /// <see cref="GetDefaultStarDetectorParams"/> so the two can never diverge in how they compute pixel scale or
+        /// apply the AF overrides.
+        /// </summary>
+        private void ApplyDetectionImageContext(StarDetectorParams detectorParams, IRenderedImage image, StarDetectionRegion starDetectionRegion, bool isAutoFocus) {
+            var binning = Math.Max(image.RawImageData.MetaData.Camera.BinX, 1);
+            var pixelScale = MathUtility.ArcsecPerPixel(profileService.ActiveProfile.CameraSettings.PixelSize, profileService.ActiveProfile.TelescopeSettings.FocalLength) * binning;
+            if (double.IsNaN(pixelScale)) {
+                if (!pixelScaleWarningShown) {
+                    pixelScaleWarningShown = true;
+                    Notification.ShowWarning("Pixel Scale is NaN. Make sure pixel size and focal length are set in Options.");
+                }
+                Logger.Warning("Pixel Scale is NaN. Make sure pixel size and focal length are set in Options.");
+            }
+
+            detectorParams.PixelScale = pixelScale;
+            detectorParams.Region = starDetectionRegion;
+
+            // For AutoFocus, don't save intermediate data or model PSFs.
+            if (isAutoFocus) {
+                detectorParams.SaveIntermediateFilesPath = string.Empty;
+                detectorParams.ModelPSF = false;
+                // Design decision (accuracy analysis F1): the TooFlat gate (StarDetector rejects candidates whose
+                // median >= PeakResponse*peak) is intentionally left ACTIVE during AutoFocus. It can reject bright,
+                // heavily-defocused flat-top/donut stars, but relaxing it here risks admitting flat noise blobs, and
+                // PeakResponse is also reused in the sensitivity (NormalizedBrightness) calc so loosening it has side
+                // effects. Revisit with a real defocus dataset (TestApp focus-sweep) if AF star counts drop at sweep
+                // extremes.
+            }
+        }
+```
+
+- [ ] **Step 2: Declare `GetDefaultStarDetectorParams` on the interface**
+
+In `Joko.NINA.Plugins.HocusFocus/Interfaces/IHocusFocusStarDetection.cs`, add the new method declaration directly under the existing `GetStarDetectorParams` declaration (line 35):
+
+Old:
+```csharp
+        StarDetectorParams GetStarDetectorParams(IRenderedImage image, StarDetectionRegion starDetectionRegion, bool isAutoFocus);
+```
+
+New:
+```csharp
+        StarDetectorParams GetStarDetectorParams(IRenderedImage image, StarDetectionRegion starDetectionRegion, bool isAutoFocus);
+
+        /// <summary>The Optimization Wizard's seed: fully-default detector params with the same image-context +
+        /// auto-focus overrides as <see cref="GetStarDetectorParams"/>. Read-only with respect to options.</summary>
+        StarDetectorParams GetDefaultStarDetectorParams(IRenderedImage image, StarDetectionRegion starDetectionRegion, bool isAutoFocus);
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run:
+```bash
+dotnet build Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Joko.NINA.Plugins.HocusFocus.csproj -c Debug --nologo
+```
+Expected: BUILD SUCCEEDED. (Any test double / fake of `IHocusFocusStarDetection` in the test project would now need the new member — none exists today; if the test build later flags one, implement it by delegating to `BuildDefaultStarDetectorParams` + the same image context.)
+
+- [ ] **Step 4: Run the affected detection tests to confirm no regression**
+
+Run:
+```bash
+dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~HocusFocusStarDetectionTests"
+```
+Expected: PASS (the `GetStarDetectorParams` refactor preserved behavior).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IHocusFocusStarDetection.cs
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "feat: add GetDefaultStarDetectorParams + shared image-context helper
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `LoadedRun.Baseline` + loader wiring
+
+**Files:**
+- Modify: `Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationLoader.cs:34-38` (`LoadedRun`) and `:147-181` (`LoadSavedRunAsync` seed/return)
+- Test: `Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationLoaderTests.cs` (add `LoadedRun.Baseline` fallback unit test)
+
+- [ ] **Step 1: Write the failing `LoadedRun.Baseline` fallback test**
+
+Add this test to `RunEvaluationLoaderTests.cs` (inside its test class). It pins the contract that `Baseline` falls back to `Seed` when not separately set, and is independent when set — the behavior the wizard and existing tests rely on.
+
+```csharp
+    [Test]
+    public void LoadedRun_Baseline_FallsBackToSeed_WhenNotSet() {
+        var seed = new StarDetectorParams { Sensitivity = 3.0 };
+        var run = new LoadedRun { Seed = seed };
+        Assert.That(run.Baseline, Is.SameAs(seed), "Baseline defaults to Seed when not provided");
+
+        var baseline = new StarDetectorParams { Sensitivity = 9.0 };
+        run.Baseline = baseline;
+        Assert.Multiple(() => {
+            Assert.That(run.Baseline, Is.SameAs(baseline), "an explicitly set Baseline is independent of Seed");
+            Assert.That(run.Seed, Is.SameAs(seed), "setting Baseline does not change Seed");
+        });
+    }
+```
+
+If `RunEvaluationLoaderTests.cs` does not already `using NINA.Joko.Plugins.HocusFocus.Interfaces;` (for `StarDetectorParams`), add it.
+
+- [ ] **Step 2: Run the test to verify it fails (does not compile)**
+
+Run:
+```bash
+dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~RunEvaluationLoaderTests.LoadedRun_Baseline_FallsBackToSeed_WhenNotSet"
+```
+Expected: BUILD FAILS — `LoadedRun` has no `Baseline`.
+
+- [ ] **Step 3: Add `Baseline` to `LoadedRun`**
+
+In `RunEvaluationLoader.cs`, replace the `LoadedRun` class (lines 34-38):
+
+Old:
+```csharp
+    public sealed class LoadedRun {
+        public RunEvaluationData Data { get; set; }
+        public StarDetectorParams Seed { get; set; }
+        public AutoFocusEngineOptions AfOptions { get; set; }
+    }
+```
+
+New:
+```csharp
+    public sealed class LoadedRun {
+        public RunEvaluationData Data { get; set; }
+
+        /// <summary>The params the optimizer starts its search from. In production this is the fully-DEFAULT
+        /// detector params (see <see cref="IHocusFocusStarDetection.GetDefaultStarDetectorParams"/>), carrying
+        /// PixelScale + Region + ModelPSF=false.</summary>
+        public StarDetectorParams Seed { get; set; }
+
+        private StarDetectorParams baseline;
+
+        /// <summary>The user's CURRENT settings — the displayed "before" baseline (σ, cost J, the "Current" curve,
+        /// and the changed-parameters before-column). Defaults to <see cref="Seed"/> when not separately provided,
+        /// so a caller/test that sets only <see cref="Seed"/> keeps the legacy "the seed is the baseline" behavior.</summary>
+        public StarDetectorParams Baseline {
+            get => baseline ?? Seed;
+            set => baseline = value;
+        }
+
+        public AutoFocusEngineOptions AfOptions { get; set; }
+    }
+```
+
+- [ ] **Step 4: Wire the loader to set the default Seed + current-settings Baseline**
+
+In `LoadSavedRunAsync`, the seed is built at line 149. Replace:
+
+Old:
+```csharp
+            // Seed = AF-base detector params for the first image (PixelScale + Region + ModelPSF=false). This is
+            // the bundle the optimizer starts from and tunes.
+            var seed = detection.GetStarDetectorParams(firstImage, region, isAutoFocus: true);
+```
+
+New:
+```csharp
+            // Seed = fully-DEFAULT AF-base detector params for the first image (PixelScale + Region + ModelPSF=false):
+            // the optimizer starts its search from a clean, reproducible default regardless of the user's current
+            // settings. Baseline = the user's CURRENT settings, kept for the displayed "before" comparison (σ, cost J,
+            // the "Current" curve). Both carry the same image context; neither writes to options.
+            var seed = detection.GetDefaultStarDetectorParams(firstImage, region, isAutoFocus: true);
+            var baseline = detection.GetStarDetectorParams(firstImage, region, isAutoFocus: true);
+```
+
+Then update the return (lines 177-181):
+
+Old:
+```csharp
+            return new LoadedRun {
+                Data = data,
+                Seed = seed,
+                AfOptions = afOptions
+            };
+```
+
+New:
+```csharp
+            return new LoadedRun {
+                Data = data,
+                Seed = seed,
+                Baseline = baseline,
+                AfOptions = afOptions
+            };
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run:
+```bash
+dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~RunEvaluationLoaderTests"
+```
+Expected: PASS (the new fallback test + the existing loader tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationLoader.cs \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationLoaderTests.cs
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "feat: split LoadedRun into default Seed + current-settings Baseline
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Wizard — measure improvement vs current settings
+
+**Files:**
+- Modify: `Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs`
+- Test: `Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs`
+
+This task has several interdependent edits in one file; they are applied together and validated by the suite at the end. All line numbers are anchors as of the current file.
+
+- [ ] **Step 1: Write the failing decoupling test**
+
+Add a factory + test to `StarDetectionOptimizerWizardVMTests.cs`. The factory builds a `LoadedRun` with a DEFAULT-like `Seed` (Sensitivity=2) and a DISTINCT `Baseline` (Sensitivity=8). The test asserts the optimizer started from `Seed` (its raw `Result.ChangedVariables` before-value is 2) while the displayed `Summary.ChangedParameters` before-value is the `Baseline` (8) — proving the decoupling.
+
+Add this factory next to `GoodRun` (after line 90):
+
+```csharp
+    // A run whose optimizer SEED (default) and displayed BASELINE (current settings) differ, so a test can prove
+    // the optimizer starts from Seed while the summary's "before" column reflects Baseline.
+    private static LoadedRun SeedBaselineSplitRun(
+        string id = "split", double optSensitivity = 10.0, int seedSensitivity = 2, int baselineSensitivity = 8) {
+        var data = new RunEvaluationData(id, NineFrames(), OptimizableDetect(optSensitivity), NewAlglib(), DefaultFitConfig());
+        return new LoadedRun {
+            Data = data,
+            Seed = new StarDetectorParams { Sensitivity = seedSensitivity, StarClippingMultiplier = 2.0 },
+            Baseline = new StarDetectorParams { Sensitivity = baselineSensitivity, StarClippingMultiplier = 2.0 },
+            AfOptions = new AutoFocusEngineOptions { AutoFocusStepSize = DefaultStepSize, AutoFocusInitialOffsetSteps = 4 }
+        };
+    }
+```
+
+Add this test (after `Start_ChangedParametersRow_CarriesSeedAndBestValues`, ~line 326):
+
+```csharp
+    [Test]
+    public async Task Start_OptimizerStartsFromSeed_ButSummaryBaselineIsCurrentSettings() {
+        // The optimizer must start from the (default) Seed, while the displayed improvement/changed-parameters
+        // "before" column must reflect the user's CURRENT settings (Baseline). Seed.Sensitivity=2 (default),
+        // Baseline.Sensitivity=8 (current); both optimize toward 10.
+        var vm = NewVM(LoaderReturning(SeedBaselineSplitRun()));
+        vm.SourcePaths[0] = @"C:\run1";
+
+        await vm.StartAsync(CancellationToken.None);
+
+        // The optimizer's own record (Result.ChangedVariables) starts from the Seed (2).
+        var rawSensitivity = vm.Result.ChangedVariables
+            .FirstOrDefault(c => c.Name == nameof(StarDetectorParams.Sensitivity));
+        Assert.That(rawSensitivity.Name, Is.EqualTo(nameof(StarDetectorParams.Sensitivity)),
+            "the optimizer changed Sensitivity from its seed");
+        Assert.That(rawSensitivity.SeedValue, Is.EqualTo(2.0).Within(1e-9), "the optimizer started from the default Seed (2)");
+
+        // The displayed summary's "before" column reflects the current-settings Baseline (8).
+        var displayedSensitivity = vm.Summary.ChangedParameters
+            .FirstOrDefault(r => r.Name == nameof(StarDetectorParams.Sensitivity));
+        Assert.That(displayedSensitivity, Is.Not.Null, "the summary shows the Sensitivity change vs current settings");
+        Assert.Multiple(() => {
+            Assert.That(displayedSensitivity.SeedValue, Is.EqualTo(8.0).Within(1e-9),
+                "the summary 'before' value is the user's current setting (8), not the default seed (2)");
+            Assert.That(Math.Abs(displayedSensitivity.OptimizedValue - 10.0),
+                Is.LessThan(Math.Abs(8.0 - 10.0)), "optimized Sensitivity is closer to the optimum than current");
+        });
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run:
+```bash
+dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~StarDetectionOptimizerWizardVMTests.Start_OptimizerStartsFromSeed_ButSummaryBaselineIsCurrentSettings"
+```
+Expected: FAIL — today `Summary.ChangedParameters` is computed from `res.ChangedVariables` (seed=2), so `displayedSensitivity.SeedValue` is 2.0, not 8.0.
+
+- [ ] **Step 3: Add the objective-constants field + `currentBaselineJ` + `ComputeBaselineJAsync` helper**
+
+Find the field block near the top of the `StarDetectionOptimizerWizardVM` class (where private fields like `cts`, `running`, `loadedRunFolders` live). Add these two fields and the helper. A good place for the helper is next to `AnalyzeWithProgressAsync` (~line 1158). Add the fields with the other private fields:
+
+```csharp
+        // The objective the optimizer uses by default (StarDetectionOptimizer ctor defaults to new ObjectiveConstants()).
+        // The wizard computes the current-settings baseline J with the SAME constants so it is comparable to BestJ.
+        private readonly ObjectiveConstants objectiveConstants = new ObjectiveConstants();
+
+        // J of the user's CURRENT settings (Baseline), evaluated on the loaded runs. The displayed "before" for the
+        // improvement readouts (summary SeedJ + live ProgressSeedJ). Set in StartAsync (and the re-optimize path)
+        // before the optimize + summary steps.
+        private double currentBaselineJ;
+```
+
+Add the helper method (e.g. immediately after `AnalyzeWithProgressAsync`):
+
+```csharp
+        /// <summary>
+        /// Computes the objective J of the user's CURRENT settings (each run's <see cref="LoadedRun.Baseline"/>) on the
+        /// loaded runs, using the same <see cref="ObjectiveConstants"/> and JRun/JTotal aggregation the optimizer uses,
+        /// so the value is directly comparable to <see cref="OptimizationResult.BestJ"/>. This is the displayed
+        /// "before" baseline for the improvement readouts. Cheap after the seed guard warmed the early-detection
+        /// contexts (the late stage re-runs against the warmed cache).
+        /// </summary>
+        private async Task<double> ComputeBaselineJAsync(IReadOnlyList<LoadedRun> runs, CancellationToken token) {
+            // Use a SINGLE current-settings bundle (runs[0].Baseline) across every run, exactly as the optimizer's
+            // evaluator applies one StarDetectorParams across all runs — so this J is directly comparable to BestJ.
+            var baseline = runs[0].Baseline;
+            var perRunJ = new List<double>(runs.Count);
+            for (var i = 0; i < runs.Count; i++) {
+                token.ThrowIfCancellationRequested();
+                var eval = await runs[i].Data.EvaluateAndFitAsync(baseline, token).ConfigureAwait(true);
+                perRunJ.Add(OptimizationObjective.JRun(eval.Metrics, objectiveConstants));
+            }
+            return OptimizationObjective.JTotal(perRunJ, objectiveConstants);
+        }
+```
+
+- [ ] **Step 4: Seed guard evaluates the Baseline (current settings)**
+
+In `SeedFitIsUsableAsync` (line ~1131), change the evaluated bundle from `r.Seed` to `r.Baseline` so the "usable at your current settings" guard keeps its meaning and warms the current-settings contexts:
+
+Old:
+```csharp
+            var results = await AnalyzeWithProgressAsync(runs, r => r.Seed, token).ConfigureAwait(true);
+```
+
+New:
+```csharp
+            var results = await AnalyzeWithProgressAsync(runs, r => r.Baseline, token).ConfigureAwait(true);
+```
+
+- [ ] **Step 5: Compute `currentBaselineJ`, warm the default seed, in `StartAsync`**
+
+In `StartAsync`, after the seed guard passes (line 964-966) and before the optimize/UseCurrentSettings branch (line ~972), insert the baseline-J computation. Replace:
+
+Old:
+```csharp
+                // 2. Seed guard — evaluate the seed once; bail with a clear error on a degenerate run.
+                if (!await SeedFitIsUsableAsync(loadedRuns, token).ConfigureAwait(true)) {
+                    return; // ErrorMessage set by the guard
+                }
+
+                // 3. Optimize — off the UI thread, progress marshaled back. OptimizeAsync always returns a
+```
+
+New:
+```csharp
+                // 2. Seed guard — evaluate the current settings once; bail with a clear error on a degenerate run.
+                if (!await SeedFitIsUsableAsync(loadedRuns, token).ConfigureAwait(true)) {
+                    return; // ErrorMessage set by the guard
+                }
+
+                // 2b. Baseline J = the user's CURRENT settings' objective, the displayed "before" for improvement.
+                //     Computed once here (cheap: the guard just warmed the current-settings contexts).
+                currentBaselineJ = await ComputeBaselineJAsync(loadedRuns, token).ConfigureAwait(true);
+                ProgressSeedJ = currentBaselineJ;
+
+                // 3. Optimize — off the UI thread, progress marshaled back. OptimizeAsync always returns a
+```
+
+Then, in the `else` (optimize) branch, warm the DEFAULT seed contexts before optimizing so the optimizer's first evaluation does not stall the progress bar (mirrors the re-optimize path's warm-up; all cache hits when the user's settings already equal the defaults). Replace:
+
+Old:
+```csharp
+                } else {
+                    CurrentStep = WizardStep.Optimize;
+                    optimizeResult = await OptimizeAsync(loadedRuns, token).ConfigureAwait(true);
+                    optimized = true;
+                }
+```
+
+New:
+```csharp
+                } else {
+                    CurrentStep = WizardStep.Optimize;
+                    // Warm the DEFAULT-seed early contexts (the optimizer starts here) so the bar moves during the
+                    // first build instead of sitting on the optimizer's seed evaluation.
+                    await AnalyzeWithProgressAsync(loadedRuns, r => r.Seed, token).ConfigureAwait(true);
+                    optimizeResult = await OptimizeAsync(loadedRuns, token).ConfigureAwait(true);
+                    optimized = true;
+                }
+```
+
+- [ ] **Step 6: "Use current settings" mode applies the Baseline (not the default Seed)**
+
+In the `OptimizeMode == WizardOptimizeMode.UseCurrentSettings` branch (lines 974-984), the "no optimization" result must carry the user's CURRENT settings and the baseline J. Replace:
+
+Old:
+```csharp
+                if (OptimizeMode == WizardOptimizeMode.UseCurrentSettings) {
+                    SetProgress("Using current settings (no optimization)", 0, 0);
+                    optimizeResult = new OptimizationResult {
+                        BestParams = loadedRuns[0].Seed,
+                        SeedJ = 0.0,
+                        BestJ = 0.0,
+                        Evaluations = 0,
+                        ImprovedOverSeed = false,
+                        ChangedVariables = new List<(string Name, double SeedValue, double BestValue)>()
+                    };
+                    optimized = false;
+```
+
+New:
+```csharp
+                if (OptimizeMode == WizardOptimizeMode.UseCurrentSettings) {
+                    SetProgress("Using current settings (no optimization)", 0, 0);
+                    optimizeResult = new OptimizationResult {
+                        BestParams = loadedRuns[0].Baseline,
+                        SeedJ = currentBaselineJ,
+                        BestJ = currentBaselineJ,
+                        Evaluations = 0,
+                        ImprovedOverSeed = false,
+                        ChangedVariables = new List<(string Name, double SeedValue, double BestValue)>()
+                    };
+                    optimized = false;
+```
+
+- [ ] **Step 7: "Current" variant result uses the Baseline + baseline J**
+
+In `StartAsync`, the `currentResult` block (lines 997-1004). Replace:
+
+Old:
+```csharp
+                currentResult = new OptimizationResult {
+                    BestParams = loadedRuns[0].Seed,
+                    SeedJ = optimizeResult.SeedJ,
+                    BestJ = optimizeResult.SeedJ,
+                    Evaluations = 0,
+                    ImprovedOverSeed = false,
+                    ChangedVariables = new List<(string Name, double SeedValue, double BestValue)>()
+                };
+```
+
+New:
+```csharp
+                currentResult = new OptimizationResult {
+                    BestParams = loadedRuns[0].Baseline,
+                    SeedJ = currentBaselineJ,
+                    BestJ = currentBaselineJ,
+                    Evaluations = 0,
+                    ImprovedOverSeed = false,
+                    ChangedVariables = new List<(string Name, double SeedValue, double BestValue)>()
+                };
+```
+
+- [ ] **Step 8: Live progress shows improvement vs the current-settings baseline**
+
+In `OptimizeAsync` (the progress callback, line ~1189), the seed J displayed during the search must be the current-settings baseline, not the optimizer's (default) seed J. Replace:
+
+Old:
+```csharp
+            var progress = new Progress<OptimizationProgress>(p => {
+                ProgressCurrent = p.Evaluations;
+                ProgressTotal = p.MaxEvaluations;
+                ProgressBestJ = p.BestJ;
+                ProgressSeedJ = p.SeedJ;
+                Phase = FriendlyPhase(p.Phase);
+            });
+```
+
+New:
+```csharp
+            var progress = new Progress<OptimizationProgress>(p => {
+                ProgressCurrent = p.Evaluations;
+                ProgressTotal = p.MaxEvaluations;
+                ProgressBestJ = p.BestJ;
+                // The displayed baseline is the user's CURRENT settings (currentBaselineJ), not the optimizer's
+                // default seed J (p.SeedJ), so the live "improved ~X%" reads vs current and matches the summary.
+                ProgressSeedJ = currentBaselineJ;
+                Phase = FriendlyPhase(p.Phase);
+            });
+```
+
+- [ ] **Step 9: `BuildSummaryAsync` — before-σ/J + changed-params vs current settings**
+
+Replace the body of `BuildSummaryAsync` from the `var seed = ...` line through the `var summary = ...` assignment (lines 1220-1268). Key changes: evaluate `Baseline` for the "before" σ and the "Current" curve; `SeedJ = currentBaselineJ`; compute the changed-parameters table as current(Baseline) → optimized(BestParams) over the curated variable set.
+
+Old:
+```csharp
+            var seed = runs[0].Seed;
+            var changed = res.ChangedVariables
+                .Select(c => new ChangedParameterRow { Name = c.Name, SeedValue = c.SeedValue, OptimizedValue = c.BestValue })
+                .ToList();
+
+            // σ(focus) before/after, averaged over the runs (the first run also yields the representative best fit
+            // AND the curves we plot — seed = "Current", best = "Optimized"; both carry the scatter points + fit).
+            double seedSigmaSum = 0.0, bestSigmaSum = 0.0;
+            var seedSigmaCount = 0; var bestSigmaCount = 0;
+            AlglibHyperbolicFitting representativeBestFit = null;
+            OptimizationCurve currentCurveLocal = null, optimizedCurveLocal = null;
+            for (var i = 0; i < runs.Count; i++) {
+                token.ThrowIfCancellationRequested();
+                var seedEval = await runs[i].Data.EvaluateAndFitAsync(seed, token).ConfigureAwait(true);
+                var bestEval = await runs[i].Data.EvaluateAndFitAsync(res.BestParams, token).ConfigureAwait(true);
+                if (double.IsFinite(seedEval.Metrics.SigmaFocus)) { seedSigmaSum += seedEval.Metrics.SigmaFocus; seedSigmaCount++; }
+                if (double.IsFinite(bestEval.Metrics.SigmaFocus)) { bestSigmaSum += bestEval.Metrics.SigmaFocus; bestSigmaCount++; }
+                if (i == 0) {
+                    representativeBestFit = bestEval.BestFit;
+                    currentCurveLocal = new OptimizationCurve {
+                        Label = "Current", Points = seedEval.Points, Fit = seedEval.BestFit,
+                        FrameStarCounts = seedEval.Metrics.FrameStarCounts,
+                        FrameFocuserPositions = seedEval.Metrics.FrameFocuserPositions
+                    };
+                    optimizedCurveLocal = new OptimizationCurve {
+                        Label = "Optimized", Points = bestEval.Points, Fit = bestEval.BestFit,
+                        FrameStarCounts = bestEval.Metrics.FrameStarCounts,
+                        FrameFocuserPositions = bestEval.Metrics.FrameFocuserPositions
+                    };
+                }
+            }
+
+            var currentStepSize = runs[0].AfOptions?.AutoFocusStepSize ?? DefaultCurrentStepSize;
+            var currentOffsetSteps = runs[0].AfOptions?.AutoFocusInitialOffsetSteps ?? DefaultCurrentOffsetSteps;
+            var recommendation = StepSizeRecommender.Recommend(representativeBestFit, currentStepSize, GetFocuserMaxStep());
+
+            var summary = new OptimizationSummary {
+                ChangedParameters = changed,
+                SeedJ = res.SeedJ,
+                BestJ = res.BestJ,
+                SeedSigmaFocus = seedSigmaCount > 0 ? seedSigmaSum / seedSigmaCount : double.NaN,
+                BestSigmaFocus = bestSigmaCount > 0 ? bestSigmaSum / bestSigmaCount : double.NaN,
+                RunCount = runs.Count,
+                RecommendedStepSize = recommendation.StepSize,
+                RecommendedOffsetSteps = recommendation.OffsetSteps,
+                CurrentStepSize = currentStepSize,
+                CurrentOffsetSteps = currentOffsetSteps,
+                ImprovedOverSeed = res.ImprovedOverSeed
+            };
+            return (summary, currentCurveLocal, optimizedCurveLocal);
+```
+
+New:
+```csharp
+            // The displayed "before" is the user's CURRENT settings (Baseline), NOT the optimizer's default seed.
+            var baseline = runs[0].Baseline;
+
+            // Changed-parameters table = current (Baseline) -> optimized (BestParams) over the curated knobs, so it is
+            // exactly the diff the user would accept onto their live settings (consistent with the σ/J improvement,
+            // which is also measured vs current). This intentionally replaces res.ChangedVariables (default -> best).
+            var changed = new List<ChangedParameterRow>();
+            foreach (var v in OptimizerVariable.CreateCuratedSet()) {
+                var before = v.Read(baseline);
+                var after = v.Read(res.BestParams);
+                if (Math.Abs(before - after) > 1e-9) {
+                    changed.Add(new ChangedParameterRow { Name = v.Name, SeedValue = before, OptimizedValue = after });
+                }
+            }
+
+            // σ(focus) before/after, averaged over the runs (the first run also yields the representative best fit
+            // AND the curves we plot — baseline = "Current", best = "Optimized"; both carry the scatter points + fit).
+            double baselineSigmaSum = 0.0, bestSigmaSum = 0.0;
+            var baselineSigmaCount = 0; var bestSigmaCount = 0;
+            AlglibHyperbolicFitting representativeBestFit = null;
+            OptimizationCurve currentCurveLocal = null, optimizedCurveLocal = null;
+            for (var i = 0; i < runs.Count; i++) {
+                token.ThrowIfCancellationRequested();
+                var baselineEval = await runs[i].Data.EvaluateAndFitAsync(baseline, token).ConfigureAwait(true);
+                var bestEval = await runs[i].Data.EvaluateAndFitAsync(res.BestParams, token).ConfigureAwait(true);
+                if (double.IsFinite(baselineEval.Metrics.SigmaFocus)) { baselineSigmaSum += baselineEval.Metrics.SigmaFocus; baselineSigmaCount++; }
+                if (double.IsFinite(bestEval.Metrics.SigmaFocus)) { bestSigmaSum += bestEval.Metrics.SigmaFocus; bestSigmaCount++; }
+                if (i == 0) {
+                    representativeBestFit = bestEval.BestFit;
+                    currentCurveLocal = new OptimizationCurve {
+                        Label = "Current", Points = baselineEval.Points, Fit = baselineEval.BestFit,
+                        FrameStarCounts = baselineEval.Metrics.FrameStarCounts,
+                        FrameFocuserPositions = baselineEval.Metrics.FrameFocuserPositions
+                    };
+                    optimizedCurveLocal = new OptimizationCurve {
+                        Label = "Optimized", Points = bestEval.Points, Fit = bestEval.BestFit,
+                        FrameStarCounts = bestEval.Metrics.FrameStarCounts,
+                        FrameFocuserPositions = bestEval.Metrics.FrameFocuserPositions
+                    };
+                }
+            }
+
+            var currentStepSize = runs[0].AfOptions?.AutoFocusStepSize ?? DefaultCurrentStepSize;
+            var currentOffsetSteps = runs[0].AfOptions?.AutoFocusInitialOffsetSteps ?? DefaultCurrentOffsetSteps;
+            var recommendation = StepSizeRecommender.Recommend(representativeBestFit, currentStepSize, GetFocuserMaxStep());
+
+            var summary = new OptimizationSummary {
+                ChangedParameters = changed,
+                SeedJ = currentBaselineJ,
+                BestJ = res.BestJ,
+                SeedSigmaFocus = baselineSigmaCount > 0 ? baselineSigmaSum / baselineSigmaCount : double.NaN,
+                BestSigmaFocus = bestSigmaCount > 0 ? bestSigmaSum / bestSigmaCount : double.NaN,
+                RunCount = runs.Count,
+                RecommendedStepSize = recommendation.StepSize,
+                RecommendedOffsetSteps = recommendation.OffsetSteps,
+                CurrentStepSize = currentStepSize,
+                CurrentOffsetSteps = currentOffsetSteps,
+                ImprovedOverSeed = res.ImprovedOverSeed
+            };
+            return (summary, currentCurveLocal, optimizedCurveLocal);
+```
+
+Also update the `BuildSummaryAsync` doc-comment line (1213-1216) wording "re-evaluated at seed and best" → "re-evaluated at the current settings (baseline) and best" (cosmetic; keeps the comment honest).
+
+- [ ] **Step 10: Re-optimize (feedback) path sets `currentBaselineJ` too**
+
+In `ReOptimizeWithLabelsAsync`, after the warm-up `AnalyzeWithProgressAsync(reloaded, ...)` (line ~1640) and before `OptimizeAsync(reloaded, ...)` (line ~1643), compute the baseline J for the reloaded runs so the feedback summary's "before" is also the user's current settings. Replace:
+
+Old:
+```csharp
+                // Warm + report the per-frame early contexts for the params the optimizer will start from (re-optimize
+                // skips the seed-guard, so this is the parity warm-up that makes the bar move during the initial build).
+                await AnalyzeWithProgressAsync(reloaded, _ => seedOverride ?? reloaded[0].Seed, token).ConfigureAwait(true);
+
+                // Re-run the optimize + summary pipeline over the labeled runs (warm-started when we have a recommendation).
+                var optimizeResult = await OptimizeAsync(reloaded, token, seedOverride, variablesOverride).ConfigureAwait(true);
+```
+
+New:
+```csharp
+                // Warm + report the per-frame early contexts for the params the optimizer will start from (re-optimize
+                // skips the seed-guard, so this is the parity warm-up that makes the bar move during the initial build).
+                await AnalyzeWithProgressAsync(reloaded, _ => seedOverride ?? reloaded[0].Seed, token).ConfigureAwait(true);
+
+                // Baseline J for the reloaded runs (current settings) — the displayed "before" for the feedback summary,
+                // keeping the improvement measured vs the user's current settings on this path too.
+                currentBaselineJ = await ComputeBaselineJAsync(reloaded, token).ConfigureAwait(true);
+
+                // Re-run the optimize + summary pipeline over the labeled runs (warm-started when we have a recommendation).
+                var optimizeResult = await OptimizeAsync(reloaded, token, seedOverride, variablesOverride).ConfigureAwait(true);
+```
+
+- [ ] **Step 11: `Apply` records the displayed (vs-current) before/after J**
+
+In `Apply` (lines 1339-1344), record the summary's baseline/best J (the vs-current numbers the user saw) in the persisted snapshot + log, instead of the optimizer's default-seed J. Replace:
+
+Old:
+```csharp
+            var dto = OptimizedStarDetectionSettings.FromParams(
+                result.BestParams, summary.RunCount, result.SeedJ, result.BestJ,
+                summary.RecommendedStepSize, summary.RecommendedOffsetSteps);
+
+            starDetectionOptions.ApplyOptimizedSettings(dto);
+            Logger.Info($"Applied optimized star-detection settings (J {result.SeedJ:F3} -> {result.BestJ:F3}, {summary.RunCount} run(s))");
+```
+
+New:
+```csharp
+            // Record the displayed (vs current-settings) before/after J in the snapshot + log, so the persisted record
+            // matches the improvement the user saw. summary.SeedJ is the current-settings baseline J; summary.BestJ is
+            // the optimizer's best (== result.BestJ).
+            var dto = OptimizedStarDetectionSettings.FromParams(
+                result.BestParams, summary.RunCount, summary.SeedJ, summary.BestJ,
+                summary.RecommendedStepSize, summary.RecommendedOffsetSteps);
+
+            starDetectionOptions.ApplyOptimizedSettings(dto);
+            Logger.Info($"Applied optimized star-detection settings (J {summary.SeedJ:F3} -> {summary.BestJ:F3}, {summary.RunCount} run(s))");
+```
+
+- [ ] **Step 12: Run the new decoupling test to verify it passes**
+
+Run:
+```bash
+dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~StarDetectionOptimizerWizardVMTests.Start_OptimizerStartsFromSeed_ButSummaryBaselineIsCurrentSettings"
+```
+Expected: PASS.
+
+- [ ] **Step 13: Run the full wizard + options test classes to confirm no regression**
+
+Run:
+```bash
+dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~StarDetectionOptimizerWizardVMTests|FullyQualifiedName~StarDetectionOptionsTests|FullyQualifiedName~RunEvaluationLoaderTests"
+```
+Expected: ALL PASS. In particular these existing tests must stay green (they rely on `Baseline` falling back to `Seed` in the in-memory factories, so the before-values equal the seed values they assert): `Start_ChangedParametersRow_CarriesSeedAndBestValues`, `Start_GoodRun_PopulatesSummaryModel`, `Apply_CallsApplyOptimizedSettingsWithCuratedValuesAndMetadata`, `Start_UseCurrentSettings_*`, `SelectingCurrentVariant_*`.
+
+If `Apply_CallsApplyOptimizedSettingsWithCuratedValuesAndMetadata` fails on `dto.BaselineJ`/`dto.FinalJ`: confirm Step 11 used `summary.SeedJ`/`summary.BestJ` (in the in-memory tests these equal `result.SeedJ`/`result.BestJ` because Baseline==Seed, so the assertions still hold).
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "feat: optimize from default seed, show improvement vs current settings
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the entire suite**
+
+Run:
+```bash
+dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo
+```
+Expected: BUILD SUCCEEDED and ALL tests PASS (0 failed). If any fail, fix the underlying cause (do not skip/ignore tests).
+
+- [ ] **Step 2: Confirm no stray options mutation**
+
+Verify by reading the diff that the only write to `IStarDetectionOptions`/`StarDetectionOptions` settings on the wizard path is still `ApplyOptimizedSettings` inside `Apply` (called only from `Accept`). Run:
+```bash
+git diff develop...HEAD -- Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/
+```
+Expected: no new setter calls on options outside `Apply`; `GetDefaultStarDetectorParams` is read-only.
+
+- [ ] **Step 3: Manual verification notes (in NINA, performed by the user later)**
+
+These cannot be unit-tested; record them for the PR description:
+- Open the wizard with **non-default** current star-detection settings; run a replay optimization. The search starts from defaults; the summary's "before" σ/cost + changed-parameters table read against your **current** settings.
+- **Reject** (Close): live star-detection options are unchanged (no `ApplyOptimizedSettings`).
+- **Accept**: the optimized snapshot is applied (`UseOptimizedSettings = true`).
+- If your current settings were already better than the search-from-default result, the summary honestly shows little/no improvement (σ "unchanged" or worse); rejecting keeps your current settings.
+
+- [ ] **Step 4: Finish the branch**
+
+Use the `superpowers:finishing-a-development-branch` skill to choose how to integrate (open a PR to `develop` — never push to `develop` directly, per CLAUDE.md).
+
+---
+
+## Self-Review Notes (for the implementer)
+
+- **Spec coverage:** default seed (Task 1+2+3), save/measure current baseline (Task 4 Steps 3,5,9,10), display improvement vs current (Task 4 Steps 8,9,11), revert-on-reject = automatic/no options mutation (verified Task 5 Step 2), changed-params current→optimized (Task 4 Step 9), drift guard (Task 1), feedback path keeps warm-start but baseline-vs-current (Task 4 Step 10), "Use current settings" applies current not default (Task 4 Step 6). All covered.
+- **Type consistency:** `Baseline` (LoadedRun) get/set; `currentBaselineJ` (double) + `objectiveConstants` (ObjectiveConstants) fields; `ComputeBaselineJAsync(IReadOnlyList<LoadedRun>, CancellationToken) -> Task<double>`; `OptimizationObjective.JRun(RunEvaluationMetrics, ObjectiveConstants)` and `JTotal(IReadOnlyList<double>, ObjectiveConstants)`; `OptimizerVariable.Read(StarDetectorParams) -> double` and `CreateCuratedSet()`; `BuildDefaultStarDetectorParams()` / `GetDefaultStarDetectorParams(IRenderedImage, StarDetectionRegion, bool)`. Consistent across tasks.
+- **Behavioral note (intended):** with the seed at default, `BestJ` can be below the current-settings baseline; the improvement readouts clamp negatives and the user rejects to keep current. Do NOT add a guard that forces best ≥ current — out of scope.


### PR DESCRIPTION
## Summary

Changes the Star Detection Optimization Wizard so optimization **starts from a fully-default star-detection seed** while still **measuring and displaying improvement against the user's current settings**. Live `StarDetectionOptions` are never written until **Accept**, so rejecting/cancelling leaves current settings untouched (revert is automatic — no crash window).

Previously the optimizer seeded from the user's *current* settings, which biased the derivative-free search (it could get trapped near a local optimum) and made results depend on prior state. Now the seed is a clean, reproducible default; the displayed "before" is decoupled from the seed and tracks the user's actual current settings.

### How it works
- `LoadedRun` is split into **`Seed`** (fully-default params → optimizer start) and **`Baseline`** (current settings → before-σ/J, "Current" curve, changed-params before-column). `Baseline` falls back to `Seed` when not set (back-compat).
- New `HocusFocusStarDetection.BuildDefaultStarDetectorParams()` / `GetDefaultStarDetectorParams(...)` (shared image-context helper with `GetStarDetectorParams`; read-only wrt options). A **drift-guard test** asserts the default seed equals `BuildStarDetectorParams(ResetDefaults'd options)` field-for-field.
- Wizard computes `currentBaselineJ` (same `ObjectiveConstants`/`JRun`/`JTotal` the optimizer uses, single bundle across runs → comparable to `BestJ`). Live progress, summary σ/J, the changed-parameters table (**current → optimized**), the "Current" variant, "Use current settings" mode, and the persisted `Apply` snapshot all read vs current.
- Scope: initial optimization only. The feedback re-optimize keeps its analytic warm-start; its improvement is still reported vs current settings.

### Behavioral consequence (intended)
Starting from default, the optimized result *can* be worse than already-well-tuned current settings. The improvement readouts show this honestly (σ/J "unchanged" or worse); the user rejects to keep current. Accept stays disabled on the "Current" variant. No auto-guard forcing best ≥ current (out of scope).

Design: `docs/optimizer-default-seed-baseline-design.md` · Plan: `plans/optimizer-default-seed-baseline-plan.md`

## Test Plan
- [x] `dotnet test` full suite green — **1272 passed, 0 failed**
- [x] Drift-guard test: default seed ≡ `ResetDefaults` build (38 fields)
- [x] New decoupling test: optimizer starts from `Seed`; summary "before" reflects `Baseline`
- [x] Existing wizard/options/loader tests unchanged-green (107 in those classes)
- [x] Confirmed no new options mutation; `Apply`→`ApplyOptimizedSettings` is the only settings write
- [ ] Manual in NINA: run wizard with non-default current settings → search starts from default, improvement shown vs current; **reject** leaves options unchanged; **accept** applies the snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)