### PR TITLE
fix(optimizer-wizard): pin footer, scroll body, and clamp window to the monitor work area

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/ClampWindowToWorkArea.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/ClampWindowToWorkArea.cs
@@ -11,19 +11,28 @@
 #endregion "copyright"
 
 using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Interop;
 
 namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
     /// <summary>
-    /// Attached behavior that clamps the host <see cref="Window"/>'s <see cref="FrameworkElement.MaxHeight"/> to the
-    /// working area (screen height minus the taskbar) of the monitor the window is on, so the wizard never opens or
-    /// resizes taller than the visible desktop. NINA's WindowService sizes the dialog to its content, which on a small
-    /// laptop can exceed the screen; this caps it. Paired with the wizard body's ScrollViewer, anything taller than the
-    /// work area then scrolls inside the body while the footer buttons stay pinned and reachable.
+    /// Attached behavior that keeps the host <see cref="Window"/> within the working area (screen minus the taskbar)
+    /// of the monitor it is on. NINA hosts the wizard in a custom-chrome window sized to its content, which on a small
+    /// laptop opens taller than the screen and (being custom-chrome) maximizes over the taskbar, so the footer buttons
+    /// end up off-screen or behind the taskbar.
     ///
-    /// Applied as <c>local:ClampWindowToWorkArea.Enabled="True"</c> on the wizard DataTemplate's root element.
+    /// A WPF <c>MaxHeight</c> is not reliable here (custom chrome + per-monitor DPI), so this works at the Win32 level in
+    /// physical pixels, which is DPI-agnostic:
+    /// <list type="bullet">
+    /// <item>WM_GETMINMAXINFO — maximize fills the work area (taskbar stays visible) and the max track size is capped.</item>
+    /// <item>WM_WINDOWPOSCHANGING — every normal-state resize (including NINA's per-step SizeToContent growth and user
+    /// drag) is clamped to the work-area height and nudged back on-screen.</item>
+    /// </list>
+    /// Paired with the wizard body's ScrollViewer, content taller than the work area then scrolls while the footer stays
+    /// pinned. Applied as <c>local:ClampWindowToWorkArea.Enabled="True"</c> on the wizard DataTemplate's root element.
     /// </summary>
     public static class ClampWindowToWorkArea {
 
@@ -38,6 +47,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
         public static void SetEnabled(DependencyObject obj, bool value) => obj.SetValue(EnabledProperty, value);
 
+        // One hook per window; the modal dialog and its HwndSource are short-lived, so the hook dies with the window.
+        // The table only guards against a repeated Loaded re-adding the hook, and lets the window be collected.
+        private static readonly ConditionalWeakTable<Window, object> hookedWindows = new();
+
         private static void OnEnabledChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
             if (d is not FrameworkElement fe) {
                 return;
@@ -45,7 +58,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             if ((bool)e.NewValue) {
                 fe.Loaded += OnLoaded;
                 if (fe.IsLoaded) {
-                    ApplyClamp(fe);
+                    Attach(fe);
                 }
             } else {
                 fe.Loaded -= OnLoaded;
@@ -54,38 +67,187 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
         private static void OnLoaded(object sender, RoutedEventArgs e) {
             if (sender is FrameworkElement fe) {
-                ApplyClamp(fe);
+                Attach(fe);
             }
         }
 
-        private static void ApplyClamp(FrameworkElement fe) {
+        private static void Attach(FrameworkElement fe) {
             var window = Window.GetWindow(fe);
             if (window is null) {
                 return;
             }
-            try {
-                window.MaxHeight = GetWorkAreaHeightDip(window);
-            } catch {
-                // A sizing convenience must never break showing the dialog; fall back to the primary work area.
-                window.MaxHeight = SystemParameters.WorkArea.Height;
+            var hwnd = new WindowInteropHelper(window).Handle;
+            if (hwnd == IntPtr.Zero) {
+                return;
+            }
+            var source = HwndSource.FromHwnd(hwnd);
+            if (source is null) {
+                return;
+            }
+            if (!hookedWindows.TryGetValue(window, out _)) {
+                hookedWindows.Add(window, hookedWindows);
+                HwndSourceHook hook = (IntPtr h, int msg, IntPtr wParam, IntPtr lParam, ref bool handled) =>
+                    WndProc(window, h, msg, lParam, ref handled);
+                source.AddHook(hook);
+            }
+            // The first shown step is small, but clamp the current bounds defensively in case it already overshoots.
+            ClampNow(hwnd);
+        }
+
+        private static IntPtr WndProc(Window window, IntPtr hwnd, int msg, IntPtr lParam, ref bool handled) {
+            switch (msg) {
+                case WM_GETMINMAXINFO:
+                    if (TryGetWorkArea(hwnd, out var maxWork, out var monitor)) {
+                        var mmi = Marshal.PtrToStructure<MINMAXINFO>(lParam);
+                        // Maximize to the work area (taskbar stays visible) instead of the full monitor.
+                        mmi.ptMaxPosition.X = maxWork.Left - monitor.Left;
+                        mmi.ptMaxPosition.Y = maxWork.Top - monitor.Top;
+                        mmi.ptMaxSize.X = maxWork.Right - maxWork.Left;
+                        mmi.ptMaxSize.Y = maxWork.Bottom - maxWork.Top;
+                        // Cap how large the window can be made (covers SizeToContent and user drag).
+                        mmi.ptMaxTrackSize.X = maxWork.Right - maxWork.Left;
+                        mmi.ptMaxTrackSize.Y = maxWork.Bottom - maxWork.Top;
+                        Marshal.StructureToPtr(mmi, lParam, false);
+                        handled = true; // take over so WPF's default (unbounded) max does not overwrite ours
+                    }
+                    break;
+
+                case WM_WINDOWPOSCHANGING:
+                    if (window.WindowState == WindowState.Normal && TryGetWorkArea(hwnd, out var work, out _)) {
+                        var pos = Marshal.PtrToStructure<WINDOWPOS>(lParam);
+                        var sizing = (pos.flags & SWP_NOSIZE) == 0;
+                        if (sizing) {
+                            var changed = false;
+                            var maxHeight = work.Bottom - work.Top;
+                            if (pos.cy > maxHeight) {
+                                pos.cy = maxHeight;
+                                changed = true;
+                            }
+                            // If this change also moves the window, keep the (clamped) window inside the work area.
+                            if ((pos.flags & SWP_NOMOVE) == 0) {
+                                if (pos.y + pos.cy > work.Bottom) {
+                                    pos.y = work.Bottom - pos.cy;
+                                    changed = true;
+                                }
+                                if (pos.y < work.Top) {
+                                    pos.y = work.Top;
+                                    changed = true;
+                                }
+                            }
+                            if (changed) {
+                                Marshal.StructureToPtr(pos, lParam, false);
+                            }
+                        }
+                    }
+                    break;
+            }
+            return IntPtr.Zero;
+        }
+
+        /// <summary>One-time clamp of the window's current bounds into the work area (height only; keeps it on-screen).</summary>
+        private static void ClampNow(IntPtr hwnd) {
+            if (!TryGetWorkArea(hwnd, out var work, out _) || !GetWindowRect(hwnd, out var r)) {
+                return;
+            }
+            int cx = r.Right - r.Left, cy = r.Bottom - r.Top, x = r.Left, y = r.Top;
+            int workHeight = work.Bottom - work.Top;
+            var changed = false;
+            if (cy > workHeight) {
+                cy = workHeight;
+                changed = true;
+            }
+            if (y < work.Top) {
+                y = work.Top;
+                changed = true;
+            }
+            if (y + cy > work.Bottom) {
+                y = work.Bottom - cy;
+                changed = true;
+            }
+            if (changed) {
+                SetWindowPos(hwnd, IntPtr.Zero, x, y, cx, cy, SWP_NOZORDER | SWP_NOACTIVATE);
             }
         }
 
-        /// <summary>
-        /// Work-area height (screen minus taskbar) of the window's monitor, in WPF device-independent units. Uses the
-        /// per-monitor work area in physical pixels and converts it through the window's own device transform so it is
-        /// correct under high-DPI scaling; falls back to the primary screen's work area (already in DIPs) if the window
-        /// is not yet connected to a presentation source.
-        /// </summary>
-        private static double GetWorkAreaHeightDip(Window window) {
-            var source = PresentationSource.FromVisual(window);
-            var handle = new WindowInteropHelper(window).Handle;
-            if (source?.CompositionTarget is null || handle == IntPtr.Zero) {
-                return SystemParameters.WorkArea.Height;
+        private static bool TryGetWorkArea(IntPtr hwnd, out RECT work, out RECT monitor) {
+            work = default;
+            monitor = default;
+            var hMonitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+            if (hMonitor == IntPtr.Zero) {
+                return false;
             }
-            var workAreaPx = System.Windows.Forms.Screen.FromHandle(handle).WorkingArea;
-            var deviceToDip = source.CompositionTarget.TransformFromDevice; // M22 = 1 / vertical DPI scale
-            return workAreaPx.Height * deviceToDip.M22;
+            var info = new MONITORINFO { cbSize = Marshal.SizeOf<MONITORINFO>() };
+            if (!GetMonitorInfo(hMonitor, ref info)) {
+                return false;
+            }
+            work = info.rcWork;
+            monitor = info.rcMonitor;
+            return true;
+        }
+
+        private const int WM_GETMINMAXINFO = 0x0024;
+        private const int WM_WINDOWPOSCHANGING = 0x0046;
+        private const int MONITOR_DEFAULTTONEAREST = 0x0002;
+        private const uint SWP_NOSIZE = 0x0001;
+        private const uint SWP_NOMOVE = 0x0002;
+        private const uint SWP_NOZORDER = 0x0004;
+        private const uint SWP_NOACTIVATE = 0x0010;
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr MonitorFromWindow(IntPtr hwnd, int dwFlags);
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetMonitorInfo(IntPtr hMonitor, ref MONITORINFO lpmi);
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetWindowRect(IntPtr hwnd, out RECT lpRect);
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool SetWindowPos(IntPtr hwnd, IntPtr hwndInsertAfter, int x, int y, int cx, int cy, uint flags);
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct POINT {
+            public int X;
+            public int Y;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct RECT {
+            public int Left;
+            public int Top;
+            public int Right;
+            public int Bottom;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct MINMAXINFO {
+            public POINT ptReserved;
+            public POINT ptMaxSize;
+            public POINT ptMaxPosition;
+            public POINT ptMinTrackSize;
+            public POINT ptMaxTrackSize;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct MONITORINFO {
+            public int cbSize;
+            public RECT rcMonitor;
+            public RECT rcWork;
+            public int dwFlags;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct WINDOWPOS {
+            public IntPtr hwnd;
+            public IntPtr hwndInsertAfter;
+            public int x;
+            public int y;
+            public int cx;
+            public int cy;
+            public uint flags;
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/ClampWindowToWorkArea.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/ClampWindowToWorkArea.cs
@@ -1,0 +1,91 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Windows;
+using System.Windows.Interop;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
+
+    /// <summary>
+    /// Attached behavior that clamps the host <see cref="Window"/>'s <see cref="FrameworkElement.MaxHeight"/> to the
+    /// working area (screen height minus the taskbar) of the monitor the window is on, so the wizard never opens or
+    /// resizes taller than the visible desktop. NINA's WindowService sizes the dialog to its content, which on a small
+    /// laptop can exceed the screen; this caps it. Paired with the wizard body's ScrollViewer, anything taller than the
+    /// work area then scrolls inside the body while the footer buttons stay pinned and reachable.
+    ///
+    /// Applied as <c>local:ClampWindowToWorkArea.Enabled="True"</c> on the wizard DataTemplate's root element.
+    /// </summary>
+    public static class ClampWindowToWorkArea {
+
+        public static readonly DependencyProperty EnabledProperty =
+            DependencyProperty.RegisterAttached(
+                "Enabled",
+                typeof(bool),
+                typeof(ClampWindowToWorkArea),
+                new PropertyMetadata(false, OnEnabledChanged));
+
+        public static bool GetEnabled(DependencyObject obj) => (bool)obj.GetValue(EnabledProperty);
+
+        public static void SetEnabled(DependencyObject obj, bool value) => obj.SetValue(EnabledProperty, value);
+
+        private static void OnEnabledChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+            if (d is not FrameworkElement fe) {
+                return;
+            }
+            if ((bool)e.NewValue) {
+                fe.Loaded += OnLoaded;
+                if (fe.IsLoaded) {
+                    ApplyClamp(fe);
+                }
+            } else {
+                fe.Loaded -= OnLoaded;
+            }
+        }
+
+        private static void OnLoaded(object sender, RoutedEventArgs e) {
+            if (sender is FrameworkElement fe) {
+                ApplyClamp(fe);
+            }
+        }
+
+        private static void ApplyClamp(FrameworkElement fe) {
+            var window = Window.GetWindow(fe);
+            if (window is null) {
+                return;
+            }
+            try {
+                window.MaxHeight = GetWorkAreaHeightDip(window);
+            } catch {
+                // A sizing convenience must never break showing the dialog; fall back to the primary work area.
+                window.MaxHeight = SystemParameters.WorkArea.Height;
+            }
+        }
+
+        /// <summary>
+        /// Work-area height (screen minus taskbar) of the window's monitor, in WPF device-independent units. Uses the
+        /// per-monitor work area in physical pixels and converts it through the window's own device transform so it is
+        /// correct under high-DPI scaling; falls back to the primary screen's work area (already in DIPs) if the window
+        /// is not yet connected to a presentation source.
+        /// </summary>
+        private static double GetWorkAreaHeightDip(Window window) {
+            var source = PresentationSource.FromVisual(window);
+            var handle = new WindowInteropHelper(window).Handle;
+            if (source?.CompositionTarget is null || handle == IntPtr.Zero) {
+                return SystemParameters.WorkArea.Height;
+            }
+            var workAreaPx = System.Windows.Forms.Screen.FromHandle(handle).WorkingArea;
+            var deviceToDip = source.CompositionTarget.TransformFromDevice; // M22 = 1 / vertical DPI scale
+            return workAreaPx.Height * deviceToDip.M22;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -204,7 +204,7 @@
               lives on the scrollable body below, NOT here: keeping a MinHeight floor on the root grid prevented it
               from shrinking to a smaller window, so the bottom row (footer buttons) overflowed and clipped. With the
               floor gone the grid shrinks to the window, the body scrolls, and the footer stays pinned.  -->
-        <Grid Margin="10">
+        <Grid Margin="10" local:ClampWindowToWorkArea.Enabled="True">
             <Grid.Style>
                 <Style TargetType="Grid">
                     <Setter Property="Width" Value="640" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -200,24 +200,23 @@
 
     <!--  The wizard window content. Implicit DataType template so the WindowService's ContentPresenter resolves it by VM type.  -->
     <DataTemplate DataType="{x:Type local:StarDetectionOptimizerWizardVM}">
-        <!--  Width/height grow for the Review step (it embeds a full interactive image viewer); the other steps keep
-              the compact wizard footprint.  -->
+        <!--  Width grows per step (the Review step embeds a full interactive image viewer). The preferred HEIGHT now
+              lives on the scrollable body below, NOT here: keeping a MinHeight floor on the root grid prevented it
+              from shrinking to a smaller window, so the bottom row (footer buttons) overflowed and clipped. With the
+              floor gone the grid shrinks to the window, the body scrolls, and the footer stays pinned.  -->
         <Grid Margin="10">
             <Grid.Style>
                 <Style TargetType="Grid">
                     <Setter Property="Width" Value="640" />
-                    <Setter Property="MinHeight" Value="420" />
                     <Style.Triggers>
                         <!--  Wider on the results page so the auto-focus curve chart has room…  -->
                         <DataTrigger Binding="{Binding IsSummary}" Value="True">
                             <Setter Property="Width" Value="820" />
-                            <Setter Property="MinHeight" Value="560" />
                         </DataTrigger>
                         <!--  …and widest for the Review step (embeds the full interactive image viewer). Listed last
                               so it wins; the two are mutually exclusive anyway.  -->
                         <DataTrigger Binding="{Binding IsReview}" Value="True">
                             <Setter Property="Width" Value="1120" />
-                            <Setter Property="MinHeight" Value="720" />
                         </DataTrigger>
                     </Style.Triggers>
                 </Style>
@@ -237,8 +236,26 @@
                 FontWeight="Bold"
                 Text="Star Detection Optimization Wizard" />
 
-            <!--  Body: one panel visible per step  -->
-            <Grid Grid.Row="1">
+            <!--  Body: one panel visible per step. Wrapped in a ScrollViewer so that when the window is shorter than
+                  the body's preferred height, the body scrolls (the footer below stays pinned) instead of the whole
+                  grid overflowing and clipping the footer. The per-step MinHeight on the inner grid sets the
+                  preferred/opening height; on a tall-enough window the body fills (no scrollbar) exactly as before,
+                  so the StarReviewControl still gets the full area when there is room.  -->
+            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+            <Grid>
+                <Grid.Style>
+                    <Style TargetType="Grid">
+                        <Setter Property="MinHeight" Value="380" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsSummary}" Value="True">
+                                <Setter Property="MinHeight" Value="520" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding IsReview}" Value="True">
+                                <Setter Property="MinHeight" Value="660" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Grid.Style>
 
                 <!--  Step 1: Select Source  -->
                 <StackPanel Visibility="{Binding ShowSelectSource, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
@@ -669,6 +686,7 @@
                     DataContext="{Binding ReviewVM}"
                     Visibility="{Binding DataContext.ShowReview, RelativeSource={RelativeSource AncestorType=Grid}, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
             </Grid>
+            </ScrollViewer>
 
             <!--  Error banner  -->
             <TextBlock


### PR DESCRIPTION
Three commits so the Star Detection Optimization Wizard is usable on a monitor too small to show the whole window.

## 1. Pin the footer, scroll the body
**Problem:** shrinking the window pushed the bottom navigation buttons (Back / Optimize with feedback / Accept / Close, etc.) off the bottom, unreachable by scrolling.
**Cause:** a per-step `MinHeight` floor on the root grid (420/560/720) stopped it from shrinking, so the grid overflowed the window and the footer clipped.
**Fix:** remove the root-grid `MinHeight` floor (grid shrinks to the window, the `Auto` footer row stays visible) and wrap the body in a `ScrollViewer`, moving the per-step preferred height onto the body's inner grid. Tall window -> body fills as before; short window -> center scrolls, footer pinned.

## 2. Clamp the window to the monitor work area
**Ask:** the window should never open or resize taller than the visible desktop (screen height minus the taskbar), and maximizing shouldn't hide the buttons behind the taskbar.
**Why a WPF `MaxHeight` wasn't enough (commit 2 -> corrected in commit 3):** NINA hosts the dialog in a custom-chrome (`WindowChrome`) window sized with `SizeToContent`. A WPF `MaxHeight` did not constrain it — the window still opened taller than the screen and maximized over the taskbar.
**Fix:** a `ClampWindowToWorkArea` attached behavior installs a Win32 message hook on the host window, working in physical pixels (DPI-agnostic):
- `WM_GETMINMAXINFO` caps the maximized size/position to the monitor work area, so maximize keeps the taskbar (and the footer) visible.
- `WM_WINDOWPOSCHANGING` clamps every normal-state resize — including NINA's per-step `SizeToContent` growth and user drag — to the work-area height, and keeps the window on-screen.

Together with fix 1, content taller than the work area scrolls inside the body while the footer stays pinned. Applied via `local:ClampWindowToWorkArea.Enabled="True"` on the wizard root.

The other review surfaces (AutoFocus Review Frames, Aberration Inspector Review Frames) keep their buttons in a top toolbar, so they were unaffected.

## Verification
- Build compiles the XAML + behavior cleanly; full suite green (1549 passed, 0 failures).
- The Win32 window behavior (open height, resize, maximize) needs a visual check in a running NINA — not yet done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
