### PR TITLE
Reliable 6-step tilt calibration + save/replay

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -103,6 +103,30 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         }
 
         [Test]
+        public void SaveAFRuns_DefaultsOff_AndResetsOnRestart() {
+            // Saving must be explicitly enabled for each run, so it defaults off and Restart clears it.
+            var (vm, _, _, _) = Build();
+            Assert.That(vm.SaveAFRuns, Is.False);
+            vm.SaveAFRuns = true;
+            vm.RestartCommand.Execute(null);
+            Assert.That(vm.SaveAFRuns, Is.False);
+        }
+
+        [Test]
+        public void SaveAFRunsPath_WritesThroughToOptions() {
+            var (vm, options, _, _) = Build();
+            vm.SaveAFRunsPath = @"C:\temp\tilt";
+            options.Received().SaveAFRunsPath = @"C:\temp\tilt";
+        }
+
+        [Test]
+        public void BaselineInstructions_DoNotRequireAFixedScrewPosition() {
+            // Req 1: screw 1 no longer needs to be at any particular clock position.
+            var (vm, _, _, _) = Build();
+            Assert.That(vm.StepInstructions, Does.Not.Contain("12 o'clock"));
+        }
+
+        [Test]
         public void StepInstructions_DiffersByScrewCountAtAllScrewsStep() {
             var (vm3, _, _, _) = Build(screwCount: 3);
             var (vm4, _, _, _) = Build(screwCount: 4);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
@@ -111,7 +111,7 @@ public class TiltCalibrationCalculatorTests {
         var inputs = new TiltCalibrationInputs {
             ScrewCount = 3,
             Baseline = new TiltGradient(0, 0, 1000),
-            AllScrews = new TiltGradient(0, 0, 1000),
+            AllInward = new TiltGradient(0, 0, 1000),
             Screw1 = SingleScrewReading(0, pitch, 3),
             Screw2 = SingleScrewReading(120, pitch, 3),
             ImageWidthPixels = ImgW,
@@ -132,7 +132,7 @@ public class TiltCalibrationCalculatorTests {
         var inputs = new TiltCalibrationInputs {
             ScrewCount = 3,
             Baseline = new TiltGradient(0, 0, 0),
-            AllScrews = new TiltGradient(0, 0, 0),
+            AllInward = new TiltGradient(0, 0, 0),
             Screw1 = SingleScrewReading(0, axial, 3),
             Screw2 = SingleScrewReading(120, axial, 3),
             ImageWidthPixels = ImgW,
@@ -152,7 +152,7 @@ public class TiltCalibrationCalculatorTests {
         var inputs = new TiltCalibrationInputs {
             ScrewCount = 3,
             Baseline = new TiltGradient(0, 0, 0),
-            AllScrews = new TiltGradient(0, 0, 0),
+            AllInward = new TiltGradient(0, 0, 0),
             Screw1 = SingleScrewReading(0, 400, 3),
             Screw2 = SingleScrewReading(120, 400, 3),
             ImageWidthPixels = ImgW,
@@ -183,7 +183,7 @@ public class TiltCalibrationCalculatorTests {
         var inputs = new TiltCalibrationInputs {
             ScrewCount = 3,
             Baseline = new TiltGradient(0, 0, 0),
-            AllScrews = new TiltGradient(0, 0, 0),
+            AllInward = new TiltGradient(0, 0, 0),
             Screw1 = SingleScrewReading(0, 200, 3),
             Screw2 = SingleScrewReading(120, 400, 3),
             ImageWidthPixels = ImgW,
@@ -196,13 +196,64 @@ public class TiltCalibrationCalculatorTests {
         Assert.That(TiltCalibrationCalculator.Calibrate(inputs).MoveMagnitudeRatio, Is.EqualTo(2.0).Within(1e-6));
     }
 
+    private static TiltGradient Plus(TiltGradient a, TiltGradient b) =>
+        new TiltGradient(a.A + b.A, a.B + b.B, a.MeanFocuserPosition + b.MeanFocuserPosition);
+
+    [Test]
+    public void Calibrate_DerivesScrewDeltasFromReBaselineNotBaseline() {
+        // The screw moves are measured against the re-baseline that precedes them (c→d, e→f), so a drifted
+        // re-baseline (offset from the original baseline) must NOT contaminate the recovered angles: the single
+        // screw move is added on top of the re-baseline reading and the delta isolates it.
+        const double pitch = 400.0;
+        var reBaseline1 = new TiltGradient(12.0, -7.0, 1000);  // c drifted from baseline a
+        var reBaseline2 = new TiltGradient(-4.0, 9.0, 1000);   // e drifted from c
+        var inputs = new TiltCalibrationInputs {
+            ScrewCount = 3,
+            Baseline = new TiltGradient(0, 0, 1000),
+            AllInward = new TiltGradient(0, 0, 1075),
+            ReBaseline1 = reBaseline1,
+            Screw1 = Plus(reBaseline1, SingleScrewReading(0, pitch, 3)),
+            ReBaseline2 = reBaseline2,
+            Screw2 = Plus(reBaseline2, SingleScrewReading(120, pitch, 3)),
+            ImageWidthPixels = ImgW,
+            ImageHeightPixels = ImgH,
+            PixelSizeMicrons = PixelSize,
+            FocuserStepMicrons = FStep,
+            ScrewRadiusMillimeters = RadiusMm,
+            CalibrationAppliedAmount = 1.0,
+            IsStepperAdjustment = false
+        };
+        var r = TiltCalibrationCalculator.Calibrate(inputs);
+        Assert.Multiple(() => {
+            Assert.That(r.Screw1AngleDegrees, Is.EqualTo(0).Within(1e-4));
+            Assert.That(r.Screw2AngleDegrees, Is.EqualTo(120).Within(1e-4));
+            Assert.That(r.Screw3AngleDegrees, Is.EqualTo(240).Within(1e-4));
+            Assert.That(r.MeasuredHardwareMicrons, Is.EqualTo(pitch).Within(1e-3));
+            Assert.That(r.CurvatureSign, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void RebaselineDriftRatio_ZeroWhenNoDrift_GrowsWithDrift() {
+        Assert.Multiple(() => {
+            // No drift relative to a move of magnitude 10 -> 0.
+            Assert.That(TiltCalibrationCalculator.RebaselineDriftRatio(0, 0, 0, 10), Is.EqualTo(0.0).Within(1e-9));
+            // Drift magnitude 5 vs move magnitude 10 -> 0.5.
+            Assert.That(TiltCalibrationCalculator.RebaselineDriftRatio(3, 4, 0, 10), Is.EqualTo(0.5).Within(1e-9));
+            // Drift equal to the move -> 1.
+            Assert.That(TiltCalibrationCalculator.RebaselineDriftRatio(0, 10, 10, 0), Is.EqualTo(1.0).Within(1e-9));
+            // Zero move magnitude -> NaN.
+            Assert.That(double.IsNaN(TiltCalibrationCalculator.RebaselineDriftRatio(1, 1, 0, 0)), Is.True);
+        });
+    }
+
     [Test]
     public void Calibrate_EndToEnd_ThreeScrew_RecoversAnglesPitchAndSign() {
         const double pitch = 400.0;
         var inputs = new TiltCalibrationInputs {
             ScrewCount = 3,
             Baseline = new TiltGradient(0, 0, 1000),
-            AllScrews = new TiltGradient(0, 0, 1075), // all-screws-inward raised mean focus -> +1
+            AllInward = new TiltGradient(0, 0, 1075), // all-screws-inward raised mean focus -> +1
             Screw1 = SingleScrewReading(0, pitch, 3, 1000),
             Screw2 = SingleScrewReading(120, pitch, 3, 1000),
             ImageWidthPixels = ImgW,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationMetadataTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationMetadataTests.cs
@@ -64,6 +64,16 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             Assert.That(md.IsStepperAdjustment, Is.False);
         }
 
+        [Test]
+        public void ExpectedPositionAngleScrew1Deg_DefaultsToNaN_AndRoundTrips() {
+            // NaN signals "not provided" (a wizard-written file) so the headless validator reports the angle as
+            // n/a instead of failing it against a bogus 0° expectation.
+            var md = new TiltCalibrationMetadata();
+            Assert.That(double.IsNaN(md.ExpectedPositionAngleScrew1Deg), Is.True);
+            var back = TiltCalibrationMetadata.Deserialize(md.Serialize());
+            Assert.That(double.IsNaN(back.ExpectedPositionAngleScrew1Deg), Is.True);
+        }
+
         [TestCase(5)]
         [TestCase(2)]
         public void Validate_RejectsBadScrewCount(int screwCount) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationMetadataTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationMetadataTests.cs
@@ -1,0 +1,85 @@
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
+
+    [TestFixture]
+    public class TiltCalibrationMetadataTests {
+
+        [Test]
+        public void StepOrder_HasSixDiscreteSteps() {
+            Assert.That(TiltCalibrationMetadata.StepOrder,
+                Is.EqualTo(new[] { "Baseline", "AllInward", "ReBaseline1", "Screw1", "ReBaseline2", "Screw2" }));
+        }
+
+        [Test]
+        public void Serialize_RoundTripsAllFields() {
+            var md = new TiltCalibrationMetadata {
+                NumberOfScrews = 4,
+                AdjustmentType = "StepperMotors",
+                StepperStepSizeMicrons = 1.25,
+                ScrewRadiusMillimeters = 44.0,
+                PixelSizeMicrons = 3.76,
+                FocuserStepSizeMicrons = 3.58,
+                CalibrationAppliedAmount = 2.0,
+                MeasurementAverageCount = 3,
+                RunStepMapping = new List<TiltRunStepMapping> {
+                    new TiltRunStepMapping { Step = "Baseline", Folder = @"C:\runs\01_Baseline\AutoFocus_x" }
+                },
+                PerStep = new List<TiltPerStepResult> {
+                    new TiltPerStepResult {
+                        Step = "Baseline", TiltPlaneA = 1.1, TiltPlaneB = -2.2, MeanFocuserPosition = 1000,
+                        TiltAngleDeg = 0.5, DirectionDeg = 153.4,
+                        CurvatureRadiusMillimeters = 1234.5, CurvatureEffectMicronsAtScrewRadius = 5.5
+                    }
+                },
+                Calibration = new TiltCalibrationResultRecord {
+                    Screw1AngleDegrees = 10, Screw2AngleDegrees = 100, CurvatureSign = -1, MeasuredHardwareMicrons = 400
+                }
+            };
+
+            var back = TiltCalibrationMetadata.Deserialize(md.Serialize());
+
+            Assert.Multiple(() => {
+                Assert.That(back.SchemaVersion, Is.EqualTo(TiltCalibrationMetadata.CurrentSchemaVersion));
+                Assert.That(back.NumberOfScrews, Is.EqualTo(4));
+                Assert.That(back.IsStepperAdjustment, Is.True);
+                Assert.That(back.StepperStepSizeMicrons, Is.EqualTo(1.25).Within(1e-9));
+                Assert.That(back.CalibrationAppliedAmount, Is.EqualTo(2.0).Within(1e-9));
+                Assert.That(back.MeasurementAverageCount, Is.EqualTo(3));
+                Assert.That(back.RunStepMapping[0].Folder, Is.EqualTo(@"C:\runs\01_Baseline\AutoFocus_x"));
+                Assert.That(back.PerStep[0].TiltPlaneB, Is.EqualTo(-2.2).Within(1e-9));
+                Assert.That(back.PerStep[0].CurvatureRadiusMillimeters, Is.EqualTo(1234.5).Within(1e-9));
+                Assert.That(back.PerStep[0].CurvatureEffectMicronsAtScrewRadius, Is.EqualTo(5.5).Within(1e-9));
+                Assert.That(back.Calibration.MeasuredHardwareMicrons, Is.EqualTo(400).Within(1e-9));
+                Assert.That(back.Calibration.CurvatureSign, Is.EqualTo(-1));
+            });
+        }
+
+        [Test]
+        public void IsStepperAdjustment_FalseForScrews() {
+            var md = new TiltCalibrationMetadata { AdjustmentType = "Screws" };
+            Assert.That(md.IsStepperAdjustment, Is.False);
+        }
+
+        [TestCase(5)]
+        [TestCase(2)]
+        public void Validate_RejectsBadScrewCount(int screwCount) {
+            var md = new TiltCalibrationMetadata {
+                NumberOfScrews = screwCount, PixelSizeMicrons = 1, FocuserStepSizeMicrons = 1, ScrewRadiusMillimeters = 1
+            };
+            Assert.That(() => md.Validate(), Throws.TypeOf<InvalidOperationException>());
+        }
+
+        [Test]
+        public void Validate_PassesForWellFormedMetadata() {
+            var md = new TiltCalibrationMetadata {
+                NumberOfScrews = 3, PixelSizeMicrons = 3.76, FocuserStepSizeMicrons = 3.58,
+                ScrewRadiusMillimeters = 44.0, CalibrationAppliedAmount = 1.0
+            };
+            Assert.That(() => md.Validate(), Throws.Nothing);
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
@@ -605,7 +605,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     analysisResult = hfAnalysisResult;
                 }
 
-                if (!string.IsNullOrWhiteSpace(state.SaveFolder)) {
+                if (!state.Options.SaveExposuresOnly && !string.IsNullOrWhiteSpace(state.SaveFolder)) {
                     var saveAttemptFolder = GetSaveAttemptFolder(state, imageState.AttemptNumber, imageState.FinalValidation);
                     var resultFileName = BuildStarDetectionResultFileName(imageState.ImageNumber, imageState.FrameNumber, regionState.RegionIndex);
                     var resultTargetPath = Path.Combine(saveAttemptFolder, resultFileName);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -194,8 +194,27 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         private CancellationTokenSource analyzeCts;
         private Task<bool> analyzeTask;
 
-        public async Task<bool> AnalyzeAutoFocus(CancellationToken token, bool captureCameraBlock = false) {
-            var task = AnalyzeAutoFocusImpl(captureCameraBlock);
+        // Folder of the most recent AutoFocus run (the engine's timestamped attempt root, == result.SaveFolder).
+        // Set after a successful run that saved frames; null/empty when the last run did not save. The Tilt
+        // Adapter Wizard reads this to record each calibration step's saved location for later replay.
+        public string LastSaveFolder { get; private set; }
+
+        public async Task<bool> AnalyzeAutoFocus(CancellationToken token, bool captureCameraBlock = false, AutoFocusSaveOverride saveOverride = null) {
+            var task = AnalyzeAutoFocusImpl(captureCameraBlock, saveOverride);
+            token.Register(() => analyzeCts?.Cancel());
+            return await task;
+        }
+
+        /// <summary>
+        /// Re-analyzes a saved AutoFocus attempt from an explicit folder path (no folder-picker dialog), for
+        /// replaying a saved calibration step. The folder should be the engine's attempt root (the level that
+        /// contains a single <c>attempt*</c> subfolder), i.e. <see cref="LastSaveFolder"/> from the original run.
+        /// </summary>
+        public async Task<bool> AnalyzeAutoFocusFromSavedPath(string folderPath, CancellationToken token) {
+            if (string.IsNullOrEmpty(folderPath)) {
+                return false;
+            }
+            var task = AnalyzeAutoFocusFromSavedImpl(folderPath);
             token.Register(() => analyzeCts?.Cancel());
             return await task;
         }
@@ -295,7 +314,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             }
         }
 
-        private async Task<bool> AnalyzeAutoFocusImpl(bool captureCameraBlock) {
+        private async Task<bool> AnalyzeAutoFocusImpl(bool captureCameraBlock, AutoFocusSaveOverride saveOverride = null) {
             var localAnalyzeTask = analyzeTask;
             if (localAnalyzeTask != null && !localAnalyzeTask.IsCompleted) {
                 Notification.ShowError("Analysis still in progress");
@@ -314,6 +333,14 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
                     var autoFocusEngine = autoFocusEngineFactory.Create();
                     var options = GetAutoFocusEngineOptions(autoFocusEngine);
+                    if (saveOverride != null) {
+                        options.Save = saveOverride.Save;
+                        options.SavePath = saveOverride.SavePath;
+                        if (options.Save) {
+                            // Mirror GetAutoFocusEngineOptions: keep exposures so the run can be re-analyzed later.
+                            options.PreserveExposures = true;
+                        }
+                    }
                     var sensorCurveModelEnabled = inspectorOptions.SensorCurveModelEnabled;
                     var regions = GetStarDetectionRegions(options, sensorCurveModelEnabled: sensorCurveModelEnabled);
                     var imagingFilter = GetImagingFilter();
@@ -328,12 +355,14 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     ActivateAutoFocusChart();
                     ResetErrors();
                     ResetExposureAnalysis();
+                    LastSaveFolder = null;
                     var result = await autoFocusEngine.RunWithRegions(options, imagingFilter, regions, localAnalyzeCts.Token, this.progress);
                     if (result == null) {
                         InspectorErrorText = "AutoFocus Analysis Failed";
                         DeactivateAutoFocusAnalysis();
                         return false;
                     }
+                    LastSaveFolder = result.SaveFolder;
 
                     var autoFocusAnalysisResult = await AnalyzeAutoFocusResult(options, result, sensorCurveModelEnabled: sensorCurveModelEnabled, ct: localAnalyzeCts.Token);
                     if (!autoFocusAnalysisResult) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -219,7 +219,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             return await task;
         }
 
-        public async Task<bool> AnalyzeAutoFocusFromSaved(CancellationToken token, Action onFolderSelected = null) {
+        public async Task<bool> AnalyzeAutoFocusFromSaved(CancellationToken token, Action onFolderSelected = null, AutoFocusSaveOverride saveOverride = null) {
             string folderPath;
             using (var dialog = new System.Windows.Forms.FolderBrowserDialog()) {
                 if (!String.IsNullOrEmpty(autoFocusOptions.LastSelectedLoadPath)) {
@@ -232,12 +232,12 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 autoFocusOptions.LastSelectedLoadPath = folderPath;
             }
             onFolderSelected?.Invoke();
-            var task = AnalyzeAutoFocusFromSavedImpl(folderPath);
+            var task = AnalyzeAutoFocusFromSavedImpl(folderPath, saveOverride);
             token.Register(() => analyzeCts?.Cancel());
             return await task;
         }
 
-        private async Task<bool> AnalyzeAutoFocusFromSavedImpl(string folderPath) {
+        private async Task<bool> AnalyzeAutoFocusFromSavedImpl(string folderPath, AutoFocusSaveOverride saveOverride = null) {
             var localAnalyzeTask = analyzeTask;
             if (localAnalyzeTask != null && !localAnalyzeTask.IsCompleted) {
                 Notification.ShowError("Analysis still in progress");
@@ -260,8 +260,20 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             }
 
             Logger.Info($"Rerunning auto focus attempt from {folderPath}");
+            bool suppressAuxiliaryFiles = saveOverride?.SuppressAuxiliaryFiles == true;
+            bool savedSaveIntermediateImages = starDetectionOptions.SaveIntermediateImages;
+            if (suppressAuxiliaryFiles) {
+                starDetectionOptions.SaveIntermediateImages = false;
+            }
             localAnalyzeTask = Task.Run(async () => {
                 var options = GetAutoFocusEngineOptions(autoFocusEngine, savedAttempt);
+                if (saveOverride != null) {
+                    options.Save = saveOverride.Save;
+                    options.SavePath = saveOverride.SavePath;
+                    if (options.Save) {
+                        options.PreserveExposures = true;
+                    }
+                }
                 var sensorCurveModelEnabled = inspectorOptions.SensorCurveModelEnabled;
                 var regions = GetStarDetectionRegions(options, sensorCurveModelEnabled: sensorCurveModelEnabled);
 
@@ -276,14 +288,16 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 ResetErrors();
                 ResetExposureAnalysis();
 
+                LastSaveFolder = null;
                 var result = await autoFocusEngine.RerunWithRegions(options, savedAttempt, imagingFilter, regions, localAnalyzeCts.Token, this.progress);
                 if (result == null) {
                     InspectorErrorText = "AutoFocus Analysis Failed";
                     DeactivateAutoFocusAnalysis();
                     return false;
                 }
+                LastSaveFolder = result.SaveFolder;
 
-                var analysisResult = await AnalyzeAutoFocusResult(options, result, sensorCurveModelEnabled: sensorCurveModelEnabled, ct: localAnalyzeCts.Token, true);
+                var analysisResult = await AnalyzeAutoFocusResult(options, result, sensorCurveModelEnabled: sensorCurveModelEnabled, ct: localAnalyzeCts.Token, forRerun: true, suppressRegisteredImages: suppressAuxiliaryFiles);
                 if (!analysisResult) {
                     Notification.ShowError("AutoFocus Analysis Failed");
                     InspectorErrorText = "AutoFocus Analysis Failed";
@@ -310,6 +324,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 DeactivateAutoFocusAnalysis();
                 return false;
             } finally {
+                if (suppressAuxiliaryFiles) {
+                    starDetectionOptions.SaveIntermediateImages = savedSaveIntermediateImages;
+                }
                 RaisePropertyChanged(nameof(IsAnalysisRunning));
             }
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -325,6 +325,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             var localAnalyzeCts = new CancellationTokenSource();
             analyzeCts = localAnalyzeCts;
 
+            bool suppressAuxiliaryFiles = saveOverride?.SuppressAuxiliaryFiles == true;
+            bool savedSaveIntermediateImages = starDetectionOptions.SaveIntermediateImages;
             localAnalyzeTask = Task.Run(async () => {
                 try {
                     if (captureCameraBlock) {
@@ -340,6 +342,11 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                             // Mirror GetAutoFocusEngineOptions: keep exposures so the run can be re-analyzed later.
                             options.PreserveExposures = true;
                         }
+                    }
+                    if (suppressAuxiliaryFiles) {
+                        // A saved calibration run keeps only the raw frames — suppress star-detection intermediate
+                        // files (restored in the finally) and, below, the registered/annotated alignment images.
+                        starDetectionOptions.SaveIntermediateImages = false;
                     }
                     var sensorCurveModelEnabled = inspectorOptions.SensorCurveModelEnabled;
                     var regions = GetStarDetectionRegions(options, sensorCurveModelEnabled: sensorCurveModelEnabled);
@@ -364,7 +371,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     }
                     LastSaveFolder = result.SaveFolder;
 
-                    var autoFocusAnalysisResult = await AnalyzeAutoFocusResult(options, result, sensorCurveModelEnabled: sensorCurveModelEnabled, ct: localAnalyzeCts.Token);
+                    var autoFocusAnalysisResult = await AnalyzeAutoFocusResult(options, result, sensorCurveModelEnabled: sensorCurveModelEnabled, ct: localAnalyzeCts.Token, suppressRegisteredImages: suppressAuxiliaryFiles);
                     if (!autoFocusAnalysisResult) {
                         InspectorErrorText = "AutoFocus Analysis Failed. View saved AF report in the AutoFocus tab.";
                         Notification.ShowError("AutoFocus Analysis Failed. View saved AF report in the AutoFocus tab.");
@@ -383,6 +390,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     Notification.ShowInformation("Aberration Inspection Complete");
                     return true;
                 } finally {
+                    if (suppressAuxiliaryFiles) {
+                        starDetectionOptions.SaveIntermediateImages = savedSaveIntermediateImages;
+                    }
                     if (captureCameraBlock) {
                         this.cameraMediator.ReleaseCaptureBlock(this);
                     }
@@ -425,7 +435,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             AutoFocusResult result,
             bool sensorCurveModelEnabled,
             CancellationToken ct,
-            bool forRerun = false) {
+            bool forRerun = false,
+            bool suppressRegisteredImages = false) {
             if (result == null || !result.Succeeded) {
                 Logger.Error("Inspection analysis failed, due to failed AutoFocus");
                 return false;
@@ -458,7 +469,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     progress,
                     ct: ct);
 
-                if ((!forRerun) || (inspectorOptions.SaveImagesOnReruns)) {
+                if (!suppressRegisteredImages && ((!forRerun) || (inspectorOptions.SaveImagesOnReruns))) {
                     if (!String.IsNullOrEmpty(result.SaveFolder)) {
                         await SaveRegisteredImages(result.SaveFolder,
                             SensorModel.SensorModelResult.RegisteredStars,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -325,18 +325,31 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         // Copies a saved attempt's raw exposure frames into a fresh AutoFocus_<ts>/attempt01 folder under
         // <savePathRoot>, returning that AutoFocus_<ts> folder (the level a replay points at). Used by the Tilt
         // Adapter Wizard so re-analyzing a saved run still produces a self-contained, replayable per-step folder.
+        // Best-effort: the tilt measurement has already succeeded by the time this runs, so any copy failure is
+        // logged and yields a null result (this step simply won't be replayable) rather than failing the step.
         private static string CopySavedFramesForReplay(SavedAutoFocusAttempt savedAttempt, string savePathRoot) {
-            var runFolder = Path.Combine(savePathRoot, $"AutoFocus_{DateTime.Now:yyyyMMdd_HHmmss}");
-            var attemptFolder = Path.Combine(runFolder, "attempt01");
-            Directory.CreateDirectory(attemptFolder);
-            foreach (var img in savedAttempt.SavedImages) {
-                if (string.IsNullOrEmpty(img.Path) || !File.Exists(img.Path)) {
-                    continue;
+            try {
+                var runFolder = Path.Combine(savePathRoot, $"AutoFocus_{DateTime.Now:yyyyMMdd_HHmmss}");
+                var attemptFolder = Path.Combine(runFolder, "attempt01");
+                Directory.CreateDirectory(attemptFolder);
+                int copied = 0;
+                foreach (var img in savedAttempt.SavedImages) {
+                    if (string.IsNullOrEmpty(img.Path) || !File.Exists(img.Path)) {
+                        continue;
+                    }
+                    var dest = Path.Combine(attemptFolder, Path.GetFileName(img.Path));
+                    File.Copy(img.Path, dest, overwrite: true);
+                    copied++;
                 }
-                var dest = Path.Combine(attemptFolder, Path.GetFileName(img.Path));
-                File.Copy(img.Path, dest, overwrite: true);
+                if (copied == 0) {
+                    Logger.Warning($"No source frames could be copied to {runFolder}; this calibration step will not be replayable.");
+                    return null;
+                }
+                return runFolder;
+            } catch (Exception ex) {
+                Logger.Error(ex, "Failed to copy saved frames for replay; this calibration step will not be replayable");
+                return null;
             }
-            return runFolder;
         }
 
         private async Task<bool> AnalyzeAutoFocusImpl(bool captureCameraBlock, AutoFocusSaveOverride saveOverride = null) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -261,19 +261,11 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
             Logger.Info($"Rerunning auto focus attempt from {folderPath}");
             bool suppressAuxiliaryFiles = saveOverride?.SuppressAuxiliaryFiles == true;
-            bool savedSaveIntermediateImages = starDetectionOptions.SaveIntermediateImages;
-            if (suppressAuxiliaryFiles) {
-                starDetectionOptions.SaveIntermediateImages = false;
-            }
             localAnalyzeTask = Task.Run(async () => {
+                // A rerun re-analyzes existing frames and never captures, so the engine cannot write raw frames to a
+                // new location. Leave the engine save OFF (no annotated/JSON artifacts) and, on success, copy the
+                // source raw frames into the requested per-step folder so the calibration run stays replayable.
                 var options = GetAutoFocusEngineOptions(autoFocusEngine, savedAttempt);
-                if (saveOverride != null) {
-                    options.Save = saveOverride.Save;
-                    options.SavePath = saveOverride.SavePath;
-                    if (options.Save) {
-                        options.PreserveExposures = true;
-                    }
-                }
                 var sensorCurveModelEnabled = inspectorOptions.SensorCurveModelEnabled;
                 var regions = GetStarDetectionRegions(options, sensorCurveModelEnabled: sensorCurveModelEnabled);
 
@@ -295,7 +287,6 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     DeactivateAutoFocusAnalysis();
                     return false;
                 }
-                LastSaveFolder = result.SaveFolder;
 
                 var analysisResult = await AnalyzeAutoFocusResult(options, result, sensorCurveModelEnabled: sensorCurveModelEnabled, ct: localAnalyzeCts.Token, forRerun: true, suppressRegisteredImages: suppressAuxiliaryFiles);
                 if (!analysisResult) {
@@ -303,6 +294,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     InspectorErrorText = "AutoFocus Analysis Failed";
                     DeactivateAutoFocusAnalysis();
                     return false;
+                }
+                if (saveOverride?.Save == true && !string.IsNullOrEmpty(saveOverride.SavePath)) {
+                    LastSaveFolder = CopySavedFramesForReplay(savedAttempt, saveOverride.SavePath);
                 }
                 ActivateTiltMeasurement();
                 return true;
@@ -324,11 +318,25 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 DeactivateAutoFocusAnalysis();
                 return false;
             } finally {
-                if (suppressAuxiliaryFiles) {
-                    starDetectionOptions.SaveIntermediateImages = savedSaveIntermediateImages;
-                }
                 RaisePropertyChanged(nameof(IsAnalysisRunning));
             }
+        }
+
+        // Copies a saved attempt's raw exposure frames into a fresh AutoFocus_<ts>/attempt01 folder under
+        // <savePathRoot>, returning that AutoFocus_<ts> folder (the level a replay points at). Used by the Tilt
+        // Adapter Wizard so re-analyzing a saved run still produces a self-contained, replayable per-step folder.
+        private static string CopySavedFramesForReplay(SavedAutoFocusAttempt savedAttempt, string savePathRoot) {
+            var runFolder = Path.Combine(savePathRoot, $"AutoFocus_{DateTime.Now:yyyyMMdd_HHmmss}");
+            var attemptFolder = Path.Combine(runFolder, "attempt01");
+            Directory.CreateDirectory(attemptFolder);
+            foreach (var img in savedAttempt.SavedImages) {
+                if (string.IsNullOrEmpty(img.Path) || !File.Exists(img.Path)) {
+                    continue;
+                }
+                var dest = Path.Combine(attemptFolder, Path.GetFileName(img.Path));
+                File.Copy(img.Path, dest, overwrite: true);
+            }
+            return runFolder;
         }
 
         private async Task<bool> AnalyzeAutoFocusImpl(bool captureCameraBlock, AutoFocusSaveOverride saveOverride = null) {
@@ -343,7 +351,6 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             analyzeCts = localAnalyzeCts;
 
             bool suppressAuxiliaryFiles = saveOverride?.SuppressAuxiliaryFiles == true;
-            bool savedSaveIntermediateImages = starDetectionOptions.SaveIntermediateImages;
             localAnalyzeTask = Task.Run(async () => {
                 try {
                     if (captureCameraBlock) {
@@ -358,12 +365,10 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                         if (options.Save) {
                             // Mirror GetAutoFocusEngineOptions: keep exposures so the run can be re-analyzed later.
                             options.PreserveExposures = true;
+                            // A saved calibration run keeps only the raw frames — no per-region annotated TIFFs /
+                            // detection-result JSONs (and, below, no registered/alignment images).
+                            options.SaveExposuresOnly = suppressAuxiliaryFiles;
                         }
-                    }
-                    if (suppressAuxiliaryFiles) {
-                        // A saved calibration run keeps only the raw frames — suppress star-detection intermediate
-                        // files (restored in the finally) and, below, the registered/annotated alignment images.
-                        starDetectionOptions.SaveIntermediateImages = false;
                     }
                     var sensorCurveModelEnabled = inspectorOptions.SensorCurveModelEnabled;
                     var regions = GetStarDetectionRegions(options, sensorCurveModelEnabled: sensorCurveModelEnabled);
@@ -407,9 +412,6 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     Notification.ShowInformation("Aberration Inspection Complete");
                     return true;
                 } finally {
-                    if (suppressAuxiliaryFiles) {
-                        starDetectionOptions.SaveIntermediateImages = savedSaveIntermediateImages;
-                    }
                     if (captureCameraBlock) {
                         this.cameraMediator.ReleaseCaptureBlock(this);
                     }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IAutoFocusEngine.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IAutoFocusEngine.cs
@@ -88,6 +88,11 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         public double ReducedChiSquaredRejectionThreshold { get; set; }
         public bool PreserveExposures { get; set; }
 
+        // When true, a saving run writes ONLY the raw exposure frames — the per-region annotated TIFFs and
+        // star-detection result JSONs are skipped. Used by the Tilt Adapter Wizard so a saved calibration run is
+        // a compact, replayable set of raw frames with no auxiliary artifacts.
+        public bool SaveExposuresOnly { get; set; }
+
         // When replaying a saved auto-focus run, reuse the per-region star-detection JSON saved alongside each
         // exposure instead of re-running detection — but ONLY when the saved result's detector version and
         // params (region included) still match the current run. OFF by default and intentionally not exposed in

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IAutoFocusEngine.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IAutoFocusEngine.cs
@@ -47,6 +47,17 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         public bool IsBayered { get; set; }
     }
 
+    /// <summary>
+    /// Optional per-run override of where (and whether) an AutoFocus run's frames are saved, letting a caller
+    /// (e.g. the Tilt Adapter Wizard) redirect saves into a specific per-step folder without touching the user's
+    /// AutoFocusOptions. When applied, the engine still creates its usual timestamped attempt folder under
+    /// <see cref="SavePath"/>; read it back from <see cref="AutoFocusResult.SaveFolder"/>.
+    /// </summary>
+    public class AutoFocusSaveOverride {
+        public bool Save { get; set; }
+        public string SavePath { get; set; }
+    }
+
     public class AutoFocusEngineOptions {
         public bool DebayerImage { get; set; }
         public int NumberOfAFStars { get; set; }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IAutoFocusEngine.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IAutoFocusEngine.cs
@@ -56,6 +56,11 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
     public class AutoFocusSaveOverride {
         public bool Save { get; set; }
         public string SavePath { get; set; }
+
+        // When true, suppress the auxiliary artifacts a normal inspection run writes — the registered/annotated
+        // alignment images and the star-detection intermediate files — so a saved calibration run keeps only the
+        // raw frames needed for replay.
+        public bool SuppressAuxiliaryFiles { get; set; }
     }
 
     public class AutoFocusEngineOptions {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltAdapterOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltAdapterOptions.cs
@@ -45,5 +45,10 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         // Selected device preset name ("Manual" = user-editable hardware fields). Choosing a preset
         // pre-fills and locks the hardware fields. See TiltAdapterDevicePreset.
         string DeviceName { get; set; }
+
+        // Folder the wizard saves each calibration run's AutoFocus sweeps into when saving is enabled.
+        // Persisted (independent of AutoFocusOptions.SavePath) so the location is reused; "" = unset.
+        // NOTE: whether saving is ON is a transient per-run toggle on the VM, not persisted here.
+        string SaveAFRunsPath { get; set; }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
@@ -1112,5 +1112,16 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             RaiseAllPropertiesChanged(); // refresh UI bindings for all live advanced props
         }
 
+        /// <summary>Clears any stored optimized-settings snapshot (and its persisted JSON), leaving the options with
+        /// no optimized settings. Used to undo a transient <see cref="ApplyOptimizedSettings"/> (e.g. after a tilt
+        /// calibration replay) for a profile that had none to begin with. Does not change the Use* flags.</summary>
+        public void ClearOptimizedSettings() {
+            optimizedSettings = null;
+            optionsAccessor.SetValueString(OptimizedSettingsJsonKey, "");
+            RaisePropertyChanged(nameof(HasOptimizedSettings));
+            ConfigureSimpleSettings();
+            RaiseAllPropertiesChanged();
+        }
+
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -302,11 +302,13 @@
                     </UniformGrid>
 
                     <!--  Save AutoFocus runs (opt-in per run; folder persisted for reuse, toggle resets each run)  -->
-                    <CheckBox
+                    <StackPanel
                         Margin="0,10,0,0"
-                        Content="Save AutoFocus runs (for replay)"
-                        IsChecked="{Binding SaveAFRuns}"
-                        ToolTip="Save each calibration step's AutoFocus sweep into a per-run folder with a metadata.json so the run can be replayed later. Off by default; enable before each run." />
+                        Orientation="Horizontal"
+                        ToolTip="Save each calibration step's AutoFocus sweep into a per-run folder with a metadata.json so the run can be replayed later. Off by default; enable before each run.">
+                        <CheckBox VerticalAlignment="Center" IsChecked="{Binding SaveAFRuns}" Checked="SaveAFRuns_Checked" />
+                        <TextBlock Margin="6,0,0,0" VerticalAlignment="Center" Text="Save AutoFocus runs (for replay)" />
+                    </StackPanel>
                     <Grid Margin="0,4,0,0" HorizontalAlignment="Stretch">
                         <Grid.Style>
                             <Style TargetType="Grid">
@@ -353,7 +355,7 @@
                         <TextBlock
                             Margin="10,5,10,5"
                             Foreground="{StaticResource ButtonForegroundBrush}"
-                            Text="Replay Saved Run…" />
+                            Text="Replay" />
                     </Button>
 
                     <TextBlock Margin="0,10,0,0" Text="No calibration saved.">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -301,6 +301,40 @@
                         <TextBox MinWidth="60" Text="{Binding FocuserStepSizeMicronsValue, UpdateSourceTrigger=LostFocus}" />
                     </UniformGrid>
 
+                    <!--  Save AutoFocus runs (opt-in per run; folder persisted for reuse, toggle resets each run)  -->
+                    <CheckBox
+                        Margin="0,10,0,0"
+                        Content="Save AutoFocus runs (for replay)"
+                        IsChecked="{Binding SaveAFRuns}"
+                        ToolTip="Save each calibration step's AutoFocus sweep into a per-run folder with a metadata.json so the run can be replayed later. Off by default; enable before each run." />
+                    <Grid Margin="0,4,0,0" HorizontalAlignment="Stretch">
+                        <Grid.Style>
+                            <Style TargetType="Grid">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding SaveAFRuns}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Grid.Style>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBox
+                            Grid.Column="0"
+                            VerticalAlignment="Center"
+                            Text="{Binding SaveAFRunsPath, UpdateSourceTrigger=LostFocus}"
+                            ToolTip="Folder where calibration runs are saved. A TiltCalibration_&lt;timestamp&gt; subfolder is created per run." />
+                        <Button Grid.Column="1" Margin="6,0,0,0" Command="{Binding BrowseSaveFolderCommand}">
+                            <TextBlock
+                                Margin="10,3,10,3"
+                                Foreground="{StaticResource ButtonForegroundBrush}"
+                                Text="Browse…" />
+                        </Button>
+                    </Grid>
+
                     <Button
                         Margin="0,8,0,2"
                         HorizontalAlignment="Left"
@@ -309,6 +343,17 @@
                             Margin="10,5,10,5"
                             Foreground="{StaticResource ButtonForegroundBrush}"
                             Text="Start Calibration" />
+                    </Button>
+
+                    <Button
+                        Margin="0,2,0,2"
+                        HorizontalAlignment="Left"
+                        Command="{Binding ReplayCommand}"
+                        ToolTip="Replay a saved calibration run from a folder containing metadata.json. Uses the run's stored star-detection settings and restores your settings afterward.">
+                        <TextBlock
+                            Margin="10,5,10,5"
+                            Foreground="{StaticResource ButtonForegroundBrush}"
+                            Text="Replay Saved Run…" />
                     </Button>
 
                     <TextBlock Margin="0,10,0,0" Text="No calibration saved.">
@@ -660,6 +705,28 @@
                             </Style>
                         </Border.Style>
                         <TextBlock Text="{Binding WarningText}" TextWrapping="Wrap" />
+                    </Border>
+
+                    <!--  Re-baseline drift warning (an undo between moves left residual tilt)  -->
+                    <Border
+                        Margin="0,5"
+                        Padding="5"
+                        BorderBrush="{StaticResource NotificationErrorBrush}"
+                        BorderThickness="1">
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasRebaselineDriftWarning}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <TextBlock
+                            Foreground="{StaticResource NotificationErrorBrush}"
+                            Text="{Binding RebaselineDriftWarningText}"
+                            TextWrapping="Wrap" />
                     </Border>
 
                     <Grid Margin="0,5,0,5" HorizontalAlignment="Stretch">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -301,13 +301,32 @@
                         <TextBox MinWidth="60" Text="{Binding FocuserStepSizeMicronsValue, UpdateSourceTrigger=LostFocus}" />
                     </UniformGrid>
 
-                    <!--  Save AutoFocus runs (opt-in per run; folder persisted for reuse, toggle resets each run)  -->
+                    <!--  Calibrate + Replay side by side  -->
+                    <StackPanel Margin="0,8,0,0" Orientation="Horizontal">
+                        <Button Command="{Binding StartCommand}">
+                            <TextBlock
+                                Margin="10,5,10,5"
+                                Foreground="{StaticResource ButtonForegroundBrush}"
+                                Text="Calibrate" />
+                        </Button>
+                        <Button
+                            Margin="6,0,0,0"
+                            Command="{Binding ReplayCommand}"
+                            ToolTip="Replay a saved calibration run from a folder containing metadata.json. Uses the run's stored star-detection settings and restores your settings afterward.">
+                            <TextBlock
+                                Margin="10,5,10,5"
+                                Foreground="{StaticResource ButtonForegroundBrush}"
+                                Text="Replay" />
+                        </Button>
+                    </StackPanel>
+
+                    <!--  Save calibration for replay (opt-in per run; folder persisted for reuse, toggle resets each run)  -->
                     <StackPanel
-                        Margin="0,10,0,0"
+                        Margin="0,8,0,0"
                         Orientation="Horizontal"
                         ToolTip="Save each calibration step's AutoFocus sweep into a per-run folder with a metadata.json so the run can be replayed later. Off by default; enable before each run.">
                         <CheckBox VerticalAlignment="Center" IsChecked="{Binding SaveAFRuns}" Checked="SaveAFRuns_Checked" />
-                        <TextBlock Margin="6,0,0,0" VerticalAlignment="Center" Text="Save AutoFocus runs (for replay)" />
+                        <TextBlock Margin="6,0,0,0" VerticalAlignment="Center" Text="Save Calibration for Replay" />
                     </StackPanel>
                     <Grid Margin="0,4,0,0" HorizontalAlignment="Stretch">
                         <Grid.Style>
@@ -336,27 +355,6 @@
                                 Text="Browse…" />
                         </Button>
                     </Grid>
-
-                    <Button
-                        Margin="0,8,0,2"
-                        HorizontalAlignment="Left"
-                        Command="{Binding StartCommand}">
-                        <TextBlock
-                            Margin="10,5,10,5"
-                            Foreground="{StaticResource ButtonForegroundBrush}"
-                            Text="Start Calibration" />
-                    </Button>
-
-                    <Button
-                        Margin="0,2,0,2"
-                        HorizontalAlignment="Left"
-                        Command="{Binding ReplayCommand}"
-                        ToolTip="Replay a saved calibration run from a folder containing metadata.json. Uses the run's stored star-detection settings and restores your settings afterward.">
-                        <TextBlock
-                            Margin="10,5,10,5"
-                            Foreground="{StaticResource ButtonForegroundBrush}"
-                            Text="Replay" />
-                    </Button>
 
                     <TextBlock Margin="0,10,0,0" Text="No calibration saved.">
                         <TextBlock.Style>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -312,11 +312,20 @@
                         <Button
                             Margin="6,0,0,0"
                             Command="{Binding ReplayCommand}"
-                            ToolTip="Replay a saved calibration run from a folder containing metadata.json. Uses the run's stored star-detection settings and restores your settings afterward.">
+                            ToolTip="Replay a saved calibration run from a folder containing metadata.json. Uses the run's stored star-detection and tilt-calibration settings (restoring your settings afterward).">
                             <TextBlock
                                 Margin="10,5,10,5"
                                 Foreground="{StaticResource ButtonForegroundBrush}"
                                 Text="Replay" />
+                        </Button>
+                        <Button
+                            Margin="6,0,0,0"
+                            Command="{Binding ReplayCurrentSettingsCommand}"
+                            ToolTip="Replay a saved calibration run using your CURRENT star-detection and tilt-calibration settings instead of the ones stored in metadata.json. Your profile settings are left unchanged.">
+                            <TextBlock
+                                Margin="10,5,10,5"
+                                Foreground="{StaticResource ButtonForegroundBrush}"
+                                Text="Replay Current Settings" />
                         </Button>
                     </StackPanel>
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml.cs
@@ -12,6 +12,7 @@
 
 using System.ComponentModel.Composition;
 using System.Windows;
+using System.Windows.Controls;
 
 namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
@@ -20,6 +21,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         public DataTemplates() {
             InitializeComponent();
+        }
+
+        // Enabling "Save AutoFocus runs" immediately prompts for the folder so the user picks it in one click.
+        private void SaveAFRuns_Checked(object sender, RoutedEventArgs e) {
+            if (sender is FrameworkElement fe && fe.DataContext is TiltAdapterWizardVM vm) {
+                vm.PromptForSaveFolderIfNeeded();
+            }
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
@@ -62,6 +62,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             lastMeasuredThreadPitchMicrons = optionsAccessor.GetValueDouble(nameof(LastMeasuredThreadPitchMicrons), -1.0);
             lastMeasuredStepperStepSizeMicrons = optionsAccessor.GetValueDouble(nameof(LastMeasuredStepperStepSizeMicrons), -1.0);
             deviceName = optionsAccessor.GetValueString(nameof(DeviceName), TiltAdapterDevicePreset.ManualName);
+            saveAFRunsPath = optionsAccessor.GetValueString(nameof(SaveAFRunsPath), string.Empty);
         }
 
         private int screwCount;
@@ -267,6 +268,20 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 if (deviceName != value) {
                     deviceName = value;
                     optionsAccessor.SetValueString(nameof(DeviceName), deviceName);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private string saveAFRunsPath;
+
+        public string SaveAFRunsPath {
+            get => saveAFRunsPath;
+            set {
+                var newValue = value ?? string.Empty;
+                if (saveAFRunsPath != newValue) {
+                    saveAFRunsPath = newValue;
+                    optionsAccessor.SetValueString(nameof(SaveAFRunsPath), saveAFRunsPath);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -738,6 +738,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 try {
                     var perStepDir = Path.Combine(runRootFolder, StepFolderName(step));
                     Directory.CreateDirectory(perStepDir);
+                    // Re-running a step (e.g. after a failed run) must not leave the prior attempt behind — clear
+                    // any earlier runs so the folder holds only this attempt's run(s).
+                    PruneStepFolderExcept(perStepDir, keepFolder: null);
                     // Keep only the raw frames needed for replay — no annotated/alignment or intermediate files.
                     saveOverride = new AutoFocusSaveOverride { Save = true, SavePath = perStepDir, SuppressAuxiliaryFiles = true };
                 } catch (Exception ex) {
@@ -778,7 +781,31 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 SaveFolder = saveOverride != null ? inspector.LastSaveFolder : null
             };
             PopulateCurvature(ref reading);
+
+            // Keep only the run the metadata references (when averaging > 1 the earlier runs are not replayed).
+            if (saveOverride != null && !string.IsNullOrEmpty(reading.SaveFolder)) {
+                PruneStepFolderExcept(saveOverride.SavePath, reading.SaveFolder);
+            }
             return reading;
+        }
+
+        // Deletes every AutoFocus run subfolder under a per-step folder except the one to keep (null = delete all),
+        // so a step folder never accumulates stale/failed runs. Best-effort; logs and continues on any failure.
+        private static void PruneStepFolderExcept(string perStepDir, string keepFolder) {
+            if (string.IsNullOrEmpty(perStepDir) || !Directory.Exists(perStepDir)) {
+                return;
+            }
+            var keepFull = string.IsNullOrEmpty(keepFolder) ? null : Path.GetFullPath(keepFolder);
+            foreach (var dir in Directory.GetDirectories(perStepDir)) {
+                if (keepFull != null && string.Equals(Path.GetFullPath(dir), keepFull, StringComparison.OrdinalIgnoreCase)) {
+                    continue;
+                }
+                try {
+                    Directory.Delete(dir, recursive: true);
+                } catch (Exception ex) {
+                    Logger.Warning($"Failed to delete stale calibration run folder {dir}: {ex.Message}");
+                }
+            }
         }
 
         private void AppendSummaryRows(List<(double A, double B, double Mean)> readings, string stepDescription,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -13,6 +13,7 @@
 using CommunityToolkit.Mvvm.Input;
 using NINA.Core.Model;
 using NINA.Core.Utility;
+using NINA.Core.Utility.Notification;
 using NINA.Equipment.Equipment;
 using NINA.Equipment.Equipment.MyCamera;
 using NINA.Equipment.Equipment.MyFocuser;
@@ -21,6 +22,8 @@ using NINA.Equipment.Interfaces.ViewModel;
 using NINA.Equipment.Model;
 using NINA.Joko.Plugins.HocusFocus.AutoFocus;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
 using NINA.Profile.Interfaces;
 using NINA.WPF.Base.Interfaces.Mediator;
 using NINA.WPF.Base.ViewModel;
@@ -29,20 +32,30 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel.Composition;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using Logger = NINA.Core.Utility.Logger;
 using RelayCommand = CommunityToolkit.Mvvm.Input.RelayCommand;
 
 namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
+    /// <summary>
+    /// The discrete calibration measurement steps. Each step is a single physical screw move followed by one
+    /// measurement, so two changes are never compounded between measurements: the all-inward and per-screw moves
+    /// are each bracketed by an explicit re-baseline. Screw angles are derived from the move relative to the
+    /// re-baseline that immediately precedes it (c→d for screw 1, e→f for screw 2).
+    /// </summary>
     public enum WizardStep {
-        Baseline = 0,
-        AllScrews = 1,
-        Screw1 = 2,
-        Screw2 = 3,
-        Complete = 4
+        Baseline = 0,     // a
+        AllInward = 1,    // b: all screws inward once (curvature/backfocus sign via a→b)
+        ReBaseline1 = 2,  // c: all screws back out once (≈ baseline)
+        Screw1 = 3,       // d: screw 1 inward once (4-screw: + screw 3 outward)
+        ReBaseline2 = 4,  // e: undo the screw-1 move (≈ c)
+        Screw2 = 5,       // f: screw 2 inward once (4-screw: + screw 4 outward)
+        Complete = 6
     }
 
     [PartCreationPolicy(CreationPolicy.Shared)]
@@ -60,16 +73,17 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         private WizardStep currentStep = WizardStep.Baseline;
         private bool isWizardRunning = false;
         private bool isMeasuring = false;
+        private bool isReplaying = false;
         private bool hasWarning = false;
         private string warningText = string.Empty;
         private string statusText = string.Empty;
         private bool hasMeasurementConsistencyWarning = false;
         private string measurementConsistencyWarningText = string.Empty;
-        private (double A, double B) baselineReading;
-        private (double A, double B) screw1Reading;
-        private (double A, double B) screw2Reading;
-        private double baselineCurvatureReading;
-        private double allScrewsCurvatureReading;
+        private bool hasRebaselineDriftWarning = false;
+        private string rebaselineDriftWarningText = string.Empty;
+
+        // One (A, B, mean) tilt-plane reading plus the per-step field-curvature characterization, keyed by step.
+        private readonly Dictionary<WizardStep, StepReading> stepReadings = new Dictionary<WizardStep, StepReading>();
         private CancellationTokenSource measureCts;
 
         private double calibrationAppliedAmount = 1.0;
@@ -77,8 +91,36 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         private double calibrationPixelSizeMicrons;
         private double calibrationFocuserStepMicrons;
         private double calibrationScrewRadiusMm;
+        private double lastRawAngleDiff = double.NaN;
+        private double lastMoveMagnitudeRatio = double.NaN;
+
+        // Per-run save state (transient; only populated while saving AF runs for the current calibration run).
+        private bool saveAFRuns;
+        private string runRootFolder;
+        private string metadataPath;
+        private TiltCalibrationMetadata currentMetadata;
 
         private const double MeasurementConsistencyWarningThreshold = 0.02;
+        // A re-baseline that returns close to the prior state drifts ~0; warn once the residual reaches half the
+        // screw-move signal (backlash / uneven undo would corrupt the recovered angle/hardware for that screw).
+        private const double RebaselineDriftWarnThreshold = 0.5;
+
+        // The six measurement steps in capture order.
+        private static readonly WizardStep[] MeasurementSteps = {
+            WizardStep.Baseline, WizardStep.AllInward, WizardStep.ReBaseline1,
+            WizardStep.Screw1, WizardStep.ReBaseline2, WizardStep.Screw2
+        };
+
+        private struct StepReading {
+            public double A;
+            public double B;
+            public double Mean;
+            public double TiltAngleDeg;
+            public double DirectionDeg;
+            public double CurvatureRadiusMm;
+            public double CurvatureEffectAtScrewRadiusMicrons;
+            public string SaveFolder;
+        }
 
         [ImportingConstructor]
         public TiltAdapterWizardVM(
@@ -120,6 +162,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             CancelCommand = new RelayCommand(CancelMeasurement, () => IsMeasuring);
             RestartCommand = new RelayCommand(Restart);
             UseMeasuredHardwareCommand = new RelayCommand(UseMeasuredHardware, () => HasMeasuredHardware);
+            BrowseSaveFolderCommand = new RelayCommand(BrowseSaveFolder);
+            ReplayCommand = new AsyncRelayCommand(ReplayAsync, () => !IsWizardRunning && !IsMeasuring);
 
             tiltAdapterOptions.PropertyChanged += (s, e) => {
                 if (e.PropertyName == nameof(ITiltAdapterOptions.ScrewInwardCurvatureSign)) {
@@ -138,6 +182,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 if (e.PropertyName == nameof(ITiltAdapterOptions.DeviceName)) {
                     RaisePropertyChanged(nameof(SelectedDevice));
                     RaisePropertyChanged(nameof(IsManualDevice));
+                }
+                if (e.PropertyName == nameof(ITiltAdapterOptions.SaveAFRunsPath)) {
+                    RaisePropertyChanged(nameof(SaveAFRunsPath));
                 }
                 if (e.PropertyName == nameof(ITiltAdapterOptions.AdjustmentType) ||
                     e.PropertyName == nameof(ITiltAdapterOptions.ThreadPitchMicrons) ||
@@ -159,6 +206,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 RaisePropertyChanged(nameof(FocuserStepSizeMicronsValue));
                 RaisePropertyChanged(nameof(SelectedDevice));
                 RaisePropertyChanged(nameof(IsManualDevice));
+                RaisePropertyChanged(nameof(SaveAFRunsPath));
             };
 
             // Re-assert and lock a persisted device preset on load.
@@ -206,11 +254,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public bool IsComplete => currentStep == WizardStep.Complete;
 
         // Steps that end with running the aberration inspector (measurement auto-advances)
-        public bool IsOnMeasurementStep =>
-            currentStep == WizardStep.Baseline ||
-            currentStep == WizardStep.AllScrews ||
-            currentStep == WizardStep.Screw1 ||
-            currentStep == WizardStep.Screw2;
+        public bool IsOnMeasurementStep => MeasurementSteps.Contains(currentStep);
 
         public bool IsCalibrationValid =>
             tiltAdapterOptions.IsCalibrated &&
@@ -334,24 +378,69 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
         }
 
+        public bool HasRebaselineDriftWarning {
+            get => hasRebaselineDriftWarning;
+            private set {
+                hasRebaselineDriftWarning = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public string RebaselineDriftWarningText {
+            get => rebaselineDriftWarningText;
+            private set {
+                rebaselineDriftWarningText = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        // Transient per-run toggle: save each calibration step's AutoFocus sweep so the run can be replayed.
+        // Always starts OFF and must be explicitly enabled before each run (not persisted). The folder is
+        // persisted (SaveAFRunsPath) so the location is reused.
+        public bool SaveAFRuns {
+            get => saveAFRuns;
+            set {
+                if (saveAFRuns != value) {
+                    saveAFRuns = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public string SaveAFRunsPath {
+            get => tiltAdapterOptions.SaveAFRunsPath;
+            set {
+                if (tiltAdapterOptions.SaveAFRunsPath != value) {
+                    tiltAdapterOptions.SaveAFRunsPath = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
         public string StepInstructions {
             get {
                 int n = tiltAdapterOptions.ScrewCount;
                 switch (currentStep) {
                     case WizardStep.Baseline:
                         return "Ensure all screws are at their starting position, then click Run Measurement to take a baseline reading.";
-                    case WizardStep.AllScrews:
-                        return n == 3
-                            ? "Identify your screws. Label them 1, 2, and 3. Screw 1 is at the top of the adapter (12 o'clock); the remaining screws are numbered clockwise: Screw 2 at lower-right, Screw 3 at lower-left.\n\nTurn ALL screws INWARD exactly 1 full turn each, then click Run Measurement."
-                            : "Identify your screws. Label them 1, 2, 3, and 4. Screw 1 is at the top-right of the adapter; the remaining screws are numbered clockwise: Screw 2 at lower-right, Screw 3 at lower-left, Screw 4 at upper-left.\n\nTurn ALL screws INWARD exactly 1 full turn each, then click Run Measurement.";
+                    case WizardStep.AllInward:
+                        return "Label your screws 1, 2, and 3 (or 1–4 for a 4-screw adapter) in a consistent clockwise order. " +
+                            "Screw 1 does NOT need to be at any particular clock position — the wizard determines each screw's actual " +
+                            "position from the measurements.\n\nTurn ALL screws INWARD exactly 1 full turn each, then click Run Measurement.";
+                    case WizardStep.ReBaseline1:
+                        return "Turn ALL screws back OUT exactly 1 full turn each, returning to the baseline position, then click Run Measurement.";
                     case WizardStep.Screw1:
                         return n == 3
-                            ? "Turn screws 1, 2, and 3 each back OUT 1 full turn to return to baseline. Then turn screw 1 INWARD exactly 1 full turn, then click Run Measurement."
-                            : "Turn screws 1, 2, 3, and 4 each back OUT 1 full turn to return to baseline. Then turn screw 1 INWARD and screw 3 OUTWARD exactly 1 full turn each, then click Run Measurement.";
+                            ? "Turn screw 1 INWARD exactly 1 full turn, then click Run Measurement."
+                            : "Turn screw 1 INWARD and screw 3 OUTWARD exactly 1 full turn each, then click Run Measurement.";
+                    case WizardStep.ReBaseline2:
+                        return n == 3
+                            ? "Turn screw 1 back OUT exactly 1 full turn, returning to the baseline position, then click Run Measurement."
+                            : "Turn screw 1 back OUT and screw 3 back IN exactly 1 full turn each, returning to the baseline position, then click Run Measurement.";
                     case WizardStep.Screw2:
                         return n == 3
-                            ? "Turn screw 1 back OUT 1 full turn to return to baseline. Then turn screw 2 INWARD exactly 1 full turn, then click Run Measurement."
-                            : "Turn screw 1 back OUT and screw 3 back IN 1 full turn to return to baseline. Then turn screw 2 INWARD and screw 4 OUTWARD exactly 1 full turn each, then click Run Measurement.";
+                            ? "Turn screw 2 INWARD exactly 1 full turn, then click Run Measurement."
+                            : "Turn screw 2 INWARD and screw 4 OUTWARD exactly 1 full turn each, then click Run Measurement.";
                     case WizardStep.Complete:
                         return "Restore all screws to their original position.";
                     default:
@@ -366,6 +455,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public ICommand CancelCommand { get; }
         public ICommand RestartCommand { get; }
         public ICommand UseMeasuredHardwareCommand { get; }
+        public ICommand BrowseSaveFolderCommand { get; }
+        public ICommand ReplayCommand { get; }
 
         // Known amount the user moves each screw during the per-screw calibration steps (full turns
         // for screws, steps for steppers). Defaults to 1.0 to match the "1 full turn" instructions.
@@ -486,9 +577,78 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         private Task StartAsync() {
             StatusText = string.Empty;
+            stepReadings.Clear();
+            HasRebaselineDriftWarning = false;
+            RebaselineDriftWarningText = string.Empty;
+            HasWarning = false;
+            WarningText = string.Empty;
+            StepMeasurementSummary.Clear();
+            runRootFolder = null;
+            metadataPath = null;
+            currentMetadata = null;
+
+            if (saveAFRuns) {
+                if (!SetUpSaveRun()) {
+                    // Could not set up the save folder; continue without saving.
+                    SaveAFRuns = false;
+                }
+            }
+
             CurrentStep = WizardStep.Baseline;
             IsWizardRunning = true;
             return Task.CompletedTask;
+        }
+
+        // Creates the per-run root folder and captures the live star-detection settings into the metadata so the
+        // run can be replayed later. Returns false (and warns) if the save folder is unset / cannot be created.
+        private bool SetUpSaveRun() {
+            if (string.IsNullOrWhiteSpace(SaveAFRunsPath)) {
+                Notification.ShowWarning("Choose a folder to save AutoFocus runs, or turn off saving.");
+                return false;
+            }
+            try {
+                runRootFolder = Path.Combine(SaveAFRunsPath, "TiltCalibration_" + DateTime.Now.ToString("yyyyMMdd_HHmmss"));
+                Directory.CreateDirectory(runRootFolder);
+            } catch (Exception ex) {
+                Notification.ShowError($"Could not create the AutoFocus save folder: {ex.Message}");
+                Logger.Error(ex, "Failed to create tilt calibration save folder");
+                return false;
+            }
+            metadataPath = Path.Combine(runRootFolder, "metadata.json");
+            currentMetadata = BuildInitialMetadata();
+            WriteMetadata();
+            return true;
+        }
+
+        private TiltCalibrationMetadata BuildInitialMetadata() {
+            return new TiltCalibrationMetadata {
+                NumberOfScrews = tiltAdapterOptions.ScrewCount,
+                AdjustmentType = IsStepperAdjustment ? "StepperMotors" : "Screws",
+                ScrewThreadPitchMicrons = tiltAdapterOptions.ThreadPitchMicrons,
+                StepperStepSizeMicrons = tiltAdapterOptions.StepperStepSizeMicrons,
+                ScrewRadiusMillimeters = tiltAdapterOptions.ScrewRadiusMillimeters,
+                PixelSizeMicrons = profileService.ActiveProfile.CameraSettings.PixelSize,
+                FocuserStepSizeMicrons = EffectiveFocuserStepMicrons(),
+                CalibrationAppliedAmount = calibrationAppliedAmount,
+                MeasurementAverageCount = Math.Max(1, tiltAdapterOptions.MeasurementAverageCount),
+                OptimizedStarDetectionSettings = CaptureDetectionSettings(),
+                RunStepMapping = new List<TiltRunStepMapping>(),
+                PerStep = new List<TiltPerStepResult>()
+            };
+        }
+
+        // Capture the effective live star-detection params as a snapshot DTO. BuildStarDetectorParams is the same
+        // source the runtime AF detection path uses; the optimization-only J/step args are inert metadata.
+        private static OptimizedStarDetectionSettings CaptureDetectionSettings() {
+            var p = HocusFocusStarDetection.BuildStarDetectorParams(HocusFocusPlugin.StarDetectionOptions);
+            return OptimizedStarDetectionSettings.FromParams(p, runCount: 0, baselineJ: 0.0, finalJ: 0.0,
+                recommendedStepSize: 0, recommendedOffsetSteps: 0);
+        }
+
+        private double EffectiveFocuserStepMicrons() {
+            var v = inspector.InspectorOptions?.MicronsPerFocuserStep ?? -1;
+            if (v > 0) return v;
+            return focuserInfo.StepSize > 0 ? focuserInfo.StepSize : -1;
         }
 
         private async Task RunMeasurementAsync() {
@@ -501,64 +661,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             IsMeasuring = true;
 
             try {
-                bool success = false;
-
-                switch (currentStep) {
-                    case WizardStep.Baseline: {
-                        StepMeasurementSummary.Clear();
-                        var result = await RunAveragedTiltMeasurement(token, "Baseline");
-                        if (result != null) {
-                            baselineReading = result.Value;
-                            baselineCurvatureReading = inspector.TiltModel?.TiltPlaneModel?.MeanFocuserPosition ?? 0.0;
-                            success = true;
-                        }
-                        break;
-                    }
-                    case WizardStep.AllScrews: {
-                        var result = await RunAveragedCurvatureMeasurement(token, AllScrewsDescription);
-                        if (result != null) {
-                            allScrewsCurvatureReading = result.Value;
-                            success = true;
-                        }
-                        break;
-                    }
-                    case WizardStep.Screw1: {
-                        var result = await RunAveragedTiltMeasurement(token, Screw1Description);
-                        if (result != null) {
-                            screw1Reading = result.Value;
-                            success = true;
-                        }
-                        break;
-                    }
-                    case WizardStep.Screw2: {
-                        var result = await RunAveragedTiltMeasurement(token, Screw2Description);
-                        if (result != null) {
-                            screw2Reading = result.Value;
-                            success = true;
-                        }
-                        break;
-                    }
-                }
-
-                if (success) {
-                    NextStep();
-                } else {
-                    StatusText = "Measurement failed.";
-                }
+                await MeasureStep(currentStep, token, fromSaved: false);
             } catch (OperationCanceledException) {
                 StatusText = "Measurement cancelled.";
             } finally {
                 IsMeasuring = false;
             }
         }
-
-        private string AllScrewsDescription => "All screws ↓";
-
-        private string Screw1Description =>
-            tiltAdapterOptions.ScrewCount == 3 ? "Screw 1 ↓" : "Screw 1 ↓, Screw 3 ↑";
-
-        private string Screw2Description =>
-            tiltAdapterOptions.ScrewCount == 3 ? "Screw 2 ↓" : "Screw 2 ↓, Screw 4 ↑";
 
         private async Task RunSavedMeasurementAsync() {
             HasMeasurementConsistencyWarning = false;
@@ -569,49 +678,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             var token = measureCts.Token;
 
             try {
-                bool success = false;
-                switch (currentStep) {
-                    case WizardStep.Baseline: {
-                        StepMeasurementSummary.Clear();
-                        var result = await RunAveragedSavedTiltMeasurement(token, "Baseline");
-                        if (result != null) {
-                            baselineReading = result.Value;
-                            baselineCurvatureReading = inspector.TiltModel?.TiltPlaneModel?.MeanFocuserPosition ?? 0.0;
-                            success = true;
-                        }
-                        break;
-                    }
-                    case WizardStep.AllScrews: {
-                        var result = await RunAveragedSavedCurvatureMeasurement(token, AllScrewsDescription);
-                        if (result != null) {
-                            allScrewsCurvatureReading = result.Value;
-                            success = true;
-                        }
-                        break;
-                    }
-                    case WizardStep.Screw1: {
-                        var result = await RunAveragedSavedTiltMeasurement(token, Screw1Description);
-                        if (result != null) {
-                            screw1Reading = result.Value;
-                            success = true;
-                        }
-                        break;
-                    }
-                    case WizardStep.Screw2: {
-                        var result = await RunAveragedSavedTiltMeasurement(token, Screw2Description);
-                        if (result != null) {
-                            screw2Reading = result.Value;
-                            success = true;
-                        }
-                        break;
-                    }
-                }
-
-                if (success) {
-                    NextStep();
-                } else {
-                    StatusText = "Measurement failed.";
-                }
+                await MeasureStep(currentStep, token, fromSaved: true);
             } catch (OperationCanceledException) {
                 StatusText = "Measurement cancelled.";
             } finally {
@@ -619,28 +686,94 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
         }
 
-        private async Task<(double A, double B)?> RunAveragedSavedTiltMeasurement(CancellationToken token, string stepDescription) {
+        private async Task MeasureStep(WizardStep step, CancellationToken token, bool fromSaved) {
+            if (step == WizardStep.Baseline) {
+                StepMeasurementSummary.Clear();
+            }
+            var reading = await RunAveragedMeasurement(token, step, StepDescription(step), fromSaved);
+            if (reading == null) {
+                StatusText = "Measurement failed.";
+                return;
+            }
+            stepReadings[step] = reading.Value;
+            RecordStepIntoMetadata(step, reading.Value);
+            NextStep();
+        }
+
+        // Description shown on each summary row, reflecting the single move performed for the step.
+        private string StepDescription(WizardStep step) {
+            bool four = tiltAdapterOptions.ScrewCount == 4;
+            switch (step) {
+                case WizardStep.Baseline: return "Baseline";
+                case WizardStep.AllInward: return "All screws ↓";
+                case WizardStep.ReBaseline1: return "Re-baseline (all ↑)";
+                case WizardStep.Screw1: return four ? "Screw 1 ↓, Screw 3 ↑" : "Screw 1 ↓";
+                case WizardStep.ReBaseline2: return four ? "Re-baseline (Screw 1 ↑, Screw 3 ↓)" : "Re-baseline (Screw 1 ↑)";
+                case WizardStep.Screw2: return four ? "Screw 2 ↓, Screw 4 ↑" : "Screw 2 ↓";
+                default: return step.ToString();
+            }
+        }
+
+        private static string StepFolderName(WizardStep step) => $"{(int)step + 1:00}_{step}";
+
+        // Runs the aberration inspector MeasurementAverageCount times, averages the tilt plane, appends summary
+        // rows + the consistency warning, and captures the per-step field-curvature characterization. When saving
+        // (live only), each step's run is redirected into its own folder and the saved location is recorded.
+        private async Task<StepReading?> RunAveragedMeasurement(CancellationToken token, WizardStep step, string stepDescription, bool fromSaved) {
             int count = Math.Max(1, tiltAdapterOptions.MeasurementAverageCount);
-            var readings = new List<(double A, double B)>(count);
+            var readings = new List<(double A, double B, double Mean)>(count);
+
+            AutoFocusSaveOverride saveOverride = null;
+            if (!fromSaved && saveAFRuns && !string.IsNullOrEmpty(runRootFolder)) {
+                try {
+                    var perStepDir = Path.Combine(runRootFolder, StepFolderName(step));
+                    Directory.CreateDirectory(perStepDir);
+                    saveOverride = new AutoFocusSaveOverride { Save = true, SavePath = perStepDir };
+                } catch (Exception ex) {
+                    Logger.Error(ex, "Failed to create per-step save folder; continuing without saving this step");
+                }
+            }
 
             for (int i = 0; i < count; i++) {
                 token.ThrowIfCancellationRequested();
                 StatusText = $"Run {i + 1}/{count}...";
-                // IsMeasuring is set via callback after the folder dialog closes so the
-                // chart doesn't appear until the user has confirmed a selection.
-                bool ok = await inspector.AnalyzeAutoFocusFromSaved(token, onFolderSelected: () => IsMeasuring = true);
+                bool ok;
+                if (fromSaved) {
+                    // IsMeasuring is set via callback after the folder dialog closes so the chart doesn't appear
+                    // until the user has confirmed a selection.
+                    ok = await inspector.AnalyzeAutoFocusFromSaved(token, onFolderSelected: () => IsMeasuring = true);
+                } else {
+                    ok = await inspector.AnalyzeAutoFocus(token, captureCameraBlock: true, saveOverride);
+                }
                 if (!ok) return null;
                 var m = inspector.TiltModel?.TiltPlaneModel;
                 if (m == null) return null;
-                readings.Add((m.A, m.B));
+                readings.Add((m.A, m.B, m.MeanFocuserPosition));
             }
 
             double avgA = readings.Average(r => r.A);
             double avgB = readings.Average(r => r.B);
+            double avgMean = readings.Average(r => r.Mean);
 
             var latestModel = inspector.TiltModel?.TiltPlaneModel;
+            AppendSummaryRows(readings, stepDescription, latestModel, count, avgA, avgB);
+
+            var reading = new StepReading {
+                A = avgA,
+                B = avgB,
+                Mean = avgMean,
+                TiltAngleDeg = ComputeTiltAngleDeg(avgA, avgB, latestModel),
+                DirectionDeg = NormalizeAngle(Math.Atan2(avgA, -avgB) * 180.0 / Math.PI),
+                SaveFolder = (!fromSaved && saveOverride != null) ? inspector.LastSaveFolder : null
+            };
+            PopulateCurvature(ref reading);
+            return reading;
+        }
+
+        private void AppendSummaryRows(List<(double A, double B, double Mean)> readings, string stepDescription,
+            TiltPlaneModel latestModel, int count, double avgA, double avgB) {
             for (int i = 0; i < readings.Count; i++) {
-                var (a, b) = readings[i];
+                var (a, b, _) = readings[i];
                 StepMeasurementSummary.Add(new TiltMeasurementSummaryRow {
                     RunNumber = i + 1,
                     Direction = NormalizeAngle(Math.Atan2(a, -b) * 180.0 / Math.PI),
@@ -667,51 +800,21 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                         $"Measurements inconsistent: max deviation {maxDev:F4} exceeds {MeasurementConsistencyWarningThreshold:F4}. Consider re-running.";
                 }
             }
-
-            return (avgA, avgB);
         }
 
-        private async Task<double?> RunAveragedSavedCurvatureMeasurement(CancellationToken token, string stepDescription) {
-            int count = Math.Max(1, tiltAdapterOptions.MeasurementAverageCount);
-            double sum = 0;
-            var tiltReadings = new List<(double A, double B)>(count);
-
-            for (int i = 0; i < count; i++) {
-                token.ThrowIfCancellationRequested();
-                StatusText = $"Run {i + 1}/{count}...";
-                bool ok = await inspector.AnalyzeAutoFocusFromSaved(token, onFolderSelected: () => IsMeasuring = true);
-                if (!ok) return null;
-                var plane = inspector.TiltModel?.TiltPlaneModel;
-                if (plane == null) return null;
-                sum += plane.MeanFocuserPosition;
-                tiltReadings.Add((plane.A, plane.B));
+        // Field-curvature characterization for the metadata (req 9), read from the inspector's sensor model when
+        // the sensor curve model is enabled. CurvatureAt takes microns; the screw-radius evaluation point is the
+        // screw distance from the optical center. NaN when the curve model is unavailable.
+        private void PopulateCurvature(ref StepReading reading) {
+            reading.CurvatureRadiusMm = double.NaN;
+            reading.CurvatureEffectAtScrewRadiusMicrons = double.NaN;
+            var aberration = inspector.SensorModel?.SensorModelResult;
+            if (aberration?.Model == null) return;
+            reading.CurvatureRadiusMm = aberration.CurvatureRadiusMillimeters;
+            double radiusMicrons = tiltAdapterOptions.ScrewRadiusMillimeters * 1000.0;
+            if (radiusMicrons > 0) {
+                reading.CurvatureEffectAtScrewRadiusMicrons = aberration.Model.CurvatureAt(radiusMicrons, 0);
             }
-
-            var latestModel = inspector.TiltModel?.TiltPlaneModel;
-            for (int i = 0; i < tiltReadings.Count; i++) {
-                var (a, b) = tiltReadings[i];
-                StepMeasurementSummary.Add(new TiltMeasurementSummaryRow {
-                    RunNumber = i + 1,
-                    Direction = NormalizeAngle(Math.Atan2(a, -b) * 180.0 / Math.PI),
-                    TiltAngleDeg = ComputeTiltAngleDeg(a, b, latestModel),
-                    IsAverage = false,
-                    StepDescription = stepDescription
-                });
-            }
-
-            if (count > 1) {
-                double avgA = tiltReadings.Average(r => r.A);
-                double avgB = tiltReadings.Average(r => r.B);
-                StepMeasurementSummary.Add(new TiltMeasurementSummaryRow {
-                    RunNumber = 0,
-                    Direction = NormalizeAngle(Math.Atan2(avgA, -avgB) * 180.0 / Math.PI),
-                    TiltAngleDeg = ComputeTiltAngleDeg(avgA, avgB, latestModel),
-                    IsAverage = true,
-                    StepDescription = stepDescription
-                });
-            }
-
-            return sum / count;
         }
 
         private double ComputeTiltAngleDeg(double a, double b, TiltPlaneModel model) {
@@ -732,113 +835,23 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             return Math.Atan(Math.Sqrt(gx * gx + gy * gy)) * 180.0 / Math.PI;
         }
 
-        private async Task<(double A, double B)?> RunAveragedTiltMeasurement(CancellationToken token, string stepDescription = "") {
-            int count = Math.Max(1, tiltAdapterOptions.MeasurementAverageCount);
-            var readings = new List<(double A, double B)>(count);
-
-            for (int i = 0; i < count; i++) {
-                token.ThrowIfCancellationRequested();
-                StatusText = $"Run {i + 1}/{count}...";
-                bool ok = await inspector.AnalyzeAutoFocus(token, captureCameraBlock: true);
-                if (!ok) return null;
-                var m = inspector.TiltModel?.TiltPlaneModel;
-                if (m == null) return null;
-                readings.Add((m.A, m.B));
-            }
-
-            double avgA = readings.Average(r => r.A);
-            double avgB = readings.Average(r => r.B);
-
-            var latestModel = inspector.TiltModel?.TiltPlaneModel;
-            for (int i = 0; i < readings.Count; i++) {
-                var (a, b) = readings[i];
-                StepMeasurementSummary.Add(new TiltMeasurementSummaryRow {
-                    RunNumber = i + 1,
-                    Direction = NormalizeAngle(Math.Atan2(a, -b) * 180.0 / Math.PI),
-                    TiltAngleDeg = ComputeTiltAngleDeg(a, b, latestModel),
-                    IsAverage = false,
-                    StepDescription = stepDescription
-                });
-            }
-
-            if (count > 1) {
-                StepMeasurementSummary.Add(new TiltMeasurementSummaryRow {
-                    RunNumber = 0,
-                    Direction = NormalizeAngle(Math.Atan2(avgA, -avgB) * 180.0 / Math.PI),
-                    TiltAngleDeg = ComputeTiltAngleDeg(avgA, avgB, latestModel),
-                    IsAverage = true,
-                    StepDescription = stepDescription
-                });
-
-                double maxDev = readings.Max(r =>
-                    Math.Sqrt(Math.Pow(r.A - avgA, 2) + Math.Pow(r.B - avgB, 2)));
-                if (maxDev > MeasurementConsistencyWarningThreshold) {
-                    HasMeasurementConsistencyWarning = true;
-                    MeasurementConsistencyWarningText =
-                        $"Measurements inconsistent: max deviation {maxDev:F4} exceeds {MeasurementConsistencyWarningThreshold:F4}. Consider re-running.";
-                }
-            }
-
-            return (avgA, avgB);
-        }
-
-        private async Task<double?> RunAveragedCurvatureMeasurement(CancellationToken token, string stepDescription = "") {
-            int count = Math.Max(1, tiltAdapterOptions.MeasurementAverageCount);
-            double sum = 0;
-            var tiltReadings = new List<(double A, double B)>(count);
-            for (int i = 0; i < count; i++) {
-                token.ThrowIfCancellationRequested();
-                StatusText = $"Run {i + 1}/{count}...";
-                bool ok = await inspector.AnalyzeAutoFocus(token, captureCameraBlock: true);
-                if (!ok) return null;
-                var plane = inspector.TiltModel?.TiltPlaneModel;
-                if (plane == null) return null;
-                sum += plane.MeanFocuserPosition;
-                tiltReadings.Add((plane.A, plane.B));
-            }
-
-            var latestModel = inspector.TiltModel?.TiltPlaneModel;
-            for (int i = 0; i < tiltReadings.Count; i++) {
-                var (a, b) = tiltReadings[i];
-                StepMeasurementSummary.Add(new TiltMeasurementSummaryRow {
-                    RunNumber = i + 1,
-                    Direction = NormalizeAngle(Math.Atan2(a, -b) * 180.0 / Math.PI),
-                    TiltAngleDeg = ComputeTiltAngleDeg(a, b, latestModel),
-                    IsAverage = false,
-                    StepDescription = stepDescription
-                });
-            }
-
-            if (count > 1) {
-                double avgA = tiltReadings.Average(r => r.A);
-                double avgB = tiltReadings.Average(r => r.B);
-                StepMeasurementSummary.Add(new TiltMeasurementSummaryRow {
-                    RunNumber = 0,
-                    Direction = NormalizeAngle(Math.Atan2(avgA, -avgB) * 180.0 / Math.PI),
-                    TiltAngleDeg = ComputeTiltAngleDeg(avgA, avgB, latestModel),
-                    IsAverage = true,
-                    StepDescription = stepDescription
-                });
-            }
-
-            return sum / count;
-        }
-
         private void CancelMeasurement() {
             measureCts?.Cancel();
         }
 
         private void NextStep() {
-            if (currentStep == WizardStep.AllScrews) {
-                CalculateAndSaveCurvatureSign();
-            }
-
             WizardStep next = currentStep + 1;
 
             if (next == WizardStep.Complete) {
-                CalculateAndSaveAngles();
-                CalculateAndSaveHardware();
+                RunCalibrationMath(
+                    tiltAdapterOptions.ScrewCount,
+                    tiltAdapterOptions.ScrewRadiusMillimeters,
+                    profileService.ActiveProfile.CameraSettings.PixelSize,
+                    EffectiveFocuserStepMicrons(),
+                    calibrationAppliedAmount,
+                    IsStepperAdjustment);
                 RebuildDiagram();
+                FinalizeMetadata();
             }
 
             HasMeasurementConsistencyWarning = false;
@@ -851,16 +864,23 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             measureCts?.Cancel();
             IsWizardRunning = false;
             IsMeasuring = false;
-            baselineReading = default;
-            screw1Reading = default;
-            screw2Reading = default;
-            baselineCurvatureReading = 0;
-            allScrewsCurvatureReading = 0;
+            isReplaying = false;
+            SaveAFRuns = false; // saving must be re-enabled explicitly for each run
+            stepReadings.Clear();
             measuredHardwareMicrons = double.NaN;
+            lastRawAngleDiff = double.NaN;
+            lastMoveMagnitudeRatio = double.NaN;
+            runRootFolder = null;
+            metadataPath = null;
+            currentMetadata = null;
             RaiseHardwareSummaryChanged();
             StepMeasurementSummary.Clear();
             HasMeasurementConsistencyWarning = false;
             MeasurementConsistencyWarningText = string.Empty;
+            HasRebaselineDriftWarning = false;
+            RebaselineDriftWarningText = string.Empty;
+            HasWarning = false;
+            WarningText = string.Empty;
             StatusText = string.Empty;
             CurrentStep = WizardStep.Baseline;
         }
@@ -896,47 +916,86 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             RaiseHardwareSummaryChanged();
         }
 
-        // Recover thread pitch (µm/turn) or stepper step size (µm/step) from the known per-screw
-        // calibration moves and the measured tilt-plane changes. Stored as the "last measured" value;
-        // the user can copy it into the active saved value via UseMeasuredHardwareCommand.
-        private void CalculateAndSaveHardware() {
+        private void BrowseSaveFolder() {
+            using (var dialog = new System.Windows.Forms.FolderBrowserDialog()) {
+                if (!string.IsNullOrEmpty(SaveAFRunsPath)) {
+                    dialog.SelectedPath = SaveAFRunsPath;
+                }
+                if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK) {
+                    SaveAFRunsPath = dialog.SelectedPath;
+                }
+            }
+        }
+
+        // Runs the full calibration math from the six step readings and writes the results to the options. Shared
+        // by a live run (geometry from the current options/profile) and a replay (geometry from the metadata).
+        private void RunCalibrationMath(int screwCount, double radiusMm, double pixelSize, double fStep,
+            double appliedAmount, bool isStepper) {
+            var a = Reading(WizardStep.Baseline);
+            var b = Reading(WizardStep.AllInward);
+            var c = Reading(WizardStep.ReBaseline1);
+            var d = Reading(WizardStep.Screw1);
+            var e = Reading(WizardStep.ReBaseline2);
+            var f = Reading(WizardStep.Screw2);
+
+            // Curvature (backfocus) sign from baseline (a) → all-inward (b) mean focus.
+            tiltAdapterOptions.ScrewInwardCurvatureSign = TiltCalibrationCalculator.ComputeCurvatureSign(b.Mean, a.Mean);
+
+            // Screw angles from each move relative to its preceding re-baseline (c→d, e→f).
+            double d1A = d.A - c.A, d1B = d.B - c.B;
+            double d2A = f.A - e.A, d2B = f.B - e.B;
+            var (s1, s2, s3, s4, rawDiff) = TiltCalibrationCalculator.ComputeScrewAngles(d1A, d1B, d2A, d2B, screwCount);
+
+            tiltAdapterOptions.Screw1AngleDegrees = s1;
+            tiltAdapterOptions.Screw2AngleDegrees = s2;
+            tiltAdapterOptions.Screw3AngleDegrees = s3;
+            tiltAdapterOptions.Screw4AngleDegrees = s4;
+            if (tiltAdapterOptions.ScrewCount != screwCount) {
+                tiltAdapterOptions.ScrewCount = screwCount; // replaying a run captured with a different screw count
+            }
+            tiltAdapterOptions.CalibratedScrewCount = screwCount;
+            tiltAdapterOptions.IsCalibrated = true;
+
+            lastRawAngleDiff = rawDiff;
+            lastMoveMagnitudeRatio = TiltCalibrationCalculator.MoveMagnitudeRatio(d1A, d1B, d2A, d2B);
+            ValidateCalibrationQuality(rawDiff, lastMoveMagnitudeRatio, screwCount);
+
+            // Recover the adapter hardware (µm/turn or µm/step).
             measuredHardwareMicrons = double.NaN;
-            calibrationScrewRadiusMm = tiltAdapterOptions.ScrewRadiusMillimeters;
-
-            var model = inspector.TiltModel?.TiltPlaneModel;
-            if (model == null) { RaiseHardwareSummaryChanged(); return; }
-
-            double pixelSize = profileService.ActiveProfile.CameraSettings.PixelSize;
-            double fStep = model.FocuserStepSizeMicrons;
-            if (double.IsNaN(fStep) || fStep <= 0) fStep = focuserInfo.StepSize;
+            calibrationScrewRadiusMm = radiusMm;
             calibrationPixelSizeMicrons = pixelSize;
             calibrationFocuserStepMicrons = fStep;
 
-            // The pitch/step recovery math lives in the pure TiltCalibrationCalculator (shared with the validator);
-            // it applies the same guards (radius/applied/pixel/fStep/sensor > 0) and returns NaN otherwise.
-            var inputs = new TiltCalibrationInputs {
-                ScrewCount = tiltAdapterOptions.ScrewCount,
-                Baseline = new TiltGradient(baselineReading.A, baselineReading.B, 0),
-                Screw1 = new TiltGradient(screw1Reading.A, screw1Reading.B, 0),
-                Screw2 = new TiltGradient(screw2Reading.A, screw2Reading.B, 0),
-                ImageWidthPixels = model.ImageSize.Width,
-                ImageHeightPixels = model.ImageSize.Height,
-                PixelSizeMicrons = pixelSize,
-                FocuserStepMicrons = fStep,
-                ScrewRadiusMillimeters = tiltAdapterOptions.ScrewRadiusMillimeters,
-                CalibrationAppliedAmount = calibrationAppliedAmount,
-                IsStepperAdjustment = IsStepperAdjustment
-            };
-            double measured = TiltCalibrationCalculator.RecoverHardwareMicrons(inputs);
-            if (double.IsNaN(measured)) { RaiseHardwareSummaryChanged(); return; }
-
-            measuredHardwareMicrons = measured;
-            if (IsStepperAdjustment) {
-                tiltAdapterOptions.LastMeasuredStepperStepSizeMicrons = measured;
-            } else {
-                tiltAdapterOptions.LastMeasuredThreadPitchMicrons = measured;
+            var model = inspector.TiltModel?.TiltPlaneModel;
+            if (model != null) {
+                var inputs = new TiltCalibrationInputs {
+                    ScrewCount = screwCount,
+                    Baseline = new TiltGradient(a.A, a.B, a.Mean),
+                    AllInward = new TiltGradient(b.A, b.B, b.Mean),
+                    ReBaseline1 = new TiltGradient(c.A, c.B, c.Mean),
+                    Screw1 = new TiltGradient(d.A, d.B, d.Mean),
+                    ReBaseline2 = new TiltGradient(e.A, e.B, e.Mean),
+                    Screw2 = new TiltGradient(f.A, f.B, f.Mean),
+                    ImageWidthPixels = model.ImageSize.Width,
+                    ImageHeightPixels = model.ImageSize.Height,
+                    PixelSizeMicrons = pixelSize,
+                    FocuserStepMicrons = fStep,
+                    ScrewRadiusMillimeters = radiusMm,
+                    CalibrationAppliedAmount = appliedAmount,
+                    IsStepperAdjustment = isStepper
+                };
+                double measured = TiltCalibrationCalculator.RecoverHardwareMicrons(inputs);
+                if (!double.IsNaN(measured)) {
+                    measuredHardwareMicrons = measured;
+                    if (isStepper) {
+                        tiltAdapterOptions.LastMeasuredStepperStepSizeMicrons = measured;
+                    } else {
+                        tiltAdapterOptions.LastMeasuredThreadPitchMicrons = measured;
+                    }
+                }
             }
 
+            EvaluateRebaselineDrift();
             RaiseHardwareSummaryChanged();
         }
 
@@ -952,40 +1011,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             ((RelayCommand)UseMeasuredHardwareCommand).NotifyCanExecuteChanged();
         }
 
-        private void CalculateAndSaveCurvatureSign() {
-            tiltAdapterOptions.ScrewInwardCurvatureSign = TiltCalibrationCalculator.ComputeCurvatureSign(
-                allScrewsCurvatureReading, baselineCurvatureReading);
-        }
-
-        private void CalculateAndSaveAngles() {
-            // The per-screw angle math (winding detection + constrained equal-spacing fit) lives in the pure
-            // TiltCalibrationCalculator, shared with the headless validator so the two can never drift.
-            double d1A = screw1Reading.A - baselineReading.A;
-            double d1B = screw1Reading.B - baselineReading.B;
-            double d2A = screw2Reading.A - baselineReading.A;
-            double d2B = screw2Reading.B - baselineReading.B;
-
-            var (s1, s2, s3, s4, rawDiff) = TiltCalibrationCalculator.ComputeScrewAngles(
-                d1A, d1B, d2A, d2B, tiltAdapterOptions.ScrewCount);
-
-            tiltAdapterOptions.Screw1AngleDegrees = s1;
-            tiltAdapterOptions.Screw2AngleDegrees = s2;
-            tiltAdapterOptions.Screw3AngleDegrees = s3;
-            tiltAdapterOptions.Screw4AngleDegrees = s4;
-            tiltAdapterOptions.CalibratedScrewCount = tiltAdapterOptions.ScrewCount;
-            tiltAdapterOptions.IsCalibrated = true;
-            var magnitudeRatio = TiltCalibrationCalculator.MoveMagnitudeRatio(d1A, d1B, d2A, d2B);
-            ValidateCalibrationQuality(rawDiff, magnitudeRatio);
-        }
-
         // Two single-screw turns of the same amount should produce gradient changes that are ~equal in magnitude
         // and the correct angular distance apart. A bad angle gap OR very unequal magnitudes (uneven turning /
         // backlash) means the recovered geometry/hardware is unreliable — warn so the user recalibrates.
         private const double MagnitudeRatioWarnThreshold = 1.5; // larger move > 1.5x smaller => suspect
 
-        private void ValidateCalibrationQuality(double rawDiff, double magnitudeRatio) {
-            int n = tiltAdapterOptions.ScrewCount;
-            double expected = n == 3 ? 120.0 : 90.0;
+        private void ValidateCalibrationQuality(double rawDiff, double magnitudeRatio, int screwCount) {
+            double expected = screwCount == 3 ? 120.0 : 90.0;
             // Fold the diff so it is in [0, 180] — both CW and CCW gaps compare to the same expected value.
             double foldedDiff = rawDiff <= 180.0 ? rawDiff : 360.0 - rawDiff;
             double deviation = Math.Abs(foldedDiff - expected);
@@ -1005,6 +1037,219 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 parts.Add($"the two screw turns produced very unequal tilt changes ({magnitudeRatio:F1}× apart) — turn each screw the same amount");
             }
             WarningText = string.Join("; ", parts) + ". Consider recalibrating.";
+        }
+
+        // Re-baseline drift: each re-baseline (c, e) should return close to the prior state. A large residual
+        // relative to the subsequent screw move means backlash / an uneven undo contaminated the calibration.
+        private void EvaluateRebaselineDrift() {
+            var a = Reading(WizardStep.Baseline);
+            var c = Reading(WizardStep.ReBaseline1);
+            var d = Reading(WizardStep.Screw1);
+            var e = Reading(WizardStep.ReBaseline2);
+            var f = Reading(WizardStep.Screw2);
+
+            double drift1 = TiltCalibrationCalculator.RebaselineDriftRatio(c.A - a.A, c.B - a.B, d.A - c.A, d.B - c.B);
+            double drift2 = TiltCalibrationCalculator.RebaselineDriftRatio(e.A - c.A, e.B - c.B, f.A - e.A, f.B - e.B);
+
+            var parts = new List<string>(2);
+            if (!double.IsNaN(drift1) && drift1 > RebaselineDriftWarnThreshold) {
+                parts.Add($"re-baseline 1 drifted {drift1 * 100.0:F0}% of the screw-1 move");
+            }
+            if (!double.IsNaN(drift2) && drift2 > RebaselineDriftWarnThreshold) {
+                parts.Add($"re-baseline 2 drifted {drift2 * 100.0:F0}% of the screw-2 move");
+            }
+            HasRebaselineDriftWarning = parts.Count > 0;
+            RebaselineDriftWarningText = parts.Count == 0
+                ? string.Empty
+                : "Re-baseline drift detected: " + string.Join("; ", parts) +
+                    ". The undo between moves left residual tilt (backlash or an uneven turn); consider recalibrating.";
+        }
+
+        private StepReading Reading(WizardStep step) =>
+            stepReadings.TryGetValue(step, out var r) ? r : default;
+
+        // ---- Replay -----------------------------------------------------------------------------------------
+
+        // Replays a saved calibration run from a folder: reads metadata.json, applies its star-detection settings
+        // transiently (restored afterward), re-analyzes each step from its saved frames, and recomputes the
+        // calibration. The user's profile star-detection settings are restored in the finally block.
+        private async Task ReplayAsync() {
+            string folder;
+            using (var dialog = new System.Windows.Forms.FolderBrowserDialog()) {
+                if (!string.IsNullOrEmpty(SaveAFRunsPath)) {
+                    dialog.SelectedPath = SaveAFRunsPath;
+                }
+                if (dialog.ShowDialog() != System.Windows.Forms.DialogResult.OK) {
+                    return;
+                }
+                folder = dialog.SelectedPath;
+            }
+
+            var metadataFile = Path.Combine(folder, "metadata.json");
+            if (!File.Exists(metadataFile)) {
+                Notification.ShowError("No metadata.json found in the selected folder.");
+                return;
+            }
+
+            TiltCalibrationMetadata metadata;
+            try {
+                metadata = TiltCalibrationMetadata.Deserialize(File.ReadAllText(metadataFile));
+                metadata.Validate();
+            } catch (Exception ex) {
+                Notification.ShowError($"Could not read metadata.json: {ex.Message}");
+                Logger.Error(ex, "Failed to read tilt calibration metadata for replay");
+                return;
+            }
+
+            var byStep = (metadata.RunStepMapping ?? new List<TiltRunStepMapping>())
+                .GroupBy(m => m.Step, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key, g => g.Last().Folder, StringComparer.OrdinalIgnoreCase);
+            foreach (var step in MeasurementSteps) {
+                if (!byStep.ContainsKey(step.ToString())) {
+                    Notification.ShowError($"metadata.json has no saved folder for step '{step}'. Cannot replay.");
+                    return;
+                }
+            }
+
+            measureCts?.Dispose();
+            measureCts = new CancellationTokenSource();
+            var token = measureCts.Token;
+
+            var opts = HocusFocusPlugin.StarDetectionOptions;
+            var savedUseOptimized = opts.UseOptimizedSettings;
+            var savedUseAdvanced = opts.UseAdvanced;
+            var savedDto = opts.GetOptimizedSettings();
+
+            isReplaying = true;
+            IsWizardRunning = true;
+            IsMeasuring = true;
+            stepReadings.Clear();
+            StepMeasurementSummary.Clear();
+            HasMeasurementConsistencyWarning = false;
+            MeasurementConsistencyWarningText = string.Empty;
+            HasRebaselineDriftWarning = false;
+            RebaselineDriftWarningText = string.Empty;
+            HasWarning = false;
+            WarningText = string.Empty;
+            StatusText = string.Empty;
+
+            try {
+                if (metadata.OptimizedStarDetectionSettings != null) {
+                    opts.ApplyOptimizedSettings(metadata.OptimizedStarDetectionSettings);
+                }
+
+                foreach (var step in MeasurementSteps) {
+                    token.ThrowIfCancellationRequested();
+                    StatusText = $"Replaying {step}...";
+                    bool ok = await inspector.AnalyzeAutoFocusFromSavedPath(byStep[step.ToString()], token);
+                    if (!ok) {
+                        StatusText = $"Replay failed at {step}.";
+                        return;
+                    }
+                    var m = inspector.TiltModel?.TiltPlaneModel;
+                    if (m == null) {
+                        StatusText = $"Replay produced no tilt model at {step}.";
+                        return;
+                    }
+                    var reading = new StepReading {
+                        A = m.A,
+                        B = m.B,
+                        Mean = m.MeanFocuserPosition,
+                        TiltAngleDeg = ComputeTiltAngleDeg(m.A, m.B, m),
+                        DirectionDeg = NormalizeAngle(Math.Atan2(m.A, -m.B) * 180.0 / Math.PI)
+                    };
+                    PopulateCurvature(ref reading);
+                    stepReadings[step] = reading;
+                    StepMeasurementSummary.Add(new TiltMeasurementSummaryRow {
+                        RunNumber = 0,
+                        Direction = reading.DirectionDeg,
+                        TiltAngleDeg = reading.TiltAngleDeg,
+                        IsAverage = false,
+                        StepDescription = StepDescription(step)
+                    });
+                }
+
+                calibrationAppliedAmount = metadata.CalibrationAppliedAmount;
+                RaisePropertyChanged(nameof(CalibrationAppliedAmount));
+                RaisePropertyChanged(nameof(CalibrationAppliedAmountDisplay));
+                RunCalibrationMath(
+                    metadata.NumberOfScrews,
+                    metadata.ScrewRadiusMillimeters,
+                    metadata.PixelSizeMicrons,
+                    metadata.FocuserStepSizeMicrons,
+                    metadata.CalibrationAppliedAmount,
+                    metadata.IsStepperAdjustment);
+                RebuildDiagram();
+                StatusText = "Replay complete.";
+                CurrentStep = WizardStep.Complete;
+            } catch (OperationCanceledException) {
+                StatusText = "Replay cancelled.";
+            } catch (Exception ex) {
+                Notification.ShowError($"Replay failed: {ex.Message}");
+                Logger.Error(ex, "Tilt calibration replay failed");
+            } finally {
+                // Restore the user's star-detection settings (the profile auto-saves, so this must be explicit).
+                if (savedDto != null) {
+                    opts.ApplyOptimizedSettings(savedDto);
+                    opts.UseOptimizedSettings = savedUseOptimized;
+                    opts.UseAdvanced = savedUseAdvanced;
+                } else {
+                    opts.ClearOptimizedSettings();
+                    opts.UseAdvanced = savedUseAdvanced;
+                    opts.UseOptimizedSettings = savedUseOptimized;
+                }
+                isReplaying = false;
+                IsMeasuring = false;
+            }
+        }
+
+        // ---- Metadata ---------------------------------------------------------------------------------------
+
+        private void RecordStepIntoMetadata(WizardStep step, StepReading reading) {
+            if (!saveAFRuns || currentMetadata == null) return;
+            string stepName = step.ToString();
+
+            currentMetadata.RunStepMapping.RemoveAll(m => string.Equals(m.Step, stepName, StringComparison.OrdinalIgnoreCase));
+            if (!string.IsNullOrEmpty(reading.SaveFolder)) {
+                currentMetadata.RunStepMapping.Add(new TiltRunStepMapping { Step = stepName, Folder = reading.SaveFolder });
+            }
+
+            currentMetadata.PerStep.RemoveAll(p => string.Equals(p.Step, stepName, StringComparison.OrdinalIgnoreCase));
+            currentMetadata.PerStep.Add(new TiltPerStepResult {
+                Step = stepName,
+                TiltPlaneA = reading.A,
+                TiltPlaneB = reading.B,
+                MeanFocuserPosition = reading.Mean,
+                TiltAngleDeg = reading.TiltAngleDeg,
+                DirectionDeg = reading.DirectionDeg,
+                CurvatureRadiusMillimeters = reading.CurvatureRadiusMm,
+                CurvatureEffectMicronsAtScrewRadius = reading.CurvatureEffectAtScrewRadiusMicrons
+            });
+            WriteMetadata();
+        }
+
+        private void FinalizeMetadata() {
+            if (!saveAFRuns || currentMetadata == null) return;
+            currentMetadata.Calibration = new TiltCalibrationResultRecord {
+                Screw1AngleDegrees = tiltAdapterOptions.Screw1AngleDegrees,
+                Screw2AngleDegrees = tiltAdapterOptions.Screw2AngleDegrees,
+                Screw3AngleDegrees = tiltAdapterOptions.Screw3AngleDegrees,
+                Screw4AngleDegrees = tiltAdapterOptions.Screw4AngleDegrees,
+                CurvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign,
+                MeasuredHardwareMicrons = measuredHardwareMicrons,
+                RawAngleDiffDegrees = lastRawAngleDiff,
+                MoveMagnitudeRatio = lastMoveMagnitudeRatio
+            };
+            WriteMetadata();
+        }
+
+        private void WriteMetadata() {
+            if (currentMetadata == null || string.IsNullOrEmpty(metadataPath)) return;
+            try {
+                File.WriteAllText(metadataPath, currentMetadata.Serialize());
+            } catch (Exception ex) {
+                Logger.Error(ex, "Failed to write tilt calibration metadata");
+            }
         }
 
         private void RebuildDiagram() {
@@ -1052,6 +1297,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             ((AsyncRelayCommand)UseSavedAFCommand).NotifyCanExecuteChanged();
             ((RelayCommand)CancelCommand).NotifyCanExecuteChanged();
             ((RelayCommand)UseMeasuredHardwareCommand).NotifyCanExecuteChanged();
+            ((AsyncRelayCommand)ReplayCommand).NotifyCanExecuteChanged();
         }
 
         private static double NormalizeAngle(double deg) => ((deg % 360) + 360) % 360;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -163,7 +163,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             RestartCommand = new RelayCommand(Restart);
             UseMeasuredHardwareCommand = new RelayCommand(UseMeasuredHardware, () => HasMeasuredHardware);
             BrowseSaveFolderCommand = new RelayCommand(BrowseSaveFolder);
-            ReplayCommand = new AsyncRelayCommand(ReplayAsync, () => !IsWizardRunning && !IsMeasuring);
+            ReplayCommand = new AsyncRelayCommand(() => ReplayAsync(useMetadataSettings: true), () => !IsWizardRunning && !IsMeasuring);
+            ReplayCurrentSettingsCommand = new AsyncRelayCommand(() => ReplayAsync(useMetadataSettings: false), () => !IsWizardRunning && !IsMeasuring);
 
             tiltAdapterOptions.PropertyChanged += (s, e) => {
                 if (e.PropertyName == nameof(ITiltAdapterOptions.ScrewInwardCurvatureSign)) {
@@ -465,6 +466,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public ICommand UseMeasuredHardwareCommand { get; }
         public ICommand BrowseSaveFolderCommand { get; }
         public ICommand ReplayCommand { get; }
+        public ICommand ReplayCurrentSettingsCommand { get; }
 
         // Known amount the user moves each screw during the per-screw calibration steps (full turns
         // for screws, steps for steppers). Defaults to 1.0 to match the "1 full turn" instructions.
@@ -1108,10 +1110,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         // ---- Replay -----------------------------------------------------------------------------------------
 
-        // Replays a saved calibration run from a folder: reads metadata.json, applies its star-detection settings
-        // transiently (restored afterward), re-analyzes each step from its saved frames, and recomputes the
-        // calibration. The user's profile star-detection settings are restored in the finally block.
-        private async Task ReplayAsync() {
+        // Replays a saved calibration run from a folder: reads metadata.json, re-analyzes each step from its saved
+        // frames, and recomputes the calibration.
+        // - useMetadataSettings = true ("Replay"): apply the run's stored star-detection settings transiently
+        //   (restored afterward) and use the run's stored geometry — reproduces the original calibration exactly.
+        // - useMetadataSettings = false ("Replay Current Settings"): leave the current profile's star-detection and
+        //   tilt-calibration settings in place, so metadata.json does not override what is configured now.
+        private async Task ReplayAsync(bool useMetadataSettings) {
             string folder;
             using (var dialog = new System.Windows.Forms.FolderBrowserDialog()) {
                 if (!string.IsNullOrEmpty(SaveAFRunsPath)) {
@@ -1153,7 +1158,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             measureCts = new CancellationTokenSource();
             var token = measureCts.Token;
 
+            // Only override (and therefore snapshot/restore) the profile's star-detection settings when replaying
+            // with the run's stored settings. "Replay Current Settings" leaves the profile untouched.
             var opts = HocusFocusPlugin.StarDetectionOptions;
+            bool overrideDetection = useMetadataSettings && metadata.OptimizedStarDetectionSettings != null;
             var savedUseOptimized = opts.UseOptimizedSettings;
             var savedUseAdvanced = opts.UseAdvanced;
             var savedDto = opts.GetOptimizedSettings();
@@ -1172,7 +1180,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             StatusText = string.Empty;
 
             try {
-                if (metadata.OptimizedStarDetectionSettings != null) {
+                if (overrideDetection) {
                     opts.ApplyOptimizedSettings(metadata.OptimizedStarDetectionSettings);
                 }
 
@@ -1207,16 +1215,27 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     });
                 }
 
-                calibrationAppliedAmount = metadata.CalibrationAppliedAmount;
-                RaisePropertyChanged(nameof(CalibrationAppliedAmount));
-                RaisePropertyChanged(nameof(CalibrationAppliedAmountDisplay));
-                RunCalibrationMath(
-                    metadata.NumberOfScrews,
-                    metadata.ScrewRadiusMillimeters,
-                    metadata.PixelSizeMicrons,
-                    metadata.FocuserStepSizeMicrons,
-                    metadata.CalibrationAppliedAmount,
-                    metadata.IsStepperAdjustment);
+                if (useMetadataSettings) {
+                    calibrationAppliedAmount = metadata.CalibrationAppliedAmount;
+                    RaisePropertyChanged(nameof(CalibrationAppliedAmount));
+                    RaisePropertyChanged(nameof(CalibrationAppliedAmountDisplay));
+                    RunCalibrationMath(
+                        metadata.NumberOfScrews,
+                        metadata.ScrewRadiusMillimeters,
+                        metadata.PixelSizeMicrons,
+                        metadata.FocuserStepSizeMicrons,
+                        metadata.CalibrationAppliedAmount,
+                        metadata.IsStepperAdjustment);
+                } else {
+                    // Use the current profile / tilt-adapter settings, exactly as a live calibration would.
+                    RunCalibrationMath(
+                        tiltAdapterOptions.ScrewCount,
+                        tiltAdapterOptions.ScrewRadiusMillimeters,
+                        profileService.ActiveProfile.CameraSettings.PixelSize,
+                        EffectiveFocuserStepMicrons(),
+                        calibrationAppliedAmount,
+                        IsStepperAdjustment);
+                }
                 RebuildDiagram();
                 StatusText = "Replay complete.";
                 CurrentStep = WizardStep.Complete;
@@ -1226,15 +1245,18 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 Notification.ShowError($"Replay failed: {ex.Message}");
                 Logger.Error(ex, "Tilt calibration replay failed");
             } finally {
-                // Restore the user's star-detection settings (the profile auto-saves, so this must be explicit).
-                if (savedDto != null) {
-                    opts.ApplyOptimizedSettings(savedDto);
-                    opts.UseOptimizedSettings = savedUseOptimized;
-                    opts.UseAdvanced = savedUseAdvanced;
-                } else {
-                    opts.ClearOptimizedSettings();
-                    opts.UseAdvanced = savedUseAdvanced;
-                    opts.UseOptimizedSettings = savedUseOptimized;
+                // Restore the user's star-detection settings only if we overrode them (the profile auto-saves, so
+                // this must be explicit). "Replay Current Settings" never touched them.
+                if (overrideDetection) {
+                    if (savedDto != null) {
+                        opts.ApplyOptimizedSettings(savedDto);
+                        opts.UseOptimizedSettings = savedUseOptimized;
+                        opts.UseAdvanced = savedUseAdvanced;
+                    } else {
+                        opts.ClearOptimizedSettings();
+                        opts.UseAdvanced = savedUseAdvanced;
+                        opts.UseOptimizedSettings = savedUseOptimized;
+                    }
                 }
                 isReplaying = false;
                 IsMeasuring = false;
@@ -1336,6 +1358,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             ((RelayCommand)CancelCommand).NotifyCanExecuteChanged();
             ((RelayCommand)UseMeasuredHardwareCommand).NotifyCanExecuteChanged();
             ((AsyncRelayCommand)ReplayCommand).NotifyCanExecuteChanged();
+            ((AsyncRelayCommand)ReplayCurrentSettingsCommand).NotifyCanExecuteChanged();
         }
 
         private static double NormalizeAngle(double deg) => ((deg % 360) + 360) % 360;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -730,7 +730,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // rows + the consistency warning, and captures the per-step field-curvature characterization. When saving
         // (live only), each step's run is redirected into its own folder and the saved location is recorded.
         private async Task<StepReading?> RunAveragedMeasurement(CancellationToken token, WizardStep step, string stepDescription, bool fromSaved) {
-            int count = Math.Max(1, tiltAdapterOptions.MeasurementAverageCount);
+            // Re-analyzing the same saved frames repeatedly yields identical readings (and would pop the folder
+            // dialog once per run), so the saved path runs a single pass regardless of the averaging count.
+            int count = fromSaved ? 1 : Math.Max(1, tiltAdapterOptions.MeasurementAverageCount);
             var readings = new List<(double A, double B, double Mean)>(count);
 
             // Redirect this step's run into its own folder when saving — for both live capture and the
@@ -1154,6 +1156,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 }
             }
 
+            // "Replay Current Settings" applies the current screw geometry to the saved deltas; if the saved run
+            // used a different screw count, the angle fit is meaningless. Warn rather than silently corrupt.
+            if (!useMetadataSettings && metadata.NumberOfScrews != tiltAdapterOptions.ScrewCount) {
+                Notification.ShowWarning($"The saved run used {metadata.NumberOfScrews} screws but the current setting is " +
+                    $"{tiltAdapterOptions.ScrewCount}. Replaying with current settings may produce incorrect angles.");
+            }
+
             measureCts?.Dispose();
             measureCts = new CancellationTokenSource();
             var token = measureCts.Token;
@@ -1179,6 +1188,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             WarningText = string.Empty;
             StatusText = string.Empty;
 
+            bool completed = false;
             try {
                 if (overrideDetection) {
                     opts.ApplyOptimizedSettings(metadata.OptimizedStarDetectionSettings);
@@ -1190,11 +1200,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     bool ok = await inspector.AnalyzeAutoFocusFromSavedPath(byStep[step.ToString()], token);
                     if (!ok) {
                         StatusText = $"Replay failed at {step}.";
+                        Notification.ShowError($"Replay failed at step '{step}'. The saved frames could not be analyzed.");
                         return;
                     }
                     var m = inspector.TiltModel?.TiltPlaneModel;
                     if (m == null) {
                         StatusText = $"Replay produced no tilt model at {step}.";
+                        Notification.ShowError($"Replay produced no tilt model at step '{step}'.");
                         return;
                     }
                     var reading = new StepReading {
@@ -1239,6 +1251,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 RebuildDiagram();
                 StatusText = "Replay complete.";
                 CurrentStep = WizardStep.Complete;
+                completed = true;
             } catch (OperationCanceledException) {
                 StatusText = "Replay cancelled.";
             } catch (Exception ex) {
@@ -1260,6 +1273,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 }
                 isReplaying = false;
                 IsMeasuring = false;
+                // A successful replay ends on the Complete panel (like a live run); a failed/cancelled replay
+                // returns to the idle config panel so the user can retry instead of being stuck mid-run.
+                if (!completed) {
+                    IsWizardRunning = false;
+                }
             }
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -407,6 +407,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
         }
 
+        // Enabling saving immediately prompts for the folder (one click). Invoked from the view's CheckBox.Checked
+        // so the property setter stays free of UI side effects (unit-testable). No-op if a folder is already set.
+        public void PromptForSaveFolderIfNeeded() {
+            if (saveAFRuns && string.IsNullOrWhiteSpace(SaveAFRunsPath)) {
+                BrowseSaveFolder();
+            }
+        }
+
         public string SaveAFRunsPath {
             get => tiltAdapterOptions.SaveAFRunsPath;
             set {
@@ -728,7 +736,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 try {
                     var perStepDir = Path.Combine(runRootFolder, StepFolderName(step));
                     Directory.CreateDirectory(perStepDir);
-                    saveOverride = new AutoFocusSaveOverride { Save = true, SavePath = perStepDir };
+                    // Keep only the raw frames needed for replay — no annotated/alignment or intermediate files.
+                    saveOverride = new AutoFocusSaveOverride { Save = true, SavePath = perStepDir, SuppressAuxiliaryFiles = true };
                 } catch (Exception ex) {
                     Logger.Error(ex, "Failed to create per-step save folder; continuing without saving this step");
                 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -731,8 +731,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             int count = Math.Max(1, tiltAdapterOptions.MeasurementAverageCount);
             var readings = new List<(double A, double B, double Mean)>(count);
 
+            // Redirect this step's run into its own folder when saving — for both live capture and the
+            // "Use Saved AF" path (re-analyzing a previously captured run still writes a replayable per-step run).
             AutoFocusSaveOverride saveOverride = null;
-            if (!fromSaved && saveAFRuns && !string.IsNullOrEmpty(runRootFolder)) {
+            if (saveAFRuns && !string.IsNullOrEmpty(runRootFolder)) {
                 try {
                     var perStepDir = Path.Combine(runRootFolder, StepFolderName(step));
                     Directory.CreateDirectory(perStepDir);
@@ -750,7 +752,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 if (fromSaved) {
                     // IsMeasuring is set via callback after the folder dialog closes so the chart doesn't appear
                     // until the user has confirmed a selection.
-                    ok = await inspector.AnalyzeAutoFocusFromSaved(token, onFolderSelected: () => IsMeasuring = true);
+                    ok = await inspector.AnalyzeAutoFocusFromSaved(token, onFolderSelected: () => IsMeasuring = true, saveOverride: saveOverride);
                 } else {
                     ok = await inspector.AnalyzeAutoFocus(token, captureCameraBlock: true, saveOverride);
                 }
@@ -773,7 +775,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 Mean = avgMean,
                 TiltAngleDeg = ComputeTiltAngleDeg(avgA, avgB, latestModel),
                 DirectionDeg = NormalizeAngle(Math.Atan2(avgA, -avgB) * 180.0 / Math.PI),
-                SaveFolder = (!fromSaved && saveOverride != null) ? inspector.LastSaveFolder : null
+                SaveFolder = saveOverride != null ? inspector.LastSaveFolder : null
             };
             PopulateCurvature(ref reading);
             return reading;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
@@ -32,13 +32,19 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public double MeanFocuserPosition { get; }
     }
 
-    /// <summary>Geometry + per-step readings needed to calibrate a tilt adapter from a sequence of measurements.</summary>
+    /// <summary>Geometry + per-step readings needed to calibrate a tilt adapter from a sequence of measurements.
+    /// The discrete 6-step flow measures: Baseline (a), AllInward (b), ReBaseline1 (c), Screw1 (d), ReBaseline2 (e),
+    /// Screw2 (f). Each screw's angle/hardware is derived from the move relative to the re-baseline that immediately
+    /// precedes it (c→d for screw 1, e→f for screw 2), so a single physical move is isolated per measurement pair.
+    /// </summary>
     public sealed class TiltCalibrationInputs {
         public int ScrewCount { get; set; }                 // 3 or 4
-        public TiltGradient Baseline { get; set; }
-        public TiltGradient AllScrews { get; set; }         // for the curvature (backfocus) sign
-        public TiltGradient Screw1 { get; set; }
-        public TiltGradient Screw2 { get; set; }
+        public TiltGradient Baseline { get; set; }          // a
+        public TiltGradient AllInward { get; set; }         // b: all screws inward once; for the curvature (backfocus) sign (a→b)
+        public TiltGradient ReBaseline1 { get; set; }       // c: all screws back out once (≈ baseline); reference for screw 1
+        public TiltGradient Screw1 { get; set; }            // d: screw 1 inward once (4-screw: + screw 3 outward)
+        public TiltGradient ReBaseline2 { get; set; }       // e: undo the screw-1 move (≈ c); reference for screw 2
+        public TiltGradient Screw2 { get; set; }            // f: screw 2 inward once (4-screw: + screw 4 outward)
         public double ImageWidthPixels { get; set; }
         public double ImageHeightPixels { get; set; }
         public double PixelSizeMicrons { get; set; }
@@ -153,10 +159,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             double radiusMicrons = radiusMm * 1000.0;
             int n = inputs.ScrewCount;
 
-            double d1A = inputs.Screw1.A - inputs.Baseline.A;
-            double d1B = inputs.Screw1.B - inputs.Baseline.B;
-            double d2A = inputs.Screw2.A - inputs.Baseline.A;
-            double d2B = inputs.Screw2.B - inputs.Baseline.B;
+            // Each screw move is measured relative to the re-baseline that immediately precedes it (c→d, e→f),
+            // isolating a single physical move per pair.
+            double d1A = inputs.Screw1.A - inputs.ReBaseline1.A;
+            double d1B = inputs.Screw1.B - inputs.ReBaseline1.B;
+            double d2A = inputs.Screw2.A - inputs.ReBaseline2.A;
+            double d2B = inputs.Screw2.B - inputs.ReBaseline2.B;
 
             var (g1x, g1y) = TiltScrewGeometry.PlaneGradientToPhysical(d1A, d1B, fStep, sensorW, sensorH);
             var (g2x, g2y) = TiltScrewGeometry.PlaneGradientToPhysical(d2A, d2B, fStep, sensorW, sensorH);
@@ -170,12 +178,27 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             return measured;
         }
 
+        /// <summary>
+        /// Drift of a re-baseline relative to its reference, as a fraction of the subsequent screw-move magnitude.
+        /// A good re-baseline returns close to the prior state, so this ratio is near 0; a large value means the
+        /// undo/redo left residual tilt (backlash or an uneven turn) comparable to the screw-move signal, so the
+        /// recovered angle/hardware for that screw is unreliable. Returns NaN when the screw-move magnitude is 0.
+        /// </summary>
+        public static double RebaselineDriftRatio(double driftA, double driftB, double moveA, double moveB) {
+            double moveMag = Math.Sqrt(moveA * moveA + moveB * moveB);
+            if (moveMag <= 0) {
+                return double.NaN;
+            }
+            double driftMag = Math.Sqrt(driftA * driftA + driftB * driftB);
+            return driftMag / moveMag;
+        }
+
         /// <summary>Runs the full calibration: screw angles, curvature sign, and recovered hardware.</summary>
         public static TiltCalibrationResult Calibrate(TiltCalibrationInputs inputs) {
-            double d1A = inputs.Screw1.A - inputs.Baseline.A;
-            double d1B = inputs.Screw1.B - inputs.Baseline.B;
-            double d2A = inputs.Screw2.A - inputs.Baseline.A;
-            double d2B = inputs.Screw2.B - inputs.Baseline.B;
+            double d1A = inputs.Screw1.A - inputs.ReBaseline1.A;
+            double d1B = inputs.Screw1.B - inputs.ReBaseline1.B;
+            double d2A = inputs.Screw2.A - inputs.ReBaseline2.A;
+            double d2B = inputs.Screw2.B - inputs.ReBaseline2.B;
 
             var (s1, s2, s3, s4, rawDiff) = ComputeScrewAngles(d1A, d1B, d2A, d2B, inputs.ScrewCount);
 
@@ -187,7 +210,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 CalibratedScrewCount = inputs.ScrewCount,
                 IsCalibrated = true,
                 RawAngleDiffDegrees = rawDiff,
-                CurvatureSign = ComputeCurvatureSign(inputs.AllScrews.MeanFocuserPosition, inputs.Baseline.MeanFocuserPosition),
+                CurvatureSign = ComputeCurvatureSign(inputs.AllInward.MeanFocuserPosition, inputs.Baseline.MeanFocuserPosition),
                 MeasuredHardwareMicrons = RecoverHardwareMicrons(inputs),
                 Screw1DirectionDegrees = NormalizeAngle(Math.Atan2(d1A, -d1B) * 180.0 / Math.PI),
                 Screw2DirectionDegrees = NormalizeAngle(Math.Atan2(d2A, -d2B) * 180.0 / Math.PI),

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
@@ -99,7 +99,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public TiltCalibrationResultRecord Calibration { get; set; }
 
         // ---- Optional validator-only ground truth (omitted by the wizard) ----
-        public double ExpectedPositionAngleScrew1Deg { get; set; }
+        // NaN = not provided (a wizard-written file): the headless validator then reports the screw-1 angle as
+        // "n/a" instead of failing it against a bogus 0° expectation.
+        public double ExpectedPositionAngleScrew1Deg { get; set; } = double.NaN;
         public bool DefocusAwareDetectionNeeded { get; set; }
 
         [JsonIgnore]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
@@ -1,0 +1,124 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using System;
+using System.Collections.Generic;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
+
+    /// <summary>One entry of the run → wizard-step folder map. The folder is the AutoFocus attempt root
+    /// (== <c>InspectorVM.LastSaveFolder</c>) that a replay/validation run loads.</summary>
+    public sealed class TiltRunStepMapping {
+        public string Step { get; set; }
+        public string Folder { get; set; }
+    }
+
+    /// <summary>
+    /// Per-step measured tilt-plane and field-curvature characterization (req 9), recorded for every measured
+    /// step. The tilt plane is the focus surface gradient: <c>plane = A·x + B·y</c> in focuser steps per
+    /// normalized image coordinate (range [-0.5, 0.5]). Curvature fields require the sensor curve model to be
+    /// enabled; they carry NaN otherwise.
+    /// </summary>
+    public sealed class TiltPerStepResult {
+        public string Step { get; set; }
+        public double TiltPlaneA { get; set; }
+        public double TiltPlaneB { get; set; }
+        public double MeanFocuserPosition { get; set; }
+        public double TiltAngleDeg { get; set; }
+        public double DirectionDeg { get; set; }
+        public double CurvatureRadiusMillimeters { get; set; } = double.NaN;
+        public double CurvatureEffectMicronsAtScrewRadius { get; set; } = double.NaN;
+    }
+
+    /// <summary>The computed calibration result stored for reference (the wizard/validator re-derive this from
+    /// the per-step readings via the shared <see cref="TiltCalibrationCalculator"/>).</summary>
+    public sealed class TiltCalibrationResultRecord {
+        public double Screw1AngleDegrees { get; set; }
+        public double Screw2AngleDegrees { get; set; }
+        public double Screw3AngleDegrees { get; set; }
+        public double Screw4AngleDegrees { get; set; }
+        public int CurvatureSign { get; set; }
+        public double MeasuredHardwareMicrons { get; set; }
+        public double RawAngleDiffDegrees { get; set; }
+        public double MoveMagnitudeRatio { get; set; }
+    }
+
+    /// <summary>
+    /// Serialization unit for a saved Tilt Adapter calibration run, shared by the live wizard (writer + replay)
+    /// and the headless <c>TestApp tilt</c> validator so a wizard-saved run replays both in-app and offline.
+    /// Holds the calibration settings, the star-detection settings used (so replay reproduces detection without
+    /// mutating the profile), the run → step folder map, and the per-step / final results. The validator-only
+    /// ground-truth fields are optional and omitted by the wizard.
+    /// </summary>
+    public sealed class TiltCalibrationMetadata {
+
+        public const int CurrentSchemaVersion = 1;
+
+        /// <summary>The six discrete measurement steps, in capture order. Same for 3- and 4-screw adapters.</summary>
+        public static readonly string[] StepOrder = {
+            "Baseline", "AllInward", "ReBaseline1", "Screw1", "ReBaseline2", "Screw2"
+        };
+
+        public static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings {
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            Formatting = Formatting.Indented,
+            NullValueHandling = NullValueHandling.Include
+        };
+
+        public int SchemaVersion { get; set; } = CurrentSchemaVersion;
+
+        // ---- Calibration settings (req 3) ----
+        public int NumberOfScrews { get; set; }
+        public string AdjustmentType { get; set; } = "Screws";       // "Screws" | "StepperMotors"
+        public double ScrewThreadPitchMicrons { get; set; } = -1;     // µm/turn (screws)
+        public double StepperStepSizeMicrons { get; set; } = -1;      // µm/step (steppers)
+        public double ScrewRadiusMillimeters { get; set; }
+        public double PixelSizeMicrons { get; set; }
+        public double FocuserStepSizeMicrons { get; set; }
+        public double CalibrationAppliedAmount { get; set; } = 1.0;   // turns/steps applied per screw step
+        public int MeasurementAverageCount { get; set; } = 1;
+
+        // ---- Replay payload ----
+        public List<TiltRunStepMapping> RunStepMapping { get; set; }
+        public OptimizedStarDetectionSettings OptimizedStarDetectionSettings { get; set; }
+
+        // ---- Results ----
+        public List<TiltPerStepResult> PerStep { get; set; }
+        public TiltCalibrationResultRecord Calibration { get; set; }
+
+        // ---- Optional validator-only ground truth (omitted by the wizard) ----
+        public double ExpectedPositionAngleScrew1Deg { get; set; }
+        public bool DefocusAwareDetectionNeeded { get; set; }
+
+        [JsonIgnore]
+        public bool IsStepperAdjustment =>
+            string.Equals(AdjustmentType, "StepperMotors", StringComparison.OrdinalIgnoreCase);
+
+        public string Serialize() => JsonConvert.SerializeObject(this, JsonSettings);
+
+        public static TiltCalibrationMetadata Deserialize(string json) =>
+            JsonConvert.DeserializeObject<TiltCalibrationMetadata>(json, JsonSettings);
+
+        public void Validate() {
+            if (NumberOfScrews != 3 && NumberOfScrews != 4) {
+                throw new InvalidOperationException($"numberOfScrews must be 3 or 4 (was {NumberOfScrews}).");
+            }
+            if (PixelSizeMicrons <= 0) throw new InvalidOperationException("pixelSizeMicrons must be > 0.");
+            if (FocuserStepSizeMicrons <= 0) throw new InvalidOperationException("focuserStepSizeMicrons must be > 0.");
+            if (ScrewRadiusMillimeters <= 0) throw new InvalidOperationException("screwRadiusMillimeters must be > 0.");
+            if (CalibrationAppliedAmount <= 0) throw new InvalidOperationException("calibrationAppliedAmount must be > 0.");
+        }
+    }
+}

--- a/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
@@ -605,17 +605,21 @@ namespace TestApp {
             Line($"Curvature (backfocus) inward sign: {calibration.CurvatureSign:+0;-0}");
             Line();
 
-            // Verdicts
-            bool angleOk = !double.IsNaN(screw1Deviation) && screw1Deviation <= 30.0;
+            // Verdicts. The screw-1 angle and hardware checks need ground truth that a wizard-written metadata.json
+            // does not carry; when absent they are reported "n/a" and do not fail the run.
+            bool angleProvided = !double.IsNaN(metadata.ExpectedPositionAngleScrew1Deg);
+            bool hardwareProvided = groundTruthHardware > 0;
+            bool angleOk = !angleProvided || (!double.IsNaN(screw1Deviation) && screw1Deviation <= 30.0);
             bool gapOk = Math.Abs(FoldGap(calibration.RawAngleDiffDegrees) - (metadata.NumberOfScrews == 3 ? 120.0 : 90.0)) <= 30.0;
-            bool hardwareOk = !double.IsNaN(hardwarePctDelta) && hardwarePctDelta <= 25.0;
+            bool hardwareOk = !hardwareProvided || (!double.IsNaN(hardwarePctDelta) && hardwarePctDelta <= 25.0);
             bool magnitudeOk = !double.IsNaN(calibration.MoveMagnitudeRatio) && calibration.MoveMagnitudeRatio <= 1.5;
             if (!magnitudeOk) {
                 Line("  NOTE: the two screw turns produced very unequal tilt changes — the recovered hardware/angles " +
                     "are unreliable. Re-capture turning each screw the same amount.");
             }
-            Line($"VERDICT: Screw1 angle {(angleOk ? "PASS" : "FAIL")}, angle separation {(gapOk ? "PASS" : "FAIL")}, " +
-                $"hardware {(hardwareOk ? "PASS" : "FAIL")}, move balance {(magnitudeOk ? "PASS" : "FAIL")}");
+            string V(bool ok, bool provided) => !provided ? "n/a" : (ok ? "PASS" : "FAIL");
+            Line($"VERDICT: Screw1 angle {V(angleOk, angleProvided)}, angle separation {(gapOk ? "PASS" : "FAIL")}, " +
+                $"hardware {V(hardwareOk, hardwareProvided)}, move balance {(magnitudeOk ? "PASS" : "FAIL")}");
 
             File.WriteAllText(Path.Combine(outDir, "tilt_summary.txt"), sb.ToString());
 

--- a/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
@@ -39,8 +39,9 @@ using Logger = NINA.Core.Utility.Logger;
 namespace TestApp {
 
     /// <summary>
-    /// Headless validator for the Tilt Adapter Wizard's calibration. Given a dataset folder containing the 4
-    /// saved AF runs the wizard consumes in sequence (Baseline → AllScrews → Screw1 → Screw2), it measures each
+    /// Headless validator for the Tilt Adapter Wizard's calibration. Given a dataset folder containing the 6
+    /// saved AF runs the wizard consumes in sequence (Baseline → AllInward → ReBaseline1 → Screw1 → ReBaseline2 →
+    /// Screw2), it measures each
     /// run's tilt plane, runs the SAME pure <see cref="TiltCalibrationCalculator"/> the live wizard uses, and
     /// reports the computed per-screw position angles + recovered hardware (thread pitch / step size) against
     /// ground-truth metadata stored in a per-dataset JSON file. It can also run (and persist) the star-detection
@@ -57,18 +58,15 @@ namespace TestApp {
     /// </summary>
     internal static class TiltCalibrationRunner {
 
-        // The 4 wizard measurement steps, in capture order. Same for 3- and 4-screw adapters.
-        private static readonly string[] StepOrder = { "Baseline", "AllScrews", "Screw1", "Screw2" };
+        // The 6 wizard measurement steps, in capture order. Same for 3- and 4-screw adapters. Shared with the
+        // live wizard via TiltCalibrationMetadata so a wizard-saved run replays both in-app and headlessly.
+        private static readonly string[] StepOrder = TiltCalibrationMetadata.StepOrder;
 
         // Sigma rejections matching the wizard's RunEvaluationLoader / the optimize harness (HocusFocusDetectionParams defaults).
         private const double HighSigmaOutlierRejection = 4.0;
         private const double LowSigmaOutlierRejection = 3.0;
 
-        private static readonly JsonSerializerSettings MetadataJsonSettings = new JsonSerializerSettings {
-            ContractResolver = new CamelCasePropertyNamesContractResolver(),
-            Formatting = Formatting.Indented,
-            NullValueHandling = NullValueHandling.Include
-        };
+        private static readonly JsonSerializerSettings MetadataJsonSettings = TiltCalibrationMetadata.JsonSettings;
 
         public static async Task Run(string[] args) {
             try {
@@ -121,7 +119,12 @@ namespace TestApp {
 
             var datasetName = new DirectoryInfo(datasetDir).Name;
             var parentDir = Directory.GetParent(datasetDir)?.FullName ?? datasetDir;
-            var metadataPath = Path.Combine(parentDir, datasetName + ".tilt.json");
+            // A live wizard run drops its metadata.json into the run root; prefer it so a saved run replays
+            // directly. Otherwise fall back to the validation-dataset convention (<parent>/<name>.tilt.json).
+            var wizardMetadataPath = Path.Combine(datasetDir, "metadata.json");
+            var metadataPath = File.Exists(wizardMetadataPath)
+                ? wizardMetadataPath
+                : Path.Combine(parentDir, datasetName + ".tilt.json");
 
             Console.WriteLine($"Dataset: {datasetDir}");
             Console.WriteLine($"Metadata: {metadataPath}");
@@ -140,7 +143,7 @@ namespace TestApp {
                 return;
             }
 
-            var metadata = JsonConvert.DeserializeObject<TiltMetadata>(File.ReadAllText(metadataPath), MetadataJsonSettings)
+            var metadata = JsonConvert.DeserializeObject<TiltCalibrationMetadata>(File.ReadAllText(metadataPath), MetadataJsonSettings)
                 ?? throw new InvalidOperationException($"Could not parse metadata file {metadataPath}");
             metadata.Validate();
 
@@ -200,8 +203,10 @@ namespace TestApp {
             var inputs = new TiltCalibrationInputs {
                 ScrewCount = metadata.NumberOfScrews,
                 Baseline = byStep["Baseline"].Gradient,
-                AllScrews = byStep["AllScrews"].Gradient,
+                AllInward = byStep["AllInward"].Gradient,
+                ReBaseline1 = byStep["ReBaseline1"].Gradient,
                 Screw1 = byStep["Screw1"].Gradient,
+                ReBaseline2 = byStep["ReBaseline2"].Gradient,
                 Screw2 = byStep["Screw2"].Gradient,
                 ImageWidthPixels = imageSize.Width,
                 ImageHeightPixels = imageSize.Height,
@@ -225,7 +230,7 @@ namespace TestApp {
             public List<(int Focuser, string Path)> Frames;
         }
 
-        private static List<RunStep> MapRunsToSteps(TiltMetadata metadata, List<string> runFolders, string datasetDir) {
+        private static List<RunStep> MapRunsToSteps(TiltCalibrationMetadata metadata, List<string> runFolders, string datasetDir) {
             // Build the ordered (step, folder) list.
             List<(string Step, string Folder)> ordered;
             if (metadata.RunStepMapping != null && metadata.RunStepMapping.Count > 0) {
@@ -281,7 +286,7 @@ namespace TestApp {
         // ---- Optimization (resolve detection params) ------------------------------------------------------
 
         private static async Task<(StarDetectorParams Params, string Source)> ResolveDetectionParamsAsync(
-            TiltMetadata metadata, string metadataPath, string outDir, bool reoptimize, int? maxEvals,
+            TiltCalibrationMetadata metadata, string metadataPath, string outDir, bool reoptimize, int? maxEvals,
             List<RunStep> orderedRuns, ProfileService profileService, StarDetectionOptions starDetectionOptions,
             AutoFocusOptions afOptions, AlglibAPI alglibAPI, double pixelScale) {
 
@@ -548,7 +553,7 @@ namespace TestApp {
         // ---- Reporting -------------------------------------------------------------------------------------
 
         private static void WriteReport(
-            string outDir, TiltMetadata metadata, string optimizationSource, List<StepResult> perStep,
+            string outDir, TiltCalibrationMetadata metadata, string optimizationSource, List<StepResult> perStep,
             TiltCalibrationInputs inputs, TiltCalibrationResult calibration) {
 
             bool isStepper = inputs.IsStepperAdjustment;
@@ -662,7 +667,7 @@ namespace TestApp {
         // ---- Metadata --------------------------------------------------------------------------------------
 
         private static void WriteMetadataTemplate(string metadataPath, string outDir, List<string> runFolders) {
-            var template = new TiltMetadata {
+            var template = new TiltCalibrationMetadata {
                 NumberOfScrews = 3,
                 ScrewThreadPitchMicrons = 0,
                 ScrewRadiusMillimeters = 0,
@@ -673,7 +678,7 @@ namespace TestApp {
                 CalibrationAppliedAmount = 1.0,
                 AdjustmentType = "Screws",
                 StepperStepSizeMicrons = -1,
-                RunStepMapping = runFolders.Select((f, i) => new RunStepMap {
+                RunStepMapping = runFolders.Select((f, i) => new TiltRunStepMapping {
                     Step = i < StepOrder.Length ? StepOrder[i] : $"Extra{i}",
                     Folder = Path.GetFileName(f)
                 }).ToList(),
@@ -685,7 +690,7 @@ namespace TestApp {
 
         private static void PrintUsage() {
             Console.Error.WriteLine("Usage: TestApp tilt --dataset <folder> [--profile-id <guid>] [--out <dir>] [--reoptimize] [--max-evals <int>]");
-            Console.Error.WriteLine("  --dataset    (required) folder containing the 4 AF runs (Baseline, AllScrews, Screw1, Screw2).");
+            Console.Error.WriteLine("  --dataset    (required) folder containing the 6 AF runs (Baseline, AllInward, ReBaseline1, Screw1, ReBaseline2, Screw2).");
             Console.Error.WriteLine("  --profile-id (default active) NINA profile id (settings + focal length).");
             Console.Error.WriteLine("  --out        (default %LOCALAPPDATA%\\NINA\\Logs\\hf-diag\\tilt\\<timestamp>) output directory.");
             Console.Error.WriteLine("  --reoptimize force re-running star-detection optimization and overwrite the stored settings in metadata.");
@@ -694,35 +699,5 @@ namespace TestApp {
         }
 
         private static string F(double d) => double.IsNaN(d) ? "NaN" : d.ToString("0.####", CultureInfo.InvariantCulture);
-
-        public sealed class RunStepMap {
-            public string Step { get; set; }
-            public string Folder { get; set; }
-        }
-
-        public sealed class TiltMetadata {
-            public int NumberOfScrews { get; set; }
-            public double ScrewThreadPitchMicrons { get; set; }
-            public double ScrewRadiusMillimeters { get; set; }
-            public double PixelSizeMicrons { get; set; }
-            public double FocuserStepSizeMicrons { get; set; }
-            public double ExpectedPositionAngleScrew1Deg { get; set; }
-            public bool DefocusAwareDetectionNeeded { get; set; }
-            public double CalibrationAppliedAmount { get; set; } = 1.0;
-            public string AdjustmentType { get; set; } = "Screws";
-            public double StepperStepSizeMicrons { get; set; } = -1;
-            public List<RunStepMap> RunStepMapping { get; set; }
-            public OptimizedStarDetectionSettings OptimizedStarDetectionSettings { get; set; }
-
-            public void Validate() {
-                if (NumberOfScrews != 3 && NumberOfScrews != 4) {
-                    throw new InvalidOperationException($"numberOfScrews must be 3 or 4 (was {NumberOfScrews}).");
-                }
-                if (PixelSizeMicrons <= 0) throw new InvalidOperationException("pixelSizeMicrons must be > 0.");
-                if (FocuserStepSizeMicrons <= 0) throw new InvalidOperationException("focuserStepSizeMicrons must be > 0.");
-                if (ScrewRadiusMillimeters <= 0) throw new InvalidOperationException("screwRadiusMillimeters must be > 0.");
-                if (CalibrationAppliedAmount <= 0) throw new InvalidOperationException("calibrationAppliedAmount must be > 0.");
-            }
-        }
     }
 }


### PR DESCRIPTION
## Context

Improves reliability and replayability of the Tilt Adapter Calibration Wizard.

Two problems motivated this:
1. **Compound-move contamination** — each per-screw step asked the user to undo the prior move *and* make the next move before a single measurement, so backlash/uneven turns corrupted the recovered geometry.
2. **No replayability** — a calibration run could not be saved and re-analyzed.

## Changes

### Reliability
- **Discrete 6-step flow** (was 4): `Baseline → AllInward → ReBaseline1 → Screw1 → ReBaseline2 → Screw2`, one physical move per measurement. Curvature is derived from a→b, screw 1 from **c→d**, screw 2 from **e→f**.
- **Dropped the fixed "12 o'clock" requirement** — screws just need a consistent clockwise labeling; the wizard recovers each angle from the data.
- **Re-baseline drift warning** (`TiltCalibrationCalculator.RebaselineDriftRatio`), plus the existing magnitude-ratio and 120°/90° spread checks.

### Replayability
- **Save Calibration for Replay** opt-in toggle (transient, resets off each run) + persisted, independent `SaveAFRunsPath`. Enabling it opens the folder picker immediately. Each step's sweep is saved into a per-run named subfolder (`TiltCalibration_<ts>/NN_<Step>/`).
- Works for **both** live capture and the **"Use Saved AF"** path; reruns copy the source raw frames into the per-step folder so the bundle stays self-contained and replayable.
- **Raw frames only** — a new `AutoFocusEngineOptions.SaveExposuresOnly` suppresses the per-region annotated TIFFs / `star_detection_result.json` artifacts; no alignment/intermediate files are written.
- **Stale-run pruning** — a per-step folder keeps only the run the metadata references (clears prior failed/averaged runs).
- **`metadata.json`** — shared `TiltCalibrationMetadata`: calibration settings, captured star-detection settings (`OptimizedStarDetectionSettings` DTO), 6-step folder map, and **per-step** tilt plane (`A·x + B·y`), curvature radius (mm), and curvature effect (µm) at screw radius.
- **Replay** — reads `metadata.json`, applies the run's stored star-detection settings transiently (restored afterward), replays each step (`InspectorVM.AnalyzeAutoFocusFromSavedPath`), and recomputes the calibration with the stored geometry.
- **Replay Current Settings** — same replay, but uses the **current** profile's star-detection and tilt-calibration settings instead of the metadata's, leaving the profile untouched.
- **Headless parity** — the `TestApp tilt` validator uses the same 6-step shared schema and prefers a wizard-written `metadata.json`.

### UI
Calibrate + Replay + Replay Current Settings on one row; the save toggle ("Save Calibration for Replay") and folder browser below.

## Tests
- Calculator: re-baseline delta isolation (c→d / e→f), drift ratio.
- `TiltCalibrationMetadata` round-trip + validation + 6-step order.
- VM: save-toggle defaults/reset, path write-through, instruction text no longer mentions "12 o'clock".
- Full suite: **1387 passed**, solution builds clean.

## Not yet verified live
- In-NINA save→replay round-trip (and confirming `StarDetectionOptions` restore on "Replay").
- Headless `TestApp tilt` parity run against a real wizard-saved run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbCuns9Qdw2ZfzjQkBzZKm