### PR TITLE
feat(optimizer): plateau tie-breaker + never-return-worse-than-current guard

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationObjectiveTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationObjectiveTests.cs
@@ -206,7 +206,7 @@ public class OptimizationObjectiveTests {
 
     [Test]
     public void JRun_WithoutLabels_UsesThreeWeightsSummingToOne() {
-        var c = C;
+        var c = new ObjectiveConstants { Wtie = 0.0 }; // isolate the weight-normalization invariant from the tie-breaker
         // With a perfect run (all sub-scores = 1) J must equal 1 exactly => weights normalized to sum 1.
         var j = OptimizationObjective.JRun(PerfectRun(), c);
         Assert.That(j, Is.EqualTo(1.0).Within(1e-9));
@@ -214,7 +214,7 @@ public class OptimizationObjectiveTests {
 
     [Test]
     public void JRun_WithLabels_RenormalizesFourWeightsToSumToOne() {
-        var c = C;
+        var c = new ObjectiveConstants { Wtie = 0.0 }; // isolate the weight-normalization invariant from the tie-breaker
         // Perfect run including a perfect label score => J = 1 exactly.
         var j = OptimizationObjective.JRun(PerfectRun(), c, recall: 1.0, precision: 1.0);
         Assert.That(j, Is.EqualTo(1.0).Within(1e-9));
@@ -390,7 +390,7 @@ public class OptimizationObjectiveTests {
 
     [Test]
     public void JRun_BitIdentical_Unlabeled_WhenRelaxedCountsAllZero() {
-        var c = C;
+        var c = new ObjectiveConstants { Wtie = 0.0 }; // bit-identity is the F3-penalty guarantee; isolate from the tie-breaker
         var m = RunWithPositions(frameCount: 9, starsPerFrame: 40, sigmaFocus: 0.18); // all-zero relaxed
         var actual = OptimizationObjective.JRun(m, c);
         var expected = LegacyJRun(m, c, null, null);
@@ -400,7 +400,7 @@ public class OptimizationObjectiveTests {
 
     [Test]
     public void JRun_BitIdentical_Labeled_WhenRelaxedCountsAllZero() {
-        var c = C;
+        var c = new ObjectiveConstants { Wtie = 0.0 }; // bit-identity is the F3-penalty guarantee; isolate from the tie-breaker
         var m = RunWithPositions(frameCount: 9, starsPerFrame: 12, sigmaFocus: 0.22); // all-zero relaxed
         var actual = OptimizationObjective.JRun(m, c, recall: 0.7, precision: 0.6);
         var expected = LegacyJRun(m, c, 0.7, 0.6);
@@ -410,7 +410,7 @@ public class OptimizationObjectiveTests {
 
     [Test]
     public void JRun_BitIdentical_WhenNoRelaxationPlumbingAtAll() {
-        var c = C;
+        var c = new ObjectiveConstants { Wtie = 0.0 }; // bit-identity is the F3-penalty guarantee; isolate from the tie-breaker
         // GoodRun has null FrameRelaxationAdmittedCounts/positions — the legacy callers' shape. Must be unchanged.
         var m = GoodRun(sigmaFocus: 0.2, frameCount: 10, starsPerFrame: 25);
         Assert.That(OptimizationObjective.JRun(m, c), Is.EqualTo(LegacyJRun(m, c, null, null)));
@@ -440,6 +440,107 @@ public class OptimizationObjectiveTests {
         var jDonut = OptimizationObjective.JRun(donut, c);
         Assert.That(jDonut, Is.EqualTo(jClean),
             "legitimate donut recovery on the defocused extremes must not be penalized");
+    }
+
+    // ---- TieBreakerScore (plateau tie-breaker) + JRun blend ----
+
+    // A run whose PRIMARY sub-scores all saturate to 1.0 (sharp focus, perfect fit, counts past both knees),
+    // so J_primary == 1.0 regardless of star count — the saturated-plateau case the tie-breaker targets.
+    private static RunEvaluationMetrics PlateauRun(int starsPerFrame, double sigmaFocus = 1e-6) => new RunEvaluationMetrics {
+        SigmaFocus = sigmaFocus,
+        LooStdError = double.NaN,
+        StepSize = 100.0,
+        RSquared = 1.0,
+        ReducedChiSquared = 1.0,
+        FrameStarCounts = Enumerable.Repeat(starsPerFrame, 9).ToList()
+    };
+
+    [Test]
+    public void TieBreakerScore_IncreasesWithStarCount() {
+        var c = C;
+        var fewer = OptimizationObjective.TieBreakerScore(PlateauRun(100), c);
+        var more = OptimizationObjective.TieBreakerScore(PlateauRun(300), c);
+        Assert.That(more, Is.GreaterThan(fewer));
+    }
+
+    [Test]
+    public void TieBreakerScore_DecreasesWithSigma() {
+        var c = C;
+        var sharp = OptimizationObjective.TieBreakerScore(PlateauRun(100, sigmaFocus: 0.1), c);
+        var soft = OptimizationObjective.TieBreakerScore(PlateauRun(100, sigmaFocus: 100.0), c);
+        Assert.That(sharp, Is.GreaterThan(soft));
+    }
+
+    [Test]
+    public void TieBreakerScore_NeverSaturates_StillRewardsBeyondKnees() {
+        var c = C; // NFloor=8, NTarget=20 — primary S_stars CLAMPS here; the tie-breaker must NOT.
+        var atKnees = OptimizationObjective.TieBreakerScore(PlateauRun(20), c);
+        var farAbove = OptimizationObjective.TieBreakerScore(PlateauRun(2000), c);
+        Assert.Multiple(() => {
+            Assert.That(farAbove, Is.GreaterThan(atKnees), "more stars beyond the S_stars knee still scores higher");
+            Assert.That(farAbove, Is.LessThan(1.0), "asymptotic: never reaches 1.0");
+        });
+    }
+
+    [Test]
+    public void TieBreakerScore_RewardsTotalRichness_NotJustTheWorstFrame() {
+        var c = C;
+        // Regression for the observed gaming: on the mufti plateau the optimizer raised ONLY the worst frame
+        // (82->91) while dropping ~27% of the total stars (1247->904). The tie-breaker must reward overall
+        // richness, so the star-richer set must win even though its MINIMUM frame is lower.
+        var richOverall = new RunEvaluationMetrics { // total 1247, min 82
+            SigmaFocus = 1e-6, LooStdError = double.NaN, StepSize = 100.0, RSquared = 1.0, ReducedChiSquared = 1.0,
+            FrameStarCounts = new[] { 97, 140, 226, 334, 219, 149, 82 }
+        };
+        var leanButFlatter = new RunEvaluationMetrics { // total 904, min 91
+            SigmaFocus = 1e-6, LooStdError = double.NaN, StepSize = 100.0, RSquared = 1.0, ReducedChiSquared = 1.0,
+            FrameStarCounts = new[] { 103, 141, 125, 150, 144, 150, 91 }
+        };
+        Assert.That(OptimizationObjective.TieBreakerScore(richOverall, c),
+            Is.GreaterThan(OptimizationObjective.TieBreakerScore(leanButFlatter, c)),
+            "tie-breaker must reward total star richness, not be gamed by raising only the worst frame");
+    }
+
+    [Test]
+    public void JRun_OnSaturatedPlateau_PrefersMoreStars() {
+        var c = C; // default Wtie > 0
+        var c0 = new ObjectiveConstants { Wtie = 0.0 };
+        Assert.Multiple(() => {
+            // Both runs saturate the PRIMARY objective (J_primary == 1.0) ...
+            Assert.That(OptimizationObjective.JRun(PlateauRun(300), c0), Is.EqualTo(1.0).Within(1e-9));
+            Assert.That(OptimizationObjective.JRun(PlateauRun(120), c0), Is.EqualTo(1.0).Within(1e-9));
+            // ... yet WITH the tie-breaker the star-richer run is preferred.
+            Assert.That(OptimizationObjective.JRun(PlateauRun(300), c),
+                Is.GreaterThan(OptimizationObjective.JRun(PlateauRun(120), c)));
+        });
+    }
+
+    [Test]
+    public void JRun_TieBreaker_DisabledWhenWtieZero() {
+        var c0 = new ObjectiveConstants { Wtie = 0.0 };
+        var rich = OptimizationObjective.JRun(PlateauRun(300), c0);
+        var lean = OptimizationObjective.JRun(PlateauRun(120), c0);
+        Assert.That(rich, Is.EqualTo(lean), "Wtie=0 => pure primary objective => plateau ties stay tied");
+    }
+
+    [Test]
+    public void JRun_TieBreaker_DoesNotOverrideRealPrimaryDifference() {
+        var c = C; // the tiny tie-breaker must NOT flip a genuine focus-quality gap
+        // A: sharp focus (better primary) but FEWER stars. B: soft focus (worse primary) but MORE stars.
+        var sharpFewer = OptimizationObjective.JRun(PlateauRun(50, sigmaFocus: 10.0), c);   // rho=0.1
+        var softMore = OptimizationObjective.JRun(PlateauRun(400, sigmaFocus: 30.0), c);    // rho=0.3
+        Assert.That(sharpFewer, Is.GreaterThan(softMore), "a real primary-J advantage dominates the tie-breaker");
+    }
+
+    [Test]
+    public void JRun_TieBreaker_DoesNotRescueHardFail() {
+        var c = C;
+        var starved = PlateauRun(300);
+        var counts = starved.FrameStarCounts.ToList();
+        counts[0] = 1; // below NHard=3 => hard fail
+        starved.FrameStarCounts = counts;
+        Assert.That(OptimizationObjective.JRun(starved, c), Is.EqualTo(0.0),
+            "the tie-breaker is applied only on the feasible path; it never rescues an infeasible run");
     }
 
     // ---- JTotal ----

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -1000,6 +1000,34 @@ public class StarDetectionOptimizerWizardVMTests {
         });
     }
 
+    // A run where the user's CURRENT settings (Baseline) are ALREADY at the detection optimum (Sensitivity =
+    // optSensitivity), while the optimizer seeds from the default (Sensitivity 2). The search can only climb
+    // TOWARD the same optimum, so it can never beat current — the saturated-plateau / local-optimum case.
+    private static LoadedRun AlreadyOptimalBaselineRun(string id = "optimal", double optSensitivity = 10.0) {
+        var data = new RunEvaluationData(id, NineFrames(), OptimizableDetect(optSensitivity), NewAlglib(), DefaultFitConfig());
+        return new LoadedRun {
+            Data = data,
+            Seed = new StarDetectorParams { Sensitivity = 2, StarClippingMultiplier = 2.0 },
+            Baseline = new StarDetectorParams { Sensitivity = optSensitivity, StarClippingMultiplier = 2.0 },
+            AfOptions = new AutoFocusEngineOptions { AutoFocusStepSize = DefaultStepSize, AutoFocusInitialOffsetSteps = 4 }
+        };
+    }
+
+    [Test]
+    public async Task Start_OptimizerCannotBeatCurrent_DefaultsToCurrentVariant() {
+        var vm = NewVM(LoaderReturning(AlreadyOptimalBaselineRun()));
+        vm.SourcePaths[0] = @"C:\run1";
+
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.OptimizerImprovedOverCurrent, Is.False, "the optimizer could not beat the already-optimal current settings");
+            Assert.That(vm.SelectedVariant, Is.EqualTo(OptimizationVariant.Current),
+                "when the optimizer can't beat current, default to Current so the default Accept keeps current settings");
+            Assert.That(vm.HasOptimized, Is.True, "the optimized variant is still available to inspect");
+        });
+    }
+
     [Test]
     public async Task SelectingCurrentVariant_SwitchesCurveAndSummary_AndDisablesAccept() {
         var vm = NewVM(LoaderReturning(GoodRun()));

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -301,6 +301,15 @@
                                 Visibility="{Binding HasFeedback, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                         </StackPanel>
 
+                        <!--  Shown when the optimizer could not beat the user's current settings: the page defaults to
+                              Current so Accept keeps it. Explains why + points at "Start from my current settings".  -->
+                        <TextBlock
+                            Margin="0,0,0,8"
+                            FontStyle="Italic"
+                            TextWrapping="Wrap"
+                            Text="{Binding OptimizerNoImprovementNote, Mode=OneWay}"
+                            Visibility="{Binding ShowNoImprovementNote, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+
                         <!--  Auto-focus curve for the selected variant (rebuilt on toggle via the ContentControl).  -->
                         <Border
                             Height="260"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationObjective.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationObjective.cs
@@ -46,6 +46,18 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
         public double Beta { get; set; } = 0.5;  // J_total = (1-β)·mean + β·min over runs
 
+        // ── Plateau tie-breaker (Wtie) ─────────────────────────────────────────────────────────────────────
+        // On an easy AF run every primary sub-score clamps to 1.0 (sharp focus, perfect fit, counts past the
+        // S_stars knees), so J saturates at 1.0 over a whole plateau of settings and the search — which only
+        // accepts strictly-improving moves and seeds from the DEFAULT params — wanders to an arbitrary tie-point
+        // far from (and often worse than) the user's settings (e.g. it halves the star count for no J gain).
+        // TieBreakerScore is an UNSATURATING secondary score (more stars / lower σ ⇒ higher, forever) blended
+        // into J as a convex combination: J = (1−Wtie)·J_primary + Wtie·T. Wtie is tiny so any genuine primary-J
+        // difference (≥~1e-3) dominates and off-plateau ranking is unchanged; on the plateau (J_primary tied) T
+        // decides, steering toward the star-rich / sharper basin. Wtie = 0 ⇒ J is bit-identical to the pre-tie
+        // -breaker objective. See docs/optimizer-plateau-tiebreaker-design.md.
+        public double Wtie { get; set; } = 1e-3;
+
         // ── F3: label-free precision / false-positive penalty (SDefocusPrecision) ──────────────────────────
         // These gate the MULTIPLICATIVE penalty the objective applies for defocus-relaxation that admits junk.
         // They are deliberately CONSERVATIVE: with the defocus-aware gates OFF (the baseline) every per-frame
@@ -234,7 +246,53 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // drops below 1 for the near-focus junk signature; legitimate defocused-extreme donut recovery is not
             // penalized. Composes identically in the labeled and unlabeled cases (applied after the weighted sum).
             j *= SDefocusPrecision(m, c);
+
+            // Plateau tie-breaker: blend in the unsaturating secondary score so that when the primary objective is
+            // flat (J saturated at 1.0 over a region) the search still prefers more stars / lower σ. Applied ONLY on
+            // this feasible path (the hard-fail returns above keep returning 0.0, so it never rescues an infeasible
+            // run). Wtie = 0 ⇒ exactly j (bit-identical to the pre-tie-breaker objective). Convex ⇒ J stays in [0,1].
+            if (c.Wtie > 0.0) {
+                j = (1.0 - c.Wtie) * j + c.Wtie * TieBreakerScore(m, c);
+            }
             return Clamp01(j);
+        }
+
+        /// <summary>
+        /// Unsaturating secondary "quality" score in [0, 1), used by <see cref="JRun"/> to break ties on the
+        /// saturated objective plateau. Rewards MORE stars and LOWER focus σ with strictly-monotone, never-clamping
+        /// Michaelis–Menten terms (<c>n/(n+k)</c>, <c>RhoRef/(RhoRef+ρ)</c>) so it retains a gradient exactly where
+        /// the primary sub-scores (which CLAMP at the NFloor/NTarget/RhoRef knees) have none. The knees are reused as
+        /// half-saturation points so no new tuning constants are introduced; star count dominates (0.6) because it is
+        /// the robust, large-signal indicator of sensor-model quality, with σ a gentle secondary (0.4). Returns 0 for
+        /// an empty run.
+        ///
+        /// <para>The star term uses the per-run MEAN (total richness across the whole sweep), NOT a minimum-dominated
+        /// blend: on the plateau every frame is already well past the S_stars knees, so minimum-frame protection is
+        /// redundant (the hard floor + primary S_stars own it), and a min-dominated tie-breaker is GAMEABLE — the
+        /// search can lift only the worst frame while shedding stars on the rich frames (observed on the mufti run:
+        /// it raised the min 82→91 while dropping total 1247→904). Mean rewards keeping stars everywhere, which is
+        /// what a tilt/sensor model needs.</para>
+        /// </summary>
+        public static double TieBreakerScore(RunEvaluationMetrics m, ObjectiveConstants c) {
+            if (m?.FrameStarCounts == null || m.FrameStarCounts.Count == 0) {
+                return 0.0;
+            }
+            var nMean = m.FrameStarCounts.Average();
+            // Unsaturating total-star richness: mean/(mean+k), half-saturated at the S_stars target knee.
+            var tStars = nMean / (nMean + c.NTarget);
+
+            // Unsaturating focus sharpness: lower ρ = σ/step ⇒ higher. Falls back to the LOO σ like SFocus; if no
+            // usable σ/step, contribute the neutral 0.5 so the term is well-defined (the star term still dominates).
+            var sigma = IsFinite(m.SigmaFocus) ? m.SigmaFocus : (IsFinite(m.LooStdError) ? m.LooStdError : double.NaN);
+            double tFocus;
+            if (IsFinite(sigma) && m.StepSize > 0.0 && c.RhoRef > 0.0) {
+                var rho = sigma / m.StepSize;
+                tFocus = c.RhoRef / (c.RhoRef + rho);
+            } else {
+                tFocus = 0.5;
+            }
+
+            return 0.6 * tStars + 0.4 * tFocus;
         }
 
         /// <summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -208,6 +208,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         // the pre-cut 400-eval budget instead of the standard one.
         private const int DonutMaxEvaluations = 400;
 
+        // Minimum strictly-positive J margin for the optimized result to count as beating the user's current settings
+        // (drives OptimizerImprovedOverCurrent / the default-to-Current guard). Just above double round-off so a true
+        // tie (e.g. the StartFromCurrentSettings path returning current unchanged) reads as "no improvement".
+        private const double ImprovementEpsilon = 1e-9;
+
         // The review-build seam: given the snapshotted frame descriptors + the params to detect with, produces the
         // per-frame FrameReviews the StarReviewVM renders. Production wires FrameReviewBuilder over a real
         // StarDetector + a profile-aware disk loader; the unit tests inject a fake so the step-flow can be exercised
@@ -653,6 +658,38 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public bool HasOptimized => optimizedResult != null;
         public bool HasFeedback => feedbackResult != null;
 
+        private bool optimizerImprovedOverCurrent;
+
+        /// <summary>True when an optimization pass produced a result that STRICTLY beats the user's current settings
+        /// (BestJ &gt; current-settings J). The optimizer seeds from the fully-default params and only guarantees
+        /// "&ge; the seed", NOT "&ge; current" — on an easy/saturated run it can converge to a local optimum that is
+        /// worse than a well-tuned current setup. When this is false the results page defaults to the Current variant
+        /// (so the default Accept keeps current); the Optimized variant is still available to inspect. The UI binds
+        /// this to show a "could not improve on your current settings" note.</summary>
+        public bool OptimizerImprovedOverCurrent {
+            get => optimizerImprovedOverCurrent;
+            private set {
+                if (optimizerImprovedOverCurrent != value) {
+                    optimizerImprovedOverCurrent = value;
+                    RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(OptimizerNoImprovementNote));
+                    RaisePropertyChanged(nameof(ShowNoImprovementNote));
+                }
+            }
+        }
+
+        /// <summary>True when an optimization pass ran but could not beat the current settings — drives the
+        /// visibility of the "kept Current" note on the results page.</summary>
+        public bool ShowNoImprovementNote => HasOptimized && !OptimizerImprovedOverCurrent;
+
+        /// <summary>A short note shown when an optimization pass ran but could not beat the current settings; empty
+        /// otherwise. Lets the user understand why the page defaulted to Current rather than the optimized variant.</summary>
+        public string OptimizerNoImprovementNote =>
+            ShowNoImprovementNote
+                ? "The optimizer could not improve on your current settings — keeping Current. " +
+                  "Tip: enable \"Start from my current settings\" to refine them, or inspect the Optimized variant below."
+                : string.Empty;
+
         private bool IsVariantAvailable(OptimizationVariant v) => v switch {
             OptimizationVariant.Feedback => HasFeedback,
             OptimizationVariant.Optimized => HasOptimized,
@@ -771,6 +808,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             currentSummary = optimizedSummary = feedbackSummary = null;
             currentCurve = optimizedCurve = feedbackCurve = null;
             selectedVariant = OptimizationVariant.Current;
+            OptimizerImprovedOverCurrent = false;
             RaiseSelectedVariantDependents();
         }
 
@@ -1068,8 +1106,17 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     optimizedResult = optimizeResult;
                     optimizedSummary = built.Summary;
                     optimizedCurve = built.OptimizedCurve;
-                    selectedVariant = OptimizationVariant.Optimized; // default to showing the improvement
+                    // Only PRESENT the optimized result as the recommendation when it strictly beats the user's
+                    // current settings. The search seeds from the default params and guarantees ">= seed", NOT
+                    // ">= current"; on a saturated/easy run it can converge to a local optimum worse than a well-tuned
+                    // current setup (validated on the mufti run: BestJ 0.999919 < current 0.999939). In that case
+                    // default to Current so the default Accept keeps current; the Optimized variant stays available.
+                    OptimizerImprovedOverCurrent = optimizeResult.BestJ > currentBaselineJ + ImprovementEpsilon;
+                    selectedVariant = OptimizerImprovedOverCurrent
+                        ? OptimizationVariant.Optimized // default to showing the genuine improvement
+                        : OptimizationVariant.Current;  // optimizer couldn't beat current => keep current by default
                 } else {
+                    OptimizerImprovedOverCurrent = false;
                     selectedVariant = OptimizationVariant.Current; // review-only: only the current curve exists
                 }
                 RaiseSelectedVariantDependents();

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -181,12 +181,21 @@ namespace TestApp {
                 p.SaveIntermediateFilesPath = string.Empty;
                 return p;
             }
-            var seed = ApplyAfContext(HocusFocusStarDetection.BuildDefaultStarDetectorParams());
             var baseline = ApplyAfContext(HocusFocusStarDetection.BuildStarDetectorParams(starDetectionOptions));
+            // --start-from-current mirrors the wizard's "Start from my current settings" toggle: the optimizer SEED
+            // becomes the user's current settings (Baseline) instead of the fully-default params, so the never-regress
+            // floor is the current J and the search refines from the current basin (it can only improve on current).
+            bool startFromCurrent = DiagnosticUtil.HasFlag(args, "--start-from-current");
+            var seed = startFromCurrent
+                ? ApplyAfContext(HocusFocusStarDetection.BuildStarDetectorParams(starDetectionOptions))
+                : ApplyAfContext(HocusFocusStarDetection.BuildDefaultStarDetectorParams());
             if (forceDonut) {
                 seed.DefocusAwareDonutDetection = true;
                 baseline.DefocusAwareDonutDetection = true;
                 Console.WriteLine("--donut: DefocusAwareDonutDetection forced ON (optimizer will explore the donut/spike axes)");
+            }
+            if (startFromCurrent) {
+                Console.WriteLine("--start-from-current: optimizer seed = current settings (never regresses below current)");
             }
 
             Console.WriteLine($"Default seed params: Sensitivity={F(seed.Sensitivity)}, StarClippingMultiplier={F(seed.StarClippingMultiplier)}, " +

--- a/docs/optimizer-plateau-tiebreaker-design.md
+++ b/docs/optimizer-plateau-tiebreaker-design.md
@@ -1,0 +1,117 @@
+# Optimizer Plateau Tie-Breaker — Design
+
+## Problem
+
+On an "easy" auto-focus run (star-rich, well-sampled, a clean V-curve) the optimization objective **J
+saturates at its maximum 1.0 over a large region of parameter space**. Every sub-score clamps:
+
+- `S_focus = 1/(1+(ρ/RhoRef)²)` ≈ 1 when ρ = σ/step ≪ RhoRef (e.g. σ≈1e-4, step=100 ⇒ ρ≈1e-6).
+- `S_stars = 0.6·clamp01(nMin/NFloor) + 0.4·clamp01(nMed/NTarget)` = **1.0 exactly** once nMin≥NFloor(8)
+  and nMed≥NTarget(20) — a hard clamp, no gradient.
+- `S_fit = clamp01(R²)·penalty` = 1.0 when R²≥1 and reducedχ² ≤ ChiTau.
+
+So `J = Wf+Ws+Wc = 1.0` for a whole plateau of settings. Empirically (run
+`mufti/AutoFocus_20260607_030642…`, profile b10b1d6d): the user's hand-tuned settings score **J=1.0** AND a
+wildly different setting set (StarClippingMultiplier 0.375→9.5, Sensitivity 16.67→49.25) also scores **J=1.0**
+("no improvement over current"). Because the search **seeds from the fully-default params** and only accepts
+strictly-improving moves, with no gradient on the plateau it **wanders to an arbitrary tie-point** far from
+the user's settings — one that roughly **halves the star count** (best-focus frame 334→147) and worsens
+σ_focus ~20× (both still scoring 1.0). Fewer, less-distributed stars ⇒ a noisier tilt/sensor model, which is
+the "worse results" the user observes. See `optimizer-saturated-objective-finding` (memory) for the full
+diagnosis.
+
+## Approach
+
+Add a small, **unsaturating secondary "quality" score `T`** that breaks ties on the plateau in favour of the
+two things that actually degraded — **more stars** and **lower σ_focus** — and fold it into J as a convex
+blend so J stays in [0,1]:
+
+```
+J = (1 − Wtie)·J_primary + Wtie·T          (only on the feasible path; hard fails still return 0.0)
+```
+
+- `J_primary` = the existing weighted-sum × SDefocusPrecision (unchanged).
+- `Wtie` (ObjectiveConstants, **default 1e-3**) — small enough that any genuine primary-J difference
+  (≥~1e-3, which a real star-count/σ change produces) dominates, so **off-plateau ranking is unchanged**; on
+  the plateau (J_primary tied) `T` decides.
+- `Wtie = 0` ⇒ J is **bit-identical** to today (used by the core weight-normalization / F3 bit-identity unit
+  tests).
+
+### The tie-breaker score T (unsaturating, ∈ [0,1))
+
+Reuses the existing knees as half-saturation points so it needs no new tuning constants, and uses the
+Michaelis–Menten form `n/(n+k)` which is strictly monotone everywhere (never clamps):
+
+```
+Tstars = nMean / (nMean + NTarget)        // TOTAL richness across the sweep — more stars ⇒ higher, forever
+Tfocus = RhoRef / (RhoRef + ρ)            // lower σ ⇒ higher, forever
+T      = 0.6·Tstars + 0.4·Tfocus          // star-count dominant
+```
+
+Star count dominates because it is the robust, large-signal indicator of sensor-model quality (334 vs 147 is
+a clear difference) and because at plateau-tiny σ the focus term is near-equal for all candidates. The
+star/focus split (0.6/0.4) mirrors the primary objective's focus emphasis without letting σ alone decide.
+
+**Why MEAN, not a minimum-dominated blend (empirical correction).** A first cut used
+`0.6·(nMin/(nMin+NFloor)) + 0.4·(nMed/(nMed+NTarget))`, mirroring the primary `S_stars`. Re-validating on the
+mufti run showed it **did not work**: the optimizer still drifted to the corner (clip 10, Sensitivity 48.75),
+because that corner *raised only the worst frame* (min 82→91) while shedding 27% of the total stars
+(1247→904) — and the min-dominant tie-breaker scored the gamed set HIGHER (0.9411 vs 0.9396). On the plateau
+every frame is already well past the `S_stars` knees, so minimum-frame protection is redundant (the hard
+floor + primary `S_stars` own starvation). The mean rewards keeping stars *everywhere*, which is what a tilt
+model needs and is not gameable by lifting one frame.
+
+### Why this fixes it (and its limits)
+
+On the plateau `J_primary` is flat, so the compass search now climbs `T` — toward **more stars / lower σ**,
+i.e. away from the star-halving extreme and toward the star-rich basin the user's settings live in. It works
+**even when seeded from the default params** (the wizard's default), and composes with "Start from my current
+settings" (the never-regress floor then already includes T).
+
+Crucially, `Wtie` is tiny: if loosening detection to gain stars starts admitting junk that **hurts the fit**
+(σ_focus up, χ² up, a starved frame), `J_primary` drops by ≫1e-3 and the tie-breaker cannot rescue it — the
+primary objective still guards quality. The tie-breaker only operates among **AF-equivalent** configs. It is
+therefore **not** a substitute for precision labels on a genuinely noisy field; it is a sensible default
+preference ("when AF quality is tied, keep more stars") for the unlabeled plateau case.
+
+Hard fails (NaN focus σ, too many starved frames) return 0.0 **before** the blend, so the tie-breaker can
+never rescue an infeasible run.
+
+## Scope
+
+- `ObjectiveConstants`: add `Wtie` (default 1e-3) + the (reused) knees already present.
+- `OptimizationObjective`: add `TieBreakerScore(m, c)`; blend it into `JRun` on the feasible path.
+- Production picks it up automatically (`new ObjectiveConstants()` in the wizard + TestApp).
+- Tests: 5 existing tests that pin the pure weighted sum set `Wtie = 0`; new tests pin `TieBreakerScore`
+  monotonicity and the plateau-tie-break behaviour of `JRun`.
+
+## Validation
+
+Headless `TestApp optimize` on the mufti run (donut on, 400 evals, profile b10b1d6d):
+
+| Objective | seed | Best J vs Current J | result |
+|---|---|---|---|
+| pre-tie-breaker | default | 1.0 vs 1.0 (tie) | drifts to corner (clip 9.5, halved stars) |
+| nMin tie-breaker | default | 0.999941 **> 0.99994** | STILL drifts (gamed the min frame) |
+| mean tie-breaker | default | 0.999919 **< 0.999939** | objective now ranks current ABOVE the corner ✓ |
+| mean tie-breaker | **current** | ≥ current (guaranteed) | refines current; never the corner ✓ |
+
+**Key finding — the tie-breaker is necessary but not sufficient.** With the (corrected) mean tie-breaker the
+objective correctly ranks the user's current settings ABOVE the drifted corner (0.999939 > 0.999919). But the
+default-seeded search **still returns the corner**: the corner is a genuine local optimum reachable from the
+default params (the trajectory converged at eval 333, flat to 400 — NOT budget-limited), and the user's
+settings live in a different basin (low clip/sensitivity) that a local compass search starting from default
+cannot climb across to. The optimizer only guarantees "≥ the **seed**" (default), not "≥ current".
+
+**Complete fix = tie-breaker + seed-from-current + a wizard guard.**
+
+1. **Seed-from-current** (`StartFromCurrentSettings`, the wizard's "Start from my current settings" toggle;
+   `--start-from-current` in TestApp) makes the never-regress floor the current J, so the result can never be
+   worse than current — and the tie-breaker gives the search a gradient to refine current toward MORE stars /
+   lower σ rather than returning it unchanged. Validated: returns the mufti settings exactly unchanged.
+
+2. **Wizard guard (implemented).** Seed-independent protection for users who DON'T enable the toggle: the
+   results page now defaults to the **Current** variant (and shows a "could not improve on your current
+   settings — keeping Current" note) whenever `BestJ ≤ currentBaselineJ + ε`. The Optimized variant stays
+   available to inspect, but the default Accept keeps current. Exposed as `OptimizerImprovedOverCurrent` /
+   `ShowNoImprovementNote` / `OptimizerNoImprovementNote` on the wizard VM; red-green verified.


### PR DESCRIPTION
## Problem

On an easy auto-focus run the objective **J saturates at its maximum (1.0)** over a wide region of parameter space — sharp focus, star counts past the `S_stars` knees, and a perfect fit all clamp their sub-scores. With no gradient and the search seeding from the **default** params, the optimizer wanders to an arbitrary J-tie far from (and often worse than) the user's hand-tuned settings. On the `mufti` run it returned settings that **halved the star count** (best-focus frame 334→150) for zero J gain — degrading the sensor/tilt model.

## Changes

1. **Plateau tie-breaker** (`ObjectiveConstants.Wtie`, default `1e-3` + `OptimizationObjective.TieBreakerScore`). J becomes a convex blend `(1−Wtie)·J_primary + Wtie·T`, where `T` is an **unsaturating** secondary score (mean star richness + lower σ via never-clamping `n/(n+k)` terms) that keeps a gradient exactly where the primary sub-scores clamp flat. `Wtie=0` ⇒ bit-identical.
   - The first cut was `nMin`-dominant and got **gamed** (the search raised only the worst frame while shedding total stars); corrected to reward **mean/total** richness, with a regression test pinning that case.

2. **Wizard guard** — the results page now defaults to the **Current** variant (with a *"could not improve on your current settings — keeping Current"* note) whenever `BestJ ≤ currentBaselineJ`. The optimizer only guarantees "≥ seed" (default), not "≥ current"; on a saturated run it can converge to a local optimum worse than a well-tuned current setup. The Optimized variant stays available to inspect.

3. **TestApp** — `optimize --start-from-current` (seed = current settings) mirroring the wizard's "Start from my current settings" toggle, for headless validation.

## Validation (headless, `mufti` run, donut on)

| objective | seed | Best J vs Current J | result |
|---|---|---|---|
| pre-change | default | 1.0 = 1.0 (flat tie) | drifts to corner, stars halved |
| tie-breaker | default | 0.999919 **< 0.999939** | objective ranks **current above the corner** → guard keeps Current |
| tie-breaker | **current** | = current | **returns current settings exactly unchanged** (no drift) |

The complete cure is **tie-breaker + seed-from-current**; the guard protects users who don't enable the toggle. The search converged at eval 333 (not budget-limited), confirming the corner is a genuine local optimum from the default basin.

## Tests

- **1303 tests pass.** New tie-breaker tests (monotonicity, never-saturates, gaming regression, plateau preference, `Wtie=0` bit-identity) and the wizard-guard test are **red-green verified**.

Design notes: `docs/optimizer-plateau-tiebreaker-design.md`.

> Not yet verified live in NINA (headless validation only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bKikA1geXC6gNtnCm3wnL