### PR TITLE
Continue optimizing: per-round focus precision + round-relative live improvement

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationSummaryTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationSummaryTests.cs
@@ -76,6 +76,38 @@ public class OptimizationSummaryTests {
     }
 
     [Test]
+    public void FormatSigmaTrajectory_MultiRound_JoinsPathAndShowsTighter() {
+        // baseline → R1 → R2 σ path with a "(~N% tighter)" suffix from first vs last ((2.20-1.52)/2.20 ≈ 31%).
+        var s = OptimizationSummary.FormatSigmaTrajectory(new[] { 2.20, 1.85, 1.52 });
+        Assert.Multiple(() => {
+            Assert.That(s, Does.Contain("2.20 → 1.85 → 1.52"));
+            Assert.That(s, Does.Contain("31% tighter"));
+            Assert.That(s.Split('→').Length, Is.EqualTo(3), "two arrows across three stages");
+        });
+    }
+
+    [Test]
+    public void FormatSigmaTrajectory_NonImproving_NoTighterSuffix() {
+        // σ that holds or worsens (last >= first) renders the path only — no false "tighter" claim.
+        Assert.Multiple(() => {
+            Assert.That(OptimizationSummary.FormatSigmaTrajectory(new[] { 1.50, 1.80, 2.00 }), Is.EqualTo("1.50 → 1.80 → 2.00"));
+            Assert.That(OptimizationSummary.FormatSigmaTrajectory(new[] { 1.50, 1.50 }), Is.EqualTo("1.50 → 1.50"));
+        });
+    }
+
+    [Test]
+    public void FormatSigmaTrajectory_DropsNonFinite_AndHandlesEmpty() {
+        Assert.Multiple(() => {
+            // Non-finite stages are dropped; the suffix compares the surviving first/last (2.00 → 1.50 ≈ 25%).
+            Assert.That(OptimizationSummary.FormatSigmaTrajectory(new[] { double.NaN, 2.00, double.NaN, 1.50 }),
+                Does.Contain("2.00 → 1.50").And.Contain("25% tighter"));
+            Assert.That(OptimizationSummary.FormatSigmaTrajectory(new[] { double.NaN, double.NaN }), Is.Empty);
+            Assert.That(OptimizationSummary.FormatSigmaTrajectory(new double[0]), Is.Empty);
+            Assert.That(OptimizationSummary.FormatSigmaTrajectory(null), Is.Empty);
+        });
+    }
+
+    [Test]
     public void PercentBetter_HigherIsBetter_ClampedAndGuarded() {
         Assert.Multiple(() => {
             Assert.That(OptimizationSummary.PercentBetter(1.0, 1.5), Is.EqualTo(50.0).Within(1e-9), "higher best => positive %");

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -940,6 +940,42 @@ public class StarDetectionOptimizerWizardVMTests {
         });
     }
 
+    [Test]
+    public async Task Continue_FocusPrecision_ShowsEveryRound() {
+        var loader = new RecordingLoader();
+        var vm = NewVM(loader, frameReviewBuilder: new FakeReviewBuilder().Build);
+        vm.SourcePaths[0] = @"C:\cont-run";
+
+        await vm.StartAsync(CancellationToken.None);
+        // A single pass has no chain to show, so focus precision is the start→finish SigmaText (no per-round path).
+        Assert.That(vm.FocusPrecisionText, Is.EqualTo(vm.Summary.SigmaText));
+
+        await vm.ContinueOptimizationCommand.ExecuteAsync(null); // 2 rounds -> baseline + R1 + R2
+        // The σ row now shows the full per-round path (baseline → R1 → R2), mirroring the J rounds header — two arrows.
+        Assert.Multiple(() => {
+            Assert.That(vm.IsOptimizedVariant, Is.True);
+            Assert.That(vm.FocusPrecisionText.Count(c => c == '→'), Is.EqualTo(2),
+                "baseline → R1 → R2 renders one σ per stage");
+        });
+    }
+
+    [Test]
+    public async Task Continue_LiveImprovementBaseline_IsMostRecentRound() {
+        var loader = new RecordingLoader();
+        var vm = NewVM(loader, frameReviewBuilder: new FakeReviewBuilder().Build);
+        vm.SourcePaths[0] = @"C:\cont-run";
+
+        await vm.StartAsync(CancellationToken.None);
+        vm.IsOptimizedVariant = true;            // read the optimized best regardless of the default selection
+        var priorBestJ = vm.Result.BestJ;
+
+        await vm.ContinueOptimizationCommand.ExecuteAsync(null);
+
+        // The live "improved ~X%" baseline for a Continue pass is the PRIOR round's best (the seed for this pass),
+        // not the initial current-settings baseline — so ProgressSeedJ tracks where the last round left off.
+        Assert.That(vm.ProgressSeedJ, Is.EqualTo(priorBestJ).Within(1e-9));
+    }
+
     // ---- Optimize for aberration inspection -------------------------------------------------------------
 
     [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
@@ -26,8 +26,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new release build of a plugin
-[assembly: AssemblyVersion("3.0.0.35")]
-[assembly: AssemblyFileVersion("3.0.0.35")]
+[assembly: AssemblyVersion("3.0.0.36")]
+[assembly: AssemblyFileVersion("3.0.0.36")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("Hocus Focus")]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -467,9 +467,12 @@
                         <!--  Before / after — plain language, no jargon "J" (the abstract objective stays in logs).
                               Every row is "[label Width=200][value]" with uniform spacing so the values line up in a
                               column and the row gaps match across the whole summary.  -->
+                        <!--  Focus precision shows the full per-round σ path "baseline → R1 → R2 → …" after "Continue
+                              optimizing" (FocusPrecisionText), mirroring the J rounds header; a single pass collapses to
+                              the start→finish SigmaText.  -->
                         <StackPanel Orientation="Horizontal" Margin="0,2">
                             <TextBlock Width="200" Text="Focus precision (σ, lower is better)" />
-                            <TextBlock Text="{Binding Summary.SigmaText, Mode=OneWay}" />
+                            <TextBlock Text="{Binding FocusPrecisionText, Mode=OneWay}" />
                         </StackPanel>
                         <!--  Feedback variant only: how much the feedback round tightened σ over the plain optimization.  -->
                         <StackPanel Orientation="Horizontal" Margin="0,2"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -180,6 +180,24 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public static string FormatRecommendation(int current, int recommended) =>
             current == recommended ? $"{recommended} (unchanged)" : $"{current} → {recommended}";
 
+        /// <summary>Arrow-joined σ(focus) path "2.20 → 1.85 → 1.52" across the optimization rounds, with a
+        /// "(~N% tighter)" suffix when the last σ improved on the first (σ is lower-is-better). Non-finite σ are
+        /// dropped; an empty/all-NaN input yields "". Pure — unit-tested.</summary>
+        public static string FormatSigmaTrajectory(IReadOnlyList<double> sigmas) {
+            var finite = sigmas?.Where(double.IsFinite).ToList() ?? new List<double>();
+            if (finite.Count == 0) {
+                return string.Empty;
+            }
+            var path = string.Join(" → ", finite.Select(s => s.ToString("F2")));
+            var first = finite[0];
+            var last = finite[finite.Count - 1];
+            if (first > 1e-9 && last < first) {
+                var pct = (first - last) / first * 100.0;
+                return $"{path}  (~{pct:F0}% tighter)";
+            }
+            return path;
+        }
+
         /// <summary>Percent improvement of <paramref name="improved"/> over <paramref name="baseline"/> for a
         /// higher-is-better score, clamped at 0 and guarded against non-finite / near-zero baselines. Pure —
         /// unit-tested.</summary>
@@ -749,6 +767,22 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
         public bool HasRoundsSummary => RoundsSummaryText.Length > 0;
 
+        /// <summary>Focus-precision (σ) readout for the summary row. For the Optimized variant after more than one
+        /// pass it shows the full per-round σ path "baseline → R1 → R2 → …" (mirroring <see cref="RoundsSummaryText"/>'s
+        /// J path and <see cref="StarsPerFrame"/>'s counts, all read off the same retained curves); otherwise it falls
+        /// back to the start→finish <see cref="OptimizationSummary.SigmaText"/> (which carries the "(unchanged)" wording
+        /// for a single pass). Stage 0 is the current-settings σ (the same baseline RoundsSummaryText uses for J).</summary>
+        public string FocusPrecisionText {
+            get {
+                if (selectedVariant == OptimizationVariant.Optimized && optimizedRoundCurves.Count > 1 && currentCurve != null) {
+                    var sigmas = new List<double>(optimizedRoundCurves.Count + 1) { currentCurve.MinimumStdError };
+                    sigmas.AddRange(optimizedRoundCurves.Select(c => c.MinimumStdError));
+                    return OptimizationSummary.FormatSigmaTrajectory(sigmas);
+                }
+                return Summary?.SigmaText ?? string.Empty;
+            }
+        }
+
         private OptimizationResult SelectedResult => selectedVariant switch {
             OptimizationVariant.Feedback => feedbackResult,
             OptimizationVariant.Optimized => optimizedResult,
@@ -984,6 +1018,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             RaisePropertyChanged(nameof(RoundsCompleted));
             RaisePropertyChanged(nameof(RoundsSummaryText));
             RaisePropertyChanged(nameof(HasRoundsSummary));
+            RaisePropertyChanged(nameof(FocusPrecisionText));
             AcceptCommand.NotifyCanExecuteChanged();
             BackCommand.NotifyCanExecuteChanged();
             ContinueOptimizationCommand.NotifyCanExecuteChanged();
@@ -1545,7 +1580,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// "Optimize with feedback" path), the search starts from the analytic recommendation and explores only the
         /// narrowed/curated axes it produced; otherwise it uses the first run's seed and the full curated set.</summary>
         private async Task<OptimizationResult> OptimizeAsync(IReadOnlyList<LoadedRun> runs, CancellationToken token,
-            StarDetectorParams seedOverride = null, IReadOnlyList<OptimizerVariable> variablesOverride = null) {
+            StarDetectorParams seedOverride = null, IReadOnlyList<OptimizerVariable> variablesOverride = null,
+            double? progressBaselineJOverride = null) {
             // All runs share the same camera/optics, so the search starts from the first run's seed (or the override).
             // With StartFromCurrentSettings, seed from the current settings (Baseline) to refine them rather than the
             // fully-default params. The warm-start override (feedback path) always wins.
@@ -1567,9 +1603,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 ProgressCurrent = p.Evaluations;
                 ProgressTotal = p.MaxEvaluations;
                 ProgressBestJ = p.BestJ;
-                // The displayed baseline is the user's CURRENT settings (currentBaselineJ), not the optimizer's
-                // default seed J (p.SeedJ), so the live "improved ~X%" reads vs current and matches the summary.
-                ProgressSeedJ = currentBaselineJ;
+                // The displayed baseline is the user's CURRENT settings (currentBaselineJ) for a fresh Start/feedback
+                // pass — not the optimizer's default seed J (p.SeedJ) — so the live "improved ~X%" reads vs current and
+                // matches the summary. A "Continue optimizing" pass overrides it with the PRIOR ROUND's best (the seed
+                // for that pass) so the live readout reflects the gain the continued search is making, not the total
+                // gain since the initial baseline.
+                ProgressSeedJ = progressBaselineJOverride ?? currentBaselineJ;
                 Phase = FriendlyPhase(p.Phase);
             });
 
@@ -2111,10 +2150,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // The seed for this pass is the CURRENT Optimized best (captured before any UI churn). optimizedResult is
             // not cleared by this path, so this stays valid through the reload.
             var seedForContinue = optimizedResult.BestParams;
+            // The prior round's best J is the live-improvement baseline for THIS pass: the user wants "improved ~X%"
+            // to read relative to where the last round left off, not the initial current-settings baseline.
+            var seedForContinueJ = optimizedResult.BestJ;
 
             ErrorMessage = null;
             SetProgress(null, 0, 0);
-            ProgressSeedJ = 0;
+            // Seed the live baseline synchronously (not via the async progress callback) so the readout is correct from
+            // the first frame and deterministic for tests; ProgressBestJ stays 0 so it starts at "Searching…".
+            ProgressSeedJ = seedForContinueJ;
             ProgressBestJ = 0;
             IsBusy = true;
 
@@ -2146,8 +2190,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 currentBaselineJ = await ComputeBaselineJAsync(reloaded, token).ConfigureAwait(true);
 
                 // Another optimize pass seeded from the prior best; variablesOverride=null ⇒ OptimizeAsync builds a
-                // fresh CreateCuratedSet(seedForContinue) with reset step scale.
-                var optimizeResult = await OptimizeAsync(reloaded, token, seedForContinue).ConfigureAwait(true);
+                // fresh CreateCuratedSet(seedForContinue) with reset step scale. The progress baseline override makes
+                // the live "improved ~X%" read vs the prior round's best rather than the current-settings baseline.
+                var optimizeResult = await OptimizeAsync(reloaded, token, seedForContinue,
+                    progressBaselineJOverride: seedForContinueJ).ConfigureAwait(true);
                 var built = await BuildSummaryAsync(reloaded, optimizeResult, token).ConfigureAwait(true);
 
                 // The latest pass REPLACES the Optimized variant (chart + Accept follow it); append the trajectory stage.


### PR DESCRIPTION
## Context

The star-detection optimizer wizard's **Continue optimizing** flow runs another pass seeded from the current Optimized best, appending a *round* (capped at 3). The summary already shows the per-round progression for objective J (`RoundsSummaryText`), accepted star counts (`StarsPerFrame`), and each changed parameter's value (`Trajectory`). Two gaps remained, both user-reported:

1. **Summary — focus precision showed only start → finish.** The "Focus precision (σ, lower is better)" row bound `Summary.SigmaText` (two scalars on an `OptimizationSummary` that is *replaced* each round), so after multiple rounds it still showed only the original baseline σ and the latest σ — not the per-round path the other metrics show.
2. **Live progress — improvement was measured vs the initial baseline even when continuing.** While a pass ran, "Detection improved ~X% so far" compared the best-so-far against `currentBaselineJ` (the user's current settings) for *every* pass, so on a Continue the percentage was dominated by earlier rounds rather than reflecting the gain the continued search is making.

## Changes

**Fix 1 — per-round σ path on the summary**
- New pure `OptimizationSummary.FormatSigmaTrajectory(...)` → `"2.20 → 1.85 → 1.52  (~31% tighter)"`.
- New `FocusPrecisionText` VM property builds the σ path from the already-retained curves (`currentCurve.MinimumStdError` + each `optimizedRoundCurves[i].MinimumStdError`), mirroring `RoundsSummaryText`/`StarsPerFrame`. A single pass falls back to the start→finish `SigmaText` (keeping its "(unchanged)" wording).
- XAML row rebound `Summary.SigmaText` → `FocusPrecisionText`; raised in `RaiseSelectedVariantDependents`.

**Fix 2 — live improvement vs the most recent round (Continue only)**
- `OptimizeAsync` gains an optional `progressBaselineJOverride`; the progress callback uses `progressBaselineJOverride ?? currentBaselineJ`.
- `ContinueOptimizationAsync` captures the prior round's best (`optimizedResult.BestJ`), sets `ProgressSeedJ` synchronously, and passes the override. Start/feedback paths are unchanged. The optimizer never regresses below its seed, so a Continue that finds nothing better honestly stays at 0% / "Searching for a better fit…".

## Tests
5 new tests; full suite **1605 passed, 0 failed** (3 pre-existing benchmark skips):
- `OptimizationSummaryTests`: `FormatSigmaTrajectory_MultiRound_JoinsPathAndShowsTighter`, `_NonImproving_NoTighterSuffix`, `_DropsNonFinite_AndHandlesEmpty`.
- `StarDetectionOptimizerWizardVMTests`: `Continue_FocusPrecision_ShowsEveryRound`, `Continue_LiveImprovementBaseline_IsMostRecentRound`.

Also bumps the plugin version to **3.0.0.36**.

## Verify in NINA
Run the Star Detection Optimization wizard on a saved AF run → Optimize → press **Continue optimizing** once or twice. The "Focus precision (σ…)" row should show the full per-round path, and while a Continue pass runs the "improved ~X%" should reflect the gain over the previous round (small/zero when the prior round was already near-optimal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)