### PR TITLE
Adaptive NoiseClippingMultiplier (spatially-adaptive binarization) — default ON

### DIFF
--- a/.claude/skills/generating-af-golden-data/SKILL.md
+++ b/.claude/skills/generating-af-golden-data/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: generating-af-golden-data
+description: Use when building or refreshing the detector-independent golden star reference (per-image *.golden.json) for AF-bank runs — the recall/precision ground truth that bank-verify / golden eval score against. Covers snr_ref + montage + LLM QA + build_goldens, including the rate-limit and XISF/Bayer gotchas.
+---
+
+# Generating AF golden data
+
+## Overview
+
+The golden set is a **detector-independent** reference of the real stars in each AF frame, stored per image as
+`<frame>.golden.json` (`{imageFile, focuserPosition, stars:[{x,y,w,h,confidence}]}`) beside the frame. It is the
+ground truth `bank-verify` / `golden eval` score recall/precision against. Built once and reused across detector
+configs (it does not depend on detector settings). Tools live in `tools/golden/`.
+
+**Method:** an independent SNR/connected-component detector on the *linear* frame (`snr_ref.py`, different blind
+spots than HF) → **auto-confirm the SNR≥12 high tier** (real after saturation-masking + area filtering; this is the
+recall@≥12 reference) → **LLM montage-QA only a bounded slice of the uncertain SNR<12 tier** (for precision) →
+assemble. Do NOT build the reference by pure LLM vision de-novo (see `.claude/docs/golden-star-set.md` for why).
+
+## Environment / prerequisites
+
+- **Windows + WSL** (TestApp is a Windows exe; Python tools run in WSL). **Run `bank-donut-meta` first** (the
+  running-af-bank-validation skill) so each run's `run_meta.json` carries `donutAware` — that flag decides which
+  runs need snr_ref `--donut`.
+- **NINA profile**: `export-linear` loads the active NINA profile (it uses NINA's XISF/Bayer loader); pass
+  `--profile-id <guid>` if there's no active profile.
+- **Python deps**: needs `numpy` + `scipy` + `Pillow`. Bare WSL often lacks pip — bootstrap:
+  `curl -sSL https://bootstrap.pypa.io/get-pip.py | python3 - --user` then `python3 -m pip install --user numpy scipy Pillow`.
+- **The bank loop + `<runtag>` convention**: runs are `attempt*` folders holding `*_Focuser<NNNN>.fits/.xisf`
+  frames. `<runtag>` = the run's path relative to the bank root with `/` and spaces → `_`
+  (e.g. `mufti/AutoFocus_.../attempt01` → `mufti_AutoFocus_..._attempt01`). `--snr-dir`, `--qa-dir`, and
+  `golden_prep`'s `--out` must all use the same `$SP/<runtag>`.
+
+## Pipeline
+
+```bash
+SP=<scratch>/golden_gen ; BANK="D:\Autofocus Bank" ; BANKW=/mnt/d/Autofocus\ Bank
+EXE=./Joko.NINA.Plugins/TestApp/bin/Debug/net8.0-windows7.0/TestApp.exe
+python3 -c "import numpy,scipy; from PIL import Image" || python3 -m pip install --user numpy scipy Pillow
+
+# 1. Linear mono FITS for XISF/Bayered runs (snr_ref reads ONLY mono FITS; NINA loader reads XISF + debayers).
+$EXE export-linear --runs "$BANK"        # writes <frame>.linear.fits beside each frame (skip-existing)
+
+# 2. Per run (loop attempt folders): snr_ref + bounded uncertain-tier montages.
+find "$BANKW" -type d -iname 'attempt*' | while read d; do
+  runtag=$(echo "$d" | sed "s#$BANKW/##; s#[/ ]#_#g")
+  donut=""; grep -q '"donutAware": true' "$d/run_meta.json" 2>/dev/null && donut="--donut --sat-radius 60"
+  python3 tools/golden/golden_prep.py --run-dir "$d" --out "$SP/$runtag" $donut --budget-montages 4
+done                                     # -> per run: snr_<foc>.json, f<foc>/montage_*.png, manifest.json
+
+# 3. Compact QA worklist across all prepped runs (small enough to pass inline as Workflow args).
+python3 tools/golden/build_qa_worklist.py --scratch-root "$SP" --out worklist.json --max-montages-per-frame 4
+
+# 4. LLM montage QA — invoke the Workflow TOOL (not bash). MUST chunk to dodge rate-limiting (gotcha #1):
+#       Workflow({ scriptPath: "tools/golden/qa_workflow.js", args: <contents of worklist.json with "chunk":4 added> })
+#    args is the worklist OBJECT itself ({base,grid,runs}) + chunk — NOT a file path (Workflow scripts can't read
+#    files). Each montage agent returns {"real":[cells], "donut":[cells]}; the script maps cells->global indices and
+#    returns { byKey: { "<runtag> <foc>": {confirmed:[...], donut:[...]} } }. Extract that byKey from the workflow's
+#    task .output JSON (result.byKey) and write it to qa_result.json.
+
+# 5. Persist QA + assemble goldens (auto-confirms SNR>=12 + unions QA-confirmed uncertain), looping runs again.
+python3 tools/golden/persist_qa.py --bykey qa_result.json --scratch-root "$SP"   # -> qa_<foc>.json per run
+for man in "$SP"/*/manifest.json; do
+  rundir=$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['runDir'])" "$man"); runtag=$(basename "$(dirname "$man")")
+  python3 tools/golden/build_goldens.py --run-dir "$rundir" --snr-dir "$SP/$runtag" --qa-dir "$SP/$runtag" --auto-confirm-snr 12
+done                                     # -> <frame>.golden.json sidecars beside the frames
+```
+
+Confidence tiers: SNR ≥12 high, 8–12 medium, 5–8 low. `golden_prep` writes the run's source dir into
+`manifest.json` (`runDir`), so step 5 recovers each run path from there.
+
+## Gotchas (hard-won)
+
+- **Server-side rate-limiting throttles image-heavy QA.** The default ~16-way workflow concurrency trips
+  "Server is temporarily limiting requests (not your usage limit)" after ~50–100 montage reads and most agents
+  fail. **FIX: run the QA in small SEQUENTIAL chunks** — `qa_workflow.js` takes `chunk` in args (use **4**); it
+  processes 4-at-a-time so it never bursts the limiter (488 montages completed with **0** failures at chunk=4 vs
+  hundreds of failures at 16). Don't run two image-heavy workflows at once.
+- **Half the bank is XISF and some FITS are Bayered (e.g. timmer).** `snr_ref.py` parses ONLY mono FITS.
+  `export-linear` MUST run first — it uses NINA's loader (reads XISF, debayers Bayer to luminance) and writes a
+  mono FITS the reference can read. `golden_prep` prefers `<frame>.linear.fits`, falling back to a mono `.fits`
+  original.
+- **Wide-field/deep frames have 10k–100k candidates** → QA-ing the whole uncertain tier is infeasible (~40k
+  montages bank-wide). The design is **bounded on purpose**: auto-confirm the SNR≥12 high tier (no QA), and LLM-QA
+  only the top ~4 montages/frame of the uncertain tier (highest-SNR-first). **Consequence:** recall@SNR≥12 is exact
+  everywhere, but **precision is a lower bound** on deep runs whose uncertain tier is under-sampled. State this when
+  reporting precision.
+- **Workflow args must be COMPACT.** A per-montage worklist (paths + 36-int maps) is too big to inline. Because
+  `golden_prep` renders the uncertain montages contiguously, a cell's global index = `b + montage*36 + cell` where
+  `b` = the frame's high-tier count. So `build_qa_worklist` emits only `{base, runs:[{tag, frames:[{foc, n, b}]}]}`
+  (~6 KB for the whole bank) and `qa_workflow.js` reconstructs montage paths + indices itself.
+- **Workflow scripts have no filesystem access** — everything the script needs comes via `args`; agents read the
+  montage PNGs with the Read tool. `qa_workflow.js` also defensively `JSON.parse`s string args (the runtime
+  sometimes delivers args as a JSON string → otherwise `args.work` is empty and 0 agents run).
+- **Python env is bare in WSL** — no pip/scipy/Pillow by default. Bootstrap: download `get-pip.py`
+  (`bootstrap.pypa.io`), `python3 get-pip.py --user`, `pip install --user scipy Pillow` (network works).
+- **snr_ref `--donut` is slow** (multi-scale matched filter on the full frame, ~1 min/frame); budget ~75 min for
+  the bank's compute (export-linear + snr_ref + montage render). It's all detector-independent → cache it.
+- **Driver-loop pitfall:** a shell `ls a.fits b.xisf` test to detect frames returns non-zero if EITHER glob has no
+  match, silently skipping pure-mono-FITS runs. Let `golden_prep` discover frames, or test each glob separately.
+
+## Reference
+
+- Method + the "pure-vision doesn't work" lesson: `.claude/docs/golden-star-set.md`.
+- Tools: `tools/golden/{snr_ref,qa_montage,golden_prep,build_qa_worklist,persist_qa,build_goldens}.py`,
+  `qa_workflow.js`, `README.md`.
+- Consumer of the goldens: the **running-af-bank-validation** skill.

--- a/.claude/skills/running-af-bank-validation/SKILL.md
+++ b/.claude/skills/running-af-bank-validation/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: running-af-bank-validation
+description: Use when verifying HocusFocus star-detector recall/precision, autofocus fit, or sensor-model fit across the saved AF-run bank, regression-comparing a detector change, or sweeping NoiseClippingMultiplier — i.e. running TestApp bank-verify / bank-clean / bank-donut-meta over "D:\Autofocus Bank".
+---
+
+# Running AF-bank validation
+
+## Overview
+
+`TestApp bank-verify` measures the star detector against a detector-independent golden set across every run in the
+AF bank, per run × config, and writes a timestamped regression report to the bank root
+(`verification_<UTC>.{json,md}`, schema `afbank-verify/2`). Configs: **C0** (as-default, swept over
+NoiseClippingMultiplier), **A** (optimized donut-off), **B** (optimized donut-on). Use it to confirm a detector
+change (e.g. an NC default, a new gate) helps bank-wide, not just on one frame.
+
+**Prerequisite:** the golden set must already exist (per-image `*.golden.json` beside the frames). To create it,
+use **generating-af-golden-data**. Goldens are detector-independent, so generate once and reuse across configs.
+
+## Environment / prerequisites
+
+- **Windows + WSL**: TestApp is a Windows `.exe` invoked from WSL (paths quote cleanly through interop). You need
+  Windows `dotnet`, `cmd.exe`, and `wslpath` available — i.e. the normal dev box, not a Linux-only checkout.
+- **NINA profile**: every detector subcommand loads a NINA profile (it reads camera/pixel-scale + options). With
+  no arg it uses the **active** profile (run NINA once to create one); to pick a specific one pass
+  `--profile-id <guid>` (GUIDs are the `*.profile` filenames under `%LOCALAPPDATA%\NINA\Profiles`). If you see
+  `No active NINA profile could be loaded`, that's this — pass `--profile-id`.
+- **Bank path is machine-local** (here: `D:\Autofocus Bank`, WSL `/mnt/d/Autofocus Bank`). It holds the AF runs +
+  their golden sidecars; it is NOT in the repo. `cwhite_2026` (the validation anchor below) is a run *folder inside
+  this bank* — a complete dry-run replica with full goldens already present.
+
+## Pipeline (in order)
+
+```bash
+EXE=./Joko.NINA.Plugins/TestApp/bin/Debug/net8.0-windows7.0/TestApp.exe
+cmd.exe /c "dotnet build Joko.NINA.Plugins\TestApp\TestApp.csproj -c Debug --nologo"   # build first
+
+# 1. Tidy stale per-config clutter (DESTRUCTIVE; keeps frames, autofocus_report_Region*.json, labels/,
+#    *.golden.json, run_meta.json, *.linear.fits). Dry-run first (no --apply) and read the list.
+$EXE bank-clean --runs "D:\Autofocus Bank"            # lists
+$EXE bank-clean --runs "D:\Autofocus Bank" --apply    # deletes
+
+# 2. Per-run donut decision -> run_meta.json (donutAware flag drives golden-gen --donut + report grouping).
+$EXE bank-donut-meta --runs "D:\Autofocus Bank" --refresh
+
+# 3. Optimizer A/B prepass (only needed for the A/B columns; C0 NC-sweep needs none). ~1.5-3 hr.
+$EXE optimize --per-run            --runs "D:\Autofocus Bank" --out "$(wslpath -w opt_A)"
+$EXE optimize --per-run --donut    --runs "D:\Autofocus Bank" --out "$(wslpath -w opt_B)"
+
+# 4. The verification. C0 NC sweep + A/B. Report -> bank root. ~1-2 hr.
+$EXE bank-verify --runs "D:\Autofocus Bank" --out "D:\Autofocus Bank" \
+     --nc-sweep 2,3,4 --match-radius 12 --commit $(git rev-parse --short HEAD) \
+     --opt-a "$(wslpath -w opt_A)" --opt-b "$(wslpath -w opt_B)"
+```
+
+Omit `--opt-a/--opt-b` for a C0-only sweep (the headline recall answer; no optimizer prepass needed — much faster).
+
+## Logic / interpretation
+
+- **recall@SNR≥12 is the reliable headline** — the golden high tier is complete, so this number is trustworthy on
+  every run.
+- **precision is a LOWER BOUND where goldens are high-tier-dominated** (deep wide-field runs whose faint tier was
+  only sampled). HF's real faint detections then count as false positives. The built-in `RecommendNoiseClip` can be
+  skewed by this — **do not read the NC recommendation off bank-median precision.** Trust instead the **optimizer's
+  converged NoiseClippingMultiplier** per run (it optimizes σ_focus, immune to the precision artifact) as the
+  "what does the live data want" signal.
+- **Donut runs (`donutAware=true`) have broken C0 numbers** (as-default has donut detection OFF → can't form
+  candidates on rings → recall ~0.1–0.3, NaN AF σ, garbage sensor R²). Only **config B** evaluates them fairly.
+- **A/B sit at the opposite corner** from C0: optimized settings shed faint stars for AF tightness → recall low,
+  precision ~1.0, σ_focus ~1. For max recall use C0 (as-default); the optimizer optimizes σ, not star count.
+- Run discovery is attempt-anchored (≥3 focuser positions). Frameless folders (e.g. an artifacts-only `astrodet`)
+  are skipped. Dataset copies (`sensitivity_example1`≡`fmeschia`, `sensitivity_example2`≡`LinwoodFocus`) must
+  produce bit-identical metrics — a free determinism check.
+
+## Gotchas (hard-won)
+
+- **bank-verify runs on a dedicated STA thread with a PUMPED Dispatcher — do not "simplify" that away.** It chains
+  `RunEvaluationData.EvaluateAndFitAsync` (optimizer eval) + `StarDetector.Detect` + `SensorModel.RegisterStarsAndFit`
+  in one process. Under a bare `new Application()` (no dispatcher pump) two things hang: (1) the EvaluateAndFitAsync
+  await deadlocks on the captured non-pumping context; (2) the sensor fit is thread-affine and hangs on a
+  thread-pool thread. The fix (in `BankVerifyRunner.Run`) is the StarReviewRunner pattern: dedicated STA thread +
+  `DispatcherSynchronizationContext` + `Dispatcher.Run()`, and **NO `ConfigureAwait(false)`** (continuations must
+  stay on the pumping STA thread). If you see it hang ~3 min in, this is why.
+- **WSL block-buffers the Windows exe's stdout** → live stdout is useless for diagnosing long runs. Watch the
+  flushed file log **`<out>/bank_verify_progress.log`** (and per-run `<out>/bank_verify/<runtag>/verify.json`).
+  A flat CPU with no new progress lines = blocked; climbing CPU = just slow.
+- **Close any running NINA first.** It locks the profile (`MigrateModularizedSolutionNamespaceChange` IO errors —
+  benign but noisy) and competes for CPU (~2–3× slower on the 61–102 MP frames).
+- **Launch long runs detached** (`nohup … & disown`) and poll the progress file, or use a tracked background job
+  that exits when `verification_*.md` appears. Per-config ≈ 60–90 s on 61 MP; donut/optimized configs are slower.
+- **WSL UNC opt paths work**: pass `--opt-a "$(wslpath -w opt_A)"` → `\\wsl.localhost\...`; the Windows exe reads it
+  (`Test-Path` confirms). `LoadOptimized` looks for `<optRoot>/<sanitizedRunId>/optimized_settings.json` then
+  `<optRoot>/optimized_settings.json`.
+- **Validate the harness before trusting it:** `cwhite_2026` is a complete dry-run replica — bank-verify reproduces
+  its config-B numbers exactly (P=0.848, recall@≥12=0.181, sensor R²=0.9933, 7/9 aligned). If those don't match,
+  fix the harness before reading bank-wide results.
+- **bank-clean `--apply` is destructive** — always dry-run first and confirm the list is only regenerated artifacts
+  (`*_star_detection_result*.json`, diagnostic PNGs, `optimized_settings.json`, optimize/eval/contamination
+  outputs). It re-runs idempotently (second pass deletes 0).
+
+## Reference
+
+- Plan + report schema: `plans/autofocus-bank-verification-plan.md`; results write-up `docs/af-bank-noiseclip-sweep-results.md`.
+- TestApp CLI: `.claude/docs/testapp-cli.md`. Golden set method: `.claude/docs/golden-star-set.md`.
+- Schema note: the live report is `afbank-verify/2` (the plan text predates it and says `/1` — code wins).

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/MeanFluxDenominatorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/MeanFluxDenominatorTests.cs
@@ -63,6 +63,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
             Sensitivity = sensitivity,
             StarClippingMultiplier = StarClippingMultiplier,
             NoiseClippingMultiplier = 4.0, // pin pre-audit default so this sensitivity-gate logic test stays stable
+            LocallyAdaptiveBinarization = false, // pin legacy scalar binarization too (now ON by default) — same reason
         };
 
         [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectorEquivalenceTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectorEquivalenceTests.cs
@@ -1,5 +1,7 @@
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NUnit.Framework;
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
@@ -146,6 +148,54 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
                 "Detected stars and metrics must exactly match the committed pre-change baseline. " +
                 "If this fails after a parallelization change, the change has altered results — " +
                 "investigate before updating the baseline.");
+        }
+
+        /// <summary>
+        /// Bit-identical gate for the spatially-adaptive binarization rollout: with
+        /// <see cref="StarDetectorParams.LocallyAdaptiveBinarization"/> OFF the binarization seam runs the exact
+        /// legacy scalar path (the new coarse grids are never even computed), so the full detected-star + metrics
+        /// signature MUST equal the committed pre-change baseline. This is the guarantee that lets the option's
+        /// default be flipped ON safely while keeping the boolean as an off-switch.
+        /// </summary>
+        [Test]
+        public async Task Detect_AdaptiveBinarizationOff_MatchesLegacyBaseline() {
+            var p = StarDetectorEquivalence.StandardParams();
+            p.LocallyAdaptiveBinarization = false;
+            using var field = StarDetectorEquivalence.BuildSmallField();
+            var result = await StarDetectorEquivalence.RunDetect(field, p);
+            var sig = StarDetectorEquivalence.Signature(result);
+
+            Assert.That(sig, Is.EqualTo(GoldenSignature),
+                "LocallyAdaptiveBinarization=false must be byte-for-byte identical to the legacy baseline.");
+        }
+
+        /// <summary>
+        /// End-to-end smoke test for the ON path: on a spatially-uniform field the local-median + NC·local-σ surface
+        /// degenerates to ~the global threshold, so adaptive binarization must execute and recover the same bright
+        /// stars as the legacy path. This is a behavioural check (same stars, within a fraction of a pixel), NOT a
+        /// bit-identical one — the estimators differ (block median / 1.4826·MAD vs histogram-median / kappa-sigma),
+        /// so a candidate at the pixel margin may differ. The real ON-path validation is the AF-bank audit (Step 6).
+        /// </summary>
+        [Test]
+        public async Task Detect_AdaptiveBinarizationOn_RecoversSameStarsOnUniformField() {
+            var pOff = StarDetectorEquivalence.StandardParams();
+            var pOn = StarDetectorEquivalence.StandardParams();
+            pOn.LocallyAdaptiveBinarization = true;
+            pOn.AdaptiveNoiseBlockSize = 128;
+
+            using var field1 = StarDetectorEquivalence.BuildSmallField();
+            var off = await StarDetectorEquivalence.RunDetect(field1, pOff);
+            using var field2 = StarDetectorEquivalence.BuildSmallField();
+            var on = await StarDetectorEquivalence.RunDetect(field2, pOn);
+
+            TestContext.Progress.WriteLine($"[adaptive] off={off.DetectedStars.Count} on={on.DetectedStars.Count}");
+            Assert.That(on.DetectedStars.Count, Is.EqualTo(off.DetectedStars.Count).Within(1),
+                "adaptive ON should recover essentially the same star count on a uniform field");
+            foreach (var s in off.DetectedStars) {
+                Assert.That(
+                    on.DetectedStars.Any(t => Math.Abs(t.Center.X - s.Center.X) < 0.5 && Math.Abs(t.Center.Y - s.Center.Y) < 0.5),
+                    Is.True, $"adaptive ON dropped a star near ({s.Center.X:F1},{s.Center.Y:F1})");
+            }
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/LocalBackgroundGridTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/LocalBackgroundGridTests.cs
@@ -1,0 +1,190 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NUnit.Framework;
+using OpenCvSharp;
+using System;
+using Size = OpenCvSharp.Size;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Utility {
+
+    /// <summary>
+    /// Unit tests for the pure coarse-grid local-background helper that backs spatially-adaptive binarization.
+    /// It computes, per block, the robust background (block median) and noise (1.4826·MAD, floored), matching
+    /// tools/golden/snr_ref.py:coarse_bg semantics. The upsample (Cv2.Resize bilinear) is intentionally NOT tested
+    /// here — only the grid reduction, which is the unit under test.
+    /// </summary>
+    [TestFixture]
+    public class LocalBackgroundGridTests {
+
+        private static Mat MakeF32(int width, int height, Func<int, int, float> valueAt) {
+            var mat = new Mat(new Size(width, height), MatType.CV_32F);
+            unsafe {
+                var p = (float*)mat.DataPointer;
+                for (var y = 0; y < height; ++y) {
+                    for (var x = 0; x < width; ++x) {
+                        p[y * width + x] = valueAt(x, y);
+                    }
+                }
+            }
+            return mat;
+        }
+
+        [Test]
+        public void RejectsNonF32() {
+            using var mat = new Mat(new Size(8, 8), MatType.CV_8UC1);
+            Assert.Throws<ArgumentException>(() => CvImageUtility.ComputeLocalBackgroundGrid(mat, blockSize: 4, sigmaFloor: 0f));
+        }
+
+        [Test]
+        public void RejectsNonPositiveBlockSize() {
+            using var mat = MakeF32(8, 8, (x, y) => 0.5f);
+            Assert.Throws<ArgumentException>(() => CvImageUtility.ComputeLocalBackgroundGrid(mat, blockSize: 0, sigmaFloor: 0f));
+        }
+
+        [Test]
+        public void UniformImage_FlatSurface_MedianEqualsValue_SigmaIsZero() {
+            using var mat = MakeF32(16, 16, (x, y) => 0.5f);
+            var grid = CvImageUtility.ComputeLocalBackgroundGrid(mat, blockSize: 8, sigmaFloor: 0f);
+            Assert.Multiple(() => {
+                Assert.That(grid.GridRows, Is.EqualTo(2));
+                Assert.That(grid.GridCols, Is.EqualTo(2));
+                for (var r = 0; r < grid.GridRows; ++r) {
+                    for (var c = 0; c < grid.GridCols; ++c) {
+                        Assert.That(grid.MedianAt(r, c), Is.EqualTo(0.5f).Within(1e-6), $"median[{r},{c}]");
+                        Assert.That(grid.SigmaAt(r, c), Is.EqualTo(0.0f).Within(1e-6), $"sigma[{r},{c}]");
+                    }
+                }
+            });
+        }
+
+        [Test]
+        public void KnownBlock_UpperMiddleMedian_And_ScaledMad() {
+            // 2x2 block of {1,2,3,4}. Upper-middle median (length>>1) = sorted[2] = 3 (matches CalculateStatistics).
+            // |x-3| = {2,1,0,1} -> sorted {0,1,1,2} -> MAD = sorted[2] = 1 -> sigma = 1*1.4826.
+            using var mat = MakeF32(2, 2, (x, y) => 1f + x + 2 * y); // (0,0)=1 (1,0)=2 (0,1)=3 (1,1)=4
+            var grid = CvImageUtility.ComputeLocalBackgroundGrid(mat, blockSize: 2, sigmaFloor: 0f);
+            Assert.Multiple(() => {
+                Assert.That(grid.GridRows, Is.EqualTo(1));
+                Assert.That(grid.GridCols, Is.EqualTo(1));
+                Assert.That(grid.MedianAt(0, 0), Is.EqualTo(3f).Within(1e-6));
+                Assert.That(grid.SigmaAt(0, 0), Is.EqualTo(1.4826f).Within(1e-4));
+            });
+        }
+
+        [Test]
+        public void NoisyRegion_HasLargerSigmaThanCleanRegion() {
+            // Left half (cols 0..127) uniform -> sigma ~ 0; right half (cols 128..255) checkerboard 0.4/0.6
+            // -> MAD = 0.2 -> sigma = 0.2*1.4826 ~ 0.2965. Grid is 1 row x 2 cols at blockSize 128.
+            using var mat = MakeF32(256, 128, (x, y) => x < 128 ? 0.5f : (((x + y) % 2 == 0) ? 0.6f : 0.4f));
+            var grid = CvImageUtility.ComputeLocalBackgroundGrid(mat, blockSize: 128, sigmaFloor: 0f);
+            Assert.Multiple(() => {
+                Assert.That(grid.GridRows, Is.EqualTo(1));
+                Assert.That(grid.GridCols, Is.EqualTo(2));
+                Assert.That(grid.SigmaAt(0, 0), Is.EqualTo(0.0f).Within(1e-6), "clean block sigma");
+                Assert.That(grid.SigmaAt(0, 1), Is.GreaterThan(0.25f), "noisy block sigma");
+                Assert.That(grid.SigmaAt(0, 1), Is.GreaterThan(grid.SigmaAt(0, 0)));
+            });
+        }
+
+        [Test]
+        public void SigmaFloor_IsApplied_WhenMadIsZero() {
+            using var mat = MakeF32(8, 8, (x, y) => 0.3f);
+            var grid = CvImageUtility.ComputeLocalBackgroundGrid(mat, blockSize: 8, sigmaFloor: 0.05f);
+            Assert.That(grid.SigmaAt(0, 0), Is.EqualTo(0.05f).Within(1e-6));
+        }
+
+        [Test]
+        public void BlockSizeLargerThanImage_ProducesSingleGlobalCell() {
+            using var mat = MakeF32(8, 8, (x, y) => x < 4 ? 0.2f : 0.8f);
+            var grid = CvImageUtility.ComputeLocalBackgroundGrid(mat, blockSize: 64, sigmaFloor: 0f);
+            Assert.Multiple(() => {
+                Assert.That(grid.GridRows, Is.EqualTo(1));
+                Assert.That(grid.GridCols, Is.EqualTo(1));
+                // 32 px at 0.2 and 32 px at 0.8; upper-middle median (index 32) = 0.8; |x-0.8| -> MAD = 0.6.
+                Assert.That(grid.MedianAt(0, 0), Is.EqualTo(0.8f).Within(1e-6));
+                Assert.That(grid.SigmaAt(0, 0), Is.EqualTo(0.6f * 1.4826f).Within(1e-4));
+            });
+        }
+
+        [Test]
+        public void NonMultipleSize_CeilGrid_PartialEdgeBlocksComputedFromTheirOwnPixels() {
+            // 5x5, blockSize 4 -> ceil grid 2x2. The bottom-right cell is a single pixel (4,4): median = that pixel,
+            // MAD of a 1-element block = 0 -> sigma = floor.
+            using var mat = MakeF32(5, 5, (x, y) => 0.1f * (x + y)); // (4,4) = 0.8
+            var grid = CvImageUtility.ComputeLocalBackgroundGrid(mat, blockSize: 4, sigmaFloor: 0f);
+            Assert.Multiple(() => {
+                Assert.That(grid.GridRows, Is.EqualTo(2));
+                Assert.That(grid.GridCols, Is.EqualTo(2));
+                Assert.That(grid.MedianAt(1, 1), Is.EqualTo(0.8f).Within(1e-6), "single-pixel corner median");
+                Assert.That(grid.SigmaAt(1, 1), Is.EqualTo(0.0f).Within(1e-6), "single-pixel corner sigma");
+            });
+        }
+
+        [Test]
+        public void RowMajorIndexerMatchesBackingArray() {
+            using var mat = MakeF32(24, 16, (x, y) => 0.01f * (x % 7) + 0.02f * (y % 5));
+            var grid = CvImageUtility.ComputeLocalBackgroundGrid(mat, blockSize: 8, sigmaFloor: 0f);
+            for (var r = 0; r < grid.GridRows; ++r) {
+                for (var c = 0; c < grid.GridCols; ++c) {
+                    Assert.That(grid.MedianAt(r, c), Is.EqualTo(grid.Median[r * grid.GridCols + c]));
+                    Assert.That(grid.SigmaAt(r, c), Is.EqualTo(grid.Sigma[r * grid.GridCols + c]));
+                }
+            }
+        }
+
+        [Test]
+        public void BinarizeAdaptive_PerPixelThreshold_StrictGreater() {
+            using var src = MakeF32(2, 2, (x, y) => new[] { 0.1f, 0.4f, 0.6f, 0.9f }[y * 2 + x]);
+            using var surface = MakeF32(2, 2, (x, y) => new[] { 0.2f, 0.4f, 0.5f, 0.95f }[y * 2 + x]);
+            using var dst = new Mat();
+            CvImageUtility.BinarizeAdaptive(src, dst, surface);
+            unsafe {
+                var p = (float*)dst.DataPointer;
+                // 0.1>0.2 no; 0.4>0.4 no (strict); 0.6>0.5 yes; 0.9>0.95 no
+                Assert.Multiple(() => {
+                    Assert.That(p[0], Is.EqualTo(0.0f));
+                    Assert.That(p[1], Is.EqualTo(0.0f));
+                    Assert.That(p[2], Is.EqualTo(1.0f));
+                    Assert.That(p[3], Is.EqualTo(0.0f));
+                });
+            }
+        }
+
+        [Test]
+        public void BinarizeAdaptive_ConstantSurface_MatchesScalarBinarize() {
+            const float threshold = 0.5f;
+            using var src = MakeF32(8, 8, (x, y) => 0.05f * (x + y)); // 0.0 .. 0.7
+            using var surface = MakeF32(8, 8, (x, y) => threshold);
+            using var adaptive = new Mat();
+            using var scalar = new Mat();
+            CvImageUtility.BinarizeAdaptive(src, adaptive, surface);
+            CvImageUtility.Binarize(src, scalar, threshold);
+            unsafe {
+                var a = (float*)adaptive.DataPointer;
+                var s = (float*)scalar.DataPointer;
+                for (var i = 0; i < 64; ++i) {
+                    Assert.That(a[i], Is.EqualTo(s[i]), $"pixel {i}");
+                }
+            }
+        }
+
+        [Test]
+        public void BinarizeAdaptive_RejectsSizeMismatch() {
+            using var src = MakeF32(4, 4, (x, y) => 0.5f);
+            using var surface = MakeF32(2, 2, (x, y) => 0.5f);
+            using var dst = new Mat();
+            Assert.Throws<ArgumentException>(() => CvImageUtility.BinarizeAdaptive(src, dst, surface));
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/StarDetectionSettingsSnapshot.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/StarDetectionSettingsSnapshot.cs
@@ -62,6 +62,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay {
         public double DefocusCenteringToleranceFactor { get; set; }
         public bool DefocusAwareDonutDetection { get; set; }
         public int DonutMorphCloseSize { get; set; }
+        public bool LocallyAdaptiveBinarization { get; set; }
+        public int AdaptiveNoiseBlockSize { get; set; } = 128;
         public double DonutMinAnnularityHoleFraction { get; set; }
         public double DonutMaxStreakEccentricity { get; set; }
         public double DonutSaturationBloomRadius { get; set; }
@@ -130,6 +132,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay {
                 DefocusCenteringToleranceFactor = o.DefocusCenteringToleranceFactor,
                 DefocusAwareDonutDetection = o.DefocusAwareDonutDetection,
                 DonutMorphCloseSize = o.DonutMorphCloseSize,
+                LocallyAdaptiveBinarization = o.LocallyAdaptiveBinarization,
+                AdaptiveNoiseBlockSize = o.AdaptiveNoiseBlockSize,
                 DonutMinAnnularityHoleFraction = o.DonutMinAnnularityHoleFraction,
                 DonutMaxStreakEccentricity = o.DonutMaxStreakEccentricity,
                 DonutSaturationBloomRadius = o.DonutSaturationBloomRadius,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetectionOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetectionOptions.cs
@@ -100,6 +100,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         double DefocusCenteringToleranceFactor { get; set; }
         bool DefocusAwareDonutDetection { get; set; }
         int DonutMorphCloseSize { get; set; }
+        bool LocallyAdaptiveBinarization { get; set; }
+        int AdaptiveNoiseBlockSize { get; set; }
         double DonutMinAnnularityHoleFraction { get; set; }
         double DonutMaxStreakEccentricity { get; set; }
         double DonutSaturationBloomRadius { get; set; }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
@@ -249,6 +249,25 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         // at stable best-focus and only modest HFR scatter. See docs/star-detection-golden-audit-cwhite-results.md.
         public double NoiseClippingMultiplier { get; set; } = 2.0;
 
+        // Spatially-adaptive structure-map binarization (opt-in, default OFF for bit-identical detection). When OFF
+        // the structure map is binarized against the legacy SINGLE global scalar threshold
+        // (global-median + NoiseClippingMultiplier · global-σ), so candidate formation is byte-for-byte legacy.
+        // When ON the scalar is replaced by a spatially-varying threshold surface
+        // (local-median(x,y) + NoiseClippingMultiplier · local-σ(x,y)) computed from robust per-block statistics on
+        // a coarse grid and bilinearly upsampled — making the SAME NoiseClippingMultiplier locally fair (low where
+        // the background is clean, high where it is noisy). local-σ is sampled on the same noise-reduced source the
+        // global σ uses (F4 σ-consistency) and local-median on the structure map actually thresholded; with constant
+        // grids this reduces exactly to the global formula. EARLY param (it changes candidate formation): listed in
+        // StarDetector.EarlyCacheKeyProperties. See docs/adaptive-noiseclip-design.md.
+        public bool LocallyAdaptiveBinarization { get; set; } = false;
+
+        // EARLY adaptive-binarization knob (only when LocallyAdaptiveBinarization is true). Side length (px) of the
+        // square blocks the robust local median/σ surface is estimated on (matches tools/golden/snr_ref.py coarse_bg,
+        // grid 128). Larger ⇒ smoother surface (less local adaptivity, cheaper); smaller ⇒ more adaptive but noisier
+        // and risks tracking real extended structure into the background. Sane range 64–256. EARLY param (changes
+        // candidate formation): listed in StarDetector.EarlyCacheKeyProperties. Ignored entirely when the flag is OFF.
+        public int AdaptiveNoiseBlockSize { get; set; } = 128;
+
         // Number of measurement-image noise standard deviations above the local background median to filter star
         // candidate pixels out from star consideration and HFR analysis. σ is measured on the image actually
         // sampled (F4) and the level + gate-only policy were chosen empirically — see

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
@@ -259,7 +259,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         // global σ uses (F4 σ-consistency) and local-median on the structure map actually thresholded; with constant
         // grids this reduces exactly to the global formula. EARLY param (it changes candidate formation): listed in
         // StarDetector.EarlyCacheKeyProperties. See docs/adaptive-noiseclip-design.md.
-        public bool LocallyAdaptiveBinarization { get; set; } = false;
+        // Default ON: AF-bank validated (recall@SNR≥12 + precision both improved at NC=2, no AF/donut regression —
+        // see docs/af-bank-noiseclip-sweep-results.md). Retained as a user/regression off-switch.
+        public bool LocallyAdaptiveBinarization { get; set; } = true;
 
         // EARLY adaptive-binarization knob (only when LocallyAdaptiveBinarization is true). Side length (px) of the
         // square blocks the robust local median/σ surface is estimated on (matches tools/golden/snr_ref.py coarse_bg,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
@@ -451,6 +451,8 @@
     <TextBlock x:Key="StructureLayerBoost_Tooltip" Text="Only used while Defocus-Aware Structure is enabled. The number of extra wavelet layers added when removing large-scale structure, making the removal coarser so larger defocused donuts survive and form candidates. 0 means no change (identical to the feature being off). Raise it (1–6) if very out-of-focus stars never appear; raising it too far can let nebulosity/background structure leak in as false candidates. Default 0." />
     <TextBlock x:Key="DefocusAwareDonutDetection_Tooltip" Text="MASTER toggle for defocus-aware donut detection (also on the optimizer wizard's start page). When ON, out-of-focus DONUT stars (heavily defocused stars that appear as hollow rings) are recovered: a morphological close reconnects fragmented rings and an annularity test lets a hollow ring pass the distortion gate like a filled disk (detection-only — it never changes HFR). It also unlocks the optimizer to tune ALL defocus-aware settings and to enable diffraction-spike / saturated-bloom suppression. Recommended for telescopes with a central obstruction (Newtonians/SCTs); leave OFF for refractors. Off by default; when OFF, detection is exactly as before." />
     <TextBlock x:Key="DonutMorphCloseSize_Tooltip" Text="Only used while Defocus-Aware Donut Detection is on. Diameter (px) of the morphological-close kernel that reconnects fragmented donut-ring arcs into one candidate (the dominant cause of donuts being dropped as 'too small'). 1 means no close. Keep it smaller than the gap between a bright star's diffraction spikes so it doesn't bridge them. EARLY-stage setting. Default 5." />
+    <TextBlock x:Key="LocallyAdaptiveBinarization_Tooltip" Text="Makes the structure-map binarization threshold spatially adaptive. Normally a single global threshold (background median + Noise Clipping Multiplier × global noise σ) is applied across the whole frame, which is too high in clean regions (losing faint stars) and too low in noisy corners (admitting noise). When enabled, the threshold becomes a smooth surface computed from robust local statistics on a coarse block grid — local background median + Noise Clipping Multiplier × local noise σ — so the same Noise Clipping Multiplier is locally fair everywhere. Recovers faint real stars in clean regions while rejecting noise in vignetted/gradient-heavy corners. Off by default; when off, detection is exactly as before. EARLY-stage setting." />
+    <TextBlock x:Key="AdaptiveNoiseBlockSize_Tooltip" Text="Only used while Locally Adaptive Binarization is on. The side length (in pixels) of the square blocks the local median/noise surface is estimated on. Larger values give a smoother, cheaper surface with less local adaptivity; smaller values adapt more finely but produce a noisier surface and risk absorbing real extended structure (large defocused donuts) into the background. The sane range is 64–256. Default 128." />
     <TextBlock x:Key="DonutMinAnnularityHoleFraction_Tooltip" Text="Only used while Defocus-Aware Donut Detection is on. Minimum size of a candidate's enclosed dark center (as a fraction of its bounding-box area) for it to count as a donut whose hole is filled for the distortion test — so a hollow ring is judged like a filled disk. This is detection-only and never changes the measured HFR/flux/center. Lower it to accept thinner rings; raise it to be stricter. Default 0.15." />
     <TextBlock x:Key="DonutMaxStreakEccentricity_Tooltip" Text="Only used while Defocus-Aware Donut Detection is on. Rejects very LINEAR candidates (diffraction spikes from a bright star, or satellite/aircraft trails) when their elongation (eccentricity) meets or exceeds this value. 1.0 means OFF (a perfect line has eccentricity 1.0, so nothing is rejected); lower it toward 0.95 to enable. Round donuts measure well below this, so they are never affected. Default 1.0 (OFF — the optimizer enables it when you label false detections)." />
     <TextBlock x:Key="DonutSaturationBloomRadius_Tooltip" Text="Only used while Defocus-Aware Donut Detection is on. Rejects candidates whose center lies within this many pixels of a saturated star, removing the bloom/halo fragments around a bright saturated star while keeping the star itself. 0 means OFF. Default 0 (OFF — the optimizer enables it when you label the saturated star's artifacts as should-reject)." />
@@ -1101,6 +1103,9 @@
                 <RowDefinition Style="{StaticResource ShowOnUseAdvancedAndDonutDetection}" />
                 <RowDefinition Style="{StaticResource ShowOnUseAdvancedAndDonutDetection}" />
                 <RowDefinition Style="{StaticResource ShowOnUseAdvancedAndDonutDetection}" />
+                <!--  52: Locally Adaptive Binarization toggle (advanced-only); 53: its block-size knob (advanced-only).  -->
+                <RowDefinition Style="{StaticResource ShowOnUseAdvanced}" />
+                <RowDefinition Style="{StaticResource ShowOnUseAdvanced}" />
             </Grid.RowDefinitions>
             <TextBlock
                 Grid.Row="0"
@@ -1756,6 +1761,49 @@
                         <rules:DoubleRangeRule>
                             <rules:DoubleRangeRule.ValidRange>
                                 <rules:DoubleRangeChecker Maximum="100" Minimum="0" />
+                            </rules:DoubleRangeRule.ValidRange>
+                        </rules:DoubleRangeRule>
+                    </Binding.ValidationRules>
+                </Binding>
+            </ninactrl:UnitTextBox>
+
+            <!--  52: Locally Adaptive Binarization master toggle; 53: its block-size knob.  -->
+            <TextBlock
+                Grid.Row="52"
+                Grid.Column="0"
+                VerticalAlignment="Center"
+                Text="Locally Adaptive Binarization"
+                ToolTip="{StaticResource LocallyAdaptiveBinarization_Tooltip}" />
+            <CheckBox
+                Grid.Row="52"
+                Grid.Column="1"
+                MinWidth="80"
+                Margin="5,5,0,0"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                IsChecked="{Binding StarDetectionOptions.LocallyAdaptiveBinarization}"
+                ToolTip="{StaticResource LocallyAdaptiveBinarization_Tooltip}" />
+
+            <TextBlock
+                Grid.Row="53"
+                Grid.Column="0"
+                VerticalAlignment="Center"
+                Text="Adaptive Noise Block Size"
+                ToolTip="{StaticResource AdaptiveNoiseBlockSize_Tooltip}" />
+            <ninactrl:UnitTextBox
+                Grid.Row="53"
+                Grid.Column="1"
+                MinWidth="80"
+                Margin="5,5,0,0"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                Unit="px"
+                ToolTip="{StaticResource AdaptiveNoiseBlockSize_Tooltip}">
+                <Binding Path="StarDetectionOptions.AdaptiveNoiseBlockSize" UpdateSourceTrigger="LostFocus">
+                    <Binding.ValidationRules>
+                        <rules:DoubleRangeRule>
+                            <rules:DoubleRangeRule.ValidRange>
+                                <rules:DoubleRangeChecker Maximum="256" Minimum="64" />
                             </rules:DoubleRangeRule.ValidRange>
                         </rules:DoubleRangeRule>
                     </Binding.ValidationRules>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
@@ -398,7 +398,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                 // StarDetectionOptions.ResetDefaults by BuildDefaultStarDetectorParams_MatchesResetDefaultsBuild.
                 DefocusAwareDonutDetection = false,
                 DonutMorphCloseSize = 5,
-                LocallyAdaptiveBinarization = false,
+                LocallyAdaptiveBinarization = true,   // default ON (AF-bank validated)
                 AdaptiveNoiseBlockSize = 128,
                 DonutMinAnnularityHoleFraction = 0.15,
                 DonutMaxStreakEccentricity = 1.0,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
@@ -331,6 +331,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                 // (when the master is OFF none of them are consulted ⇒ bit-identical).
                 DefocusAwareDonutDetection = options.DefocusAwareDonutDetection,
                 DonutMorphCloseSize = options.DonutMorphCloseSize,
+                // Spatially-adaptive binarization (independent of the donut master): passed verbatim. When OFF the
+                // detector keeps the legacy scalar binarize threshold ⇒ bit-identical. EARLY param.
+                LocallyAdaptiveBinarization = options.LocallyAdaptiveBinarization,
+                AdaptiveNoiseBlockSize = options.AdaptiveNoiseBlockSize,
                 DonutMinAnnularityHoleFraction = options.DonutMinAnnularityHoleFraction,
                 DonutMaxStreakEccentricity = options.DonutMaxStreakEccentricity,
                 DonutSaturationBloomRadius = options.DonutSaturationBloomRadius,
@@ -394,6 +398,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                 // StarDetectionOptions.ResetDefaults by BuildDefaultStarDetectorParams_MatchesResetDefaultsBuild.
                 DefocusAwareDonutDetection = false,
                 DonutMorphCloseSize = 5,
+                LocallyAdaptiveBinarization = false,
+                AdaptiveNoiseBlockSize = 128,
                 DonutMinAnnularityHoleFraction = 0.15,
                 DonutMaxStreakEccentricity = 1.0,
                 DonutSaturationBloomRadius = 0.0,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
@@ -53,6 +53,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public int StructureLayerBoost { get; set; } = 0;
         public bool DefocusAwareDonutDetection { get; set; } = false;
         public int DonutMorphCloseSize { get; set; } = 5;
+        // Spatially-adaptive binarization (not optimizer-tuned; carried so the headless harness overlays can exercise
+        // it). Inert defaults so an older snapshot missing these keys deserializes to legacy scalar binarization.
+        public bool LocallyAdaptiveBinarization { get; set; } = false;
+        public int AdaptiveNoiseBlockSize { get; set; } = 128;
         public double DonutMinAnnularityHoleFraction { get; set; } = 0.15;
         public double DonutMaxStreakEccentricity { get; set; } = 1.0;
         public double DonutSaturationBloomRadius { get; set; } = 0.0;
@@ -109,6 +113,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 StructureLayerBoost = p.StructureLayerBoost,
                 DefocusAwareDonutDetection = p.DefocusAwareDonutDetection,
                 DonutMorphCloseSize = p.DonutMorphCloseSize,
+                LocallyAdaptiveBinarization = p.LocallyAdaptiveBinarization,
+                AdaptiveNoiseBlockSize = p.AdaptiveNoiseBlockSize,
                 DonutMinAnnularityHoleFraction = p.DonutMinAnnularityHoleFraction,
                 DonutMaxStreakEccentricity = p.DonutMaxStreakEccentricity,
                 DonutSaturationBloomRadius = p.DonutSaturationBloomRadius,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
@@ -229,7 +229,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             defocusCenteringToleranceFactor = optionsAccessor.GetValueDouble("DefocusCenteringToleranceFactor", 2.0);
             defocusAwareDonutDetection = optionsAccessor.GetValueBoolean("DefocusAwareDonutDetection", false);
             donutMorphCloseSize = optionsAccessor.GetValueInt32("DonutMorphCloseSize", 5);
-            locallyAdaptiveBinarization = optionsAccessor.GetValueBoolean("LocallyAdaptiveBinarization", false);
+            locallyAdaptiveBinarization = optionsAccessor.GetValueBoolean("LocallyAdaptiveBinarization", true);
             adaptiveNoiseBlockSize = optionsAccessor.GetValueInt32("AdaptiveNoiseBlockSize", 128);
             donutMinAnnularityHoleFraction = optionsAccessor.GetValueDouble("DonutMinAnnularityHoleFraction", 0.15);
             donutMaxStreakEccentricity = optionsAccessor.GetValueDouble("DonutMaxStreakEccentricity", 1.0);
@@ -299,7 +299,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             DefocusCenteringToleranceFactor = 2.0;
             DefocusAwareDonutDetection = false;
             DonutMorphCloseSize = 5;
-            LocallyAdaptiveBinarization = false;
+            LocallyAdaptiveBinarization = true;   // default ON (AF-bank validated)
             AdaptiveNoiseBlockSize = 128;
             DonutMinAnnularityHoleFraction = 0.15;
             DonutMaxStreakEccentricity = 1.0;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
@@ -104,6 +104,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             StructureLayerBoost = s.StructureLayerBoost;
             DefocusAwareDonutDetection = s.DefocusAwareDonutDetection;
             DonutMorphCloseSize = s.DonutMorphCloseSize;
+            LocallyAdaptiveBinarization = s.LocallyAdaptiveBinarization;
+            AdaptiveNoiseBlockSize = s.AdaptiveNoiseBlockSize;
             DonutMinAnnularityHoleFraction = s.DonutMinAnnularityHoleFraction;
             DonutMaxStreakEccentricity = s.DonutMaxStreakEccentricity;
             DonutSaturationBloomRadius = s.DonutSaturationBloomRadius;
@@ -227,6 +229,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             defocusCenteringToleranceFactor = optionsAccessor.GetValueDouble("DefocusCenteringToleranceFactor", 2.0);
             defocusAwareDonutDetection = optionsAccessor.GetValueBoolean("DefocusAwareDonutDetection", false);
             donutMorphCloseSize = optionsAccessor.GetValueInt32("DonutMorphCloseSize", 5);
+            locallyAdaptiveBinarization = optionsAccessor.GetValueBoolean("LocallyAdaptiveBinarization", false);
+            adaptiveNoiseBlockSize = optionsAccessor.GetValueInt32("AdaptiveNoiseBlockSize", 128);
             donutMinAnnularityHoleFraction = optionsAccessor.GetValueDouble("DonutMinAnnularityHoleFraction", 0.15);
             donutMaxStreakEccentricity = optionsAccessor.GetValueDouble("DonutMaxStreakEccentricity", 1.0);
             donutSaturationBloomRadius = optionsAccessor.GetValueDouble("DonutSaturationBloomRadius", 0.0);
@@ -295,6 +299,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             DefocusCenteringToleranceFactor = 2.0;
             DefocusAwareDonutDetection = false;
             DonutMorphCloseSize = 5;
+            LocallyAdaptiveBinarization = false;
+            AdaptiveNoiseBlockSize = 128;
             DonutMinAnnularityHoleFraction = 0.15;
             DonutMaxStreakEccentricity = 1.0;
             DonutSaturationBloomRadius = 0.0;
@@ -722,6 +728,42 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                     }
                     donutMorphCloseSize = value;
                     optionsAccessor.SetValueInt32("DonutMorphCloseSize", donutMorphCloseSize);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool locallyAdaptiveBinarization;
+
+        // Spatially-adaptive structure-map binarization (default OFF ⇒ bit-identical legacy detection). When ON the
+        // single global binarize threshold is replaced by a local-median + NoiseClippingMultiplier·local-σ surface
+        // (robust per-block statistics, bilinearly upsampled), making the same NoiseClippingMultiplier locally fair.
+        // EARLY param. See docs/adaptive-noiseclip-design.md.
+        public bool LocallyAdaptiveBinarization {
+            get => locallyAdaptiveBinarization;
+            set {
+                if (locallyAdaptiveBinarization != value) {
+                    locallyAdaptiveBinarization = value;
+                    optionsAccessor.SetValueBoolean("LocallyAdaptiveBinarization", locallyAdaptiveBinarization);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private int adaptiveNoiseBlockSize;
+
+        // Side length (px) of the square blocks the adaptive binarization surface is estimated on (only while
+        // LocallyAdaptiveBinarization is ON). Larger = smoother/cheaper; smaller = more adaptive but noisier. EARLY
+        // param. Range [16, 1024] (sane working range 64–256). Default 128 (matches snr_ref.coarse_bg grid).
+        public int AdaptiveNoiseBlockSize {
+            get => adaptiveNoiseBlockSize;
+            set {
+                if (adaptiveNoiseBlockSize != value) {
+                    if (value < 16 || value > 1024) {
+                        throw new ArgumentException("AdaptiveNoiseBlockSize must be within [16, 1024]", "AdaptiveNoiseBlockSize");
+                    }
+                    adaptiveNoiseBlockSize = value;
+                    optionsAccessor.SetValueInt32("AdaptiveNoiseBlockSize", adaptiveNoiseBlockSize);
                     RaisePropertyChanged();
                 }
             }
@@ -1177,6 +1219,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             DefocusCenteringToleranceFactor = source.DefocusCenteringToleranceFactor;
             DefocusAwareDonutDetection = source.DefocusAwareDonutDetection;
             DonutMorphCloseSize = source.DonutMorphCloseSize;
+            LocallyAdaptiveBinarization = source.LocallyAdaptiveBinarization;
+            AdaptiveNoiseBlockSize = source.AdaptiveNoiseBlockSize;
             DonutMinAnnularityHoleFraction = source.DonutMinAnnularityHoleFraction;
             DonutMaxStreakEccentricity = source.DonutMaxStreakEccentricity;
             DonutSaturationBloomRadius = source.DonutSaturationBloomRadius;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
@@ -99,6 +99,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
         //
         // Notes on a few subtle entries:
         //  - NoiseClippingMultiplier: sets the K-σ clip AND the binarize threshold ⇒ changes the candidate set.
+        //  - LocallyAdaptiveBinarization / AdaptiveNoiseBlockSize: swap the scalar binarize threshold for a
+        //    per-block local-median+NC·local-σ surface (and set its granularity) ⇒ change the candidate set.
         //  - StarMeasurementNoiseReductionEnabled / NoiseReductionRadius / Hotpixel*: drive SrcImagePreparation and
         //    the structure-map source, and which of the two noise estimates is computed (measurement vs structure).
         //  - SaturationThreshold: read by EvaluateGlobalMetrics (early) to tally SaturatedPixelCount, so it is early
@@ -121,6 +123,25 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
         // EffectiveClipMultiplier; ungated profiles with StarClippingMultiplier <= this cap are unaffected.
         private const double DonutClipMultiplierCap = 2.0;
 
+        // Numerical floor on the per-block local σ used by spatially-adaptive binarization (in normalized image
+        // units). Guards a degenerate dead-flat block from a zero/near-zero local σ; small enough not to suppress
+        // the genuine low-noise local thresholds in clean regions that drive the recall gain.
+        private const float AdaptiveBinarizationSigmaFloor = 1e-6f;
+
+        // Result of the structure-map source noise estimate task: the global kappa-sigma σ used for the scalar
+        // binarize threshold, PLUS (only when LocallyAdaptiveBinarization is on) the per-block local-σ grid sampled
+        // on that SAME noise-reduced source (F4 σ-consistency), captured inside the task before the source is
+        // disposed. SigmaGrid is null on the legacy (flag-off) path.
+        private readonly struct StructureNoiseEstimate {
+            public StructureNoiseEstimate(CvImageUtility.KappaSigmaNoiseEstimateResult noise, CvImageUtility.LocalBackgroundGrid sigmaGrid) {
+                Noise = noise;
+                SigmaGrid = sigmaGrid;
+            }
+
+            public CvImageUtility.KappaSigmaNoiseEstimateResult Noise { get; }
+            public CvImageUtility.LocalBackgroundGrid SigmaGrid { get; }
+        }
+
         private static readonly HashSet<string> EarlyCacheKeyProperties = new HashSet<string>(StringComparer.Ordinal) {
             nameof(StarDetectorParams.HotpixelFiltering),
             nameof(StarDetectorParams.HotpixelThresholdingEnabled),
@@ -129,6 +150,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             nameof(StarDetectorParams.StarMeasurementNoiseReductionEnabled),
             nameof(StarDetectorParams.NoiseReductionRadius),
             nameof(StarDetectorParams.NoiseClippingMultiplier),
+            // Spatially-adaptive binarization: the master flag swaps the scalar threshold for a per-block
+            // local-median+NC·local-σ surface, and the block size sets that surface's granularity — both change
+            // candidate formation, so both MUST be early-keyed.
+            nameof(StarDetectorParams.LocallyAdaptiveBinarization),
+            nameof(StarDetectorParams.AdaptiveNoiseBlockSize),
             nameof(StarDetectorParams.StructureLayers),
             nameof(StarDetectorParams.DefocusAwareStructure),
             nameof(StarDetectorParams.StructureLayerBoost),
@@ -496,9 +522,17 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                         Logger.Trace(ksigmaTraceStructureMap);
                         MaybeSaveIntermediateText(ksigmaTraceStructureMap, p, "02-ksigma-estimate-noise-reduced.txt");
 
+                        // Spatially-adaptive binarization (opt-in): sample the per-block local-σ grid on the SAME
+                        // noise-reduced source the global σ above is computed from (F4 σ-consistency), HERE — before
+                        // the source is disposed below. Null on the legacy path ⇒ bit-identical detection.
+                        CvImageUtility.LocalBackgroundGrid sigmaGrid = null;
+                        if (p.LocallyAdaptiveBinarization) {
+                            sigmaGrid = CvImageUtility.ComputeLocalBackgroundGrid(noiseReducedImage, Math.Max(1, p.AdaptiveNoiseBlockSize), AdaptiveBinarizationSigmaFloor);
+                        }
+
                         noiseReducedImage.Dispose();
                         noiseReducedImage = null;
-                        return result;
+                        return new StructureNoiseEstimate(result, sigmaGrid);
                     });
 
                     // F4 (σ consistency): thresholds applied to the image actually sampled must use that image's σ.
@@ -556,9 +590,17 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                     // Log histograms produce more accurate results due to clustering in very low ADUs, but are substantially more computationally expensive
                     // The difference doesn't seem worth it based on tests done so far
                     var structureMapStats = CalculateStatistics_Histogram(structureMap, useLogHistogram: false, flags: CvImageStatisticsFlags.Median);
+                    // Spatially-adaptive binarization (opt-in): sample the per-block local background (median) on the
+                    // SAME structure map the global median above is taken from, and BEFORE the dilation below — so it
+                    // mirrors the scalar path's pre-dilation median. Null on the legacy path ⇒ bit-identical.
+                    CvImageUtility.LocalBackgroundGrid adaptiveMedianGrid = null;
+                    if (p.LocallyAdaptiveBinarization) {
+                        adaptiveMedianGrid = CvImageUtility.ComputeLocalBackgroundGrid(structureMap, Math.Max(1, p.AdaptiveNoiseBlockSize), AdaptiveBinarizationSigmaFloor);
+                    }
                     stopWatch.RecordEntry("BinarizationStatistics");
 
-                    var noiseReducedImageNoise = await noiseReducedNoiseEstimateTask;
+                    var structureNoiseEstimate = await noiseReducedNoiseEstimateTask;
+                    var noiseReducedImageNoise = structureNoiseEstimate.Noise;
                     var measurementImageNoise = measurementNoiseEstimateTask != null
                         ? await measurementNoiseEstimateTask
                         : noiseReducedImageNoise;
@@ -586,8 +628,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
 
                     progress?.Report(new ApplicationStatus() { Status = "Structure Detection" });
 
-                    // Step 7: Binarize foreground structures based on noise estimates
-                    CvImageUtility.Binarize(structureMap, structureMap, binarizeThreshold);
+                    // Step 7: Binarize foreground structures based on noise estimates. Legacy (default): a single
+                    // global scalar threshold. Spatially-adaptive (opt-in): a per-pixel threshold surface
+                    // (local-median + NC·local-σ) upsampled from the coarse grids. The flag-off path is byte-for-byte
+                    // the legacy scalar Binarize.
+                    if (p.LocallyAdaptiveBinarization && adaptiveMedianGrid != null && structureNoiseEstimate.SigmaGrid != null) {
+                        ApplyAdaptiveBinarization(structureMap, adaptiveMedianGrid, structureNoiseEstimate.SigmaGrid, p.NoiseClippingMultiplier);
+                    } else {
+                        CvImageUtility.Binarize(structureMap, structureMap, binarizeThreshold);
+                    }
                     if (p.Region.InnerCropBoundary != null) {
                         var innerRoiRect = new Rect(
                             (int)Math.Floor(srcImage.Cols * p.Region.InnerCropBoundary.StartX),
@@ -813,6 +862,36 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             var tcs = new TaskCompletionSource();
             using (ct.Register(() => tcs.SetCanceled(), useSynchronizationContext: false)) {
                 await Task.WhenAny(Task.WhenAll(allTasks), tcs.Task);
+            }
+        }
+
+        /// <summary>
+        /// Builds the spatially-varying binarization threshold surface (local-median + NC·local-σ) from the two
+        /// coarse grids and binarizes <paramref name="structureMap"/> against it in place. The median grid is sampled
+        /// on the structure map (the image actually thresholded) and the σ grid on the noise-reduced source (F4
+        /// σ-consistency); both share the block size, so their grids are congruent. Because bilinear upsampling is
+        /// linear, the (median + NC·σ) combination is formed at GRID resolution and the small result upsampled ONCE
+        /// (equivalent to upsampling each grid then combining, at a fraction of the cost and memory).
+        /// </summary>
+        private static void ApplyAdaptiveBinarization(Mat structureMap, CvImageUtility.LocalBackgroundGrid medianGrid, CvImageUtility.LocalBackgroundGrid sigmaGrid, double noiseClippingMultiplier) {
+            if (medianGrid.GridRows != sigmaGrid.GridRows || medianGrid.GridCols != sigmaGrid.GridCols) {
+                throw new InvalidOperationException(
+                    $"Adaptive binarization grid mismatch: median {medianGrid.GridRows}x{medianGrid.GridCols} vs sigma {sigmaGrid.GridRows}x{sigmaGrid.GridCols}");
+            }
+
+            int rows = medianGrid.GridRows;
+            int cols = medianGrid.GridCols;
+            int n = rows * cols;
+            using (var thresholdGrid = new Mat(rows, cols, MatType.CV_32F))
+            using (var thresholdSurface = new Mat()) {
+                unsafe {
+                    var dst = (float*)thresholdGrid.DataPointer;
+                    for (int i = 0; i < n; ++i) {
+                        dst[i] = (float)(medianGrid.Median[i] + noiseClippingMultiplier * sigmaGrid.Sigma[i]);
+                    }
+                }
+                Cv2.Resize(thresholdGrid, thresholdSurface, new Size(structureMap.Cols, structureMap.Rows), 0, 0, InterpolationFlags.Linear);
+                CvImageUtility.BinarizeAdaptive(structureMap, structureMap, thresholdSurface);
             }
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/CvImageUtility.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/CvImageUtility.cs
@@ -18,6 +18,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using NINA.Core.Enum;
 using NINA.Core.Locale;
 using Accord.Imaging;
@@ -564,6 +565,126 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
             }
 
             Cv2.Threshold(src, dst, threshold, 1.0d, ThresholdTypes.Binary);
+        }
+
+        /// <summary>
+        /// A coarse grid of robust per-block local background (block median) and noise (1.4826·MAD, floored)
+        /// statistics. Backs spatially-adaptive structure-map binarization: the local-median + NC·local-σ surface
+        /// is built by upsampling these grids. Stored row-major (length GridRows·GridCols).
+        /// </summary>
+        public sealed class LocalBackgroundGrid {
+            public int GridRows { get; }
+            public int GridCols { get; }
+            public int BlockSize { get; }
+            public float[] Median { get; }
+            public float[] Sigma { get; }
+
+            public LocalBackgroundGrid(int gridRows, int gridCols, int blockSize, float[] median, float[] sigma) {
+                GridRows = gridRows;
+                GridCols = gridCols;
+                BlockSize = blockSize;
+                Median = median;
+                Sigma = sigma;
+            }
+
+            public float MedianAt(int row, int col) => Median[row * GridCols + col];
+
+            public float SigmaAt(int row, int col) => Sigma[row * GridCols + col];
+        }
+
+        private const double MadToSigma = 1.4826d;
+
+        /// <summary>
+        /// Computes, over a coarse grid of square <paramref name="blockSize"/>-px blocks, the robust local background
+        /// (block median) and local noise (1.4826·MAD, floored at <paramref name="sigmaFloor"/>) of a CV_32F image.
+        /// This is the grid reduction behind spatially-adaptive binarization and mirrors the semantics of the
+        /// detector-independent reference detector (tools/golden/snr_ref.py:coarse_bg). The grid is ceil-sized
+        /// (GridRows = ceil(height/blockSize), GridCols = ceil(width/blockSize)); the trailing block in each row and
+        /// column is a partial block computed from only its own pixels, so every pixel contributes to exactly one
+        /// block (no remainder is dropped). The median is the upper-middle order statistic (index count&gt;&gt;1),
+        /// matching <see cref="CalculateStatistics"/>. Pure and deterministic: block results are independent, so the
+        /// parallel reduction cannot affect the output. The upsample to a full-resolution threshold surface is the
+        /// caller's responsibility (bilinear <c>Cv2.Resize</c>).
+        /// </summary>
+        public static LocalBackgroundGrid ComputeLocalBackgroundGrid(Mat image, int blockSize, float sigmaFloor) {
+            if (image == null) {
+                throw new ArgumentNullException(nameof(image));
+            }
+            if (image.Type() != MatType.CV_32F) {
+                throw new ArgumentException("Only CV_32F supported");
+            }
+            if (blockSize <= 0) {
+                throw new ArgumentException("blockSize must be positive", nameof(blockSize));
+            }
+
+            int width = image.Cols;
+            int height = image.Rows;
+            int gridCols = (width + blockSize - 1) / blockSize;
+            int gridRows = (height + blockSize - 1) / blockSize;
+            var median = new float[gridRows * gridCols];
+            var sigma = new float[gridRows * gridCols];
+            IntPtr dataPtr = image.Data;
+            long step = image.Step();
+
+            Parallel.For(0, gridRows, blockRow => {
+                var buf = new float[blockSize * blockSize];
+                var dev = new float[blockSize * blockSize];
+                int y0 = blockRow * blockSize;
+                int y1 = Math.Min(y0 + blockSize, height);
+                for (int blockCol = 0; blockCol < gridCols; ++blockCol) {
+                    int x0 = blockCol * blockSize;
+                    int x1 = Math.Min(x0 + blockSize, width);
+
+                    int count = 0;
+                    unsafe {
+                        var basePtr = (byte*)dataPtr;
+                        for (int y = y0; y < y1; ++y) {
+                            var rowPtr = (float*)(basePtr + (long)y * step);
+                            for (int x = x0; x < x1; ++x) {
+                                buf[count++] = rowPtr[x];
+                            }
+                        }
+                    }
+
+                    Array.Sort(buf, 0, count);
+                    float med = buf[count >> 1];
+                    for (int i = 0; i < count; ++i) {
+                        dev[i] = Math.Abs(buf[i] - med);
+                    }
+                    Array.Sort(dev, 0, count);
+                    float sig = (float)(dev[count >> 1] * MadToSigma);
+                    if (sig < sigmaFloor) {
+                        sig = sigmaFloor;
+                    }
+
+                    int gi = blockRow * gridCols + blockCol;
+                    median[gi] = med;
+                    sigma[gi] = sig;
+                }
+            });
+
+            return new LocalBackgroundGrid(gridRows, gridCols, blockSize, median, sigma);
+        }
+
+        /// <summary>
+        /// Binarizes <paramref name="src"/> against a per-pixel <paramref name="thresholdSurface"/> instead of a
+        /// single scalar: dst(x,y) = src(x,y) &gt; thresholdSurface(x,y) ? 1.0f : 0.0f. This is the spatially-varying
+        /// analogue of <see cref="Binarize(Mat, Mat, double)"/> (same strict-greater, same {0,1} CV_32F output), used
+        /// by the adaptive-binarization path. <paramref name="dst"/> may alias <paramref name="src"/>.
+        /// </summary>
+        public static void BinarizeAdaptive(Mat src, Mat dst, Mat thresholdSurface) {
+            if (src.Type() != MatType.CV_32F) {
+                throw new ArgumentException("Only CV_32F supported");
+            }
+            if (src.Size() != thresholdSurface.Size()) {
+                throw new ArgumentException("thresholdSurface size must match src");
+            }
+
+            // (src - surface) > 0  ⟺  src > surface (strict greater, matching the scalar Binarize). Done via
+            // Subtract + THRESH_BINARY (the same primitive Binarize uses) so the output is {0.0f, 1.0f} CV_32F.
+            // dst may alias src (the in-place detector call), in which case the subtract writes through src.
+            Cv2.Subtract(src, thresholdSurface, dst);
+            Cv2.Threshold(dst, dst, 0.0d, 1.0d, ThresholdTypes.Binary);
         }
 
         public static System.Drawing.Rectangle ToDrawingRectangle(this OpenCvSharp.Rect openCvRect) {

--- a/Joko.NINA.Plugins/TestApp/BankVerifyRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/BankVerifyRunner.cs
@@ -100,7 +100,8 @@ namespace TestApp {
             var runs = DiagnosticUtil.GetArg(args, "--runs");
             if (string.IsNullOrWhiteSpace(runs) || !Directory.Exists(runs)) {
                 Console.Error.WriteLine("Usage: TestApp bank-verify --runs <bank-root> [--out <dir>] [--nc-sweep 2,3,4] " +
-                    "[--opt-a <dir>] [--opt-b <dir>] [--golden <dir>] [--match-radius 12] [--commit <hash>] [--profile-id <guid>]");
+                    "[--opt-a <dir>] [--opt-b <dir>] [--golden <dir>] [--match-radius 12] [--commit <hash>] [--profile-id <guid>] " +
+                    "[--adaptive-binarize] [--adaptive-block 128]");
                 Environment.ExitCode = 2;
                 return;
             }
@@ -115,6 +116,12 @@ namespace TestApp {
             var commit = DiagnosticUtil.GetArg(args, "--commit") ?? "unknown";
             var profileId = DiagnosticUtil.GetArg(args, "--profile-id");
             var ncSweep = ParseNcSweep(DiagnosticUtil.GetArg(args, "--nc-sweep") ?? "2,3,4");
+            // Spatially-adaptive binarization override for the C0 (as-default) configs — the flag-on-vs-off A/B that
+            // the adaptive-noiseclip feature is validated by (docs/adaptive-noiseclip-design.md). Default OFF mirrors
+            // the shipped default. The optimized A/B configs instead receive these via OverlayOptimized.
+            var adaptiveBinarize = DiagnosticUtil.HasFlag(args, "--adaptive-binarize");
+            var adaptiveBlock = DiagnosticUtil.GetArg(args, "--adaptive-block");
+            int adaptiveBlockSize = (adaptiveBlock != null && int.TryParse(adaptiveBlock, NumberStyles.Integer, CultureInfo.InvariantCulture, out var abv)) ? abv : 128;
 
             Logger.SetLogLevel(LogLevelEnum.INFO);
             // The WPF Application + dispatcher SynchronizationContext are set up by Run() on this STA thread.
@@ -132,7 +139,7 @@ namespace TestApp {
 
             var discovery = OptimizationRunDiscovery.Discover(runs);
             Console.WriteLine($"bank-verify: {discovery.Runs.Count} run(s) under {runs}; NC sweep [{string.Join(",", ncSweep.Select(x => x.ToString(CultureInfo.InvariantCulture)))}]; " +
-                $"A={(optA ?? "(none)")} B={(optB ?? "(none)")}; matchRadius={matchRadius}");
+                $"A={(optA ?? "(none)")} B={(optB ?? "(none)")}; matchRadius={matchRadius}; adaptiveBinarize={adaptiveBinarize}" + (adaptiveBinarize ? $"(block={adaptiveBlockSize})" : ""));
 
             var runResults = new List<RunResult>();
             int idx = 0;
@@ -141,7 +148,8 @@ namespace TestApp {
                 Console.WriteLine($"[{idx}/{discovery.Runs.Count}] {run.RunId}");
                 try {
                     var rr = await VerifyRunAsync(run, runs, outDir, ncSweep, optA, optB, goldenDir, matchRadius,
-                        profileService, activeProfile, starDetectionOptions, inspectorOptions, autoFocusOptions, detector, alglib, pixelScale);
+                        profileService, activeProfile, starDetectionOptions, inspectorOptions, autoFocusOptions, detector, alglib, pixelScale,
+                        adaptiveBinarize, adaptiveBlockSize);
                     runResults.Add(rr);
                 } catch (Exception ex) {
                     Console.Error.WriteLine($"  FAILED: {ex.GetType().Name}: {ex.Message}");
@@ -161,7 +169,7 @@ namespace TestApp {
             OptimizationRunDiscovery.DiscoveredRun run, string runsRoot, string outDir, double[] ncSweep, string optA, string optB,
             string goldenDir, double matchRadius, ProfileService profileService, NINA.Profile.Interfaces.IProfile activeProfile,
             StarDetectionOptions sdOptions, InspectorOptions inspectorOptions, AutoFocusOptions afOptions,
-            StarDetector detector, AlglibAPI alglib, double pixelScale) {
+            StarDetector detector, AlglibAPI alglib, double pixelScale, bool adaptiveBinarize, int adaptiveBlockSize) {
 
             var runFolder = Path.GetDirectoryName(run.Frames.First().Path);
             var ordered = run.Frames.OrderBy(f => f.FocuserPosition).ToList();
@@ -223,6 +231,8 @@ namespace TestApp {
             foreach (var nc in ncSweep) {
                 var p = BaseDefault();
                 p.NoiseClippingMultiplier = nc;
+                p.LocallyAdaptiveBinarization = adaptiveBinarize;
+                p.AdaptiveNoiseBlockSize = adaptiveBlockSize;
                 var cm = await ScoreConfigAsync($"C0@nc{nc:0.#}", nc, false, p, evalData, loaded, goldenByFocuser, matchRadius,
                     inspectorOptions, alglib, profileService, activeProfile, stepSize, detector);
                 rr.configs.Add(cm);
@@ -376,6 +386,7 @@ namespace TestApp {
             p.StructureLayers = s.StructureLayers; p.NoiseReductionRadius = s.NoiseReductionRadius;
             p.MinimumStarBoundingBoxSize = s.MinStarBoundingBoxSize; p.HotpixelThresholdingEnabled = s.HotpixelThresholdingEnabled;
             p.HotpixelThreshold = s.HotpixelThreshold;
+            p.LocallyAdaptiveBinarization = s.LocallyAdaptiveBinarization; p.AdaptiveNoiseBlockSize = s.AdaptiveNoiseBlockSize;
             var master = forceDonutMaster || s.DefocusAwareDonutDetection;
             p.DefocusAwareDonutDetection = master;
             p.DefocusAwareDistortion = s.DefocusAwareGates && master; p.DefocusAwareCentering = s.DefocusAwareGates && master;

--- a/Joko.NINA.Plugins/TestApp/GoldenEvalRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/GoldenEvalRunner.cs
@@ -325,6 +325,8 @@ namespace TestApp {
             Dbl("--max-distortion", v => p.MaxDistortion = v, "maxDist");
             Dbl("--min-hfr", v => p.MinHFR = v, "minHFR");
             Dbl("--star-center-tolerance", v => p.StarCenterTolerance = v, "centerTol");
+            Int("--adaptive-block", v => p.AdaptiveNoiseBlockSize = v, "adaptiveBlock");  // adaptive-binarization grid (candidate formation)
+            if (DiagnosticUtil.HasFlag(args, "--adaptive-binarize")) { p.LocallyAdaptiveBinarization = true; notes.Add("adaptiveBinarize"); }
             if (notes.Count > 0) {
                 sourceLabel += " +params[" + string.Join(",", notes) + "]";
             }
@@ -346,6 +348,8 @@ namespace TestApp {
             p.MinimumStarBoundingBoxSize = s.MinStarBoundingBoxSize;
             p.HotpixelThresholdingEnabled = s.HotpixelThresholdingEnabled;
             p.HotpixelThreshold = s.HotpixelThreshold;
+            p.LocallyAdaptiveBinarization = s.LocallyAdaptiveBinarization;
+            p.AdaptiveNoiseBlockSize = s.AdaptiveNoiseBlockSize;
 
             var master = s.DefocusAwareDonutDetection;
             p.DefocusAwareDonutDetection = master;

--- a/Joko.NINA.Plugins/TestApp/InspectAlignRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/InspectAlignRunner.cs
@@ -208,6 +208,7 @@ namespace TestApp {
                     p.StructureLayers = s.StructureLayers; p.NoiseReductionRadius = s.NoiseReductionRadius;
                     p.MinimumStarBoundingBoxSize = s.MinStarBoundingBoxSize; p.HotpixelThresholdingEnabled = s.HotpixelThresholdingEnabled;
                     p.HotpixelThreshold = s.HotpixelThreshold;
+                    p.LocallyAdaptiveBinarization = s.LocallyAdaptiveBinarization; p.AdaptiveNoiseBlockSize = s.AdaptiveNoiseBlockSize;
                     var master = s.DefocusAwareDonutDetection;
                     p.DefocusAwareDonutDetection = master;
                     p.DefocusAwareDistortion = s.DefocusAwareGates && master; p.DefocusAwareCentering = s.DefocusAwareGates && master;
@@ -223,6 +224,9 @@ namespace TestApp {
             }
             var nc = DiagnosticUtil.GetArg(args, "--noise-clip");
             if (nc != null && double.TryParse(nc, NumberStyles.Float, CultureInfo.InvariantCulture, out var ncv)) { p.NoiseClippingMultiplier = ncv; }
+            var adaptiveBlock = DiagnosticUtil.GetArg(args, "--adaptive-block");
+            if (adaptiveBlock != null && int.TryParse(adaptiveBlock, NumberStyles.Integer, CultureInfo.InvariantCulture, out var abv)) { p.AdaptiveNoiseBlockSize = abv; }
+            if (DiagnosticUtil.HasFlag(args, "--adaptive-binarize")) { p.LocallyAdaptiveBinarization = true; }
             if (DiagnosticUtil.HasFlag(args, "--defocus-donut")) { p.DefocusAwareDonutDetection = true; }
             if (DiagnosticUtil.HasFlag(args, "--defocus-gates")) { p.DefocusAwareDistortion = true; p.DefocusAwareCentering = true; }
             if (DiagnosticUtil.HasFlag(args, "--defocus-structure")) { p.DefocusAwareStructure = true; if (p.StructureLayerBoost <= 0) p.StructureLayerBoost = 2; }

--- a/docs/adaptive-noiseclip-design.md
+++ b/docs/adaptive-noiseclip-design.md
@@ -133,6 +133,11 @@ Reuses the harness this design came from:
      regresses donuts / AF σ): remove the option rather than leave a permanent default-OFF flag. The opt-in/default-
      OFF state in steps 1–4 exists **only** to make this go/no-go comparison clean — it is not a shipping outcome.
 
+   **Outcome (2026-06-24): PASSED — shipped ON.** OFF-vs-ON at NC=2 across the 17-run bank improved bank-median
+   recall@SNR≥12 (0.870→0.877), precision (0.585→0.618), and AF σ_focus (10.26→8.84); cwhite_2026 recall 0.459→0.862;
+   donut runs no regression (Panos flat, mufti +26%). Default flipped ON (commit `c59a4b1`, PR #98); full numbers +
+   per-run table in `docs/af-bank-noiseclip-sweep-results.md`.
+
 ## Risks & notes
 
 - **Tracking real extended structure into the background.** A too-small block could absorb a large defocused

--- a/docs/af-bank-noiseclip-sweep-results.md
+++ b/docs/af-bank-noiseclip-sweep-results.md
@@ -27,6 +27,54 @@ both precision up). All four rollout-gate criteria passed, so **`LocallyAdaptive
 (retained as a user/regression off-switch; legacy-OFF stays bit-identical). NC itself stays at 2 — the adaptive
 surface makes that 2 locally fair everywhere.
 
+### Per-run, OFF → ON at NC=2 (for the record)
+
+C0 (as-default, donut OFF) unless noted. recall = recall@SNR≥12. Grouped by golden coverage (precision is a lower
+bound on the deep runs — see the precision caveat further down).
+
+| run | coverage | recall OFF→ON | precision OFF→ON | AF σ OFF→ON |
+|---|---|---|---|---|
+| cwhite_2026 | well-covered | 0.459 → **0.862** | 0.811 → 0.779 | 10.65 → **4.10** |
+| fmeschia¹ | well-covered | 0.966 → 0.963 | 0.792 → 0.806 | 34.2 → 40.2 |
+| caboose | well-covered | 0.885 → 0.892 | 0.698 → 0.629 | 6.33 → 5.53 |
+| CWhiteFocus | large mono | 0.870 → 0.877 | 0.528 → 0.507 | 7.81 → 8.84 |
+| FlyData | mono | 0.765 → 0.779 | 0.585 → **0.674** | 9.86 → 11.05 |
+| muggsie | mono | 0.933 → 0.932 | 0.600 → 0.618 | 24.9 → 23.3 |
+| standard_example1 | large mono | 0.936 → 0.935 | 0.575 → 0.585 | 28.5 → 31.6 |
+| uneven | large mono | 0.970 → 0.971 | 0.529 → 0.521 | 33.96 → **28.74** |
+| mccomiskey | deep (P=lower bnd) | 0.890 → 0.892 | 0.399 → 0.418 | 3.28 → 3.32 |
+| toml999 | deep (P=lower bnd) | 0.916 → 0.916 | 0.443 → 0.449 | 0.84 → 0.86 |
+| timmer | deep (P=lower bnd) | 0.553 → 0.557 | 0.733 → 0.733 | 1.36 → 1.34 |
+| Panos (donut-aware) | donut | 0.242 → 0.240 | 0.571 → 0.588 | — |
+| mufti (donut-aware) | donut | 0.395 → **0.499** | 0.619 → 0.624 | — |
+
+¹ `sensitivity_example1` ≡ `fmeschia` and `sensitivity_example2` ≡ `LinwoodFocus` are bit-identical dataset copies
+(they inherit those rows). Bank medians above are over all 17 runs. The donut rows are run via donut-aware detection
+(`--defocus-donut`) — C0's donut-OFF numbers on donut runs are broken either way, so the adaptive check there is
+done with donut detection on; recall there is recall@high.
+
+**Reading it:** recall@≥12 is up or flat on every run (the big lift is the previously-starved cwhite_2026,
+0.459→0.862). Precision moves both ways per run but the bank median rises (0.585→0.618) — adaptive recovers faint
+reals in clean regions *and* suppresses noise in noisy corners. AF σ_focus is mixed per run (a few small,
+poorly-constrained runs get marginally noisier from the extra faint stars) but the median tightens 10.26→8.84, and
+the gold-standard run tightens dramatically. Donut recall does not regress (Panos flat, mufti +26%).
+
+### Rollout-gate decision
+
+| criterion | result |
+|---|---|
+| recall@SNR≥12 ↑ | PASS — median 0.870→0.877; cwhite_2026 0.459→0.862 |
+| precision not ↓ | PASS — median 0.585→0.618 |
+| no AF σ regression | PASS — median 10.26→8.84 (a few small runs marginally noisier; net better) |
+| no donut-recall regression | PASS — Panos flat, mufti +26% |
+
+All four passed ⇒ default flipped ON (commit `c59a4b1`): `StarDetectorParams` initializer,
+`BuildDefaultStarDetectorParams`, `StarDetectionOptions.InitializeOptions` + `ResetDefaults`. The sensitivity-gate
+logic test (`MeanFluxDenominatorTests.Detect_HighSensitivityGate_…`) pins `LocallyAdaptiveBinarization=false` (the
+same way it already pins `NoiseClippingMultiplier=4`) so it keeps testing the gate, not the new default. Full suite
+green 1528/0. Method note: OFF is bit-identical to this build, so the prior `verification_20260624T142723Z` C0 rows
+serve as the OFF baseline (same complete goldens); the ON sweep was `verification_20260624T155647Z`.
+
 The original NC 4→2 analysis below still stands and is the foundation for this.
 
 The verification config **C0 (as-default)** — the shipped defaults with NC swept over {2, 3, 4} — is the honest

--- a/docs/af-bank-noiseclip-sweep-results.md
+++ b/docs/af-bank-noiseclip-sweep-results.md
@@ -14,11 +14,14 @@ Report: `D:\Autofocus Bank\verification_<UTC>.{json,md}` (schema `afbank-verify/
 
 ## Headline — recall vs NC (bank median over 17 runs)
 
-| NC | median recall@SNR≥12 | median precision* | median AF σ_focus | median sensor R² |
-|----|----------------------|-------------------|-------------------|------------------|
-| 2  | **0.870**            | 0.508*            | 10.26             | 0.832            |
-| 3  | 0.831                | 0.598*            | 10.97             | 0.898            |
-| 4  | 0.797                | 0.668*            | 9.55              | 0.769            |
+| NC | median recall@SNR≥12 | median recall@all | median precision* | median AF σ_focus | median sensor R² |
+|----|----------------------|-------------------|-------------------|-------------------|------------------|
+| 2  | **0.870**            | 0.851             | 0.585*            | 10.26             | 0.832            |
+| 3  | 0.831                | 0.798             | 0.694*            | 10.97             | 0.898            |
+| 4  | 0.797                | 0.724             | 0.764*            | 9.55              | 0.769            |
+
+(Numbers from the complete-QA goldens, `verification_20260624T142723Z`. The first pass used a rate-limited partial
+QA; completing it raised precision ~+0.08 at every NC — confirming the artifact direction below.)
 
 **recall@SNR≥12 rises monotonically as NC falls, on every run and at the bank median (4→2 lifts median recall
 0.797 → 0.870).** This reproduces and generalizes the cwhite golden-set audit that motivated 4→2: a lower
@@ -40,15 +43,20 @@ The bank-median precision (0.51 at NC=2) is **deflated by an artifact of the gol
   (`BankVerifyAggregate.RecommendNoiseClip`, which picks the lowest NC clearing a 0.60 precision floor) toward
   NC=4. **The recommender logic is sound; its precision input is unreliable for high-candidate runs.**
 
-Where the golden IS complete, precision holds up at NC=2:
+Even after completing the QA, the deep wide-field runs are only *sampled* (4 montages/frame can't cover a
+60k-candidate uncertain tier), so their precision stays a lower bound. The split at **NC=2** is stark:
 
-| run | golden quality | recall@≥12 NC2→NC4 | precision NC2→NC4 |
-|---|---|---|---|
-| **cwhite_2026** | **complete** (7875 stars, full QA from the dry-run) | 0.459 → 0.189 | **0.811 → 0.849** |
+| golden coverage | runs (precision @ NC=2) | reads as |
+|---|---|---|
+| **well-covered** (small uncertain tier, ~fully QA'd) | cwhite_2026 **0.811**, fmeschia **0.792**, caboose **0.698** | true precision — all well above the 0.60 floor |
+| **under-sampled** (huge uncertain tier) | mccomiskey **0.399**, toml999 **0.443** | lower bound — real faint detections miscounted as FP |
 
-cwhite_2026 — the only run with a fully-QA'd golden — shows NC=2 **more than doubles** recall@≥12 (0.189→0.459)
-at **<5% precision cost** (0.849→0.811, still well above any sane floor). That is the gold-standard data point,
-and it endorses NC=2 unambiguously.
+The bank **median** precision at NC=2 (0.585) is dragged below 0.60 entirely by the under-sampled runs; where the
+golden is reasonably complete, NC=2 precision is 0.70–0.81. And note the recommender's pick **moves toward lower NC
+as the golden gets more complete** — NC=4 (high-tier-only) → NC=3 (complete-QA but deep runs still sampled) → it
+would reach **NC=2** if the deep runs' uncertain tiers could be fully QA'd. The trajectory itself points at 2.
+cwhite_2026 (the most complete golden) shows NC=2 **more than doubles** recall@≥12 (0.189→0.459) at a few-% precision
+cost (0.849→0.811) — the gold-standard data point, and it endorses NC=2 unambiguously.
 
 ## Verdict
 
@@ -63,9 +71,11 @@ and it endorses NC=2 unambiguously.
    *below* 2. So a single global default of 2 is well-centered, but deriving NC per frame from the measured local
    noise floor (σ from `coarse_bg`-style block statistics) during candidate formation could recover a little more
    on the cleanest frames while staying safe on the noisiest. Concrete follow-up, not a regression.
-3. **Ignore the auto-recommender's "NC=4".** `BankVerifyAggregate.RecommendNoiseClip` picks the lowest NC clearing
-   a precision floor; fed the artifact-deflated C0 precision it returns NC=4. The recommender logic is fine; its
-   input isn't. The optimizer's converged NC (point 1c) is the trustworthy machine signal.
+3. **Ignore the auto-recommender's "NC=3".** `BankVerifyAggregate.RecommendNoiseClip` picks the lowest NC clearing
+   a precision floor; fed the still-artifact-deflated bank-median precision it returns NC=3 (it returned NC=4 on the
+   partial goldens — the pick walks toward 2 as the golden completes, which is itself the tell). The recommender
+   logic is fine; its input — a precision *lower bound* on the deep runs — isn't. The optimizer's converged NC
+   (point 1c) and the well-covered runs' precision (0.70–0.81 at NC=2) are the trustworthy signals.
 
 ## Per-run notes
 

--- a/docs/af-bank-noiseclip-sweep-results.md
+++ b/docs/af-bank-noiseclip-sweep-results.md
@@ -5,6 +5,30 @@ whole `D:\Autofocus Bank` (17 AF runs, mixed cameras/optics), using the repeatab
 (`plans/autofocus-bank-verification-plan.md`, PR #96). The user's question: *was 4→2 the best change, or should NC
 be derived adaptively from the live data?*
 
+## Update — adaptive NC validated, shipped ON by default
+
+The "derive NC adaptively" follow-up was built and validated. Rather than a per-frame *scalar* NC, the win is
+making the threshold NC scales **spatially adaptive**: `local-median(x,y) + NC·local-σ(x,y)` from robust per-block
+statistics (design: `docs/adaptive-noiseclip-design.md`; option `LocallyAdaptiveBinarization`). It was A/B-tested
+OFF (legacy, bit-identical) vs ON at NC=2 across the bank (`bv_on/verification_20260624T155647Z` vs the OFF
+baseline `verification_20260624T142723Z`):
+
+| metric @ NC=2 (bank median) | OFF | ON |
+|---|---|---|
+| recall@SNR≥12 | 0.870 | **0.877** ↑ |
+| precision | 0.585 | **0.618** ↑ |
+| AF σ_focus | 10.26 | **8.84** ↑ (tighter) |
+
+It improves **recall *and* precision together** — which no single global NC can, because the defect was the
+threshold's *shape* (a global scalar over a spatially non-uniform frame), not its level. The standout is the
+well-covered run **cwhite_2026**: recall@≥12 **0.459 → 0.862** at a few-% precision cost (0.811→0.779) with AF σ
+tightened **10.65 → 4.1**. Donut runs did not regress (donut-aware: Panos 0.242→0.240 flat, mufti 0.395→**0.499**,
+both precision up). All four rollout-gate criteria passed, so **`LocallyAdaptiveBinarization` now defaults ON**
+(retained as a user/regression off-switch; legacy-OFF stays bit-identical). NC itself stays at 2 — the adaptive
+surface makes that 2 locally fair everywhere.
+
+The original NC 4→2 analysis below still stands and is the foundation for this.
+
 The verification config **C0 (as-default)** — the shipped defaults with NC swept over {2, 3, 4} — is the honest
 recall reference (no optimization). Each config is scored against a detector-independent golden set
 (`snr_ref.py` SNR/connected-component reference on the linear frames, with the SNR≥12 tier auto-confirmed and the

--- a/plans/adaptive-noiseclip-plan.md
+++ b/plans/adaptive-noiseclip-plan.md
@@ -12,10 +12,12 @@ permanent opt-in flag.
 
 ## Execution status — HANDOFF (2026-06-24)
 
-**Steps 1–5 are DONE and committed on `ghilios/adaptive-noiseclip`. The feature is fully implemented behind the
-`LocallyAdaptiveBinarization` option (default OFF) and bit-identical when off. Full unit suite green: 1528 passed /
-0 failed (was 1514 before; +14 new tests). Steps 6 (AF-bank validation) and 7 (rollout gate) REMAIN — to be run in
-a fresh session.**
+**ALL STEPS DONE.** Steps 1–5 (implementation, commit `9a80324`). **Step 6 (validation) + Step 7 (rollout gate)
+COMPLETE:** the OFF-vs-ON AF-bank A/B at NC=2 PASSED all four gate criteria — bank-median recall@SNR≥12 0.870→0.877,
+precision 0.585→0.618, AF σ 10.26→8.84 (all ↑); cwhite_2026 recall 0.459→0.862; donut runs no regression (Panos
+flat, mufti +26%). So **`LocallyAdaptiveBinarization` default flipped to ON** (4 seams) and the gate-logic test
+`Detect_HighSensitivityGate_RejectsCoreHaloStarsOnHonestMeanFlux` pins legacy-OFF (same as its NC pin). Full suite
+green 1528/0. Results in `docs/af-bank-noiseclip-sweep-results.md`. Ready for PR into develop.
 
 ### Build/test cycle on this machine (WSL → Windows) — important
 - There is **no Linux dotnet**; build/test with the **Windows** `dotnet.exe` at `/mnt/c/Program Files/dotnet/dotnet.exe`

--- a/plans/adaptive-noiseclip-plan.md
+++ b/plans/adaptive-noiseclip-plan.md
@@ -10,6 +10,84 @@ behind a flag that is bit-identical when off, then — per the design's rollout 
 improves recall AND precision at NC=2 on the AF bank with no AF/donut regression, else drop the feature.** No
 permanent opt-in flag.
 
+## Execution status — HANDOFF (2026-06-24)
+
+**Steps 1–5 are DONE and committed on `ghilios/adaptive-noiseclip`. The feature is fully implemented behind the
+`LocallyAdaptiveBinarization` option (default OFF) and bit-identical when off. Full unit suite green: 1528 passed /
+0 failed (was 1514 before; +14 new tests). Steps 6 (AF-bank validation) and 7 (rollout gate) REMAIN — to be run in
+a fresh session.**
+
+### Build/test cycle on this machine (WSL → Windows) — important
+- There is **no Linux dotnet**; build/test with the **Windows** `dotnet.exe` at `/mnt/c/Program Files/dotnet/dotnet.exe`
+  (v10.0.301). Pass **Windows-style paths** (WSL interop does NOT translate `/mnt/c/...` for a Windows exe).
+- Run the unit suite scoped to the **Tests project** (this is the CLAUDE.md invariant command, and it dodges a
+  TestApp output-DLL lock — see Step 6 note):
+  `"/mnt/c/Program Files/dotnet/dotnet.exe" test 'C:\Users\ghili\src\nina.plugins\Joko.NINA.Plugins\Joko.NINA.Plugins.HocusFocus.Tests\Joko.NINA.Plugins.HocusFocus.Tests.csproj' -c Debug --nologo`
+  (Building the whole `.sln` also builds TestApp, whose post-build copy fails while a TestApp is running — that is the
+  lock, not a code error. TestApp itself compiles clean: `dotnet.exe build TestApp.csproj` shows zero `CS####`,
+  only `MSB3021/3027` copy-lock errors.)
+
+### What was implemented (all behind the flag; OFF ⇒ byte-for-byte legacy)
+- **New options** `LocallyAdaptiveBinarization` (bool, default false) + `AdaptiveNoiseBlockSize` (int, default 128,
+  setter-validated [16,1024]) plumbed everywhere `DonutMorphCloseSize`/`DefocusAwareDonutDetection` live:
+  `StarDetectorParams` (Interfaces/IStarDetector.cs) + both added to `StarDetector.EarlyCacheKeyProperties`;
+  `IStarDetectionOptions`; `StarDetectionOptions` (backing fields, accessors, InitializeOptions, ResetDefaults,
+  ApplyOptimizedSnapshotToLiveProperties, ApplyKnobs); `HocusFocusStarDetection.BuildStarDetectorParams` +
+  `BuildDefaultStarDetectorParams`; `OptimizedStarDetectionSettings` (+ FromParams, inert defaults);
+  `StarDetectionSettingsSnapshot` (+ FromOptions); `OptionsDataTemplates.xaml` (Advanced CheckBox + `UnitTextBox`
+  with `DoubleRangeRule` 64–256 — the codebase uses DoubleRangeRule for ints, not IntegerRangeRule — + two tooltips,
+  grid rows 52/53).
+- **Pure helper** `CvImageUtility.ComputeLocalBackgroundGrid(image, blockSize, sigmaFloor)` → `LocalBackgroundGrid`
+  (per-block median + 1.4826·MAD, σ floored, ceil grid, partial edge blocks, parallel, upper-middle median matching
+  `CalculateStatistics`; matches `snr_ref.coarse_bg`). TDD'd in `Tests/Utility/LocalBackgroundGridTests.cs`.
+- **`CvImageUtility.BinarizeAdaptive(src, dst, surface)`** — per-pixel `src > surface` via Subtract+THRESH_BINARY
+  (strict-greater, {0,1} CV_32F, matches scalar `Binarize`; degenerate-equivalence + per-pixel tests).
+- **Wiring in `StarDetector`** (the binarization seam): when ON, the σ grid is sampled on `noiseReducedImage` INSIDE
+  the existing kappa-sigma background task (before that image is disposed → F4 σ-consistency, same scale as the
+  global σ so NC stays meaningful), the median grid on `structureMap` pre-dilation (mirrors the global median), the
+  two grids are combined `median + NC·σ` at GRID resolution (bilinear upsample is linear, so one `Cv2.Resize`),
+  upsampled, and `BinarizeAdaptive` applied. When OFF, none of this runs — the exact legacy
+  `CvImageUtility.Binarize(structureMap, structureMap, binarizeThreshold)` line. Guarded by `StructureNoiseEstimate`
+  (the task now returns kappa-sigma result + optional σ grid). Sigma floor `1e-6f` (numerical only).
+- **TestApp harness parity:** `bank-verify` `--adaptive-binarize` / `--adaptive-block <n>` (applied to C0 BaseDefault
+  next to the NC sweep) + `OverlayOptimized`; `golden eval` `--adaptive-binarize` / `--adaptive-block` in
+  `ApplyParamOverrides` + `OverlayAll`; `InspectAlignRunner.ApplySettingsOverrides` + `OverlayAll`.
+
+### Bit-identical proof (the rollout gate)
+`Tests/StarDetection/StarDetectorEquivalenceTests.cs`: `Detect_AdaptiveBinarizationOff_MatchesLegacyBaseline`
+(flag OFF == committed golden signature) and `Detect_AdaptiveBinarizationOn_RecoversSameStarsOnUniformField`
+(ON path runs end-to-end and recovers the same stars on a uniform field). The pre-existing
+`Detect_SmallField_MatchesGoldenBaseline` (default params = flag OFF) also still passes.
+
+### Step 6 — how to resume (NOT yet run)
+At handoff a prior session's full `bank-verify` (PID 38176, commit `b331479`, opt_A/opt_B, started 08:59) was still
+running and held the TestApp output-DLL lock, so `TestApp.exe` could not be rebuilt the normal way. Either:
+  1. **Wait** for it to finish — done when a new `D:\Autofocus Bank\verification_<UTC>.md` appears (watch the flushed
+     `D:\Autofocus Bank\bank_verify_progress.log`), then build TestApp normally; OR
+  2. **Build TestApp to a separate output dir** to dodge the lock:
+     `"/mnt/c/Program Files/dotnet/dotnet.exe" build 'C:\...\TestApp\TestApp.csproj' -c Debug -o <freshdir>`
+     then run `<freshdir>\TestApp.exe`.
+Then run the OFF-vs-ON comparison at NC=2 (close any running NINA first; watch `<out>/bank_verify_progress.log`;
+~1–2 hr per config, ON slower due to the per-block reduction):
+```
+TestApp bank-verify --runs "D:\Autofocus Bank" --out <scratchOFF> --nc-sweep 2,3,4 --match-radius 12
+TestApp bank-verify --runs "D:\Autofocus Bank" --out <scratchON>  --nc-sweep 2,3,4 --match-radius 12 --adaptive-binarize
+```
+(The latest `D:\Autofocus Bank\verification_*.{json,md}` / `_prior_reports` can serve as the flag-OFF baseline if you
+prefer not to re-run OFF.) Goldens already exist (147 sidecars) — **do NOT regenerate**. Expected at NC=2:
+recall@SNR≥12 up further AND precision held/improved (largest gains on vignetted/gradient frames); no AF σ_focus
+regression; no donut-recall regression — verify Panos + mufti explicitly (donut runs need donut-aware: run them via
+config B, or `--adaptive-binarize` together with `--defocus-donut` on `golden eval` / `inspect-align`).
+
+### Step 7 — where the default flips on a PASS (mechanical)
+Flip false→true in: `StarDetectorParams.LocallyAdaptiveBinarization` initializer (Interfaces/IStarDetector.cs);
+`BuildDefaultStarDetectorParams` (HocusFocusStarDetection.cs); `StarDetectionOptions.InitializeOptions`
+(`GetValueBoolean("LocallyAdaptiveBinarization", false)`) + `ResetDefaults`. The XAML checkbox binds to the option,
+so it needs no separate literal. Keep `AdaptiveNoiseBlockSize`=128. Keep the boolean as an off-switch and KEEP the
+bit-identical test (it pins legacy-OFF). Re-baseline nothing. Update `docs/af-bank-noiseclip-sweep-results.md` with
+the on-vs-off bank numbers. On a FAIL, remove the option entirely and write up why in
+`docs/adaptive-noiseclip-design.md`. Then `superpowers:finishing-a-development-branch` → PR into develop.
+
 ## Project invariants (from CLAUDE.md — do not skip)
 - TDD: write the failing test first for every pure helper; run the full suite after every change:
   `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`.

--- a/plans/adaptive-noiseclip-plan.md
+++ b/plans/adaptive-noiseclip-plan.md
@@ -1,0 +1,100 @@
+# Plan: adaptive NoiseClippingMultiplier (spatially-adaptive binarization)
+
+**Read first:** `docs/adaptive-noiseclip-design.md` (the approved design — why, the exact root cause, the
+algorithm, the knobs, the rollout gate). This plan is the bite-sized execution of that spec. **Branch:**
+`ghilios/adaptive-noiseclip` (already created off `develop`; PR #96's verification harness is merged into develop,
+so `bank-verify` is available). Run `/clear` before starting so no stale context leaks in.
+
+**One-line goal:** make the structure-map binarization threshold spatially adaptive (`local-median + NC·local-σ`)
+behind a flag that is bit-identical when off, then — per the design's rollout gate — **flip the default ON if it
+improves recall AND precision at NC=2 on the AF bank with no AF/donut regression, else drop the feature.** No
+permanent opt-in flag.
+
+## Project invariants (from CLAUDE.md — do not skip)
+- TDD: write the failing test first for every pure helper; run the full suite after every change:
+  `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`.
+- A new persisted `*Options` value **must** also get a control in `Resources/OptionsDataTemplates.xaml`.
+- Read `.claude/docs/star-detection-internals.md` and `.claude/docs/options-system.md` before touching the
+  detector / options.
+- Commit with the privacy email (`322725+ghilios@users.noreply.github.com`); never push to develop directly.
+
+## Step 1 — Orient (read, don't code yet)
+- `StarDetector.cs`, the binarization block (search `binarizeThreshold`): currently
+  `structureMapStats.Median + p.NoiseClippingMultiplier * noiseReducedImageNoise.Sigma` — a single global scalar.
+  This is the seam. Note the `EarlyParamKeys` list near the top (NoiseClippingMultiplier is in it) — the two new
+  params are EARLY params (they change the candidate set) and must be added there so the optimizer split-frame
+  cache stays correct.
+- Mirror how `DefocusAwareDonutDetection` is plumbed end-to-end (it is the template for an opt-in, bit-identical
+  detector flag): grep it across `Interfaces/IStarDetector.cs` (the `StarDetectorParams` field),
+  `StarDetection/HocusFocusStarDetection.cs` (`BuildStarDetectorParams` + `BuildDefaultStarDetectorParams`),
+  `StarDetection/StarDetectionOptions.cs` (field + accessor + `ResetDefaults`), and
+  `Resources/OptionsDataTemplates.xaml` (the Advanced CheckBox + tooltip).
+
+## Step 2 — Add the params + options (default OFF)
+- `StarDetectorParams` (`Interfaces/IStarDetector.cs`): `bool LocallyAdaptiveBinarization = false;` and
+  `int AdaptiveNoiseBlockSize = 128;`. Add `LocallyAdaptiveBinarization` to the EARLY param key list.
+- `StarDetectionOptions.cs`: backing fields + accessor get/set (persist via `optionsAccessor`) + set both in
+  `ResetDefaults` (OFF / 128). Plumb both through `BuildStarDetectorParams` AND `BuildDefaultStarDetectorParams`.
+- `OptionsDataTemplates.xaml`: an Advanced CheckBox for the bool + a `UnitTextBox`+`IntegerRangeRule` (≈64–256) for
+  the block size, with tooltips (copy the donut-flag block's style).
+- TestApp overlay parity (so the harness can exercise it): add both fields to `OptimizedStarDetectionSettings` +
+  the overlay in `BankVerifyRunner.OverlayOptimized`, `GoldenEvalRunner` `OverlayAll`, and
+  `InspectAlignRunner.ApplySettingsOverrides`. Add a `--adaptive-binarize` / `--adaptive-block <n>` CLI override to
+  `golden eval` and `bank-verify` (mirror the existing `--noise-clip` override) so you can A/B the flag without
+  changing the default yet.
+- Build; full suite green (these are additive, no behavior change yet).
+
+## Step 3 — TDD the pure block-statistics helper
+- New pure helper (e.g. `CvImageUtility.ComputeLocalNoiseSurface` or a small static in the detector namespace) that,
+  given an image + block size, returns per-block `(median, 1.4826·MAD)` on a coarse grid (floor σ at a small eps),
+  matching `tools/golden/snr_ref.py:coarse_bg` semantics (block median + MAD·1.4826, edge blocks pad by
+  replication). Keep the grid reduction separate from the upsample so it is unit-testable on a tiny synthetic Mat.
+- RED→GREEN tests: a uniform image → flat surface = (median, ~0); a two-region image (clean half + noisy half) →
+  the noisy block's σ is larger; edge padding behaves. Put tests under `Tests/` (link any TestApp-resident helper
+  like the existing `OptimizationRunDiscovery` pattern, or test the plugin helper directly).
+
+## Step 4 — Wire it into binarization (guarded; bit-identical when off)
+- At the binarization seam: if `!p.LocallyAdaptiveBinarization`, keep the EXACT current scalar path (do not even
+  compute the surface) — this is the bit-identical guarantee. If on: compute the coarse `(median_local, σ_local)`
+  grids from the **same source the global estimate uses** (the noise-reduced structure-map source; honor the F4
+  σ-consistency note), bilinearly upsample to full res, and binarize `structureMap(x,y) > median_local + NC·σ_local`
+  instead of the scalar compare. Everything downstream (dilation, flood-fill, gates) is unchanged.
+- Use OpenCvSharp for the upsample (`Cv2.Resize` bilinear) and a tight loop / `Cv2.Compare` for the threshold; keep
+  it in the cacheable EARLY context.
+
+## Step 5 — Bit-identical regression test
+- A test that detects a real (or synthetic) frame with the flag OFF and asserts the accepted-star set is identical
+  to a pre-change baseline (same guarantee `DefocusAwareDonutDetection`-off has). This is the gate that lets the
+  default flip safely. Full suite green.
+
+## Step 6 — Validate on the AF bank (the design's validation plan)
+The golden set + optimizer settings already exist on **this machine** (do NOT regenerate):
+- Goldens: `*.golden.json` beside the frames in `D:\Autofocus Bank\...` (147 sidecars; **high-tier complete**,
+  uncertain tier complete for small/moderate runs, a sample for deep wide-field runs — so trust **recall@SNR≥12**
+  everywhere and **precision** on the well-covered runs; mccomiskey/timmer precision stays a lower bound).
+- Prior baseline reports: `D:\Autofocus Bank\_prior_reports\` and the latest `verification_<UTC>.{json,md}` at the
+  bank root (flag-OFF baseline).
+- Optimizer A/B settings (optional, only needed for the A/B columns): the run that produced them is gone, but
+  re-run `optimize --per-run [--donut]` if you want A/B; for THIS feature the **C0 flag-on-vs-off** comparison is
+  what matters.
+
+Run, comparing flag OFF vs ON at NC=2 (use the `--adaptive-binarize` override from Step 2, or temporarily default it
+ON):
+```
+TestApp bank-verify --runs "D:\Autofocus Bank" --out <scratch> --nc-sweep 2,3,4 --match-radius 12
+TestApp bank-verify --runs "D:\Autofocus Bank" --out <scratch> --nc-sweep 2,3,4 --match-radius 12 --adaptive-binarize
+```
+Expected at fixed NC=2: recall@SNR≥12 up further AND precision held/improved (the spatial surface improves both
+axes — no single global NC can). Largest gains on vignetted/gradient frames. Confirm AF σ_focus does not regress
+and donut runs (Panos, mufti) do not lose donut recall.
+- Operational notes: `bank-verify` writes a flushed progress log `<out>/bank_verify_progress.log` (WSL block-buffers
+  stdout, so watch that file, not stdout); per-run sidecars in `<out>/bank_verify/<runtag>/verify.json`; full bank
+  is ~1–2 hr on 61–102 MP frames; close any running NINA so it doesn't lock the profile / contend for CPU.
+
+## Step 7 — Rollout gate (the whole point)
+- **Pass** (recall ↑ AND precision not ↓, no AF/donut regression): flip `LocallyAdaptiveBinarization` default to
+  **ON** in `BuildDefaultStarDetectorParams`, the `StarDetectionOptions` default + `ResetDefaults`, and the
+  XAML initial value. Keep the boolean as an off-switch + for the bit-identical test. Update
+  `docs/af-bank-noiseclip-sweep-results.md` with the on-vs-off numbers. Full suite green.
+- **Fail:** remove the option entirely (no permanent default-OFF flag) and write up why in the design doc.
+- Finish via `superpowers:finishing-a-development-branch` → PR into develop.


### PR DESCRIPTION
Makes the structure-map binarization threshold **spatially adaptive** — `local-median(x,y) + NC·local-σ(x,y)` from robust per-block statistics, bilinearly upsampled — so the same NC=2 is locally fair (low threshold in clean regions → recovers faint reals; high in noisy corners → rejects noise). The root cause it fixes: the old threshold was a single **global scalar** over a spatially non-uniform frame, so it was simultaneously too high in the clean center (lost recall) and too low in the noisy corners (lost precision). Design + rationale: `docs/adaptive-noiseclip-design.md`.

## What's here
- **New options** `LocallyAdaptiveBinarization` (**default ON**) + `AdaptiveNoiseBlockSize` (128), plumbed everywhere the donut flags live (params + EARLY cache keys, options + interface + replay snapshot, optimizer DTO, XAML control + tooltips) and through the TestApp harness (`bank-verify`/`golden eval`/`inspect-align` overlays + `--adaptive-binarize`/`--adaptive-block`).
- **Pure helpers** `CvImageUtility.ComputeLocalBackgroundGrid` (per-block median + 1.4826·MAD, matches `snr_ref.coarse_bg`) + `BinarizeAdaptive`, both TDD'd. Combine is done at grid resolution with a single upsample (bilinear is linear).
- **Bit-identical when OFF** (the spatial path is never entered) — pinned by `StarDetectorEquivalenceTests`. The flag is retained as a user/regression off-switch.

## Validation (the rollout gate)
OFF-vs-ON A/B at NC=2 across the 17-run AF bank passed all four gate criteria:

| metric @ NC=2 (bank median) | OFF | ON |
|---|---|---|
| recall@SNR≥12 | 0.870 | **0.877** ↑ |
| precision | 0.585 | **0.618** ↑ |
| AF σ_focus | 10.26 | **8.84** ↑ |

It improves recall **and** precision together (no global NC can). Standout: the well-covered **cwhite_2026** — recall@≥12 **0.459 → 0.862** at a few-% precision cost, AF σ **10.65 → 4.1**. Donut runs no regression (donut-aware: Panos 0.242→0.240 flat, mufti 0.395→**0.499** +26%, both precision up). Numbers in `docs/af-bank-noiseclip-sweep-results.md`.

Default flipped ON in the four seams; the one sensitivity-gate logic test pins legacy-OFF (same as its existing NC pin). **Full suite green: 1528 / 0.**

## Also in this branch (post-PR #96 work)
- Two reusable skills: `running-af-bank-validation` + `generating-af-golden-data`.
- Precision-corrected AF-bank NC-sweep results (complete-QA goldens) confirming the 4→2 verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)