### PR TITLE
Review-UI improvements: layout, tilt replay (consolidation + portability), AF rename, frame picker

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/Review/FrameReviewVMBaseTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/Review/FrameReviewVMBaseTests.cs
@@ -1,0 +1,73 @@
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Optimization.Review {
+
+    [TestFixture]
+    public class FrameReviewVMBaseTests {
+
+        // Minimal concrete subclass: records LoadFrame calls so jumps are observable without image/UI work.
+        private sealed class TestReviewVM : FrameReviewVMBase<int> {
+            public int LoadedIndex { get; private set; } = -1;
+            public int LoadCount { get; private set; }
+            public TestReviewVM(int frameCount) : base(frameCount) { }
+            protected override void LoadFrame(int index) { LoadedIndex = index; LoadCount++; }
+            protected override IReadOnlyList<StarReviewLegendEntry> BuildLegend() => new List<StarReviewLegendEntry>();
+        }
+
+        [Test]
+        public void SelectedFrameNumber_Get_IsOneBasedCurrentIndex() {
+            var vm = new TestReviewVM(5);
+            Assert.That(vm.SelectedFrameNumber, Is.EqualTo(1));   // CurrentIndex defaults to 0
+        }
+
+        [Test]
+        public void SelectedFrameNumber_Set_JumpsAndLoadsThatFrame() {
+            var vm = new TestReviewVM(5);
+            vm.SelectedFrameNumber = 3;                            // 1-based -> index 2
+            Assert.Multiple(() => {
+                Assert.That(vm.CurrentIndex, Is.EqualTo(2));
+                Assert.That(vm.LoadedIndex, Is.EqualTo(2));
+                Assert.That(vm.SelectedFrameNumber, Is.EqualTo(3));
+            });
+        }
+
+        [TestCase(0)]    // index -1
+        [TestCase(6)]    // index 5 == FrameCount (out of range)
+        [TestCase(99)]
+        public void SelectedFrameNumber_Set_OutOfRange_IsIgnored(int oneBasedValue) {
+            var vm = new TestReviewVM(5);
+            vm.SelectedFrameNumber = 3;                            // move to index 2 first
+            var loadsBefore = vm.LoadCount;
+            vm.SelectedFrameNumber = oneBasedValue;
+            Assert.Multiple(() => {
+                Assert.That(vm.CurrentIndex, Is.EqualTo(2));        // unchanged
+                Assert.That(vm.LoadCount, Is.EqualTo(loadsBefore)); // no reload
+            });
+        }
+
+        [Test]
+        public void SelectedFrameNumber_Set_SameValue_DoesNotReload() {
+            var vm = new TestReviewVM(5);
+            vm.SelectedFrameNumber = 3;
+            var loadsBefore = vm.LoadCount;
+            vm.SelectedFrameNumber = 3;                            // no-op
+            Assert.That(vm.LoadCount, Is.EqualTo(loadsBefore));
+        }
+
+        [Test]
+        public void NextCommand_RaisesSelectedFrameNumber_AndUpdatesValue() {
+            var vm = new TestReviewVM(5);
+            var raised = new List<string>();
+            vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+            vm.NextCommand.Execute(null);   // 0 -> 1
+
+            Assert.Multiple(() => {
+                Assert.That(vm.SelectedFrameNumber, Is.EqualTo(2));
+                Assert.That(raised, Does.Contain(nameof(vm.SelectedFrameNumber)));
+            });
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationMetadataTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationMetadataTests.cs
@@ -91,5 +91,40 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             };
             Assert.That(() => md.Validate(), Throws.Nothing);
         }
+
+        [Test]
+        public void StepFolder_RelativizesAndResolvesRoundTrip() {
+            // A step folder under the run root is stored relative, then resolves back to the same absolute path.
+            var runRoot = @"C:\TiltCalibration\TiltCalibration_20260621_214304";
+            var absolute = @"C:\TiltCalibration\TiltCalibration_20260621_214304\01_Baseline\AutoFocus_20260621_214312";
+
+            var relative = TiltCalibrationMetadata.ToRelativeStepFolder(runRoot, absolute);
+            Assert.That(relative, Is.EqualTo(@"01_Baseline\AutoFocus_20260621_214312"));
+            Assert.That(TiltCalibrationMetadata.ResolveStepFolder(runRoot, relative), Is.EqualTo(absolute));
+        }
+
+        [Test]
+        public void ResolveStepFolder_RebasesRelativeOntoSelectedRunRoot() {
+            // The whole point: a run captured under one path replays from another — the relative folder follows
+            // the run directory the user actually selected.
+            var resolved = TiltCalibrationMetadata.ResolveStepFolder(
+                @"D:\Moved\TiltCalibration_20260621_214304", @"01_Baseline\AutoFocus_20260621_214312");
+            Assert.That(resolved,
+                Is.EqualTo(@"D:\Moved\TiltCalibration_20260621_214304\01_Baseline\AutoFocus_20260621_214312"));
+        }
+
+        [Test]
+        public void ResolveStepFolder_HonorsLegacyAbsolutePaths() {
+            // Pre-relative files stored absolute capture-machine paths; honor them as-is (no rebasing).
+            var absolute = @"C:\Users\someone\Desktop\runs\01_Baseline\AutoFocus_x";
+            Assert.That(TiltCalibrationMetadata.ResolveStepFolder(@"C:\Elsewhere", absolute), Is.EqualTo(absolute));
+        }
+
+        [Test]
+        public void ToRelativeStepFolder_KeepsAbsoluteWhenNotUnderRunRoot() {
+            // A folder on a different volume can't be made relative; keep it absolute rather than emit "..\..".
+            var other = @"D:\external\01_Baseline\AutoFocus_x";
+            Assert.That(TiltCalibrationMetadata.ToRelativeStepFolder(@"C:\runs\run1", other), Is.EqualTo(other));
+        }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltReplayModeResolverTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltReplayModeResolverTests.cs
@@ -1,0 +1,46 @@
+using System;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
+
+    [TestFixture]
+    public class TiltReplayModeResolverTests {
+
+        [Test]
+        public void UseCurrentSettings_CurrentGeometry_NoOverride_NoMutation() {
+            var mode = TiltReplayModeResolver.Resolve(ReplaySettingsChoice.UseCurrentSettings);
+            Assert.Multiple(() => {
+                Assert.That(mode.UseMetadataGeometry, Is.False);
+                Assert.That(mode.ApplyCaptureTimeOverridePerStep, Is.False);
+                Assert.That(mode.UpdateProfileToCaptureTime, Is.False);
+            });
+        }
+
+        [Test]
+        public void UseCaptureTimeInMemory_MetadataGeometry_PerStepOverride_NoMutation() {
+            var mode = TiltReplayModeResolver.Resolve(ReplaySettingsChoice.UseCaptureTimeSettingsInMemory);
+            Assert.Multiple(() => {
+                Assert.That(mode.UseMetadataGeometry, Is.True);
+                Assert.That(mode.ApplyCaptureTimeOverridePerStep, Is.True);
+                Assert.That(mode.UpdateProfileToCaptureTime, Is.False);
+            });
+        }
+
+        [Test]
+        public void UpdateProfile_MetadataGeometry_NoPerStepOverride_Mutates() {
+            var mode = TiltReplayModeResolver.Resolve(ReplaySettingsChoice.UpdateProfileToCaptureTime);
+            Assert.Multiple(() => {
+                Assert.That(mode.UseMetadataGeometry, Is.True);
+                Assert.That(mode.ApplyCaptureTimeOverridePerStep, Is.False);
+                Assert.That(mode.UpdateProfileToCaptureTime, Is.True);
+            });
+        }
+
+        [Test]
+        public void Cancel_Throws() {
+            Assert.Throws<ArgumentOutOfRangeException>(() => TiltReplayModeResolver.Resolve(ReplaySettingsChoice.Cancel));
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltReplayModeResolverTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltReplayModeResolverTests.cs
@@ -29,11 +29,13 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         }
 
         [Test]
-        public void UpdateProfile_MetadataGeometry_NoPerStepOverride_Mutates() {
+        public void UpdateProfile_MetadataGeometry_PerStepOverride_Mutates() {
+            // Update-profile replays per-step in memory (like the in-memory mode); the live profile is persisted only
+            // after a successful replay, so the per-step override still drives the replay itself.
             var mode = TiltReplayModeResolver.Resolve(ReplaySettingsChoice.UpdateProfileToCaptureTime);
             Assert.Multiple(() => {
                 Assert.That(mode.UseMetadataGeometry, Is.True);
-                Assert.That(mode.ApplyCaptureTimeOverridePerStep, Is.False);
+                Assert.That(mode.ApplyCaptureTimeOverridePerStep, Is.True);
                 Assert.That(mode.UpdateProfileToCaptureTime, Is.True);
             });
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -617,12 +617,12 @@
                 Padding="5,0,5,0"
                 HorizontalAlignment="Left"
                 VerticalAlignment="Bottom"
-                ButtonText="Reprocess Saved Run"
+                ButtonText="Replay Saved AF"
                 CancelButtonImage="{StaticResource CancelSVG}"
                 CancelCommand="{Binding CancelLoadSavedAutoFocusRunCommand}"
                 CancelToolTip="{ns:Loc LblCancel}"
                 Command="{Binding LoadSavedAutoFocusRunCommand}"
-                ToolTip="Reprocesses AutoFocus images saved by having Save enabled in Hocus Focus -&gt; Auto Focus Options. This produces an auto focus curve using whatever the current star detection and fit settings are" />
+                ToolTip="Replays saved AutoFocus images (Save enabled in Hocus Focus -&gt; Auto Focus Options) to produce an auto focus curve using whatever the current star detection and fit settings are" />
             <StackPanel
                 Grid.Row="3"
                 Margin="0,15,10,5"
@@ -634,14 +634,14 @@
                     Padding="5,0,5,0"
                     VerticalAlignment="Center"
                     Command="{Binding ReviewFramesCommand}"
-                    ToolTip="Open the Review Frames window to inspect each frame of the last auto-focus run started from this pane (a live run or a Reprocess Saved Run) — its detected stars with the Hocus Focus Star Annotator's bounds, per-star text, rejection-reason and ROI boxes, plus per-frame HFR statistics. Enabled after such a run completes with &quot;Keep frames for review&quot; turned on.">
+                    ToolTip="Open the Review Frames window to inspect each frame of the last auto-focus run started from this pane (a live run or a Replay Saved AF) — its detected stars with the Hocus Focus Star Annotator's bounds, per-star text, rejection-reason and ROI boxes, plus per-frame HFR statistics. Enabled after such a run completes with &quot;Keep frames for review&quot; turned on.">
                     <TextBlock Margin="5,0,5,0" Text="Review Frames" />
                 </Button>
                 <StackPanel
                     Margin="12,0,0,0"
                     VerticalAlignment="Center"
                     Orientation="Horizontal"
-                    ToolTip="When on, the per-frame images from an auto-focus run started here in the AutoFocus pane — a live run or a Reprocess Saved Run — are kept in memory so the &quot;Review Frames&quot; button can show each frame with its detected stars and HFRs. Only applies to runs from this pane — auto-focus during an imaging sequence never keeps frames (it would use too much memory). The frames are released when you start a new run or close the review window. Off by default; saved in your profile.">
+                    ToolTip="When on, the per-frame images from an auto-focus run started here in the AutoFocus pane — a live run or a Replay Saved AF — are kept in memory so the &quot;Review Frames&quot; button can show each frame with its detected stars and HFRs. Only applies to runs from this pane — auto-focus during an imaging sequence never keeps frames (it would use too much memory). The frames are released when you start a new run or close the review window. Off by default; saved in your profile.">
                     <CheckBox
                         VerticalAlignment="Center"
                         IsChecked="{Binding AutoFocusOptions.KeepFramesForReview}" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/ReplaySettingsPrompt.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/ReplaySettingsPrompt.cs
@@ -26,12 +26,12 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay {
         /// replay thread: the awaited <see cref="ReplaySettingsPromptVM.Choice"/> completes when the user clicks a
         /// button or closes the window, and continuations run off the captured context.
         /// </summary>
-        public static async Task<ReplaySettingsChoice> ShowAsync(IWindowServiceFactory windowServiceFactory, AutoFocusReplayMetadata metadata) {
+        public static async Task<ReplaySettingsChoice> ShowAsync(IWindowServiceFactory windowServiceFactory, AutoFocusReplayMetadata metadata, ReplaySettingsPromptTexts texts = null) {
             if (windowServiceFactory == null) {
                 throw new ArgumentNullException(nameof(windowServiceFactory));
             }
 
-            var vm = new ReplaySettingsPromptVM(metadata);
+            var vm = new ReplaySettingsPromptVM(metadata, texts);
             var windowService = windowServiceFactory.Create();
 
             // A button (or the X) raises RequestClose; close the host window, which fires OnClosed below.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/ReplaySettingsPromptControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/ReplaySettingsPromptControl.xaml
@@ -56,7 +56,7 @@
             FontSize="16"
             FontWeight="Bold"
             Foreground="{StaticResource Fg}"
-            Text="Replay Saved AutoFocus Run" />
+            Text="{Binding Title}" />
 
         <TextBlock
             Grid.Row="1"
@@ -69,7 +69,7 @@
             Grid.Row="2"
             Margin="0,10,0,12"
             Foreground="{StaticResource FgDim}"
-            Text="This run was saved with the detection and AutoFocus settings used at capture time. Choose how to replay it:"
+            Text="{Binding Intro}"
             TextWrapping="Wrap" />
 
         <!--  (a) current settings  -->
@@ -81,11 +81,11 @@
                 <TextBlock
                     FontWeight="Bold"
                     Foreground="{StaticResource Fg}"
-                    Text="Use current settings" />
+                    Text="{Binding UseCurrentCaption}" />
                 <TextBlock
                     Margin="0,3,0,0"
                     Foreground="{StaticResource FgDim}"
-                    Text="Replay using your current profile's detection and AutoFocus settings."
+                    Text="{Binding UseCurrentDescription}"
                     TextWrapping="Wrap" />
             </StackPanel>
         </Button>
@@ -99,11 +99,11 @@
                 <TextBlock
                     FontWeight="Bold"
                     Foreground="{StaticResource Fg}"
-                    Text="Use the captured settings (don't change my profile)" />
+                    Text="{Binding UseCaptureCaption}" />
                 <TextBlock
                     Margin="0,3,0,0"
                     Foreground="{StaticResource FgDim}"
-                    Text="Replay using the settings from when this run was captured, held in memory only. Your profile settings are left untouched."
+                    Text="{Binding UseCaptureDescription}"
                     TextWrapping="Wrap" />
             </StackPanel>
         </Button>
@@ -117,11 +117,11 @@
                 <TextBlock
                     FontWeight="Bold"
                     Foreground="{StaticResource Fg}"
-                    Text="Update my profile to the captured settings" />
+                    Text="{Binding UpdateProfileCaption}" />
                 <TextBlock
                     Margin="0,3,0,0"
                     Foreground="{StaticResource FgDim}"
-                    Text="Overwrite your current profile's detection, AutoFocus, and ROI settings with the captured ones, then replay."
+                    Text="{Binding UpdateProfileDescription}"
                     TextWrapping="Wrap" />
             </StackPanel>
         </Button>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/ReplaySettingsPromptTexts.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/ReplaySettingsPromptTexts.cs
@@ -1,0 +1,54 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay {
+
+    /// <summary>
+    /// User-facing strings for the replay-settings modal, so the same dialog describes different replay flows
+    /// accurately: the AutoFocus pane / Aberration Inspector update detection + AutoFocus + ROI on "update profile",
+    /// while the Tilt Adapter wizard updates only star-detection. <see cref="AutoFocus"/> is the default.
+    /// </summary>
+    public sealed class ReplaySettingsPromptTexts {
+        public string Title { get; init; }
+        public string Intro { get; init; }
+        public string UseCurrentCaption { get; init; }
+        public string UseCurrentDescription { get; init; }
+        public string UseCaptureCaption { get; init; }
+        public string UseCaptureDescription { get; init; }
+        public string UpdateProfileCaption { get; init; }
+        public string UpdateProfileDescription { get; init; }
+
+        /// <summary>Default wording for the AutoFocus pane / Aberration Inspector replay (detection + AutoFocus + ROI).</summary>
+        public static ReplaySettingsPromptTexts AutoFocus { get; } = new ReplaySettingsPromptTexts {
+            Title = "Replay Saved AutoFocus Run",
+            Intro = "This run was saved with the detection and AutoFocus settings used at capture time. Choose how to replay it:",
+            UseCurrentCaption = "Use current settings",
+            UseCurrentDescription = "Replay using your current profile's detection and AutoFocus settings.",
+            UseCaptureCaption = "Use the captured settings (don't change my profile)",
+            UseCaptureDescription = "Replay using the settings from when this run was captured, held in memory only. Your profile settings are left untouched.",
+            UpdateProfileCaption = "Update my profile to the captured settings",
+            UpdateProfileDescription = "Overwrite your current profile's detection, AutoFocus, and ROI settings with the captured ones, then replay.",
+        };
+
+        /// <summary>Wording for the Tilt Adapter wizard replay, which applies only star-detection settings.</summary>
+        public static ReplaySettingsPromptTexts TiltCalibration { get; } = new ReplaySettingsPromptTexts {
+            Title = "Replay Saved Tilt Calibration",
+            Intro = "This calibration was saved with the star-detection settings used at capture time. Choose how to replay it:",
+            UseCurrentCaption = "Use current settings",
+            UseCurrentDescription = "Replay using your current profile's star-detection and tilt-calibration settings.",
+            UseCaptureCaption = "Use the captured settings (don't change my profile)",
+            UseCaptureDescription = "Replay using the star-detection settings from when this calibration was captured, held in memory only. Your profile is left untouched.",
+            UpdateProfileCaption = "Update my profile to the captured settings",
+            UpdateProfileDescription = "Overwrite your current profile's star-detection settings with the captured ones, then replay.",
+        };
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/ReplaySettingsPromptVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/ReplaySettingsPromptVM.cs
@@ -33,6 +33,15 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay {
 
         public string CaptureSummary { get; }
 
+        public string Title { get; }
+        public string Intro { get; }
+        public string UseCurrentCaption { get; }
+        public string UseCurrentDescription { get; }
+        public string UseCaptureCaption { get; }
+        public string UseCaptureDescription { get; }
+        public string UpdateProfileCaption { get; }
+        public string UpdateProfileDescription { get; }
+
         public ICommand UseCurrentCommand { get; }
         public ICommand UseCaptureInMemoryCommand { get; }
         public ICommand UpdateProfileCommand { get; }
@@ -41,7 +50,16 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay {
         /// <summary>Completes when the user picks an option (or cancels / closes the window).</summary>
         public Task<ReplaySettingsChoice> Choice => tcs.Task;
 
-        public ReplaySettingsPromptVM(AutoFocusReplayMetadata metadata) {
+        public ReplaySettingsPromptVM(AutoFocusReplayMetadata metadata, ReplaySettingsPromptTexts texts = null) {
+            texts ??= ReplaySettingsPromptTexts.AutoFocus;
+            Title = texts.Title;
+            Intro = texts.Intro;
+            UseCurrentCaption = texts.UseCurrentCaption;
+            UseCurrentDescription = texts.UseCurrentDescription;
+            UseCaptureCaption = texts.UseCaptureCaption;
+            UseCaptureDescription = texts.UseCaptureDescription;
+            UpdateProfileCaption = texts.UpdateProfileCaption;
+            UpdateProfileDescription = texts.UpdateProfileDescription;
             CaptureSummary = BuildSummary(metadata);
             UseCurrentCommand = new RelayCommand(() => Pick(ReplaySettingsChoice.UseCurrentSettings));
             UseCaptureInMemoryCommand = new RelayCommand(() => Pick(ReplaySettingsChoice.UseCaptureTimeSettingsInMemory));

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
@@ -125,6 +125,17 @@
         <DockPanel Grid.Row="1" Grid.Column="0" LastChildFill="False" Margin="0,0,0,6">
             <Button DockPanel.Dock="Left" Content="Fit" Command="{Binding FitCommand}" Margin="0,0,4,0" />
             <Button DockPanel.Dock="Left" Content="◀ Prev" Command="{Binding PrevCommand}" />
+            <ComboBox DockPanel.Dock="Left" Margin="4,0" VerticalAlignment="Center" MinWidth="96"
+                      Style="{StaticResource HF_LightCombo}"
+                      ItemsSource="{Binding FramePickerItems}"
+                      SelectedValuePath="Number"
+                      SelectedValue="{Binding SelectedFrameNumber, Mode=TwoWay}">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Foreground="Black" Text="{Binding Label}" />
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
             <Button DockPanel.Dock="Left" Content="Next ▶" Command="{Binding NextCommand}" />
             <Button DockPanel.Dock="Right" Content="Close" Command="{Binding CloseCommand}" />
         </DockPanel>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
@@ -110,7 +110,7 @@
         </Grid.RowDefinitions>
 
         <!-- Summary header: focuser position, detected-star count, HFR ± deviation stats, frame index. -->
-        <Border Grid.Row="0" Grid.Column="0" Margin="0,0,0,6" Padding="8,5" CornerRadius="3" Background="#FF262B31">
+        <Border Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,0,0,6" Padding="8,5" CornerRadius="3" Background="#FF262B31">
             <DockPanel LastChildFill="False">
                 <TextBlock DockPanel.Dock="Left" FontWeight="SemiBold" Text="{Binding FrameHeader}" />
                 <TextBlock DockPanel.Dock="Left" Margin="16,0,0,0" Foreground="#FFB0B6BD" Text="{Binding DetectedCountText}" />
@@ -315,7 +315,7 @@
 
         <!-- Right column: legend (disabled rows greyed) + per-star text / star-bounds selectors + help. Scrollable so
              it never clips on a short window. -->
-        <ScrollViewer Grid.Row="0" Grid.RowSpan="3" Grid.Column="1" Width="240" Margin="12,0,0,0"
+        <ScrollViewer Grid.Row="1" Grid.RowSpan="2" Grid.Column="1" VerticalAlignment="Top" Width="240" Margin="12,0,0,0"
                       VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
         <StackPanel>
             <TextBlock FontWeight="Bold" Margin="0,0,0,6" Text="Legend" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
@@ -88,9 +88,36 @@
             </Setter>
         </Style>
 
+        <!-- Self-contained toolbar button: keep Fit/Prev/Next/Close legible on the fixed dark panel regardless of the
+             active NINA theme (NINA's themed Button binds to theme brushes and ignores instance colors — same reason
+             the combo uses HF_LightCombo and the replay prompt uses ChoiceButton). -->
         <Style TargetType="Button">
             <Setter Property="Margin" Value="4,0" />
             <Setter Property="Padding" Value="10,4" />
+            <Setter Property="Foreground" Value="#FFE6E9ED" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bd" Background="#FF2A2F36" BorderBrush="#FF3E4650" BorderThickness="1"
+                                CornerRadius="3" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="True">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
+                                              TextElement.Foreground="{TemplateBinding Foreground}" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="#FF34404C" />
+                                <Setter TargetName="Bd" Property="BorderBrush" Value="#FF5A86C0" />
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="#FF2C3742" />
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="Bd" Property="Opacity" Value="0.45" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
         </Style>
         <Style TargetType="TextBlock">
             <Setter Property="Foreground" Value="{StaticResource Fg}" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewVM.cs
@@ -99,6 +99,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
         public AutoFocusFrameReviewVM(AutoFocusFrameReviewSnapshot snapshot, IStarAnnotatorOptions annotatorOptions, IApplicationDispatcher applicationDispatcher, MeasurementAverageEnum measurementAverage)
             : base((snapshot ?? throw new ArgumentNullException(nameof(snapshot))).Frames.Count) {
             this.snapshot = snapshot;
+            FramePickerItems = snapshot.Frames
+                .Select((f, i) => new FramePickerItem(i + 1, $"{i + 1} — {f.FocuserPosition:0}"))
+                .ToList();
             this.annotatorOptions = annotatorOptions ?? throw new ArgumentNullException(nameof(annotatorOptions));
             this.applicationDispatcher = applicationDispatcher ?? throw new ArgumentNullException(nameof(applicationDispatcher));
             this.measurementAverage = measurementAverage;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FramePickerItem.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FramePickerItem.cs
@@ -1,0 +1,25 @@
+#region "copyright"
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+#endregion "copyright"
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
+
+    /// <summary>One entry in a review toolbar's frame-number dropdown: the 1-based frame <see cref="Number"/> (the
+    /// ComboBox selection value, tracking the current frame) and a human <see cref="Label"/> like "3 — 2745"
+    /// (number — focuser position).</summary>
+    public sealed class FramePickerItem {
+        public FramePickerItem(int number, string label) {
+            Number = number;
+            Label = label;
+        }
+
+        public int Number { get; }
+        public string Label { get; }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
@@ -129,6 +129,16 @@
         <DockPanel Grid.Row="1" Grid.Column="0" LastChildFill="False" Margin="0,0,0,6">
             <Button DockPanel.Dock="Left" Content="Fit" Command="{Binding FitCommand}" Margin="0,0,4,0" />
             <Button DockPanel.Dock="Left" Content="◀ Prev" Command="{Binding PrevCommand}" />
+            <ComboBox DockPanel.Dock="Left" Margin="4,0" VerticalAlignment="Center" MinWidth="96"
+                      ItemsSource="{Binding FramePickerItems}"
+                      SelectedValuePath="Number"
+                      SelectedValue="{Binding SelectedFrameNumber, Mode=TwoWay}">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Foreground="Black" Text="{Binding Label}" />
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
             <Button DockPanel.Dock="Left" Content="Next ▶" Command="{Binding NextCommand}" />
             <Button DockPanel.Dock="Right" Content="Close" Command="{Binding CloseCommand}" />
         </DockPanel>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
@@ -8,6 +8,84 @@
         <BooleanToVisibilityConverter x:Key="BoolToVis" />
         <SolidColorBrush x:Key="Fg" Color="White" />
 
+        <!-- Self-contained light ComboBox: NINA's app-wide themed ComboBox ignores instance Background/Foreground (its
+             template binds to theme brushes), so a fully custom template is the only reliable way to get a light box
+             with dark, legible text on this dark panel. (Mirrors AutoFocusFrameReviewControl's HF_LightCombo.) -->
+        <Style x:Key="HF_LightCombo" TargetType="ComboBox">
+            <Setter Property="Foreground" Value="Black" />
+            <Setter Property="Height" Value="24" />
+            <Setter Property="HorizontalContentAlignment" Value="Left" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="ItemContainerStyle">
+                <Setter.Value>
+                    <Style TargetType="ComboBoxItem">
+                        <Setter Property="Foreground" Value="Black" />
+                        <Setter Property="Padding" Value="6,3" />
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="ComboBoxItem">
+                                    <Border x:Name="ItemBorder" Background="White" Padding="{TemplateBinding Padding}">
+                                        <ContentPresenter TextElement.Foreground="Black" />
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="IsHighlighted" Value="True">
+                                            <Setter TargetName="ItemBorder" Property="Background" Value="#FFCCE5FF" />
+                                        </Trigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </Setter.Value>
+            </Setter>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ComboBox">
+                        <Grid>
+                            <ToggleButton Grid.Column="0" Focusable="False" ClickMode="Press"
+                                          IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
+                                <ToggleButton.Template>
+                                    <ControlTemplate TargetType="ToggleButton">
+                                        <Border x:Name="Border" CornerRadius="2" BorderThickness="1"
+                                                Background="White" BorderBrush="#FF8A8A8A">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*" />
+                                                    <ColumnDefinition Width="20" />
+                                                </Grid.ColumnDefinitions>
+                                                <Path Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                      Data="M 0 0 L 4 4 L 8 0 Z" Fill="#FF303030" />
+                                            </Grid>
+                                        </Border>
+                                        <ControlTemplate.Triggers>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter TargetName="Border" Property="Background" Value="#FFF2F2F2" />
+                                            </Trigger>
+                                        </ControlTemplate.Triggers>
+                                    </ControlTemplate>
+                                </ToggleButton.Template>
+                            </ToggleButton>
+                            <ContentPresenter IsHitTestVisible="False"
+                                              Margin="6,0,24,0" VerticalAlignment="Center" HorizontalAlignment="Left"
+                                              Content="{TemplateBinding SelectionBoxItem}"
+                                              ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                              TextElement.Foreground="Black" />
+                            <Popup IsOpen="{TemplateBinding IsDropDownOpen}" Placement="Bottom" Focusable="False"
+                                   AllowsTransparency="True" PopupAnimation="Slide">
+                                <Border MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}"
+                                        MaxHeight="{TemplateBinding MaxDropDownHeight}"
+                                        Background="White" BorderThickness="1" BorderBrush="#FF8A8A8A" SnapsToDevicePixels="True">
+                                    <ScrollViewer>
+                                        <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" />
+                                    </ScrollViewer>
+                                </Border>
+                            </Popup>
+                        </Grid>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
         <!-- NINA's default toggle (StandardCheckBox) hard-codes the OFF label to {StaticResource PrimaryBrush},
              which is too dark on this panel and CANNOT be overridden from the consumer (StaticResource is baked
              into NINA's parsed style). So we keep NINA's exact toggle look but re-template it locally, pointing
@@ -130,6 +208,7 @@
             <Button DockPanel.Dock="Left" Content="Fit" Command="{Binding FitCommand}" Margin="0,0,4,0" />
             <Button DockPanel.Dock="Left" Content="◀ Prev" Command="{Binding PrevCommand}" />
             <ComboBox DockPanel.Dock="Left" Margin="4,0" VerticalAlignment="Center" MinWidth="96"
+                      Style="{StaticResource HF_LightCombo}"
                       ItemsSource="{Binding FramePickerItems}"
                       SelectedValuePath="Number"
                       SelectedValue="{Binding SelectedFrameNumber, Mode=TwoWay}">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
@@ -109,7 +109,7 @@
 
         <!-- Summary header (above the image): focuser position, frame index, detected-star count, reference note,
              and the registration transform. -->
-        <Border Grid.Row="0" Grid.Column="0" Margin="0,0,0,6" Padding="8,5" CornerRadius="3" Background="#FF262B31">
+        <Border Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,0,0,6" Padding="8,5" CornerRadius="3" Background="#FF262B31">
             <StackPanel>
                 <DockPanel LastChildFill="False">
                     <TextBlock DockPanel.Dock="Left" FontWeight="SemiBold" Text="{Binding FrameHeader}" />
@@ -330,7 +330,7 @@
         </Grid>
 
         <!-- Right column: legend (disabled rows greyed) + toggles + help. -->
-        <StackPanel Grid.Row="0" Grid.RowSpan="3" Grid.Column="1" Width="240" Margin="12,0,0,0">
+        <StackPanel Grid.Row="1" Grid.RowSpan="2" Grid.Column="1" VerticalAlignment="Top" Width="240" Margin="12,0,0,0">
             <TextBlock FontWeight="Bold" Margin="0,0,0,6" Text="Legend" />
             <ItemsControl ItemsSource="{Binding LegendEntries}">
                 <ItemsControl.ItemTemplate>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
@@ -164,9 +164,36 @@
             </Setter>
         </Style>
 
+        <!-- Self-contained toolbar button: keep Fit/Prev/Next/Close legible on the fixed dark panel regardless of the
+             active NINA theme (NINA's themed Button binds to theme brushes and ignores instance colors — same reason
+             the combo uses HF_LightCombo and the replay prompt uses ChoiceButton). -->
         <Style TargetType="Button">
             <Setter Property="Margin" Value="4,0" />
             <Setter Property="Padding" Value="10,4" />
+            <Setter Property="Foreground" Value="#FFE6E9ED" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bd" Background="#FF2A2F36" BorderBrush="#FF3E4650" BorderThickness="1"
+                                CornerRadius="3" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="True">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
+                                              TextElement.Foreground="{TemplateBinding Foreground}" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="#FF34404C" />
+                                <Setter TargetName="Bd" Property="BorderBrush" Value="#FF5A86C0" />
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="#FF2C3742" />
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="Bd" Property="Opacity" Value="0.45" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
         </Style>
         <Style TargetType="TextBlock">
             <Setter Property="Foreground" Value="{StaticResource Fg}" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVM.cs
@@ -17,6 +17,7 @@ using OxyPlot;
 using OxyPlot.Series;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 
@@ -116,6 +117,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         public FrameReviewVM(FrameReviewSnapshot snapshot)
             : base((snapshot ?? throw new ArgumentNullException(nameof(snapshot))).Frames.Count) {
             this.snapshot = snapshot;
+            FramePickerItems = snapshot.Frames
+                .Select((f, i) => new FramePickerItem(i + 1, $"{i + 1} — {f.FocuserPosition:0}"))
+                .ToList();
             RebuildLegend();
 
             CurrentIndex = 0;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVMBase.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVMBase.cs
@@ -32,6 +32,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             NextCommand = new RelayCommand(Next, () => CurrentIndex < FrameCount - 1);
             FitCommand = new RelayCommand(() => FitRequested?.Invoke(this, EventArgs.Empty));
             CloseCommand = new RelayCommand(() => RequestClose?.Invoke(this, EventArgs.Empty));
+            FramePickerItems = Array.Empty<FramePickerItem>();
         }
 
         public event EventHandler RequestClose;
@@ -58,11 +59,30 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
                     currentIndex = value;
                     RaisePropertyChanged();
                     RaisePropertyChanged(nameof(PositionLabel));
+                    RaisePropertyChanged(nameof(SelectedFrameNumber));
                 }
             }
         }
 
         public string PositionLabel => FrameCount > 0 ? $"{CurrentIndex + 1} / {FrameCount}" : "0 / 0";
+
+        /// <summary>Toolbar frame-picker entries (1-based number + focuser-position label). Populated by the subclass,
+        /// the only place with the per-frame focuser positions.</summary>
+        public IReadOnlyList<FramePickerItem> FramePickerItems { get; protected set; }
+
+        /// <summary>Two-way bound by the toolbar frame picker (1-based, matching <see cref="PositionLabel"/>). Selecting
+        /// a frame jumps to it exactly as Prev/Next do — set the index, then LoadCurrent(fit:false) so zoom/pan is
+        /// preserved. Out-of-range and no-op selections are ignored.</summary>
+        public int SelectedFrameNumber {
+            get => CurrentIndex + 1;
+            set {
+                var index = value - 1;
+                if (index >= 0 && index < FrameCount && index != CurrentIndex) {
+                    CurrentIndex = index;
+                    LoadCurrent(fit: false);
+                }
+            }
+        }
 
         private BitmapSource frameImage;
         public BitmapSource FrameImage {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -108,7 +108,7 @@
         </Grid.RowDefinitions>
 
         <!-- Header -->
-        <DockPanel Grid.Row="0" Grid.Column="0" LastChildFill="False" Margin="0,0,0,6">
+        <DockPanel Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" LastChildFill="False" Margin="0,0,0,6">
             <TextBlock DockPanel.Dock="Left" FontWeight="SemiBold" Text="{Binding FrameHeader}" />
             <TextBlock DockPanel.Dock="Right" Text="{Binding PositionLabel}" />
             <!-- Sensor (image-pixel) coordinates under the cursor, for describing a region precisely. -->
@@ -398,13 +398,13 @@
         </Grid>
 
         <!-- Concise, wrapping interaction instructions (the color key now lives in the legend panel at right) + counts. -->
-        <StackPanel Grid.Row="3" Grid.Column="0" Margin="0,6,0,0">
+        <StackPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,6,0,0">
             <TextBlock Foreground="#FFB0B6BD" Text="{Binding HelpText}" TextWrapping="Wrap" />
             <TextBlock Margin="0,4,0,0" Foreground="#FFB0B6BD" Text="{Binding CountsLabel}" />
         </StackPanel>
 
         <!-- Color legend (right column), generated from the VM's single color source so it tracks the overlays. -->
-        <StackPanel Grid.Row="0" Grid.RowSpan="4" Grid.Column="1" Width="230" Margin="12,0,0,0">
+        <StackPanel Grid.Row="1" Grid.RowSpan="2" Grid.Column="1" VerticalAlignment="Top" Width="230" Margin="12,0,0,0">
             <TextBlock FontWeight="Bold" Margin="0,0,0,6" Text="Legend" />
             <ItemsControl ItemsSource="{Binding LegendEntries}">
                 <ItemsControl.ItemTemplate>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -163,9 +163,36 @@
             </Setter>
         </Style>
 
+        <!-- Self-contained toolbar button: keep Fit/Prev/Next/Close legible on the fixed dark panel regardless of the
+             active NINA theme (NINA's themed Button binds to theme brushes and ignores instance colors — same reason
+             the combo uses HF_LightCombo and the replay prompt uses ChoiceButton). -->
         <Style TargetType="Button">
             <Setter Property="Margin" Value="4,0" />
             <Setter Property="Padding" Value="10,4" />
+            <Setter Property="Foreground" Value="#FFE6E9ED" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bd" Background="#FF2A2F36" BorderBrush="#FF3E4650" BorderThickness="1"
+                                CornerRadius="3" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="True">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
+                                              TextElement.Foreground="{TemplateBinding Foreground}" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="#FF34404C" />
+                                <Setter TargetName="Bd" Property="BorderBrush" Value="#FF5A86C0" />
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="#FF2C3742" />
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="Bd" Property="Opacity" Value="0.45" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
         </Style>
         <Style TargetType="TextBlock">
             <Setter Property="Foreground" Value="{StaticResource Fg}" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -7,6 +7,84 @@
         <BooleanToVisibilityConverter x:Key="BoolToVis" />
         <SolidColorBrush x:Key="Fg" Color="White" />
 
+        <!-- Self-contained light ComboBox: NINA's app-wide themed ComboBox ignores instance Background/Foreground (its
+             template binds to theme brushes), so a fully custom template is the only reliable way to get a light box
+             with dark, legible text on this dark panel. (Mirrors AutoFocusFrameReviewControl's HF_LightCombo.) -->
+        <Style x:Key="HF_LightCombo" TargetType="ComboBox">
+            <Setter Property="Foreground" Value="Black" />
+            <Setter Property="Height" Value="24" />
+            <Setter Property="HorizontalContentAlignment" Value="Left" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="ItemContainerStyle">
+                <Setter.Value>
+                    <Style TargetType="ComboBoxItem">
+                        <Setter Property="Foreground" Value="Black" />
+                        <Setter Property="Padding" Value="6,3" />
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="ComboBoxItem">
+                                    <Border x:Name="ItemBorder" Background="White" Padding="{TemplateBinding Padding}">
+                                        <ContentPresenter TextElement.Foreground="Black" />
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="IsHighlighted" Value="True">
+                                            <Setter TargetName="ItemBorder" Property="Background" Value="#FFCCE5FF" />
+                                        </Trigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </Setter.Value>
+            </Setter>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ComboBox">
+                        <Grid>
+                            <ToggleButton Grid.Column="0" Focusable="False" ClickMode="Press"
+                                          IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
+                                <ToggleButton.Template>
+                                    <ControlTemplate TargetType="ToggleButton">
+                                        <Border x:Name="Border" CornerRadius="2" BorderThickness="1"
+                                                Background="White" BorderBrush="#FF8A8A8A">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*" />
+                                                    <ColumnDefinition Width="20" />
+                                                </Grid.ColumnDefinitions>
+                                                <Path Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                      Data="M 0 0 L 4 4 L 8 0 Z" Fill="#FF303030" />
+                                            </Grid>
+                                        </Border>
+                                        <ControlTemplate.Triggers>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter TargetName="Border" Property="Background" Value="#FFF2F2F2" />
+                                            </Trigger>
+                                        </ControlTemplate.Triggers>
+                                    </ControlTemplate>
+                                </ToggleButton.Template>
+                            </ToggleButton>
+                            <ContentPresenter IsHitTestVisible="False"
+                                              Margin="6,0,24,0" VerticalAlignment="Center" HorizontalAlignment="Left"
+                                              Content="{TemplateBinding SelectionBoxItem}"
+                                              ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                              TextElement.Foreground="Black" />
+                            <Popup IsOpen="{TemplateBinding IsDropDownOpen}" Placement="Bottom" Focusable="False"
+                                   AllowsTransparency="True" PopupAnimation="Slide">
+                                <Border MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}"
+                                        MaxHeight="{TemplateBinding MaxDropDownHeight}"
+                                        Background="White" BorderThickness="1" BorderBrush="#FF8A8A8A" SnapsToDevicePixels="True">
+                                    <ScrollViewer>
+                                        <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" />
+                                    </ScrollViewer>
+                                </Border>
+                            </Popup>
+                        </Grid>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
         <!-- NINA's default toggle (StandardCheckBox) hard-codes the OFF label to {StaticResource PrimaryBrush},
              which is too dark on this panel and CANNOT be overridden from the consumer (StaticResource is baked
              into NINA's parsed style). So we keep NINA's exact toggle look but re-template it locally, pointing
@@ -120,6 +198,7 @@
             <Button Content="Fit" Command="{Binding FitCommand}" Margin="0,0,4,0" />
             <Button Content="◀ Prev" Command="{Binding PrevCommand}" />
             <ComboBox Margin="4,0" VerticalAlignment="Center" MinWidth="96"
+                      Style="{StaticResource HF_LightCombo}"
                       ItemsSource="{Binding FramePickerItems}"
                       SelectedValuePath="Number"
                       SelectedValue="{Binding SelectedFrameNumber, Mode=TwoWay}">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -119,6 +119,16 @@
         <WrapPanel Grid.Row="1" Grid.Column="0" Margin="0,0,0,6">
             <Button Content="Fit" Command="{Binding FitCommand}" Margin="0,0,4,0" />
             <Button Content="◀ Prev" Command="{Binding PrevCommand}" />
+            <ComboBox Margin="4,0" VerticalAlignment="Center" MinWidth="96"
+                      ItemsSource="{Binding FramePickerItems}"
+                      SelectedValuePath="Number"
+                      SelectedValue="{Binding SelectedFrameNumber, Mode=TwoWay}">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Foreground="Black" Text="{Binding Label}" />
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
             <Button Content="Next ▶" Command="{Binding NextCommand}" />
             <Button Content="Undo" Command="{Binding UndoCommand}" Margin="16,0,4,0" />
             <Button Content="Redo" Command="{Binding RedoCommand}" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
@@ -206,6 +206,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             string labelsDir,
             MeasurementAverageEnum measurementAverage = MeasurementAverageEnum.Median) {
             this.queue = queue ?? throw new ArgumentNullException(nameof(queue));
+            FramePickerItems = queue
+                .Select((f, i) => new FramePickerItem(i + 1, $"{i + 1} — {f.FocuserPosition}"))
+                .ToList();
             this.labelsByRun = labelsByRun ?? throw new ArgumentNullException(nameof(labelsByRun));
             this.labelsDir = labelsDir ?? throw new ArgumentNullException(nameof(labelsDir));
             this.measurementAverage = measurementAverage;
@@ -234,6 +237,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
                     currentIndex = value;
                     RaisePropertyChanged();
                     RaisePropertyChanged(nameof(PositionLabel));
+                    RaisePropertyChanged(nameof(SelectedFrameNumber));
                 }
             }
         }
@@ -241,6 +245,23 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         public int QueueCount => queue.Count;
 
         public string PositionLabel => $"{CurrentIndex + 1} / {queue.Count}";
+
+        /// <summary>Toolbar frame-picker entries (1-based number + focuser-position label).</summary>
+        public IReadOnlyList<FramePickerItem> FramePickerItems { get; }
+
+        /// <summary>Two-way bound by the toolbar frame picker (1-based, matching <see cref="PositionLabel"/>). Selecting
+        /// a frame jumps to it the same way Prev/Next do (set index, then LoadCurrent(fitView:false) to preserve
+        /// zoom/pan). Out-of-range and no-op selections are ignored.</summary>
+        public int SelectedFrameNumber {
+            get => CurrentIndex + 1;
+            set {
+                var index = value - 1;
+                if (index >= 0 && index < queue.Count && index != CurrentIndex) {
+                    CurrentIndex = index;
+                    LoadCurrent(fitView: false);
+                }
+            }
+        }
 
         private string cursorPositionText;
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -312,20 +312,11 @@
                         <Button
                             Margin="6,0,0,0"
                             Command="{Binding ReplayCommand}"
-                            ToolTip="Replay a saved calibration run from a folder containing metadata.json. Uses the run's stored star-detection and tilt-calibration settings (restoring your settings afterward).">
+                            ToolTip="Replay a saved calibration run from a folder containing metadata.json. Choose how in the prompt: your current settings, the run's capture-time settings held in memory (profile untouched), or after updating your profile to the run's capture-time settings.">
                             <TextBlock
                                 Margin="10,5,10,5"
                                 Foreground="{StaticResource ButtonForegroundBrush}"
                                 Text="Replay" />
-                        </Button>
-                        <Button
-                            Margin="6,0,0,0"
-                            Command="{Binding ReplayCurrentSettingsCommand}"
-                            ToolTip="Replay a saved calibration run using your CURRENT star-detection and tilt-calibration settings instead of the ones stored in metadata.json. Your profile settings are left unchanged.">
-                            <TextBlock
-                                Margin="10,5,10,5"
-                                Foreground="{StaticResource ButtonForegroundBrush}"
-                                Text="Replay Current Settings" />
                         </Button>
                     </StackPanel>
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -14,6 +14,7 @@ using CommunityToolkit.Mvvm.Input;
 using NINA.Core.Model;
 using NINA.Core.Utility;
 using NINA.Core.Utility.Notification;
+using NINA.Core.Utility.WindowService;
 using NINA.Equipment.Equipment;
 using NINA.Equipment.Equipment.MyCamera;
 using NINA.Equipment.Equipment.MyFocuser;
@@ -67,6 +68,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         private readonly ITiltAdapterOptions tiltAdapterOptions;
         private readonly InspectorVM inspector;
         private readonly IApplicationDispatcher applicationDispatcher;
+        // WindowServiceFactory is not a MEF export (NINA exposes the concrete type with a default ctor only), so it is
+        // constructed directly, matching InspectorVM / HocusFocusVM. Used to show the shared replay-settings modal.
+        private readonly IWindowServiceFactory windowServiceFactory = new WindowServiceFactory();
         private readonly IProgress<ApplicationStatus> progress;
 
         private CameraInfo cameraInfo = DeviceInfo.CreateDefaultInstance<CameraInfo>();
@@ -167,8 +171,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             RestartCommand = new RelayCommand(Restart);
             UseMeasuredHardwareCommand = new RelayCommand(UseMeasuredHardware, () => HasMeasuredHardware);
             BrowseSaveFolderCommand = new RelayCommand(BrowseSaveFolder);
-            ReplayCommand = new AsyncRelayCommand(() => ReplayAsync(useMetadataSettings: true), () => !IsWizardRunning && !IsMeasuring);
-            ReplayCurrentSettingsCommand = new AsyncRelayCommand(() => ReplayAsync(useMetadataSettings: false), () => !IsWizardRunning && !IsMeasuring);
+            ReplayCommand = new AsyncRelayCommand(ReplayAsync, () => !IsWizardRunning && !IsMeasuring);
 
             tiltAdapterOptions.PropertyChanged += (s, e) => OnUIThread(() => {
                 if (e.PropertyName == nameof(ITiltAdapterOptions.ScrewInwardCurvatureSign)) {
@@ -483,7 +486,6 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public ICommand UseMeasuredHardwareCommand { get; }
         public ICommand BrowseSaveFolderCommand { get; }
         public ICommand ReplayCommand { get; }
-        public ICommand ReplayCurrentSettingsCommand { get; }
 
         // Known amount the user moves each screw during the per-screw calibration steps (full turns
         // for screws, steps for steppers). Defaults to 1.0 to match the "1 full turn" instructions.
@@ -1130,12 +1132,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // ---- Replay -----------------------------------------------------------------------------------------
 
         // Replays a saved calibration run from a folder: reads metadata.json, re-analyzes each step from its saved
-        // frames, and recomputes the calibration.
-        // - useMetadataSettings = true ("Replay"): apply the run's stored star-detection settings transiently
-        //   (restored afterward) and use the run's stored geometry — reproduces the original calibration exactly.
-        // - useMetadataSettings = false ("Replay Current Settings"): leave the current profile's star-detection and
-        //   tilt-calibration settings in place, so metadata.json does not override what is configured now.
-        private async Task ReplayAsync(bool useMetadataSettings) {
+        // frames, and recomputes the calibration. A single "Replay" button opens the shared replay-settings modal,
+        // which offers three modes (see TiltReplayModeResolver):
+        // - Use current settings: current profile star-detection + current tilt geometry (metadata does not override).
+        // - Use capture-time settings in memory: the run's stored star-detection as a transient per-step override
+        //   (profile untouched) + the run's stored geometry — reproduces the original calibration exactly.
+        // - Update profile to capture-time: persist the run's star-detection settings to the live profile, then replay
+        //   against it + the run's stored geometry.
+        private async Task ReplayAsync() {
             string folder;
             using (var dialog = new System.Windows.Forms.FolderBrowserDialog()) {
                 if (!string.IsNullOrEmpty(SaveAFRunsPath)) {
@@ -1173,9 +1177,28 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 }
             }
 
-            // "Replay Current Settings" applies the current screw geometry to the saved deltas; if the saved run
+            // Consolidated replay: one button, three modes resolved by the shared replay-settings modal (seeded from a
+            // representative per-step AutoFocus replay snapshot). Cancelling / closing the modal aborts.
+            var representativeStepFolder = byStep[MeasurementSteps.First().ToString()];
+            AutoFocusReplayMetadata.TryLoad(representativeStepFolder, out var replayMetadata, out _);
+            var choice = await ReplaySettingsPrompt.ShowAsync(windowServiceFactory, replayMetadata);
+            if (choice == ReplaySettingsChoice.Cancel) {
+                return;
+            }
+            var mode = TiltReplayModeResolver.Resolve(choice);
+
+            // "Update profile to capture-time": persist the run's capture-time star-detection settings to the live
+            // profile, then replay against it (no per-step override needed). ApplyFullSnapshot raises INPC -> UI thread.
+            if (mode.UpdateProfileToCaptureTime) {
+                var captureSnapshot = BuildTiltReplayDetectionOverride(representativeStepFolder, metadata);
+                if (captureSnapshot != null) {
+                    OnUIThread(() => HocusFocusPlugin.StarDetectionOptions?.ApplyFullSnapshot(captureSnapshot));
+                }
+            }
+
+            // Replaying with current geometry applies the current screw count to the saved deltas; if the saved run
             // used a different screw count, the angle fit is meaningless. Warn rather than silently corrupt.
-            if (!useMetadataSettings && metadata.NumberOfScrews != tiltAdapterOptions.ScrewCount) {
+            if (!mode.UseMetadataGeometry && metadata.NumberOfScrews != tiltAdapterOptions.ScrewCount) {
                 Notification.ShowWarning($"The saved run used {metadata.NumberOfScrews} screws but the current setting is " +
                     $"{tiltAdapterOptions.ScrewCount}. Replaying with current settings may produce incorrect angles.");
             }
@@ -1202,10 +1225,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 foreach (var step in MeasurementSteps) {
                     token.ThrowIfCancellationRequested();
                     StatusText = $"Replaying {step}...";
-                    // No-mutation replay: when using the run's stored settings, pass a detached capture-time
-                    // star-detection snapshot as an override so the profile is never modified (and never needs
-                    // restoring). "Replay Current Settings" passes null and uses the current profile settings.
-                    var detectionOverride = useMetadataSettings
+                    // Capture-time-in-memory replay passes a detached per-step star-detection snapshot as an override so
+                    // the profile is never touched. "Use current settings" and "update profile" both pass null (the
+                    // latter has already mutated the live profile to the capture-time settings).
+                    var detectionOverride = mode.ApplyCaptureTimeOverridePerStep
                         ? BuildTiltReplayDetectionOverride(byStep[step.ToString()], metadata)
                         : null;
                     bool ok = await inspector.AnalyzeAutoFocusFromSavedPath(byStep[step.ToString()], token, detectionOverride);
@@ -1238,7 +1261,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     });
                 }
 
-                if (useMetadataSettings) {
+                if (mode.UseMetadataGeometry) {
                     calibrationAppliedAmount = metadata.CalibrationAppliedAmount;
                     RaisePropertyChanged(nameof(CalibrationAppliedAmount));
                     RaisePropertyChanged(nameof(CalibrationAppliedAmountDisplay));
@@ -1269,8 +1292,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 Notification.ShowError($"Replay failed: {ex.Message}");
                 Logger.Error(ex, "Tilt calibration replay failed");
             } finally {
-                // No profile mutation to undo: capture-time detection settings are passed to the replay as an
-                // in-memory override (see BuildTiltReplayDetectionOverride), so the user's profile is never touched.
+                // "Use capture-time in memory" passes detection settings as an in-memory override, so nothing is undone.
+                // "Update profile to capture-time" intentionally persisted the capture-time settings to the profile (the
+                // user opted in via the modal), so it is likewise not restored.
                 isReplaying = false;
                 IsMeasuring = false;
                 // A successful replay ends on the Complete panel (like a live run); a failed/cancelled replay
@@ -1434,7 +1458,6 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             ((RelayCommand)CancelCommand).NotifyCanExecuteChanged();
             ((RelayCommand)UseMeasuredHardwareCommand).NotifyCanExecuteChanged();
             ((AsyncRelayCommand)ReplayCommand).NotifyCanExecuteChanged();
-            ((AsyncRelayCommand)ReplayCurrentSettingsCommand).NotifyCanExecuteChanged();
         }
 
         private static double NormalizeAngle(double deg) => ((deg % 360) + 360) % 360;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -1167,9 +1167,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 return;
             }
 
+            // Resolve each step folder against the run directory the user selected, so a run that was moved or copied
+            // (its stored paths now pointing at the original capture location) still replays. Relative entries (the
+            // current format) rebase onto the selected folder; legacy absolute entries are honored as-is.
             var byStep = (metadata.RunStepMapping ?? new List<TiltRunStepMapping>())
                 .GroupBy(m => m.Step, StringComparer.OrdinalIgnoreCase)
-                .ToDictionary(g => g.Key, g => g.Last().Folder, StringComparer.OrdinalIgnoreCase);
+                .ToDictionary(g => g.Key, g => TiltCalibrationMetadata.ResolveStepFolder(folder, g.Last().Folder), StringComparer.OrdinalIgnoreCase);
             foreach (var step in MeasurementSteps) {
                 if (!byStep.ContainsKey(step.ToString())) {
                     Notification.ShowError($"metadata.json has no saved folder for step '{step}'. Cannot replay.");
@@ -1362,7 +1365,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
             currentMetadata.RunStepMapping.RemoveAll(m => string.Equals(m.Step, stepName, StringComparison.OrdinalIgnoreCase));
             if (!string.IsNullOrEmpty(reading.SaveFolder)) {
-                currentMetadata.RunStepMapping.Add(new TiltRunStepMapping { Step = stepName, Folder = reading.SaveFolder });
+                // Store the folder relative to the run root so the saved run replays after being moved/copied.
+                currentMetadata.RunStepMapping.Add(new TiltRunStepMapping {
+                    Step = stepName,
+                    Folder = TiltCalibrationMetadata.ToRelativeStepFolder(runRootFolder, reading.SaveFolder)
+                });
             }
 
             currentMetadata.PerStep.RemoveAll(p => string.Equals(p.Step, stepName, StringComparison.OrdinalIgnoreCase));

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -1184,20 +1184,27 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // representative per-step AutoFocus replay snapshot). Cancelling / closing the modal aborts.
             var representativeStepFolder = byStep[MeasurementSteps.First().ToString()];
             AutoFocusReplayMetadata.TryLoad(representativeStepFolder, out var replayMetadata, out _);
-            var choice = await ReplaySettingsPrompt.ShowAsync(windowServiceFactory, replayMetadata);
+            var choice = await ReplaySettingsPrompt.ShowAsync(windowServiceFactory, replayMetadata, ReplaySettingsPromptTexts.TiltCalibration);
             if (choice == ReplaySettingsChoice.Cancel) {
                 return;
             }
             var mode = TiltReplayModeResolver.Resolve(choice);
 
-            // "Update profile to capture-time": persist the run's capture-time star-detection settings to the live
-            // profile, then replay against it (no per-step override needed). ApplyFullSnapshot raises INPC -> UI thread.
-            if (mode.UpdateProfileToCaptureTime) {
-                var captureSnapshot = BuildTiltReplayDetectionOverride(representativeStepFolder, metadata);
-                if (captureSnapshot != null) {
-                    OnUIThread(() => HocusFocusPlugin.StarDetectionOptions?.ApplyFullSnapshot(captureSnapshot));
-                }
+            // The run's representative capture-time star-detection snapshot: used to warn when the run stored none, and
+            // — for "update profile" — to persist to the live profile AFTER a successful replay. Reuse the metadata
+            // already loaded above when present; otherwise build it (which also overlays legacy optimized settings).
+            var captureTimeSnapshot = mode.ApplyCaptureTimeOverridePerStep
+                ? (replayMetadata?.StarDetection ?? BuildTiltReplayDetectionOverride(representativeStepFolder, metadata))
+                : null;
+            if (mode.ApplyCaptureTimeOverridePerStep && captureTimeSnapshot == null) {
+                Notification.ShowWarning(mode.UpdateProfileToCaptureTime
+                    ? "This saved run has no stored star-detection settings, so it will replay with your current settings and your profile will not be changed."
+                    : "This saved run has no stored star-detection settings, so it will replay with your current settings.");
             }
+            // Failure/cancel happens before the profile write below, so the profile is never left half-changed.
+            var profileNotChangedNote = mode.UpdateProfileToCaptureTime
+                ? " Your profile was not changed (it is only updated after a successful replay)."
+                : string.Empty;
 
             // Replaying with current geometry applies the current screw count to the saved deltas; if the saved run
             // used a different screw count, the angle fit is meaningless. Warn rather than silently corrupt.
@@ -1228,22 +1235,22 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 foreach (var step in MeasurementSteps) {
                     token.ThrowIfCancellationRequested();
                     StatusText = $"Replaying {step}...";
-                    // Capture-time-in-memory replay passes a detached per-step star-detection snapshot as an override so
-                    // the profile is never touched. "Use current settings" and "update profile" both pass null (the
-                    // latter has already mutated the live profile to the capture-time settings).
+                    // Capture-time modes ("use captured in memory" and "update profile") replay each step with its own
+                    // detached capture-time star-detection snapshot as an override, so the live profile is untouched
+                    // during the replay. "Use current settings" passes null and uses the current profile.
                     var detectionOverride = mode.ApplyCaptureTimeOverridePerStep
                         ? BuildTiltReplayDetectionOverride(byStep[step.ToString()], metadata)
                         : null;
                     bool ok = await inspector.AnalyzeAutoFocusFromSavedPath(byStep[step.ToString()], token, detectionOverride);
                     if (!ok) {
                         StatusText = $"Replay failed at {step}.";
-                        Notification.ShowError($"Replay failed at step '{step}'. The saved frames could not be analyzed.");
+                        Notification.ShowError($"Replay failed at step '{step}'. The saved frames could not be analyzed.{profileNotChangedNote}");
                         return;
                     }
                     var m = inspector.TiltModel?.TiltPlaneModel;
                     if (m == null) {
                         StatusText = $"Replay produced no tilt model at {step}.";
-                        Notification.ShowError($"Replay produced no tilt model at step '{step}'.");
+                        Notification.ShowError($"Replay produced no tilt model at step '{step}'.{profileNotChangedNote}");
                         return;
                     }
                     var reading = new StepReading {
@@ -1286,18 +1293,23 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                         IsStepperAdjustment);
                 }
                 RebuildDiagram();
+                // Update-profile choice: the replay succeeded, so now persist the run's capture-time star-detection
+                // settings to the live profile (no-op if the run stored none — the user was warned above).
+                if (mode.UpdateProfileToCaptureTime && captureTimeSnapshot != null) {
+                    OnUIThread(() => HocusFocusPlugin.StarDetectionOptions?.ApplyFullSnapshot(captureTimeSnapshot));
+                }
                 StatusText = "Replay complete.";
                 CurrentStep = WizardStep.Complete;
                 completed = true;
             } catch (OperationCanceledException) {
                 StatusText = "Replay cancelled.";
             } catch (Exception ex) {
-                Notification.ShowError($"Replay failed: {ex.Message}");
+                Notification.ShowError($"Replay failed: {ex.Message}{profileNotChangedNote}");
                 Logger.Error(ex, "Tilt calibration replay failed");
             } finally {
-                // "Use capture-time in memory" passes detection settings as an in-memory override, so nothing is undone.
-                // "Update profile to capture-time" intentionally persisted the capture-time settings to the profile (the
-                // user opted in via the modal), so it is likewise not restored.
+                // The live profile is only persisted on a successful "update profile to capture-time" replay (above), so
+                // a cancelled/failed replay leaves it untouched — nothing to restore. The in-memory per-step override
+                // never touches the profile either.
                 isReplaying = false;
                 IsMeasuring = false;
                 // A successful replay ends on the Complete panel (like a live run); a failed/cancelled replay

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
@@ -15,11 +15,16 @@ using Newtonsoft.Json.Serialization;
 using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
 using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
     /// <summary>One entry of the run → wizard-step folder map. The folder is the AutoFocus attempt root
-    /// (== <c>InspectorVM.LastSaveFolder</c>) that a replay/validation run loads.</summary>
+    /// (== <c>InspectorVM.LastSaveFolder</c>) that a replay/validation run loads. It is stored <b>relative to the
+    /// run root</b> (the directory holding <c>metadata.json</c>) so a saved run stays replayable after it is moved
+    /// or copied to another machine; legacy files that stored an absolute path are still honored on read. Use
+    /// <see cref="TiltCalibrationMetadata.ToRelativeStepFolder"/> when writing and
+    /// <see cref="TiltCalibrationMetadata.ResolveStepFolder"/> when reading.</summary>
     public sealed class TiltRunStepMapping {
         public string Step { get; set; }
         public string Folder { get; set; }
@@ -112,6 +117,32 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         public static TiltCalibrationMetadata Deserialize(string json) =>
             JsonConvert.DeserializeObject<TiltCalibrationMetadata>(json, JsonSettings);
+
+        /// <summary>
+        /// Converts a step folder to one stored relative to <paramref name="runRootFolder"/> (the directory holding
+        /// <c>metadata.json</c>) so a saved run stays replayable after it is moved or copied. A folder that is not
+        /// under the run root (e.g. a different volume) is kept absolute rather than emitting a brittle
+        /// <c>..\..</c> chain. Inverse of <see cref="ResolveStepFolder"/>.
+        /// </summary>
+        public static string ToRelativeStepFolder(string runRootFolder, string stepFolder) {
+            if (string.IsNullOrEmpty(stepFolder) || string.IsNullOrEmpty(runRootFolder)) {
+                return stepFolder;
+            }
+            var relative = Path.GetRelativePath(runRootFolder, stepFolder);
+            return Path.IsPathRooted(relative) ? stepFolder : relative;
+        }
+
+        /// <summary>
+        /// Resolves a stored step folder against the run root the caller actually selected. Relative entries (the
+        /// current format) are rebased onto <paramref name="runRootFolder"/>; absolute entries (legacy files) are
+        /// honored as-is. Mirrors the headless <c>TestApp</c> resolver so in-app and offline replay agree.
+        /// </summary>
+        public static string ResolveStepFolder(string runRootFolder, string storedFolder) {
+            if (string.IsNullOrEmpty(storedFolder) || string.IsNullOrEmpty(runRootFolder) || Path.IsPathRooted(storedFolder)) {
+                return storedFolder;
+            }
+            return Path.GetFullPath(Path.Combine(runRootFolder, storedFolder));
+        }
 
         public void Validate() {
             if (NumberOfScrews != 3 && NumberOfScrews != 4) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltReplayMode.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltReplayMode.cs
@@ -34,7 +34,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         /// <summary>Pass the per-step capture-time star-detection snapshot as an in-memory override (true) or use the live profile (false).</summary>
         public bool ApplyCaptureTimeOverridePerStep { get; }
 
-        /// <summary>Persist the run's capture-time star-detection settings to the live profile before replaying.</summary>
+        /// <summary>Persist the run's capture-time star-detection settings to the live profile AFTER a successful replay.</summary>
         public bool UpdateProfileToCaptureTime { get; }
     }
 
@@ -51,7 +51,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 case ReplaySettingsChoice.UseCaptureTimeSettingsInMemory:
                     return new TiltReplayMode(useMetadataGeometry: true, applyCaptureTimeOverridePerStep: true, updateProfileToCaptureTime: false);
                 case ReplaySettingsChoice.UpdateProfileToCaptureTime:
-                    return new TiltReplayMode(useMetadataGeometry: true, applyCaptureTimeOverridePerStep: false, updateProfileToCaptureTime: true);
+                    return new TiltReplayMode(useMetadataGeometry: true, applyCaptureTimeOverridePerStep: true, updateProfileToCaptureTime: true);
                 default:
                     throw new ArgumentOutOfRangeException(nameof(choice), choice, "Cancel must be handled before resolving a replay mode.");
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltReplayMode.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltReplayMode.cs
@@ -1,0 +1,60 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
+
+    /// <summary>
+    /// How a tilt-calibration replay sources its settings, derived from the user's choice in the shared
+    /// replay-settings modal. Decouples the two independent decisions (which geometry, which star-detection settings)
+    /// that the old two-button UI coupled into a single bool.
+    /// </summary>
+    internal readonly struct TiltReplayMode {
+
+        public TiltReplayMode(bool useMetadataGeometry, bool applyCaptureTimeOverridePerStep, bool updateProfileToCaptureTime) {
+            UseMetadataGeometry = useMetadataGeometry;
+            ApplyCaptureTimeOverridePerStep = applyCaptureTimeOverridePerStep;
+            UpdateProfileToCaptureTime = updateProfileToCaptureTime;
+        }
+
+        /// <summary>Recompute the calibration from the run's stored geometry (true) or the current profile/tilt settings (false).</summary>
+        public bool UseMetadataGeometry { get; }
+
+        /// <summary>Pass the per-step capture-time star-detection snapshot as an in-memory override (true) or use the live profile (false).</summary>
+        public bool ApplyCaptureTimeOverridePerStep { get; }
+
+        /// <summary>Persist the run's capture-time star-detection settings to the live profile before replaying.</summary>
+        public bool UpdateProfileToCaptureTime { get; }
+    }
+
+    internal static class TiltReplayModeResolver {
+
+        /// <summary>
+        /// Maps a <see cref="ReplaySettingsChoice"/> to a <see cref="TiltReplayMode"/>.
+        /// <see cref="ReplaySettingsChoice.Cancel"/> must be handled by the caller before resolving (it has no replay mode).
+        /// </summary>
+        public static TiltReplayMode Resolve(ReplaySettingsChoice choice) {
+            switch (choice) {
+                case ReplaySettingsChoice.UseCurrentSettings:
+                    return new TiltReplayMode(useMetadataGeometry: false, applyCaptureTimeOverridePerStep: false, updateProfileToCaptureTime: false);
+                case ReplaySettingsChoice.UseCaptureTimeSettingsInMemory:
+                    return new TiltReplayMode(useMetadataGeometry: true, applyCaptureTimeOverridePerStep: true, updateProfileToCaptureTime: false);
+                case ReplaySettingsChoice.UpdateProfileToCaptureTime:
+                    return new TiltReplayMode(useMetadataGeometry: true, applyCaptureTimeOverridePerStep: false, updateProfileToCaptureTime: true);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(choice), choice, "Cancel must be handled before resolving a replay mode.");
+            }
+        }
+    }
+}

--- a/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
@@ -276,12 +276,10 @@ namespace TestApp {
             return result;
         }
 
-        private static string ResolveFolder(string folder, string datasetDir) {
-            if (Path.IsPathRooted(folder)) {
-                return folder;
-            }
-            return Path.GetFullPath(Path.Combine(datasetDir, folder));
-        }
+        // Shared with the in-app wizard replay so offline and in-app resolution agree (relative entries rebase onto
+        // the dataset dir; legacy absolute entries are honored as-is).
+        private static string ResolveFolder(string folder, string datasetDir) =>
+            TiltCalibrationMetadata.ResolveStepFolder(datasetDir, folder);
 
         // ---- Optimization (resolve detection params) ------------------------------------------------------
 

--- a/docs/frame-number-picker-design.md
+++ b/docs/frame-number-picker-design.md
@@ -1,0 +1,121 @@
+# Frame-Number Picker in the Review Toolbars — Design
+
+**Status:** Approved (design); implementation plan to follow in `plans/frame-number-picker-plan.md`.
+**Date:** 2026-06-23
+
+## Purpose
+
+Add a drop-down frame picker between the **Prev** and **Next** buttons in each review UI. Its value tracks
+the currently displayed frame, and selecting an entry jumps to that frame. Each entry shows the **1-based
+frame number plus the frame's focuser position** (e.g. `3 — 2745`).
+
+## Where it applies
+
+The three image-with-overlays review controls, each with a Fit / Prev / Next toolbar:
+
+| # | Control | View-model | Toolbar |
+|---|---|---|---|
+| 1 | `AutoFocus/Review/AutoFocusFrameReviewControl.xaml` | `AutoFocusFrameReviewVM : FrameReviewVMBase<…>` | `DockPanel` |
+| 2 | `StarDetection/Optimization/Review/FrameReviewControl.xaml` (Inspector) | `StarDetection/Optimization/Review/FrameReviewVM.cs : FrameReviewVMBase<…>` | `DockPanel` |
+| 3 | `StarDetection/Optimization/Review/StarReviewControl.xaml` | `StarReviewVM` (standalone `BaseINPC`) | `WrapPanel` |
+
+Controls #1 and #2 share the base **`FrameReviewVMBase<TMarker>`** (it owns `CurrentIndex`, `FrameCount`,
+`Prev()/Next()`, `LoadCurrent(bool)`, the 1-based `PositionLabel`). Control #3 is a separate hierarchy but
+has the identical shape (`CurrentIndex`, a private `queue`, `Prev/Next` → `LoadCurrent`, the same
+`PositionLabel`).
+
+## Existing frame model (verified)
+
+- The current frame is a **0-based `int CurrentIndex`** (public getter, non-public setter that raises
+  `PropertyChanged` for itself and `PositionLabel`). It is not two-way bindable as-is.
+- Navigation jumps go through **`LoadCurrent(fit:false)`** (clears markers, calls `LoadFrame(CurrentIndex)`,
+  refreshes Prev/Next `CanExecute`). `fit:false` preserves the user's zoom/pan — Prev/Next and the ◀/▶ keys
+  all use it.
+- The frames themselves are **private** (`snapshot.Frames` for #1/#2, `queue` for #3); each frame exposes a
+  `FocuserPosition`. There is **no** public bindable frames/numbers collection and **no** absolute "jump to N"
+  entry point today — both must be added.
+- `PositionLabel` is already 1-based (`"{CurrentIndex+1} / {FrameCount}"`), so a 1-based picker number is
+  consistent with what the user already sees.
+
+## Approach
+
+### New type: `FramePickerItem`
+
+A small immutable item (in the Review folder/namespace, shared by all three VMs):
+
+```
+public sealed class FramePickerItem {
+    public FramePickerItem(int number, string label) { Number = number; Label = label; }
+    public int Number { get; }    // 1-based frame number; the ComboBox selection value
+    public string Label { get; }  // e.g. "3 — 2745"  (number — focuser position)
+}
+```
+
+### `FrameReviewVMBase` (covers #1 and #2)
+
+- `public IReadOnlyList<FramePickerItem> FramePickerItems { get; protected set; }` — the ComboBox
+  `ItemsSource`. The **subclass** populates it in its ctor (the base has no frame data, only `FrameCount`).
+- `public int SelectedFrameNumber` — the ComboBox `SelectedValue` (1-based):
+  - `get => CurrentIndex + 1;`
+  - `set`: `var idx = value - 1; if (idx in [0, FrameCount) && idx != CurrentIndex) { CurrentIndex = idx;
+    LoadCurrent(fit:false); }` — same sequence as Prev/Next, so zoom/pan is preserved and Prev/Next
+    `CanExecute` refresh.
+- In the existing `CurrentIndex` setter, also `RaisePropertyChanged(nameof(SelectedFrameNumber))` so the
+  dropdown selection follows the Prev/Next buttons and the ◀/▶ keys.
+
+### Subclass ctors (#1 `AutoFocusFrameReviewVM`, #2 `FrameReviewVM`)
+
+After the base ctor runs, build the items from the snapshot, e.g.:
+
+```
+FramePickerItems = snapshot.Frames
+    .Select((f, i) => new FramePickerItem(i + 1, $"{i + 1} — {f.FocuserPosition:0}"))
+    .ToList();
+```
+
+(Frames are already in display order — focuser-sweep order for #1 — so item `N` is the same frame the
+`n / N` label and Prev/Next refer to.)
+
+### `StarReviewVM` (#3, standalone)
+
+The same three additions directly on the VM:
+- `public IReadOnlyList<FramePickerItem> FramePickerItems { get; }` built in the ctor from `queue`
+  (`$"{i + 1} — {f.FocuserPosition}"`; `FocuserPosition` is an `int` here).
+- `public int SelectedFrameNumber` with the same get/jump/guard, using `queue.Count`, the private
+  `CurrentIndex` setter, `LoadCurrent(fitView:false)`, and `Next/PrevCommand.NotifyCanExecuteChanged()`.
+- Add `RaisePropertyChanged(nameof(SelectedFrameNumber))` to the existing `CurrentIndex` setter (so Prev /
+  Next / arrow keys / undo-redo `NavigateTo` all keep the dropdown in sync).
+
+~8 lines duplicated between the base and `StarReviewVM`; acceptable since the two VM hierarchies don't share
+a base and a shared interface would be heavier than the duplication it removes.
+
+### XAML — all three toolbars
+
+Insert a `ComboBox` between Prev and Next (so it renders in that position: `DockPanel.Dock="Left"` after the
+Prev button for #1/#2; plain child after Prev for #3's `WrapPanel`):
+
+```xml
+<ComboBox DockPanel.Dock="Left" Margin="4,0" VerticalAlignment="Center" MinWidth="96"
+          ItemsSource="{Binding FramePickerItems}" DisplayMemberPath="Label"
+          SelectedValuePath="Number" SelectedValue="{Binding SelectedFrameNumber, Mode=TwoWay}" />
+```
+
+Reuse the existing `HF_LightCombo` style where the control already defines it (the dark-panel light-box look
+the other combos use); otherwise a plain `ComboBox` with an explicit foreground/vertical-centering. Drop
+`DockPanel.Dock="Left"` for #3 (`WrapPanel` lays out left-to-right by document order).
+
+## Testing
+
+- Unit-test the `SelectedFrameNumber` jump/guard logic on `FrameReviewVMBase` via a minimal test subclass
+  (generic marker + a trivial `LoadFrame` that records the loaded index): setting `SelectedFrameNumber`
+  moves `CurrentIndex` and triggers a load; out-of-range and equal-value sets are no-ops; `get` returns
+  `CurrentIndex + 1`. (If the base's other members make a test subclass impractical, fall back to verifying
+  the same logic and rely on build + manual for the binding.)
+- The XAML wiring and visual placement are verified by build + manual smoke (the dropdown shows
+  `number — focuser`, tracks Prev/Next and the arrow keys, and jumps on selection).
+
+## Out of scope
+
+No change to Prev/Next behavior, the `n / N` label, frame ordering, zoom/pan on navigation, or the frame
+data model. No new persisted option or `StarDetectorMetrics` field, so those UI-template invariants do not
+apply.

--- a/docs/ui-feedback-prerelease-design.md
+++ b/docs/ui-feedback-prerelease-design.md
@@ -1,0 +1,202 @@
+# Pre-Release UI Feedback — Design
+
+**Status:** Approved (design); implementation plan to follow in `plans/ui-feedback-prerelease-plan.md`.
+**Date:** 2026-06-23
+
+## Purpose
+
+Three pieces of UI feedback to incorporate before the next release:
+
+1. **Review UI layout** — in the review UIs, the header and footer should span the full window
+   width, the right pane (legend) should size to its content height, and the image canvas should take
+   the remaining space.
+2. **Tilt adapter wizard replay** — the wizard currently exposes two replay buttons; with the recently
+   added replay-settings modal ("ReplayVM"), consolidate to a single button driven by that modal.
+3. **AutoFocus button rename** — rename the "Reprocess Saved Run" button to **"Replay Saved AF"**.
+
+This is pre-release polish. The guiding constraint throughout is **lowest-risk change that satisfies
+the feedback**: per-file edits over refactors, no changes to window default sizes, follow existing
+XAML/VM idioms.
+
+---
+
+## Item 1 — Review UI layout
+
+### What exists today
+
+Four "review" surfaces display an image with overlays plus a legend:
+
+| # | Control | Root | Footer? |
+|---|---|---|---|
+| 1 | `AutoFocus/Review/AutoFocusFrameReviewControl.xaml` | `ReviewViewportHostBase` | no |
+| 2 | `StarDetection/Optimization/Review/FrameReviewControl.xaml` (Inspector) | `ReviewViewportHostBase` | no |
+| 3 | `StarDetection/Optimization/Review/StarReviewControl.xaml` | plain `UserControl` | yes (help/counts) |
+| 4 | Optimizer wizard `DataTemplate` (`StarDetection/Optimization/DataTemplates.xaml`) | container; embeds #3 | own header/footer |
+
+All three canvas controls (#1–#3) share one copy-structured idiom: an outer `Grid` (Margin=10) with
+two columns — `Col0 Width="*"` (image area) and `Col1 Width="Auto"` (fixed-width right legend pane) —
+and rows for a header (`Auto`), a toolbar (`Auto`), the image+scrollbars (`*`), and (only in #3) a
+footer (`Auto`). The header, toolbar, and footer are all placed in **`Grid.Column=0` only**, so they
+stretch to the image-column width rather than the full window width. The legend pane is a fixed-width
+element (`230`/`240`) that **`RowSpan`s every row**, so it is allotted the full control height; in #1
+the legend is additionally wrapped in a `ScrollViewer` (`VerticalScrollBarVisibility=Auto`) that forces
+full height + scrolling. The image canvas already occupies a `Height="*"` cell and takes the remaining
+space.
+
+There is **no shared base style / `ResourceDictionary`** governing this row/column layout — the grid is
+duplicated per file.
+
+### Approach (chosen layout)
+
+> Header & footer span the full window width; the **toolbar stays at image-column width**; the legend
+> sizes to its content height (top-aligned); the canvas fills the rest.
+
+Apply a uniform rule **per-file** to #1–#3 (no shared-template refactor pre-release):
+
+- **Header** → top row, `Grid.ColumnSpan="2"` → spans image + legend columns (full width).
+- **Footer** (only #3) → bottom row, `Grid.ColumnSpan="2"` → full width. #1 and #2 have no footer, so
+  nothing is added there.
+- **Toolbar** (Fit / Prev / Next / Close / Undo / Redo) → remains in `Col0` at image-column width.
+- **Legend pane** → drop the all-rows `RowSpan`; place it in the toolbar+image band (`Col1`),
+  `VerticalAlignment="Top"`, so it sizes to its content height. For #1, this also relaxes the
+  `ScrollViewer`'s forced full height: with `VerticalAlignment="Top"` it fits content and only scrolls
+  as an overflow fallback when the legend is taller than the image area.
+- **Canvas** → unchanged; it already fills the remaining `*` cell.
+
+The legend's fixed width (`230`/`240`) is **left as-is** — the feedback is "autosize **vertically**",
+which is a height-only concern.
+
+### Out of scope
+
+- Window default sizes: `AutoFocusFrameReviewControl.xaml.cs` (`1100×720`, mins `640×440`), the
+  `FrameReviewVM` template's `MinWidth=1280`/`MinHeight=860`, and the `ReviewDialogHost` window chrome.
+  These set the initial/min size; resizing is already allowed and the layout fix is what the feedback
+  asks for.
+- The optimizer **wizard's** own fixed per-step width (`Grid.Style` 640/820/1120). Making the wizard
+  stretch to the window is a broader behavior change; out of scope. The wizard's review step still
+  benefits because the embedded `StarReviewControl` (#3) is fixed by this item.
+- No shared layout template / `UserControl` is introduced. (Noted as a possible future cleanup, since
+  the grid is currently duplicated across the three files.)
+
+### Risks
+
+Low. Pure XAML grid attribute changes following the existing idiom. The main thing to watch is that the
+header's right-docked content (e.g. `PositionLabel` in a `LastChildFill=False` `DockPanel`) now docks
+to the full window's right edge — which is the intended "full width" behavior.
+
+---
+
+## Item 2 — Tilt wizard: one replay button + ReplayVM modal (all three choices)
+
+### What exists today
+
+The Tilt Adapter Wizard (`TiltAdapterWizard/DataTemplates.xaml`, VM `TiltAdapterWizardVM.cs`) has two
+buttons, both calling the same `ReplayAsync(useMetadataSettings)`:
+
+- **"Replay"** → `ReplayCommand` → `ReplayAsync(useMetadataSettings: true)`: re-analyzes each
+  calibration step's saved AF frames using the run's **capture-time** star-detection settings (built
+  per step via `BuildTiltReplayDetectionOverride`) and recomputes calibration math from the
+  **metadata** geometry (screw count/radius, pixel size, focuser step, applied amount).
+- **"Replay Current Settings"** → `ReplayCurrentSettingsCommand` → `ReplayAsync(useMetadataSettings:
+  false)`: re-analyzes with the **current** profile star-detection settings (null override) and
+  recomputes from **current** geometry. (Added 2026-06-21.)
+
+The "ReplayVM" referenced in the feedback is **`ReplaySettingsPromptVM`**
+(`AutoFocus/Replay/ReplaySettingsPromptVM.cs`), the view-model for a 3-choice modal introduced
+2026-06-22. It resolves a `ReplaySettingsChoice` ∈ `{ UseCurrentSettings,
+UseCaptureTimeSettingsInMemory, UpdateProfileToCaptureTime, Cancel }`. The AutoFocus pane and the
+Inspector rerun already use it (via `AutoFocusReplayCoordinator.ResolveAsync`) to collapse exactly this
+current-vs-capture-time decision into a single button. The same commit migrated the tilt wizard onto
+the new no-mutation override seam (`BuildTiltReplayDetectionOverride` +
+`AnalyzeAutoFocusFromSavedPath`'s `starDetectionOptionsOverride`) but kept its two pre-existing
+buttons — so the two tilt buttons are now redundant with the modal pattern used everywhere else.
+
+### Approach
+
+Collapse to a **single "Replay" button** whose command drives the **`ReplaySettingsPromptVM`** modal,
+offering all three choices.
+
+- **XAML:** remove the "Replay Current Settings" button; keep the single "Replay" button bound to
+  `ReplayCommand`.
+- **VM:** delete `ReplayCurrentSettingsCommand` (declaration, construction, and its
+  `NotifyCanExecuteChanged` site). `ReplayCommand` no longer hard-codes `useMetadataSettings`. After
+  the folder pick + tilt-metadata load, it shows the modal (reusing `ReplaySettingsPrompt.ShowAsync`)
+  and maps the resolved choice:
+
+  | Choice | Star-detection override | Calibration geometry | Profile mutation |
+  |---|---|---|---|
+  | `UseCurrentSettings` | null (current profile) | current | none |
+  | `UseCaptureTimeSettingsInMemory` | capture-time (per-step `BuildTiltReplayDetectionOverride`) | metadata | none |
+  | `UpdateProfileToCaptureTime` | capture-time | metadata | persist capture-time **star-detection settings** to the live profile |
+  | `Cancel` | — | — | abort |
+
+  `UseCurrentSettings` reproduces the old "Replay Current Settings"; `UseCaptureTimeSettingsInMemory`
+  reproduces the old "Replay". `UpdateProfileToCaptureTime` adds: persist the run's capture-time
+  star-detection settings to the profile (reuse `AutoFocusReplayOptionsMapper` / the snapshot-apply
+  mechanism), then run the capture-time + metadata-geometry path.
+
+- **Reuse the prompt, not the whole coordinator.** `AutoFocusReplayCoordinator` maps to
+  `AutoFocusEngineOptions`, which the tilt path does not use (it calls
+  `inspector.AnalyzeAutoFocusFromSavedPath` + its own `RunCalibrationMath`). So the tilt wizard reuses
+  the **prompt VM/dialog** (and the profile-apply mapper for the update-profile case) while keeping its
+  per-step override lookup and calibration math internal and unchanged. The per-step override remains an
+  internal detail — the modal resolves a single current-vs-capture-time intent for the whole run, which
+  is unchanged from how the two buttons behaved.
+
+### Seams to verify during plan-writing
+
+This is the highest-risk item. The plan must confirm (by reading code) before settling final steps:
+
+1. **DI:** that `TiltAdapterWizardVM` can obtain `IWindowServiceFactory` (and any other deps
+   `ReplaySettingsPrompt.ShowAsync` needs) — it currently uses `profileService` and `HocusFocusPlugin`
+   singletons; `windowServiceFactory` may need to be added to the constructor.
+2. **Metadata compatibility:** that the tilt run's `metadata.json` carries a capture-time
+   star-detection snapshot compatible with the prompt's `CaptureSummary` text and with the
+   profile-apply mapper used by `UpdateProfileToCaptureTime`. A **tilt-specific `CaptureSummary`**
+   variant may be needed (the AF summary is AF-centric).
+3. **Update-profile semantics for tilt:** confirm the profile-apply path writes only star-detection
+   settings (matching the AF behavior) and does **not** touch tilt-adapter geometry options (which are
+   not part of the capture-time snapshot).
+4. **Tests:** `TiltAdapterWizardVMTests` / `TiltAdapterWizardBehavioralTests` reference both commands
+   and must be updated to the single-command + prompt-choice flow.
+
+### Risks
+
+Medium-high relative to the other two items: DI wiring, reusing an AF-centric prompt for tilt, and
+adding profile-mutation semantics to the tilt path. Mitigated by reusing the existing modal + mapper
+rather than inventing new infrastructure, and by the test updates above.
+
+---
+
+## Item 3 — Rename "Reprocess Saved Run" → "Replay Saved AF"
+
+### What exists today
+
+Exactly one button: a `ninactrl:CancellableButton` in `AutoFocus/DataTemplates.xaml` with
+`ButtonText="Reprocess Saved Run"` (line ~620), bound to `LoadSavedAutoFocusRunCommand`. The label is a
+**plain literal** (the HocusFocus project has no `.resx`; localized strings elsewhere use `{ns:Loc …}`).
+Three nearby tooltips reference the old name in prose: the button's own tooltip (~625), the "Review
+Frames" tooltip (~637), and the "Keep frames for review" tooltip (~644).
+
+### Approach
+
+- Change `ButtonText` to **"Replay Saved AF"**.
+- Reword the button's own tooltip ("Reprocesses…" → "Replays saved AutoFocus images…").
+- Update the two cross-reference tooltips (Review Frames, Keep-frames) that name the old button to use
+  "Replay Saved AF".
+- **Leave unchanged:** internal code-behind strings in `HocusFocusVM.cs` (a comment ~961 and
+  log/notification strings ~972/973) — not user-facing. The command name
+  `LoadSavedAutoFocusRunCommand` is not shown to users and does not change.
+
+### Risks
+
+Trivial. Literal text edits in one XAML file.
+
+---
+
+## Close-out
+
+- Run the full unit test suite after implementation (`dotnet test …`) — project invariant. Item 2's VM
+  test updates are part of this item, not an afterthought.
+- No new persisted options or `StarDetectorMetrics` fields are introduced, so the associated UI-template
+  invariants do not apply.

--- a/plans/frame-number-picker-plan.md
+++ b/plans/frame-number-picker-plan.md
@@ -1,0 +1,494 @@
+# Frame-Number Picker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a dropdown frame picker between Prev and Next in all three review toolbars; its value tracks the current frame (showing `number — focuser position`) and selecting an entry jumps to that frame.
+
+**Architecture:** A shared `FramePickerItem { Number, Label }` feeds a `ComboBox`. Controls #1 (AutoFocus) and #2 (Inspector) share `FrameReviewVMBase`, so the picker properties (`FramePickerItems`, two-way `SelectedFrameNumber`) live there once; each subclass fills `FramePickerItems` from its snapshot. Control #3 (`StarReviewVM`, a separate hierarchy) gets the same three additions directly. Selection jumps via the existing `LoadCurrent(fit:false)` path (preserving zoom/pan, identical to Prev/Next).
+
+**Tech Stack:** C# / .NET 8.0-windows, WPF, NUnit 4.4.0, CommunityToolkit.Mvvm.
+
+**Branch:** `ghilios/ui-feedback-prerelease` (the session's review-UI branch). **Design:** `docs/frame-number-picker-design.md`.
+
+**Build/test (WSL → Windows):**
+- Full test: `rtk dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`
+- Filtered test: `rtk dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~FrameReviewVMBaseTests"`
+- Build: `rtk dotnet build Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`
+- NOTE: `rtk dotnet build` prints `fail dotnet build:` in its header even on success — trust `errors=0` + exit 0. Set Bash `timeout` to `600000`.
+
+**Commit command pattern (every commit):**
+```bash
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" -m "<message>
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 1: `FramePickerItem` + `FrameReviewVMBase` picker (TDD)
+
+**Files:**
+- Create: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FramePickerItem.cs`
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVMBase.cs` (CurrentIndex setter ~54-63; insert after PositionLabel ~65)
+- Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/Review/FrameReviewVMBaseTests.cs`
+
+- [ ] **Step 1: Create the `FramePickerItem` type**
+
+Create `FramePickerItem.cs`:
+```csharp
+#region "copyright"
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+#endregion "copyright"
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
+
+    /// <summary>One entry in a review toolbar's frame-number dropdown: the 1-based frame <see cref="Number"/> (the
+    /// ComboBox selection value, tracking the current frame) and a human <see cref="Label"/> like "3 — 2745"
+    /// (number — focuser position).</summary>
+    public sealed class FramePickerItem {
+        public FramePickerItem(int number, string label) {
+            Number = number;
+            Label = label;
+        }
+
+        public int Number { get; }
+        public string Label { get; }
+    }
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `FrameReviewVMBaseTests.cs`:
+```csharp
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Optimization.Review {
+
+    [TestFixture]
+    public class FrameReviewVMBaseTests {
+
+        // Minimal concrete subclass: records LoadFrame calls so jumps are observable without image/UI work.
+        private sealed class TestReviewVM : FrameReviewVMBase<int> {
+            public int LoadedIndex { get; private set; } = -1;
+            public int LoadCount { get; private set; }
+            public TestReviewVM(int frameCount) : base(frameCount) { }
+            protected override void LoadFrame(int index) { LoadedIndex = index; LoadCount++; }
+            protected override IReadOnlyList<StarReviewLegendEntry> BuildLegend() => new List<StarReviewLegendEntry>();
+        }
+
+        [Test]
+        public void SelectedFrameNumber_Get_IsOneBasedCurrentIndex() {
+            var vm = new TestReviewVM(5);
+            Assert.That(vm.SelectedFrameNumber, Is.EqualTo(1));   // CurrentIndex defaults to 0
+        }
+
+        [Test]
+        public void SelectedFrameNumber_Set_JumpsAndLoadsThatFrame() {
+            var vm = new TestReviewVM(5);
+            vm.SelectedFrameNumber = 3;                            // 1-based -> index 2
+            Assert.Multiple(() => {
+                Assert.That(vm.CurrentIndex, Is.EqualTo(2));
+                Assert.That(vm.LoadedIndex, Is.EqualTo(2));
+                Assert.That(vm.SelectedFrameNumber, Is.EqualTo(3));
+            });
+        }
+
+        [TestCase(0)]    // index -1
+        [TestCase(6)]    // index 5 == FrameCount (out of range)
+        [TestCase(99)]
+        public void SelectedFrameNumber_Set_OutOfRange_IsIgnored(int oneBasedValue) {
+            var vm = new TestReviewVM(5);
+            vm.SelectedFrameNumber = 3;                            // move to index 2 first
+            var loadsBefore = vm.LoadCount;
+            vm.SelectedFrameNumber = oneBasedValue;
+            Assert.Multiple(() => {
+                Assert.That(vm.CurrentIndex, Is.EqualTo(2));        // unchanged
+                Assert.That(vm.LoadCount, Is.EqualTo(loadsBefore)); // no reload
+            });
+        }
+
+        [Test]
+        public void SelectedFrameNumber_Set_SameValue_DoesNotReload() {
+            var vm = new TestReviewVM(5);
+            vm.SelectedFrameNumber = 3;
+            var loadsBefore = vm.LoadCount;
+            vm.SelectedFrameNumber = 3;                            // no-op
+            Assert.That(vm.LoadCount, Is.EqualTo(loadsBefore));
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails (compile error — `SelectedFrameNumber` missing)**
+
+Run: `rtk dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~FrameReviewVMBaseTests"`
+Expected: build failure — `FrameReviewVMBase` has no `SelectedFrameNumber`.
+
+- [ ] **Step 4: Add the picker properties to `FrameReviewVMBase`**
+
+In `FrameReviewVMBase.cs`, replace this block (the `CurrentIndex` property through the `PositionLabel` line, ~54-65):
+```csharp
+        private int currentIndex;
+        public int CurrentIndex {
+            get => currentIndex;
+            protected set {
+                if (currentIndex != value) {
+                    currentIndex = value;
+                    RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(PositionLabel));
+                }
+            }
+        }
+
+        public string PositionLabel => FrameCount > 0 ? $"{CurrentIndex + 1} / {FrameCount}" : "0 / 0";
+```
+with:
+```csharp
+        private int currentIndex;
+        public int CurrentIndex {
+            get => currentIndex;
+            protected set {
+                if (currentIndex != value) {
+                    currentIndex = value;
+                    RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(PositionLabel));
+                    RaisePropertyChanged(nameof(SelectedFrameNumber));
+                }
+            }
+        }
+
+        public string PositionLabel => FrameCount > 0 ? $"{CurrentIndex + 1} / {FrameCount}" : "0 / 0";
+
+        /// <summary>Toolbar frame-picker entries (1-based number + focuser-position label). Populated by the subclass,
+        /// the only place with the per-frame focuser positions.</summary>
+        public IReadOnlyList<FramePickerItem> FramePickerItems { get; protected set; }
+
+        /// <summary>Two-way bound by the toolbar frame picker (1-based, matching <see cref="PositionLabel"/>). Selecting
+        /// a frame jumps to it exactly as Prev/Next do — set the index, then LoadCurrent(fit:false) so zoom/pan is
+        /// preserved. Out-of-range and no-op selections are ignored.</summary>
+        public int SelectedFrameNumber {
+            get => CurrentIndex + 1;
+            set {
+                var index = value - 1;
+                if (index >= 0 && index < FrameCount && index != CurrentIndex) {
+                    CurrentIndex = index;
+                    LoadCurrent(fit: false);
+                }
+            }
+        }
+```
+(`IReadOnlyList<>` is already in scope — `using System.Collections.Generic;` at line 13. `FramePickerItem` is in this same namespace.)
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `rtk dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~FrameReviewVMBaseTests"`
+Expected: all `FrameReviewVMBaseTests` pass (6 cases).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FramePickerItem.cs \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVMBase.cs \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/Review/FrameReviewVMBaseTests.cs
+```
+then commit with the standard command, message:
+`feat(review-ui): add frame-picker model to FrameReviewVMBase (SelectedFrameNumber + items)`
+
+---
+
+## Task 2: Build the picker items in the AutoFocus + Inspector VMs
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewVM.cs` (ctor ~101)
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVM.cs` (usings ~19; ctor ~118)
+
+No new test — covered by Task 1's base test + the final manual smoke. These VMs build images and aren't headless-unit-friendly.
+
+- [ ] **Step 1: AutoFocus VM — populate `FramePickerItems` from the snapshot**
+
+In `AutoFocusFrameReviewVM.cs`, replace:
+```csharp
+            this.snapshot = snapshot;
+            this.annotatorOptions = annotatorOptions ?? throw new ArgumentNullException(nameof(annotatorOptions));
+```
+with:
+```csharp
+            this.snapshot = snapshot;
+            FramePickerItems = snapshot.Frames
+                .Select((f, i) => new FramePickerItem(i + 1, $"{i + 1} — {f.FocuserPosition:0}"))
+                .ToList();
+            this.annotatorOptions = annotatorOptions ?? throw new ArgumentNullException(nameof(annotatorOptions));
+```
+(`System.Linq` is already imported — used by `.Any()/.Where()/.ToList()` below. `FramePickerItem` resolves via the base's namespace, already imported since the class derives from `FrameReviewVMBase<…>`.)
+
+- [ ] **Step 2: Inspector VM — add `using System.Linq;`**
+
+In `FrameReviewVM.cs`, replace:
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Windows.Media;
+```
+with:
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Media;
+```
+
+- [ ] **Step 3: Inspector VM — populate `FramePickerItems` from the snapshot**
+
+In `FrameReviewVM.cs`, replace:
+```csharp
+            this.snapshot = snapshot;
+            RebuildLegend();
+```
+with:
+```csharp
+            this.snapshot = snapshot;
+            FramePickerItems = snapshot.Frames
+                .Select((f, i) => new FramePickerItem(i + 1, $"{i + 1} — {f.FocuserPosition:0}"))
+                .ToList();
+            RebuildLegend();
+```
+
+- [ ] **Step 4: Build**
+
+Run: `rtk dotnet build Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`
+Expected: `errors=0`, exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewVM.cs \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVM.cs
+```
+Message: `feat(review-ui): build frame-picker items in AutoFocus + Inspector review VMs`
+
+---
+
+## Task 3: `StarReviewVM` (standalone) picker properties
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs` (ctor ~208; CurrentIndex setter ~230-243)
+
+- [ ] **Step 1: Populate `FramePickerItems` in the ctor**
+
+In `StarReviewVM.cs`, replace:
+```csharp
+            this.queue = queue ?? throw new ArgumentNullException(nameof(queue));
+            this.labelsByRun = labelsByRun ?? throw new ArgumentNullException(nameof(labelsByRun));
+```
+with:
+```csharp
+            this.queue = queue ?? throw new ArgumentNullException(nameof(queue));
+            FramePickerItems = queue
+                .Select((f, i) => new FramePickerItem(i + 1, $"{i + 1} — {f.FocuserPosition}"))
+                .ToList();
+            this.labelsByRun = labelsByRun ?? throw new ArgumentNullException(nameof(labelsByRun));
+```
+(`System.Linq` is already imported at line 18. `FrameReview.FocuserPosition` is an `int`, so no number format. `FramePickerItem` is in this same namespace.)
+
+- [ ] **Step 2: Add the picker properties + sync the picker when CurrentIndex changes**
+
+In `StarReviewVM.cs`, replace:
+```csharp
+        private int currentIndex;
+        public int CurrentIndex {
+            get => currentIndex;
+            private set {
+                if (currentIndex != value) {
+                    currentIndex = value;
+                    RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(PositionLabel));
+                }
+            }
+        }
+
+        public int QueueCount => queue.Count;
+
+        public string PositionLabel => $"{CurrentIndex + 1} / {queue.Count}";
+```
+with:
+```csharp
+        private int currentIndex;
+        public int CurrentIndex {
+            get => currentIndex;
+            private set {
+                if (currentIndex != value) {
+                    currentIndex = value;
+                    RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(PositionLabel));
+                    RaisePropertyChanged(nameof(SelectedFrameNumber));
+                }
+            }
+        }
+
+        public int QueueCount => queue.Count;
+
+        public string PositionLabel => $"{CurrentIndex + 1} / {queue.Count}";
+
+        /// <summary>Toolbar frame-picker entries (1-based number + focuser-position label).</summary>
+        public IReadOnlyList<FramePickerItem> FramePickerItems { get; }
+
+        /// <summary>Two-way bound by the toolbar frame picker (1-based, matching <see cref="PositionLabel"/>). Selecting
+        /// a frame jumps to it the same way Prev/Next do (set index, then LoadCurrent(fitView:false) to preserve
+        /// zoom/pan). Out-of-range and no-op selections are ignored.</summary>
+        public int SelectedFrameNumber {
+            get => CurrentIndex + 1;
+            set {
+                var index = value - 1;
+                if (index >= 0 && index < queue.Count && index != CurrentIndex) {
+                    CurrentIndex = index;
+                    LoadCurrent(fitView: false);
+                }
+            }
+        }
+```
+
+- [ ] **Step 3: Build**
+
+Run: `rtk dotnet build Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`
+Expected: `errors=0`, exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewVM.cs
+```
+Message: `feat(review-ui): add frame-picker model to StarReviewVM`
+
+---
+
+## Task 4: Add the ComboBox to the three toolbars
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml` (toolbar ~127-128)
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml` (toolbar ~131-132)
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml` (toolbar ~121-122)
+
+All three bind `ItemsSource={Binding FramePickerItems}`, `SelectedValuePath="Number"`, `SelectedValue={Binding SelectedFrameNumber, Mode=TwoWay}`, with an explicit black-text `ItemTemplate` (the implicit white `TextBlock` style in these controls would otherwise render the items white-on-light).
+
+- [ ] **Step 1: AutoFocus toolbar — ComboBox between Prev and Next (reuse `HF_LightCombo`)**
+
+In `AutoFocusFrameReviewControl.xaml`, replace:
+```xml
+            <Button DockPanel.Dock="Left" Content="◀ Prev" Command="{Binding PrevCommand}" />
+            <Button DockPanel.Dock="Left" Content="Next ▶" Command="{Binding NextCommand}" />
+```
+with:
+```xml
+            <Button DockPanel.Dock="Left" Content="◀ Prev" Command="{Binding PrevCommand}" />
+            <ComboBox DockPanel.Dock="Left" Margin="4,0" VerticalAlignment="Center" MinWidth="96"
+                      Style="{StaticResource HF_LightCombo}"
+                      ItemsSource="{Binding FramePickerItems}"
+                      SelectedValuePath="Number"
+                      SelectedValue="{Binding SelectedFrameNumber, Mode=TwoWay}">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Foreground="Black" Text="{Binding Label}" />
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+            <Button DockPanel.Dock="Left" Content="Next ▶" Command="{Binding NextCommand}" />
+```
+
+- [ ] **Step 2: Inspector toolbar — ComboBox between Prev and Next**
+
+In `FrameReviewControl.xaml`, replace:
+```xml
+            <Button DockPanel.Dock="Left" Content="◀ Prev" Command="{Binding PrevCommand}" />
+            <Button DockPanel.Dock="Left" Content="Next ▶" Command="{Binding NextCommand}" />
+```
+with:
+```xml
+            <Button DockPanel.Dock="Left" Content="◀ Prev" Command="{Binding PrevCommand}" />
+            <ComboBox DockPanel.Dock="Left" Margin="4,0" VerticalAlignment="Center" MinWidth="96"
+                      ItemsSource="{Binding FramePickerItems}"
+                      SelectedValuePath="Number"
+                      SelectedValue="{Binding SelectedFrameNumber, Mode=TwoWay}">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Foreground="Black" Text="{Binding Label}" />
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+            <Button DockPanel.Dock="Left" Content="Next ▶" Command="{Binding NextCommand}" />
+```
+(If you discover `FrameReviewControl.xaml` already defines an `HF_LightCombo` style in its resources, add `Style="{StaticResource HF_LightCombo}"` to match Step 1; otherwise leave it plain.)
+
+- [ ] **Step 3: Star Detection review toolbar — ComboBox between Prev and Next (WrapPanel, no Dock)**
+
+In `StarReviewControl.xaml`, replace:
+```xml
+            <Button Content="◀ Prev" Command="{Binding PrevCommand}" />
+            <Button Content="Next ▶" Command="{Binding NextCommand}" />
+```
+with:
+```xml
+            <Button Content="◀ Prev" Command="{Binding PrevCommand}" />
+            <ComboBox Margin="4,0" VerticalAlignment="Center" MinWidth="96"
+                      ItemsSource="{Binding FramePickerItems}"
+                      SelectedValuePath="Number"
+                      SelectedValue="{Binding SelectedFrameNumber, Mode=TwoWay}">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Foreground="Black" Text="{Binding Label}" />
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+            <Button Content="Next ▶" Command="{Binding NextCommand}" />
+```
+
+- [ ] **Step 4: Build**
+
+Run: `rtk dotnet build Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`
+Expected: `errors=0`, exit 0 (XAML errors surface as build errors).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+```
+Message: `feat(review-ui): frame-number dropdown between Prev and Next in all three review toolbars`
+
+---
+
+## Task 5: Final verification
+
+- [ ] **Step 1: Full build + test**
+
+Run: `rtk dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`
+Expected: `errors=0`, all tests pass (the 1485 prior + the new `FrameReviewVMBaseTests`).
+
+- [ ] **Step 2: Manual smoke (in NINA, recommended)**
+
+In each review window (AutoFocus Review Frames, Inspector Review Frames, Star Detection review): a dropdown sits between ◀ Prev and Next ▶ showing `number — focuser` (e.g. `3 — 2745`); its value tracks the current frame as you use Prev/Next and the ◀/▶ arrow keys; selecting an entry jumps to that frame without re-fitting zoom/pan.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Dropdown between Prev and Next in all 3 review UIs → Task 4 (all 3 toolbars). ✓
+- Value tracks current frame → `SelectedFrameNumber` get = `CurrentIndex+1`, and the `CurrentIndex` setter raises `SelectedFrameNumber` (Tasks 1 & 3) so it follows Prev/Next/arrow keys. ✓
+- Changing it jumps to the selected frame → `SelectedFrameNumber` setter → `CurrentIndex = index; LoadCurrent(fit:false)` (Tasks 1 & 3). ✓
+- `number — focuser position` label → Tasks 2 & 3 build `FramePickerItem(i+1, "$"{i+1} — {focuser}")`. ✓
+- Project invariant "run the suite" → Tasks 1 & 5. ✓
+
+**Placeholder scan:** every code step shows exact before/after; no TBD/TODO.
+
+**Type consistency:** `FramePickerItem { Number, Label }`, `FramePickerItems` (IReadOnlyList), and `SelectedFrameNumber` (int, 1-based) are referenced identically across the base (Task 1), subclasses (Task 2), `StarReviewVM` (Task 3), and the XAML (`SelectedValuePath="Number"`, `DisplayMemberPath` via `ItemTemplate` on `Label`, `SelectedValue` → `SelectedFrameNumber`). `LoadCurrent` is `fit:` on the base and `fitView:` on `StarReviewVM` — matched to each class's real signature.

--- a/plans/ui-feedback-prerelease-plan.md
+++ b/plans/ui-feedback-prerelease-plan.md
@@ -1,0 +1,704 @@
+# Pre-Release UI Feedback — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Incorporate three pieces of pre-release UI feedback — review-UI layout (header/footer full width, legend fits content, canvas fills the rest), consolidate the tilt wizard's two replay buttons into one driven by the shared replay-settings modal, and rename the AutoFocus "Reprocess Saved Run" button to "Replay Saved AF".
+
+**Architecture:** Items 1 and 3 are pure XAML attribute/text edits. Item 2 reuses the existing `ReplaySettingsPrompt` modal (not the whole `AutoFocusReplayCoordinator`, whose `AutoFocusEngineOptions` output the tilt path doesn't use): the single button shows the modal, a small testable `TiltReplayModeResolver` maps the `ReplaySettingsChoice` to two independent flags (geometry source + per-step star-detection override) plus an optional one-time profile mutation, and `ReplayAsync` consumes those flags.
+
+**Tech Stack:** C# / .NET 8.0-windows, WPF, NUnit 4.4.0 + NSubstitute, CommunityToolkit.Mvvm, MEF.
+
+**Branch:** `ghilios/ui-feedback-prerelease` (already created; the design doc is committed there). All commits use the privacy email — see the commit command in each task.
+
+**Design doc:** `docs/ui-feedback-prerelease-design.md`.
+
+**Build/test commands (WSL → Windows toolchain):**
+- Build: `rtk dotnet build Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`
+  - NOTE: `rtk dotnet build` prints `fail dotnet build: ...` in its header even on success — trust the `errors=0` count and exit code 0, not the header word.
+- Test: `rtk dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`
+- If you need full warning text, re-run via `cmd.exe /c "dotnet build Joko.NINA.Plugins\Joko.NINA.Plugins.sln -c Debug --nologo"`.
+- Set the Bash `timeout` to `600000` for build/test calls.
+
+**Commit command pattern (use for every commit step):**
+```bash
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" -m "<message>
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 1: Item 3 — Rename "Reprocess Saved Run" → "Replay Saved AF"
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml` (lines ~620, ~625, ~637, ~644)
+
+No unit test — these are literal XAML text changes (verified by build). Pure string edits.
+
+- [ ] **Step 1: Rename the button label (line ~620)**
+
+Replace:
+```
+                ButtonText="Reprocess Saved Run"
+```
+with:
+```
+                ButtonText="Replay Saved AF"
+```
+
+- [ ] **Step 2: Reword the button's own tooltip (line ~625)**
+
+Replace:
+```
+                ToolTip="Reprocesses AutoFocus images saved by having Save enabled in Hocus Focus -&gt; Auto Focus Options. This produces an auto focus curve using whatever the current star detection and fit settings are" />
+```
+with:
+```
+                ToolTip="Replays saved AutoFocus images (Save enabled in Hocus Focus -&gt; Auto Focus Options) to produce an auto focus curve using whatever the current star detection and fit settings are" />
+```
+
+- [ ] **Step 3: Update the "Review Frames" cross-reference tooltip (line ~637)**
+
+In the `ToolTip` that begins `"Open the Review Frames window..."`, replace the substring:
+```
+a live run or a Reprocess Saved Run
+```
+with:
+```
+a live run or a Replay Saved AF
+```
+
+- [ ] **Step 4: Update the "Keep frames for review" cross-reference tooltip (line ~644)**
+
+In the `ToolTip` that begins `"When on, the per-frame images..."`, replace the substring:
+```
+a live run or a Reprocess Saved Run
+```
+with:
+```
+a live run or a Replay Saved AF
+```
+
+- [ ] **Step 5: Confirm no stray "Reprocess Saved Run" user-facing strings remain**
+
+Run:
+```bash
+grep -rn "Reprocess Saved Run" Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/
+```
+Expected: no matches (the only remaining "reprocess" references are internal `HocusFocusVM.cs` log/comment strings, which are intentionally left unchanged — verify any hits are those non-UI strings only).
+
+- [ ] **Step 6: Build**
+
+Run: `rtk dotnet build Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`
+Expected: `errors=0`, exit code 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" -m "feat(autofocus-ui): rename Reprocess Saved Run button to Replay Saved AF
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Item 1 — Review UI layout (header/footer full width, legend fits content)
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml` (lines ~113, ~318)
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml` (lines ~112, ~333)
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml` (lines ~111, ~401, ~407)
+
+No unit test — XAML layout (verified by build + manual). The uniform transformation: header (and footer where present) gain `Grid.ColumnSpan="2"` to span the full window width; the legend moves out of the header row to `Grid.Row="1" Grid.RowSpan="2"` and gains `VerticalAlignment="Top"` so it fits its content height; the toolbar and canvas are unchanged.
+
+### AutoFocusFrameReviewControl.xaml (3-row grid, no footer)
+
+- [ ] **Step 1: Make the header span both columns (line ~113)**
+
+Replace:
+```
+        <Border Grid.Row="0" Grid.Column="0" Margin="0,0,0,6" Padding="8,5" CornerRadius="3" Background="#FF262B31">
+```
+with:
+```
+        <Border Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,0,0,6" Padding="8,5" CornerRadius="3" Background="#FF262B31">
+```
+
+- [ ] **Step 2: Move the legend below the full-width header and let it fit its content (line ~318)**
+
+Replace:
+```
+        <ScrollViewer Grid.Row="0" Grid.RowSpan="3" Grid.Column="1" Width="240" Margin="12,0,0,0"
+```
+with:
+```
+        <ScrollViewer Grid.Row="1" Grid.RowSpan="2" Grid.Column="1" VerticalAlignment="Top" Width="240" Margin="12,0,0,0"
+```
+(The `VerticalScrollBarVisibility="Auto"` on the following line stays — it now only scrolls if the legend is taller than the toolbar+image band, instead of forcing full height.)
+
+### FrameReviewControl.xaml (3-row grid, no footer)
+
+- [ ] **Step 3: Make the header span both columns (line ~112)**
+
+Replace:
+```
+        <Border Grid.Row="0" Grid.Column="0" Margin="0,0,0,6" Padding="8,5" CornerRadius="3" Background="#FF262B31">
+```
+with:
+```
+        <Border Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,0,0,6" Padding="8,5" CornerRadius="3" Background="#FF262B31">
+```
+
+- [ ] **Step 4: Move the legend below the full-width header and let it fit its content (line ~333)**
+
+Replace:
+```
+        <StackPanel Grid.Row="0" Grid.RowSpan="3" Grid.Column="1" Width="240" Margin="12,0,0,0">
+```
+with:
+```
+        <StackPanel Grid.Row="1" Grid.RowSpan="2" Grid.Column="1" VerticalAlignment="Top" Width="240" Margin="12,0,0,0">
+```
+
+### StarReviewControl.xaml (4-row grid, has a footer)
+
+- [ ] **Step 5: Make the header span both columns (line ~111)**
+
+Replace:
+```
+        <DockPanel Grid.Row="0" Grid.Column="0" LastChildFill="False" Margin="0,0,0,6">
+```
+with:
+```
+        <DockPanel Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" LastChildFill="False" Margin="0,0,0,6">
+```
+
+- [ ] **Step 6: Make the footer span both columns (line ~401)**
+
+Replace:
+```
+        <StackPanel Grid.Row="3" Grid.Column="0" Margin="0,6,0,0">
+```
+with:
+```
+        <StackPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,6,0,0">
+```
+
+- [ ] **Step 7: Move the legend into the toolbar+image band and let it fit its content (line ~407)**
+
+Replace:
+```
+        <StackPanel Grid.Row="0" Grid.RowSpan="4" Grid.Column="1" Width="230" Margin="12,0,0,0">
+```
+with:
+```
+        <StackPanel Grid.Row="1" Grid.RowSpan="2" Grid.Column="1" VerticalAlignment="Top" Width="230" Margin="12,0,0,0">
+```
+
+- [ ] **Step 8: Build**
+
+Run: `rtk dotnet build Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`
+Expected: `errors=0`, exit code 0. (XAML errors surface as build errors, so a clean build validates the markup.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" -m "feat(review-ui): full-width header/footer and content-height legend
+
+Header (and footer, where present) span both columns to the full window
+width; the legend pane drops its all-rows RowSpan and is top-aligned in the
+toolbar+image band so it sizes to its content. The image canvas continues to
+take the remaining space.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Item 2a (TDD) — `TiltReplayModeResolver` choice mapping
+
+This is the one piece of item 2 with branching logic, and the part the user cares about (all three modes doing the right thing). Extract it into a small `internal` resolver and test it first (the test project reaches `internal` types via `[assembly: InternalsVisibleTo("Joko.NINA.Plugins.HocusFocus.Tests")]`).
+
+**Files:**
+- Create: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltReplayMode.cs`
+- Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltReplayModeResolverTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltReplayModeResolverTests.cs`:
+```csharp
+using System;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
+
+    [TestFixture]
+    public class TiltReplayModeResolverTests {
+
+        [Test]
+        public void UseCurrentSettings_CurrentGeometry_NoOverride_NoMutation() {
+            var mode = TiltReplayModeResolver.Resolve(ReplaySettingsChoice.UseCurrentSettings);
+            Assert.Multiple(() => {
+                Assert.That(mode.UseMetadataGeometry, Is.False);
+                Assert.That(mode.ApplyCaptureTimeOverridePerStep, Is.False);
+                Assert.That(mode.UpdateProfileToCaptureTime, Is.False);
+            });
+        }
+
+        [Test]
+        public void UseCaptureTimeInMemory_MetadataGeometry_PerStepOverride_NoMutation() {
+            var mode = TiltReplayModeResolver.Resolve(ReplaySettingsChoice.UseCaptureTimeSettingsInMemory);
+            Assert.Multiple(() => {
+                Assert.That(mode.UseMetadataGeometry, Is.True);
+                Assert.That(mode.ApplyCaptureTimeOverridePerStep, Is.True);
+                Assert.That(mode.UpdateProfileToCaptureTime, Is.False);
+            });
+        }
+
+        [Test]
+        public void UpdateProfile_MetadataGeometry_NoPerStepOverride_Mutates() {
+            var mode = TiltReplayModeResolver.Resolve(ReplaySettingsChoice.UpdateProfileToCaptureTime);
+            Assert.Multiple(() => {
+                Assert.That(mode.UseMetadataGeometry, Is.True);
+                Assert.That(mode.ApplyCaptureTimeOverridePerStep, Is.False);
+                Assert.That(mode.UpdateProfileToCaptureTime, Is.True);
+            });
+        }
+
+        [Test]
+        public void Cancel_Throws() {
+            Assert.Throws<ArgumentOutOfRangeException>(() => TiltReplayModeResolver.Resolve(ReplaySettingsChoice.Cancel));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails (does not compile — type missing)**
+
+Run: `rtk dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`
+Expected: build/compile failure — `TiltReplayModeResolver` / `TiltReplayMode` do not exist yet.
+
+- [ ] **Step 3: Implement the resolver**
+
+Create `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltReplayMode.cs`:
+```csharp
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
+
+    /// <summary>
+    /// How a tilt-calibration replay sources its settings, derived from the user's choice in the shared
+    /// replay-settings modal. Decouples the two independent decisions (which geometry, which star-detection settings)
+    /// that the old two-button UI coupled into a single bool.
+    /// </summary>
+    internal readonly struct TiltReplayMode {
+
+        public TiltReplayMode(bool useMetadataGeometry, bool applyCaptureTimeOverridePerStep, bool updateProfileToCaptureTime) {
+            UseMetadataGeometry = useMetadataGeometry;
+            ApplyCaptureTimeOverridePerStep = applyCaptureTimeOverridePerStep;
+            UpdateProfileToCaptureTime = updateProfileToCaptureTime;
+        }
+
+        /// <summary>Recompute the calibration from the run's stored geometry (true) or the current profile/tilt settings (false).</summary>
+        public bool UseMetadataGeometry { get; }
+
+        /// <summary>Pass the per-step capture-time star-detection snapshot as an in-memory override (true) or use the live profile (false).</summary>
+        public bool ApplyCaptureTimeOverridePerStep { get; }
+
+        /// <summary>Persist the run's capture-time star-detection settings to the live profile before replaying.</summary>
+        public bool UpdateProfileToCaptureTime { get; }
+    }
+
+    internal static class TiltReplayModeResolver {
+
+        /// <summary>
+        /// Maps a <see cref="ReplaySettingsChoice"/> to a <see cref="TiltReplayMode"/>.
+        /// <see cref="ReplaySettingsChoice.Cancel"/> must be handled by the caller before resolving (it has no replay mode).
+        /// </summary>
+        public static TiltReplayMode Resolve(ReplaySettingsChoice choice) {
+            switch (choice) {
+                case ReplaySettingsChoice.UseCurrentSettings:
+                    return new TiltReplayMode(useMetadataGeometry: false, applyCaptureTimeOverridePerStep: false, updateProfileToCaptureTime: false);
+                case ReplaySettingsChoice.UseCaptureTimeSettingsInMemory:
+                    return new TiltReplayMode(useMetadataGeometry: true, applyCaptureTimeOverridePerStep: true, updateProfileToCaptureTime: false);
+                case ReplaySettingsChoice.UpdateProfileToCaptureTime:
+                    return new TiltReplayMode(useMetadataGeometry: true, applyCaptureTimeOverridePerStep: false, updateProfileToCaptureTime: true);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(choice), choice, "Cancel must be handled before resolving a replay mode.");
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `rtk dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`
+Expected: all `TiltReplayModeResolverTests` pass; whole suite still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltReplayMode.cs \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltReplayModeResolverTests.cs
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" -m "feat(tilt-wizard): add TiltReplayModeResolver mapping replay choice to mode
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Item 2b — Single "Replay" button driving the shared modal
+
+Wire the consolidated button: add the window-service factory, reshape `ReplayAsync` to show the modal + resolve the mode + optionally mutate the profile, rewire the per-step override / geometry / warning to the mode flags, remove the second command, and delete the second XAML button.
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs` (using ~16; field ~69; ctor ~170-171; `ReplayAsync` ~1130-1282; command decl ~485-486; notify ~1436-1437)
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml` (buttons ~312-330)
+
+- [ ] **Step 1: Add the `WindowService` using (after line ~16)**
+
+Replace:
+```
+using NINA.Core.Utility.Notification;
+```
+with:
+```
+using NINA.Core.Utility.Notification;
+using NINA.Core.Utility.WindowService;
+```
+
+- [ ] **Step 2: Add the window-service-factory field (after the `applicationDispatcher` field, line ~69)**
+
+Replace:
+```
+        private readonly IApplicationDispatcher applicationDispatcher;
+        private readonly IProgress<ApplicationStatus> progress;
+```
+with:
+```
+        private readonly IApplicationDispatcher applicationDispatcher;
+        // WindowServiceFactory is not a MEF export (NINA exposes the concrete type with a default ctor only), so it is
+        // constructed directly, matching InspectorVM / HocusFocusVM. Used to show the shared replay-settings modal.
+        private readonly IWindowServiceFactory windowServiceFactory = new WindowServiceFactory();
+        private readonly IProgress<ApplicationStatus> progress;
+```
+
+- [ ] **Step 3: Collapse the two replay commands to one in the constructor (lines ~170-171)**
+
+Replace:
+```
+            ReplayCommand = new AsyncRelayCommand(() => ReplayAsync(useMetadataSettings: true), () => !IsWizardRunning && !IsMeasuring);
+            ReplayCurrentSettingsCommand = new AsyncRelayCommand(() => ReplayAsync(useMetadataSettings: false), () => !IsWizardRunning && !IsMeasuring);
+```
+with:
+```
+            ReplayCommand = new AsyncRelayCommand(ReplayAsync, () => !IsWizardRunning && !IsMeasuring);
+```
+
+- [ ] **Step 4: Remove the second command declaration (lines ~485-486)**
+
+Replace:
+```
+        public ICommand ReplayCommand { get; }
+        public ICommand ReplayCurrentSettingsCommand { get; }
+```
+with:
+```
+        public ICommand ReplayCommand { get; }
+```
+
+- [ ] **Step 5: Remove the second command's `NotifyCanExecuteChanged` (lines ~1436-1437)**
+
+Replace:
+```
+            ((AsyncRelayCommand)ReplayCommand).NotifyCanExecuteChanged();
+            ((AsyncRelayCommand)ReplayCurrentSettingsCommand).NotifyCanExecuteChanged();
+```
+with:
+```
+            ((AsyncRelayCommand)ReplayCommand).NotifyCanExecuteChanged();
+```
+
+- [ ] **Step 6: Update the `ReplayAsync` doc comment + signature (lines ~1130-1138)**
+
+Replace:
+```
+        // ---- Replay -----------------------------------------------------------------------------------------
+
+        // Replays a saved calibration run from a folder: reads metadata.json, re-analyzes each step from its saved
+        // frames, and recomputes the calibration.
+        // - useMetadataSettings = true ("Replay"): apply the run's stored star-detection settings transiently
+        //   (restored afterward) and use the run's stored geometry — reproduces the original calibration exactly.
+        // - useMetadataSettings = false ("Replay Current Settings"): leave the current profile's star-detection and
+        //   tilt-calibration settings in place, so metadata.json does not override what is configured now.
+        private async Task ReplayAsync(bool useMetadataSettings) {
+```
+with:
+```
+        // ---- Replay -----------------------------------------------------------------------------------------
+
+        // Replays a saved calibration run from a folder: reads metadata.json, re-analyzes each step from its saved
+        // frames, and recomputes the calibration. A single "Replay" button opens the shared replay-settings modal,
+        // which offers three modes (see TiltReplayModeResolver):
+        // - Use current settings: current profile star-detection + current tilt geometry (metadata does not override).
+        // - Use capture-time settings in memory: the run's stored star-detection as a transient per-step override
+        //   (profile untouched) + the run's stored geometry — reproduces the original calibration exactly.
+        // - Update profile to capture-time: persist the run's star-detection settings to the live profile, then replay
+        //   against it + the run's stored geometry.
+        private async Task ReplayAsync() {
+```
+
+- [ ] **Step 7: Insert the modal + mode resolution + optional profile mutation (after the per-step presence check, before the screw-count warning, line ~1175)**
+
+Find this existing block (the `byStep` presence-check loop ending at line ~1174) and insert the new block immediately after its closing `}` and before the `// "Replay Current Settings" applies...` comment:
+```
+            foreach (var step in MeasurementSteps) {
+                if (!byStep.ContainsKey(step.ToString())) {
+                    Notification.ShowError($"metadata.json has no saved folder for step '{step}'. Cannot replay.");
+                    return;
+                }
+            }
+
+            // "Replay Current Settings" applies the current screw geometry to the saved deltas; if the saved run
+```
+Replace it with (adds the modal/mode block in the gap, and rewords the warning comment + condition):
+```
+            foreach (var step in MeasurementSteps) {
+                if (!byStep.ContainsKey(step.ToString())) {
+                    Notification.ShowError($"metadata.json has no saved folder for step '{step}'. Cannot replay.");
+                    return;
+                }
+            }
+
+            // Consolidated replay: one button, three modes resolved by the shared replay-settings modal (seeded from a
+            // representative per-step AutoFocus replay snapshot). Cancelling / closing the modal aborts.
+            var representativeStepFolder = byStep[MeasurementSteps.First().ToString()];
+            AutoFocusReplayMetadata.TryLoad(representativeStepFolder, out var replayMetadata, out _);
+            var choice = await ReplaySettingsPrompt.ShowAsync(windowServiceFactory, replayMetadata);
+            if (choice == ReplaySettingsChoice.Cancel) {
+                return;
+            }
+            var mode = TiltReplayModeResolver.Resolve(choice);
+
+            // "Update profile to capture-time": persist the run's capture-time star-detection settings to the live
+            // profile, then replay against it (no per-step override needed). ApplyFullSnapshot raises INPC -> UI thread.
+            if (mode.UpdateProfileToCaptureTime) {
+                var captureSnapshot = BuildTiltReplayDetectionOverride(representativeStepFolder, metadata);
+                if (captureSnapshot != null) {
+                    OnUIThread(() => HocusFocusPlugin.StarDetectionOptions?.ApplyFullSnapshot(captureSnapshot));
+                }
+            }
+
+            // Replaying with current geometry applies the current screw count to the saved deltas; if the saved run
+```
+
+- [ ] **Step 8: Rewire the screw-count-mismatch warning condition (line ~1178)**
+
+Replace:
+```
+            if (!useMetadataSettings && metadata.NumberOfScrews != tiltAdapterOptions.ScrewCount) {
+```
+with:
+```
+            if (!mode.UseMetadataGeometry && metadata.NumberOfScrews != tiltAdapterOptions.ScrewCount) {
+```
+
+- [ ] **Step 9: Rewire the per-step detection override (lines ~1205-1210)**
+
+Replace:
+```
+                    // No-mutation replay: when using the run's stored settings, pass a detached capture-time
+                    // star-detection snapshot as an override so the profile is never modified (and never needs
+                    // restoring). "Replay Current Settings" passes null and uses the current profile settings.
+                    var detectionOverride = useMetadataSettings
+                        ? BuildTiltReplayDetectionOverride(byStep[step.ToString()], metadata)
+                        : null;
+```
+with:
+```
+                    // Capture-time-in-memory replay passes a detached per-step star-detection snapshot as an override so
+                    // the profile is never touched. "Use current settings" and "update profile" both pass null (the
+                    // latter has already mutated the live profile to the capture-time settings).
+                    var detectionOverride = mode.ApplyCaptureTimeOverridePerStep
+                        ? BuildTiltReplayDetectionOverride(byStep[step.ToString()], metadata)
+                        : null;
+```
+
+- [ ] **Step 10: Rewire the geometry selection (line ~1241)**
+
+Replace:
+```
+                if (useMetadataSettings) {
+                    calibrationAppliedAmount = metadata.CalibrationAppliedAmount;
+```
+with:
+```
+                if (mode.UseMetadataGeometry) {
+                    calibrationAppliedAmount = metadata.CalibrationAppliedAmount;
+```
+
+- [ ] **Step 11: Update the `finally` comment (lines ~1271-1273)**
+
+Replace:
+```
+            } finally {
+                // No profile mutation to undo: capture-time detection settings are passed to the replay as an
+                // in-memory override (see BuildTiltReplayDetectionOverride), so the user's profile is never touched.
+                isReplaying = false;
+```
+with:
+```
+            } finally {
+                // "Use capture-time in memory" passes detection settings as an in-memory override, so nothing is undone.
+                // "Update profile to capture-time" intentionally persisted the capture-time settings to the profile (the
+                // user opted in via the modal), so it is likewise not restored.
+                isReplaying = false;
+```
+
+- [ ] **Step 12: Remove the second XAML button and reword the surviving "Replay" tooltip (DataTemplates.xaml, lines ~312-330)**
+
+Replace:
+```
+                        <Button
+                            Margin="6,0,0,0"
+                            Command="{Binding ReplayCommand}"
+                            ToolTip="Replay a saved calibration run from a folder containing metadata.json. Uses the run's stored star-detection and tilt-calibration settings (restoring your settings afterward).">
+                            <TextBlock
+                                Margin="10,5,10,5"
+                                Foreground="{StaticResource ButtonForegroundBrush}"
+                                Text="Replay" />
+                        </Button>
+                        <Button
+                            Margin="6,0,0,0"
+                            Command="{Binding ReplayCurrentSettingsCommand}"
+                            ToolTip="Replay a saved calibration run using your CURRENT star-detection and tilt-calibration settings instead of the ones stored in metadata.json. Your profile settings are left unchanged.">
+                            <TextBlock
+                                Margin="10,5,10,5"
+                                Foreground="{StaticResource ButtonForegroundBrush}"
+                                Text="Replay Current Settings" />
+                        </Button>
+```
+with:
+```
+                        <Button
+                            Margin="6,0,0,0"
+                            Command="{Binding ReplayCommand}"
+                            ToolTip="Replay a saved calibration run from a folder containing metadata.json. Choose how in the prompt: your current settings, the run's capture-time settings held in memory (profile untouched), or after updating your profile to the run's capture-time settings.">
+                            <TextBlock
+                                Margin="10,5,10,5"
+                                Foreground="{StaticResource ButtonForegroundBrush}"
+                                Text="Replay" />
+                        </Button>
+```
+
+- [ ] **Step 13: Confirm no dangling references to the removed command**
+
+Run:
+```bash
+grep -rn "ReplayCurrentSettingsCommand\|useMetadataSettings" Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/
+```
+Expected: no matches (the command is gone and the bool parameter is fully replaced by `mode.*`).
+
+- [ ] **Step 14: Build**
+
+Run: `rtk dotnet build Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`
+Expected: `errors=0`, exit code 0. If `IWindowServiceFactory`/`WindowServiceFactory` is unresolved, re-check the Step 1 using (`NINA.Core.Utility.WindowService`).
+
+- [ ] **Step 15: Run the full test suite**
+
+Run: `rtk dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`
+Expected: all tests pass (existing `TiltAdapterWizardVMTests` still build/pass — they construct the VM via the unchanged 7-arg constructor; the new `windowServiceFactory` is a field initializer like the one InspectorVM already uses headlessly in `BuildInspector()`).
+
+- [ ] **Step 16: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" -m "feat(tilt-wizard): consolidate two replay buttons into one using ReplayVM modal
+
+Replace the separate Replay / Replay Current Settings buttons with a single
+Replay button that opens the shared replay-settings modal (ReplaySettingsPrompt).
+The chosen ReplaySettingsChoice maps via TiltReplayModeResolver to current vs
+capture-time geometry, an optional per-step in-memory star-detection override,
+and (new for tilt) an opt-in profile update to the run's capture-time settings.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Final verification
+
+- [ ] **Step 1: Full clean build + test**
+
+Run: `rtk dotnet build Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo` then
+`rtk dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`
+Expected: `errors=0`, all tests pass.
+
+- [ ] **Step 2: Manual smoke check (in NINA, optional but recommended pre-release)**
+
+Because items 1 and 3 are not unit-testable, verify visually if a NINA session is available:
+- AutoFocus pane: the button reads **"Replay Saved AF"**; its tooltip and the Review-Frames / Keep-frames tooltips read "Replay Saved AF".
+- Review windows (AutoFocus Review Frames, Inspector Review Frames, Star Detection review): resize the window — header (and the Star-Detection-review footer) stretch to the full width; the legend pane sits at the top and is only as tall as its content; the image fills the rest.
+- Tilt Adapter Wizard: a single **"Replay"** button; clicking it (after picking a saved run folder) shows the Replay Settings modal with the three choices, and each behaves per its label.
+
+- [ ] **Step 3: Push and open the PR** (only when the user asks to publish)
+
+```bash
+git push -u origin ghilios/ui-feedback-prerelease
+gh pr create --base develop --head ghilios/ui-feedback-prerelease \
+  --title "Pre-release UI feedback: review layout, tilt replay consolidation, AF rename" \
+  --body "$(cat <<'EOF'
+Incorporates three pieces of pre-release UI feedback.
+
+1. **Review UIs** — header (and footer, where present) span the full window width; the legend pane is top-aligned and sizes to its content; the image canvas takes the remaining space. (AutoFocusFrameReviewControl, FrameReviewControl, StarReviewControl.)
+2. **Tilt Adapter Wizard** — the two replay buttons collapse into one that drives the shared replay-settings modal (`ReplaySettingsPrompt`); `TiltReplayModeResolver` maps the choice to geometry/override/profile-update behavior.
+3. **AutoFocus** — "Reprocess Saved Run" button renamed to "Replay Saved AF" (label + related tooltips).
+
+Design: `docs/ui-feedback-prerelease-design.md`. Plan: `plans/ui-feedback-prerelease-plan.md`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review (against the design doc)
+
+**Spec coverage:**
+- Item 1 (header/footer full width, legend fits content, canvas fills rest) → Task 2 (all three controls; header+footer `ColumnSpan=2`, legend `Row=1 RowSpan=2 VerticalAlignment=Top`). ✓
+- Item 2 (one button + ReplayVM modal, all three choices incl. profile update) → Tasks 3 (resolver, TDD) + 4 (modal wiring, profile mutation via `ApplyFullSnapshot`, command/XAML removal). ✓
+- Item 3 (rename + tooltips) → Task 1 (label + own tooltip + two cross-reference tooltips). ✓
+- Project invariant "run the full suite" → Tasks 3/4/5 run `dotnet test`. ✓
+
+**Placeholder scan:** every code step shows the exact before/after text; no TBD/TODO. ✓
+
+**Type consistency:** `TiltReplayMode` properties (`UseMetadataGeometry`, `ApplyCaptureTimeOverridePerStep`, `UpdateProfileToCaptureTime`) and `TiltReplayModeResolver.Resolve` are referenced identically in the resolver (Task 3), the tests (Task 3), and `ReplayAsync` (Task 4 steps 7–10). `ReplaySettingsPrompt.ShowAsync(IWindowServiceFactory, AutoFocusReplayMetadata)`, `AutoFocusReplayMetadata.TryLoad`, `BuildTiltReplayDetectionOverride`, and `StarDetectionOptions.ApplyFullSnapshot(IStarDetectionOptions)` match the verified signatures. ✓
+
+**Scope notes (carried from the design):** window default sizes, the optimizer wizard's fixed per-step width, the legend's fixed widths (230/240), and internal `HocusFocusVM.cs` reprocess log/comment strings are intentionally untouched.


### PR DESCRIPTION
## Summary

A batch of review-UI improvements (all on the review / auto-focus surfaces).

1. **Review UI layout** — header (and footer, where present) span the full window width; the legend pane is top-aligned and sizes to its content; the image canvas takes the remaining space. (`AutoFocusFrameReviewControl`, `FrameReviewControl`, `StarReviewControl`.)
2. **Tilt wizard — replay consolidation** — the two replay buttons collapse into one that drives the shared replay-settings modal (`ReplaySettingsPrompt`); `TiltReplayModeResolver` maps the choice to geometry / per-step star-detection override / opt-in profile update.
3. **AutoFocus rename** — "Reprocess Saved Run" → "Replay Saved AF" (label + related tooltips).
4. **Tilt replay — path portability** — saved runs now record each step's folder **relative to the run root**, and replay resolves folders against the selected run directory, so a run copied/moved to another path or machine still replays. Legacy absolute paths are honored as-is. Shared `TiltCalibrationMetadata.ToRelativeStepFolder` / `ResolveStepFolder`; the headless `TestApp` resolver delegates to the same helper.
5. **Frame-number picker** — a dropdown between Prev and Next in all three review toolbars, showing `number — focuser position` (e.g. `3 — 2745`). Its value tracks the current frame (follows Prev/Next and the ◀/▶ keys) and selecting an entry jumps to that frame, preserving zoom/pan.

Design/plan docs accompany each item under `docs/` and `plans/`.

## Test Plan

- [x] Full unit suite green (`dotnet test` — 1492 passed, 0 failed)
- [x] New unit tests: `TiltReplayModeResolver` (3 modes + Cancel), `TiltCalibrationMetadata` relative/resolve round-trip, `FrameReviewVMBase.SelectedFrameNumber` jump/guard + Prev→notify
- [ ] Manual (in NINA): full-width header/footer + content-height legend on resize; AF button reads "Replay Saved AF"; tilt wizard shows one Replay button with the 3-choice modal; a moved/copied tilt run replays; the frame dropdown shows `n — focuser`, tracks Prev/Next/arrows, and jumps on selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
