### PR TITLE
fix: two bugs from a user log — Tilt Wizard cross-thread broadcast crash + AutoFocus in-progress guard brick

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusEngineTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusEngineTests.cs
@@ -265,6 +265,24 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
             });
         }
 
+        [Test]
+        public async Task Run_WithNullProgress_ClearsStaticInProgressGuard_EvenWhenAutoFocusFails() {
+            // Regression: the Star Detection Optimizer's live attempt calls Run with a null progress. RunImpl's
+            // finally used to call progress.Report(...) BEFORE clearing the static AutoFocusInProgress guard, so a
+            // null progress threw an NRE that skipped the reset. The static flag stuck true and bricked every
+            // subsequent AutoFocus ("Another AutoFocus is already in progress") app-wide until NINA was restarted.
+            var engine = Build();
+            Assume.That(engine.AutoFocusInProgress, Is.False, "static guard should start clear");
+
+            try {
+                await engine.Run(new AutoFocusEngineOptions { AutoFocusTimeout = TimeSpan.FromMinutes(1) }, imagingFilter: null, token: default, progress: null);
+            } catch {
+                // AutoFocus fails fast on the all-mocked equipment; we only care that the guard is released.
+            }
+
+            Assert.That(engine.AutoFocusInProgress, Is.False, "AutoFocusInProgress must be cleared even when the run fails with a null progress");
+        }
+
         private sealed class TempDir : IDisposable {
             public string Path { get; }
             public TempDir() {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TestDoubles/RecordingApplicationDispatcher.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TestDoubles/RecordingApplicationDispatcher.cs
@@ -1,0 +1,27 @@
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using System;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles {
+
+    /// <summary>
+    /// Runs dispatched actions inline (like <see cref="SynchronousApplicationDispatcher"/>) but counts how many times
+    /// <c>DispatchSynchronizationContext</c> was invoked, so tests can assert that a code path actually marshals UI work
+    /// through the dispatcher instead of touching commands/collections directly on the calling thread.
+    /// </summary>
+    internal sealed class RecordingApplicationDispatcher : IApplicationDispatcher {
+
+        public int DispatchCount { get; private set; }
+
+        public void DispatchSynchronizationContext(Action action) {
+            DispatchCount++;
+            action();
+        }
+
+        public T DispatchSynchronizationContext<T>(Func<T> func) {
+            DispatchCount++;
+            return func();
+        }
+
+        public T GetResource<T>(string name, T fallback) => fallback;
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardBehavioralTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardBehavioralTests.cs
@@ -23,6 +23,7 @@ public class TiltAdapterWizardBehavioralTests {
             cameraMediator: bundle.CameraMediator,
             focuserMediator: bundle.FocuserMediator,
             inspector: inspector,
+            applicationDispatcher: bundle.ApplicationDispatcher,
             tiltAdapterOptions: bundle.TiltAdapterOptions);
         return (vm, bundle);
     }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -43,7 +43,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 tiltAdapterOptions: Substitute.For<ITiltAdapterOptions>());
         }
 
-        private static (TiltAdapterWizardVM vm, ITiltAdapterOptions options, ICameraMediator camera, IFocuserMediator focuser) Build(int screwCount = 3) {
+        private static (TiltAdapterWizardVM vm, ITiltAdapterOptions options, ICameraMediator camera, IFocuserMediator focuser) Build(int screwCount = 3, IApplicationDispatcher dispatcher = null) {
             var profileService = Substitute.For<IProfileService>();
             var camera = Substitute.For<ICameraMediator>();
             var focuser = Substitute.For<IFocuserMediator>();
@@ -57,6 +57,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 cameraMediator: camera,
                 focuserMediator: focuser,
                 inspector: inspector,
+                applicationDispatcher: dispatcher ?? new SynchronousApplicationDispatcher(),
                 tiltAdapterOptions: options);
             return (vm, options, camera, focuser);
         }
@@ -153,6 +154,24 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 Assert.That(vm.AreDevicesConnected, Is.True);
                 Assert.That(vm.ConnectionWarningText, Is.Empty);
             });
+        }
+
+        [Test]
+        public void UpdateDeviceInfo_FromBackgroundThread_MarshalsCommandNotificationsThroughDispatcher() {
+            // Reported crash: DeviceMediator.Broadcast pushes device info on a background thread, and the
+            // CameraInfo/FocuserInfo setters raised CanExecuteChanged on WPF commands off the UI thread
+            // ("The calling thread cannot access this object because a different thread owns it."). The command
+            // notifications must now flow through the dispatcher so they are marshaled to the UI thread.
+            var dispatcher = new RecordingApplicationDispatcher();
+            var (vm, _, _, _) = Build(dispatcher: dispatcher);
+            var before = dispatcher.DispatchCount;
+
+            Task.Run(() => {
+                vm.UpdateDeviceInfo(new CameraInfo { Connected = true });
+                vm.UpdateDeviceInfo(new FocuserInfo { Connected = true });
+            }).GetAwaiter().GetResult();
+
+            Assert.That(dispatcher.DispatchCount - before, Is.GreaterThanOrEqualTo(2));
         }
 
         [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
@@ -1549,9 +1549,20 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 } catch (Exception ex) {
                     Logger.Warning($"Failure during post AF actions. {ex.Message}");
                 } finally {
-                    progress.Report(new ApplicationStatus() { Status = string.Empty });
+                    // Clear the (static) in-progress guard FIRST and unconditionally. If anything below this throws,
+                    // the flag stays set and EVERY future AutoFocus across the whole app is rejected with "Another
+                    // AutoFocus is already in progress" until NINA is restarted. progress is optional (the Star
+                    // Detection Optimizer's live attempt passes null), so report through it defensively.
                     AutoFocusInProgress = false;
+                    progress?.Report(new ApplicationStatus() { Status = string.Empty });
                 }
+            }
+
+            if (autoFocusState == null) {
+                // InitializeState never produced state (cancelled, timed out, or an equipment error already logged
+                // above). There is nothing to build a result from; return null like the in-progress guard does,
+                // rather than dereferencing a null state below.
+                return null;
             }
 
             return new AutoFocusResult() {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -65,6 +65,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         private readonly ITiltAdapterOptions tiltAdapterOptions;
         private readonly InspectorVM inspector;
+        private readonly IApplicationDispatcher applicationDispatcher;
         private readonly IProgress<ApplicationStatus> progress;
 
         private CameraInfo cameraInfo = DeviceInfo.CreateDefaultInstance<CameraInfo>();
@@ -130,7 +131,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             IFocuserMediator focuserMediator,
             InspectorVM inspector)
             : this(profileService, applicationStatusMediator, cameraMediator, focuserMediator, inspector,
-                   HocusFocusPlugin.TiltAdapterOptions) { }
+                   HocusFocusPlugin.ApplicationDispatcher, HocusFocusPlugin.TiltAdapterOptions) { }
 
         public TiltAdapterWizardVM(
             IProfileService profileService,
@@ -138,10 +139,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             ICameraMediator cameraMediator,
             IFocuserMediator focuserMediator,
             InspectorVM inspector,
+            IApplicationDispatcher applicationDispatcher,
             ITiltAdapterOptions tiltAdapterOptions)
             : base(profileService) {
             this.inspector = inspector;
             this.tiltAdapterOptions = tiltAdapterOptions;
+            this.applicationDispatcher = applicationDispatcher;
             this.progress = ProgressFactory.Create(applicationStatusMediator, "Tilt Adapter Wizard");
 
             this.Title = "Tilt Adapter Wizard";
@@ -166,7 +169,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             ReplayCommand = new AsyncRelayCommand(() => ReplayAsync(useMetadataSettings: true), () => !IsWizardRunning && !IsMeasuring);
             ReplayCurrentSettingsCommand = new AsyncRelayCommand(() => ReplayAsync(useMetadataSettings: false), () => !IsWizardRunning && !IsMeasuring);
 
-            tiltAdapterOptions.PropertyChanged += (s, e) => {
+            tiltAdapterOptions.PropertyChanged += (s, e) => OnUIThread(() => {
                 if (e.PropertyName == nameof(ITiltAdapterOptions.ScrewInwardCurvatureSign)) {
                     RaisePropertyChanged(nameof(HasCurvatureCalibration));
                     RaisePropertyChanged(nameof(CurvatureSignDescription));
@@ -200,15 +203,15 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     RaisePropertyChanged(nameof(ScrewRadiusMillimetersValue));
                     RaiseHardwareSummaryChanged();
                 }
-            };
+            });
 
-            profileService.ProfileChanged += (s, e) => {
+            profileService.ProfileChanged += (s, e) => OnUIThread(() => {
                 RaisePropertyChanged(nameof(PixelSizeMicronsValue));
                 RaisePropertyChanged(nameof(FocuserStepSizeMicronsValue));
                 RaisePropertyChanged(nameof(SelectedDevice));
                 RaisePropertyChanged(nameof(IsManualDevice));
                 RaisePropertyChanged(nameof(SaveAFRunsPath));
-            };
+            });
 
             // Re-assert and lock a persisted device preset on load.
             ApplyDevice(tiltAdapterOptions.DeviceName);
@@ -220,8 +223,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         }
 
         private void OnSummaryCollectionChanged(object sender, NotifyCollectionChangedEventArgs e) {
-            RaisePropertyChanged(nameof(HasMeasurementFeedback));
-            RaisePropertyChanged(nameof(HasMeasurementResults));
+            OnUIThread(() => {
+                RaisePropertyChanged(nameof(HasMeasurementFeedback));
+                RaisePropertyChanged(nameof(HasMeasurementResults));
+            });
         }
 
         public ITiltAdapterOptions TiltAdapterOptions => tiltAdapterOptions;
@@ -1050,7 +1055,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             RaisePropertyChanged(nameof(CalibrationFocuserStepDisplay));
             RaisePropertyChanged(nameof(CalibrationScrewRadiusDisplay));
             RaisePropertyChanged(nameof(CalibrationAppliedAmountDisplay));
-            ((RelayCommand)UseMeasuredHardwareCommand).NotifyCanExecuteChanged();
+            OnUIThread(() => ((RelayCommand)UseMeasuredHardwareCommand).NotifyCanExecuteChanged());
         }
 
         // Two single-screw turns of the same amount should produce gradient changes that are ~equal in magnitude
@@ -1369,14 +1374,21 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
         }
 
+        // CanExecuteChanged on WPF commands and ObservableCollection mutations must touch UI-owned objects on the
+        // UI thread. DispatchSynchronizationContext is a synchronous Send with a same-context fast path, so calling
+        // this from the UI thread is free and calling it from a DeviceMediator background broadcast marshals safely.
+        private void OnUIThread(Action action) => applicationDispatcher.DispatchSynchronizationContext(action);
+
         private void NotifyCommandsCanExecuteChanged() {
-            ((AsyncRelayCommand)StartCommand).NotifyCanExecuteChanged();
-            ((AsyncRelayCommand)RunMeasurementCommand).NotifyCanExecuteChanged();
-            ((AsyncRelayCommand)UseSavedAFCommand).NotifyCanExecuteChanged();
-            ((RelayCommand)CancelCommand).NotifyCanExecuteChanged();
-            ((RelayCommand)UseMeasuredHardwareCommand).NotifyCanExecuteChanged();
-            ((AsyncRelayCommand)ReplayCommand).NotifyCanExecuteChanged();
-            ((AsyncRelayCommand)ReplayCurrentSettingsCommand).NotifyCanExecuteChanged();
+            OnUIThread(() => {
+                ((AsyncRelayCommand)StartCommand).NotifyCanExecuteChanged();
+                ((AsyncRelayCommand)RunMeasurementCommand).NotifyCanExecuteChanged();
+                ((AsyncRelayCommand)UseSavedAFCommand).NotifyCanExecuteChanged();
+                ((RelayCommand)CancelCommand).NotifyCanExecuteChanged();
+                ((RelayCommand)UseMeasuredHardwareCommand).NotifyCanExecuteChanged();
+                ((AsyncRelayCommand)ReplayCommand).NotifyCanExecuteChanged();
+                ((AsyncRelayCommand)ReplayCurrentSettingsCommand).NotifyCanExecuteChanged();
+            });
         }
 
         private static double NormalizeAngle(double deg) => ((deg % 360) + 360) % 360;


### PR DESCRIPTION
Two independent crash/hang bugs surfaced by a single user's ~7-hour NINA session log (27,335 errors). Both are fixed here.

---

## 1. Tilt Adapter Wizard cross-thread crash (99% of the log — 27,063 errors)

```
ERROR | DeviceMediator.cs | Broadcast
System.InvalidOperationException: The calling thread cannot access this object because a different thread owns it.
  at TiltAdapterWizardVM.NotifyCommandsCanExecuteChanged()
  at TiltAdapterWizardVM.set_CameraInfo(value)
  at TiltAdapterWizardVM.UpdateDeviceInfo(CameraInfo deviceInfo)
```

**Root cause.** `TiltAdapterWizardVM` is an `ICameraConsumer`/`IFocuserConsumer`. NINA's `DeviceMediator.Broadcast` delivers device info on a **background thread**; the `CameraInfo`/`FocuserInfo` setters called `NotifyCommandsCanExecuteChanged()`, raising `CanExecuteChanged` on WPF commands off the UI thread. (Scalar `RaisePropertyChanged` is auto-marshaled by binding/`BaseINPC`, so only the command `CanExecuteChanged` threw.) Verified: all 27,063 broadcast errors go through this one method (both camera and focuser paths).

**Fix.** Inject the existing `IApplicationDispatcher` (same pattern `InspectorVM` uses) and route command `CanExecuteChanged` through `DispatchSynchronizationContext` — a synchronous `Send` with a same-context fast path (free on the UI thread, marshals safely from a background thread). A single `OnUIThread(...)` helper wraps `NotifyCommandsCanExecuteChanged()` (the chokepoint for all five setters); defensively also marshals the standalone `UseMeasuredHardwareCommand` notify and the `options`/`profile` `PropertyChanged` handlers (which call `RebuildDiagram()` → UI-bound `ObservableCollection` mutations).

---

## 2. AutoFocus in-progress guard stuck → ~5-hour AF outage (64 errors + cascade)

A single `NullReferenceException` at 22:38 from the **Star Detection Optimizer Wizard's live attempt** left autofocus dead for the rest of the night: 17 successful AF runs before 22:38, then `Another AutoFocus is already in progress` 64× and **zero successful AF afterward**.

**Root cause.** `StarDetectionOptimizerWizardVM.RunLiveAttemptAsync` calls `autoFocusEngine.Run(options, null, token, null)` — a **null `progress`**. `RunImpl`'s `finally` ran `progress.Report(...)` **before** `AutoFocusInProgress = false`, so the null `progress` threw and skipped the reset. `AutoFocusInProgress` is backed by a **`static`** field (the global one-AF-at-a-time guard shared across every `autoFocusEngineFactory.Create()` instance), so it stuck `true` and rejected every later autofocus app-wide until restart. The 1× optimizer NRE and the 64× cascade are the **same bug**.

**Fix.** Clear `AutoFocusInProgress` first and unconditionally in the `finally`, then `progress?.Report(...)` defensively (it's optional); and return `null` instead of dereferencing a null `AutoFocusState` when `InitializeState` never produced one.

---

## Tests

- Cross-thread: `RecordingApplicationDispatcher` double + a regression test driving `UpdateDeviceInfo` from a background thread and asserting the notifications are marshaled.
- AF brick: `Run_WithNullProgress_ClearsStaticInProgressGuard_EvenWhenAutoFocusFails`, verified **red→green**.
- Full suite: **1390 passed, 0 failed.**

## Verification still needed

Live confirmation in NINA (no more `DeviceMediator | Broadcast` cross-thread errors with the Tilt Adapter Wizard open; the Star Detection Optimizer live attempt no longer bricks autofocus) — could not be exercised by the unit suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
