### PR TITLE
docs: present optimization as single-run (multiple runs are tilt-only)

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
@@ -107,7 +107,7 @@ Check out his website at [https://www.smallstarspot.com](https://www.smallstarsp
 * Results are safe and reversible: optimized settings are stored separately and activated by a single toggle that appears only after a successful run, and the wizard never hands back a result worse than your current settings.
 * Improvement is reported honestly against what your rig does today, the wizard can seed from defaults or from your current settings, and it recommends an auto-focus step size tailored to your focal ratio, pixel scale, and focuser.
 * Selectable objectives: default auto-focus repeatability, an ""Optimize for Aberration Inspection"" objective that recovers far more stars across the frame, and a ""Recover out-of-focus donut stars"" mode for defocus-aware tuning.
-* ""Continue optimizing"" runs successive refinement passes; optional hand-drawn bounding-box labels add a recall/precision term that pushes the optimizer toward your own judgment on hard frames; and several runs from the same optical setup can be optimized together so a winning setting holds up across nights instead of overfitting a single run.
+* ""Continue optimizing"" runs successive refinement passes, and optional hand-drawn bounding-box labels add a recall/precision term that pushes the optimizer toward your own judgment on hard frames.
 
 *Aberration Inspector & Tilt Correction*
 

--- a/documentation/docs/optimization/af-curve-fitting.md
+++ b/documentation/docs/optimization/af-curve-fitting.md
@@ -166,21 +166,12 @@ steps per side and is clamped to at least 1 (and to the focuser's limits when kn
     **future** runs, not a re-measurement of the one you replayed. It is written to your profile only
     when you apply the wizard's results.
 
-## How this scales to a budgeted search and to multiple runs
+## How this scales to a budgeted search
 
-This whole pipeline runs once per candidate, per run, and the search tries hundreds of candidates (up
+This whole pipeline runs once per candidate, and the search tries hundreds of candidates (up
 to 400 evaluations). Two facts keep that affordable. First, detection is split into an expensive
 **early** stage (hot-pixel filtering, structure preparation, wavelet, binarization, candidate
 collection) and a cheap **late** stage (gate + measure); the early stage is cached per frame and
 reused whenever a candidate changes only late-stage gate parameters, which is the bulk of the search.
 Second, identical parameter bundles are memoized, so a revisited point never re-detects. The result is
 **bit-identical** scores at roughly 10–13× the speed.
-
-When you optimize several runs together, each run is scored by this pipeline independently, and the
-per-run scores are blended so a candidate must be good on average **and** not bad on any single run;
-this is detailed under [multi-run blending](objective-function.md).
-
-!!! warning
-    Only group runs from the **same** optical setup. The blend assumes the runs are comparable; a
-    joint score across different cameras or scopes is meaningless, because their focus curves and star
-    fields are not the same problem.

--- a/documentation/docs/optimization/index.md
+++ b/documentation/docs/optimization/index.md
@@ -90,10 +90,6 @@ default to 1.0: one for defocus-relaxed junk, and one for leaning on a saturated
 inflated HFR. A hard floor guards against starved frames: if any frame falls below 3 accepted stars,
 that run scores \( J_{\text{run}} = 0 \).
 
-When more than one run is optimized together, the per-run scores are blended as
-\( J_{\text{total}} = (1-\beta)\,\text{mean} + \beta\,\text{min} \) with \( \beta = 0.5 \), so a
-setting must be good on average **and** not bad on any single run.
-
 The full breakdown of each sub-score lives on the dedicated pages below.
 
 ## Section map
@@ -101,14 +97,14 @@ The full breakdown of each sub-score lives on the dedicated pages below.
 This section documents every moving part of the optimizer:
 
 - **[Objective function](objective-function.md):** the composite score \( J \): how \( S_{\text{focus}} \),
-  \( S_{\text{stars}} \), and \( S_{\text{fit}} \) are computed, the hard floors, the multi-run blend,
-  and the label-free precision penalty.
+  \( S_{\text{stars}} \), and \( S_{\text{fit}} \) are computed, the hard floors, and the label-free
+  precision penalty.
 - **[Search variables](search-variables.md):** the curated set of tunable parameters, their bounds,
   initial step sizes, and the synthetic defocus-aware knobs.
 - **[Search algorithm](search-algorithm.md):** the staged compass/pattern search: the coarse seed
   grid, the alternating late/early stages, step halving, the memoization that makes repeated
   evaluation cheap, and the evaluation budget.
-- **[AF curve fitting](af-curve-fitting.md):** how each run is detected, pooled by focuser position,
+- **[AF curve fitting](af-curve-fitting.md):** how the run is detected, pooled by focuser position,
   and fit to extract \( \sigma_{\text{focus}} \), \( R^2 \), and reduced \( \chi^2 \).
 - **[Labels: recall & precision](labels-recall-precision.md):** the optional ground-truth labeling
   loop and how box-containment recall/precision enter the objective.

--- a/documentation/docs/optimization/objective-function.md
+++ b/documentation/docs/optimization/objective-function.md
@@ -277,24 +277,6 @@ Two properties make this safe:
   out of the curve point; this penalty additionally discourages settings that would lean on such a star in the first
   place.
 
-## Combining multiple runs
-
-When you optimize several autofocus runs together (only ever from the **same** optical setup), each run
-produces its own \(J_{\text{run}}\) and the wizard blends them with a mean/min mixture:
-
-\[
-J_{\text{total}} = (1 - \beta) \cdot \operatorname{mean}_r\!\left(J_{\text{run},r}\right)
-+ \beta \cdot \min_r\!\left(J_{\text{run},r}\right), \qquad \beta = 0.5
-\]
-
-With \(\beta = 0.5\) the score is the average of the mean and the worst-case run. The \(\min\) term enforces
-**balance**: a candidate must be good on average *and* not bad on any single run, so the wizard cannot win by
-sacrificing one run to flatter the others. A single run reduces to its own \(J\) (mean and min coincide).
-
-![Multi-run blend of mean and minimum per-run J](../assets/figures/multirun-blend.png){ width=620 }
-*\(J_{\text{total}} = (1-\beta)\cdot\text{mean} + \beta\cdot\text{min}\) over per-run scores, with
-\(\beta = 0.5\): the minimum term pulls the blend toward the weakest run.*
-
 ## All constants at a glance
 
 | Constant | Symbol | Value | Where it acts |
@@ -319,7 +301,6 @@ sacrificing one run to flatter the others. A single run reduces to its own \(J\)
 | HFR-outlier strength | — | 1.0 | \(S_{\text{hfr-outlier}}\) |
 | HFR-outlier min factor | — | 0.5 | \(S_{\text{hfr-outlier}}\) |
 | Near-focus window | — | 1.5 steps | \(S_{\text{defocus-precision}}\), \(S_{\text{cov}}\), \(S_{\text{hfr-outlier}}\) |
-| Multi-run blend | \(\beta\) | 0.5 | \(J_{\text{total}}\) |
 
 For how this objective is searched (the coarse grid and staged compass search), see
 [Search algorithm](search-algorithm.md); for the knobs it is allowed to move, see

--- a/documentation/docs/optimization/search-algorithm.md
+++ b/documentation/docs/optimization/search-algorithm.md
@@ -123,8 +123,8 @@ Two hard stops bound the work:
 
 ## What a single evaluation costs
 
-One evaluation scores a candidate against **every run** the wizard is optimizing, and the per-run
-score is what the objective consumes. For each run the evaluator (`RunEvaluationData`):
+One evaluation scores a candidate against the run the wizard is optimizing. The evaluator
+(`RunEvaluationData`):
 
 1. **Detects every frame** in the run, concurrently but capped (default \(\approx \max(2,
    \text{ProcessorCount}/4)\) frames in flight) to fill idle cores during the largely single-threaded
@@ -138,15 +138,8 @@ score is what the objective consumes. For each run the evaluator (`RunEvaluation
 4. Reads \(\sigma_{\text{focus}}\), \(R^2\), and reduced \(\chi^2\) off the winning fit, plus recall
    and precision when labels exist.
 
-The per-run scores are then blended into one number with the multi-run aggregate
-\(J_{\text{total}} = (1-\beta)\cdot\text{mean} + \beta\cdot\text{min}\), \(\beta = 0.5\), so a
-candidate must be good on average **and** not bad on any single run (see
+These metrics feed the composite objective \(J\) for the run (see
 [Objective function](objective-function.md)).
-
-!!! warning "Only group runs from the same optical setup"
-    The joint objective averages and worst-cases scores across all runs. Blending runs from different
-    cameras or scopes is meaningless. Use the wizard's per-run path (or the harness `--per-run` flag)
-    to tune setups independently.
 
 ### The early-context cache — why staging matters
 


### PR DESCRIPTION
Per your note: **multiple auto-focus runs are used only by tilt-adapter calibration** — not by star-detection optimization or sensor modeling — and **multiple images per focus point** is an autofocus capture setting. This corrects the manual and the plugin's store description to match that.

## What I verified in code first

- **Optimization Wizard → single run.** `StarDetection/Optimization/DataTemplates.xaml` literally comments *"the multi-run selector was removed"*; the only run control is a single saved-run picker and `RunCount` defaults to 1 with no UI to raise it. (`OptimizationObjective.JTotal` and the TestApp `optimize --per-run` path still exist in the engine, but the wizard does not expose them, so they are out of the user manual.)
- **Sensor model → one multi-region run** (center + corners + full frame), not multiple runs.
- **Tilt calibration → multiple runs** (the 6-step Baseline → AllInward → ReBaseline → Screw … sequence). This is the genuine multi-run feature.
- **Multiple images per focus point → autofocus** (`AutoFocusNumberOfFramesPerPoint` / `FramesPerPoint`). The optimizer only re-pools those AF-captured frames within one run, which the docs already describe correctly.

## Changes

- **AssemblyInfo `LongDescription`** — drop the "several runs from the same optical setup can be optimized together … across nights" clause.
- **`optimization/objective-function.md`** — remove the "Combining multiple runs" section and the multi-run-blend (`β`) constants row.
- **`optimization/index.md`** — remove the multi-run-blend paragraph and the section-map mention; singularize "the run".
- **`optimization/af-curve-fitting.md`** — drop the "scales to multiple runs" subsection content and the same-optical-setup warning.
- **`optimization/search-algorithm.md`** — score a candidate against "the run" (not "every run"); remove the multi-run aggregate paragraph and warning.

No changes to sensor-model docs (they already describe a single multi-region run) or to the multi-image-per-point wording (already attributed to autofocus).

## Verification

`mkdocs build --strict` → clean (all links/anchors resolve); the HocusFocus plugin builds (the AssemblyInfo verbatim string stays well-formed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)