### PR TITLE
fix(af-replay): serialize image decode to stop duplicate-HFR race

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
@@ -1589,16 +1589,29 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         private async Task<IRenderedImage> ReloadSavedFile(
             AutoFocusState state,
             SavedAutoFocusImage savedFile,
+            SemaphoreSlim loadSerializer,
             CancellationToken token) {
             var isBayered = savedFile.IsBayered;
             var bitDepth = savedFile.BitDepth;
 
-            var sw = new Stopwatch();
-            sw.Start();
-            var imageData = await this.imageDataFactory.CreateFromFile(savedFile.Path, bitDepth, isBayered, profileService.ActiveProfile.CameraSettings.RawConverter, token);
-            sw.Stop();
-            Logger.Info($"Load file took {sw.Elapsed}");
-            return await PrepareExposure(state, imageData, token);
+            // Serialize the decode + prepare so only ONE saved frame is being decoded/prepared at a time. The
+            // NINA-core image pipeline (IImageDataFactory.CreateFromFile + IImagingMediator.PrepareImage) is not
+            // safe for concurrent invocation; the live AF path only ever decodes one frame at a time, but replay's
+            // bounded prefetch starts several loads at once. Two concurrent loads could otherwise corrupt/share pixel
+            // data, so two distinct focuser positions occasionally got an identical HFR. Detection (which reads the
+            // already-materialized RawImageData) stays fully parallel, and the prefetch still overlaps this
+            // serialized load with the parallel detection of an already-loaded frame.
+            await loadSerializer.WaitAsync(token);
+            try {
+                var sw = new Stopwatch();
+                sw.Start();
+                var imageData = await this.imageDataFactory.CreateFromFile(savedFile.Path, bitDepth, isBayered, profileService.ActiveProfile.CameraSettings.RawConverter, token);
+                sw.Stop();
+                Logger.Info($"Load file took {sw.Elapsed}");
+                return await PrepareExposure(state, imageData, token);
+            } finally {
+                loadSerializer.Release();
+            }
         }
 
         private async Task<MeasureAndError> AnalyzeSavedFile(
@@ -1688,6 +1701,10 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             // Floor 2: one frame can load while the previous is analyzed; ceiling 4: memory (multi-MB decoded frames) grows linearly with little extra overlap benefit past this.
             var maxPrefetch = Math.Max(2, Math.Min(4, Environment.ProcessorCount));
             var prefetchSemaphore = new SemaphoreSlim(maxPrefetch, maxPrefetch);
+            // Serializes the decode + prepare stage across all in-flight loads (see ReloadSavedFile): the NINA-core
+            // CreateFromFile/PrepareImage pipeline is not safe for concurrent invocation, which the prefetch would
+            // otherwise trigger. Detection stays parallel; only load<->load overlap is removed.
+            var loadSerializer = new SemaphoreSlim(1, 1);
             // Flat list of every post-task spawned, so the finally can wait for ALL of them (each of which releases
             // its slot) before disposing the semaphore — even if the loop is left early via cancellation/exception
             // before a group's combined task is added to focuserPositionTasks. Avoids disposing while a Release is
@@ -1730,7 +1747,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                         // Start the load without awaiting it inline so loads overlap each other and analysis. The
                         // returned Task is awaited by the region-analysis tasks below. Any load failure is captured
                         // in loadTask and surfaces when those tasks await it.
-                        var loadTask = ReloadSavedFile(state, savedFile, token);
+                        var loadTask = ReloadSavedFile(state, savedFile, loadSerializer, token);
                         // Source for the replay reuse cache (consumed only when Options.ReuseSavedDetection is on).
                         // Uses the ORIGINAL image/frame numbers from the saved filename (NOT imageState.ImageNumber,
                         // which OnNextImage reassigned as a fresh ordering counter) and the saved file's own folder,
@@ -1820,6 +1837,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 } catch {
                 }
                 prefetchSemaphore.Dispose();
+                loadSerializer.Dispose();
                 await Task.Delay(1000);
                 progress.Report(new ApplicationStatus());
             }


### PR DESCRIPTION
## Problem

Replaying a saved AutoFocus run (Tilt Adapter Wizard **Replay** / **Replay Current Settings**, or Inspector **Analyze Saved Run**) **occasionally** showed two different focuser positions with an **identical HFR** — e.g. the points at ~1290 and ~1460 both landing at HFR ≈ 12.5 when 1460 should be higher. Intermittent, and gone on the next attempt — a data race.

## Root cause

`RerunImpl` was parallelized (commit `00d4f61`) to prefetch **2–4 saved frames concurrently** via a `SemaphoreSlim`. Each load runs `ReloadSavedFile` → NINA-core `imageDataFactory.CreateFromFile` + `imagingMediator.PrepareImage`. The **live AF path only ever decodes one frame at a time**, so concurrent invocation of those NINA-core image APIs was never exercised. Detection reads the per-file `image.RawImageData`, so two concurrent decodes corrupting/sharing pixel data make two frames carry the same pixels → identical HFR. Matches every symptom: replay-only, intermittent, two positions equal.

Ruled out first (with code evidence): engine pooling is keyed by `focuserPosition` under a per-region lock; `StarDetector` is state-clean (only field is `readonly IAlglibAPI`, all scratch per-call); alglib/PSF state is per-fit locals and `ModelPSF` is off on replay; `ReuseSavedDetection` is off and `PerRegionStarDetectionResults` (prior fix `756b6a9`) is already region-keyed; the `AddSorted` consumer is shared with the live `HocusFocusVM` path that never shows the bug.

## Fix

Add a per-run `SemaphoreSlim(1,1)` ("load serializer") that serializes only the decode+prepare critical section in `ReloadSavedFile`. Star detection stays fully parallel, and the prefetch still overlaps a (serialized) load with the detection of an already-loaded frame — only **load↔load** concurrency is removed. Disposed alongside `prefetchSemaphore` after all post-tasks complete.

## Verification

- `dotnet build` succeeds (warnings pre-existing/unrelated).
- `dotnet test` — **1388/1388 pass**.
- No unit test can reproduce a timing race; the real confirmation is replaying the same saved run repeatedly in NINA and confirming no two positions share an HFR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)