### PR TITLE
feat(star-detection): import/export settings for cross-machine transfer

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionImportApplyTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionImportApplyTests.cs
@@ -1,0 +1,127 @@
+using NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NINA.Profile.Interfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
+
+    [TestFixture]
+    public class StarDetectionImportApplyTests {
+
+        private static StarDetectionOptions NewOptions() =>
+            new StarDetectionOptions(Substitute.For<IProfileService>(), new InMemoryPluginOptionsAccessor());
+
+        private static OptimizedStarDetectionSettings SampleOptimized() => new OptimizedStarDetectionSettings() {
+            BrightnessSensitivity = 3.5,
+            StarClippingMultiplier = 2.0,
+            NoiseClippingMultiplier = 4.0,
+            StarPeakResponse = 0.7,
+            MaxDistortion = 0.55,
+            MinHFR = 1.3,
+            StarCenterTolerance = 0.4,
+            StructureLayers = 5,
+            NoiseReductionRadius = 3,
+            MinStarBoundingBoxSize = 5,
+            HotpixelThresholdingEnabled = true,
+            HotpixelThreshold = 0.002
+        };
+
+        [Test]
+        public void ApplyImportedSnapshot_RestoresAdvancedKnobs_ThroughFileRoundTrip() {
+            var source = NewOptions();
+            source.UseAdvanced = true;
+            source.BrightnessSensitivity = 8.4;
+            source.StructureLayers = 6;
+            source.MaxDistortion = 0.31;
+            source.MinHFR = 1.05;
+
+            // Full export → JSON → import, exercising the file format end to end.
+            var json = StarDetectionSettingsExport.FromOptions(source).Serialize();
+            var export = StarDetectionSettingsExport.Deserialize(json);
+
+            var target = NewOptions(); // starts in Simple mode
+            Assume.That(target.UseAdvanced, Is.False);
+
+            target.ApplyImportedSnapshot(export.StarDetection);
+
+            Assert.Multiple(() => {
+                Assert.That(target.UseAdvanced, Is.True);
+                Assert.That(target.BrightnessSensitivity, Is.EqualTo(8.4));
+                Assert.That(target.StructureLayers, Is.EqualTo(6));
+                Assert.That(target.MaxDistortion, Is.EqualTo(0.31));
+                Assert.That(target.MinHFR, Is.EqualTo(1.05));
+            });
+        }
+
+        [Test]
+        public void ApplyImportedSnapshot_RestoresSimpleOptimizedMode() {
+            var source = NewOptions();
+            source.ApplyOptimizedSettings(SampleOptimized());
+            var snapshot = StarDetectionSettingsSnapshot.FromOptions(source);
+
+            var target = NewOptions();
+            target.UseAdvanced = true;
+
+            target.ApplyImportedSnapshot(snapshot);
+
+            Assert.Multiple(() => {
+                Assert.That(target.UseAdvanced, Is.False);
+                Assert.That(target.UseOptimizedSettings, Is.True);
+                Assert.That(target.HasOptimizedSettings, Is.True);
+                Assert.That(target.BrightnessSensitivity, Is.EqualTo(3.5));
+                Assert.That(target.MaxDistortion, Is.EqualTo(0.55));
+            });
+        }
+
+        [Test]
+        public void ApplyImportedSnapshot_LeavesMachineLocalPerfAndDebugUntouched() {
+            var source = NewOptions();
+            source.UseAdvanced = true;
+            source.BrightnessSensitivity = 9.1;
+            source.PSFParallelPartitionSize = 999;
+            source.DebugMode = true;
+            var snapshot = StarDetectionSettingsSnapshot.FromOptions(source);
+
+            var target = NewOptions();
+            target.UseAdvanced = true;
+            target.PSFParallelPartitionSize = 50;
+            target.DebugMode = false;
+            target.BrightnessSensitivity = 2.0;
+
+            target.ApplyImportedSnapshot(snapshot);
+
+            Assert.Multiple(() => {
+                // A normal algorithm knob IS imported.
+                Assert.That(target.BrightnessSensitivity, Is.EqualTo(9.1));
+                // The machine-local parallelism + diagnostics knobs are preserved on the imaging machine.
+                Assert.That(target.PSFParallelPartitionSize, Is.EqualTo(50));
+                Assert.That(target.DebugMode, Is.False);
+            });
+        }
+
+        [Test]
+        public void ApplyFullSnapshot_StillCopiesMachineLocalPerfAndDebug() {
+            // Guards the behavioral split: the same-machine replay path (option c) must keep copying these two.
+            var source = NewOptions();
+            source.UseAdvanced = true;
+            source.PSFParallelPartitionSize = 999;
+            source.DebugMode = true;
+            var snapshot = StarDetectionSettingsSnapshot.FromOptions(source);
+
+            var target = NewOptions();
+            target.UseAdvanced = true;
+            target.PSFParallelPartitionSize = 50;
+            target.DebugMode = false;
+
+            target.ApplyFullSnapshot(snapshot);
+
+            Assert.Multiple(() => {
+                Assert.That(target.PSFParallelPartitionSize, Is.EqualTo(999));
+                Assert.That(target.DebugMode, Is.True);
+            });
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionSettingsDiffTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionSettingsDiffTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NINA.Profile.Interfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
+
+    [TestFixture]
+    public class StarDetectionSettingsDiffTests {
+
+        private static StarDetectionOptions NewOptions() =>
+            new StarDetectionOptions(Substitute.For<IProfileService>(), new InMemoryPluginOptionsAccessor());
+
+        // A snapshot that initially mirrors the current options, so a single mutation produces a single diff row.
+        private static StarDetectionSettingsSnapshot Mirror(StarDetectionOptions current) =>
+            StarDetectionSettingsSnapshot.FromOptions(current);
+
+        [Test]
+        public void BuildDiff_IsEmpty_ForIdenticalSettings() {
+            var current = NewOptions();
+            var imported = Mirror(current);
+
+            var diff = StarDetectionSettingsDiff.BuildDiff(current, imported);
+
+            Assert.That(diff, Is.Empty);
+        }
+
+        [Test]
+        public void BuildDiff_ReportsChangedDouble_WithFormatting() {
+            var current = NewOptions(); // BrightnessSensitivity default 2.0
+            var imported = Mirror(current);
+            imported.BrightnessSensitivity = 9.1;
+
+            var diff = StarDetectionSettingsDiff.BuildDiff(current, imported);
+
+            Assert.That(diff, Has.Count.EqualTo(1));
+            var row = diff[0];
+            Assert.Multiple(() => {
+                Assert.That(row.Name, Is.EqualTo("Brightness Sensitivity"));
+                Assert.That(row.CurrentValue, Is.EqualTo("2"));
+                Assert.That(row.NewValue, Is.EqualTo("9.1"));
+            });
+        }
+
+        [Test]
+        public void BuildDiff_FormatsEnumsAndBooleans() {
+            var current = NewOptions();
+            var imported = Mirror(current);
+            imported.Simple_NoiseLevel = NoiseLevelEnum.High;       // enum, default Typical
+            imported.RejectContaminatedStars = false;              // bool, default true
+
+            var diff = StarDetectionSettingsDiff.BuildDiff(current, imported);
+
+            var byName = diff.ToDictionary(r => r.Name);
+            Assert.Multiple(() => {
+                Assert.That(diff, Has.Count.EqualTo(2));
+                Assert.That(byName["Noise Level"].CurrentValue, Is.EqualTo("Typical"));
+                Assert.That(byName["Noise Level"].NewValue, Is.EqualTo("High"));
+                Assert.That(byName["Reject Contaminated Stars"].CurrentValue, Is.EqualTo("On"));
+                Assert.That(byName["Reject Contaminated Stars"].NewValue, Is.EqualTo("Off"));
+            });
+        }
+
+        [Test]
+        public void BuildDiff_IgnoresMachineLocalKnobs() {
+            var current = NewOptions();
+            var imported = Mirror(current);
+            imported.PSFParallelPartitionSize = 12345;
+            imported.DebugMode = true;
+            imported.IntermediateSavePath = @"C:\somewhere\else";
+            imported.SaveIntermediateImages = true;
+
+            var diff = StarDetectionSettingsDiff.BuildDiff(current, imported);
+
+            Assert.That(diff, Is.Empty);
+        }
+
+        [Test]
+        public void BuildDiff_ReportsOptimizerResultChange() {
+            var current = NewOptions(); // no optimizer result
+            var imported = Mirror(current);
+            imported.OptimizedSettings = new OptimizedStarDetectionSettings() {
+                FinalJ = 0.98,
+                RunCount = 2,
+                CreatedAtUtc = new DateTime(2026, 6, 28, 12, 0, 0, DateTimeKind.Utc)
+            };
+
+            var diff = StarDetectionSettingsDiff.BuildDiff(current, imported);
+
+            Assert.That(diff, Has.Count.EqualTo(1));
+            Assert.Multiple(() => {
+                Assert.That(diff[0].Name, Is.EqualTo("Optimizer result"));
+                Assert.That(diff[0].CurrentValue, Is.EqualTo("none"));
+                Assert.That(diff[0].NewValue, Does.StartWith("present"));
+            });
+        }
+
+        [Test]
+        public void ImportableSettings_CoverExactlyTheImportableInterfaceProperties() {
+            // Drift guard: every read/write IStarDetectionOptions property must be either importable (with a label) or
+            // explicitly excluded as machine-local. A newly added knob that is wired into neither fails here.
+            var readWrite = typeof(IStarDetectionOptions).GetProperties()
+                .Where(p => p.CanRead && p.CanWrite)
+                .Select(p => p.Name)
+                .ToHashSet();
+
+            var importable = StarDetectionSettingsDiff.ImportableSettings.Select(x => x.Property).ToList();
+            var excluded = StarDetectionSettingsDiff.ExcludedFromImport.ToList();
+
+            var union = new HashSet<string>(importable);
+            union.UnionWith(excluded);
+
+            Assert.Multiple(() => {
+                Assert.That(importable, Is.Unique, "ImportableSettings must not contain duplicate properties.");
+                Assert.That(importable.Intersect(excluded), Is.Empty, "A property cannot be both importable and excluded.");
+                Assert.That(union, Is.EquivalentTo(readWrite),
+                    "ImportableSettings ∪ ExcludedFromImport must cover exactly the read/write IStarDetectionOptions properties.");
+            });
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionSettingsExportTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionSettingsExportTests.cs
@@ -1,0 +1,219 @@
+using System;
+using System.IO;
+using NINA.Core.Enum;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NINA.Profile.Interfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
+
+    [TestFixture]
+    public class StarDetectionSettingsExportTests {
+
+        private static StarDetectionSettingsExport BuildPopulated() {
+            return new StarDetectionSettingsExport() {
+                FileType = StarDetectionSettingsExport.ExpectedFileType,
+                SchemaVersion = StarDetectionSettingsExport.CurrentSchemaVersion,
+                CreatedAtUtc = new DateTime(2026, 6, 28, 1, 2, 3, DateTimeKind.Utc),
+                PluginVersion = "3.0.0.99",
+                StarDetection = new StarDetectionSettingsSnapshot() {
+                    UseAdvanced = true,
+                    UseOptimizedSettings = false,
+                    BrightnessSensitivity = 7.25,
+                    StructureLayers = 5,
+                    MaxDistortion = 0.42,
+                    MinHFR = 1.1,
+                    StarPeakResponse = 0.8,
+                    NoiseReductionRadius = 4,
+                    PSFFitType = StarDetectorPSFFitType.Gaussian,
+                    MeasurementAverage = MeasurementAverageEnum.MeanOutliers,
+                    DefocusAwareDonutDetection = true,
+                    DonutMorphCloseSize = 7,
+                    SaturationThreshold = 0.95,
+                    OptimizedSettings = new OptimizedStarDetectionSettings() {
+                        BrightnessSensitivity = 7.25,
+                        MaxDistortion = 0.42,
+                        RunCount = 3,
+                        FinalJ = 0.87,
+                        CreatedAtUtc = new DateTime(2026, 6, 27, 0, 0, 0, DateTimeKind.Utc)
+                    }
+                }
+            };
+        }
+
+        [Test]
+        public void RoundTrips_WithoutTypeNameHandling() {
+            var original = BuildPopulated();
+            var json = original.Serialize();
+
+            Assert.That(json, Does.Not.Contain("$type"));
+            Assert.That(json, Does.Contain("fileType"));
+
+            var restored = StarDetectionSettingsExport.Deserialize(json);
+
+            Assert.Multiple(() => {
+                Assert.That(restored.FileType, Is.EqualTo(StarDetectionSettingsExport.ExpectedFileType));
+                Assert.That(restored.SchemaVersion, Is.EqualTo(original.SchemaVersion));
+                Assert.That(restored.CreatedAtUtc, Is.EqualTo(original.CreatedAtUtc));
+                Assert.That(restored.PluginVersion, Is.EqualTo("3.0.0.99"));
+
+                Assert.That(restored.StarDetection.BrightnessSensitivity, Is.EqualTo(7.25));
+                Assert.That(restored.StarDetection.StructureLayers, Is.EqualTo(5));
+                Assert.That(restored.StarDetection.PSFFitType, Is.EqualTo(StarDetectorPSFFitType.Gaussian));
+                Assert.That(restored.StarDetection.MeasurementAverage, Is.EqualTo(MeasurementAverageEnum.MeanOutliers));
+
+                // Nested optimized layer round-trips field-for-field.
+                Assert.That(restored.StarDetection.OptimizedSettings, Is.Not.Null);
+                Assert.That(restored.StarDetection.OptimizedSettings.FinalJ, Is.EqualTo(0.87));
+                Assert.That(restored.StarDetection.OptimizedSettings.RunCount, Is.EqualTo(3));
+            });
+        }
+
+        [Test]
+        public void FromOptions_BlanksMachineLocalIntermediateSettings() {
+            var options = new StarDetectionOptions(Substitute.For<IProfileService>(), new InMemoryPluginOptionsAccessor());
+            options.SaveIntermediateImages = true;
+            options.BrightnessSensitivity = 4.2;
+
+            // The live options have a non-empty default intermediate path.
+            Assume.That(options.IntermediateSavePath, Is.Not.Empty);
+
+            var export = StarDetectionSettingsExport.FromOptions(options);
+
+            Assert.Multiple(() => {
+                Assert.That(export.FileType, Is.EqualTo(StarDetectionSettingsExport.ExpectedFileType));
+                Assert.That(export.SchemaVersion, Is.EqualTo(StarDetectionSettingsExport.CurrentSchemaVersion));
+                // Machine-local: blanked so the exported file carries neither a local path nor the debug flag.
+                Assert.That(export.StarDetection.IntermediateSavePath, Is.Empty);
+                Assert.That(export.StarDetection.SaveIntermediateImages, Is.False);
+                // Algorithm knob: captured.
+                Assert.That(export.StarDetection.BrightnessSensitivity, Is.EqualTo(4.2));
+            });
+        }
+
+        [Test]
+        public void Validate_Throws_WhenFileTypeWrong() {
+            var export = BuildPopulated();
+            export.FileType = "SomethingElse";
+            Assert.Throws<InvalidOperationException>(() => export.Validate());
+        }
+
+        [Test]
+        public void Validate_Throws_WhenFileTypeNull() {
+            var export = BuildPopulated();
+            export.FileType = null;
+            Assert.Throws<InvalidOperationException>(() => export.Validate());
+        }
+
+        [Test]
+        public void Validate_Throws_WhenStarDetectionMissing() {
+            var export = BuildPopulated();
+            export.StarDetection = null;
+            Assert.Throws<InvalidOperationException>(() => export.Validate());
+        }
+
+        [Test]
+        public void Validate_Throws_WhenSchemaVersionNonPositive() {
+            var export = BuildPopulated();
+            export.SchemaVersion = 0;
+            Assert.Throws<InvalidOperationException>(() => export.Validate());
+        }
+
+        [Test]
+        public void TryLoad_ReturnsTrue_ForValidFile() {
+            var path = Path.Combine(Path.GetTempPath(), "HFExport_" + Guid.NewGuid().ToString("N") + ".json");
+            try {
+                File.WriteAllText(path, BuildPopulated().Serialize());
+
+                var ok = StarDetectionSettingsExport.TryLoad(path, out var export, out var error);
+
+                Assert.Multiple(() => {
+                    Assert.That(ok, Is.True);
+                    Assert.That(error, Is.Null);
+                    Assert.That(export, Is.Not.Null);
+                    Assert.That(export.StarDetection.BrightnessSensitivity, Is.EqualTo(7.25));
+                });
+            } finally {
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public void TryLoad_ReturnsFalseWithError_WhenCorrupt() {
+            var path = Path.Combine(Path.GetTempPath(), "HFExport_" + Guid.NewGuid().ToString("N") + ".json");
+            try {
+                File.WriteAllText(path, "{ not valid json ");
+                var ok = StarDetectionSettingsExport.TryLoad(path, out var export, out var error);
+                Assert.Multiple(() => {
+                    Assert.That(ok, Is.False);
+                    Assert.That(error, Is.Not.Null);
+                    Assert.That(export, Is.Null);
+                });
+            } finally {
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public void TryLoad_ReturnsFalseWithError_WhenSchemaNewerThanSupported() {
+            var path = Path.Combine(Path.GetTempPath(), "HFExport_" + Guid.NewGuid().ToString("N") + ".json");
+            try {
+                var future = BuildPopulated();
+                future.SchemaVersion = StarDetectionSettingsExport.CurrentSchemaVersion + 1;
+                File.WriteAllText(path, future.Serialize());
+
+                var ok = StarDetectionSettingsExport.TryLoad(path, out var export, out var error);
+
+                Assert.Multiple(() => {
+                    Assert.That(ok, Is.False);
+                    Assert.That(error, Is.Not.Null);
+                    Assert.That(export, Is.Null);
+                });
+            } finally {
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public void TryLoad_ReturnsFalseWithError_WhenFileMissing() {
+            var path = Path.Combine(Path.GetTempPath(), "HFExport_" + Guid.NewGuid().ToString("N") + ".json");
+            var ok = StarDetectionSettingsExport.TryLoad(path, out var export, out var error);
+            Assert.Multiple(() => {
+                Assert.That(ok, Is.False);
+                Assert.That(error, Is.Not.Null);
+                Assert.That(export, Is.Null);
+            });
+        }
+
+        [Test]
+        public void TryLoad_RejectsAutoFocusMetadataFile() {
+            // An AutoFocus metadata.json has the same schemaVersion + starDetection shape but no "fileType"
+            // discriminator, so it must be rejected rather than silently imported as star-detection settings.
+            var path = Path.Combine(Path.GetTempPath(), "HFExport_" + Guid.NewGuid().ToString("N") + ".json");
+            try {
+                var afMetadata = new AutoFocusReplayMetadata() {
+                    SchemaVersion = AutoFocusReplayMetadata.CurrentSchemaVersion,
+                    CreatedAtUtc = new DateTime(2026, 6, 28, 0, 0, 0, DateTimeKind.Utc),
+                    StarDetection = new StarDetectionSettingsSnapshot() { BrightnessSensitivity = 3.0 },
+                    AutoFocus = new AutoFocusOptionsSnapshot()
+                };
+                File.WriteAllText(path, afMetadata.Serialize());
+
+                var ok = StarDetectionSettingsExport.TryLoad(path, out var export, out var error);
+
+                Assert.Multiple(() => {
+                    Assert.That(ok, Is.False);
+                    Assert.That(error, Is.Not.Null);
+                    Assert.That(export, Is.Null);
+                });
+            } finally {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/HocusFocusPlugin.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/HocusFocusPlugin.cs
@@ -38,6 +38,7 @@ using NINA.WPF.Base.Interfaces.Mediator;
 using NINA.WPF.Base.Interfaces.ViewModel;
 using NINA.Core.Model;
 using RelayCommand = CommunityToolkit.Mvvm.Input.RelayCommand;
+using AsyncRelayCommand = CommunityToolkit.Mvvm.Input.AsyncRelayCommand;
 
 namespace NINA.Joko.Plugins.HocusFocus {
 
@@ -144,6 +145,8 @@ namespace NINA.Joko.Plugins.HocusFocus {
             ChooseSavePathDiagCommand = new RelayCommand(ChooseSavePathDiag);
             OptimizeStarDetectionCommand = new RelayCommand(OptimizeStarDetection);
             LaunchStarDetectionOptimizer = OptimizeStarDetection;
+            ExportStarDetectionSettingsCommand = new RelayCommand(() => StarDetectionSettingsIO.Export(StarDetectionOptions));
+            ImportStarDetectionSettingsCommand = new AsyncRelayCommand(() => StarDetectionSettingsIO.ImportAsync(StarDetectionOptions, windowServiceFactory));
         }
 
         /// <summary>
@@ -269,5 +272,9 @@ namespace NINA.Joko.Plugins.HocusFocus {
         public ICommand ChooseSavePathDiagCommand { get; private set; }
 
         public ICommand OptimizeStarDetectionCommand { get; private set; }
+
+        public ICommand ExportStarDetectionSettingsCommand { get; private set; }
+
+        public ICommand ImportStarDetectionSettingsCommand { get; private set; }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
@@ -26,8 +26,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new release build of a plugin
-[assembly: AssemblyVersion("3.0.0.34")]
-[assembly: AssemblyFileVersion("3.0.0.34")]
+[assembly: AssemblyVersion("3.0.0.35")]
+[assembly: AssemblyFileVersion("3.0.0.35")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("Hocus Focus")]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
@@ -935,31 +935,6 @@
                         TextWrapping="Wrap" />
                 </Button>
             </Grid>
-            <!--  Import / Export the star-detection parameters only (tune on a fast machine, import on the imaging machine).  -->
-            <StackPanel
-                Margin="5,0,5,10"
-                HorizontalAlignment="Left"
-                Orientation="Horizontal">
-                <Button
-                    Margin="0,0,8,0"
-                    Command="{Binding ImportStarDetectionSettingsCommand}"
-                    ToolTip="{StaticResource ImportStarDetectionSettings_Tooltip}">
-                    <TextBlock
-                        Margin="10,5,10,5"
-                        Foreground="{StaticResource ButtonForegroundBrush}"
-                        Text="Import"
-                        TextWrapping="Wrap" />
-                </Button>
-                <Button
-                    Command="{Binding ExportStarDetectionSettingsCommand}"
-                    ToolTip="{StaticResource ExportStarDetectionSettings_Tooltip}">
-                    <TextBlock
-                        Margin="10,5,10,5"
-                        Foreground="{StaticResource ButtonForegroundBrush}"
-                        Text="Export"
-                        TextWrapping="Wrap" />
-                </Button>
-            </StackPanel>
         <Grid
             Margin="5"
             VerticalAlignment="Top"
@@ -2290,6 +2265,31 @@
                 IsChecked="{Binding StarDetectionOptions.SaveIntermediateImages}"
                 ToolTip="{StaticResource SaveIntermediateFiles_Tooltip}" />
         </Grid>
+            <!--  Import / Export the star-detection parameters only (tune on a fast machine, import on the imaging machine).  -->
+            <StackPanel
+                Margin="5,10,5,5"
+                HorizontalAlignment="Left"
+                Orientation="Horizontal">
+                <Button
+                    Margin="0,0,8,0"
+                    Command="{Binding ImportStarDetectionSettingsCommand}"
+                    ToolTip="{StaticResource ImportStarDetectionSettings_Tooltip}">
+                    <TextBlock
+                        Margin="10,5,10,5"
+                        Foreground="{StaticResource ButtonForegroundBrush}"
+                        Text="Import"
+                        TextWrapping="Wrap" />
+                </Button>
+                <Button
+                    Command="{Binding ExportStarDetectionSettingsCommand}"
+                    ToolTip="{StaticResource ExportStarDetectionSettings_Tooltip}">
+                    <TextBlock
+                        Margin="10,5,10,5"
+                        Foreground="{StaticResource ButtonForegroundBrush}"
+                        Text="Export"
+                        TextWrapping="Wrap" />
+                </Button>
+            </StackPanel>
         </StackPanel>
     </DataTemplate>
     <DataTemplate x:Key="HocusFocus_StarAnnotator_Options">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
@@ -496,6 +496,8 @@
     <TextBlock x:Key="SaveIntermediateFiles_Tooltip" Text="If enabled, every step of star detection emits a debugging file to the intermediate path" />
     <TextBlock x:Key="UseAdvanced_Tooltip" Text="Enables advanced mode with fine-grained control over star detection parameters. Not recommended unless you're an expert" />
     <TextBlock x:Key="OptimizeStarDetection_Tooltip" Text="Opens the Star Detection Optimization Wizard, which tunes star detection against a saved auto-focus run and (optionally) applies the result as your Simple-Mode settings" />
+    <TextBlock x:Key="ExportStarDetectionSettings_Tooltip" Text="Saves the current Star Detection parameters to a .json file so they can be moved to another machine (e.g. tune on a fast computer, import on the imaging computer). Only star-detection settings are exported — not autofocus, inspector, or tilt. The machine-local intermediate-image path is not included." />
+    <TextBlock x:Key="ImportStarDetectionSettings_Tooltip" Text="Loads Star Detection parameters from a .json file exported on another machine. A confirmation dialog shows exactly which settings will change before they replace the current ones on this profile. The intermediate-image path, Debug Mode, and PSF Parallel Size stay local to this machine." />
     <TextBlock x:Key="UseOptimizedSettings_Tooltip" Text="When enabled, the optimized star-detection settings produced by the optimization wizard drive detection instead of the Noise Level / Pixel Scale / Focus Range presets. Only available in Simple Mode after the wizard has produced and applied a result" />
     <TextBlock x:Key="ModelPSF_Tooltip" Text="Whether to fit PSF models to detected stars. This is required for FWHM and Eccentricity" />
     <TextBlock x:Key="PSFFitType_Tooltip" Text="What type of PSF model to fit. Moffat 0.4 more closely resembles real stars and is the default used by PixInsight" />
@@ -933,6 +935,31 @@
                         TextWrapping="Wrap" />
                 </Button>
             </Grid>
+            <!--  Import / Export the star-detection parameters only (tune on a fast machine, import on the imaging machine).  -->
+            <StackPanel
+                Margin="5,0,5,10"
+                HorizontalAlignment="Left"
+                Orientation="Horizontal">
+                <Button
+                    Margin="0,0,8,0"
+                    Command="{Binding ImportStarDetectionSettingsCommand}"
+                    ToolTip="{StaticResource ImportStarDetectionSettings_Tooltip}">
+                    <TextBlock
+                        Margin="10,5,10,5"
+                        Foreground="{StaticResource ButtonForegroundBrush}"
+                        Text="Import"
+                        TextWrapping="Wrap" />
+                </Button>
+                <Button
+                    Command="{Binding ExportStarDetectionSettingsCommand}"
+                    ToolTip="{StaticResource ExportStarDetectionSettings_Tooltip}">
+                    <TextBlock
+                        Margin="10,5,10,5"
+                        Foreground="{StaticResource ButtonForegroundBrush}"
+                        Text="Export"
+                        TextWrapping="Wrap" />
+                </Button>
+            </StackPanel>
         <Grid
             Margin="5"
             VerticalAlignment="Top"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/DataTemplates.xaml
@@ -1,7 +1,8 @@
 ﻿<ResourceDictionary
     x:Class="NINA.Joko.Plugins.HocusFocus.StarDetection.DataTemplates"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:sd="clr-namespace:NINA.Joko.Plugins.HocusFocus.StarDetection">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="../Resources/OptionsDataTemplates.xaml" />
     </ResourceDictionary.MergedDictionaries>
@@ -52,5 +53,10 @@
         <ScrollViewer VerticalScrollBarVisibility="Auto">
             <ContentControl Content="{Binding StarAnnotatorOptions}" ContentTemplate="{StaticResource HocusFocus_StarAnnotator_Options}" />
         </ScrollViewer>
+    </DataTemplate>
+
+    <!--  Implicit template so NINA's WindowService can resolve the import-confirmation dialog's visual from its VM type.  -->
+    <DataTemplate DataType="{x:Type sd:ImportStarDetectionPreviewVM}">
+        <sd:ImportStarDetectionPreviewControl />
     </DataTemplate>
 </ResourceDictionary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/ImportStarDetectionPreview.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/ImportStarDetectionPreview.cs
@@ -1,0 +1,58 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Utility.WindowService;
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
+
+    /// <summary>Shows the import-confirmation dialog modally and awaits the user's Apply/Cancel decision.</summary>
+    public static class ImportStarDetectionPreview {
+
+        /// <summary>
+        /// Shows <paramref name="vm"/> via NINA's <see cref="IWindowService"/> (which marshals window creation onto the
+        /// application dispatcher internally) and returns true when the user clicks Apply, false on Cancel or close.
+        /// The dialog Task itself is fire-and-forget; the result flows back through the VM's TCS, which is awaited here.
+        /// </summary>
+        public static async Task<bool> ShowAsync(IWindowServiceFactory windowServiceFactory, ImportStarDetectionPreviewVM vm) {
+            if (windowServiceFactory == null) {
+                throw new ArgumentNullException(nameof(windowServiceFactory));
+            }
+            if (vm == null) {
+                throw new ArgumentNullException(nameof(vm));
+            }
+
+            var windowService = windowServiceFactory.Create();
+
+            // A button (or the X) raises RequestClose; close the host window, which fires OnClosed below.
+            void onRequestClose(object s, EventArgs e) {
+                _ = windowService.Close();
+            }
+
+            EventHandler onClosed = null;
+            onClosed = (s, e) => {
+                windowService.OnClosed -= onClosed;
+                vm.RequestClose -= onRequestClose;
+                // Dispose resolves the result to Cancel if no button set it (window closed via the X). No-op otherwise.
+                vm.Dispose();
+            };
+            windowService.OnClosed += onClosed;
+            vm.RequestClose += onRequestClose;
+
+            _ = windowService.ShowDialog(vm, "Import Star Detection Settings", ResizeMode.CanResize, WindowStyle.SingleBorderWindow);
+
+            return await vm.Result;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/ImportStarDetectionPreviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/ImportStarDetectionPreviewControl.xaml
@@ -1,0 +1,92 @@
+<UserControl
+    x:Class="NINA.Joko.Plugins.HocusFocus.StarDetection.ImportStarDetectionPreviewControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Border Background="{StaticResource BackgroundBrush}" Padding="16">
+        <Grid Width="600">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <TextBlock
+                Grid.Row="0"
+                FontSize="16"
+                FontWeight="Bold"
+                Foreground="{StaticResource PrimaryBrush}"
+                Text="Import Star Detection Settings" />
+
+            <TextBlock
+                Grid.Row="1"
+                Margin="0,6,0,0"
+                Foreground="{StaticResource SecondaryBrush}"
+                Text="{Binding HeaderText}"
+                TextWrapping="Wrap" />
+
+            <TextBlock
+                Grid.Row="2"
+                Margin="0,4,0,0"
+                FontStyle="Italic"
+                Foreground="{StaticResource SecondaryBrush}"
+                Text="{Binding SourceSummary}"
+                TextWrapping="Wrap"
+                Visibility="{Binding HasSourceSummary, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+
+            <DataGrid
+                Grid.Row="3"
+                Margin="0,12,0,0"
+                AutoGenerateColumns="False"
+                CanUserAddRows="False"
+                CanUserReorderColumns="False"
+                CanUserSortColumns="False"
+                HeadersVisibility="Column"
+                IsReadOnly="True"
+                ItemsSource="{Binding Rows}"
+                MaxHeight="340">
+                <DataGrid.Columns>
+                    <DataGridTextColumn
+                        Width="2.4*"
+                        Binding="{Binding Name}"
+                        Header="Setting" />
+                    <DataGridTextColumn
+                        Width="1.3*"
+                        Binding="{Binding CurrentValue}"
+                        Header="Current" />
+                    <DataGridTextColumn
+                        Width="1.3*"
+                        Binding="{Binding NewValue}"
+                        Header="Imported" />
+                </DataGrid.Columns>
+            </DataGrid>
+
+            <StackPanel
+                Grid.Row="4"
+                Margin="0,14,0,0"
+                HorizontalAlignment="Right"
+                Orientation="Horizontal">
+                <Button
+                    MinWidth="100"
+                    Margin="0,0,8,0"
+                    Padding="12,6"
+                    Command="{Binding ApplyCommand}"
+                    IsDefault="True">
+                    <TextBlock
+                        Foreground="{StaticResource ButtonForegroundBrush}"
+                        Text="Apply" />
+                </Button>
+                <Button
+                    MinWidth="100"
+                    Padding="12,6"
+                    Command="{Binding CancelCommand}"
+                    IsCancel="True">
+                    <TextBlock
+                        Foreground="{StaticResource ButtonForegroundBrush}"
+                        Text="Cancel" />
+                </Button>
+            </StackPanel>
+        </Grid>
+    </Border>
+</UserControl>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/ImportStarDetectionPreviewControl.xaml.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/ImportStarDetectionPreviewControl.xaml.cs
@@ -1,0 +1,26 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System.Windows.Controls;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
+
+    /// <summary>
+    /// Interaction logic for ImportStarDetectionPreviewControl.xaml
+    /// </summary>
+    public partial class ImportStarDetectionPreviewControl : UserControl {
+
+        public ImportStarDetectionPreviewControl() {
+            InitializeComponent();
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/ImportStarDetectionPreviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/ImportStarDetectionPreviewVM.cs
@@ -1,0 +1,71 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Utility;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using RelayCommand = CommunityToolkit.Mvvm.Input.RelayCommand;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
+
+    /// <summary>
+    /// View model for the modal shown before applying an imported star-detection settings file. Presents the table of
+    /// settings that will change (Setting / Current / Imported) and exposes the user's decision as an awaitable
+    /// <see cref="Result"/> (true = apply, false = cancel). Mirrors the
+    /// <see cref="NINA.Core.Utility.WindowService"/> + <c>RequestClose</c> pattern used by the other plugin dialogs.
+    /// </summary>
+    public sealed class ImportStarDetectionPreviewVM : BaseINPC, IDisposable {
+        private readonly TaskCompletionSource<bool> tcs =
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public event EventHandler RequestClose;
+
+        public ImportStarDetectionPreviewVM(IReadOnlyList<StarDetectionSettingDiffRow> rows, string sourceSummary = null) {
+            Rows = rows ?? Array.Empty<StarDetectionSettingDiffRow>();
+            HeaderText = Rows.Count == 1
+                ? "1 setting will change. Applying replaces your current star-detection settings on this profile."
+                : $"{Rows.Count} settings will change. Applying replaces your current star-detection settings on this profile.";
+            SourceSummary = sourceSummary;
+            ApplyCommand = new RelayCommand(() => Finish(true));
+            CancelCommand = new RelayCommand(() => Finish(false));
+        }
+
+        public IReadOnlyList<StarDetectionSettingDiffRow> Rows { get; }
+
+        public string HeaderText { get; }
+
+        /// <summary>Provenance line for the imported file (e.g. when it was exported and by which plugin version).</summary>
+        public string SourceSummary { get; }
+
+        public bool HasSourceSummary => !string.IsNullOrEmpty(SourceSummary);
+
+        public ICommand ApplyCommand { get; }
+
+        public ICommand CancelCommand { get; }
+
+        /// <summary>Completes when the user clicks Apply (true) or Cancel / closes the window (false).</summary>
+        public Task<bool> Result => tcs.Task;
+
+        private void Finish(bool apply) {
+            tcs.TrySetResult(apply);
+            RequestClose?.Invoke(this, EventArgs.Empty);
+        }
+
+        public void Dispose() {
+            // Window dismissed without an explicit choice (e.g. the X button) ⇒ treat as Cancel. TrySetResult is a
+            // no-op if a button already set the result.
+            tcs.TrySetResult(false);
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
@@ -1160,11 +1160,24 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
         /// Restores the full star-detection configuration from <paramref name="source"/> — used by AutoFocus replay's
         /// "update profile to capture-time settings" option (c). Faithfully reproduces the captured MODE, not just the
         /// effective values: the optimized-settings snapshot, the Simple/Advanced flag, the "Use Optimized Settings"
-        /// flag, the Simple-mode presets, and every advanced knob. The local <see cref="IntermediateSavePath"/> /
-        /// <see cref="SaveIntermediateImages"/> are intentionally NOT copied — they are machine-local and
-        /// detection-irrelevant for replay.
+        /// flag, the Simple-mode presets, and every advanced knob (including the machine-local
+        /// <see cref="PSFParallelPartitionSize"/> and <see cref="DebugMode"/>). The local
+        /// <see cref="IntermediateSavePath"/> / <see cref="SaveIntermediateImages"/> are intentionally NOT copied —
+        /// they are machine-local and detection-irrelevant for replay.
         /// </summary>
-        public void ApplyFullSnapshot(IStarDetectionOptions source) {
+        public void ApplyFullSnapshot(IStarDetectionOptions source) => ApplySnapshotCore(source, includeMachineLocalPerfKnobs: true);
+
+        /// <summary>
+        /// Cross-machine IMPORT of star-detection parameters. Same faithful mode / optimized-layer / preset / knob
+        /// restore as <see cref="ApplyFullSnapshot"/>, but additionally leaves the machine-local
+        /// <see cref="PSFParallelPartitionSize"/> (CPU parallelism) and <see cref="DebugMode"/> (local diagnostics)
+        /// untouched — alongside the already-excluded <see cref="IntermediateSavePath"/> /
+        /// <see cref="SaveIntermediateImages"/> — so an imaging machine keeps its own parallelism and diagnostics when
+        /// importing settings tuned on a different machine.
+        /// </summary>
+        public void ApplyImportedSnapshot(IStarDetectionOptions source) => ApplySnapshotCore(source, includeMachineLocalPerfKnobs: false);
+
+        private void ApplySnapshotCore(IStarDetectionOptions source, bool includeMachineLocalPerfKnobs) {
             if (source == null) {
                 throw new ArgumentNullException(nameof(source));
             }
@@ -1189,14 +1202,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             // 3) Copy every knob verbatim LAST. Setting these non-"Simple" properties does NOT re-trigger the
             //    Simple-mode recompute (only Simple_*/UseAdvanced/UseOptimizedSettings do), so the captured resolved
             //    values stick exactly in either mode — and they already equal what the recompute would produce.
-            ApplyKnobs(source);
+            ApplyKnobs(source, includeMachineLocalPerfKnobs);
 
             RaiseAllPropertiesChanged();
         }
 
         // Copies every advanced knob (not the Simple_* presets, the mode flags, or the machine-local intermediate-save
-        // settings) from a source. Used as the final step of ApplyFullSnapshot.
-        private void ApplyKnobs(IStarDetectionOptions source) {
+        // settings) from a source. Used as the final step of ApplySnapshotCore. When includeMachineLocalPerfKnobs is
+        // false (cross-machine import), the machine-local DebugMode and PSFParallelPartitionSize are left untouched.
+        private void ApplyKnobs(IStarDetectionOptions source, bool includeMachineLocalPerfKnobs) {
             ModelPSF = source.ModelPSF;
             HotpixelFiltering = source.HotpixelFiltering;
             HotpixelThresholdingEnabled = source.HotpixelThresholdingEnabled;
@@ -1231,8 +1245,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             StructureDilationSize = source.StructureDilationSize;
             StructureDilationCount = source.StructureDilationCount;
             PixelSampleSize = source.PixelSampleSize;
-            DebugMode = source.DebugMode;
-            PSFParallelPartitionSize = source.PSFParallelPartitionSize;
+            if (includeMachineLocalPerfKnobs) {
+                // Machine-local: copied for same-machine replay (option c), skipped for cross-machine import so the
+                // imaging machine keeps its own parallelism / diagnostics settings.
+                DebugMode = source.DebugMode;
+                PSFParallelPartitionSize = source.PSFParallelPartitionSize;
+            }
             PSFFitType = source.PSFFitType;
             PSFResolution = source.PSFResolution;
             PSFFitThreshold = source.PSFFitThreshold;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptionsVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptionsVM.cs
@@ -11,6 +11,7 @@
 #endregion "copyright"
 
 using NINA.Core.Utility;
+using NINA.Core.Utility.WindowService;
 using NINA.Equipment.Interfaces.ViewModel;
 using NINA.Profile.Interfaces;
 using NINA.WPF.Base.ViewModel;
@@ -19,11 +20,16 @@ using System.ComponentModel.Composition;
 using System.Windows;
 using System.Windows.Input;
 using RelayCommand = CommunityToolkit.Mvvm.Input.RelayCommand;
+using AsyncRelayCommand = CommunityToolkit.Mvvm.Input.AsyncRelayCommand;
 
 namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
 
     [Export(typeof(IDockableVM))]
     public class StarDetectionOptionsVM : DockableVM {
+
+        // WindowServiceFactory is not a MEF export (NINA exposes the concrete type with a default ctor only), so it is
+        // instantiated directly here, mirroring HocusFocusPlugin. Used to show the import-confirmation dialog.
+        private readonly IWindowServiceFactory windowServiceFactory = new WindowServiceFactory();
 
         [ImportingConstructor]
         public StarDetectionOptionsVM(IProfileService profileService)
@@ -38,6 +44,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
 
             ChooseIntermediatePathDiagCommand = new RelayCommand(ChooseIntermediatePathDiag);
             OptimizeStarDetectionCommand = new RelayCommand(OptimizeStarDetection);
+            ExportStarDetectionSettingsCommand = new RelayCommand(() => StarDetectionSettingsIO.Export(StarDetectionOptions));
+            ImportStarDetectionSettingsCommand = new AsyncRelayCommand(() => StarDetectionSettingsIO.ImportAsync(StarDetectionOptions, windowServiceFactory));
         }
 
         private void OptimizeStarDetection() {
@@ -63,5 +71,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
         public ICommand ChooseIntermediatePathDiagCommand { get; private set; }
 
         public ICommand OptimizeStarDetectionCommand { get; private set; }
+
+        public ICommand ExportStarDetectionSettingsCommand { get; private set; }
+
+        public ICommand ImportStarDetectionSettingsCommand { get; private set; }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionSettingsDiff.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionSettingsDiff.cs
@@ -1,0 +1,181 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Reflection;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
+
+    /// <summary>One changed star-detection setting, for the import confirmation table.</summary>
+    public sealed class StarDetectionSettingDiffRow {
+        public string Name { get; set; }
+        public string CurrentValue { get; set; }
+        public string NewValue { get; set; }
+    }
+
+    /// <summary>
+    /// Computes the human-readable difference between the current star-detection settings and an imported snapshot,
+    /// for the import confirmation dialog. The <see cref="ImportableSettings"/> map is the single source of truth for
+    /// which <see cref="IStarDetectionOptions"/> properties transfer between machines and their UI labels (the labels
+    /// match the Star Detection Options pane). The machine-local knobs in <see cref="ExcludedFromImport"/> are NOT
+    /// shown or applied (see <see cref="StarDetectionOptions.ApplyImportedSnapshot"/>).
+    /// </summary>
+    public static class StarDetectionSettingsDiff {
+
+        /// <summary>The machine-local knobs that are never imported (and therefore never shown in the diff). Kept here
+        /// as the single source of truth; a unit test asserts ImportableSettings ∪ ExcludedFromImport covers exactly
+        /// the read/write properties of <see cref="IStarDetectionOptions"/>.</summary>
+        public static readonly IReadOnlyList<string> ExcludedFromImport = new[] {
+            nameof(IStarDetectionOptions.PSFParallelPartitionSize),
+            nameof(IStarDetectionOptions.DebugMode),
+            nameof(IStarDetectionOptions.IntermediateSavePath),
+            nameof(IStarDetectionOptions.SaveIntermediateImages),
+        };
+
+        /// <summary>Ordered (property name → UI label) for every importable star-detection setting. Labels are copied
+        /// verbatim from the Star Detection Options pane (Resources/OptionsDataTemplates.xaml).</summary>
+        public static readonly IReadOnlyList<(string Property, string Label)> ImportableSettings = new (string, string)[] {
+            (nameof(IStarDetectionOptions.UseAdvanced), "Advanced Mode"),
+            (nameof(IStarDetectionOptions.Simple_NoiseLevel), "Noise Level"),
+            (nameof(IStarDetectionOptions.Simple_PixelScale), "Pixel Scale"),
+            (nameof(IStarDetectionOptions.Simple_FocusRange), "Focus Range"),
+            (nameof(IStarDetectionOptions.UseOptimizedSettings), "Use Optimized Settings"),
+            (nameof(IStarDetectionOptions.HotpixelThresholdingEnabled), "Use Hotpixel Thresholding"),
+            (nameof(IStarDetectionOptions.UseAutoFocusCrop), "Use AutoFocus Crop"),
+            (nameof(IStarDetectionOptions.ModelPSF), "Fit PSF"),
+            (nameof(IStarDetectionOptions.HotpixelFiltering), "Hotpixel Filtering"),
+            (nameof(IStarDetectionOptions.StarMeasurementNoiseReductionEnabled), "Noise Reduced Star Measurement"),
+            (nameof(IStarDetectionOptions.NoiseReductionRadius), "Noise Reduction Radius"),
+            (nameof(IStarDetectionOptions.NoiseClippingMultiplier), "Noise Clipping Multiplier"),
+            (nameof(IStarDetectionOptions.StarClippingMultiplier), "Star Clipping Multiplier"),
+            (nameof(IStarDetectionOptions.ContaminationSensitivity), "Contamination Sensitivity"),
+            (nameof(IStarDetectionOptions.RejectContaminatedStars), "Reject Contaminated Stars"),
+            (nameof(IStarDetectionOptions.StructureLayers), "Structure Layers"),
+            (nameof(IStarDetectionOptions.BrightnessSensitivity), "Brightness Sensitivity"),
+            (nameof(IStarDetectionOptions.StarPeakResponse), "Star Peak Response"),
+            (nameof(IStarDetectionOptions.MaxDistortion), "Max Distortion"),
+            (nameof(IStarDetectionOptions.DefocusAwareGates), "Defocus-Aware Gates"),
+            (nameof(IStarDetectionOptions.DefocusDistortionSizeReference), "Defocus Size Reference"),
+            (nameof(IStarDetectionOptions.DefocusDistortionMinFactor), "Defocus Distortion Min Factor"),
+            (nameof(IStarDetectionOptions.DefocusCenteringToleranceFactor), "Defocus Centering Tolerance Factor"),
+            (nameof(IStarDetectionOptions.DefocusAwareStructure), "Defocus-Aware Structure"),
+            (nameof(IStarDetectionOptions.StructureLayerBoost), "Structure Layer Boost"),
+            (nameof(IStarDetectionOptions.DefocusAwareDonutDetection), "Defocus-Aware Donut Detection"),
+            (nameof(IStarDetectionOptions.DonutMorphCloseSize), "Donut Morph Close Size"),
+            (nameof(IStarDetectionOptions.DonutMinAnnularityHoleFraction), "Donut Min Annularity Hole Fraction"),
+            (nameof(IStarDetectionOptions.DonutMaxStreakEccentricity), "Donut Max Streak Eccentricity"),
+            (nameof(IStarDetectionOptions.DonutSaturationBloomRadius), "Donut Saturation Bloom Radius"),
+            (nameof(IStarDetectionOptions.LocallyAdaptiveBinarization), "Locally Adaptive Binarization"),
+            (nameof(IStarDetectionOptions.AdaptiveNoiseBlockSize), "Adaptive Noise Block Size"),
+            (nameof(IStarDetectionOptions.StarCenterTolerance), "Star Center Tolerance"),
+            (nameof(IStarDetectionOptions.StarBackgroundBoxExpansion), "Background Box Expansion"),
+            (nameof(IStarDetectionOptions.MinStarBoundingBoxSize), "Min Bounding Box Size"),
+            (nameof(IStarDetectionOptions.MinHFR), "Min HFR"),
+            (nameof(IStarDetectionOptions.StructureDilationSize), "Structure Dilation Size"),
+            (nameof(IStarDetectionOptions.StructureDilationCount), "Structure Dilation Iterations"),
+            (nameof(IStarDetectionOptions.PixelSampleSize), "Pixel Sample Size"),
+            (nameof(IStarDetectionOptions.PSFFitType), "PSF Type"),
+            (nameof(IStarDetectionOptions.PSFResolution), "PSF Resolution"),
+            (nameof(IStarDetectionOptions.PSFFitThreshold), "PSF Fit Threshold"),
+            (nameof(IStarDetectionOptions.PSFPixelIntegration), "PSF Pixel Integration"),
+            (nameof(IStarDetectionOptions.UsePSFAbsoluteDeviation), "PSF MAD Fitting"),
+            (nameof(IStarDetectionOptions.HotpixelThreshold), "Hotpixel Threshold"),
+            (nameof(IStarDetectionOptions.SaturationThreshold), "Saturation Threshold"),
+            (nameof(IStarDetectionOptions.MeasurementAverage), "Measurement Averaging"),
+        };
+
+        /// <summary>
+        /// Returns one row per importable setting whose value differs between <paramref name="current"/> and
+        /// <paramref name="imported"/>, plus a trailing "Optimizer result" summary row when the stored optimizer
+        /// snapshot changes. An empty result means importing would change nothing.
+        /// </summary>
+        public static IReadOnlyList<StarDetectionSettingDiffRow> BuildDiff(IStarDetectionOptions current, IStarDetectionOptions imported) {
+            if (current == null) {
+                throw new ArgumentNullException(nameof(current));
+            }
+            if (imported == null) {
+                throw new ArgumentNullException(nameof(imported));
+            }
+
+            var rows = new List<StarDetectionSettingDiffRow>();
+            foreach (var (property, label) in ImportableSettings) {
+                var info = typeof(IStarDetectionOptions).GetProperty(property);
+                var currentValue = info.GetValue(current);
+                var importedValue = info.GetValue(imported);
+                if (!Equals(currentValue, importedValue)) {
+                    rows.Add(new StarDetectionSettingDiffRow() {
+                        Name = label,
+                        CurrentValue = FormatValue(currentValue),
+                        NewValue = FormatValue(importedValue)
+                    });
+                }
+            }
+
+            var currentOptimized = current.GetOptimizedSettings();
+            var importedOptimized = imported.GetOptimizedSettings();
+            if (!OptimizedEquivalent(currentOptimized, importedOptimized)) {
+                rows.Add(new StarDetectionSettingDiffRow() {
+                    Name = "Optimizer result",
+                    CurrentValue = FormatOptimized(currentOptimized),
+                    NewValue = FormatOptimized(importedOptimized)
+                });
+            }
+
+            return rows;
+        }
+
+        // Identity comparison for the stored optimizer snapshot: same run (timestamp) and same final score is treated
+        // as equivalent. This is for the human-facing summary row only — the actual import always restores the layer.
+        private static bool OptimizedEquivalent(OptimizedStarDetectionSettings a, OptimizedStarDetectionSettings b) {
+            if (a == null && b == null) {
+                return true;
+            }
+            if (a == null || b == null) {
+                return false;
+            }
+            return a.CreatedAtUtc == b.CreatedAtUtc && a.FinalJ.Equals(b.FinalJ) && a.RunCount == b.RunCount;
+        }
+
+        private static string FormatOptimized(OptimizedStarDetectionSettings s) {
+            if (s == null) {
+                return "none";
+            }
+            return $"present (J={s.FinalJ.ToString("0.###", CultureInfo.InvariantCulture)}, {s.RunCount} {(s.RunCount == 1 ? "round" : "rounds")})";
+        }
+
+        private static string FormatValue(object value) {
+            switch (value) {
+                case null:
+                    return "(none)";
+                case bool b:
+                    return b ? "On" : "Off";
+                case double d:
+                    return d.ToString("0.###", CultureInfo.InvariantCulture);
+                case Enum e:
+                    return GetEnumDescription(e);
+                default:
+                    return Convert.ToString(value, CultureInfo.InvariantCulture);
+            }
+        }
+
+        private static string GetEnumDescription(Enum value) {
+            var field = value.GetType().GetField(value.ToString());
+            var attribute = field?.GetCustomAttribute<DescriptionAttribute>();
+            return attribute?.Description ?? value.ToString();
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionSettingsExport.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionSettingsExport.cs
@@ -1,0 +1,131 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using System;
+using System.IO;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
+
+    /// <summary>
+    /// File envelope for exporting/importing ONLY star-detection parameters between machines (tune on a fast box,
+    /// import on the imaging box). Wraps a flat, profile-detached <see cref="StarDetectionSettingsSnapshot"/> with a
+    /// schema version + provenance. The JSON conventions and the never-throwing <see cref="TryLoad"/> pattern mirror
+    /// <see cref="AutoFocusReplayMetadata"/>; the envelope fields are kept OUT of the snapshot itself because that type
+    /// is reused as the AF replay payload and as the engine's in-memory override, where a schema/provenance would be
+    /// meaningless.
+    /// </summary>
+    public sealed class StarDetectionSettingsExport {
+        public const int CurrentSchemaVersion = 1;
+
+        /// <summary>Discriminator that distinguishes this file from an AutoFocus <c>metadata.json</c> — the latter also
+        /// has a <c>schemaVersion</c> and a <c>starDetection</c> node of the same type, so it would otherwise
+        /// deserialize cleanly into this envelope.</summary>
+        public const string ExpectedFileType = "HocusFocusStarDetectionSettings";
+
+        public static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings() {
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            Formatting = Formatting.Indented,
+            NullValueHandling = NullValueHandling.Include
+        };
+
+        // NOTE: no default initializer. If this were defaulted to ExpectedFileType, a JSON file lacking the
+        // "fileType" key (e.g. an AutoFocus metadata.json, which has the same schemaVersion + starDetection shape)
+        // would deserialize with FileType already set to the expected value and wrongly pass Validate. Leaving it null
+        // means a file without the discriminator is correctly rejected.
+        public string FileType { get; set; }
+        public int SchemaVersion { get; set; } = CurrentSchemaVersion;
+        public DateTime CreatedAtUtc { get; set; }
+
+        // Informational provenance — not used to drive an import.
+        public string PluginVersion { get; set; }
+
+        /// <summary>The full star-detection knob set + optimized-settings layer (see
+        /// <see cref="StarDetectionSettingsSnapshot"/>).</summary>
+        public StarDetectionSettingsSnapshot StarDetection { get; set; }
+
+        /// <summary>Captures the live options into a portable export. The machine-local intermediate-image path and
+        /// save-intermediate flag are blanked: they are never applied on import and the path would otherwise leak a
+        /// local user directory into the shared file.</summary>
+        public static StarDetectionSettingsExport FromOptions(IStarDetectionOptions options) {
+            if (options == null) {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            var snapshot = StarDetectionSettingsSnapshot.FromOptions(options);
+            snapshot.IntermediateSavePath = "";
+            snapshot.SaveIntermediateImages = false;
+
+            return new StarDetectionSettingsExport() {
+                FileType = ExpectedFileType,
+                SchemaVersion = CurrentSchemaVersion,
+                CreatedAtUtc = DateTime.UtcNow,
+                PluginVersion = typeof(StarDetectionSettingsExport).Assembly.GetName().Version?.ToString(),
+                StarDetection = snapshot
+            };
+        }
+
+        public string Serialize() => JsonConvert.SerializeObject(this, JsonSettings);
+
+        public static StarDetectionSettingsExport Deserialize(string json) =>
+            JsonConvert.DeserializeObject<StarDetectionSettingsExport>(json, JsonSettings);
+
+        public void Validate() {
+            if (!string.Equals(FileType, ExpectedFileType, StringComparison.Ordinal)) {
+                throw new InvalidOperationException("This file is not a HocusFocus Star Detection settings export.");
+            }
+            if (SchemaVersion <= 0) {
+                throw new InvalidOperationException("schemaVersion must be > 0.");
+            }
+            if (StarDetection == null) {
+                throw new InvalidOperationException("starDetection is required.");
+            }
+        }
+
+        /// <summary>
+        /// Loads + validates an export file chosen by the user. Unlike <see cref="AutoFocusReplayMetadata.TryLoad"/>
+        /// (which resolves <c>metadata.json</c> inside a folder), this takes the file path directly. A missing or
+        /// unreadable file, malformed JSON, a wrong file type, or a newer schema all return false with
+        /// <paramref name="error"/> set. Never throws.
+        /// </summary>
+        public static bool TryLoad(string filePath, out StarDetectionSettingsExport export, out string error) {
+            export = null;
+            error = null;
+            if (string.IsNullOrWhiteSpace(filePath)) {
+                error = "No file specified.";
+                return false;
+            }
+            try {
+                if (!File.Exists(filePath)) {
+                    throw new FileNotFoundException("File not found.", filePath);
+                }
+                var loaded = Deserialize(File.ReadAllText(filePath));
+                if (loaded == null) {
+                    throw new InvalidOperationException("File deserialized to null.");
+                }
+                loaded.Validate();
+                if (loaded.SchemaVersion > CurrentSchemaVersion) {
+                    throw new InvalidOperationException(
+                        $"settings schema {loaded.SchemaVersion} is newer than the supported {CurrentSchemaVersion}; update the HocusFocus plugin.");
+                }
+                export = loaded;
+                return true;
+            } catch (Exception e) {
+                error = e.Message;
+                return false;
+            }
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionSettingsIO.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionSettingsIO.cs
@@ -1,0 +1,117 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Utility.Notification;
+using NINA.Core.Utility.WindowService;
+using System;
+using System.Globalization;
+using System.IO;
+using System.Threading.Tasks;
+using Logger = NINA.Core.Utility.Logger;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
+
+    /// <summary>
+    /// UI-thread Import/Export of star-detection parameters to a single JSON file, so settings tuned on a powerful
+    /// machine can be carried to a lower-power imaging machine. Shared by the options-tab host (HocusFocusPlugin) and
+    /// the dockable StarDetectionOptionsVM. All file I/O is wrapped; nothing throws to the UI.
+    /// </summary>
+    internal static class StarDetectionSettingsIO {
+        private const string FileFilter = "HocusFocus Star Detection Settings (*.json)|*.json";
+
+        /// <summary>Prompts for a destination and writes the current star-detection settings to a JSON file. A
+        /// cancelled dialog is a silent no-op.</summary>
+        public static void Export(StarDetectionOptions options) {
+            if (options == null) {
+                return;
+            }
+            try {
+                var dialog = new Microsoft.Win32.SaveFileDialog() {
+                    Title = "Export Star Detection Settings",
+                    Filter = FileFilter,
+                    DefaultExt = ".json",
+                    AddExtension = true,
+                    OverwritePrompt = true,
+                    FileName = $"HocusFocusStarDetection_{DateTime.Now.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture)}.json",
+                    InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)
+                };
+                if (dialog.ShowDialog() != true) {
+                    return;
+                }
+
+                var export = StarDetectionSettingsExport.FromOptions(options);
+                File.WriteAllText(dialog.FileName, export.Serialize());
+                Logger.Info($"Exported star detection settings to {dialog.FileName}");
+                Notification.ShowInformation($"Exported star detection settings to {Path.GetFileName(dialog.FileName)}");
+            } catch (Exception ex) {
+                Logger.Error(ex, "Failed to export star detection settings");
+                Notification.ShowError($"Failed to export star detection settings: {ex.Message}");
+            }
+        }
+
+        /// <summary>Prompts for a file, validates it, shows the diff-confirmation dialog, and — only on Apply — applies
+        /// the imported settings to the active profile. Cancel / corrupt / wrong-type / newer-schema files leave the
+        /// current settings untouched.</summary>
+        public static async Task ImportAsync(StarDetectionOptions options, IWindowServiceFactory windowServiceFactory) {
+            if (options == null) {
+                return;
+            }
+            try {
+                // Shown before any await, so this stays on the UI thread.
+                var dialog = new Microsoft.Win32.OpenFileDialog() {
+                    Title = "Import Star Detection Settings",
+                    Filter = FileFilter,
+                    DefaultExt = ".json",
+                    CheckFileExists = true,
+                    Multiselect = false,
+                    InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)
+                };
+                if (dialog.ShowDialog() != true) {
+                    return;
+                }
+
+                if (!StarDetectionSettingsExport.TryLoad(dialog.FileName, out var export, out var error)) {
+                    Logger.Warning($"Could not import star detection settings from {dialog.FileName}: {error}");
+                    Notification.ShowError($"Could not import star detection settings: {error}");
+                    return;
+                }
+
+                var diff = StarDetectionSettingsDiff.BuildDiff(options, export.StarDetection);
+                if (diff.Count == 0) {
+                    Notification.ShowInformation("Imported settings match the current settings; nothing to change.");
+                    return;
+                }
+
+                var vm = new ImportStarDetectionPreviewVM(diff, BuildSourceSummary(export));
+                var apply = await ImportStarDetectionPreview.ShowAsync(windowServiceFactory, vm);
+                if (!apply) {
+                    return;
+                }
+
+                options.ApplyImportedSnapshot(export.StarDetection);
+                Logger.Info($"Imported star detection settings from {dialog.FileName} ({diff.Count} setting(s) changed)");
+                Notification.ShowInformation($"Imported star detection settings from {Path.GetFileName(dialog.FileName)}");
+            } catch (Exception ex) {
+                Logger.Error(ex, "Failed to import star detection settings");
+                Notification.ShowError($"Failed to import star detection settings: {ex.Message}");
+            }
+        }
+
+        private static string BuildSourceSummary(StarDetectionSettingsExport export) {
+            var when = export.CreatedAtUtc == default(DateTime)
+                ? "unknown time"
+                : export.CreatedAtUtc.ToLocalTime().ToString("g", CultureInfo.CurrentCulture);
+            var version = string.IsNullOrEmpty(export.PluginVersion) ? "unknown" : export.PluginVersion;
+            return $"Exported {when}  ·  plugin {version}";
+        }
+    }
+}

--- a/plans/star-detection-settings-import-export-plan.md
+++ b/plans/star-detection-settings-import-export-plan.md
@@ -1,0 +1,230 @@
+# Plan: Import / Export Star Detection Settings (cross-machine transfer)
+
+## Context
+
+Star-detection optimization is CPU-heavy. The user wants to run the optimizer on a powerful
+machine, then carry the resulting **star-detection parameters only** (not autofocus, inspector, or
+tilt settings) over to a lower-power imaging machine. Today there is no way to move these settings
+between machines — they live per-profile in NINA's plugin settings store. This adds **Export** and
+**Import** buttons to the Star Detection Options pane: Export writes the current star-detection
+parameters to a `.json` file; Import reads such a file, shows a **confirmation dialog with a table of
+exactly which values will change**, and (on confirm) applies them to the active profile.
+
+### Decisions locked with the user
+1. **Import scope — keep machine-local knobs.** Import everything EXCEPT `PSFParallelPartitionSize`
+   (CPU-parallelism throughput) and `DebugMode` (local diagnostics), so the imaging machine keeps its
+   own. `IntermediateSavePath` / `SaveIntermediateImages` are also never transferred (already excluded
+   by the existing snapshot-apply path, and they leak a local user path).
+2. **Buttons shown in both views.** Place them in the shared `HocusFocus_StarDetection_Options`
+   template next to "Optimize Star Detection", so they appear in **both** the Options-window tab and
+   the dockable "Star Detection Options" panel — consistent with how Optimize already behaves. This
+   requires wiring the commands on **both** host classes (`HocusFocusPlugin` and
+   `StarDetectionOptionsVM`), which is the established pattern for the existing shared commands.
+3. **Confirm with a diff table.** Import opens a modal showing rows of *Setting / Current / Imported*
+   for every value that differs, with Apply / Cancel. Applying overwrites and persists the profile's
+   star-detection settings.
+
+## What we reuse (do not reinvent)
+
+- **Export payload already exists:** `StarDetectionSettingsSnapshot.FromOptions(IStarDetectionOptions)`
+  (`AutoFocus/Replay/StarDetectionSettingsSnapshot.cs:107`) — a flat, profile-detached
+  `IStarDetectionOptions` that captures every knob + the optimizer-result layer and round-trips
+  through Newtonsoft with no `TypeNameHandling`.
+- **Import-apply ordering already exists:** `StarDetectionOptions.ApplyFullSnapshot` /`ApplyKnobs`
+  (`StarDetection/StarDetectionOptions.cs:1167`/`:1199`) — restores optimized layer → Simple presets
+  + mode flags → every knob, then `RaiseAllPropertiesChanged()`; each setter persists via
+  `optionsAccessor`. We split it so import can skip the two machine-local perf/debug knobs.
+- **Versioned-file envelope house style:** `AutoFocus/Replay/AutoFocusReplayMetadata.cs` —
+  `CurrentSchemaVersion` const, static `JsonSettings` (CamelCase + Indented + NullValueHandling.Include),
+  `Serialize()`/`Deserialize()`/`Validate()`/never-throwing `TryLoad`. Mirror exactly.
+- **Modal-with-result pattern:** `AutoFocus/Replay/ReplaySettingsPrompt.cs` +
+  `ReplaySettingsPromptVM.cs` + `ReplaySettingsPromptControl.xaml` — `IWindowServiceFactory`
+  → `windowService.ShowDialog(vm, title, …)`, result via a VM `TaskCompletionSource` + `RequestClose`
+  event. This is the exact template for the import-confirm dialog.
+- **Diff-table XAML:** the optimizer's "Changed parameters" `DataGrid`
+  (`StarDetection/Optimization/DataTemplates.xaml:568`) + its `ChangedParameterRow` row model.
+- **File feedback:** `NINA.Core.Utility.Notification.ShowSuccess/ShowError` + `Logger.Info/Warning/Error`.
+- **Test mirrors:** `AutoFocus/Replay/AutoFocusReplayMetadataTests.cs`,
+  `AutoFocus/Replay/ApplyFullSnapshotTests.cs`, and the `TestDoubles/InMemoryPluginOptionsAccessor.cs`
+  double already exist.
+
+## Implementation (ordered, file-by-file)
+
+> First execution step: per the project CLAUDE.md, copy this plan to
+> `plans/star-detection-settings-import-export-plan.md` in the repo, and do the work on a feature
+> branch `ghilios/star-detection-settings-import-export` (never push to `develop`). All commits use the
+> privacy email per CLAUDE.md.
+
+### 1. New: `StarDetection/StarDetectionSettingsExport.cs` (file envelope)
+Wrapper around `StarDetectionSettingsSnapshot`, mirroring `AutoFocusReplayMetadata`. Keep the envelope
+fields OUT of `StarDetectionSettingsSnapshot` (that type is reused as the AF replay payload and as the
+engine's in-memory override — envelope fields there would be wrong).
+
+- Fields: `public const int CurrentSchemaVersion = 1;`, `public const string ExpectedFileType =
+  "HocusFocusStarDetectionSettings";`, static `JsonSettings` (copy from `AutoFocusReplayMetadata`),
+  `FileType`, `SchemaVersion`, `CreatedAtUtc`, `PluginVersion`, `StarDetectionSettingsSnapshot StarDetection`.
+- `FileType` discriminator is **required**: an AF `metadata.json` also has `schemaVersion` + a
+  `starDetection` node of the same type and would otherwise deserialize cleanly — `Validate()` rejects
+  any file whose `FileType != ExpectedFileType`.
+- `FromOptions(IStarDetectionOptions options)`: build snapshot via `StarDetectionSettingsSnapshot.FromOptions`,
+  then **blank the leaked local path**: `snapshot.IntermediateSavePath = ""`,
+  `snapshot.SaveIntermediateImages = false` (these are never imported anyway). Stamp `CreatedAtUtc =
+  DateTime.UtcNow`, `PluginVersion = typeof(...).Assembly.GetName().Version?.ToString()`.
+- `Serialize()`, `static Deserialize(json)`, `Validate()` (FileType match, SchemaVersion > 0,
+  StarDetection != null), and `static bool TryLoad(string filePath, out export, out error)` that takes
+  a **file path directly** (unlike the AF folder-based `TryLoad`), never throws, and rejects
+  `SchemaVersion > CurrentSchemaVersion`.
+
+### 2. Edit: `StarDetection/StarDetectionOptions.cs` (add import-apply variant)
+Split the existing apply into a parameterized core; keep `ApplyFullSnapshot` behavior identical (AF
+replay option (c) still copies perf+debug), add a sibling for cross-machine import:
+
+```csharp
+public void ApplyFullSnapshot(IStarDetectionOptions source)
+    => ApplySnapshotCore(source, includeMachineLocalPerfKnobs: true);
+
+/// <summary>Cross-machine IMPORT: same faithful restore as ApplyFullSnapshot, but leaves the
+/// machine-local PSFParallelPartitionSize and DebugMode untouched so the imaging machine keeps its own.</summary>
+public void ApplyImportedSnapshot(IStarDetectionOptions source)
+    => ApplySnapshotCore(source, includeMachineLocalPerfKnobs: false);
+
+private void ApplySnapshotCore(IStarDetectionOptions source, bool includeMachineLocalPerfKnobs) {
+    // ...exact body of current ApplyFullSnapshot (lines 1168-1194), but call ApplyKnobs(source, includeMachineLocalPerfKnobs)...
+}
+```
+In `ApplyKnobs`, move ONLY the `DebugMode` (`:1234`) and `PSFParallelPartitionSize` (`:1235`)
+assignments inside `if (includeMachineLocalPerfKnobs) { … }`; all other knob copies stay unconditional.
+
+### 3. New: `StarDetection/StarDetectionSettingsDiff.cs` (diff model + labels)
+Single source of truth for what is importable and its friendly label (there is **no** reusable
+property→label map in the codebase; labels live only as hardcoded TextBlocks in
+`OptionsDataTemplates.xaml`).
+
+- `public sealed class DiffRow { public string Name; public string CurrentValue; public string NewValue; }`
+- An ordered `IReadOnlyList<(string Property, string Label)> ImportableSettings` covering every
+  `IStarDetectionOptions` scalar/enum/bool property EXCEPT the excluded set
+  (`PSFParallelPartitionSize`, `DebugMode`, `IntermediateSavePath`, `SaveIntermediateImages`,
+  `HasOptimizedSettings`). Labels copied verbatim from the pane (e.g. `NoiseClippingMultiplier` →
+  "Noise Clipping Multiplier", `MinHFR` → "Min HFR", `UseAdvanced` → "Advanced Mode",
+  `UseOptimizedSettings` → "Use Optimized Settings"; ~45 entries).
+- `static IReadOnlyList<DiffRow> BuildDiff(IStarDetectionOptions current, IStarDetectionOptions imported)`:
+  for each importable property read both values via `typeof(IStarDetectionOptions).GetProperty(name)`,
+  format (enum → `[Description]` via the existing enum-description helper used by
+  `EnumStaticDescriptionConverter`; double → `"0.###"`; bool → "On"/"Off"); emit a `DiffRow` only when
+  they differ. Append one summary row when the stored optimizer result presence/identity differs
+  ("Optimizer result" → e.g. "none → present" / "present → updated").
+- Value formatting + reflection kept here so it is unit-testable independent of UI.
+
+### 4. New: import-confirm modal (mirror `ReplaySettingsPrompt` trio)
+- `StarDetection/ImportStarDetectionPreviewVM.cs` — `BaseINPC, IDisposable`; ctor takes
+  `IReadOnlyList<DiffRow>`; exposes `Rows`, a header string ("N settings will change"),
+  `OkCommand`/`CancelCommand` (CommunityToolkit `RelayCommand`), `event EventHandler RequestClose`, and
+  `TaskCompletionSource<bool>` exposed as `Task<bool> Result` (constructed
+  `RunContinuationsAsynchronously`; `Dispose()`/X-button ⇒ `TrySetResult(false)`).
+- `StarDetection/ImportStarDetectionPreviewControl.xaml` (+ `.xaml.cs`) — a `DataGrid`
+  (`AutoGenerateColumns=False`, `IsReadOnly`, `CanUserAddRows=False`, `MaxHeight` w/ scroll) with three
+  columns: "Setting" → `Name`, "Current" → `CurrentValue`, "Imported" → `NewValue` (copy the optimizer
+  table at `Optimization/DataTemplates.xaml:568`); header text + right-aligned Apply / Cancel buttons
+  (copy `ReplaySettingsPromptControl.xaml:129`).
+- `StarDetection/ImportStarDetectionPreview.cs` — `static Task<bool> ShowAsync(IWindowServiceFactory
+  factory, ImportStarDetectionPreviewVM vm)` mirroring `ReplaySettingsPrompt.ShowAsync`
+  (wire `RequestClose`→`windowService.Close()`, `OnClosed`→`vm.Dispose()`, `_ = ShowDialog(vm,
+  "Import Star Detection Settings", ResizeMode.CanResize, WindowStyle.SingleBorderWindow); return await vm.Result;`).
+- Register the implicit template in an **exported** `ResourceDictionary`:
+  `<DataTemplate DataType="{x:Type sd:ImportStarDetectionPreviewVM}"><sd:ImportStarDetectionPreviewControl/></DataTemplate>`.
+  Prefer `StarDetection/DataTemplates.xaml` **after confirming it has `[Export(typeof(ResourceDictionary))]`**;
+  if not, use `StarDetection/Optimization/DataTemplates.xaml` (confirmed exported).
+
+### 5. New: `StarDetection/StarDetectionSettingsIO.cs` (the two handlers)
+- `static void Export(StarDetectionOptions options)`: `Microsoft.Win32.SaveFileDialog` (filter
+  `"HocusFocus Star Detection Settings (*.json)|*.json"`, `DefaultExt=".json"`, `AddExtension`,
+  `OverwritePrompt`, default name `HocusFocusStarDetection_yyyyMMdd_HHmmss.json`,
+  `InitialDirectory = MyDocuments`); on OK → `File.WriteAllText(path,
+  StarDetectionSettingsExport.FromOptions(options).Serialize())` → `Logger.Info` + `Notification.ShowSuccess`.
+  Cancel = silent. Whole body in try/catch → `Logger.Error` + `Notification.ShowError` (never throws).
+- `static async Task ImportAsync(StarDetectionOptions options, IWindowServiceFactory windowServiceFactory)`:
+  show `Microsoft.Win32.OpenFileDialog` **before any await** (stays on UI thread); on OK →
+  `StarDetectionSettingsExport.TryLoad(path, out export, out error)`; on failure →
+  `Logger.Warning` + `Notification.ShowError(error)` and return (no mutation). Build
+  `StarDetectionSettingsDiff.BuildDiff(options, export.StarDetection)`; if empty →
+  `Notification.ShowInformation("Imported settings match the current settings; nothing to change.")`
+  and return. Otherwise `var ok = await ImportStarDetectionPreview.ShowAsync(windowServiceFactory, new
+  ImportStarDetectionPreviewVM(diff));` if `ok` → `options.ApplyImportedSnapshot(export.StarDetection)`
+  → `Logger.Info` + `Notification.ShowSuccess`. Whole body try/catch.
+
+### 6. Edit hosts: `HocusFocusPlugin.cs` and `StarDetection/StarDetectionOptionsVM.cs`
+Both already expose `StarDetectionOptions` and the existing shared commands. Add to **each**:
+```csharp
+ExportStarDetectionSettingsCommand = new RelayCommand(() => StarDetectionSettingsIO.Export(StarDetectionOptions));
+ImportStarDetectionSettingsCommand = new AsyncRelayCommand(() => StarDetectionSettingsIO.ImportAsync(StarDetectionOptions, windowServiceFactory));
+// public ICommand ExportStarDetectionSettingsCommand { get; private set; }
+// public ICommand ImportStarDetectionSettingsCommand { get; private set; }
+```
+- `HocusFocusPlugin` already has `windowServiceFactory` (`:59`). `StarDetectionOptionsVM` needs one —
+  add `private readonly IWindowServiceFactory windowServiceFactory = new WindowServiceFactory();`
+  (mirror the plugin). `using AsyncRelayCommand = CommunityToolkit.Mvvm.Input.AsyncRelayCommand;`.
+- `StarDetectionOptions` is the concrete type on both hosts, so `ApplyImportedSnapshot` is reachable.
+
+### 7. Edit: `Resources/OptionsDataTemplates.xaml` (the buttons)
+Insert a horizontal button row in the outer `StackPanel` of `HocusFocus_StarDetection_Options`,
+**after** the Optimize button `</Grid>` (line 935) and **before** the options `<Grid>` (line 936),
+matching the plain-button style (`<TextBlock Foreground="{StaticResource ButtonForegroundBrush}"
+TextWrapping="Wrap">`): two buttons `Import` (→ `ImportStarDetectionSettingsCommand`) and `Export`
+(→ `ExportStarDetectionSettingsCommand`). Add two tooltip resources `ImportStarDetectionSettings_Tooltip`
+/ `ExportStarDetectionSettings_Tooltip` next to `OptimizeStarDetection_Tooltip` (line ~498), noting that
+only star-detection settings transfer and that intermediate-path/debug/PSF-parallel-size stay local.
+
+### 8. Tests (new, under `Tests/StarDetection/`)
+- `StarDetectionSettingsExportTests.cs` (mirror `AutoFocusReplayMetadataTests`): round-trips with no
+  `$type`; `Validate` throws on wrong `FileType` / missing `StarDetection` / non-positive version;
+  `TryLoad` true for a valid temp file; false+error for corrupt JSON, newer schema, missing file, and
+  **a serialized `AutoFocusReplayMetadata`** (proves the `FileType` discriminator). Assert
+  `FromOptions` blanks `IntermediateSavePath`/`SaveIntermediateImages`.
+- `StarDetectionImportApplyTests.cs` (mirror `ApplyFullSnapshotTests`, using `new StarDetectionOptions(
+  Substitute.For<IProfileService>(), new InMemoryPluginOptionsAccessor())`): import round-trip restores
+  advanced knobs / Simple-optimized / Simple-preset modes; and a contrast test —
+  `ApplyImportedSnapshot` leaves the target's own `PSFParallelPartitionSize`/`DebugMode` while a normal
+  knob (e.g. `BrightnessSensitivity`) does change, whereas `ApplyFullSnapshot` on a fresh target DOES
+  copy those two (guards the behavioral split).
+- `StarDetectionSettingsDiffTests.cs`: `BuildDiff` emits a row only for changed values, formats
+  enums/doubles/bools, and returns empty for identical inputs; a **drift guard** asserting the
+  `ImportableSettings` label-map keys equal exactly the `IStarDetectionOptions` public instance
+  properties minus the excluded set (catches a future added knob that isn't wired into import/diff).
+
+## Edge cases / invariants
+- **No new persisted option** is introduced (envelope fields live only in the file), so the CLAUDE.md
+  "every persisted option needs a UI control" invariant is not triggered — we add buttons only.
+- **Shared template ⇒ both hosts**: the commands MUST exist on both `HocusFocusPlugin` and
+  `StarDetectionOptionsVM`, else the dockable panel's buttons silently disable.
+- **Threading**: Export/Import start on the UI thread (RelayCommand/AsyncRelayCommand); the file dialog
+  is shown before any await; `WindowService.ShowDialog` marshals internally; `ApplyImportedSnapshot`'s
+  `RaiseAllPropertiesChanged()` runs on the UI thread. No `Task.Run`, no dispatcher needed.
+- **Graceful failures**: cancel = no-op; corrupt/wrong-type/newer-schema/missing file →
+  `Notification.ShowError`, no mutation; nothing throws to the UI.
+- **Persistence**: `ApplyImportedSnapshot` drives the public setters, so an import is durable to the
+  active profile (reflected in the tooltip wording).
+
+## Verification
+1. **Build + tests** (Windows dotnet from WSL, scoped to the Tests csproj per the repo convention):
+   `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/...csproj -c Debug --nologo`.
+   All existing + new tests pass.
+2. **Manual in NINA** (both surfaces): Options → Star Detection tab AND the floating "Star Detection
+   Options" panel — confirm Import/Export appear in both.
+   - Export → choose a path → file written; open it and confirm it contains only star-detection
+     settings, `fileType: "HocusFocusStarDetectionSettings"`, and a blank `intermediateSavePath`.
+   - Change a couple of settings → Import that file → confirm the diff table lists exactly the changed
+     rows with correct Current/Imported values → Apply → settings update and persist (reopen Options to
+     confirm). Re-import the same file with no changes → "nothing to change" info, no dialog.
+   - Cancel in the dialog → nothing changes. Import a corrupt file, an unrelated `.json`, and an AF
+     `metadata.json` → each is rejected with an error toast, no mutation.
+3. **Cross-machine smoke**: export on machine A, copy file to machine B, import → verify B's
+   `PSFParallelPartitionSize`/`DebugMode`/intermediate path are unchanged while detection knobs match A.
+
+## Files
+- New: `StarDetection/StarDetectionSettingsExport.cs`, `StarDetection/StarDetectionSettingsDiff.cs`,
+  `StarDetection/StarDetectionSettingsIO.cs`, `StarDetection/ImportStarDetectionPreviewVM.cs`,
+  `StarDetection/ImportStarDetectionPreviewControl.xaml(.cs)`, `StarDetection/ImportStarDetectionPreview.cs`,
+  3 test files under `Tests/StarDetection/`.
+- Edit: `StarDetection/StarDetectionOptions.cs`, `HocusFocusPlugin.cs`,
+  `StarDetection/StarDetectionOptionsVM.cs`, `Resources/OptionsDataTemplates.xaml`, and the exported
+  `StarDetection/DataTemplates.xaml` (or `StarDetection/Optimization/DataTemplates.xaml`).


### PR DESCRIPTION
## Why

Star-detection optimization is CPU-heavy. This lets you tune star-detection parameters on a powerful machine, export them to a file, and import them on a lower-power imaging machine. **Star-detection settings only** — not autofocus, inspector, or tilt.

## What

Adds **Import** and **Export** buttons next to "Optimize Star Detection" in the shared Star Detection Options pane, so they appear in **both** the Options-window tab and the floating "Star Detection Options" panel.

- **Export** → `SaveFileDialog` → writes a versioned JSON file (`HocusFocusStarDetection_<timestamp>.json`). The machine-local intermediate-image path is blanked so the file doesn't leak a user directory.
- **Import** → `OpenFileDialog` → validates → **confirmation dialog with a diff table** (Setting / Current / Imported, plus a provenance line) → Apply or Cancel. Nothing changes until you confirm.

## Design decisions (agreed up front)

1. **Keep machine-local knobs.** `ApplyImportedSnapshot` skips `PSFParallelPartitionSize` (CPU parallelism) and `DebugMode`, alongside the already-excluded intermediate path/flag, so the imaging machine keeps its own. `ApplyFullSnapshot` (same-machine AF replay) still copies them — a test guards the split.
2. **Both views.** Commands wired on both `HocusFocusPlugin` and `StarDetectionOptionsVM` (the shared template requires both).
3. **Confirm with a diff table.** Modal mirrors the existing `ReplaySettingsPrompt` pattern (`IWindowServiceFactory` + `TaskCompletionSource` + `RequestClose`); table mirrors the optimizer's "Changed parameters" `DataGrid`.

## Reuse, not reinvention

`StarDetectionSettingsSnapshot.FromOptions` (payload), the `ApplyFullSnapshot`/`ApplyKnobs` ordering (refactored into `ApplySnapshotCore(includeMachineLocalPerfKnobs)`), the `AutoFocusReplayMetadata` envelope style, and the `ReplaySettingsPrompt` modal.

## Safety

- `fileType` discriminator (no default initializer) → an AutoFocus `metadata.json` is **rejected**, not silently imported.
- Schema-version reject-newer; never-throwing `TryLoad`; all I/O wrapped so nothing throws to the UI.
- **Drift guard** test: fails if a future `IStarDetectionOptions` knob is added without being wired into import/diff.

## Tests

21 new tests; **full suite 1573 passing, 0 failing**. Covers JSON round-trip (no `$type`), validation/rejection cases (corrupt, newer schema, wrong file type, missing), the import-apply (advanced / simple-optimized / simple-preset modes), the machine-local preserve-vs-copy split, and the diff/labels (formatting + drift guard).

Plan: `plans/star-detection-settings-import-export-plan.md`.

## Not covered by tests (needs a manual pass)

The file dialogs and the confirmation modal can't be exercised by unit tests — worth verifying live in NINA on both UI surfaces (Options tab + dockable panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)