### PR TITLE
Per-frame HFR avg±deviation corner stats + outlier coloring in the review UI

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarReviewTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarReviewTests.cs
@@ -18,6 +18,7 @@ using Newtonsoft.Json;
 using NUnit.Framework;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review;
+using NINA.Joko.Plugins.HocusFocus.Utility;
 using TestApp.StarReview;
 using Rect = OpenCvSharp.Rect;
 
@@ -400,6 +401,123 @@ public class StarReviewTests {
             Assert.That(vm.AcceptedMarkers[0].Width, Is.EqualTo(box.Width));
             Assert.That(vm.AcceptedMarkers[0].Height, Is.EqualTo(box.Height));
         });
+    }
+
+    // ---- Per-frame HFR stats + outlier coloring -----------------------------------------------------------
+
+    [Test]
+    public void HfrStats_Compute_MedianMode_MatchesMedianMad() {
+        var hfrs = new[] { 2.0, 2.1, 2.2, 2.3, 2.4 };
+        var (center, dev) = StarReviewHfrStats.Compute(hfrs, MeasurementAverageEnum.Median);
+        var (expMedian, expMad) = hfrs.MedianMAD();
+        Assert.Multiple(() => {
+            Assert.That(center, Is.EqualTo(expMedian).Within(1e-12));
+            Assert.That(dev, Is.EqualTo(expMad).Within(1e-12));
+        });
+    }
+
+    [Test]
+    public void HfrStats_Compute_MeanMode_MatchesMeanStdDev() {
+        var hfrs = new[] { 2.0, 2.5, 3.0, 3.5 };
+        var (center, dev) = StarReviewHfrStats.Compute(hfrs, MeasurementAverageEnum.MeanOutliers);
+        var (expMean, expVar) = hfrs.MeanVar();
+        Assert.Multiple(() => {
+            Assert.That(center, Is.EqualTo(expMean).Within(1e-12));
+            Assert.That(dev, Is.EqualTo(Math.Sqrt(expVar)).Within(1e-12));
+        });
+    }
+
+    [Test]
+    public void HfrStats_Compute_FiltersNonPositive_AndHandlesDegenerateCounts() {
+        // Non-positive / NaN HFRs (unmeasured stars) are excluded.
+        var (c1, d1) = StarReviewHfrStats.Compute(new[] { 2.0, 0.0, -1.0, double.NaN, 2.4 }, MeasurementAverageEnum.Median);
+        var (expMedian, expMad) = new[] { 2.0, 2.4 }.MedianMAD();
+        // No valid values -> (NaN, NaN); single value -> (value, NaN spread).
+        var (c0, d0) = StarReviewHfrStats.Compute(new[] { 0.0, -1.0 }, MeasurementAverageEnum.Median);
+        var (cs, ds) = StarReviewHfrStats.Compute(new[] { 3.3 }, MeasurementAverageEnum.Median);
+        Assert.Multiple(() => {
+            Assert.That(c1, Is.EqualTo(expMedian).Within(1e-12));
+            Assert.That(d1, Is.EqualTo(expMad).Within(1e-12));
+            Assert.That(c0, Is.NaN);
+            Assert.That(d0, Is.NaN);
+            Assert.That(cs, Is.EqualTo(3.3).Within(1e-12));
+            Assert.That(ds, Is.NaN);
+        });
+    }
+
+    [Test]
+    public void HfrStats_IsOutlier_FlagsBothSidesBeyondThreshold() {
+        // center 2.2, dev 0.1 => threshold = 3 * 0.1 = 0.3 on either side.
+        Assert.Multiple(() => {
+            Assert.That(StarReviewHfrStats.IsOutlier(2.6, 2.2, 0.1), Is.True, "above");
+            Assert.That(StarReviewHfrStats.IsOutlier(1.8, 2.2, 0.1), Is.True, "below");
+            Assert.That(StarReviewHfrStats.IsOutlier(2.4, 2.2, 0.1), Is.False, "within");
+            Assert.That(StarReviewHfrStats.IsOutlier(5.0, 2.2, 0.0), Is.False, "zero deviation -> nothing is an outlier");
+            Assert.That(StarReviewHfrStats.IsOutlier(5.0, double.NaN, double.NaN), Is.False, "undefined stats");
+        });
+    }
+
+    [Test]
+    public void HfrStats_FormatStats_MatchesModeAndDegenerateCases() {
+        Assert.Multiple(() => {
+            Assert.That(StarReviewHfrStats.FormatStats(2.2, 0.15, 5, MeasurementAverageEnum.Median),
+                Is.EqualTo("Median HFR: 2.20 ± 0.15  (n=5)"));
+            Assert.That(StarReviewHfrStats.FormatStats(2.2, 0.15, 5, MeasurementAverageEnum.MeanOutliers),
+                Is.EqualTo("Mean HFR: 2.20 ± 0.15  (n=5)"));
+            // Single star: no spread term.
+            Assert.That(StarReviewHfrStats.FormatStats(3.3, double.NaN, 1, MeasurementAverageEnum.Median),
+                Is.EqualTo("Median HFR: 3.30  (n=1)"));
+            // No stars: empty (overlay hides).
+            Assert.That(StarReviewHfrStats.FormatStats(double.NaN, double.NaN, 0, MeasurementAverageEnum.Median),
+                Is.EqualTo(string.Empty));
+        });
+    }
+
+    [Test]
+    public void AcceptedOverlay_OutlierHfrRecolored_AndCornerStatsPopulated_MedianMode() {
+        // Four tight stars + one grossly bloated one. In robust (Median) mode the bloated star trips the ±3·MAD
+        // band and is recolored; the rest keep the normal brush. The corner caption reads the Median label.
+        var stars = new List<(double, double, double, Rect)> {
+            (10, 10, 2.00, new Rect(10, 10, 8, 8)),
+            (30, 10, 2.05, new Rect(30, 10, 8, 8)),
+            (50, 10, 2.10, new Rect(50, 10, 8, 8)),
+            (70, 10, 2.15, new Rect(70, 10, 8, 8)),
+            (90, 10, 9.00, new Rect(90, 10, 30, 30)), // the outlier
+        };
+        var review = new FrameReview { RunId = "run1", FocuserPosition = 5000, FramePath = "f.fits", ImageProvider = null, Accepted = stars };
+        var labelsByRun = new Dictionary<string, StarReviewRunLabels> { { "run1", new StarReviewRunLabels { RunId = "run1" } } };
+
+        var vm = new StarReviewVM(new[] { review }, labelsByRun, string.Empty); // default = Median
+
+        Assert.Multiple(() => {
+            Assert.That(vm.AcceptedMarkers, Has.Count.EqualTo(5));
+            for (var i = 0; i < 4; i++) {
+                Assert.That(vm.AcceptedMarkers[i].HfrBrush, Is.SameAs(vm.HfrNormalBrush), $"star {i} should be normal");
+            }
+            Assert.That(vm.AcceptedMarkers[4].HfrBrush, Is.SameAs(vm.HfrOutlierBrush), "bloated star should be the outlier");
+            Assert.That(vm.FrameStatsText, Does.StartWith("Median HFR:"));
+            Assert.That(vm.FrameStatsText, Does.Contain("(n=5)"));
+            Assert.That(vm.ShowFrameStats, Is.True);
+        });
+    }
+
+    [Test]
+    public void CornerStats_MeanModeLabel_AndFollowsShowHfrToggle() {
+        var stars = new List<(double, double, double, Rect)> {
+            (10, 10, 2.0, new Rect(10, 10, 8, 8)),
+            (30, 10, 2.4, new Rect(30, 10, 8, 8)),
+        };
+        var review = new FrameReview { RunId = "run1", FocuserPosition = 5000, FramePath = "f.fits", ImageProvider = null, Accepted = stars };
+        var labelsByRun = new Dictionary<string, StarReviewRunLabels> { { "run1", new StarReviewRunLabels { RunId = "run1" } } };
+
+        var vm = new StarReviewVM(new[] { review }, labelsByRun, string.Empty, MeasurementAverageEnum.MeanOutliers);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.FrameStatsText, Does.StartWith("Mean HFR:"));
+            Assert.That(vm.ShowFrameStats, Is.True, "shown when Show HFR is on (default)");
+        });
+        vm.ShowHfr = false;
+        Assert.That(vm.ShowFrameStats, Is.False, "corner stats follow the Show HFR toggle");
     }
 
     // The reported "box is off" bug: the green ACCEPTED box renders OFFSET from its star. The box Rectangle lives

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
@@ -26,8 +26,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new release build of a plugin
-[assembly: AssemblyVersion("3.0.0.30")]
-[assembly: AssemblyFileVersion("3.0.0.30")]
+[assembly: AssemblyVersion("3.0.0.31")]
+[assembly: AssemblyFileVersion("3.0.0.31")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("Hocus Focus")]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -138,6 +138,7 @@
         <!-- Image + overlays. The Image and all marker layers share one transform (zoom/pan) so markers stay
              pinned to image pixels. Mouse events are handled in code-behind against the viewport. -->
         <Border Grid.Row="0" Grid.Column="0" ClipToBounds="True" Background="Black" BorderBrush="#FF3F4958" BorderThickness="1">
+          <Grid>
             <Canvas x:Name="ViewportCanvas"
                     Background="Transparent"
                     MouseWheel="ViewportCanvas_MouseWheel"
@@ -212,7 +213,7 @@
                                      the box with no overlap. -->
                                 <TextBlock Text="{Binding HfrText}"
                                            HorizontalAlignment="Left" VerticalAlignment="Top"
-                                           FontSize="10" Foreground="White" Background="#B0000000" Padding="2,0"
+                                           FontSize="10" Foreground="{Binding HfrBrush}" Background="#B0000000" Padding="2,0"
                                            IsHitTestVisible="False" RenderTransformOrigin="0,0"
                                            Visibility="{Binding DataContext.ShowHfr, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}">
                                     <TextBlock.RenderTransform>
@@ -378,6 +379,15 @@
                            StrokeThickness="{Binding LabelStrokeThickness}"
                            IsHitTestVisible="False" />
             </Canvas>
+
+            <!-- Corner HFR-stats HUD. A sibling of the zoomed canvas (NOT inside its RenderTransform), so it stays a
+                 fixed size pinned to the image's top-left corner regardless of zoom/pan. Follows the Show HFR toggle. -->
+            <Border HorizontalAlignment="Left" VerticalAlignment="Top" Margin="6"
+                    Background="#B0000000" Padding="6,3" CornerRadius="3" IsHitTestVisible="False"
+                    Visibility="{Binding ShowFrameStats, Converter={StaticResource BoolToVis}}">
+                <TextBlock Text="{Binding FrameStatsText}" Foreground="White" FontSize="12" FontWeight="SemiBold" />
+            </Border>
+          </Grid>
         </Border>
 
             <!-- Scrollbars: driven from code-behind (UpdateScrollBars); the Scroll handlers map value -> viewport offset. -->

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewHfrStats.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewHfrStats.cs
@@ -1,0 +1,84 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
+
+    /// <summary>
+    /// Pure, unit-tested per-frame HFR statistics for the review overlay. The center + deviation choice mirrors how
+    /// <c>HocusFocusStarDetection</c> reduces a frame to <c>AverageHFR</c>/<c>HFRStdDev</c>: in
+    /// <see cref="MeasurementAverageEnum.Median"/> mode the center is the median and the deviation is the scaled MAD
+    /// (the codebase's robust σ estimate, 1.483·MAD, via <see cref="MathUtility.MedianMAD"/>); in
+    /// <see cref="MeasurementAverageEnum.MeanOutliers"/> mode the center is the mean and the deviation is the sample
+    /// standard deviation (sqrt of <see cref="MathUtility.MeanVar"/>). A star is flagged an outlier when its HFR is
+    /// more than <see cref="OutlierDeviations"/> deviations from the center on EITHER side.
+    /// </summary>
+    public static class StarReviewHfrStats {
+
+        /// <summary>How many deviations from the frame center an HFR must be (either side) to be flagged an outlier.</summary>
+        public const double OutlierDeviations = 3.0;
+
+        /// <summary>
+        /// Computes the frame's HFR center and deviation over the valid (HFR &gt; 0) values, per the averaging mode.
+        /// Returns (NaN, NaN) when no valid value exists, and (value, NaN) for a single value (no spread is defined).
+        /// </summary>
+        public static (double Center, double Deviation) Compute(IEnumerable<double> hfrs, MeasurementAverageEnum mode) {
+            var valid = (hfrs ?? Enumerable.Empty<double>()).Where(h => !double.IsNaN(h) && h > 0.0).ToList();
+            if (valid.Count == 0) {
+                return (double.NaN, double.NaN);
+            }
+            if (valid.Count == 1) {
+                return (valid[0], double.NaN);
+            }
+            if (mode == MeasurementAverageEnum.MeanOutliers) {
+                var (mean, variance) = valid.MeanVar();
+                return (mean, Math.Sqrt(variance));
+            }
+            // Median mode: MedianMAD already scales the MAD by 1.483 into a robust σ estimate.
+            var (median, mad) = valid.MedianMAD();
+            return (median, mad);
+        }
+
+        /// <summary>True when <paramref name="hfr"/> lies more than <see cref="OutlierDeviations"/> deviations from the
+        /// center on either side. False when the stats are undefined (NaN) or the deviation is non-positive (e.g. an
+        /// all-identical frame, where nothing is an outlier).</summary>
+        public static bool IsOutlier(double hfr, double center, double deviation) {
+            if (double.IsNaN(hfr) || double.IsNaN(center) || double.IsNaN(deviation) || deviation <= 0.0) {
+                return false;
+            }
+            return Math.Abs(hfr - center) > OutlierDeviations * deviation;
+        }
+
+        /// <summary>
+        /// Formats the corner overlay caption, e.g. "Median HFR: 2.34 ± 0.12  (n=42)" or "Mean HFR: 2.34 ± 0.12
+        /// (n=42)". The "± deviation" term is omitted when the deviation is undefined (a single star), and an empty
+        /// string is returned when there are no valid stars (the overlay hides itself).
+        /// </summary>
+        public static string FormatStats(double center, double deviation, int starCount, MeasurementAverageEnum mode) {
+            if (starCount <= 0 || double.IsNaN(center)) {
+                return string.Empty;
+            }
+            var label = mode == MeasurementAverageEnum.MeanOutliers ? "Mean HFR" : "Median HFR";
+            var c = center.ToString("F2", CultureInfo.InvariantCulture);
+            var dev = double.IsNaN(deviation)
+                ? string.Empty
+                : " ± " + deviation.ToString("F2", CultureInfo.InvariantCulture);
+            return $"{label}: {c}{dev}  (n={starCount})";
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
@@ -11,6 +11,7 @@
 #endregion "copyright"
 
 using NINA.Core.Utility;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -62,6 +63,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
         /// <summary>Preformatted HFR for the optional on-overlay HFR label ("2.34", or "—" when unavailable).</summary>
         public string HfrText { get; set; }
+
+        /// <summary>Foreground brush for the HFR label — normally white, recolored when this star's HFR is an outlier
+        /// for the frame (more than <see cref="StarReviewHfrStats.OutlierDeviations"/> deviations from the center).</summary>
+        public Brush HfrBrush { get; set; }
     }
 
     /// <summary>The detector's measured star position (the flux-weighted <c>Center</c>) for an accepted star, in
@@ -132,6 +137,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         private readonly Dictionary<string, StarReviewRunLabels> labelsByRun;
         private readonly string labelsDir;
 
+        // The profile's "Measurement Averaging" choice — drives whether the corner stats + per-star outlier test use
+        // median + scaled MAD (Median) or mean + std-dev (MeanOutliers), matching the detector's HFR aggregation.
+        private readonly MeasurementAverageEnum measurementAverage;
+
         // Per-reason overlay colors, matching T6's annotated-PNG legend (RGB here; BGR there).
         private static readonly Dictionary<string, Color> ReasonColors = new(StringComparer.Ordinal) {
             { "TooDistorted",   Color.FromRgb(255, 255, 0) },   // yellow
@@ -173,6 +182,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         /// <summary>User "wrongly-rejected / keep" label stroke (bright green, dashed).</summary>
         public Brush WronglyRejectedBrush { get; } = FrozenBrush(WronglyRejectedColor);
 
+        /// <summary>Normal (non-outlier) HFR label color — white, matching the rest of the overlay text.</summary>
+        public Brush HfrNormalBrush { get; } = FrozenBrush(Colors.White);
+
+        /// <summary>Outlier HFR label color — bright red, to pull the eye to a star whose HFR is far from the frame's
+        /// center (bloated or suspiciously tiny). Distinct from the green/orange/cyan box strokes.</summary>
+        public Brush HfrOutlierBrush { get; } = FrozenBrush(Color.FromRgb(0xFF, 0x40, 0x40));
+
         private static SolidColorBrush FrozenBrush(Color c) {
             var b = new SolidColorBrush(c);
             b.Freeze();
@@ -182,10 +198,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         public StarReviewVM(
             IReadOnlyList<FrameReview> queue,
             Dictionary<string, StarReviewRunLabels> labelsByRun,
-            string labelsDir) {
+            string labelsDir,
+            MeasurementAverageEnum measurementAverage = MeasurementAverageEnum.Median) {
             this.queue = queue ?? throw new ArgumentNullException(nameof(queue));
             this.labelsByRun = labelsByRun ?? throw new ArgumentNullException(nameof(labelsByRun));
             this.labelsDir = labelsDir ?? throw new ArgumentNullException(nameof(labelsDir));
+            this.measurementAverage = measurementAverage;
 
             Viewport = new StarReviewViewport();
             LegendEntries = BuildLegend();
@@ -276,8 +294,22 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         /// HFR on the overlay. Bound to a checkbox in the toolbar.</summary>
         public bool ShowHfr {
             get => showHfr;
-            set { if (showHfr != value) { showHfr = value; RaisePropertyChanged(); } }
+            set { if (showHfr != value) { showHfr = value; RaisePropertyChanged(); RaisePropertyChanged(nameof(ShowFrameStats)); } }
         }
+
+        private string frameStatsText = string.Empty;
+
+        /// <summary>The corner-overlay caption summarizing the current frame's accepted-star HFRs — e.g.
+        /// "Median HFR: 2.34 ± 0.12  (n=42)" (Median mode) or "Mean HFR: …" (MeanOutliers mode). Empty when the frame
+        /// has no measured stars. Recomputed per frame in <see cref="LoadCurrent"/>.</summary>
+        public string FrameStatsText {
+            get => frameStatsText;
+            private set { if (frameStatsText != value) { frameStatsText = value; RaisePropertyChanged(); RaisePropertyChanged(nameof(ShowFrameStats)); } }
+        }
+
+        /// <summary>Whether the corner HFR-stats overlay is shown: it follows the "Show HFR" toggle and hides when the
+        /// frame has no stats text.</summary>
+        public bool ShowFrameStats => ShowHfr && !string.IsNullOrEmpty(FrameStatsText);
 
         /// <summary>Raises the zoom-dependent marker-thickness/text bindings. The view calls this after any viewport
         /// change (wheel-zoom, fit, pan) so the stroke widths + HFR text size track the current scale.</summary>
@@ -403,10 +435,16 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
             // Overlays in image coords — accepted stars draw the detector's REAL bounding box (top-left + size).
             // The measured-Center crosshair is a dev-only overlay, hidden by default (see ShowCentroidMarkers).
+            // Per-frame HFR center + deviation (over the accepted stars), per the profile's averaging mode. Drives the
+            // corner stats overlay and recolors each star's HFR label when it is an outlier for this frame.
+            var (hfrCenter, hfrDeviation) = StarReviewHfrStats.Compute(f.Accepted.Select(a => a.HFR), measurementAverage);
+            FrameStatsText = StarReviewHfrStats.FormatStats(hfrCenter, hfrDeviation, f.Accepted.Count, measurementAverage);
+
             AcceptedMarkers.Clear();
             CentroidMarkers.Clear();
             foreach (var (cx, cy, hfr, b) in f.Accepted) {
-                AcceptedMarkers.Add(new AcceptedMarker { X = b.X, Y = b.Y, Width = b.Width, Height = b.Height, HFR = hfr, HfrText = FormatHfr(hfr) });
+                var hfrBrush = StarReviewHfrStats.IsOutlier(hfr, hfrCenter, hfrDeviation) ? HfrOutlierBrush : HfrNormalBrush;
+                AcceptedMarkers.Add(new AcceptedMarker { X = b.X, Y = b.Y, Width = b.Width, Height = b.Height, HFR = hfr, HfrText = FormatHfr(hfr), HfrBrush = hfrBrush });
                 if (ShowCentroidMarkers) {
                     CentroidMarkers.Add(new CentroidMarker { X = cx, Y = cy });
                 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -1603,7 +1603,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 if (ReviewVM != null) {
                     ReviewVM.PropertyChanged -= OnReviewLabelsChanged;
                 }
-                ReviewVM = new StarReviewVM(reviews, labelsByRun, labelsDir ?? string.Empty);
+                ReviewVM = new StarReviewVM(reviews, labelsByRun, labelsDir ?? string.Empty, starDetectionOptions.MeasurementAverage);
                 // Surface label edits live: the "Optimize with feedback" button enables as soon as the user labels
                 // anything (the StarReviewVM raises CountsLabel on every add/remove).
                 ReviewVM.PropertyChanged += OnReviewLabelsChanged;

--- a/Joko.NINA.Plugins/TestApp/StarReview/StarReviewRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/StarReview/StarReviewRunner.cs
@@ -198,7 +198,7 @@ namespace TestApp.StarReview {
             var reviewFrames = queue.Select(q => detections[(q.RunId, q.FocuserPosition)]).ToList();
 
             Console.WriteLine("Opening review window. Mark Missed (false negatives) and Should-Reject (false positives), then Save.");
-            ShowReviewWindowSta(reviewFrames, labelsByRun, labelsDir);
+            ShowReviewWindowSta(reviewFrames, labelsByRun, labelsDir, starDetectionOptions.MeasurementAverage);
 
             Console.WriteLine($"Labels written to {labelsDir}");
             Console.WriteLine($"Next: TestApp optimize --runs \"{runsDir}\" --labels \"{labelsDir}\"");
@@ -222,7 +222,8 @@ namespace TestApp.StarReview {
         private static void ShowReviewWindowSta(
             List<FrameReview> reviewFrames,
             Dictionary<string, StarReviewRunLabels> labelsByRun,
-            string labelsDir) {
+            string labelsDir,
+            MeasurementAverageEnum measurementAverage) {
             Exception uiError = null;
             var thread = new Thread(() => {
                 try {
@@ -233,7 +234,7 @@ namespace TestApp.StarReview {
                     SynchronizationContext.SetSynchronizationContext(
                         new DispatcherSynchronizationContext(Dispatcher.CurrentDispatcher));
 
-                    var vm = new StarReviewVM(reviewFrames, labelsByRun, labelsDir);
+                    var vm = new StarReviewVM(reviewFrames, labelsByRun, labelsDir, measurementAverage);
                     var window = new StarReviewWindow();
                     window.DataContext = vm;
                     // Save-on-close: the plugin VM no longer takes a Window, so the host wires the flush. (The VM


### PR DESCRIPTION
## Summary

The Star Detection Optimization Wizard's **Review** step (and the TestApp `review` dev tool) now shows a small **corner overlay** with the frame's average HFR ± deviation, and **recolors** a per-star HFR label (white → bright red) when that star is an HFR outlier for the frame. This gives the labeler a quick read on the frame's central HFR/spread and pulls the eye to anomalous (bloated or suspiciously tiny) stars.

## Behavior

- **Average/deviation follow the profile's "Measurement Averaging" setting** (`IStarDetectionOptions.MeasurementAverage`):
  - `Median` → **median + scaled MAD** (the codebase's robust σ estimate, `1.483·MAD`)
  - `MeanOutliers` → **mean + sample standard deviation**

  This mirrors how `HocusFocusStarDetection` already reduces a frame to `AverageHFR`/`HFRStdDev`.
- **Outlier rule:** `|hfr − center| > 3 · deviation`, flagged on **both** sides.
- **Visibility:** corner stats and outlier coloring follow the existing **Show HFR** checkbox (default on).
- Stats are computed over the frame's accepted stars (HFR > 0). Corner reads e.g. `Median HFR: 2.34 ± 0.12  (n=42)` (or `Mean HFR: …`).

## Changes

- **`StarReviewHfrStats.cs`** (new) — pure, unit-tested helper (`Compute` / `IsOutlier` / `FormatStats`), reusing `MathUtility.MedianMAD`/`MeanVar`.
- **`StarReviewVM.cs`** — optional `measurementAverage` ctor param; `HfrNormalBrush`/`HfrOutlierBrush`; `AcceptedMarker.HfrBrush`; `FrameStatsText` + `ShowFrameStats`; per-frame compute in `LoadCurrent`.
- **`StarReviewControl.xaml`** — corner HUD pinned top-left **outside** the zoom transform (fixed size); accepted HFR text `Foreground` bound to `HfrBrush`.
- **Call sites** — wizard VM and TestApp runner pass the averaging mode; the 3-arg ctor defaults to Median.
- **Tests** — 7 new tests (helper math, both modes, edge cases, outlier recoloring, mode label, Show-HFR gating).
- Assembly version bump `3.0.0.30` → `3.0.0.31`.

## Verification

- `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug` — **1310 passed, 0 failed**.
- TestApp builds clean.
- Live eyeball check via `TestApp.exe review --runs "<focus-run folder>"` (Windows/NINA) still recommended: confirm the corner caption, red outlier labels, the Show-HFR toggle hiding both, and the Mean-mode label after switching the profile's averaging setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bKikA1geXC6gNtnCm3wnL