### PR TITLE
Add Review Frames diagnostic to Aberration Inspector

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorOptionsTests.cs
@@ -48,6 +48,7 @@ public class InspectorOptionsTests {
             Assert.That(options.UseRANSAC, Is.True);
             Assert.That(options.SaveImagesOnReruns, Is.False);
             Assert.That(options.SaveAlignmentImages, Is.False);
+            Assert.That(options.FrameReviewEnabled, Is.False);
             Assert.That(options.MaxStarsPerRegion, Is.EqualTo(-1));
             Assert.That(options.InterpolationEnabled, Is.False);
         });
@@ -80,6 +81,7 @@ public class InspectorOptionsTests {
         options.UseRANSAC = false;
         options.SaveImagesOnReruns = true;
         options.SaveAlignmentImages = true;
+        options.FrameReviewEnabled = true;
         options.MaxStarsPerRegion = 50;
 
         Assert.Multiple(() => {
@@ -107,6 +109,7 @@ public class InspectorOptionsTests {
             Assert.That(store.Snapshot[nameof(InspectorOptions.UseRANSAC)], Is.False);
             Assert.That(store.Snapshot[nameof(InspectorOptions.SaveImagesOnReruns)], Is.True);
             Assert.That(store.Snapshot[nameof(InspectorOptions.SaveAlignmentImages)], Is.True);
+            Assert.That(store.Snapshot[nameof(InspectorOptions.FrameReviewEnabled)], Is.True);
             Assert.That(store.Snapshot[nameof(InspectorOptions.MaxStarsPerRegion)], Is.EqualTo(50));
         });
     }
@@ -179,6 +182,7 @@ public class InspectorOptionsTests {
     [TestCase(nameof(InspectorOptions.MicronsPerFocuserStep), 2.5)]
     [TestCase(nameof(InspectorOptions.SensorROI), 0.6)]
     [TestCase(nameof(InspectorOptions.UseRANSAC), false)]
+    [TestCase(nameof(InspectorOptions.FrameReviewEnabled), true)]
     [TestCase(nameof(InspectorOptions.MaxStarsPerRegion), 30)]
     public void Setter_RaisesPropertyChanged(string propertyName, object newValue) {
         var (options, _, _) = Build();

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
@@ -34,6 +34,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
         public double StartingBrightnessDiff { get; set; } = -1;
         public bool SaveImagesOnReruns { get; set; }
         public bool SaveAlignmentImages { get; set; }
+        public bool FrameReviewEnabled { get; set; }
         public int MaxStarsPerRegion { get; set; } = -1;
         public double AcceptableRSquaredMin { get; set; } = 0.05;
     }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FrameReviewSnapshotBuilderTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FrameReviewSnapshotBuilderTests.cs
@@ -1,7 +1,9 @@
 using NINA.Image.ImageAnalysis;
 using NINA.Image.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.Inspection;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.Tests.Synthetic;
 using NINA.Joko.Plugins.HocusFocus.Utility;
 using NSubstitute;
 using NUnit.Framework;
@@ -14,6 +16,13 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
 
     [TestFixture]
     public class FrameReviewSnapshotBuilderTests {
+
+        private IAlglibAPI alglibAPI;
+
+        [SetUp]
+        public void SetUp() {
+            alglibAPI = new AlglibAPI();
+        }
 
         // ---- helpers ------------------------------------------------------------------------------------
 
@@ -33,12 +42,14 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
             double hfr = 2.0,
             double posX = 10, double posY = 20,
             double? origX = null, double? origY = null,
-            int boxX = 8, int boxY = 18, int boxW = 5, int boxH = 7) {
+            int boxX = 8, int boxY = 18, int boxW = 5, int boxH = 7,
+            int? origBoxX = null, int? origBoxY = null, int? origBoxW = null, int? origBoxH = null) {
             return new HocusFocusDetectedStar {
                 HFR = hfr,
                 Position = new Accord.Point((float)posX, (float)posY),
                 OriginalPosition = new Accord.Point((float)(origX ?? posX), (float)(origY ?? posY)),
                 BoundingBox = new System.Drawing.Rectangle(boxX, boxY, boxW, boxH),
+                OriginalBoundingBox = new System.Drawing.Rectangle(origBoxX ?? boxX, origBoxY ?? boxY, origBoxW ?? boxW, origBoxH ?? boxH),
             };
         }
 
@@ -58,25 +69,38 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
         }
 
         private static SensorModel.RegisteredStar MakeRegistered(params (HocusFocusDetectedStar star, int imageIndex)[] matches) {
-            var rs = new SensorModel.RegisteredStar();
+            return MakeFittedRegistered(null, matches);
+        }
+
+        private static SensorModel.RegisteredStar MakeFittedRegistered(AlglibHyperbolicFitting fit, params (HocusFocusDetectedStar star, int imageIndex)[] matches) {
+            var rs = new SensorModel.RegisteredStar { Fitting = fit };
             foreach (var (star, imageIndex) in matches) {
                 rs.MatchedStars.Add(new SensorModel.MatchedStar { Star = star, ImageIndex = imageIndex, FocuserPosition = imageIndex });
             }
             return rs;
         }
 
+        // A genuine, solved symmetric-hyperbola fit whose best focus is approximately x0.
+        private AlglibHyperbolicFitting MakeFit(double x0) {
+            var points = SyntheticFocusCurveSamples.SymmetricHyperbolaPoints(
+                x0: x0, y0: 0.0, a: 2.0, b: 80.0, xStart: x0 - 400, xStep: 20, count: 41, errorY: 1.0);
+            var fit = HyperbolicFittingAlglib.Create(alglibAPI, points, useWeights: false);
+            fit.HuberIrlsEnabled = false;
+            Assert.That(fit.Solve(), Is.True);
+            return fit;
+        }
+
         // ---- tests --------------------------------------------------------------------------------------
 
         [Test]
         public void Build_MapsSamePhysicalStarToSameRegistrationIdAcrossFrames() {
-            var a0 = MakeStar(posX: 10, posY: 10); // physical star A in frame 0
-            var a1 = MakeStar(posX: 11, posY: 10); // physical star A in frame 1
-            var b0 = MakeStar(posX: 50, posY: 50); // physical star B in frame 0
+            var a0 = MakeStar(posX: 10, posY: 10);
+            var a1 = MakeStar(posX: 11, posY: 10);
+            var b0 = MakeStar(posX: 50, posY: 50);
 
             var frame0 = MakeFrame(100, new[] { a0, b0 }, MakeImage());
             var frame1 = MakeFrame(200, new[] { a1 }, MakeImage());
 
-            // registeredStars[0] = physical star A (matched in frames 0 and 1); [1] = physical star B (frame 0 only)
             var registered = new[] {
                 MakeRegistered((a0, 0), (a1, 1)),
                 MakeRegistered((b0, 0)),
@@ -92,13 +116,13 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
 
             Assert.Multiple(() => {
                 Assert.That(a0Star.RegistrationId, Is.EqualTo(0));
-                Assert.That(a1Star.RegistrationId, Is.EqualTo(0)); // same physical star → same id across frames
+                Assert.That(a1Star.RegistrationId, Is.EqualTo(0));
                 Assert.That(b0Star.RegistrationId, Is.EqualTo(1));
             });
         }
 
         [Test]
-        public void Build_UnmatchedStar_HasNullRegistrationId() {
+        public void Build_UnmatchedStar_HasNullRegistrationIdAndUnmatchedState() {
             var matched = MakeStar(posX: 10);
             var unmatched = MakeStar(posX: 99);
             var frame = MakeFrame(100, new[] { matched, unmatched }, MakeImage());
@@ -107,12 +131,96 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
             var snapshot = FrameReviewSnapshotBuilder.Build(new[] { frame }, registered, referenceImageIndex: 0, ransacEnabled: true);
 
             var unmatchedStar = snapshot.Frames.Single().Stars.Single(s => s.CenterX == 99);
-            Assert.That(unmatchedStar.RegistrationId, Is.Null);
+            Assert.Multiple(() => {
+                Assert.That(unmatchedStar.RegistrationId, Is.Null);
+                Assert.That(unmatchedStar.RegistrationState, Is.EqualTo(FrameReviewRegistrationState.Unmatched));
+                Assert.That(unmatchedStar.FocusOffsetFromMean, Is.Null);
+            });
         }
 
         [Test]
-        public void Build_RansacOff_NoArrowsEvenWhenPositionMoved() {
-            // Position differs from OriginalPosition, alignment set — but RANSAC off → no arrows, empty transform.
+        public void Build_RegistrationState_MapsUnmatchedNoFitAndWithFit() {
+            var unmatched = MakeStar(posX: 10);
+            var noFit = MakeStar(posX: 20);
+            var withFit = MakeStar(posX: 30);
+            var frame = MakeFrame(100, new[] { unmatched, noFit, withFit }, MakeImage());
+            var registered = new[] {
+                MakeRegistered((noFit, 0)),                 // matched, no fit
+                MakeFittedRegistered(MakeFit(5000), (withFit, 0)), // matched, with fit
+            };
+
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { frame }, registered, referenceImageIndex: 0, ransacEnabled: true);
+            var stars = snapshot.Frames.Single().Stars;
+
+            Assert.Multiple(() => {
+                Assert.That(stars.Single(s => s.CenterX == 10).RegistrationState, Is.EqualTo(FrameReviewRegistrationState.Unmatched));
+                Assert.That(stars.Single(s => s.CenterX == 20).RegistrationState, Is.EqualTo(FrameReviewRegistrationState.MatchedNoFit));
+                Assert.That(stars.Single(s => s.CenterX == 30).RegistrationState, Is.EqualTo(FrameReviewRegistrationState.MatchedWithFit));
+                // No-fit star has no focus offset; with-fit star does.
+                Assert.That(stars.Single(s => s.CenterX == 20).FocusOffsetFromMean, Is.Null);
+                Assert.That(stars.Single(s => s.CenterX == 30).FocusOffsetFromMean, Is.Not.Null);
+            });
+        }
+
+        [Test]
+        public void Build_FocusOffsetFromMean_IsSignedAndSumsToZero() {
+            var starLow = MakeStar(posX: 10);
+            var starHigh = MakeStar(posX: 20);
+            var frame = MakeFrame(100, new[] { starLow, starHigh }, MakeImage());
+            var registered = new[] {
+                MakeFittedRegistered(MakeFit(5000), (starLow, 0)),  // lower best-focus
+                MakeFittedRegistered(MakeFit(5080), (starHigh, 0)), // higher best-focus
+            };
+
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { frame }, registered, referenceImageIndex: 0, ransacEnabled: true);
+            var stars = snapshot.Frames.Single().Stars;
+            var low = stars.Single(s => s.CenterX == 10).FocusOffsetFromMean.Value;
+            var high = stars.Single(s => s.CenterX == 20).FocusOffsetFromMean.Value;
+
+            Assert.Multiple(() => {
+                Assert.That(low, Is.LessThan(0.0));            // below the field mean
+                Assert.That(high, Is.GreaterThan(0.0));         // above the field mean
+                Assert.That(low + high, Is.EqualTo(0.0).Within(1e-6)); // two stars → offsets are equal and opposite
+            });
+        }
+
+        [Test]
+        public void Build_FocusOffsetFromMean_SingleFittedStarIsZero() {
+            var star = MakeStar(posX: 10);
+            var frame = MakeFrame(100, new[] { star }, MakeImage());
+            var registered = new[] { MakeFittedRegistered(MakeFit(5000), (star, 0)) };
+
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { frame }, registered, referenceImageIndex: 0, ransacEnabled: true);
+
+            Assert.That(snapshot.Frames.Single().Stars.Single().FocusOffsetFromMean.Value, Is.EqualTo(0.0).Within(1e-9));
+        }
+
+        [Test]
+        public void Build_FocusCurves_PopulatedForFittedStarsOnly() {
+            var withFit = MakeStar(posX: 30);
+            var noFit = MakeStar(posX: 20);
+            var frame = MakeFrame(100, new[] { noFit, withFit }, MakeImage());
+            var fit = MakeFit(5000);
+            var registered = new[] {
+                MakeRegistered((noFit, 0)),
+                MakeFittedRegistered(fit, (withFit, 0), (withFit, 1)),
+            };
+
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { frame }, registered, referenceImageIndex: 0, ransacEnabled: true);
+
+            Assert.Multiple(() => {
+                Assert.That(snapshot.FocusCurvesByRegistrationId.ContainsKey(0), Is.False); // no-fit star
+                Assert.That(snapshot.FocusCurvesByRegistrationId.ContainsKey(1), Is.True);
+                var curve = snapshot.FocusCurvesByRegistrationId[1];
+                Assert.That(curve.Fit, Is.SameAs(fit));
+                Assert.That(curve.Points.Count, Is.EqualTo(2)); // one per matched star
+                Assert.That(curve.RSquared, Is.EqualTo(fit.RSquared));
+                Assert.That(curve.BestFocus, Is.EqualTo(fit.Minimum.X));
+            });
+        }
+
+        [Test]
+        public void Build_RansacOff_NoRegistrationLineEvenWhenPositionMoved() {
             var star = MakeStar(posX: 30, posY: 30, origX: 10, origY: 10);
             var refFrame = MakeFrame(100, new[] { MakeStar() }, MakeImage());
             var movedFrame = MakeFrame(200, new[] { star }, MakeImage(), alignment: Matrix3x2.Identity, hasBeenAligned: true);
@@ -121,59 +229,63 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
 
             Assert.Multiple(() => {
                 Assert.That(snapshot.RansacEnabled, Is.False);
-                Assert.That(snapshot.Frames.SelectMany(f => f.Stars).Any(s => s.HasArrow), Is.False);
+                Assert.That(snapshot.Frames.SelectMany(f => f.Stars).Any(s => s.HasRegistrationLine), Is.False);
                 Assert.That(snapshot.Frames.All(f => f.TransformText == ""), Is.True);
             });
         }
 
         [Test]
-        public void Build_ReferenceFrame_IsFlaggedWithNoArrowsAndEmptyTransform() {
-            var star = MakeStar(posX: 10, posY: 10); // reference frame: Position == OriginalPosition
+        public void Build_ReferenceFrame_IsFlaggedWithNoLineAndEmptyTransform() {
+            var star = MakeStar(posX: 10, posY: 10);
             var refFrame = MakeFrame(100, new[] { star }, MakeImage());
-            var otherFrame = MakeFrame(200, new[] { MakeStar(posX: 33, posY: 33, origX: 10, origY: 10) }, MakeImage(), alignment: Matrix3x2.Identity, hasBeenAligned: true);
+            var otherStar = MakeStar(posX: 33, posY: 33, origX: 10, origY: 10);
+            var otherFrame = MakeFrame(200, new[] { otherStar }, MakeImage(), alignment: Matrix3x2.Identity, hasBeenAligned: true);
+            var registered = new[] { MakeRegistered((star, 0), (otherStar, 1)) };
 
-            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { refFrame, otherFrame }, new SensorModel.RegisteredStar[0], referenceImageIndex: 0, ransacEnabled: true);
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { refFrame, otherFrame }, registered, referenceImageIndex: 0, ransacEnabled: true);
 
             var reference = snapshot.Frames.Single(f => f.ImageIndex == 0);
             Assert.Multiple(() => {
                 Assert.That(reference.IsReference, Is.True);
                 Assert.That(reference.TransformText, Is.EqualTo(""));
-                Assert.That(reference.Stars.Any(s => s.HasArrow), Is.False);
+                Assert.That(reference.Stars.Any(s => s.HasRegistrationLine), Is.False);
                 Assert.That(snapshot.Frames.Single(f => f.ImageIndex == 1).IsReference, Is.False);
             });
         }
 
         [Test]
-        public void Build_NonReferenceAlignedFrame_HasArrowFromOriginalToPosition() {
+        public void Build_NonReferenceAlignedFrame_HasLineFromRawCenterToAlignedTarget() {
             var star = MakeStar(posX: 33, posY: 44, origX: 10, origY: 12);
             var refFrame = MakeFrame(100, new[] { MakeStar() }, MakeImage());
             var movedFrame = MakeFrame(200, new[] { star }, MakeImage(), alignment: Matrix3x2.Identity, hasBeenAligned: true);
+            var registered = new[] { MakeRegistered((star, 1)) };
 
-            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { refFrame, movedFrame }, new SensorModel.RegisteredStar[0], referenceImageIndex: 0, ransacEnabled: true);
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { refFrame, movedFrame }, registered, referenceImageIndex: 0, ransacEnabled: true);
 
             var moved = snapshot.Frames.Single(f => f.ImageIndex == 1).Stars.Single();
             Assert.Multiple(() => {
-                Assert.That(moved.HasArrow, Is.True);
-                Assert.That(moved.OriginalX, Is.EqualTo(10));
-                Assert.That(moved.OriginalY, Is.EqualTo(12));
-                Assert.That(moved.CenterX, Is.EqualTo(33));
-                Assert.That(moved.CenterY, Is.EqualTo(44));
+                Assert.That(moved.HasRegistrationLine, Is.True);
+                Assert.That(moved.CenterX, Is.EqualTo(10)); // raw detected center
+                Assert.That(moved.CenterY, Is.EqualTo(12));
+                Assert.That(moved.TargetX, Is.EqualTo(33)); // aligned position = registration target
+                Assert.That(moved.TargetY, Is.EqualTo(44));
             });
         }
 
         [Test]
-        public void Build_NonReferenceFrame_StarNotMoved_HasNoArrow() {
-            var star = MakeStar(posX: 10, posY: 10); // Position == OriginalPosition (failed/identity alignment)
+        public void Build_NonReferenceFrame_StarNotMoved_HasNoLine() {
+            var star = MakeStar(posX: 10, posY: 10);
             var refFrame = MakeFrame(100, new[] { MakeStar() }, MakeImage());
             var frame = MakeFrame(200, new[] { star }, MakeImage(), hasBeenAligned: false);
+            var registered = new[] { MakeRegistered((star, 1)) };
 
-            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { refFrame, frame }, new SensorModel.RegisteredStar[0], referenceImageIndex: 0, ransacEnabled: true);
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { refFrame, frame }, registered, referenceImageIndex: 0, ransacEnabled: true);
 
-            Assert.That(snapshot.Frames.Single(f => f.ImageIndex == 1).Stars.Single().HasArrow, Is.False);
+            Assert.That(snapshot.Frames.Single(f => f.ImageIndex == 1).Stars.Single().HasRegistrationLine, Is.False);
         }
 
         [Test]
-        public void Build_NonReferenceAlignedFrame_TransformTextFromAlignment() {
+        public void Build_NonReferenceAlignedFrame_TransformTextUsesDegreeSymbol() {
             var transform = new Matrix3x2(1, 0, 0, 1, 5, 7);
             var refFrame = MakeFrame(100, new[] { MakeStar() }, MakeImage());
             var movedFrame = MakeFrame(200, new[] { MakeStar(posX: 15, origX: 10) }, MakeImage(), alignment: transform, hasBeenAligned: true);
@@ -182,8 +294,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
 
             var moved = snapshot.Frames.Single(f => f.ImageIndex == 1);
             Assert.Multiple(() => {
-                Assert.That(moved.TransformText, Is.EqualTo(transform.ToFullString()));
-                Assert.That(moved.TransformText, Is.Not.Empty);
+                Assert.That(moved.TransformText, Is.EqualTo(FrameReviewTransformFormatter.Format(transform)));
+                Assert.That(moved.TransformText, Does.Contain("°"));
+                Assert.That(moved.TransformText, Does.Not.Contain("deg"));
             });
         }
 
@@ -199,7 +312,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
 
             Assert.Multiple(() => {
                 Assert.That(snapshot.Frames.Count, Is.EqualTo(1));
-                Assert.That(snapshot.Frames.Single().ImageIndex, Is.EqualTo(2)); // original index preserved
+                Assert.That(snapshot.Frames.Single().ImageIndex, Is.EqualTo(2));
             });
         }
 
@@ -225,10 +338,11 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
             var snapshot = FrameReviewSnapshotBuilder.Build(new[] { frame }, new SensorModel.RegisteredStar[0], referenceImageIndex: 0, ransacEnabled: true);
             var captured = snapshot.Frames.Single().Stars.Single();
 
-            // Mutate the source star the way the registration/alignment pass would, after the snapshot is built.
             star.Position = new Accord.Point(999, 888);
             star.HFR = 99;
             star.BoundingBox = new System.Drawing.Rectangle(1, 2, 3, 4);
+            star.OriginalPosition = new Accord.Point(777, 666);
+            star.OriginalBoundingBox = new System.Drawing.Rectangle(11, 12, 13, 14);
 
             Assert.Multiple(() => {
                 Assert.That(captured.CenterX, Is.EqualTo(10));
@@ -240,23 +354,27 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
         }
 
         [Test]
-        public void Build_CopiesStarPrimitivesAndBoxTopLeft() {
-            var star = MakeStar(hfr: 3.5, posX: 12.0, posY: 24.0, origX: 11.0, origY: 23.0, boxX: 9, boxY: 21, boxW: 6, boxH: 8);
+        public void Build_UsesRawCoordinates_NotAlignedBoxOrCenter() {
+            // Position/BoundingBox are the (aligned) values; OriginalPosition/OriginalBoundingBox are the raw values.
+            var star = MakeStar(hfr: 3.5,
+                posX: 12.0, posY: 24.0, origX: 11.0, origY: 23.0,
+                boxX: 50, boxY: 60, boxW: 6, boxH: 8,
+                origBoxX: 9, origBoxY: 21, origBoxW: 6, origBoxH: 8);
             var frame = MakeFrame(100, new[] { star }, MakeImage());
 
             var snapshot = FrameReviewSnapshotBuilder.Build(new[] { frame }, new SensorModel.RegisteredStar[0], referenceImageIndex: 0, ransacEnabled: true);
             var s = snapshot.Frames.Single().Stars.Single();
 
             Assert.Multiple(() => {
-                Assert.That(s.CenterX, Is.EqualTo(12.0));
-                Assert.That(s.CenterY, Is.EqualTo(24.0));
-                Assert.That(s.OriginalX, Is.EqualTo(11.0));
-                Assert.That(s.OriginalY, Is.EqualTo(23.0));
-                Assert.That(s.Hfr, Is.EqualTo(3.5));
-                Assert.That(s.BoxX, Is.EqualTo(9));
+                Assert.That(s.CenterX, Is.EqualTo(11.0)); // raw center, NOT aligned 12.0
+                Assert.That(s.CenterY, Is.EqualTo(23.0));
+                Assert.That(s.BoxX, Is.EqualTo(9));        // raw box top-left, NOT aligned 50
                 Assert.That(s.BoxY, Is.EqualTo(21));
                 Assert.That(s.BoxWidth, Is.EqualTo(6));
                 Assert.That(s.BoxHeight, Is.EqualTo(8));
+                Assert.That(s.TargetX, Is.EqualTo(12.0));  // aligned position = target
+                Assert.That(s.TargetY, Is.EqualTo(24.0));
+                Assert.That(s.Hfr, Is.EqualTo(3.5));
             });
         }
 
@@ -288,7 +406,10 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
         [Test]
         public void Build_EmptyInput_ProducesEmptySnapshot() {
             var snapshot = FrameReviewSnapshotBuilder.Build(new SensorDetectedStars[0], new SensorModel.RegisteredStar[0], referenceImageIndex: 0, ransacEnabled: true);
-            Assert.That(snapshot.Frames, Is.Empty);
+            Assert.Multiple(() => {
+                Assert.That(snapshot.Frames, Is.Empty);
+                Assert.That(snapshot.FocusCurvesByRegistrationId, Is.Empty);
+            });
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FrameReviewSnapshotBuilderTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FrameReviewSnapshotBuilderTests.cs
@@ -1,0 +1,294 @@
+using NINA.Image.ImageAnalysis;
+using NINA.Image.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.Inspection;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NSubstitute;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
+
+    [TestFixture]
+    public class FrameReviewSnapshotBuilderTests {
+
+        // ---- helpers ------------------------------------------------------------------------------------
+
+        private static BitmapSource MakeBitmap() {
+            var bmp = BitmapSource.Create(2, 2, 96, 96, PixelFormats.Gray8, null, new byte[] { 0, 0, 0, 0 }, 2);
+            bmp.Freeze();
+            return bmp;
+        }
+
+        private static IRenderedImage MakeImage() {
+            var img = Substitute.For<IRenderedImage>();
+            img.Image.Returns(MakeBitmap());
+            return img;
+        }
+
+        private static HocusFocusDetectedStar MakeStar(
+            double hfr = 2.0,
+            double posX = 10, double posY = 20,
+            double? origX = null, double? origY = null,
+            int boxX = 8, int boxY = 18, int boxW = 5, int boxH = 7) {
+            return new HocusFocusDetectedStar {
+                HFR = hfr,
+                Position = new Accord.Point((float)posX, (float)posY),
+                OriginalPosition = new Accord.Point((float)(origX ?? posX), (float)(origY ?? posY)),
+                BoundingBox = new System.Drawing.Rectangle(boxX, boxY, boxW, boxH),
+            };
+        }
+
+        private static SensorDetectedStars MakeFrame(
+            double focuserPosition,
+            IEnumerable<HocusFocusDetectedStar> stars,
+            IRenderedImage image,
+            Matrix3x2 alignment = null,
+            bool hasBeenAligned = false) {
+            var result = new HocusFocusStarDetectionResult {
+                StarList = stars.Cast<DetectedStar>().ToList(),
+            };
+            return new SensorDetectedStars(focuserPosition, result, image) {
+                AlignmentTransform = alignment,
+                HasBeenAligned = hasBeenAligned,
+            };
+        }
+
+        private static SensorModel.RegisteredStar MakeRegistered(params (HocusFocusDetectedStar star, int imageIndex)[] matches) {
+            var rs = new SensorModel.RegisteredStar();
+            foreach (var (star, imageIndex) in matches) {
+                rs.MatchedStars.Add(new SensorModel.MatchedStar { Star = star, ImageIndex = imageIndex, FocuserPosition = imageIndex });
+            }
+            return rs;
+        }
+
+        // ---- tests --------------------------------------------------------------------------------------
+
+        [Test]
+        public void Build_MapsSamePhysicalStarToSameRegistrationIdAcrossFrames() {
+            var a0 = MakeStar(posX: 10, posY: 10); // physical star A in frame 0
+            var a1 = MakeStar(posX: 11, posY: 10); // physical star A in frame 1
+            var b0 = MakeStar(posX: 50, posY: 50); // physical star B in frame 0
+
+            var frame0 = MakeFrame(100, new[] { a0, b0 }, MakeImage());
+            var frame1 = MakeFrame(200, new[] { a1 }, MakeImage());
+
+            // registeredStars[0] = physical star A (matched in frames 0 and 1); [1] = physical star B (frame 0 only)
+            var registered = new[] {
+                MakeRegistered((a0, 0), (a1, 1)),
+                MakeRegistered((b0, 0)),
+            };
+
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { frame0, frame1 }, registered, referenceImageIndex: 0, ransacEnabled: true);
+
+            var f0 = snapshot.Frames.Single(f => f.ImageIndex == 0);
+            var f1 = snapshot.Frames.Single(f => f.ImageIndex == 1);
+            var a0Star = f0.Stars.Single(s => s.CenterX == 10);
+            var b0Star = f0.Stars.Single(s => s.CenterX == 50);
+            var a1Star = f1.Stars.Single();
+
+            Assert.Multiple(() => {
+                Assert.That(a0Star.RegistrationId, Is.EqualTo(0));
+                Assert.That(a1Star.RegistrationId, Is.EqualTo(0)); // same physical star → same id across frames
+                Assert.That(b0Star.RegistrationId, Is.EqualTo(1));
+            });
+        }
+
+        [Test]
+        public void Build_UnmatchedStar_HasNullRegistrationId() {
+            var matched = MakeStar(posX: 10);
+            var unmatched = MakeStar(posX: 99);
+            var frame = MakeFrame(100, new[] { matched, unmatched }, MakeImage());
+            var registered = new[] { MakeRegistered((matched, 0)) };
+
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { frame }, registered, referenceImageIndex: 0, ransacEnabled: true);
+
+            var unmatchedStar = snapshot.Frames.Single().Stars.Single(s => s.CenterX == 99);
+            Assert.That(unmatchedStar.RegistrationId, Is.Null);
+        }
+
+        [Test]
+        public void Build_RansacOff_NoArrowsEvenWhenPositionMoved() {
+            // Position differs from OriginalPosition, alignment set — but RANSAC off → no arrows, empty transform.
+            var star = MakeStar(posX: 30, posY: 30, origX: 10, origY: 10);
+            var refFrame = MakeFrame(100, new[] { MakeStar() }, MakeImage());
+            var movedFrame = MakeFrame(200, new[] { star }, MakeImage(), alignment: Matrix3x2.Identity, hasBeenAligned: true);
+
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { refFrame, movedFrame }, new SensorModel.RegisteredStar[0], referenceImageIndex: 0, ransacEnabled: false);
+
+            Assert.Multiple(() => {
+                Assert.That(snapshot.RansacEnabled, Is.False);
+                Assert.That(snapshot.Frames.SelectMany(f => f.Stars).Any(s => s.HasArrow), Is.False);
+                Assert.That(snapshot.Frames.All(f => f.TransformText == ""), Is.True);
+            });
+        }
+
+        [Test]
+        public void Build_ReferenceFrame_IsFlaggedWithNoArrowsAndEmptyTransform() {
+            var star = MakeStar(posX: 10, posY: 10); // reference frame: Position == OriginalPosition
+            var refFrame = MakeFrame(100, new[] { star }, MakeImage());
+            var otherFrame = MakeFrame(200, new[] { MakeStar(posX: 33, posY: 33, origX: 10, origY: 10) }, MakeImage(), alignment: Matrix3x2.Identity, hasBeenAligned: true);
+
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { refFrame, otherFrame }, new SensorModel.RegisteredStar[0], referenceImageIndex: 0, ransacEnabled: true);
+
+            var reference = snapshot.Frames.Single(f => f.ImageIndex == 0);
+            Assert.Multiple(() => {
+                Assert.That(reference.IsReference, Is.True);
+                Assert.That(reference.TransformText, Is.EqualTo(""));
+                Assert.That(reference.Stars.Any(s => s.HasArrow), Is.False);
+                Assert.That(snapshot.Frames.Single(f => f.ImageIndex == 1).IsReference, Is.False);
+            });
+        }
+
+        [Test]
+        public void Build_NonReferenceAlignedFrame_HasArrowFromOriginalToPosition() {
+            var star = MakeStar(posX: 33, posY: 44, origX: 10, origY: 12);
+            var refFrame = MakeFrame(100, new[] { MakeStar() }, MakeImage());
+            var movedFrame = MakeFrame(200, new[] { star }, MakeImage(), alignment: Matrix3x2.Identity, hasBeenAligned: true);
+
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { refFrame, movedFrame }, new SensorModel.RegisteredStar[0], referenceImageIndex: 0, ransacEnabled: true);
+
+            var moved = snapshot.Frames.Single(f => f.ImageIndex == 1).Stars.Single();
+            Assert.Multiple(() => {
+                Assert.That(moved.HasArrow, Is.True);
+                Assert.That(moved.OriginalX, Is.EqualTo(10));
+                Assert.That(moved.OriginalY, Is.EqualTo(12));
+                Assert.That(moved.CenterX, Is.EqualTo(33));
+                Assert.That(moved.CenterY, Is.EqualTo(44));
+            });
+        }
+
+        [Test]
+        public void Build_NonReferenceFrame_StarNotMoved_HasNoArrow() {
+            var star = MakeStar(posX: 10, posY: 10); // Position == OriginalPosition (failed/identity alignment)
+            var refFrame = MakeFrame(100, new[] { MakeStar() }, MakeImage());
+            var frame = MakeFrame(200, new[] { star }, MakeImage(), hasBeenAligned: false);
+
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { refFrame, frame }, new SensorModel.RegisteredStar[0], referenceImageIndex: 0, ransacEnabled: true);
+
+            Assert.That(snapshot.Frames.Single(f => f.ImageIndex == 1).Stars.Single().HasArrow, Is.False);
+        }
+
+        [Test]
+        public void Build_NonReferenceAlignedFrame_TransformTextFromAlignment() {
+            var transform = new Matrix3x2(1, 0, 0, 1, 5, 7);
+            var refFrame = MakeFrame(100, new[] { MakeStar() }, MakeImage());
+            var movedFrame = MakeFrame(200, new[] { MakeStar(posX: 15, origX: 10) }, MakeImage(), alignment: transform, hasBeenAligned: true);
+
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { refFrame, movedFrame }, new SensorModel.RegisteredStar[0], referenceImageIndex: 0, ransacEnabled: true);
+
+            var moved = snapshot.Frames.Single(f => f.ImageIndex == 1);
+            Assert.Multiple(() => {
+                Assert.That(moved.TransformText, Is.EqualTo(transform.ToFullString()));
+                Assert.That(moved.TransformText, Is.Not.Empty);
+            });
+        }
+
+        [Test]
+        public void Build_DropsFramesWithNullImageOrNullImageImage() {
+            var nullImageFrame = MakeFrame(100, new[] { MakeStar() }, null);
+            var nullInnerImage = Substitute.For<IRenderedImage>();
+            nullInnerImage.Image.Returns((BitmapSource)null);
+            var nullInnerFrame = MakeFrame(200, new[] { MakeStar() }, nullInnerImage);
+            var goodFrame = MakeFrame(300, new[] { MakeStar() }, MakeImage());
+
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { nullImageFrame, nullInnerFrame, goodFrame }, new SensorModel.RegisteredStar[0], referenceImageIndex: 0, ransacEnabled: true);
+
+            Assert.Multiple(() => {
+                Assert.That(snapshot.Frames.Count, Is.EqualTo(1));
+                Assert.That(snapshot.Frames.Single().ImageIndex, Is.EqualTo(2)); // original index preserved
+            });
+        }
+
+        [Test]
+        public void Build_OrdersSurvivingFramesByFocuserPositionButKeepsOriginalImageIndex() {
+            var f0 = MakeFrame(300, new[] { MakeStar() }, MakeImage());
+            var f1 = MakeFrame(100, new[] { MakeStar() }, MakeImage());
+            var f2 = MakeFrame(200, new[] { MakeStar() }, MakeImage());
+
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { f0, f1, f2 }, new SensorModel.RegisteredStar[0], referenceImageIndex: 0, ransacEnabled: true);
+
+            Assert.Multiple(() => {
+                Assert.That(snapshot.Frames.Select(f => f.FocuserPosition), Is.EqualTo(new[] { 100.0, 200.0, 300.0 }));
+                Assert.That(snapshot.Frames.Select(f => f.ImageIndex), Is.EqualTo(new[] { 1, 2, 0 }));
+            });
+        }
+
+        [Test]
+        public void Build_SnapshotIsImmutableAfterSourceStarMutation() {
+            var star = MakeStar(hfr: 2.0, posX: 10, posY: 20, boxX: 8, boxY: 18, boxW: 5, boxH: 7);
+            var frame = MakeFrame(100, new[] { star }, MakeImage());
+
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { frame }, new SensorModel.RegisteredStar[0], referenceImageIndex: 0, ransacEnabled: true);
+            var captured = snapshot.Frames.Single().Stars.Single();
+
+            // Mutate the source star the way the registration/alignment pass would, after the snapshot is built.
+            star.Position = new Accord.Point(999, 888);
+            star.HFR = 99;
+            star.BoundingBox = new System.Drawing.Rectangle(1, 2, 3, 4);
+
+            Assert.Multiple(() => {
+                Assert.That(captured.CenterX, Is.EqualTo(10));
+                Assert.That(captured.CenterY, Is.EqualTo(20));
+                Assert.That(captured.Hfr, Is.EqualTo(2.0));
+                Assert.That(captured.BoxX, Is.EqualTo(8));
+                Assert.That(captured.BoxWidth, Is.EqualTo(5));
+            });
+        }
+
+        [Test]
+        public void Build_CopiesStarPrimitivesAndBoxTopLeft() {
+            var star = MakeStar(hfr: 3.5, posX: 12.0, posY: 24.0, origX: 11.0, origY: 23.0, boxX: 9, boxY: 21, boxW: 6, boxH: 8);
+            var frame = MakeFrame(100, new[] { star }, MakeImage());
+
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { frame }, new SensorModel.RegisteredStar[0], referenceImageIndex: 0, ransacEnabled: true);
+            var s = snapshot.Frames.Single().Stars.Single();
+
+            Assert.Multiple(() => {
+                Assert.That(s.CenterX, Is.EqualTo(12.0));
+                Assert.That(s.CenterY, Is.EqualTo(24.0));
+                Assert.That(s.OriginalX, Is.EqualTo(11.0));
+                Assert.That(s.OriginalY, Is.EqualTo(23.0));
+                Assert.That(s.Hfr, Is.EqualTo(3.5));
+                Assert.That(s.BoxX, Is.EqualTo(9));
+                Assert.That(s.BoxY, Is.EqualTo(21));
+                Assert.That(s.BoxWidth, Is.EqualTo(6));
+                Assert.That(s.BoxHeight, Is.EqualTo(8));
+            });
+        }
+
+        [Test]
+        public void Build_DetectedStarCount_EqualsAcceptedStarCount() {
+            var frame = MakeFrame(100, new[] { MakeStar(posX: 1), MakeStar(posX: 2), MakeStar(posX: 3) }, MakeImage());
+
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { frame }, new SensorModel.RegisteredStar[0], referenceImageIndex: 0, ransacEnabled: true);
+
+            var f = snapshot.Frames.Single();
+            Assert.Multiple(() => {
+                Assert.That(f.DetectedStarCount, Is.EqualTo(3));
+                Assert.That(f.Stars.Count, Is.EqualTo(3));
+            });
+        }
+
+        [Test]
+        public void Build_CarriesRansacFlagAndReferenceIndex() {
+            var frame = MakeFrame(100, new[] { MakeStar() }, MakeImage());
+
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { frame }, new SensorModel.RegisteredStar[0], referenceImageIndex: 5, ransacEnabled: true);
+
+            Assert.Multiple(() => {
+                Assert.That(snapshot.RansacEnabled, Is.True);
+                Assert.That(snapshot.ReferenceImageIndex, Is.EqualTo(5));
+            });
+        }
+
+        [Test]
+        public void Build_EmptyInput_ProducesEmptySnapshot() {
+            var snapshot = FrameReviewSnapshotBuilder.Build(new SensorDetectedStars[0], new SensorModel.RegisteredStar[0], referenceImageIndex: 0, ransacEnabled: true);
+            Assert.That(snapshot.Frames, Is.Empty);
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FrameReviewSnapshotBuilderTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FrameReviewSnapshotBuilderTests.cs
@@ -196,7 +196,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
         }
 
         [Test]
-        public void Build_FocusCurves_PopulatedForFittedStarsOnly() {
+        public void Build_FocusCurves_PopulatedForAllMatchedStars_FitWhenAvailable() {
             var withFit = MakeStar(posX: 30);
             var noFit = MakeStar(posX: 20);
             var frame = MakeFrame(100, new[] { noFit, withFit }, MakeImage());
@@ -209,7 +209,14 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
             var snapshot = FrameReviewSnapshotBuilder.Build(new[] { frame }, registered, referenceImageIndex: 0, ransacEnabled: true);
 
             Assert.Multiple(() => {
-                Assert.That(snapshot.FocusCurvesByRegistrationId.ContainsKey(0), Is.False); // no-fit star
+                // The registered-but-unfitted star now gets a points-only curve (no Fit) so its cross-frame points
+                // can be shown on hover.
+                Assert.That(snapshot.FocusCurvesByRegistrationId.ContainsKey(0), Is.True);
+                var noFitCurve = snapshot.FocusCurvesByRegistrationId[0];
+                Assert.That(noFitCurve.Fit, Is.Null);
+                Assert.That(noFitCurve.Points.Count, Is.EqualTo(1));
+                Assert.That(noFitCurve.OffsetFromMean, Is.Null);
+
                 Assert.That(snapshot.FocusCurvesByRegistrationId.ContainsKey(1), Is.True);
                 var curve = snapshot.FocusCurvesByRegistrationId[1];
                 Assert.That(curve.Fit, Is.SameAs(fit));

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -1331,6 +1331,22 @@
                             Text="Review Frames"
                             TextWrapping="Wrap" />
                     </Button>
+                    <StackPanel
+                        Grid.Row="3"
+                        Grid.Column="2"
+                        Margin="5"
+                        VerticalAlignment="Center"
+                        Orientation="Horizontal"
+                        ToolTip="When on, the per-frame images from a Sensor Curve Model run are retained in memory so the &quot;Review Frames&quot; button can show each frame with its detected stars, HFRs, and cross-frame registration. Requires the Sensor Curve Model to be enabled. Increases memory use while the run's results are kept (the frames are released when you clear the analysis or start a new run). Off by default.">
+                        <CheckBox
+                            VerticalAlignment="Center"
+                            IsChecked="{Binding InspectorOptions.FrameReviewEnabled}"
+                            IsEnabled="{Binding InspectorOptions.SensorCurveModelEnabled}" />
+                        <TextBlock
+                            Margin="5,0,0,0"
+                            VerticalAlignment="Center"
+                            Text="Keep frames for Review" />
+                    </StackPanel>
                 </Grid>
                 <Expander
                     Grid.Row="1"
@@ -1893,23 +1909,6 @@
                                             </Binding>
                                         </ninactrl:UnitTextBox.Text>
                                     </ninactrl:UnitTextBox>
-                                </StackPanel>
-
-                                <TextBlock
-                                    Grid.Row="4"
-                                    Grid.Column="2"
-                                    Margin="5"
-                                    VerticalAlignment="Center"
-                                    Text="Keep frames for Review"
-                                    ToolTip="When on, the per-frame images from a Sensor Curve Model run are retained in memory so the &quot;Review Frames&quot; button can show each frame with its detected stars, HFRs, and cross-frame registration. Requires the Sensor Curve Model to be enabled. Increases memory use while the run's results are kept (the frames are released when you clear the analysis or start a new run). Off by default." />
-                                <StackPanel
-                                    Grid.Row="4"
-                                    Grid.Column="3"
-                                    Orientation="Horizontal">
-                                    <CheckBox
-                                        Margin="5,0,0,0"
-                                        IsChecked="{Binding InspectorOptions.FrameReviewEnabled}"
-                                        IsEnabled="{Binding InspectorOptions.SensorCurveModelEnabled}" />
                                 </StackPanel>
                             </Grid>
                         </Expander>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -1316,6 +1316,21 @@
                             Text="Clear Analyses"
                             TextWrapping="Wrap" />
                     </Button>
+                    <Button
+                        Grid.Row="3"
+                        Grid.Column="1"
+                        Margin="5"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Command="{Binding ReviewFramesCommand}"
+                        IsEnabled="{Binding ReviewFramesAvailable}"
+                        ToolTip="Open the Review Frames window to inspect each Sensor Curve Model frame — its detected stars, HFRs, and cross-frame registration (with alignment arrows when RANSAC alignment is on). Enabled after a run completes with &quot;Keep frames for Review&quot; turned on.">
+                        <TextBlock
+                            Margin="10,5,10,5"
+                            Foreground="{StaticResource ButtonForegroundBrush}"
+                            Text="Review Frames"
+                            TextWrapping="Wrap" />
+                    </Button>
                 </Grid>
                 <Expander
                     Grid.Row="1"
@@ -1878,6 +1893,23 @@
                                             </Binding>
                                         </ninactrl:UnitTextBox.Text>
                                     </ninactrl:UnitTextBox>
+                                </StackPanel>
+
+                                <TextBlock
+                                    Grid.Row="4"
+                                    Grid.Column="2"
+                                    Margin="5"
+                                    VerticalAlignment="Center"
+                                    Text="Keep frames for Review"
+                                    ToolTip="When on, the per-frame images from a Sensor Curve Model run are retained in memory so the &quot;Review Frames&quot; button can show each frame with its detected stars, HFRs, and cross-frame registration. Requires the Sensor Curve Model to be enabled. Increases memory use while the run's results are kept (the frames are released when you clear the analysis or start a new run). Off by default." />
+                                <StackPanel
+                                    Grid.Row="4"
+                                    Grid.Column="3"
+                                    Orientation="Horizontal">
+                                    <CheckBox
+                                        Margin="5,0,0,0"
+                                        IsChecked="{Binding InspectorOptions.FrameReviewEnabled}"
+                                        IsEnabled="{Binding InspectorOptions.SensorCurveModelEnabled}" />
                                 </StackPanel>
                             </Grid>
                         </Expander>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
@@ -73,6 +73,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             astigmaticCurvatureEnabled = optionsAccessor.GetValueBoolean(nameof(AstigmaticCurvatureEnabled), false);
             saveImagesOnReruns = optionsAccessor.GetValueBoolean(nameof(SaveImagesOnReruns), false);
             saveAlignmentImages = optionsAccessor.GetValueBoolean(nameof(SaveAlignmentImages), false);
+            frameReviewEnabled = optionsAccessor.GetValueBoolean(nameof(FrameReviewEnabled), false);
             maxStarsPerRegion = optionsAccessor.GetValueInt32(nameof(MaxStarsPerRegion), -1);
             acceptableRSquaredMin = optionsAccessor.GetValueDouble(nameof(AcceptableRSquaredMin), SensorAberrationCalculator.DefaultAcceptableRSquaredMin);
         }
@@ -102,6 +103,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             useRANSAC = true;
             useAffineAlignment = false;
             astigmaticCurvatureEnabled = false;
+            FrameReviewEnabled = false;
             AcceptableRSquaredMin = SensorAberrationCalculator.DefaultAcceptableRSquaredMin;
         }
 
@@ -485,6 +487,19 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 if (saveAlignmentImages != value) {
                     saveAlignmentImages = value;
                     optionsAccessor.SetValueBoolean(nameof(SaveAlignmentImages), saveAlignmentImages);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool frameReviewEnabled = false;
+
+        public bool FrameReviewEnabled {
+            get => frameReviewEnabled;
+            set {
+                if (frameReviewEnabled != value) {
+                    frameReviewEnabled = value;
+                    optionsAccessor.SetValueBoolean(nameof(FrameReviewEnabled), frameReviewEnabled);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -19,6 +19,7 @@ using NINA.Core.Model;
 using NINA.Core.Model.Equipment;
 using NINA.Core.Utility;
 using NINA.Core.Utility.Notification;
+using NINA.Core.Utility.WindowService;
 using NINA.Equipment.Equipment;
 using NINA.Equipment.Equipment.MyCamera;
 using NINA.Equipment.Equipment.MyFocuser;
@@ -33,6 +34,7 @@ using NINA.Joko.Plugins.HocusFocus.Inspection;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.Scottplot;
 using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review;
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
 using NINA.Joko.Plugins.HocusFocus.Utility;
 using NINA.Profile.Interfaces;
@@ -92,6 +94,10 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         private readonly IApplicationDispatcher applicationDispatcher;
         private readonly IProgress<ApplicationStatus> progress;
         private readonly ITiltAdapterOptions tiltAdapterOptions;
+
+        // WindowServiceFactory is not a MEF export (NINA exposes the concrete type with a default ctor only), so it
+        // is instantiated directly here, mirroring HocusFocusPlugin — used to show the modal Review Frames dialog.
+        private readonly IWindowServiceFactory windowServiceFactory = new WindowServiceFactory();
 
         [ImportingConstructor]
         public InspectorVM(
@@ -180,6 +186,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             SlewToZenithEastCommand = new AsyncRelayCommand(() => SlewToZenith(false), canExecute: () => TelescopeInfo.Connected && (slewToZenithTask == null || slewToZenithTask?.Status >= TaskStatus.RanToCompletion));
             SlewToZenithWestCommand = new AsyncRelayCommand(() => SlewToZenith(true), canExecute: () => TelescopeInfo.Connected && (slewToZenithTask == null || slewToZenithTask?.Status >= TaskStatus.RanToCompletion));
             CancelSlewToZenithCommand = new RelayCommand(() => slewToZenithCts?.Cancel());
+            ReviewFramesCommand = new RelayCommand(ShowFrameReview, canExecute: () => ReviewFramesAvailable);
         }
 
         private bool AnalysisRunning() {
@@ -511,6 +518,23 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                             SensorModel.ReferenceImage,
                             inspectorOptions.SaveAlignmentImages);
                     }
+                }
+
+                // Build the Review Frames snapshot from the same full-sensor detections and registration just computed.
+                // UpdateModel has already applied the alignment transforms, so Position/OriginalPosition/BoundingBox are
+                // final. Runs after the sweep completes (no concurrent SubMeasurementPointCompleted adds), but copy the
+                // list under the lock to stay consistent with the rest of the class.
+                if (frameReviewRequestedForRun) {
+                    List<SensorDetectedStars> framesForReview;
+                    lock (fullSensorDetectedStarsLock) {
+                        framesForReview = FullSensorDetectedStars.ToList();
+                    }
+                    reviewSnapshot = FrameReviewSnapshotBuilder.Build(
+                        framesForReview,
+                        SensorModel.SensorModelResult.RegisteredStars,
+                        SensorModel.ReferenceImage,
+                        inspectorOptions.UseRANSAC);
+                    NotifyReviewFramesAvailabilityChanged();
                 }
             }
 
@@ -1003,7 +1027,11 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             if (inspectorOptions.DetailedAnalysisExposureSeconds > 0) {
                 options.OverrideAutoFocusExposureTime = TimeSpan.FromSeconds(inspectorOptions.DetailedAnalysisExposureSeconds);
             }
-            if (options.Save) {
+            // Freeze the frame-review decision at run start (atomically with the retention decision). Review needs the
+            // per-frame images retained, which the engine only does when PreserveExposures is on; force it on for review
+            // even on non-saving runs. Applies to all run/rerun paths since they all build options through here.
+            frameReviewRequestedForRun = inspectorOptions.FrameReviewEnabled && inspectorOptions.SensorCurveModelEnabled;
+            if (options.Save || frameReviewRequestedForRun) {
                 options.PreserveExposures = true;
             }
             return options;
@@ -1422,6 +1450,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             lock (fullSensorDetectedStarsLock) {
                 FullSensorDetectedStars.Clear();
             }
+            ClearReviewSnapshot();
             ClearPlots();
         }
 
@@ -1489,8 +1518,64 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         public ICommand SlewToZenithWestCommand { get; private set; }
         public ICommand CancelSlewToZenithCommand { get; private set; }
 
+        // RelayCommand (not ICommand) so we can call NotifyCanExecuteChanged when the snapshot becomes (un)available.
+        public RelayCommand ReviewFramesCommand { get; private set; }
+
         private readonly object fullSensorDetectedStarsLock = new object();
         private readonly List<SensorDetectedStars> FullSensorDetectedStars = new List<SensorDetectedStars>();
+
+        // The immutable per-frame review data built at the end of a sensor-model run when "Keep frames for Review" was
+        // on. Null until a qualifying run completes; cleared at run start and on Clear Analyses. frameReviewRequestedForRun
+        // freezes the toggle's value at run start (when PreserveExposures is decided) so a mid-run toggle change can't
+        // desync image retention from the snapshot build.
+        private FrameReviewSnapshot reviewSnapshot;
+        private bool frameReviewRequestedForRun;
+
+        /// <summary>Whether a completed sensor-model run produced reviewable frames (drives the "Review Frames" button).</summary>
+        public bool ReviewFramesAvailable => reviewSnapshot?.Frames.Count > 0;
+
+        // Raise the availability binding + re-evaluate the command, marshaled to the UI thread (the snapshot is built /
+        // cleared on the analysis background task). DispatchSynchronizationContext is a synchronous Send with a
+        // same-context fast path, so it is safe to call from either thread.
+        private void NotifyReviewFramesAvailabilityChanged() {
+            applicationDispatcher.DispatchSynchronizationContext(() => {
+                RaisePropertyChanged(nameof(ReviewFramesAvailable));
+                ReviewFramesCommand.NotifyCanExecuteChanged();
+            });
+        }
+
+        private void ClearReviewSnapshot() {
+            reviewSnapshot = null;
+            NotifyReviewFramesAvailabilityChanged();
+        }
+
+        // Shows the modal Review Frames dialog, mirroring HocusFocusPlugin.OptimizeStarDetection: the VM is presented in
+        // a ContentPresenter resolved by the implicit DataType DataTemplate for FrameReviewVM, and is disposed when the
+        // window closes (releasing the retained frame bitmaps).
+        private void ShowFrameReview() {
+            var snapshot = reviewSnapshot;
+            if (snapshot == null || snapshot.Frames.Count == 0) {
+                return;
+            }
+
+            var vm = new FrameReviewVM(snapshot);
+            var windowService = windowServiceFactory.Create();
+
+            void onRequestClose(object s, EventArgs e) {
+                _ = windowService.Close();
+            }
+
+            EventHandler onClosed = null;
+            onClosed = (s, e) => {
+                windowService.OnClosed -= onClosed;
+                vm.RequestClose -= onRequestClose;
+                vm.Dispose();
+            };
+            windowService.OnClosed += onClosed;
+            vm.RequestClose += onRequestClose;
+
+            windowService.ShowDialog(vm, "Review Frames", ResizeMode.CanResize, WindowStyle.SingleBorderWindow);
+        }
         public AsyncObservableCollection<ScatterErrorPoint>[] RegionFocusPoints { get; private set; }
         public AsyncObservableCollection<DataPoint>[] RegionPlotFocusPoints { get; private set; }
         public AsyncObservableCollection<DataPoint> RegionFinalFocusPoints { get; private set; }
@@ -2109,6 +2194,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             AutoFocusCompleted = false;
             ResetErrors();
             RebuildTiltGuidance();
+            ClearReviewSnapshot();
         }
 
         private void ActivateAutoFocusChart() {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/FrameReviewSnapshot.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/FrameReviewSnapshot.cs
@@ -1,0 +1,179 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Media.Imaging;
+
+namespace NINA.Joko.Plugins.HocusFocus.Inspection {
+
+    /// <summary>
+    /// One accepted star in a reviewable frame, captured as PRIMITIVES (image-pixel coordinates) so the snapshot is
+    /// immutable against later mutation of the source <see cref="HocusFocusDetectedStar"/> (whose Position/BoundingBox
+    /// the registration pass overwrites in place). <see cref="CenterX"/>/<see cref="CenterY"/> are the detector's
+    /// (possibly aligned) Position; <see cref="BoxX"/>/<see cref="BoxY"/> are the bounding-box TOP-LEFT (for the
+    /// overlay's Canvas.Left/Top binding); <see cref="OriginalX"/>/<see cref="OriginalY"/> are the raw pre-alignment
+    /// detection position (the arrow start).
+    /// </summary>
+    public sealed class FrameReviewStar {
+        public double CenterX { get; init; }
+        public double CenterY { get; init; }
+        public double BoxX { get; init; }
+        public double BoxY { get; init; }
+        public double BoxWidth { get; init; }
+        public double BoxHeight { get; init; }
+        public double Hfr { get; init; }
+
+        /// <summary>The index into the run's RegisteredStars array for the physical star this maps to (stable across
+        /// frames), or null when this star was not matched into any registered star.</summary>
+        public int? RegistrationId { get; init; }
+
+        public double OriginalX { get; init; }
+        public double OriginalY { get; init; }
+
+        /// <summary>Whether to draw a registration arrow from (OriginalX,OriginalY) to (CenterX,CenterY): true only
+        /// when RANSAC alignment was on, this is not the reference frame, and the position actually moved.</summary>
+        public bool HasArrow { get; init; }
+    }
+
+    /// <summary>
+    /// One reviewable frame: its image (a frozen, display-ready <see cref="BitmapSource"/> the engine already held),
+    /// the accepted stars overlaid on it, and the registration metadata. Holds only the bitmap reference + primitives,
+    /// so disposing/mutating the source data after the snapshot is built does not affect it.
+    /// </summary>
+    public sealed class FrameReviewFrame {
+        /// <summary>The frame's original index in the per-run detected-stars list (== the registration ReferenceImage
+        /// index space), preserved even though <see cref="FrameReviewSnapshot.Frames"/> is ordered by focuser position.</summary>
+        public int ImageIndex { get; init; }
+
+        public double FocuserPosition { get; init; }
+        public bool IsReference { get; init; }
+
+        /// <summary>The alignment transform's human-readable scale/rotation/translation, or "" for the reference frame
+        /// and when RANSAC alignment was off (no meaningful transform).</summary>
+        public string TransformText { get; init; }
+
+        public int DetectedStarCount { get; init; }
+        public BitmapSource Image { get; init; }
+        public IReadOnlyList<FrameReviewStar> Stars { get; init; }
+    }
+
+    /// <summary>An immutable, render-ready description of a completed sensor-model run's per-frame detections and
+    /// cross-frame registration, built once at the end of analysis and consumed by the Review Frames window.</summary>
+    public sealed class FrameReviewSnapshot {
+        public bool RansacEnabled { get; init; }
+        public int ReferenceImageIndex { get; init; }
+        public IReadOnlyList<FrameReviewFrame> Frames { get; init; }
+    }
+
+    /// <summary>
+    /// Builds a <see cref="FrameReviewSnapshot"/> from the full-sensor per-frame detections and the cross-frame
+    /// registration the Sensor Curve Model already computed. Pure (no WPF/UI besides carrying the frozen bitmaps), so
+    /// it is unit-tested directly.
+    ///
+    /// <para>The registration identifier is recovered by reference identity: each <see cref="SensorModel.MatchedStar"/>
+    /// in <c>registeredStars[i].MatchedStars</c> carries the SAME <see cref="HocusFocusDetectedStar"/> object that
+    /// lives in the frame's <c>StarList</c> (see <c>SensorModel.MatchStarsUsingKdTree</c>), so a reference-equality
+    /// dictionary maps each accepted star to its registered-star index <c>i</c>.</para>
+    /// </summary>
+    public static class FrameReviewSnapshotBuilder {
+
+        public static FrameReviewSnapshot Build(
+            IReadOnlyList<SensorDetectedStars> allDetectedStars,
+            IReadOnlyList<SensorModel.RegisteredStar> registeredStars,
+            int referenceImageIndex,
+            bool ransacEnabled) {
+
+            // Reference-identity map: each accepted star object -> its registered-star index. MatchedStar.Star is the
+            // SAME object reference as the frame's StarList entry, so reference equality recovers the registration id.
+            var idByStar = new Dictionary<object, int>(ReferenceEqualityComparer.Instance);
+            if (registeredStars != null) {
+                for (int i = 0; i < registeredStars.Count; i++) {
+                    var matched = registeredStars[i]?.MatchedStars;
+                    if (matched == null) {
+                        continue;
+                    }
+                    foreach (var ms in matched) {
+                        if (ms?.Star != null && !idByStar.ContainsKey(ms.Star)) {
+                            idByStar[ms.Star] = i;
+                        }
+                    }
+                }
+            }
+
+            var frames = new List<FrameReviewFrame>();
+            var frameCount = allDetectedStars?.Count ?? 0;
+            for (int imageIndex = 0; imageIndex < frameCount; imageIndex++) {
+                var sds = allDetectedStars[imageIndex];
+                var bitmap = sds?.Image?.Image;
+                if (bitmap == null) {
+                    continue; // Drop frames whose per-frame image was not retained.
+                }
+
+                var isReference = imageIndex == referenceImageIndex;
+                var stars = new List<FrameReviewStar>();
+                var starList = sds.StarDetectionResult?.StarList;
+                if (starList != null) {
+                    foreach (var detected in starList) {
+                        var hf = detected as HocusFocusDetectedStar;
+                        double centerX = detected.Position.X;
+                        double centerY = detected.Position.Y;
+                        double originalX = hf?.OriginalPosition.X ?? centerX;
+                        double originalY = hf?.OriginalPosition.Y ?? centerY;
+                        var box = detected.BoundingBox;
+                        int? registrationId = idByStar.TryGetValue(detected, out var id) ? id : (int?)null;
+                        // Arrows only make sense for a registered (aligned) non-reference frame whose position moved.
+                        bool hasArrow = ransacEnabled && !isReference && (centerX != originalX || centerY != originalY);
+                        stars.Add(new FrameReviewStar {
+                            CenterX = centerX,
+                            CenterY = centerY,
+                            BoxX = box.X,
+                            BoxY = box.Y,
+                            BoxWidth = box.Width,
+                            BoxHeight = box.Height,
+                            Hfr = detected.HFR,
+                            RegistrationId = registrationId,
+                            OriginalX = originalX,
+                            OriginalY = originalY,
+                            HasArrow = hasArrow,
+                        });
+                    }
+                }
+
+                // The reference frame keeps the identity transform, and a non-RANSAC run never aligns — neither has a
+                // meaningful transform to show.
+                var transformText = (!isReference && ransacEnabled && sds.AlignmentTransform != null)
+                    ? sds.AlignmentTransform.ToFullString()
+                    : "";
+
+                frames.Add(new FrameReviewFrame {
+                    ImageIndex = imageIndex,
+                    FocuserPosition = sds.FocuserPosition,
+                    IsReference = isReference,
+                    TransformText = transformText,
+                    DetectedStarCount = stars.Count,
+                    Image = bitmap,
+                    Stars = stars,
+                });
+            }
+
+            // Present frames in focuser-sweep order; ImageIndex still carries the original (registration) index.
+            var ordered = frames.OrderBy(f => f.FocuserPosition).ToList();
+            return new FrameReviewSnapshot {
+                RansacEnabled = ransacEnabled,
+                ReferenceImageIndex = referenceImageIndex,
+                Frames = ordered,
+            };
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/FrameReviewSnapshot.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/FrameReviewSnapshot.cs
@@ -11,19 +11,35 @@
 #endregion "copyright"
 
 using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using OxyPlot.Series;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Media.Imaging;
 
 namespace NINA.Joko.Plugins.HocusFocus.Inspection {
 
+    /// <summary>The registration + focus-fit status of an accepted star, which drives its overlay box color.</summary>
+    public enum FrameReviewRegistrationState {
+        /// <summary>Accepted but never matched into a registered star (no cross-frame registration).</summary>
+        Unmatched,
+
+        /// <summary>Matched/registered, but it produced no accepted per-star focus fit (too few points, failed solve,
+        /// or below the per-star R² gate), so it did not contribute to the sensor model.</summary>
+        MatchedNoFit,
+
+        /// <summary>Matched/registered with an accepted per-star focus fit (contributed to the model).</summary>
+        MatchedWithFit
+    }
+
     /// <summary>
-    /// One accepted star in a reviewable frame, captured as PRIMITIVES (image-pixel coordinates) so the snapshot is
-    /// immutable against later mutation of the source <see cref="HocusFocusDetectedStar"/> (whose Position/BoundingBox
-    /// the registration pass overwrites in place). <see cref="CenterX"/>/<see cref="CenterY"/> are the detector's
-    /// (possibly aligned) Position; <see cref="BoxX"/>/<see cref="BoxY"/> are the bounding-box TOP-LEFT (for the
-    /// overlay's Canvas.Left/Top binding); <see cref="OriginalX"/>/<see cref="OriginalY"/> are the raw pre-alignment
-    /// detection position (the arrow start).
+    /// One accepted star in a reviewable frame, captured as PRIMITIVES in the frame's RAW (pre-alignment) coordinates,
+    /// so the overlay sits on the displayed raw image and the snapshot is immutable against later mutation of the
+    /// source <see cref="HocusFocusDetectedStar"/>. <see cref="CenterX"/>/<see cref="CenterY"/> are the raw detected
+    /// centroid (the cyan registration marker); <see cref="BoxX"/>/<see cref="BoxY"/> are the raw bounding-box
+    /// top-left; <see cref="TargetX"/>/<see cref="TargetY"/> are the star's ALIGNED (reference-frame) position — the
+    /// registration target the orange line/marker points to.
     /// </summary>
     public sealed class FrameReviewStar {
         public double CenterX { get; init; }
@@ -34,33 +50,34 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
         public double BoxHeight { get; init; }
         public double Hfr { get; init; }
 
-        /// <summary>The index into the run's RegisteredStars array for the physical star this maps to (stable across
-        /// frames), or null when this star was not matched into any registered star.</summary>
+        /// <summary>The index into the run's RegisteredStars for the physical star this maps to, or null if unmatched.</summary>
         public int? RegistrationId { get; init; }
 
-        public double OriginalX { get; init; }
-        public double OriginalY { get; init; }
+        public FrameReviewRegistrationState RegistrationState { get; init; }
 
-        /// <summary>Whether to draw a registration arrow from (OriginalX,OriginalY) to (CenterX,CenterY): true only
-        /// when RANSAC alignment was on, this is not the reference frame, and the position actually moved.</summary>
-        public bool HasArrow { get; init; }
+        public double TargetX { get; init; }
+        public double TargetY { get; init; }
+
+        /// <summary>Whether to draw the registration line (center → target): true only when RANSAC alignment was on,
+        /// this is not the reference frame, the star is matched, and its aligned position actually moved.</summary>
+        public bool HasRegistrationLine { get; init; }
+
+        /// <summary>Signed offset (focuser steps) of this star's best focus from the field-mean best focus over all
+        /// fitted stars; null when the star has no accepted focus fit.</summary>
+        public double? FocusOffsetFromMean { get; init; }
     }
 
     /// <summary>
-    /// One reviewable frame: its image (a frozen, display-ready <see cref="BitmapSource"/> the engine already held),
-    /// the accepted stars overlaid on it, and the registration metadata. Holds only the bitmap reference + primitives,
-    /// so disposing/mutating the source data after the snapshot is built does not affect it.
+    /// One reviewable frame: its frozen raw <see cref="BitmapSource"/>, the accepted stars overlaid on it, and the
+    /// registration metadata. Holds only the bitmap reference + primitives.
     /// </summary>
     public sealed class FrameReviewFrame {
-        /// <summary>The frame's original index in the per-run detected-stars list (== the registration ReferenceImage
-        /// index space), preserved even though <see cref="FrameReviewSnapshot.Frames"/> is ordered by focuser position.</summary>
         public int ImageIndex { get; init; }
-
         public double FocuserPosition { get; init; }
         public bool IsReference { get; init; }
 
-        /// <summary>The alignment transform's human-readable scale/rotation/translation, or "" for the reference frame
-        /// and when RANSAC alignment was off (no meaningful transform).</summary>
+        /// <summary>The alignment transform's human-readable scale/rotation/translation (with a degree symbol), or ""
+        /// for the reference frame and when RANSAC alignment was off.</summary>
         public string TransformText { get; init; }
 
         public int DetectedStarCount { get; init; }
@@ -68,23 +85,58 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
         public IReadOnlyList<FrameReviewStar> Stars { get; init; }
     }
 
-    /// <summary>An immutable, render-ready description of a completed sensor-model run's per-frame detections and
-    /// cross-frame registration, built once at the end of analysis and consumed by the Review Frames window.</summary>
+    /// <summary>
+    /// Per-registered-star focus-curve data for the Review Frames hover graph (one per physical star, shared across
+    /// frames). Disposal-safe: <see cref="Points"/> are value structs and <see cref="Fit"/>'s curve closure captures
+    /// only a <c>double[]</c> solution, so it survives the disposal of the run's heavy data.
+    /// </summary>
+    public sealed class FrameReviewFocusCurve {
+        public int RegistrationId { get; init; }
+        public AlglibHyperbolicFitting Fit { get; init; }
+        public IReadOnlyList<ScatterErrorPoint> Points { get; init; }
+        public double RSquared { get; init; }
+
+        /// <summary>Focuser position at best focus (the fit minimum's X).</summary>
+        public double BestFocus { get; init; }
+
+        public double? OffsetFromMean { get; init; }
+    }
+
+    /// <summary>An immutable, render-ready description of a completed sensor-model run's per-frame detections,
+    /// cross-frame registration, and per-star focus fits, built once at the end of analysis.</summary>
     public sealed class FrameReviewSnapshot {
         public bool RansacEnabled { get; init; }
         public int ReferenceImageIndex { get; init; }
         public IReadOnlyList<FrameReviewFrame> Frames { get; init; }
+
+        /// <summary>Per-registered-star focus curves, keyed by registration id (only stars with an accepted fit).</summary>
+        public IReadOnlyDictionary<int, FrameReviewFocusCurve> FocusCurvesByRegistrationId { get; init; }
+    }
+
+    /// <summary>Formats a registration transform like <c>Matrix3x2.ToFullString</c> but with a "°" degree symbol, for
+    /// the Review Frames header. Kept separate so the shared <c>ToFullString</c> (used by diagnostic image annotations)
+    /// is not perturbed.</summary>
+    public static class FrameReviewTransformFormatter {
+        public static string Format(Matrix3x2 t) {
+            if (t == null) {
+                return string.Empty;
+            }
+            var scaleX = Math.Sqrt(t.M11 * t.M11 + t.M21 * t.M21);
+            var scaleY = Math.Sqrt(t.M12 * t.M12 + t.M22 * t.M22);
+            var rotationDegrees = Math.Atan2(t.M21, t.M11) * 180.0 / Math.PI;
+            return $"Scale(x,y):({scaleX:0.###},{scaleY:0.###}), rotation:{rotationDegrees:0.###}°, translation(x,y):{t.M31:0.###},{t.M32:0.###}";
+        }
     }
 
     /// <summary>
     /// Builds a <see cref="FrameReviewSnapshot"/> from the full-sensor per-frame detections and the cross-frame
-    /// registration the Sensor Curve Model already computed. Pure (no WPF/UI besides carrying the frozen bitmaps), so
-    /// it is unit-tested directly.
+    /// registration + per-star fits the Sensor Curve Model already computed. Pure (no WPF/UI besides carrying the
+    /// frozen bitmaps), so it is unit-tested directly.
     ///
     /// <para>The registration identifier is recovered by reference identity: each <see cref="SensorModel.MatchedStar"/>
     /// in <c>registeredStars[i].MatchedStars</c> carries the SAME <see cref="HocusFocusDetectedStar"/> object that
-    /// lives in the frame's <c>StarList</c> (see <c>SensorModel.MatchStarsUsingKdTree</c>), so a reference-equality
-    /// dictionary maps each accepted star to its registered-star index <c>i</c>.</para>
+    /// lives in the frame's <c>StarList</c>, so a reference-equality dictionary maps each accepted star to its
+    /// registered-star index <c>i</c>.</para>
     /// </summary>
     public static class FrameReviewSnapshotBuilder {
 
@@ -94,8 +146,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             int referenceImageIndex,
             bool ransacEnabled) {
 
-            // Reference-identity map: each accepted star object -> its registered-star index. MatchedStar.Star is the
-            // SAME object reference as the frame's StarList entry, so reference equality recovers the registration id.
+            // Reference-identity map: each accepted star object -> its registered-star index.
             var idByStar = new Dictionary<object, int>(ReferenceEqualityComparer.Instance);
             if (registeredStars != null) {
                 for (int i = 0; i < registeredStars.Count; i++) {
@@ -107,6 +158,40 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                         if (ms?.Star != null && !idByStar.ContainsKey(ms.Star)) {
                             idByStar[ms.Star] = i;
                         }
+                    }
+                }
+            }
+
+            // Per-registered-star focus curves + the field-mean best-focus offset. Only stars with an accepted fit
+            // (RegisteredStar.Fitting != null) have a curve; the offset is each fitted star's best focus minus the
+            // mean best focus across all fitted stars.
+            var focusCurves = new Dictionary<int, FrameReviewFocusCurve>();
+            var offsetByRegId = new Dictionary<int, double>();
+            if (registeredStars != null) {
+                var fittedIds = new List<int>();
+                for (int i = 0; i < registeredStars.Count; i++) {
+                    if (registeredStars[i]?.Fitting != null) {
+                        fittedIds.Add(i);
+                    }
+                }
+                if (fittedIds.Count > 0) {
+                    var meanBestFocus = fittedIds.Average(i => registeredStars[i].Fitting.Minimum.X);
+                    foreach (var i in fittedIds) {
+                        var rs = registeredStars[i];
+                        var bestFocus = rs.Fitting.Minimum.X;
+                        var offset = bestFocus - meanBestFocus;
+                        offsetByRegId[i] = offset;
+                        var points = (rs.MatchedStars ?? new List<SensorModel.MatchedStar>())
+                            .Select(m => new ScatterErrorPoint(m.FocuserPosition, m.Star.HFR, 0.0, SensorModel.EstimateHfrStdDev(m.Star)))
+                            .ToList();
+                        focusCurves[i] = new FrameReviewFocusCurve {
+                            RegistrationId = i,
+                            Fit = rs.Fitting,
+                            Points = points,
+                            RSquared = rs.Fitting.RSquared,
+                            BestFocus = bestFocus,
+                            OffsetFromMean = offset,
+                        };
                     }
                 }
             }
@@ -126,14 +211,33 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                 if (starList != null) {
                     foreach (var detected in starList) {
                         var hf = detected as HocusFocusDetectedStar;
-                        double centerX = detected.Position.X;
-                        double centerY = detected.Position.Y;
-                        double originalX = hf?.OriginalPosition.X ?? centerX;
-                        double originalY = hf?.OriginalPosition.Y ?? centerY;
-                        var box = detected.BoundingBox;
+                        // Raw center + raw bounding box so the overlay sits on the displayed (raw) frame.
+                        double centerX = hf?.OriginalPosition.X ?? detected.Position.X;
+                        double centerY = hf?.OriginalPosition.Y ?? detected.Position.Y;
+                        var box = hf != null ? hf.OriginalBoundingBox : detected.BoundingBox;
+                        // Aligned (reference-frame) position = the registration target.
+                        double targetX = detected.Position.X;
+                        double targetY = detected.Position.Y;
+
                         int? registrationId = idByStar.TryGetValue(detected, out var id) ? id : (int?)null;
-                        // Arrows only make sense for a registered (aligned) non-reference frame whose position moved.
-                        bool hasArrow = ransacEnabled && !isReference && (centerX != originalX || centerY != originalY);
+                        FrameReviewRegistrationState state;
+                        if (registrationId == null) {
+                            state = FrameReviewRegistrationState.Unmatched;
+                        } else if (registeredStars != null && registeredStars[registrationId.Value]?.Fitting != null) {
+                            state = FrameReviewRegistrationState.MatchedWithFit;
+                        } else {
+                            state = FrameReviewRegistrationState.MatchedNoFit;
+                        }
+
+                        double? focusOffset = (registrationId != null && offsetByRegId.TryGetValue(registrationId.Value, out var off))
+                            ? off
+                            : (double?)null;
+
+                        // The line is only meaningful for a registered star on an aligned (RANSAC) non-reference frame
+                        // whose aligned position differs from its raw position.
+                        bool hasRegistrationLine = ransacEnabled && !isReference && registrationId != null
+                            && (targetX != centerX || targetY != centerY);
+
                         stars.Add(new FrameReviewStar {
                             CenterX = centerX,
                             CenterY = centerY,
@@ -143,18 +247,18 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                             BoxHeight = box.Height,
                             Hfr = detected.HFR,
                             RegistrationId = registrationId,
-                            OriginalX = originalX,
-                            OriginalY = originalY,
-                            HasArrow = hasArrow,
+                            RegistrationState = state,
+                            TargetX = targetX,
+                            TargetY = targetY,
+                            HasRegistrationLine = hasRegistrationLine,
+                            FocusOffsetFromMean = focusOffset,
                         });
                     }
                 }
 
-                // The reference frame keeps the identity transform, and a non-RANSAC run never aligns — neither has a
-                // meaningful transform to show.
                 var transformText = (!isReference && ransacEnabled && sds.AlignmentTransform != null)
-                    ? sds.AlignmentTransform.ToFullString()
-                    : "";
+                    ? FrameReviewTransformFormatter.Format(sds.AlignmentTransform)
+                    : string.Empty;
 
                 frames.Add(new FrameReviewFrame {
                     ImageIndex = imageIndex,
@@ -173,6 +277,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                 RansacEnabled = ransacEnabled,
                 ReferenceImageIndex = referenceImageIndex,
                 Frames = ordered,
+                FocusCurvesByRegistrationId = focusCurves,
             };
         }
     }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/FrameReviewSnapshot.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/FrameReviewSnapshot.cs
@@ -124,7 +124,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             var scaleX = Math.Sqrt(t.M11 * t.M11 + t.M21 * t.M21);
             var scaleY = Math.Sqrt(t.M12 * t.M12 + t.M22 * t.M22);
             var rotationDegrees = Math.Atan2(t.M21, t.M11) * 180.0 / Math.PI;
-            return $"Scale(x,y):({scaleX:0.###},{scaleY:0.###}), rotation:{rotationDegrees:0.###}°, translation(x,y):{t.M31:0.###},{t.M32:0.###}";
+            return $"Scale(x,y): ({scaleX:0.###},{scaleY:0.###}), rotation: {rotationDegrees:0.###}°, translation(x,y): {t.M31:0.###},{t.M32:0.###}";
         }
     }
 
@@ -168,31 +168,40 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             var focusCurves = new Dictionary<int, FrameReviewFocusCurve>();
             var offsetByRegId = new Dictionary<int, double>();
             if (registeredStars != null) {
-                var fittedIds = new List<int>();
+                // Field-mean best focus over the FITTED stars only (drives the offset-from-mean label).
+                var fittedBestFoci = new List<double>();
                 for (int i = 0; i < registeredStars.Count; i++) {
                     if (registeredStars[i]?.Fitting != null) {
-                        fittedIds.Add(i);
+                        fittedBestFoci.Add(registeredStars[i].Fitting.Minimum.X);
                     }
                 }
-                if (fittedIds.Count > 0) {
-                    var meanBestFocus = fittedIds.Average(i => registeredStars[i].Fitting.Minimum.X);
-                    foreach (var i in fittedIds) {
-                        var rs = registeredStars[i];
-                        var bestFocus = rs.Fitting.Minimum.X;
-                        var offset = bestFocus - meanBestFocus;
-                        offsetByRegId[i] = offset;
-                        var points = (rs.MatchedStars ?? new List<SensorModel.MatchedStar>())
-                            .Select(m => new ScatterErrorPoint(m.FocuserPosition, m.Star.HFR, 0.0, SensorModel.EstimateHfrStdDev(m.Star)))
-                            .ToList();
-                        focusCurves[i] = new FrameReviewFocusCurve {
-                            RegistrationId = i,
-                            Fit = rs.Fitting,
-                            Points = points,
-                            RSquared = rs.Fitting.RSquared,
-                            BestFocus = bestFocus,
-                            OffsetFromMean = offset,
-                        };
+                double? meanBestFocus = fittedBestFoci.Count > 0 ? fittedBestFoci.Average() : (double?)null;
+
+                // Build a focus curve for EVERY matched star, so a registered-but-unfitted star still shows how its
+                // detections look across the other frames on hover. Fitted stars additionally carry the curve, R²,
+                // best focus, and the offset from the field mean.
+                for (int i = 0; i < registeredStars.Count; i++) {
+                    var rs = registeredStars[i];
+                    var matched = rs?.MatchedStars;
+                    if (matched == null || matched.Count == 0) {
+                        continue;
                     }
+                    var points = matched
+                        .Select(m => new ScatterErrorPoint(m.FocuserPosition, m.Star.HFR, 0.0, SensorModel.EstimateHfrStdDev(m.Star)))
+                        .ToList();
+                    double? offset = null;
+                    if (rs.Fitting != null && meanBestFocus.HasValue) {
+                        offset = rs.Fitting.Minimum.X - meanBestFocus.Value;
+                        offsetByRegId[i] = offset.Value;
+                    }
+                    focusCurves[i] = new FrameReviewFocusCurve {
+                        RegistrationId = i,
+                        Fit = rs.Fitting,
+                        Points = points,
+                        RSquared = rs.Fitting?.RSquared ?? double.NaN,
+                        BestFocus = rs.Fitting?.Minimum.X ?? double.NaN,
+                        OffsetFromMean = offset,
+                    };
                 }
             }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/FrameReviewSnapshot.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/FrameReviewSnapshot.cs
@@ -186,8 +186,11 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                     if (matched == null || matched.Count == 0) {
                         continue;
                     }
+                    // Display points only: one detection per focuser position, so there is no sample spread to show.
+                    // Zero error (the chart draws plain markers, no error bars); the per-star fit computes its own
+                    // weights independently in SensorModel.FitImages.
                     var points = matched
-                        .Select(m => new ScatterErrorPoint(m.FocuserPosition, m.Star.HFR, 0.0, SensorModel.EstimateHfrStdDev(m.Star)))
+                        .Select(m => new ScatterErrorPoint(m.FocuserPosition, m.Star.HFR, 0.0, 0.0))
                         .ToList();
                     double? offset = null;
                     if (rs.Fitting != null && meanBestFocus.HasValue) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
@@ -405,6 +405,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                                                                     .Select((star, index) => ((HocusFocusDetectedStar)star, index))) {
                         star.NormalisedBrightness = (float)((star.AverageBrightness - imageMinBrightness) / (imageMaxBrightness - imageMinBrightness));
                         star.OriginalPosition = star.Position;
+                        star.OriginalBoundingBox = star.BoundingBox;
                     }
                 }
                 stopwatch.RecordEntry("normalise brightness");
@@ -586,7 +587,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
         // on a detected star (mean brightness above background, with a shot-noise-like denominator). This
         // makes the previously no-op WeightedHyperbolicFitEnabled meaningful. It does not affect the
         // best-focus standard error, which is self-calibrated from the fit residuals.
-        private static double EstimateHfrStdDev(HocusFocusDetectedStar star) {
+        internal static double EstimateHfrStdDev(HocusFocusDetectedStar star) {
             var signal = star.AverageBrightness - star.Background;
             var noise = Math.Sqrt(Math.Max(star.AverageBrightness, 1.0));
             var snr = signal > 0 ? signal / noise : 0.0;
@@ -722,6 +723,11 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                         discardedFlags[registeredStarIndex] = true;
                         return;
                     }
+
+                    // Retain the accepted per-star fit on the registered star so the Review Frames UI can show this
+                    // star's focus curve / R² / best focus. Each Parallel.For iteration writes a distinct registeredStar,
+                    // and this array is the one returned to (and surfaced by) SensorModelResult.RegisteredStars.
+                    registeredStar.Fitting = fitting;
 
                     rejectedCounts[registeredStarIndex] = rejectedCount;
                     var dataPointX = (registeredStar.RegistrationX - (imageSize.Width / 2.0)) * pixelSize;
@@ -1314,7 +1320,12 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
         public class RegisteredStar {
             public double RegistrationX { get; set; } = double.NaN;
             public double RegistrationY { get; set; } = double.NaN;
-            public HyperbolicFittingAlglib Fitting { get; set; }
+
+            // The accepted per-star hyperbolic focus fit (set by FitImages only when the star solved AND passed the
+            // per-star R² gate, i.e. it contributed to the surface fit). Non-null ⇔ "matched with a successful fit".
+            // Carries the curve function, minimum (best focus), and R² for the Review Frames focus-graph overlay; its
+            // Fitting closure captures only a double[] so it is safe to retain after the run's heavy data is freed.
+            public AlglibHyperbolicFitting Fitting { get; set; }
             public List<MatchedStar> MatchedStars { get; private set; } = new List<MatchedStar>();
 
             public override string ToString() {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
@@ -587,7 +587,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
         // on a detected star (mean brightness above background, with a shot-noise-like denominator). This
         // makes the previously no-op WeightedHyperbolicFitEnabled meaningful. It does not affect the
         // best-focus standard error, which is self-calibrated from the fit residuals.
-        internal static double EstimateHfrStdDev(HocusFocusDetectedStar star) {
+        private static double EstimateHfrStdDev(HocusFocusDetectedStar star) {
             var signal = star.AverageBrightness - star.Background;
             var noise = Math.Sqrt(Math.Max(star.AverageBrightness, 1.0));
             var snr = signal > 0 ? signal / noise : 0.0;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IInspectorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IInspectorOptions.cs
@@ -73,6 +73,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         double StartingBrightnessDiff { get; set; }
         bool SaveImagesOnReruns { get; set; }
         bool SaveAlignmentImages { get; set; }
+        bool FrameReviewEnabled { get; set; }
         int MaxStarsPerRegion { get; set; }
         double AcceptableRSquaredMin { get; set; }
     }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
@@ -208,6 +208,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
         public PSFModel PSF { get; set; }
         public float NormalisedBrightness { get; set; }
         public Accord.Point OriginalPosition { get; set; }
+
+        // The detector's bounding box BEFORE any registration/alignment transform overwrites BoundingBox. Captured
+        // alongside OriginalPosition so the Review Frames overlay can draw boxes in the raw frame's own coordinates
+        // (the displayed image is the raw frame; the aligned BoundingBox would be offset on non-reference frames).
+        public System.Drawing.Rectangle OriginalBoundingBox { get; set; }
+
         public bool StarContaminationSuspected { get; set; }
 
         public override string ToString() {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -89,6 +89,12 @@
         </oxy:Plot>
     </DataTemplate>
 
+    <!--  The Aberration Inspector "Review Frames" window content. Implicit DataType template so the WindowService's
+          ContentPresenter resolves it by VM type (same mechanism as the wizard below).  -->
+    <DataTemplate DataType="{x:Type review:FrameReviewVM}">
+        <review:FrameReviewControl />
+    </DataTemplate>
+
     <!--  The wizard window content. Implicit DataType template so the WindowService's ContentPresenter resolves it by VM type.  -->
     <DataTemplate DataType="{x:Type local:StarDetectionOptimizerWizardVM}">
         <!--  Width/height grow for the Review step (it embeds a full interactive image viewer); the other steps keep

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -89,6 +89,54 @@
         </oxy:Plot>
     </DataTemplate>
 
+    <!--  Points-only focus graph for a registered star with NO accepted fit (Review Frames hover). Same axes/scatter
+          as the OptimizationCurve chart but no fitted-curve/minimum annotations (which require a non-null fit).  -->
+    <DataTemplate DataType="{x:Type review:FrameReviewScatterGraph}">
+        <oxy:Plot
+            MinHeight="240"
+            Background="{StaticResource BackgroundBrush}"
+            PlotAreaBackground="{StaticResource BackgroundBrush}"
+            PlotAreaBorderColor="{Binding Path=Color, Source={StaticResource BorderBrush}}"
+            TextColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}">
+            <oxy:Plot.Axes>
+                <oxy:LinearAxis
+                    AxislineColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
+                    IsPanEnabled="False"
+                    IsZoomEnabled="False"
+                    MajorGridlineColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}, Converter={StaticResource SetAlphaToColorConverter}, ConverterParameter=60}"
+                    MajorGridlineStyle="LongDash"
+                    MaximumPadding="0.1"
+                    MinimumPadding="0.1"
+                    Position="Left"
+                    TextColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
+                    TicklineColor="{Binding Path=Color, Source={StaticResource SecondaryBrush}}"
+                    Title="HFR" />
+                <oxy:LinearAxis
+                    AxislineColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
+                    IsPanEnabled="False"
+                    IsZoomEnabled="False"
+                    MajorGridlineColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}, Converter={StaticResource SetAlphaToColorConverter}, ConverterParameter=60}"
+                    MajorGridlineStyle="LongDash"
+                    MaximumPadding="0.1"
+                    MinimumPadding="0.1"
+                    Position="Bottom"
+                    TextColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
+                    TicklineColor="{Binding Path=Color, Source={StaticResource SecondaryBrush}}"
+                    Title="Focuser position" />
+            </oxy:Plot.Axes>
+            <oxy:Plot.Series>
+                <oxy:ScatterErrorSeries
+                    ErrorBarColor="{Binding Path=Color, Source={StaticResource NotificationErrorBrush}}"
+                    ErrorBarStopWidth="2"
+                    ErrorBarStrokeThickness="2"
+                    ItemsSource="{Binding Points}"
+                    MarkerFill="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
+                    MarkerType="Circle"
+                    TrackerFormatString="Focuser: {2:0}, HFR: {4:0.000}" />
+            </oxy:Plot.Series>
+        </oxy:Plot>
+    </DataTemplate>
+
     <!--  The Aberration Inspector "Review Frames" window content. Implicit DataType template so the WindowService's
           ContentPresenter resolves it by VM type (same mechanism as the wizard below).  -->
     <DataTemplate DataType="{x:Type review:FrameReviewVM}">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -89,8 +89,64 @@
         </oxy:Plot>
     </DataTemplate>
 
-    <!--  Points-only focus graph for a registered star with NO accepted fit (Review Frames hover). Same axes/scatter
-          as the OptimizationCurve chart but no fitted-curve/minimum annotations (which require a non-null fit).  -->
+    <!--  Fitted focus graph for a registered star WITH an accepted fit (Review Frames hover): plain scatter (NO error
+          bars — each point is a single detection, so there is no sample spread) + the fitted curve + best-focus marker.  -->
+    <DataTemplate DataType="{x:Type review:FrameReviewFocusGraph}">
+        <oxy:Plot
+            MinHeight="240"
+            Background="{StaticResource BackgroundBrush}"
+            PlotAreaBackground="{StaticResource BackgroundBrush}"
+            PlotAreaBorderColor="{Binding Path=Color, Source={StaticResource BorderBrush}}"
+            TextColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}">
+            <oxy:Plot.Axes>
+                <oxy:LinearAxis
+                    AxislineColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
+                    IsPanEnabled="False"
+                    IsZoomEnabled="False"
+                    MajorGridlineColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}, Converter={StaticResource SetAlphaToColorConverter}, ConverterParameter=60}"
+                    MajorGridlineStyle="LongDash"
+                    MaximumPadding="0.1"
+                    MinimumPadding="0.1"
+                    Position="Left"
+                    TextColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
+                    TicklineColor="{Binding Path=Color, Source={StaticResource SecondaryBrush}}"
+                    Title="HFR" />
+                <oxy:LinearAxis
+                    AxislineColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
+                    IsPanEnabled="False"
+                    IsZoomEnabled="False"
+                    MajorGridlineColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}, Converter={StaticResource SetAlphaToColorConverter}, ConverterParameter=60}"
+                    MajorGridlineStyle="LongDash"
+                    MaximumPadding="0.1"
+                    MinimumPadding="0.1"
+                    Position="Bottom"
+                    TextColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
+                    TicklineColor="{Binding Path=Color, Source={StaticResource SecondaryBrush}}"
+                    Title="Focuser position" />
+            </oxy:Plot.Axes>
+            <oxy:Plot.Series>
+                <oxy:ScatterSeries
+                    ItemsSource="{Binding Points}"
+                    MarkerFill="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
+                    MarkerType="Circle"
+                    TrackerFormatString="Focuser: {2:0}, HFR: {4:0.000}" />
+            </oxy:Plot.Series>
+            <oxy:Plot.Annotations>
+                <oxy:FunctionAnnotation
+                    Color="{Binding Path=Color, Source={StaticResource SecondaryBrush}}"
+                    Equation="{Binding Fitting}" />
+                <oxy:PointAnnotation
+                    Fill="{Binding Path=Color, Source={StaticResource NotificationErrorBrush}}"
+                    Shape="Diamond"
+                    Stroke="{Binding Path=Color, Source={StaticResource NotificationErrorBrush}}"
+                    X="{Binding Minimum.X}"
+                    Y="{Binding Minimum.Y}" />
+            </oxy:Plot.Annotations>
+        </oxy:Plot>
+    </DataTemplate>
+
+    <!--  Points-only focus graph for a registered star with NO accepted fit (Review Frames hover): plain scatter only,
+          no fitted-curve/minimum annotations (which would require a non-null fit).  -->
     <DataTemplate DataType="{x:Type review:FrameReviewScatterGraph}">
         <oxy:Plot
             MinHeight="240"
@@ -125,10 +181,7 @@
                     Title="Focuser position" />
             </oxy:Plot.Axes>
             <oxy:Plot.Series>
-                <oxy:ScatterErrorSeries
-                    ErrorBarColor="{Binding Path=Color, Source={StaticResource NotificationErrorBrush}}"
-                    ErrorBarStopWidth="2"
-                    ErrorBarStrokeThickness="2"
+                <oxy:ScatterSeries
                     ItemsSource="{Binding Points}"
                     MarkerFill="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
                     MarkerType="Circle"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -92,7 +92,8 @@
     <!--  The Aberration Inspector "Review Frames" window content. Implicit DataType template so the WindowService's
           ContentPresenter resolves it by VM type (same mechanism as the wizard below).  -->
     <DataTemplate DataType="{x:Type review:FrameReviewVM}">
-        <review:FrameReviewControl />
+        <!--  Open large by default; MinWidth/MinHeight let the window (CanResize) grow and the control fill it.  -->
+        <review:FrameReviewControl MinWidth="1280" MinHeight="860" />
     </DataTemplate>
 
     <!--  The wizard window content. Implicit DataType template so the WindowService's ContentPresenter resolves it by VM type.  -->

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
@@ -7,6 +7,84 @@
         <BooleanToVisibilityConverter x:Key="BoolToVis" />
         <SolidColorBrush x:Key="Fg" Color="White" />
 
+        <!-- NINA's default toggle (StandardCheckBox) hard-codes the OFF label to {StaticResource PrimaryBrush},
+             which is too dark on this panel and CANNOT be overridden from the consumer (StaticResource is baked
+             into NINA's parsed style). So we keep NINA's exact toggle look but re-template it locally, pointing
+             ONLY the OFF text at a light brush; the remaining theme brushes use DynamicResource so the switch
+             still matches the active theme. (Mirrors StarReviewControl's HF_ReviewToggle.) -->
+        <SolidColorBrush x:Key="HF_ToggleOffText" Color="#FFD8DCE0" />
+        <Style x:Key="HF_ReviewToggle" TargetType="{x:Type CheckBox}">
+            <Setter Property="Focusable" Value="False" />
+            <Setter Property="Width" Value="65" />
+            <Setter Property="Height" Value="25" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="CheckBox">
+                        <Grid>
+                            <Border
+                                x:Name="SwitchTrack"
+                                Background="Transparent"
+                                BorderBrush="{DynamicResource BorderBrush}"
+                                BorderThickness="1"
+                                CornerRadius="12.5" />
+                            <Grid>
+                                <TextBlock
+                                    x:Name="OnText"
+                                    Margin="8,0,0,0"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    FontWeight="Bold"
+                                    Foreground="{StaticResource HF_ToggleOffText}"
+                                    Text="ON"
+                                    Visibility="Collapsed" />
+                                <TextBlock
+                                    x:Name="OffText"
+                                    Margin="0,0,8,0"
+                                    HorizontalAlignment="Right"
+                                    VerticalAlignment="Center"
+                                    Foreground="{StaticResource HF_ToggleOffText}"
+                                    Text="OFF"
+                                    Visibility="Visible" />
+                            </Grid>
+                            <Ellipse
+                                x:Name="SwitchThumb"
+                                Width="21"
+                                Height="21"
+                                Margin="2"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                Fill="{DynamicResource SecondaryBackgroundBrush}"
+                                RenderTransformOrigin="0.5,0.5">
+                                <Ellipse.RenderTransform>
+                                    <TranslateTransform x:Name="ThumbTransform" />
+                                </Ellipse.RenderTransform>
+                            </Ellipse>
+                        </Grid>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsChecked" Value="True">
+                                <Setter TargetName="SwitchTrack" Property="Background" Value="{DynamicResource TertiaryBackgroundBrush}" />
+                                <Setter TargetName="SwitchThumb" Property="HorizontalAlignment" Value="Right" />
+                                <Setter TargetName="OnText" Property="Visibility" Value="Visible" />
+                                <Setter TargetName="OffText" Property="Visibility" Value="Collapsed" />
+                            </Trigger>
+                            <Trigger Property="IsChecked" Value="False">
+                                <Setter TargetName="SwitchTrack" Property="Background" Value="Transparent" />
+                                <Setter TargetName="SwitchThumb" Property="HorizontalAlignment" Value="Left" />
+                                <Setter TargetName="OnText" Property="Visibility" Value="Collapsed" />
+                                <Setter TargetName="OffText" Property="Visibility" Value="Visible" />
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="SwitchTrack" Property="Opacity" Value="0.4" />
+                                <Setter TargetName="SwitchThumb" Property="Opacity" Value="0.4" />
+                                <Setter TargetName="OnText" Property="Opacity" Value="0.4" />
+                                <Setter TargetName="OffText" Property="Opacity" Value="0.4" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
         <Style TargetType="Button">
             <Setter Property="Margin" Value="4,0" />
             <Setter Property="Padding" Value="10,4" />
@@ -265,12 +343,14 @@
             </ItemsControl>
 
             <Separator Margin="0,12,0,8" />
-            <CheckBox IsChecked="{Binding ShowRegistration}" VerticalAlignment="Center">
-                <TextBlock Text="Show registration" VerticalAlignment="Center" />
-            </CheckBox>
-            <CheckBox Margin="0,6,0,0" IsChecked="{Binding ShowFocusOffset}" VerticalAlignment="Center">
-                <TextBlock Text="Show optimal-focus offset" VerticalAlignment="Center" />
-            </CheckBox>
+            <StackPanel Orientation="Horizontal">
+                <CheckBox Style="{StaticResource HF_ReviewToggle}" IsChecked="{Binding ShowRegistration}" VerticalAlignment="Center" />
+                <TextBlock Margin="8,0,0,0" VerticalAlignment="Center" Text="Show registration" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                <CheckBox Style="{StaticResource HF_ReviewToggle}" IsChecked="{Binding ShowFocusOffset}" VerticalAlignment="Center" />
+                <TextBlock Margin="8,0,0,0" VerticalAlignment="Center" Text="Show optimal-focus offset" />
+            </StackPanel>
 
             <Separator Margin="0,12,0,0" />
             <TextBlock Margin="0,8,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
@@ -234,7 +234,7 @@
                                     <!-- HFR label, constant on-screen size, just above the box. -->
                                     <TextBlock Text="{Binding HfrText}"
                                                HorizontalAlignment="Left" VerticalAlignment="Top"
-                                               FontSize="10" Background="#80000000" Padding="2,0"
+                                               FontSize="10" Background="#40000000" Padding="2,0"
                                                IsHitTestVisible="False" RenderTransformOrigin="0,0"
                                                Foreground="{Binding DataContext.HfrBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}">
                                         <TextBlock.RenderTransform>
@@ -248,7 +248,7 @@
                                     <!-- Registration-id label below the box (shown only when Show registration is on). -->
                                     <TextBlock Text="{Binding RegistrationIdText}"
                                                HorizontalAlignment="Left" VerticalAlignment="Top"
-                                               FontSize="10" Background="#80000000" Padding="2,0"
+                                               FontSize="10" Background="#40000000" Padding="2,0"
                                                IsHitTestVisible="False" RenderTransformOrigin="0,0"
                                                Foreground="{Binding DataContext.RegistrationBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                                Visibility="{Binding DataContext.ShowRegistration, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}">
@@ -283,7 +283,7 @@
                             <DataTemplate>
                                 <TextBlock Text="{Binding FocusOffsetText}"
                                            HorizontalAlignment="Left" VerticalAlignment="Top"
-                                           FontSize="10" Background="#80000000" Padding="2,0"
+                                           FontSize="10" Background="#40000000" Padding="2,0"
                                            IsHitTestVisible="False" RenderTransformOrigin="0,0"
                                            Foreground="{Binding DataContext.FocusOffsetBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                            Visibility="{Binding HasFocusOffset, Converter={StaticResource BoolToVis}}">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
@@ -1,0 +1,218 @@
+<UserControl
+    x:Class="NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review.FrameReviewControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Background="#FF1E2125">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis" />
+        <SolidColorBrush x:Key="Fg" Color="White" />
+
+        <Style TargetType="Button">
+            <Setter Property="Margin" Value="4,0" />
+            <Setter Property="Padding" Value="10,4" />
+        </Style>
+        <Style TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{StaticResource Fg}" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+    </UserControl.Resources>
+
+    <Grid Margin="10">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <DockPanel Grid.Row="0" Grid.Column="0" LastChildFill="False" Margin="0,0,0,6">
+            <TextBlock DockPanel.Dock="Left" FontWeight="SemiBold" Text="{Binding FrameHeader}" />
+            <TextBlock DockPanel.Dock="Right" Text="{Binding PositionLabel}" />
+        </DockPanel>
+
+        <!-- Toolbar: navigation + close (read-only — no labeling). -->
+        <DockPanel Grid.Row="1" Grid.Column="0" LastChildFill="False" Margin="0,0,0,6">
+            <Button DockPanel.Dock="Left" Content="Fit" Command="{Binding FitCommand}" Margin="0,0,4,0" />
+            <Button DockPanel.Dock="Left" Content="◀ Prev" Command="{Binding PrevCommand}" />
+            <Button DockPanel.Dock="Left" Content="Next ▶" Command="{Binding NextCommand}" />
+            <Button DockPanel.Dock="Right" Content="Close" Command="{Binding CloseCommand}" />
+        </DockPanel>
+
+        <!-- Image + scrollbars: the image Border sits at (0,0); scrollbars appear only when zoomed beyond fit. -->
+        <Grid Grid.Row="2" Grid.Column="0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <!-- Image + overlays. The Image and all marker layers share one transform (zoom/pan) so markers stay
+                 pinned to image pixels. Mouse events are handled in code-behind against the viewport. -->
+            <Border Grid.Row="0" Grid.Column="0" ClipToBounds="True" Background="Black" BorderBrush="#FF3F4958" BorderThickness="1">
+                <Grid>
+                    <Canvas x:Name="ViewportCanvas"
+                            Background="Transparent"
+                            MouseWheel="ViewportCanvas_MouseWheel"
+                            MouseRightButtonDown="ViewportCanvas_MouseRightButtonDown"
+                            MouseRightButtonUp="ViewportCanvas_MouseRightButtonUp"
+                            MouseMove="ViewportCanvas_MouseMove"
+                            SizeChanged="ViewportCanvas_SizeChanged">
+                        <Canvas.RenderTransform>
+                            <TransformGroup>
+                                <ScaleTransform x:Name="ContentScale" ScaleX="1" ScaleY="1" />
+                                <TranslateTransform x:Name="ContentTranslate" X="0" Y="0" />
+                            </TransformGroup>
+                        </Canvas.RenderTransform>
+
+                        <!-- Background frame (image-pixel coords; the canvas transform handles zoom/pan). -->
+                        <Image x:Name="FrameImageControl"
+                               Source="{Binding FrameImage}"
+                               Canvas.Left="0" Canvas.Top="0"
+                               Stretch="None"
+                               RenderOptions.BitmapScalingMode="NearestNeighbor" />
+
+                        <!-- Registration arrows: each from a star's raw detection (start) to its registered target
+                             (end), with a precomputed arrowhead triangle. Drawn under the boxes. Container sits at the
+                             canvas origin so the absolute image-pixel coords place the line/arrowhead directly. -->
+                        <ItemsControl ItemsSource="{Binding Markers}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Canvas Visibility="{Binding HasArrow, Converter={StaticResource BoolToVis}}" IsHitTestVisible="False">
+                                        <Line X1="{Binding ArrowStartX}" Y1="{Binding ArrowStartY}"
+                                              X2="{Binding ArrowEndX}" Y2="{Binding ArrowEndY}"
+                                              Stroke="{Binding DataContext.ArrowBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                              StrokeThickness="{Binding DataContext.MarkerStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                        <Polygon Points="{Binding ArrowHead}"
+                                                 Fill="{Binding DataContext.ArrowBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                    </Canvas>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+
+                        <!-- Accepted stars: the detector's real bounding box (green) + HFR label (yellow, above) +
+                             registration-id label (cyan, below). All labels keep a constant on-screen size via the
+                             inverse-zoom ScaleTransform. -->
+                        <ItemsControl ItemsSource="{Binding Markers}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemContainerStyle>
+                                <Style TargetType="ContentPresenter">
+                                    <Setter Property="Canvas.Left" Value="{Binding BoxX}" />
+                                    <Setter Property="Canvas.Top" Value="{Binding BoxY}" />
+                                </Style>
+                            </ItemsControl.ItemContainerStyle>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid>
+                                        <Rectangle Width="{Binding BoxWidth}" Height="{Binding BoxHeight}"
+                                                   HorizontalAlignment="Left" VerticalAlignment="Top"
+                                                   IsHitTestVisible="False"
+                                                   Stroke="{Binding DataContext.AcceptedBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                   StrokeThickness="{Binding DataContext.MarkerStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                        <!-- HFR label: anchored at the box top-left, constant on-screen size, lifted up
+                                             one text-height so it sits just ABOVE the box. -->
+                                        <TextBlock Text="{Binding HfrText}"
+                                                   HorizontalAlignment="Left" VerticalAlignment="Top"
+                                                   FontSize="10" Background="#B0000000" Padding="2,0"
+                                                   IsHitTestVisible="False" RenderTransformOrigin="0,0"
+                                                   Foreground="{Binding DataContext.HfrBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}">
+                                            <TextBlock.RenderTransform>
+                                                <TransformGroup>
+                                                    <ScaleTransform ScaleX="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                                    ScaleY="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                                    <TranslateTransform Y="{Binding DataContext.HfrLabelOffset, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                                </TransformGroup>
+                                            </TextBlock.RenderTransform>
+                                        </TextBlock>
+                                        <!-- Registration-id label: anchored at the box top-left, dropped to the box
+                                             bottom (per-marker BoxHeight) plus a small constant gap, BELOW the box. -->
+                                        <TextBlock Text="{Binding RegistrationIdText}"
+                                                   HorizontalAlignment="Left" VerticalAlignment="Top"
+                                                   FontSize="10" Background="#B0000000" Padding="2,0"
+                                                   IsHitTestVisible="False" RenderTransformOrigin="0,0"
+                                                   Foreground="{Binding DataContext.RegistrationBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}">
+                                            <TextBlock.RenderTransform>
+                                                <TransformGroup>
+                                                    <ScaleTransform ScaleX="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                                    ScaleY="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                                    <TranslateTransform Y="{Binding BoxHeight}" />
+                                                    <TranslateTransform Y="{Binding DataContext.RegistrationLabelOffset, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                                </TransformGroup>
+                                            </TextBlock.RenderTransform>
+                                        </TextBlock>
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </Canvas>
+
+                    <!-- HUD: detected-star count, reference-frame note, and the alignment transform. A sibling of the
+                         zoomed canvas (NOT inside its RenderTransform), so it stays a fixed size pinned to the top-left
+                         corner regardless of zoom/pan. -->
+                    <Border HorizontalAlignment="Left" VerticalAlignment="Top" Margin="6"
+                            Background="#B0000000" Padding="6,4" CornerRadius="3" IsHitTestVisible="False">
+                        <StackPanel>
+                            <TextBlock Text="{Binding DetectedCountText}" Foreground="White" FontSize="12" FontWeight="SemiBold" />
+                            <TextBlock Margin="0,2,0,0" Text="{Binding ReferenceNote}" Foreground="#FFB0B6BD" FontSize="12"
+                                       Visibility="{Binding ShowReferenceNote, Converter={StaticResource BoolToVis}}" />
+                            <TextBlock Margin="0,2,0,0" Text="{Binding TransformText}" Foreground="#FFB0B6BD" FontSize="11" TextWrapping="Wrap" MaxWidth="360"
+                                       Visibility="{Binding ShowTransform, Converter={StaticResource BoolToVis}}" />
+                        </StackPanel>
+                    </Border>
+                </Grid>
+            </Border>
+
+            <!-- Scrollbars: driven from code-behind (UpdateScrollBars); the Scroll handlers map value -> viewport offset. -->
+            <ScrollBar x:Name="VScroll" Grid.Row="0" Grid.Column="1" Orientation="Vertical"
+                       Visibility="Collapsed" Scroll="VScroll_Scroll" />
+            <ScrollBar x:Name="HScroll" Grid.Row="1" Grid.Column="0" Orientation="Horizontal"
+                       Visibility="Collapsed" Scroll="HScroll_Scroll" />
+        </Grid>
+
+        <!-- Color legend (right column), generated from the VM's single color source so it tracks the overlays. -->
+        <StackPanel Grid.Row="0" Grid.RowSpan="3" Grid.Column="1" Width="230" Margin="12,0,0,0">
+            <TextBlock FontWeight="Bold" Margin="0,0,0,6" Text="Legend" />
+            <ItemsControl ItemsSource="{Binding LegendEntries}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Margin="0,2" Orientation="Horizontal">
+                            <Rectangle Width="20" Height="12" Margin="0,0,8,0" VerticalAlignment="Center"
+                                       Fill="Transparent" Stroke="{Binding Brush}" StrokeThickness="2">
+                                <Rectangle.Style>
+                                    <Style TargetType="Rectangle">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Dashed}" Value="True">
+                                                <Setter Property="StrokeDashArray" Value="3 2" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Rectangle.Style>
+                            </Rectangle>
+                            <!-- Explicit Foreground: the control's implicit white-TextBlock style does not reach
+                                 TextBlocks generated inside this ItemTemplate, so they'd render dark-on-dark. -->
+                            <TextBlock Width="190" VerticalAlignment="Center" Foreground="{StaticResource Fg}"
+                                       Text="{Binding Caption}" TextWrapping="Wrap" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+
+            <Separator Margin="0,12,0,0" />
+            <TextBlock Margin="0,8,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
+                       Text="Read-only diagnostic view. Step through every frame and zoom into regions to see how many stars were detected, their HFRs, and how each frame registered to the reference." />
+            <TextBlock Margin="0,8,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
+                       Text="Wheel to zoom, right-drag to pan, Fit to reset. ◀ ▶ or Prev/Next to change frames." />
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
@@ -28,13 +28,25 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <!-- Header -->
-        <DockPanel Grid.Row="0" Grid.Column="0" LastChildFill="False" Margin="0,0,0,6">
-            <TextBlock DockPanel.Dock="Left" FontWeight="SemiBold" Text="{Binding FrameHeader}" />
-            <TextBlock DockPanel.Dock="Right" Text="{Binding PositionLabel}" />
-        </DockPanel>
+        <!-- Summary header (above the image): focuser position, frame index, detected-star count, reference note,
+             and the registration transform. -->
+        <Border Grid.Row="0" Grid.Column="0" Margin="0,0,0,6" Padding="8,5" CornerRadius="3" Background="#FF262B31">
+            <StackPanel>
+                <DockPanel LastChildFill="False">
+                    <TextBlock DockPanel.Dock="Left" FontWeight="SemiBold" Text="{Binding FrameHeader}" />
+                    <TextBlock DockPanel.Dock="Left" Margin="16,0,0,0" Foreground="#FFB0B6BD" Text="{Binding DetectedCountText}" />
+                    <TextBlock DockPanel.Dock="Left" Margin="16,0,0,0" Foreground="#FF7FD4FF" FontWeight="SemiBold"
+                               Text="{Binding ReferenceNote}"
+                               Visibility="{Binding ShowReferenceNote, Converter={StaticResource BoolToVis}}" />
+                    <TextBlock DockPanel.Dock="Right" Text="{Binding PositionLabel}" />
+                </DockPanel>
+                <TextBlock Margin="0,3,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
+                           Text="{Binding TransformText}"
+                           Visibility="{Binding ShowTransform, Converter={StaticResource BoolToVis}}" />
+            </StackPanel>
+        </Border>
 
-        <!-- Toolbar: navigation + close (read-only — no labeling). -->
+        <!-- Toolbar: navigation + close (read-only). -->
         <DockPanel Grid.Row="1" Grid.Column="0" LastChildFill="False" Margin="0,0,0,6">
             <Button DockPanel.Dock="Left" Content="Fit" Command="{Binding FitCommand}" Margin="0,0,4,0" />
             <Button DockPanel.Dock="Left" Content="◀ Prev" Command="{Binding PrevCommand}" />
@@ -42,7 +54,7 @@
             <Button DockPanel.Dock="Right" Content="Close" Command="{Binding CloseCommand}" />
         </DockPanel>
 
-        <!-- Image + scrollbars: the image Border sits at (0,0); scrollbars appear only when zoomed beyond fit. -->
+        <!-- Image + scrollbars. -->
         <Grid Grid.Row="2" Grid.Column="0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
@@ -53,140 +65,186 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <!-- Image + overlays. The Image and all marker layers share one transform (zoom/pan) so markers stay
-                 pinned to image pixels. Mouse events are handled in code-behind against the viewport. -->
             <Border Grid.Row="0" Grid.Column="0" ClipToBounds="True" Background="Black" BorderBrush="#FF3F4958" BorderThickness="1">
-                <Grid>
-                    <Canvas x:Name="ViewportCanvas"
-                            Background="Transparent"
-                            MouseWheel="ViewportCanvas_MouseWheel"
-                            MouseRightButtonDown="ViewportCanvas_MouseRightButtonDown"
-                            MouseRightButtonUp="ViewportCanvas_MouseRightButtonUp"
-                            MouseMove="ViewportCanvas_MouseMove"
-                            SizeChanged="ViewportCanvas_SizeChanged">
-                        <Canvas.RenderTransform>
-                            <TransformGroup>
-                                <ScaleTransform x:Name="ContentScale" ScaleX="1" ScaleY="1" />
-                                <TranslateTransform x:Name="ContentTranslate" X="0" Y="0" />
-                            </TransformGroup>
-                        </Canvas.RenderTransform>
+                <Canvas x:Name="ViewportCanvas"
+                        Background="Transparent"
+                        MouseWheel="ViewportCanvas_MouseWheel"
+                        MouseRightButtonDown="ViewportCanvas_MouseRightButtonDown"
+                        MouseRightButtonUp="ViewportCanvas_MouseRightButtonUp"
+                        MouseMove="ViewportCanvas_MouseMove"
+                        MouseLeave="ViewportCanvas_MouseLeave"
+                        SizeChanged="ViewportCanvas_SizeChanged">
+                    <Canvas.RenderTransform>
+                        <TransformGroup>
+                            <ScaleTransform x:Name="ContentScale" ScaleX="1" ScaleY="1" />
+                            <TranslateTransform x:Name="ContentTranslate" X="0" Y="0" />
+                        </TransformGroup>
+                    </Canvas.RenderTransform>
 
-                        <!-- Background frame (image-pixel coords; the canvas transform handles zoom/pan). -->
-                        <Image x:Name="FrameImageControl"
-                               Source="{Binding FrameImage}"
-                               Canvas.Left="0" Canvas.Top="0"
-                               Stretch="None"
-                               RenderOptions.BitmapScalingMode="NearestNeighbor" />
+                    <!-- Background frame (raw image-pixel coords; the canvas transform handles zoom/pan). -->
+                    <Image x:Name="FrameImageControl"
+                           Source="{Binding FrameImage}"
+                           Canvas.Left="0" Canvas.Top="0"
+                           Stretch="None"
+                           RenderOptions.BitmapScalingMode="NearestNeighbor" />
 
-                        <!-- Registration arrows: each from a star's raw detection (start) to its registered target
-                             (end), with a precomputed arrowhead triangle. Drawn under the boxes. Container sits at the
-                             canvas origin so the absolute image-pixel coords place the line/arrowhead directly. -->
-                        <ItemsControl ItemsSource="{Binding Markers}">
-                            <ItemsControl.ItemsPanel>
-                                <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
-                            </ItemsControl.ItemsPanel>
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <Canvas Visibility="{Binding HasArrow, Converter={StaticResource BoolToVis}}" IsHitTestVisible="False">
-                                        <Line X1="{Binding ArrowStartX}" Y1="{Binding ArrowStartY}"
-                                              X2="{Binding ArrowEndX}" Y2="{Binding ArrowEndY}"
-                                              Stroke="{Binding DataContext.ArrowBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
-                                              StrokeThickness="{Binding DataContext.MarkerStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
-                                        <Polygon Points="{Binding ArrowHead}"
-                                                 Fill="{Binding DataContext.ArrowBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
-                                    </Canvas>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
+                    <!-- Registration overlay (gated by Show registration): cyan center "+" + orange line + orange
+                         target "+". Reg-id label lives in the box layer below. Container at canvas origin so absolute
+                         image coords place the markers directly. -->
+                    <ItemsControl ItemsSource="{Binding Markers}"
+                                  Visibility="{Binding ShowRegistration, Converter={StaticResource BoolToVis}}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Canvas IsHitTestVisible="False">
+                                    <!-- Orange registration line: raw center -> aligned target. -->
+                                    <Line X1="{Binding CenterX}" Y1="{Binding CenterY}" X2="{Binding TargetX}" Y2="{Binding TargetY}"
+                                          Stroke="{Binding DataContext.RegistrationTargetBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                          StrokeThickness="{Binding DataContext.MarkerStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                          Visibility="{Binding HasRegistrationLine, Converter={StaticResource BoolToVis}}" />
+                                    <!-- Cyan "+" at the star's raw detected center (registered stars). -->
+                                    <Path Data="M -4,0 L 4,0 M 0,-4 L 0,4" StrokeThickness="1.5"
+                                          Stroke="{Binding DataContext.RegistrationBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                          Visibility="{Binding HasRegistrationId, Converter={StaticResource BoolToVis}}">
+                                        <Path.RenderTransform>
+                                            <TransformGroup>
+                                                <ScaleTransform ScaleX="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                                ScaleY="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                                <TranslateTransform X="{Binding CenterX}" Y="{Binding CenterY}" />
+                                            </TransformGroup>
+                                        </Path.RenderTransform>
+                                    </Path>
+                                    <!-- Orange "+" at the registration target (aligned position). -->
+                                    <Path Data="M -4,0 L 4,0 M 0,-4 L 0,4" StrokeThickness="1.5"
+                                          Stroke="{Binding DataContext.RegistrationTargetBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                          Visibility="{Binding HasRegistrationLine, Converter={StaticResource BoolToVis}}">
+                                        <Path.RenderTransform>
+                                            <TransformGroup>
+                                                <ScaleTransform ScaleX="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                                ScaleY="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                                <TranslateTransform X="{Binding TargetX}" Y="{Binding TargetY}" />
+                                            </TransformGroup>
+                                        </Path.RenderTransform>
+                                    </Path>
+                                </Canvas>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
 
-                        <!-- Accepted stars: the detector's real bounding box (green) + HFR label (yellow, above) +
-                             registration-id label (cyan, below). All labels keep a constant on-screen size via the
-                             inverse-zoom ScaleTransform. -->
-                        <ItemsControl ItemsSource="{Binding Markers}">
-                            <ItemsControl.ItemsPanel>
-                                <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
-                            </ItemsControl.ItemsPanel>
-                            <ItemsControl.ItemContainerStyle>
-                                <Style TargetType="ContentPresenter">
-                                    <Setter Property="Canvas.Left" Value="{Binding BoxX}" />
-                                    <Setter Property="Canvas.Top" Value="{Binding BoxY}" />
-                                </Style>
-                            </ItemsControl.ItemContainerStyle>
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <Grid>
-                                        <Rectangle Width="{Binding BoxWidth}" Height="{Binding BoxHeight}"
-                                                   HorizontalAlignment="Left" VerticalAlignment="Top"
-                                                   IsHitTestVisible="False"
-                                                   Stroke="{Binding DataContext.AcceptedBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
-                                                   StrokeThickness="{Binding DataContext.MarkerStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
-                                        <!-- HFR label: anchored at the box top-left, constant on-screen size, lifted up
-                                             one text-height so it sits just ABOVE the box. -->
-                                        <TextBlock Text="{Binding HfrText}"
-                                                   HorizontalAlignment="Left" VerticalAlignment="Top"
-                                                   FontSize="10" Background="#B0000000" Padding="2,0"
-                                                   IsHitTestVisible="False" RenderTransformOrigin="0,0"
-                                                   Foreground="{Binding DataContext.HfrBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}">
-                                            <TextBlock.RenderTransform>
-                                                <TransformGroup>
-                                                    <ScaleTransform ScaleX="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
-                                                                    ScaleY="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
-                                                    <TranslateTransform Y="{Binding DataContext.HfrLabelOffset, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
-                                                </TransformGroup>
-                                            </TextBlock.RenderTransform>
-                                        </TextBlock>
-                                        <!-- Registration-id label: anchored at the box top-left, dropped to the box
-                                             bottom (per-marker BoxHeight) plus a small constant gap, BELOW the box. -->
-                                        <TextBlock Text="{Binding RegistrationIdText}"
-                                                   HorizontalAlignment="Left" VerticalAlignment="Top"
-                                                   FontSize="10" Background="#B0000000" Padding="2,0"
-                                                   IsHitTestVisible="False" RenderTransformOrigin="0,0"
-                                                   Foreground="{Binding DataContext.RegistrationBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}">
-                                            <TextBlock.RenderTransform>
-                                                <TransformGroup>
-                                                    <ScaleTransform ScaleX="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
-                                                                    ScaleY="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
-                                                    <TranslateTransform Y="{Binding BoxHeight}" />
-                                                    <TranslateTransform Y="{Binding DataContext.RegistrationLabelOffset, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
-                                                </TransformGroup>
-                                            </TextBlock.RenderTransform>
-                                        </TextBlock>
-                                    </Grid>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-                    </Canvas>
-
-                    <!-- HUD: detected-star count, reference-frame note, and the alignment transform. A sibling of the
-                         zoomed canvas (NOT inside its RenderTransform), so it stays a fixed size pinned to the top-left
-                         corner regardless of zoom/pan. -->
-                    <Border HorizontalAlignment="Left" VerticalAlignment="Top" Margin="6"
-                            Background="#B0000000" Padding="6,4" CornerRadius="3" IsHitTestVisible="False">
-                        <StackPanel>
-                            <TextBlock Text="{Binding DetectedCountText}" Foreground="White" FontSize="12" FontWeight="SemiBold" />
-                            <TextBlock Margin="0,2,0,0" Text="{Binding ReferenceNote}" Foreground="#FFB0B6BD" FontSize="12"
-                                       Visibility="{Binding ShowReferenceNote, Converter={StaticResource BoolToVis}}" />
-                            <TextBlock Margin="0,2,0,0" Text="{Binding TransformText}" Foreground="#FFB0B6BD" FontSize="11" TextWrapping="Wrap" MaxWidth="360"
-                                       Visibility="{Binding ShowTransform, Converter={StaticResource BoolToVis}}" />
-                        </StackPanel>
-                    </Border>
-                </Grid>
+                    <!-- Accepted-star boxes (colored by registration/fit state) + HFR (above) + reg-id (below, gated) +
+                         best-focus offset (right, gated). -->
+                    <ItemsControl ItemsSource="{Binding Markers}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Canvas.Left" Value="{Binding BoxX}" />
+                                <Setter Property="Canvas.Top" Value="{Binding BoxY}" />
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Grid>
+                                    <Rectangle Width="{Binding BoxWidth}" Height="{Binding BoxHeight}"
+                                               HorizontalAlignment="Left" VerticalAlignment="Top"
+                                               IsHitTestVisible="False"
+                                               Stroke="{Binding BoxBrush}"
+                                               StrokeThickness="{Binding DataContext.MarkerStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                    <!-- HFR label, constant on-screen size, just above the box. -->
+                                    <TextBlock Text="{Binding HfrText}"
+                                               HorizontalAlignment="Left" VerticalAlignment="Top"
+                                               FontSize="10" Background="#B0000000" Padding="2,0"
+                                               IsHitTestVisible="False" RenderTransformOrigin="0,0"
+                                               Foreground="{Binding DataContext.HfrBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}">
+                                        <TextBlock.RenderTransform>
+                                            <TransformGroup>
+                                                <ScaleTransform ScaleX="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                                ScaleY="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                                <TranslateTransform Y="{Binding DataContext.HfrLabelOffset, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                            </TransformGroup>
+                                        </TextBlock.RenderTransform>
+                                    </TextBlock>
+                                    <!-- Registration-id label below the box (shown only when Show registration is on). -->
+                                    <TextBlock Text="{Binding RegistrationIdText}"
+                                               HorizontalAlignment="Left" VerticalAlignment="Top"
+                                               FontSize="10" Background="#B0000000" Padding="2,0"
+                                               IsHitTestVisible="False" RenderTransformOrigin="0,0"
+                                               Foreground="{Binding DataContext.RegistrationBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                               Visibility="{Binding DataContext.ShowRegistration, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}">
+                                        <TextBlock.RenderTransform>
+                                            <TransformGroup>
+                                                <ScaleTransform ScaleX="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                                ScaleY="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                                <TranslateTransform Y="{Binding BoxHeight}" />
+                                                <TranslateTransform Y="{Binding DataContext.RegistrationLabelOffset, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                            </TransformGroup>
+                                        </TextBlock.RenderTransform>
+                                    </TextBlock>
+                                    <!-- Best-focus offset label to the right of the box (shown only when its toggle is on;
+                                         empty for non-fitted stars so nothing is drawn). -->
+                                    <TextBlock Text="{Binding FocusOffsetText}"
+                                               HorizontalAlignment="Left" VerticalAlignment="Top"
+                                               FontSize="10" Background="#B0000000" Padding="2,0"
+                                               IsHitTestVisible="False" RenderTransformOrigin="0,0"
+                                               Foreground="{Binding DataContext.FocusOffsetBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                               Visibility="{Binding DataContext.ShowFocusOffset, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}">
+                                        <TextBlock.RenderTransform>
+                                            <TransformGroup>
+                                                <ScaleTransform ScaleX="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                                ScaleY="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                                <TranslateTransform X="{Binding BoxWidth}" />
+                                                <TranslateTransform X="{Binding DataContext.RegistrationLabelOffset, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                            </TransformGroup>
+                                        </TextBlock.RenderTransform>
+                                    </TextBlock>
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </Canvas>
             </Border>
 
-            <!-- Scrollbars: driven from code-behind (UpdateScrollBars); the Scroll handlers map value -> viewport offset. -->
+            <!-- Hover focus-graph overlay: a fixed corner panel (sibling of the clipped image Border, so it is not
+                 clipped). Shows the hovered registered+fitted star's focus curve, R², and best focus. -->
+            <Border Grid.Row="0" Grid.Column="0"
+                    HorizontalAlignment="Right" VerticalAlignment="Top" Margin="10"
+                    Width="360" Background="#E6202429" BorderBrush="#FF3F4958" BorderThickness="1" CornerRadius="4"
+                    Visibility="{Binding ShowHover, Converter={StaticResource BoolToVis}}">
+                <StackPanel Margin="8">
+                    <TextBlock FontWeight="SemiBold" Text="{Binding HoverHeaderText}" />
+                    <Border Height="220" Margin="0,4,0,0">
+                        <ContentControl Content="{Binding HoverCurve}" />
+                    </Border>
+                    <TextBlock Margin="0,4,0,0" Foreground="#FFB0B6BD" Text="{Binding HoverRSquaredText}" />
+                    <TextBlock Foreground="#FFB0B6BD" Text="{Binding HoverOptimalFocusText}" />
+                </StackPanel>
+            </Border>
+
             <ScrollBar x:Name="VScroll" Grid.Row="0" Grid.Column="1" Orientation="Vertical"
                        Visibility="Collapsed" Scroll="VScroll_Scroll" />
             <ScrollBar x:Name="HScroll" Grid.Row="1" Grid.Column="0" Orientation="Horizontal"
                        Visibility="Collapsed" Scroll="HScroll_Scroll" />
         </Grid>
 
-        <!-- Color legend (right column), generated from the VM's single color source so it tracks the overlays. -->
-        <StackPanel Grid.Row="0" Grid.RowSpan="3" Grid.Column="1" Width="230" Margin="12,0,0,0">
+        <!-- Right column: legend (disabled rows greyed) + toggles + help. -->
+        <StackPanel Grid.Row="0" Grid.RowSpan="3" Grid.Column="1" Width="240" Margin="12,0,0,0">
             <TextBlock FontWeight="Bold" Margin="0,0,0,6" Text="Legend" />
             <ItemsControl ItemsSource="{Binding LegendEntries}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
                         <StackPanel Margin="0,2" Orientation="Horizontal">
+                            <StackPanel.Style>
+                                <Style TargetType="StackPanel">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Enabled}" Value="False">
+                                            <Setter Property="Opacity" Value="0.4" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </StackPanel.Style>
                             <Rectangle Width="20" Height="12" Margin="0,0,8,0" VerticalAlignment="Center"
                                        Fill="Transparent" Stroke="{Binding Brush}" StrokeThickness="2">
                                 <Rectangle.Style>
@@ -199,18 +257,24 @@
                                     </Style>
                                 </Rectangle.Style>
                             </Rectangle>
-                            <!-- Explicit Foreground: the control's implicit white-TextBlock style does not reach
-                                 TextBlocks generated inside this ItemTemplate, so they'd render dark-on-dark. -->
-                            <TextBlock Width="190" VerticalAlignment="Center" Foreground="{StaticResource Fg}"
+                            <TextBlock Width="200" VerticalAlignment="Center" Foreground="{StaticResource Fg}"
                                        Text="{Binding Caption}" TextWrapping="Wrap" />
                         </StackPanel>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
 
+            <Separator Margin="0,12,0,8" />
+            <CheckBox IsChecked="{Binding ShowRegistration}" VerticalAlignment="Center">
+                <TextBlock Text="Show registration" VerticalAlignment="Center" />
+            </CheckBox>
+            <CheckBox Margin="0,6,0,0" IsChecked="{Binding ShowFocusOffset}" VerticalAlignment="Center">
+                <TextBlock Text="Show optimal-focus offset" VerticalAlignment="Center" />
+            </CheckBox>
+
             <Separator Margin="0,12,0,0" />
             <TextBlock Margin="0,8,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
-                       Text="Read-only diagnostic view. Step through every frame and zoom into regions to see how many stars were detected, their HFRs, and how each frame registered to the reference." />
+                       Text="Read-only diagnostic view. Box color shows each star's registration + focus-fit state. Hover a green (fitted) star to see its focus curve, R², and best focus." />
             <TextBlock Margin="0,8,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
                        Text="Wheel to zoom, right-drag to pan, Fit to reset. ◀ ▶ or Prev/Next to change frames." />
         </StackPanel>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
@@ -234,7 +234,7 @@
                                     <!-- HFR label, constant on-screen size, just above the box. -->
                                     <TextBlock Text="{Binding HfrText}"
                                                HorizontalAlignment="Left" VerticalAlignment="Top"
-                                               FontSize="10" Background="#B0000000" Padding="2,0"
+                                               FontSize="10" Background="#80000000" Padding="2,0"
                                                IsHitTestVisible="False" RenderTransformOrigin="0,0"
                                                Foreground="{Binding DataContext.HfrBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}">
                                         <TextBlock.RenderTransform>
@@ -248,7 +248,7 @@
                                     <!-- Registration-id label below the box (shown only when Show registration is on). -->
                                     <TextBlock Text="{Binding RegistrationIdText}"
                                                HorizontalAlignment="Left" VerticalAlignment="Top"
-                                               FontSize="10" Background="#B0000000" Padding="2,0"
+                                               FontSize="10" Background="#80000000" Padding="2,0"
                                                IsHitTestVisible="False" RenderTransformOrigin="0,0"
                                                Foreground="{Binding DataContext.RegistrationBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                                Visibility="{Binding DataContext.ShowRegistration, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}">
@@ -261,24 +261,41 @@
                                             </TransformGroup>
                                         </TextBlock.RenderTransform>
                                     </TextBlock>
-                                    <!-- Best-focus offset label to the right of the box (shown only when its toggle is on;
-                                         empty for non-fitted stars so nothing is drawn). -->
-                                    <TextBlock Text="{Binding FocusOffsetText}"
-                                               HorizontalAlignment="Left" VerticalAlignment="Top"
-                                               FontSize="10" Background="#B0000000" Padding="2,0"
-                                               IsHitTestVisible="False" RenderTransformOrigin="0,0"
-                                               Foreground="{Binding DataContext.FocusOffsetBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
-                                               Visibility="{Binding DataContext.ShowFocusOffset, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource BoolToVis}}">
-                                        <TextBlock.RenderTransform>
-                                            <TransformGroup>
-                                                <ScaleTransform ScaleX="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
-                                                                ScaleY="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
-                                                <TranslateTransform X="{Binding BoxWidth}" />
-                                                <TranslateTransform X="{Binding DataContext.RegistrationLabelOffset, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
-                                            </TransformGroup>
-                                        </TextBlock.RenderTransform>
-                                    </TextBlock>
                                 </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!-- Best-focus offset overlay (gated by Show optimal-focus offset). Per-item visibility on
+                         HasFocusOffset so registered-but-unfitted stars draw nothing (no empty label box). -->
+                    <ItemsControl ItemsSource="{Binding Markers}"
+                                  Visibility="{Binding ShowFocusOffset, Converter={StaticResource BoolToVis}}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Canvas.Left" Value="{Binding BoxX}" />
+                                <Setter Property="Canvas.Top" Value="{Binding BoxY}" />
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding FocusOffsetText}"
+                                           HorizontalAlignment="Left" VerticalAlignment="Top"
+                                           FontSize="10" Background="#80000000" Padding="2,0"
+                                           IsHitTestVisible="False" RenderTransformOrigin="0,0"
+                                           Foreground="{Binding DataContext.FocusOffsetBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                           Visibility="{Binding HasFocusOffset, Converter={StaticResource BoolToVis}}">
+                                    <TextBlock.RenderTransform>
+                                        <TransformGroup>
+                                            <ScaleTransform ScaleX="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                            ScaleY="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                            <TranslateTransform X="{Binding BoxWidth}" />
+                                            <TranslateTransform X="{Binding DataContext.RegistrationLabelOffset, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                        </TransformGroup>
+                                    </TextBlock.RenderTransform>
+                                </TextBlock>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
@@ -293,8 +310,8 @@
                     Visibility="{Binding ShowHover, Converter={StaticResource BoolToVis}}">
                 <StackPanel Margin="8">
                     <TextBlock FontWeight="SemiBold" Text="{Binding HoverHeaderText}" />
-                    <Border Height="220" Margin="0,4,0,0">
-                        <ContentControl Content="{Binding HoverCurve}" />
+                    <Border Height="250" Margin="0,4,0,0">
+                        <ContentControl Content="{Binding HoverContent}" />
                     </Border>
                     <TextBlock Margin="0,4,0,0" Foreground="#FFB0B6BD" Text="{Binding HoverRSquaredText}" />
                     <TextBlock Foreground="#FFB0B6BD" Text="{Binding HoverOptimalFocusText}" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
@@ -303,10 +303,14 @@
             </Border>
 
             <!-- Hover focus-graph overlay: a fixed corner panel (sibling of the clipped image Border, so it is not
-                 clipped). Shows the hovered registered+fitted star's focus curve, R², and best focus. -->
+                 clipped). Shows the hovered registered+fitted star's focus curve, R², and best focus. IsHitTestVisible
+                 is false so the panel never steals the mouse from the canvas underneath — otherwise, when the panel
+                 appears under the cursor (hovering a star in that corner), the canvas would fire MouseLeave, the hover
+                 would clear, the panel would hide, and it would flicker on/off. -->
             <Border Grid.Row="0" Grid.Column="0"
                     HorizontalAlignment="Right" VerticalAlignment="Top" Margin="10"
                     Width="360" Background="#E6202429" BorderBrush="#FF3F4958" BorderThickness="1" CornerRadius="4"
+                    IsHitTestVisible="False"
                     Visibility="{Binding ShowHover, Converter={StaticResource BoolToVis}}">
                 <StackPanel Margin="8">
                     <TextBlock FontWeight="SemiBold" Text="{Binding HoverHeaderText}" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml.cs
@@ -1,0 +1,212 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
+
+    /// <summary>
+    /// Read-only fork of <see cref="StarReviewControl"/> for the Aberration Inspector "Review Frames" dialog: an
+    /// MTF-stretched frame in a zoom/pan canvas with accepted-star boxes, HFR + registration-id labels, and
+    /// registration arrows. Binds to a <see cref="FrameReviewVM"/>. Only the viewport plumbing (zoom/pan/fit/scroll)
+    /// is kept from StarReviewControl — all labeling/drag/undo input is dropped.
+    /// </summary>
+    public partial class FrameReviewControl : UserControl {
+
+        private FrameReviewVM Vm => DataContext as FrameReviewVM;
+
+        private bool panning;
+        private System.Windows.Point lastPanScreen;
+        private bool hasFitOnce;
+
+        public FrameReviewControl() {
+            InitializeComponent();
+            DataContextChanged += OnDataContextChanged;
+            KeyDown += OnKeyDown;
+        }
+
+        private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e) {
+            if (e.OldValue is FrameReviewVM oldVm) {
+                oldVm.FitRequested -= OnFitRequested;
+            }
+            if (e.NewValue is FrameReviewVM newVm) {
+                newVm.FitRequested += OnFitRequested;
+            }
+        }
+
+        private void OnKeyDown(object sender, KeyEventArgs e) {
+            var vm = Vm;
+            if (vm == null) {
+                return;
+            }
+            switch (e.Key) {
+                case Key.Left:
+                    if (vm.PrevCommand.CanExecute(null)) {
+                        vm.PrevCommand.Execute(null);
+                    }
+                    e.Handled = true;
+                    break;
+                case Key.Right:
+                    if (vm.NextCommand.CanExecute(null)) {
+                        vm.NextCommand.Execute(null);
+                    }
+                    e.Handled = true;
+                    break;
+                case Key.F:
+                    OnFitRequested(this, EventArgs.Empty);
+                    e.Handled = true;
+                    break;
+            }
+        }
+
+        private void OnFitRequested(object sender, EventArgs e) {
+            var vm = Vm;
+            if (vm == null || ViewportCanvas.ActualWidth <= 0 || vm.ImageWidth <= 0) {
+                return;
+            }
+            // Collapse the scrollbars and force a layout pass FIRST so the fit is measured against the final
+            // (scrollbar-free) viewport — otherwise the image lands off-center until a second Fit (see StarReviewControl).
+            HScroll.Visibility = Visibility.Collapsed;
+            VScroll.Visibility = Visibility.Collapsed;
+            ViewportCanvas.UpdateLayout();
+            if (ViewportCanvas.ActualWidth <= 0 || ViewportCanvas.ActualHeight <= 0) {
+                return;
+            }
+            vm.Viewport.FitTo(ViewportCanvas.ActualWidth, ViewportCanvas.ActualHeight, vm.ImageWidth, vm.ImageHeight);
+            ApplyViewport();
+        }
+
+        private void ApplyViewport() {
+            var vm = Vm;
+            if (vm == null) {
+                return;
+            }
+            vm.Viewport.ClampToBounds(ViewportCanvas.ActualWidth, ViewportCanvas.ActualHeight, vm.ImageWidth, vm.ImageHeight);
+            ContentScale.ScaleX = vm.Viewport.Scale;
+            ContentScale.ScaleY = vm.Viewport.Scale;
+            ContentTranslate.X = vm.Viewport.OffsetX;
+            ContentTranslate.Y = vm.Viewport.OffsetY;
+            UpdateScrollBars();
+            // Markers scale with the canvas transform, so refresh the zoom-inverse stroke/label sizes after any change.
+            vm.NotifyViewportChanged();
+        }
+
+        private bool suppressScrollEvents;
+
+        private void UpdateScrollBars() {
+            var vm = Vm;
+            if (vm == null) {
+                return;
+            }
+            suppressScrollEvents = true;
+            try {
+                UpdateScrollBar(HScroll, ViewportCanvas.ActualWidth, vm.ImageWidth * vm.Viewport.Scale, -vm.Viewport.OffsetX);
+                UpdateScrollBar(VScroll, ViewportCanvas.ActualHeight, vm.ImageHeight * vm.Viewport.Scale, -vm.Viewport.OffsetY);
+            } finally {
+                suppressScrollEvents = false;
+            }
+        }
+
+        private static void UpdateScrollBar(System.Windows.Controls.Primitives.ScrollBar bar, double viewport, double content, double scrollPos) {
+            var scrollable = content - viewport;
+            if (scrollable > 0.5 && viewport > 0) {
+                bar.Visibility = Visibility.Visible;
+                bar.Minimum = 0;
+                bar.Maximum = scrollable;
+                bar.ViewportSize = viewport;
+                bar.LargeChange = viewport * 0.9;
+                bar.SmallChange = Math.Max(1.0, viewport * 0.1);
+                bar.Value = Math.Min(Math.Max(scrollPos, 0.0), scrollable);
+            } else {
+                bar.Visibility = Visibility.Collapsed;
+                bar.Value = 0;
+            }
+        }
+
+        private void HScroll_Scroll(object sender, System.Windows.Controls.Primitives.ScrollEventArgs e) {
+            var vm = Vm;
+            if (vm == null || suppressScrollEvents) {
+                return;
+            }
+            vm.Viewport.Set(vm.Viewport.Scale, -e.NewValue, vm.Viewport.OffsetY);
+            ApplyViewport();
+        }
+
+        private void VScroll_Scroll(object sender, System.Windows.Controls.Primitives.ScrollEventArgs e) {
+            var vm = Vm;
+            if (vm == null || suppressScrollEvents) {
+                return;
+            }
+            vm.Viewport.Set(vm.Viewport.Scale, vm.Viewport.OffsetX, -e.NewValue);
+            ApplyViewport();
+        }
+
+        // The canvas RenderTransform maps image space -> screen space, so a mouse position taken relative to the
+        // canvas's PARENT (the Border) is in screen space.
+        private System.Windows.Point ScreenPoint(MouseEventArgs e) {
+            var parent = (UIElement)ViewportCanvas.Parent;
+            return e.GetPosition(parent);
+        }
+
+        private void ViewportCanvas_MouseWheel(object sender, MouseWheelEventArgs e) {
+            var vm = Vm;
+            if (vm == null) {
+                return;
+            }
+            var anchor = ScreenPoint(e);
+            var factor = e.Delta > 0 ? 1.2 : 1.0 / 1.2;
+            vm.Viewport.ZoomAt(factor, anchor.X, anchor.Y);
+            ApplyViewport();
+            e.Handled = true;
+        }
+
+        private void ViewportCanvas_MouseRightButtonDown(object sender, MouseButtonEventArgs e) {
+            panning = true;
+            lastPanScreen = ScreenPoint(e);
+            ViewportCanvas.CaptureMouse();
+            e.Handled = true;
+        }
+
+        private void ViewportCanvas_MouseRightButtonUp(object sender, MouseButtonEventArgs e) {
+            panning = false;
+            ViewportCanvas.ReleaseMouseCapture();
+            e.Handled = true;
+        }
+
+        private void ViewportCanvas_MouseMove(object sender, MouseEventArgs e) {
+            var vm = Vm;
+            if (vm == null || !panning) {
+                return;
+            }
+            var screen = ScreenPoint(e);
+            var dx = screen.X - lastPanScreen.X;
+            var dy = screen.Y - lastPanScreen.Y;
+            lastPanScreen = screen;
+            vm.Viewport.PanBy(dx, dy);
+            ApplyViewport();
+        }
+
+        private void ViewportCanvas_SizeChanged(object sender, SizeChangedEventArgs e) {
+            // Re-fit only on the first meaningful size (initial layout); afterwards keep the user's zoom/pan.
+            if (hasFitOnce) {
+                return;
+            }
+            if (ViewportCanvas.ActualWidth > 0 && Vm?.ImageWidth > 0) {
+                hasFitOnce = true;
+                OnFitRequested(this, EventArgs.Empty);
+            }
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml.cs
@@ -187,15 +187,53 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
         private void ViewportCanvas_MouseMove(object sender, MouseEventArgs e) {
             var vm = Vm;
-            if (vm == null || !panning) {
+            if (vm == null) {
+                return;
+            }
+            if (panning) {
+                var screen = ScreenPoint(e);
+                var dx = screen.X - lastPanScreen.X;
+                var dy = screen.Y - lastPanScreen.Y;
+                lastPanScreen = screen;
+                vm.Viewport.PanBy(dx, dy);
+                ApplyViewport();
+                return;
+            }
+            UpdateHover(e);
+        }
+
+        // Show the focus graph for the registered+fitted star under the cursor (smallest box wins); clear it otherwise.
+        // Boxes are in raw image coords (matching the displayed raw frame), so the cursor maps via the viewport directly.
+        private void UpdateHover(MouseEventArgs e) {
+            var vm = Vm;
+            if (vm == null) {
                 return;
             }
             var screen = ScreenPoint(e);
-            var dx = screen.X - lastPanScreen.X;
-            var dy = screen.Y - lastPanScreen.Y;
-            lastPanScreen = screen;
-            vm.Viewport.PanBy(dx, dy);
-            ApplyViewport();
+            var (imgX, imgY) = vm.Viewport.ScreenToImage(screen.X, screen.Y);
+            FrameReviewMarker best = null;
+            double bestArea = double.MaxValue;
+            foreach (var m in vm.Markers) {
+                if (!m.CanShowFocusGraph || m.RegistrationId == null) {
+                    continue;
+                }
+                if (imgX >= m.BoxX && imgY >= m.BoxY && imgX <= m.BoxX + m.BoxWidth && imgY <= m.BoxY + m.BoxHeight) {
+                    var area = m.BoxWidth * m.BoxHeight;
+                    if (area < bestArea) {
+                        bestArea = area;
+                        best = m;
+                    }
+                }
+            }
+            if (best != null) {
+                vm.SetHover(best.RegistrationId.Value);
+            } else {
+                vm.ClearHover();
+            }
+        }
+
+        private void ViewportCanvas_MouseLeave(object sender, MouseEventArgs e) {
+            Vm?.ClearHover();
         }
 
         private void ViewportCanvas_SizeChanged(object sender, SizeChangedEventArgs e) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVM.cs
@@ -1,0 +1,291 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Utility;
+using NINA.Joko.Plugins.HocusFocus.Inspection;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using RelayCommand = CommunityToolkit.Mvvm.Input.RelayCommand;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
+
+    /// <summary>One drawable accepted-star marker for the Frame Review overlay, in image-pixel coords. Box geometry is
+    /// the detector's real bounding box (TOP-LEFT + size, for the Canvas.Left/Top binding); the two labels are the HFR
+    /// (above the box) and the registration id (below). The optional arrow runs from the raw detection
+    /// (<see cref="ArrowStartX"/>,<see cref="ArrowStartY"/>) to the registered target
+    /// (<see cref="ArrowEndX"/>,<see cref="ArrowEndY"/>); <see cref="ArrowHead"/> is a precomputed triangle at the
+    /// target so the XAML needs no rotation math.</summary>
+    public sealed class FrameReviewMarker {
+        public double BoxX { get; init; }
+        public double BoxY { get; init; }
+        public double BoxWidth { get; init; }
+        public double BoxHeight { get; init; }
+        public string HfrText { get; init; }
+        public string RegistrationIdText { get; init; }
+        public bool HasArrow { get; init; }
+        public double ArrowStartX { get; init; }
+        public double ArrowStartY { get; init; }
+        public double ArrowEndX { get; init; }
+        public double ArrowEndY { get; init; }
+        public PointCollection ArrowHead { get; init; }
+    }
+
+    /// <summary>
+    /// Read-only viewer VM for the Aberration Inspector "Review Frames" dialog — a stripped fork of
+    /// <see cref="StarReviewVM"/> with all labeling/undo removed. Steps through the captured frames one at a time,
+    /// overlaying each accepted star's bounding box, its HFR + registration-id labels, and (when RANSAC alignment was
+    /// on) a registration arrow to its target. Reuses the unit-tested <see cref="StarReviewViewport"/> zoom/pan math
+    /// and the <see cref="StarReviewLegendEntry"/> legend-row type. Disposing releases the retained frame bitmaps.
+    /// </summary>
+    public sealed class FrameReviewVM : BaseINPC, IDisposable {
+
+        private static SolidColorBrush FrozenBrush(Color c) {
+            var b = new SolidColorBrush(c);
+            b.Freeze();
+            return b;
+        }
+
+        /// <summary>Accepted-star bounding-box stroke (green) — matches StarReview's accepted color.</summary>
+        public Brush AcceptedBrush { get; } = FrozenBrush(Color.FromRgb(0x00, 0xFF, 0x00));
+
+        /// <summary>Registration-id label color (cyan).</summary>
+        public Brush RegistrationBrush { get; } = FrozenBrush(Color.FromRgb(0x00, 0xE5, 0xFF));
+
+        /// <summary>HFR label color (yellow).</summary>
+        public Brush HfrBrush { get; } = FrozenBrush(Color.FromRgb(0xFF, 0xD7, 0x00));
+
+        /// <summary>Registration-arrow color (orange).</summary>
+        public Brush ArrowBrush { get; } = FrozenBrush(Color.FromRgb(0xFF, 0x8C, 0x00));
+
+        private FrameReviewSnapshot snapshot;
+
+        /// <summary>Raised when the VM's Close command asks the host to dismiss the dialog.</summary>
+        public event EventHandler RequestClose;
+
+        /// <summary>Raised when the view should re-fit the image to the viewport (Fit button / new frame load).</summary>
+        public event EventHandler FitRequested;
+
+        public StarReviewViewport Viewport { get; }
+        public IReadOnlyList<StarReviewLegendEntry> LegendEntries { get; }
+        public ObservableCollection<FrameReviewMarker> Markers { get; } = new();
+
+        public RelayCommand PrevCommand { get; }
+        public RelayCommand NextCommand { get; }
+        public RelayCommand FitCommand { get; }
+        public RelayCommand CloseCommand { get; }
+
+        public FrameReviewVM(FrameReviewSnapshot snapshot) {
+            this.snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));
+            Viewport = new StarReviewViewport();
+            LegendEntries = BuildLegend();
+
+            PrevCommand = new RelayCommand(Prev, () => CurrentIndex > 0);
+            NextCommand = new RelayCommand(Next, () => CurrentIndex < FrameCount - 1);
+            FitCommand = new RelayCommand(() => FitRequested?.Invoke(this, EventArgs.Empty));
+            CloseCommand = new RelayCommand(() => RequestClose?.Invoke(this, EventArgs.Empty));
+
+            CurrentIndex = 0;
+            LoadCurrent(fit: true);
+        }
+
+        private int FrameCount => snapshot?.Frames.Count ?? 0;
+
+        private int currentIndex;
+        public int CurrentIndex {
+            get => currentIndex;
+            private set {
+                if (currentIndex != value) {
+                    currentIndex = value;
+                    RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(PositionLabel));
+                }
+            }
+        }
+
+        public string PositionLabel => FrameCount > 0 ? $"{CurrentIndex + 1} / {FrameCount}" : "0 / 0";
+
+        private BitmapSource frameImage;
+        public BitmapSource FrameImage {
+            get => frameImage;
+            private set {
+                frameImage = value;
+                RaisePropertyChanged();
+                RaisePropertyChanged(nameof(ImageWidth));
+                RaisePropertyChanged(nameof(ImageHeight));
+            }
+        }
+
+        public double ImageWidth => frameImage?.PixelWidth ?? 0;
+        public double ImageHeight => frameImage?.PixelHeight ?? 0;
+
+        private string frameHeader;
+        public string FrameHeader {
+            get => frameHeader;
+            private set { frameHeader = value; RaisePropertyChanged(); }
+        }
+
+        private string detectedCountText;
+        public string DetectedCountText {
+            get => detectedCountText;
+            private set { detectedCountText = value; RaisePropertyChanged(); }
+        }
+
+        private string referenceNote;
+        public string ReferenceNote {
+            get => referenceNote;
+            private set { referenceNote = value; RaisePropertyChanged(); RaisePropertyChanged(nameof(ShowReferenceNote)); }
+        }
+
+        public bool ShowReferenceNote => !string.IsNullOrEmpty(ReferenceNote);
+
+        private string transformText;
+        public string TransformText {
+            get => transformText;
+            private set { transformText = value; RaisePropertyChanged(); RaisePropertyChanged(nameof(ShowTransform)); }
+        }
+
+        public bool ShowTransform => !string.IsNullOrEmpty(TransformText);
+
+        // All markers live inside a canvas whose RenderTransform scales everything (including stroke width and text),
+        // so bind these INVERSELY to the current scale to keep stroke/text/labels a roughly constant on-screen size.
+        // Clamped to MinScale so they never blow up at extreme zoom-out. (Copied from StarReviewVM.)
+        public double MarkerStrokeThickness => 1.5 / Math.Max(StarReviewViewport.MinScale, Viewport.Scale);
+        public double MarkerTextScale => 1.0 / Math.Max(StarReviewViewport.MinScale, Viewport.Scale);
+
+        // HFR label one text-height ABOVE the box top (≈15 px on screen at any zoom); reg-id label a small gap BELOW
+        // the box (the per-marker BoxHeight translate puts it at the box bottom; this adds the gap).
+        public double HfrLabelOffset => -15.0 * MarkerTextScale;
+        public double RegistrationLabelOffset => 3.0 * MarkerTextScale;
+
+        /// <summary>Re-raises the zoom-dependent overlay bindings. The view calls this after any viewport change
+        /// (wheel-zoom, fit, pan) so stroke widths + label sizes track the current scale.</summary>
+        public void NotifyViewportChanged() {
+            RaisePropertyChanged(nameof(MarkerStrokeThickness));
+            RaisePropertyChanged(nameof(MarkerTextScale));
+            RaisePropertyChanged(nameof(HfrLabelOffset));
+            RaisePropertyChanged(nameof(RegistrationLabelOffset));
+        }
+
+        private void Prev() {
+            if (CurrentIndex > 0) {
+                CurrentIndex--;
+                LoadCurrent(fit: false);
+            }
+        }
+
+        private void Next() {
+            if (CurrentIndex < FrameCount - 1) {
+                CurrentIndex++;
+                LoadCurrent(fit: false);
+            }
+        }
+
+        private void LoadCurrent(bool fit) {
+            var frames = snapshot?.Frames;
+            Markers.Clear();
+            if (frames == null || frames.Count == 0) {
+                FrameImage = null;
+                FrameHeader = string.Empty;
+                DetectedCountText = string.Empty;
+                ReferenceNote = string.Empty;
+                TransformText = string.Empty;
+                PrevCommand.NotifyCanExecuteChanged();
+                NextCommand.NotifyCanExecuteChanged();
+                return;
+            }
+
+            var frame = frames[Math.Min(CurrentIndex, frames.Count - 1)];
+            FrameImage = frame.Image;
+            FrameHeader = $"Focuser position: {frame.FocuserPosition:0}";
+            DetectedCountText = $"Detected stars: {frame.DetectedStarCount}";
+            ReferenceNote = frame.IsReference ? "Reference frame" : string.Empty;
+            TransformText = frame.TransformText ?? string.Empty;
+
+            foreach (var s in frame.Stars) {
+                Markers.Add(BuildMarker(s));
+            }
+
+            PrevCommand.NotifyCanExecuteChanged();
+            NextCommand.NotifyCanExecuteChanged();
+            if (fit) {
+                FitRequested?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        private static FrameReviewMarker BuildMarker(FrameReviewStar s) {
+            return new FrameReviewMarker {
+                BoxX = s.BoxX,
+                BoxY = s.BoxY,
+                BoxWidth = s.BoxWidth,
+                BoxHeight = s.BoxHeight,
+                HfrText = FormatHfr(s.Hfr),
+                RegistrationIdText = s.RegistrationId?.ToString() ?? "—",
+                HasArrow = s.HasArrow,
+                ArrowStartX = s.OriginalX,
+                ArrowStartY = s.OriginalY,
+                ArrowEndX = s.CenterX,
+                ArrowEndY = s.CenterY,
+                ArrowHead = s.HasArrow ? BuildArrowHead(s.OriginalX, s.OriginalY, s.CenterX, s.CenterY) : null,
+            };
+        }
+
+        private static string FormatHfr(double hfr) => double.IsNaN(hfr) || hfr <= 0.0 ? "—" : hfr.ToString("F2");
+
+        // A small filled triangle at the arrow's target end, precomputed in image coords so the XAML needs no rotation
+        // math. Sized in image pixels (scales with the line under zoom — acceptable for a diagnostic overlay).
+        private static PointCollection BuildArrowHead(double sx, double sy, double ex, double ey) {
+            const double headLen = 8.0;
+            const double headWidth = 5.0;
+            var dx = ex - sx;
+            var dy = ey - sy;
+            var len = Math.Sqrt(dx * dx + dy * dy);
+            if (len < 1e-6) {
+                return new PointCollection();
+            }
+            var ux = dx / len;
+            var uy = dy / len;        // unit direction (start -> end)
+            var px = -uy;
+            var py = ux;              // unit perpendicular
+            var baseX = ex - ux * headLen;
+            var baseY = ey - uy * headLen;
+            var pc = new PointCollection {
+                new System.Windows.Point(ex, ey),                                         // tip
+                new System.Windows.Point(baseX + px * headWidth, baseY + py * headWidth),  // base corner 1
+                new System.Windows.Point(baseX - px * headWidth, baseY - py * headWidth),  // base corner 2
+            };
+            pc.Freeze();
+            return pc;
+        }
+
+        private IReadOnlyList<StarReviewLegendEntry> BuildLegend() {
+            var entries = new List<StarReviewLegendEntry> {
+                new() { Brush = AcceptedBrush, Caption = "Accepted star", Dashed = false },
+                new() { Brush = RegistrationBrush, Caption = "Registration ID (— = unmatched)", Dashed = false },
+                new() { Brush = HfrBrush, Caption = "HFR", Dashed = false },
+            };
+            // The arrow only appears when RANSAC alignment was on, so only show its legend row then.
+            if (snapshot?.RansacEnabled == true) {
+                entries.Add(new StarReviewLegendEntry { Brush = ArrowBrush, Caption = "Registration arrow (to target)", Dashed = false });
+            }
+            return entries;
+        }
+
+        public void Dispose() {
+            Markers.Clear();
+            FrameImage = null;
+            snapshot = null;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVM.cs
@@ -12,6 +12,7 @@
 
 using NINA.Core.Utility;
 using NINA.Joko.Plugins.HocusFocus.Inspection;
+using OxyPlot;
 using OxyPlot.Series;
 using System;
 using System.Collections.Generic;
@@ -56,9 +57,19 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         public bool CanShowFocusGraph { get; init; }
     }
 
+    /// <summary>A fitted focus graph for a registered star WITH an accepted hyperbolic fit: the cross-frame scatter
+    /// plus the fitted curve and its best-focus minimum. Rendered with plain markers (no error bars — each point is a
+    /// single detection, so there is no sample spread to draw).</summary>
+    public sealed class FrameReviewFocusGraph {
+        public string Label { get; init; }
+        public IReadOnlyList<ScatterErrorPoint> Points { get; init; }
+        public AlglibHyperbolicFitting Fit { get; init; }
+        public Func<double, double> Fitting => Fit?.Fitting;
+        public DataPoint Minimum => Fit?.Minimum ?? default;
+    }
+
     /// <summary>A points-only focus graph for a registered star that has NO accepted hyperbolic fit: just the
-    /// cross-frame (focuser position, HFR) scatter, so the user can see why the fit failed. Rendered by a dedicated
-    /// DataTemplate (no fitted-curve / minimum annotations, which would require a non-null fit).</summary>
+    /// cross-frame (focuser position, HFR) scatter, so the user can see why the fit failed (no curve/minimum).</summary>
     public sealed class FrameReviewScatterGraph {
         public string Label { get; init; }
         public IReadOnlyList<ScatterErrorPoint> Points { get; init; }
@@ -68,8 +79,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
     /// Read-only viewer VM for the Aberration Inspector "Review Frames" dialog. Steps through the captured frames,
     /// overlaying each accepted star's bounding box (colored by registration/fit state), HFR, optional registration
     /// id + path, and optional best-focus offset; and shows a per-star focus graph on hover. Reuses the unit-tested
-    /// <see cref="StarReviewViewport"/> zoom/pan math, the <see cref="StarReviewLegendEntry"/> legend-row type, and the
-    /// <see cref="OptimizationCurve"/> OxyPlot chart for the hover graph. Disposing releases the retained bitmaps.
+    /// <see cref="StarReviewViewport"/> zoom/pan math and the <see cref="StarReviewLegendEntry"/> legend-row type;
+    /// the hover graph uses <see cref="FrameReviewFocusGraph"/> / <see cref="FrameReviewScatterGraph"/> OxyPlot charts.
+    /// Disposing releases the retained bitmaps.
     /// </summary>
     public sealed class FrameReviewVM : BaseINPC, IDisposable {
 
@@ -231,7 +243,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
         // ---- hover focus graph ----------------------------------------------------------------------------
 
-        // Either an OptimizationCurve (fitted: points + curve + minimum) or a FrameReviewScatterGraph (no fit:
+        // Either a FrameReviewFocusGraph (fitted: points + curve + minimum) or a FrameReviewScatterGraph (no fit:
         // cross-frame points only). The hover overlay's ContentControl resolves the right DataTemplate by type.
         private object hoverContent;
         public object HoverContent {
@@ -280,7 +292,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             hoverRegistrationId = registrationId;
             HoverHeaderText = $"Star {registrationId}";
             if (curve.Fit != null) {
-                HoverContent = new OptimizationCurve {
+                HoverContent = new FrameReviewFocusGraph {
                     Label = $"Star {registrationId}",
                     Points = curve.Points,
                     Fit = curve.Fit,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVM.cs
@@ -21,33 +21,46 @@ using RelayCommand = CommunityToolkit.Mvvm.Input.RelayCommand;
 
 namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
-    /// <summary>One drawable accepted-star marker for the Frame Review overlay, in image-pixel coords. Box geometry is
-    /// the detector's real bounding box (TOP-LEFT + size, for the Canvas.Left/Top binding); the two labels are the HFR
-    /// (above the box) and the registration id (below). The optional arrow runs from the raw detection
-    /// (<see cref="ArrowStartX"/>,<see cref="ArrowStartY"/>) to the registered target
-    /// (<see cref="ArrowEndX"/>,<see cref="ArrowEndY"/>); <see cref="ArrowHead"/> is a precomputed triangle at the
-    /// target so the XAML needs no rotation math.</summary>
+    /// <summary>One drawable accepted-star marker for the Frame Review overlay, in the frame's RAW image coords. The
+    /// box (<see cref="BoxX"/>/<see cref="BoxY"/> top-left + size) is drawn in <see cref="BoxBrush"/> (green/red/grey by
+    /// registration state). The cyan registration marker sits at the raw centroid (<see cref="CenterX"/>/<see
+    /// cref="CenterY"/>); the orange registration line runs to the aligned target (<see cref="TargetX"/>/<see
+    /// cref="TargetY"/>). Label/line/offset visibility is gated by the VM toggles at the layer level, and per-marker by
+    /// <see cref="HasRegistrationId"/>/<see cref="HasRegistrationLine"/>/<see cref="HasFocusOffset"/>.</summary>
     public sealed class FrameReviewMarker {
         public double BoxX { get; init; }
         public double BoxY { get; init; }
         public double BoxWidth { get; init; }
         public double BoxHeight { get; init; }
+        public Brush BoxBrush { get; init; }
+
         public string HfrText { get; init; }
+
+        public double CenterX { get; init; }
+        public double CenterY { get; init; }
+        public double TargetX { get; init; }
+        public double TargetY { get; init; }
+
+        public bool HasRegistrationId { get; init; }
         public string RegistrationIdText { get; init; }
-        public bool HasArrow { get; init; }
-        public double ArrowStartX { get; init; }
-        public double ArrowStartY { get; init; }
-        public double ArrowEndX { get; init; }
-        public double ArrowEndY { get; init; }
-        public PointCollection ArrowHead { get; init; }
+        public bool HasRegistrationLine { get; init; }
+
+        public string FocusOffsetText { get; init; }
+        public bool HasFocusOffset { get; init; }
+
+        /// <summary>Registration id (for the hover focus-graph lookup); null when unmatched.</summary>
+        public int? RegistrationId { get; init; }
+
+        /// <summary>True when this star has an accepted focus fit, so hovering it can show a focus graph.</summary>
+        public bool CanShowFocusGraph { get; init; }
     }
 
     /// <summary>
-    /// Read-only viewer VM for the Aberration Inspector "Review Frames" dialog — a stripped fork of
-    /// <see cref="StarReviewVM"/> with all labeling/undo removed. Steps through the captured frames one at a time,
-    /// overlaying each accepted star's bounding box, its HFR + registration-id labels, and (when RANSAC alignment was
-    /// on) a registration arrow to its target. Reuses the unit-tested <see cref="StarReviewViewport"/> zoom/pan math
-    /// and the <see cref="StarReviewLegendEntry"/> legend-row type. Disposing releases the retained frame bitmaps.
+    /// Read-only viewer VM for the Aberration Inspector "Review Frames" dialog. Steps through the captured frames,
+    /// overlaying each accepted star's bounding box (colored by registration/fit state), HFR, optional registration
+    /// id + path, and optional best-focus offset; and shows a per-star focus graph on hover. Reuses the unit-tested
+    /// <see cref="StarReviewViewport"/> zoom/pan math, the <see cref="StarReviewLegendEntry"/> legend-row type, and the
+    /// <see cref="OptimizationCurve"/> OxyPlot chart for the hover graph. Disposing releases the retained bitmaps.
     /// </summary>
     public sealed class FrameReviewVM : BaseINPC, IDisposable {
 
@@ -57,28 +70,33 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             return b;
         }
 
-        /// <summary>Accepted-star bounding-box stroke (green) — matches StarReview's accepted color.</summary>
+        /// <summary>Accepted star WITH an accepted focus fit (green) — contributed to the model.</summary>
         public Brush AcceptedBrush { get; } = FrozenBrush(Color.FromRgb(0x00, 0xFF, 0x00));
 
-        /// <summary>Registration-id label color (cyan).</summary>
+        /// <summary>Registered star with NO successful focus fit (red).</summary>
+        public Brush RegisteredNoFitBrush { get; } = FrozenBrush(Color.FromRgb(0xFF, 0x52, 0x52));
+
+        /// <summary>Accepted but unregistered star (grey).</summary>
+        public Brush UnregisteredBrush { get; } = FrozenBrush(Color.FromRgb(0x9E, 0x9E, 0x9E));
+
+        /// <summary>Registration id label + center marker (cyan).</summary>
         public Brush RegistrationBrush { get; } = FrozenBrush(Color.FromRgb(0x00, 0xE5, 0xFF));
 
-        /// <summary>HFR label color (yellow).</summary>
+        /// <summary>HFR label (yellow).</summary>
         public Brush HfrBrush { get; } = FrozenBrush(Color.FromRgb(0xFF, 0xD7, 0x00));
 
-        /// <summary>Registration-arrow color (orange).</summary>
-        public Brush ArrowBrush { get; } = FrozenBrush(Color.FromRgb(0xFF, 0x8C, 0x00));
+        /// <summary>Registration path line + target marker (orange).</summary>
+        public Brush RegistrationTargetBrush { get; } = FrozenBrush(Color.FromRgb(0xFF, 0x8C, 0x00));
+
+        /// <summary>Best-focus offset label (violet).</summary>
+        public Brush FocusOffsetBrush { get; } = FrozenBrush(Color.FromRgb(0xE0, 0x40, 0xFB));
 
         private FrameReviewSnapshot snapshot;
 
-        /// <summary>Raised when the VM's Close command asks the host to dismiss the dialog.</summary>
         public event EventHandler RequestClose;
-
-        /// <summary>Raised when the view should re-fit the image to the viewport (Fit button / new frame load).</summary>
         public event EventHandler FitRequested;
 
         public StarReviewViewport Viewport { get; }
-        public IReadOnlyList<StarReviewLegendEntry> LegendEntries { get; }
         public ObservableCollection<FrameReviewMarker> Markers { get; } = new();
 
         public RelayCommand PrevCommand { get; }
@@ -89,7 +107,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         public FrameReviewVM(FrameReviewSnapshot snapshot) {
             this.snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));
             Viewport = new StarReviewViewport();
-            LegendEntries = BuildLegend();
+            legendEntries = BuildLegend();
 
             PrevCommand = new RelayCommand(Prev, () => CurrentIndex > 0);
             NextCommand = new RelayCommand(Next, () => CurrentIndex < FrameCount - 1);
@@ -101,6 +119,36 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         }
 
         private int FrameCount => snapshot?.Frames.Count ?? 0;
+
+        // ---- toggles --------------------------------------------------------------------------------------
+
+        private bool showRegistration;
+        /// <summary>Show registration ids + path (cyan center marker + orange line/target). Off by default.</summary>
+        public bool ShowRegistration {
+            get => showRegistration;
+            set {
+                if (showRegistration != value) {
+                    showRegistration = value;
+                    RaisePropertyChanged();
+                    RebuildLegend();
+                }
+            }
+        }
+
+        private bool showFocusOffset;
+        /// <summary>Show each fitted star's best-focus offset from the field mean. Off by default.</summary>
+        public bool ShowFocusOffset {
+            get => showFocusOffset;
+            set {
+                if (showFocusOffset != value) {
+                    showFocusOffset = value;
+                    RaisePropertyChanged();
+                    RebuildLegend();
+                }
+            }
+        }
+
+        // ---- navigation / current frame -------------------------------------------------------------------
 
         private int currentIndex;
         public int CurrentIndex {
@@ -158,25 +206,108 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
         public bool ShowTransform => !string.IsNullOrEmpty(TransformText);
 
-        // All markers live inside a canvas whose RenderTransform scales everything (including stroke width and text),
-        // so bind these INVERSELY to the current scale to keep stroke/text/labels a roughly constant on-screen size.
-        // Clamped to MinScale so they never blow up at extreme zoom-out. (Copied from StarReviewVM.)
+        // ---- inverse-zoom overlay bindings ----------------------------------------------------------------
+
         public double MarkerStrokeThickness => 1.5 / Math.Max(StarReviewViewport.MinScale, Viewport.Scale);
         public double MarkerTextScale => 1.0 / Math.Max(StarReviewViewport.MinScale, Viewport.Scale);
-
-        // HFR label one text-height ABOVE the box top (≈15 px on screen at any zoom); reg-id label a small gap BELOW
-        // the box (the per-marker BoxHeight translate puts it at the box bottom; this adds the gap).
         public double HfrLabelOffset => -15.0 * MarkerTextScale;
         public double RegistrationLabelOffset => 3.0 * MarkerTextScale;
 
-        /// <summary>Re-raises the zoom-dependent overlay bindings. The view calls this after any viewport change
-        /// (wheel-zoom, fit, pan) so stroke widths + label sizes track the current scale.</summary>
         public void NotifyViewportChanged() {
             RaisePropertyChanged(nameof(MarkerStrokeThickness));
             RaisePropertyChanged(nameof(MarkerTextScale));
             RaisePropertyChanged(nameof(HfrLabelOffset));
             RaisePropertyChanged(nameof(RegistrationLabelOffset));
         }
+
+        // ---- hover focus graph ----------------------------------------------------------------------------
+
+        private OptimizationCurve hoverCurve;
+        public OptimizationCurve HoverCurve {
+            get => hoverCurve;
+            private set { hoverCurve = value; RaisePropertyChanged(); }
+        }
+
+        private bool showHover;
+        public bool ShowHover {
+            get => showHover;
+            private set { if (showHover != value) { showHover = value; RaisePropertyChanged(); } }
+        }
+
+        private string hoverHeaderText;
+        public string HoverHeaderText {
+            get => hoverHeaderText;
+            private set { hoverHeaderText = value; RaisePropertyChanged(); }
+        }
+
+        private string hoverRSquaredText;
+        public string HoverRSquaredText {
+            get => hoverRSquaredText;
+            private set { hoverRSquaredText = value; RaisePropertyChanged(); }
+        }
+
+        private string hoverOptimalFocusText;
+        public string HoverOptimalFocusText {
+            get => hoverOptimalFocusText;
+            private set { hoverOptimalFocusText = value; RaisePropertyChanged(); }
+        }
+
+        private int? hoverRegistrationId;
+
+        /// <summary>Show the focus graph for the registered star with the given id (no-op if already shown / no curve).</summary>
+        public void SetHover(int registrationId) {
+            if (hoverRegistrationId == registrationId && ShowHover) {
+                return;
+            }
+            if (snapshot?.FocusCurvesByRegistrationId == null ||
+                !snapshot.FocusCurvesByRegistrationId.TryGetValue(registrationId, out var curve)) {
+                ClearHover();
+                return;
+            }
+            hoverRegistrationId = registrationId;
+            HoverCurve = new OptimizationCurve {
+                Label = $"Star {registrationId}",
+                Points = curve.Points,
+                Fit = curve.Fit,
+            };
+            HoverHeaderText = $"Star {registrationId}";
+            HoverRSquaredText = $"R²: {curve.RSquared:0.###}";
+            var offset = curve.OffsetFromMean ?? 0.0;
+            HoverOptimalFocusText = $"Best focus: {curve.BestFocus:0}  (Δ field {offset:+0.#;-0.#;0})";
+            ShowHover = true;
+        }
+
+        public void ClearHover() {
+            hoverRegistrationId = null;
+            ShowHover = false;
+            HoverCurve = null;
+        }
+
+        // ---- legend ---------------------------------------------------------------------------------------
+
+        private IReadOnlyList<StarReviewLegendEntry> legendEntries;
+        public IReadOnlyList<StarReviewLegendEntry> LegendEntries {
+            get => legendEntries;
+            private set { legendEntries = value; RaisePropertyChanged(); }
+        }
+
+        private void RebuildLegend() {
+            LegendEntries = BuildLegend();
+        }
+
+        private IReadOnlyList<StarReviewLegendEntry> BuildLegend() {
+            return new List<StarReviewLegendEntry> {
+                new() { Brush = AcceptedBrush, Caption = "Accepted (focus fit)", Dashed = false },
+                new() { Brush = RegisteredNoFitBrush, Caption = "Registered, no focus fit", Dashed = false },
+                new() { Brush = UnregisteredBrush, Caption = "Not registered", Dashed = false },
+                new() { Brush = HfrBrush, Caption = "HFR", Dashed = false },
+                new() { Brush = RegistrationBrush, Caption = "Registration ID & marker", Dashed = false, Enabled = ShowRegistration },
+                new() { Brush = RegistrationTargetBrush, Caption = "Registration target (aligned)", Dashed = false, Enabled = ShowRegistration },
+                new() { Brush = FocusOffsetBrush, Caption = "Best-focus offset from field mean", Dashed = false, Enabled = ShowFocusOffset },
+            };
+        }
+
+        // ---- frame loading --------------------------------------------------------------------------------
 
         private void Prev() {
             if (CurrentIndex > 0) {
@@ -193,8 +324,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         }
 
         private void LoadCurrent(bool fit) {
-            var frames = snapshot?.Frames;
+            ClearHover();
             Markers.Clear();
+            var frames = snapshot?.Frames;
             if (frames == null || frames.Count == 0) {
                 FrameImage = null;
                 FrameHeader = string.Empty;
@@ -224,65 +356,39 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             }
         }
 
-        private static FrameReviewMarker BuildMarker(FrameReviewStar s) {
+        private FrameReviewMarker BuildMarker(FrameReviewStar s) {
+            var boxBrush = s.RegistrationState switch {
+                FrameReviewRegistrationState.MatchedWithFit => AcceptedBrush,
+                FrameReviewRegistrationState.MatchedNoFit => RegisteredNoFitBrush,
+                _ => UnregisteredBrush,
+            };
             return new FrameReviewMarker {
                 BoxX = s.BoxX,
                 BoxY = s.BoxY,
                 BoxWidth = s.BoxWidth,
                 BoxHeight = s.BoxHeight,
+                BoxBrush = boxBrush,
                 HfrText = FormatHfr(s.Hfr),
+                CenterX = s.CenterX,
+                CenterY = s.CenterY,
+                TargetX = s.TargetX,
+                TargetY = s.TargetY,
+                HasRegistrationId = s.RegistrationId != null,
                 RegistrationIdText = s.RegistrationId?.ToString() ?? "—",
-                HasArrow = s.HasArrow,
-                ArrowStartX = s.OriginalX,
-                ArrowStartY = s.OriginalY,
-                ArrowEndX = s.CenterX,
-                ArrowEndY = s.CenterY,
-                ArrowHead = s.HasArrow ? BuildArrowHead(s.OriginalX, s.OriginalY, s.CenterX, s.CenterY) : null,
+                HasRegistrationLine = s.HasRegistrationLine,
+                FocusOffsetText = FormatOffset(s.FocusOffsetFromMean),
+                HasFocusOffset = s.FocusOffsetFromMean.HasValue,
+                RegistrationId = s.RegistrationId,
+                CanShowFocusGraph = s.RegistrationState == FrameReviewRegistrationState.MatchedWithFit && s.RegistrationId != null,
             };
         }
 
         private static string FormatHfr(double hfr) => double.IsNaN(hfr) || hfr <= 0.0 ? "—" : hfr.ToString("F2");
 
-        // A small filled triangle at the arrow's target end, precomputed in image coords so the XAML needs no rotation
-        // math. Sized in image pixels (scales with the line under zoom — acceptable for a diagnostic overlay).
-        private static PointCollection BuildArrowHead(double sx, double sy, double ex, double ey) {
-            const double headLen = 8.0;
-            const double headWidth = 5.0;
-            var dx = ex - sx;
-            var dy = ey - sy;
-            var len = Math.Sqrt(dx * dx + dy * dy);
-            if (len < 1e-6) {
-                return new PointCollection();
-            }
-            var ux = dx / len;
-            var uy = dy / len;        // unit direction (start -> end)
-            var px = -uy;
-            var py = ux;              // unit perpendicular
-            var baseX = ex - ux * headLen;
-            var baseY = ey - uy * headLen;
-            var pc = new PointCollection {
-                new System.Windows.Point(ex, ey),                                         // tip
-                new System.Windows.Point(baseX + px * headWidth, baseY + py * headWidth),  // base corner 1
-                new System.Windows.Point(baseX - px * headWidth, baseY - py * headWidth),  // base corner 2
-            };
-            pc.Freeze();
-            return pc;
-        }
-
-        private IReadOnlyList<StarReviewLegendEntry> BuildLegend() {
-            var entries = new List<StarReviewLegendEntry> {
-                new() { Brush = AcceptedBrush, Caption = "Accepted star", Dashed = false },
-                new() { Brush = RegistrationBrush, Caption = "Registration ID (— = unmatched)", Dashed = false },
-                new() { Brush = HfrBrush, Caption = "HFR", Dashed = false },
-            };
-            // The arrow only appears when RANSAC alignment was on, so only show its legend row then.
-            if (snapshot?.RansacEnabled == true) {
-                entries.Add(new StarReviewLegendEntry { Brush = ArrowBrush, Caption = "Registration arrow (to target)", Dashed = false });
-            }
-            return entries;
-        }
+        private static string FormatOffset(double? offset) => offset.HasValue ? offset.Value.ToString("+0;-0;0") : string.Empty;
 
         public void Dispose() {
+            ClearHover();
             Markers.Clear();
             FrameImage = null;
             snapshot = null;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVM.cs
@@ -12,6 +12,7 @@
 
 using NINA.Core.Utility;
 using NINA.Joko.Plugins.HocusFocus.Inspection;
+using OxyPlot.Series;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -53,6 +54,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
         /// <summary>True when this star has an accepted focus fit, so hovering it can show a focus graph.</summary>
         public bool CanShowFocusGraph { get; init; }
+    }
+
+    /// <summary>A points-only focus graph for a registered star that has NO accepted hyperbolic fit: just the
+    /// cross-frame (focuser position, HFR) scatter, so the user can see why the fit failed. Rendered by a dedicated
+    /// DataTemplate (no fitted-curve / minimum annotations, which would require a non-null fit).</summary>
+    public sealed class FrameReviewScatterGraph {
+        public string Label { get; init; }
+        public IReadOnlyList<ScatterErrorPoint> Points { get; init; }
     }
 
     /// <summary>
@@ -222,10 +231,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
         // ---- hover focus graph ----------------------------------------------------------------------------
 
-        private OptimizationCurve hoverCurve;
-        public OptimizationCurve HoverCurve {
-            get => hoverCurve;
-            private set { hoverCurve = value; RaisePropertyChanged(); }
+        // Either an OptimizationCurve (fitted: points + curve + minimum) or a FrameReviewScatterGraph (no fit:
+        // cross-frame points only). The hover overlay's ContentControl resolves the right DataTemplate by type.
+        private object hoverContent;
+        public object HoverContent {
+            get => hoverContent;
+            private set { hoverContent = value; RaisePropertyChanged(); }
         }
 
         private bool showHover;
@@ -254,7 +265,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
         private int? hoverRegistrationId;
 
-        /// <summary>Show the focus graph for the registered star with the given id (no-op if already shown / no curve).</summary>
+        /// <summary>Show the focus graph for the registered star with the given id (no-op if already shown / no curve).
+        /// Fitted stars show the curve + R² + best focus; registered-but-unfitted stars show their cross-frame
+        /// points only (so the user can see why the fit failed).</summary>
         public void SetHover(int registrationId) {
             if (hoverRegistrationId == registrationId && ShowHover) {
                 return;
@@ -265,22 +278,31 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
                 return;
             }
             hoverRegistrationId = registrationId;
-            HoverCurve = new OptimizationCurve {
-                Label = $"Star {registrationId}",
-                Points = curve.Points,
-                Fit = curve.Fit,
-            };
             HoverHeaderText = $"Star {registrationId}";
-            HoverRSquaredText = $"R²: {curve.RSquared:0.###}";
-            var offset = curve.OffsetFromMean ?? 0.0;
-            HoverOptimalFocusText = $"Best focus: {curve.BestFocus:0}  (Δ field {offset:+0.#;-0.#;0})";
+            if (curve.Fit != null) {
+                HoverContent = new OptimizationCurve {
+                    Label = $"Star {registrationId}",
+                    Points = curve.Points,
+                    Fit = curve.Fit,
+                };
+                HoverRSquaredText = $"R²: {curve.RSquared:0.###}";
+                var offset = curve.OffsetFromMean ?? 0.0;
+                HoverOptimalFocusText = $"Best focus: {curve.BestFocus:0}  (Δ field {offset:+0.#;-0.#;0})";
+            } else {
+                HoverContent = new FrameReviewScatterGraph {
+                    Label = $"Star {registrationId}",
+                    Points = curve.Points,
+                };
+                HoverRSquaredText = "No accepted focus fit";
+                HoverOptimalFocusText = $"{curve.Points.Count} detection(s) across frames";
+            }
             ShowHover = true;
         }
 
         public void ClearHover() {
             hoverRegistrationId = null;
             ShowHover = false;
-            HoverCurve = null;
+            HoverContent = null;
         }
 
         // ---- legend ---------------------------------------------------------------------------------------
@@ -379,7 +401,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
                 FocusOffsetText = FormatOffset(s.FocusOffsetFromMean),
                 HasFocusOffset = s.FocusOffsetFromMean.HasValue,
                 RegistrationId = s.RegistrationId,
-                CanShowFocusGraph = s.RegistrationState == FrameReviewRegistrationState.MatchedWithFit && s.RegistrationId != null,
+                // Any matched star with a focus curve can be hovered: fitted stars show the curve, registered-but-
+                // unfitted stars show their cross-frame points only.
+                CanShowFocusGraph = s.RegistrationId != null
+                    && snapshot?.FocusCurvesByRegistrationId != null
+                    && snapshot.FocusCurvesByRegistrationId.ContainsKey(s.RegistrationId.Value),
             };
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
@@ -109,6 +109,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         public Brush Brush { get; set; }
         public string Caption { get; set; }
         public bool Dashed { get; set; }
+
+        /// <summary>Whether the feature this row describes is currently active. False ⇒ the row is shown greyed (a
+        /// toggle controlling the feature is off). Defaults true so existing consumers (the Star Review wizard) are
+        /// unaffected.</summary>
+        public bool Enabled { get; set; } = true;
     }
 
     /// <summary>The kind of detector box (if any) found under a click point by <see cref="StarReviewVM.HitTestCandidate(IEnumerable{Rect}, IEnumerable{Rect}, double, double)"/>.</summary>

--- a/plans/frame-review-feedback-plan.md
+++ b/plans/frame-review-feedback-plan.md
@@ -1,0 +1,108 @@
+# Review Frames — Feedback Round 1
+
+## Context
+
+The "Review Frames" diagnostic (PR #88, branch `ghilios/frame-review`) lets a user step through a Sensor Curve Model sweep and see each frame's accepted stars with HFR + registration overlays. After trying it, the user asked for 10 refinements that (a) surface *why* a star did or didn't contribute to the sensor-model fit (registration + focus-fit status per star), (b) make the registration geometry and focus quality directly visible (per-star focus graph on hover, optimal-focus offsets), and (c) fix usability (window too small, summary buried in an in-image HUD, "deg" instead of "°"). 
+
+Two findings shape the work:
+- **Per-star fit data is currently discarded.** `RegisteredStar.Fitting` is declared but never assigned; `SensorModel.FitImages` computes each star's hyperbolic fit (R², best-focus, curve) into locals and throws it away. Items 2/7/8 require persisting it.
+- **Overlays are mis-registered on aligned frames.** The displayed image is the *raw* per-frame bitmap, but `ApplyAlignmentTransform` overwrites each star's `Position`/`BoundingBox` to *reference* coordinates, so with RANSAC on the boxes sit offset from the actual stars. We fix overlays to draw in raw-frame coordinates (item 3).
+
+**Execution note:** On starting execution, copy this plan into the repo at `plans/frame-review-feedback-plan.md` (per CLAUDE.md), branch from the current PR branch `ghilios/frame-review` (continue the same PR #88, or a stacked branch if preferred), and run the suite via Windows dotnet: `dotnet.exe test 'C:\Users\ghili\src\nina.plugins\Joko.NINA.Plugins\Joko.NINA.Plugins.sln' -c Debug --nologo`.
+
+### Decisions already made with the user
+- **Item 3 target** = the star's *aligned* `Position` (registration displacement); overlays drawn in raw-frame coords.
+- **Item 8** = per-star **offset from the field-mean** best-focus (e.g. "+18"), legend-colored text label, toggle off by default.
+- **Item 7 overlay** = a **fixed corner panel** (never clipped), reusing the existing `OptimizationCurve` OxyPlot DataTemplate.
+
+---
+
+## Step 1 — Persist per-star data (enabling change)
+
+**`StarDetection/HocusFocusStarDetection.cs`** (`HocusFocusDetectedStar`, ~line 210): add
+`public System.Drawing.Rectangle OriginalBoundingBox { get; set; }` next to `OriginalPosition`.
+
+**`Inspection/SensorModel.cs`**:
+- ~line 407 (the pre-alignment brightness loop, right after `star.OriginalPosition = star.Position;`): add `star.OriginalBoundingBox = star.BoundingBox;`. This is the one place that runs for every star before `ApplyAlignmentTransform`, so it captures the raw box.
+- `RegisteredStar.Fitting` (~line 1317): widen the field type `HyperbolicFittingAlglib` → `AlglibHyperbolicFitting` (superclass; matches `OptimizationCurve.Fit`). **Verify zero existing readers** (grep `.Fitting` on RegisteredStar — exploration found none).
+- `FitImages` `Parallel.For` body: insert `registeredStar.Fitting = fitting;` **between line 724 and 726** — i.e. only on the success path, after both discard gates (`!solveResult || fitting == null` at 714, and `RSquared < PerStarAcceptableRSquared` at 720). This makes `RegisteredStar.Fitting != null` an exact proxy for **MatchedWithFit**, leaves the surface-fit discard logic untouched, and is race-free (each iteration writes a distinct `registeredStar`).
+- Make `EstimateHfrStdDev` (~line 589) `internal static` so the snapshot builder can reconstruct faithful error bars for the hover chart (same assembly).
+
+**Risk to verify during execution:** confirm the `registeredStars` array `FitImages` mutates is the same one that flows into `SensorModel.SensorModelResult.RegisteredStars` (the brightness-search loop keeps `bestReg`). If `FitImages` runs per brightness-iteration on different arrays, ensure the winning array's objects carry `Fitting`.
+
+## Step 2 — Snapshot DTOs + builder + tests (`Inspection/FrameReviewSnapshot.cs`)
+
+Extend the DTOs (keep init-only, immutable, disposal-safe):
+- `enum FrameReviewRegistrationState { Unmatched, MatchedNoFit, MatchedWithFit }`.
+- `FrameReviewStar`: box coords now from **`OriginalBoundingBox`** + center from **`OriginalPosition`** (raw); add `TargetX/TargetY` (the aligned `Position`), `RegistrationState`, `double? FocusOffsetFromMean`. Keep `RegistrationId`, `HasArrow`→rename to `HasRegistrationLine` (= `ransacEnabled && !IsReference && RegistrationId != null && (TargetX/Y != raw center)`).
+- New `FrameReviewFocusCurve` DTO: `int RegistrationId`, `AlglibHyperbolicFitting Fit`, `IReadOnlyList<ScatterErrorPoint> Points`, `double RSquared`, `double BestFocus`, `double? OffsetFromMean`.
+- `FrameReviewSnapshot`: add `IReadOnlyDictionary<int, FrameReviewFocusCurve> FocusCurvesByRegistrationId` (one per matched-with-fit registered star, shared across frames).
+
+`FrameReviewSnapshotBuilder.Build`:
+- Map each accepted star's `RegistrationState`: `Unmatched` if `RegistrationId == null`; else read `registeredStars[id].Fitting` — `MatchedWithFit` if non-null, `MatchedNoFit` otherwise.
+- Compute **field-mean best-focus** = mean of `registeredStars[*].Fitting.Minimum.X` over all matched-with-fit stars; per-star `FocusOffsetFromMean = Fitting.Minimum.X - mean` (focuser steps; null for non-fitted).
+- Build `FocusCurvesByRegistrationId`: for each matched-with-fit registered star, `Points` from `MatchedStars.Select(s => new ScatterErrorPoint(s.FocuserPosition, s.Star.HFR, 0, EstimateHfrStdDev(s.Star)))`, `Fit = registeredStars[id].Fitting`, plus `RSquared`/`BestFocus`/`OffsetFromMean`.
+- Transform text: add a Review-specific `FrameReviewTransformFormatter.Format(Matrix3x2)` mirroring `ToFullString` but emitting **`°`** (degree symbol). **Do NOT edit `Matrix3x2.ToFullString`** (3 other callers depend on it). Call it from the builder.
+
+**Tests** (`Tests/Inspection/FrameReviewSnapshotBuilderTests.cs`):
+- *Change*: the transform-text test → assert the new formatter + `°`; the box-coords + immutability tests → set/assert `OriginalBoundingBox` (raw) rather than the transformed box.
+- *Add*: registration-state mapping (unmatched / matched-no-fit / matched-with-fit), `FocusOffsetFromMean` (signed offset vs computed mean), target = aligned `Position`, focus-curve population (one per fitted star, points + RSquared), formatter `°`. Constructing a real `AlglibHyperbolicFitting` for "with-fit" needs an alglib solve — check for an existing test helper / `IAlglibAPI` fake; if none, fit a tiny synthetic point set.
+
+## Step 3 — `FrameReviewVM`
+
+- Toggles (default **false**): `bool ShowRegistration`, `bool ShowFocusOffset` (raise PropertyChanged + re-evaluate marker/legend visibility on change).
+- New frozen brushes: `RegisteredNoFitBrush` (red, e.g. `#FF5252`), `UnregisteredBrush` (grey, e.g. `#9E9E9E`), `FocusOffsetBrush` (violet, e.g. `#E040FB`). Keep AcceptedBrush green / RegistrationBrush cyan / ArrowBrush orange.
+- `FrameReviewMarker`: raw `BoxX/Y/Width/Height`; `Brush BoxBrush` (green/red/grey per `RegistrationState`); `RegistrationIdText`; `HasRegistrationLine` + `CenterX/Y` (raw, cyan "+") and `TargetX/Y` (aligned, orange "+"); `FocusOffsetText` (e.g. "+18"/"−12"/""). Drop the old `ArrowHead`.
+- Hover: `OptimizationCurve HoverCurve`, `string HoverRSquaredText`, `string HoverOptimalFocusText`, `bool ShowHover`; `SetHover(int registrationId)` (looks up `snapshot.FocusCurvesByRegistrationId`, builds/owns an `OptimizationCurve { Points, Fit }`, sets R² + optimal-focus text) and `ClearHover()`.
+- Header summary props already exist (`DetectedCountText`, `ReferenceNote`, `TransformText`) — keep; they move to the header in the View.
+- Legend: extend `StarReviewLegendEntry` (StarReviewVM.cs) with `bool Enabled { get; set; } = true` (additive; StarReview wizard unaffected). Rebuild `LegendEntries` (raise PropertyChanged; drop init-only) on toggle change, setting `Enabled` per toggle: rows = Accepted(fit)/RegisteredNoFit/Unregistered (always enabled) + Registration ID & path (cyan) + Registration target (orange) [enabled = ShowRegistration] + Best-focus offset (violet) [enabled = ShowFocusOffset].
+
+## Step 4 — `FrameReviewControl.xaml(.cs)`
+
+- **Header (item 5):** add a summary header above the image (extend the row-0 area) showing `FrameHeader` + `PositionLabel` + `DetectedCountText` + `ReferenceNote` + wrapped `TransformText`. **Delete the in-image HUD `Border`.**
+- **Overlays in raw coords (item 3):** box layer `Stroke="{Binding BoxBrush}"`; replace the arrow layer with: a cyan "+" at `CenterX/Y`, an orange `Line` (`CenterX/Y`→`TargetX/Y`) + orange "+" at `TargetX/Y`. Render each "+" as two short crossing `Line`s (or a `Path`) sized constant on-screen via the inverse-zoom `MarkerTextScale`. Gate the reg-id label + the cyan/orange "+" + line on `ShowRegistration` (BoolToVis). Add a `FocusOffsetText` label (violet) near the box, gated on `ShowFocusOffset`.
+- **Hover graph (item 7):** a fixed-corner overlay `Border` (top-right of the image area, sibling of the image Border so it isn't clipped), visible on `ShowHover`, containing `<ContentControl Content="{Binding HoverCurve}"/>` (resolves the existing `OptimizationCurve` OxyPlot template) + TextBlocks for `HoverRSquaredText` and `HoverOptimalFocusText`. In code-behind `MouseMove` (currently pan-only): when not panning, map cursor via `Vm.Viewport.ScreenToImage`, hit-test `Vm.Markers` (smallest-area `Contains`, only `MatchedWithFit`); call `Vm.SetHover(id)` or `ClearHover()`. Wire the Canvas `MouseLeave` to `ClearHover()`.
+- **Toggles (item 4, 8) + greyed legend (item 9):** under the legend add two checkboxes — "Show registration" and "Show optimal-focus offset" (both bound to the VM toggles). In the legend `ItemTemplate`, add an `Opacity` DataTrigger on `Enabled == false` → `0.4` (greys disabled rows).
+- **OxyPlot availability:** add `xmlns:oxy="clr-namespace:OxyPlot.Wpf;assembly=OxyPlot.Contrib.Wpf"` if directly referencing `<oxy:Plot>`; preferred is the `ContentControl`+implicit-template route (no xmlns needed) — but the `OptimizationCurve` template lives in `StarDetection/Optimization/DataTemplates.xaml`; confirm it's in scope for `FrameReviewControl` (it is the same merged dictionary the control's own template is registered in; if resolution fails, add a `MergedDictionaries` ref or move the template).
+- **Larger window (item 10):** in `StarDetection/Optimization/DataTemplates.xaml`, wrap the `FrameReviewVM` template content in a root with the wizard's `Grid.Style` size idiom — set ~`Width=1280`, `MinHeight=860` (resizable, `WindowStyle.SingleBorderWindow`).
+
+## Critical files
+
+| File | Change |
+|---|---|
+| `StarDetection/HocusFocusStarDetection.cs` | `OriginalBoundingBox` on `HocusFocusDetectedStar` |
+| `Inspection/SensorModel.cs` | capture raw bbox (~407); widen + assign `RegisteredStar.Fitting` (~724); `EstimateHfrStdDev` internal |
+| `Inspection/FrameReviewSnapshot.cs` | DTO extensions, registration-state + offset + focus-curve + `°` formatter |
+| `StarDetection/Optimization/Review/FrameReviewVM.cs` | toggles, brushes, marker fields, hover (`OptimizationCurve`), legend `Enabled` |
+| `StarDetection/Optimization/Review/FrameReviewControl.xaml(.cs)` | header, raw-coord overlays, plus/line, hover overlay, toggles, greyed legend, hover hit-test |
+| `StarDetection/Optimization/DataTemplates.xaml` | larger default size on the `FrameReviewVM` template |
+| `StarDetection/Optimization/Review/StarReviewVM.cs` | add `StarReviewLegendEntry.Enabled` (additive) |
+| `Tests/Inspection/FrameReviewSnapshotBuilderTests.cs` | update 3, add ~9 tests |
+
+## Sequencing
+
+1. Step 1 (SensorModel/star) → build.
+2. Step 2 (snapshot + tests) → **green before any UI**.
+3. Step 3 (VM) → build.
+4. Step 4 (XAML/code-behind) → full build + suite.
+
+## Verification
+
+- **Unit:** `dotnet.exe test … --filter FrameReviewSnapshotBuilderTests` green, then full suite (expect ~1410+ pass, 0 fail).
+- **Manual in NINA:** enable Sensor Curve Model + "Keep frames for Review"; run a Detailed Analysis; open Review Frames and confirm:
+  - Boxes sit *on* the stars on a RANSAC-aligned non-reference frame (raw-coord fix); box colors = green (fit) / red (registered, no fit) / grey (unregistered).
+  - "Show registration" off by default; toggling on shows reg-id labels + cyan "+" at star centers + orange line/"+" to the aligned target. Reference frame: no lines.
+  - Header above the image shows detected count + transform with a "°" symbol; no in-image HUD.
+  - Hovering a green (matched-with-fit) star pops the corner focus-graph overlay with the hyperbola + points + R² + optimal focus; moving off / leaving clears it.
+  - "Show optimal-focus offset" off by default; on → violet "+N/−N" labels per fitted star.
+  - Legend rows for disabled toggles are greyed; window opens large and resizes.
+  - Toggle RANSAC off + rerun → reg-id still computed, no lines/target; everything else intact.
+
+## Risks
+
+- **`FitImages` array identity** (Step 1) — verify the mutated `registeredStars` is the one surfaced in `SensorModelResult.RegisteredStars`.
+- **OxyPlot template scope** in the separate UserControl — fall back to `MergedDictionaries` if the implicit `OptimizationCurve` template doesn't resolve.
+- **Legend greying** needs `LegendEntries` to rebuild on toggle (no longer init-only).
+- **Reference / non-RANSAC frames** (`Position == OriginalPosition`) must still render boxes with no registration line — existing builder tests guard this; keep them green.
+- **`°` test** — update the equality assertion to the new formatter, not `ToFullString`.
+- **Hover scatter points** reconstructed from `MatchedStars` (pre-regularization) — the fitted curve is exact; dot positions are diagnostic-acceptable.

--- a/plans/frame-review-plan.md
+++ b/plans/frame-review-plan.md
@@ -1,0 +1,210 @@
+# Aberration Inspector — "Review Frames" Diagnostic Preview
+
+## Context
+
+The Aberration Inspector runs an autofocus sweep, detects stars across the full sensor in each
+frame, registers those stars across frames, and fits a sensor model (tilt + field curvature). When
+the model fit looks wrong, the user currently has no in-app way to see *why* — whether a frame had
+too few stars, bad HFRs, or a registration that mis-aligned frames. Today the only visual diagnostic
+is a set of TIFF files written to disk (`InspectorVM.SaveRegisteredImage`), and only when saving.
+
+This feature adds a **"Review Frames"** button that opens a modal dialog showing, one frame at a
+time: the frame image with its **accepted** detected stars overlaid, two text labels per star (a
+**registration identifier** and the **HFR**, in different colors), the **number of detected stars**,
+and — when RANSAC alignment was enabled — the **transformation details** (scale/rotation/translation)
+plus **arrows from each star to its registered target location**. A right-side **legend** explains
+the markers, mirroring the existing Star Review labeling UI. Goal: let the user visually diagnose
+data-quality issues that impact the sensor-model fit.
+
+### Confirmed product decisions
+1. **Requires the Sensor Curve Model to be enabled** — Review reuses the full-sensor per-frame data
+   and cross-frame registration that path already computes; no new detection/registration plumbing.
+2. **New persisted toggle `FrameReviewEnabled`** (default OFF, in the profile). Its job is to force
+   per-frame image retention so review works even on non-saving runs. The button is enabled only if
+   the toggle was ON before the run **and** a sensor-model run completed with retained frames.
+3. **Annotate all accepted detected stars** — every accepted (non-rejected) star shows its HFR; the
+   registration-identifier shows the registered-star index where matched across frames, else **"—"**.
+4. **Two labels per star in different colors** + a right-side legend (reuse `StarReviewLegendEntry`).
+5. **Modal dialog window**, opened via NINA's window service (same mechanism as the optimizer wizard).
+
+## Key findings driving the design (verified)
+- Per-frame data lives in `InspectorVM.FullSensorDetectedStars` (`List<SensorDetectedStars>`,
+  ~line 1492), populated for **region index 6 only** (`AutoFocusEngine_SubMeasurementPointCompleted`
+  ~1211), and region 6 is added **only when the Sensor Curve Model is enabled** (`GetStarDetectionRegions`
+  ~1187). `SensorModel.UpdateModel(...)` (called at ~497) runs only under `sensorCurveModelEnabled` (~485).
+- `SensorDetectedStars` (`Inspection/SensorModel.cs` ~36-56): `FocuserPosition`,
+  `StarDetectionResult` (`.StarList` = accepted stars; `.AverageHFR`), `Image` (`IRenderedImage`;
+  `.Image` is a display-ready, frozen `BitmapSource`), `HasBeenAligned`, `AlignmentTransform`
+  (`RANSACRegistration.Matrix3x2?`).
+- **Image retention is the memory cost the toggle gates.** `AutoFocusEngine` keeps the per-frame image
+  only when `options.PreserveExposures` (AutoFocusEngine.cs ~641); `GetAutoFocusEngineOptions`
+  (InspectorVM.cs ~1006) currently sets that true only when `options.Save`.
+- Registration results after a run: `SensorModel.SensorModelResult.RegisteredStars` (`RegisteredStar[]`),
+  `SensorModel.ReferenceImage` (int). `RegisteredStar.MatchedStars` is `List<MatchedStar>`;
+  `MatchedStar` has `ImageIndex` and `Star` (`HocusFocusDetectedStar`). **`MatchedStar.Star` is the
+  same object reference as the `StarList` entry** (`SensorModel.MatchStarsUsingKdTree` ~1196-1210) —
+  so a reference-identity dictionary maps each accepted star to its registered-star index. The index
+  in `RegisteredStars` is the registration identifier and is stable for the same physical star across
+  frames. Registration (and thus IDs) is computed **even when RANSAC is off**; RANSAC only controls
+  whether frames are aligned (arrows/transform meaningful).
+- Arrow endpoints: each star's `OriginalPosition` (raw detection) is the start; `Position` (overwritten
+  to the transformed target by `ApplyAlignmentTransform` ~871-885) is the end. Reference frame keeps
+  identity (`Position == OriginalPosition`) → no arrow. Transform text via
+  `RANSACRegistration.Matrix3x2.ToFullString()` (~949). RANSAC flag: `IInspectorOptions.UseRANSAC`.
+- **Reusable Star Review assets** (`StarDetection/Optimization/Review/`): `StarReviewViewport.cs` (pure,
+  unit-tested zoom/pan + screen↔image math — reuse verbatim); `StarReviewLegendEntry` (legend row type);
+  the Image+Canvas overlay structure + inverse-zoom bindings in `StarReviewControl.xaml(.cs)` (fork,
+  stripped to read-only). `StarReviewImaging` is **not** needed (the image is already a `BitmapSource`).
+- **Hosting**: `windowService.ShowDialog(vm, title, ResizeMode.CanResize, WindowStyle.SingleBorderWindow)`
+  presents the VM in a `ContentPresenter` resolved by an **implicit `DataType` DataTemplate** in the
+  exported `StarDetection/Optimization/DataTemplates.xaml` (see the wizard at lines 92-93). InspectorVM
+  has `applicationDispatcher` (line 92) and uses CommunityToolkit `RelayCommand`; it must construct its
+  own `new WindowServiceFactory()` (not injected; mirrors `HocusFocusPlugin`).
+
+---
+
+## Implementation
+
+### 1. New persisted option `FrameReviewEnabled`
+- `Interfaces/IInspectorOptions.cs`: add `bool FrameReviewEnabled { get; set; }` (after `SaveAlignmentImages`).
+- `AutoFocus/InspectorOptions.cs`: clone the `SaveAlignmentImages` boolean pattern — backing field +
+  property with `optionsAccessor.SetValueBoolean(nameof(FrameReviewEnabled), …)` in the setter,
+  `frameReviewEnabled = optionsAccessor.GetValueBoolean(nameof(FrameReviewEnabled), false)` in
+  `InitializeOptions()`, and `FrameReviewEnabled = false;` in `ResetDefaults()`.
+- **Update every `IInspectorOptions` implementer in the Tests project** (grep `: IInspectorOptions`) with
+  a `public bool FrameReviewEnabled { get; set; }` auto-prop, or the suite won't compile.
+- **UI control (project invariant)** — `AutoFocus/DataTemplates.xaml` inspector options sub-panel
+  (~1819-1844, the `SaveImagesOnReruns`/`SaveAlignmentImages` rows): add a "Keep frames for Review" label
+  + checkbox bound to `InspectorOptions.FrameReviewEnabled`, `IsEnabled` bound to
+  `InspectorOptions.SensorCurveModelEnabled` (the dependency). Add a tooltip resource explaining the
+  memory cost + Sensor-Curve-Model requirement. Add one `<RowDefinition Height="Auto"/>` to the grid.
+
+### 2. Snapshot DTOs + builder — new file `Inspection/FrameReviewSnapshot.cs`
+Pure POCOs + a static builder in the `Inspection` namespace (no WPF dependency in the builder logic →
+unit-testable; it may reference `System.Windows.Media.Imaging.BitmapSource` only as a carried value).
+- `FrameReviewStar`: `CenterX/Y` (= `Position`), `BoxX/Y/Width/Height` (from `BoundingBox`), `Hfr`,
+  `int? RegistrationId` (null ⇒ unmatched), `OriginalX/Y`, `bool HasArrow`.
+- `FrameReviewFrame`: `ImageIndex`, `FocuserPosition`, `bool IsReference`, `string TransformText`
+  (`ToFullString()` or "" for reference/non-RANSAC), `int DetectedStarCount`, `BitmapSource Image`
+  (= `SensorDetectedStars.Image.Image`), `IReadOnlyList<FrameReviewStar> Stars`.
+- `FrameReviewSnapshot`: `bool RansacEnabled`, `int ReferenceImageIndex`, `IReadOnlyList<FrameReviewFrame> Frames`.
+- `FrameReviewSnapshotBuilder.Build(allDetectedStars, registeredStars, referenceImageIndex, ransacEnabled)`:
+  - Build `Dictionary<HocusFocusDetectedStar,int>` keyed by **`ReferenceEqualityComparer.Instance`** from
+    `registeredStars[i].MatchedStars` → `i`.
+  - Drop frames whose `Image`/`Image.Image` is null; order surviving frames by `FocuserPosition`.
+  - Per accepted `HocusFocusDetectedStar` in `StarList`: copy primitives into a `FrameReviewStar`,
+    `RegistrationId` from the map (else null), `HasArrow = ransacEnabled && !isReference && Position≠OriginalPosition`.
+  - Copy only primitives + the frozen `BitmapSource` reference → snapshot is immutable against later
+    star mutation. (Use plain `{ get; set; }` if `init`/`IsExternalInit` isn't already used in the project.)
+
+### 3. Capture + command wiring in `AutoFocus/InspectorVM.cs`
+- **Force retention** (~1006): `if (options.Save || (inspectorOptions.FrameReviewEnabled &&
+  inspectorOptions.SensorCurveModelEnabled)) { options.PreserveExposures = true; }`.
+- **Freeze the per-run decision**: set `frameReviewRequestedForRun = inspectorOptions.FrameReviewEnabled
+  && inspectorOptions.SensorCurveModelEnabled;` immediately before the `RunWithRegions`/`RerunWithRegions`
+  call so a mid-run toggle change can't desync retention from snapshot.
+- **Build the snapshot** at the end of the `if (sensorCurveModelEnabled)` block in `AnalyzeAutoFocusResult`
+  (just after `SaveRegisteredImages`, ~514), guarded by `frameReviewRequestedForRun`, from
+  `FullSensorDetectedStars`, `SensorModel.SensorModelResult.RegisteredStars`, `SensorModel.ReferenceImage`,
+  `inspectorOptions.UseRANSAC`. Store in a `private FrameReviewSnapshot reviewSnapshot` field. This point
+  runs after `UpdateModel` applied transforms, so `Position`/`OriginalPosition`/`BoundingBox` are final.
+- **Availability + command**: `public bool ReviewFramesAvailable => reviewSnapshot?.Frames.Count > 0;`
+  and `public RelayCommand ReviewFramesCommand` (`canExecute: () => ReviewFramesAvailable`), declared near
+  the other commands (~1483) and initialized in the ctor (~175-182).
+- After building the snapshot, marshal via `applicationDispatcher` (background thread): raise
+  `ReviewFramesAvailable` and call `ReviewFramesCommand.NotifyCanExecuteChanged()`.
+- **Clear** `reviewSnapshot = null` (+ raise/notify) in `ClearAnalysis()` (run start, ~1421) and
+  `ClearAnalyses()` (button, ~2102).
+- **`ShowFrameReview()`** (private; model on `HocusFocusPlugin.OptimizeStarDetection` ~156-201): construct
+  `new FrameReviewVM(reviewSnapshot)`, `new WindowServiceFactory().Create()`, wire `vm.RequestClose →
+  windowService.Close()` and `windowService.OnClosed → vm.Dispose()`, then
+  `windowService.ShowDialog(vm, "Review Frames", ResizeMode.CanResize, WindowStyle.SingleBorderWindow)`.
+
+### 4. New VM — `StarDetection/Optimization/Review/FrameReviewVM.cs`
+`BaseINPC`, `IDisposable`, exposes `event EventHandler RequestClose` and `event EventHandler FitRequested`.
+Read-only fork of `StarReviewVM` (drops all labeling/undo). Reuses `StarReviewViewport` and `StarReviewLegendEntry`.
+- ctor `(FrameReviewSnapshot snapshot)`: store snapshot, `Viewport = new StarReviewViewport()`, build
+  `LegendEntries`, `PrevCommand`/`NextCommand`/`FitCommand`/`CloseCommand`, `CurrentIndex = 0`, `LoadCurrent(fit:true)`.
+- Properties: `CurrentIndex`, `PositionLabel` ("3 / 12"), `BitmapSource FrameImage`, `ImageWidth/Height`,
+  `FrameHeader`, `DetectedCountText`, `ReferenceNote`, `TransformText`, `bool ShowTransform`,
+  `StarReviewViewport Viewport`, `ObservableCollection<FrameReviewMarker> Markers`,
+  `IReadOnlyList<StarReviewLegendEntry> LegendEntries`.
+- Inverse-zoom bindings copied from `StarReviewVM` (~275-321): `MarkerStrokeThickness`, `MarkerTextScale`,
+  `HfrLabelOffset` (HFR label **above** box), plus a `RegistrationLabelOffset` (reg-id label **below** box);
+  `NotifyViewportChanged()` re-raises them.
+- `FrameReviewMarker` (image-pixel coords, all primitives): box geometry, `RegistrationIdText` ("12"/"—"),
+  `HfrText` ("2.34"/"—"), `bool HasArrow`, `ArrowStartX/Y` (= OriginalPosition), `ArrowEndX/Y` (= Position),
+  and a precomputed `PointCollection ArrowHead` (small triangle at the target end, so XAML needs no rotation math).
+- Frozen brushes: reg-id = cyan `#00E5FF`, HFR = yellow `#FFD700`, accepted box = green `#00FF00`,
+  arrow = orange `#FF8C00`. `LegendEntries`: Accepted star / Registration ID (— = unmatched) / HFR /
+  Registration arrow (target).
+- `LoadCurrent(bool fit)`: set header/count/reference/transform/image, rebuild `Markers` from the frame's
+  `Stars`, raise `ShowTransform`, update `Prev/Next` CanExecute; `Next`/`Prev` use `fit:false` (preserve zoom).
+- `Dispose()`: drop snapshot + collections so the retained `BitmapSource`s become collectible.
+
+### 5. New View + host
+- `StarDetection/Optimization/Review/FrameReviewControl.xaml(.cs)` — read-only fork of `StarReviewControl`:
+  header + `PositionLabel`; toolbar (`Fit`, `◀ Prev`, `Next ▶`, right-aligned `Close`); the Image + a
+  `ViewportCanvas` with the shared `TransformGroup` (`ScaleTransform` + `TranslateTransform`); a
+  `<Image Source="{Binding FrameImage}" Stretch="None" BitmapScalingMode="NearestNeighbor"/>`. Two overlay
+  `ItemsControl`s bound to `Markers`:
+  1. star layer — green `Rectangle` (box) + HFR `TextBlock` (yellow, above) + reg-id `TextBlock` (cyan,
+     below), all with inverse-zoom `ScaleTransform` and `IsHitTestVisible="False"`, faint `#B0000000` bg;
+  2. arrow layer (container at canvas origin) — `Line` (`ArrowStart→ArrowEnd`) + `Polygon` (`ArrowHead`),
+     orange, `Visibility` from `HasArrow` via `BooleanToVisibilityConverter`.
+  A HUD `Border` **outside** the RenderTransform shows `DetectedCountText`, `ReferenceNote`, and (when
+  `ShowTransform`) `TransformText`. Right-column legend `StackPanel` bound to `LegendEntries` (copied from
+  `StarReviewControl`). Code-behind: copy only the read-only viewport plumbing (`OnDataContextChanged`,
+  `OnFitRequested`/`ApplyViewport`, `UpdateScrollBars`, scroll handlers, `MouseWheel` zoom, right-drag pan,
+  `SizeChanged` re-fit, Left/Right/F keys). No labeling/drag/undo handlers.
+- Register the implicit template in `StarDetection/Optimization/DataTemplates.xaml` (xmlns:review exists,
+  line 8) near the wizard template (~93):
+  `<DataTemplate DataType="{x:Type review:FrameReviewVM}"><review:FrameReviewControl/></DataTemplate>`.
+- Add the **"Review Frames" button** to the inspector button bar in `AutoFocus/DataTemplates.xaml`
+  (~1157-1318), `Command="{Binding ReviewFramesCommand}"`, `IsEnabled="{Binding ReviewFramesAvailable}"`
+  (clone an existing button; the Clear Analyses button ~1299-1318 shows the pattern).
+
+### 6. Cross-cutting
+- No new MEF exports. Declare `<BooleanToVisibilityConverter x:Key="BoolToVis"/>` locally in the new
+  control (as `StarReviewControl.xaml:7` does); no new converter classes.
+- Threading: snapshot is built on the analysis background task (only reads computed data + copies frozen
+  bitmap refs); marshal the `RaisePropertyChanged`/`NotifyCanExecuteChanged` via `applicationDispatcher`.
+  `ShowFrameReview` runs on the dispatcher (RelayCommand); `WindowService` handles window creation.
+
+## Critical files
+| File | Change |
+|---|---|
+| `Interfaces/IInspectorOptions.cs`, `AutoFocus/InspectorOptions.cs` | new `FrameReviewEnabled` option |
+| `Inspection/FrameReviewSnapshot.cs` *(new)* | snapshot DTOs + `FrameReviewSnapshotBuilder` |
+| `AutoFocus/InspectorVM.cs` | force `PreserveExposures`; capture/clear snapshot; `ReviewFramesCommand` + `ShowFrameReview` |
+| `StarDetection/Optimization/Review/FrameReviewVM.cs` *(new)* | read-only review VM (reuses `StarReviewViewport`, `StarReviewLegendEntry`) |
+| `StarDetection/Optimization/Review/FrameReviewControl.xaml(.cs)` *(new)* | read-only forked viewer + overlays + legend |
+| `StarDetection/Optimization/DataTemplates.xaml` | implicit `DataTemplate` for `FrameReviewVM` |
+| `AutoFocus/DataTemplates.xaml` | "Keep frames for Review" checkbox + "Review Frames" button |
+| Tests `IInspectorOptions` fakes | add `FrameReviewEnabled` |
+
+## Verification
+- **Unit tests** (`Tests/Inspection/FrameReviewSnapshotBuilderTests.cs`): reference-identity ID mapping
+  (same physical star → same ID across frames); unmatched → null/"—"; arrow gating (off when RANSAC
+  disabled / reference frame; on with start=OriginalPosition, end=Position otherwise); reference-frame
+  flag + transform text empty for reference; null-image frames dropped; frames ordered by focuser
+  position; snapshot immutable after source mutation. Add a `FrameReviewEnabled` round-trip case to the
+  existing options tests. Run: `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`.
+- **Manual in NINA**: enable Sensor Curve Model + "Keep frames for Review" (verify the checkbox is
+  disabled when Sensor Curve Model is off). Run a non-saving Detailed Analysis → "Review Frames" enables.
+  Open it: modal dialog, one frame at a time, accepted-star boxes, cyan reg-id + yellow HFR labels, star
+  count + transform in the HUD, orange arrows on non-reference frames (RANSAC on), "Reference frame" note
+  with no arrows/transform on the reference, legend present; Prev/Next/Fit/wheel-zoom/pan/Close work.
+  Toggle RANSAC off and rerun → labels remain, no arrows/transform. Run with the toggle OFF → button stays
+  disabled. Clear Analyses / start a new run → button disables and snapshot clears.
+
+## Risks / edge cases
+- **Reference frame**: identity transform → no arrows, empty transform text, "Reference frame" note.
+- **RANSAC disabled**: IDs still computed (matching still runs); all `HasArrow=false`, `TransformText=""`;
+  optionally hide the arrow legend row when `!RansacEnabled`.
+- **Unmatched stars**: `RegistrationId=null` → "—"; HFR still shown.
+- **Null images / all frames dropped**: `Frames.Count==0` → button stays disabled.
+- **Memory**: snapshot holds references to the *same* frozen bitmaps the engine already kept (no copies);
+  `Dispose()` + clearing on new run/ClearAnalyses release them; tooltip documents the cost.
+- **Two-label overlap** at dense fields: labels are constant on-screen (inverse-zoom), one above/one below
+  — acceptable for a diagnostic view (matches Star Review).


### PR DESCRIPTION
## Summary
Adds a **Review Frames** modal to the Aberration Inspector so the user can visually diagnose why a Sensor Curve Model fit looks wrong. It shows each sweep frame one at a time with the accepted detected stars overlaid:
- green bounding box per accepted star,
- **HFR** (yellow, above the box) and the cross-frame **registration id** (cyan, below; `—` when unmatched),
- detected-star count + reference-frame note in a HUD,
- when RANSAC alignment is on: the per-frame scale/rotation/translation transform and an orange **arrow** from each star's raw detection to its registered target.

### How it works
- **New persisted toggle `FrameReviewEnabled`** (default off, enabled only when the Sensor Curve Model is on). Its job is to force per-frame image retention (`PreserveExposures`) so review works even on non-saving runs. Surfaced as a "Keep frames for Review" checkbox in the inspector options.
- **`FrameReviewSnapshotBuilder`** (pure, unit-tested) turns the full-sensor per-frame detections + cross-frame registration into an immutable snapshot. Registration ids are recovered by **reference identity** (`MatchedStar.Star` is the same object as the frame's `StarList` entry). Copies only primitives + the frozen `BitmapSource`, so it's immutable against later star mutation.
- **`InspectorVM`** builds the snapshot at the end of a sensor-model run; the decision is frozen in `GetAutoFocusEngineOptions` (atomically with the retention decision) so it applies to all three run/rerun paths and a mid-run toggle change can't desync. Exposes `ReviewFramesCommand`/`ReviewFramesAvailable`; clears the snapshot on new run and Clear Analyses.
- **`FrameReviewVM` + `FrameReviewControl`** are a read-only fork of the Star Review viewer (zoom/pan/fit, no labeling/undo), reusing `StarReviewViewport` and `StarReviewLegendEntry`, hosted via the WindowService implicit `DataTemplate`.

### Notable corrections applied during implementation
The plan was verified against current code first; the snapshot uses the real types (`Matrix3x2` in `…Utility`, `Accord.Point`, `System.Drawing.Rectangle`), marshals via `IApplicationDispatcher.DispatchSynchronizationContext`, and reuses the existing `WindowServiceFactory` pattern.

## Test Plan
- [x] `dotnet test` — **1403 pass, 0 fail** (14 new `FrameReviewSnapshotBuilder` tests: reference-identity ids, unmatched→null, arrow gating, reference-frame flag/empty transform, null-image drop, focuser ordering, immutability, primitive copy).
- [ ] In NINA: enable Sensor Curve Model + "Keep frames for Review"; run a non-saving Detailed Analysis → "Review Frames" enables; open it and verify boxes, cyan/yellow labels, count + transform HUD, orange arrows on non-reference frames, "Reference frame" note + no arrows on the reference, legend, Prev/Next/Fit/wheel-zoom/pan/Close.
- [ ] Verify the checkbox is disabled when Sensor Curve Model is off; toggle RANSAC off and rerun → labels remain, no arrows/transform; run with the toggle off → button stays disabled; Clear Analyses → button disables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyYPA51XQ67aQzhgbps6XH