### PR TITLE
Improve Aberration Inspector Frame Review hover overlay

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FrameReviewSnapshotBuilderTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FrameReviewSnapshotBuilderTests.cs
@@ -7,6 +7,7 @@ using NINA.Joko.Plugins.HocusFocus.Tests.Synthetic;
 using NINA.Joko.Plugins.HocusFocus.Utility;
 using NSubstitute;
 using NUnit.Framework;
+using OxyPlot.Series;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -224,6 +225,56 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
                 Assert.That(curve.Points.Count, Is.EqualTo(2)); // one per matched star
                 Assert.That(curve.RSquared, Is.EqualTo(fit.RSquared));
                 Assert.That(curve.BestFocus, Is.EqualTo(fit.Minimum.X));
+            });
+        }
+
+        [Test]
+        public void Build_FocusCurve_CarriesRejectedPointsForFittedStar_ProjectedToZeroError() {
+            var star = MakeStar(posX: 30);
+            var frame = MakeFrame(100, new[] { star }, MakeImage());
+            var fitted = MakeFittedRegistered(MakeFit(5000), (star, 0), (star, 1));
+            // The fit rejected one detection (carries a nonzero weight/error from the fit's input).
+            fitted.RejectedPoints = new[] { new ScatterErrorPoint(1.0, 7.5, 0.0, 0.3) };
+            var registered = new[] { fitted };
+
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { frame }, registered, referenceImageIndex: 0, ransacEnabled: true);
+
+            var curve = snapshot.FocusCurvesByRegistrationId[0];
+            Assert.Multiple(() => {
+                Assert.That(curve.RejectedPoints.Count, Is.EqualTo(1));
+                Assert.That(curve.RejectedPoints[0].X, Is.EqualTo(1.0)); // focuser position carried through
+                Assert.That(curve.RejectedPoints[0].Y, Is.EqualTo(7.5)); // HFR carried through
+                Assert.That(curve.RejectedPoints[0].ErrorY, Is.EqualTo(0.0)); // projected to zero error like display points
+            });
+        }
+
+        [Test]
+        public void Build_FocusCurve_NoRejectedPoints_IsEmpty() {
+            var star = MakeStar(posX: 30);
+            var frame = MakeFrame(100, new[] { star }, MakeImage());
+            var registered = new[] { MakeFittedRegistered(MakeFit(5000), (star, 0), (star, 1)) };
+
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { frame }, registered, referenceImageIndex: 0, ransacEnabled: true);
+
+            Assert.That(snapshot.FocusCurvesByRegistrationId[0].RejectedPoints, Is.Empty);
+        }
+
+        [Test]
+        public void Build_FocusCurve_UnfittedStar_HasNoRejectedPoints() {
+            var star = MakeStar(posX: 20);
+            var frame = MakeFrame(100, new[] { star }, MakeImage());
+            // A registered-but-unfitted star: even if rejected points were somehow set, the builder only surfaces them
+            // for fitted stars (a fitless star had no fit to reject from).
+            var noFit = MakeRegistered((star, 0));
+            noFit.RejectedPoints = new[] { new ScatterErrorPoint(0.0, 5.0, 0.0, 0.0) };
+            var registered = new[] { noFit };
+
+            var snapshot = FrameReviewSnapshotBuilder.Build(new[] { frame }, registered, referenceImageIndex: 0, ransacEnabled: true);
+
+            var curve = snapshot.FocusCurvesByRegistrationId[0];
+            Assert.Multiple(() => {
+                Assert.That(curve.Fit, Is.Null);
+                Assert.That(curve.RejectedPoints, Is.Empty);
             });
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/FocusGraphAxisBoundsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/FocusGraphAxisBoundsTests.cs
@@ -1,0 +1,105 @@
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NUnit.Framework;
+using OxyPlot;
+using OxyPlot.Series;
+using System.Collections.Generic;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
+
+    [TestFixture]
+    public class FocusGraphAxisBoundsTests {
+
+        private static List<ScatterErrorPoint> Pts(params (double x, double y)[] xy) {
+            var list = new List<ScatterErrorPoint>();
+            foreach (var (x, y) in xy) {
+                list.Add(new ScatterErrorPoint(x, y, 0.0, 0.0));
+            }
+            return list;
+        }
+
+        [Test]
+        public void Compute_VertexBelowPoints_ExtendsYDownToVertex() {
+            // The bug case: a steep curve whose minimum HFR (2.0) sits below every sampled point (>= 5).
+            var pts = Pts((100, 10), (300, 6), (500, 5), (800, 7), (1000, 9));
+            var bounds = FocusGraphAxisBounds.Compute(pts, new DataPoint(600, 2.0));
+
+            Assert.Multiple(() => {
+                Assert.That(bounds.YMin, Is.LessThanOrEqualTo(2.0)); // vertex now visible at the bottom
+                Assert.That(bounds.YMax, Is.GreaterThanOrEqualTo(10.0)); // tallest point still inside
+            });
+        }
+
+        [Test]
+        public void Compute_VertexXOutsidePointSpan_ExtendsXToVertex() {
+            // All points sampled left of focus; the minimum is to the right of the last sampled point.
+            var pts = Pts((100, 10), (200, 8), (300, 7));
+            var bounds = FocusGraphAxisBounds.Compute(pts, new DataPoint(600, 4.0));
+
+            Assert.Multiple(() => {
+                Assert.That(bounds.XMax, Is.GreaterThanOrEqualTo(600.0)); // vertex X inside the range
+                Assert.That(bounds.XMin, Is.LessThanOrEqualTo(100.0));
+            });
+        }
+
+        [Test]
+        public void Compute_VertexWithinPoints_EqualsPaddedPointExtent() {
+            var pts = Pts((100, 10), (1000, 9));
+            // Vertex inside the point span on both axes -> the points alone determine the (padded) extent.
+            var bounds = FocusGraphAxisBounds.Compute(pts, new DataPoint(550, 9.5), pad: 0.1);
+
+            Assert.Multiple(() => {
+                Assert.That(bounds.XMin, Is.EqualTo(100 - 0.1 * 900).Within(1e-9)); // 10
+                Assert.That(bounds.XMax, Is.EqualTo(1000 + 0.1 * 900).Within(1e-9)); // 1090
+                Assert.That(bounds.YMin, Is.EqualTo(9 - 0.1 * 1).Within(1e-9));      // 8.9
+                Assert.That(bounds.YMax, Is.EqualTo(10 + 0.1 * 1).Within(1e-9));     // 10.1
+            });
+        }
+
+        [Test]
+        public void Compute_NullVertex_UsesPointsOnly() {
+            var pts = Pts((100, 5), (200, 7));
+            var bounds = FocusGraphAxisBounds.Compute(pts, null, pad: 0.1);
+
+            Assert.Multiple(() => {
+                Assert.That(bounds.XMin, Is.EqualTo(100 - 0.1 * 100).Within(1e-9)); // 90
+                Assert.That(bounds.XMax, Is.EqualTo(200 + 0.1 * 100).Within(1e-9)); // 210
+                Assert.That(bounds.YMin, Is.EqualTo(5 - 0.1 * 2).Within(1e-9));      // 4.8
+                Assert.That(bounds.YMax, Is.EqualTo(7 + 0.1 * 2).Within(1e-9));      // 7.2
+            });
+        }
+
+        [Test]
+        public void Compute_NonFiniteVertex_IsIgnored() {
+            var pts = Pts((100, 5), (200, 7));
+            var bounds = FocusGraphAxisBounds.Compute(pts, new DataPoint(double.NaN, double.NaN));
+
+            Assert.Multiple(() => {
+                Assert.That(bounds.XMin, Is.EqualTo(90).Within(1e-9)); // same as points-only
+                Assert.That(bounds.XMax, Is.EqualTo(210).Within(1e-9));
+            });
+        }
+
+        [Test]
+        public void Compute_SinglePointZeroWidth_ExpandsAroundValue() {
+            var pts = Pts((500, 5));
+            var bounds = FocusGraphAxisBounds.Compute(pts, null);
+
+            Assert.Multiple(() => {
+                Assert.That(bounds.XMin, Is.LessThan(500));
+                Assert.That(bounds.XMax, Is.GreaterThan(500));
+                Assert.That(bounds.YMin, Is.LessThan(5));
+                Assert.That(bounds.YMax, Is.GreaterThan(5));
+            });
+        }
+
+        [Test]
+        public void Compute_NoFiniteData_ReturnsBenignNonDegenerateRange() {
+            var bounds = FocusGraphAxisBounds.Compute(new List<ScatterErrorPoint>(), null);
+
+            Assert.Multiple(() => {
+                Assert.That(bounds.XMax, Is.GreaterThan(bounds.XMin));
+                Assert.That(bounds.YMax, Is.GreaterThan(bounds.YMin));
+            });
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
@@ -96,25 +96,29 @@
         <Style x:Key="HF_ReviewToolbarButton" TargetType="Button">
             <Setter Property="Margin" Value="4,0" />
             <Setter Property="Padding" Value="10,4" />
-            <Setter Property="Foreground" Value="#FFE6E9ED" />
+            <Setter Property="Foreground" Value="#FF15181C" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="Button">
-                        <Border x:Name="Bd" Background="#FF3A4453" BorderBrush="#FF6E86A6" BorderThickness="1"
+                        <Border x:Name="Bd" Background="#FFD7DCE3" BorderBrush="#FF9AA5B3" BorderThickness="1"
                                 CornerRadius="3" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="True">
                             <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
                                               TextElement.Foreground="{TemplateBinding Foreground}" />
                         </Border>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsMouseOver" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="#FF49566A" />
+                                <Setter TargetName="Bd" Property="Background" Value="#FFFFFFFF" />
                                 <Setter TargetName="Bd" Property="BorderBrush" Value="#FF5A86C0" />
                             </Trigger>
                             <Trigger Property="IsPressed" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="#FF313A47" />
+                                <Setter TargetName="Bd" Property="Background" Value="#FFB9C1CC" />
                             </Trigger>
+                            <!--  Disabled: a muted medium fill with light text (NOT a faded opacity, which made the text
+                                  unreadable) so a disabled Prev/Next still reads clearly as a greyed-out button.  -->
                             <Trigger Property="IsEnabled" Value="False">
-                                <Setter TargetName="Bd" Property="Opacity" Value="0.45" />
+                                <Setter TargetName="Bd" Property="Background" Value="#FF515A66" />
+                                <Setter TargetName="Bd" Property="BorderBrush" Value="#FF626C7A" />
+                                <Setter Property="Foreground" Value="#FFC9CED6" />
                             </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
@@ -100,18 +100,18 @@
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="Button">
-                        <Border x:Name="Bd" Background="#FF2A2F36" BorderBrush="#FF3E4650" BorderThickness="1"
+                        <Border x:Name="Bd" Background="#FF3A4453" BorderBrush="#FF6E86A6" BorderThickness="1"
                                 CornerRadius="3" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="True">
                             <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
                                               TextElement.Foreground="{TemplateBinding Foreground}" />
                         </Border>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsMouseOver" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="#FF34404C" />
+                                <Setter TargetName="Bd" Property="Background" Value="#FF49566A" />
                                 <Setter TargetName="Bd" Property="BorderBrush" Value="#FF5A86C0" />
                             </Trigger>
                             <Trigger Property="IsPressed" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="#FF2C3742" />
+                                <Setter TargetName="Bd" Property="Background" Value="#FF313A47" />
                             </Trigger>
                             <Trigger Property="IsEnabled" Value="False">
                                 <Setter TargetName="Bd" Property="Opacity" Value="0.45" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/FrameReviewSnapshot.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/FrameReviewSnapshot.cs
@@ -94,6 +94,11 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
         public int RegistrationId { get; init; }
         public AlglibHyperbolicFitting Fit { get; init; }
         public IReadOnlyList<ScatterErrorPoint> Points { get; init; }
+
+        /// <summary>The detections the fit rejected as outliers (subset of <see cref="Points"/> by coordinate), so the
+        /// hover graph can mark them with a red X. Empty when none were rejected.</summary>
+        public IReadOnlyList<ScatterErrorPoint> RejectedPoints { get; init; } = Array.Empty<ScatterErrorPoint>();
+
         public double RSquared { get; init; }
 
         /// <summary>Focuser position at best focus (the fit minimum's X).</summary>
@@ -197,10 +202,16 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                         offset = rs.Fitting.Minimum.X - meanBestFocus.Value;
                         offsetByRegId[i] = offset.Value;
                     }
+                    // Rejected outliers only for fitted stars (a fitless star has no fit to reject from); projected to
+                    // zero-error points like the display Points, since the graph draws plain red-X markers.
+                    var rejected = (rs.Fitting != null ? rs.RejectedPoints : null)?
+                        .Select(p => new ScatterErrorPoint(p.X, p.Y, 0.0, 0.0))
+                        .ToList() ?? (IReadOnlyList<ScatterErrorPoint>)Array.Empty<ScatterErrorPoint>();
                     focusCurves[i] = new FrameReviewFocusCurve {
                         RegistrationId = i,
                         Fit = rs.Fitting,
                         Points = points,
+                        RejectedPoints = rejected,
                         RSquared = rs.Fitting?.RSquared ?? double.NaN,
                         BestFocus = rs.Fitting?.Minimum.X ?? double.NaN,
                         OffsetFromMean = offset,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
@@ -677,6 +677,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                     AlglibHyperbolicFitting fitting;
                     bool solveResult;
                     int rejectedCount;
+                    // The points this star's fit rejected as outliers (same focuser position + HFR as the displayed
+                    // detections, only re-weighted), retained so the Review Frames graph can mark them with a red X.
+                    IReadOnlyList<ScatterErrorPoint> rejectedForStar;
                     if (autoFocusOptions.HyperbolicFitModel == HyperbolicFitModel.Hybrid) {
                         // Pick the best model for THIS star after each candidate rejects its own outliers — outlier-ness
                         // is model-specific, so the winner is judged on the curve it produces once cleaned, exactly like
@@ -690,6 +693,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                             maxDegreeOfParallelism: 1);
                         solveResult = fitting != null;
                         rejectedCount = rejected.Count;
+                        rejectedForStar = rejected;
                     } else {
                         // Fixed model: reject its own outliers via reject-and-refit (unchanged).
                         var modelForStar = autoFocusOptions.HyperbolicFitModel;
@@ -710,6 +714,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                             }
                         } while (continueFitting);
                         rejectedCount = rejectedPoints.Count;
+                        rejectedForStar = rejectedPoints;
                     }
 
                     if (!solveResult || fitting == null) {
@@ -728,6 +733,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                     // star's focus curve / R² / best focus. Each Parallel.For iteration writes a distinct registeredStar,
                     // and this array is the one returned to (and surfaced by) SensorModelResult.RegisteredStars.
                     registeredStar.Fitting = fitting;
+                    registeredStar.RejectedPoints = rejectedForStar ?? Array.Empty<ScatterErrorPoint>();
 
                     rejectedCounts[registeredStarIndex] = rejectedCount;
                     var dataPointX = (registeredStar.RegistrationX - (imageSize.Width / 2.0)) * pixelSize;
@@ -1326,6 +1332,10 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             // Carries the curve function, minimum (best focus), and R² for the Review Frames focus-graph overlay; its
             // Fitting closure captures only a double[] so it is safe to retain after the run's heavy data is freed.
             public AlglibHyperbolicFitting Fitting { get; set; }
+
+            // The per-frame detections this star's fit rejected as outliers (focuser position + HFR), set by FitImages
+            // alongside Fitting so the Review Frames focus graph can mark them with a red X. Empty when none rejected.
+            public IReadOnlyList<ScatterErrorPoint> RejectedPoints { get; set; } = Array.Empty<ScatterErrorPoint>();
             public List<MatchedStar> MatchedStars { get; private set; } = new List<MatchedStar>();
 
             public override string ToString() {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -40,14 +40,15 @@
             PlotAreaBorderColor="{Binding Path=Color, Source={StaticResource BorderBrush}}"
             TextColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}">
             <oxy:Plot.Axes>
+                <!--  Explicit bounds (incl. the best-focus minimum, padded) so a steep curve's optimum is never clipped.  -->
                 <oxy:LinearAxis
                     AxislineColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
                     IsPanEnabled="False"
                     IsZoomEnabled="False"
                     MajorGridlineColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}, Converter={StaticResource SetAlphaToColorConverter}, ConverterParameter=60}"
                     MajorGridlineStyle="LongDash"
-                    MaximumPadding="0.1"
-                    MinimumPadding="0.1"
+                    Maximum="{Binding Bounds.YMax}"
+                    Minimum="{Binding Bounds.YMin}"
                     Position="Left"
                     TextColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
                     TicklineColor="{Binding Path=Color, Source={StaticResource SecondaryBrush}}"
@@ -58,8 +59,8 @@
                     IsZoomEnabled="False"
                     MajorGridlineColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}, Converter={StaticResource SetAlphaToColorConverter}, ConverterParameter=60}"
                     MajorGridlineStyle="LongDash"
-                    MaximumPadding="0.1"
-                    MinimumPadding="0.1"
+                    Maximum="{Binding Bounds.XMax}"
+                    Minimum="{Binding Bounds.XMin}"
                     Position="Bottom"
                     TextColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
                     TicklineColor="{Binding Path=Color, Source={StaticResource SecondaryBrush}}"
@@ -99,14 +100,15 @@
             PlotAreaBorderColor="{Binding Path=Color, Source={StaticResource BorderBrush}}"
             TextColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}">
             <oxy:Plot.Axes>
+                <!--  Explicit bounds (incl. the best-focus minimum, padded) so a steep curve's optimum is never clipped.  -->
                 <oxy:LinearAxis
                     AxislineColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
                     IsPanEnabled="False"
                     IsZoomEnabled="False"
                     MajorGridlineColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}, Converter={StaticResource SetAlphaToColorConverter}, ConverterParameter=60}"
                     MajorGridlineStyle="LongDash"
-                    MaximumPadding="0.1"
-                    MinimumPadding="0.1"
+                    Maximum="{Binding Bounds.YMax}"
+                    Minimum="{Binding Bounds.YMin}"
                     Position="Left"
                     TextColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
                     TicklineColor="{Binding Path=Color, Source={StaticResource SecondaryBrush}}"
@@ -117,8 +119,8 @@
                     IsZoomEnabled="False"
                     MajorGridlineColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}, Converter={StaticResource SetAlphaToColorConverter}, ConverterParameter=60}"
                     MajorGridlineStyle="LongDash"
-                    MaximumPadding="0.1"
-                    MinimumPadding="0.1"
+                    Maximum="{Binding Bounds.XMax}"
+                    Minimum="{Binding Bounds.XMin}"
                     Position="Bottom"
                     TextColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
                     TicklineColor="{Binding Path=Color, Source={StaticResource SecondaryBrush}}"
@@ -130,6 +132,14 @@
                     MarkerFill="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
                     MarkerType="Circle"
                     TrackerFormatString="Focuser: {2:0}, HFR: {4:0.000}" />
+                <!--  Outlier-rejected detections: a red X drawn over the rejected point's dot (mirrors the AutoFocus graph).  -->
+                <oxy:ScatterSeries
+                    ItemsSource="{Binding RejectedPoints}"
+                    MarkerSize="6"
+                    MarkerStroke="Red"
+                    MarkerStrokeThickness="2"
+                    MarkerType="Cross"
+                    TrackerFormatString="Rejected — Focuser: {2:0}, HFR: {4:0.000}" />
             </oxy:Plot.Series>
             <oxy:Plot.Annotations>
                 <oxy:FunctionAnnotation

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/FocusGraphAxisBounds.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/FocusGraphAxisBounds.cs
@@ -1,0 +1,99 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using OxyPlot;
+using OxyPlot.Series;
+using System;
+using System.Collections.Generic;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
+
+    /// <summary>
+    /// Explicit axis bounds for a focus-graph chart (HFR vs. focuser position) that include the fitted curve's
+    /// best-focus minimum, not just the scatter points.
+    ///
+    /// <para>OxyPlot auto-ranges an axis to its <c>Series</c> only; a <c>FunctionAnnotation</c> (the fitted curve)
+    /// and a <c>PointAnnotation</c> (the best-focus diamond) do NOT participate. So a steep curve whose minimum
+    /// sits outside the sampled point span — e.g. below the lowest sampled HFR — gets clipped off the plot. This
+    /// unions the scatter extent with the (real) fit minimum and pads each axis by <paramref name="pad"/> of its
+    /// range, reproducing the templates' former <c>MinimumPadding</c>/<c>MaximumPadding</c> = 0.1 while keeping the
+    /// optimum visible. Pure and side-effect free so it is unit-tested directly.</para>
+    /// </summary>
+    public readonly struct FocusGraphAxisBounds {
+        public double XMin { get; }
+        public double XMax { get; }
+        public double YMin { get; }
+        public double YMax { get; }
+
+        public FocusGraphAxisBounds(double xMin, double xMax, double yMin, double yMax) {
+            XMin = xMin;
+            XMax = xMax;
+            YMin = yMin;
+            YMax = yMax;
+        }
+
+        /// <summary>
+        /// Compute padded axis bounds over the scatter <paramref name="points"/> unioned with the fit
+        /// <paramref name="minimum"/> (pass <c>null</c> when there is no fit, so the phantom <c>default(DataPoint)</c>
+        /// at (0,0) is not folded in). Guards: non-finite point/vertex coordinates are skipped; a zero-width range is
+        /// expanded around the value; with nothing finite to show, a benign unit range is returned so the axis still
+        /// renders.
+        /// </summary>
+        public static FocusGraphAxisBounds Compute(IReadOnlyList<ScatterErrorPoint> points, DataPoint? minimum, double pad = 0.1) {
+            double xMin = double.PositiveInfinity, xMax = double.NegativeInfinity;
+            double yMin = double.PositiveInfinity, yMax = double.NegativeInfinity;
+            bool any = false;
+
+            if (points != null) {
+                foreach (var p in points) {
+                    if (!IsFinite(p.X) || !IsFinite(p.Y)) {
+                        continue;
+                    }
+                    xMin = Math.Min(xMin, p.X);
+                    xMax = Math.Max(xMax, p.X);
+                    yMin = Math.Min(yMin, p.Y);
+                    yMax = Math.Max(yMax, p.Y);
+                    any = true;
+                }
+            }
+
+            if (minimum.HasValue && IsFinite(minimum.Value.X) && IsFinite(minimum.Value.Y)) {
+                xMin = Math.Min(xMin, minimum.Value.X);
+                xMax = Math.Max(xMax, minimum.Value.X);
+                yMin = Math.Min(yMin, minimum.Value.Y);
+                yMax = Math.Max(yMax, minimum.Value.Y);
+                any = true;
+            }
+
+            if (!any) {
+                return new FocusGraphAxisBounds(0.0, 1.0, 0.0, 1.0);
+            }
+
+            var (px0, px1) = Pad(xMin, xMax, pad);
+            var (py0, py1) = Pad(yMin, yMax, pad);
+            return new FocusGraphAxisBounds(px0, px1, py0, py1);
+        }
+
+        private static (double min, double max) Pad(double min, double max, double pad) {
+            double range = max - min;
+            if (!(range > 0.0)) {
+                // Zero-width (single distinct value): expand around it so the axis is not a degenerate line.
+                double half = Math.Max(1.0, Math.Abs(max) * pad);
+                return (min - half, max + half);
+            }
+            double delta = range * pad;
+            return (min - delta, max + delta);
+        }
+
+        private static bool IsFinite(double v) => !double.IsNaN(v) && !double.IsInfinity(v);
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationCurve.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationCurve.cs
@@ -57,6 +57,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// <summary>The fitted curve minimum (best-focus position + HFR) for the chart's optimum marker.</summary>
         public DataPoint Minimum => Fit?.Minimum ?? default;
 
+        /// <summary>Explicit chart axis bounds that include the best-focus minimum (not just the scatter points), so a
+        /// steep curve's optimum is never clipped off the plot. Null vertex when there is no fit, so points-only.</summary>
+        public FocusGraphAxisBounds Bounds => FocusGraphAxisBounds.Compute(Points, Fit != null ? Fit.Minimum : (DataPoint?)null);
+
         public double MinimumStdError => Fit?.MinimumStdError ?? double.NaN;
         public double RSquared => Fit?.RSquared ?? double.NaN;
         public double ReducedChiSquared => Fit?.ReducedChiSquared ?? double.NaN;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
@@ -176,18 +176,18 @@
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="Button">
-                        <Border x:Name="Bd" Background="#FF2A2F36" BorderBrush="#FF3E4650" BorderThickness="1"
+                        <Border x:Name="Bd" Background="#FF3A4453" BorderBrush="#FF6E86A6" BorderThickness="1"
                                 CornerRadius="3" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="True">
                             <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
                                               TextElement.Foreground="{TemplateBinding Foreground}" />
                         </Border>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsMouseOver" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="#FF34404C" />
+                                <Setter TargetName="Bd" Property="Background" Value="#FF49566A" />
                                 <Setter TargetName="Bd" Property="BorderBrush" Value="#FF5A86C0" />
                             </Trigger>
                             <Trigger Property="IsPressed" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="#FF2C3742" />
+                                <Setter TargetName="Bd" Property="Background" Value="#FF313A47" />
                             </Trigger>
                             <Trigger Property="IsEnabled" Value="False">
                                 <Setter TargetName="Bd" Property="Opacity" Value="0.45" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
@@ -172,25 +172,29 @@
         <Style x:Key="HF_ReviewToolbarButton" TargetType="Button">
             <Setter Property="Margin" Value="4,0" />
             <Setter Property="Padding" Value="10,4" />
-            <Setter Property="Foreground" Value="#FFE6E9ED" />
+            <Setter Property="Foreground" Value="#FF15181C" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="Button">
-                        <Border x:Name="Bd" Background="#FF3A4453" BorderBrush="#FF6E86A6" BorderThickness="1"
+                        <Border x:Name="Bd" Background="#FFD7DCE3" BorderBrush="#FF9AA5B3" BorderThickness="1"
                                 CornerRadius="3" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="True">
                             <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
                                               TextElement.Foreground="{TemplateBinding Foreground}" />
                         </Border>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsMouseOver" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="#FF49566A" />
+                                <Setter TargetName="Bd" Property="Background" Value="#FFFFFFFF" />
                                 <Setter TargetName="Bd" Property="BorderBrush" Value="#FF5A86C0" />
                             </Trigger>
                             <Trigger Property="IsPressed" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="#FF313A47" />
+                                <Setter TargetName="Bd" Property="Background" Value="#FFB9C1CC" />
                             </Trigger>
+                            <!--  Disabled: a muted medium fill with light text (NOT a faded opacity, which made the text
+                                  unreadable) so a disabled Prev/Next still reads clearly as a greyed-out button.  -->
                             <Trigger Property="IsEnabled" Value="False">
-                                <Setter TargetName="Bd" Property="Opacity" Value="0.45" />
+                                <Setter TargetName="Bd" Property="Background" Value="#FF515A66" />
+                                <Setter TargetName="Bd" Property="BorderBrush" Value="#FF626C7A" />
+                                <Setter Property="Foreground" Value="#FFC9CED6" />
                             </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewVM.cs
@@ -63,9 +63,20 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
     public sealed class FrameReviewFocusGraph {
         public string Label { get; init; }
         public IReadOnlyList<ScatterErrorPoint> Points { get; init; }
+
+        /// <summary>The detections this star's fit rejected as outliers, drawn as a red X over their dots. Empty when
+        /// none were rejected.</summary>
+        public IReadOnlyList<ScatterErrorPoint> RejectedPoints { get; init; }
+
         public AlglibHyperbolicFitting Fit { get; init; }
         public Func<double, double> Fitting => Fit?.Fitting;
         public DataPoint Minimum => Fit?.Minimum ?? default;
+
+        private FocusGraphAxisBounds? bounds;
+
+        /// <summary>Explicit chart axis bounds that include the best-focus minimum (not just the scatter points), so a
+        /// steep curve's optimum diamond is never clipped off the plot. Computed once on first access.</summary>
+        public FocusGraphAxisBounds Bounds => bounds ??= FocusGraphAxisBounds.Compute(Points, Fit != null ? Fit.Minimum : (DataPoint?)null);
     }
 
     /// <summary>A points-only focus graph for a registered star that has NO accepted hyperbolic fit: just the
@@ -252,6 +263,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review {
                 HoverContent = new FrameReviewFocusGraph {
                     Label = $"Star {registrationId}",
                     Points = curve.Points,
+                    RejectedPoints = curve.RejectedPoints,
                     Fit = curve.Fit,
                 };
                 HoverRSquaredText = $"R²: {curve.RSquared:0.###}";

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -175,18 +175,18 @@
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="Button">
-                        <Border x:Name="Bd" Background="#FF2A2F36" BorderBrush="#FF3E4650" BorderThickness="1"
+                        <Border x:Name="Bd" Background="#FF3A4453" BorderBrush="#FF6E86A6" BorderThickness="1"
                                 CornerRadius="3" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="True">
                             <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
                                               TextElement.Foreground="{TemplateBinding Foreground}" />
                         </Border>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsMouseOver" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="#FF34404C" />
+                                <Setter TargetName="Bd" Property="Background" Value="#FF49566A" />
                                 <Setter TargetName="Bd" Property="BorderBrush" Value="#FF5A86C0" />
                             </Trigger>
                             <Trigger Property="IsPressed" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="#FF2C3742" />
+                                <Setter TargetName="Bd" Property="Background" Value="#FF313A47" />
                             </Trigger>
                             <Trigger Property="IsEnabled" Value="False">
                                 <Setter TargetName="Bd" Property="Opacity" Value="0.45" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -171,25 +171,29 @@
         <Style x:Key="HF_ReviewToolbarButton" TargetType="Button">
             <Setter Property="Margin" Value="4,0" />
             <Setter Property="Padding" Value="10,4" />
-            <Setter Property="Foreground" Value="#FFE6E9ED" />
+            <Setter Property="Foreground" Value="#FF15181C" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="Button">
-                        <Border x:Name="Bd" Background="#FF3A4453" BorderBrush="#FF6E86A6" BorderThickness="1"
+                        <Border x:Name="Bd" Background="#FFD7DCE3" BorderBrush="#FF9AA5B3" BorderThickness="1"
                                 CornerRadius="3" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="True">
                             <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
                                               TextElement.Foreground="{TemplateBinding Foreground}" />
                         </Border>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsMouseOver" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="#FF49566A" />
+                                <Setter TargetName="Bd" Property="Background" Value="#FFFFFFFF" />
                                 <Setter TargetName="Bd" Property="BorderBrush" Value="#FF5A86C0" />
                             </Trigger>
                             <Trigger Property="IsPressed" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="#FF313A47" />
+                                <Setter TargetName="Bd" Property="Background" Value="#FFB9C1CC" />
                             </Trigger>
+                            <!--  Disabled: a muted medium fill with light text (NOT a faded opacity, which made the text
+                                  unreadable) so a disabled Prev/Next still reads clearly as a greyed-out button.  -->
                             <Trigger Property="IsEnabled" Value="False">
-                                <Setter TargetName="Bd" Property="Opacity" Value="0.45" />
+                                <Setter TargetName="Bd" Property="Background" Value="#FF515A66" />
+                                <Setter TargetName="Bd" Property="BorderBrush" Value="#FF626C7A" />
+                                <Setter Property="Foreground" Value="#FFC9CED6" />
                             </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>


### PR DESCRIPTION
Three improvements to the per-star "Star N" focus-graph overlay shown on hover in the Aberration Inspector **Review Frames** dialog.

## 1. Best-focus vertex no longer clipped off the chart
OxyPlot auto-ranges axes to the scatter `Series` only — the fitted-curve `FunctionAnnotation` and the best-focus `PointAnnotation` are *annotations*, which it excludes from auto-range. So a steep curve whose minimum sits below the lowest sampled HFR was drawn below the visible plot area (the optimum was invisible).

New pure, unit-tested helper `FocusGraphAxisBounds.Compute(points, DataPoint? minimum, pad)` unions the scatter extent with the (finite) fit vertex and bakes in the former 10% padding. Exposed as a `Bounds` property on `FrameReviewFocusGraph` (cached) and `OptimizationCurve`, and bound to the `oxy:LinearAxis` `Minimum`/`Maximum` in both templates. Applied to the optimizer-wizard AF curve too, which shared the identical latent bug. The points-only `FrameReviewScatterGraph` (no fit/vertex) is left unchanged.

## 2. Red X over outlier-rejected points
The per-star hyperbola fit already rejects outliers, but reduced them to a count and discarded the identities. Threaded the rejected `ScatterErrorPoint`s end-to-end: `SensorModel.FitImages` (both Hybrid `SelectBestModel` and Fixed reject-loop paths) → new `RegisteredStar.RejectedPoints` → `FrameReviewFocusCurve.RejectedPoints` (builder projects to zero-error) → `FrameReviewFocusGraph.RejectedPoints` → a red `MarkerType="Cross"` `ScatterSeries` overlaid on the dots, mirroring `AutoFocus/DataTemplates.xaml`. Coordinates already match the displayed dots, so the X lands exactly on them. Scoped to the Inspector overlay.

## 3. Toolbar buttons legible against the dark panel
The hardcoded `HF_ReviewToolbarButton` fill (`#FF2A2F36`) was too close to the `#FF1E2125` review panel. Raised the resting/hover/pressed fill and border contrast identically across the three review controls (FrameReview, AutoFocusFrameReview, StarReview). Final hex values are tunable and worth a quick visual confirm in NINA.

## Tests
New `FocusGraphAxisBoundsTests` (7 cases: vertex-below-points, vertex-X-outside-span, vertex-within-points, null/non-finite vertex, zero-width, empty) + 3 rejected-point cases added to `FrameReviewSnapshotBuilderTests`. **1617 tests pass**, clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)