### PR TITLE
fix: address deprecation warnings across the solution

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj
@@ -8,6 +8,7 @@
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>NU1701</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerTests.cs
@@ -280,7 +280,7 @@ public class StarDetectionOptimizerTests {
     }
 
     [Test]
-    [Timeout(30000)]
+    [CancelAfter(30000)]
     public void Optimize_AllDiscreteVariables_Terminates() {
         // REGRESSION (BLOCKING): an all-Integer/Boolean variable set used to hang forever. With no continuous
         // variables, ContinuousStepsBelowFloor returned false, so Phase-B's loop guard

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -58,6 +58,8 @@ using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using RelayCommand = CommunityToolkit.Mvvm.Input.RelayCommand;
+using AsyncRelayCommand = CommunityToolkit.Mvvm.Input.AsyncRelayCommand;
 using static NINA.Joko.Plugins.HocusFocus.Inspection.SensorModel;
 using DrawingColor = System.Drawing.Color;
 using Logger = NINA.Core.Utility.Logger;
@@ -170,14 +172,14 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             ImageGeometry = (System.Windows.Media.GeometryGroup)dict["InspectorSVG"];
             ImageGeometry.Freeze();
 
-            RunAutoFocusAnalysisCommand = new AsyncCommand<bool>(() => AnalyzeAutoFocusImpl(true), canExecute: (o) => !AnalysisRunning() && CameraInfo.Connected && FocuserInfo.Connected);
-            RunExposureAnalysisCommand = new AsyncCommand<bool>(AnalyzeExposure, canExecute: (o) => !AnalysisRunning() && CameraInfo.Connected);
-            RerunSavedAutoFocusAnalysisCommand = new AsyncCommand<bool>(AnalyzeSavedAutoFocusRun, canExecute: (o) => !AnalysisRunning());
-            ClearAnalysesCommand = new RelayCommand(ClearAnalyses, canExecute: (o) => !AnalysisRunning());
+            RunAutoFocusAnalysisCommand = new AsyncRelayCommand(() => AnalyzeAutoFocusImpl(true), canExecute: () => !AnalysisRunning() && CameraInfo.Connected && FocuserInfo.Connected);
+            RunExposureAnalysisCommand = new AsyncRelayCommand(AnalyzeExposure, canExecute: () => !AnalysisRunning() && CameraInfo.Connected);
+            RerunSavedAutoFocusAnalysisCommand = new AsyncRelayCommand(AnalyzeSavedAutoFocusRun, canExecute: () => !AnalysisRunning());
+            ClearAnalysesCommand = new RelayCommand(ClearAnalyses, canExecute: () => !AnalysisRunning());
             CancelAnalyzeCommand = new RelayCommand(CancelAnalyze);
-            SlewToZenithEastCommand = new AsyncCommand<bool>(() => SlewToZenith(false), canExecute: (o) => TelescopeInfo.Connected && (slewToZenithTask == null || slewToZenithTask?.Status >= TaskStatus.RanToCompletion));
-            SlewToZenithWestCommand = new AsyncCommand<bool>(() => SlewToZenith(true), canExecute: (o) => TelescopeInfo.Connected && (slewToZenithTask == null || slewToZenithTask?.Status >= TaskStatus.RanToCompletion));
-            CancelSlewToZenithCommand = new RelayCommand((o) => slewToZenithCts?.Cancel());
+            SlewToZenithEastCommand = new AsyncRelayCommand(() => SlewToZenith(false), canExecute: () => TelescopeInfo.Connected && (slewToZenithTask == null || slewToZenithTask?.Status >= TaskStatus.RanToCompletion));
+            SlewToZenithWestCommand = new AsyncRelayCommand(() => SlewToZenith(true), canExecute: () => TelescopeInfo.Connected && (slewToZenithTask == null || slewToZenithTask?.Status >= TaskStatus.RanToCompletion));
+            CancelSlewToZenithCommand = new RelayCommand(() => slewToZenithCts?.Cancel());
         }
 
         private bool AnalysisRunning() {
@@ -1436,7 +1438,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             AutoFocusCompleted = false;
         }
 
-        private void CancelAnalyze(object o) {
+        private void CancelAnalyze() {
             analyzeCts?.Cancel();
         }
 
@@ -1455,10 +1457,12 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             slewToZenithCts = localCts;
 
             localTask = Task.Run(async () => {
-                var latitude = Angle.ByDegree(profileService.ActiveProfile.AstrometrySettings.Latitude);
-                var longitude = Angle.ByDegree(profileService.ActiveProfile.AstrometrySettings.Longitude);
+                var astrometry = profileService.ActiveProfile.AstrometrySettings;
+                var latitude = Angle.ByDegree(astrometry.Latitude);
+                var longitude = Angle.ByDegree(astrometry.Longitude);
                 var azimuth = west ? Angle.ByDegree(90) : Angle.ByDegree(270);
-                return await telescopeMediator.SlewToCoordinatesAsync(new TopocentricCoordinates(azimuth, Angle.ByDegree(89), latitude, longitude), localCts.Token);
+                var coordinates = new TopocentricCoordinates(azimuth, Angle.ByDegree(89), latitude, longitude, astrometry.Elevation);
+                return await telescopeMediator.SlewToTopocentricCoordinates(coordinates, localCts.Token);
             }, localCts.Token);
             slewToZenithTask = localTask;
 
@@ -2095,7 +2099,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             }
         }
 
-        private void ClearAnalyses(object o) {
+        private void ClearAnalyses() {
             DeactivateAutoFocusAnalysis();
             ResetExposureAnalysis();
             AutoFocusChartActivatedOnce = false;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Joko.NINA.Plugins.HocusFocus.csproj
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Joko.NINA.Plugins.HocusFocus.csproj
@@ -17,13 +17,13 @@
     <OutputPath>bin\x64\Debug\</OutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoStdLib>true</NoStdLib>
-    <NoWarn>1701;1702;CA1416</NoWarn>
+    <NoWarn>1701;1702;CA1416;NU1701</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoStdLib>true</NoStdLib>
-    <NoWarn>1701;1702;CA1416</NoWarn>
+    <NoWarn>1701;1702;CA1416;NU1701</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
@@ -61,10 +61,10 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>1701;1702;CA1416</NoWarn>
+    <NoWarn>1701;1702;CA1416;NU1701</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <NoWarn>1701;1702;CA1416</NoWarn>
+    <NoWarn>1701;1702;CA1416;NU1701</NoWarn>
   </PropertyGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Command="echo TargetDir: $(TargetDir)&#xD;&#xA;&#xD;&#xA;      if not exist &quot;%25localappdata%25\NINA\Plugins&quot; (&#xD;&#xA;      echo Creating $(PlatformName) Plugins folder&#xD;&#xA;      mkdir  &quot;%25localappdata%25\NINA\Plugins&quot;&#xD;&#xA;      mkdir  &quot;%25localappdata%25\NINA\Plugins\3.0.0&quot;&#xD;&#xA;      )&#xD;&#xA;      if not exist &quot;%25localappdata%25\NINA\Plugin\Hocus Focus\&quot; (&#xD;&#xA;      echo &quot;Creating $(PlatformName) Plugins Hocus Focus folder&quot;&#xD;&#xA;      mkdir  &quot;%25localappdata%25\NINA\Plugins\3.0.0\Hocus Focus&quot;&#xD;&#xA;      mkdir  &quot;%25localappdata%25\NINA\Plugins\3.0.0\Hocus Focus\dll\x86&quot;&#xD;&#xA;      mkdir  &quot;%25localappdata%25\NINA\Plugins\3.0.0\Hocus Focus\dll\x64&quot;&#xD;&#xA;      )&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;      echo &quot;Copying $(PlatformName) Hocus Focus&quot;&#xD;&#xA;      xcopy &quot;$(TargetPath)&quot; &quot;%25localappdata%25\NINA\Plugins\3.0.0\Hocus Focus&quot; /h/k/r/y&#xD;&#xA;      xcopy &quot;$(TargetDir)\$(TargetName).pdb&quot; &quot;%25localappdata%25\NINA\Plugins\3.0.0\Hocus Focus&quot; /h/k/r/y&#xD;&#xA;&#xD;&#xA;      echo &quot;Copying $(PlatformName) Hocus Focus Dependencies&quot;&#xD;&#xA;      xcopy &quot;$(TargetDir)alglib.net.dll&quot; &quot;%25localappdata%25\NINA\Plugins\3.0.0\Hocus Focus&quot; /h/k/r/y&#xD;&#xA;      xcopy &quot;$(TargetDir)OpenCVSharp.dll&quot; &quot;%25localappdata%25\NINA\Plugins\3.0.0\Hocus Focus&quot; /h/k/r/y&#xD;&#xA;      xcopy &quot;$(TargetDir)OpenCVSharp.Extensions.dll&quot; &quot;%25localappdata%25\NINA\Plugins\3.0.0\Hocus Focus&quot; /h/k/r/y&#xD;&#xA;      xcopy &quot;$(TargetDir)runtimes\win-x86\native\OpenCvSharpExtern.dll&quot; &quot;%25localappdata%25\NINA\Plugins\3.0.0\Hocus Focus\dll\x86&quot; /h/k/r/y&#xD;&#xA;      xcopy &quot;$(TargetDir)runtimes\win-x64\native\OpenCvSharpExtern.dll&quot; &quot;%25localappdata%25\NINA\Plugins\3.0.0\Hocus Focus\dll\x64&quot; /h/k/r/y&#xD;&#xA;      xcopy &quot;$(TargetDir)ScottPlot*.dll&quot; &quot;%25localappdata%25\NINA\Plugins\3.0.0\Hocus Focus&quot; /h/k/r/y&#xD;&#xA;      xcopy &quot;$(TargetDir)KdTree*.dll&quot; &quot;%25localappdata%25\NINA\Plugins\3.0.0\Hocus Focus&quot; /h/k/r/y&#xD;&#xA;      xcopy &quot;$(TargetDir)MathNet.*.dll&quot; &quot;%25localappdata%25\NINA\Plugins\3.0.0\Hocus Focus&quot; /h/k/r/y&#xD;&#xA;      xcopy &quot;$(TargetDir)Microsoft.CodeAnalysis*.dll&quot; &quot;%25localappdata%25\NINA\Plugins\3.0.0\Hocus Focus&quot; /h/k/r/y" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptionsVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptionsVM.cs
@@ -18,6 +18,7 @@ using System;
 using System.ComponentModel.Composition;
 using System.Windows;
 using System.Windows.Input;
+using RelayCommand = CommunityToolkit.Mvvm.Input.RelayCommand;
 
 namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
 
@@ -39,13 +40,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             OptimizeStarDetectionCommand = new RelayCommand(OptimizeStarDetection);
         }
 
-        private void OptimizeStarDetection(object obj) {
+        private void OptimizeStarDetection() {
             // Delegates to the shared launcher set by HocusFocusPlugin. Null-safe so the command is a no-op
             // when no plugin instance has been constructed (e.g. a unit test constructing this VM directly).
             HocusFocusPlugin.LaunchStarDetectionOptimizer?.Invoke();
         }
 
-        private void ChooseIntermediatePathDiag(object obj) {
+        private void ChooseIntermediatePathDiag() {
             using (var dialog = new System.Windows.Forms.FolderBrowserDialog()) {
                 dialog.SelectedPath = StarDetectionOptions.IntermediateSavePath;
 

--- a/Joko.NINA.Plugins/TestApp/TestApp.csproj
+++ b/Joko.NINA.Plugins/TestApp/TestApp.csproj
@@ -18,19 +18,19 @@
     <OutputPath>bin\x64\Debug\</OutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoStdLib>true</NoStdLib>
-    <NoWarn>1701;1702;CA1416</NoWarn>
+    <NoWarn>1701;1702;CA1416;NU1701</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoStdLib>true</NoStdLib>
-    <NoWarn>1701;1702;CA1416</NoWarn>
+    <NoWarn>1701;1702;CA1416;NU1701</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>1701;1702;CA1416</NoWarn>
+    <NoWarn>1701;1702;CA1416;NU1701</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <NoWarn>1701;1702;CA1416</NoWarn>
+    <NoWarn>1701;1702;CA1416;NU1701</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Joko.NINA.Plugins.HocusFocus\Joko.NINA.Plugins.HocusFocus.csproj" />


### PR DESCRIPTION
## Summary

Removes all actionable obsolete/deprecation warnings so the solution builds clean and uses currently-supported APIs. Four tiers, all approved:

- **MVVM commands (CS0618 ×10):** migrate NINA `RelayCommand`/`AsyncCommand<bool>` → `CommunityToolkit.Mvvm.Input` `RelayCommand`/`AsyncRelayCommand` in `InspectorVM.cs` and `StarDetectionOptionsVM.cs`. CommunityToolkit uses parameterless delegates, so `(o) =>` canExecute lambdas and two unused-`object` handler methods drop their parameter. Matches the direction already documented in `CLAUDE.md`.
- **Astrometry/telescope API (CS0618/CS0612 ×2):** in `InspectorVM.SlewToZenith`, pass the observer `Elevation` to `TopocentricCoordinates` and slew via the non-obsolete `ITelescopeMediator.SlewToTopocentricCoordinates(...)` instead of the obsolete `SlewToCoordinatesAsync(TopocentricCoordinates, ...)` overload. Replacements confirmed by decompiling NINA `3.2.0.2001-beta`.
- **NUnit (CS0618 ×1):** `[Timeout(30000)]` → `[CancelAfter(30000)]` in `StarDetectionOptimizerTests.cs` (.NET no longer supports thread-abort timeouts).
- **NU1701 (×6):** suppress transitive NINA package framework-mismatch warnings (ToastNotifications, VVVV.FreeImage) via `NoWarn` in the three project files.

## Verification

- `dotnet build -c Debug`: **0 errors, 0 deprecation warnings** (CS0618/CS0612/NU1701 all gone). Remaining 7 warnings are pre-existing and unrelated (unused event/field, unreachable code, nullable-annotation context).
- `dotnet test -c Debug`: **1388 passed, 0 failed**, including the `[CancelAfter]`-migrated `Optimize_AllDiscreteVariables_Terminates`.

## Needs live verification

The astrometry/telescope change touches a real mount slew (Inspector → "Slew to Zenith East/West"). Behavior should be equivalent or better at 89° altitude (`SlewToTopocentricCoordinates` may issue a native Alt/Az slew; supplying real elevation only refines refraction, negligible near zenith), but this can't be tested without NINA + a mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)