### PR TITLE
feat(optimizer): Continue-optimizing chain + Aberration-Inspection objective

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationObjectiveTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationObjectiveTests.cs
@@ -670,4 +670,107 @@ public class OptimizationObjectiveTests {
             Assert.That(OptimizationObjective.Clamp01(2.0), Is.EqualTo(1.0));
         });
     }
+
+    // ---- SFitGuard (aberration-inspection fit bound) ----
+
+    private static RunEvaluationMetrics SigmaRun(double sigmaFocus) => new RunEvaluationMetrics {
+        SigmaFocus = sigmaFocus,
+        LooStdError = double.NaN,
+        StepSize = 1.0,
+        RSquared = 0.99,
+        ReducedChiSquared = 1.0,
+        FrameStarCounts = Enumerable.Repeat(40, 10).ToList()
+    };
+
+    [Test]
+    public void SFitGuard_ReturnsOne_ForStandardConstants() {
+        // Default constants leave ReferenceSigmaFocus = NaN ⇒ guard inert (J bit-identical to pre-guard).
+        var c = C;
+        Assert.That(OptimizationObjective.SFitGuard(SigmaRun(5.0), c), Is.EqualTo(1.0));
+    }
+
+    [Test]
+    public void SFitGuard_ReturnsOne_WithinMargin() {
+        // refσ = 0.10, margin 0.5 ⇒ no penalty up to σ = 0.15.
+        var c = ObjectiveConstants.ForAberrationInspection(referenceSigmaFocus: 0.10);
+        Assert.Multiple(() => {
+            Assert.That(OptimizationObjective.SFitGuard(SigmaRun(0.10), c), Is.EqualTo(1.0)); // at reference
+            Assert.That(OptimizationObjective.SFitGuard(SigmaRun(0.14), c), Is.EqualTo(1.0)); // within margin
+            Assert.That(OptimizationObjective.SFitGuard(SigmaRun(0.15), c), Is.EqualTo(1.0).Within(1e-12)); // exactly at the knee
+        });
+    }
+
+    [Test]
+    public void SFitGuard_DecreasesMonotonically_AndClampsToFloor_BeyondMargin() {
+        var c = ObjectiveConstants.ForAberrationInspection(referenceSigmaFocus: 0.10);
+        var pJust = OptimizationObjective.SFitGuard(SigmaRun(0.16), c);  // just past the knee
+        var pMore = OptimizationObjective.SFitGuard(SigmaRun(0.20), c);  // further
+        var pFar = OptimizationObjective.SFitGuard(SigmaRun(1.00), c);   // far past ⇒ clamped to floor
+        Assert.Multiple(() => {
+            Assert.That(pJust, Is.LessThan(1.0));
+            Assert.That(pMore, Is.LessThan(pJust));
+            Assert.That(pFar, Is.EqualTo(c.FitGuardMinFactor).Within(1e-12));
+            Assert.That(pMore, Is.GreaterThanOrEqualTo(c.FitGuardMinFactor));
+        });
+    }
+
+    [Test]
+    public void JRun_BitIdentical_WithDefaultConstants_RegardlessOfSigma() {
+        // The fit guard must not perturb the standard objective: a default-constants JRun is unchanged whether σ is
+        // tiny or large (SFitGuard ≡ 1.0). Compare against an explicit recompute of the weighted sub-scores.
+        var c = C;
+        var m = GoodRun(sigmaFocus: 2.5, frameCount: 10, starsPerFrame: 40); // a soft fit
+        var sFocus = OptimizationObjective.SFocus(m.SigmaFocus, m.LooStdError, m.StepSize, c);
+        var sStars = OptimizationObjective.SStars(m.FrameStarCounts, c);
+        var sFit = OptimizationObjective.SFit(m.RSquared, m.ReducedChiSquared, c);
+        var expected = (c.Wf * sFocus + c.Ws * sStars + c.Wc * sFit) / (c.Wf + c.Ws + c.Wc);
+        expected = (1.0 - c.Wtie) * expected + c.Wtie * OptimizationObjective.TieBreakerScore(m, c);
+        Assert.That(OptimizationObjective.JRun(m, c), Is.EqualTo(expected).Within(1e-12));
+    }
+
+    // ---- ForAberrationInspection (star-favoring reweight) ----
+
+    [Test]
+    public void ForAberrationInspection_FlipsRankingTowardMoreStars() {
+        // A = sharp focus but star-poor; B = slightly softer focus (still within the fit-guard margin of A's σ) but
+        // star-rich. Under the STANDARD objective the sharp run wins; under the inspection objective (anchored to A's
+        // σ as "current settings") the star-rich run wins — the whole point of the mode.
+        var sharpStarPoor = new RunEvaluationMetrics {
+            SigmaFocus = 0.10, LooStdError = double.NaN, StepSize = 1.0, RSquared = 0.99, ReducedChiSquared = 1.0,
+            FrameStarCounts = Enumerable.Repeat(12, 10).ToList()
+        };
+        var softStarRich = new RunEvaluationMetrics {
+            SigmaFocus = 0.13, LooStdError = double.NaN, StepSize = 1.0, RSquared = 0.99, ReducedChiSquared = 1.0,
+            FrameStarCounts = Enumerable.Repeat(60, 10).ToList()
+        };
+
+        var standard = C;
+        var inspection = ObjectiveConstants.ForAberrationInspection(referenceSigmaFocus: 0.10);
+
+        Assert.Multiple(() => {
+            Assert.That(OptimizationObjective.JRun(sharpStarPoor, standard),
+                Is.GreaterThan(OptimizationObjective.JRun(softStarRich, standard)),
+                "standard objective should prefer the sharper run");
+            Assert.That(OptimizationObjective.JRun(softStarRich, inspection),
+                Is.GreaterThan(OptimizationObjective.JRun(sharpStarPoor, inspection)),
+                "inspection objective should prefer the star-rich run");
+        });
+    }
+
+    [Test]
+    public void ForAberrationInspection_PenalizesRunsThatBlowPastTheFitBound() {
+        // A star-rich run whose σ degrades far past the margin is held back by SFitGuard: its J is lower than the same
+        // star count would earn within the margin — bounding how far the optimizer can trade fit for stars.
+        var inspection = ObjectiveConstants.ForAberrationInspection(referenceSigmaFocus: 0.10);
+        var withinBound = new RunEvaluationMetrics {
+            SigmaFocus = 0.12, LooStdError = double.NaN, StepSize = 1.0, RSquared = 0.99, ReducedChiSquared = 1.0,
+            FrameStarCounts = Enumerable.Repeat(60, 10).ToList()
+        };
+        var wayPastBound = new RunEvaluationMetrics {
+            SigmaFocus = 0.60, LooStdError = double.NaN, StepSize = 1.0, RSquared = 0.99, ReducedChiSquared = 1.0,
+            FrameStarCounts = Enumerable.Repeat(60, 10).ToList()
+        };
+        Assert.That(OptimizationObjective.JRun(wayPastBound, inspection),
+            Is.LessThan(OptimizationObjective.JRun(withinBound, inspection)));
+    }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -965,6 +965,40 @@ public class StarDetectionOptimizerWizardVMTests {
         });
     }
 
+    // ---- Elapsed / run-duration clock -------------------------------------------------------------------
+
+    [Test]
+    public void FormatDuration_RendersMinutesAndZeroPaddedSeconds() {
+        Assert.Multiple(() => {
+            Assert.That(StarDetectionOptimizerWizardVM.FormatDuration(TimeSpan.Zero), Is.EqualTo("0:00"));
+            Assert.That(StarDetectionOptimizerWizardVM.FormatDuration(TimeSpan.FromSeconds(9)), Is.EqualTo("0:09"));
+            Assert.That(StarDetectionOptimizerWizardVM.FormatDuration(TimeSpan.FromSeconds(65)), Is.EqualTo("1:05"));
+            Assert.That(StarDetectionOptimizerWizardVM.FormatDuration(TimeSpan.FromSeconds(605)), Is.EqualTo("10:05"));
+        });
+    }
+
+    [Test]
+    public void BeforeAnyRun_NoRunDuration() {
+        var vm = NewVM(LoaderReturning(GoodRun()));
+        Assert.Multiple(() => {
+            Assert.That(vm.HasRunDuration, Is.False);
+            Assert.That(vm.RunDurationText, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task AfterRun_RunDuration_IsRecordedAndFormatted() {
+        var vm = NewVM(LoaderReturning(GoodRun()));
+        vm.SourcePaths[0] = @"C:\run1";
+
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.HasRunDuration, Is.True, "the completed run records how long it took");
+            Assert.That(vm.RunDurationText, Does.Match(@"^\d+:\d{2}$"), "shown as M:SS on the summary");
+        });
+    }
+
     // ---- Source mode + summary UX (starry-hopper PR1) ---------------------------------------------------
 
     // ---- Start validation (starry-hopper) ---------------------------------------------------------------

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -999,6 +999,88 @@ public class StarDetectionOptimizerWizardVMTests {
         });
     }
 
+    // ---- Stars per frame (per-run star-count trajectory) ------------------------------------------------
+
+    [Test]
+    public void FrameStarCountTrajectory_RendersCountsAndNetDelta() {
+        var single = new FrameStarCountTrajectory { FocuserPosition = 100, Stages = new[] { 52 } };
+        var rising = new FrameStarCountTrajectory { FocuserPosition = 200, Stages = new[] { 52, 61, 78 } };
+        var falling = new FrameStarCountTrajectory { FocuserPosition = 300, Stages = new[] { 80, 74 } };
+        Assert.Multiple(() => {
+            Assert.That(single.CountsText, Is.EqualTo("52"));
+            Assert.That(single.HasDelta, Is.False);
+            Assert.That(single.DeltaText, Is.Empty);
+
+            Assert.That(rising.CountsText, Is.EqualTo("52→61→78"));
+            Assert.That(rising.HasDelta, Is.True);
+            Assert.That(rising.Delta, Is.EqualTo(26));
+            Assert.That(rising.DeltaText, Is.EqualTo("+26"));
+
+            Assert.That(falling.DeltaText, Is.EqualTo("-6"));
+        });
+    }
+
+    [Test]
+    public void BeforeAnyRun_NoStarsPerFrame() {
+        var vm = NewVM(LoaderReturning(GoodRun()));
+        Assert.That(vm.HasStarsPerFrame, Is.False);
+    }
+
+    [Test]
+    public async Task OptimizedVariant_StarsPerFrame_ShowsCurrentToOptimizedTrajectory() {
+        var vm = NewVM(LoaderReturning(GoodRun()));
+        vm.SourcePaths[0] = @"C:\run1";
+
+        await vm.StartAsync(CancellationToken.None);
+        vm.IsOptimizedVariant = true; // ensure the Optimized variant is selected
+
+        Assert.Multiple(() => {
+            Assert.That(vm.IsOptimizedVariant, Is.True);
+            Assert.That(vm.HasStarsPerFrame, Is.True);
+            Assert.That(vm.StarsPerFrameLabel, Does.Contain("current"));
+            foreach (var r in vm.StarsPerFrame) {
+                Assert.That(r.Stages.Count, Is.EqualTo(vm.RoundsCompleted + 1), "current + one round");
+                Assert.That(r.CountsText, Does.Contain("→"));
+            }
+        });
+    }
+
+    [Test]
+    public async Task Continue_ExtendsStarsPerFrameTrajectory() {
+        var loader = new RecordingLoader();
+        var vm = NewVM(loader, frameReviewBuilder: new FakeReviewBuilder().Build);
+        vm.SourcePaths[0] = @"C:\cont-run";
+
+        await vm.StartAsync(CancellationToken.None);
+        await vm.ContinueOptimizationCommand.ExecuteAsync(null); // chain -> [current, r1, r2]
+
+        Assert.Multiple(() => {
+            Assert.That(vm.IsOptimizedVariant, Is.True);
+            Assert.That(vm.HasStarsPerFrame, Is.True);
+            foreach (var r in vm.StarsPerFrame) {
+                Assert.That(r.Stages.Count, Is.EqualTo(vm.RoundsCompleted + 1), "current + each round");
+            }
+        });
+    }
+
+    [Test]
+    public async Task CurrentVariant_StarsPerFrame_ShowsCountsOnly_NoDelta() {
+        var vm = NewVM(LoaderReturning(GoodRun()));
+        vm.SourcePaths[0] = @"C:\run1";
+
+        await vm.StartAsync(CancellationToken.None);
+        vm.IsCurrentVariant = true;
+
+        Assert.Multiple(() => {
+            Assert.That(vm.HasStarsPerFrame, Is.True, "Current variant shows the per-frame counts");
+            foreach (var r in vm.StarsPerFrame) {
+                Assert.That(r.Stages.Count, Is.EqualTo(1), "a single (current) stage");
+                Assert.That(r.HasDelta, Is.False);
+                Assert.That(r.DeltaText, Is.Empty);
+            }
+        });
+    }
+
     // ---- Source mode + summary UX (starry-hopper PR1) ---------------------------------------------------
 
     // ---- Start validation (starry-hopper) ---------------------------------------------------------------

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -859,6 +859,112 @@ public class StarDetectionOptimizerWizardVMTests {
         Assert.That(vm.ReviewVM, Is.Not.Null);
     }
 
+    // ---- Continue optimizing (chained rounds) -----------------------------------------------------------
+
+    [Test]
+    public void Continue_BeforeAnyRun_CanExecuteIsFalse() {
+        var vm = NewVM(new RecordingLoader());
+        Assert.Multiple(() => {
+            Assert.That(vm.CanContinueOptimization, Is.False);
+            Assert.That(vm.ContinueOptimizationCommand.CanExecute(null), Is.False);
+            Assert.That(vm.RoundsCompleted, Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public async Task Continue_AfterOptimize_AppendsRound_AndStaysOptimizedVariant() {
+        var loader = new RecordingLoader();
+        var vm = NewVM(loader, frameReviewBuilder: new FakeReviewBuilder().Build);
+        vm.SourcePaths[0] = @"C:\cont-run";
+
+        await vm.StartAsync(CancellationToken.None);
+        Assert.Multiple(() => {
+            Assert.That(vm.HasOptimized, Is.True, "precondition: an optimization pass produced the Optimized variant");
+            Assert.That(vm.RoundsCompleted, Is.EqualTo(1), "the initial optimize is round 1");
+            Assert.That(vm.CanContinueOptimization, Is.True, "continue is available after the first pass");
+        });
+
+        await vm.ContinueOptimizationCommand.ExecuteAsync(null);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Summary), "continue returns to an updated Summary");
+            Assert.That(vm.ErrorMessage, Is.Null.Or.Empty);
+            Assert.That(vm.RoundsCompleted, Is.EqualTo(2), "continue appended a round");
+            Assert.That(vm.IsOptimizedVariant, Is.True, "the latest round IS the Optimized variant (chart + Accept follow it)");
+        });
+    }
+
+    [Test]
+    public async Task Continue_CapsAtThreeTotalRounds() {
+        var loader = new RecordingLoader();
+        var vm = NewVM(loader, frameReviewBuilder: new FakeReviewBuilder().Build);
+        vm.SourcePaths[0] = @"C:\cont-run";
+
+        await vm.StartAsync(CancellationToken.None);     // round 1
+        await vm.ContinueOptimizationCommand.ExecuteAsync(null); // round 2
+        await vm.ContinueOptimizationCommand.ExecuteAsync(null); // round 3
+        Assert.Multiple(() => {
+            Assert.That(vm.RoundsCompleted, Is.EqualTo(3));
+            Assert.That(vm.CanContinueOptimization, Is.False, "capped at 3 total passes");
+            Assert.That(vm.ContinueOptimizationCommand.CanExecute(null), Is.False);
+        });
+
+        // A further invocation must be a guarded no-op (no 4th round, still on Summary).
+        await vm.ContinueOptimizationCommand.ExecuteAsync(null);
+        Assert.Multiple(() => {
+            Assert.That(vm.RoundsCompleted, Is.EqualTo(3), "the cap blocks a 4th round");
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Summary));
+        });
+    }
+
+    [Test]
+    public async Task Continue_TrajectoryRows_CarryEveryStage() {
+        var loader = new RecordingLoader();
+        var vm = NewVM(loader, frameReviewBuilder: new FakeReviewBuilder().Build);
+        vm.SourcePaths[0] = @"C:\cont-run";
+
+        await vm.StartAsync(CancellationToken.None);
+        await vm.ContinueOptimizationCommand.ExecuteAsync(null); // 2 rounds -> chain [baseline, r1, r2]
+
+        // The curated detector rows carry the full per-round path; the appended AF step-size/offset rows are a
+        // separate 2-stage concern, so scope to the trajectory (multi-stage) rows.
+        var trajectoryRows = vm.ChangedParametersDisplay.Where(r => r.Stages != null).ToList();
+        Assert.That(trajectoryRows, Is.Not.Empty, "the optimizer changed at least one curated param (Sensitivity)");
+        // Each multi-stage row carries one value per stage: current + each round (= RoundsCompleted + 1).
+        Assert.Multiple(() => {
+            foreach (var r in trajectoryRows) {
+                Assert.That(r.Stages.Count, Is.EqualTo(vm.RoundsCompleted + 1));
+            }
+            Assert.That(trajectoryRows[0].Trajectory, Does.Contain("→"), "the trajectory renders the arrowed per-round path");
+            Assert.That(vm.HasRoundsSummary, Is.True, "the multi-round J header is shown");
+        });
+    }
+
+    // ---- Optimize for aberration inspection -------------------------------------------------------------
+
+    [Test]
+    public void OptimizeForAberrationInspection_DefaultsOff() {
+        var vm = NewVM(new RecordingLoader());
+        Assert.That(vm.OptimizeForAberrationInspection, Is.False);
+    }
+
+    [Test]
+    public async Task OptimizeForAberrationInspection_Enabled_RunCompletesToSummary() {
+        // Exercises the inspection plumbing end-to-end: ComputeBaselineJAsync builds ForAberrationInspection from the
+        // measured current-settings σ and hands it to the optimizer, and the run still lands on a valid Summary.
+        var vm = NewVM(new RecordingLoader(), frameReviewBuilder: new FakeReviewBuilder().Build);
+        vm.SourcePaths[0] = @"C:\insp-run";
+        vm.OptimizeForAberrationInspection = true;
+
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Summary));
+            Assert.That(vm.ErrorMessage, Is.Null.Or.Empty);
+            Assert.That(vm.Summary, Is.Not.Null);
+        });
+    }
+
     // ---- Source mode + summary UX (starry-hopper PR1) ---------------------------------------------------
 
     // ---- Start validation (starry-hopper) ---------------------------------------------------------------

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -23,6 +23,8 @@
     <TextBlock x:Key="SDOpt_ReOptimize_Tooltip" Text="Re-run the optimization using the labels you just made in Review. Your missed / wrongly-rejected stars steer the optimizer to recover them (recall), and your should-reject stars steer it to exclude them (precision). The run is re-read from disk and the search re-runs, landing on an updated summary you can review again or accept." />
     <TextBlock x:Key="SDOpt_Variant_Tooltip" Text="Switch the chart and the summary below between your current settings, the optimized settings, and (after Optimize with feedback) the feedback-optimized settings. Accept applies whichever variant is shown (Current can't be accepted — it's your baseline)." />
     <TextBlock x:Key="SDOpt_DonutDetection_Tooltip" Text="When checked, the optimizer is allowed to recover out-of-focus DONUT stars — heavily defocused stars that appear as hollow rings — which the detector otherwise drops (they fragment or fail the fill-ratio test). It also unlocks diffraction-spike and saturated-bloom suppression so a bright star's rays aren't mistaken for stars. Recommended for telescopes with a central obstruction (Newtonians/SCTs) whose defocused stars become donuts; leave OFF for refractors (defocused stars are filled disks, not rings). Saved to your profile and default OFF. When OFF, star detection is exactly as before." />
+    <TextBlock x:Key="SDOpt_Inspection_Tooltip" Text="When checked, the optimizer favors detecting MANY MORE stars spread across the frame, which the aberration inspector needs to measure sensor tilt and field curvature. It does this by trading away a little auto-focus-curve sharpness for star count — but the fit is bounded: settings that make the focus curve noticeably worse than your current settings are penalized, so focus stays usable. Leave OFF to optimize purely for the tightest auto-focus curve (the default). Only applies in Optimize mode; nothing is saved until you Accept." />
+    <TextBlock x:Key="SDOpt_Continue_Tooltip" Text="Run another optimization pass starting from the settings just found, giving the search a fresh chance to refine further (it resets its step sizes, so it can make larger moves again). Useful when the last pass looks like it stopped just short. Limited to 3 total passes; the Changed parameters table shows the value of each setting after every pass." />
 
     <!--  Auto-focus curve chart for ONE settings variant. The Summary panel hosts this via a ContentControl bound to
           SelectedCurve, so toggling the variant rebuilds the plot from a fresh OptimizationCurve instance (a robust
@@ -209,6 +211,23 @@
                             ToolTip="{StaticResource SDOpt_DonutDetection_Tooltip}" />
                     </StackPanel>
 
+                    <!--  Optimize-for-aberration-inspection toggle (VM-only, default OFF). Swaps in a star-favoring
+                          objective bounded relative to the current settings' fit; details in the tooltip. Only
+                          meaningful in Optimize mode (it shapes the search), so disabled in Use-current mode.  -->
+                    <StackPanel Margin="0,4" Orientation="Horizontal">
+                        <CheckBox
+                            VerticalAlignment="Center"
+                            IsChecked="{Binding OptimizeForAberrationInspection}"
+                            IsEnabled="{Binding IsOptimizeMode}"
+                            ToolTip="{StaticResource SDOpt_Inspection_Tooltip}" />
+                        <TextBlock
+                            Margin="6,0,0,0"
+                            VerticalAlignment="Center"
+                            IsEnabled="{Binding IsOptimizeMode}"
+                            Text="Optimize for aberration inspection (favor more stars)"
+                            ToolTip="{StaticResource SDOpt_Inspection_Tooltip}" />
+                    </StackPanel>
+
                     <!--  Single saved-run folder picker (Saved Auto-Focus only). Optimizing against one run at a time
                           keeps the recommendation interpretable; the multi-run selector was removed.  -->
                     <ItemsControl
@@ -364,6 +383,15 @@
                             Margin="0,4,0,4"
                             FontWeight="Bold"
                             Text="Changed parameters" />
+                        <!--  Multi-round header: after "Continue optimizing", shows the per-pass J path (e.g.
+                              "3 rounds  •  J: 0.940 → 0.985 → 0.990"). Hidden for a single pass.  -->
+                        <TextBlock
+                            Margin="0,0,0,4"
+                            FontStyle="Italic"
+                            Text="{Binding RoundsSummaryText, Mode=OneWay}"
+                            Visibility="{Binding HasRoundsSummary, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                        <!--  The value column shows the full path "current → optimized" (and, after Continue, the
+                              per-round trajectory "current → R1 → R2 → …") via the row's arrow-joined Trajectory.  -->
                         <DataGrid
                             AutoGenerateColumns="False"
                             CanUserAddRows="False"
@@ -377,13 +405,9 @@
                                     Binding="{Binding Name}"
                                     Header="Parameter" />
                                 <DataGridTextColumn
-                                    Width="*"
-                                    Binding="{Binding SeedValue, StringFormat=F3}"
-                                    Header="Current" />
-                                <DataGridTextColumn
-                                    Width="*"
-                                    Binding="{Binding OptimizedValue, StringFormat=F3}"
-                                    Header="Optimized" />
+                                    Width="3*"
+                                    Binding="{Binding Trajectory}"
+                                    Header="Current → Optimized" />
                             </DataGrid.Columns>
                         </DataGrid>
 
@@ -536,6 +560,15 @@
                     Command="{Binding ReviewCommand}"
                     Content="Review frames"
                     ToolTip="{StaticResource SDOpt_Review_Tooltip}"
+                    Visibility="{Binding ShowSummary, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                <!--  Continue optimizing: another pass from the current best. Disabled (greyed) once 3 passes have
+                      run, via the command's CanContinueOptimization. Only shown on the Summary page.  -->
+                <Button
+                    Width="140"
+                    Margin="0,0,8,0"
+                    Command="{Binding ContinueOptimizationCommand}"
+                    Content="Continue optimizing"
+                    ToolTip="{StaticResource SDOpt_Continue_Tooltip}"
                     Visibility="{Binding ShowSummary, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                 <Button
                     Width="90"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -271,21 +271,17 @@
                         Maximum="{Binding ProgressTotal}"
                         Minimum="0"
                         Value="{Binding ProgressCurrent, Mode=OneWay}" />
+                    <!--  Count + elapsed clock on one line: "X / Y (MM:SS)" while a determinate count is known, else
+                          just "(MM:SS)". Ticks once a second.  -->
                     <TextBlock
                         Margin="0,4,0,0"
                         HorizontalAlignment="Center"
-                        Text="{Binding ProgressCountText}"
-                        Visibility="{Binding HasProgressCount, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                        Text="{Binding ProgressCountElapsedText, Mode=OneWay}" />
                     <TextBlock
                         Margin="0,2,0,0"
                         HorizontalAlignment="Center"
                         Text="{Binding ProgressImprovementText}"
                         Visibility="{Binding IsOptimizing, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
-                    <!--  Elapsed-time clock (minutes:seconds), below all the progress text. Ticks once a second.  -->
-                    <TextBlock
-                        Margin="0,6,0,0"
-                        HorizontalAlignment="Center"
-                        Text="{Binding ElapsedText, StringFormat=Elapsed {0}, Mode=OneWay}" />
                 </StackPanel>
 
                 <!--  Step 4: Summary (the results page)  -->

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -362,6 +362,46 @@
                             <TextBlock Text="{Binding RunDurationText, Mode=OneWay}" />
                         </StackPanel>
 
+                        <!--  Stars per frame: accepted-star count at each focuser position and how it moved across the
+                              optimization passes (current → optimized, and current → R1 → R2 after Continue). A wrapping
+                              row of compact cells in the main results flow (NOT the gray feedback panel). Shown for the
+                              Optimized variant (with a net delta) and the Current variant (counts only).  -->
+                        <StackPanel Margin="0,8,0,0"
+                                    Visibility="{Binding HasStarsPerFrame, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                            <TextBlock Margin="0,0,0,4" FontWeight="Bold" Text="{Binding StarsPerFrameLabel, Mode=OneWay}" />
+                            <ItemsControl ItemsSource="{Binding StarsPerFrame}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <WrapPanel Orientation="Horizontal" />
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border
+                                            Margin="0,0,6,6"
+                                            Padding="6,3"
+                                            BorderBrush="{StaticResource BorderBrush}"
+                                            BorderThickness="1"
+                                            CornerRadius="3">
+                                            <StackPanel>
+                                                <TextBlock
+                                                    HorizontalAlignment="Center"
+                                                    FontSize="10"
+                                                    Foreground="{StaticResource SecondaryBrush}"
+                                                    Text="{Binding FocuserPosition}" />
+                                                <TextBlock HorizontalAlignment="Center" Text="{Binding CountsText}" />
+                                                <TextBlock
+                                                    HorizontalAlignment="Center"
+                                                    FontWeight="Bold"
+                                                    Text="{Binding DeltaText}"
+                                                    Visibility="{Binding HasDelta, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                                            </StackPanel>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+
                         <!--  Auto-focus block: the recommended step size / offset steps PLUS the toggle that applies
                               them on Accept, grouped so the toggle's purpose is obvious.  -->
                         <TextBlock Margin="0,8,0,2" FontWeight="Bold" Text="Auto-focus settings" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -281,6 +281,11 @@
                         HorizontalAlignment="Center"
                         Text="{Binding ProgressImprovementText}"
                         Visibility="{Binding IsOptimizing, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                    <!--  Elapsed-time clock (minutes:seconds), below all the progress text. Ticks once a second.  -->
+                    <TextBlock
+                        Margin="0,6,0,0"
+                        HorizontalAlignment="Center"
+                        Text="{Binding ElapsedText, StringFormat=Elapsed {0}, Mode=OneWay}" />
                 </StackPanel>
 
                 <!--  Step 4: Summary (the results page)  -->
@@ -349,6 +354,12 @@
                                     Visibility="{Binding Summary.HasFeedbackComparison, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
                             <TextBlock Width="200" Text="vs optimized (no feedback)" />
                             <TextBlock Text="{Binding Summary.FeedbackVsOptimizedText, Mode=OneWay}" />
+                        </StackPanel>
+                        <!--  How long the most recent optimization run took (minutes:seconds).  -->
+                        <StackPanel Orientation="Horizontal" Margin="0,2"
+                                    Visibility="{Binding HasRunDuration, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                            <TextBlock Width="200" Text="Optimization time" />
+                            <TextBlock Text="{Binding RunDurationText, Mode=OneWay}" />
                         </StackPanel>
 
                         <!--  Auto-focus block: the recommended step size / offset steps PLUS the toggle that applies

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationCurve.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationCurve.cs
@@ -87,6 +87,30 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
     }
 
     /// <summary>
+    /// One frame's accepted-star count and how it moved across the optimization passes, at a given focuser
+    /// position. <see cref="Stages"/> is the summed accepted-star count per stage: [current, round1, round2, …]
+    /// for the Optimized variant (after "Continue optimizing"), or a single [current] entry for the Current
+    /// variant. Shown as a compact wrapping list of per-position cells on the summary, mirroring
+    /// <see cref="FrameStarCountChange"/> but carrying the full per-round path like <c>ChangedParameterRow.Stages</c>.
+    /// </summary>
+    public sealed class FrameStarCountTrajectory {
+        public int FocuserPosition { get; set; }
+        public IReadOnlyList<int> Stages { get; set; }
+
+        /// <summary>Arrow-joined counts across the stages, e.g. "52→61→78" (or just "52" for a single stage).</summary>
+        public string CountsText => Stages == null ? string.Empty : string.Join("→", Stages);
+
+        /// <summary>Net change from the first stage (current) to the last (latest optimization). 0 for a single stage.</summary>
+        public int Delta => Stages != null && Stages.Count > 1 ? Stages[Stages.Count - 1] - Stages[0] : 0;
+
+        /// <summary>True when there is more than one stage (i.e. an optimization change to show a delta for).</summary>
+        public bool HasDelta => Stages != null && Stages.Count > 1;
+
+        /// <summary>Signed net delta ("+26" / "-4"); empty when there is no change to show (single stage).</summary>
+        public string DeltaText => !HasDelta ? string.Empty : (Delta > 0 ? $"+{Delta}" : Delta.ToString());
+    }
+
+    /// <summary>
     /// Determinate progress for the wizard's long-running per-item phases (loading frames from disk, building the
     /// per-frame early-detection contexts during the seed-guard, and detecting frames for review). Both fields are
     /// 1-based running counts: <see cref="Current"/> items done out of <see cref="Total"/>.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationObjective.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationObjective.cs
@@ -90,6 +90,51 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         // stars before the run-level relaxed-fraction fallback may apply any penalty.
         public int MinFramesForPenalty { get; set; } = 3;
         public int MinAcceptedForPenalty { get; set; } = 1;
+
+        // ── Aberration-inspection fit guard (SFitGuard) ────────────────────────────────────────────────────
+        // The "Optimize for Aberration Inspection" mode reweights J toward star count (raised Ws + NFloor/NTarget
+        // knees, lowered Wf) so the optimizer trades some AF-curve sharpness for many more stars across the frame
+        // (what a tilt/curvature model needs). To keep the fit from degrading without bound, SFitGuard applies a
+        // MULTIPLICATIVE penalty once the focus σ grows past a margin over a reference σ (the sharpest curve the
+        // data supports — see StarDetectionOptimizerWizardVM, which seeds ReferenceSigmaFocus from the current
+        // settings' σ and ratchets it down to the best σ the search has seen).
+        //
+        // ReferenceSigmaFocus is NaN for the STANDARD objective, which makes SFitGuard return exactly 1.0 (J
+        // bit-identical to the pre-guard objective — every existing test is unaffected). It is set to a finite σ
+        // only by ForAberrationInspection / the wizard's inspection path.
+        public double ReferenceSigmaFocus { get; set; } = double.NaN;
+
+        // Allowed σ degradation before the penalty starts, as a fraction of ReferenceSigmaFocus: the penalty is
+        // exactly 1.0 while σ ≤ (1 + FitGuardMarginFraction)·ReferenceSigmaFocus. CALIBRATED on a real defocus-aware
+        // AF run (astrodet) so the star-recovery optimum (low sensitivity) lands inside the margin while a genuinely
+        // bad fit does not — see docs / the plan's calibration step. Only consulted when ReferenceSigmaFocus is finite.
+        public double FitGuardMarginFraction { get; set; } = 0.5;
+
+        // Penalty strength: how hard J is scaled down per unit of excess σ fraction above the margin. The penalty is
+        // 1 − Strength · max(0, σ/refσ − (1 + Margin)), clamped to [MinFactor, 1].
+        public double FitGuardStrength { get; set; } = 1.5;
+
+        // Floor on the fit-guard penalty so a single very-soft fit can't drive J to 0 on its own (the hard σ checks
+        // own the hard-fail path). 0.25 ⇒ at most a 4× reduction from this term alone.
+        public double FitGuardMinFactor { get; set; } = 0.25;
+
+        /// <summary>
+        /// Builds the constants for the "Optimize for Aberration Inspection" objective: reweighted toward star
+        /// count (so the optimizer recovers many more stars across the frame for tilt/curvature modeling) while the
+        /// fit stays bounded by <see cref="SFitGuard"/> relative to <paramref name="referenceSigmaFocus"/> (the
+        /// sharpest AF curve the data supports). All other knobs (curve-fit weight, hard floors, tie-breaker, the
+        /// defocus-precision penalty) are left at their standard values. When <paramref name="referenceSigmaFocus"/>
+        /// is NaN the fit guard is inert (no σ anchor), so the mode then degrades to a pure reweight.
+        /// </summary>
+        public static ObjectiveConstants ForAberrationInspection(double referenceSigmaFocus) {
+            return new ObjectiveConstants {
+                Wf = 0.30,   // focus matters less — we accept a slightly noisier curve for more stars
+                Ws = 0.45,   // star count dominates the primary trade
+                NFloor = 20, // raise the knees so the extra recovered stars keep paying off (don't clamp early)
+                NTarget = 60,
+                ReferenceSigmaFocus = referenceSigmaFocus
+            };
+        }
     }
 
     /// <summary>
@@ -247,6 +292,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // penalized. Composes identically in the labeled and unlabeled cases (applied after the weighted sum).
             j *= SDefocusPrecision(m, c);
 
+            // Aberration-inspection fit guard: MULTIPLICATIVE penalty that bounds how far the focus σ may degrade
+            // relative to the reference σ. Returns exactly 1.0 for the STANDARD objective (ReferenceSigmaFocus NaN)
+            // and while σ stays within the margin, so J is bit-identical unless the inspection mode set a finite
+            // reference AND the fit has degraded past it. Applied after the weighted sum, like SDefocusPrecision.
+            j *= SFitGuard(m, c);
+
             // Plateau tie-breaker: blend in the unsaturating secondary score so that when the primary objective is
             // flat (J saturated at 1.0 over a region) the search still prefers more stars / lower σ. Applied ONLY on
             // this feasible path (the hard-fail returns above keep returning 0.0, so it never rescues an infeasible
@@ -389,6 +440,41 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             }
             var penalty = 1.0 - c.DefocusPrecisionStrength * excess;
             var floor = c.DefocusPrecisionMinFactor;
+            if (penalty < floor) {
+                penalty = floor;
+            }
+            if (penalty > 1.0) {
+                penalty = 1.0;
+            }
+            return penalty;
+        }
+
+        /// <summary>
+        /// Aberration-inspection fit guard in (0, 1], MULTIPLIED into J by <see cref="JRun"/>. Returns
+        /// <b>exactly 1.0</b> (no penalty) when <see cref="ObjectiveConstants.ReferenceSigmaFocus"/> is non-finite
+        /// (the STANDARD objective — so J is bit-identical) OR when the run's focus σ is within the allowed margin
+        /// over the reference σ. Beyond the margin it decays linearly with the excess σ fraction, clamped to
+        /// [<see cref="ObjectiveConstants.FitGuardMinFactor"/>, 1].
+        ///
+        /// <para>σ is selected exactly like <see cref="SFocus"/> (SigmaFocus, else the leave-one-out fallback); if
+        /// neither is finite the guard is inert (1.0) — JRun already hard-fails an unusable σ before reaching here.
+        /// Penalty shape: <c>1 − Strength · max(0, σ/refσ − (1 + Margin))</c>.</para>
+        /// </summary>
+        public static double SFitGuard(RunEvaluationMetrics m, ObjectiveConstants c) {
+            if (m == null || !IsFinite(c.ReferenceSigmaFocus) || c.ReferenceSigmaFocus <= 0.0) {
+                return 1.0; // standard objective (no anchor) ⇒ no guard, J bit-identical
+            }
+            var sigma = IsFinite(m.SigmaFocus) ? m.SigmaFocus : (IsFinite(m.LooStdError) ? m.LooStdError : double.NaN);
+            if (!IsFinite(sigma) || sigma <= 0.0) {
+                return 1.0; // no usable σ ⇒ nothing to bound (the hard-fail path owns unusable σ)
+            }
+            var ratio = sigma / c.ReferenceSigmaFocus;
+            var excess = ratio - (1.0 + c.FitGuardMarginFraction);
+            if (excess <= 0.0) {
+                return 1.0; // within the allowed degradation margin
+            }
+            var penalty = 1.0 - c.FitGuardStrength * excess;
+            var floor = c.FitGuardMinFactor;
             if (penalty < floor) {
                 penalty = floor;
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -66,11 +66,23 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         Live
     }
 
-    /// <summary>One row of the summary's changed-parameters table (seed vs optimized for a single knob).</summary>
+    /// <summary>One row of the summary's changed-parameters table (seed vs optimized for a single knob). For a
+    /// single optimization pass this is just current → optimized; after "Continue optimizing" it carries the full
+    /// per-round path in <see cref="Stages"/> (current → round1 → round2 → …), rendered as an arrowed
+    /// <see cref="Trajectory"/>.</summary>
     public sealed class ChangedParameterRow {
         public string Name { get; set; }
         public double SeedValue { get; set; }
         public double OptimizedValue { get; set; }
+
+        /// <summary>The value of this parameter at each stage: [current, round1, round2, …]. Defaults to the
+        /// 2-stage [SeedValue, OptimizedValue] when not explicitly set (single-pass rows / AF step-size rows).</summary>
+        public IReadOnlyList<double> Stages { get; set; }
+
+        /// <summary>The full path as an arrowed string, e.g. "0.500 → 0.620 → 0.680 → 0.700". Falls back to
+        /// current → optimized when <see cref="Stages"/> was not populated.</summary>
+        public string Trajectory =>
+            string.Join("  →  ", (Stages ?? new[] { SeedValue, OptimizedValue }).Select(v => v.ToString("F3")));
     }
 
     /// <summary>
@@ -253,9 +265,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         private int running; // 0 = idle, 1 = a Start is in flight (guards against double-start)
         private bool disposed;
 
-        // The objective the optimizer uses by default (StarDetectionOptimizer ctor defaults to new ObjectiveConstants()).
-        // The wizard computes the current-settings baseline J with the SAME constants so it is comparable to BestJ.
-        private readonly ObjectiveConstants objectiveConstants = new ObjectiveConstants();
+        // The objective the optimizer uses. Rebuilt once per run in ComputeBaselineJAsync: the STANDARD objective by
+        // default, or — when OptimizeForAberrationInspection is on — ObjectiveConstants.ForAberrationInspection
+        // anchored to the measured current-settings σ. The wizard computes the current-settings baseline J with the
+        // SAME constants it hands the optimizer, so the before/after numbers stay comparable to BestJ.
+        private ObjectiveConstants objectiveConstants = new ObjectiveConstants();
 
         // J of the user's CURRENT settings (Baseline), evaluated on the loaded runs. The displayed "before" for the
         // improvement readouts (summary SeedJ + live ProgressSeedJ). Set in StartAsync (and the re-optimize path)
@@ -332,6 +346,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             ReviewCommand = new AsyncRelayCommand(EnterReviewAsync, CanEnterReview);
             BackToSummaryCommand = new RelayCommand(BackToSummary, () => CurrentStep == WizardStep.Review && !IsBusy);
             ReOptimizeCommand = new AsyncRelayCommand(() => ReOptimizeWithLabelsAsync(CancellationToken.None), () => HasLabels && !IsBusy);
+            ContinueOptimizationCommand = new AsyncRelayCommand(() => ContinueOptimizationAsync(CancellationToken.None), () => CanContinueOptimization);
 
             // Start enables/disables as the per-run paths are filled in (Saved Auto-Focus), so re-evaluate its
             // CanExecute whenever a path is set or the run count changes.
@@ -361,6 +376,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     ReviewCommand.NotifyCanExecuteChanged();
                     BackToSummaryCommand.NotifyCanExecuteChanged();
                     AcceptCommand.NotifyCanExecuteChanged();
+                    ContinueOptimizationCommand.NotifyCanExecuteChanged();
+                    RaisePropertyChanged(nameof(CanContinueOptimization));
+                    RaisePropertyChanged(nameof(RoundsSummaryText));
+                    RaisePropertyChanged(nameof(HasRoundsSummary));
                 }
             }
         }
@@ -443,6 +462,24 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             }
         }
 
+        private bool optimizeForAberrationInspection;
+
+        /// <summary>When true (default OFF), the optimizer uses the aberration-inspection objective
+        /// (<see cref="ObjectiveConstants.ForAberrationInspection"/>): reweighted toward star count so it recovers
+        /// many more stars across the frame (what a tilt/curvature model needs), with the AF-curve fit bounded by
+        /// <see cref="OptimizationObjective.SFitGuard"/> relative to the current settings' σ so focus stays usable.
+        /// VM-only (resets each launch, like <see cref="StartFromCurrentSettings"/>): it only shapes the optimizer
+        /// search, not runtime detection, so nothing is persisted until Accept. Only meaningful in Optimize mode.</summary>
+        public bool OptimizeForAberrationInspection {
+            get => optimizeForAberrationInspection;
+            set {
+                if (optimizeForAberrationInspection != value) {
+                    optimizeForAberrationInspection = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
         private SourceMode sourceMode = SourceMode.Replay;
 
         public SourceMode SourceMode {
@@ -496,6 +533,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     ReviewCommand.NotifyCanExecuteChanged();
                     BackToSummaryCommand.NotifyCanExecuteChanged();
                     ReOptimizeCommand.NotifyCanExecuteChanged();
+                    ContinueOptimizationCommand.NotifyCanExecuteChanged();
+                    RaisePropertyChanged(nameof(CanContinueOptimization));
                 }
             }
         }
@@ -612,6 +651,37 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         private OptimizationSummary currentSummary, optimizedSummary, feedbackSummary;
         private OptimizationCurve currentCurve, optimizedCurve, feedbackCurve;
         private OptimizationVariant selectedVariant = OptimizationVariant.Current;
+
+        // "Continue optimizing" chain for the Optimized variant: the params at each stage [baseline, round1Best,
+        // round2Best, …] and the per-round BestJ. Round 1 is the initial StartAsync optimize; each Continue appends a
+        // stage by re-seeding from the prior best. The latest stage IS the Optimized variant (chart + Accept follow
+        // it); the chain only drives the multi-stage trajectory shown in the Changed-parameters table. Capped at
+        // MaxOptimizationRounds total passes.
+        private const int MaxOptimizationRounds = 3;
+        private readonly List<StarDetectorParams> optimizedChain = new List<StarDetectorParams>();
+        private readonly List<double> optimizedRoundJ = new List<double>();
+
+        /// <summary>Number of optimization passes that have produced the current Optimized variant (1 after the
+        /// initial optimize; up to <see cref="MaxOptimizationRounds"/> after Continue). 0 when no optimization ran.</summary>
+        public int RoundsCompleted => Math.Max(0, optimizedChain.Count - 1);
+
+        /// <summary>True while another "Continue optimizing" pass is allowed (an Optimized variant exists, the cap
+        /// hasn't been reached, and nothing is running). Drives the Continue button's enabled state.</summary>
+        public bool CanContinueOptimization => !IsBusy && IsSummary && HasOptimized && RoundsCompleted < MaxOptimizationRounds;
+
+        /// <summary>Header shown above the Changed-parameters table once more than one optimization pass has run:
+        /// e.g. "3 rounds  •  J: 0.940 → 0.985 → 0.990". Empty for a single round (no chain to summarize).</summary>
+        public string RoundsSummaryText {
+            get {
+                if (selectedVariant != OptimizationVariant.Optimized || optimizedRoundJ.Count <= 1) {
+                    return string.Empty;
+                }
+                var js = string.Join(" → ", optimizedRoundJ.Select(j => j.ToString("F3")));
+                return $"{optimizedRoundJ.Count} rounds  •  J: {currentBaselineJ:F3} → {js}";
+            }
+        }
+
+        public bool HasRoundsSummary => RoundsSummaryText.Length > 0;
 
         private OptimizationResult SelectedResult => selectedVariant switch {
             OptimizationVariant.Feedback => feedbackResult,
@@ -798,8 +868,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             RaisePropertyChanged(nameof(StarCountChangeBaselineLabel));
             RaisePropertyChanged(nameof(ShowReoptimizePrompt));
             RaisePropertyChanged(nameof(ShowFeedbackPanel));
+            RaisePropertyChanged(nameof(CanContinueOptimization));
+            RaisePropertyChanged(nameof(RoundsCompleted));
+            RaisePropertyChanged(nameof(RoundsSummaryText));
+            RaisePropertyChanged(nameof(HasRoundsSummary));
             AcceptCommand.NotifyCanExecuteChanged();
             BackCommand.NotifyCanExecuteChanged();
+            ContinueOptimizationCommand.NotifyCanExecuteChanged();
         }
 
         /// <summary>Resets all retained variants (called at the top of a fresh Start).</summary>
@@ -807,6 +882,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             currentResult = optimizedResult = feedbackResult = null;
             currentSummary = optimizedSummary = feedbackSummary = null;
             currentCurve = optimizedCurve = feedbackCurve = null;
+            optimizedChain.Clear();
+            optimizedRoundJ.Clear();
             selectedVariant = OptimizationVariant.Current;
             OptimizerImprovedOverCurrent = false;
             RaiseSelectedVariantDependents();
@@ -839,7 +916,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 if (Summary?.ChangedParameters == null) {
                     return Array.Empty<ChangedParameterRow>();
                 }
-                var rows = new List<ChangedParameterRow>(Summary.ChangedParameters);
+                // For the Optimized variant after one or more "Continue" passes, show the FULL per-round path
+                // (Current → R1 → R2 → …) from the chain; otherwise the plain current → optimized rows.
+                var baseRows = (selectedVariant == OptimizationVariant.Optimized && optimizedChain.Count > 2)
+                    ? BuildTrajectoryRows()
+                    : new List<ChangedParameterRow>(Summary.ChangedParameters);
+                var rows = baseRows;
                 if (ApplyRecommendedStepSize && CanApplyRecommendedStepSize) {
                     if (Summary.RecommendedStepSize != Summary.CurrentStepSize) {
                         rows.Add(new ChangedParameterRow {
@@ -858,6 +940,27 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 }
                 return rows;
             }
+        }
+
+        /// <summary>Builds the multi-stage changed-parameter rows from the Continue chain: one row per curated knob
+        /// that changed at ANY stage, carrying its value at every stage [current, round1, round2, …] so the table can
+        /// render the full Current → R1 → R2 → … trajectory. Mirrors BuildSummaryAsync's "diff over the curated set"
+        /// but across all stages rather than just current → best.</summary>
+        private List<ChangedParameterRow> BuildTrajectoryRows() {
+            var rows = new List<ChangedParameterRow>();
+            var baseline = optimizedChain[0];
+            foreach (var v in OptimizerVariable.CreateCuratedSet(baseline)) {
+                var stages = optimizedChain.Select(p => v.Read(p)).ToList();
+                if (stages.Skip(1).Any(s => Math.Abs(s - stages[0]) > 1e-9)) {
+                    rows.Add(new ChangedParameterRow {
+                        Name = v.Name,
+                        SeedValue = stages[0],
+                        OptimizedValue = stages[stages.Count - 1],
+                        Stages = stages
+                    });
+                }
+            }
+            return rows;
         }
 
         private StarReviewVM reviewVM;
@@ -916,6 +1019,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// feeds the labels the user made into the optimizer's recall/precision objective term, and returns to an
         /// updated Summary. Enabled only when <see cref="HasLabels"/> is true and the VM is idle.</summary>
         public AsyncRelayCommand ReOptimizeCommand { get; }
+
+        /// <summary>Summary → continue optimizing: re-loads the runs from disk and runs another optimization pass
+        /// seeded from the current best (fresh step scale), updating the Optimized variant in place and appending a
+        /// stage to the trajectory. Enabled only while <see cref="CanContinueOptimization"/> (≤ 3 total passes).</summary>
+        public AsyncRelayCommand ContinueOptimizationCommand { get; }
 
         #endregion Commands
 
@@ -1106,6 +1214,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     optimizedResult = optimizeResult;
                     optimizedSummary = built.Summary;
                     optimizedCurve = built.OptimizedCurve;
+                    // Round 1 of the "Continue optimizing" chain: [current settings, this pass's best]. Continue
+                    // appends a stage per pass; the trajectory table reads these.
+                    optimizedChain.Clear();
+                    optimizedChain.Add(loadedRuns[0].Baseline);
+                    optimizedChain.Add(optimizeResult.BestParams);
+                    optimizedRoundJ.Clear();
+                    optimizedRoundJ.Add(optimizeResult.BestJ);
                     // Only PRESENT the optimized result as the recommendation when it strictly beats the user's
                     // current settings. The search seeds from the default params and guarantees ">= seed", NOT
                     // ">= current"; on a saturated/easy run it can converge to a local optimum worse than a well-tuned
@@ -1285,12 +1400,27 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // Use a SINGLE current-settings bundle (runs[0].Baseline) across every run, exactly as the optimizer's
             // evaluator applies one StarDetectorParams across all runs — so this J is directly comparable to BestJ.
             var baseline = runs[0].Baseline;
-            var perRunJ = new List<double>(runs.Count);
+            // Evaluate the current settings on each run ONCE: this yields both the σ that anchors the
+            // aberration-inspection fit guard and the metrics for the baseline J. σ is averaged over the runs that
+            // produced a finite focus σ (matching BuildSummaryAsync's baseline-σ aggregation).
+            var metrics = new List<RunEvaluationMetrics>(runs.Count);
+            double sigmaSum = 0.0; var sigmaCount = 0;
             for (var i = 0; i < runs.Count; i++) {
                 token.ThrowIfCancellationRequested();
                 var eval = await runs[i].Data.EvaluateAndFitAsync(baseline, token).ConfigureAwait(true);
-                perRunJ.Add(OptimizationObjective.JRun(eval.Metrics, objectiveConstants));
+                metrics.Add(eval.Metrics);
+                if (double.IsFinite(eval.Metrics.SigmaFocus)) { sigmaSum += eval.Metrics.SigmaFocus; sigmaCount++; }
             }
+
+            // Finalize the objective for THIS run before scoring: aberration-inspection reweights toward stars and
+            // bounds the fit relative to the measured current-settings σ; otherwise the standard objective. The same
+            // constants are then handed to the optimizer (OptimizeAsync), so the baseline J and BestJ are comparable.
+            var currentSigma = sigmaCount > 0 ? sigmaSum / sigmaCount : double.NaN;
+            objectiveConstants = OptimizeForAberrationInspection
+                ? ObjectiveConstants.ForAberrationInspection(currentSigma)
+                : new ObjectiveConstants();
+
+            var perRunJ = metrics.Select(m => OptimizationObjective.JRun(m, objectiveConstants)).ToList();
             return OptimizationObjective.JTotal(perRunJ, objectiveConstants);
         }
 
@@ -1327,7 +1457,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 Phase = FriendlyPhase(p.Phase);
             });
 
-            var optimizer = new StarDetectionOptimizer();
+            // Hand the optimizer the SAME objective the wizard scored the baseline with (standard, or the
+            // aberration-inspection reweight + fit guard) so BestJ and the displayed before/after stay comparable.
+            var optimizer = new StarDetectionOptimizer(objectiveConstants);
             IsOptimizing = true;
             try {
                 return await Task.Run(
@@ -1833,6 +1965,94 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             } catch (Exception ex) {
                 Logger.Error(ex, "Star detection re-optimization failed");
                 ErrorMessage = $"Re-optimization failed: {ex.Message}";
+                CurrentStep = WizardStep.Summary;
+            } finally {
+                DisposeLoadedRuns(reloaded);
+                IsBusy = false;
+                Interlocked.Exchange(ref running, 0);
+            }
+        }
+
+        /// <summary>
+        /// Summary → "Continue optimizing": runs ANOTHER optimization pass seeded from the current Optimized best,
+        /// updating the Optimized variant in place and appending a stage to the trajectory (Current → R1 → R2 → …).
+        /// Like <see cref="ReOptimizeWithLabelsAsync"/> it RE-LOADS the runs from disk (the first pass disposed the
+        /// in-memory data). Re-seeding with a FRESH curated set (built inside <see cref="OptimizeAsync"/> from the new
+        /// seed) resets the pattern-search step scale, so the search can make larger moves again — the whole point of
+        /// continuing. Never regresses: each pass's never-regress floor is its own seed (the prior best). Capped at
+        /// <see cref="MaxOptimizationRounds"/> total passes via <see cref="CanContinueOptimization"/>. No labels are
+        /// used (the feedback variant, if any, is left untouched).
+        /// </summary>
+        private async Task ContinueOptimizationAsync(CancellationToken externalToken) {
+            if (!CanContinueOptimization || reoptimizeRunFolders == null || reoptimizeRunFolders.Count == 0) {
+                return;
+            }
+            if (Interlocked.CompareExchange(ref running, 1, 0) != 0) {
+                return; // a Start/re-optimize/continue is already in flight
+            }
+
+            // The seed for this pass is the CURRENT Optimized best (captured before any UI churn). optimizedResult is
+            // not cleared by this path, so this stays valid through the reload.
+            var seedForContinue = optimizedResult.BestParams;
+
+            ErrorMessage = null;
+            SetProgress(null, 0, 0);
+            ProgressSeedJ = 0;
+            ProgressBestJ = 0;
+            IsBusy = true;
+
+            cts?.Dispose();
+            cts = CancellationTokenSource.CreateLinkedTokenSource(externalToken);
+            var token = cts.Token;
+
+            List<LoadedRun> reloaded = null;
+            try {
+                CurrentStep = WizardStep.Optimize;
+                reloaded = new List<LoadedRun>(reoptimizeRunFolders.Count);
+                for (var i = 0; i < reoptimizeRunFolders.Count; i++) {
+                    token.ThrowIfCancellationRequested();
+                    SetProgress("Re-loading frames", 0, 0);
+                    var folder = reoptimizeRunFolders[i];
+                    var loadProgress = new Progress<RunLoadProgress>(rp =>
+                        SetProgress("Loading frames", rp.Current, rp.Total));
+                    // No labels for a plain continue (byte-identical to the no-label load).
+                    var loaded = await loader.LoadSavedRunAsync(folder, region, null, loadProgress, token).ConfigureAwait(true);
+                    reloaded.Add(loaded);
+                }
+
+                // Warm the early contexts the optimizer will start from (the new seed), so the bar moves during the
+                // first build (continue skips the seed-guard, like the re-optimize path).
+                await AnalyzeWithProgressAsync(reloaded, _ => seedForContinue, token).ConfigureAwait(true);
+
+                // Baseline J (current settings) for the reloaded runs — also (re)builds objectiveConstants for THIS
+                // run, so the inspection-vs-standard objective stays consistent across continued passes.
+                currentBaselineJ = await ComputeBaselineJAsync(reloaded, token).ConfigureAwait(true);
+
+                // Another optimize pass seeded from the prior best; variablesOverride=null ⇒ OptimizeAsync builds a
+                // fresh CreateCuratedSet(seedForContinue) with reset step scale.
+                var optimizeResult = await OptimizeAsync(reloaded, token, seedForContinue).ConfigureAwait(true);
+                var built = await BuildSummaryAsync(reloaded, optimizeResult, token).ConfigureAwait(true);
+
+                // The latest pass REPLACES the Optimized variant (chart + Accept follow it); append the trajectory stage.
+                optimizedResult = optimizeResult;
+                optimizedSummary = built.Summary;
+                optimizedCurve = built.OptimizedCurve;
+                optimizedChain.Add(optimizeResult.BestParams);
+                optimizedRoundJ.Add(optimizeResult.BestJ);
+                OptimizerImprovedOverCurrent = optimizeResult.BestJ > currentBaselineJ + ImprovementEpsilon;
+                selectedVariant = OptimizationVariant.Optimized;
+                RaiseSelectedVariantDependents();
+
+                // Re-snapshot so a further Continue (or Review) stays reachable from the freshly-reloaded runs.
+                SnapshotReviewInputs(reloaded, reoptimizeRunFolders, reoptimizeRunIds);
+
+                CurrentStep = WizardStep.Summary;
+            } catch (OperationCanceledException) {
+                Logger.Info("Star detection continue-optimization cancelled");
+                CurrentStep = WizardStep.Summary;
+            } catch (Exception ex) {
+                Logger.Error(ex, "Star detection continue-optimization failed");
+                ErrorMessage = $"Continue optimization failed: {ex.Message}";
                 CurrentStep = WizardStep.Summary;
             } finally {
                 DisposeLoadedRuns(reloaded);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -709,6 +709,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         private const int MaxOptimizationRounds = 3;
         private readonly List<StarDetectorParams> optimizedChain = new List<StarDetectorParams>();
         private readonly List<double> optimizedRoundJ = new List<double>();
+        // The Optimized variant's curve per round [round1, round2, …] (parallel to the chain's non-baseline stages),
+        // retained so the per-frame "Stars per frame" trajectory can show counts across each pass. The latest one is
+        // also held in optimizedCurve for the chart; this list is the only place earlier rounds' curves survive.
+        private readonly List<OptimizationCurve> optimizedRoundCurves = new List<OptimizationCurve>();
 
         /// <summary>Number of optimization passes that have produced the current Optimized variant (1 after the
         /// initial optimize; up to <see cref="MaxOptimizationRounds"/> after Continue). 0 when no optimization ran.</summary>
@@ -843,6 +847,49 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// re-run prompt, the star-count comparison, or the label→gate breakdown.</summary>
         public bool ShowFeedbackPanel => ShowReoptimizePrompt || HasStarCountChanges || HasRecommendation;
 
+        /// <summary>Per-frame (per focuser position) accepted-star count and how it moved across the optimization
+        /// passes, shown in the main results flow (NOT the feedback panel). For the Optimized variant the stages are
+        /// [current, round1, round2, …] (the full Continue path); for the Current variant it is the single current
+        /// count; empty for the Feedback variant (its own <see cref="StarCountChanges"/> panel covers that view).</summary>
+        public IReadOnlyList<FrameStarCountTrajectory> StarsPerFrame {
+            get {
+                if (selectedVariant == OptimizationVariant.Optimized && currentCurve != null && optimizedRoundCurves.Count > 0) {
+                    var stages = new List<OptimizationCurve> { currentCurve }; // stage 0 = current settings
+                    stages.AddRange(optimizedRoundCurves);                      // then each optimization round
+                    return BuildStarCountTrajectories(stages);
+                }
+                if (selectedVariant == OptimizationVariant.Current && currentCurve != null) {
+                    return BuildStarCountTrajectories(new[] { currentCurve });  // counts only (single stage)
+                }
+                return Array.Empty<FrameStarCountTrajectory>();
+            }
+        }
+
+        public bool HasStarsPerFrame => StarsPerFrame.Count > 0;
+
+        /// <summary>Heading for the Stars-per-frame section: the Optimized variant shows a current→optimized change,
+        /// the Current variant just the per-frame counts.</summary>
+        public string StarsPerFrameLabel =>
+            selectedVariant == OptimizationVariant.Optimized ? "Stars per frame (current → optimized)" : "Stars per frame";
+
+        /// <summary>Builds per-position star-count trajectories across an ordered list of stage curves (each detects
+        /// the SAME frames, so positions line up). Each row carries that position's summed accepted-star count at
+        /// every stage (missing → 0). Curves that lack per-frame arrays contribute an empty stage.</summary>
+        private static IReadOnlyList<FrameStarCountTrajectory> BuildStarCountTrajectories(IReadOnlyList<OptimizationCurve> stageCurves) {
+            var byStage = stageCurves
+                .Select(c => (c?.FrameStarCounts != null && c.FrameFocuserPositions != null)
+                    ? SumStarCountsByPosition(c.FrameFocuserPositions, c.FrameStarCounts)
+                    : new Dictionary<int, int>())
+                .ToList();
+            var positions = byStage.SelectMany(d => d.Keys).Distinct().OrderBy(p => p).ToList();
+            var rows = new List<FrameStarCountTrajectory>(positions.Count);
+            foreach (var pos in positions) {
+                var stages = byStage.Select(d => d.TryGetValue(pos, out var v) ? v : 0).ToList();
+                rows.Add(new FrameStarCountTrajectory { FocuserPosition = pos, Stages = stages });
+            }
+            return rows;
+        }
+
         /// <summary>Builds the per-position accepted-star-count change between two variants' representative-run frames
         /// (positions match because both detect the SAME frames). Returns empty when either side lacks counts.</summary>
         private static IReadOnlyList<FrameStarCountChange> BuildStarCountChanges(OptimizationCurve baseline, OptimizationCurve feedback) {
@@ -915,6 +962,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             RaisePropertyChanged(nameof(StarCountChanges));
             RaisePropertyChanged(nameof(HasStarCountChanges));
             RaisePropertyChanged(nameof(StarCountChangeBaselineLabel));
+            RaisePropertyChanged(nameof(StarsPerFrame));
+            RaisePropertyChanged(nameof(HasStarsPerFrame));
+            RaisePropertyChanged(nameof(StarsPerFrameLabel));
             RaisePropertyChanged(nameof(ShowReoptimizePrompt));
             RaisePropertyChanged(nameof(ShowFeedbackPanel));
             RaisePropertyChanged(nameof(CanContinueOptimization));
@@ -933,6 +983,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             currentCurve = optimizedCurve = feedbackCurve = null;
             optimizedChain.Clear();
             optimizedRoundJ.Clear();
+            optimizedRoundCurves.Clear();
             selectedVariant = OptimizationVariant.Current;
             OptimizerImprovedOverCurrent = false;
             RaiseSelectedVariantDependents();
@@ -1270,6 +1321,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     optimizedChain.Add(optimizeResult.BestParams);
                     optimizedRoundJ.Clear();
                     optimizedRoundJ.Add(optimizeResult.BestJ);
+                    optimizedRoundCurves.Clear();
+                    optimizedRoundCurves.Add(built.OptimizedCurve); // round-1 curve (stage 0 = currentCurve, the baseline)
                     // Only PRESENT the optimized result as the recommendation when it strictly beats the user's
                     // current settings. The search seeds from the default params and guarantees ">= seed", NOT
                     // ">= current"; on a saturated/easy run it can converge to a local optimum worse than a well-tuned
@@ -2090,6 +2143,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 optimizedCurve = built.OptimizedCurve;
                 optimizedChain.Add(optimizeResult.BestParams);
                 optimizedRoundJ.Add(optimizeResult.BestJ);
+                optimizedRoundCurves.Add(built.OptimizedCurve); // retain this round's curve for the per-frame trajectory
                 OptimizerImprovedOverCurrent = optimizeResult.BestJ > currentBaselineJ + ImprovementEpsilon;
                 selectedVariant = OptimizationVariant.Optimized;
                 RaiseSelectedVariantDependents();

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -551,8 +551,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         private DispatcherTimer elapsedTimer;
         private TimeSpan lastRunDuration;
 
-        /// <summary>Live "M:SS" elapsed time for the in-progress run, shown under the progress text. Updates each
-        /// second while busy.</summary>
+        /// <summary>Live "M:SS" elapsed time for the in-progress run, shown inline with the progress count. Updates
+        /// each second while busy.</summary>
         public string ElapsedText => FormatDuration(runStopwatch.Elapsed);
 
         /// <summary>"M:SS" total time the most recent run took, shown on the summary. Empty until a run has completed.</summary>
@@ -566,10 +566,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
         private void StartRunTimer() {
             runStopwatch.Restart();
-            RaisePropertyChanged(nameof(ElapsedText));
+            RaiseElapsedChanged();
             if (elapsedTimer == null) {
                 elapsedTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
-                elapsedTimer.Tick += (_, __) => RaisePropertyChanged(nameof(ElapsedText));
+                elapsedTimer.Tick += (_, __) => RaiseElapsedChanged();
             }
             elapsedTimer.Start();
         }
@@ -577,7 +577,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         private void StopRunTimer() {
             elapsedTimer?.Stop();
             runStopwatch.Stop();
+            RaiseElapsedChanged();
+        }
+
+        /// <summary>Refreshes the elapsed readout and the combined "X / Y (M:SS)" progress line each tick.</summary>
+        private void RaiseElapsedChanged() {
             RaisePropertyChanged(nameof(ElapsedText));
+            RaisePropertyChanged(nameof(ProgressCountElapsedText));
         }
 
         /// <summary>Captures the in-progress run's elapsed time as the displayed run duration (called on the success
@@ -613,7 +619,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// analyzed / combinations tried / frames detected for review).</summary>
         public int ProgressCurrent {
             get => progressCurrent;
-            private set { progressCurrent = value; RaisePropertyChanged(); RaisePropertyChanged(nameof(ProgressCountText)); }
+            private set { progressCurrent = value; RaisePropertyChanged(); RaisePropertyChanged(nameof(ProgressCountText)); RaisePropertyChanged(nameof(ProgressCountElapsedText)); }
         }
 
         private int progressTotal;
@@ -626,6 +632,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 progressTotal = value;
                 RaisePropertyChanged();
                 RaisePropertyChanged(nameof(ProgressCountText));
+                RaisePropertyChanged(nameof(ProgressCountElapsedText));
                 RaisePropertyChanged(nameof(HasProgressCount));
                 RaisePropertyChanged(nameof(IsProgressIndeterminate));
             }
@@ -639,6 +646,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
         /// <summary>The "N / M" count line shown under the progress bar; empty when there is no determinate total.</summary>
         public string ProgressCountText => progressTotal > 0 ? $"{progressCurrent} / {progressTotal}" : string.Empty;
+
+        /// <summary>The progress line under the bar: "X / Y (M:SS)" when there is a determinate count, else just the
+        /// elapsed clock "(M:SS)" (so the timer stays visible during indeterminate phases). Re-raised each second by
+        /// the elapsed timer and whenever the count changes.</summary>
+        public string ProgressCountElapsedText =>
+            HasProgressCount ? $"{ProgressCountText} ({ElapsedText})" : $"({ElapsedText})";
 
         private bool isOptimizing;
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -29,6 +29,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Threading;
 using AsyncRelayCommand = CommunityToolkit.Mvvm.Input.AsyncRelayCommand;
 using Logger = NINA.Core.Utility.Logger;
 using RelayCommand = CommunityToolkit.Mvvm.Input.RelayCommand;
@@ -525,6 +526,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             private set {
                 if (isBusy != value) {
                     isBusy = value;
+                    // Drive the elapsed-time clock off the busy state: it runs for the whole busy span the progress
+                    // window is shown for (load → analyze → optimize → build review), so the timer and the summary's
+                    // duration measure exactly the run the user sees progress for.
+                    if (value) { StartRunTimer(); } else { StopRunTimer(); }
                     RaisePropertyChanged();
                     RaiseStepVisibilityChanged();
                     StartCommand.NotifyCanExecuteChanged();
@@ -537,6 +542,50 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     RaisePropertyChanged(nameof(CanContinueOptimization));
                 }
             }
+        }
+
+        // Elapsed-time clock for the run currently in progress. runStopwatch measures the busy span; elapsedTimer
+        // ticks once a second to refresh ElapsedText in the progress window. lastRunDuration is the final elapsed of
+        // the most recent completed run, shown on the summary.
+        private readonly System.Diagnostics.Stopwatch runStopwatch = new System.Diagnostics.Stopwatch();
+        private DispatcherTimer elapsedTimer;
+        private TimeSpan lastRunDuration;
+
+        /// <summary>Live "M:SS" elapsed time for the in-progress run, shown under the progress text. Updates each
+        /// second while busy.</summary>
+        public string ElapsedText => FormatDuration(runStopwatch.Elapsed);
+
+        /// <summary>"M:SS" total time the most recent run took, shown on the summary. Empty until a run has completed.</summary>
+        public string RunDurationText => lastRunDuration > TimeSpan.Zero ? FormatDuration(lastRunDuration) : string.Empty;
+
+        /// <summary>Whether a completed-run duration is available to show on the summary.</summary>
+        public bool HasRunDuration => lastRunDuration > TimeSpan.Zero;
+
+        /// <summary>Formats a duration as minutes:seconds (e.g. "3:07"); pure — unit-tested.</summary>
+        public static string FormatDuration(TimeSpan t) => $"{(int)t.TotalMinutes}:{t.Seconds:D2}";
+
+        private void StartRunTimer() {
+            runStopwatch.Restart();
+            RaisePropertyChanged(nameof(ElapsedText));
+            if (elapsedTimer == null) {
+                elapsedTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+                elapsedTimer.Tick += (_, __) => RaisePropertyChanged(nameof(ElapsedText));
+            }
+            elapsedTimer.Start();
+        }
+
+        private void StopRunTimer() {
+            elapsedTimer?.Stop();
+            runStopwatch.Stop();
+            RaisePropertyChanged(nameof(ElapsedText));
+        }
+
+        /// <summary>Captures the in-progress run's elapsed time as the displayed run duration (called on the success
+        /// path, just before landing on the Summary, while the stopwatch is still running).</summary>
+        private void RecordRunDuration() {
+            lastRunDuration = runStopwatch.Elapsed;
+            RaisePropertyChanged(nameof(RunDurationText));
+            RaisePropertyChanged(nameof(HasRunDuration));
         }
 
         private string errorMessage;
@@ -1241,6 +1290,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 // step must detect from DISK afterward using only these paths/positions.
                 SnapshotReviewInputs(loadedRuns, loadedRunFolders, loadedRunIds);
 
+                RecordRunDuration();
                 CurrentStep = WizardStep.Summary;
             } catch (OperationCanceledException) {
                 Logger.Info("Star detection optimization cancelled");
@@ -1958,6 +2008,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 // the RunIds are deterministic from the folders, so the same snapshot carries forward.
                 SnapshotReviewInputs(reloaded, reoptimizeRunFolders, reoptimizeRunIds);
 
+                RecordRunDuration();
                 CurrentStep = WizardStep.Summary;
             } catch (OperationCanceledException) {
                 Logger.Info("Star detection re-optimization cancelled");
@@ -2046,6 +2097,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 // Re-snapshot so a further Continue (or Review) stays reachable from the freshly-reloaded runs.
                 SnapshotReviewInputs(reloaded, reoptimizeRunFolders, reoptimizeRunIds);
 
+                RecordRunDuration();
                 CurrentStep = WizardStep.Summary;
             } catch (OperationCanceledException) {
                 Logger.Info("Star detection continue-optimization cancelled");
@@ -2186,6 +2238,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 return;
             }
             disposed = true;
+            elapsedTimer?.Stop();
+            elapsedTimer = null;
+            runStopwatch.Stop();
             cts?.Dispose();
             cts = null;
         }

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -109,6 +109,22 @@ namespace TestApp {
             // master follows the profile (default OFF) and no defocus axis is searched — for A/B before/after.
             bool forceDonut = DiagnosticUtil.HasFlag(args, "--donut");
 
+            // --inspection mirrors the wizard's "Optimize for aberration inspection" toggle: swap in the
+            // star-favoring objective (ObjectiveConstants.ForAberrationInspection) bounded relative to the current
+            // settings' σ. Off ⇒ the standard objective (bit-identical to before).
+            bool inspection = DiagnosticUtil.HasFlag(args, "--inspection");
+
+            // --continue-rounds <0-2> mirrors the wizard's "Continue optimizing" button: after the first optimize,
+            // re-seed from the prior best and run again (fresh curated set / step scale) up to this many more times
+            // (3 passes total). Validates the chaining headlessly; per-round J is reported.
+            int continueRounds = 0;
+            var continueRoundsArg = DiagnosticUtil.GetArg(args, "--continue-rounds");
+            if (!string.IsNullOrWhiteSpace(continueRoundsArg)) {
+                if (!int.TryParse(continueRoundsArg, NumberStyles.Integer, CultureInfo.InvariantCulture, out continueRounds) || continueRounds < 0 || continueRounds > 2) {
+                    throw new ArgumentException($"--continue-rounds: '{continueRoundsArg}' must be an integer in [0, 2]");
+                }
+            }
+
             var labelsDir = DiagnosticUtil.GetArg(args, "--labels");
 
             // --per-run is a valueless flag: optimize each discovered run INDEPENDENTLY (one optimization, one
@@ -247,8 +263,16 @@ namespace TestApp {
                 Variables = OptimizerVariable.CreateCuratedSet(seed),
                 MaxEvals = maxEvals,
                 LabelsDir = labelsDir,
-                AnnotateAll = annotateAll
+                AnnotateAll = annotateAll,
+                Inspection = inspection,
+                ContinueRounds = continueRounds
             };
+            if (inspection) {
+                Console.WriteLine("--inspection: aberration-inspection objective (favor more stars, fit bounded vs current σ)");
+            }
+            if (continueRounds > 0) {
+                Console.WriteLine($"--continue-rounds: {continueRounds} extra pass(es) after the first ({continueRounds + 1} total)");
+            }
 
             if (perRun) {
                 await RunPerRun(ctx, runsDir, outDir, discovery.Runs, labelsByRun).ConfigureAwait(false);
@@ -272,6 +296,8 @@ namespace TestApp {
             public int? MaxEvals;
             public string LabelsDir;
             public bool AnnotateAll;
+            public bool Inspection;     // --inspection: use the aberration-inspection objective
+            public int ContinueRounds;  // --continue-rounds: extra chained passes after the first (0-2)
         }
 
         /// <summary>Outcome of optimizing one set of runs (joint or a single per-run), for the aggregate report.</summary>
@@ -412,23 +438,36 @@ namespace TestApp {
             }
 
             var variables = ctx.Variables;
-            var optimizer = new StarDetectionOptimizer();
 
             var dataList = loadedRuns.Select(r => r.Data).ToList();
             var evaluator = RunEvaluationData.CreateEvaluator(dataList);
-            var objectiveConstants = new ObjectiveConstants();
 
             // "Before" = the user's CURRENT settings (ctx.Baseline) — the wizard's displayed baseline, NOT the default
-            // seed the optimizer started from. Evaluate it FIRST so baselineJ (the SAME JTotal the optimizer uses, over
-            // the single baseline bundle across runs) is available to the progress + completion lines, keeping every
-            // console/report number "vs current" — consistent with the final summary and the live wizard.
+            // seed the optimizer started from. Evaluate it FIRST so it yields BOTH the current-settings σ (the
+            // aberration-inspection fit-guard anchor) and the baselineJ (the SAME JTotal the optimizer uses, over the
+            // single baseline bundle across runs), keeping every console/report number "vs current" — consistent with
+            // the final summary and the live wizard.
             var perRunBaseline = new List<RunEvaluationResult>(loadedRuns.Count);
             foreach (var r in loadedRuns) {
                 perRunBaseline.Add(await r.Data.EvaluateAndFitAsync(ctx.Baseline, CancellationToken.None).ConfigureAwait(false));
             }
+
+            // Finalize the objective: aberration-inspection (reweighted toward stars, fit bounded relative to the
+            // current-settings σ) when --inspection, else standard. The wizard builds these exact constants in
+            // ComputeBaselineJAsync; mirroring that here keeps the headless harness authoritative.
+            var baselineSigmas = perRunBaseline.Select(pr => pr.Metrics.SigmaFocus).Where(s => double.IsFinite(s)).ToList();
+            var currentSigma = baselineSigmas.Count > 0 ? baselineSigmas.Average() : double.NaN;
+            var objectiveConstants = ctx.Inspection
+                ? ObjectiveConstants.ForAberrationInspection(currentSigma)
+                : new ObjectiveConstants();
+            var optimizer = new StarDetectionOptimizer(objectiveConstants);
+
             var baselineJ = OptimizationObjective.JTotal(
                 perRunBaseline.Select(pr => OptimizationObjective.JRun(pr.Metrics, objectiveConstants)).ToList(), objectiveConstants);
             Console.WriteLine($"Current settings J: {F(baselineJ)}");
+            if (ctx.Inspection) {
+                Console.WriteLine($"  inspection objective: reference σ = {F(currentSigma)} (current settings), margin = {F(objectiveConstants.FitGuardMarginFraction)}");
+            }
 
             // Trajectory capture (eval-budget analysis): the optimizer reports on the seed + every accepted move, so
             // these rows are the bestJ-vs-evals staircase. Written to optimize_trajectory.csv; analyzed offline to
@@ -446,7 +485,24 @@ namespace TestApp {
 
             var sw = System.Diagnostics.Stopwatch.StartNew();
             var result = await optimizer.OptimizeAsync(ctx.Seed, variables, evaluator, settings, progress, CancellationToken.None).ConfigureAwait(false);
+
+            // --continue-rounds: chain additional passes, each re-seeded from the prior best with a FRESH curated set
+            // (resets the pattern-search step scale, so it can make larger moves again — the point of "Continue").
+            // Mirrors the wizard's Continue button (latest replaces Optimized); per-round J reported. Never regresses
+            // (each pass's never-regress floor is its own seed = the prior best).
+            var roundBestJ = new List<double> { result.BestJ };
+            for (var roundIdx = 0; roundIdx < ctx.ContinueRounds; roundIdx++) {
+                var seedN = result.BestParams;
+                var variablesN = OptimizerVariable.CreateCuratedSet(seedN);
+                var next = await optimizer.OptimizeAsync(seedN, variablesN, evaluator, settings, progress, CancellationToken.None).ConfigureAwait(false);
+                Console.WriteLine($"Continue round {roundIdx + 1}: bestJ {F(result.BestJ)} -> {F(next.BestJ)}");
+                result = next;
+                roundBestJ.Add(next.BestJ);
+            }
             sw.Stop();
+            if (ctx.ContinueRounds > 0) {
+                Console.WriteLine($"Per-round J: {string.Join(" -> ", roundBestJ.Select(F))}");
+            }
             Console.WriteLine($"Optimization complete: currentJ={F(baselineJ)} -> bestJ={F(result.BestJ)} ({(result.BestJ > baselineJ ? "improved over current" : "no improvement over current")}), evals={result.Evaluations}");
 
             // Cache-health + wall-clock readout (the early-context build:reuse ratio is the direct measure of how much
@@ -665,7 +721,7 @@ namespace TestApp {
         }
 
         private static void PrintUsage() {
-            Console.Error.WriteLine("Usage: TestApp optimize --runs <folder> [--per-run] [--profile-id <guid>] [--out <dir>] [--max-evals <int>] [--annotate extremes|all] [--labels <dir>] [--verbose]");
+            Console.Error.WriteLine("Usage: TestApp optimize --runs <folder> [--per-run] [--profile-id <guid>] [--out <dir>] [--max-evals <int>] [--annotate extremes|all] [--labels <dir>] [--inspection] [--continue-rounds <0-2>] [--verbose]");
             Console.Error.WriteLine("  --runs       (required) folder of saved AF runs. Runs are 'attempt*' folders (recursively, <=4 deep) with >=3 focuser positions; or --runs itself.");
             Console.Error.WriteLine("  --per-run    (optional) optimize each discovered run INDEPENDENTLY into its own subfolder + an aggregate_summary.txt (use for a multi-setup bank).");
             Console.Error.WriteLine("  --profile-id (default active) NINA profile id to load (settings + PixelScale).");
@@ -673,6 +729,8 @@ namespace TestApp {
             Console.Error.WriteLine("  --max-evals  (optional) override the optimizer's MaxEvaluations budget.");
             Console.Error.WriteLine("  --annotate   (default extremes) annotate only min/max-focuser frames, or 'all' frames.");
             Console.Error.WriteLine("  --labels     (optional) folder of label JSON files; activates the recall/precision objective term.");
+            Console.Error.WriteLine("  --inspection (optional) use the aberration-inspection objective (favor more stars; fit bounded relative to current σ).");
+            Console.Error.WriteLine("  --continue-rounds (optional, 0-2) extra chained passes after the first, each re-seeded from the prior best (3 total).");
             Console.Error.WriteLine("  --verbose    (optional) restore TRACE logging (default INFO). Slower: serializes per-detection stage timings to the NINA log.");
         }
 


### PR DESCRIPTION
## Summary

Enhancements to the Star Detection Optimization Wizard for long-tail refinement, aberration-inspection tuning, and richer summary feedback.

### 1. Continue optimizing (chain up to 3 rounds)
- A **Continue optimizing** button on the summary runs another pass seeded from the current best with a fresh step scale, so the pattern search escapes its step floor and keeps refining.
- Capped at 3 total passes (greys out at the cap). The latest round **replaces the Optimized variant** (chart + Accept follow it).
- The Changed-parameters table shows the full per-round path — `Current → R1 → R2 → R3` — plus a rounds-J header.

### 2. Optimize for Aberration Inspection
- Start-screen toggle (with tooltip) swaps in a star-favoring objective (`ObjectiveConstants.ForAberrationInspection`: Wf 0.30, Ws 0.45, raised star knees) bounded by a new multiplicative `SFitGuard` penalty relative to the current settings' σ.
- Recovers many more stars across the frame (for tilt/curvature modeling) while keeping a usable AF curve.
- **Bit-identical** to the standard objective when off: `SFitGuard ≡ 1.0` when `ReferenceSigmaFocus` is NaN (covered by `JRun_BitIdentical_WithDefaultConstants`).

### 3. Elapsed time + run duration
- The progress window shows a live elapsed clock inline with the count: **`X / Y (MM:SS)`** (or `(MM:SS)` during indeterminate phases), ticking once a second.
- The summary shows **how long the most recent run took** ("Optimization time", `MM:SS`), captured on each success path.

### 4. Stars per frame on the summary
- A **"Stars per frame"** section in the main results flow (not the gray panel), reusing the post-labeling per-position cell rendering.
- Each cell shows a focuser position's accepted star count and how it moved across passes: `current → optimized` for one pass, the full `current → R1 → R2` path after Continue, plus a bold net delta.
- Shown for the **Optimized** variant (trajectory + delta) and the **Current** variant (counts only); the **Feedback** variant keeps its existing panel. Per-round optimized curves are now retained so earlier rounds' counts survive.

### TestApp parity
`optimize` gains `--inspection` and `--continue-rounds <0-2>` so the headless harness mirrors the wizard.

## Validation
Measured on `astrodet AutoFocus_20260613_232909` (250-eval budget):

| | Sensitivity | total stars | stars @ best focus | σ_focus (steps) | hard floor |
|---|---|---|---|---|---|
| Standard | 14 → 16.67 | 431 | 136 | 5.37 → 0.158 | PASS |
| Inspection | 14 → 11.67 | **645 (+50%)** | **230 (+69%)** | 5.37 → 1.94 | PASS |

σ_focus is best-focus *position* uncertainty in focuser steps, so ~2 steps is still a tight, usable curve. Continue-rounds validated headless (J 0.999844 → 0.999851 → 0.999851 — improves then converges, never regresses).

All **1376 tests pass**.

## Design note
The inspection fit bound is anchored to the **current settings' σ** (fixed per run — not a mid-search ratchet, to preserve optimizer determinism). This is a coherent "stay within X% of your current fit quality" semantic: the primary star/fit trade is driven by the reweighted weights, with `SFitGuard` as a catastrophe backstop. Loose-current users get aggressive recovery; tight-current users get modest recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)