### PR TITLE
fix(optimizer): suppress per-detection HFR INFO flood during optimization

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/SuppressInfoLoggingTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/SuppressInfoLoggingTests.cs
@@ -1,0 +1,55 @@
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
+
+    /// <summary>
+    /// Guards the optimizer's log-flood suppression flag
+    /// (<see cref="StarDetectorParams.SuppressInfoLogging"/>). The optimizer wizard runs star detection
+    /// thousands of times; left unguarded, the per-region "Average HFR / Detected Stars" INFO summary in
+    /// <c>HocusFocusStarDetection.BuildStarDetectionResult</c> floods the NINA log with ~10k+ lines per run.
+    /// Setting this flag on the optimizer's seed/baseline params skips that one INFO line — and must change
+    /// NOTHING else.
+    ///
+    /// Therefore the flag must be (1) OFF by default so normal autofocus keeps the summary, (2) excluded from the
+    /// detection cache key (it is a pure side channel), and (3) output-neutral (no detected-star/metric change).
+    /// </summary>
+    [TestFixture]
+    public class SuppressInfoLoggingTests {
+
+        [Test]
+        public void SuppressInfoLogging_DefaultsToFalse() {
+            Assert.That(new StarDetectorParams().SuppressInfoLogging, Is.False,
+                "Normal autofocus must keep the per-region HFR INFO summary; only the optimizer opts in.");
+        }
+
+        [Test]
+        public void SuppressInfoLogging_FlagExcludedFromCacheKey() {
+            var pOff = StarDetectorEquivalence.StandardParams();
+            var pOn = StarDetectorEquivalence.StandardParams();
+            pOn.SuppressInfoLogging = true;
+
+            // Logging-only side channel: it must NOT change the canonical cache string, else the optimizer's
+            // early-context cache could treat suppress-on and suppress-off as different detections and miss.
+            Assert.That(pOn.ToCanonicalCacheString(), Is.EqualTo(pOff.ToCanonicalCacheString()),
+                "SuppressInfoLogging must be excluded from the detection cache key.");
+        }
+
+        [Test]
+        public async Task SuppressInfoLogging_OffVsOn_DetectionBitIdentical() {
+            var pOff = StarDetectorEquivalence.StandardParams();
+            var pOn = StarDetectorEquivalence.StandardParams();
+            pOn.SuppressInfoLogging = true;
+
+            using var field1 = StarDetectorEquivalence.BuildSmallField();
+            var resultOff = await StarDetectorEquivalence.RunDetect(field1, pOff);
+
+            using var field2 = StarDetectorEquivalence.BuildSmallField();
+            var resultOn = await StarDetectorEquivalence.RunDetect(field2, pOn);
+
+            Assert.That(StarDetectorEquivalence.Signature(resultOn), Is.EqualTo(StarDetectorEquivalence.Signature(resultOff)),
+                "Suppressing the INFO summary must not change any detected star or metric.");
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
@@ -301,6 +301,14 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         // detection stays bit-identical. Excluded from the cache key (output-neutral side channel).
         public bool CollectRejectedCandidateDiagnostics { get; set; } = false;
 
+        // Logging suppression opt-in (output-neutral). When true, the detector skips the per-region
+        // "Average HFR / Detected Stars" INFO summary in HocusFocusStarDetection.BuildStarDetectionResult. The
+        // optimizer wizard sets this on its seed/baseline params (RunEvaluationLoader) so a single optimization —
+        // which re-runs detection thousands of times — does not flood the NINA log with ~10k+ INFO lines; normal
+        // autofocus leaves it false and keeps the summary. Affects logging only (no detected-star value or
+        // accept/reject decision changes), so it is excluded from the cache key below.
+        public bool SuppressInfoLogging { get; set; } = false;
+
         // Half size of a median box filter, used for hotpixel removal if HotpixelFiltering is enabled. Only 1 is supported for now, since OpenCV has native support for
         // a median box filter but not a general circular one
         public int HotpixelFilterRadius { get; set; } = 1;
@@ -513,6 +521,11 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
             // detected-star value are unaffected — the records are emitted at the same gate sites that already
             // run, after the reject decision is made — so this is output-neutral.
             nameof(CollectRejectedCandidateDiagnostics),
+
+            // Logging only: when true the per-region "Average HFR / Detected Stars" INFO summary in
+            // BuildStarDetectionResult is skipped. No detected-star value or accept/reject decision depends on it,
+            // so it is output-neutral and must not change which detections the optimizer's cache treats as equal.
+            nameof(SuppressInfoLogging),
 
             // Debug/intermediate-output only: stashes the structure map into DebugData for inspection. Does not
             // change which stars are detected or any measured value.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
@@ -657,13 +657,17 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                     var hfrVariance = starList.Sum(s => (s.HFR - result.AverageHFR) * (s.HFR - result.AverageHFR)) / (starList.Count - 1);
                     result.HFRStdDev = Math.Sqrt(hfrVariance);
 
-                    Logger.Info($"Average HFR: {result.AverageHFR}, HFR σ: {result.HFRStdDev}, Detected Stars {result.StarList.Count}, Region: {result?.Region.Index ?? 0}");
+                    if (!detectorParams.SuppressInfoLogging) {
+                        Logger.Info($"Average HFR: {result.AverageHFR}, HFR σ: {result.HFRStdDev}, Detected Stars {result.StarList.Count}, Region: {result?.Region.Index ?? 0}");
+                    }
                 } else {
                     var (hfrMedian, hfrMAD) = starList.Select(s => s.HFR).MedianMAD();
                     result.AverageHFR = hfrMedian;
                     result.HFRStdDev = hfrMAD;
 
-                    Logger.Info($"Average HFR: {result.AverageHFR}, HFR MAD: {result.HFRStdDev}, Detected Stars {result.StarList.Count}, Region: {result?.Region.Index ?? 0}");
+                    if (!detectorParams.SuppressInfoLogging) {
+                        Logger.Info($"Average HFR: {result.AverageHFR}, HFR MAD: {result.HFRStdDev}, Detected Stars {result.StarList.Count}, Region: {result?.Region.Index ?? 0}");
+                    }
                 }
             }
             result.DebugData = starDetectorResult.DebugData;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationLoader.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationLoader.cs
@@ -166,6 +166,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             var seed = detection.GetDefaultStarDetectorParams(firstImage, region, isAutoFocus: true);
             var baseline = detection.GetStarDetectorParams(firstImage, region, isAutoFocus: true);
 
+            // Every detection these params drive is an OPTIMIZER evaluation — the seed (and the candidates the
+            // optimizer materializes from it via Clone) and the baseline are each detected across all frames many
+            // thousands of times during a single optimization. Suppress the per-region "Average HFR" INFO summary
+            // so one optimization run does not flood the NINA log with ~10k+ INFO lines. The flag is output-neutral
+            // and excluded from the detection cache key, so detection results stay byte-identical; only the wizard
+            // path sets it (TestApp diagnostics build RunEvaluationData directly and are unaffected).
+            seed.SuppressInfoLogging = true;
+            baseline.SuppressInfoLogging = true;
+
             // AF detection params: the auto-focus detection contract (sigma rejections + AF flag). NumberOfAFStars
             // is left at 0 so detection keeps every accepted star — the optimizer scores on the full accepted set,
             // not the brightest-N subset the live AF picks for centroiding.


### PR DESCRIPTION
## Problem

The optimizer wizard re-runs star detection across *candidates × frames × regions*. `HocusFocusStarDetection.BuildStarDetectionResult` emits an `Average HFR: …, Detected Stars …, Region: …` **INFO** line once per region per detection (lines 660/666), so a single optimization run floods the NINA log. In a sample log, **13,701 of 13,846 INFO lines (99%)** were this one message.

## Fix

Add an output-neutral `StarDetectorParams.SuppressInfoLogging` flag that gates those two INFO calls, and stamp it on the optimizer's `seed`/`baseline` params in `RunEvaluationLoader`.

**Why the loader is the right chokepoint:** `RunEvaluationLoader` is constructed *only* by the wizard, and every wizard detection path flows from its `seed`/`baseline`:
- optimizer candidates are `seed.Clone()` (MemberwiseClone inherits the flag)
- seed guard / baseline-J / analysis use `Baseline`
- summary re-eval and review build use `BestParams` (a seed clone, or `Baseline` in "use current settings" mode)

So one stamp suppresses the whole flood. **Normal autofocus** leaves the flag `false` and keeps the per-region summary. **TestApp diagnostics** build `RunEvaluationData` directly (bypassing the loader), so they're unaffected.

The flag is **excluded from the detection cache key** (pure logging side channel), so detection results stay byte-identical and the optimizer's early-context cache is unaffected.

## Net effect

An optimization run drops from ~13.7k INFO lines to a handful of per-run setup lines; ordinary single autofocus still logs its `Average HFR / Detected Stars` summary.

## Changed files

- `Interfaces/IStarDetector.cs` — new `SuppressInfoLogging` property (default `false`) + added to `CacheKeyExcludedProperties`
- `StarDetection/HocusFocusStarDetection.cs` — gate lines 660/666
- `StarDetection/Optimization/RunEvaluationLoader.cs` — stamp seed/baseline
- `…Tests/StarDetection/SuppressInfoLoggingTests.cs` — 3 guards: default-off, cache-key-excluded, detection bit-identical on/off

## Testing

`dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug` → **1552 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)