### PR TITLE
Fix missing 4th-screw backfocus arrow in tilt adapter guidance

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/TiltAdapterGuidanceVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/TiltAdapterGuidanceVMTests.cs
@@ -37,4 +37,17 @@ public class TiltAdapterGuidanceVMTests {
     public void FormatTotal_NoDirection_ShowsMagnitudeOnly() {
         Assert.That(TiltAdapterGuidanceVM.FormatTotal(0.95, steps: false, hasDirection: false), Is.EqualTo("0.95 turns"));
     }
+
+    // The Screw 4 backfocus arrow is shown only when the adapter has four screws AND the backfocus row
+    // is active. This gating bool lets the XAML use a single plain Visibility binding (like every other
+    // cell) instead of a MultiDataTrigger that failed to re-apply on the whole-object guidance swap.
+    [Test]
+    public void HasFourScrewBackfocus_RequiresFourScrewsAndBackfocusRow() {
+        Assert.Multiple(() => {
+            Assert.That(new TiltAdapterGuidanceVM { ScrewCount = 4, HasBackfocusRow = true }.HasFourScrewBackfocus, Is.True);
+            Assert.That(new TiltAdapterGuidanceVM { ScrewCount = 3, HasBackfocusRow = true }.HasFourScrewBackfocus, Is.False);
+            Assert.That(new TiltAdapterGuidanceVM { ScrewCount = 4, HasBackfocusRow = false }.HasFourScrewBackfocus, Is.False);
+            Assert.That(new TiltAdapterGuidanceVM { ScrewCount = 3, HasBackfocusRow = false }.HasFourScrewBackfocus, Is.False);
+        });
+    }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -2875,22 +2875,8 @@
                                     Grid.Column="4"
                                     HorizontalAlignment="Center"
                                     FontSize="18"
-                                    Text="{Binding TiltGuidance.Screw4BackfocusArrow}">
-                                    <TextBlock.Style>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="Visibility" Value="Collapsed" />
-                                            <Style.Triggers>
-                                                <MultiDataTrigger>
-                                                    <MultiDataTrigger.Conditions>
-                                                        <Condition Binding="{Binding TiltGuidance.HasFourScrews}" Value="True" />
-                                                        <Condition Binding="{Binding TiltGuidance.HasBackfocusRow}" Value="True" />
-                                                    </MultiDataTrigger.Conditions>
-                                                    <Setter Property="Visibility" Value="Visible" />
-                                                </MultiDataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBlock.Style>
-                                </TextBlock>
+                                    Text="{Binding TiltGuidance.Screw4BackfocusArrow}"
+                                    Visibility="{Binding TiltGuidance.HasFourScrewBackfocus, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                             </Grid>
 
                             <!--  Precise numeric adjustments (turns / steps) — shown when adapter hardware is configured  -->

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltScrewGuidanceRow.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltScrewGuidanceRow.cs
@@ -20,6 +20,12 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         public bool HasTiltGuidance { get; set; }
         public bool HasBackfocusRow { get; set; }
 
+        // Gate for the 4th-screw backfocus arrow: needs both the 4th screw to exist and the backfocus
+        // row to be active. Exposed as a single bool so the XAML can use one plain Visibility binding
+        // (like every other cell) instead of a MultiDataTrigger, which did not re-apply when the whole
+        // guidance object is swapped (this VM raises no per-property change notifications).
+        public bool HasFourScrewBackfocus => HasFourScrews && HasBackfocusRow;
+
         public string Screw1TiltArrow { get; set; } = "—";
         public string Screw2TiltArrow { get; set; } = "—";
         public string Screw3TiltArrow { get; set; } = "—";


### PR DESCRIPTION
## Problem

In the Aberration Inspector's **Tilt Adapter Guidance** table, a 4-screw adapter showed only **3 backfocus arrows** — the Screw 4 backfocus arrow was missing — even though its numeric backfocus value (and its tilt arrow, and all numeric columns) rendered correctly.

## Root cause

The Screw 4 backfocus arrow was the **only** cell in the table rendered via a `Style` + `MultiDataTrigger` (default `Visibility=Collapsed`, set `Visible` only when both `HasFourScrews` AND `HasBackfocusRow` are true). Every other cell uses a plain single-condition `Visibility` binding.

`TiltAdapterGuidanceVM` is a notification-less POCO: `HasFourScrews`/`HasBackfocusRow` never raise `PropertyChanged`. New guidance is published by swapping the whole object via `RaisePropertyChanged(nameof(TiltGuidance))`. Plain target-property bindings re-resolve their full path on that swap (which is why every sibling cell rendered), but the multi-condition trigger did not re-apply its `Visible` setter — so the cell stayed `Collapsed`.

The data was always correct: when `n == 4`, `Screw4BackfocusArrow` is set to the *same* glyph as Screws 1-3, so this was purely a XAML visibility issue on that one cell.

## Fix

- Add `HasFourScrewBackfocus => HasFourScrews && HasBackfocusRow` to `TiltAdapterGuidanceVM`.
- Bind the Screw 4 backfocus cell's `Visibility` to it with the standard `BooleanToVisibilityCollapsedConverter`, matching every other cell in the table.

Both conditions remain required: gating on `HasBackfocusRow` alone would leave a stray em dash in the otherwise-hidden Screw 4 column on a 3-screw adapter.

## Tests

- New `HasFourScrewBackfocus_RequiresFourScrewsAndBackfocusRow` covers all four `ScrewCount` × `HasBackfocusRow` combinations (TDD: confirmed RED on the missing property, then GREEN).
- Full suite: **1606 passed, 0 failed**.

## Not covered by automated tests

The actual WPF render (seeing the 4th arrow appear in NINA) requires a live run — the gating logic is unit-tested, but the binding itself is not exercised here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)