### PR TITLE
Remove vestigial multi-run text from the Star Detection Optimizer UI

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
@@ -488,7 +488,7 @@
     <TextBlock x:Key="SaveIntermediatePath_Tooltip" Text="When Save Intermediate Files is enabled, they are written to this path the next time star detection runs" />
     <TextBlock x:Key="SaveIntermediateFiles_Tooltip" Text="If enabled, every step of star detection emits a debugging file to the intermediate path" />
     <TextBlock x:Key="UseAdvanced_Tooltip" Text="Enables advanced mode with fine-grained control over star detection parameters. Not recommended unless you're an expert" />
-    <TextBlock x:Key="OptimizeStarDetection_Tooltip" Text="Opens the Star Detection Optimization Wizard, which tunes star detection against one or more saved auto-focus runs and (optionally) applies the result as your Simple-Mode settings" />
+    <TextBlock x:Key="OptimizeStarDetection_Tooltip" Text="Opens the Star Detection Optimization Wizard, which tunes star detection against a saved auto-focus run and (optionally) applies the result as your Simple-Mode settings" />
     <TextBlock x:Key="UseOptimizedSettings_Tooltip" Text="When enabled, the optimized star-detection settings produced by the optimization wizard drive detection instead of the Noise Level / Pixel Scale / Focus Range presets. Only available in Simple Mode after the wizard has produced and applied a result" />
     <TextBlock x:Key="ModelPSF_Tooltip" Text="Whether to fit PSF models to detected stars. This is required for FWHM and Eccentricity" />
     <TextBlock x:Key="PSFFitType_Tooltip" Text="What type of PSF model to fit. Moffat 0.4 more closely resembles real stars and is the default used by PixInsight" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -14,13 +14,12 @@
     </ResourceDictionary.MergedDictionaries>
 
     <!--  Tooltips  -->
-    <TextBlock x:Key="SDOpt_SourceMode_Tooltip" Text="Replay optimizes against one or more saved auto-focus runs (recommended). Live triggers a fresh auto-focus that saves its frames, then optimizes against those." />
+    <TextBlock x:Key="SDOpt_SourceMode_Tooltip" Text="Replay optimizes against a saved auto-focus run (recommended). Live triggers a fresh auto-focus that saves its frames, then optimizes against those." />
     <TextBlock x:Key="SDOpt_OptimizeMode_Tooltip" Text="Optimize runs the parameter search and recommends improved settings. Use current settings skips the search entirely and jumps straight to a summary built from your current settings, so you can review (and label) today's detection without an optimization pass. Either way, after reviewing you can still run Optimize with feedback to recover the stars you labeled." />
     <TextBlock x:Key="SDOpt_FeedbackBreakdown_Tooltip" Text="How your labels map to the detector's gates: each row is the gate that rejected the stars you marked, and the setting change that would recover them — bounded so it doesn't admit too many unlabeled candidates (precision). Optimize with feedback starts the optimizer from these recommendations." />
-    <TextBlock x:Key="SDOpt_RunCount_Tooltip" Text="How many saved auto-focus runs to optimize against together. Using two or three runs balances the settings across them and reduces overfitting to a single night's conditions." />
     <TextBlock x:Key="SDOpt_ApplyStepSize_Tooltip" Text="When checked, clicking Accept also writes the recommended auto-focus step size and offset steps to the active profile (they appear in the Changed parameters list above). The step size is sized so a sweep lands several measurement points across the focus-sensitive region of the curve. Disabled when the recommendation already matches your current settings (nothing to apply)." />
     <TextBlock x:Key="SDOpt_Review_Tooltip" Text="Optional: review the optimized detector boxes over every loaded frame and label any missed, falsely-accepted, or wrongly-rejected stars. The labels are saved next to the run and can drive a future re-optimization. Reviewing is not required — you can Accept directly." />
-    <TextBlock x:Key="SDOpt_ReOptimize_Tooltip" Text="Re-run the optimization using the labels you just made in Review. Your missed / wrongly-rejected stars steer the optimizer to recover them (recall), and your should-reject stars steer it to exclude them (precision). The runs are re-read from disk and the search re-runs, landing on an updated summary you can review again or accept." />
+    <TextBlock x:Key="SDOpt_ReOptimize_Tooltip" Text="Re-run the optimization using the labels you just made in Review. Your missed / wrongly-rejected stars steer the optimizer to recover them (recall), and your should-reject stars steer it to exclude them (precision). The run is re-read from disk and the search re-runs, landing on an updated summary you can review again or accept." />
     <TextBlock x:Key="SDOpt_Variant_Tooltip" Text="Switch the chart and the summary below between your current settings, the optimized settings, and (after Optimize with feedback) the feedback-optimized settings. Accept applies whichever variant is shown (Current can't be accepted — it's your baseline)." />
 
     <!--  Auto-focus curve chart for ONE settings variant. The Summary panel hosts this via a ContentControl bound to
@@ -132,7 +131,7 @@
                 <StackPanel Visibility="{Binding ShowSelectSource, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
                     <TextBlock
                         Margin="0,0,0,8"
-                        Text="Choose one or more saved auto-focus runs to tune star detection against. The optimizer re-runs detection on those frames with many parameter combinations and keeps the settings that best pin down focus."
+                        Text="Choose a saved auto-focus run to tune star detection against. The optimizer re-runs detection on its frames with many parameter combinations and keeps the settings that best pin down focus."
                         TextWrapping="Wrap" />
 
                     <StackPanel Margin="0,4" Orientation="Horizontal">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -876,11 +876,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             for (var i = 0; i < RunCount; i++) {
                 var path = i < SourcePaths.Count ? SourcePaths[i] : null;
                 if (string.IsNullOrWhiteSpace(path)) {
-                    ErrorMessage = $"Select a saved auto-focus folder for run {i + 1}.";
+                    ErrorMessage = "Select a saved auto-focus folder.";
                     return false;
                 }
                 if (!normalized.Add(NormalizePath(path))) {
-                    ErrorMessage = "Each run must use a different saved auto-focus folder.";
+                    ErrorMessage = "Each selected auto-focus folder must be different.";
                     return false;
                 }
             }
@@ -1059,17 +1059,16 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     } else {
                         folder = i < SourcePaths.Count ? SourcePaths[i] : null;
                         if (string.IsNullOrEmpty(folder)) {
-                            ErrorMessage = $"Select a saved auto-focus folder for run {i + 1}.";
+                            ErrorMessage = "Select a saved auto-focus folder.";
                             CurrentStep = WizardStep.SelectSource;
                             DisposeLoadedRuns(runs);
                             return null;
                         }
                     }
 
-                    var runIndex = i;
-                    SetProgress($"Loading run {runIndex + 1} of {RunCount}", 0, 0);
+                    SetProgress("Loading frames", 0, 0);
                     var loadProgress = new Progress<RunLoadProgress>(rp =>
-                        SetProgress($"Loading frames (run {runIndex + 1} of {RunCount})", rp.Current, rp.Total));
+                        SetProgress("Loading frames", rp.Current, rp.Total));
                     var loaded = await loader.LoadSavedRunAsync(folder, region, null, loadProgress, token).ConfigureAwait(true);
                     runs.Add(loaded);
                     // Record the actual folder loaded (in load order) so the re-optimize path can re-read it from disk
@@ -1150,7 +1149,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
         /// <summary>
         /// Evaluates <paramref name="paramsSelector"/>'s params on each run while reporting determinate
-        /// "Analyzing frames (run i of N)" progress as each frame's detection completes. Used to surface — and warm —
+        /// "Analyzing frames" progress as each frame's detection completes. Used to surface — and warm —
         /// the expensive first-evaluation early-context build so the progress bar moves during the long initial wait.
         /// Returns the per-run results (the seed-guard reads them; the re-optimize warm-up discards them, the call
         /// having only primed the cache).
@@ -1160,9 +1159,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             var results = new List<RunEvaluationResult>(runs.Count);
             for (var i = 0; i < runs.Count; i++) {
                 token.ThrowIfCancellationRequested();
-                var runIndex = i;
                 var run = runs[i];
-                var label = $"Analyzing frames (run {runIndex + 1} of {runs.Count})";
+                var label = "Analyzing frames";
                 SetProgress(label, 0, run.Data.FrameCount);
                 var frameProgress = new Progress<RunLoadProgress>(rp => SetProgress(label, rp.Current, rp.Total));
                 results.Add(await run.Data.EvaluateAndFitAsync(paramsSelector(run), frameProgress, token).ConfigureAwait(true));
@@ -1601,8 +1599,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 reloaded = new List<LoadedRun>(reoptimizeRunFolders.Count);
                 for (var i = 0; i < reoptimizeRunFolders.Count; i++) {
                     token.ThrowIfCancellationRequested();
-                    var runIndex = i;
-                    SetProgress($"Re-loading run {runIndex + 1} of {reoptimizeRunFolders.Count}", 0, 0);
+                    SetProgress("Re-loading frames", 0, 0);
                     var folder = reoptimizeRunFolders[i];
 
                     // The RunId was recorded during the first acquire (it is a deterministic function of the folder),
@@ -1615,7 +1612,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     // delegates to this one with labels: null), so a label-less run is loaded the same as before.
                     var frameLabels = LabelConverter.ToFrameLabels(runLabels);
                     var loadProgress = new Progress<RunLoadProgress>(rp =>
-                        SetProgress($"Loading frames (run {runIndex + 1} of {reoptimizeRunFolders.Count})", rp.Current, rp.Total));
+                        SetProgress("Loading frames", rp.Current, rp.Total));
                     var loaded = await loader.LoadSavedRunAsync(folder, region, frameLabels, loadProgress, token).ConfigureAwait(true);
                     reloaded.Add(loaded);
                 }


### PR DESCRIPTION
## Summary

The Star Detection Optimizer wizard's multi-run **source selector was already removed** (you now pick a single saved auto-focus run), but the UI still carried run-enumeration text that implied multiple runs. This removes those vestigial traces:

- **Progress messages:** `Loading run X of Y` / `Loading frames (run X of Y)` / `Analyzing frames (run i of N)` / `Re-loading run X of Y` → `Loading frames` / `Analyzing frames` / `Re-loading frames`.
- **Errors:** `Select a saved auto-focus folder for run N.` → `Select a saved auto-focus folder.`; `Each run must use a different saved auto-focus folder.` → `Each selected auto-focus folder must be different.`
- **Tooltips:** "one or more saved auto-focus runs" → "a saved auto-focus run" (source-mode tooltip, the source-picker description, and the Options button tooltip); "The runs are re-read" → "The run is re-read".
- Removed the now-dead `SDOpt_RunCount_Tooltip` resource (the RunCount selector it documented is gone) and fixed a stale doc-comment.
- Dropped the now-unused `runIndex` locals that only fed the removed counters.

**Out of scope (intentionally untouched):** the **Tilt Adapter Wizard**, whose `Run {i+1}/{count}` status and `Run 1 / Run 2 / Avg` labels are a live, user-configurable feature (`MeasurementAverageCount`, averaged measurement runs) — not vestigial.

The multi-run VM plumbing (`RunCount`, joint-optimization loops, tests) is left intact; this PR only removes user-visible text.

## Test Plan
- [x] `dotnet test` full suite green — **1269 passed, 0 failed**
- [x] Optimizer wizard tests green (47), incl. the duplicate-folder error test (rewording keeps "different")
- [x] Build compiles (XAML + removed `runIndex` locals, no warnings introduced)
- [ ] Manual in NINA: open the optimizer wizard; progress/errors/tooltips no longer say "run X of Y" or "one or more runs"

🤖 Generated with [Claude Code](https://claude.com/claude-code)