### PR TITLE
Fix tilt-adapter docs: screws correct backfocus/curvature, not just tilt

### DIFF
--- a/documentation/docs/overview/sensor-model.md
+++ b/documentation/docs/overview/sensor-model.md
@@ -33,9 +33,11 @@ The inspector fits the focus surface at two levels of detail.
 The two are not rivals. The 4-corners model captures only the linear part of the focus surface: drop
 the curvature terms from the paraboloid and you are left with the same kind of tilt plane. It is
 enough for a quick corner-versus-center check. The surface model is what you want when you intend to correct the sensor
-physically: a successful fit measures tilt and backfocus independently, with field curvature separated
-from both, so you can address each one systematically (tilt with the adapter screws, backfocus and
-curvature with spacing).
+physically: a successful fit measures tilt, field curvature, and centering independently, so you can
+address each systematically. Correct tilt with differential screw moves. The wizard reads the field
+curvature as a spacing error and derives a backfocus correction from it, applied by moving all the
+adapter screws together (or adding spacers); the curvature that remains at the optimal spacing is the
+optical residual you can only minimize.
 
 ![Best-focus offset across the sensor, decomposed into a tilt plane, field curvature, and their sum](../assets/figures/tilt-heatmap.png){ width=560 }
 
@@ -285,7 +287,8 @@ The fitted parameters are converted into the quantities the panel displays.
 
 The grading uses the critical focus zone as the yardstick. Tilt is called acceptable when its effect
 is within \(0.25 \times \text{CFZ}\); curvature when its effect is within \(1.5 \times \text{CFZ}\). A
-tilt adapter can remove the planar part (see the
-[Tilt Adapter Wizard](tilt-adapter-wizard.md)); the
-curvature residual is a property of the corrector and focal ratio and is addressed with spacing, not
-screws.
+tilt adapter removes the tilt (linear) part with differential screw moves, and reduces the curvature
+effect by moving all screws together to change the backfocus spacing (see the
+[Tilt Adapter Wizard](tilt-adapter-wizard.md)); the curvature that remains at the optimal spacing is a
+property of the corrector and focal ratio, addressed with a better-matched corrector or stopping down
+rather than the adapter.

--- a/documentation/docs/overview/tilt-adapter-wizard.md
+++ b/documentation/docs/overview/tilt-adapter-wizard.md
@@ -51,11 +51,18 @@ inconsistent repeats so you can re-run.
     are still reported in focuser steps, and the tilt-angle calculation falls back to the connected
     focuser's reported step size when available.
 
-!!! tip "Tilt vs. curvature: which can a tilt adapter fix?"
-    A tilt adapter corrects the **linear** part of the focus surface, the tilt plane. It cannot
-    flatten genuine **field curvature** (the bowl/dome residual after the plane is removed); that is
-    an optical property of your flattener/corrector and focal ratio. Use the *Tilt effect* and
-    *Curvature effect* numbers to tell which problem dominates before reaching for the screwdriver.
+!!! tip "Tilt, backfocus, and curvature: what the screws can fix"
+    The Sensor Model splits the focus surface into two effects. The **Tilt Effect** is the linear
+    plane (one side focuses ahead of the opposite side); you null it by moving the screws
+    *differentially*, reported as the per-screw **Tilt** amount.
+
+    The **Curvature Effect** is the symmetric corners-versus-center bowl. The wizard reads it as a
+    spacing error and derives a **backfocus** correction from it, reported as the per-screw
+    **Backfocus** amount: turn all screws the same way to move the whole sensor along the optical axis
+    (or add spacers for changes beyond the adapter's travel), then re-measure and repeat until the
+    Curvature Effect stops dropping. What remains is the residual curvature of a correctly spaced
+    system, set by your corrector design and focal ratio; the adapter cannot remove it (a
+    better-matched corrector or stopping down does).
 
 ## Hardware model and device presets
 


### PR DESCRIPTION
## Summary

Corrects a factual error in the tilt-adapter documentation. The "what a tilt adapter can fix" tip previously claimed the screws **cannot** address field curvature. They can: moving all screws together (common-mode) changes the backfocus spacing, and the wizard already derives a per-screw **Backfocus** amount from the Sensor Model's **Curvature Effect** (`TiltScrewGeometry.ScrewCorrectionMicrons` computes `-CurvatureAt(corner)`). So the old wording contradicted both the optics and the shipping code.

## Changes
- **`tilt-adapter-wizard.md`** — rewrote the tip around the two surface-model effects the Sensor Model actually measures, **Tilt Effect** (corrected by differential screw moves) and **Curvature Effect** (the wizard derives the per-screw **Backfocus** spacing correction from it; iterate until it stops dropping). The residual at optimal spacing is the corrector/focal-ratio limit the adapter can't remove.
- **`sensor-model.md`** — fixed two lines that treated backfocus as a separately *measured* effect. The surface model measures tilt, field curvature, and centering; backfocus is the *derived* correction from curvature.

## Verification
- Optics cross-checked against Astro-Physics (Roland Christen), telescope-optics.net, Celestron/OPT, ASG, and Gerd Neumann sources: wrong corrector spacing induces the symmetric corners-vs-center error; correcting spacing reduces it; only the residual at correct spacing is the fixed optical limit.
- Behavior cross-checked against the HocusFocus source (per-screw Backfocus guidance derived from the curvature coefficients; the "all screws inward" calibration step measures the common-mode sign).
- `mkdocs build --strict` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
