### PR TITLE
Review Frames for the manual AutoFocus pane

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusAnnotationTextTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusAnnotationTextTests.cs
@@ -1,0 +1,98 @@
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NUnit.Framework;
+using System;
+using System.Globalization;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
+
+    [TestFixture]
+    public class AutoFocusAnnotationTextTests {
+
+        private static AutoFocusReviewStar WithPsf() => new AutoFocusReviewStar {
+            Hfr = 2.0,
+            Background = 12.5,
+            HasPsf = true,
+            FwhmArcsec = 4.2426406,
+            FwhmPixels = 2.8284271,
+            FwhmX = 4.0,
+            FwhmY = 2.0,
+            Eccentricity = 0.8660254,
+            PsfThetaDegrees = 90.0,
+            PsfBackground = 56.0,
+            PsfPeak = 1234.0,
+            MoffatBeta = 4.0,
+        };
+
+        private static AutoFocusReviewStar NoPsf() => new AutoFocusReviewStar {
+            Hfr = 2.0,
+            Background = 12.5,
+            HasPsf = false,
+            FwhmArcsec = double.NaN,
+            FwhmPixels = double.NaN,
+            FwhmX = double.NaN,
+            FwhmY = double.NaN,
+            Eccentricity = double.NaN,
+            PsfThetaDegrees = double.NaN,
+            PsfBackground = double.NaN,
+            PsfPeak = double.NaN,
+            MoffatBeta = double.NaN,
+        };
+
+        private static string F(double v, string fmt) => v.ToString(fmt, CultureInfo.CurrentCulture);
+
+        [Test]
+        public void Format_WithPsf_MatchesAnnotatorFormatsForEveryType() {
+            var s = WithPsf();
+            Assert.Multiple(() => {
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.None), Is.EqualTo(string.Empty));
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.HFR), Is.EqualTo(F(2.0, "#0.00")));
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.Background), Is.EqualTo(F(12.5, "#.0000")));
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.FWHM), Is.EqualTo(F(4.2426406, "#0.00")));
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.FWHMPixels), Is.EqualTo(F(2.8284271, "#0.00")));
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.FWHM_X), Is.EqualTo(F(4.0, "#0.00")));
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.FWHM_Y), Is.EqualTo(F(2.0, "#0.00")));
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.Eccentricity), Is.EqualTo(F(0.8660254, "#.00")));
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.PSFTheta), Is.EqualTo(Math.Round(90.0).ToString("##0", CultureInfo.CurrentCulture) + "°"));
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.PSFBackground), Is.EqualTo(F(56.0, "#.0000")));
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.PSFPeak), Is.EqualTo(F(1234.0, "#.0000")));
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.MoffatBeta), Is.EqualTo(F(4.0, "0.##")));
+            });
+        }
+
+        [Test]
+        public void Format_WithoutPsf_PsfOnlyTypesAreEmptyButHfrAndBackgroundStillRender() {
+            var s = NoPsf();
+            Assert.Multiple(() => {
+                // Non-PSF values still render.
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.HFR), Is.EqualTo(F(2.0, "#0.00")));
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.Background), Is.EqualTo(F(12.5, "#.0000")));
+                // PSF-only values draw nothing (matching the annotator's `psf != null` guards).
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.FWHM), Is.EqualTo(string.Empty));
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.FWHMPixels), Is.EqualTo(string.Empty));
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.FWHM_X), Is.EqualTo(string.Empty));
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.FWHM_Y), Is.EqualTo(string.Empty));
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.Eccentricity), Is.EqualTo(string.Empty));
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.PSFTheta), Is.EqualTo(string.Empty));
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.PSFBackground), Is.EqualTo(string.Empty));
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.PSFPeak), Is.EqualTo(string.Empty));
+                Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.MoffatBeta), Is.EqualTo(string.Empty));
+            });
+        }
+
+        [Test]
+        public void Format_MoffatBetaNaN_IsEmptyEvenWithPsf() {
+            var s = WithPsf();
+            s = new AutoFocusReviewStar {
+                HasPsf = true,
+                MoffatBeta = double.NaN,
+            };
+            Assert.That(AutoFocusAnnotationText.Format(s, ShowAnnotationTypeEnum.MoffatBeta), Is.EqualTo(string.Empty));
+        }
+
+        [Test]
+        public void Format_NullStar_IsEmpty() {
+            Assert.That(AutoFocusAnnotationText.Format(null, ShowAnnotationTypeEnum.HFR), Is.EqualTo(string.Empty));
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusFrameReviewSnapshotBuilderTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusFrameReviewSnapshotBuilderTests.cs
@@ -1,0 +1,253 @@
+using NINA.Image.ImageAnalysis;
+using NINA.Image.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
+
+    [TestFixture]
+    public class AutoFocusFrameReviewSnapshotBuilderTests {
+
+        // ---- helpers ------------------------------------------------------------------------------------
+
+        private static BitmapSource MakeBitmap(int w = 2, int h = 2) {
+            var stride = w;
+            var bmp = BitmapSource.Create(w, h, 96, 96, PixelFormats.Gray8, null, new byte[stride * h], stride);
+            bmp.Freeze();
+            return bmp;
+        }
+
+        private static IRenderedImage MakeImage(int w = 2, int h = 2) {
+            var img = Substitute.For<IRenderedImage>();
+            img.Image.Returns(MakeBitmap(w, h));
+            return img;
+        }
+
+        private static PSFModel MakePsf(
+            double offsetX = 0.3, double offsetY = -0.4,
+            double peak = 1000, double background = 50,
+            double fwhmX = 4.0, double fwhmY = 2.0,
+            double thetaRadians = Math.PI / 4, double pixelScale = 1.5, double beta = 4.0) {
+            return new PSFModel(StarDetectorPSFFitType.Moffat_40, offsetX, offsetY, peak, background,
+                sigmaX: fwhmX / 2.0, sigmaY: fwhmY / 2.0, fwhmX: fwhmX, fwhmY: fwhmY,
+                thetaRadians: thetaRadians, rSquared: 0.9, pixelScale: pixelScale, reducedChiSquared: 1.0, beta: beta);
+        }
+
+        private static HocusFocusDetectedStar MakeStar(
+            double hfr = 2.0, double posX = 10, double posY = 20, double background = 12.5,
+            int boxX = 8, int boxY = 18, int boxW = 5, int boxH = 7,
+            PSFModel psf = null) {
+            return new HocusFocusDetectedStar {
+                HFR = hfr,
+                Position = new Accord.Point((float)posX, (float)posY),
+                Background = background,
+                BoundingBox = new System.Drawing.Rectangle(boxX, boxY, boxW, boxH),
+                PSF = psf,
+            };
+        }
+
+        private static (double, HocusFocusStarDetectionResult, IRenderedImage) Frame(
+            double focuserPosition,
+            IEnumerable<HocusFocusDetectedStar> stars,
+            IRenderedImage image,
+            StarDetectorMetrics metrics = null,
+            StarDetectorParams detectorParams = null) {
+            var result = new HocusFocusStarDetectionResult {
+                StarList = stars?.Cast<DetectedStar>().ToList(),
+                Metrics = metrics,
+                DetectorParams = detectorParams,
+            };
+            return (focuserPosition, result, image);
+        }
+
+        // ---- tests --------------------------------------------------------------------------------------
+
+        [Test]
+        public void Build_OrdersFramesByFocuserPosition_StableForEqualPositions() {
+            var f300 = Frame(300, new[] { MakeStar() }, MakeImage());
+            var f100 = Frame(100, new[] { MakeStar() }, MakeImage());
+            var f200a = Frame(200, new[] { MakeStar(posX: 1) }, MakeImage());
+            var f200b = Frame(200, new[] { MakeStar(posX: 2) }, MakeImage());
+
+            var snapshot = AutoFocusFrameReviewSnapshotBuilder.Build(new[] { f300, f100, f200a, f200b });
+
+            Assert.Multiple(() => {
+                Assert.That(snapshot.Frames.Select(f => f.FocuserPosition), Is.EqualTo(new[] { 100.0, 200.0, 200.0, 300.0 }));
+                // Original capture index preserved, and the two 200s keep their capture order (stable sort).
+                Assert.That(snapshot.Frames.Select(f => f.FrameIndex), Is.EqualTo(new[] { 1, 2, 3, 0 }));
+                Assert.That(snapshot.Frames[1].Stars.Single().CenterX, Is.EqualTo(1)); // f200a before f200b
+                Assert.That(snapshot.Frames[2].Stars.Single().CenterX, Is.EqualTo(2));
+            });
+        }
+
+        [Test]
+        public void Build_DropsFramesWithNullImageOrNullInnerImage() {
+            var nullImage = Frame(100, new[] { MakeStar() }, null);
+            var nullInner = Substitute.For<IRenderedImage>();
+            nullInner.Image.Returns((BitmapSource)null);
+            var nullInnerFrame = Frame(200, new[] { MakeStar() }, nullInner);
+            var good = Frame(300, new[] { MakeStar() }, MakeImage());
+
+            var snapshot = AutoFocusFrameReviewSnapshotBuilder.Build(new[] { nullImage, nullInnerFrame, good });
+
+            Assert.Multiple(() => {
+                Assert.That(snapshot.Frames.Count, Is.EqualTo(1));
+                Assert.That(snapshot.Frames.Single().FocuserPosition, Is.EqualTo(300.0));
+                Assert.That(snapshot.Frames.Single().FrameIndex, Is.EqualTo(2));
+            });
+        }
+
+        [Test]
+        public void Build_PopulatesStarGeometryAndCount() {
+            var frame = Frame(100, new[] {
+                MakeStar(hfr: 3.5, posX: 12, posY: 24, boxX: 9, boxY: 21, boxW: 6, boxH: 8),
+                MakeStar(posX: 50),
+            }, MakeImage());
+
+            var snapshot = AutoFocusFrameReviewSnapshotBuilder.Build(new[] { frame });
+            var f = snapshot.Frames.Single();
+            var s = f.Stars.First();
+
+            Assert.Multiple(() => {
+                Assert.That(f.DetectedStarCount, Is.EqualTo(2));
+                Assert.That(s.CenterX, Is.EqualTo(12)); // Position, NOT the box top-left
+                Assert.That(s.CenterY, Is.EqualTo(24));
+                Assert.That(s.BoxX, Is.EqualTo(9));
+                Assert.That(s.BoxY, Is.EqualTo(21));
+                Assert.That(s.BoxWidth, Is.EqualTo(6));
+                Assert.That(s.BoxHeight, Is.EqualTo(8));
+                Assert.That(s.Hfr, Is.EqualTo(3.5));
+            });
+        }
+
+        [Test]
+        public void Build_StarWithoutPsf_HasNoPsfAndNaNDerivedFields() {
+            var frame = Frame(100, new[] { MakeStar(psf: null, background: 7.0) }, MakeImage());
+
+            var s = AutoFocusFrameReviewSnapshotBuilder.Build(new[] { frame }).Frames.Single().Stars.Single();
+
+            Assert.Multiple(() => {
+                Assert.That(s.HasPsf, Is.False);
+                Assert.That(s.Background, Is.EqualTo(7.0)); // star background is NOT PSF-gated
+                Assert.That(s.FwhmArcsec, Is.NaN);
+                Assert.That(s.FwhmPixels, Is.NaN);
+                Assert.That(s.FwhmX, Is.NaN);
+                Assert.That(s.FwhmY, Is.NaN);
+                Assert.That(s.Eccentricity, Is.NaN);
+                Assert.That(s.PsfThetaDegrees, Is.NaN);
+                Assert.That(s.PsfBackground, Is.NaN);
+                Assert.That(s.PsfPeak, Is.NaN);
+                Assert.That(s.MoffatBeta, Is.NaN);
+            });
+        }
+
+        [Test]
+        public void Build_StarWithPsf_PopulatesPsfFieldsAndThetaInDegrees() {
+            var psf = MakePsf(offsetX: 0.3, offsetY: -0.4, peak: 1234, background: 56,
+                fwhmX: 4.0, fwhmY: 2.0, thetaRadians: Math.PI / 2, pixelScale: 1.5, beta: 4.0);
+            var frame = Frame(100, new[] { MakeStar(psf: psf) }, MakeImage());
+
+            var s = AutoFocusFrameReviewSnapshotBuilder.Build(new[] { frame }).Frames.Single().Stars.Single();
+
+            Assert.Multiple(() => {
+                Assert.That(s.HasPsf, Is.True);
+                Assert.That(s.PsfOffsetX, Is.EqualTo(0.3).Within(1e-9));
+                Assert.That(s.PsfOffsetY, Is.EqualTo(-0.4).Within(1e-9));
+                Assert.That(s.FwhmX, Is.EqualTo(4.0).Within(1e-9));
+                Assert.That(s.FwhmY, Is.EqualTo(2.0).Within(1e-9));
+                Assert.That(s.FwhmPixels, Is.EqualTo(Math.Sqrt(8.0)).Within(1e-9));
+                Assert.That(s.FwhmArcsec, Is.EqualTo(Math.Sqrt(8.0) * 1.5).Within(1e-9));
+                Assert.That(s.PsfPeak, Is.EqualTo(1234).Within(1e-9));
+                Assert.That(s.PsfBackground, Is.EqualTo(56).Within(1e-9));
+                Assert.That(s.MoffatBeta, Is.EqualTo(4.0).Within(1e-9));
+                Assert.That(s.PsfThetaDegrees, Is.EqualTo(90.0).Within(1e-6)); // π/2 rad → 90°
+            });
+        }
+
+        [Test]
+        public void Build_MapsAllSevenRejectionReasonRects() {
+            var metrics = new StarDetectorMetrics();
+            metrics.TooDistortedBounds.Add(new OpenCvSharp.Rect(1, 2, 3, 4));
+            metrics.DegenerateBounds.Add(new OpenCvSharp.Rect(5, 6, 7, 8));
+            metrics.SaturatedBounds.Add(new OpenCvSharp.Rect(9, 10, 11, 12));
+            metrics.LowSensitivityBounds.Add(new OpenCvSharp.Rect(13, 14, 15, 16));
+            metrics.NotCenteredBounds.Add(new OpenCvSharp.Rect(17, 18, 19, 20));
+            metrics.TooFlatBounds.Add(new OpenCvSharp.Rect(21, 22, 23, 24));
+            metrics.ContaminatedBounds.Add(new OpenCvSharp.Rect(25, 26, 27, 28));
+            var frame = Frame(100, new[] { MakeStar() }, MakeImage(), metrics: metrics);
+
+            var f = AutoFocusFrameReviewSnapshotBuilder.Build(new[] { frame }).Frames.Single();
+
+            Assert.Multiple(() => {
+                Assert.That(f.TooDistorted.Single(), Is.EqualTo(new System.Windows.Rect(1, 2, 3, 4)));
+                Assert.That(f.Degenerate.Single(), Is.EqualTo(new System.Windows.Rect(5, 6, 7, 8)));
+                Assert.That(f.Saturated.Single(), Is.EqualTo(new System.Windows.Rect(9, 10, 11, 12)));
+                Assert.That(f.LowSensitivity.Single(), Is.EqualTo(new System.Windows.Rect(13, 14, 15, 16)));
+                Assert.That(f.NotCentered.Single(), Is.EqualTo(new System.Windows.Rect(17, 18, 19, 20)));
+                Assert.That(f.TooFlat.Single(), Is.EqualTo(new System.Windows.Rect(21, 22, 23, 24)));
+                Assert.That(f.Contaminated.Single(), Is.EqualTo(new System.Windows.Rect(25, 26, 27, 28)));
+            });
+        }
+
+        [Test]
+        public void Build_NullMetrics_AllReasonRectListsEmptyNotNull() {
+            var frame = Frame(100, new[] { MakeStar() }, MakeImage(), metrics: null);
+
+            var f = AutoFocusFrameReviewSnapshotBuilder.Build(new[] { frame }).Frames.Single();
+
+            Assert.Multiple(() => {
+                Assert.That(f.TooDistorted, Is.Empty);
+                Assert.That(f.Degenerate, Is.Empty);
+                Assert.That(f.Saturated, Is.Empty);
+                Assert.That(f.LowSensitivity, Is.Empty);
+                Assert.That(f.NotCentered, Is.Empty);
+                Assert.That(f.TooFlat, Is.Empty);
+                Assert.That(f.Contaminated, Is.Empty);
+                Assert.That(f.RoiRects, Is.Empty);
+            });
+        }
+
+        [Test]
+        public void Build_RoiRects_EmptyForFullOrNullRegion() {
+            var nullParams = Frame(100, new[] { MakeStar() }, MakeImage(), detectorParams: null);
+            var fullRegion = Frame(200, new[] { MakeStar() }, MakeImage(),
+                detectorParams: new StarDetectorParams { Region = StarDetectionRegion.Full });
+
+            var snapshot = AutoFocusFrameReviewSnapshotBuilder.Build(new[] { nullParams, fullRegion });
+
+            Assert.Multiple(() => {
+                Assert.That(snapshot.Frames[0].RoiRects, Is.Empty);
+                Assert.That(snapshot.Frames[1].RoiRects, Is.Empty);
+            });
+        }
+
+        [Test]
+        public void Build_RoiRects_ScalesOuterAndInnerToImagePixels() {
+            // 100x80 image; inner crop must be entirely contained within the outer boundary → two rects scaled to pixels.
+            var region = new StarDetectionRegion(new RatioRect(0.1, 0.1, 0.8, 0.8), new RatioRect(0.2, 0.25, 0.4, 0.3));
+            var frame = Frame(100, new[] { MakeStar() }, MakeImage(100, 80),
+                detectorParams: new StarDetectorParams { Region = region });
+
+            var roi = AutoFocusFrameReviewSnapshotBuilder.Build(new[] { frame }).Frames.Single().RoiRects;
+
+            Assert.Multiple(() => {
+                Assert.That(roi.Count, Is.EqualTo(2));
+                Assert.That(roi[0], Is.EqualTo(new System.Windows.Rect(10, 8, 80, 64)));    // outer × (100,80)
+                Assert.That(roi[1], Is.EqualTo(new System.Windows.Rect(20, 20, 40, 24)));   // inner × (100,80)
+            });
+        }
+
+        [Test]
+        public void Build_EmptyInput_ProducesEmptySnapshot() {
+            Assert.That(AutoFocusFrameReviewSnapshotBuilder.Build(Array.Empty<(double, HocusFocusStarDetectionResult, IRenderedImage)>()).Frames, Is.Empty);
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusOptionsTests.cs
@@ -35,6 +35,7 @@ public class AutoFocusOptionsTests {
             Assert.That(options.HFRImprovementThreshold, Is.EqualTo(0.15));
             Assert.That(options.SavePath, Is.EqualTo(""));
             Assert.That(options.Save, Is.False);
+            Assert.That(options.KeepFramesForReview, Is.False);
             Assert.That(options.LastSelectedLoadPath, Is.EqualTo(""));
             Assert.That(options.FocuserOffset, Is.EqualTo(0));
             Assert.That(options.MaxOutlierRejections, Is.EqualTo(1));
@@ -58,6 +59,7 @@ public class AutoFocusOptionsTests {
         options.HFRImprovementThreshold = 0.25;
         options.SavePath = @"C:\AF";
         options.Save = true;
+        options.KeepFramesForReview = true;
         options.LastSelectedLoadPath = @"C:\AF\last";
         options.FocuserOffset = -10;
         options.MaxOutlierRejections = 3;
@@ -77,6 +79,7 @@ public class AutoFocusOptionsTests {
             Assert.That(store.Snapshot["HFRImprovementThreshold"], Is.EqualTo(0.25));
             Assert.That(store.Snapshot["SavePath"], Is.EqualTo(@"C:\AF"));
             Assert.That(store.Snapshot["Save"], Is.True);
+            Assert.That(store.Snapshot[nameof(AutoFocusOptions.KeepFramesForReview)], Is.True);
             Assert.That(store.Snapshot["LastSelectedLoadPath"], Is.EqualTo(@"C:\AF\last"));
             Assert.That(store.Snapshot["FocuserOffset"], Is.EqualTo(-10));
             Assert.That(store.Snapshot[nameof(AutoFocusOptions.MaxOutlierRejections)], Is.EqualTo(3));
@@ -92,6 +95,7 @@ public class AutoFocusOptionsTests {
         options.FastFocusModeEnabled = true;
         options.HFRImprovementThreshold = 0.99;
         options.Save = true;
+        options.KeepFramesForReview = true;
         options.MaxOutlierRejections = 4;
 
         options.ResetDefaults();
@@ -101,6 +105,7 @@ public class AutoFocusOptionsTests {
             Assert.That(options.FastFocusModeEnabled, Is.False);
             Assert.That(options.HFRImprovementThreshold, Is.EqualTo(0.15));
             Assert.That(options.Save, Is.False);
+            Assert.That(options.KeepFramesForReview, Is.False);
             Assert.That(options.MaxOutlierRejections, Is.EqualTo(1));
             Assert.That(options.OutlierRejectionConfidence, Is.EqualTo(0.90));
             Assert.That(options.WeightedHyperbolicFitEnabled, Is.True);
@@ -115,6 +120,7 @@ public class AutoFocusOptionsTests {
     [TestCase(nameof(AutoFocusOptions.ValidateHfrImprovement), false)]
     [TestCase(nameof(AutoFocusOptions.HFRImprovementThreshold), 0.5)]
     [TestCase(nameof(AutoFocusOptions.Save), true)]
+    [TestCase(nameof(AutoFocusOptions.KeepFramesForReview), true)]
     [TestCase(nameof(AutoFocusOptions.SavePath), "x")]
     [TestCase(nameof(AutoFocusOptions.LastSelectedLoadPath), "y")]
     [TestCase(nameof(AutoFocusOptions.FocuserOffset), 5)]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/HocusFocusVMFactoryTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/HocusFocusVMFactoryTests.cs
@@ -25,7 +25,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
                 starDetectionOptions: Substitute.For<IStarDetectionOptions>(),
                 autoFocusEngineFactory: Substitute.For<IAutoFocusEngineFactory>(),
                 starDetectionSelector: Substitute.For<IPluggableBehaviorSelector<IStarDetection>>(),
-                alglibAPI: Substitute.For<IAlglibAPI>());
+                alglibAPI: Substitute.For<IAlglibAPI>(),
+                applicationDispatcher: Substitute.For<IApplicationDispatcher>());
         }
 
         [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/HocusFocusVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/HocusFocusVMTests.cs
@@ -33,7 +33,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
                 filterWheelMediator: Substitute.For<IFilterWheelMediator>(),
                 applicationStatusMediator: Substitute.For<IApplicationStatusMediator>(),
                 starDetectionSelector: Substitute.For<IPluggableBehaviorSelector<IStarDetection>>(),
-                alglibAPI: alglibAPI ?? new AlglibAPI());
+                alglibAPI: alglibAPI ?? new AlglibAPI(),
+                applicationDispatcher: new NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles.SynchronousApplicationDispatcher());
         }
 
         [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
@@ -54,6 +54,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
         public int AutoFocusTimeoutSeconds { get; set; }
         public string SavePath { get; set; }
         public bool Save { get; set; }
+        public bool KeepFramesForReview { get; set; }
         public string LastSelectedLoadPath { get; set; }
         public int FocuserOffset { get; set; }
         public int MaxOutlierRejections { get; set; }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TestDoubles/MediatorBundle.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TestDoubles/MediatorBundle.cs
@@ -96,6 +96,7 @@ internal sealed class MediatorBundle {
             filterWheelMediator: FilterWheelMediator,
             applicationStatusMediator: ApplicationStatusMediator,
             starDetectionSelector: StarDetectionSelector,
-            alglibAPI: AlglibAPI);
+            alglibAPI: AlglibAPI,
+            applicationDispatcher: ApplicationDispatcher);
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
@@ -578,7 +578,13 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                         analysisParams.InnerCropRatio = profileService.ActiveProfile.FocuserSettings.AutoFocusInnerCropRatio;
                         analysisParams.OuterCropRatio = profileService.ActiveProfile.FocuserSettings.AutoFocusOuterCropRatio;
                     }
-                    analysisResult = await starDetection.Detect(image, pixelFormat, analysisParams, progress: null, token);
+                    // For a Review-Frames run, model PSFs (auto-focus normally skips them) so the review shows the
+                    // PSF-derived per-star properties — detection is otherwise identical, so the HFR curve is unaffected.
+                    if (state.Options.ModelPSF && starDetection is IHocusFocusStarDetection hfReviewDetection) {
+                        analysisResult = await hfReviewDetection.Detect(image, pixelFormat, analysisParams, null, token, modelPSFForAutoFocus: true);
+                    } else {
+                        analysisResult = await starDetection.Detect(image, pixelFormat, analysisParams, progress: null, token);
+                    }
                 } else {
                     var hfStarDetection = (IHocusFocusStarDetection)starDetection;
                     var hfParams = hfStarDetection.ToHocusFocusParams(analysisParams);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusFrameReviewSnapshot.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusFrameReviewSnapshot.cs
@@ -1,0 +1,259 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Image.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Windows;
+using System.Windows.Media.Imaging;
+
+namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
+
+    /// <summary>
+    /// One detected star in a reviewable manual-AF frame, captured as PRIMITIVES in the frame's image-pixel
+    /// coordinates so the overlay sits directly on the displayed raw image and the snapshot is immutable against later
+    /// mutation of the source <see cref="HocusFocusDetectedStar"/>. Carries every field needed to render any
+    /// <see cref="ShowAnnotationTypeEnum"/> per-star text, the bounding box (for the Box/Ellipse bounds), and the PSF
+    /// geometry (for the PSF-ellipse bounds + star-center). PSF-derived values are <see cref="double.NaN"/> when the
+    /// star has no PSF fit (<see cref="HasPsf"/> false), matching the annotator which draws nothing for them.
+    /// </summary>
+    public sealed class AutoFocusReviewStar {
+
+        /// <summary>The detected centroid (<c>star.Position</c>), i.e. the star-bounds Box/Ellipse anchor and the
+        /// non-PSF star-center.</summary>
+        public double CenterX { get; init; }
+
+        public double CenterY { get; init; }
+
+        public double BoxX { get; init; }
+        public double BoxY { get; init; }
+        public double BoxWidth { get; init; }
+        public double BoxHeight { get; init; }
+
+        /// <summary>Whether a PSF fit is available; gates the PSF-ellipse bounds, the PSF-offset star-center, and all
+        /// PSF-derived annotation text.</summary>
+        public bool HasPsf { get; init; }
+
+        /// <summary>PSF sub-pixel offset from <see cref="CenterX"/>/<see cref="CenterY"/>, applied to the star-center
+        /// crosshair when the bounds type is PSF (matching <c>HocusFocusStarAnnotator</c>).</summary>
+        public double PsfOffsetX { get; init; }
+
+        public double PsfOffsetY { get; init; }
+
+        /// <summary>PSF FWHM along the major/minor axes (pixels), used to size the rotated PSF-ellipse bounds
+        /// (width = 2·FWHMx, height = 2·FWHMy, centered at the centroid).</summary>
+        public double PsfFwhmX { get; init; }
+
+        public double PsfFwhmY { get; init; }
+
+        /// <summary>PSF rotation in degrees (the annotator rotates the ellipse clockwise by this, and the PSFTheta text
+        /// shows it rounded with a degree symbol).</summary>
+        public double PsfThetaDegrees { get; init; }
+
+        // ---- annotation values (one per ShowAnnotationTypeEnum) ----
+        public double Hfr { get; init; }
+        public double Background { get; init; }
+        public double FwhmArcsec { get; init; }
+        public double FwhmPixels { get; init; }
+        public double FwhmX { get; init; }
+        public double FwhmY { get; init; }
+        public double Eccentricity { get; init; }
+        public double PsfBackground { get; init; }
+        public double PsfPeak { get; init; }
+        public double MoffatBeta { get; init; }
+    }
+
+    /// <summary>
+    /// One reviewable manual-AF frame: its frozen <see cref="BitmapSource"/>, the detected stars overlaid on it, and
+    /// the detector's rejection-reason / ROI rectangles (image-pixel coords) so the review can reproduce the Hocus
+    /// Focus Star Annotator's overlays. Holds only the bitmap reference + primitives.
+    /// </summary>
+    public sealed class AutoFocusReviewFrame {
+        public int FrameIndex { get; init; }
+        public double FocuserPosition { get; init; }
+        public int DetectedStarCount { get; init; }
+        public BitmapSource Image { get; init; }
+        public IReadOnlyList<AutoFocusReviewStar> Stars { get; init; }
+
+        // The detector's per-reason rejection rectangles (the same seven the annotator draws), each colored by the
+        // matching IStarAnnotatorOptions color/show-flag at render time. Always non-null (empty when none).
+        public IReadOnlyList<Rect> TooDistorted { get; init; }
+        public IReadOnlyList<Rect> Degenerate { get; init; }
+        public IReadOnlyList<Rect> Saturated { get; init; }
+        public IReadOnlyList<Rect> LowSensitivity { get; init; }
+        public IReadOnlyList<Rect> NotCentered { get; init; }
+        public IReadOnlyList<Rect> TooFlat { get; init; }
+        public IReadOnlyList<Rect> Contaminated { get; init; }
+
+        /// <summary>The detection ROI rectangles (outer, plus inner crop when present); empty for a full-frame
+        /// detection.</summary>
+        public IReadOnlyList<Rect> RoiRects { get; init; }
+    }
+
+    /// <summary>An immutable, render-ready description of a completed manual-AF run's per-frame detections, built once
+    /// at the end of the run from the retained per-frame images + star-detection results.</summary>
+    public sealed class AutoFocusFrameReviewSnapshot {
+        public IReadOnlyList<AutoFocusReviewFrame> Frames { get; init; }
+    }
+
+    /// <summary>
+    /// Formats the per-star annotation text for the review overlay, byte-for-byte matching
+    /// <c>HocusFocusStarAnnotator</c>'s <c>DrawString</c> output for each <see cref="ShowAnnotationTypeEnum"/>. PSF-only
+    /// properties yield an empty string when the star has no PSF (so nothing is drawn, exactly as the annotator skips
+    /// the <c>psf != null</c> branches), and Moffat Beta is blank when NaN.
+    /// </summary>
+    public static class AutoFocusAnnotationText {
+
+        public static string Format(AutoFocusReviewStar star, ShowAnnotationTypeEnum type) {
+            if (star == null) {
+                return string.Empty;
+            }
+            switch (type) {
+                case ShowAnnotationTypeEnum.HFR:
+                    return star.Hfr.ToString("#0.00", CultureInfo.CurrentCulture);
+                case ShowAnnotationTypeEnum.Background:
+                    return star.Background.ToString("#.0000", CultureInfo.CurrentCulture);
+                case ShowAnnotationTypeEnum.FWHM:
+                    return star.HasPsf ? star.FwhmArcsec.ToString("#0.00", CultureInfo.CurrentCulture) : string.Empty;
+                case ShowAnnotationTypeEnum.FWHMPixels:
+                    return star.HasPsf ? star.FwhmPixels.ToString("#0.00", CultureInfo.CurrentCulture) : string.Empty;
+                case ShowAnnotationTypeEnum.FWHM_X:
+                    return star.HasPsf ? star.FwhmX.ToString("#0.00", CultureInfo.CurrentCulture) : string.Empty;
+                case ShowAnnotationTypeEnum.FWHM_Y:
+                    return star.HasPsf ? star.FwhmY.ToString("#0.00", CultureInfo.CurrentCulture) : string.Empty;
+                case ShowAnnotationTypeEnum.Eccentricity:
+                    return star.HasPsf ? star.Eccentricity.ToString("#.00", CultureInfo.CurrentCulture) : string.Empty;
+                case ShowAnnotationTypeEnum.PSFTheta:
+                    return star.HasPsf ? Math.Round(star.PsfThetaDegrees).ToString("##0", CultureInfo.CurrentCulture) + "°" : string.Empty;
+                case ShowAnnotationTypeEnum.PSFBackground:
+                    return star.HasPsf ? star.PsfBackground.ToString("#.0000", CultureInfo.CurrentCulture) : string.Empty;
+                case ShowAnnotationTypeEnum.PSFPeak:
+                    return star.HasPsf ? star.PsfPeak.ToString("#.0000", CultureInfo.CurrentCulture) : string.Empty;
+                case ShowAnnotationTypeEnum.MoffatBeta:
+                    return star.HasPsf && !double.IsNaN(star.MoffatBeta) ? star.MoffatBeta.ToString("0.##", CultureInfo.CurrentCulture) : string.Empty;
+                case ShowAnnotationTypeEnum.None:
+                default:
+                    return string.Empty;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds an <see cref="AutoFocusFrameReviewSnapshot"/> from the per-frame star-detection results + retained images
+    /// of a completed manual auto-focus run. Pure (no WPF beyond carrying the frozen bitmaps), so it is unit-tested
+    /// directly. Unlike the Aberration Inspector's <c>FrameReviewSnapshotBuilder</c>, a manual AF run uses a single
+    /// region with no cross-frame registration, so there is no alignment/target/fit machinery — the box and center are
+    /// the detector's own <c>BoundingBox</c>/<c>Position</c> (NOT the Original* fields, which are only populated by the
+    /// inspector's alignment pass).
+    /// </summary>
+    public static class AutoFocusFrameReviewSnapshotBuilder {
+
+        public static AutoFocusFrameReviewSnapshot Build(
+            IReadOnlyList<(double FocuserPosition, HocusFocusStarDetectionResult Result, IRenderedImage Image)> frames) {
+
+            var built = new List<AutoFocusReviewFrame>();
+            var frameCount = frames?.Count ?? 0;
+            for (int i = 0; i < frameCount; i++) {
+                var (focuserPosition, result, image) = frames[i];
+                var bitmap = image?.Image;
+                if (bitmap == null) {
+                    continue; // Drop frames whose per-frame image was not retained.
+                }
+
+                var stars = new List<AutoFocusReviewStar>();
+                var starList = result?.StarList;
+                if (starList != null) {
+                    foreach (var detected in starList) {
+                        var hf = detected as HocusFocusDetectedStar;
+                        var psf = hf?.PSF;
+                        var box = detected.BoundingBox;
+                        stars.Add(new AutoFocusReviewStar {
+                            CenterX = detected.Position.X,
+                            CenterY = detected.Position.Y,
+                            BoxX = box.X,
+                            BoxY = box.Y,
+                            BoxWidth = box.Width,
+                            BoxHeight = box.Height,
+                            HasPsf = psf != null,
+                            PsfOffsetX = psf?.OffsetX ?? 0.0,
+                            PsfOffsetY = psf?.OffsetY ?? 0.0,
+                            PsfFwhmX = psf?.FWHMx ?? double.NaN,
+                            PsfFwhmY = psf?.FWHMy ?? double.NaN,
+                            PsfThetaDegrees = psf != null ? MathUtility.RadiansToDegrees(psf.ThetaRadians) : double.NaN,
+                            Hfr = detected.HFR,
+                            Background = detected.Background,
+                            FwhmArcsec = psf?.FWHMArcsecs ?? double.NaN,
+                            FwhmPixels = psf?.FWHMPixels ?? double.NaN,
+                            FwhmX = psf?.FWHMx ?? double.NaN,
+                            FwhmY = psf?.FWHMy ?? double.NaN,
+                            Eccentricity = psf?.Eccentricity ?? double.NaN,
+                            PsfBackground = psf?.Background ?? double.NaN,
+                            PsfPeak = psf?.Peak ?? double.NaN,
+                            MoffatBeta = psf?.Beta ?? double.NaN,
+                        });
+                    }
+                }
+
+                var metrics = result?.Metrics;
+                built.Add(new AutoFocusReviewFrame {
+                    FrameIndex = i,
+                    FocuserPosition = focuserPosition,
+                    DetectedStarCount = stars.Count,
+                    Image = bitmap,
+                    Stars = stars,
+                    TooDistorted = ToRects(metrics?.TooDistortedBounds),
+                    Degenerate = ToRects(metrics?.DegenerateBounds),
+                    Saturated = ToRects(metrics?.SaturatedBounds),
+                    LowSensitivity = ToRects(metrics?.LowSensitivityBounds),
+                    NotCentered = ToRects(metrics?.NotCenteredBounds),
+                    TooFlat = ToRects(metrics?.TooFlatBounds),
+                    Contaminated = ToRects(metrics?.ContaminatedBounds),
+                    RoiRects = BuildRoiRects(result, bitmap.PixelWidth, bitmap.PixelHeight),
+                });
+            }
+
+            // Present frames in focuser-sweep order; OrderBy is stable so multiple frames per position keep their
+            // capture order (and FrameIndex still records the original capture index).
+            var ordered = built.OrderBy(f => f.FocuserPosition).ToList();
+            return new AutoFocusFrameReviewSnapshot { Frames = ordered };
+        }
+
+        private static IReadOnlyList<Rect> ToRects(IEnumerable<OpenCvSharp.Rect> bounds) {
+            if (bounds == null) {
+                return Array.Empty<Rect>();
+            }
+            return bounds.Select(r => new Rect(r.X, r.Y, r.Width, r.Height)).ToList();
+        }
+
+        // Mirrors HocusFocusStarAnnotator's ROI drawing: the outer boundary, plus the inner crop boundary when present,
+        // scaled from normalized region coordinates to image pixels. Empty when the region covers the full frame.
+        private static IReadOnlyList<Rect> BuildRoiRects(HocusFocusStarDetectionResult result, int pixelWidth, int pixelHeight) {
+            var region = result?.DetectorParams?.Region;
+            if (region == null || region.IsFull()) {
+                return Array.Empty<Rect>();
+            }
+            var rects = new List<Rect>();
+            var outer = region.OuterBoundary;
+            rects.Add(new Rect(outer.StartX * pixelWidth, outer.StartY * pixelHeight, outer.Width * pixelWidth, outer.Height * pixelHeight));
+            var inner = region.InnerCropBoundary;
+            if (inner != null) {
+                rects.Add(new Rect(inner.StartX * pixelWidth, inner.StartY * pixelHeight, inner.Width * pixelWidth, inner.Height * pixelHeight));
+            }
+            return rects;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusOptions.cs
@@ -61,6 +61,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             hfrImprovementThreshold = optionsAccessor.GetValueDouble("HFRImprovementThreshold", 0.15);
             savePath = optionsAccessor.GetValueString("SavePath", "");
             save = optionsAccessor.GetValueBoolean("Save", false);
+            keepFramesForReview = optionsAccessor.GetValueBoolean(nameof(KeepFramesForReview), false);
             lastSelectedLoadPath = optionsAccessor.GetValueString("LastSelectedLoadPath", "");
             focuserOffset = optionsAccessor.GetValueInt32("FocuserOffset", 0);
             maxOutlierRejections = optionsAccessor.GetValueInt32(nameof(MaxOutlierRejections), 1);
@@ -84,6 +85,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             HFRImprovementThreshold = 0.15;
             SavePath = "";
             Save = false;
+            KeepFramesForReview = false;
             LastSelectedLoadPath = "";
             FocuserOffset = 0;
             MaxOutlierRejections = 1;
@@ -269,6 +271,19 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 if (save != value) {
                     save = value;
                     optionsAccessor.SetValueBoolean(nameof(Save), save);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool keepFramesForReview;
+
+        public bool KeepFramesForReview {
+            get => keepFramesForReview;
+            set {
+                if (keepFramesForReview != value) {
+                    keepFramesForReview = value;
+                    optionsAccessor.SetValueBoolean(nameof(KeepFramesForReview), keepFramesForReview);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -91,7 +91,9 @@
     <!--  The manual AutoFocus "Review Frames" window content. Implicit DataType template so the WindowService's
           ContentPresenter resolves it by VM type (same mechanism as the Aberration Inspector's Review Frames).  -->
     <DataTemplate DataType="{x:Type afreview:AutoFocusFrameReviewVM}">
-        <afreview:AutoFocusFrameReviewControl MinWidth="1280" MinHeight="860" />
+        <!--  No fixed min size: the control sizes its host window to fit the screen on load (see code-behind), and the
+              layout shrinks the image column first so the legend stays visible when the window is made smaller.  -->
+        <afreview:AutoFocusFrameReviewControl />
     </DataTemplate>
 
     <DataTemplate x:Key="NINA.Joko.Plugins.HocusFocus.AutoFocus.HocusFocusVM_Dockable">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -103,7 +103,6 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <oxy:Plot
                 Background="{StaticResource BackgroundBrush}"
@@ -619,10 +618,10 @@
                 IsEnabled="{Binding AutoFocusInProgress, Converter={StaticResource InverseBooleanConverter}}"
                 ToolTip="Reprocesses AutoFocus images saved by having Save enabled in Hocus Focus -&gt; Auto Focus Options. This produces an auto focus curve using whatever the current star detection and fit settings are" />
             <StackPanel
-                Grid.Row="4"
-                Margin="10,0,10,8"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
+                Grid.Row="3"
+                Margin="0,15,10,5"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Bottom"
                 Orientation="Horizontal">
                 <Button
                     Height="25"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -101,6 +101,7 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <oxy:Plot
                 Background="{StaticResource BackgroundBrush}"
@@ -616,13 +617,22 @@
                 IsEnabled="{Binding AutoFocusInProgress, Converter={StaticResource InverseBooleanConverter}}"
                 ToolTip="Reprocesses AutoFocus images saved by having Save enabled in Hocus Focus -&gt; Auto Focus Options. This produces an auto focus curve using whatever the current star detection and fit settings are" />
             <StackPanel
-                Grid.Row="3"
-                Margin="0,15,10,5"
-                HorizontalAlignment="Right"
-                VerticalAlignment="Bottom"
+                Grid.Row="4"
+                Margin="10,0,10,8"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
                 Orientation="Horizontal">
+                <Button
+                    Height="25"
+                    Padding="5,0,5,0"
+                    VerticalAlignment="Center"
+                    Command="{Binding ReviewFramesCommand}"
+                    IsEnabled="{Binding ReviewFramesAvailable}"
+                    ToolTip="Open the Review Frames window to inspect each frame of the last manual auto-focus run — its detected stars with the Hocus Focus Star Annotator's bounds, per-star text, rejection-reason and ROI boxes, plus per-frame HFR statistics. Enabled after an interactive run from this pane completes with &quot;Keep frames for review&quot; turned on.">
+                    <TextBlock Margin="5,0,5,0" Text="Review Frames" />
+                </Button>
                 <StackPanel
-                    Margin="0,0,12,0"
+                    Margin="12,0,0,0"
                     VerticalAlignment="Center"
                     Orientation="Horizontal"
                     ToolTip="When on, the per-frame images from a MANUAL auto-focus run started here in the AutoFocus pane are kept in memory so the &quot;Review Frames&quot; button can show each frame with its detected stars and HFRs. Only applies to interactive runs from this pane — auto-focus during an imaging sequence never keeps frames (it would use too much memory). The frames are released when you start a new run or close the review window. Off by default; saved in your profile.">
@@ -634,15 +644,6 @@
                         VerticalAlignment="Center"
                         Text="Keep frames for review" />
                 </StackPanel>
-                <Button
-                    Height="25"
-                    Padding="5,0,5,0"
-                    VerticalAlignment="Bottom"
-                    Command="{Binding ReviewFramesCommand}"
-                    IsEnabled="{Binding ReviewFramesAvailable}"
-                    ToolTip="Open the Review Frames window to inspect each frame of the last manual auto-focus run — its detected stars with the Hocus Focus Star Annotator's bounds, per-star text, rejection-reason and ROI boxes, plus per-frame HFR statistics. Enabled after an interactive run from this pane completes with &quot;Keep frames for review&quot; turned on.">
-                    <TextBlock Margin="5,0,5,0" Text="Review Frames" />
-                </Button>
             </StackPanel>
         </Grid>
     </DataTemplate>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -628,14 +628,14 @@
                     VerticalAlignment="Center"
                     Command="{Binding ReviewFramesCommand}"
                     IsEnabled="{Binding ReviewFramesAvailable}"
-                    ToolTip="Open the Review Frames window to inspect each frame of the last manual auto-focus run — its detected stars with the Hocus Focus Star Annotator's bounds, per-star text, rejection-reason and ROI boxes, plus per-frame HFR statistics. Enabled after an interactive run from this pane completes with &quot;Keep frames for review&quot; turned on.">
+                    ToolTip="Open the Review Frames window to inspect each frame of the last auto-focus run started from this pane (a live run or a Reprocess Saved Run) — its detected stars with the Hocus Focus Star Annotator's bounds, per-star text, rejection-reason and ROI boxes, plus per-frame HFR statistics. Enabled after such a run completes with &quot;Keep frames for review&quot; turned on.">
                     <TextBlock Margin="5,0,5,0" Text="Review Frames" />
                 </Button>
                 <StackPanel
                     Margin="12,0,0,0"
                     VerticalAlignment="Center"
                     Orientation="Horizontal"
-                    ToolTip="When on, the per-frame images from a MANUAL auto-focus run started here in the AutoFocus pane are kept in memory so the &quot;Review Frames&quot; button can show each frame with its detected stars and HFRs. Only applies to interactive runs from this pane — auto-focus during an imaging sequence never keeps frames (it would use too much memory). The frames are released when you start a new run or close the review window. Off by default; saved in your profile.">
+                    ToolTip="When on, the per-frame images from an auto-focus run started here in the AutoFocus pane — a live run or a Reprocess Saved Run — are kept in memory so the &quot;Review Frames&quot; button can show each frame with its detected stars and HFRs. Only applies to runs from this pane — auto-focus during an imaging sequence never keeps frames (it would use too much memory). The frames are released when you start a new run or close the review window. Off by default; saved in your profile.">
                     <CheckBox
                         VerticalAlignment="Center"
                         IsChecked="{Binding AutoFocusOptions.KeepFramesForReview}" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -7,6 +7,7 @@
     xmlns:hfenum="clr-namespace:NINA.Joko.Plugins.HocusFocus.Interfaces"
     xmlns:hfrules="clr-namespace:NINA.Joko.Plugins.HocusFocus.ValidationRules"
     xmlns:local="clr-namespace:NINA.Joko.Plugins.HocusFocus.AutoFocus"
+    xmlns:afreview="clr-namespace:NINA.Joko.Plugins.HocusFocus.AutoFocus.Review"
     xmlns:ninactrl="clr-namespace:NINA.CustomControlLibrary;assembly=NINA.CustomControlLibrary"
     xmlns:ns="clr-namespace:NINA.Core.Locale;assembly=NINA.Core"
     xmlns:oxy="clr-namespace:OxyPlot.Wpf;assembly=OxyPlot.Contrib.Wpf"
@@ -87,8 +88,14 @@
     <TextBlock x:Key="SDR_BloomSuppressed_Tooltip" Text="Candidates rejected because they fell within the saturation bloom radius of a bright saturated star (halo/bloom fragments). Only active when Defocus-Aware Donut Detection and a bloom radius are enabled." />
     <TextBlock x:Key="SDR_RelaxationAdmitted_Tooltip" Text="Accepted stars that were admitted only because a defocus-aware gate (distortion and/or centering) relaxed its threshold — they would have failed the strict gate. Always zero when the defocus-aware gates are off. Large near-focus values can indicate the relaxation is admitting junk blobs." />
 
+    <!--  The manual AutoFocus "Review Frames" window content. Implicit DataType template so the WindowService's
+          ContentPresenter resolves it by VM type (same mechanism as the Aberration Inspector's Review Frames).  -->
+    <DataTemplate DataType="{x:Type afreview:AutoFocusFrameReviewVM}">
+        <afreview:AutoFocusFrameReviewControl MinWidth="1280" MinHeight="860" />
+    </DataTemplate>
+
     <DataTemplate x:Key="NINA.Joko.Plugins.HocusFocus.AutoFocus.HocusFocusVM_Dockable">
-        <Grid>
+        <Grid local:InteractiveHostBehavior.HostInteractive="True">
             <Grid.RowDefinitions>
                 <RowDefinition MinHeight="150" />
                 <RowDefinition Height="Auto" />
@@ -608,6 +615,35 @@
                 Command="{Binding LoadSavedAutoFocusRunCommand}"
                 IsEnabled="{Binding AutoFocusInProgress, Converter={StaticResource InverseBooleanConverter}}"
                 ToolTip="Reprocesses AutoFocus images saved by having Save enabled in Hocus Focus -&gt; Auto Focus Options. This produces an auto focus curve using whatever the current star detection and fit settings are" />
+            <StackPanel
+                Grid.Row="3"
+                Margin="0,15,10,5"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Bottom"
+                Orientation="Horizontal">
+                <StackPanel
+                    Margin="0,0,12,0"
+                    VerticalAlignment="Center"
+                    Orientation="Horizontal"
+                    ToolTip="When on, the per-frame images from a MANUAL auto-focus run started here in the AutoFocus pane are kept in memory so the &quot;Review Frames&quot; button can show each frame with its detected stars and HFRs. Only applies to interactive runs from this pane — auto-focus during an imaging sequence never keeps frames (it would use too much memory). The frames are released when you start a new run or close the review window. Off by default; saved in your profile.">
+                    <CheckBox
+                        VerticalAlignment="Center"
+                        IsChecked="{Binding AutoFocusOptions.KeepFramesForReview}" />
+                    <TextBlock
+                        Margin="5,0,0,0"
+                        VerticalAlignment="Center"
+                        Text="Keep frames for review" />
+                </StackPanel>
+                <Button
+                    Height="25"
+                    Padding="5,0,5,0"
+                    VerticalAlignment="Bottom"
+                    Command="{Binding ReviewFramesCommand}"
+                    IsEnabled="{Binding ReviewFramesAvailable}"
+                    ToolTip="Open the Review Frames window to inspect each frame of the last manual auto-focus run — its detected stars with the Hocus Focus Star Annotator's bounds, per-star text, rejection-reason and ROI boxes, plus per-frame HFR statistics. Enabled after an interactive run from this pane completes with &quot;Keep frames for review&quot; turned on.">
+                    <TextBlock Margin="5,0,5,0" Text="Review Frames" />
+                </Button>
+            </StackPanel>
         </Grid>
     </DataTemplate>
     <DataTemplate DataType="{x:Type local:HocusFocusVM}">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/HocusFocusVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/HocusFocusVM.cs
@@ -551,6 +551,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 frameReviewRequestedForRun = IsInteractive && autoFocusOptions.KeepFramesForReview;
                 if (frameReviewRequestedForRun) {
                     options.PreserveExposures = true;
+                    // Model PSFs during this review run iff PSF modeling is enabled in the star-detection options, so
+                    // the review can show the PSF-derived per-star properties (AF normally skips PSF fitting for speed).
+                    options.ModelPSF = starDetectionOptions.ModelPSF;
                 }
                 var result = await autoFocusEngine.Run(options, imagingFilter, token, progress);
                 if (result == null || !result.Succeeded) {
@@ -883,10 +886,12 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 var options = autoFocusEngine.GetOptions(savedAttempt);
 
                 // Replay is an interactive pane action, so it supports Review Frames on the same terms as a live run:
-                // keep frames when interactive + the toggle is on, forcing the engine to retain each reloaded exposure.
+                // keep frames when interactive + the toggle is on, forcing the engine to retain each reloaded exposure,
+                // and model PSFs (when enabled in star-detection options) so PSF properties are available in the review.
                 frameReviewRequestedForRun = IsInteractive && autoFocusOptions.KeepFramesForReview;
                 if (frameReviewRequestedForRun) {
                     options.PreserveExposures = true;
+                    options.ModelPSF = starDetectionOptions.ModelPSF;
                 }
 
                 var result = await autoFocusEngine.Rerun(options, savedAttempt, imagingFilter, loadSavedAutoFocusRunCts.Token, this.progress);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/HocusFocusVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/HocusFocusVM.cs
@@ -18,8 +18,11 @@ using NINA.Core.Model;
 using NINA.Core.Model.Equipment;
 using NINA.Core.Utility;
 using NINA.Core.Utility.Notification;
+using NINA.Core.Utility.WindowService;
 using NINA.Equipment.Interfaces.Mediator;
 using NINA.Image.ImageAnalysis;
+using NINA.Image.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus.Review;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.StarDetection;
 using NINA.Joko.Plugins.HocusFocus.Utility;
@@ -68,6 +71,23 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         private readonly IFilterWheelMediator filterWheelMediator;
         private readonly IProgress<ApplicationStatus> progress;
         private readonly IPluggableBehaviorSelector<IStarDetection> starDetectionSelector;
+        private readonly IApplicationDispatcher applicationDispatcher;
+
+        // WindowServiceFactory is not a MEF export (NINA exposes the concrete type), so it is instantiated directly,
+        // mirroring InspectorVM / HocusFocusPlugin.
+        private readonly IWindowServiceFactory windowServiceFactory = new WindowServiceFactory();
+
+        // ---- Review Frames (manual-AF only) -------------------------------------------------------------
+        // Each retained per-frame (focuser position, detection result, image) tuple is accumulated under the lock as
+        // SubMeasurementPointCompleted fires concurrently across focuser positions, then built into the immutable
+        // reviewSnapshot at run completion. frameReviewRequestedForRun freezes the "keep frames" decision at run start
+        // (when PreserveExposures is decided) so a mid-run toggle change can't desync image retention from the build.
+        private readonly object frameReviewLock = new object();
+        private readonly List<(double FocuserPosition, HocusFocusStarDetectionResult Result, IRenderedImage Image)> reviewFrames
+            = new List<(double, HocusFocusStarDetectionResult, IRenderedImage)>();
+        private bool frameReviewRequestedForRun;
+        private AutoFocusFrameReviewSnapshot reviewSnapshot;
+
         public static readonly string ReportDirectory = Path.Combine(CoreUtil.APPLICATIONTEMPPATH, "AutoFocus");
 
         static HocusFocusVM() {
@@ -87,7 +107,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             IFilterWheelMediator filterWheelMediator,
             IApplicationStatusMediator applicationStatusMediator,
             IPluggableBehaviorSelector<IStarDetection> starDetectionSelector,
-            IAlglibAPI alglibAPI
+            IAlglibAPI alglibAPI,
+            IApplicationDispatcher applicationDispatcher
         ) : base(profileService) {
             this.focuserMediator = focuserMediator;
             this.autoFocusEngineFactory = autoFocusEngineFactory;
@@ -96,6 +117,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             this.starDetectionOptions = starDetectionOptions;
             this.autoFocusOptions = autoFocusOptions;
             this.alglibAPI = alglibAPI;
+            this.applicationDispatcher = applicationDispatcher;
 
             FocusPoints = new AsyncObservableCollection<ScatterErrorPoint>();
             PlotFinalFocusPointWithError = new AsyncObservableCollection<ScatterErrorPoint>();
@@ -121,6 +143,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 return Task.Run(() => LoadSavedAutoFocusRun(path));
             });
             CancelLoadSavedAutoFocusRunCommand = new RelayCommand(CancelLoadSavedAutoFocusRun);
+            ReviewFramesCommand = new RelayCommand(ShowFrameReview, () => ReviewFramesAvailable);
         }
 
         private readonly IAlglibAPI alglibAPI;
@@ -517,9 +540,18 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 autoFocusEngine.InitialHFRCalculated += AutoFocusEngine_InitialHFRCalculated;
                 autoFocusEngine.IterationFailed += AutoFocusEngine_IterationFailed;
                 autoFocusEngine.MeasurementPointCompleted += AutoFocusEngine_MeasurementPointCompleted;
+                autoFocusEngine.SubMeasurementPointCompleted += AutoFocusEngine_SubMeasurementPointCompleted;
                 autoFocusEngine.Completed += AutoFocusEngine_Completed;
                 autoFocusEngine.Failed += AutoFocusEngine_Failed;
                 var options = autoFocusEngine.GetOptions();
+
+                // Retain per-frame images for review ONLY for an interactive run started from the AF pane AND with the
+                // persisted "Keep frames for review" toggle on. Frozen here (at run start, where PreserveExposures is
+                // decided) so a sequence-triggered run — whose VM is never marked interactive — never retains frames.
+                frameReviewRequestedForRun = IsInteractive && autoFocusOptions.KeepFramesForReview;
+                if (frameReviewRequestedForRun) {
+                    options.PreserveExposures = true;
+                }
                 var result = await autoFocusEngine.Run(options, imagingFilter, token, progress);
                 if (result == null || !result.Succeeded) {
                     return null;
@@ -565,6 +597,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             focuserMediator.BroadcastSuccessfulAutoFocusRun(autoFocusInfo);
 
             LastReport = report;
+            BuildFrameReviewSnapshotIfRequested();
         }
 
         private void AutoFocusEngine_Failed(object sender, AutoFocusFailedEventArgs e) {
@@ -587,6 +620,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 File.WriteAllText(targetFilePath, reportText);
             }
             LastReport = report;
+            // Build the review snapshot even for a failed sweep — seeing why detection struggled is often the most
+            // useful case (the frames were only retained for an interactive pane run with the toggle on).
+            BuildFrameReviewSnapshotIfRequested();
         }
 
         private void AutoFocusEngine_IterationFailed(object sender, AutoFocusFailedEventArgs e) {
@@ -687,12 +723,114 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             this.QuadraticFitting = e.Fittings.QuadraticFitting;
         }
 
+        // ---- Review Frames (manual-AF only) -------------------------------------------------------------
+
+        private bool isInteractive;
+
+        /// <summary>
+        /// True only for the VM instance hosted in the AutoFocus pane (set by InteractiveHostBehavior when the pane
+        /// DataTemplate loads). Sequence-triggered AF runs construct their own transient VM via the factory, which is
+        /// never rendered through the pane template, so it stays false — gating frame retention to interactive runs.
+        /// </summary>
+        public bool IsInteractive {
+            get => isInteractive;
+            set {
+                if (isInteractive != value) {
+                    isInteractive = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>Exposes the persisted AF options for the pane's "Keep frames for review" toggle binding (mirrors
+        /// InspectorVM.InspectorOptions).</summary>
+        public IAutoFocusOptions AutoFocusOptions => this.autoFocusOptions;
+
+        public RelayCommand ReviewFramesCommand { get; }
+
+        /// <summary>Whether a completed run produced reviewable frames (drives the "Review Frames" button).</summary>
+        public bool ReviewFramesAvailable => reviewSnapshot?.Frames.Count > 0;
+
+        private void AutoFocusEngine_SubMeasurementPointCompleted(object sender, AutoFocusSubMeasurementPointCompletedEventArgs e) {
+            // Standard (non-inspector) AF uses a single region 0; the image is only present when PreserveExposures was
+            // forced on (i.e. frameReviewRequestedForRun). Accumulate one tuple per fired frame.
+            if (!frameReviewRequestedForRun || e.RegionIndex != 0) {
+                return;
+            }
+            if (e.StarDetectionResult is not HocusFocusStarDetectionResult hf || e.Image == null) {
+                return;
+            }
+            lock (frameReviewLock) {
+                reviewFrames.Add((e.FocuserPosition, hf, e.Image));
+            }
+        }
+
+        private void BuildFrameReviewSnapshotIfRequested() {
+            if (!frameReviewRequestedForRun) {
+                return;
+            }
+            List<(double, HocusFocusStarDetectionResult, IRenderedImage)> framesForReview;
+            lock (frameReviewLock) {
+                framesForReview = reviewFrames
+                    .Select(f => (f.FocuserPosition, f.Result, f.Image))
+                    .ToList();
+            }
+            reviewSnapshot = AutoFocusFrameReviewSnapshotBuilder.Build(framesForReview);
+            NotifyReviewFramesAvailabilityChanged();
+        }
+
+        // Raise the availability binding + re-evaluate the command, marshaled to the UI thread (the snapshot is built /
+        // cleared on the engine's background task). DispatchSynchronizationContext is a synchronous Send with a
+        // same-context fast path, so it is safe to call from either thread.
+        private void NotifyReviewFramesAvailabilityChanged() {
+            applicationDispatcher.DispatchSynchronizationContext(() => {
+                RaisePropertyChanged(nameof(ReviewFramesAvailable));
+                ReviewFramesCommand.NotifyCanExecuteChanged();
+            });
+        }
+
+        // Shows the modal Review Frames dialog. The VM is presented in a ContentPresenter resolved by the implicit
+        // DataType DataTemplate for AutoFocusFrameReviewVM, and is disposed when the window closes (releasing the
+        // retained frame bitmaps).
+        private void ShowFrameReview() {
+            var snapshot = reviewSnapshot;
+            if (snapshot == null || snapshot.Frames.Count == 0) {
+                return;
+            }
+
+            var vm = new AutoFocusFrameReviewVM(snapshot, HocusFocusPlugin.StarAnnotatorOptions, starDetectionOptions.MeasurementAverage);
+            var windowService = windowServiceFactory.Create();
+
+            void onRequestClose(object s, EventArgs e) {
+                _ = windowService.Close();
+            }
+
+            EventHandler onClosed = null;
+            onClosed = (s, e) => {
+                windowService.OnClosed -= onClosed;
+                vm.RequestClose -= onRequestClose;
+                vm.Dispose();
+            };
+            windowService.OnClosed += onClosed;
+            vm.RequestClose += onRequestClose;
+
+            windowService.ShowDialog(vm, "Review Frames", System.Windows.ResizeMode.CanResize, System.Windows.WindowStyle.SingleBorderWindow);
+        }
+
         private void AutoFocusEngine_InitialHFRCalculated(object sender, AutoFocusInitialHFRCalculatedEventArgs e) {
             this.InitialHFR = e.InitialHFR.Measure;
         }
 
         private void AutoFocusEngine_AutoFocusStarted(object sender, AutoFocusStartedEventArgs e) {
             this.ClearCharts();
+
+            // Drop any frames/snapshot from a prior run (a new run supersedes the previous review). frameReviewRequestedForRun
+            // is NOT reset here — it is set per-entry-path (StartAutoFocus / LoadSavedAutoFocusRun) before Run() raises Started.
+            lock (frameReviewLock) {
+                reviewFrames.Clear();
+            }
+            reviewSnapshot = null;
+            NotifyReviewFramesAvailabilityChanged();
 
             this.focuserMediator.BroadcastAutoFocusRunStarting();
             this.LastAutoFocusPoint = new ReportAutoFocusPoint() {
@@ -714,6 +852,10 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     return false;
                 }
                 AutoFocusInProgress = true;
+
+                // Reprocessing a saved run never keeps frames for review (it does not subscribe to per-frame events),
+                // so make sure a stale "true" from a prior live run can't trigger a snapshot build at its completion.
+                frameReviewRequestedForRun = false;
 
                 loadSavedAutoFocusRunCts?.Cancel();
                 loadSavedAutoFocusRunCts = new CancellationTokenSource();

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/HocusFocusVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/HocusFocusVM.cs
@@ -853,10 +853,6 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 }
                 AutoFocusInProgress = true;
 
-                // Reprocessing a saved run never keeps frames for review (it does not subscribe to per-frame events),
-                // so make sure a stale "true" from a prior live run can't trigger a snapshot build at its completion.
-                frameReviewRequestedForRun = false;
-
                 loadSavedAutoFocusRunCts?.Cancel();
                 loadSavedAutoFocusRunCts = new CancellationTokenSource();
                 var autoFocusEngine = autoFocusEngineFactory.Create();
@@ -875,6 +871,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 autoFocusEngine.InitialHFRCalculated += AutoFocusEngine_InitialHFRCalculated;
                 autoFocusEngine.IterationFailed += AutoFocusEngine_IterationFailed;
                 autoFocusEngine.MeasurementPointCompleted += AutoFocusEngine_MeasurementPointCompleted;
+                autoFocusEngine.SubMeasurementPointCompleted += AutoFocusEngine_SubMeasurementPointCompleted;
                 autoFocusEngine.Completed += AutoFocusEngine_CompletedNoReport;
 
                 var filterInfo = filterWheelMediator.GetInfo();
@@ -884,8 +881,19 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 }
 
                 var options = autoFocusEngine.GetOptions(savedAttempt);
+
+                // Replay is an interactive pane action, so it supports Review Frames on the same terms as a live run:
+                // keep frames when interactive + the toggle is on, forcing the engine to retain each reloaded exposure.
+                frameReviewRequestedForRun = IsInteractive && autoFocusOptions.KeepFramesForReview;
+                if (frameReviewRequestedForRun) {
+                    options.PreserveExposures = true;
+                }
+
                 var result = await autoFocusEngine.Rerun(options, savedAttempt, imagingFilter, loadSavedAutoFocusRunCts.Token, this.progress);
                 if (result != null) {
+                    // The reprocess path wires Completed -> CompletedNoReport (no report handler), so build the review
+                    // snapshot here once the replay has finished and every reloaded frame has been collected.
+                    BuildFrameReviewSnapshotIfRequested();
                     InitialFocuserPosition = result.InitialFocuserPosition;
                     return result.Succeeded;
                 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/HocusFocusVMFactory.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/HocusFocusVMFactory.cs
@@ -34,6 +34,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         private readonly IStarDetectionOptions starDetectionOptions;
         private readonly IPluggableBehaviorSelector<IStarDetection> starDetectionSelector;
         private readonly IAlglibAPI alglibAPI;
+        private readonly IApplicationDispatcher applicationDispatcher;
 
         [ImportingConstructor]
         public HocusFocusVMFactory(
@@ -41,7 +42,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             IFocuserMediator focuserMediator,
             IFilterWheelMediator filterWheelMediator,
             IApplicationStatusMediator applicationStatusMediator,
-            IPluggableBehaviorSelector<IStarDetection> starDetectionSelector) : this(profileService, focuserMediator, filterWheelMediator, applicationStatusMediator, HocusFocusPlugin.AutoFocusOptions, HocusFocusPlugin.StarDetectionOptions, HocusFocusPlugin.AutoFocusEngineFactory, starDetectionSelector, HocusFocusPlugin.AlglibAPI) {
+            IPluggableBehaviorSelector<IStarDetection> starDetectionSelector) : this(profileService, focuserMediator, filterWheelMediator, applicationStatusMediator, HocusFocusPlugin.AutoFocusOptions, HocusFocusPlugin.StarDetectionOptions, HocusFocusPlugin.AutoFocusEngineFactory, starDetectionSelector, HocusFocusPlugin.AlglibAPI, HocusFocusPlugin.ApplicationDispatcher) {
         }
 
         public HocusFocusVMFactory(
@@ -53,7 +54,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             IStarDetectionOptions starDetectionOptions,
             IAutoFocusEngineFactory autoFocusEngineFactory,
             IPluggableBehaviorSelector<IStarDetection> starDetectionSelector,
-            IAlglibAPI alglibAPI) {
+            IAlglibAPI alglibAPI,
+            IApplicationDispatcher applicationDispatcher) {
             this.profileService = profileService;
             this.focuserMediator = focuserMediator;
             this.filterWheelMediator = filterWheelMediator;
@@ -63,6 +65,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             this.autoFocusEngineFactory = autoFocusEngineFactory;
             this.starDetectionSelector = starDetectionSelector;
             this.alglibAPI = alglibAPI;
+            this.applicationDispatcher = applicationDispatcher;
         }
 
         public string Name => "Hocus Focus";
@@ -70,7 +73,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         public string ContentId => this.GetType().FullName;
 
         public IAutoFocusVM Create() {
-            return new HocusFocusVM(profileService, focuserMediator, autoFocusEngineFactory, autoFocusOptions, starDetectionOptions, filterWheelMediator, applicationStatusMediator, starDetectionSelector, alglibAPI);
+            return new HocusFocusVM(profileService, focuserMediator, autoFocusEngineFactory, autoFocusOptions, starDetectionOptions, filterWheelMediator, applicationStatusMediator, starDetectionSelector, alglibAPI, applicationDispatcher);
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InteractiveHostBehavior.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InteractiveHostBehavior.cs
@@ -1,0 +1,73 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System.Windows;
+
+namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
+
+    /// <summary>
+    /// Attached behavior that marks the <see cref="HocusFocusVM"/> hosted in the AutoFocus pane as interactive while
+    /// the pane is loaded. The AF pane and the sequencer's RunAutofocus both call <see cref="HocusFocusVM.StartAutoFocus"/>
+    /// through the same <c>IAutoFocusVMFactory</c>, so the only reliable discriminator is that ONLY the pane's VM is
+    /// ever rendered through the <c>HocusFocusVM_Dockable</c> DataTemplate. Applying
+    /// <c>InteractiveHostBehavior.HostInteractive="True"</c> on that template's root sets <see cref="HocusFocusVM.IsInteractive"/>
+    /// on the bound VM; a sequence-created VM is never rendered there, so it stays false and never retains frames.
+    /// </summary>
+    public static class InteractiveHostBehavior {
+
+        public static readonly DependencyProperty HostInteractiveProperty =
+            DependencyProperty.RegisterAttached(
+                "HostInteractive",
+                typeof(bool),
+                typeof(InteractiveHostBehavior),
+                new PropertyMetadata(false, OnHostInteractiveChanged));
+
+        public static bool GetHostInteractive(DependencyObject obj) => (bool)obj.GetValue(HostInteractiveProperty);
+
+        public static void SetHostInteractive(DependencyObject obj, bool value) => obj.SetValue(HostInteractiveProperty, value);
+
+        private static void OnHostInteractiveChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+            if (d is not FrameworkElement fe) {
+                return;
+            }
+            if ((bool)e.NewValue) {
+                fe.Loaded += OnLoaded;
+                fe.Unloaded += OnUnloaded;
+                if (fe.IsLoaded) {
+                    SetInteractive(fe, true);
+                }
+            } else {
+                fe.Loaded -= OnLoaded;
+                fe.Unloaded -= OnUnloaded;
+                SetInteractive(fe, false);
+            }
+        }
+
+        private static void OnLoaded(object sender, RoutedEventArgs e) {
+            if (sender is FrameworkElement fe) {
+                SetInteractive(fe, true);
+            }
+        }
+
+        private static void OnUnloaded(object sender, RoutedEventArgs e) {
+            if (sender is FrameworkElement fe) {
+                SetInteractive(fe, false);
+            }
+        }
+
+        private static void SetInteractive(FrameworkElement fe, bool value) {
+            if (fe.DataContext is HocusFocusVM vm) {
+                vm.IsInteractive = value;
+            }
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
@@ -3,8 +3,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:hfconverters="clr-namespace:NINA.Joko.Plugins.HocusFocus.Converters"
-    xmlns:interfaces="clr-namespace:NINA.Joko.Plugins.HocusFocus.Interfaces"
-    xmlns:util="clr-namespace:NINA.Core.Utility;assembly=NINA.Core"
     Background="#FF1E2125">
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVis" />
@@ -51,11 +49,18 @@
             <Button DockPanel.Dock="Left" Content="Next ▶" Command="{Binding NextCommand}" />
             <TextBlock DockPanel.Dock="Left" Margin="16,0,6,0" Text="Show:" />
             <ComboBox DockPanel.Dock="Left" Width="150" VerticalAlignment="Center"
-                      ItemsSource="{Binding Source={util:EnumBindingSource {x:Type interfaces:ShowAnnotationTypeEnum}}}"
+                      Foreground="White" Background="#FF2A2F36" BorderBrush="#FF3F4958"
+                      ItemsSource="{Binding AvailableAnnotationTypes}"
                       SelectedItem="{Binding ShowAnnotationType}">
+                <ComboBox.ItemContainerStyle>
+                    <Style TargetType="ComboBoxItem">
+                        <Setter Property="Background" Value="#FF2A2F36" />
+                        <Setter Property="Foreground" Value="White" />
+                    </Style>
+                </ComboBox.ItemContainerStyle>
                 <ComboBox.ItemTemplate>
                     <DataTemplate>
-                        <TextBlock Text="{Binding Converter={StaticResource HF_EnumStaticDescriptionValueConverter}}" />
+                        <TextBlock Foreground="White" Text="{Binding Converter={StaticResource HF_EnumStaticDescriptionValueConverter}}" />
                     </DataTemplate>
                 </ComboBox.ItemTemplate>
             </ComboBox>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
@@ -1,0 +1,281 @@
+<UserControl
+    x:Class="NINA.Joko.Plugins.HocusFocus.AutoFocus.Review.AutoFocusFrameReviewControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:hfconverters="clr-namespace:NINA.Joko.Plugins.HocusFocus.Converters"
+    xmlns:interfaces="clr-namespace:NINA.Joko.Plugins.HocusFocus.Interfaces"
+    xmlns:util="clr-namespace:NINA.Core.Utility;assembly=NINA.Core"
+    Background="#FF1E2125">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis" />
+        <hfconverters:EnumStaticDescriptionValueConverter x:Key="HF_EnumStaticDescriptionValueConverter" />
+        <SolidColorBrush x:Key="Fg" Color="White" />
+
+        <Style TargetType="Button">
+            <Setter Property="Margin" Value="4,0" />
+            <Setter Property="Padding" Value="10,4" />
+        </Style>
+        <Style TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{StaticResource Fg}" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+    </UserControl.Resources>
+
+    <Grid Margin="10">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <!-- Summary header: focuser position, detected-star count, HFR ± deviation stats, frame index. -->
+        <Border Grid.Row="0" Grid.Column="0" Margin="0,0,0,6" Padding="8,5" CornerRadius="3" Background="#FF262B31">
+            <DockPanel LastChildFill="False">
+                <TextBlock DockPanel.Dock="Left" FontWeight="SemiBold" Text="{Binding FrameHeader}" />
+                <TextBlock DockPanel.Dock="Left" Margin="16,0,0,0" Foreground="#FFB0B6BD" Text="{Binding DetectedCountText}" />
+                <TextBlock DockPanel.Dock="Left" Margin="16,0,0,0" Foreground="#FFFFD700" FontWeight="SemiBold"
+                           Text="{Binding StatsText}"
+                           Visibility="{Binding ShowStats, Converter={StaticResource BoolToVis}}" />
+                <TextBlock DockPanel.Dock="Right" Text="{Binding PositionLabel}" />
+            </DockPanel>
+        </Border>
+
+        <!-- Toolbar: navigation + per-star text selector + close. -->
+        <DockPanel Grid.Row="1" Grid.Column="0" LastChildFill="False" Margin="0,0,0,6">
+            <Button DockPanel.Dock="Left" Content="Fit" Command="{Binding FitCommand}" Margin="0,0,4,0" />
+            <Button DockPanel.Dock="Left" Content="◀ Prev" Command="{Binding PrevCommand}" />
+            <Button DockPanel.Dock="Left" Content="Next ▶" Command="{Binding NextCommand}" />
+            <TextBlock DockPanel.Dock="Left" Margin="16,0,6,0" Text="Show:" />
+            <ComboBox DockPanel.Dock="Left" Width="150" VerticalAlignment="Center"
+                      ItemsSource="{Binding Source={util:EnumBindingSource {x:Type interfaces:ShowAnnotationTypeEnum}}}"
+                      SelectedItem="{Binding ShowAnnotationType}">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Converter={StaticResource HF_EnumStaticDescriptionValueConverter}}" />
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+            <Button DockPanel.Dock="Right" Content="Close" Command="{Binding CloseCommand}" />
+        </DockPanel>
+
+        <!-- Image + scrollbars. -->
+        <Grid Grid.Row="2" Grid.Column="0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <Border Grid.Row="0" Grid.Column="0" ClipToBounds="True" Background="Black" BorderBrush="#FF3F4958" BorderThickness="1">
+                <Canvas x:Name="ViewportCanvas"
+                        Background="Transparent"
+                        MouseWheel="ViewportCanvas_MouseWheel"
+                        MouseRightButtonDown="ViewportCanvas_MouseRightButtonDown"
+                        MouseRightButtonUp="ViewportCanvas_MouseRightButtonUp"
+                        MouseMove="ViewportCanvas_MouseMove"
+                        SizeChanged="ViewportCanvas_SizeChanged">
+                    <Canvas.RenderTransform>
+                        <TransformGroup>
+                            <ScaleTransform x:Name="ContentScale" ScaleX="1" ScaleY="1" />
+                            <TranslateTransform x:Name="ContentTranslate" X="0" Y="0" />
+                        </TransformGroup>
+                    </Canvas.RenderTransform>
+
+                    <!-- Background frame (raw image-pixel coords; the canvas transform handles zoom/pan). -->
+                    <Image x:Name="FrameImageControl"
+                           Source="{Binding FrameImage}"
+                           Canvas.Left="0" Canvas.Top="0"
+                           Stretch="None"
+                           RenderOptions.BitmapScalingMode="NearestNeighbor" />
+
+                    <!-- Rejection-reason + ROI rectangles (pre-colored per the annotator's enabled reasons). -->
+                    <ItemsControl ItemsSource="{Binding RectOverlays}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Canvas.Left" Value="{Binding X}" />
+                                <Setter Property="Canvas.Top" Value="{Binding Y}" />
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Rectangle Width="{Binding Width}" Height="{Binding Height}"
+                                           HorizontalAlignment="Left" VerticalAlignment="Top"
+                                           IsHitTestVisible="False"
+                                           Stroke="{Binding Brush}"
+                                           StrokeThickness="{Binding DataContext.MarkerStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!-- Star bounds: Box / Ellipse (anchored at the detector bounding box, gated by Show star bounds). -->
+                    <ItemsControl ItemsSource="{Binding Markers}"
+                                  Visibility="{Binding ShowStarBounds, Converter={StaticResource BoolToVis}}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Canvas.Left" Value="{Binding BoxX}" />
+                                <Setter Property="Canvas.Top" Value="{Binding BoxY}" />
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Grid>
+                                    <Rectangle Width="{Binding BoxWidth}" Height="{Binding BoxHeight}"
+                                               HorizontalAlignment="Left" VerticalAlignment="Top"
+                                               IsHitTestVisible="False"
+                                               Visibility="{Binding ShowBox, Converter={StaticResource BoolToVis}}"
+                                               Stroke="{Binding DataContext.StarBoundsBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                               StrokeThickness="{Binding DataContext.MarkerStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                    <Ellipse Width="{Binding BoxWidth}" Height="{Binding BoxHeight}"
+                                             HorizontalAlignment="Left" VerticalAlignment="Top"
+                                             IsHitTestVisible="False"
+                                             Visibility="{Binding ShowEllipse, Converter={StaticResource BoolToVis}}"
+                                             Stroke="{Binding DataContext.StarBoundsBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                             StrokeThickness="{Binding DataContext.MarkerStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!-- Star bounds: rotated PSF ellipse (anchored at the centroid, gated by Show star bounds). -->
+                    <ItemsControl ItemsSource="{Binding Markers}"
+                                  Visibility="{Binding ShowStarBounds, Converter={StaticResource BoolToVis}}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Canvas.Left" Value="{Binding PsfCenterX}" />
+                                <Setter Property="Canvas.Top" Value="{Binding PsfCenterY}" />
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Ellipse Width="{Binding PsfEllipseWidth}" Height="{Binding PsfEllipseHeight}"
+                                         HorizontalAlignment="Left" VerticalAlignment="Top"
+                                         IsHitTestVisible="False"
+                                         Visibility="{Binding ShowPsfEllipse, Converter={StaticResource BoolToVis}}"
+                                         Stroke="{Binding DataContext.StarBoundsBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                         StrokeThickness="{Binding DataContext.MarkerStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}">
+                                    <Ellipse.RenderTransform>
+                                        <TransformGroup>
+                                            <TranslateTransform X="{Binding PsfTranslateX}" Y="{Binding PsfTranslateY}" />
+                                            <RotateTransform Angle="{Binding PsfRotationDegrees}" CenterX="0" CenterY="0" />
+                                        </TransformGroup>
+                                    </Ellipse.RenderTransform>
+                                </Ellipse>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!-- Star-center crosshair (anchored at the centroid, gated by Show star center). -->
+                    <ItemsControl ItemsSource="{Binding Markers}"
+                                  Visibility="{Binding ShowStarCenter, Converter={StaticResource BoolToVis}}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Canvas.Left" Value="{Binding CrossCenterX}" />
+                                <Setter Property="Canvas.Top" Value="{Binding CrossCenterY}" />
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Canvas IsHitTestVisible="False">
+                                    <Line X1="{Binding NegCrossHalfX}" Y1="0" X2="{Binding CrossHalfX}" Y2="0"
+                                          Stroke="{Binding DataContext.StarCenterBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                          StrokeThickness="{Binding DataContext.MarkerStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                    <Line X1="0" Y1="{Binding NegCrossHalfY}" X2="0" Y2="{Binding CrossHalfY}"
+                                          Stroke="{Binding DataContext.StarCenterBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                          StrokeThickness="{Binding DataContext.MarkerStrokeThickness, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                </Canvas>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!-- Per-star annotation text, constant on-screen size with a 75%-transparent background, anchored at
+                         the bounding box's top-right (matching the annotator). -->
+                    <ItemsControl ItemsSource="{Binding Markers}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate><Canvas /></ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Canvas.Left" Value="{Binding TextX}" />
+                                <Setter Property="Canvas.Top" Value="{Binding TextY}" />
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding AnnotationText}"
+                                           HorizontalAlignment="Left" VerticalAlignment="Top"
+                                           FontSize="10" Background="#40000000" Padding="2,0"
+                                           IsHitTestVisible="False" RenderTransformOrigin="0,0"
+                                           Visibility="{Binding HasAnnotationText, Converter={StaticResource BoolToVis}}"
+                                           Foreground="{Binding DataContext.AnnotationBrush, RelativeSource={RelativeSource AncestorType=ItemsControl}}">
+                                    <TextBlock.RenderTransform>
+                                        <TransformGroup>
+                                            <ScaleTransform ScaleX="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                            ScaleY="{Binding DataContext.MarkerTextScale, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                            <TranslateTransform Y="{Binding DataContext.LabelOffset, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                        </TransformGroup>
+                                    </TextBlock.RenderTransform>
+                                </TextBlock>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </Canvas>
+            </Border>
+
+            <ScrollBar x:Name="VScroll" Grid.Row="0" Grid.Column="1" Orientation="Vertical"
+                       Visibility="Collapsed" Scroll="VScroll_Scroll" />
+            <ScrollBar x:Name="HScroll" Grid.Row="1" Grid.Column="0" Orientation="Horizontal"
+                       Visibility="Collapsed" Scroll="HScroll_Scroll" />
+        </Grid>
+
+        <!-- Right column: legend (disabled rows greyed) + help. -->
+        <StackPanel Grid.Row="0" Grid.RowSpan="3" Grid.Column="1" Width="240" Margin="12,0,0,0">
+            <TextBlock FontWeight="Bold" Margin="0,0,0,6" Text="Legend" />
+            <ItemsControl ItemsSource="{Binding LegendEntries}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Margin="0,2" Orientation="Horizontal">
+                            <StackPanel.Style>
+                                <Style TargetType="StackPanel">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Enabled}" Value="False">
+                                            <Setter Property="Opacity" Value="0.4" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </StackPanel.Style>
+                            <Rectangle Width="20" Height="12" Margin="0,0,8,0" VerticalAlignment="Center"
+                                       Fill="Transparent" Stroke="{Binding Brush}" StrokeThickness="2" />
+                            <TextBlock Width="200" VerticalAlignment="Center" Foreground="{StaticResource Fg}"
+                                       Text="{Binding Caption}" TextWrapping="Wrap" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+
+            <Separator Margin="0,12,0,0" />
+            <TextBlock Margin="0,8,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
+                       Text="Read-only review of every frame from the auto-focus run. Star bounds, the per-star text (selected above), the star-center crosshair, the rejection-reason boxes, and the ROI all follow your Hocus Focus Star Annotator settings." />
+            <TextBlock Margin="0,8,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
+                       Text="Wheel to zoom, right-drag to pan, Fit to reset. ◀ ▶ or Prev/Next to change frames." />
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
@@ -9,6 +9,84 @@
         <hfconverters:EnumStaticDescriptionValueConverter x:Key="HF_EnumStaticDescriptionValueConverter" />
         <SolidColorBrush x:Key="Fg" Color="White" />
 
+        <!-- Self-contained light ComboBox: NINA's app-wide themed ComboBox ignores instance Background/Foreground (its
+             template binds to theme brushes), so a fully custom template is the only reliable way to get a light box
+             with dark, legible text on this dark panel. -->
+        <Style x:Key="HF_LightCombo" TargetType="ComboBox">
+            <Setter Property="Foreground" Value="Black" />
+            <Setter Property="Height" Value="24" />
+            <Setter Property="HorizontalContentAlignment" Value="Left" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="ItemContainerStyle">
+                <Setter.Value>
+                    <Style TargetType="ComboBoxItem">
+                        <Setter Property="Foreground" Value="Black" />
+                        <Setter Property="Padding" Value="6,3" />
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="ComboBoxItem">
+                                    <Border x:Name="ItemBorder" Background="White" Padding="{TemplateBinding Padding}">
+                                        <ContentPresenter TextElement.Foreground="Black" />
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="IsHighlighted" Value="True">
+                                            <Setter TargetName="ItemBorder" Property="Background" Value="#FFCCE5FF" />
+                                        </Trigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </Setter.Value>
+            </Setter>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ComboBox">
+                        <Grid>
+                            <ToggleButton Grid.Column="0" Focusable="False" ClickMode="Press"
+                                          IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
+                                <ToggleButton.Template>
+                                    <ControlTemplate TargetType="ToggleButton">
+                                        <Border x:Name="Border" CornerRadius="2" BorderThickness="1"
+                                                Background="White" BorderBrush="#FF8A8A8A">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*" />
+                                                    <ColumnDefinition Width="20" />
+                                                </Grid.ColumnDefinitions>
+                                                <Path Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                      Data="M 0 0 L 4 4 L 8 0 Z" Fill="#FF303030" />
+                                            </Grid>
+                                        </Border>
+                                        <ControlTemplate.Triggers>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter TargetName="Border" Property="Background" Value="#FFF2F2F2" />
+                                            </Trigger>
+                                        </ControlTemplate.Triggers>
+                                    </ControlTemplate>
+                                </ToggleButton.Template>
+                            </ToggleButton>
+                            <ContentPresenter IsHitTestVisible="False"
+                                              Margin="6,0,24,0" VerticalAlignment="Center" HorizontalAlignment="Left"
+                                              Content="{TemplateBinding SelectionBoxItem}"
+                                              ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                              TextElement.Foreground="Black" />
+                            <Popup IsOpen="{TemplateBinding IsDropDownOpen}" Placement="Bottom" Focusable="False"
+                                   AllowsTransparency="True" PopupAnimation="Slide">
+                                <Border MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}"
+                                        MaxHeight="{TemplateBinding MaxDropDownHeight}"
+                                        Background="White" BorderThickness="1" BorderBrush="#FF8A8A8A" SnapsToDevicePixels="True">
+                                    <ScrollViewer>
+                                        <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" />
+                                    </ScrollViewer>
+                                </Border>
+                            </Popup>
+                        </Grid>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
         <Style TargetType="Button">
             <Setter Property="Margin" Value="4,0" />
             <Setter Property="Padding" Value="10,4" />
@@ -265,15 +343,9 @@
             <Separator Margin="0,12,0,8" />
             <TextBlock Text="Per-star text" />
             <ComboBox Margin="0,3,0,0" HorizontalAlignment="Left" Width="200"
-                      Foreground="Black" Background="White" BorderBrush="#FF3F4958"
+                      Style="{StaticResource HF_LightCombo}"
                       ItemsSource="{Binding AvailableAnnotationTypes}"
                       SelectedItem="{Binding ShowAnnotationType}">
-                <ComboBox.ItemContainerStyle>
-                    <Style TargetType="ComboBoxItem">
-                        <Setter Property="Background" Value="White" />
-                        <Setter Property="Foreground" Value="Black" />
-                    </Style>
-                </ComboBox.ItemContainerStyle>
                 <ComboBox.ItemTemplate>
                     <DataTemplate>
                         <TextBlock Foreground="Black" Text="{Binding Converter={StaticResource HF_EnumStaticDescriptionValueConverter}}" />
@@ -283,15 +355,9 @@
 
             <TextBlock Margin="0,10,0,0" Text="Star bounds" />
             <ComboBox Margin="0,3,0,0" HorizontalAlignment="Left" Width="200"
-                      Foreground="Black" Background="White" BorderBrush="#FF3F4958"
+                      Style="{StaticResource HF_LightCombo}"
                       ItemsSource="{Binding AvailableBoundsTypes}"
                       SelectedItem="{Binding StarBoundsType}">
-                <ComboBox.ItemContainerStyle>
-                    <Style TargetType="ComboBoxItem">
-                        <Setter Property="Background" Value="White" />
-                        <Setter Property="Foreground" Value="Black" />
-                    </Style>
-                </ComboBox.ItemContainerStyle>
                 <ComboBox.ItemTemplate>
                     <DataTemplate>
                         <TextBlock Foreground="Black" Text="{Binding}" />
@@ -301,7 +367,7 @@
 
             <Separator Margin="0,12,0,0" />
             <TextBlock Margin="0,8,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
-                       Text="Read-only review of every frame from the auto-focus run. Star bounds, the per-star text, the star-center crosshair, the rejection-reason boxes, and the ROI all follow your Hocus Focus Star Annotator settings. (PSF-based options are unavailable because auto-focus does not fit PSFs.)" />
+                       Text="Read-only review of every frame from the auto-focus run. Star bounds, the per-star text, the star-center crosshair, the rejection-reason boxes, and the ROI all follow your Hocus Focus Star Annotator settings. (PSF-based options appear only when Fit PSF is enabled in Star Detection options.)" />
             <TextBlock Margin="0,8,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
                        Text="Wheel to zoom, right-drag to pan, Fit to reset. ◀ ▶ or Prev/Next to change frames." />
         </StackPanel>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
@@ -42,28 +42,11 @@
             </DockPanel>
         </Border>
 
-        <!-- Toolbar: navigation + per-star text selector + close. -->
+        <!-- Toolbar: navigation + close. (The per-star text + star-bounds selectors live under the legend.) -->
         <DockPanel Grid.Row="1" Grid.Column="0" LastChildFill="False" Margin="0,0,0,6">
             <Button DockPanel.Dock="Left" Content="Fit" Command="{Binding FitCommand}" Margin="0,0,4,0" />
             <Button DockPanel.Dock="Left" Content="◀ Prev" Command="{Binding PrevCommand}" />
             <Button DockPanel.Dock="Left" Content="Next ▶" Command="{Binding NextCommand}" />
-            <TextBlock DockPanel.Dock="Left" Margin="16,0,6,0" Text="Show:" />
-            <ComboBox DockPanel.Dock="Left" Width="150" VerticalAlignment="Center"
-                      Foreground="White" Background="#FF2A2F36" BorderBrush="#FF3F4958"
-                      ItemsSource="{Binding AvailableAnnotationTypes}"
-                      SelectedItem="{Binding ShowAnnotationType}">
-                <ComboBox.ItemContainerStyle>
-                    <Style TargetType="ComboBoxItem">
-                        <Setter Property="Background" Value="#FF2A2F36" />
-                        <Setter Property="Foreground" Value="White" />
-                    </Style>
-                </ComboBox.ItemContainerStyle>
-                <ComboBox.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Foreground="White" Text="{Binding Converter={StaticResource HF_EnumStaticDescriptionValueConverter}}" />
-                    </DataTemplate>
-                </ComboBox.ItemTemplate>
-            </ComboBox>
             <Button DockPanel.Dock="Right" Content="Close" Command="{Binding CloseCommand}" />
         </DockPanel>
 
@@ -251,8 +234,11 @@
                        Visibility="Collapsed" Scroll="HScroll_Scroll" />
         </Grid>
 
-        <!-- Right column: legend (disabled rows greyed) + help. -->
-        <StackPanel Grid.Row="0" Grid.RowSpan="3" Grid.Column="1" Width="240" Margin="12,0,0,0">
+        <!-- Right column: legend (disabled rows greyed) + per-star text / star-bounds selectors + help. Scrollable so
+             it never clips on a short window. -->
+        <ScrollViewer Grid.Row="0" Grid.RowSpan="3" Grid.Column="1" Width="240" Margin="12,0,0,0"
+                      VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+        <StackPanel>
             <TextBlock FontWeight="Bold" Margin="0,0,0,6" Text="Legend" />
             <ItemsControl ItemsSource="{Binding LegendEntries}">
                 <ItemsControl.ItemTemplate>
@@ -276,11 +262,49 @@
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
 
+            <Separator Margin="0,12,0,8" />
+            <TextBlock Text="Per-star text" />
+            <ComboBox Margin="0,3,0,0" HorizontalAlignment="Left" Width="200"
+                      Foreground="Black" Background="White" BorderBrush="#FF3F4958"
+                      ItemsSource="{Binding AvailableAnnotationTypes}"
+                      SelectedItem="{Binding ShowAnnotationType}">
+                <ComboBox.ItemContainerStyle>
+                    <Style TargetType="ComboBoxItem">
+                        <Setter Property="Background" Value="White" />
+                        <Setter Property="Foreground" Value="Black" />
+                    </Style>
+                </ComboBox.ItemContainerStyle>
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Foreground="Black" Text="{Binding Converter={StaticResource HF_EnumStaticDescriptionValueConverter}}" />
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+
+            <TextBlock Margin="0,10,0,0" Text="Star bounds" />
+            <ComboBox Margin="0,3,0,0" HorizontalAlignment="Left" Width="200"
+                      Foreground="Black" Background="White" BorderBrush="#FF3F4958"
+                      ItemsSource="{Binding AvailableBoundsTypes}"
+                      SelectedItem="{Binding StarBoundsType}">
+                <ComboBox.ItemContainerStyle>
+                    <Style TargetType="ComboBoxItem">
+                        <Setter Property="Background" Value="White" />
+                        <Setter Property="Foreground" Value="Black" />
+                    </Style>
+                </ComboBox.ItemContainerStyle>
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Foreground="Black" Text="{Binding}" />
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+
             <Separator Margin="0,12,0,0" />
             <TextBlock Margin="0,8,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
-                       Text="Read-only review of every frame from the auto-focus run. Star bounds, the per-star text (selected above), the star-center crosshair, the rejection-reason boxes, and the ROI all follow your Hocus Focus Star Annotator settings." />
+                       Text="Read-only review of every frame from the auto-focus run. Star bounds, the per-star text, the star-center crosshair, the rejection-reason boxes, and the ROI all follow your Hocus Focus Star Annotator settings. (PSF-based options are unavailable because auto-focus does not fit PSFs.)" />
             <TextBlock Margin="0,8,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
                        Text="Wheel to zoom, right-drag to pan, Fit to reset. ◀ ▶ or Prev/Next to change frames." />
         </StackPanel>
+        </ScrollViewer>
     </Grid>
 </UserControl>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml.cs
@@ -30,11 +30,41 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
         private bool panning;
         private System.Windows.Point lastPanScreen;
         private bool hasFitOnce;
+        private bool windowSized;
 
         public AutoFocusFrameReviewControl() {
             InitializeComponent();
             DataContextChanged += OnDataContextChanged;
             KeyDown += OnKeyDown;
+            Loaded += OnLoaded;
+        }
+
+        // Size the host window to FIT the screen on first load (clamped to the work area, centered), with a small
+        // minimum so it can be shrunk freely. The WindowService opens the window sized-to-content, which — without this —
+        // would honor whatever large size the content asks for and open off-screen on smaller displays. A small Min lets
+        // the layout redistribute (the image column shrinks first, so the right-hand legend stays visible).
+        private void OnLoaded(object sender, RoutedEventArgs e) {
+            if (windowSized) {
+                return;
+            }
+            var window = Window.GetWindow(this);
+            if (window == null) {
+                return;
+            }
+            windowSized = true;
+
+            var work = SystemParameters.WorkArea; // device-independent pixels, excludes the taskbar
+            const double desiredWidth = 1100.0;
+            const double desiredHeight = 720.0;
+            const double margin = 40.0; // leave a little breathing room around the window
+
+            window.SizeToContent = SizeToContent.Manual;
+            window.MinWidth = Math.Min(640.0, work.Width);
+            window.MinHeight = Math.Min(440.0, work.Height);
+            window.Width = Math.Min(desiredWidth, Math.Max(window.MinWidth, work.Width - margin));
+            window.Height = Math.Min(desiredHeight, Math.Max(window.MinHeight, work.Height - margin));
+            window.Left = work.Left + (work.Width - window.Width) / 2.0;
+            window.Top = work.Top + (work.Height - window.Height) / 2.0;
         }
 
         private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml.cs
@@ -1,0 +1,212 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
+
+    /// <summary>
+    /// Read-only viewer for the manual AutoFocus "Review Frames" dialog: an MTF-stretched frame in a zoom/pan canvas
+    /// with the Star Annotator's overlays (bounds, per-star text, center, rejection-reason + ROI boxes). Binds to an
+    /// <see cref="AutoFocusFrameReviewVM"/>. The viewport plumbing (zoom/pan/fit/scroll) mirrors the Aberration
+    /// Inspector's <c>FrameReviewControl</c>; there is no hover focus graph here.
+    /// </summary>
+    public partial class AutoFocusFrameReviewControl : UserControl {
+
+        private AutoFocusFrameReviewVM Vm => DataContext as AutoFocusFrameReviewVM;
+
+        private bool panning;
+        private System.Windows.Point lastPanScreen;
+        private bool hasFitOnce;
+
+        public AutoFocusFrameReviewControl() {
+            InitializeComponent();
+            DataContextChanged += OnDataContextChanged;
+            KeyDown += OnKeyDown;
+        }
+
+        private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e) {
+            if (e.OldValue is AutoFocusFrameReviewVM oldVm) {
+                oldVm.FitRequested -= OnFitRequested;
+            }
+            if (e.NewValue is AutoFocusFrameReviewVM newVm) {
+                newVm.FitRequested += OnFitRequested;
+            }
+        }
+
+        private void OnKeyDown(object sender, KeyEventArgs e) {
+            var vm = Vm;
+            if (vm == null) {
+                return;
+            }
+            switch (e.Key) {
+                case Key.Left:
+                    if (vm.PrevCommand.CanExecute(null)) {
+                        vm.PrevCommand.Execute(null);
+                    }
+                    e.Handled = true;
+                    break;
+                case Key.Right:
+                    if (vm.NextCommand.CanExecute(null)) {
+                        vm.NextCommand.Execute(null);
+                    }
+                    e.Handled = true;
+                    break;
+                case Key.F:
+                    OnFitRequested(this, EventArgs.Empty);
+                    e.Handled = true;
+                    break;
+            }
+        }
+
+        private void OnFitRequested(object sender, EventArgs e) {
+            var vm = Vm;
+            if (vm == null || ViewportCanvas.ActualWidth <= 0 || vm.ImageWidth <= 0) {
+                return;
+            }
+            // Collapse the scrollbars and force a layout pass FIRST so the fit is measured against the final
+            // (scrollbar-free) viewport — otherwise the image lands off-center until a second Fit.
+            HScroll.Visibility = Visibility.Collapsed;
+            VScroll.Visibility = Visibility.Collapsed;
+            ViewportCanvas.UpdateLayout();
+            if (ViewportCanvas.ActualWidth <= 0 || ViewportCanvas.ActualHeight <= 0) {
+                return;
+            }
+            vm.Viewport.FitTo(ViewportCanvas.ActualWidth, ViewportCanvas.ActualHeight, vm.ImageWidth, vm.ImageHeight);
+            ApplyViewport();
+        }
+
+        private void ApplyViewport() {
+            var vm = Vm;
+            if (vm == null) {
+                return;
+            }
+            vm.Viewport.ClampToBounds(ViewportCanvas.ActualWidth, ViewportCanvas.ActualHeight, vm.ImageWidth, vm.ImageHeight);
+            ContentScale.ScaleX = vm.Viewport.Scale;
+            ContentScale.ScaleY = vm.Viewport.Scale;
+            ContentTranslate.X = vm.Viewport.OffsetX;
+            ContentTranslate.Y = vm.Viewport.OffsetY;
+            UpdateScrollBars();
+            // Markers scale with the canvas transform, so refresh the zoom-inverse stroke/label sizes after any change.
+            vm.NotifyViewportChanged();
+        }
+
+        private bool suppressScrollEvents;
+
+        private void UpdateScrollBars() {
+            var vm = Vm;
+            if (vm == null) {
+                return;
+            }
+            suppressScrollEvents = true;
+            try {
+                UpdateScrollBar(HScroll, ViewportCanvas.ActualWidth, vm.ImageWidth * vm.Viewport.Scale, -vm.Viewport.OffsetX);
+                UpdateScrollBar(VScroll, ViewportCanvas.ActualHeight, vm.ImageHeight * vm.Viewport.Scale, -vm.Viewport.OffsetY);
+            } finally {
+                suppressScrollEvents = false;
+            }
+        }
+
+        private static void UpdateScrollBar(System.Windows.Controls.Primitives.ScrollBar bar, double viewport, double content, double scrollPos) {
+            var scrollable = content - viewport;
+            if (scrollable > 0.5 && viewport > 0) {
+                bar.Visibility = Visibility.Visible;
+                bar.Minimum = 0;
+                bar.Maximum = scrollable;
+                bar.ViewportSize = viewport;
+                bar.LargeChange = viewport * 0.9;
+                bar.SmallChange = Math.Max(1.0, viewport * 0.1);
+                bar.Value = Math.Min(Math.Max(scrollPos, 0.0), scrollable);
+            } else {
+                bar.Visibility = Visibility.Collapsed;
+                bar.Value = 0;
+            }
+        }
+
+        private void HScroll_Scroll(object sender, System.Windows.Controls.Primitives.ScrollEventArgs e) {
+            var vm = Vm;
+            if (vm == null || suppressScrollEvents) {
+                return;
+            }
+            vm.Viewport.Set(vm.Viewport.Scale, -e.NewValue, vm.Viewport.OffsetY);
+            ApplyViewport();
+        }
+
+        private void VScroll_Scroll(object sender, System.Windows.Controls.Primitives.ScrollEventArgs e) {
+            var vm = Vm;
+            if (vm == null || suppressScrollEvents) {
+                return;
+            }
+            vm.Viewport.Set(vm.Viewport.Scale, vm.Viewport.OffsetX, -e.NewValue);
+            ApplyViewport();
+        }
+
+        // The canvas RenderTransform maps image space -> screen space, so a mouse position taken relative to the
+        // canvas's PARENT (the Border) is in screen space.
+        private System.Windows.Point ScreenPoint(MouseEventArgs e) {
+            var parent = (UIElement)ViewportCanvas.Parent;
+            return e.GetPosition(parent);
+        }
+
+        private void ViewportCanvas_MouseWheel(object sender, MouseWheelEventArgs e) {
+            var vm = Vm;
+            if (vm == null) {
+                return;
+            }
+            var anchor = ScreenPoint(e);
+            var factor = e.Delta > 0 ? 1.2 : 1.0 / 1.2;
+            vm.Viewport.ZoomAt(factor, anchor.X, anchor.Y);
+            ApplyViewport();
+            e.Handled = true;
+        }
+
+        private void ViewportCanvas_MouseRightButtonDown(object sender, MouseButtonEventArgs e) {
+            panning = true;
+            lastPanScreen = ScreenPoint(e);
+            ViewportCanvas.CaptureMouse();
+            e.Handled = true;
+        }
+
+        private void ViewportCanvas_MouseRightButtonUp(object sender, MouseButtonEventArgs e) {
+            panning = false;
+            ViewportCanvas.ReleaseMouseCapture();
+            e.Handled = true;
+        }
+
+        private void ViewportCanvas_MouseMove(object sender, MouseEventArgs e) {
+            var vm = Vm;
+            if (vm == null || !panning) {
+                return;
+            }
+            var screen = ScreenPoint(e);
+            var dx = screen.X - lastPanScreen.X;
+            var dy = screen.Y - lastPanScreen.Y;
+            lastPanScreen = screen;
+            vm.Viewport.PanBy(dx, dy);
+            ApplyViewport();
+        }
+
+        private void ViewportCanvas_SizeChanged(object sender, SizeChangedEventArgs e) {
+            // Re-fit only on the first meaningful size (initial layout); afterwards keep the user's zoom/pan.
+            if (hasFitOnce) {
+                return;
+            }
+            if (ViewportCanvas.ActualWidth > 0 && Vm?.ImageWidth > 0) {
+                hasFitOnce = true;
+                OnFitRequested(this, EventArgs.Empty);
+            }
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml.cs
@@ -65,6 +65,14 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
             window.Height = Math.Min(desiredHeight, Math.Max(window.MinHeight, work.Height - margin));
             window.Left = work.Left + (work.Width - window.Width) / 2.0;
             window.Top = work.Top + (work.Height - window.Height) / 2.0;
+
+            // The initial auto-fit (ViewportCanvas_SizeChanged) ran against the pre-resize canvas size, so suppress it
+            // and re-fit against the FINAL window size once the resize layout pass has settled (DispatcherPriority.Loaded
+            // runs after layout). Without this the image stays fit to the smaller starting size.
+            hasFitOnce = true;
+            Dispatcher.BeginInvoke(
+                new Action(() => OnFitRequested(this, EventArgs.Empty)),
+                System.Windows.Threading.DispatcherPriority.Loaded);
         }
 
         private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewVM.cs
@@ -92,6 +92,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
         private AutoFocusFrameReviewSnapshot snapshot;
         private readonly IStarAnnotatorOptions annotatorOptions;
         private readonly MeasurementAverageEnum measurementAverage;
+        private readonly bool psfAvailable;
 
         public event EventHandler RequestClose;
         public event EventHandler FitRequested;
@@ -109,7 +110,18 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
             this.snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));
             this.annotatorOptions = annotatorOptions ?? throw new ArgumentNullException(nameof(annotatorOptions));
             this.measurementAverage = measurementAverage;
-            this.showAnnotationType = annotatorOptions.ShowAnnotationType; // review-local seed; not written back
+
+            // PSF fitting is intentionally disabled during auto-focus, so the PSF-derived annotation options (FWHM,
+            // eccentricity, PSF rotation/background/peak, Moffat beta) have no data and would always render blank. Only
+            // offer the options that AF actually produces, and seed the selection from the configured Star Annotator
+            // option — falling back to HFR when that configured option is a (now-unavailable) PSF property.
+            this.psfAvailable = snapshot.Frames.Any(f => f.Stars.Any(s => s.HasPsf));
+            AvailableAnnotationTypes = Enum.GetValues<ShowAnnotationTypeEnum>()
+                .Where(t => psfAvailable || !RequiresPsf(t))
+                .ToList();
+            var configured = annotatorOptions.ShowAnnotationType;
+            this.showAnnotationType = AvailableAnnotationTypes.Contains(configured) ? configured : ShowAnnotationTypeEnum.HFR;
+
             Viewport = new StarReviewViewport();
 
             annotatorOptions.PropertyChanged += AnnotatorOptions_PropertyChanged;
@@ -151,6 +163,24 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
         public bool ShowStarCenter => annotatorOptions.ShowStarCenter;
 
         // ---- per-star text selection (review-local) -------------------------------------------------------
+
+        /// <summary>The annotation-text options offered in the review. PSF-derived properties are excluded when the run
+        /// has no PSF fits (auto-focus disables PSF fitting), so the combo never offers options that render blank.</summary>
+        public IReadOnlyList<ShowAnnotationTypeEnum> AvailableAnnotationTypes { get; }
+
+        /// <summary>Whether an annotation type needs a PSF fit (everything except None/HFR/Background, which read fields
+        /// the detector always populates). Mirrors the PSF-null guards in <see cref="AutoFocusAnnotationText"/>.</summary>
+        private static bool RequiresPsf(ShowAnnotationTypeEnum t) =>
+            t != ShowAnnotationTypeEnum.None && t != ShowAnnotationTypeEnum.HFR && t != ShowAnnotationTypeEnum.Background;
+
+        /// <summary>The star-bounds shape to draw. Falls back from PSF to Box when the run has no PSF fits (so the
+        /// configured PSF bounds don't silently render nothing during auto-focus).</summary>
+        private StarBoundsTypeEnum EffectiveBoundsType {
+            get {
+                var configured = annotatorOptions.StarBoundsType;
+                return (!psfAvailable && configured == StarBoundsTypeEnum.PSF) ? StarBoundsTypeEnum.Box : configured;
+            }
+        }
 
         private ShowAnnotationTypeEnum showAnnotationType;
         public ShowAnnotationTypeEnum ShowAnnotationType {
@@ -241,7 +271,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
 
         private IReadOnlyList<StarReviewLegendEntry> BuildLegend() {
             var entries = new List<StarReviewLegendEntry> {
-                new() { Brush = StarBoundsBrush, Caption = $"Star bounds ({annotatorOptions.StarBoundsType})", Enabled = annotatorOptions.ShowStarBounds },
+                new() { Brush = StarBoundsBrush, Caption = $"Star bounds ({EffectiveBoundsType})", Enabled = annotatorOptions.ShowStarBounds },
                 new() { Brush = AnnotationBrush, Caption = "Star annotation text", Enabled = ShowAnnotationType != ShowAnnotationTypeEnum.None },
                 new() { Brush = StarCenterBrush, Caption = "Star center", Enabled = annotatorOptions.ShowStarCenter },
             };
@@ -326,7 +356,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
             if (frame == null) {
                 return;
             }
-            var boundsType = annotatorOptions.StarBoundsType;
+            var boundsType = EffectiveBoundsType;
             foreach (var s in frame.Stars) {
                 Markers.Add(BuildMarker(s, boundsType));
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewVM.cs
@@ -122,6 +122,14 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
             var configured = annotatorOptions.ShowAnnotationType;
             this.showAnnotationType = AvailableAnnotationTypes.Contains(configured) ? configured : ShowAnnotationTypeEnum.HFR;
 
+            // Star-bounds shapes: PSF bounds need a PSF fit (unavailable during auto-focus), so offer only the shapes
+            // that can actually draw. Review-local, seeded from the configured annotator option (PSF -> Box fallback).
+            AvailableBoundsTypes = Enum.GetValues<StarBoundsTypeEnum>()
+                .Where(t => psfAvailable || t != StarBoundsTypeEnum.PSF)
+                .ToList();
+            var configuredBounds = annotatorOptions.StarBoundsType;
+            this.starBoundsType = AvailableBoundsTypes.Contains(configuredBounds) ? configuredBounds : StarBoundsTypeEnum.Box;
+
             Viewport = new StarReviewViewport();
 
             annotatorOptions.PropertyChanged += AnnotatorOptions_PropertyChanged;
@@ -173,12 +181,21 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
         private static bool RequiresPsf(ShowAnnotationTypeEnum t) =>
             t != ShowAnnotationTypeEnum.None && t != ShowAnnotationTypeEnum.HFR && t != ShowAnnotationTypeEnum.Background;
 
-        /// <summary>The star-bounds shape to draw. Falls back from PSF to Box when the run has no PSF fits (so the
-        /// configured PSF bounds don't silently render nothing during auto-focus).</summary>
-        private StarBoundsTypeEnum EffectiveBoundsType {
-            get {
-                var configured = annotatorOptions.StarBoundsType;
-                return (!psfAvailable && configured == StarBoundsTypeEnum.PSF) ? StarBoundsTypeEnum.Box : configured;
+        /// <summary>The star-bounds shapes offered in the review (PSF excluded when there are no PSF fits).</summary>
+        public IReadOnlyList<StarBoundsTypeEnum> AvailableBoundsTypes { get; }
+
+        /// <summary>Review-local star-bounds shape (Box/Ellipse/PSF), seeded from the annotator option. Changing it
+        /// re-renders the overlay without touching the saved Star Annotator setting.</summary>
+        private StarBoundsTypeEnum starBoundsType;
+        public StarBoundsTypeEnum StarBoundsType {
+            get => starBoundsType;
+            set {
+                if (starBoundsType != value) {
+                    starBoundsType = value;
+                    RaisePropertyChanged();
+                    RebuildCurrentFrameOverlays();
+                    RebuildLegend();
+                }
             }
         }
 
@@ -271,7 +288,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
 
         private IReadOnlyList<StarReviewLegendEntry> BuildLegend() {
             var entries = new List<StarReviewLegendEntry> {
-                new() { Brush = StarBoundsBrush, Caption = $"Star bounds ({EffectiveBoundsType})", Enabled = annotatorOptions.ShowStarBounds },
+                new() { Brush = StarBoundsBrush, Caption = $"Star bounds ({StarBoundsType})", Enabled = annotatorOptions.ShowStarBounds },
                 new() { Brush = AnnotationBrush, Caption = "Star annotation text", Enabled = ShowAnnotationType != ShowAnnotationTypeEnum.None },
                 new() { Brush = StarCenterBrush, Caption = "Star center", Enabled = annotatorOptions.ShowStarCenter },
             };
@@ -356,7 +373,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
             if (frame == null) {
                 return;
             }
-            var boundsType = EffectiveBoundsType;
+            var boundsType = StarBoundsType;
             foreach (var s in frame.Stars) {
                 Markers.Add(BuildMarker(s, boundsType));
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewVM.cs
@@ -1,0 +1,404 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Utility;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using RelayCommand = CommunityToolkit.Mvvm.Input.RelayCommand;
+
+namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
+
+    /// <summary>One drawable star marker for the manual-AF frame-review overlay, in the frame's image-pixel coords.
+    /// Exactly one of <see cref="ShowBox"/>/<see cref="ShowEllipse"/>/<see cref="ShowPsfEllipse"/> is set (per the
+    /// annotator's StarBoundsType, with the PSF ellipse only when a PSF fit exists). The annotation text + star-center
+    /// crosshair are independent (gated at the layer level by the annotator's show-flags).</summary>
+    public sealed class AutoFocusReviewMarker {
+        // Box / Ellipse bounds (anchored at the detector bounding box).
+        public bool ShowBox { get; init; }
+        public bool ShowEllipse { get; init; }
+        public double BoxX { get; init; }
+        public double BoxY { get; init; }
+        public double BoxWidth { get; init; }
+        public double BoxHeight { get; init; }
+
+        // PSF-ellipse bounds (anchored at the star centroid, rotated by the PSF angle).
+        public bool ShowPsfEllipse { get; init; }
+        public double PsfCenterX { get; init; }
+        public double PsfCenterY { get; init; }
+        public double PsfEllipseWidth { get; init; }
+        public double PsfEllipseHeight { get; init; }
+        public double PsfTranslateX { get; init; }
+        public double PsfTranslateY { get; init; }
+        public double PsfRotationDegrees { get; init; }
+
+        // Per-star annotation text, anchored at the bounding box's top-right (matching the annotator).
+        public bool HasAnnotationText { get; init; }
+        public string AnnotationText { get; init; }
+        public double TextX { get; init; }
+        public double TextY { get; init; }
+
+        // Star-center crosshair (image-pixel arm half-lengths, like the annotator).
+        public double CrossCenterX { get; init; }
+        public double CrossCenterY { get; init; }
+        public double CrossHalfX { get; init; }
+        public double CrossHalfY { get; init; }
+        public double NegCrossHalfX => -CrossHalfX;
+        public double NegCrossHalfY => -CrossHalfY;
+    }
+
+    /// <summary>A detector rejection-reason / ROI rectangle, pre-colored with its annotator brush and ready to draw
+    /// (built per frame from only the enabled reasons).</summary>
+    public sealed class AutoFocusReviewRectOverlay {
+        public double X { get; init; }
+        public double Y { get; init; }
+        public double Width { get; init; }
+        public double Height { get; init; }
+        public Brush Brush { get; init; }
+    }
+
+    /// <summary>
+    /// Read-only viewer VM for the manual AutoFocus "Review Frames" dialog. Steps through the captured frames,
+    /// reproducing the Hocus Focus Star Annotator's overlays — star bounds (box/ellipse/PSF), a selectable per-star
+    /// annotation text, the star-center crosshair, the seven rejection-reason rectangles, and the ROI — honoring the
+    /// shared <see cref="IStarAnnotatorOptions"/> colors/show-flags live. Reuses the unit-tested
+    /// <see cref="StarReviewViewport"/> zoom/pan math, <see cref="StarReviewHfrStats"/> for the per-frame HFR header,
+    /// and <see cref="StarReviewLegendEntry"/> for the legend. The per-star text selection is review-local (initialized
+    /// from the annotator setting, not written back). Disposing releases the retained bitmaps.
+    /// </summary>
+    public sealed class AutoFocusFrameReviewVM : BaseINPC, IDisposable {
+
+        private static SolidColorBrush FrozenBrush(Color c) {
+            var b = new SolidColorBrush(c);
+            b.Freeze();
+            return b;
+        }
+
+        private AutoFocusFrameReviewSnapshot snapshot;
+        private readonly IStarAnnotatorOptions annotatorOptions;
+        private readonly MeasurementAverageEnum measurementAverage;
+
+        public event EventHandler RequestClose;
+        public event EventHandler FitRequested;
+
+        public StarReviewViewport Viewport { get; }
+        public ObservableCollection<AutoFocusReviewMarker> Markers { get; } = new();
+        public ObservableCollection<AutoFocusReviewRectOverlay> RectOverlays { get; } = new();
+
+        public RelayCommand PrevCommand { get; }
+        public RelayCommand NextCommand { get; }
+        public RelayCommand FitCommand { get; }
+        public RelayCommand CloseCommand { get; }
+
+        public AutoFocusFrameReviewVM(AutoFocusFrameReviewSnapshot snapshot, IStarAnnotatorOptions annotatorOptions, MeasurementAverageEnum measurementAverage) {
+            this.snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));
+            this.annotatorOptions = annotatorOptions ?? throw new ArgumentNullException(nameof(annotatorOptions));
+            this.measurementAverage = measurementAverage;
+            this.showAnnotationType = annotatorOptions.ShowAnnotationType; // review-local seed; not written back
+            Viewport = new StarReviewViewport();
+
+            annotatorOptions.PropertyChanged += AnnotatorOptions_PropertyChanged;
+
+            PrevCommand = new RelayCommand(Prev, () => CurrentIndex > 0);
+            NextCommand = new RelayCommand(Next, () => CurrentIndex < FrameCount - 1);
+            FitCommand = new RelayCommand(() => FitRequested?.Invoke(this, EventArgs.Empty));
+            CloseCommand = new RelayCommand(() => RequestClose?.Invoke(this, EventArgs.Empty));
+
+            legendEntries = BuildLegend();
+            CurrentIndex = 0;
+            LoadCurrent(fit: true);
+        }
+
+        private int FrameCount => snapshot?.Frames.Count ?? 0;
+
+        // Changing any annotator color/show-flag/bounds-type re-renders the overlays + legend live (same UX as the
+        // image annotator, which also re-annotates on option change).
+        private void AnnotatorOptions_PropertyChanged(object sender, PropertyChangedEventArgs e) {
+            RaiseAnnotatorVisualsChanged();
+            RebuildCurrentFrameOverlays();
+            RebuildLegend();
+        }
+
+        private void RaiseAnnotatorVisualsChanged() {
+            RaisePropertyChanged(nameof(StarBoundsBrush));
+            RaisePropertyChanged(nameof(AnnotationBrush));
+            RaisePropertyChanged(nameof(StarCenterBrush));
+            RaisePropertyChanged(nameof(ShowStarBounds));
+            RaisePropertyChanged(nameof(ShowStarCenter));
+        }
+
+        // ---- annotator-driven visuals ---------------------------------------------------------------------
+
+        public Brush StarBoundsBrush => FrozenBrush(annotatorOptions.StarBoundsColor);
+        public Brush AnnotationBrush => FrozenBrush(annotatorOptions.AnnotationColor);
+        public Brush StarCenterBrush => FrozenBrush(annotatorOptions.StarCenterColor);
+        public bool ShowStarBounds => annotatorOptions.ShowStarBounds;
+        public bool ShowStarCenter => annotatorOptions.ShowStarCenter;
+
+        // ---- per-star text selection (review-local) -------------------------------------------------------
+
+        private ShowAnnotationTypeEnum showAnnotationType;
+        public ShowAnnotationTypeEnum ShowAnnotationType {
+            get => showAnnotationType;
+            set {
+                if (showAnnotationType != value) {
+                    showAnnotationType = value;
+                    RaisePropertyChanged();
+                    RebuildCurrentFrameOverlays();
+                    RebuildLegend();
+                }
+            }
+        }
+
+        // ---- navigation / current frame -------------------------------------------------------------------
+
+        private int currentIndex;
+        public int CurrentIndex {
+            get => currentIndex;
+            private set {
+                if (currentIndex != value) {
+                    currentIndex = value;
+                    RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(PositionLabel));
+                }
+            }
+        }
+
+        public string PositionLabel => FrameCount > 0 ? $"{CurrentIndex + 1} / {FrameCount}" : "0 / 0";
+
+        private BitmapSource frameImage;
+        public BitmapSource FrameImage {
+            get => frameImage;
+            private set {
+                frameImage = value;
+                RaisePropertyChanged();
+                RaisePropertyChanged(nameof(ImageWidth));
+                RaisePropertyChanged(nameof(ImageHeight));
+            }
+        }
+
+        public double ImageWidth => frameImage?.PixelWidth ?? 0;
+        public double ImageHeight => frameImage?.PixelHeight ?? 0;
+
+        private string frameHeader;
+        public string FrameHeader {
+            get => frameHeader;
+            private set { frameHeader = value; RaisePropertyChanged(); }
+        }
+
+        private string detectedCountText;
+        public string DetectedCountText {
+            get => detectedCountText;
+            private set { detectedCountText = value; RaisePropertyChanged(); }
+        }
+
+        private string statsText;
+        public string StatsText {
+            get => statsText;
+            private set { statsText = value; RaisePropertyChanged(); RaisePropertyChanged(nameof(ShowStats)); }
+        }
+
+        public bool ShowStats => !string.IsNullOrEmpty(StatsText);
+
+        // ---- inverse-zoom overlay bindings ----------------------------------------------------------------
+
+        public double MarkerStrokeThickness => 1.5 / Math.Max(StarReviewViewport.MinScale, Viewport.Scale);
+        public double MarkerTextScale => 1.0 / Math.Max(StarReviewViewport.MinScale, Viewport.Scale);
+        public double LabelOffset => -15.0 * MarkerTextScale;
+
+        public void NotifyViewportChanged() {
+            RaisePropertyChanged(nameof(MarkerStrokeThickness));
+            RaisePropertyChanged(nameof(MarkerTextScale));
+            RaisePropertyChanged(nameof(LabelOffset));
+        }
+
+        // ---- legend ---------------------------------------------------------------------------------------
+
+        private IReadOnlyList<StarReviewLegendEntry> legendEntries;
+        public IReadOnlyList<StarReviewLegendEntry> LegendEntries {
+            get => legendEntries;
+            private set { legendEntries = value; RaisePropertyChanged(); }
+        }
+
+        private void RebuildLegend() {
+            LegendEntries = BuildLegend();
+        }
+
+        private IReadOnlyList<StarReviewLegendEntry> BuildLegend() {
+            var entries = new List<StarReviewLegendEntry> {
+                new() { Brush = StarBoundsBrush, Caption = $"Star bounds ({annotatorOptions.StarBoundsType})", Enabled = annotatorOptions.ShowStarBounds },
+                new() { Brush = AnnotationBrush, Caption = "Star annotation text", Enabled = ShowAnnotationType != ShowAnnotationTypeEnum.None },
+                new() { Brush = StarCenterBrush, Caption = "Star center", Enabled = annotatorOptions.ShowStarCenter },
+            };
+            foreach (var r in Reasons()) {
+                entries.Add(new StarReviewLegendEntry { Brush = FrozenBrush(r.Color), Caption = r.Caption, Enabled = r.Show });
+            }
+            entries.Add(new StarReviewLegendEntry { Brush = FrozenBrush(annotatorOptions.ROIColor), Caption = "Detection ROI", Enabled = annotatorOptions.ShowROI });
+            return entries;
+        }
+
+        // The seven rejection reasons the annotator draws, with their annotator show-flag + color + a plain-language
+        // caption — the single source the overlays AND the legend iterate, so they can't drift.
+        private IEnumerable<(bool Show, Color Color, string Caption, Func<AutoFocusReviewFrame, IReadOnlyList<System.Windows.Rect>> Rects)> Reasons() {
+            yield return (annotatorOptions.ShowTooDistorted, annotatorOptions.TooDistortedColor, "Too distorted", f => f.TooDistorted);
+            yield return (annotatorOptions.ShowDegenerate, annotatorOptions.DegenerateColor, "Degenerate shape", f => f.Degenerate);
+            yield return (annotatorOptions.ShowSaturated, annotatorOptions.SaturatedColor, "Saturated", f => f.Saturated);
+            yield return (annotatorOptions.ShowLowSensitivity, annotatorOptions.LowSensitivityColor, "Below sensitivity", f => f.LowSensitivity);
+            yield return (annotatorOptions.ShowNotCentered, annotatorOptions.NotCenteredColor, "Off-center", f => f.NotCentered);
+            yield return (annotatorOptions.ShowTooFlat, annotatorOptions.TooFlatColor, "Too flat", f => f.TooFlat);
+            yield return (annotatorOptions.ShowContaminated, annotatorOptions.ContaminatedColor, "Contaminated", f => f.Contaminated);
+        }
+
+        // ---- frame loading --------------------------------------------------------------------------------
+
+        private void Prev() {
+            if (CurrentIndex > 0) {
+                CurrentIndex--;
+                LoadCurrent(fit: false);
+            }
+        }
+
+        private void Next() {
+            if (CurrentIndex < FrameCount - 1) {
+                CurrentIndex++;
+                LoadCurrent(fit: false);
+            }
+        }
+
+        private AutoFocusReviewFrame CurrentFrame {
+            get {
+                var frames = snapshot?.Frames;
+                if (frames == null || frames.Count == 0) {
+                    return null;
+                }
+                return frames[Math.Min(CurrentIndex, frames.Count - 1)];
+            }
+        }
+
+        private void LoadCurrent(bool fit) {
+            var frame = CurrentFrame;
+            if (frame == null) {
+                FrameImage = null;
+                FrameHeader = string.Empty;
+                DetectedCountText = string.Empty;
+                StatsText = string.Empty;
+                Markers.Clear();
+                RectOverlays.Clear();
+                PrevCommand.NotifyCanExecuteChanged();
+                NextCommand.NotifyCanExecuteChanged();
+                return;
+            }
+
+            FrameImage = frame.Image;
+            FrameHeader = $"Focuser position: {frame.FocuserPosition:0}";
+            DetectedCountText = $"Detected stars: {frame.DetectedStarCount}";
+            var (center, deviation) = StarReviewHfrStats.Compute(frame.Stars.Select(s => s.Hfr), measurementAverage);
+            StatsText = StarReviewHfrStats.FormatStats(center, deviation, frame.DetectedStarCount, measurementAverage);
+
+            RebuildCurrentFrameOverlays();
+
+            PrevCommand.NotifyCanExecuteChanged();
+            NextCommand.NotifyCanExecuteChanged();
+            if (fit) {
+                FitRequested?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        private void RebuildCurrentFrameOverlays() {
+            Markers.Clear();
+            RectOverlays.Clear();
+            var frame = CurrentFrame;
+            if (frame == null) {
+                return;
+            }
+            var boundsType = annotatorOptions.StarBoundsType;
+            foreach (var s in frame.Stars) {
+                Markers.Add(BuildMarker(s, boundsType));
+            }
+            foreach (var r in Reasons()) {
+                if (!r.Show) {
+                    continue;
+                }
+                var brush = FrozenBrush(r.Color);
+                foreach (var rect in r.Rects(frame)) {
+                    RectOverlays.Add(ToOverlay(rect, brush));
+                }
+            }
+            if (annotatorOptions.ShowROI) {
+                var roiBrush = FrozenBrush(annotatorOptions.ROIColor);
+                foreach (var rect in frame.RoiRects) {
+                    RectOverlays.Add(ToOverlay(rect, roiBrush));
+                }
+            }
+        }
+
+        private static AutoFocusReviewRectOverlay ToOverlay(System.Windows.Rect rect, Brush brush) {
+            return new AutoFocusReviewRectOverlay { X = rect.X, Y = rect.Y, Width = rect.Width, Height = rect.Height, Brush = brush };
+        }
+
+        private AutoFocusReviewMarker BuildMarker(AutoFocusReviewStar s, StarBoundsTypeEnum boundsType) {
+            // Star-center crosshair: center at the centroid (offset by the PSF sub-pixel offset when the bounds type is
+            // PSF, exactly as the annotator does), arms sized to half the distance to the nearest box edge.
+            var centerX = s.CenterX;
+            var centerY = s.CenterY;
+            if (boundsType == StarBoundsTypeEnum.PSF && s.HasPsf) {
+                centerX += s.PsfOffsetX;
+                centerY += s.PsfOffsetY;
+            }
+            var halfX = Math.Max(1.0, Math.Min(centerX - s.BoxX, s.BoxX + s.BoxWidth - centerX)) / 2.0;
+            var halfY = Math.Max(1.0, Math.Min(centerY - s.BoxY, s.BoxY + s.BoxHeight - centerY)) / 2.0;
+
+            var showPsfEllipse = boundsType == StarBoundsTypeEnum.PSF && s.HasPsf;
+            var text = AutoFocusAnnotationText.Format(s, ShowAnnotationType);
+
+            return new AutoFocusReviewMarker {
+                ShowBox = boundsType == StarBoundsTypeEnum.Box,
+                ShowEllipse = boundsType == StarBoundsTypeEnum.Ellipse,
+                BoxX = s.BoxX,
+                BoxY = s.BoxY,
+                BoxWidth = s.BoxWidth,
+                BoxHeight = s.BoxHeight,
+                ShowPsfEllipse = showPsfEllipse,
+                PsfCenterX = s.CenterX,
+                PsfCenterY = s.CenterY,
+                PsfEllipseWidth = showPsfEllipse ? s.PsfFwhmX * 2.0 : 0.0,
+                PsfEllipseHeight = showPsfEllipse ? s.PsfFwhmY * 2.0 : 0.0,
+                PsfTranslateX = showPsfEllipse ? -s.PsfFwhmX : 0.0,
+                PsfTranslateY = showPsfEllipse ? -s.PsfFwhmY : 0.0,
+                // Annotator rotation is clockwise whereas PSF theta is counter-clockwise, so negate (matches annotator).
+                PsfRotationDegrees = showPsfEllipse ? -s.PsfThetaDegrees : 0.0,
+                HasAnnotationText = !string.IsNullOrEmpty(text),
+                AnnotationText = text,
+                TextX = s.BoxX + s.BoxWidth,
+                TextY = s.BoxY,
+                CrossCenterX = centerX,
+                CrossCenterY = centerY,
+                CrossHalfX = halfX,
+                CrossHalfY = halfY,
+            };
+        }
+
+        public void Dispose() {
+            annotatorOptions.PropertyChanged -= AnnotatorOptions_PropertyChanged;
+            Markers.Clear();
+            RectOverlays.Clear();
+            FrameImage = null;
+            snapshot = null;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewVM.cs
@@ -355,7 +355,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
             FrameHeader = $"Focuser position: {frame.FocuserPosition:0}";
             DetectedCountText = $"Detected stars: {frame.DetectedStarCount}";
             var (center, deviation) = StarReviewHfrStats.Compute(frame.Stars.Select(s => s.Hfr), measurementAverage);
-            StatsText = StarReviewHfrStats.FormatStats(center, deviation, frame.DetectedStarCount, measurementAverage);
+            // Omit the "(n=…)" count — the detected-star count is already shown separately in the header.
+            StatsText = StarReviewHfrStats.FormatStats(center, deviation, frame.DetectedStarCount, measurementAverage, includeCount: false);
 
             RebuildCurrentFrameOverlays();
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IAutoFocusEngine.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IAutoFocusEngine.cs
@@ -88,6 +88,12 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         public double ReducedChiSquaredRejectionThreshold { get; set; }
         public bool PreserveExposures { get; set; }
 
+        // When true, PSFs are modeled during this auto-focus run (auto-focus normally skips PSF fitting for speed).
+        // Set by the manual AF "Review Frames" feature — only when frame review is requested AND PSF modeling is
+        // enabled in the star-detection options — so the review can show PSF-derived per-star properties. Modeling
+        // PSFs only adds per-star PSF data; it does not change the detected stars or HFR, so the AF curve is unaffected.
+        public bool ModelPSF { get; set; }
+
         // When true, a saving run writes ONLY the raw exposure frames — the per-region annotated TIFFs and
         // star-detection result JSONs are skipped. Used by the Tilt Adapter Wizard so a saved calibration run is
         // a compact, replayable set of raw frames with no auxiliary artifacts.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IAutoFocusOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IAutoFocusOptions.cs
@@ -25,6 +25,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         int AutoFocusTimeoutSeconds { get; set; }
         string SavePath { get; set; }
         bool Save { get; set; }
+        bool KeepFramesForReview { get; set; }
         string LastSelectedLoadPath { get; set; }
         int FocuserOffset { get; set; }
         int MaxOutlierRejections { get; set; }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IHocusFocusStarDetection.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IHocusFocusStarDetection.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Media;
 
 namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
 
@@ -31,6 +32,15 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
     public interface IHocusFocusStarDetection : IStarDetection {
 
         HocusFocusDetectionParams ToHocusFocusParams(StarDetectionParams p);
+
+        /// <summary>
+        /// Same as <see cref="IStarDetection.Detect(IRenderedImage, PixelFormat, StarDetectionParams, IProgress{ApplicationStatus}, CancellationToken)"/>,
+        /// but when <paramref name="modelPSFForAutoFocus"/> is true the auto-focus PSF-off override is lifted so PSFs
+        /// are modeled (per the star-detection options) during an auto-focus run — used by the manual AF "Review Frames"
+        /// feature so the review can show PSF-derived per-star properties. Detection is otherwise identical, so the AF
+        /// HFR curve is unaffected.
+        /// </summary>
+        Task<StarDetectionResult> Detect(IRenderedImage image, PixelFormat pf, StarDetectionParams p, IProgress<ApplicationStatus> progress, CancellationToken token, bool modelPSFForAutoFocus);
 
         StarDetectorParams GetStarDetectorParams(IRenderedImage image, StarDetectionRegion starDetectionRegion, bool isAutoFocus);
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
@@ -253,7 +253,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             ImageStatisticsVM = imageStatisticsVM;
         }
 
-        public async Task<StarDetectionResult> Detect(IRenderedImage image, PixelFormat pf, StarDetectionParams p, IProgress<ApplicationStatus> progress, CancellationToken token) {
+        public Task<StarDetectionResult> Detect(IRenderedImage image, PixelFormat pf, StarDetectionParams p, IProgress<ApplicationStatus> progress, CancellationToken token) {
+            return Detect(image, pf, p, progress, token, modelPSFForAutoFocus: false);
+        }
+
+        public async Task<StarDetectionResult> Detect(IRenderedImage image, PixelFormat pf, StarDetectionParams p, IProgress<ApplicationStatus> progress, CancellationToken token, bool modelPSFForAutoFocus) {
             var selectedAutoFocusBehavior = profileService.ActiveProfile.ApplicationSettings.SelectedPluggableBehaviors.Where(k => k.Key == typeof(IAutoFocusVMFactory).FullName).ToList();
             var ninaStockAutoFocus = selectedAutoFocusBehavior.Count == 0 || selectedAutoFocusBehavior.First().Value == "NINA";
             var isNinaAutoFocus = ninaStockAutoFocus && p.IsAutoFocus;
@@ -263,6 +267,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
 
             var starDetectionRegion = StarDetectionRegion.FromStarDetectionParams(p);
             var detectorParams = GetStarDetectorParams(image, starDetectionRegion, p.IsAutoFocus);
+            // GetStarDetectorParams forces ModelPSF off for auto-focus (speed); lift that for a Review-Frames run so the
+            // per-star PSF properties are populated, honoring the star-detection options' PSF setting + fit type.
+            if (modelPSFForAutoFocus) {
+                detectorParams.ModelPSF = starDetectionOptions.ModelPSF;
+            }
             var hocusFocusParams = ToHocusFocusParams(p);
 
             var detectionResult = await Detect(image, hocusFocusParams, detectorParams, progress, token);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewHfrStats.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewHfrStats.cs
@@ -69,7 +69,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         /// (n=42)". The "± deviation" term is omitted when the deviation is undefined (a single star), and an empty
         /// string is returned when there are no valid stars (the overlay hides itself).
         /// </summary>
-        public static string FormatStats(double center, double deviation, int starCount, MeasurementAverageEnum mode) {
+        public static string FormatStats(double center, double deviation, int starCount, MeasurementAverageEnum mode, bool includeCount = true) {
             if (starCount <= 0 || double.IsNaN(center)) {
                 return string.Empty;
             }
@@ -78,7 +78,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             var dev = double.IsNaN(deviation)
                 ? string.Empty
                 : " ± " + deviation.ToString("F2", CultureInfo.InvariantCulture);
-            return $"{label}: {c}{dev}  (n={starCount})";
+            var count = includeCount ? $"  (n={starCount})" : string.Empty;
+            return $"{label}: {c}{dev}{count}";
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a **Review Frames** capability to the manual AutoFocus pane — a button + a persisted **Keep frames for review** toggle (default off) that opens a zoomable, annotated viewer of every frame of the last manual auto-focus run. It mirrors the Aberration Inspector's Review Frames but is annotation-richer, reproducing the full Hocus Focus Star Annotator overlay set.

Closes the goal: review frames when performing a manual autofocus directly from the AF pane.

## What's included

- **Pane UI** — Review Frames button + "Keep frames for review" toggle on the pane (mirrors the Inspector). Toggle persists in the profile (`AutoFocusOptions.KeepFramesForReview`, default off).
- **Pane-only memory guard** — both the pane and the sequencer call the same `HocusFocusVM.StartAutoFocus`, so a new `InteractiveHostBehavior` attached property marks only the pane-hosted VM as interactive. Retention = `IsInteractive && KeepFramesForReview`, frozen at run start and forcing `PreserveExposures`; sequence-triggered AF never retains frames.
- **Annotator-faithful viewer** — forked from the Inspector's frame review (hover/focus-graph dropped). Draws the full annotator set as crisp XAML vectors honoring the shared `StarAnnotatorOptions` live: star bounds (Box/Ellipse/rotated PSF), a selectable per-star text combo (all `ShowAnnotationTypeEnum` options, review-local), star-center crosshair, the 7 rejection-reason rectangles, ROI, and a matching legend.
- **Zoom-stable text** — inverse-zoom `ScaleTransform` with a 75%-transparent (`#40000000`) background, exactly like the Inspector frame review.
- **Per-frame header** — focuser position, detected-star count, and HFR ± MAD/StdDev (reusing the unit-tested `StarReviewHfrStats`).
- **Failed runs reviewable** — snapshot built on both success and failure. Structure-map overlay excluded (debug raster, not crisply vector-drawable).

## Key files

- New: `AutoFocus/AutoFocusFrameReviewSnapshot.cs` (immutable model + pure builder + `AutoFocusAnnotationText`), `AutoFocus/InteractiveHostBehavior.cs`, `AutoFocus/Review/AutoFocusFrameReviewVM.cs` + `AutoFocusFrameReviewControl.xaml(.cs)`.
- Modified: `IAutoFocusOptions`/`AutoFocusOptions`, `HocusFocusVM` (retention wiring + launch), `HocusFocusVMFactory` (threads `IApplicationDispatcher`), `AutoFocus/DataTemplates.xaml` (pane UI + DataTemplate registration).
- Reuses `StarReviewViewport`, `StarReviewHfrStats`, `StarReviewLegendEntry`.

## Testing

- `dotnet test` — **1424/1424 pass**, including new `AutoFocusFrameReviewSnapshotBuilderTests`, `AutoFocusAnnotationTextTests`, and extended `AutoFocusOptionsTests`.
- Not yet verified live in NINA — the overlay rendering and the pane-vs-sequence memory behavior should be confirmed in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)