### PR TITLE
Phase 7 (PR B): Frame-review de-duplication & altitude refactor (F07/F20, F24, F25, F08, F23, F28)

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/HocusFocusVMInteractiveTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/HocusFocusVMInteractiveTests.cs
@@ -1,0 +1,53 @@
+#region "copyright"
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
+
+    [TestFixture]
+    public class HocusFocusVMInteractiveTests {
+
+        // The interactive/retain decision must be an explicit flag with no public setter, toggled only through the named
+        // MarkInteractive()/MarkNonInteractive() opt-in methods (called by InteractiveHostBehavior for the pane instance).
+        // This guards the F07/F20 contract that intent is declared explicitly, never via an arbitrary settable property.
+        [Test]
+        public void IsInteractive_HasNoPublicSetter_AndMarkMethodsExist() {
+            Assert.Multiple(() => {
+                // nonPublic:false returns only a PUBLIC set accessor (null when the setter is private/absent). The spec's
+                // contract is "no PUBLIC setter" while still allowing the private set used by MarkInteractive/MarkNonInteractive;
+                // GetSetMethod(nonPublic:true) would return the private accessor and is therefore the wrong probe here.
+                Assert.That(typeof(HocusFocusVM).GetProperty(nameof(HocusFocusVM.IsInteractive)).GetSetMethod(nonPublic: false),
+                    Is.Null, "IsInteractive must not expose a public setter; it is toggled via MarkInteractive()/MarkNonInteractive().");
+                Assert.That(typeof(HocusFocusVM).GetMethod(nameof(HocusFocusVM.MarkInteractive)), Is.Not.Null,
+                    "MarkInteractive() must exist as the explicit opt-in.");
+                Assert.That(typeof(HocusFocusVM).GetMethod(nameof(HocusFocusVM.MarkNonInteractive)), Is.Not.Null,
+                    "MarkNonInteractive() must exist as the explicit opt-out.");
+            });
+        }
+
+        // Behavioral check that the Mark methods actually toggle the flag and that a freshly-built (sequencer-style) VM
+        // defaults to non-interactive — the core F07/F20 contract. Uses the shared MediatorBundle helper the other
+        // behavioral tests use, so the DI cost is one line.
+        [Test]
+        public void MarkMethods_ToggleIsInteractive() {
+            var vm = new MediatorBundle().BuildHocusFocusVM();
+            Assert.Multiple(() => {
+                Assert.That(vm.IsInteractive, Is.False, "A freshly-built VM (as the sequencer creates) must default non-interactive.");
+            });
+            vm.MarkInteractive();
+            Assert.That(vm.IsInteractive, Is.True);
+            vm.MarkNonInteractive();
+            Assert.That(vm.IsInteractive, Is.False);
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Review/FrameReviewVMBaseTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Review/FrameReviewVMBaseTests.cs
@@ -1,0 +1,71 @@
+#region "copyright"
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Review {
+
+    [TestFixture]
+    public class FrameReviewVMBaseTests {
+
+        // Minimal concrete subclass over a fixed frame count to exercise the shared navigation/viewport logic.
+        private sealed class TestReviewVM : FrameReviewVMBase<object> {
+            public TestReviewVM(int frameCount) : base(frameCount) { }
+            protected override void LoadFrame(int index) { }
+            protected override System.Collections.Generic.IReadOnlyList<StarReviewLegendEntry> BuildLegend()
+                => System.Array.Empty<StarReviewLegendEntry>();
+        }
+
+        [Test]
+        public void Navigation_ClampsAtEnds_AndUpdatesCanExecute() {
+            var vm = new TestReviewVM(frameCount: 3);
+            Assert.Multiple(() => {
+                Assert.That(vm.CurrentIndex, Is.EqualTo(0));
+                Assert.That(vm.PrevCommand.CanExecute(null), Is.False, "Prev disabled at first frame");
+                Assert.That(vm.NextCommand.CanExecute(null), Is.True);
+                Assert.That(vm.PositionLabel, Is.EqualTo("1 / 3"));
+            });
+
+            vm.NextCommand.Execute(null);
+            vm.NextCommand.Execute(null);
+            Assert.Multiple(() => {
+                Assert.That(vm.CurrentIndex, Is.EqualTo(2));
+                Assert.That(vm.NextCommand.CanExecute(null), Is.False, "Next disabled at last frame");
+                Assert.That(vm.PrevCommand.CanExecute(null), Is.True);
+                Assert.That(vm.PositionLabel, Is.EqualTo("3 / 3"));
+            });
+
+            vm.NextCommand.Execute(null); // no-op past the end
+            Assert.That(vm.CurrentIndex, Is.EqualTo(2));
+        }
+
+        // The marker stroke/text bindings scale inversely with zoom so overlays keep a constant on-screen size.
+        // Exercise the real 1.5/Scale and 1.0/Scale math at a representative (non-floored) scale.
+        [Test]
+        public void InverseZoom_ScalesMarkersInverselyToZoom() {
+            var vm = new TestReviewVM(frameCount: 1);
+            vm.Viewport.Set(0.5, 0, 0);
+            Assert.Multiple(() => {
+                Assert.That(vm.MarkerStrokeThickness, Is.EqualTo(1.5 / 0.5).Within(1e-9)); // 3.0
+                Assert.That(vm.MarkerTextScale, Is.EqualTo(1.0 / 0.5).Within(1e-9));        // 2.0
+            });
+        }
+
+        // At extreme zoom-out the viewport floors Scale at MinScale, so the inverse-zoom bindings stay bounded
+        // (markers don't blow up to infinity). Documents the combined viewport-clamp + binding behavior.
+        [Test]
+        public void InverseZoom_StaysBoundedAtMinScale() {
+            var vm = new TestReviewVM(frameCount: 1);
+            vm.Viewport.Set(StarReviewViewport.MinScale / 2.0, 0, 0); // viewport clamps Scale up to MinScale
+            Assert.That(vm.MarkerStrokeThickness, Is.EqualTo(1.5 / StarReviewViewport.MinScale).Within(1e-9));
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
@@ -1737,7 +1737,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             var focuserPositionTasks = new List<Task>();
             int completedCount = 0;
             int totalCount = savedFiles.Count;
-            progress.Report(new ApplicationStatus() {
+            progress?.Report(new ApplicationStatus() {
                 Status = "Data Points",
                 MaxProgress = totalCount,
                 Progress = 0,
@@ -1840,7 +1840,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                                 // otherwise re-save raw frames). No-op when not saving.
                                 MaybeCopyReplayFrame(state, savedFile, imageState.AttemptNumber, imageState.FinalValidation);
                                 var incrementedCompletedCount = Interlocked.Increment(ref completedCount);
-                                progress.Report(new ApplicationStatus() {
+                                progress?.Report(new ApplicationStatus() {
                                     Status = "Data Points",
                                     MaxProgress = totalCount,
                                     Progress = incrementedCompletedCount,
@@ -1897,7 +1897,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 prefetchSemaphore.Dispose();
                 loadSerializer.Dispose();
                 await Task.Delay(1000);
-                progress.Report(new ApplicationStatus());
+                progress?.Report(new ApplicationStatus());
             }
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/HocusFocusVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/HocusFocusVM.cs
@@ -740,19 +740,29 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         private bool isInteractive;
 
         /// <summary>
-        /// True only for the VM instance hosted in the AutoFocus pane (set by InteractiveHostBehavior when the pane
-        /// DataTemplate loads). Sequence-triggered AF runs construct their own transient VM via the factory, which is
-        /// never rendered through the pane template, so it stays false — gating frame retention to interactive runs.
+        /// True only for the VM instance hosted in the AutoFocus pane. Toggled exclusively through
+        /// <see cref="MarkInteractive"/> / <see cref="MarkNonInteractive"/> (called by InteractiveHostBehavior while the
+        /// pane DataTemplate is loaded). Sequence-triggered AF runs construct their own transient VM via the factory,
+        /// which is never rendered through the pane template, so it stays false — gating frame retention to interactive
+        /// runs. No public setter, so the flag can never be flipped from arbitrary binding/code (F07/F20).
         /// </summary>
         public bool IsInteractive {
             get => isInteractive;
-            set {
+            private set {
                 if (isInteractive != value) {
                     isInteractive = value;
                     RaisePropertyChanged();
                 }
             }
         }
+
+        /// <summary>Explicit opt-in: marks THIS VM instance interactive so its runs retain per-frame images for review.
+        /// Called by InteractiveHostBehavior when the pane DataTemplate hosting this VM is loaded (F07/F20).</summary>
+        public void MarkInteractive() => IsInteractive = true;
+
+        /// <summary>Explicit opt-out: reverts the interactive flag when the pane unloads or its DataContext is swapped
+        /// away, so a recycled host never leaves a non-pane VM marked interactive (F20).</summary>
+        public void MarkNonInteractive() => IsInteractive = false;
 
         /// <summary>Exposes the persisted AF options for the pane's "Keep frames for review" toggle binding (mirrors
         /// InspectorVM.InspectorOptions).</summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/HocusFocusVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/HocusFocusVM.cs
@@ -838,31 +838,16 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             }
 
             var vm = new AutoFocusFrameReviewVM(snapshot, HocusFocusPlugin.StarAnnotatorOptions, HocusFocusPlugin.ApplicationDispatcher, starDetectionOptions.MeasurementAverage);
-            var windowService = windowServiceFactory.Create();
-
-            void onRequestClose(object s, EventArgs e) {
-                _ = windowService.Close();
-            }
-
-            EventHandler onClosed = null;
-            onClosed = (s, e) => {
-                windowService.OnClosed -= onClosed;
-                vm.RequestClose -= onRequestClose;
-                vm.Dispose();
-                // vm.Dispose() only nulls the child VM's copy; the pane VM still holds the snapshot's
-                // frozen bitmaps (F04) and any source IRenderedImage buffers (F06). Release them here so
-                // "released when you ... close the review window" is honored without waiting for the next
-                // run (which uses a different VM for sequence-driven AF anyway).
+            ReviewDialogHost.Show(windowServiceFactory, vm, "Review Frames", () => {
+                // vm.Dispose() only nulls the child VM's copy; the pane VM still holds the snapshot's frozen bitmaps
+                // (F04) and source IRenderedImage buffers (F06). Release them on close so "released when you close the
+                // review window" is honored without waiting for the next run.
                 lock (frameReviewLock) {
                     reviewFrames.Clear();
                 }
                 reviewSnapshot = null;
                 NotifyReviewFramesAvailabilityChanged();
-            };
-            windowService.OnClosed += onClosed;
-            vm.RequestClose += onRequestClose;
-
-            windowService.ShowDialog(vm, "Review Frames", System.Windows.ResizeMode.CanResize, System.Windows.WindowStyle.SingleBorderWindow);
+            });
         }
 
         private void AutoFocusEngine_InitialHFRCalculated(object sender, AutoFocusInitialHFRCalculatedEventArgs e) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/HocusFocusVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/HocusFocusVM.cs
@@ -546,6 +546,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         }
 
         public async Task<AutoFocusReport> StartAutoFocus(FilterInfo imagingFilter, CancellationToken token, IProgress<ApplicationStatus> progress) {
+            IAutoFocusEngine autoFocusEngine = null;
             try {
                 if (AutoFocusInProgress) {
                     Notification.ShowError("Another AutoFocus is already in progress");
@@ -553,7 +554,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 }
                 AutoFocusInProgress = true;
 
-                var autoFocusEngine = autoFocusEngineFactory.Create();
+                autoFocusEngine = autoFocusEngineFactory.Create();
                 autoFocusEngine.Started += AutoFocusEngine_AutoFocusStarted;
                 autoFocusEngine.InitialHFRCalculated += AutoFocusEngine_InitialHFRCalculated;
                 autoFocusEngine.IterationFailed += AutoFocusEngine_IterationFailed;
@@ -571,6 +572,18 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 InitialFocuserPosition = result.InitialFocuserPosition;
                 return LastReport;
             } finally {
+                // Detach the per-run engine handlers symmetrically. Correctness doesn't depend on it today (the factory
+                // returns a fresh engine each run), but it makes the subscribe/unsubscribe contract explicit and guards
+                // against any future engine reuse leaking handlers across runs. (F28)
+                if (autoFocusEngine != null) {
+                    autoFocusEngine.Started -= AutoFocusEngine_AutoFocusStarted;
+                    autoFocusEngine.InitialHFRCalculated -= AutoFocusEngine_InitialHFRCalculated;
+                    autoFocusEngine.IterationFailed -= AutoFocusEngine_IterationFailed;
+                    autoFocusEngine.MeasurementPointCompleted -= AutoFocusEngine_MeasurementPointCompleted;
+                    autoFocusEngine.SubMeasurementPointCompleted -= AutoFocusEngine_SubMeasurementPointCompleted;
+                    autoFocusEngine.Completed -= AutoFocusEngine_Completed;
+                    autoFocusEngine.Failed -= AutoFocusEngine_Failed;
+                }
                 // A successful run already moved frames into the snapshot (and cleared reviewFrames); this
                 // covers cancellation / null-init paths where Completed/Failed never fired, so captured
                 // exposures aren't pinned until the next run. (F22)
@@ -885,6 +898,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         private CancellationTokenSource loadSavedAutoFocusRunCts;
 
         private async Task<bool> LoadSavedAutoFocusRun(string selectedPath) {
+            IAutoFocusEngine autoFocusEngine = null;
             try {
                 if (AutoFocusInProgress) {
                     Notification.ShowError("Another AutoFocus is already in progress");
@@ -894,7 +908,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
                 loadSavedAutoFocusRunCts?.Cancel();
                 loadSavedAutoFocusRunCts = new CancellationTokenSource();
-                var autoFocusEngine = autoFocusEngineFactory.Create();
+                autoFocusEngine = autoFocusEngineFactory.Create();
                 SavedAutoFocusAttempt savedAttempt;
 
                 try {
@@ -959,6 +973,16 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 Logger.Error("Failed reprocessing saved AF", e);
                 return false;
             } finally {
+                // Detach the per-run engine handlers symmetrically (F28). This path wires Completed ->
+                // AutoFocusEngine_CompletedNoReport and does not subscribe Failed, so the -= list mirrors that exactly.
+                if (autoFocusEngine != null) {
+                    autoFocusEngine.Started -= AutoFocusEngine_AutoFocusStarted;
+                    autoFocusEngine.InitialHFRCalculated -= AutoFocusEngine_InitialHFRCalculated;
+                    autoFocusEngine.IterationFailed -= AutoFocusEngine_IterationFailed;
+                    autoFocusEngine.MeasurementPointCompleted -= AutoFocusEngine_MeasurementPointCompleted;
+                    autoFocusEngine.SubMeasurementPointCompleted -= AutoFocusEngine_SubMeasurementPointCompleted;
+                    autoFocusEngine.Completed -= AutoFocusEngine_CompletedNoReport;
+                }
                 ReleaseUnsnapshottedReviewFrames();
                 AutoFocusInProgress = false;
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/HocusFocusVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/HocusFocusVM.cs
@@ -532,6 +532,19 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             PlotFinalFocusPointWithError.Add(new ScatterErrorPoint(minimum.X, minimum.Y, errorX, 0.0));
         }
 
+        // Single source for the interactive frame-review retention policy used by BOTH StartAutoFocus and
+        // LoadSavedAutoFocusRun: retain per-frame images for review only when this VM is interactive (pane) AND the
+        // persisted "Keep frames for review" toggle is on. When retaining, force the engine to preserve exposures and
+        // model PSFs (iff PSF modeling is enabled in star-detection options) so the review can show PSF-derived
+        // per-star properties (AF normally skips PSF fitting for speed). Sets frameReviewRequestedForRun as a side effect.
+        private void ApplyFrameReviewOptions(AutoFocusEngineOptions options) {
+            frameReviewRequestedForRun = IsInteractive && autoFocusOptions.KeepFramesForReview;
+            if (frameReviewRequestedForRun) {
+                options.PreserveExposures = true;
+                options.ModelPSF = starDetectionOptions.ModelPSF;
+            }
+        }
+
         public async Task<AutoFocusReport> StartAutoFocus(FilterInfo imagingFilter, CancellationToken token, IProgress<ApplicationStatus> progress) {
             try {
                 if (AutoFocusInProgress) {
@@ -550,16 +563,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 autoFocusEngine.Failed += AutoFocusEngine_Failed;
                 var options = autoFocusEngine.GetOptions();
 
-                // Retain per-frame images for review ONLY for an interactive run started from the AF pane AND with the
-                // persisted "Keep frames for review" toggle on. Frozen here (at run start, where PreserveExposures is
-                // decided) so a sequence-triggered run — whose VM is never marked interactive — never retains frames.
-                frameReviewRequestedForRun = IsInteractive && autoFocusOptions.KeepFramesForReview;
-                if (frameReviewRequestedForRun) {
-                    options.PreserveExposures = true;
-                    // Model PSFs during this review run iff PSF modeling is enabled in the star-detection options, so
-                    // the review can show the PSF-derived per-star properties (AF normally skips PSF fitting for speed).
-                    options.ModelPSF = starDetectionOptions.ModelPSF;
-                }
+                ApplyFrameReviewOptions(options);
                 var result = await autoFocusEngine.Run(options, imagingFilter, token, progress);
                 if (result == null || !result.Succeeded) {
                     return null;
@@ -945,14 +949,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 }
                 var options = resolution.Options;
 
-                // Replay is an interactive pane action, so it supports Review Frames on the same terms as a live run:
-                // keep frames when interactive + the toggle is on, forcing the engine to retain each reloaded exposure,
-                // and model PSFs (when enabled in star-detection options) so PSF properties are available in the review.
-                frameReviewRequestedForRun = IsInteractive && autoFocusOptions.KeepFramesForReview;
-                if (frameReviewRequestedForRun) {
-                    options.PreserveExposures = true;
-                    options.ModelPSF = starDetectionOptions.ModelPSF;
-                }
+                // Replay is an interactive pane action, so it supports Review Frames on the same terms as a live run.
+                ApplyFrameReviewOptions(options);
 
                 // Option (b) supplies the run's capture-time regions so its ROI is honored through the explicit-region
                 // path (the engine consumes the star-detection override there) without mutating the profile. Otherwise

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -30,6 +30,7 @@ using NINA.Equipment.Model;
 using NINA.Image.ImageAnalysis;
 using NINA.Image.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus.Review;
 using NINA.Joko.Plugins.HocusFocus.Controls;
 using NINA.Joko.Plugins.HocusFocus.Inspection;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
@@ -1599,27 +1600,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 return;
             }
 
+            // Release this VM's frozen snapshot bitmaps on close (F36) via the shared host's afterClosed callback.
             var vm = new FrameReviewVM(snapshot);
-            var windowService = windowServiceFactory.Create();
-
-            void onRequestClose(object s, EventArgs e) {
-                _ = windowService.Close();
-            }
-
-            EventHandler onClosed = null;
-            onClosed = (s, e) => {
-                windowService.OnClosed -= onClosed;
-                vm.RequestClose -= onRequestClose;
-                vm.Dispose();
-                // vm.Dispose() only nulls the child VM's copy; InspectorVM still holds the snapshot's frozen
-                // bitmaps. Release them on close so the documented "released when you ... close the review
-                // window" contract holds without waiting for Clear Analyses / the next run. (F36)
-                ClearReviewSnapshot();
-            };
-            windowService.OnClosed += onClosed;
-            vm.RequestClose += onRequestClose;
-
-            windowService.ShowDialog(vm, "Review Frames", ResizeMode.CanResize, WindowStyle.SingleBorderWindow);
+            ReviewDialogHost.Show(windowServiceFactory, vm, "Review Frames", ClearReviewSnapshot);
         }
         public AsyncObservableCollection<ScatterErrorPoint>[] RegionFocusPoints { get; private set; }
         public AsyncObservableCollection<DataPoint>[] RegionPlotFocusPoints { get; private set; }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InteractiveHostBehavior.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InteractiveHostBehavior.cs
@@ -21,6 +21,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
     /// ever rendered through the <c>HocusFocusVM_Dockable</c> DataTemplate. Applying
     /// <c>InteractiveHostBehavior.HostInteractive="True"</c> on that template's root sets <see cref="HocusFocusVM.IsInteractive"/>
     /// on the bound VM; a sequence-created VM is never rendered there, so it stays false and never retains frames.
+    /// Tracks Loaded/Unloaded AND DataContextChanged so the marking follows the bound VM through host recycling (F20),
+    /// routing through MarkInteractive()/MarkNonInteractive() rather than a public setter.
     /// </summary>
     public static class InteractiveHostBehavior {
 
@@ -42,12 +44,14 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             if ((bool)e.NewValue) {
                 fe.Loaded += OnLoaded;
                 fe.Unloaded += OnUnloaded;
+                fe.DataContextChanged += OnDataContextChanged;
                 if (fe.IsLoaded) {
                     SetInteractive(fe, true);
                 }
             } else {
                 fe.Loaded -= OnLoaded;
                 fe.Unloaded -= OnUnloaded;
+                fe.DataContextChanged -= OnDataContextChanged;
                 SetInteractive(fe, false);
             }
         }
@@ -64,9 +68,25 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             }
         }
 
+        // Track DataContext swaps so a recycled host re-marks the newly-bound VM (and un-marks the old one) rather than
+        // relying on Loaded/Unloaded alone (F20): a host that swaps its VM while staying loaded would otherwise leave the
+        // new VM unmarked (pane silently stops retaining frames) or the old VM still marked.
+        private static void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e) {
+            if (e.OldValue is HocusFocusVM oldVm) {
+                oldVm.MarkNonInteractive();
+            }
+            if (sender is FrameworkElement fe && fe.IsLoaded) {
+                SetInteractive(fe, true);
+            }
+        }
+
         private static void SetInteractive(FrameworkElement fe, bool value) {
             if (fe.DataContext is HocusFocusVM vm) {
-                vm.IsInteractive = value;
+                if (value) {
+                    vm.MarkInteractive();
+                } else {
+                    vm.MarkNonInteractive();
+                }
             }
         }
     }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
@@ -1,10 +1,11 @@
-<UserControl
+<review:ReviewViewportHostBase
     x:Class="NINA.Joko.Plugins.HocusFocus.AutoFocus.Review.AutoFocusFrameReviewControl"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:hfconverters="clr-namespace:NINA.Joko.Plugins.HocusFocus.Converters"
+    xmlns:review="clr-namespace:NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review"
     Background="#FF1E2125">
-    <UserControl.Resources>
+    <review:ReviewViewportHostBase.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVis" />
         <hfconverters:EnumStaticDescriptionValueConverter x:Key="HF_EnumStaticDescriptionValueConverter" />
         <SolidColorBrush x:Key="Fg" Color="White" />
@@ -95,7 +96,7 @@
             <Setter Property="Foreground" Value="{StaticResource Fg}" />
             <Setter Property="VerticalAlignment" Value="Center" />
         </Style>
-    </UserControl.Resources>
+    </review:ReviewViewportHostBase.Resources>
 
     <Grid Margin="10">
         <Grid.ColumnDefinitions>
@@ -373,4 +374,4 @@
         </StackPanel>
         </ScrollViewer>
     </Grid>
-</UserControl>
+</review:ReviewViewportHostBase>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml.cs
@@ -10,49 +10,39 @@
 
 #endregion "copyright"
 
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review;
 using System;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Input;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
 
 namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
 
     /// <summary>
-    /// Read-only viewer for the manual AutoFocus "Review Frames" dialog: an MTF-stretched frame in a zoom/pan canvas
-    /// with the Star Annotator's overlays (bounds, per-star text, center, rejection-reason + ROI boxes). Binds to an
-    /// <see cref="AutoFocusFrameReviewVM"/>. The viewport plumbing (zoom/pan/fit/scroll) mirrors the Aberration
-    /// Inspector's <c>FrameReviewControl</c>; there is no hover focus graph here.
+    /// Read-only viewer for the manual AutoFocus "Review Frames" dialog. Shares all zoom/pan/fit/scroll plumbing with
+    /// the Aberration Inspector's review control via <see cref="ReviewViewportHostBase"/>; adds only the first-load
+    /// window sizing. No hover focus graph here.
     /// </summary>
-    public partial class AutoFocusFrameReviewControl : UserControl {
+    public partial class AutoFocusFrameReviewControl : ReviewViewportHostBase {
 
-        private AutoFocusFrameReviewVM Vm => DataContext as AutoFocusFrameReviewVM;
-
-        private bool panning;
-        private System.Windows.Point lastPanScreen;
-        private bool hasFitOnce;
         private bool windowSized;
+
+        protected override Canvas ViewportCanvasPart => ViewportCanvas;
+        protected override ScrollBar HScrollPart => HScroll;
+        protected override ScrollBar VScrollPart => VScroll;
+        protected override ScaleTransform ContentScalePart => ContentScale;
+        protected override TranslateTransform ContentTranslatePart => ContentTranslate;
+        protected override IViewportHostViewModel Vm => DataContext as IViewportHostViewModel;
 
         public AutoFocusFrameReviewControl() {
             InitializeComponent();
-            DataContextChanged += OnDataContextChanged;
-            KeyDown += OnKeyDown;
             Loaded += OnLoaded;
-            Unloaded += OnUnloaded;
-        }
-
-        // Detach the VM->control FitRequested edge when the control leaves the visual tree, so a long-lived host
-        // that re-uses this control across DataContexts (or tears down without a DataContext swap) cannot leak the
-        // control through the VM's event. The modal case is unaffected (it unloads on close).
-        private void OnUnloaded(object sender, RoutedEventArgs e) {
-            if (Vm != null) {
-                Vm.FitRequested -= OnFitRequested;
-            }
         }
 
         // Size the host window to FIT the screen on first load (clamped to the work area, centered), with a small
         // minimum so it can be shrunk freely. The WindowService opens the window sized-to-content, which — without this —
-        // would honor whatever large size the content asks for and open off-screen on smaller displays. A small Min lets
-        // the layout redistribute (the image column shrinks first, so the right-hand legend stays visible).
+        // would honor whatever large size the content asks for and open off-screen on smaller displays.
         private void OnLoaded(object sender, RoutedEventArgs e) {
             if (windowSized) {
                 return;
@@ -66,7 +56,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
             var work = SystemParameters.WorkArea; // device-independent pixels, excludes the taskbar
             const double desiredWidth = 1100.0;
             const double desiredHeight = 720.0;
-            const double margin = 40.0; // leave a little breathing room around the window
+            const double margin = 40.0;
 
             window.SizeToContent = SizeToContent.Manual;
             window.MinWidth = Math.Min(640.0, work.Width);
@@ -78,192 +68,10 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
 
             // The initial auto-fit (ViewportCanvas_SizeChanged) ran against the pre-resize canvas size, so re-fit
             // against the FINAL window size once the resize layout pass has settled (DispatcherPriority.Loaded runs
-            // after layout). Latch hasFitOnce only if that deferred fit actually succeeds; if the canvas still
-            // reports ActualWidth<=0 (or Vm isn't attached yet), leave hasFitOnce false so the SizeChanged auto-fit
-            // can still perform the first real fit. Without this the image could open unfit on slow layout passes.
+            // after layout). Latch hasFitOnce only if that deferred fit actually succeeds (F19).
             Dispatcher.BeginInvoke(
                 new Action(() => { if (TryFit()) { hasFitOnce = true; } }),
                 System.Windows.Threading.DispatcherPriority.Loaded);
-        }
-
-        private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e) {
-            if (e.OldValue is AutoFocusFrameReviewVM oldVm) {
-                oldVm.FitRequested -= OnFitRequested;
-            }
-            if (e.NewValue is AutoFocusFrameReviewVM newVm) {
-                newVm.FitRequested += OnFitRequested;
-            }
-        }
-
-        private void OnKeyDown(object sender, KeyEventArgs e) {
-            var vm = Vm;
-            if (vm == null) {
-                return;
-            }
-            switch (e.Key) {
-                case Key.Left:
-                    if (vm.PrevCommand.CanExecute(null)) {
-                        vm.PrevCommand.Execute(null);
-                    }
-                    e.Handled = true;
-                    break;
-                case Key.Right:
-                    if (vm.NextCommand.CanExecute(null)) {
-                        vm.NextCommand.Execute(null);
-                    }
-                    e.Handled = true;
-                    break;
-                case Key.F:
-                    OnFitRequested(this, EventArgs.Empty);
-                    e.Handled = true;
-                    break;
-            }
-        }
-
-        private void OnFitRequested(object sender, EventArgs e) {
-            TryFit();
-        }
-
-        // Returns true only when a fit was actually applied (canvas measured and VM ready), so callers can gate
-        // the one-shot hasFitOnce latch on a real fit rather than on a deferred attempt that returned early.
-        private bool TryFit() {
-            var vm = Vm;
-            if (vm == null || ViewportCanvas.ActualWidth <= 0 || vm.ImageWidth <= 0) {
-                return false;
-            }
-            // Collapse the scrollbars and force a layout pass FIRST so the fit is measured against the final
-            // (scrollbar-free) viewport — otherwise the image lands off-center until a second Fit.
-            HScroll.Visibility = Visibility.Collapsed;
-            VScroll.Visibility = Visibility.Collapsed;
-            ViewportCanvas.UpdateLayout();
-            if (ViewportCanvas.ActualWidth <= 0 || ViewportCanvas.ActualHeight <= 0) {
-                return false;
-            }
-            vm.Viewport.FitTo(ViewportCanvas.ActualWidth, ViewportCanvas.ActualHeight, vm.ImageWidth, vm.ImageHeight);
-            ApplyViewport();
-            return true;
-        }
-
-        private void ApplyViewport() {
-            var vm = Vm;
-            if (vm == null) {
-                return;
-            }
-            vm.Viewport.ClampToBounds(ViewportCanvas.ActualWidth, ViewportCanvas.ActualHeight, vm.ImageWidth, vm.ImageHeight);
-            ContentScale.ScaleX = vm.Viewport.Scale;
-            ContentScale.ScaleY = vm.Viewport.Scale;
-            ContentTranslate.X = vm.Viewport.OffsetX;
-            ContentTranslate.Y = vm.Viewport.OffsetY;
-            UpdateScrollBars();
-            // Markers scale with the canvas transform, so refresh the zoom-inverse stroke/label sizes after any change.
-            vm.NotifyViewportChanged();
-        }
-
-        private bool suppressScrollEvents;
-
-        private void UpdateScrollBars() {
-            var vm = Vm;
-            if (vm == null) {
-                return;
-            }
-            suppressScrollEvents = true;
-            try {
-                UpdateScrollBar(HScroll, ViewportCanvas.ActualWidth, vm.ImageWidth * vm.Viewport.Scale, -vm.Viewport.OffsetX);
-                UpdateScrollBar(VScroll, ViewportCanvas.ActualHeight, vm.ImageHeight * vm.Viewport.Scale, -vm.Viewport.OffsetY);
-            } finally {
-                suppressScrollEvents = false;
-            }
-        }
-
-        private static void UpdateScrollBar(System.Windows.Controls.Primitives.ScrollBar bar, double viewport, double content, double scrollPos) {
-            var scrollable = content - viewport;
-            if (scrollable > 0.5 && viewport > 0) {
-                bar.Visibility = Visibility.Visible;
-                bar.Minimum = 0;
-                bar.Maximum = scrollable;
-                bar.ViewportSize = viewport;
-                bar.LargeChange = viewport * 0.9;
-                bar.SmallChange = Math.Max(1.0, viewport * 0.1);
-                bar.Value = Math.Min(Math.Max(scrollPos, 0.0), scrollable);
-            } else {
-                bar.Visibility = Visibility.Collapsed;
-                bar.Value = 0;
-            }
-        }
-
-        private void HScroll_Scroll(object sender, System.Windows.Controls.Primitives.ScrollEventArgs e) {
-            var vm = Vm;
-            if (vm == null || suppressScrollEvents) {
-                return;
-            }
-            vm.Viewport.Set(vm.Viewport.Scale, -e.NewValue, vm.Viewport.OffsetY);
-            ApplyViewport();
-        }
-
-        private void VScroll_Scroll(object sender, System.Windows.Controls.Primitives.ScrollEventArgs e) {
-            var vm = Vm;
-            if (vm == null || suppressScrollEvents) {
-                return;
-            }
-            vm.Viewport.Set(vm.Viewport.Scale, vm.Viewport.OffsetX, -e.NewValue);
-            ApplyViewport();
-        }
-
-        // The canvas RenderTransform maps image space -> screen space, so a mouse position taken relative to the
-        // canvas's PARENT (the Border) is in screen space.
-        private System.Windows.Point ScreenPoint(MouseEventArgs e) {
-            var parent = (UIElement)ViewportCanvas.Parent;
-            return e.GetPosition(parent);
-        }
-
-        private void ViewportCanvas_MouseWheel(object sender, MouseWheelEventArgs e) {
-            var vm = Vm;
-            if (vm == null) {
-                return;
-            }
-            var anchor = ScreenPoint(e);
-            var factor = e.Delta > 0 ? 1.2 : 1.0 / 1.2;
-            vm.Viewport.ZoomAt(factor, anchor.X, anchor.Y);
-            ApplyViewport();
-            e.Handled = true;
-        }
-
-        private void ViewportCanvas_MouseRightButtonDown(object sender, MouseButtonEventArgs e) {
-            panning = true;
-            lastPanScreen = ScreenPoint(e);
-            ViewportCanvas.CaptureMouse();
-            e.Handled = true;
-        }
-
-        private void ViewportCanvas_MouseRightButtonUp(object sender, MouseButtonEventArgs e) {
-            panning = false;
-            ViewportCanvas.ReleaseMouseCapture();
-            e.Handled = true;
-        }
-
-        private void ViewportCanvas_MouseMove(object sender, MouseEventArgs e) {
-            var vm = Vm;
-            if (vm == null || !panning) {
-                return;
-            }
-            var screen = ScreenPoint(e);
-            var dx = screen.X - lastPanScreen.X;
-            var dy = screen.Y - lastPanScreen.Y;
-            lastPanScreen = screen;
-            vm.Viewport.PanBy(dx, dy);
-            ApplyViewport();
-        }
-
-        private void ViewportCanvas_SizeChanged(object sender, SizeChangedEventArgs e) {
-            // Re-fit only on the first meaningful size (initial layout); afterwards keep the user's zoom/pan.
-            if (hasFitOnce) {
-                return;
-            }
-            // Latch only when a fit actually applies, so a too-early SizeChanged (ActualWidth still settling)
-            // does not permanently suppress the first real fit.
-            if (TryFit()) {
-                hasFitOnce = true;
-            }
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewVM.cs
@@ -20,7 +20,6 @@ using System.ComponentModel;
 using System.Linq;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using RelayCommand = CommunityToolkit.Mvvm.Input.RelayCommand;
 
 namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
 
@@ -81,7 +80,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
     /// and <see cref="StarReviewLegendEntry"/> for the legend. The per-star text selection is review-local (initialized
     /// from the annotator setting, not written back). Disposing releases the retained bitmaps.
     /// </summary>
-    public sealed class AutoFocusFrameReviewVM : BaseINPC, IReviewDialogViewModel, IViewportHostViewModel {
+    public sealed class AutoFocusFrameReviewVM : FrameReviewVMBase<AutoFocusReviewMarker>, IReviewDialogViewModel {
 
         private static SolidColorBrush FrozenBrush(Color c) {
             var b = new SolidColorBrush(c);
@@ -95,24 +94,11 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
         private readonly MeasurementAverageEnum measurementAverage;
         private readonly bool psfAvailable;
 
-        public event EventHandler RequestClose;
-        public event EventHandler FitRequested;
-
-        public StarReviewViewport Viewport { get; }
-        public ObservableCollection<AutoFocusReviewMarker> Markers { get; } = new();
         public ObservableCollection<AutoFocusReviewRectOverlay> RectOverlays { get; } = new();
 
-        public RelayCommand PrevCommand { get; }
-        public RelayCommand NextCommand { get; }
-        public RelayCommand FitCommand { get; }
-        public RelayCommand CloseCommand { get; }
-
-        // The public PrevCommand/NextCommand are RelayCommand; expose them as ICommand for the viewport host (F08).
-        System.Windows.Input.ICommand IViewportHostViewModel.PrevCommand => PrevCommand;
-        System.Windows.Input.ICommand IViewportHostViewModel.NextCommand => NextCommand;
-
-        public AutoFocusFrameReviewVM(AutoFocusFrameReviewSnapshot snapshot, IStarAnnotatorOptions annotatorOptions, IApplicationDispatcher applicationDispatcher, MeasurementAverageEnum measurementAverage) {
-            this.snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));
+        public AutoFocusFrameReviewVM(AutoFocusFrameReviewSnapshot snapshot, IStarAnnotatorOptions annotatorOptions, IApplicationDispatcher applicationDispatcher, MeasurementAverageEnum measurementAverage)
+            : base((snapshot ?? throw new ArgumentNullException(nameof(snapshot))).Frames.Count) {
+            this.snapshot = snapshot;
             this.annotatorOptions = annotatorOptions ?? throw new ArgumentNullException(nameof(annotatorOptions));
             this.applicationDispatcher = applicationDispatcher ?? throw new ArgumentNullException(nameof(applicationDispatcher));
             this.measurementAverage = measurementAverage;
@@ -136,24 +122,15 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
             var configuredBounds = annotatorOptions.StarBoundsType;
             this.starBoundsType = AvailableBoundsTypes.Contains(configuredBounds) ? configuredBounds : StarBoundsTypeEnum.Box;
 
-            Viewport = new StarReviewViewport();
-
             annotatorOptions.PropertyChanged += AnnotatorOptions_PropertyChanged;
 
-            PrevCommand = new RelayCommand(Prev, () => CurrentIndex > 0);
-            NextCommand = new RelayCommand(Next, () => CurrentIndex < FrameCount - 1);
-            FitCommand = new RelayCommand(() => FitRequested?.Invoke(this, EventArgs.Empty));
-            CloseCommand = new RelayCommand(() => RequestClose?.Invoke(this, EventArgs.Empty));
-
-            legendEntries = BuildLegend();
+            RebuildLegend();
             CurrentIndex = 0;
             // No fit here: FitRequested has zero subscribers at construction time (the control subscribes in
             // OnDataContextChanged, after the ctor returns). The initial fit is driven by the control's first
             // layout (Loaded/SizeChanged). Passing fit:false makes that contract explicit.
             LoadCurrent(fit: false);
         }
-
-        private int FrameCount => snapshot?.Frames.Count ?? 0;
 
         // Overlay-affecting annotator properties: a change to any of these re-renders the overlays + legend live
         // (same UX as the image annotator). Properties the review does not render are ignored to avoid wasted rebuilds.
@@ -251,34 +228,6 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
 
         // ---- navigation / current frame -------------------------------------------------------------------
 
-        private int currentIndex;
-        public int CurrentIndex {
-            get => currentIndex;
-            private set {
-                if (currentIndex != value) {
-                    currentIndex = value;
-                    RaisePropertyChanged();
-                    RaisePropertyChanged(nameof(PositionLabel));
-                }
-            }
-        }
-
-        public string PositionLabel => FrameCount > 0 ? $"{CurrentIndex + 1} / {FrameCount}" : "0 / 0";
-
-        private BitmapSource frameImage;
-        public BitmapSource FrameImage {
-            get => frameImage;
-            private set {
-                frameImage = value;
-                RaisePropertyChanged();
-                RaisePropertyChanged(nameof(ImageWidth));
-                RaisePropertyChanged(nameof(ImageHeight));
-            }
-        }
-
-        public double ImageWidth => frameImage?.PixelWidth ?? 0;
-        public double ImageHeight => frameImage?.PixelHeight ?? 0;
-
         private string frameHeader;
         public string FrameHeader {
             get => frameHeader;
@@ -301,29 +250,16 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
 
         // ---- inverse-zoom overlay bindings ----------------------------------------------------------------
 
-        public double MarkerStrokeThickness => 1.5 / Math.Max(StarReviewViewport.MinScale, Viewport.Scale);
-        public double MarkerTextScale => 1.0 / Math.Max(StarReviewViewport.MinScale, Viewport.Scale);
         public double LabelOffset => -15.0 * MarkerTextScale;
 
-        public void NotifyViewportChanged() {
-            RaisePropertyChanged(nameof(MarkerStrokeThickness));
-            RaisePropertyChanged(nameof(MarkerTextScale));
+        public override void NotifyViewportChanged() {
+            base.NotifyViewportChanged();
             RaisePropertyChanged(nameof(LabelOffset));
         }
 
         // ---- legend ---------------------------------------------------------------------------------------
 
-        private IReadOnlyList<StarReviewLegendEntry> legendEntries;
-        public IReadOnlyList<StarReviewLegendEntry> LegendEntries {
-            get => legendEntries;
-            private set { legendEntries = value; RaisePropertyChanged(); }
-        }
-
-        private void RebuildLegend() {
-            LegendEntries = BuildLegend();
-        }
-
-        private IReadOnlyList<StarReviewLegendEntry> BuildLegend() {
+        protected override IReadOnlyList<StarReviewLegendEntry> BuildLegend() {
             var entries = new List<StarReviewLegendEntry> {
                 new() { Brush = StarBoundsBrush, Caption = $"Star bounds ({StarBoundsType})", Enabled = annotatorOptions.ShowStarBounds },
                 new() { Brush = AnnotationBrush, Caption = "Star annotation text", Enabled = ShowAnnotationType != ShowAnnotationTypeEnum.None },
@@ -353,20 +289,6 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
 
         // ---- frame loading --------------------------------------------------------------------------------
 
-        private void Prev() {
-            if (CurrentIndex > 0) {
-                CurrentIndex--;
-                LoadCurrent(fit: false);
-            }
-        }
-
-        private void Next() {
-            if (CurrentIndex < FrameCount - 1) {
-                CurrentIndex++;
-                LoadCurrent(fit: false);
-            }
-        }
-
         private AutoFocusReviewFrame CurrentFrame {
             get {
                 var frames = snapshot?.Frames;
@@ -377,17 +299,16 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
             }
         }
 
-        private void LoadCurrent(bool fit) {
+        // The base LoadCurrent already cleared Markers and will fire CanExecute/fit; this only sets the
+        // frame-specific image/header/stats/overlays. CurrentFrame reads CurrentIndex (== index here).
+        protected override void LoadFrame(int index) {
             var frame = CurrentFrame;
             if (frame == null) {
                 FrameImage = null;
                 FrameHeader = string.Empty;
                 DetectedCountText = string.Empty;
                 StatsText = string.Empty;
-                Markers.Clear();
                 RectOverlays.Clear();
-                PrevCommand.NotifyCanExecuteChanged();
-                NextCommand.NotifyCanExecuteChanged();
                 return;
             }
 
@@ -399,12 +320,6 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
             StatsText = StarReviewHfrStats.FormatStats(center, deviation, frame.DetectedStarCount, measurementAverage, includeCount: false);
 
             RebuildCurrentFrameOverlays();
-
-            PrevCommand.NotifyCanExecuteChanged();
-            NextCommand.NotifyCanExecuteChanged();
-            if (fit) {
-                FitRequested?.Invoke(this, EventArgs.Empty);
-            }
         }
 
         private void RebuildCurrentFrameOverlays() {
@@ -488,8 +403,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
             RectOverlays.Clear();
             FrameImage = null;
             snapshot = null;
-            FitRequested = null;
-            RequestClose = null;
+            DetachReviewEvents();
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewVM.cs
@@ -81,7 +81,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
     /// and <see cref="StarReviewLegendEntry"/> for the legend. The per-star text selection is review-local (initialized
     /// from the annotator setting, not written back). Disposing releases the retained bitmaps.
     /// </summary>
-    public sealed class AutoFocusFrameReviewVM : BaseINPC, IDisposable {
+    public sealed class AutoFocusFrameReviewVM : BaseINPC, IReviewDialogViewModel {
 
         private static SolidColorBrush FrozenBrush(Color c) {
             var b = new SolidColorBrush(c);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewVM.cs
@@ -81,7 +81,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
     /// and <see cref="StarReviewLegendEntry"/> for the legend. The per-star text selection is review-local (initialized
     /// from the annotator setting, not written back). Disposing releases the retained bitmaps.
     /// </summary>
-    public sealed class AutoFocusFrameReviewVM : BaseINPC, IReviewDialogViewModel {
+    public sealed class AutoFocusFrameReviewVM : BaseINPC, IReviewDialogViewModel, IViewportHostViewModel {
 
         private static SolidColorBrush FrozenBrush(Color c) {
             var b = new SolidColorBrush(c);
@@ -106,6 +106,10 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
         public RelayCommand NextCommand { get; }
         public RelayCommand FitCommand { get; }
         public RelayCommand CloseCommand { get; }
+
+        // The public PrevCommand/NextCommand are RelayCommand; expose them as ICommand for the viewport host (F08).
+        System.Windows.Input.ICommand IViewportHostViewModel.PrevCommand => PrevCommand;
+        System.Windows.Input.ICommand IViewportHostViewModel.NextCommand => NextCommand;
 
         public AutoFocusFrameReviewVM(AutoFocusFrameReviewSnapshot snapshot, IStarAnnotatorOptions annotatorOptions, IApplicationDispatcher applicationDispatcher, MeasurementAverageEnum measurementAverage) {
             this.snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/ReviewDialogHost.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/ReviewDialogHost.cs
@@ -1,0 +1,52 @@
+#region "copyright"
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+#endregion "copyright"
+
+using NINA.Core.Utility.WindowService;
+using System;
+using System.Windows;
+
+namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
+
+    /// <summary>A review-dialog VM that can be closed via a UI event and disposed when the window closes.</summary>
+    public interface IReviewDialogViewModel : IDisposable {
+        event EventHandler RequestClose;
+    }
+
+    /// <summary>
+    /// Single owner of the modal "Review Frames" show/dispose lifecycle (F24): creates a WindowService, wires the
+    /// self-unsubscribing RequestClose/OnClosed handler pair, disposes the VM on close, then runs an optional
+    /// per-caller cleanup. Previously copy-pasted verbatim into HocusFocusVM and InspectorVM.
+    /// </summary>
+    public static class ReviewDialogHost {
+
+        /// <param name="afterClosed">Optional per-VM cleanup invoked AFTER vm.Dispose() (e.g. releasing the owning
+        /// VM's own snapshot/bitmaps), matching the pre-extraction order.</param>
+        public static void Show(IWindowServiceFactory windowServiceFactory, IReviewDialogViewModel vm, string title, Action afterClosed = null) {
+            ArgumentNullException.ThrowIfNull(windowServiceFactory);
+            ArgumentNullException.ThrowIfNull(vm);
+            var windowService = windowServiceFactory.Create();
+
+            void onRequestClose(object s, EventArgs e) => _ = windowService.Close();
+
+            EventHandler onClosed = null;
+            onClosed = (s, e) => {
+                // Defensive hygiene: OnClosed fires once, but detach both handlers before disposing so nothing dangles.
+                windowService.OnClosed -= onClosed;
+                vm.RequestClose -= onRequestClose;
+                vm.Dispose();
+                afterClosed?.Invoke();
+            };
+            windowService.OnClosed += onClosed;
+            vm.RequestClose += onRequestClose;
+
+            windowService.ShowDialog(vm, title, ResizeMode.CanResize, WindowStyle.SingleBorderWindow);
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
@@ -1,9 +1,10 @@
-<UserControl
+<review:ReviewViewportHostBase
     x:Class="NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review.FrameReviewControl"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:review="clr-namespace:NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review"
     Background="#FF1E2125">
-    <UserControl.Resources>
+    <review:ReviewViewportHostBase.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVis" />
         <SolidColorBrush x:Key="Fg" Color="White" />
 
@@ -93,7 +94,7 @@
             <Setter Property="Foreground" Value="{StaticResource Fg}" />
             <Setter Property="VerticalAlignment" Value="Center" />
         </Style>
-    </UserControl.Resources>
+    </review:ReviewViewportHostBase.Resources>
 
     <Grid Margin="10">
         <Grid.ColumnDefinitions>
@@ -380,4 +381,4 @@
                        Text="Wheel to zoom, right-drag to pan, Fit to reset. ◀ ▶ or Prev/Next to change frames." />
         </StackPanel>
     </Grid>
-</UserControl>
+</review:ReviewViewportHostBase>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml.cs
@@ -11,212 +11,45 @@
 #endregion "copyright"
 
 using System;
-using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using System.Windows.Media;
 
 namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
     /// <summary>
-    /// Read-only fork of <see cref="StarReviewControl"/> for the Aberration Inspector "Review Frames" dialog: an
-    /// MTF-stretched frame in a zoom/pan canvas with accepted-star boxes, HFR + registration-id labels, and
-    /// registration arrows. Binds to a <see cref="FrameReviewVM"/>. Only the viewport plumbing (zoom/pan/fit/scroll)
-    /// is kept from StarReviewControl — all labeling/drag/undo input is dropped.
+    /// Read-only viewer for the Aberration Inspector "Review Frames" dialog. Shares all zoom/pan/fit/scroll plumbing
+    /// with the AutoFocus review control via <see cref="ReviewViewportHostBase"/>; adds only the hover focus-graph.
     /// </summary>
-    public partial class FrameReviewControl : UserControl {
+    public partial class FrameReviewControl : ReviewViewportHostBase {
 
-        private FrameReviewVM Vm => DataContext as FrameReviewVM;
+        private FrameReviewVM HoverVm => DataContext as FrameReviewVM;
 
-        private bool panning;
-        private System.Windows.Point lastPanScreen;
-        private bool hasFitOnce;
+        protected override Canvas ViewportCanvasPart => ViewportCanvas;
+        protected override ScrollBar HScrollPart => HScroll;
+        protected override ScrollBar VScrollPart => VScroll;
+        protected override ScaleTransform ContentScalePart => ContentScale;
+        protected override TranslateTransform ContentTranslatePart => ContentTranslate;
+        protected override IViewportHostViewModel Vm => DataContext as IViewportHostViewModel;
 
         public FrameReviewControl() {
             InitializeComponent();
-            DataContextChanged += OnDataContextChanged;
-            KeyDown += OnKeyDown;
-            Unloaded += OnUnloaded;
         }
 
-        // Detach the VM->control FitRequested edge when the control leaves the visual tree, so a long-lived host
-        // that re-uses this control across DataContexts (or tears down without a DataContext swap) cannot leak the
-        // control through the VM's event. The modal case is unaffected (it unloads on close).
-        private void OnUnloaded(object sender, RoutedEventArgs e) {
-            if (Vm != null) {
-                Vm.FitRequested -= OnFitRequested;
-            }
-        }
-
-        private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e) {
-            if (e.OldValue is FrameReviewVM oldVm) {
-                oldVm.FitRequested -= OnFitRequested;
-            }
-            if (e.NewValue is FrameReviewVM newVm) {
-                newVm.FitRequested += OnFitRequested;
-            }
-        }
-
-        private void OnKeyDown(object sender, KeyEventArgs e) {
-            var vm = Vm;
-            if (vm == null) {
-                return;
-            }
-            switch (e.Key) {
-                case Key.Left:
-                    if (vm.PrevCommand.CanExecute(null)) {
-                        vm.PrevCommand.Execute(null);
-                    }
-                    e.Handled = true;
-                    break;
-                case Key.Right:
-                    if (vm.NextCommand.CanExecute(null)) {
-                        vm.NextCommand.Execute(null);
-                    }
-                    e.Handled = true;
-                    break;
-                case Key.F:
-                    OnFitRequested(this, EventArgs.Empty);
-                    e.Handled = true;
-                    break;
-            }
-        }
-
-        private void OnFitRequested(object sender, EventArgs e) {
-            var vm = Vm;
-            if (vm == null || ViewportCanvas.ActualWidth <= 0 || vm.ImageWidth <= 0) {
-                return;
-            }
-            // Collapse the scrollbars and force a layout pass FIRST so the fit is measured against the final
-            // (scrollbar-free) viewport — otherwise the image lands off-center until a second Fit (see StarReviewControl).
-            HScroll.Visibility = Visibility.Collapsed;
-            VScroll.Visibility = Visibility.Collapsed;
-            ViewportCanvas.UpdateLayout();
-            if (ViewportCanvas.ActualWidth <= 0 || ViewportCanvas.ActualHeight <= 0) {
-                return;
-            }
-            vm.Viewport.FitTo(ViewportCanvas.ActualWidth, ViewportCanvas.ActualHeight, vm.ImageWidth, vm.ImageHeight);
-            ApplyViewport();
-        }
-
-        private void ApplyViewport() {
-            var vm = Vm;
-            if (vm == null) {
-                return;
-            }
-            vm.Viewport.ClampToBounds(ViewportCanvas.ActualWidth, ViewportCanvas.ActualHeight, vm.ImageWidth, vm.ImageHeight);
-            ContentScale.ScaleX = vm.Viewport.Scale;
-            ContentScale.ScaleY = vm.Viewport.Scale;
-            ContentTranslate.X = vm.Viewport.OffsetX;
-            ContentTranslate.Y = vm.Viewport.OffsetY;
-            UpdateScrollBars();
-            // Markers scale with the canvas transform, so refresh the zoom-inverse stroke/label sizes after any change.
-            vm.NotifyViewportChanged();
-        }
-
-        private bool suppressScrollEvents;
-
-        private void UpdateScrollBars() {
-            var vm = Vm;
-            if (vm == null) {
-                return;
-            }
-            suppressScrollEvents = true;
-            try {
-                UpdateScrollBar(HScroll, ViewportCanvas.ActualWidth, vm.ImageWidth * vm.Viewport.Scale, -vm.Viewport.OffsetX);
-                UpdateScrollBar(VScroll, ViewportCanvas.ActualHeight, vm.ImageHeight * vm.Viewport.Scale, -vm.Viewport.OffsetY);
-            } finally {
-                suppressScrollEvents = false;
-            }
-        }
-
-        private static void UpdateScrollBar(System.Windows.Controls.Primitives.ScrollBar bar, double viewport, double content, double scrollPos) {
-            var scrollable = content - viewport;
-            if (scrollable > 0.5 && viewport > 0) {
-                bar.Visibility = Visibility.Visible;
-                bar.Minimum = 0;
-                bar.Maximum = scrollable;
-                bar.ViewportSize = viewport;
-                bar.LargeChange = viewport * 0.9;
-                bar.SmallChange = Math.Max(1.0, viewport * 0.1);
-                bar.Value = Math.Min(Math.Max(scrollPos, 0.0), scrollable);
-            } else {
-                bar.Visibility = Visibility.Collapsed;
-                bar.Value = 0;
-            }
-        }
-
-        private void HScroll_Scroll(object sender, System.Windows.Controls.Primitives.ScrollEventArgs e) {
-            var vm = Vm;
-            if (vm == null || suppressScrollEvents) {
-                return;
-            }
-            vm.Viewport.Set(vm.Viewport.Scale, -e.NewValue, vm.Viewport.OffsetY);
-            ApplyViewport();
-        }
-
-        private void VScroll_Scroll(object sender, System.Windows.Controls.Primitives.ScrollEventArgs e) {
-            var vm = Vm;
-            if (vm == null || suppressScrollEvents) {
-                return;
-            }
-            vm.Viewport.Set(vm.Viewport.Scale, vm.Viewport.OffsetX, -e.NewValue);
-            ApplyViewport();
-        }
-
-        // The canvas RenderTransform maps image space -> screen space, so a mouse position taken relative to the
-        // canvas's PARENT (the Border) is in screen space.
-        private System.Windows.Point ScreenPoint(MouseEventArgs e) {
-            var parent = (UIElement)ViewportCanvas.Parent;
-            return e.GetPosition(parent);
-        }
-
-        private void ViewportCanvas_MouseWheel(object sender, MouseWheelEventArgs e) {
-            var vm = Vm;
-            if (vm == null) {
-                return;
-            }
-            var anchor = ScreenPoint(e);
-            var factor = e.Delta > 0 ? 1.2 : 1.0 / 1.2;
-            vm.Viewport.ZoomAt(factor, anchor.X, anchor.Y);
-            ApplyViewport();
-            e.Handled = true;
-        }
-
-        private void ViewportCanvas_MouseRightButtonDown(object sender, MouseButtonEventArgs e) {
-            panning = true;
-            lastPanScreen = ScreenPoint(e);
-            ViewportCanvas.CaptureMouse();
-            e.Handled = true;
-        }
-
-        private void ViewportCanvas_MouseRightButtonUp(object sender, MouseButtonEventArgs e) {
-            panning = false;
-            ViewportCanvas.ReleaseMouseCapture();
-            e.Handled = true;
-        }
-
-        private void ViewportCanvas_MouseMove(object sender, MouseEventArgs e) {
-            var vm = Vm;
-            if (vm == null) {
-                return;
-            }
-            if (panning) {
-                var screen = ScreenPoint(e);
-                var dx = screen.X - lastPanScreen.X;
-                var dy = screen.Y - lastPanScreen.Y;
-                lastPanScreen = screen;
-                vm.Viewport.PanBy(dx, dy);
-                ApplyViewport();
+        // Pan via the base; otherwise update the hover focus graph (inspector-only). Wired in XAML as
+        // MouseMove="ViewportCanvas_MouseMove" — virtual dispatch routes to this override.
+        protected override void ViewportCanvas_MouseMove(object sender, MouseEventArgs e) {
+            if (TryPan(e)) {
                 return;
             }
             UpdateHover(e);
         }
 
-        // Show the focus graph for any matched star under the cursor (smallest box wins); a no-fit star shows
-        // "No accepted focus fit". Clear it when no matched star is under the cursor.
+        // Show the focus graph for any matched star under the cursor (smallest box wins); clear it otherwise.
         // Boxes are in raw image coords (matching the displayed raw frame), so the cursor maps via the viewport directly.
         private void UpdateHover(MouseEventArgs e) {
-            var vm = Vm;
+            var vm = HoverVm;
             if (vm == null) {
                 return;
             }
@@ -243,19 +76,6 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             }
         }
 
-        private void ViewportCanvas_MouseLeave(object sender, MouseEventArgs e) {
-            Vm?.ClearHover();
-        }
-
-        private void ViewportCanvas_SizeChanged(object sender, SizeChangedEventArgs e) {
-            // Re-fit only on the first meaningful size (initial layout); afterwards keep the user's zoom/pan.
-            if (hasFitOnce) {
-                return;
-            }
-            if (ViewportCanvas.ActualWidth > 0 && Vm?.ImageWidth > 0) {
-                hasFitOnce = true;
-                OnFitRequested(this, EventArgs.Empty);
-            }
-        }
+        private void ViewportCanvas_MouseLeave(object sender, MouseEventArgs e) => HoverVm?.ClearHover();
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVM.cs
@@ -84,7 +84,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
     /// the hover graph uses <see cref="FrameReviewFocusGraph"/> / <see cref="FrameReviewScatterGraph"/> OxyPlot charts.
     /// Disposing releases the retained bitmaps.
     /// </summary>
-    public sealed class FrameReviewVM : BaseINPC, IReviewDialogViewModel {
+    public sealed class FrameReviewVM : BaseINPC, IReviewDialogViewModel, IViewportHostViewModel {
 
         private static SolidColorBrush FrozenBrush(Color c) {
             var b = new SolidColorBrush(c);
@@ -125,6 +125,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         public RelayCommand NextCommand { get; }
         public RelayCommand FitCommand { get; }
         public RelayCommand CloseCommand { get; }
+
+        // The public PrevCommand/NextCommand are RelayCommand; expose them as ICommand for the viewport host (F08).
+        System.Windows.Input.ICommand IViewportHostViewModel.PrevCommand => PrevCommand;
+        System.Windows.Input.ICommand IViewportHostViewModel.NextCommand => NextCommand;
 
         public FrameReviewVM(FrameReviewSnapshot snapshot) {
             this.snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVM.cs
@@ -11,6 +11,7 @@
 #endregion "copyright"
 
 using NINA.Core.Utility;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus.Review;
 using NINA.Joko.Plugins.HocusFocus.Inspection;
 using OxyPlot;
 using OxyPlot.Series;
@@ -83,7 +84,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
     /// the hover graph uses <see cref="FrameReviewFocusGraph"/> / <see cref="FrameReviewScatterGraph"/> OxyPlot charts.
     /// Disposing releases the retained bitmaps.
     /// </summary>
-    public sealed class FrameReviewVM : BaseINPC, IDisposable {
+    public sealed class FrameReviewVM : BaseINPC, IReviewDialogViewModel {
 
         private static SolidColorBrush FrozenBrush(Color c) {
             var b = new SolidColorBrush(c);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVM.cs
@@ -17,10 +17,8 @@ using OxyPlot;
 using OxyPlot.Series;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using RelayCommand = CommunityToolkit.Mvvm.Input.RelayCommand;
 
 namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
@@ -84,7 +82,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
     /// the hover graph uses <see cref="FrameReviewFocusGraph"/> / <see cref="FrameReviewScatterGraph"/> OxyPlot charts.
     /// Disposing releases the retained bitmaps.
     /// </summary>
-    public sealed class FrameReviewVM : BaseINPC, IReviewDialogViewModel, IViewportHostViewModel {
+    public sealed class FrameReviewVM : FrameReviewVMBase<FrameReviewMarker>, IReviewDialogViewModel {
 
         private static SolidColorBrush FrozenBrush(Color c) {
             var b = new SolidColorBrush(c);
@@ -115,30 +113,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
         private FrameReviewSnapshot snapshot;
 
-        public event EventHandler RequestClose;
-        public event EventHandler FitRequested;
-
-        public StarReviewViewport Viewport { get; }
-        public ObservableCollection<FrameReviewMarker> Markers { get; } = new();
-
-        public RelayCommand PrevCommand { get; }
-        public RelayCommand NextCommand { get; }
-        public RelayCommand FitCommand { get; }
-        public RelayCommand CloseCommand { get; }
-
-        // The public PrevCommand/NextCommand are RelayCommand; expose them as ICommand for the viewport host (F08).
-        System.Windows.Input.ICommand IViewportHostViewModel.PrevCommand => PrevCommand;
-        System.Windows.Input.ICommand IViewportHostViewModel.NextCommand => NextCommand;
-
-        public FrameReviewVM(FrameReviewSnapshot snapshot) {
-            this.snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));
-            Viewport = new StarReviewViewport();
-            legendEntries = BuildLegend();
-
-            PrevCommand = new RelayCommand(Prev, () => CurrentIndex > 0);
-            NextCommand = new RelayCommand(Next, () => CurrentIndex < FrameCount - 1);
-            FitCommand = new RelayCommand(() => FitRequested?.Invoke(this, EventArgs.Empty));
-            CloseCommand = new RelayCommand(() => RequestClose?.Invoke(this, EventArgs.Empty));
+        public FrameReviewVM(FrameReviewSnapshot snapshot)
+            : base((snapshot ?? throw new ArgumentNullException(nameof(snapshot))).Frames.Count) {
+            this.snapshot = snapshot;
+            RebuildLegend();
 
             CurrentIndex = 0;
             // No fit here: FitRequested has zero subscribers at construction time (the control subscribes in
@@ -146,8 +124,6 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             // layout (Loaded/SizeChanged). Passing fit:false makes that contract explicit.
             LoadCurrent(fit: false);
         }
-
-        private int FrameCount => snapshot?.Frames.Count ?? 0;
 
         // ---- toggles --------------------------------------------------------------------------------------
 
@@ -179,34 +155,6 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
         // ---- navigation / current frame -------------------------------------------------------------------
 
-        private int currentIndex;
-        public int CurrentIndex {
-            get => currentIndex;
-            private set {
-                if (currentIndex != value) {
-                    currentIndex = value;
-                    RaisePropertyChanged();
-                    RaisePropertyChanged(nameof(PositionLabel));
-                }
-            }
-        }
-
-        public string PositionLabel => FrameCount > 0 ? $"{CurrentIndex + 1} / {FrameCount}" : "0 / 0";
-
-        private BitmapSource frameImage;
-        public BitmapSource FrameImage {
-            get => frameImage;
-            private set {
-                frameImage = value;
-                RaisePropertyChanged();
-                RaisePropertyChanged(nameof(ImageWidth));
-                RaisePropertyChanged(nameof(ImageHeight));
-            }
-        }
-
-        public double ImageWidth => frameImage?.PixelWidth ?? 0;
-        public double ImageHeight => frameImage?.PixelHeight ?? 0;
-
         private string frameHeader;
         public string FrameHeader {
             get => frameHeader;
@@ -237,14 +185,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
         // ---- inverse-zoom overlay bindings ----------------------------------------------------------------
 
-        public double MarkerStrokeThickness => 1.5 / Math.Max(StarReviewViewport.MinScale, Viewport.Scale);
-        public double MarkerTextScale => 1.0 / Math.Max(StarReviewViewport.MinScale, Viewport.Scale);
         public double HfrLabelOffset => -15.0 * MarkerTextScale;
         public double RegistrationLabelOffset => 3.0 * MarkerTextScale;
 
-        public void NotifyViewportChanged() {
-            RaisePropertyChanged(nameof(MarkerStrokeThickness));
-            RaisePropertyChanged(nameof(MarkerTextScale));
+        public override void NotifyViewportChanged() {
+            base.NotifyViewportChanged();
             RaisePropertyChanged(nameof(HfrLabelOffset));
             RaisePropertyChanged(nameof(RegistrationLabelOffset));
         }
@@ -327,17 +272,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
         // ---- legend ---------------------------------------------------------------------------------------
 
-        private IReadOnlyList<StarReviewLegendEntry> legendEntries;
-        public IReadOnlyList<StarReviewLegendEntry> LegendEntries {
-            get => legendEntries;
-            private set { legendEntries = value; RaisePropertyChanged(); }
-        }
-
-        private void RebuildLegend() {
-            LegendEntries = BuildLegend();
-        }
-
-        private IReadOnlyList<StarReviewLegendEntry> BuildLegend() {
+        protected override IReadOnlyList<StarReviewLegendEntry> BuildLegend() {
             return new List<StarReviewLegendEntry> {
                 new() { Brush = AcceptedBrush, Caption = "Accepted (focus fit)", Dashed = false },
                 new() { Brush = RegisteredNoFitBrush, Caption = "Registered, no focus fit", Dashed = false },
@@ -351,23 +286,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
         // ---- frame loading --------------------------------------------------------------------------------
 
-        private void Prev() {
-            if (CurrentIndex > 0) {
-                CurrentIndex--;
-                LoadCurrent(fit: false);
-            }
-        }
-
-        private void Next() {
-            if (CurrentIndex < FrameCount - 1) {
-                CurrentIndex++;
-                LoadCurrent(fit: false);
-            }
-        }
-
-        private void LoadCurrent(bool fit) {
+        // The base LoadCurrent already cleared Markers and will fire CanExecute/fit; this only clears the hover and
+        // sets the frame-specific image/headers/markers.
+        protected override void LoadFrame(int index) {
             ClearHover();
-            Markers.Clear();
             var frames = snapshot?.Frames;
             if (frames == null || frames.Count == 0) {
                 FrameImage = null;
@@ -375,12 +297,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
                 DetectedCountText = string.Empty;
                 ReferenceNote = string.Empty;
                 TransformText = string.Empty;
-                PrevCommand.NotifyCanExecuteChanged();
-                NextCommand.NotifyCanExecuteChanged();
                 return;
             }
 
-            var frame = frames[Math.Min(CurrentIndex, frames.Count - 1)];
+            var frame = frames[Math.Min(index, frames.Count - 1)];
             FrameImage = frame.Image;
             FrameHeader = $"Focuser position: {frame.FocuserPosition:0}";
             DetectedCountText = $"Detected stars: {frame.DetectedStarCount}";
@@ -389,12 +309,6 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
 
             foreach (var s in frame.Stars) {
                 Markers.Add(BuildMarker(s));
-            }
-
-            PrevCommand.NotifyCanExecuteChanged();
-            NextCommand.NotifyCanExecuteChanged();
-            if (fit) {
-                FitRequested?.Invoke(this, EventArgs.Empty);
             }
         }
 
@@ -438,8 +352,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             Markers.Clear();
             FrameImage = null;
             snapshot = null;
-            FitRequested = null;
-            RequestClose = null;
+            DetachReviewEvents();
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVMBase.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVMBase.cs
@@ -1,0 +1,135 @@
+#region "copyright"
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+#endregion "copyright"
+
+using NINA.Core.Utility;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Windows.Media.Imaging;
+using RelayCommand = CommunityToolkit.Mvvm.Input.RelayCommand;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
+
+    /// <summary>
+    /// Shared navigation/viewport/marker/legend scaffolding for the read-only "Review Frames" VMs (F23): clamped frame
+    /// stepping, the current-frame image + size, the inverse-zoom marker bindings, and the legend rebuild pair.
+    /// Subclasses supply the per-frame load (markers, headers) and the legend contents. Implements
+    /// <see cref="IViewportHostViewModel"/> so it drives <see cref="ReviewViewportHostBase"/> directly.
+    /// </summary>
+    public abstract class FrameReviewVMBase<TMarker> : BaseINPC, IViewportHostViewModel {
+
+        protected FrameReviewVMBase(int frameCount) {
+            FrameCount = frameCount;
+            Viewport = new StarReviewViewport();
+            PrevCommand = new RelayCommand(Prev, () => CurrentIndex > 0);
+            NextCommand = new RelayCommand(Next, () => CurrentIndex < FrameCount - 1);
+            FitCommand = new RelayCommand(() => FitRequested?.Invoke(this, EventArgs.Empty));
+            CloseCommand = new RelayCommand(() => RequestClose?.Invoke(this, EventArgs.Empty));
+        }
+
+        public event EventHandler RequestClose;
+        public event EventHandler FitRequested;
+
+        public StarReviewViewport Viewport { get; }
+        public ObservableCollection<TMarker> Markers { get; } = new();
+
+        public RelayCommand PrevCommand { get; }
+        public RelayCommand NextCommand { get; }
+        public RelayCommand FitCommand { get; }
+        public RelayCommand CloseCommand { get; }
+
+        System.Windows.Input.ICommand IViewportHostViewModel.PrevCommand => PrevCommand;
+        System.Windows.Input.ICommand IViewportHostViewModel.NextCommand => NextCommand;
+
+        protected int FrameCount { get; }
+
+        private int currentIndex;
+        public int CurrentIndex {
+            get => currentIndex;
+            protected set {
+                if (currentIndex != value) {
+                    currentIndex = value;
+                    RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(PositionLabel));
+                }
+            }
+        }
+
+        public string PositionLabel => FrameCount > 0 ? $"{CurrentIndex + 1} / {FrameCount}" : "0 / 0";
+
+        private BitmapSource frameImage;
+        public BitmapSource FrameImage {
+            get => frameImage;
+            protected set {
+                frameImage = value;
+                RaisePropertyChanged();
+                RaisePropertyChanged(nameof(ImageWidth));
+                RaisePropertyChanged(nameof(ImageHeight));
+            }
+        }
+
+        public double ImageWidth => frameImage?.PixelWidth ?? 0;
+        public double ImageHeight => frameImage?.PixelHeight ?? 0;
+
+        // ---- inverse-zoom overlay bindings (subclasses add their own extra offsets and override NotifyViewportChanged) ----
+        public double MarkerStrokeThickness => 1.5 / Math.Max(StarReviewViewport.MinScale, Viewport.Scale);
+        public double MarkerTextScale => 1.0 / Math.Max(StarReviewViewport.MinScale, Viewport.Scale);
+
+        public virtual void NotifyViewportChanged() {
+            RaisePropertyChanged(nameof(MarkerStrokeThickness));
+            RaisePropertyChanged(nameof(MarkerTextScale));
+        }
+
+        // ---- legend ----
+        private IReadOnlyList<StarReviewLegendEntry> legendEntries;
+        public IReadOnlyList<StarReviewLegendEntry> LegendEntries {
+            get => legendEntries;
+            private set { legendEntries = value; RaisePropertyChanged(); }
+        }
+
+        protected void RebuildLegend() => LegendEntries = BuildLegend();
+
+        protected abstract IReadOnlyList<StarReviewLegendEntry> BuildLegend();
+
+        /// <summary>Load the frame at the given index (set FrameImage, headers, repopulate Markers/overlays).</summary>
+        protected abstract void LoadFrame(int index);
+
+        protected void Prev() {
+            if (CurrentIndex > 0) {
+                CurrentIndex--;
+                LoadCurrent(fit: false);
+            }
+        }
+
+        protected void Next() {
+            if (CurrentIndex < FrameCount - 1) {
+                CurrentIndex++;
+                LoadCurrent(fit: false);
+            }
+        }
+
+        protected void LoadCurrent(bool fit) {
+            Markers.Clear();
+            LoadFrame(CurrentIndex);
+            PrevCommand.NotifyCanExecuteChanged();
+            NextCommand.NotifyCanExecuteChanged();
+            if (fit) {
+                FitRequested?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        // F34: subclasses call this from Dispose to break the VM->control event edges (a subclass cannot null an
+        // event declared on the base).
+        protected void DetachReviewEvents() {
+            FitRequested = null;
+            RequestClose = null;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/ReviewViewportHostBase.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/ReviewViewportHostBase.cs
@@ -1,0 +1,250 @@
+#region "copyright"
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+#endregion "copyright"
+
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
+
+    /// <summary>Minimal VM contract the shared review viewport host drives (F08): zoom/pan state + image size, a
+    /// re-fit signal, a post-change notification so the inverse-zoom marker bindings refresh, and prev/next nav.</summary>
+    public interface IViewportHostViewModel {
+        StarReviewViewport Viewport { get; }
+        double ImageWidth { get; }
+        double ImageHeight { get; }
+        void NotifyViewportChanged();
+        event EventHandler FitRequested;
+        ICommand PrevCommand { get; }
+        ICommand NextCommand { get; }
+    }
+
+    /// <summary>
+    /// Single home for the zoom/pan/fit/scroll viewport math shared by the AutoFocus and Aberration-Inspector
+    /// "Review Frames" controls (F08). Subclasses supply the named XAML parts (canvas, scrollbars, transforms) and the
+    /// bound VM, and may add their own input (e.g. the inspector's hover). Carries the corrected first-fit latch
+    /// (latch only on a SUCCESSFUL fit — F19) and the Unloaded FitRequested-unsubscribe (F34), so both controls share
+    /// the fixed lifecycle. The part accessors are named *Part to avoid colliding with the same-named x:Name fields
+    /// the subclass partials generate.
+    /// </summary>
+    public abstract class ReviewViewportHostBase : UserControl {
+
+        private bool panning;
+        private System.Windows.Point lastPanScreen;
+        private bool suppressScrollEvents;
+        protected bool hasFitOnce;
+
+        protected abstract Canvas ViewportCanvasPart { get; }
+        protected abstract ScrollBar HScrollPart { get; }
+        protected abstract ScrollBar VScrollPart { get; }
+        protected abstract ScaleTransform ContentScalePart { get; }
+        protected abstract TranslateTransform ContentTranslatePart { get; }
+        protected abstract IViewportHostViewModel Vm { get; }
+
+        protected ReviewViewportHostBase() {
+            DataContextChanged += OnDataContextChanged;
+            KeyDown += OnKeyDown;
+            Unloaded += OnUnloaded;
+        }
+
+        private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e) {
+            if (e.OldValue is IViewportHostViewModel oldVm) {
+                oldVm.FitRequested -= OnFitRequested;
+            }
+            if (e.NewValue is IViewportHostViewModel newVm) {
+                newVm.FitRequested += OnFitRequested;
+            }
+        }
+
+        // F34: detach the VM->control FitRequested edge when the control leaves the visual tree, so a long-lived host
+        // that re-uses this control across DataContexts (or tears down without a DataContext swap) cannot leak the
+        // control through the VM's event. The modal case is unaffected (it unloads on close).
+        protected void OnUnloaded(object sender, RoutedEventArgs e) {
+            if (Vm != null) {
+                Vm.FitRequested -= OnFitRequested;
+            }
+        }
+
+        protected void OnKeyDown(object sender, KeyEventArgs e) {
+            var vm = Vm;
+            if (vm == null) {
+                return;
+            }
+            switch (e.Key) {
+                case Key.Left:
+                    if (vm.PrevCommand.CanExecute(null)) {
+                        vm.PrevCommand.Execute(null);
+                    }
+                    e.Handled = true;
+                    break;
+                case Key.Right:
+                    if (vm.NextCommand.CanExecute(null)) {
+                        vm.NextCommand.Execute(null);
+                    }
+                    e.Handled = true;
+                    break;
+                case Key.F:
+                    OnFitRequested(this, EventArgs.Empty);
+                    e.Handled = true;
+                    break;
+            }
+        }
+
+        protected void OnFitRequested(object sender, EventArgs e) {
+            TryFit();
+        }
+
+        // F19: returns true only when a fit was actually applied (canvas measured and VM ready), so callers can gate
+        // the one-shot hasFitOnce latch on a real fit rather than on a deferred attempt that returned early.
+        protected bool TryFit() {
+            var vm = Vm;
+            if (vm == null || ViewportCanvasPart.ActualWidth <= 0 || vm.ImageWidth <= 0) {
+                return false;
+            }
+            // Collapse the scrollbars and force a layout pass FIRST so the fit is measured against the final
+            // (scrollbar-free) viewport — otherwise the image lands off-center until a second Fit.
+            HScrollPart.Visibility = Visibility.Collapsed;
+            VScrollPart.Visibility = Visibility.Collapsed;
+            ViewportCanvasPart.UpdateLayout();
+            if (ViewportCanvasPart.ActualWidth <= 0 || ViewportCanvasPart.ActualHeight <= 0) {
+                return false;
+            }
+            vm.Viewport.FitTo(ViewportCanvasPart.ActualWidth, ViewportCanvasPart.ActualHeight, vm.ImageWidth, vm.ImageHeight);
+            ApplyViewport();
+            return true;
+        }
+
+        protected void ApplyViewport() {
+            var vm = Vm;
+            if (vm == null) {
+                return;
+            }
+            vm.Viewport.ClampToBounds(ViewportCanvasPart.ActualWidth, ViewportCanvasPart.ActualHeight, vm.ImageWidth, vm.ImageHeight);
+            ContentScalePart.ScaleX = vm.Viewport.Scale;
+            ContentScalePart.ScaleY = vm.Viewport.Scale;
+            ContentTranslatePart.X = vm.Viewport.OffsetX;
+            ContentTranslatePart.Y = vm.Viewport.OffsetY;
+            UpdateScrollBars();
+            // Markers scale with the canvas transform, so refresh the zoom-inverse stroke/label sizes after any change.
+            vm.NotifyViewportChanged();
+        }
+
+        private void UpdateScrollBars() {
+            var vm = Vm;
+            if (vm == null) {
+                return;
+            }
+            suppressScrollEvents = true;
+            try {
+                UpdateScrollBar(HScrollPart, ViewportCanvasPart.ActualWidth, vm.ImageWidth * vm.Viewport.Scale, -vm.Viewport.OffsetX);
+                UpdateScrollBar(VScrollPart, ViewportCanvasPart.ActualHeight, vm.ImageHeight * vm.Viewport.Scale, -vm.Viewport.OffsetY);
+            } finally {
+                suppressScrollEvents = false;
+            }
+        }
+
+        private static void UpdateScrollBar(ScrollBar bar, double viewport, double content, double scrollPos) {
+            var scrollable = content - viewport;
+            if (scrollable > 0.5 && viewport > 0) {
+                bar.Visibility = Visibility.Visible;
+                bar.Minimum = 0;
+                bar.Maximum = scrollable;
+                bar.ViewportSize = viewport;
+                bar.LargeChange = viewport * 0.9;
+                bar.SmallChange = Math.Max(1.0, viewport * 0.1);
+                bar.Value = Math.Min(Math.Max(scrollPos, 0.0), scrollable);
+            } else {
+                bar.Visibility = Visibility.Collapsed;
+                bar.Value = 0;
+            }
+        }
+
+        protected void HScroll_Scroll(object sender, ScrollEventArgs e) {
+            var vm = Vm;
+            if (vm == null || suppressScrollEvents) {
+                return;
+            }
+            vm.Viewport.Set(vm.Viewport.Scale, -e.NewValue, vm.Viewport.OffsetY);
+            ApplyViewport();
+        }
+
+        protected void VScroll_Scroll(object sender, ScrollEventArgs e) {
+            var vm = Vm;
+            if (vm == null || suppressScrollEvents) {
+                return;
+            }
+            vm.Viewport.Set(vm.Viewport.Scale, vm.Viewport.OffsetX, -e.NewValue);
+            ApplyViewport();
+        }
+
+        // The canvas RenderTransform maps image space -> screen space, so a mouse position taken relative to the
+        // canvas's PARENT (the Border) is in screen space.
+        protected System.Windows.Point ScreenPoint(MouseEventArgs e) {
+            var parent = (UIElement)ViewportCanvasPart.Parent;
+            return e.GetPosition(parent);
+        }
+
+        protected void ViewportCanvas_MouseWheel(object sender, MouseWheelEventArgs e) {
+            var vm = Vm;
+            if (vm == null) {
+                return;
+            }
+            var anchor = ScreenPoint(e);
+            var factor = e.Delta > 0 ? 1.2 : 1.0 / 1.2;
+            vm.Viewport.ZoomAt(factor, anchor.X, anchor.Y);
+            ApplyViewport();
+            e.Handled = true;
+        }
+
+        protected void ViewportCanvas_MouseRightButtonDown(object sender, MouseButtonEventArgs e) {
+            panning = true;
+            lastPanScreen = ScreenPoint(e);
+            ViewportCanvasPart.CaptureMouse();
+            e.Handled = true;
+        }
+
+        protected void ViewportCanvas_MouseRightButtonUp(object sender, MouseButtonEventArgs e) {
+            panning = false;
+            ViewportCanvasPart.ReleaseMouseCapture();
+            e.Handled = true;
+        }
+
+        // Returns true if a pan was consumed, so subclasses with extra move handling (hover) can early-out.
+        protected bool TryPan(MouseEventArgs e) {
+            if (!panning) {
+                return false;
+            }
+            var screen = ScreenPoint(e);
+            var dx = screen.X - lastPanScreen.X;
+            var dy = screen.Y - lastPanScreen.Y;
+            lastPanScreen = screen;
+            Vm?.Viewport.PanBy(dx, dy);
+            ApplyViewport();
+            return true;
+        }
+
+        // Virtual so the inspector subclass can fall through to hover when not panning. AF uses this base behavior.
+        protected virtual void ViewportCanvas_MouseMove(object sender, MouseEventArgs e) => TryPan(e);
+
+        protected void ViewportCanvas_SizeChanged(object sender, SizeChangedEventArgs e) {
+            // Re-fit only on the first meaningful size (initial layout); afterwards keep the user's zoom/pan. Latch only
+            // when a fit actually applies (F19), so a too-early SizeChanged does not permanently suppress the first fit.
+            if (hasFitOnce) {
+                return;
+            }
+            if (TryFit()) {
+                hasFitOnce = true;
+            }
+        }
+    }
+}

--- a/plans/pr-88-89-91-review-fixes-plan.md
+++ b/plans/pr-88-89-91-review-fixes-plan.md
@@ -12,12 +12,17 @@
 
 ## ⏱ EXECUTION STATUS (updated 2026-06-23)
 
-**PR A (Phases 1–6): ✅ COMPLETE — opened as [PR #93](https://github.com/ghilios/hocus-focus/pull/93) into `develop` (NOT yet merged).**
+**PR A (Phases 1–6): ✅ COMPLETE & MERGED — [PR #93](https://github.com/ghilios/hocus-focus/pull/93) merged into `develop` (merge commit `e82c982`).**
 - Branch `ghilios/pr-88-89-91-review-fixes` from `develop`@`47fd93d`; 23 code/test commits + this plan doc.
 - Suite: **1455 pass / 0 fail** (was 1436). New tests: F09 retention truth-table, F35/F37 snapshot boundaries, F11 atomic-claim + leak-window regression, F12/13/14 dispatcher fallback, F15/F16 marshaling, F17 static-guard reset.
 - Each phase ran implementer → spec review → code-quality review, plus a final holistic cross-phase pass. One real regression was caught & fixed mid-review: the F11 atomic claim first re-introduced a guard-leak/brick window (a throw from `OnStarted()` or the `CancellationTokenSource` ctor between the claim and the releasing `try` would permanently disable all AutoFocus) → fixed with an outer `try/finally` + fail-first test `Run_WhenStartedSubscriberThrows_StillReleasesGuard`.
 
-**PR B (Phase 7): ⏳ NOT STARTED — gated on PR #93 merging into `develop`.** When ready: `/clear`, then `git checkout develop && git pull && git checkout -b ghilios/frame-review-dedup-refactor`, then execute Phase 7. **Before executing Phase 7, read "⚠ POST-PR-A CORRECTIONS FOR PHASE 7" at the top of the Phase 7 section — several of its before/after snippets are now stale because PR A changed the same code.**
+**PR B (Phase 7): ✅ COMPLETE — opened as [PR #94](https://github.com/ghilios/hocus-focus/pull/94) into `develop` (NOT yet merged/verified live).**
+- Branch `ghilios/frame-review-dedup-refactor` from merged `develop`@`e82c982`; 7 commits (F07/F20, F25, F24, F08, F23, F28, + the rerun-path `progress?.Report` follow-up).
+- Suite: **1460 pass / 0 fail** (was 1455; +5 new tests: `HocusFocusVMInteractiveTests` ×2, `FrameReviewVMBaseTests` ×3). Each task ran implementer → spec review → code-quality review, plus a final holistic cross-task pass (READY TO MERGE, zero cross-task findings).
+- **F07 fork resolved to F20:** the preferred F07 ("delete `InteractiveHostBehavior`, mark the pane VM at its dockable construction") was infeasible — `HocusFocusVM` is not a `[Export(typeof(IDockableVM))]` and both pane + sequencer share the one `HocusFocusVMFactory.Create()`, so the visual-tree DataTemplate is the only pane discriminator. Per maintainer decision, kept + hardened `InteractiveHostBehavior` (DataContextChanged tracking) and made `IsInteractive`'s setter private + `MarkInteractive()`/`MarkNonInteractive()`.
+- **F23 scoped** to the two read-only review VMs; `StarReviewVM` (editable labeling VM) deliberately left out of scope.
+- The "⚠ POST-PR-A CORRECTIONS FOR PHASE 7" snippets below were applied; two additional plan-snippet bugs were corrected during execution: (1) the TDD test's `GetSetMethod(nonPublic:true)` → `nonPublic:false`; (2) F08's `base.FindName("ViewportCanvas")` override would collide with the x:Name field (used distinct `*Part` accessors instead) and the `ICommand` interface members need explicit implementation (the VMs expose `RelayCommand`). The test project links the new types via its existing `<ProjectReference>` (no `<Compile>` links needed, contrary to the F23 task note).
 
 **Build/test in this WSL checkout:** `dotnet` is NOT on PATH — use `"/mnt/c/Program Files/dotnet/dotnet.exe"` everywhere a task says `dotnet` (e.g. `"/mnt/c/Program Files/dotnet/dotnet.exe" test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`). Commit with the privacy email per the convention below.
 
@@ -1924,7 +1929,7 @@ Steps:
 
 ---
 
-## Phase 7 (separate follow-up PR): De-duplication & altitude refactor — ⏳ NOT STARTED (gated on PR #93 merge)
+## Phase 7 (separate follow-up PR): De-duplication & altitude refactor — ✅ COMPLETE (PR #94)
 
 > **🚦 GATE: do not begin this phase until PR A (Phases 1–6) has been merged into `develop`.**
 >


### PR DESCRIPTION
## Phase 7 (PR B) — De-duplication & altitude refactor

Follow-up to **#93** (Phases 1–6) of the post-merge review of PRs #88/#89/#91. This PR is the gated **Phase 7** structural refactor: it relocates/absorbs code the earlier phases touched, so it shipped separately after #93 merged. Plan: `plans/pr-88-89-91-review-fixes-plan.md`.

### What's in it (7 commits)

| Finding | Change |
|---|---|
| **F07/F20** | `HocusFocusVM.IsInteractive` setter made private; toggled only via new `MarkInteractive()`/`MarkNonInteractive()`. `InteractiveHostBehavior` hardened with `DataContextChanged` tracking and routed through the Mark methods. |
| **F25** | Extracted `ApplyFrameReviewOptions(options)` — single source for the interactive frame-review retention policy shared by the live (`StartAutoFocus`) and replay (`LoadSavedAutoFocusRun`) paths. |
| **F24** | Extracted `ReviewDialogHost.Show(...)` + `IReviewDialogViewModel` — one owner of the modal "Review Frames" show/dispose lifecycle (was copy-pasted into `HocusFocusVM` and `InspectorVM`). Per-VM close cleanups preserved via an `afterClosed` callback. |
| **F08** | Extracted `ReviewViewportHostBase` + `IViewportHostViewModel` — shared zoom/pan/fit/scroll plumbing for both review controls. As a side benefit this **fixes the Inspector control's first-fit bug** (it now inherits the F19 latch-on-success). |
| **F23** | Extracted `FrameReviewVMBase<TMarker>` — shared navigation/viewport/marker/legend scaffolding for the two read-only review VMs. |
| **F28** | Symmetric `-=` detach of the per-run engine handlers in both run `finally` blocks (mirrors each path's `+=` exactly). |
| follow-up | Null-safe `progress?.Report` on the `RerunImpl` rerun path (completes the F01 pattern across the engine; defensive). |

### Notable decisions
- **F07 preferred approach was infeasible.** The plan's preferred F07 ("delete `InteractiveHostBehavior`, mark the pane VM at its dockable construction") is not possible in this architecture: `HocusFocusVM` is **not** a `[Export(typeof(IDockableVM))]` — the AF pane and the sequencer both obtain their VM from the same parameterless `HocusFocusVMFactory.Create()`, so the visual-tree `HocusFocusVM_Dockable` DataTemplate is the *only* signal that distinguishes the pane instance. Per maintainer decision, implemented the plan's documented fallback (**F20**): keep `InteractiveHostBehavior` as the marker but harden it (DataContextChanged tracking) and tighten the VM API (private setter + named Mark methods).
- **`StarReviewVM` is intentionally out of scope for F23** — it is the editable labeling VM (drag/undo/label state), not a byte-for-byte duplicate of the two read-only reviewers.

### Testing
`dotnet test` → **1460 passed / 0 failed** (was 1455 after #93; +5 new tests: `HocusFocusVMInteractiveTests` ×2, `FrameReviewVMBaseTests` ×3). Each task was implemented TDD-where-testable and put through spec-compliance + code-quality review, plus a final holistic cross-task review.

### Manual NINA verification still owed (not headless-testable)
- Pane AF retains frames while a sequence-triggered AF does not (F07/F20), including after pane DataContext swap.
- Both Review Frames dialogs open/close cleanly via the shared `ReviewDialogHost` (F24).
- Both review viewers: zoom/pan/scrollbars/F-fit/Left-Right nav/resize behave identically, and the Inspector hover focus-graph still works (F08); first-fit lands correctly.
- Stepping through frames in both viewers (F23).
- Two consecutive pane AF runs show only the second run's frames (F28, no handler stacking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
