### PR TITLE
Precise per-screw turn/step amounts for tilt + backfocus

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/TiltAdapterGuidanceVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/TiltAdapterGuidanceVMTests.cs
@@ -1,0 +1,40 @@
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus;
+
+[TestFixture]
+public class TiltAdapterGuidanceVMTests {
+
+    [Test]
+    public void FormatMagnitude_Screws_ShowsTwoDecimalTurns() {
+        Assert.Multiple(() => {
+            Assert.That(TiltAdapterGuidanceVM.FormatMagnitude(0.75, steps: false), Is.EqualTo("0.75 turns"));
+            Assert.That(TiltAdapterGuidanceVM.FormatMagnitude(-0.301, steps: false), Is.EqualTo("0.30 turns"));
+            Assert.That(TiltAdapterGuidanceVM.FormatMagnitude(0.0, steps: false), Is.EqualTo("—"));
+        });
+    }
+
+    [Test]
+    public void FormatMagnitude_Steppers_RoundsToWholeSteps() {
+        Assert.Multiple(() => {
+            Assert.That(TiltAdapterGuidanceVM.FormatMagnitude(119.6, steps: true), Is.EqualTo("120 steps"));
+            Assert.That(TiltAdapterGuidanceVM.FormatMagnitude(-120.4, steps: true), Is.EqualTo("120 steps"));
+            Assert.That(TiltAdapterGuidanceVM.FormatMagnitude(0.4, steps: true), Is.EqualTo("—"));
+        });
+    }
+
+    [Test]
+    public void FormatTotal_AddsInOutDirection() {
+        Assert.Multiple(() => {
+            Assert.That(TiltAdapterGuidanceVM.FormatTotal(0.95, steps: false, hasDirection: true), Is.EqualTo("0.95 turns IN"));
+            Assert.That(TiltAdapterGuidanceVM.FormatTotal(-0.30, steps: false, hasDirection: true), Is.EqualTo("0.30 turns OUT"));
+            Assert.That(TiltAdapterGuidanceVM.FormatTotal(119.6, steps: true, hasDirection: true), Is.EqualTo("120 steps IN"));
+        });
+    }
+
+    [Test]
+    public void FormatTotal_NoDirection_ShowsMagnitudeOnly() {
+        Assert.That(TiltAdapterGuidanceVM.FormatTotal(0.95, steps: false, hasDirection: false), Is.EqualTo("0.95 turns"));
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterDevicePresetTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterDevicePresetTests.cs
@@ -1,0 +1,36 @@
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard;
+
+[TestFixture]
+public class TiltAdapterDevicePresetTests {
+
+    [Test]
+    public void Manual_IsTheDefaultSentinel() {
+        Assert.Multiple(() => {
+            Assert.That(TiltAdapterDevicePreset.Manual.IsManual, Is.True);
+            Assert.That(TiltAdapterDevicePreset.Manual.Name, Is.EqualTo("Manual"));
+            Assert.That(TiltAdapterDevicePreset.All[0], Is.SameAs(TiltAdapterDevicePreset.Manual));
+        });
+    }
+
+    [Test]
+    public void NeumannCtuXt48_HasDocumentedValues() {
+        var preset = TiltAdapterDevicePreset.ByName("Neumann CTU XT48");
+        Assert.Multiple(() => {
+            Assert.That(preset.IsManual, Is.False);
+            Assert.That(preset.ScrewCount, Is.EqualTo(3));
+            Assert.That(preset.AdjustmentType, Is.EqualTo(TiltAdjustmentType.Screws));
+            Assert.That(preset.ThreadPitchMicrons, Is.EqualTo(400));
+            Assert.That(preset.ScrewRadiusMillimeters, Is.EqualTo(44));
+        });
+    }
+
+    [Test]
+    public void ByName_UnknownFallsBackToManual() {
+        Assert.That(TiltAdapterDevicePreset.ByName("does-not-exist"), Is.SameAs(TiltAdapterDevicePreset.Manual));
+        Assert.That(TiltAdapterDevicePreset.ByName(null), Is.SameAs(TiltAdapterDevicePreset.Manual));
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs
@@ -36,6 +36,7 @@ public class TiltAdapterOptionsTests {
             Assert.That(options.ThreadPitchMicrons, Is.EqualTo(-1.0));
             Assert.That(options.StepperStepSizeMicrons, Is.EqualTo(-1.0));
             Assert.That(options.ScrewRadiusMillimeters, Is.EqualTo(-1.0));
+            Assert.That(options.DeviceName, Is.EqualTo("Manual"));
         });
     }
 
@@ -55,6 +56,7 @@ public class TiltAdapterOptionsTests {
         options.ThreadPitchMicrons = 500.0;
         options.StepperStepSizeMicrons = 1.25;
         options.ScrewRadiusMillimeters = 21.0;
+        options.DeviceName = "Neumann CTU XT48";
 
         Assert.Multiple(() => {
             Assert.That(store.Snapshot[nameof(options.ScrewCount)], Is.EqualTo(4));
@@ -70,6 +72,7 @@ public class TiltAdapterOptionsTests {
             Assert.That(store.Snapshot[nameof(options.ThreadPitchMicrons)], Is.EqualTo(500.0));
             Assert.That(store.Snapshot[nameof(options.StepperStepSizeMicrons)], Is.EqualTo(1.25));
             Assert.That(store.Snapshot[nameof(options.ScrewRadiusMillimeters)], Is.EqualTo(21.0));
+            Assert.That(store.Snapshot[nameof(options.DeviceName)], Is.EqualTo("Neumann CTU XT48"));
         });
     }
 
@@ -94,6 +97,7 @@ public class TiltAdapterOptionsTests {
     [TestCase(nameof(TiltAdapterOptions.ThreadPitchMicrons), 500.0)]
     [TestCase(nameof(TiltAdapterOptions.StepperStepSizeMicrons), 1.25)]
     [TestCase(nameof(TiltAdapterOptions.ScrewRadiusMillimeters), 21.0)]
+    [TestCase(nameof(TiltAdapterOptions.DeviceName), "Neumann CTU XT48")]
     public void Setter_RaisesPropertyChanged(string propertyName, object newValue) {
         var (options, _, _) = Build();
         var raised = new List<string>();

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
 using NINA.Profile.Interfaces;
@@ -31,6 +32,10 @@ public class TiltAdapterOptionsTests {
             Assert.That(options.CalibratedScrewCount, Is.EqualTo(0));
             Assert.That(options.MeasurementAverageCount, Is.EqualTo(1));
             Assert.That(options.ScrewInwardCurvatureSign, Is.EqualTo(0));
+            Assert.That(options.AdjustmentType, Is.EqualTo(TiltAdjustmentType.Screws));
+            Assert.That(options.ThreadPitchMicrons, Is.EqualTo(-1.0));
+            Assert.That(options.StepperStepSizeMicrons, Is.EqualTo(-1.0));
+            Assert.That(options.ScrewRadiusMillimeters, Is.EqualTo(-1.0));
         });
     }
 
@@ -46,6 +51,10 @@ public class TiltAdapterOptionsTests {
         options.CalibratedScrewCount = 4;
         options.MeasurementAverageCount = 5;
         options.ScrewInwardCurvatureSign = -1;
+        options.AdjustmentType = TiltAdjustmentType.StepperMotors;
+        options.ThreadPitchMicrons = 500.0;
+        options.StepperStepSizeMicrons = 1.25;
+        options.ScrewRadiusMillimeters = 21.0;
 
         Assert.Multiple(() => {
             Assert.That(store.Snapshot[nameof(options.ScrewCount)], Is.EqualTo(4));
@@ -57,6 +66,10 @@ public class TiltAdapterOptionsTests {
             Assert.That(store.Snapshot[nameof(options.CalibratedScrewCount)], Is.EqualTo(4));
             Assert.That(store.Snapshot[nameof(options.MeasurementAverageCount)], Is.EqualTo(5));
             Assert.That(store.Snapshot[nameof(options.ScrewInwardCurvatureSign)], Is.EqualTo(-1));
+            Assert.That(store.Snapshot[nameof(options.AdjustmentType)], Is.EqualTo(TiltAdjustmentType.StepperMotors));
+            Assert.That(store.Snapshot[nameof(options.ThreadPitchMicrons)], Is.EqualTo(500.0));
+            Assert.That(store.Snapshot[nameof(options.StepperStepSizeMicrons)], Is.EqualTo(1.25));
+            Assert.That(store.Snapshot[nameof(options.ScrewRadiusMillimeters)], Is.EqualTo(21.0));
         });
     }
 
@@ -77,6 +90,10 @@ public class TiltAdapterOptionsTests {
     [TestCase(nameof(TiltAdapterOptions.CalibratedScrewCount), 3)]
     [TestCase(nameof(TiltAdapterOptions.MeasurementAverageCount), 7)]
     [TestCase(nameof(TiltAdapterOptions.ScrewInwardCurvatureSign), 1)]
+    [TestCase(nameof(TiltAdapterOptions.AdjustmentType), TiltAdjustmentType.StepperMotors)]
+    [TestCase(nameof(TiltAdapterOptions.ThreadPitchMicrons), 500.0)]
+    [TestCase(nameof(TiltAdapterOptions.StepperStepSizeMicrons), 1.25)]
+    [TestCase(nameof(TiltAdapterOptions.ScrewRadiusMillimeters), 21.0)]
     public void Setter_RaisesPropertyChanged(string propertyName, object newValue) {
         var (options, _, _) = Build();
         var raised = new List<string>();

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -193,5 +193,36 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             Assert.That(vm.HasMeasurementFeedback, Is.False);
             Assert.That(vm.HasMeasurementResults, Is.False);
         }
+
+        [Test]
+        public void SelectedDevice_Preset_SetsAndLocksHardwareFields() {
+            var (vm, options, _, _) = Build();
+
+            vm.SelectedDevice = "Neumann CTU XT48";
+
+            Assert.Multiple(() => {
+                options.Received().DeviceName = "Neumann CTU XT48";
+                options.Received().ScrewCount = 3;
+                options.Received().AdjustmentType = TiltAdjustmentType.Screws;
+                options.Received().ThreadPitchMicrons = 400;
+                options.Received().ScrewRadiusMillimeters = 44;
+                Assert.That(vm.IsManualDevice, Is.False);
+            });
+        }
+
+        [Test]
+        public void SelectedDevice_Manual_LeavesFieldsEditableAndDoesNotWriteHardware() {
+            var (vm, options, _, _) = Build();
+            options.ClearReceivedCalls();
+
+            vm.SelectedDevice = "Manual";
+
+            Assert.Multiple(() => {
+                Assert.That(vm.IsManualDevice, Is.True);
+                options.DidNotReceive().ScrewCount = Arg.Any<int>();
+                options.DidNotReceive().ThreadPitchMicrons = Arg.Any<double>();
+                options.DidNotReceive().ScrewRadiusMillimeters = Arg.Any<double>();
+            });
+        }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltScrewGeometryTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltScrewGeometryTests.cs
@@ -1,0 +1,181 @@
+using System;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard;
+
+[TestFixture]
+public class TiltScrewGeometryTests {
+
+    private const double R = 21000.0; // 21 mm in microns
+
+    private static (double x, double y) Pos(double angleDeg, double r) => TiltScrewGeometry.ScrewPositionMicrons(angleDeg, r);
+
+    // Forward least-squares plane gradient produced by per-screw axial moves d_i.
+    // G = (2 / (n·R²)) · Σ d_i·p_i  (exact for n>=3 equally-spaced screws on a circle).
+    private static (double gx, double gy) ForwardGradient(double[] angles, double[] moves, double r) {
+        double sx = 0, sy = 0;
+        for (int i = 0; i < angles.Length; i++) {
+            var (x, y) = Pos(angles[i], r);
+            sx += moves[i] * x;
+            sy += moves[i] * y;
+        }
+        double scale = 2.0 / (angles.Length * r * r);
+        return (scale * sx, scale * sy);
+    }
+
+    [Test]
+    public void ScrewPositionMicrons_MatchesClockFaceConvention() {
+        Assert.Multiple(() => {
+            // 0° = up = -y; 90° = right = +x; 180° = down = +y; 270° = left = -x
+            Assert.That(Pos(0, R).x, Is.EqualTo(0).Within(1e-6));
+            Assert.That(Pos(0, R).y, Is.EqualTo(-R).Within(1e-6));
+            Assert.That(Pos(90, R).x, Is.EqualTo(R).Within(1e-6));
+            Assert.That(Pos(90, R).y, Is.EqualTo(0).Within(1e-6));
+            Assert.That(Pos(180, R).y, Is.EqualTo(R).Within(1e-6));
+            Assert.That(Pos(270, R).x, Is.EqualTo(-R).Within(1e-6));
+        });
+    }
+
+    [TestCase(3)]
+    [TestCase(4)]
+    public void SingleScrewMove_RoundTripsThroughGradient(int n) {
+        // Move only screw 1 by a known axial amount; the recovered move must match.
+        double delta = 137.0; // microns
+        double step = 360.0 / n;
+        var angles = new double[n];
+        var moves = new double[n];
+        for (int i = 0; i < n; i++) {
+            angles[i] = 15.0 + i * step; // generic offset, still equally spaced
+        }
+        moves[0] = delta;
+        var (gx, gy) = ForwardGradient(angles, moves, R);
+        var recovered = TiltScrewGeometry.SingleScrewAxialMoveMicrons(gx, gy, n, R);
+        Assert.That(recovered, Is.EqualTo(delta).Within(1e-6));
+    }
+
+    [TestCase(3)]
+    [TestCase(4)]
+    public void TiltCorrection_CancelsTheGradient(int n) {
+        // Given a tilt gradient, applying the per-screw corrections must reproduce -G
+        // (i.e. it flattens the tilt) under the same forward plane model.
+        double gx = 0.0012, gy = -0.0008;
+        double step = 360.0 / n;
+        var angles = new double[n];
+        var corrections = new double[n];
+        for (int i = 0; i < n; i++) {
+            angles[i] = 15.0 + i * step;
+            corrections[i] = TiltScrewGeometry.TiltCorrectionMicrons(gx, gy, angles[i], R);
+        }
+        var (gxPrime, gyPrime) = ForwardGradient(angles, corrections, R);
+        Assert.Multiple(() => {
+            Assert.That(gxPrime, Is.EqualTo(-gx).Within(1e-9));
+            Assert.That(gyPrime, Is.EqualTo(-gy).Within(1e-9));
+        });
+    }
+
+    [TestCase(0.0)]
+    [TestCase(37.0)]
+    [TestCase(120.0)]
+    [TestCase(255.0)]
+    public void TiltCorrection_SignAgreesWithLegacyArrowProjection(double angleDeg) {
+        // Legacy arrow uses (-a·sinθ + b·cosθ) with a∝gx, b∝gy (positive scale factors).
+        // The physical correction must share its sign so numbers and arrows agree.
+        double gx = 0.0009, gy = -0.0011;
+        double theta = angleDeg * Math.PI / 180.0;
+        double legacyProjection = -gx * Math.Sin(theta) + gy * Math.Cos(theta);
+        double correction = TiltScrewGeometry.TiltCorrectionMicrons(gx, gy, angleDeg, R);
+        Assert.That(Math.Sign(correction), Is.EqualTo(Math.Sign(legacyProjection)));
+    }
+
+    [Test]
+    public void Calibration_ThreeScrew_RecoversSingleScrewMove() {
+        double delta = 211.0; // microns the user moved screw 1 by
+        var angles = new[] { 15.0, 135.0, 255.0 };
+        var moves = new[] { delta, 0.0, 0.0 };
+        var (gx, gy) = ForwardGradient(angles, moves, R);
+        var recovered = TiltScrewGeometry.CalibrationAxialMoveMicrons(gx, gy, screwCount: 3, radiusMicrons: R);
+        Assert.That(recovered, Is.EqualTo(delta).Within(1e-6));
+    }
+
+    [Test]
+    public void Calibration_FourScrew_RecoversPushPullMove() {
+        double delta = 180.0; // screw 1 in / screw 3 out by this amount each
+        var angles = new[] { 15.0, 105.0, 195.0, 285.0 }; // screw 3 (index 2) is opposite screw 1
+        var moves = new[] { delta, 0.0, -delta, 0.0 };
+        var (gx, gy) = ForwardGradient(angles, moves, R);
+        var recovered = TiltScrewGeometry.CalibrationAxialMoveMicrons(gx, gy, screwCount: 4, radiusMicrons: R);
+        Assert.That(recovered, Is.EqualTo(delta).Within(1e-6));
+    }
+
+    [Test]
+    public void Backfocus_IsLinearInCurvature_NoSquareRoot() {
+        // Doubling the curvature coefficient must double the backfocus correction (it is a length,
+        // not a square-rooted quantity).
+        var a = TiltScrewGeometry.ScrewCorrectionMicrons(gx: 0, gy: 0, kx: 5e-7, ky: 5e-7, x0: 0, y0: 0, angleDegrees: 40, radiusMicrons: R);
+        var b = TiltScrewGeometry.ScrewCorrectionMicrons(gx: 0, gy: 0, kx: 1e-6, ky: 1e-6, x0: 0, y0: 0, angleDegrees: 40, radiusMicrons: R);
+        Assert.That(b.BackfocusMicrons, Is.EqualTo(2.0 * a.BackfocusMicrons).Within(1e-9));
+    }
+
+    [Test]
+    public void Backfocus_IsotropicCurvature_EqualAcrossScrews() {
+        // Kx == Ky and centered model => same radius => identical backfocus per screw.
+        double k = 8e-7;
+        var s1 = TiltScrewGeometry.ScrewCorrectionMicrons(0, 0, k, k, 0, 0, 0, R);
+        var s2 = TiltScrewGeometry.ScrewCorrectionMicrons(0, 0, k, k, 0, 0, 120, R);
+        var s3 = TiltScrewGeometry.ScrewCorrectionMicrons(0, 0, k, k, 0, 0, 240, R);
+        Assert.Multiple(() => {
+            Assert.That(s2.BackfocusMicrons, Is.EqualTo(s1.BackfocusMicrons).Within(1e-6));
+            Assert.That(s3.BackfocusMicrons, Is.EqualTo(s1.BackfocusMicrons).Within(1e-6));
+            Assert.That(s1.BackfocusMicrons, Is.EqualTo(-k * R * R).Within(1e-6));
+        });
+    }
+
+    [Test]
+    public void Backfocus_AstigmaticCurvature_VariesByAngle() {
+        var up = TiltScrewGeometry.ScrewCorrectionMicrons(0, 0, kx: 1e-6, ky: 5e-7, x0: 0, y0: 0, angleDegrees: 0, radiusMicrons: R);   // on -y axis
+        var right = TiltScrewGeometry.ScrewCorrectionMicrons(0, 0, kx: 1e-6, ky: 5e-7, x0: 0, y0: 0, angleDegrees: 90, radiusMicrons: R); // on +x axis
+        // At 0° the point is on the y axis (ky dominates); at 90° on the x axis (kx dominates).
+        Assert.That(Math.Abs(right.BackfocusMicrons), Is.GreaterThan(Math.Abs(up.BackfocusMicrons)));
+    }
+
+    [Test]
+    public void Total_IsSumOfTiltAndBackfocus() {
+        var c = TiltScrewGeometry.ScrewCorrectionMicrons(gx: 0.001, gy: -0.0006, kx: 7e-7, ky: 3e-7, x0: 1000, y0: -500, angleDegrees: 55, radiusMicrons: R);
+        Assert.That(c.TotalMicrons, Is.EqualTo(c.TiltMicrons + c.BackfocusMicrons).Within(1e-12));
+    }
+
+    [TestCase(1)]
+    [TestCase(-1)]
+    public void InwardAdjustment_SignMatchesLegacyBackfocusRule(int curvatureSign) {
+        // Legacy backfocus arrow: needsInward = curvatureEffect * sign < 0, where curvatureEffect is
+        // the curvature deviation (= -correction). So needsInward <=> sign * correction > 0.
+        double curvatureDeviation = 42.0;        // positive deviation
+        double correction = -curvatureDeviation; // correction cancels it
+        double inward = TiltScrewGeometry.InwardAdjustment(correction, unitMicrons: 500.0, curvatureSign: curvatureSign);
+        bool legacyNeedsInward = curvatureDeviation * curvatureSign < 0;
+        Assert.That(inward > 0, Is.EqualTo(legacyNeedsInward));
+    }
+
+    [Test]
+    public void PitchMismatch_TriggersPastThresholdAndSilentWithin() {
+        Assert.Multiple(() => {
+            Assert.That(TiltScrewGeometry.PitchMismatchExceeds(500, 500, 0.15), Is.False);
+            Assert.That(TiltScrewGeometry.PitchMismatchExceeds(560, 500, 0.15), Is.False); // 12% within
+            Assert.That(TiltScrewGeometry.PitchMismatchExceeds(600, 500, 0.15), Is.True);  // 20% exceeds
+            Assert.That(TiltScrewGeometry.PitchMismatchExceeds(-1, 500, 0.15), Is.False);  // unset
+            Assert.That(TiltScrewGeometry.PitchMismatchExceeds(500, -1, 0.15), Is.False);  // none measured
+        });
+    }
+
+    [Test]
+    public void PlaneGradientToPhysical_DividesByPhysicalExtent() {
+        // A = focuser steps per normalized coord; gx = A·stepMicrons / sensorWidthMicrons.
+        var (gx, gy) = TiltScrewGeometry.PlaneGradientToPhysical(
+            a: 4.0, b: -2.0, focuserStepMicrons: 5.0, sensorWidthMicrons: 10000.0, sensorHeightMicrons: 8000.0);
+        Assert.Multiple(() => {
+            Assert.That(gx, Is.EqualTo(4.0 * 5.0 / 10000.0).Within(1e-12));
+            Assert.That(gy, Is.EqualTo(-2.0 * 5.0 / 8000.0).Within(1e-12));
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -2819,6 +2819,62 @@
                                     </TextBlock.Style>
                                 </TextBlock>
                             </Grid>
+
+                            <!--  Precise numeric adjustments (turns / steps) — shown when adapter hardware is configured  -->
+                            <Grid
+                                Margin="5,8,5,0"
+                                Visibility="{Binding TiltGuidance.HasNumericGuidance, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="75" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
+                                <!--  Header  -->
+                                <TextBlock Grid.Row="0" Grid.Column="1" HorizontalAlignment="Center" FontWeight="SemiBold" Text="Screw 1" />
+                                <TextBlock Grid.Row="0" Grid.Column="2" HorizontalAlignment="Center" FontWeight="SemiBold" Text="Screw 2" />
+                                <TextBlock Grid.Row="0" Grid.Column="3" HorizontalAlignment="Center" FontWeight="SemiBold" Text="Screw 3" />
+                                <TextBlock Grid.Row="0" Grid.Column="4" HorizontalAlignment="Center" FontWeight="SemiBold" Text="Screw 4"
+                                    Visibility="{Binding TiltGuidance.HasFourScrews, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                <!--  Tilt amounts  -->
+                                <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Text="Tilt" />
+                                <TextBlock Grid.Row="1" Grid.Column="1" HorizontalAlignment="Center" Text="{Binding TiltGuidance.Screw1TiltAmount}" />
+                                <TextBlock Grid.Row="1" Grid.Column="2" HorizontalAlignment="Center" Text="{Binding TiltGuidance.Screw2TiltAmount}" />
+                                <TextBlock Grid.Row="1" Grid.Column="3" HorizontalAlignment="Center" Text="{Binding TiltGuidance.Screw3TiltAmount}" />
+                                <TextBlock Grid.Row="1" Grid.Column="4" HorizontalAlignment="Center" Text="{Binding TiltGuidance.Screw4TiltAmount}"
+                                    Visibility="{Binding TiltGuidance.HasFourScrews, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                <!--  Backfocus amounts  -->
+                                <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Text="Backfocus" />
+                                <TextBlock Grid.Row="2" Grid.Column="1" HorizontalAlignment="Center" Text="{Binding TiltGuidance.Screw1BackfocusAmount}" />
+                                <TextBlock Grid.Row="2" Grid.Column="2" HorizontalAlignment="Center" Text="{Binding TiltGuidance.Screw2BackfocusAmount}" />
+                                <TextBlock Grid.Row="2" Grid.Column="3" HorizontalAlignment="Center" Text="{Binding TiltGuidance.Screw3BackfocusAmount}" />
+                                <TextBlock Grid.Row="2" Grid.Column="4" HorizontalAlignment="Center" Text="{Binding TiltGuidance.Screw4BackfocusAmount}"
+                                    Visibility="{Binding TiltGuidance.HasFourScrews, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                <!--  Total  -->
+                                <TextBlock Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" FontWeight="SemiBold" Text="Total" />
+                                <TextBlock Grid.Row="3" Grid.Column="1" HorizontalAlignment="Center" FontWeight="SemiBold" Text="{Binding TiltGuidance.Screw1TotalAmount}" />
+                                <TextBlock Grid.Row="3" Grid.Column="2" HorizontalAlignment="Center" FontWeight="SemiBold" Text="{Binding TiltGuidance.Screw2TotalAmount}" />
+                                <TextBlock Grid.Row="3" Grid.Column="3" HorizontalAlignment="Center" FontWeight="SemiBold" Text="{Binding TiltGuidance.Screw3TotalAmount}" />
+                                <TextBlock Grid.Row="3" Grid.Column="4" HorizontalAlignment="Center" FontWeight="SemiBold" Text="{Binding TiltGuidance.Screw4TotalAmount}"
+                                    Visibility="{Binding TiltGuidance.HasFourScrews, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                            </Grid>
+
+                            <!--  Saved-vs-measured pitch mismatch warning  -->
+                            <Border
+                                Margin="5,6,5,0"
+                                Padding="5"
+                                BorderBrush="{StaticResource NotificationWarningBrush}"
+                                BorderThickness="1"
+                                Visibility="{Binding TiltGuidance.HasPitchMismatch, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                                <TextBlock Text="{Binding TiltGuidance.PitchMismatchWarning}" TextWrapping="Wrap" />
+                            </Border>
                         </StackPanel>
                     </StackPanel>
                 </Expander>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -1694,12 +1694,10 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 : tiltAdapterOptions.LastMeasuredThreadPitchMicrons;
             if (TiltScrewGeometry.PitchMismatchExceeds(unitMicrons, measured, PitchMismatchFraction)) {
                 string label = steps ? "step size" : "thread pitch";
-                string units = steps ? "µm/step" : "mm/turn";
-                double activeDisplay = steps ? unitMicrons : unitMicrons / 1000.0;
-                double measuredDisplay = steps ? measured : measured / 1000.0;
+                string units = steps ? "µm/step" : "µm/turn";
                 guidance.PitchMismatchWarning =
-                    $"Saved {label} ({activeDisplay:0.###} {units}) differs from the wizard's last measured value " +
-                    $"({measuredDisplay:0.###} {units}). Re-run the Tilt Adapter Wizard or update the saved value.";
+                    $"Saved {label} ({unitMicrons:0.###} {units}) differs from the wizard's last measured value " +
+                    $"({measured:0.###} {units}). Re-run the Tilt Adapter Wizard or update the saved value.";
             }
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -33,6 +33,7 @@ using NINA.Joko.Plugins.HocusFocus.Inspection;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.Scottplot;
 using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
 using NINA.Joko.Plugins.HocusFocus.Utility;
 using NINA.Profile.Interfaces;
 using NINA.WPF.Base.Interfaces.Mediator;
@@ -1625,8 +1626,81 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 }
             }
 
+            FillNumericGuidance(guidance, n);
+
             TiltGuidance = guidance;
             RaisePropertyChanged(nameof(TiltGuidance));
+        }
+
+        private const double PitchMismatchFraction = 0.15;
+
+        // Populate the precise per-screw turn/step amounts from the fitted paraboloid model and the
+        // configured adapter hardware. Magnitudes are direction-indicated by the existing arrows; the
+        // total carries an explicit IN/OUT word. Everything is computed in axial best-focus microns
+        // (tilt = -TiltAt, backfocus = -CurvatureAt) then divided by the saved pitch/step size — there
+        // is no square root, the curvature term is already a length.
+        private void FillNumericGuidance(TiltAdapterGuidanceVM guidance, int n) {
+            if (!HasTiltAdapterCalibration) return;
+            var model = SensorModel?.DisplayedSensorModel;
+            if (model == null) return;
+
+            bool steps = tiltAdapterOptions.AdjustmentType == TiltAdjustmentType.StepperMotors;
+            double unitMicrons = steps ? tiltAdapterOptions.StepperStepSizeMicrons : tiltAdapterOptions.ThreadPitchMicrons;
+            double radiusMm = tiltAdapterOptions.ScrewRadiusMillimeters;
+            if (unitMicrons <= 0 || radiusMm <= 0) return;
+
+            double radiusMicrons = radiusMm * 1000.0;
+            int curvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign;
+            bool hasDirection = curvatureSign != 0;
+            int signForTotal = hasDirection ? curvatureSign : 1;
+
+            var angles = new double[n];
+            angles[0] = tiltAdapterOptions.Screw1AngleDegrees;
+            angles[1] = tiltAdapterOptions.Screw2AngleDegrees;
+            angles[2] = tiltAdapterOptions.Screw3AngleDegrees;
+            if (n == 4) angles[3] = tiltAdapterOptions.Screw4AngleDegrees;
+            if (angles.Any(double.IsNaN)) return;
+
+            var tiltText = new string[n];
+            var backText = new string[n];
+            var totalText = new string[n];
+            for (int i = 0; i < n; i++) {
+                var corr = TiltScrewGeometry.ScrewCorrectionMicrons(
+                    model.Gx, model.Gy, model.Kx, model.Ky, model.X0, model.Y0, angles[i], radiusMicrons);
+                tiltText[i] = TiltAdapterGuidanceVM.FormatMagnitude(corr.TiltMicrons / unitMicrons, steps);
+                backText[i] = TiltAdapterGuidanceVM.FormatMagnitude(corr.BackfocusMicrons / unitMicrons, steps);
+                double totalInward = TiltScrewGeometry.InwardAdjustment(corr.TotalMicrons, unitMicrons, signForTotal);
+                totalText[i] = TiltAdapterGuidanceVM.FormatTotal(totalInward, steps, hasDirection);
+            }
+
+            guidance.Screw1TiltAmount = tiltText[0];
+            guidance.Screw2TiltAmount = tiltText[1];
+            guidance.Screw3TiltAmount = tiltText[2];
+            if (n == 4) guidance.Screw4TiltAmount = tiltText[3];
+            guidance.Screw1BackfocusAmount = backText[0];
+            guidance.Screw2BackfocusAmount = backText[1];
+            guidance.Screw3BackfocusAmount = backText[2];
+            if (n == 4) guidance.Screw4BackfocusAmount = backText[3];
+            guidance.Screw1TotalAmount = totalText[0];
+            guidance.Screw2TotalAmount = totalText[1];
+            guidance.Screw3TotalAmount = totalText[2];
+            if (n == 4) guidance.Screw4TotalAmount = totalText[3];
+
+            guidance.UnitsAreSteps = steps;
+            guidance.HasNumericGuidance = true;
+
+            double measured = steps
+                ? tiltAdapterOptions.LastMeasuredStepperStepSizeMicrons
+                : tiltAdapterOptions.LastMeasuredThreadPitchMicrons;
+            if (TiltScrewGeometry.PitchMismatchExceeds(unitMicrons, measured, PitchMismatchFraction)) {
+                string label = steps ? "step size" : "thread pitch";
+                string units = steps ? "µm/step" : "mm/turn";
+                double activeDisplay = steps ? unitMicrons : unitMicrons / 1000.0;
+                double measuredDisplay = steps ? measured : measured / 1000.0;
+                guidance.PitchMismatchWarning =
+                    $"Saved {label} ({activeDisplay:0.###} {units}) differs from the wizard's last measured value " +
+                    $"({measuredDisplay:0.###} {units}). Re-run the Tilt Adapter Wizard or update the saved value.";
+            }
         }
 
         private TrendlineFitting GetLineFitting(AutoFocusFitting fitting) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltScrewGuidanceRow.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltScrewGuidanceRow.cs
@@ -10,6 +10,8 @@
 
 #endregion "copyright"
 
+using System;
+
 namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
     public class TiltAdapterGuidanceVM {
@@ -27,5 +29,63 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         public string Screw2BackfocusArrow { get; set; } = "—";
         public string Screw3BackfocusArrow { get; set; } = "—";
         public string Screw4BackfocusArrow { get; set; } = "—";
+
+        // Precise numeric adjustments (turns for screws, whole steps for steppers). Populated only
+        // when the adapter hardware (thread pitch / step size + screw radius) is configured.
+        public bool HasNumericGuidance { get; set; }
+        public bool UnitsAreSteps { get; set; }
+
+        // Per-screw tilt and backfocus magnitudes (direction is shown by the arrows above), and the
+        // signed total with an explicit IN/OUT direction word.
+        public string Screw1TiltAmount { get; set; } = "—";
+        public string Screw2TiltAmount { get; set; } = "—";
+        public string Screw3TiltAmount { get; set; } = "—";
+        public string Screw4TiltAmount { get; set; } = "—";
+
+        public string Screw1BackfocusAmount { get; set; } = "—";
+        public string Screw2BackfocusAmount { get; set; } = "—";
+        public string Screw3BackfocusAmount { get; set; } = "—";
+        public string Screw4BackfocusAmount { get; set; } = "—";
+
+        public string Screw1TotalAmount { get; set; } = "—";
+        public string Screw2TotalAmount { get; set; } = "—";
+        public string Screw3TotalAmount { get; set; } = "—";
+        public string Screw4TotalAmount { get; set; } = "—";
+
+        // Set when the saved pitch/step size diverges from the value the wizard last measured.
+        public string PitchMismatchWarning { get; set; } = string.Empty;
+        public bool HasPitchMismatch => !string.IsNullOrEmpty(PitchMismatchWarning);
+
+        /// <summary>
+        /// Format an unsigned per-screw magnitude. Steppers round to whole steps (the user's choice);
+        /// screws show two decimals of a turn. Values that round to nothing render as an em dash.
+        /// </summary>
+        public static string FormatMagnitude(double amount, bool steps) {
+            double a = Math.Abs(amount);
+            if (steps) {
+                long rounded = (long)Math.Round(a, MidpointRounding.AwayFromZero);
+                return rounded == 0 ? "—" : $"{rounded} steps";
+            }
+            return a < 0.005 ? "—" : $"{a:0.00} turns";
+        }
+
+        /// <summary>
+        /// Format the signed total adjustment with an explicit IN/OUT direction (positive = inward).
+        /// When the inward direction is not calibrated (<paramref name="hasDirection"/> false) only the
+        /// magnitude is shown.
+        /// </summary>
+        public static string FormatTotal(double inwardAmount, bool steps, bool hasDirection) {
+            string magnitude;
+            if (steps) {
+                long rounded = (long)Math.Round(Math.Abs(inwardAmount), MidpointRounding.AwayFromZero);
+                if (rounded == 0) return "—";
+                magnitude = $"{rounded} steps";
+            } else {
+                if (Math.Abs(inwardAmount) < 0.005) return "—";
+                magnitude = $"{Math.Abs(inwardAmount):0.00} turns";
+            }
+            if (!hasDirection) return magnitude;
+            return $"{magnitude} {(inwardAmount >= 0 ? "IN" : "OUT")}";
+        }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltAdapterOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltAdapterOptions.cs
@@ -41,5 +41,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         // value above to warn when they diverge. -1 = none measured yet.
         double LastMeasuredThreadPitchMicrons { get; set; }
         double LastMeasuredStepperStepSizeMicrons { get; set; }
+
+        // Selected device preset name ("Manual" = user-editable hardware fields). Choosing a preset
+        // pre-fills and locks the hardware fields. See TiltAdapterDevicePreset.
+        string DeviceName { get; set; }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltAdapterOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltAdapterOptions.cs
@@ -14,6 +14,11 @@ using System.ComponentModel;
 
 namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
 
+    public enum TiltAdjustmentType {
+        Screws = 0,
+        StepperMotors = 1
+    }
+
     public interface ITiltAdapterOptions : INotifyPropertyChanged {
         int ScrewCount { get; set; }             // 3 or 4
         bool IsCalibrated { get; set; }
@@ -24,5 +29,17 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         int CalibratedScrewCount { get; set; }      // screw count at time of last calibration; 0 = never calibrated
         int MeasurementAverageCount { get; set; }
         int ScrewInwardCurvatureSign { get; set; } // +1 or -1; 0 = not yet calibrated
+
+        // Physical adapter hardware model, used to convert focus deviation into absolute
+        // screw turns (or stepper steps). -1 = unset.
+        TiltAdjustmentType AdjustmentType { get; set; }      // screws vs stepper motors
+        double ThreadPitchMicrons { get; set; }              // axial microns per full screw turn
+        double StepperStepSizeMicrons { get; set; }          // axial microns per stepper step
+        double ScrewRadiusMillimeters { get; set; }          // screw distance from sensor center
+
+        // Last value the wizard measured from a calibration run; compared against the saved
+        // value above to warn when they diverge. -1 = none measured yet.
+        double LastMeasuredThreadPitchMicrons { get; set; }
+        double LastMeasuredStepperStepSizeMicrons { get; set; }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -201,9 +201,19 @@
                         FontWeight="Bold"
                         Text="Settings" />
 
+                    <!--  Device preset: fills and locks the hardware fields below  -->
                     <UniformGrid Margin="0,2" VerticalAlignment="Center" Columns="2">
-                        <TextBlock VerticalAlignment="Center" Text="Screws" />
-                        <ComboBox MinWidth="60" SelectedItem="{Binding TiltAdapterOptions.ScrewCount}">
+                        <TextBlock VerticalAlignment="Center" Text="Device"
+                            ToolTip="Select a known tilt adapter to auto-fill and lock its hardware values, or choose Manual to enter them yourself." />
+                        <ComboBox MinWidth="120" ItemsSource="{Binding DeviceNames}" SelectedItem="{Binding SelectedDevice}" />
+                    </UniformGrid>
+
+                    <!--  Adapter hardware: drives precise screw-turn amounts in the Aberration Inspector.
+                          Disabled when a non-Manual device preset is selected.  -->
+                    <UniformGrid Margin="0,5" VerticalAlignment="Center" Columns="2">
+                        <TextBlock VerticalAlignment="Center" Text="Screws"
+                            ToolTip="Number of adjustment screws on the tilt adapter (3 = independent screws, 4 = coupled opposite pairs)." />
+                        <ComboBox MinWidth="60" IsEnabled="{Binding IsManualDevice}" SelectedItem="{Binding TiltAdapterOptions.ScrewCount}">
                             <ComboBox.ItemsSource>
                                 <x:Array Type="{x:Type s:Int32}">
                                     <s:Int32>3</s:Int32>
@@ -214,16 +224,9 @@
                     </UniformGrid>
 
                     <UniformGrid Margin="0,5" VerticalAlignment="Center" Columns="2">
-                        <TextBlock VerticalAlignment="Center" Text="Measurements" />
-                        <TextBox
-                            MinWidth="60"
-                            Text="{Binding TiltAdapterOptions.MeasurementAverageCount, UpdateSourceTrigger=LostFocus}" />
-                    </UniformGrid>
-
-                    <!--  Adapter hardware: drives precise screw-turn amounts in the Aberration Inspector  -->
-                    <UniformGrid Margin="0,5" VerticalAlignment="Center" Columns="2">
-                        <TextBlock VerticalAlignment="Center" Text="Adjustment type" />
-                        <ComboBox MinWidth="120" SelectedValuePath="Tag" SelectedValue="{Binding AdjustmentType}">
+                        <TextBlock VerticalAlignment="Center" Text="Adjustment type"
+                            ToolTip="Whether the adapter is adjusted by turning screws or by stepper motors. Determines whether amounts are shown as turns or steps." />
+                        <ComboBox MinWidth="120" IsEnabled="{Binding IsManualDevice}" SelectedValuePath="Tag" SelectedValue="{Binding AdjustmentType}">
                             <ComboBoxItem Content="Screws" Tag="{x:Static interfaces:TiltAdjustmentType.Screws}" />
                             <ComboBoxItem Content="Stepper Motors" Tag="{x:Static interfaces:TiltAdjustmentType.StepperMotors}" />
                         </ComboBox>
@@ -241,8 +244,9 @@
                                 </Style.Triggers>
                             </Style>
                         </UniformGrid.Style>
-                        <TextBlock VerticalAlignment="Center" Text="Thread pitch (mm/turn)" />
-                        <TextBox MinWidth="60" Text="{Binding ThreadPitchMillimeters, UpdateSourceTrigger=LostFocus}" />
+                        <TextBlock VerticalAlignment="Center" Text="Thread pitch (µm/turn)"
+                            ToolTip="Axial sensor travel per full screw turn, in microns. Converts the required focus correction into a number of turns." />
+                        <TextBox MinWidth="60" IsEnabled="{Binding IsManualDevice}" Text="{Binding ThreadPitchMicronsValue, UpdateSourceTrigger=LostFocus}" />
                     </UniformGrid>
 
                     <!--  Step size (steppers only)  -->
@@ -257,18 +261,44 @@
                                 </Style.Triggers>
                             </Style>
                         </UniformGrid.Style>
-                        <TextBlock VerticalAlignment="Center" Text="Step size (µm/step)" />
-                        <TextBox MinWidth="60" Text="{Binding StepperStepSizeMicronsValue, UpdateSourceTrigger=LostFocus}" />
+                        <TextBlock VerticalAlignment="Center" Text="Step size (µm/step)"
+                            ToolTip="Axial sensor travel per stepper step, in microns. Converts the required focus correction into a number of steps." />
+                        <TextBox MinWidth="60" IsEnabled="{Binding IsManualDevice}" Text="{Binding StepperStepSizeMicronsValue, UpdateSourceTrigger=LostFocus}" />
                     </UniformGrid>
 
                     <UniformGrid Margin="0,5" VerticalAlignment="Center" Columns="2">
-                        <TextBlock VerticalAlignment="Center" Text="Screw radius (mm)" />
-                        <TextBox MinWidth="60" Text="{Binding ScrewRadiusMillimetersValue, UpdateSourceTrigger=LostFocus}" />
+                        <TextBlock VerticalAlignment="Center" Text="Screw radius (mm)"
+                            ToolTip="Distance from the sensor center to each screw, in millimeters. Sets the lever arm used to convert tilt into screw adjustments." />
+                        <TextBox MinWidth="60" IsEnabled="{Binding IsManualDevice}" Text="{Binding ScrewRadiusMillimetersValue, UpdateSourceTrigger=LostFocus}" />
+                    </UniformGrid>
+
+                    <!--  Editable per-session fields (kept together, always editable)  -->
+                    <UniformGrid Margin="0,5" VerticalAlignment="Center" Columns="2">
+                        <TextBlock VerticalAlignment="Center" Text="Measurements"
+                            ToolTip="Number of autofocus runs to average per calibration step. Higher values reduce noise but take longer." />
+                        <TextBox
+                            MinWidth="60"
+                            Text="{Binding TiltAdapterOptions.MeasurementAverageCount, UpdateSourceTrigger=LostFocus}" />
                     </UniformGrid>
 
                     <UniformGrid Margin="0,5" VerticalAlignment="Center" Columns="2">
-                        <TextBlock VerticalAlignment="Center" Text="{Binding CalibrationAmountLabel}" />
+                        <TextBlock VerticalAlignment="Center" Text="{Binding CalibrationAmountLabel}"
+                            ToolTip="How far you turn each screw (or move each stepper) during the per-screw calibration steps. Used to compute the measured thread pitch / step size." />
                         <TextBox MinWidth="60" Text="{Binding CalibrationAppliedAmount, UpdateSourceTrigger=LostFocus}" />
+                    </UniformGrid>
+
+                    <!--  Shared inputs that feed the calculation — grouped below the per-session fields.
+                          Editing these writes through to their source of truth (camera profile / Inspector options).  -->
+                    <UniformGrid Margin="0,5" VerticalAlignment="Center" Columns="2">
+                        <TextBlock VerticalAlignment="Center" Text="Pixel size (µm)"
+                            ToolTip="Camera pixel size in microns. Editing here updates your NINA camera profile — the same value used everywhere." />
+                        <TextBox MinWidth="60" Text="{Binding PixelSizeMicronsValue, UpdateSourceTrigger=LostFocus}" />
+                    </UniformGrid>
+
+                    <UniformGrid Margin="0,5" VerticalAlignment="Center" Columns="2">
+                        <TextBlock VerticalAlignment="Center" Text="Focuser step size (µm)"
+                            ToolTip="Microns of focus travel per focuser step. Editing here updates the Hocus Focus Aberration Inspector's 'Microns per focuser step' setting." />
+                        <TextBox MinWidth="60" Text="{Binding FocuserStepSizeMicronsValue, UpdateSourceTrigger=LostFocus}" />
                     </UniformGrid>
 
                     <Button

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -2,7 +2,8 @@
     x:Class="NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard.DataTemplates"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:s="clr-namespace:System;assembly=mscorlib">
+    xmlns:s="clr-namespace:System;assembly=mscorlib"
+    xmlns:interfaces="clr-namespace:NINA.Joko.Plugins.HocusFocus.Interfaces">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="../Resources/OptionsDataTemplates.xaml" />
     </ResourceDictionary.MergedDictionaries>
@@ -217,6 +218,57 @@
                         <TextBox
                             MinWidth="60"
                             Text="{Binding TiltAdapterOptions.MeasurementAverageCount, UpdateSourceTrigger=LostFocus}" />
+                    </UniformGrid>
+
+                    <!--  Adapter hardware: drives precise screw-turn amounts in the Aberration Inspector  -->
+                    <UniformGrid Margin="0,5" VerticalAlignment="Center" Columns="2">
+                        <TextBlock VerticalAlignment="Center" Text="Adjustment type" />
+                        <ComboBox MinWidth="120" SelectedValuePath="Tag" SelectedValue="{Binding AdjustmentType}">
+                            <ComboBoxItem Content="Screws" Tag="{x:Static interfaces:TiltAdjustmentType.Screws}" />
+                            <ComboBoxItem Content="Stepper Motors" Tag="{x:Static interfaces:TiltAdjustmentType.StepperMotors}" />
+                        </ComboBox>
+                    </UniformGrid>
+
+                    <!--  Thread pitch (screws only)  -->
+                    <UniformGrid Margin="0,5" VerticalAlignment="Center" Columns="2">
+                        <UniformGrid.Style>
+                            <Style TargetType="UniformGrid">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsStepperAdjustment}" Value="True">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </UniformGrid.Style>
+                        <TextBlock VerticalAlignment="Center" Text="Thread pitch (mm/turn)" />
+                        <TextBox MinWidth="60" Text="{Binding ThreadPitchMillimeters, UpdateSourceTrigger=LostFocus}" />
+                    </UniformGrid>
+
+                    <!--  Step size (steppers only)  -->
+                    <UniformGrid Margin="0,5" VerticalAlignment="Center" Columns="2">
+                        <UniformGrid.Style>
+                            <Style TargetType="UniformGrid">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsStepperAdjustment}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </UniformGrid.Style>
+                        <TextBlock VerticalAlignment="Center" Text="Step size (µm/step)" />
+                        <TextBox MinWidth="60" Text="{Binding StepperStepSizeMicronsValue, UpdateSourceTrigger=LostFocus}" />
+                    </UniformGrid>
+
+                    <UniformGrid Margin="0,5" VerticalAlignment="Center" Columns="2">
+                        <TextBlock VerticalAlignment="Center" Text="Screw radius (mm)" />
+                        <TextBox MinWidth="60" Text="{Binding ScrewRadiusMillimetersValue, UpdateSourceTrigger=LostFocus}" />
+                    </UniformGrid>
+
+                    <UniformGrid Margin="0,5" VerticalAlignment="Center" Columns="2">
+                        <TextBlock VerticalAlignment="Center" Text="{Binding CalibrationAmountLabel}" />
+                        <TextBox MinWidth="60" Text="{Binding CalibrationAppliedAmount, UpdateSourceTrigger=LostFocus}" />
                     </UniformGrid>
 
                     <Button
@@ -596,6 +648,72 @@
                             ContentTemplate="{StaticResource HF_TiltScrewDiagram}"
                             Content="{Binding}" />
                     </Grid>
+
+                    <!--  Measured thread pitch / step size vs the saved value  -->
+                    <StackPanel Margin="0,10,0,0">
+                        <StackPanel.Style>
+                            <Style TargetType="StackPanel">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasMeasuredHardware}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </StackPanel.Style>
+
+                        <TextBlock FontWeight="Bold" Text="Measured Adapter Hardware" />
+
+                        <UniformGrid Margin="0,4,0,0" Columns="2">
+                            <TextBlock Text="Measured" />
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="{Binding MeasuredHardwareDisplay}" />
+                                <TextBlock Margin="8,0,0,0" Opacity="0.7" Text="{Binding HardwareDeltaDisplay}" />
+                            </StackPanel>
+                            <TextBlock Text="Saved" />
+                            <TextBlock Text="{Binding SavedHardwareDisplay}" />
+                        </UniformGrid>
+
+                        <Button
+                            Margin="0,8,0,2"
+                            HorizontalAlignment="Left"
+                            Command="{Binding UseMeasuredHardwareCommand}">
+                            <TextBlock
+                                Margin="10,5,10,5"
+                                Foreground="{StaticResource ButtonForegroundBrush}"
+                                Text="Use measured value" />
+                        </Button>
+
+                        <TextBlock Margin="0,6,0,2" FontStyle="Italic" Text="Inputs to this calculation:" />
+                        <UniformGrid Columns="2">
+                            <TextBlock Text="Pixel size" />
+                            <TextBlock Text="{Binding CalibrationPixelSizeDisplay}" />
+                            <TextBlock Text="Focuser step size" />
+                            <TextBlock Text="{Binding CalibrationFocuserStepDisplay}" />
+                            <TextBlock Text="Screw radius" />
+                            <TextBlock Text="{Binding CalibrationScrewRadiusDisplay}" />
+                            <TextBlock Text="Applied per screw" />
+                            <TextBlock Text="{Binding CalibrationAppliedAmountDisplay}" />
+                        </UniformGrid>
+                    </StackPanel>
+
+                    <TextBlock
+                        Margin="0,10,0,0"
+                        FontStyle="Italic"
+                        Opacity="0.7"
+                        Text="Set a screw radius (and thread pitch / step size) in Settings to measure adapter hardware."
+                        TextWrapping="Wrap">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasMeasuredHardware}" Value="False">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
 
                     <Button
                         Margin="0,8,0,2"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterDevicePreset.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterDevicePreset.cs
@@ -1,0 +1,62 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
+
+    /// <summary>
+    /// A known tilt-adapter device. A preset pre-fills the adapter-hardware fields (screw count,
+    /// adjustment type, thread pitch / stepper step size, screw radius) and locks them in the wizard.
+    /// "Manual" is the sentinel that leaves every field user-editable. To add a device, append one
+    /// entry to <see cref="All"/> — no other code changes are required.
+    /// </summary>
+    public sealed class TiltAdapterDevicePreset {
+        public const string ManualName = "Manual";
+
+        private TiltAdapterDevicePreset(
+            string name, bool isManual, int screwCount, TiltAdjustmentType adjustmentType,
+            double threadPitchMicrons, double stepperStepSizeMicrons, double screwRadiusMillimeters) {
+            Name = name;
+            IsManual = isManual;
+            ScrewCount = screwCount;
+            AdjustmentType = adjustmentType;
+            ThreadPitchMicrons = threadPitchMicrons;
+            StepperStepSizeMicrons = stepperStepSizeMicrons;
+            ScrewRadiusMillimeters = screwRadiusMillimeters;
+        }
+
+        public string Name { get; }
+        public bool IsManual { get; }
+        public int ScrewCount { get; }
+        public TiltAdjustmentType AdjustmentType { get; }
+        public double ThreadPitchMicrons { get; }
+        public double StepperStepSizeMicrons { get; }
+        public double ScrewRadiusMillimeters { get; }
+
+        public static readonly TiltAdapterDevicePreset Manual = new TiltAdapterDevicePreset(
+            ManualName, isManual: true, screwCount: 3, adjustmentType: TiltAdjustmentType.Screws,
+            threadPitchMicrons: -1, stepperStepSizeMicrons: -1, screwRadiusMillimeters: -1);
+
+        public static readonly IReadOnlyList<TiltAdapterDevicePreset> All = new[] {
+            Manual,
+            new TiltAdapterDevicePreset(
+                "Neumann CTU XT48", isManual: false, screwCount: 3, adjustmentType: TiltAdjustmentType.Screws,
+                threadPitchMicrons: 400, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 44),
+        };
+
+        public static TiltAdapterDevicePreset ByName(string name) =>
+            All.FirstOrDefault(p => p.Name == name) ?? Manual;
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
@@ -61,6 +61,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             screwRadiusMillimeters = optionsAccessor.GetValueDouble(nameof(ScrewRadiusMillimeters), -1.0);
             lastMeasuredThreadPitchMicrons = optionsAccessor.GetValueDouble(nameof(LastMeasuredThreadPitchMicrons), -1.0);
             lastMeasuredStepperStepSizeMicrons = optionsAccessor.GetValueDouble(nameof(LastMeasuredStepperStepSizeMicrons), -1.0);
+            deviceName = optionsAccessor.GetValueString(nameof(DeviceName), TiltAdapterDevicePreset.ManualName);
         }
 
         private int screwCount;
@@ -253,6 +254,19 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 if (lastMeasuredStepperStepSizeMicrons != value) {
                     lastMeasuredStepperStepSizeMicrons = value;
                     optionsAccessor.SetValueDouble(nameof(LastMeasuredStepperStepSizeMicrons), lastMeasuredStepperStepSizeMicrons);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private string deviceName;
+
+        public string DeviceName {
+            get => deviceName;
+            set {
+                if (deviceName != value) {
+                    deviceName = value;
+                    optionsAccessor.SetValueString(nameof(DeviceName), deviceName);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
@@ -55,6 +55,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             calibratedScrewCount = optionsAccessor.GetValueInt32(nameof(CalibratedScrewCount), 0);
             measurementAverageCount = optionsAccessor.GetValueInt32(nameof(MeasurementAverageCount), 1);
             screwInwardCurvatureSign = optionsAccessor.GetValueInt32(nameof(ScrewInwardCurvatureSign), 0);
+            adjustmentType = optionsAccessor.GetValueEnum(nameof(AdjustmentType), TiltAdjustmentType.Screws);
+            threadPitchMicrons = optionsAccessor.GetValueDouble(nameof(ThreadPitchMicrons), -1.0);
+            stepperStepSizeMicrons = optionsAccessor.GetValueDouble(nameof(StepperStepSizeMicrons), -1.0);
+            screwRadiusMillimeters = optionsAccessor.GetValueDouble(nameof(ScrewRadiusMillimeters), -1.0);
+            lastMeasuredThreadPitchMicrons = optionsAccessor.GetValueDouble(nameof(LastMeasuredThreadPitchMicrons), -1.0);
+            lastMeasuredStepperStepSizeMicrons = optionsAccessor.GetValueDouble(nameof(LastMeasuredStepperStepSizeMicrons), -1.0);
         }
 
         private int screwCount;
@@ -169,6 +175,84 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 if (screwInwardCurvatureSign != value) {
                     screwInwardCurvatureSign = value;
                     optionsAccessor.SetValueInt32(nameof(ScrewInwardCurvatureSign), screwInwardCurvatureSign);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private TiltAdjustmentType adjustmentType;
+
+        public TiltAdjustmentType AdjustmentType {
+            get => adjustmentType;
+            set {
+                if (adjustmentType != value) {
+                    adjustmentType = value;
+                    optionsAccessor.SetValueEnum(nameof(AdjustmentType), adjustmentType);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private double threadPitchMicrons;
+
+        public double ThreadPitchMicrons {
+            get => threadPitchMicrons;
+            set {
+                if (threadPitchMicrons != value) {
+                    threadPitchMicrons = value;
+                    optionsAccessor.SetValueDouble(nameof(ThreadPitchMicrons), threadPitchMicrons);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private double stepperStepSizeMicrons;
+
+        public double StepperStepSizeMicrons {
+            get => stepperStepSizeMicrons;
+            set {
+                if (stepperStepSizeMicrons != value) {
+                    stepperStepSizeMicrons = value;
+                    optionsAccessor.SetValueDouble(nameof(StepperStepSizeMicrons), stepperStepSizeMicrons);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private double screwRadiusMillimeters;
+
+        public double ScrewRadiusMillimeters {
+            get => screwRadiusMillimeters;
+            set {
+                if (screwRadiusMillimeters != value) {
+                    screwRadiusMillimeters = value;
+                    optionsAccessor.SetValueDouble(nameof(ScrewRadiusMillimeters), screwRadiusMillimeters);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private double lastMeasuredThreadPitchMicrons;
+
+        public double LastMeasuredThreadPitchMicrons {
+            get => lastMeasuredThreadPitchMicrons;
+            set {
+                if (lastMeasuredThreadPitchMicrons != value) {
+                    lastMeasuredThreadPitchMicrons = value;
+                    optionsAccessor.SetValueDouble(nameof(LastMeasuredThreadPitchMicrons), lastMeasuredThreadPitchMicrons);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private double lastMeasuredStepperStepSizeMicrons;
+
+        public double LastMeasuredStepperStepSizeMicrons {
+            get => lastMeasuredStepperStepSizeMicrons;
+            set {
+                if (lastMeasuredStepperStepSizeMicrons != value) {
+                    lastMeasuredStepperStepSizeMicrons = value;
+                    optionsAccessor.SetValueDouble(nameof(LastMeasuredStepperStepSizeMicrons), lastMeasuredStepperStepSizeMicrons);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -72,6 +72,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         private double allScrewsCurvatureReading;
         private CancellationTokenSource measureCts;
 
+        private double calibrationAppliedAmount = 1.0;
+        private double measuredHardwareMicrons = double.NaN;
+        private double calibrationPixelSizeMicrons;
+        private double calibrationFocuserStepMicrons;
+        private double calibrationScrewRadiusMm;
+
         private const double MeasurementConsistencyWarningThreshold = 0.02;
 
         [ImportingConstructor]
@@ -113,6 +119,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             UseSavedAFCommand = new AsyncRelayCommand(RunSavedMeasurementAsync, () => IsOnMeasurementStep && !IsMeasuring);
             CancelCommand = new RelayCommand(CancelMeasurement, () => IsMeasuring);
             RestartCommand = new RelayCommand(Restart);
+            UseMeasuredHardwareCommand = new RelayCommand(UseMeasuredHardware, () => HasMeasuredHardware);
 
             tiltAdapterOptions.PropertyChanged += (s, e) => {
                 if (e.PropertyName == nameof(ITiltAdapterOptions.ScrewInwardCurvatureSign)) {
@@ -127,6 +134,19 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 }
                 if (e.PropertyName == nameof(ITiltAdapterOptions.MeasurementAverageCount)) {
                     RaisePropertyChanged(nameof(ShowRunColumn));
+                }
+                if (e.PropertyName == nameof(ITiltAdapterOptions.AdjustmentType) ||
+                    e.PropertyName == nameof(ITiltAdapterOptions.ThreadPitchMicrons) ||
+                    e.PropertyName == nameof(ITiltAdapterOptions.StepperStepSizeMicrons) ||
+                    e.PropertyName == nameof(ITiltAdapterOptions.ScrewRadiusMillimeters)) {
+                    RaisePropertyChanged(nameof(IsStepperAdjustment));
+                    RaisePropertyChanged(nameof(CalibrationAmountLabel));
+                    RaisePropertyChanged(nameof(CalibrationAppliedAmountDisplay));
+                    RaisePropertyChanged(nameof(AdjustmentType));
+                    RaisePropertyChanged(nameof(ThreadPitchMillimeters));
+                    RaisePropertyChanged(nameof(StepperStepSizeMicronsValue));
+                    RaisePropertyChanged(nameof(ScrewRadiusMillimetersValue));
+                    RaiseHardwareSummaryChanged();
                 }
             };
 
@@ -330,6 +350,89 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public ICommand UseSavedAFCommand { get; }
         public ICommand CancelCommand { get; }
         public ICommand RestartCommand { get; }
+        public ICommand UseMeasuredHardwareCommand { get; }
+
+        // Known amount the user moves each screw during the per-screw calibration steps (full turns
+        // for screws, steps for steppers). Defaults to 1.0 to match the "1 full turn" instructions.
+        public double CalibrationAppliedAmount {
+            get => calibrationAppliedAmount;
+            set {
+                if (calibrationAppliedAmount != value) {
+                    calibrationAppliedAmount = value;
+                    RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(CalibrationAppliedAmountDisplay));
+                }
+            }
+        }
+
+        public bool IsStepperAdjustment => tiltAdapterOptions.AdjustmentType == TiltAdjustmentType.StepperMotors;
+
+        public string CalibrationAmountLabel => IsStepperAdjustment ? "Steps applied per screw" : "Turns applied per screw";
+
+        public bool HasMeasuredHardware => !double.IsNaN(measuredHardwareMicrons) && measuredHardwareMicrons > 0;
+
+        public string MeasuredHardwareDisplay =>
+            !HasMeasuredHardware ? "—"
+            : IsStepperAdjustment ? $"{measuredHardwareMicrons:0.###} µm/step"
+            : $"{measuredHardwareMicrons / 1000.0:0.####} mm/turn";
+
+        public string SavedHardwareDisplay {
+            get {
+                double saved = IsStepperAdjustment ? tiltAdapterOptions.StepperStepSizeMicrons : tiltAdapterOptions.ThreadPitchMicrons;
+                if (saved <= 0) return "not set";
+                return IsStepperAdjustment ? $"{saved:0.###} µm/step" : $"{saved / 1000.0:0.####} mm/turn";
+            }
+        }
+
+        public string HardwareDeltaDisplay {
+            get {
+                double saved = IsStepperAdjustment ? tiltAdapterOptions.StepperStepSizeMicrons : tiltAdapterOptions.ThreadPitchMicrons;
+                if (!HasMeasuredHardware || saved <= 0) return string.Empty;
+                double pct = (measuredHardwareMicrons - saved) / saved * 100.0;
+                return $"{pct:+0.#;-0.#;0}% vs saved";
+            }
+        }
+
+        public string CalibrationPixelSizeDisplay => calibrationPixelSizeMicrons > 0 ? $"{calibrationPixelSizeMicrons:0.##} µm" : "—";
+        public string CalibrationFocuserStepDisplay => calibrationFocuserStepMicrons > 0 ? $"{calibrationFocuserStepMicrons:0.###} µm" : "—";
+        public string CalibrationScrewRadiusDisplay => calibrationScrewRadiusMm > 0 ? $"{calibrationScrewRadiusMm:0.##} mm" : "not set";
+        public string CalibrationAppliedAmountDisplay => IsStepperAdjustment ? $"{calibrationAppliedAmount:0.##} steps" : $"{calibrationAppliedAmount:0.##} turns";
+
+        // Config-panel bindings. They wrap the persisted options, presenting thread pitch in mm and
+        // showing 0 for the unset (-1) sentinel so the textboxes read cleanly.
+        public TiltAdjustmentType AdjustmentType {
+            get => tiltAdapterOptions.AdjustmentType;
+            set {
+                if (tiltAdapterOptions.AdjustmentType != value) {
+                    tiltAdapterOptions.AdjustmentType = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public double ThreadPitchMillimeters {
+            get { var um = tiltAdapterOptions.ThreadPitchMicrons; return um > 0 ? um / 1000.0 : 0; }
+            set {
+                tiltAdapterOptions.ThreadPitchMicrons = value > 0 ? value * 1000.0 : -1;
+                RaisePropertyChanged();
+            }
+        }
+
+        public double StepperStepSizeMicronsValue {
+            get { var v = tiltAdapterOptions.StepperStepSizeMicrons; return v > 0 ? v : 0; }
+            set {
+                tiltAdapterOptions.StepperStepSizeMicrons = value > 0 ? value : -1;
+                RaisePropertyChanged();
+            }
+        }
+
+        public double ScrewRadiusMillimetersValue {
+            get { var v = tiltAdapterOptions.ScrewRadiusMillimeters; return v > 0 ? v : 0; }
+            set {
+                tiltAdapterOptions.ScrewRadiusMillimeters = value > 0 ? value : -1;
+                RaisePropertyChanged();
+            }
+        }
 
         private Task StartAsync() {
             StatusText = string.Empty;
@@ -684,6 +787,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
             if (next == WizardStep.Complete) {
                 CalculateAndSaveAngles();
+                CalculateAndSaveHardware();
                 RebuildDiagram();
             }
 
@@ -702,11 +806,86 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             screw2Reading = default;
             baselineCurvatureReading = 0;
             allScrewsCurvatureReading = 0;
+            measuredHardwareMicrons = double.NaN;
+            RaiseHardwareSummaryChanged();
             StepMeasurementSummary.Clear();
             HasMeasurementConsistencyWarning = false;
             MeasurementConsistencyWarningText = string.Empty;
             StatusText = string.Empty;
             CurrentStep = WizardStep.Baseline;
+        }
+
+        private void UseMeasuredHardware() {
+            if (!HasMeasuredHardware) return;
+            if (IsStepperAdjustment) {
+                tiltAdapterOptions.StepperStepSizeMicrons = measuredHardwareMicrons;
+            } else {
+                tiltAdapterOptions.ThreadPitchMicrons = measuredHardwareMicrons;
+            }
+            RaiseHardwareSummaryChanged();
+        }
+
+        // Recover thread pitch (µm/turn) or stepper step size (µm/step) from the known per-screw
+        // calibration moves and the measured tilt-plane changes. Stored as the "last measured" value;
+        // the user can copy it into the active saved value via UseMeasuredHardwareCommand.
+        private void CalculateAndSaveHardware() {
+            measuredHardwareMicrons = double.NaN;
+            calibrationScrewRadiusMm = tiltAdapterOptions.ScrewRadiusMillimeters;
+
+            var model = inspector.TiltModel?.TiltPlaneModel;
+            if (model == null) { RaiseHardwareSummaryChanged(); return; }
+
+            double pixelSize = profileService.ActiveProfile.CameraSettings.PixelSize;
+            double fStep = model.FocuserStepSizeMicrons;
+            if (double.IsNaN(fStep) || fStep <= 0) fStep = focuserInfo.StepSize;
+            calibrationPixelSizeMicrons = pixelSize;
+            calibrationFocuserStepMicrons = fStep;
+
+            double radiusMm = tiltAdapterOptions.ScrewRadiusMillimeters;
+            double applied = calibrationAppliedAmount;
+            double sensorW = model.ImageSize.Width * pixelSize;
+            double sensorH = model.ImageSize.Height * pixelSize;
+            if (radiusMm <= 0 || applied <= 0 || pixelSize <= 0 || fStep <= 0 || sensorW <= 0 || sensorH <= 0) {
+                RaiseHardwareSummaryChanged();
+                return;
+            }
+
+            double radiusMicrons = radiusMm * 1000.0;
+            int n = tiltAdapterOptions.ScrewCount;
+
+            double d1A = screw1Reading.A - baselineReading.A;
+            double d1B = screw1Reading.B - baselineReading.B;
+            double d2A = screw2Reading.A - baselineReading.A;
+            double d2B = screw2Reading.B - baselineReading.B;
+
+            var (g1x, g1y) = TiltScrewGeometry.PlaneGradientToPhysical(d1A, d1B, fStep, sensorW, sensorH);
+            var (g2x, g2y) = TiltScrewGeometry.PlaneGradientToPhysical(d2A, d2B, fStep, sensorW, sensorH);
+            double delta1 = TiltScrewGeometry.CalibrationAxialMoveMicrons(g1x, g1y, n, radiusMicrons);
+            double delta2 = TiltScrewGeometry.CalibrationAxialMoveMicrons(g2x, g2y, n, radiusMicrons);
+
+            double measured = 0.5 * (delta1 + delta2) / applied;
+            if (double.IsNaN(measured) || measured <= 0) { RaiseHardwareSummaryChanged(); return; }
+
+            measuredHardwareMicrons = measured;
+            if (IsStepperAdjustment) {
+                tiltAdapterOptions.LastMeasuredStepperStepSizeMicrons = measured;
+            } else {
+                tiltAdapterOptions.LastMeasuredThreadPitchMicrons = measured;
+            }
+
+            RaiseHardwareSummaryChanged();
+        }
+
+        private void RaiseHardwareSummaryChanged() {
+            RaisePropertyChanged(nameof(HasMeasuredHardware));
+            RaisePropertyChanged(nameof(MeasuredHardwareDisplay));
+            RaisePropertyChanged(nameof(SavedHardwareDisplay));
+            RaisePropertyChanged(nameof(HardwareDeltaDisplay));
+            RaisePropertyChanged(nameof(CalibrationPixelSizeDisplay));
+            RaisePropertyChanged(nameof(CalibrationFocuserStepDisplay));
+            RaisePropertyChanged(nameof(CalibrationScrewRadiusDisplay));
+            RaisePropertyChanged(nameof(CalibrationAppliedAmountDisplay));
+            ((RelayCommand)UseMeasuredHardwareCommand).NotifyCanExecuteChanged();
         }
 
         private void CalculateAndSaveCurvatureSign() {
@@ -817,6 +996,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             ((AsyncRelayCommand)RunMeasurementCommand).NotifyCanExecuteChanged();
             ((AsyncRelayCommand)UseSavedAFCommand).NotifyCanExecuteChanged();
             ((RelayCommand)CancelCommand).NotifyCanExecuteChanged();
+            ((RelayCommand)UseMeasuredHardwareCommand).NotifyCanExecuteChanged();
         }
 
         private static double NormalizeAngle(double deg) => ((deg % 360) + 360) % 360;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -135,6 +135,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 if (e.PropertyName == nameof(ITiltAdapterOptions.MeasurementAverageCount)) {
                     RaisePropertyChanged(nameof(ShowRunColumn));
                 }
+                if (e.PropertyName == nameof(ITiltAdapterOptions.DeviceName)) {
+                    RaisePropertyChanged(nameof(SelectedDevice));
+                    RaisePropertyChanged(nameof(IsManualDevice));
+                }
                 if (e.PropertyName == nameof(ITiltAdapterOptions.AdjustmentType) ||
                     e.PropertyName == nameof(ITiltAdapterOptions.ThreadPitchMicrons) ||
                     e.PropertyName == nameof(ITiltAdapterOptions.StepperStepSizeMicrons) ||
@@ -143,12 +147,22 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     RaisePropertyChanged(nameof(CalibrationAmountLabel));
                     RaisePropertyChanged(nameof(CalibrationAppliedAmountDisplay));
                     RaisePropertyChanged(nameof(AdjustmentType));
-                    RaisePropertyChanged(nameof(ThreadPitchMillimeters));
+                    RaisePropertyChanged(nameof(ThreadPitchMicronsValue));
                     RaisePropertyChanged(nameof(StepperStepSizeMicronsValue));
                     RaisePropertyChanged(nameof(ScrewRadiusMillimetersValue));
                     RaiseHardwareSummaryChanged();
                 }
             };
+
+            profileService.ProfileChanged += (s, e) => {
+                RaisePropertyChanged(nameof(PixelSizeMicronsValue));
+                RaisePropertyChanged(nameof(FocuserStepSizeMicronsValue));
+                RaisePropertyChanged(nameof(SelectedDevice));
+                RaisePropertyChanged(nameof(IsManualDevice));
+            };
+
+            // Re-assert and lock a persisted device preset on load.
+            ApplyDevice(tiltAdapterOptions.DeviceName);
 
             RebuildDiagram();
 
@@ -222,6 +236,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 RaisePropertyChanged();
                 RaisePropertyChanged(nameof(AreDevicesConnected));
                 RaisePropertyChanged(nameof(ConnectionWarningText));
+                RaisePropertyChanged(nameof(PixelSizeMicronsValue));
                 NotifyCommandsCanExecuteChanged();
             }
         }
@@ -374,13 +389,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public string MeasuredHardwareDisplay =>
             !HasMeasuredHardware ? "—"
             : IsStepperAdjustment ? $"{measuredHardwareMicrons:0.###} µm/step"
-            : $"{measuredHardwareMicrons / 1000.0:0.####} mm/turn";
+            : $"{measuredHardwareMicrons:0.#} µm/turn";
 
         public string SavedHardwareDisplay {
             get {
                 double saved = IsStepperAdjustment ? tiltAdapterOptions.StepperStepSizeMicrons : tiltAdapterOptions.ThreadPitchMicrons;
                 if (saved <= 0) return "not set";
-                return IsStepperAdjustment ? $"{saved:0.###} µm/step" : $"{saved / 1000.0:0.####} mm/turn";
+                return IsStepperAdjustment ? $"{saved:0.###} µm/step" : $"{saved:0.#} µm/turn";
             }
         }
 
@@ -410,10 +425,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
         }
 
-        public double ThreadPitchMillimeters {
-            get { var um = tiltAdapterOptions.ThreadPitchMicrons; return um > 0 ? um / 1000.0 : 0; }
+        public double ThreadPitchMicronsValue {
+            get { var um = tiltAdapterOptions.ThreadPitchMicrons; return um > 0 ? um : 0; }
             set {
-                tiltAdapterOptions.ThreadPitchMicrons = value > 0 ? value * 1000.0 : -1;
+                tiltAdapterOptions.ThreadPitchMicrons = value > 0 ? value : -1;
                 RaisePropertyChanged();
             }
         }
@@ -431,6 +446,41 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             set {
                 tiltAdapterOptions.ScrewRadiusMillimeters = value > 0 ? value : -1;
                 RaisePropertyChanged();
+            }
+        }
+
+        // Device presets. Selecting a non-Manual device fills and locks the hardware fields.
+        public IReadOnlyList<string> DeviceNames => TiltAdapterDevicePreset.All.Select(p => p.Name).ToList();
+
+        public string SelectedDevice {
+            get => tiltAdapterOptions.DeviceName;
+            set => ApplyDevice(value);
+        }
+
+        public bool IsManualDevice => TiltAdapterDevicePreset.ByName(tiltAdapterOptions.DeviceName).IsManual;
+
+        // Inputs that feed the screw-turn calculation, wired to their source of truth: pixel size to
+        // the active NINA camera profile, focuser step size to the Inspector's MicronsPerFocuserStep.
+        public double PixelSizeMicronsValue {
+            get => profileService.ActiveProfile.CameraSettings.PixelSize;
+            set {
+                if (profileService.ActiveProfile.CameraSettings.PixelSize != value) {
+                    profileService.ActiveProfile.CameraSettings.PixelSize = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public double FocuserStepSizeMicronsValue {
+            get {
+                var v = inspector.InspectorOptions?.MicronsPerFocuserStep ?? -1;
+                return v > 0 ? v : 0;
+            }
+            set {
+                if (inspector.InspectorOptions != null) {
+                    inspector.InspectorOptions.MicronsPerFocuserStep = value > 0 ? value : -1;
+                    RaisePropertyChanged();
+                }
             }
         }
 
@@ -813,6 +863,27 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             MeasurementConsistencyWarningText = string.Empty;
             StatusText = string.Empty;
             CurrentStep = WizardStep.Baseline;
+        }
+
+        private void ApplyDevice(string name) {
+            var preset = TiltAdapterDevicePreset.ByName(name);
+            tiltAdapterOptions.DeviceName = preset.Name;
+            if (!preset.IsManual) {
+                tiltAdapterOptions.ScrewCount = preset.ScrewCount;
+                tiltAdapterOptions.AdjustmentType = preset.AdjustmentType;
+                tiltAdapterOptions.ThreadPitchMicrons = preset.ThreadPitchMicrons;
+                tiltAdapterOptions.StepperStepSizeMicrons = preset.StepperStepSizeMicrons;
+                tiltAdapterOptions.ScrewRadiusMillimeters = preset.ScrewRadiusMillimeters;
+            }
+            RaisePropertyChanged(nameof(SelectedDevice));
+            RaisePropertyChanged(nameof(IsManualDevice));
+            RaisePropertyChanged(nameof(AdjustmentType));
+            RaisePropertyChanged(nameof(ThreadPitchMicronsValue));
+            RaisePropertyChanged(nameof(StepperStepSizeMicronsValue));
+            RaisePropertyChanged(nameof(ScrewRadiusMillimetersValue));
+            RaisePropertyChanged(nameof(IsStepperAdjustment));
+            RaisePropertyChanged(nameof(CalibrationAmountLabel));
+            RaisePropertyChanged(nameof(CalibrationAppliedAmountDisplay));
         }
 
         private void UseMeasuredHardware() {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltScrewGeometry.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltScrewGeometry.cs
@@ -1,0 +1,130 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
+
+    /// <summary>
+    /// Pure geometry shared by the tilt-adapter wizard (calibration) and the Aberration
+    /// Inspector (application). The two directions are exact inverses under a single
+    /// least-squares plane model of n equally-spaced screws on a circle of radius R:
+    ///
+    ///   forward (moves -> gradient): G = (2 / (n·R²)) · Σ dᵢ·pᵢ
+    ///   inverse (gradient -> moves): δᵢ = -(G·pᵢ)   (the per-screw axial move that cancels G)
+    ///
+    /// All positions and displacements are in microns; the screw angle convention matches
+    /// the rest of the plugin — degrees clockwise from straight up (12 o'clock) in image
+    /// space, where image coordinates are +x right / +y down (so "up" is -y). A screw at
+    /// angle θ therefore sits at (R·sinθ, -R·cosθ).
+    /// </summary>
+    public static class TiltScrewGeometry {
+
+        /// <summary>Screw position in sensor microns from its position angle and radius.</summary>
+        public static (double x, double y) ScrewPositionMicrons(double angleDegrees, double radiusMicrons) {
+            var t = angleDegrees * Math.PI / 180.0;
+            return (radiusMicrons * Math.Sin(t), -radiusMicrons * Math.Cos(t));
+        }
+
+        /// <summary>
+        /// Convert tilt-plane coefficients (A, B) — focuser steps per normalized image
+        /// coordinate over the range [-0.5, 0.5] — into a physical best-focus gradient in
+        /// microns of focuser travel per micron of sensor displacement (dimensionless).
+        /// Mirrors InspectorVM/TiltAdapterWizardVM's ComputeTiltAngleDeg conversion.
+        /// </summary>
+        public static (double gx, double gy) PlaneGradientToPhysical(
+            double a, double b, double focuserStepMicrons, double sensorWidthMicrons, double sensorHeightMicrons) {
+            var gx = a * focuserStepMicrons / sensorWidthMicrons;
+            var gy = b * focuserStepMicrons / sensorHeightMicrons;
+            return (gx, gy);
+        }
+
+        /// <summary>
+        /// Per-screw axial move (microns) that cancels the given best-focus tilt gradient,
+        /// evaluated at the screw location: δ = -(gx·x + gy·y). Positive = the direction
+        /// returned here is the sensor-axial displacement to apply at that screw.
+        /// </summary>
+        public static double TiltCorrectionMicrons(double gx, double gy, double angleDegrees, double radiusMicrons) {
+            var (x, y) = ScrewPositionMicrons(angleDegrees, radiusMicrons);
+            return -(gx * x + gy * y);
+        }
+
+        /// <summary>
+        /// Axial move (microns) of a single screw implied by the least-squares tilt-plane
+        /// gradient change it produced: δ = |ΔG| · n · R / 2. This is the inverse of
+        /// <see cref="TiltCorrectionMicrons"/> for an isolated single-screw move and is used by
+        /// the wizard to recover thread pitch / step size from a known applied move.
+        /// </summary>
+        public static double SingleScrewAxialMoveMicrons(double dGx, double dGy, int screwCount, double radiusMicrons) {
+            return Math.Sqrt(dGx * dGx + dGy * dGy) * screwCount * radiusMicrons / 2.0;
+        }
+
+        /// <summary>
+        /// Per-screw axial corrections (microns) needed at a screw location to flatten tilt and to
+        /// neutralize field curvature ("backfocus"), evaluated against the fitted paraboloid model.
+        /// Both are in axial best-focus microns (the same unit as physical screw travel), so the
+        /// total is simply their sum and no square root is involved — the curvature term
+        /// kx·(x-x0)² + ky·(y-y0)² is already a length.
+        /// </summary>
+        public static ScrewAxialCorrection ScrewCorrectionMicrons(
+            double gx, double gy, double kx, double ky, double x0, double y0,
+            double angleDegrees, double radiusMicrons) {
+            var (px, py) = ScrewPositionMicrons(angleDegrees, radiusMicrons);
+            double tiltCorrection = -(gx * px + gy * py);
+            double cx = px - x0;
+            double cy = py - y0;
+            double backfocusCorrection = -(kx * cx * cx + ky * cy * cy);
+            return new ScrewAxialCorrection(tiltCorrection, backfocusCorrection);
+        }
+
+        /// <summary>
+        /// Convert an axial correction (microns) into a signed adjustment in turns (screws) or
+        /// steps (steppers), where positive = turn the screw inward. Inward turning moves the
+        /// sensor axially in the direction given by <paramref name="curvatureSign"/> (= the wizard's
+        /// ScrewInwardCurvatureSign), so the inward amount is curvatureSign·correction / unitMicrons.
+        /// </summary>
+        public static double InwardAdjustment(double correctionMicrons, double unitMicrons, int curvatureSign) {
+            if (unitMicrons <= 0) return double.NaN;
+            return curvatureSign * correctionMicrons / unitMicrons;
+        }
+
+        /// <summary>
+        /// Axial move (microns) applied per screw during a wizard calibration step, recovered from
+        /// the tilt-plane gradient change it produced. The wizard's move pattern differs by adapter:
+        ///   • 3-screw: a single screw is turned inward — lever arm 1.5·R, so δ = 1.5·R·|ΔG|.
+        ///   • 4-screw: opposite screws are push-pulled by the same amount — lever arm R, so δ = R·|ΔG|.
+        /// Dividing by the known applied turns/steps yields thread pitch / step size.
+        /// </summary>
+        public static double CalibrationAxialMoveMicrons(double dGx, double dGy, int screwCount, double radiusMicrons) {
+            double magnitude = Math.Sqrt(dGx * dGx + dGy * dGy);
+            double leverArm = screwCount == 4 ? radiusMicrons : 1.5 * radiusMicrons;
+            return magnitude * leverArm;
+        }
+
+        /// <summary>True when |active − measured| / |measured| exceeds the given fraction.</summary>
+        public static bool PitchMismatchExceeds(double activeMicrons, double measuredMicrons, double fraction) {
+            if (activeMicrons <= 0 || measuredMicrons <= 0) return false;
+            return Math.Abs(activeMicrons - measuredMicrons) / measuredMicrons > fraction;
+        }
+    }
+
+    public readonly struct ScrewAxialCorrection {
+        public ScrewAxialCorrection(double tiltMicrons, double backfocusMicrons) {
+            TiltMicrons = tiltMicrons;
+            BackfocusMicrons = backfocusMicrons;
+        }
+
+        public double TiltMicrons { get; }
+        public double BackfocusMicrons { get; }
+        public double TotalMicrons => TiltMicrons + BackfocusMicrons;
+    }
+}

--- a/docs/precise-screw-adjustments-design.md
+++ b/docs/precise-screw-adjustments-design.md
@@ -1,0 +1,151 @@
+# Precise Screw-Turn Adjustments for Tilt & Backfocus — Design
+
+## Context
+
+The Aberration Inspector already detects sensor tilt and field curvature and shows the user
+**qualitative** screw guidance (arrow glyphs ⬆ ↑ — ↓ ⬇) telling them which way to turn each
+tilt-adapter screw. The magnitude is computed but thrown away, because the plugin has no physical
+model of the adapter hardware (thread pitch, stepper step size, screw radius). This feature
+surfaces **precise, absolute** adjustment amounts — how much to turn each screw, in turns (or
+stepper steps) — for both tilt and backfocus, plus a per-screw total.
+
+It is an **extension of an existing subsystem**, not greenfield. Relevant existing pieces:
+
+- `TiltAdapterWizard/TiltAdapterOptions.cs` (+ `Interfaces/ITiltAdapterOptions.cs`) — persisted
+  per-profile calibration (screw count, screw angles, curvature sign).
+- `TiltAdapterWizard/TiltAdapterWizardVM.cs` — multi-step wizard that turns screws by a known
+  amount and measures the tilt-plane change (`CalculateAndSaveAngles`,
+  `CalculateAndSaveCurvatureSign`, `ComputeTiltAngleDeg`).
+- `AutoFocus/InspectorVM.cs` `RebuildTiltGuidance()` — already computes a per-screw turn
+  projection `(2/n)·(−a·sinθ + b·cosθ)` and a backfocus direction from `CurvatureEffectMicrons`,
+  but emits only arrows.
+- `AutoFocus/TiltScrewGuidanceRow.cs` `TiltAdapterGuidanceVM` — the per-screw guidance output VM.
+- `Inspection/SensorParaboloidModel.cs` — the fitted surface, with `TiltAt(x,y)` and
+  `CurvatureAt(x,y)` returning **microns** of best-focus deviation (coords in microns from sensor
+  center). Available in the inspector via `SensorModel.DisplayedSensorModel`.
+
+## Assessment of the "square root of the effect" question
+
+**No square root is needed.** `SensorParaboloidModel.CurvatureAt(x,y)` returns `Kx·x² + Ky·y²`,
+units (1/µm)·µm² = **microns** of axial best-focus deviation — the same unit as physical screw
+axial travel (`pitch × turns`). The backfocus turn count is therefore a direct linear conversion:
+
+```
+backfocusTurns = CurvatureAt(screwPointMicrons) / pitchMicronsPerTurn
+```
+
+The square root only appears in the model's internal display parameter `C = sign(K)·√|K|`, which
+re-expresses the curvature **coefficient** `K` (units 1/µm) — not the physical defocus. Because we
+evaluate the curvature **term** (already in microns) directly at the screw point, the sqrt drops
+out. Sign/direction comes from the sign of the curvature term combined with the calibrated
+`ScrewInwardCurvatureSign`, exactly as the existing arrow logic already does.
+
+With isotropic curvature (`Kx == Ky`) every screw is at the same radius, so the backfocus
+contribution is identical across screws (a pure uniform translation = true backfocus). With
+astigmatic curvature (`Kx ≠ Ky`) it varies slightly per screw angle — that residual can't be
+fully removed by a planar move, but the per-screw number is still the correct local target.
+
+## Design
+
+### 1. Configuration options — `ITiltAdapterOptions` / `TiltAdapterOptions`
+
+New persisted, per-profile fields (existing get/set + `optionsAccessor` pattern):
+
+| Field | Type | Meaning / default |
+|---|---|---|
+| `AdjustmentType` | enum `TiltAdjustmentType { Screws, StepperMotors }` | default `Screws` |
+| `ThreadPitchMicrons` | double | µm of axial travel per **full turn** (screws). Default −1 (unset). UI shows mm. |
+| `StepperStepSizeMicrons` | double | µm of axial travel per **step** (steppers). Default −1 (unset). |
+| `ScrewRadiusMillimeters` | double | screw distance from sensor center. Default −1 (unset). |
+
+UI in `TiltAdapterWizard/DataTemplates.xaml` settings panel: enum `ComboBox` for `AdjustmentType`,
+`UnitTextBox` + `DoubleRangeRule` for pitch (mm), step size (µm), screw radius (mm), with tooltips;
+pitch-vs-step fields shown conditionally on `AdjustmentType` via a `DataTrigger`.
+
+### 2. Wizard — measure pitch / step size + summary page
+
+- New input: `CalibrationTurnsApplied` (double, default 1.0) / `CalibrationStepsApplied` (int),
+  shown on the per-screw measurement steps — the known amount the user actually moved each screw.
+- After calibration, compute the measured pitch/step size from each per-screw tilt-plane delta
+  `(ΔA, ΔB)`: convert to a physical axial displacement at the screw location via the shared helper
+  (focuser step size µm + pixel size µm + image size + screw radius lever arm), then
+  `measuredPitchMicrons = axialDisplacementMicrons / appliedAmount`, averaged across screws.
+- **Summary page** (extend the Complete panel; modeled on `OptimizationSummary` in the
+  star-detection wizard): measured pitch/step vs saved value with a delta/percent, a
+  **"Use measured value"** button that writes the measured value into the saved option, and the
+  input variables that fed the calculation: pixel size (µm), focuser step size (µm), screw radius
+  (mm), applied turns/steps.
+
+### 3. Aberration Inspector — precise numeric guidance
+
+Extend `TiltAdapterGuidanceVM` with per-screw numeric fields (keep the arrow fields — **Numbers +
+keep arrows**): `Screw{1..4}TiltAmountText`, `Screw{1..4}BackfocusAmountText`,
+`Screw{1..4}TotalAmountText`, a `UnitsAreSteps` flag, and a `PitchMismatchWarning` string.
+
+In `RebuildTiltGuidance()`, when calibrated **and** the relevant hardware option is set, evaluate
+the paraboloid model (`SensorModel.DisplayedSensorModel`) in microns at each screw point, then
+convert to turns/steps using the **saved** pitch/step size:
+
+- Screw point in sensor microns from angle θ (clockwise from up) + radius: `R_µm = radius_mm·1000`;
+  image coords +x right / +y down, up = −y ⇒ `point = (R_µm·sinθ, −R_µm·cosθ)` (verify sign
+  against the wizard's existing convention).
+- `tiltµm = model.TiltAt(point)` → `tiltTurns = tiltµm / pitch`
+- `backµm = model.CurvatureAt(point − (X0,Y0))` → `backTurns = backµm / pitch`
+- `totalTurns = tiltTurns + backTurns`
+- Tilt direction reuses the existing validated projection sign; backfocus sign reuses
+  `ScrewInwardCurvatureSign`.
+- Format: screws → `"+0.75 turns CW"` (turns, 2 dp, with direction); steppers → **whole steps
+  rounded** `"120 steps IN"`. Arrow computed from the same signed magnitude so arrow and number agree.
+- **Pitch mismatch warning:** inspector always uses the saved pitch; if a measured value exists and
+  the saved value differs by more than ~15%, set `PitchMismatchWarning`.
+
+Display: extend the guidance table in `AutoFocus/DataTemplates.xaml` (the screw-guidance grid) with
+a numeric line under each screw's arrow, a Backfocus numeric row, a Total row, and the warning
+banner; gate visibility on the hardware option being set (hint to run/configure the wizard if unset).
+
+### Orientation (must be unit-tested)
+
+Image mirroring means screw winding in image-space ≠ physical-space; the existing code derives
+winding from measured data. The new per-screw evaluation reuses the existing angle/sign convention
+(`atan2(dA, −dB)`, `(−a·sinθ + b·cosθ)`); a round-trip unit test confirms a synthetic tilt plane of
+known gradient produces per-screw turn numbers whose direction matches the existing arrow output.
+
+## Files to modify
+
+- `Interfaces/ITiltAdapterOptions.cs`, `TiltAdapterWizard/TiltAdapterOptions.cs` — new options + enum.
+- `TiltAdapterWizard/TiltAdapterWizardVM.cs` — applied amount, measured pitch/step, summary props +
+  "Use measured value" command.
+- `TiltAdapterWizard/DataTemplates.xaml` — config UI + applied-amount input + summary panel.
+- `AutoFocus/TiltScrewGuidanceRow.cs` — numeric + total + warning + units fields.
+- `AutoFocus/InspectorVM.cs` — numeric computation in `RebuildTiltGuidance()` + mismatch warning.
+- `AutoFocus/DataTemplates.xaml` — numeric/total rows + warning banner.
+- Shared helper (new, e.g. `Utility` or `TiltAdapterWizard`) — tilt-plane gradient ↔ physical axial
+  displacement at screw, used by both wizard calibration and inspector application (exact inverses).
+
+## Testing
+
+NUnit (`dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug`):
+
+- `TiltAdapterOptionsTests` — persistence/defaults of the new options.
+- Tilt-guidance tests: pure tilt → expected per-screw turns, direction agrees with arrows; pure
+  isotropic curvature → equal backfocus turns, linear in K (no sqrt); astigmatic → per-screw varies;
+  total = tilt + backfocus; stepper rounding vs fractional turns; mismatch warning threshold.
+- Wizard pitch-calibration test: synthetic known screw move → recovered pitch matches input (inverse
+  of the inspector conversion).
+
+## Verification (end-to-end)
+
+1. `dotnet build` then `dotnet test … -c Debug --nologo` — all green.
+2. NINA: Tilt Adapter Wizard — set adjustment type / pitch / radius, run/replay a calibration,
+   confirm summary shows measured-vs-saved pitch + variables and "Use measured value" updates it.
+3. NINA: Aberration Inspector on a run with known tilt/curvature — confirm per-screw tilt turns,
+   backfocus turns, totals (steps in stepper mode), arrows still present and agreeing, and that an
+   artificially mismatched saved pitch raises the warning.
+
+## Risks
+
+- The exact lever-arm/geometry constant (3-screw pivot vs 4-screw coupled pairs) is pinned by the
+  round-trip test; wizard calibration and inspector application share one helper so they are exact
+  inverses.
+- Sign conventions (image mirroring) are the main risk — covered by the orientation round-trip test
+  against the already-validated arrow logic.


### PR DESCRIPTION
## Summary

Surfaces **absolute per-screw adjustment amounts** (turns for screws, whole steps for steppers) for both **tilt** and **backfocus**, plus a per-screw **total**, in the Aberration Inspector. Previously the guidance showed only relative arrow glyphs because the plugin had no physical model of the adapter hardware. This extends the existing tilt-adapter subsystem.

## What's new

**Configuration** (per-profile, in the Tilt Adapter Wizard settings):
- Adjustment type: **Screws** or **Stepper Motors**
- **Thread pitch** (mm/turn) for screws / **step size** (µm/step) for steppers (shown conditionally)
- **Screw radius** (mm) from sensor center

**Wizard calibration + summary page:** recovers the thread pitch / step size from the known per-screw calibration moves (new "applied per screw" input), and the Complete page shows **measured vs saved** with a delta, a **"Use measured value"** button, and the input variables (pixel size, focuser step size, screw radius, applied amount).

**Inspector guidance:** existing arrows kept; a numeric grid adds per-screw **Tilt / Backfocus / Total** (`0.75 turns` / `120 steps`, total with IN/OUT), using the **saved** pitch, with a **warning** when the saved value diverges >15% from the wizard's measured one.

## Backfocus "square root" assessment (was explicitly asked)

**No square root is needed.** `CurvatureAt(x,y) = kx·x² + ky·y²` is already in microns (an axial length), the same unit as screw travel, so backfocus turns = `CurvatureAt(screwPoint) / pitch` is a direct linear conversion. The sqrt only lives in the model's internal `C = √|K|` display parameter. The feature evaluates the paraboloid (without the tilt terms) at each screw point from its position angle, radius, and the fitted model.

## Design / math

New shared pure helper `TiltAdapterWizard/TiltScrewGeometry.cs`:
- Inspector: tilt correction = `-TiltAt(p)`, backfocus = `-CurvatureAt(p)` (both axial microns), total = sum, amount = correction / saved pitch. IN/OUT uses `ScrewInwardCurvatureSign` exactly as the existing backfocus arrow.
- Wizard calibration is the exact inverse: `δ = |ΔG|·leverArm`, lever arm `1.5·R` (3-screw single move) or `R` (4-screw push-pull) — round-trip tested.

## Tests

New/extended unit tests (`TiltScrewGeometryTests`, `TiltAdapterGuidanceVMTests`, `TiltAdapterOptionsTests`) lock the round-trips, no-sqrt linearity, isotropic/astigmatic curvature, total, arrow-direction agreement, stepper rounding, and the mismatch threshold.

Full suite: **1337 passed, 0 failed**.

Design doc: `docs/precise-screw-adjustments-design.md`.

> Note: not yet verified live in NINA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)