### PR TITLE
feat(autofocus): recover from failed HFR validation + always save replay artifacts

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusEngineTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusEngineTests.cs
@@ -4,6 +4,7 @@ using NINA.Equipment.Interfaces.Mediator;
 using NINA.Image.ImageAnalysis;
 using NINA.Image.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.StarDetection;
 using NINA.Joko.Plugins.HocusFocus.Utility;
@@ -361,6 +362,83 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
             } finally {
                 AutoFocusEngine.ResetAutoFocusInProgressForTests();
             }
+        }
+
+        // --- Auto-retry-from-calculated-point decision (Change 1) ---
+        // The full sweep can't be driven through the all-mocked engine, so the retry predicate is unit-tested directly.
+
+        [Test]
+        public void ShouldRetryFromCalculatedPoint_HfrRegression_FirstTime_RetriesOnce() {
+            // A "final HFR worse than original" failure with a usable calculated point should re-center and retry.
+            Assert.That(AutoFocusEngine.ShouldRetryFromCalculatedPoint(
+                AutoFocusEngine.AutoFocusFailureMode.HfrRegression, calculatedPoint: 53929, currentSweepCenter: 54073, calculatedPointRetryUsed: false), Is.True);
+        }
+
+        [Test]
+        public void ShouldRetryFromCalculatedPoint_OutOfBounds_FirstTime_RetriesOnce() {
+            // A "focus point outside the swept range" failure (the user's saved run) should re-center and retry.
+            Assert.That(AutoFocusEngine.ShouldRetryFromCalculatedPoint(
+                AutoFocusEngine.AutoFocusFailureMode.FinalPointOutOfBounds, calculatedPoint: 53214, currentSweepCenter: 54073, calculatedPointRetryUsed: false), Is.True);
+        }
+
+        [Test]
+        public void ShouldRetryFromCalculatedPoint_SecondFailure_DoesNotRetryAgain() {
+            // The calculated-point retry is single-shot: once used, a second a/c failure must NOT trigger it again.
+            Assert.That(AutoFocusEngine.ShouldRetryFromCalculatedPoint(
+                AutoFocusEngine.AutoFocusFailureMode.HfrRegression, calculatedPoint: 53800, currentSweepCenter: 53929, calculatedPointRetryUsed: true), Is.False);
+            Assert.That(AutoFocusEngine.ShouldRetryFromCalculatedPoint(
+                AutoFocusEngine.AutoFocusFailureMode.FinalPointOutOfBounds, calculatedPoint: 53800, currentSweepCenter: 53929, calculatedPointRetryUsed: true), Is.False);
+        }
+
+        [Test]
+        public void ShouldRetryFromCalculatedPoint_NonRetryEligibleModes_DoNotRetry() {
+            // Bad-data / bad-fit failures can't be fixed by re-centering, so they fall through to the normal budget.
+            Assert.Multiple(() => {
+                Assert.That(AutoFocusEngine.ShouldRetryFromCalculatedPoint(
+                    AutoFocusEngine.AutoFocusFailureMode.FitQuality, 53929, 54073, false), Is.False);
+                Assert.That(AutoFocusEngine.ShouldRetryFromCalculatedPoint(
+                    AutoFocusEngine.AutoFocusFailureMode.InitialHfrFailed, 53929, 54073, false), Is.False);
+                Assert.That(AutoFocusEngine.ShouldRetryFromCalculatedPoint(
+                    AutoFocusEngine.AutoFocusFailureMode.FinalHfrMissing, 53929, 54073, false), Is.False);
+                Assert.That(AutoFocusEngine.ShouldRetryFromCalculatedPoint(
+                    AutoFocusEngine.AutoFocusFailureMode.None, 53929, 54073, false), Is.False);
+            });
+        }
+
+        [Test]
+        public void ShouldRetryFromCalculatedPoint_GuardsNoOpAndInvalidPoints() {
+            // calc == current center (no-op re-sweep) and an invalid (<0) point must both be rejected.
+            Assert.Multiple(() => {
+                Assert.That(AutoFocusEngine.ShouldRetryFromCalculatedPoint(
+                    AutoFocusEngine.AutoFocusFailureMode.HfrRegression, calculatedPoint: 54073, currentSweepCenter: 54073, calculatedPointRetryUsed: false), Is.False);
+                Assert.That(AutoFocusEngine.ShouldRetryFromCalculatedPoint(
+                    AutoFocusEngine.AutoFocusFailureMode.FinalPointOutOfBounds, calculatedPoint: -1, currentSweepCenter: 54073, calculatedPointRetryUsed: false), Is.False);
+            });
+        }
+
+        // --- metadata.json is written (and flagged) on the failure path (Change 2) ---
+
+        [Test]
+        public void WriteMetadataFile_WritesFailureFlaggedMetadata_ThatRoundTrips() {
+            using var tmp = new TempDir();
+            var metadata = new AutoFocusReplayMetadata() {
+                SchemaVersion = AutoFocusReplayMetadata.CurrentSchemaVersion,
+                StarDetection = new StarDetectionSettingsSnapshot(),
+                AutoFocus = new AutoFocusOptionsSnapshot(),
+                Succeeded = false,
+                FailureReason = "Calculated focus point outside the swept range"
+            };
+
+            AutoFocusEngine.WriteMetadataFile(tmp.Path, metadata);
+
+            var loaded = AutoFocusReplayMetadata.TryLoad(tmp.Path, out var restored, out var error);
+            Assert.Multiple(() => {
+                Assert.That(File.Exists(Path.Combine(tmp.Path, "metadata.json")), Is.True);
+                Assert.That(loaded, Is.True);
+                Assert.That(error, Is.Null);
+                Assert.That(restored.Succeeded, Is.False);
+                Assert.That(restored.FailureReason, Is.EqualTo("Calculated focus point outside the swept range"));
+            });
         }
 
         private sealed class TempDir : IDisposable {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMTests.cs
@@ -116,5 +116,18 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
             var vm = Build();
             Assert.That(vm.IsTool, Is.True);
         }
+
+        [Test]
+        public void HasInspectorRegionLayout_RequiresFullSixRegionGrid() {
+            // The region report indexes RegionHFRs[1..5], so fewer than 6 regions (e.g. a reprocessed single-region
+            // regular-AF run) must be rejected — the guard that turns the old IndexOutOfRange crash into a clean log.
+            Assert.Multiple(() => {
+                Assert.That(InspectorVM.HasInspectorRegionLayout(0), Is.False);
+                Assert.That(InspectorVM.HasInspectorRegionLayout(1), Is.False);
+                Assert.That(InspectorVM.HasInspectorRegionLayout(5), Is.False);
+                Assert.That(InspectorVM.HasInspectorRegionLayout(6), Is.True);
+                Assert.That(InspectorVM.HasInspectorRegionLayout(7), Is.True);
+            });
+        }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/Replay/AutoFocusReplayMetadataTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/Replay/AutoFocusReplayMetadataTests.cs
@@ -158,6 +158,66 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus.Replay {
         }
 
         [Test]
+        public void Builder_PassesThroughSucceededAndFailureReason() {
+            var metadata = AutoFocusReplayMetadataBuilder.Build(
+                starDetectionOptions: null,
+                autoFocusOptions: new AutoFocusEngineOptions(),
+                regions: null,
+                results: null,
+                createdAtUtc: new DateTime(2026, 6, 24, 0, 0, 0, DateTimeKind.Utc),
+                pluginVersion: "x",
+                starDetectorVersion: 1,
+                succeeded: false,
+                failureReason: "boom");
+
+            Assert.Multiple(() => {
+                Assert.That(metadata.Succeeded, Is.False);
+                Assert.That(metadata.FailureReason, Is.EqualTo("boom"));
+            });
+        }
+
+        [Test]
+        public void RoundTrips_WithSucceededFalseAndFailureReason() {
+            // A failed run is still saved (and replayable) with the outcome recorded so it can be inspected.
+            var original = BuildPopulated();
+            original.Succeeded = false;
+            original.FailureReason = "Final HFR worse than original";
+
+            var restored = AutoFocusReplayMetadata.Deserialize(original.Serialize());
+
+            Assert.Multiple(() => {
+                Assert.That(restored.Succeeded, Is.False);
+                Assert.That(restored.FailureReason, Is.EqualTo("Final HFR worse than original"));
+            });
+        }
+
+        [Test]
+        public void RoundTrips_WithSucceededTrue_NullReason() {
+            var original = BuildPopulated();
+            original.Succeeded = true;
+            original.FailureReason = null;
+
+            var json = original.Serialize();
+            // NullValueHandling.Include keeps the field present (additive + backward-compatible).
+            Assert.That(json, Does.Contain("failureReason"));
+
+            var restored = AutoFocusReplayMetadata.Deserialize(json);
+            Assert.Multiple(() => {
+                Assert.That(restored.Succeeded, Is.True);
+                Assert.That(restored.FailureReason, Is.Null);
+            });
+        }
+
+        [Test]
+        public void Validate_DoesNotRequire_SucceededOrFailureReason() {
+            // Metadata written before these fields existed (both null) must still validate.
+            var metadata = BuildPopulated();
+            metadata.Succeeded = null;
+            metadata.FailureReason = null;
+            Assert.DoesNotThrow(() => metadata.Validate());
+        }
+
+        [Test]
         public void Validate_Throws_WhenStarDetectionMissing() {
             var metadata = BuildPopulated();
             metadata.StarDetection = null;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/Replay/AutoFocusReplayOptionsMapperTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/Replay/AutoFocusReplayOptionsMapperTests.cs
@@ -126,7 +126,6 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus.Replay {
                 Assert.That(result.Options.NumberOfAFStars, Is.EqualTo(7));
                 Assert.That(result.Options.StarDetectionOptionsOverride, Is.Null);
                 Assert.That(result.CaptureTimeRegions, Is.Null);
-                Assert.That(result.SensorCurveModelEnabled, Is.Null);
             });
         }
 
@@ -141,7 +140,6 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus.Replay {
                 Assert.That(result.Options.NumberOfAFStars, Is.EqualTo(33));
                 Assert.That(result.Options.HyperbolicFitModel, Is.EqualTo(HyperbolicFitModel.SmoothBlend));
                 Assert.That(result.CaptureTimeRegions, Is.SameAs(metadata.Regions.Regions));
-                Assert.That(result.SensorCurveModelEnabled, Is.True);
             });
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -296,5 +296,63 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 options.DidNotReceive().ScrewRadiusMillimeters = Arg.Any<double>();
             });
         }
+
+        // --- Failure-choice panel (Change 3) ---
+
+        [Test]
+        public void StepIsAtBaseline_TrueOnlyForBaselineEquivalentSteps() {
+            Assert.Multiple(() => {
+                Assert.That(TiltAdapterWizardVM.StepIsAtBaseline(WizardStep.Baseline), Is.True);
+                Assert.That(TiltAdapterWizardVM.StepIsAtBaseline(WizardStep.ReBaseline1), Is.True);
+                Assert.That(TiltAdapterWizardVM.StepIsAtBaseline(WizardStep.ReBaseline2), Is.True);
+                Assert.That(TiltAdapterWizardVM.StepIsAtBaseline(WizardStep.Complete), Is.True);
+                Assert.That(TiltAdapterWizardVM.StepIsAtBaseline(WizardStep.AllInward), Is.False);
+                Assert.That(TiltAdapterWizardVM.StepIsAtBaseline(WizardStep.Screw1), Is.False);
+                Assert.That(TiltAdapterWizardVM.StepIsAtBaseline(WizardStep.Screw2), Is.False);
+            });
+        }
+
+        [Test]
+        public void BaselineRecoveryText_PerturbedSteps_DescribeUndoingTheMove() {
+            // 3-screw: undo only the moved screw.
+            Assert.Multiple(() => {
+                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.AllInward, 3), Does.Contain("ALL screws back OUT"));
+                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.Screw1, 3), Does.Contain("screw 1 back OUT"));
+                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.Screw2, 3), Does.Contain("screw 2 back OUT"));
+            });
+            // 4-screw: the opposing screw is undone too.
+            Assert.Multiple(() => {
+                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.Screw1, 4), Does.Contain("screw 3 back IN"));
+                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.Screw2, 4), Does.Contain("screw 4 back IN"));
+            });
+        }
+
+        [Test]
+        public void BaselineRecoveryText_BaselineSteps_SayAlreadyAtBaseline() {
+            Assert.Multiple(() => {
+                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.Baseline, 3), Does.Contain("already be at the baseline"));
+                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.ReBaseline1, 3), Does.Contain("already be at the baseline"));
+                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.ReBaseline2, 4), Does.Contain("already be at the baseline"));
+            });
+        }
+
+        [Test]
+        public void MeasurementFailureChoice_DefaultsHidden_AndClearsOnRestart() {
+            var (vm, _, _, _) = Build();
+            Assert.That(vm.HasMeasurementFailureChoice, Is.False);
+            // At the Baseline step the recovery guidance reports the user is already at baseline.
+            Assert.That(vm.IsCurrentStepAtBaseline, Is.True);
+            Assert.That(vm.BaselineRecoveryInstructions, Does.Contain("already be at the baseline"));
+
+            vm.RestartCommand.Execute(null);
+            Assert.That(vm.HasMeasurementFailureChoice, Is.False);
+        }
+
+        [Test]
+        public void RetryMeasurementCommand_CannotExecute_WithoutAFailureChoice() {
+            var (vm, _, _, _) = Build();
+            // No failure has occurred, so the retry button is disabled even though we're on a measurement step.
+            Assert.That(vm.RetryMeasurementCommand.CanExecute(null), Is.False);
+        }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
@@ -1529,13 +1529,23 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 firstRegionFinalFocusPosition += this.autoFocusOptions.FocuserOffset;
             }
 
-            await focuserMediator.MoveFocuser(firstRegionFinalFocusPosition, token);
-            token.ThrowIfCancellationRequested();
-
-            if (autoFocusState.Options.ValidateHfrImprovement) {
-                Logger.Info($"Validating HFR at final focus position {firstRegionFinalFocusPosition}");
-                await StartAutoFocusPoint(firstRegionFinalFocusPosition, autoFocusState, FinalHFRMeasurementAction, true, token, progress);
+            // Drive the focuser to the calculated point and (when HFR validation is on) capture a final-validation
+            // image there. For an OUT-OF-BOUNDS point the only reason to move is that diagnostic image: clamp the target
+            // to the swept range so an extreme/extrapolated fit center can't drive the focuser to its travel limit, and
+            // skip the move entirely when HFR validation is off (no image to capture) — matching the pre-refactor
+            // behavior of not moving on an out-of-bounds result. In-bounds (success) moves are unchanged.
+            if (!anyRegionOutOfBounds || autoFocusState.Options.ValidateHfrImprovement) {
+                var moveTarget = anyRegionOutOfBounds
+                    ? Math.Min(outOfBoundsMax, Math.Max(outOfBoundsMin, firstRegionFinalFocusPosition))
+                    : firstRegionFinalFocusPosition;
+                await focuserMediator.MoveFocuser(moveTarget, token);
                 token.ThrowIfCancellationRequested();
+
+                if (autoFocusState.Options.ValidateHfrImprovement) {
+                    Logger.Info($"Validating HFR at final focus position {moveTarget}");
+                    await StartAutoFocusPoint(moveTarget, autoFocusState, FinalHFRMeasurementAction, true, token, progress);
+                    token.ThrowIfCancellationRequested();
+                }
             }
 
             await Task.WhenAll(autoFocusState.AnalysisTasks);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
@@ -445,6 +445,35 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             }
         }
 
+        // Distinguishes WHY ValidateCalculatedFocusPosition rejected a run so RunAutoFocus can decide whether a
+        // re-centered retry is worthwhile. HfrRegression and FinalPointOutOfBounds are symptoms of a blind sweep
+        // that started far from focus (e.g. a screw adjustment shoved the focuser), which re-centering the sweep on
+        // the just-calculated focus point can fix. The other modes indicate bad data / a bad fit where re-centering
+        // would not help, so they are not retry-eligible.
+        internal enum AutoFocusFailureMode {
+            None,
+            FitQuality,
+            InitialHfrFailed,
+            FinalPointOutOfBounds,
+            HfrRegression,
+            FinalHfrMissing
+        }
+
+        // Decides whether a final-validation failure should trigger the single-shot retry that re-centers the blind
+        // sweep on the just-calculated focus point. Pure so it is unit-testable without a full sweep harness.
+        internal static bool ShouldRetryFromCalculatedPoint(AutoFocusFailureMode mode, int calculatedPoint, int currentSweepCenter, bool calculatedPointRetryUsed) {
+            if (calculatedPointRetryUsed) {
+                return false;
+            }
+            var retryEligibleMode = mode == AutoFocusFailureMode.HfrRegression
+                                 || mode == AutoFocusFailureMode.FinalPointOutOfBounds;
+            if (!retryEligibleMode) {
+                return false;
+            }
+            // Guard a no-op / runaway re-sweep: require a valid point that differs from the center we just swept.
+            return calculatedPoint >= 0 && calculatedPoint != currentSweepCenter;
+        }
+
         private class AutoFocusState {
 
             public AutoFocusState(
@@ -479,6 +508,13 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             public object StatesLock { get; private set; } = new object();
             public SemaphoreSlim ExposureSemaphore { get; private set; }
             public int InitialFocuserPosition { get; set; }
+
+            // Set by ValidateCalculatedFocusPosition at each failure site so RunAutoFocus can branch on the cause.
+            // LastCalculatedFocusPoint is the pre-offset region-0 fit center captured on a retry-eligible failure, so
+            // a re-centered retry sweeps around the actual estimated focus rather than the contaminated start.
+            public AutoFocusFailureMode LastFailureMode { get; set; } = AutoFocusFailureMode.None;
+            public int LastCalculatedFocusPoint { get; set; } = -1;
+
             public List<Task> InitialHFRTasks { get; private set; } = new List<Task>();
             public List<Task> AnalysisTasks { get; private set; } = new List<Task>();
             public AsyncAutoResetEvent MeasurementCompleteEvent { get; private set; }
@@ -498,6 +534,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
             public void OnNextAttempt() {
                 ResetFocusMeasurements();
+                LastFailureMode = AutoFocusFailureMode.None;
+                LastCalculatedFocusPoint = -1;
                 ImageNumber = 0;
                 ++AttemptNumber;
             }
@@ -1185,6 +1223,13 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 autoFocusState.InitialFocuserPosition = initialFocusPosition;
                 Logger.Info($"Starting AutoFocus with initial position {initialFocusPosition}");
 
+                // The blind sweep is normally centered on the original starting position. When a final-validation
+                // failure is fixable by re-centering (HFR regression / point outside the swept range) we retry ONCE
+                // centered on the calculated focus point instead — independent of TotalNumberOfAttempts. InitialFocuserPosition
+                // stays the true original so the focuser is restored there if the run ultimately fails.
+                int sweepCenter = initialFocusPosition;
+                bool calculatedPointRetryUsed = false;
+
                 do {
                     await StartInitialFocusPoints(initialFocusPosition, autoFocusState, token, progress);
                     reattempt = false;
@@ -1197,7 +1242,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     bool goodFocusPosition = false;
 
                     try {
-                        await pointGenerationAction(initialFocusPosition, autoFocusState, iterationCts.Token, progress);
+                        await pointGenerationAction(sweepCenter, autoFocusState, iterationCts.Token, progress);
                         token.ThrowIfCancellationRequested();
 
                         goodFocusPosition = await ValidateCalculatedFocusPosition(autoFocusState, iterationCts.Token, progress);
@@ -1217,7 +1262,24 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     if (!goodFocusPosition) {
                         // Ensure we cancel any remaining tasks from this iteration so we can start the next
                         iterationTaskCts.Cancel();
-                        if (autoFocusState.AttemptNumber < autoFocusState.Options.TotalNumberOfAttempts) {
+                        if (ShouldRetryFromCalculatedPoint(autoFocusState.LastFailureMode, autoFocusState.LastCalculatedFocusPoint, sweepCenter, calculatedPointRetryUsed)) {
+                            // The sweep started too far from focus and contaminated the curve. Re-center the next
+                            // sweep on the calculated focus point and re-attempt once (capped independently of the
+                            // normal attempt budget, so it fires even when TotalNumberOfAttempts == 1).
+                            calculatedPointRetryUsed = true;
+                            sweepCenter = autoFocusState.LastCalculatedFocusPoint;
+                            Notification.ShowWarning(Loc.Instance["LblAutoFocusReattempting"]);
+                            Logger.Warning($"AutoFocus failure ({autoFocusState.LastFailureMode}). Re-centering the sweep on the calculated focus point {sweepCenter} and re-attempting once.");
+                            await focuserMediator.MoveFocuser(sweepCenter, token);
+
+                            OnIterationFailed(
+                                state: autoFocusState,
+                                temperature: focuserMediator.GetInfo().Temperature,
+                                duration: stopWatch.Elapsed);
+                            reattempt = true;
+                        } else if (autoFocusState.AttemptNumber < autoFocusState.Options.TotalNumberOfAttempts) {
+                            // Standard reattempt restarts the sweep from the true original starting position.
+                            sweepCenter = initialFocusPosition;
                             Notification.ShowWarning(Loc.Instance["LblAutoFocusReattempting"]);
                             Logger.Warning($"Potentially bad auto-focus. Setting focuser back to {initialFocusPosition} and re-attempting.");
                             await focuserMediator.MoveFocuser(initialFocusPosition, token);
@@ -1348,6 +1410,14 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             CancellationToken token,
             IProgress<ApplicationStatus> progress) {
             var rSquaredThreshold = profileService.ActiveProfile.FocuserSettings.RSquaredThreshold;
+
+            // When the calculated point falls outside the swept range we DEFER the rejection (rather than returning
+            // immediately) so the focuser still moves there and a final-validation image is captured for diagnosis
+            // before we fail. Recorded here, applied after the move+exposure below.
+            var anyRegionOutOfBounds = false;
+            StarDetectionRegion outOfBoundsRegion = null;
+            int outOfBoundsPosition = 0, outOfBoundsMin = 0, outOfBoundsMax = 0;
+
             if (profileService.ActiveProfile.FocuserSettings.AutoFocusMethod == AFMethodEnum.STARHFR) {
                 // Evaluate R² for Fittings to be above threshold
                 foreach (var autoFocusRegionState in autoFocusState.FocusRegionStates) {
@@ -1375,6 +1445,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                                     Logger.Error($"Auto Focus Failed! R² (Coefficient of determination) for Hyperbolic Fitting is below threshold. {Math.Round(hyperbolicFitting.RSquared, 2)} / {rSquaredThreshold}; Region: {autoFocusRegionState.Region}");
                                     Notification.ShowError(string.Format(Loc.Instance["LblAutoFocusCurveCorrelationCoefficientLow"], Math.Round(hyperbolicFitting.RSquared, 2), rSquaredThreshold));
                                 }
+                                autoFocusState.LastFailureMode = AutoFocusFailureMode.FitQuality;
                                 return false;
                             }
                         }
@@ -1388,12 +1459,14 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                         if ((fitting == AFCurveFittingEnum.PARABOLIC || fitting == AFCurveFittingEnum.TRENDPARABOLIC) && quadraticBad) {
                             Logger.Error($"Auto Focus Failed! R² (Coefficient of determination) for Parabolic Fitting is below threshold. {Math.Round(fittings.QuadraticFitting.RSquared, 2)} / {rSquaredThreshold}; Region: {autoFocusRegionState.Region}");
                             Notification.ShowError(string.Format(Loc.Instance["LblAutoFocusCurveCorrelationCoefficientLow"], Math.Round(fittings.QuadraticFitting.RSquared, 2), rSquaredThreshold));
+                            autoFocusState.LastFailureMode = AutoFocusFailureMode.FitQuality;
                             return false;
                         }
 
                         if ((fitting == AFCurveFittingEnum.TRENDLINES || fitting == AFCurveFittingEnum.TRENDHYPERBOLIC || fitting == AFCurveFittingEnum.TRENDPARABOLIC) && trendlineBad) {
                             Logger.Error($"Auto Focus Failed! R² (Coefficient of determination) for Trendline Fitting is below threshold. Left: {Math.Round(fittings.TrendlineFitting.LeftTrend.RSquared, 2)} / {rSquaredThreshold}; Right: {Math.Round(fittings.TrendlineFitting.RightTrend.RSquared, 2)} / {rSquaredThreshold}; Region: {autoFocusRegionState.Region}");
                             Notification.ShowError(string.Format(Loc.Instance["LblAutoFocusCurveCorrelationCoefficientLow"], Math.Round(fittings.TrendlineFitting.LeftTrend.RSquared, 2), Math.Round(fittings.TrendlineFitting.RightTrend.RSquared, 2), rSquaredThreshold));
+                            autoFocusState.LastFailureMode = AutoFocusFailureMode.FitQuality;
                             return false;
                         }
                     }
@@ -1408,13 +1481,20 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     if (finalFocusPosition < 0) {
                         Logger.Error("Fit failed. There likely weren't enough data points with detected stars");
                         Notification.ShowError("Fit failed. There likely weren't enough data points with detected stars");
+                        autoFocusState.LastFailureMode = AutoFocusFailureMode.FitQuality;
                         return false;
                     }
 
                     if (finalFocusPosition < min || finalFocusPosition > max) {
-                        Logger.Error($"Determined focus point position is outside of the overall measurement points of the curve. Fitting is incorrect and autofocus settings are incorrect. FocusPosition {finalFocusPosition}; Min: {min}; Max: {max}; Region: {autoFocusRegionState.Region}");
-                        Notification.ShowError(Loc.Instance["LblAutoFocusPointOutsideOfBounds"]);
-                        return false;
+                        // Defer this rejection until after the final-validation image is captured below. Record the
+                        // first offending region (mirrors the original "first failure wins" ordering) and stop
+                        // checking further regions.
+                        anyRegionOutOfBounds = true;
+                        outOfBoundsRegion = autoFocusRegionState.Region;
+                        outOfBoundsPosition = finalFocusPosition;
+                        outOfBoundsMin = min;
+                        outOfBoundsMax = max;
+                        break;
                     }
                 }
             }
@@ -1423,8 +1503,13 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             if (firstRegionFinalFocusPosition < 0) {
                 Logger.Error("Fit failed. There likely weren't enough data points with detected stars");
                 Notification.ShowError("Fit failed. There likely weren't enough data points with detected stars");
+                autoFocusState.LastFailureMode = AutoFocusFailureMode.FitQuality;
                 return false;
             }
+
+            // Region-0 fit center BEFORE the focuser offset is applied — the best estimate of focus, and the center a
+            // re-centered retry should sweep around when this validation fails (see RunAutoFocus).
+            var calculatedFocusPoint = firstRegionFinalFocusPosition;
 
             if (this.autoFocusOptions.FocuserOffset != 0) {
                 Logger.Info($"Applying focuser offset of {this.autoFocusOptions.FocuserOffset} to {firstRegionFinalFocusPosition}");
@@ -1443,17 +1528,30 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             await Task.WhenAll(autoFocusState.AnalysisTasks);
             token.ThrowIfCancellationRequested();
 
+            // Apply the deferred out-of-bounds rejection now that the focuser has moved to the calculated point and
+            // (when HFR validation is on) a final-validation image was captured for diagnosis. Re-centering the sweep
+            // on the calculated point can fix this, so it is retry-eligible.
+            if (anyRegionOutOfBounds) {
+                Logger.Error($"Determined focus point position is outside of the overall measurement points of the curve. Fitting is incorrect and autofocus settings are incorrect. FocusPosition {outOfBoundsPosition}; Min: {outOfBoundsMin}; Max: {outOfBoundsMax}; Region: {outOfBoundsRegion}");
+                Notification.ShowError(Loc.Instance["LblAutoFocusPointOutsideOfBounds"]);
+                autoFocusState.LastFailureMode = AutoFocusFailureMode.FinalPointOutOfBounds;
+                autoFocusState.LastCalculatedFocusPoint = calculatedFocusPoint;
+                return false;
+            }
+
             if (autoFocusState.Options.AutoFocusMethod == AFMethodEnum.STARHFR && autoFocusState.Options.ValidateHfrImprovement) {
                 foreach (var autoFocusRegionState in autoFocusState.FocusRegionStates) {
                     lock (autoFocusRegionState.SubMeasurementsLock) {
                         if (!autoFocusRegionState.FinalHFR.HasValue || autoFocusRegionState.FinalHFR.Value.Measure == 0.0) {
                             Logger.Warning("Failed assessing HFR at the final focus point");
                             Notification.ShowWarning("Failed assessing HFR at the final focus point");
+                            autoFocusState.LastFailureMode = AutoFocusFailureMode.FinalHfrMissing;
                             return false;
                         }
                         if (!autoFocusRegionState.InitialHFR.HasValue || autoFocusRegionState.InitialHFR.Value.Measure == 0.0) {
                             Logger.Warning("Failed assessing HFR at the initial position");
                             Notification.ShowWarning("Failed assessing HFR at the initial position");
+                            autoFocusState.LastFailureMode = AutoFocusFailureMode.InitialHfrFailed;
                             return false;
                         }
 
@@ -1462,6 +1560,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                         if (finalHfr > (initialHFR * (1.0 + autoFocusState.Options.HFRImprovementThreshold))) {
                             Logger.Warning($"New focus point HFR {finalHfr} is significantly worse than original HFR {initialHFR}");
                             Notification.ShowWarning(string.Format(Loc.Instance["LblAutoFocusNewWorseThanOriginal"], finalHfr, initialHFR));
+                            autoFocusState.LastFailureMode = AutoFocusFailureMode.HfrRegression;
+                            autoFocusState.LastCalculatedFocusPoint = calculatedFocusPoint;
                             return false;
                         }
                     }
@@ -1954,7 +2054,15 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         /// capture-time override when one was used (option b), otherwise the live detector's options. Never throws /
         /// never fails the run.
         /// </summary>
-        private void WriteReplayMetadata(AutoFocusState state) {
+        // Serializes the metadata to <saveFolder>/metadata.json. Isolated + internal so the file-write contract can be
+        // unit-tested without standing up the whole engine.
+        internal static void WriteMetadataFile(string saveFolder, AutoFocusReplayMetadata metadata) {
+            var metadataPath = Path.Combine(saveFolder, "metadata.json");
+            File.WriteAllText(metadataPath, metadata.Serialize());
+            Logger.Info($"Wrote AutoFocus replay metadata to {metadataPath}");
+        }
+
+        private void WriteReplayMetadata(AutoFocusState state, bool succeeded, string failureReason) {
             try {
                 if (string.IsNullOrWhiteSpace(state.SaveFolder)) {
                     return;
@@ -2018,13 +2126,30 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
                 var pluginVersion = typeof(AutoFocusEngine).Assembly.GetName().Version?.ToString();
                 var metadata = AutoFocusReplayMetadataBuilder.Build(
-                    sdOptions, state.Options, regionGeometry, results, DateTime.UtcNow, pluginVersion, StarDetector.StarDetectorVersion);
+                    sdOptions, state.Options, regionGeometry, results, DateTime.UtcNow, pluginVersion, StarDetector.StarDetectorVersion,
+                    succeeded: succeeded, failureReason: failureReason);
 
-                var metadataPath = Path.Combine(state.SaveFolder, "metadata.json");
-                File.WriteAllText(metadataPath, metadata.Serialize());
-                Logger.Info($"Wrote AutoFocus replay metadata to {metadataPath}");
+                WriteMetadataFile(state.SaveFolder, metadata);
             } catch (Exception e) {
                 Logger.Warning($"Failed to write AutoFocus replay metadata.json: {e.Message}");
+            }
+        }
+
+        // Short human-readable reason for the metadata.json failure record, derived from the validation failure mode.
+        private static string FailureReasonText(AutoFocusFailureMode mode) {
+            switch (mode) {
+                case AutoFocusFailureMode.HfrRegression:
+                    return "Final HFR worse than original";
+                case AutoFocusFailureMode.FinalPointOutOfBounds:
+                    return "Calculated focus point outside the swept range";
+                case AutoFocusFailureMode.FitQuality:
+                    return "Fit/data quality rejected (low R²/χ² or insufficient stars)";
+                case AutoFocusFailureMode.InitialHfrFailed:
+                    return "Initial HFR measurement failed";
+                case AutoFocusFailureMode.FinalHfrMissing:
+                    return "Final HFR measurement failed";
+                default:
+                    return "AutoFocus failed";
             }
         }
 
@@ -2032,7 +2157,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             AutoFocusState state,
             double temperature,
             TimeSpan duration) {
-            WriteReplayMetadata(state);
+            WriteReplayMetadata(state, succeeded: true, failureReason: null);
             var initialFocuserPosition = state.InitialFocuserPosition;
             var filter = state.AutoFocusFilter?.Name ?? string.Empty;
             var iteration = state.AttemptNumber;
@@ -2092,6 +2217,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             AutoFocusState state,
             double temperature,
             TimeSpan duration) {
+            // A failed run is still saved with a metadata.json (flagged as failed) so it can be inspected/replayed —
+            // unlike OnIterationFailed, which is a mid-run retry boundary, this is the terminal failure.
+            WriteReplayMetadata(state, succeeded: false, failureReason: FailureReasonText(state.LastFailureMode));
             Failed?.Invoke(this, GetFailedEventArgs(state, temperature, duration));
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
@@ -1230,7 +1230,20 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 int sweepCenter = initialFocusPosition;
                 bool calculatedPointRetryUsed = false;
 
+                // Structural backstop so the retry loop can NEVER run unbounded (defense-in-depth for a hardware loop):
+                // at most TotalNumberOfAttempts attempts plus the single calculated-point retry. The conditions below
+                // already guarantee this — the calculated-point retry fires at most once (calculatedPointRetryUsed is
+                // scoped OUTSIDE this loop and is only ever set true), and the standard reattempt is gated on the
+                // strictly-increasing AttemptNumber — but the cap makes termination independent of those conditions
+                // staying correct. It should never trigger in normal operation.
+                int maxIterations = Math.Max(1, autoFocusState.Options.TotalNumberOfAttempts) + 1;
+                int iteration = 0;
+
                 do {
+                    if (++iteration > maxIterations) {
+                        Logger.Error($"AutoFocus retry loop exceeded its {maxIterations}-iteration backstop; aborting to prevent an infinite loop.");
+                        break;
+                    }
                     await StartInitialFocusPoints(initialFocusPosition, autoFocusState, token, progress);
                     reattempt = false;
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -1123,7 +1123,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 profileService,
                 savedAttempt.FolderPath,
                 isInteractive: true,
-                () => GetAutoFocusEngineOptions(autoFocusEngine, savedAttempt));
+                () => GetAutoFocusEngineOptions(autoFocusEngine, savedAttempt),
+                texts: ReplaySettingsPromptTexts.Inspector);
             if (resolution.Cancelled) {
                 return false;
             }
@@ -1459,12 +1460,15 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             BackfocusHFR = OuterHFR - InnerHFR;
         }
 
+        // The Inspector region report indexes RegionHFRs[1..5] (center = 1, corners = 2..5), so it needs the full
+        // Inspector grid of at least 6 regions. Extracted + internal so the precondition is unit-testable.
+        internal static bool HasInspectorRegionLayout(int regionCount) => regionCount >= 6;
+
         private void AutoFocusEngine_CompletedNoReport(object sender, AutoFocusCompletedEventArgs e) {
-            // This report assumes the Inspector's fixed region layout (center = 1, corners = 2..5). The reprocess path
-            // now always uses the Inspector grid (>= 6 regions), but guard defensively so a run with fewer regions logs
-            // cleanly instead of throwing an unhandled IndexOutOfRange.
-            if (e.RegionHFRs == null || e.RegionHFRs.Count < 6) {
-                Logger.Warning($"Skipping inspector region report: expected at least 6 regions but got {e.RegionHFRs?.Count ?? 0}. This run is not an Aberration Inspector run.");
+            // The reprocess path now always uses the Inspector grid (>= 6 regions), but guard defensively so a run with
+            // fewer regions logs cleanly instead of throwing an unhandled IndexOutOfRange.
+            if (e.RegionHFRs == null || !HasInspectorRegionLayout(e.RegionHFRs.Count)) {
+                Logger.Warning($"Skipping inspector region report: expected the Inspector's >= 6 region grid but got {e.RegionHFRs?.Count ?? 0}. This run is not an Aberration Inspector run.");
                 return;
             }
             var logReportBuilder = new StringBuilder();

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -1131,10 +1131,16 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             string outputFolder = null;
             localAnalyzeTask = Task.Run(async () => {
                 var options = resolution.Options;
-                // Option (b) replays with the run's capture-time settings: use its captured sensor-curve flag + regions
-                // (which honor the captured ROI through the explicit-region path) instead of the current Inspector ones.
-                var sensorCurveModelEnabled = resolution.SensorCurveModelEnabled ?? inspectorOptions.SensorCurveModelEnabled;
-                var regions = resolution.CaptureTimeRegions ?? GetStarDetectionRegions(options, sensorCurveModelEnabled: sensorCurveModelEnabled);
+                // The regions to analyze (and the sensor-curve-model flag that shapes them) are an Inspector
+                // (application) concern, not a captured one — always use the current Inspector grid so ANY saved run,
+                // including a single-region regular AutoFocus run, is analyzed across the Inspector's regions (a
+                // captured single region would otherwise leave RegionHFRs with one entry and crash the inspector
+                // report). Only the capture-time DETECTION settings (option b) are replayed, via
+                // options.StarDetectionOptionsOverride, which the explicit-region detection path applies regardless of
+                // which regions are used. ROI follows the regions: the Inspector grid uses the app's SensorROI/CornersROI
+                // and the AF region uses the app's crop (see GetAutoFocusRegion).
+                var sensorCurveModelEnabled = inspectorOptions.SensorCurveModelEnabled;
+                var regions = GetStarDetectionRegions(options, sensorCurveModelEnabled: sensorCurveModelEnabled);
 
                 autoFocusEngine.Started += AutoFocusEngine_Started;
                 autoFocusEngine.Failed += AutoFocusEngine_Failed;
@@ -1454,6 +1460,13 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         }
 
         private void AutoFocusEngine_CompletedNoReport(object sender, AutoFocusCompletedEventArgs e) {
+            // This report assumes the Inspector's fixed region layout (center = 1, corners = 2..5). The reprocess path
+            // now always uses the Inspector grid (>= 6 regions), but guard defensively so a run with fewer regions logs
+            // cleanly instead of throwing an unhandled IndexOutOfRange.
+            if (e.RegionHFRs == null || e.RegionHFRs.Count < 6) {
+                Logger.Warning($"Skipping inspector region report: expected at least 6 regions but got {e.RegionHFRs?.Count ?? 0}. This run is not an Aberration Inspector run.");
+                return;
+            }
             var logReportBuilder = new StringBuilder();
             var centerHFR = e.RegionHFRs[1].EstimatedFinalHFR;
             var centerFocuser = e.RegionHFRs[1].EstimatedFinalFocuserPosition;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/AutoFocusReplayCoordinator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/AutoFocusReplayCoordinator.cs
@@ -41,7 +41,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay {
             string runFolderPath,
             bool isInteractive,
             Func<AutoFocusEngineOptions> buildBaseOptions,
-            IStarDetectionOptions headlessStarDetectionOverride = null) {
+            IStarDetectionOptions headlessStarDetectionOverride = null,
+            ReplaySettingsPromptTexts texts = null) {
             if (buildBaseOptions == null) {
                 throw new ArgumentNullException(nameof(buildBaseOptions));
             }
@@ -60,7 +61,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay {
                 return new ReplayOptionsResolution() { Options = buildBaseOptions() };
             }
 
-            var choice = await ReplaySettingsPrompt.ShowAsync(windowServiceFactory, metadata);
+            var choice = await ReplaySettingsPrompt.ShowAsync(windowServiceFactory, metadata, texts);
             // ApplyToProfile (option c) raises INPC for the bound Options UI and must run on the UI thread. The AF-pane
             // replay runs on a background Task.Run, so marshal the mutation via the dispatcher (a synchronous Send with
             // a same-context fast path, so it is free when already on the UI thread, e.g. the Inspector path).

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/AutoFocusReplayMetadata.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/AutoFocusReplayMetadata.cs
@@ -59,6 +59,13 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay {
         /// <summary>Informational summary of the run's result(s); not used to drive a replay.</summary>
         public List<ReplayRegionResultSummary> Results { get; set; }
 
+        /// <summary>Whether the run completed successfully. Null on metadata written before this field existed; a
+        /// failed run is still saved (and replayable) so the failure can be inspected. Not used to drive a replay.</summary>
+        public bool? Succeeded { get; set; }
+
+        /// <summary>Short human-readable reason the run failed (null when it succeeded). Not used to drive a replay.</summary>
+        public string FailureReason { get; set; }
+
         public string Serialize() => JsonConvert.SerializeObject(this, JsonSettings);
 
         public static AutoFocusReplayMetadata Deserialize(string json) => JsonConvert.DeserializeObject<AutoFocusReplayMetadata>(json, JsonSettings);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/AutoFocusReplayMetadataBuilder.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/AutoFocusReplayMetadataBuilder.cs
@@ -30,7 +30,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay {
             IEnumerable<ReplayRegionResultSummary> results,
             DateTime createdAtUtc,
             string pluginVersion,
-            int starDetectorVersion) {
+            int starDetectorVersion,
+            bool? succeeded = null,
+            string failureReason = null) {
             if (autoFocusOptions == null) {
                 throw new ArgumentNullException(nameof(autoFocusOptions));
             }
@@ -42,7 +44,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay {
                 StarDetection = starDetectionOptions == null ? null : StarDetectionSettingsSnapshot.FromOptions(starDetectionOptions),
                 AutoFocus = AutoFocusReplayOptionsMapper.Capture(autoFocusOptions),
                 Regions = regions,
-                Results = results?.ToList()
+                Results = results?.ToList(),
+                Succeeded = succeeded,
+                FailureReason = failureReason
             };
         }
     }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/AutoFocusReplayOptionsMapper.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/AutoFocusReplayOptionsMapper.cs
@@ -32,13 +32,6 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay {
         /// </summary>
         public List<StarDetectionRegion> CaptureTimeRegions { get; set; }
 
-        /// <summary>
-        /// The capture-time Aberration Inspector "sensor curve model" flag, set only for the in-memory capture-time
-        /// replay (option b) so the Inspector analyzes the result the way the run was captured. Null means the caller
-        /// uses its current <c>InspectorOptions.SensorCurveModelEnabled</c>. Ignored by the AF pane.
-        /// </summary>
-        public bool? SensorCurveModelEnabled { get; set; }
-
         public static ReplayOptionsResolution Cancel() => new ReplayOptionsResolution() { Cancelled = true };
     }
 
@@ -142,8 +135,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay {
                         : new List<StarDetectionRegion>() { StarDetectionRegion.Full };
                     return new ReplayOptionsResolution() {
                         Options = options,
-                        CaptureTimeRegions = captureRegions,
-                        SensorCurveModelEnabled = metadata.Regions?.SensorCurveModelEnabled
+                        CaptureTimeRegions = captureRegions
                     };
                 }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/ReplaySettingsPromptTexts.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/ReplaySettingsPromptTexts.cs
@@ -39,6 +39,22 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay {
             UpdateProfileDescription = "Overwrite your current profile's detection, AutoFocus, and ROI settings with the captured ones, then replay.",
         };
 
+        /// <summary>
+        /// Wording for the Aberration Inspector replay. Same as <see cref="AutoFocus"/> except option (b): the Inspector
+        /// always analyzes with the CURRENT region grid / ROI / sensor-curve-model (so a regular single-region AutoFocus
+        /// run can be inspected), and only the capture-time star-DETECTION settings are replayed in memory.
+        /// </summary>
+        public static ReplaySettingsPromptTexts Inspector { get; } = new ReplaySettingsPromptTexts {
+            Title = "Replay Saved AutoFocus Run",
+            Intro = "This run was saved with the detection and AutoFocus settings used at capture time. Choose how to replay it:",
+            UseCurrentCaption = "Use current settings",
+            UseCurrentDescription = "Replay using your current profile's detection and AutoFocus settings.",
+            UseCaptureCaption = "Use the captured detection settings (don't change my profile)",
+            UseCaptureDescription = "Replay using the captured star-detection settings, held in memory only. The Aberration Inspector always analyzes with your current region grid and ROI, so those use your current Inspector settings. Your profile is left untouched.",
+            UpdateProfileCaption = "Update my profile to the captured settings",
+            UpdateProfileDescription = "Overwrite your current profile's detection, AutoFocus, and ROI settings with the captured ones, then replay.",
+        };
+
         /// <summary>Wording for the Tilt Adapter wizard replay, which applies only star-detection settings.</summary>
         public static ReplaySettingsPromptTexts TiltCalibration { get; } = new ReplaySettingsPromptTexts {
             Title = "Replay Saved Tilt Calibration",

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
@@ -90,8 +90,10 @@
 
         <!-- Self-contained toolbar button: keep Fit/Prev/Next/Close legible on the fixed dark panel regardless of the
              active NINA theme (NINA's themed Button binds to theme brushes and ignores instance colors — same reason
-             the combo uses HF_LightCombo and the replay prompt uses ChoiceButton). -->
-        <Style TargetType="Button">
+             the combo uses HF_LightCombo and the replay prompt uses ChoiceButton). Keyed and applied explicitly per
+             button: an implicit Style here did NOT override NINA's themed Button on some themes (e.g. Classic), so the
+             buttons rendered with the theme's grey background + black text. An explicit Style always wins. -->
+        <Style x:Key="HF_ReviewToolbarButton" TargetType="Button">
             <Setter Property="Margin" Value="4,0" />
             <Setter Property="Padding" Value="10,4" />
             <Setter Property="Foreground" Value="#FFE6E9ED" />
@@ -150,8 +152,8 @@
 
         <!-- Toolbar: navigation + close. (The per-star text + star-bounds selectors live under the legend.) -->
         <DockPanel Grid.Row="1" Grid.Column="0" LastChildFill="False" Margin="0,0,0,6">
-            <Button DockPanel.Dock="Left" Content="Fit" Command="{Binding FitCommand}" Margin="0,0,4,0" />
-            <Button DockPanel.Dock="Left" Content="◀ Prev" Command="{Binding PrevCommand}" />
+            <Button DockPanel.Dock="Left" Content="Fit" Command="{Binding FitCommand}" Margin="0,0,4,0" Style="{StaticResource HF_ReviewToolbarButton}" />
+            <Button DockPanel.Dock="Left" Content="◀ Prev" Command="{Binding PrevCommand}" Style="{StaticResource HF_ReviewToolbarButton}" />
             <ComboBox DockPanel.Dock="Left" Margin="4,0" VerticalAlignment="Center" MinWidth="96"
                       Style="{StaticResource HF_LightCombo}"
                       ItemsSource="{Binding FramePickerItems}"
@@ -163,8 +165,8 @@
                     </DataTemplate>
                 </ComboBox.ItemTemplate>
             </ComboBox>
-            <Button DockPanel.Dock="Left" Content="Next ▶" Command="{Binding NextCommand}" />
-            <Button DockPanel.Dock="Right" Content="Close" Command="{Binding CloseCommand}" />
+            <Button DockPanel.Dock="Left" Content="Next ▶" Command="{Binding NextCommand}" Style="{StaticResource HF_ReviewToolbarButton}" />
+            <Button DockPanel.Dock="Right" Content="Close" Command="{Binding CloseCommand}" Style="{StaticResource HF_ReviewToolbarButton}" />
         </DockPanel>
 
         <!-- Image + scrollbars. -->

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml.cs
@@ -11,8 +11,6 @@
 #endregion "copyright"
 
 using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review;
-using System;
-using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media;
@@ -20,9 +18,9 @@ using System.Windows.Media;
 namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
 
     /// <summary>
-    /// Read-only viewer for the manual AutoFocus "Review Frames" dialog. Shares all zoom/pan/fit/scroll plumbing with
-    /// the Aberration Inspector's review control via <see cref="ReviewViewportHostBase"/>; adds only the first-load
-    /// window sizing. No hover focus graph here.
+    /// Read-only viewer for the manual AutoFocus "Review Frames" dialog. Shares all zoom/pan/fit/scroll plumbing and
+    /// the first-load window sizing with the Aberration Inspector's review control via
+    /// <see cref="ReviewViewportHostBase"/>. No hover focus graph here.
     /// </summary>
     public partial class AutoFocusFrameReviewControl : ReviewViewportHostBase {
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml.cs
@@ -26,8 +26,6 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
     /// </summary>
     public partial class AutoFocusFrameReviewControl : ReviewViewportHostBase {
 
-        private bool windowSized;
-
         protected override Canvas ViewportCanvasPart => ViewportCanvas;
         protected override ScrollBar HScrollPart => HScroll;
         protected override ScrollBar VScrollPart => VScroll;
@@ -35,43 +33,10 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Review {
         protected override TranslateTransform ContentTranslatePart => ContentTranslate;
         protected override IViewportHostViewModel Vm => DataContext as IViewportHostViewModel;
 
+        // First-load window sizing (fit-to-screen + deferred re-fit) is shared with the Aberration Inspector review via
+        // ReviewViewportHostBase. The manual-AF review keeps the base's default desired size.
         public AutoFocusFrameReviewControl() {
             InitializeComponent();
-            Loaded += OnLoaded;
-        }
-
-        // Size the host window to FIT the screen on first load (clamped to the work area, centered), with a small
-        // minimum so it can be shrunk freely. The WindowService opens the window sized-to-content, which — without this —
-        // would honor whatever large size the content asks for and open off-screen on smaller displays.
-        private void OnLoaded(object sender, RoutedEventArgs e) {
-            if (windowSized) {
-                return;
-            }
-            var window = Window.GetWindow(this);
-            if (window == null) {
-                return;
-            }
-            windowSized = true;
-
-            var work = SystemParameters.WorkArea; // device-independent pixels, excludes the taskbar
-            const double desiredWidth = 1100.0;
-            const double desiredHeight = 720.0;
-            const double margin = 40.0;
-
-            window.SizeToContent = SizeToContent.Manual;
-            window.MinWidth = Math.Min(640.0, work.Width);
-            window.MinHeight = Math.Min(440.0, work.Height);
-            window.Width = Math.Min(desiredWidth, Math.Max(window.MinWidth, work.Width - margin));
-            window.Height = Math.Min(desiredHeight, Math.Max(window.MinHeight, work.Height - margin));
-            window.Left = work.Left + (work.Width - window.Width) / 2.0;
-            window.Top = work.Top + (work.Height - window.Height) / 2.0;
-
-            // The initial auto-fit (ViewportCanvas_SizeChanged) ran against the pre-resize canvas size, so re-fit
-            // against the FINAL window size once the resize layout pass has settled (DispatcherPriority.Loaded runs
-            // after layout). Latch hasFitOnce only if that deferred fit actually succeeds (F19).
-            Dispatcher.BeginInvoke(
-                new Action(() => { if (TryFit()) { hasFitOnce = true; } }),
-                System.Windows.Threading.DispatcherPriority.Loaded);
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
@@ -26,8 +26,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new release build of a plugin
-[assembly: AssemblyVersion("3.0.0.33")]
-[assembly: AssemblyFileVersion("3.0.0.33")]
+[assembly: AssemblyVersion("3.0.0.34")]
+[assembly: AssemblyFileVersion("3.0.0.34")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("Hocus Focus")]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
@@ -26,8 +26,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new release build of a plugin
-[assembly: AssemblyVersion("3.0.0.34")]
-[assembly: AssemblyFileVersion("3.0.0.34")]
+[assembly: AssemblyVersion("3.0.0.35")]
+[assembly: AssemblyFileVersion("3.0.0.35")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("Hocus Focus")]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
@@ -26,8 +26,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new release build of a plugin
-[assembly: AssemblyVersion("3.0.0.36")]
-[assembly: AssemblyFileVersion("3.0.0.36")]
+[assembly: AssemblyVersion("3.0.0.34")]
+[assembly: AssemblyFileVersion("3.0.0.34")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("Hocus Focus")]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
@@ -26,8 +26,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new release build of a plugin
-[assembly: AssemblyVersion("3.0.0.35")]
-[assembly: AssemblyFileVersion("3.0.0.35")]
+[assembly: AssemblyVersion("3.0.0.36")]
+[assembly: AssemblyFileVersion("3.0.0.36")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("Hocus Focus")]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -193,8 +193,9 @@
     <!--  The Aberration Inspector "Review Frames" window content. Implicit DataType template so the WindowService's
           ContentPresenter resolves it by VM type (same mechanism as the wizard below).  -->
     <DataTemplate DataType="{x:Type review:FrameReviewVM}">
-        <!--  Open large by default; MinWidth/MinHeight let the window (CanResize) grow and the control fill it.  -->
-        <review:FrameReviewControl MinWidth="1280" MinHeight="860" />
+        <!--  No fixed min size: the control sizes its host window to fit the screen on load (ReviewViewportHostBase),
+              opening large (1280x860) but clamped to the work area so it can be shrunk freely.  -->
+        <review:FrameReviewControl />
     </DataTemplate>
 
     <!--  The wizard window content. Implicit DataType template so the WindowService's ContentPresenter resolves it by VM type.  -->

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
@@ -445,8 +445,11 @@
                        Visibility="Collapsed" Scroll="HScroll_Scroll" />
         </Grid>
 
-        <!-- Right column: legend (disabled rows greyed) + toggles + help. -->
-        <StackPanel Grid.Row="1" Grid.RowSpan="2" Grid.Column="1" VerticalAlignment="Top" Width="240" Margin="12,0,0,0">
+        <!-- Right column: legend (disabled rows greyed) + toggles + help. Scrollable so it never clips on a short
+             window (matches the AutoFocus review). -->
+        <ScrollViewer Grid.Row="1" Grid.RowSpan="2" Grid.Column="1" VerticalAlignment="Top" Width="240" Margin="12,0,0,0"
+                      VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+        <StackPanel>
             <TextBlock FontWeight="Bold" Margin="0,0,0,6" Text="Legend" />
             <ItemsControl ItemsSource="{Binding LegendEntries}">
                 <ItemsControl.ItemTemplate>
@@ -496,5 +499,6 @@
             <TextBlock Margin="0,8,0,0" Foreground="#FFB0B6BD" TextWrapping="Wrap"
                        Text="Wheel to zoom, right-drag to pan, Fit to reset. ◀ ▶ or Prev/Next to change frames." />
         </StackPanel>
+        </ScrollViewer>
     </Grid>
 </review:ReviewViewportHostBase>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
@@ -166,8 +166,10 @@
 
         <!-- Self-contained toolbar button: keep Fit/Prev/Next/Close legible on the fixed dark panel regardless of the
              active NINA theme (NINA's themed Button binds to theme brushes and ignores instance colors — same reason
-             the combo uses HF_LightCombo and the replay prompt uses ChoiceButton). -->
-        <Style TargetType="Button">
+             the combo uses HF_LightCombo and the replay prompt uses ChoiceButton). Keyed and applied explicitly per
+             button: an implicit Style here did NOT override NINA's themed Button on some themes (e.g. Classic), so the
+             buttons rendered with the theme's grey background + black text. An explicit Style always wins. -->
+        <Style x:Key="HF_ReviewToolbarButton" TargetType="Button">
             <Setter Property="Margin" Value="4,0" />
             <Setter Property="Padding" Value="10,4" />
             <Setter Property="Foreground" Value="#FFE6E9ED" />
@@ -232,8 +234,8 @@
 
         <!-- Toolbar: navigation + close (read-only). -->
         <DockPanel Grid.Row="1" Grid.Column="0" LastChildFill="False" Margin="0,0,0,6">
-            <Button DockPanel.Dock="Left" Content="Fit" Command="{Binding FitCommand}" Margin="0,0,4,0" />
-            <Button DockPanel.Dock="Left" Content="◀ Prev" Command="{Binding PrevCommand}" />
+            <Button DockPanel.Dock="Left" Content="Fit" Command="{Binding FitCommand}" Margin="0,0,4,0" Style="{StaticResource HF_ReviewToolbarButton}" />
+            <Button DockPanel.Dock="Left" Content="◀ Prev" Command="{Binding PrevCommand}" Style="{StaticResource HF_ReviewToolbarButton}" />
             <ComboBox DockPanel.Dock="Left" Margin="4,0" VerticalAlignment="Center" MinWidth="96"
                       Style="{StaticResource HF_LightCombo}"
                       ItemsSource="{Binding FramePickerItems}"
@@ -245,8 +247,8 @@
                     </DataTemplate>
                 </ComboBox.ItemTemplate>
             </ComboBox>
-            <Button DockPanel.Dock="Left" Content="Next ▶" Command="{Binding NextCommand}" />
-            <Button DockPanel.Dock="Right" Content="Close" Command="{Binding CloseCommand}" />
+            <Button DockPanel.Dock="Left" Content="Next ▶" Command="{Binding NextCommand}" Style="{StaticResource HF_ReviewToolbarButton}" />
+            <Button DockPanel.Dock="Right" Content="Close" Command="{Binding CloseCommand}" Style="{StaticResource HF_ReviewToolbarButton}" />
         </DockPanel>
 
         <!-- Image + scrollbars. -->

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml.cs
@@ -33,6 +33,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         protected override TranslateTransform ContentTranslatePart => ContentTranslate;
         protected override IViewportHostViewModel Vm => DataContext as IViewportHostViewModel;
 
+        // The Aberration Inspector review opens larger than the manual-AF one (more regions + the hover focus graph);
+        // the base clamps this to the work area and centers it on first load.
+        protected override double DesiredWindowWidth => 1280.0;
+
+        protected override double DesiredWindowHeight => 860.0;
+
         public FrameReviewControl() {
             InitializeComponent();
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/ReviewViewportHostBase.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/ReviewViewportHostBase.cs
@@ -43,6 +43,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
         private System.Windows.Point lastPanScreen;
         private bool suppressScrollEvents;
         protected bool hasFitOnce;
+        private bool windowSized;
+
+        // Desired first-load size of the host window (device-independent px), clamped to the work area below. Subclasses
+        // override to open larger/smaller; defaults suit the manual-AF review. The Aberration Inspector review opens
+        // bigger (more regions / the hover focus graph).
+        protected virtual double DesiredWindowWidth => 1100.0;
+
+        protected virtual double DesiredWindowHeight => 720.0;
 
         protected abstract Canvas ViewportCanvasPart { get; }
         protected abstract ScrollBar HScrollPart { get; }
@@ -55,6 +63,40 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
             DataContextChanged += OnDataContextChanged;
             KeyDown += OnKeyDown;
             Unloaded += OnUnloaded;
+            Loaded += OnReviewLoaded;
+        }
+
+        // Size the host window to FIT the screen on first load (clamped to the work area, centered), with a small
+        // minimum so it can be shrunk freely. NINA's WindowService opens the window sized-to-content, which — without
+        // this — honors whatever large size the content asks for and can open off-screen on smaller displays. Shared by
+        // both review controls so the AutoFocus and Aberration Inspector windows behave identically.
+        private void OnReviewLoaded(object sender, RoutedEventArgs e) {
+            if (windowSized) {
+                return;
+            }
+            var window = Window.GetWindow(this);
+            if (window == null) {
+                return;
+            }
+            windowSized = true;
+
+            var work = SystemParameters.WorkArea; // device-independent pixels, excludes the taskbar
+            const double margin = 40.0;
+
+            window.SizeToContent = SizeToContent.Manual;
+            window.MinWidth = Math.Min(640.0, work.Width);
+            window.MinHeight = Math.Min(440.0, work.Height);
+            window.Width = Math.Min(DesiredWindowWidth, Math.Max(window.MinWidth, work.Width - margin));
+            window.Height = Math.Min(DesiredWindowHeight, Math.Max(window.MinHeight, work.Height - margin));
+            window.Left = work.Left + (work.Width - window.Width) / 2.0;
+            window.Top = work.Top + (work.Height - window.Height) / 2.0;
+
+            // The initial auto-fit (ViewportCanvas_SizeChanged) ran against the pre-resize canvas size, so re-fit against
+            // the FINAL window size once the resize layout pass has settled (DispatcherPriority.Loaded runs after
+            // layout). Latch hasFitOnce only if that deferred fit actually succeeds (F19).
+            Dispatcher.BeginInvoke(
+                new Action(() => { if (TryFit()) { hasFitOnce = true; } }),
+                System.Windows.Threading.DispatcherPriority.Loaded);
         }
 
         private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -163,10 +163,12 @@
             </Setter>
         </Style>
 
-        <!-- Self-contained toolbar button: keep Fit/Prev/Next/Close legible on the fixed dark panel regardless of the
-             active NINA theme (NINA's themed Button binds to theme brushes and ignores instance colors — same reason
-             the combo uses HF_LightCombo and the replay prompt uses ChoiceButton). -->
-        <Style TargetType="Button">
+        <!-- Self-contained toolbar button: keep Fit/Prev/Next/Undo/Redo legible on the fixed dark panel regardless of
+             the active NINA theme (NINA's themed Button binds to theme brushes and ignores instance colors — same
+             reason the combo uses HF_LightCombo and the replay prompt uses ChoiceButton). Keyed and applied explicitly
+             per button: an implicit Style here did NOT override NINA's themed Button on some themes (e.g. Classic), so
+             the buttons rendered with the theme's grey background + black text. An explicit Style always wins. -->
+        <Style x:Key="HF_ReviewToolbarButton" TargetType="Button">
             <Setter Property="Margin" Value="4,0" />
             <Setter Property="Padding" Value="10,4" />
             <Setter Property="Foreground" Value="#FFE6E9ED" />
@@ -222,8 +224,8 @@
 
         <!-- Toolbar: navigation + undo/redo (labeling is mode-less — the category is inferred from what is clicked). -->
         <WrapPanel Grid.Row="1" Grid.Column="0" Margin="0,0,0,6">
-            <Button Content="Fit" Command="{Binding FitCommand}" Margin="0,0,4,0" />
-            <Button Content="◀ Prev" Command="{Binding PrevCommand}" />
+            <Button Content="Fit" Command="{Binding FitCommand}" Margin="0,0,4,0" Style="{StaticResource HF_ReviewToolbarButton}" />
+            <Button Content="◀ Prev" Command="{Binding PrevCommand}" Style="{StaticResource HF_ReviewToolbarButton}" />
             <ComboBox Margin="4,0" VerticalAlignment="Center" MinWidth="96"
                       Style="{StaticResource HF_LightCombo}"
                       ItemsSource="{Binding FramePickerItems}"
@@ -235,9 +237,9 @@
                     </DataTemplate>
                 </ComboBox.ItemTemplate>
             </ComboBox>
-            <Button Content="Next ▶" Command="{Binding NextCommand}" />
-            <Button Content="Undo" Command="{Binding UndoCommand}" Margin="16,0,4,0" />
-            <Button Content="Redo" Command="{Binding RedoCommand}" />
+            <Button Content="Next ▶" Command="{Binding NextCommand}" Style="{StaticResource HF_ReviewToolbarButton}" />
+            <Button Content="Undo" Command="{Binding UndoCommand}" Margin="16,0,4,0" Style="{StaticResource HF_ReviewToolbarButton}" />
+            <Button Content="Redo" Command="{Binding RedoCommand}" Style="{StaticResource HF_ReviewToolbarButton}" />
         </WrapPanel>
 
         <!-- Image + scrollbars: the image Border sits at (0,0); scrollbars appear only when zoomed beyond fit. -->

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -519,8 +519,11 @@
             <TextBlock Margin="0,4,0,0" Foreground="#FFB0B6BD" Text="{Binding CountsLabel}" />
         </StackPanel>
 
-        <!-- Color legend (right column), generated from the VM's single color source so it tracks the overlays. -->
-        <StackPanel Grid.Row="1" Grid.RowSpan="2" Grid.Column="1" VerticalAlignment="Top" Width="230" Margin="12,0,0,0">
+        <!-- Color legend (right column), generated from the VM's single color source so it tracks the overlays.
+             Scrollable so it never clips on a short window (matches the AutoFocus review). -->
+        <ScrollViewer Grid.Row="1" Grid.RowSpan="2" Grid.Column="1" VerticalAlignment="Top" Width="230" Margin="12,0,0,0"
+                      VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+        <StackPanel>
             <TextBlock FontWeight="Bold" Margin="0,0,0,6" Text="Legend" />
             <ItemsControl ItemsSource="{Binding LegendEntries}">
                 <ItemsControl.ItemTemplate>
@@ -576,5 +579,6 @@
             <TextBlock Foreground="#FFB0B6BD" TextWrapping="Wrap"
                        Text="Labeling stars and re-optimizing recovers more stars, especially large defocused ones, so detected star counts go up. The cost is looser detection gates, so the auto-focus curve gets noisier and focus precision drops. This is useful for aberration inspection, where more stars help. It will not improve auto-focus." />
         </StackPanel>
+        </ScrollViewer>
     </Grid>
 </UserControl>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -544,6 +544,48 @@
                         </TextBlock.Style>
                     </TextBlock>
 
+                    <!--  AutoFocus / sensor-model failure choice: run AF again, or how to return to baseline  -->
+                    <Border
+                        Margin="0,6,0,0"
+                        Padding="5"
+                        BorderBrush="{StaticResource NotificationErrorBrush}"
+                        BorderThickness="1">
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasMeasurementFailureChoice}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <StackPanel>
+                            <TextBlock
+                                Margin="0,0,0,6"
+                                Foreground="{StaticResource NotificationErrorBrush}"
+                                Text="{Binding MeasurementFailureText}"
+                                TextWrapping="Wrap" />
+                            <Button
+                                Margin="0,0,0,6"
+                                HorizontalAlignment="Left"
+                                Command="{Binding RetryMeasurementCommand}">
+                                <TextBlock
+                                    Margin="10,5,10,5"
+                                    Foreground="{StaticResource ButtonForegroundBrush}"
+                                    Text="Run AutoFocus again" />
+                            </Button>
+                            <TextBlock
+                                Margin="0,2,0,0"
+                                FontWeight="Bold"
+                                Text="To return to baseline:" />
+                            <TextBlock
+                                Margin="0,2,0,0"
+                                Text="{Binding BaselineRecoveryInstructions}"
+                                TextWrapping="Wrap" />
+                        </StackPanel>
+                    </Border>
+
                     <!--  Live inspector view: shown only during an active measurement  -->
                     <ContentControl
                         Margin="0,8,0,0"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -87,6 +87,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         private string measurementConsistencyWarningText = string.Empty;
         private bool hasRebaselineDriftWarning = false;
         private string rebaselineDriftWarningText = string.Empty;
+        private bool hasMeasurementFailureChoice = false;
+        private string measurementFailureText = string.Empty;
 
         // One (A, B, mean) tilt-plane reading plus the per-step field-curvature characterization, keyed by step.
         private readonly Dictionary<WizardStep, StepReading> stepReadings = new Dictionary<WizardStep, StepReading>();
@@ -172,6 +174,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             UseMeasuredHardwareCommand = new RelayCommand(UseMeasuredHardware, () => HasMeasuredHardware);
             BrowseSaveFolderCommand = new RelayCommand(BrowseSaveFolder);
             ReplayCommand = new AsyncRelayCommand(ReplayAsync, () => !IsWizardRunning && !IsMeasuring);
+            RetryMeasurementCommand = new AsyncRelayCommand(RunMeasurementAsync, () => HasMeasurementFailureChoice && IsOnMeasurementStep && !IsMeasuring && AreDevicesConnected);
 
             tiltAdapterOptions.PropertyChanged += (s, e) => OnUIThread(() => {
                 if (e.PropertyName == nameof(ITiltAdapterOptions.ScrewInwardCurvatureSign)) {
@@ -266,6 +269,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 RaisePropertyChanged(nameof(IsComplete));
                 RaisePropertyChanged(nameof(IsOnMeasurementStep));
                 RaisePropertyChanged(nameof(StepInstructions));
+                RaisePropertyChanged(nameof(IsCurrentStepAtBaseline));
+                RaisePropertyChanged(nameof(BaselineRecoveryInstructions));
                 NotifyCommandsCanExecuteChanged();
             }
         }
@@ -399,6 +404,32 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
         }
 
+        // Shown after an AutoFocus / sensor-model failure: lets the user re-run AutoFocus or read how to get back to
+        // baseline, instead of the bare "Measurement failed." that left the screw-adjustment instruction on screen.
+        public bool HasMeasurementFailureChoice {
+            get => hasMeasurementFailureChoice;
+            private set {
+                hasMeasurementFailureChoice = value;
+                RaisePropertyChanged();
+                NotifyCommandsCanExecuteChanged();
+            }
+        }
+
+        public string MeasurementFailureText {
+            get => measurementFailureText;
+            private set {
+                measurementFailureText = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        // True when the current step's intended physical state IS the baseline (all screws at their starting
+        // position), so the failure panel can say "already at baseline" rather than how to undo a screw move.
+        public bool IsCurrentStepAtBaseline => StepIsAtBaseline(currentStep);
+
+        // Per-step guidance for returning to baseline before retrying, shown in the failure panel.
+        public string BaselineRecoveryInstructions => BaselineRecoveryText(currentStep, tiltAdapterOptions.ScrewCount);
+
         public bool HasRebaselineDriftWarning {
             get => hasRebaselineDriftWarning;
             private set {
@@ -478,6 +509,38 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
         }
 
+        // True for steps whose intended physical state is the baseline (all screws at the starting position).
+        internal static bool StepIsAtBaseline(WizardStep step) {
+            switch (step) {
+                case WizardStep.Baseline:
+                case WizardStep.ReBaseline1:
+                case WizardStep.ReBaseline2:
+                case WizardStep.Complete:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        // Instructions for undoing the current step's screw move to return to baseline (mirrors the ReBaseline /
+        // Complete wording in StepInstructions). For a step already at baseline, says so instead.
+        internal static string BaselineRecoveryText(WizardStep step, int screwCount) {
+            switch (step) {
+                case WizardStep.AllInward:
+                    return "Turn ALL screws back OUT exactly 1 full turn each, returning to the baseline position.";
+                case WizardStep.Screw1:
+                    return screwCount == 3
+                        ? "Turn screw 1 back OUT exactly 1 full turn, returning to the baseline position."
+                        : "Turn screw 1 back OUT and screw 3 back IN exactly 1 full turn each, returning to the baseline position.";
+                case WizardStep.Screw2:
+                    return screwCount == 3
+                        ? "Turn screw 2 back OUT exactly 1 full turn, returning to the baseline position."
+                        : "Turn screw 2 back OUT and screw 4 back IN exactly 1 full turn each, returning to the baseline position.";
+                default:
+                    return "All screws should already be at the baseline (starting) position.";
+            }
+        }
+
         public ICommand StartCommand { get; }
         public ICommand RunMeasurementCommand { get; }
         public ICommand UseSavedAFCommand { get; }
@@ -486,6 +549,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public ICommand UseMeasuredHardwareCommand { get; }
         public ICommand BrowseSaveFolderCommand { get; }
         public ICommand ReplayCommand { get; }
+        public ICommand RetryMeasurementCommand { get; }
 
         // Known amount the user moves each screw during the per-screw calibration steps (full turns
         // for screws, steps for steppers). Defaults to 1.0 to match the "1 full turn" instructions.
@@ -606,6 +670,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         private Task StartAsync() {
             StatusText = string.Empty;
+            ClearMeasurementFailureChoice();
             stepReadings.Clear();
             HasRebaselineDriftWarning = false;
             RebaselineDriftWarningText = string.Empty;
@@ -683,6 +748,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         private async Task RunMeasurementAsync() {
             HasMeasurementConsistencyWarning = false;
             MeasurementConsistencyWarningText = string.Empty;
+            ClearMeasurementFailureChoice();
 
             measureCts?.Dispose();
             measureCts = new CancellationTokenSource();
@@ -701,6 +767,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         private async Task RunSavedMeasurementAsync() {
             HasMeasurementConsistencyWarning = false;
             MeasurementConsistencyWarningText = string.Empty;
+            ClearMeasurementFailureChoice();
 
             measureCts?.Dispose();
             measureCts = new CancellationTokenSource();
@@ -722,6 +789,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             var reading = await RunAveragedMeasurement(token, step, StepDescription(step), fromSaved);
             if (reading == null) {
                 StatusText = "Measurement failed.";
+                // Offer a clear choice instead of silently leaving the screw-adjustment instruction on screen (which
+                // reads as "re-adjust the screw"). The focuser was left where the last run ended, so re-running
+                // AutoFocus often succeeds; otherwise the user can return to baseline (see BaselineRecoveryInstructions).
+                MeasurementFailureText = "AutoFocus or sensor modeling failed for this step. You can run AutoFocus again, or return the screws to baseline before retrying.";
+                HasMeasurementFailureChoice = true;
                 return;
             }
             stepReadings[step] = reading.Value;
@@ -900,6 +972,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             measureCts?.Cancel();
         }
 
+        private void ClearMeasurementFailureChoice() {
+            HasMeasurementFailureChoice = false;
+            MeasurementFailureText = string.Empty;
+        }
+
         private void NextStep() {
             WizardStep next = currentStep + 1;
 
@@ -918,6 +995,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             HasMeasurementConsistencyWarning = false;
             MeasurementConsistencyWarningText = string.Empty;
             StatusText = string.Empty;
+            ClearMeasurementFailureChoice();
             CurrentStep = next;
         }
 
@@ -943,6 +1021,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             HasWarning = false;
             WarningText = string.Empty;
             StatusText = string.Empty;
+            ClearMeasurementFailureChoice();
             CurrentStep = WizardStep.Baseline;
         }
 
@@ -1477,6 +1556,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             ((RelayCommand)CancelCommand).NotifyCanExecuteChanged();
             ((RelayCommand)UseMeasuredHardwareCommand).NotifyCanExecuteChanged();
             ((AsyncRelayCommand)ReplayCommand).NotifyCanExecuteChanged();
+            ((AsyncRelayCommand)RetryMeasurementCommand).NotifyCanExecuteChanged();
         }
 
         private static double NormalizeAngle(double deg) => ((deg % 360) + 360) % 360;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -788,10 +788,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
             var reading = await RunAveragedMeasurement(token, step, StepDescription(step), fromSaved);
             if (reading == null) {
-                StatusText = "Measurement failed.";
-                // Offer a clear choice instead of silently leaving the screw-adjustment instruction on screen (which
-                // reads as "re-adjust the screw"). The focuser was left where the last run ended, so re-running
+                // Show the inline failure panel (below) instead of the bare "Measurement failed." status — that left the
+                // screw-adjustment instruction on screen (reads as "re-adjust the screw") and duplicated the panel text
+                // right above the panel. Clear StatusText so the visible post-measurement status line doesn't leak the
+                // stale "Run N/count..." progress text. The focuser was left where the last run ended, so re-running
                 // AutoFocus often succeeds; otherwise the user can return to baseline (see BaselineRecoveryInstructions).
+                StatusText = string.Empty;
                 MeasurementFailureText = "AutoFocus or sensor modeling failed for this step. You can run AutoFocus again, or return the screws to baseline before retrying.";
                 HasMeasurementFailureChoice = true;
                 return;


### PR DESCRIPTION
This PR has two parts (two commits).

## Part 1 — Autofocus failure robustness

Diagnosed from a real Tilt Adapter Calibration failure (user log `20260623-195350-…`, saved run `AutoFocus_20260623_215748`). A screw adjustment shoved the focuser far from focus, so the blind sweep started far to the right (`54073 → 54385`) and contaminated the curve. The run failed final HFR validation, the focuser was restored to the **prior start** (not the calculated point), and every manual re-run restarted from the same contaminated position. The saved run also had **no `metadata.json`** (not replayable) and **no final image**, and the wizard just showed "Measurement failed." while leaving the *turn-the-screw* instruction on screen.

**1. Auto-retry once from the calculated focus point** (`AutoFocusEngine.cs`)
`ValidateCalculatedFocusPosition` now reports *which* failure mode occurred (`AutoFocusFailureMode`) and captures the pre-offset region-0 fit center. On an **HFR-regression** or **out-of-curve** failure, `RunAutoFocus` re-centers the blind sweep on the calculated point and retries — **at most once**, **independent of `TotalNumberOfAttempts`** (fires even when that's 1). `InitialFocuserPosition` stays the true original so the focuser is restored there on overall failure. Engine-level → all AutoFocus runs. A pure `ShouldRetryFromCalculatedPoint` predicate drives the decision and is unit-tested.

**2. Always write `metadata.json` (flagged) + save the final image on failure** (`AutoFocusEngine.cs`, `Replay/*`)
`metadata.json` was only written from the success path. `OnFailed` now writes it too, with `"succeeded": false` + a `"failureReason"` (new **nullable, backward-compatible** DTO fields; schema stays v1). `ValidateCalculatedFocusPosition` is re-ordered so the out-of-bounds rejection is **deferred** until after the focuser moves and the `finalValidation:true` exposure is taken — so a mode-c failure now leaves a **replayable** run with a diagnostic `final/` frame. The success path still captures exactly once.

**3. Wizard inline failure choice** (`TiltAdapterWizard/TiltAdapterWizardVM.cs`, `DataTemplates.xaml`)
On an AF or sensor-model failure the wizard now shows a panel with a **"Run AutoFocus again"** button plus per-step **return-to-baseline** guidance (or "you're already at baseline"), instead of silently leaving the screw-adjustment instruction up. The two layers compose: the engine retries once automatically; if it still fails, the human decides.

## Part 2 — Review-Frames window/pane sizing

The first-load fit-to-screen window sizing lived only in the manual-AutoFocus review control, so the Aberration Inspector and Star Detection review windows opened at NINA's default content size (off-screen on smaller displays). Hoisted it into the shared `ReviewViewportHostBase` (virtual desired-size; the Inspector review overrides to 1280×860), and dropped the now-fixed `MinWidth/MinHeight` on the Inspector DataTemplate so it shrinks freely. Also wrapped the Inspector and Star review **legends in a `ScrollViewer`** to match the AutoFocus review, so the legend scrolls instead of clipping on a short window (header/footer were already full-width).

## Tests / verification

- **15 new unit tests** (retry-decision predicate incl. single-shot + guards; metadata-on-failure round-trip + builder pass-through + file-write seam; wizard baseline helpers). Review-Frames changes are WPF layout (no new tests). **Full suite: 1548 pass, 0 fail** (rebased onto latest `develop`).
- Adversarial correctness review of the engine control-flow re-ordering and retry logic (9 hunted failure modes) came back clean.
- Not yet verified live in NINA — suggest replaying `AutoFocus_20260623_215748` to confirm `metadata.json` (`succeeded:false`) + a `final/` frame now appear and an a/c failure produces a re-centered `attempt02/`; and that the Inspector Review-Frames window now opens fit-to-screen with a scrolling legend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjEZonPr4qt1xMvMJPcwMH
