### PR TITLE
fix(inspector): HFR-attribution race in AF-run analysis

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/PerRegionStarDetectionResultsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/PerRegionStarDetectionResultsTests.cs
@@ -1,0 +1,66 @@
+using NINA.Image.ImageAnalysis;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
+
+    [TestFixture]
+    public class PerRegionStarDetectionResultsTests {
+
+        [Test]
+        public void Set_ThenGet_ReturnsResultForThatRegion() {
+            var store = new PerRegionStarDetectionResults();
+            var resultA = new StarDetectionResult();
+            var resultB = new StarDetectionResult();
+
+            store.Set(0, resultA);
+            store.Set(6, resultB);
+
+            Assert.Multiple(() => {
+                Assert.That(store.Get(0), Is.SameAs(resultA));
+                Assert.That(store.Get(6), Is.SameAs(resultB));
+                Assert.That(store.Get(3), Is.Null, "An unset region returns null");
+            });
+        }
+
+        // Regression for the HFR-misattribution race: the 7 region-analysis tasks of a single frame run
+        // concurrently against the same per-frame store. Each region must read back its OWN result and
+        // never another region's. With the old single shared field this clobbered across regions.
+        [Test]
+        public void ConcurrentSetDistinctRegions_EachReadsBackItsOwnResult() {
+            const int regionCount = 7;
+            const int iterations = 2000;
+
+            for (int iter = 0; iter < iterations; ++iter) {
+                var store = new PerRegionStarDetectionResults();
+                var expected = new StarDetectionResult[regionCount];
+                for (int r = 0; r < regionCount; ++r) {
+                    expected[r] = new StarDetectionResult();
+                }
+
+                var readBack = new StarDetectionResult[regionCount];
+                var barrier = new Barrier(regionCount);
+                var tasks = new List<Task>(regionCount);
+                for (int r = 0; r < regionCount; ++r) {
+                    int regionIndex = r;
+                    tasks.Add(Task.Run(() => {
+                        // Start the write/read as simultaneously as possible to maximize the chance of
+                        // exposing a cross-region clobber if the store were not per-region.
+                        barrier.SignalAndWait();
+                        store.Set(regionIndex, expected[regionIndex]);
+                        readBack[regionIndex] = store.Get(regionIndex);
+                    }));
+                }
+                Task.WaitAll(tasks.ToArray());
+
+                for (int r = 0; r < regionCount; ++r) {
+                    Assert.That(readBack[r], Is.SameAs(expected[r]),
+                        $"Region {r} read back a different region's result (iteration {iter})");
+                }
+            }
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
@@ -398,7 +398,22 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             public int FrameNumber { get; private set; }
             public int FocuserPosition { get; private set; }
             public bool FinalValidation { get; private set; }
-            public StarDetectionResult StarDetectionResult { get; set; }
+
+            // Per-region star detection results. The 7 region-analysis tasks of a single frame run concurrently and
+            // all share this one AutoFocusImageState, so a single shared StarDetectionResult field was written by one
+            // region and read back by another (HFR misattribution). Keyed by region index so each region reads its own
+            // result. Only feeds the SubMeasurementPointCompleted event (the Inspector's sensor model); the AF curve
+            // consumes the pooled MeasureAndError via SubMeasurementsByFocuserPoints instead, so this is independent.
+            private readonly PerRegionStarDetectionResults starDetectionResults = new PerRegionStarDetectionResults();
+
+            public void SetStarDetectionResult(int regionIndex, StarDetectionResult result) {
+                starDetectionResults.Set(regionIndex, result);
+            }
+
+            public StarDetectionResult GetStarDetectionResult(int regionIndex) {
+                return starDetectionResults.Get(regionIndex);
+            }
+
             public IRenderedImage PreservedExposure { get; set; }
 
             private bool measurementStarted = false;
@@ -622,7 +637,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     }
                 }
 
-                imageState.StarDetectionResult = analysisResult;
+                imageState.SetStarDetectionResult(regionState.RegionIndex, analysisResult);
                 if (state.Options.PreserveExposures) {
                     imageState.PreservedExposure = image;
                 }
@@ -1850,7 +1865,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 RegionIndex = regionState.RegionIndex,
                 Region = regionState.Region,
                 FocuserPosition = imageState.FocuserPosition,
-                StarDetectionResult = imageState.StarDetectionResult,
+                StarDetectionResult = imageState.GetStarDetectionResult(regionState.RegionIndex),
                 Image = imageState.PreservedExposure
             });
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -1137,7 +1137,11 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             if (e.RegionIndex == 6) {
                 var hfStarDetectionResult = e.StarDetectionResult as HocusFocusStarDetectionResult;
                 if (hfStarDetectionResult != null) {
-                    FullSensorDetectedStars.Add(new SensorDetectedStars(e.FocuserPosition, hfStarDetectionResult, e.Image));
+                    // SubMeasurementPointCompleted fires concurrently for different focuser positions, so guard the
+                    // List.Add against concurrent mutation. Order is irrelevant (consumers OrderBy(FocuserPosition)).
+                    lock (fullSensorDetectedStarsLock) {
+                        FullSensorDetectedStars.Add(new SensorDetectedStars(e.FocuserPosition, hfStarDetectionResult, e.Image));
+                    }
                 }
             }
         }
@@ -1340,7 +1344,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         }
 
         private void ClearAnalysis() {
-            FullSensorDetectedStars.Clear();
+            lock (fullSensorDetectedStarsLock) {
+                FullSensorDetectedStars.Clear();
+            }
             ClearPlots();
         }
 
@@ -1406,6 +1412,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         public ICommand SlewToZenithWestCommand { get; private set; }
         public ICommand CancelSlewToZenithCommand { get; private set; }
 
+        private readonly object fullSensorDetectedStarsLock = new object();
         private readonly List<SensorDetectedStars> FullSensorDetectedStars = new List<SensorDetectedStars>();
         public AsyncObservableCollection<ScatterErrorPoint>[] RegionFocusPoints { get; private set; }
         public AsyncObservableCollection<DataPoint>[] RegionPlotFocusPoints { get; private set; }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/PerRegionStarDetectionResults.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/PerRegionStarDetectionResults.cs
@@ -1,0 +1,43 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2021 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Image.ImageAnalysis;
+using System.Collections.Concurrent;
+
+namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
+
+    /// <summary>
+    /// Thread-safe per-region store of star detection results for a single auto-focus frame.
+    ///
+    /// A single frame fans out one analysis task per region (7 regions) that all share one
+    /// AutoFocusImageState and run concurrently. A previous single shared StarDetectionResult field
+    /// was written by one region and read back by another between the write and the read, so the
+    /// per-region SubMeasurementPointCompleted event (the Inspector's sensor model) carried a
+    /// different region's star list / HFR (HFR misattribution). Keying by region index gives each
+    /// region its own slot so no region can clobber another's result.
+    ///
+    /// This only feeds the SubMeasurementPointCompleted event. The auto-focus curve fit consumes the
+    /// pooled MeasureAndError via SubMeasurementsByFocuserPoints instead, so this store has no effect
+    /// on AF measurements or fitting.
+    /// </summary>
+    internal class PerRegionStarDetectionResults {
+        private readonly ConcurrentDictionary<int, StarDetectionResult> resultsByRegion = new ConcurrentDictionary<int, StarDetectionResult>();
+
+        public void Set(int regionIndex, StarDetectionResult result) {
+            resultsByRegion[regionIndex] = result;
+        }
+
+        public StarDetectionResult Get(int regionIndex) {
+            return resultsByRegion.TryGetValue(regionIndex, out var result) ? result : null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two confirmed concurrency races in the Aberration Inspector's analysis of an auto-focus run. The visible symptom was per-region star-detection results (and therefore HFR) being misattributed to the wrong region/data point. Both races stem from the fan-out of one `Task.Run` per region (7 regions) that all share the same per-frame `AutoFocusImageState` and run concurrently.

## Race 1 (primary) — shared `imageState.StarDetectionResult` clobbered across concurrent region tasks

- `AutoFocus/AutoFocusEngine.cs`: the live path `RunWithRegions` (~`:964`) and the replay path `RerunImpl` (~`:1725`) both fan out one task per region over a shared `AutoFocusImageState`.
- Each region task wrote the single shared field at `AutoFocusEngine.cs:625` (`imageState.StarDetectionResult = analysisResult;`), then read it back in `OnSubMeasurementPointCompleted` at `AutoFocusEngine.cs:1853` (`StarDetectionResult = imageState.StarDetectionResult`). Between a region's write and its read, another region overwrote the field, so the emitted per-region `SubMeasurementPointCompleted` event carried a *different region's* star list / HFR. (The focuser position is sourced from the immutable `imageState.FocuserPosition`, so only the result/HFR was wrong.)

**Fix:** replaced the single shared field with a thread-safe per-region store. New internal class `PerRegionStarDetectionResults` (a `ConcurrentDictionary<int, StarDetectionResult>` with `Set`/`Get` by region index). `AutoFocusImageState` exposes `SetStarDetectionResult(regionIndex, …)` / `GetStarDetectionResult(regionIndex)`. The writer at `:625` now keys by `regionState.RegionIndex`; the reader at `:1853` (`OnSubMeasurementPointCompleted`, which already has `regionState` in scope) reads keyed by `regionState.RegionIndex`. These are the only two sites that touch the member (confirmed by grep). Each region now reads back its own result; no cross-region clobber is possible.

- **`imageState.PreservedExposure`** (read at `:1854`) is left shared: every region task sets it to the *same* frame image, so it is never overwritten with a wrong value.

## Race 2 (secondary) — `FullSensorDetectedStars` appended without synchronization

- `AutoFocus/InspectorVM.cs:1409`: `private readonly List<SensorDetectedStars> FullSensorDetectedStars`.
- `InspectorVM.cs:1140` (`AutoFocusEngine_SubMeasurementPointCompleted`) does `FullSensorDetectedStars.Add(…)`. That handler fires concurrently for different focuser positions (the event is raised at `AutoFocusEngine.cs:714`, *before* the `lock` at `:716`), so the unsynchronized `List.Add` could corrupt the list.

**Fix:** added a dedicated `fullSensorDetectedStarsLock` and `lock` around the `Add` (`:1140`) and around the `Clear()` in `ClearAnalysis` (`:1343`). Order is irrelevant — the consume sites (`SaveRegisteredImages`, `SensorModel.UpdateModel`) `OrderBy(FocuserPosition)` and run only after the run completes.

## Why AF measurements / fitting are unaffected

`StarDetectionResult` feeds **only** the `SubMeasurementPointCompleted` event (the Inspector's sensor model). The auto-focus curve consumes the pooled `MeasureAndError` returned by `EvaluateExposure`, threaded through `FocusPointMeasurementAction` → `SubMeasurementsByFocuserPoints` / `MeasurementsByFocuserPoint` under `regionState.SubMeasurementsLock` (`AutoFocusEngine.cs:716-737`) — it never reads `imageState.StarDetectionResult`. This change touches only result attribution + list synchronization, so the AF run output (positions, pooled HFR, fitted curves) is unchanged.

## Test

`PerRegionStarDetectionResultsTests` — a deterministic regression test that, from 7 concurrent tasks (synchronized on a `Barrier` to maximize contention, ×2000 iterations), sets distinct results for distinct region indices and asserts each region reads back its own result. The store was extracted into the test-visible internal `PerRegionStarDetectionResults` (the assembly already has `InternalsVisibleTo` the test project) because `AutoFocusImageState` is a private nested type.

## Verification

- `dotnet build Joko.NINA.Plugins.sln -c Debug` → 0 errors; TestApp → 0 errors.
- `dotnet test` → all green: **1276 passed**, 0 failed (3 skipped benchmarks), including the 2 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)