### PR TITLE
docs: saturated-HFR toggle, updated objective, settings import/export

### DIFF
--- a/documentation/docs/optimization/index.md
+++ b/documentation/docs/optimization/index.md
@@ -73,19 +73,22 @@ refining its step size as it homes in on a maximum.*
 ## How a candidate is scored
 
 For each candidate the evaluator runs star detection on every frame of the saved run, pools the
-per-frame HFR by focuser position, fits the autofocus hyperbola, and reads off three things: the
-best-focus uncertainty \( \sigma_{\text{focus}} \), the fit's \( R^2 \) and reduced \( \chi^2 \), and
-the per-frame accepted-star counts. These feed a composite objective \( J \in [0, 1] \) that the
-search **maximizes**:
+per-frame HFR by focuser position, fits the autofocus hyperbola, and reads off the best-focus
+uncertainty \( \sigma_{\text{focus}} \), the fit's \( R^2 \) and reduced \( \chi^2 \), the per-frame
+accepted-star counts, and where those stars sit on the sensor. These feed a composite objective
+\( J \in [0, 1] \) that the search **maximizes**:
 
 \[
-J_{\text{run}} = \frac{w_f\,S_{\text{focus}} + w_s\,S_{\text{stars}} + w_c\,S_{\text{fit}}}{w_f + w_s + w_c}
+J_{\text{run}} = \frac{w_f\,S_{\text{focus}} + w_s\,S_{\text{stars}} + w_c\,S_{\text{fit}} + w_{\text{cov}}\,S_{\text{cov}}}{w_f + w_s + w_c + w_{\text{cov}}}
 \]
 
-with default weights \( w_f = 0.55 \) (focus), \( w_s = 0.20 \) (star count), and \( w_c = 0.25 \)
-(curve fit). When ground-truth labels are present a fourth term \( w_l = 0.25 \) is added and all
-weights are renormalized to sum to one. A hard floor guards against starved frames: if any frame
-falls below 3 accepted stars, that run scores \( J_{\text{run}} = 0 \).
+with default weights \( w_f = 0.55 \) (focus), \( w_s = 0.20 \) (star count), \( w_c = 0.25 \)
+(curve fit), and \( w_{\text{cov}} = 0.05 \) (how well the accepted stars cover the sensor). When
+ground-truth labels are present a further term \( w_l = 0.25 \) is added and all weights are
+renormalized to sum to one. The weighted score is then scaled by two multiplicative penalties that
+default to 1.0: one for defocus-relaxed junk, and one for leaning on a saturated bright star's
+inflated HFR. A hard floor guards against starved frames: if any frame falls below 3 accepted stars,
+that run scores \( J_{\text{run}} = 0 \).
 
 When more than one run is optimized together, the per-run scores are blended as
 \( J_{\text{total}} = (1-\beta)\,\text{mean} + \beta\,\text{min} \) with \( \beta = 0.5 \), so a

--- a/documentation/docs/optimization/objective-function.md
+++ b/documentation/docs/optimization/objective-function.md
@@ -22,14 +22,15 @@ fixed for a given build.
 
 For a single autofocus run, all frames are detected, frames sharing a focuser position are pooled into one
 HFR point, the HFR-vs-focuser curve is fitted, and the fit yields \(\sigma_{\text{focus}}\), \(R^2\), and the
-reduced \(\chi^2\). Those feed three sub-scores (a fourth, the label score, is added only when you have
-provided ground-truth labels). The per-run score is their weighted, renormalized average, then multiplied by a
-defocus-precision penalty:
+reduced \(\chi^2\). Those, together with the accepted-star counts and positions, feed the additive sub-scores
+below: focus repeatability, star count, curve fit, and region coverage, plus a label score when you have provided
+ground-truth labels. The per-run score is their weighted, renormalized average, then multiplied by two safety
+penalties (a defocus-precision penalty and an extreme-HFR-outlier penalty):
 
 \[
-J_{\text{run}} \;=\; \frac{W_f\,S_{\text{focus}} + W_s\,S_{\text{stars}} + W_c\,S_{\text{fit}}
-\;\bigl[\,+\;W_\ell\,S_{\text{label}}\,\bigr]}{W_f + W_s + W_c \;[\,+\;W_\ell\,]}
-\;\times\; S_{\text{defocus-precision}}
+J_{\text{run}} \;=\; \frac{W_f\,S_{\text{focus}} + W_s\,S_{\text{stars}} + W_c\,S_{\text{fit}} + W_{\text{cov}}\,S_{\text{cov}}
+\;\bigl[\,+\;W_\ell\,S_{\text{label}}\,\bigr]}{W_f + W_s + W_c + W_{\text{cov}} \;[\,+\;W_\ell\,]}
+\;\times\; S_{\text{defocus-precision}} \;\times\; S_{\text{hfr-outlier}}
 \]
 
 The label term and \(W_\ell\) are present only when labels exist for the run; otherwise both the numerator
@@ -40,9 +41,12 @@ term and the denominator term are dropped (the weights always renormalize to sum
 | Focus | \(W_f\) | 0.55 | A tight, repeatable best-focus position |
 | Stars | \(W_s\) | 0.20 | Enough usable stars on every frame |
 | Curve fit | \(W_c\) | 0.25 | A clean, well-explained HFR curve |
+| Coverage | \(W_{\text{cov}}\) | 0.05 | Accepted stars spread across the whole sensor |
 | Label | \(W_\ell\) | 0.25 | Matching your hand-labeled stars (only when labels exist) |
 
-Focus carries the largest weight because focus repeatability is the whole point of the exercise.
+Focus carries the largest weight because focus repeatability is the whole point of the exercise. The two
+multiplicative penalties default to exactly 1.0 (no effect) and only bite in specific situations, described in
+their own sections below.
 
 !!! note "The aberration-inspection objective reweights these"
     The weights above are the default, autofocus-tuned objective. When you select **"Optimize for
@@ -139,6 +143,28 @@ information and therefore no penalty.
 over-scattered fit (reduced \(\chi^2 > \chi_\tau = 2.0\)) is progressively penalized; below the knee there is
 no penalty.*
 
+## \(S_{\text{cov}}\) — region coverage (weight 0.05)
+
+A detection setting can post a tight, well-fit curve while quietly collapsing onto a handful of bright stars in one
+part of the frame. That is fragile: it ignores most of the sensor and is easily thrown off by a gradient or a
+passing cloud. \(S_{\text{cov}}\) rewards spreading the accepted stars across the whole frame, not just finding
+enough of them.
+
+The sensor is divided into a 3×3 grid of equal regions. For each near-focus frame, coverage is the fraction of those
+nine regions that hold at least one accepted star, and \(S_{\text{cov}}\) is the mean of that fraction over the
+near-focus frames. The same number of stars clustered in one corner scores lower than the same count spread evenly,
+so the optimizer is pulled toward settings that keep stars everywhere.
+
+The weight is deliberately small (0.05). Coverage is allowed to cost a little focus tightness — recovering stars
+across the frame is worth a minor rise in \(\sigma_{\text{focus}}\) — but at one-eleventh of the focus weight it
+cannot override the dominant focus term. When a run has no accepted-star positions to score, the term drops out of
+both the numerator and the denominator, so \(J_{\text{run}}\) is unchanged.
+
+!!! note "Coverage and aberration inspection"
+    This term reinforces what the **"Optimize for Aberration Inspection"** objective already favors: stars spread
+    across the sensor are exactly what a [tilt / curvature model](../overview/tilt-aberration-inspector.md) needs.
+    Under the default autofocus objective it stays a gentle nudge.
+
 ## \(S_{\text{label}}\) — recall and precision (weight 0.25, only with labels)
 
 When you have hand-labeled stars on a frame (via the labeling workflow), the run also earns a label score that
@@ -205,6 +231,52 @@ strength 0.5 down to a floor of 0.5.*
     version. It exists so the optimizer can safely explore turning the gates on — recovering bloated donuts on
     the extremes — without learning to manufacture spurious near-focus stars.
 
+## \(S_{\text{hfr-outlier}}\) — the bright-blob penalty
+
+A bright star whose core saturates measures a half-flux radius that reads too large, because its peak clips flat. If
+the optimizer keeps such a star as one of only a few accepted stars near focus, that one inflated HFR pulls the
+curve point, and the fit can look deceptively tight while resting on a bloated outlier. Like the defocus-precision
+term, \(S_{\text{hfr-outlier}}\) is a **multiplicative** penalty in \([0.5, 1.0]\) applied after the weighted sum.
+
+\[
+J_{\text{run}} \;\leftarrow\; J_{\text{run}} \times S_{\text{hfr-outlier}}, \qquad
+S_{\text{hfr-outlier}} \in [\,0.5,\; 1.0\,]
+\]
+
+The accepted-star HFRs from the near-focus frames are pooled, and a star counts as an extreme outlier only when its
+HFR clears **both** bars: at least \(4\times\) the robust scatter (median absolute deviation) above the median,
+**and** at least \(1.5\times\) the median. The first bar handles loose frames; the second guards the case where every
+star is nearly identical, so the scatter collapses toward zero. The penalty is then a function of the outlier
+**fraction** \(f\) — outliers over accepted stars in the near-focus pool:
+
+\[
+S_{\text{hfr-outlier}} = \operatorname{clip}_{[0.5,\,1]}\!\bigl(\,1 - \text{Strength}\cdot\max(0,\; f - \text{Threshold})\,\bigr),
+\qquad \text{Threshold} = 0.05,\; \text{Strength} = 1.0
+\]
+
+| Constant | Value | Role |
+|---|---|---|
+| MAD multiple | 4.0 | How far above the median (in robust scatter) an HFR must sit to count as an outlier |
+| Relative margin | 1.5 | An outlier must also be at least 1.5× the median HFR (guards the zero-scatter case) |
+| Threshold | 0.05 | Outlier fraction tolerated before any penalty |
+| Strength | 1.0 | How hard \(J\) is scaled per unit of excess outlier fraction |
+| Min factor | 0.5 | Floor — this term alone can at most halve \(J\), never zero it |
+
+Using a **fraction** rather than a flag is what makes this useful. A bright saturated star is admitted at almost any
+sensitivity, so a plain "is there a big-HFR star" test would dock every candidate equally and change nothing. The
+fraction shrinks as a lower sensitivity admits more normal stars, so the penalty eases exactly as the curve stops
+leaning on the outlier. The term therefore pulls the search toward **more stars and higher recall**, not away from
+it.
+
+Two properties make this safe:
+
+- **Off is bit-identical.** With no per-star HFR data, or no near-focus extreme outlier, \(S_{\text{hfr-outlier}} = 1.0\)
+  exactly and \(J\) is unchanged.
+- **It works with the detector, not against it.** The
+  [Exclude Saturated Stars From HFR](../settings/hotpixel-saturation.md) option keeps a saturated star's inflated HFR
+  out of the curve point; this penalty additionally discourages settings that would lean on such a star in the first
+  place.
+
 ## Combining multiple runs
 
 When you optimize several autofocus runs together (only ever from the **same** optical setup), each run
@@ -230,6 +302,7 @@ sacrificing one run to flatter the others. A single run reduces to its own \(J\)
 | Focus weight | \(W_f\) | 0.55 | \(S_{\text{focus}}\) |
 | Star-count weight | \(W_s\) | 0.20 | \(S_{\text{stars}}\) |
 | Curve-fit weight | \(W_c\) | 0.25 | \(S_{\text{fit}}\) |
+| Coverage weight | \(W_{\text{cov}}\) | 0.05 | \(S_{\text{cov}}\) |
 | Label weight | \(W_\ell\) | 0.25 | \(S_{\text{label}}\) (labels only) |
 | Focus reference | \(\rho_{\text{ref}}\) | 0.25 | \(S_{\text{focus}}\) |
 | Min-count knee | \(N_{\text{floor}}\) | 8 | \(S_{\text{stars}}\) |
@@ -240,7 +313,12 @@ sacrificing one run to flatter the others. A single run reduces to its own \(J\)
 | Precision threshold | — | 0.20 | \(S_{\text{defocus-precision}}\) |
 | Precision strength | — | 0.5 | \(S_{\text{defocus-precision}}\) |
 | Precision min factor | — | 0.5 | \(S_{\text{defocus-precision}}\) |
-| Near-focus window | — | 1.5 steps | \(S_{\text{defocus-precision}}\) |
+| HFR-outlier MAD multiple | — | 4.0 | \(S_{\text{hfr-outlier}}\) |
+| HFR-outlier relative margin | — | 1.5 | \(S_{\text{hfr-outlier}}\) |
+| HFR-outlier threshold | — | 0.05 | \(S_{\text{hfr-outlier}}\) |
+| HFR-outlier strength | — | 1.0 | \(S_{\text{hfr-outlier}}\) |
+| HFR-outlier min factor | — | 0.5 | \(S_{\text{hfr-outlier}}\) |
+| Near-focus window | — | 1.5 steps | \(S_{\text{defocus-precision}}\), \(S_{\text{cov}}\), \(S_{\text{hfr-outlier}}\) |
 | Multi-run blend | \(\beta\) | 0.5 | \(J_{\text{total}}\) |
 
 For how this objective is searched (the coarse grid and staged compass search), see

--- a/documentation/docs/quick-start.md
+++ b/documentation/docs/quick-start.md
@@ -105,4 +105,11 @@ indoors as many times as you like with different settings.
 This replay loop is the fastest way to tune detection: optimize, label any missed or false stars,
 re-optimize, and repeat, all from your desk.
 
+!!! tip "Tune on a fast machine, image on another"
+    The optimizer runs entirely from saved frames, so it does not need to run on your imaging computer. Copy a
+    saved autofocus run to a faster desktop, run the [Optimization Wizard](optimization/index.md) there, then use
+    **Export** on the Star Detection options page to write the tuned settings to a `.json` file. **Import** that file
+    on the imaging computer to apply them, after confirming exactly what will change. See
+    [exporting and importing settings](settings/index.md#exporting-and-importing-star-detection-settings).
+
 → Full detail: [Autofocus](overview/autofocus.md) and [Star Detection Optimization](optimization/index.md).

--- a/documentation/docs/settings/hotpixel-saturation.md
+++ b/documentation/docs/settings/hotpixel-saturation.md
@@ -16,6 +16,7 @@ These options live in the **Advanced** star-detection settings. In Simple mode t
 | Use Hotpixel Thresholding | On | On / Off | Replace only pixels that differ sharply from the median, instead of blurring everything |
 | Hotpixel Threshold | 0.1% (0.001) | (0, 100%] | How far a pixel must sit from its 3×3 median (as a fraction of full well) to count as a hot pixel |
 | Saturation Threshold | 99% (0.99) | (0, 100%] | Pixels at or above this fraction of full well are treated as saturated and masked during PSF fitting |
+| Exclude Saturated Stars From HFR | On | On / Off | Leave partially-saturated stars out of the per-frame HFR average; they stay detected and counted |
 
 ---
 
@@ -103,3 +104,21 @@ When a star's core clips at the sensor's full-well limit, its peak flattens into
 
 !!! note
     The same threshold gates two things: the per-image **saturated-pixel count** in the metrics, and the per-star mask applied during PSF fitting. It does not, by itself, reject stars from the accepted set.
+
+---
+
+## Exclude Saturated Stars From HFR
+
+**What it does:** keeps partially-saturated stars out of the per-frame HFR average, while still detecting and counting them.
+
+> "When enabled (default), partially-saturated stars (those whose peak reaches the Saturation Threshold) are left out of the per-frame HFR average — their flat, saturated cores bias HFR high and can pull the focus curve. The stars are still detected and counted; only the HFR average excludes them, and only while enough unsaturated stars remain. Disable to include every star's HFR as before."
+
+- **Default:** On
+- **Range:** On / Off
+
+A saturated core clips flat at the full-well limit, so the half-flux radius measured from it reads larger than the star's true size. That inflated HFR drags the frame's aggregate HFR upward and can distort the focus curve the optimizer fits to find best focus. This setting drops such stars from the per-frame **HFR average** (and its standard deviation), so the curve point reflects the well-behaved stars instead.
+
+It does not reject the star. A partially-saturated star is still a real detection with a valid position and structure, so it stays in the accepted set: the total star count, the star centers, and each star's own measured HFR are unchanged. Only the per-frame average leaves it out. Rejecting it outright would discard a genuine star, and on a frame with few stars that loss matters most. For that reason the exclusion applies only while **at least three unsaturated stars remain** on the frame; below that floor every star is kept, so a bright, saturation-heavy frame still produces an HFR. A star counts as saturated by the same test the rest of the pipeline uses: its background plus peak brightness reaches the **Saturation Threshold** above. With nothing saturated, or with this option off, the HFR average is exactly what it was before.
+
+!!! tip "When this helps"
+    Leave it **on**. It matters most on frames that hold a bright, clipped star next to fainter ones, where that single star would otherwise pull the HFR curve. Turn it **off** only to restore the legacy behavior, where every accepted star contributes to the HFR average regardless of saturation.

--- a/documentation/docs/settings/index.md
+++ b/documentation/docs/settings/index.md
@@ -62,6 +62,14 @@ Internally, this preset chooses the noise-reduction radius, whether measurement-
 
 When **Use Optimized Settings** is on and a wizard result exists, Simple mode first derives the preset baseline, then overlays the curated subset of parameters from the saved snapshot (sensitivity, clipping multipliers, peak response, distortion, min HFR, center tolerance, structure layers, noise-reduction radius, minimum bounding box, and the hotpixel knobs). Non-curated advanced knobs keep their preset defaults; the curated ones win. See [Labels, Recall & Precision](../optimization/labels-recall-precision.md) for how those values are chosen.
 
+### Exporting and importing star-detection settings
+
+Star-detection settings can move between machines. Two buttons at the bottom of the Star Detection options pane, **Export** and **Import**, write and read a single `.json` file (named `HocusFocusStarDetection_<timestamp>.json`). This is how you tune on one computer and image on another: run the [Optimization Wizard](../optimization/index.md) on a fast desktop, **Export**, then **Import** on the imaging computer.
+
+Only **star-detection** settings are written, not autofocus, inspector, or tilt settings. The wizard's optimized-settings snapshot is included too, so the imported profile can turn it on with **Use Optimized Settings**. A few values are deliberately left out because they belong to one computer: the intermediate-image path, the **Save Intermediate** flag, **Debug Mode**, and **PSF Parallel Size**. Those keep their local values on import.
+
+Import never changes anything silently. After you pick a file, a confirmation dialog lists every setting that would change in a **Setting / Current / Imported** table, and the new values are applied only when you click **Apply**. If the file matches your current settings, it tells you there is nothing to change. A file that is not a Hocus Focus star-detection export, or that comes from a newer version's format, is rejected without touching your settings.
+
 ## Reading the results: the Star Detection Results panel
 
 Throughout these pages you are told to "watch the metrics panel." That panel is the **Star Detection


### PR DESCRIPTION
Expands the user manual to cover features merged in **#105** (settings import/export) and **#106** (objective update + the saturated-HFR option), which the docs did not yet describe. Text-only; `mkdocs build --strict` passes and every constant was fact-checked against source.

## Changes

- **`settings/hotpixel-saturation.md`** — new **Exclude Saturated Stars From HFR** section + at-a-glance row. Covers the rationale for the toggle: a saturated core clips flat so its HFR reads too large and drags the focus-curve point, but the star is still a real detection, so it is dropped from the per-frame **HFR average only** (count, centers, and its own HFR unchanged) and only while at least 3 unsaturated stars remain — rather than rejected outright.
- **`optimization/objective-function.md`** (+ the `optimization/index.md` summary mirror) — documents the two new objective terms: the **region-coverage reward** `S_cov` (weight 0.05, near-focus 3×3 occupancy, rewards spread) and the **extreme-HFR outlier penalty** `S_hfr-outlier` (dilution-sensitive outlier fraction, ≥4·MAD **and** ≥1.5×median). Updates the composite formula, the weight table, and the all-constants table; explains why a fraction (not a flag) pulls the search toward higher recall.
- **`quick-start.md`** — a tip to optimize on a fast machine from a saved autofocus run, **Export** the settings, and **Import** them on the imaging machine.
- **`settings/index.md`** — new **Exporting and importing star-detection settings** section: the Export/Import buttons, the `.json` file, what transfers (star-detection settings + the optimizer snapshot) vs. what stays machine-local (intermediate path, Save Intermediate, Debug Mode, PSF Parallel Size), and the diff-confirm dialog before anything is applied.

## Verification

`mkdocs build --strict` → clean (all internal links/anchors resolve, no missing images). Documented constants (`W_cov=0.05`, HFR-outlier 4.0/1.5/0.05/1.0/0.5, the 3-unsaturated floor, the 3×3 grid, the import exclusion list) verified against `OptimizationObjective.cs`, `HocusFocusStarDetection.cs`, `IStarDetector.cs`, and `StarDetectionSettingsDiff.cs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)