### PR TITLE
fix: AutoFocus in-progress guard stuck after optimizer null-progress run (5h AF outage)

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusEngineTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusEngineTests.cs
@@ -265,6 +265,24 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
             });
         }
 
+        [Test]
+        public async Task Run_WithNullProgress_ClearsStaticInProgressGuard_EvenWhenAutoFocusFails() {
+            // Regression: the Star Detection Optimizer's live attempt calls Run with a null progress. RunImpl's
+            // finally used to call progress.Report(...) BEFORE clearing the static AutoFocusInProgress guard, so a
+            // null progress threw an NRE that skipped the reset. The static flag stuck true and bricked every
+            // subsequent AutoFocus ("Another AutoFocus is already in progress") app-wide until NINA was restarted.
+            var engine = Build();
+            Assume.That(engine.AutoFocusInProgress, Is.False, "static guard should start clear");
+
+            try {
+                await engine.Run(new AutoFocusEngineOptions { AutoFocusTimeout = TimeSpan.FromMinutes(1) }, imagingFilter: null, token: default, progress: null);
+            } catch {
+                // AutoFocus fails fast on the all-mocked equipment; we only care that the guard is released.
+            }
+
+            Assert.That(engine.AutoFocusInProgress, Is.False, "AutoFocusInProgress must be cleared even when the run fails with a null progress");
+        }
+
         private sealed class TempDir : IDisposable {
             public string Path { get; }
             public TempDir() {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
@@ -1549,9 +1549,20 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 } catch (Exception ex) {
                     Logger.Warning($"Failure during post AF actions. {ex.Message}");
                 } finally {
-                    progress.Report(new ApplicationStatus() { Status = string.Empty });
+                    // Clear the (static) in-progress guard FIRST and unconditionally. If anything below this throws,
+                    // the flag stays set and EVERY future AutoFocus across the whole app is rejected with "Another
+                    // AutoFocus is already in progress" until NINA is restarted. progress is optional (the Star
+                    // Detection Optimizer's live attempt passes null), so report through it defensively.
                     AutoFocusInProgress = false;
+                    progress?.Report(new ApplicationStatus() { Status = string.Empty });
                 }
+            }
+
+            if (autoFocusState == null) {
+                // InitializeState never produced state (cancelled, timed out, or an equipment error already logged
+                // above). There is nothing to build a result from; return null like the in-progress guard does,
+                // rather than dereferencing a null state below.
+                return null;
             }
 
             return new AutoFocusResult() {


### PR DESCRIPTION
## Problem

In a user's ~7-hour session log, **autofocus was dead for the last ~5 hours**: every autofocus trigger failed with `Another AutoFocus is already in progress`, and there were **zero successful autofocus runs after 22:38** (17 succeeded before it).

The trigger was a single `NullReferenceException` at 22:38, when the **Star Detection Optimizer Wizard's live attempt** ran:

```
System.NullReferenceException
  at HocusFocus.AutoFocus.AutoFocusEngine.RunImpl(options, imagingFilter, regions, token, progress)
  at StarDetectionOptimizerWizardVM.RunLiveAttemptAsync(...)
```

## Root cause

`StarDetectionOptimizerWizardVM.RunLiveAttemptAsync` calls `autoFocusEngine.Run(options, null, token, null)` — a **null `progress`**.

`RunImpl`'s `finally` did:

```csharp
} finally {
    progress.Report(new ApplicationStatus() { Status = string.Empty });  // NRE when progress == null
    AutoFocusInProgress = false;                                          // <- skipped
}
```

The null `progress` threw inside the `finally`, **before** `AutoFocusInProgress = false` ran. And `AutoFocusInProgress` is backed by a **`static`** field — the global "one AutoFocus at a time" guard, shared across every `autoFocusEngineFactory.Create()` instance (sequence AF, optimizer, inspector). So the guard stuck `true`, and every later autofocus (the sequence's temperature/filter triggers) was rejected app-wide until NINA restarted.

This makes the two error clusters in the log the **same bug**: the 1× optimizer NRE caused the 64× "Another AutoFocus is already in progress" cascade.

## Fix

- In the `finally`, **clear `AutoFocusInProgress` first and unconditionally**, then report through `progress?.` defensively (it's optional — the optimizer passes null). A throw in the post-AF path can no longer brick autofocus.
- Return `null` instead of dereferencing a null `AutoFocusState` when `InitializeState` never produced one (the failure path the null-progress NRE previously masked).

## Tests

- New `Run_WithNullProgress_ClearsStaticInProgressGuard_EvenWhenAutoFocusFails` — verified **red before / green after** (pre-fix it leaves the static guard stuck; post-fix it's released).
- Full suite: **1389 passed, 0 failed**.

## Note

Independent of the cross-thread crash in #89 (different subsystem), so it's a separate PR. Both were found in the same user log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
