### PR TITLE
Tilt calibration noise: SNR confidence gate, headless deadlock fix, donut-aware weighting

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
@@ -277,4 +277,94 @@ public class TiltCalibrationCalculatorTests {
             Assert.That(r.Screw2DirectionDegrees, Is.EqualTo(120).Within(1e-4));
         });
     }
+
+    // --- Calibration confidence (signal-to-noise) ---
+
+    [Test]
+    public void ComputeConfidence_CleanMeasurement_HighSnrAndReliable() {
+        // Baselines all identical (zero noise probes) and two clean equal screw moves -> infinite SNR, reliable.
+        var inputs = new TiltCalibrationInputs {
+            ScrewCount = 3,
+            Baseline = new TiltGradient(0, 0, 1000),
+            AllInward = new TiltGradient(0, 0, 1075),   // piston only: no tilt change vs baseline
+            ReBaseline1 = new TiltGradient(0, 0, 1000),
+            Screw1 = new TiltGradient(10, 0, 1000),
+            ReBaseline2 = new TiltGradient(0, 0, 1000),
+            Screw2 = new TiltGradient(0, 10, 1000),
+        };
+        var c = TiltCalibrationCalculator.ComputeConfidence(inputs);
+        Assert.Multiple(() => {
+            Assert.That(c.ScrewMoveSignal, Is.EqualTo(10).Within(1e-9));
+            Assert.That(c.NoiseEstimate, Is.EqualTo(0).Within(1e-9));
+            Assert.That(double.IsPositiveInfinity(c.SignalToNoise), Is.True);
+            Assert.That(c.PredictedAngleUncertaintyDeg, Is.EqualTo(0).Within(1e-9));
+            Assert.That(c.IsReliable, Is.True);
+        });
+    }
+
+    [Test]
+    public void ComputeConfidence_NoiseRivalsSignal_FlaggedUnreliable() {
+        // A large all-inward tilt residual (a pure piston should give ~0) drives the noise floor near the signal.
+        var inputs = new TiltCalibrationInputs {
+            ScrewCount = 3,
+            Baseline = new TiltGradient(0, 0, 1000),
+            AllInward = new TiltGradient(20, 0, 1075),  // 20-unit spurious tilt change on a piston move
+            ReBaseline1 = new TiltGradient(0, 0, 1000),
+            Screw1 = new TiltGradient(10, 0, 1000),
+            ReBaseline2 = new TiltGradient(0, 0, 1000),
+            Screw2 = new TiltGradient(0, 10, 1000),
+        };
+        var c = TiltCalibrationCalculator.ComputeConfidence(inputs);
+        Assert.Multiple(() => {
+            Assert.That(c.AllInwardTiltResidual, Is.EqualTo(20).Within(1e-9));
+            Assert.That(c.NoiseEstimate, Is.EqualTo(Math.Sqrt(400.0 / 3.0)).Within(1e-9));
+            Assert.That(c.SignalToNoise, Is.LessThan(TiltCalibrationCalculator.MinReliableSignalToNoise));
+            Assert.That(c.IsReliable, Is.False);
+        });
+    }
+
+    [Test]
+    public void ComputeConfidence_RealAstrodet6Run_IsNoiseDominated() {
+        // Regression lock on the real astrodet_6 calibration (D:\Tilt Calibration Bank\astrodet_6\...115023):
+        // the per-step tilt vectors give SNR ~0.81 and ~51° predicted screw-direction error -> not reliable.
+        var inputs = new TiltCalibrationInputs {
+            ScrewCount = 3,
+            Baseline = new TiltGradient(-2.1105835080420547, 24.121199286798387, 591.0128980765176),
+            AllInward = new TiltGradient(8.482652443992663, 6.478563541214388, 498.59261745105937),
+            ReBaseline1 = new TiltGradient(3.575182052031437, 6.397250940705116, 599.5753346049264),
+            Screw1 = new TiltGradient(7.026796200619742, -7.090700037203773, 566.0698145625257),
+            ReBaseline2 = new TiltGradient(6.01584663828578, 16.457907779687257, 609.7793117669113),
+            Screw2 = new TiltGradient(19.615438422209536, 13.583617294890002, 591.3416298243283),
+        };
+        var c = TiltCalibrationCalculator.ComputeConfidence(inputs);
+        Assert.Multiple(() => {
+            Assert.That(c.ScrewMoveSignal, Is.EqualTo(13.91).Within(0.05));
+            Assert.That(c.NoiseEstimate, Is.EqualTo(17.10).Within(0.05));
+            Assert.That(c.SignalToNoise, Is.EqualTo(0.81).Within(0.02));
+            Assert.That(c.PredictedAngleUncertaintyDeg, Is.EqualTo(50.9).Within(0.5));
+            Assert.That(c.IsReliable, Is.False);
+        });
+    }
+
+    [Test]
+    public void Calibrate_PopulatesConfidence() {
+        var inputs = new TiltCalibrationInputs {
+            ScrewCount = 3,
+            Baseline = new TiltGradient(0, 0, 1000),
+            AllInward = new TiltGradient(0, 0, 1075),
+            ReBaseline1 = new TiltGradient(0, 0, 1000),
+            Screw1 = SingleScrewReading(0, 400, 3, 1000),
+            ReBaseline2 = new TiltGradient(0, 0, 1000),
+            Screw2 = SingleScrewReading(120, 400, 3, 1000),
+            ImageWidthPixels = ImgW,
+            ImageHeightPixels = ImgH,
+            PixelSizeMicrons = PixelSize,
+            FocuserStepMicrons = FStep,
+            ScrewRadiusMillimeters = RadiusMm,
+            CalibrationAppliedAmount = 1.0,
+        };
+        var r = TiltCalibrationCalculator.Calibrate(inputs);
+        Assert.That(r.Confidence, Is.Not.Null);
+        Assert.That(r.Confidence.IsReliable, Is.True); // clean synthetic moves, zero drift
+    }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltScrewGeometryTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltScrewGeometryTests.cs
@@ -178,4 +178,25 @@ public class TiltScrewGeometryTests {
             Assert.That(gy, Is.EqualTo(-2.0 * 5.0 / 8000.0).Within(1e-12));
         });
     }
+
+    [Test]
+    public void PhysicalGradientToPlane_IsExactInverseOfPlaneGradientToPhysical() {
+        const double stepMicrons = 3.58, sensorW = 6000 * 3.76, sensorH = 4000 * 3.76;
+        // Round-trip a plane (A,B) -> physical gradient -> back, and the reverse from a physical gradient.
+        var (gx, gy) = TiltScrewGeometry.PlaneGradientToPhysical(7.0, -3.5, stepMicrons, sensorW, sensorH);
+        var (a, b) = TiltScrewGeometry.PhysicalGradientToPlane(gx, gy, stepMicrons, sensorW, sensorH);
+        Assert.Multiple(() => {
+            Assert.That(a, Is.EqualTo(7.0).Within(1e-9));
+            Assert.That(b, Is.EqualTo(-3.5).Within(1e-9));
+            // Direct formula: A = gx·sensorW/step.
+            Assert.That(TiltScrewGeometry.PhysicalGradientToPlane(0.01, 0.0, stepMicrons, sensorW, sensorH).a,
+                Is.EqualTo(0.01 * sensorW / stepMicrons).Within(1e-9));
+        });
+    }
+
+    [Test]
+    public void PhysicalGradientToPlane_ReturnsNaN_OnNonPositiveStep() {
+        var (a, b) = TiltScrewGeometry.PhysicalGradientToPlane(0.01, 0.02, 0.0, 1000, 1000);
+        Assert.That(double.IsNaN(a) && double.IsNaN(b), Is.True);
+    }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -284,7 +284,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 // keep the engine save OFF so it neither writes auxiliary artifacts nor a replay metadata.json into the
                 // global save path during tilt calibration replay.
                 options.Save = false;
-                var sensorCurveModelEnabled = inspectorOptions.SensorCurveModelEnabled;
+                var sensorCurveModelEnabled = ResolveSensorCurveModelEnabled();
                 var regions = GetStarDetectionRegions(options, sensorCurveModelEnabled: sensorCurveModelEnabled);
 
                 autoFocusEngine.Started += AutoFocusEngine_Started;
@@ -401,7 +401,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                             options.SaveExposuresOnly = suppressAuxiliaryFiles;
                         }
                     }
-                    var sensorCurveModelEnabled = inspectorOptions.SensorCurveModelEnabled;
+                    var sensorCurveModelEnabled = ResolveSensorCurveModelEnabled();
                     var regions = GetStarDetectionRegions(options, sensorCurveModelEnabled: sensorCurveModelEnabled);
                     var imagingFilter = GetImagingFilter();
 
@@ -479,6 +479,14 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         }
 
         private bool focuserStepSizeWarningShowed = false;
+
+        // When set (by the Tilt Adapter Wizard around its own calibration analyses), the per-star sensor-curve model
+        // (paraboloid) is generated even if the SensorCurveModelEnabled display option is off, so calibration can read
+        // its robust tilt. Transient and not persisted; the wizard sets it only for the duration of each analysis call.
+        public bool ForceSensorCurveModelGeneration { get; set; }
+
+        private bool ResolveSensorCurveModelEnabled() =>
+            inspectorOptions.SensorCurveModelEnabled || ForceSensorCurveModelGeneration;
 
         private async Task<bool> AnalyzeAutoFocusResult(
             AutoFocusEngineOptions options,
@@ -1140,7 +1148,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 // options.StarDetectionOptionsOverride, which the explicit-region detection path applies regardless of
                 // which regions are used. ROI follows the regions: the Inspector grid uses the app's SensorROI/CornersROI
                 // and the AF region uses the app's crop (see GetAutoFocusRegion).
-                var sensorCurveModelEnabled = inspectorOptions.SensorCurveModelEnabled;
+                var sensorCurveModelEnabled = ResolveSensorCurveModelEnabled();
                 var regions = GetStarDetectionRegions(options, sensorCurveModelEnabled: sensorCurveModelEnabled);
 
                 autoFocusEngine.Started += AutoFocusEngine_Started;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
@@ -587,11 +587,29 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
         // on a detected star (mean brightness above background, with a shot-noise-like denominator). This
         // makes the previously no-op WeightedHyperbolicFitEnabled meaningful. It does not affect the
         // best-focus standard error, which is self-calibrated from the fit residuals.
+        // Per-point HFR uncertainty (used as 1/σ² weights in the per-star sweep fit). Base term is the shot-noise
+        // estimate σ ≈ HFR / SNR, with two donut-aware adjustments that down-weight heavily-defocused points whose
+        // HFR is unreliable beyond shot noise (the dominant scatter in the per-star curves on reflector/defocus runs):
+        //   • A low SNR floor: the previous 1.0 floor pinned σ at HFR for EVERY sub-unity-SNR detection, understating
+        //     the noise of faint, spread-out donuts; letting σ = HFR/SNR grow for them reflects their true
+        //     uncertainty. (PSF quality is deliberately not used — a PSF fit is only meaningful for an in-focus star,
+        //     never a donut.)
+        //   • A contamination multiplier: the detector flags blended/overlapping detections (common among
+        //     extreme-defocus donuts), whose HFR is corrupted by a neighbour's flux.
+        // Regularize() only floors σ (caps the max weight), so these inflations pass through and reduce weight as
+        // intended. EstimateHfrStdDev is private to the sensor model, so this affects only the aberration/tilt fit,
+        // not the autofocus curve fit.
+        private const double HfrSigmaSnrFloor = 0.2;
+        private const double HfrSigmaContaminationFactor = 3.0;
+
         private static double EstimateHfrStdDev(HocusFocusDetectedStar star) {
             var signal = star.AverageBrightness - star.Background;
             var noise = Math.Sqrt(Math.Max(star.AverageBrightness, 1.0));
             var snr = signal > 0 ? signal / noise : 0.0;
-            var sigma = star.HFR / Math.Max(snr, 1.0);
+            var sigma = star.HFR / Math.Max(snr, HfrSigmaSnrFloor);
+            if (star.StarContaminationSuspected) {
+                sigma *= HfrSigmaContaminationFactor;
+            }
             return Math.Max(sigma, 1e-3);
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -771,6 +771,28 @@
                             TextWrapping="Wrap" />
                     </Border>
 
+                    <!--  Low calibration confidence: measurement noise rivals the screw-move signal (do not apply)  -->
+                    <Border
+                        Margin="0,5"
+                        Padding="5"
+                        BorderBrush="{StaticResource NotificationErrorBrush}"
+                        BorderThickness="1">
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasConfidenceWarning}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <TextBlock
+                            Foreground="{StaticResource NotificationErrorBrush}"
+                            Text="{Binding ConfidenceWarningText}"
+                            TextWrapping="Wrap" />
+                    </Border>
+
                     <Grid Margin="0,5,0,5" HorizontalAlignment="Stretch">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -87,6 +87,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         private string measurementConsistencyWarningText = string.Empty;
         private bool hasRebaselineDriftWarning = false;
         private string rebaselineDriftWarningText = string.Empty;
+        private bool hasConfidenceWarning = false;
+        private string confidenceWarningText = string.Empty;
         private bool hasMeasurementFailureChoice = false;
         private string measurementFailureText = string.Empty;
 
@@ -446,6 +448,24 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
         }
 
+        // Overall signal-to-noise of the calibration (screw-move signal vs the all-inward/re-baseline noise probes).
+        // When low, the recovered screw geometry is dominated by measurement noise / drift and should not be applied.
+        public bool HasConfidenceWarning {
+            get => hasConfidenceWarning;
+            private set {
+                hasConfidenceWarning = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public string ConfidenceWarningText {
+            get => confidenceWarningText;
+            private set {
+                confidenceWarningText = value;
+                RaisePropertyChanged();
+            }
+        }
+
         // Transient per-run toggle: save each calibration step's AutoFocus sweep so the run can be replayed.
         // Always starts OFF and must be explicitly enabled before each run (not persisted). The folder is
         // persisted (SaveAFRunsPath) so the location is reused.
@@ -674,6 +694,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             stepReadings.Clear();
             HasRebaselineDriftWarning = false;
             RebaselineDriftWarningText = string.Empty;
+            HasConfidenceWarning = false;
+            ConfidenceWarningText = string.Empty;
             HasWarning = false;
             WarningText = string.Empty;
             ClearSummaryRows();
@@ -1138,6 +1160,15 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
 
             EvaluateRebaselineDrift();
+            EvaluateCalibrationConfidence(TiltCalibrationCalculator.ComputeConfidence(new TiltCalibrationInputs {
+                ScrewCount = screwCount,
+                Baseline = new TiltGradient(a.A, a.B, a.Mean),
+                AllInward = new TiltGradient(b.A, b.B, b.Mean),
+                ReBaseline1 = new TiltGradient(c.A, c.B, c.Mean),
+                Screw1 = new TiltGradient(d.A, d.B, d.Mean),
+                ReBaseline2 = new TiltGradient(e.A, e.B, e.Mean),
+                Screw2 = new TiltGradient(f.A, f.B, f.Mean)
+            }));
             RaiseHardwareSummaryChanged();
         }
 
@@ -1205,6 +1236,23 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 ? string.Empty
                 : "Re-baseline drift detected: " + string.Join("; ", parts) +
                     ". The undo between moves left residual tilt (backlash or an uneven turn); consider recalibrating.";
+        }
+
+        // Overall calibration signal-to-noise from the six per-step tilt vectors. A low SNR means the recovered
+        // screw geometry is dominated by measurement noise / between-step drift (typically too few stars or a
+        // too-coarse focus step), regardless of how cleanly the screws were turned — warn the user not to apply it.
+        private void EvaluateCalibrationConfidence(TiltCalibrationConfidence confidence) {
+            if (confidence == null || confidence.IsReliable) {
+                HasConfidenceWarning = false;
+                ConfidenceWarningText = string.Empty;
+                return;
+            }
+            HasConfidenceWarning = true;
+            ConfidenceWarningText =
+                $"Low calibration confidence: signal-to-noise {confidence.SignalToNoise:F1} (need ≥ {TiltCalibrationCalculator.MinReliableSignalToNoise:F0}), " +
+                $"predicted screw-direction error ±{confidence.PredictedAngleUncertaintyDeg:F0}°. The tilt-measurement noise rivals the " +
+                "screw-move signal — usually too few stars or a too-coarse focus step (calibrate on a star-rich field with a finer step), " +
+                "or drift between steps. Re-capture before applying these screw angles.";
         }
 
         private StepReading Reading(WizardStep step) =>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -841,6 +841,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         private static string StepFolderName(WizardStep step) => $"{(int)step + 1:00}_{step}";
 
+        // The wizard calibrates from the per-star sensor-curve model's tilt (the paraboloid Gx/Gy, expressed as a
+        // TiltPlaneModel by SensorModelAberrationResult.CreateTiltPlaneModel) — NEVER the 4-corner region plane. The
+        // sensor model is force-generated around each measurement (inspector.ForceSensorCurveModelGeneration); this is
+        // null when the paraboloid could not be fit (too few stars), in which case the measurement fails.
+        private TiltPlaneModel CalibrationTiltPlane => inspector.SensorModel?.SensorModelResult?.TiltPlaneModel;
+
         // Runs the aberration inspector MeasurementAverageCount times, averages the tilt plane, appends summary
         // rows + the consistency warning, and captures the per-step field-curvature characterization. When saving
         // (live only), each step's run is redirected into its own folder and the saved location is recorded.
@@ -871,16 +877,27 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 token.ThrowIfCancellationRequested();
                 StatusText = $"Run {i + 1}/{count}...";
                 bool ok;
-                if (fromSaved) {
-                    // IsMeasuring is set via callback after the folder dialog closes so the chart doesn't appear
-                    // until the user has confirmed a selection.
-                    ok = await inspector.AnalyzeAutoFocusFromSaved(token, onFolderSelected: () => IsMeasuring = true, saveOverride: saveOverride);
-                } else {
-                    ok = await inspector.AnalyzeAutoFocus(token, captureCameraBlock: true, saveOverride);
+                // Force the per-star sensor-curve model so this analysis produces the paraboloid tilt the calibration
+                // reads (CalibrationTiltPlane); restore the flag immediately so it never leaks to other inspector uses.
+                var prevForce = inspector.ForceSensorCurveModelGeneration;
+                inspector.ForceSensorCurveModelGeneration = true;
+                try {
+                    if (fromSaved) {
+                        // IsMeasuring is set via callback after the folder dialog closes so the chart doesn't appear
+                        // until the user has confirmed a selection.
+                        ok = await inspector.AnalyzeAutoFocusFromSaved(token, onFolderSelected: () => IsMeasuring = true, saveOverride: saveOverride);
+                    } else {
+                        ok = await inspector.AnalyzeAutoFocus(token, captureCameraBlock: true, saveOverride);
+                    }
+                } finally {
+                    inspector.ForceSensorCurveModelGeneration = prevForce;
                 }
                 if (!ok) return null;
-                var m = inspector.TiltModel?.TiltPlaneModel;
-                if (m == null) return null;
+                var m = CalibrationTiltPlane;
+                if (m == null) {
+                    Logger.Error("Tilt calibration: the per-star sensor-curve model could not be fit for this step; cannot derive tilt.");
+                    return null;
+                }
                 readings.Add((m.A, m.B, m.MeanFocuserPosition));
             }
 
@@ -888,7 +905,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             double avgB = readings.Average(r => r.B);
             double avgMean = readings.Average(r => r.Mean);
 
-            var latestModel = inspector.TiltModel?.TiltPlaneModel;
+            var latestModel = CalibrationTiltPlane;
             AppendSummaryRows(readings, stepDescription, latestModel, count, avgA, avgB);
 
             var reading = new StepReading {
@@ -1130,7 +1147,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             calibrationPixelSizeMicrons = pixelSize;
             calibrationFocuserStepMicrons = fStep;
 
-            var model = inspector.TiltModel?.TiltPlaneModel;
+            var model = CalibrationTiltPlane;
             if (model != null) {
                 var inputs = new TiltCalibrationInputs {
                     ScrewCount = screwCount,
@@ -1370,16 +1387,24 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     var detectionOverride = mode.ApplyCaptureTimeOverridePerStep
                         ? BuildTiltReplayDetectionOverride(byStep[step.ToString()], metadata)
                         : null;
-                    bool ok = await inspector.AnalyzeAutoFocusFromSavedPath(byStep[step.ToString()], token, detectionOverride);
+                    bool ok;
+                    // Force the per-star sensor-curve model so replay derives tilt from the paraboloid, like a live run.
+                    var prevForce = inspector.ForceSensorCurveModelGeneration;
+                    inspector.ForceSensorCurveModelGeneration = true;
+                    try {
+                        ok = await inspector.AnalyzeAutoFocusFromSavedPath(byStep[step.ToString()], token, detectionOverride);
+                    } finally {
+                        inspector.ForceSensorCurveModelGeneration = prevForce;
+                    }
                     if (!ok) {
                         StatusText = $"Replay failed at {step}.";
                         Notification.ShowError($"Replay failed at step '{step}'. The saved frames could not be analyzed.{profileNotChangedNote}");
                         return;
                     }
-                    var m = inspector.TiltModel?.TiltPlaneModel;
+                    var m = CalibrationTiltPlane;
                     if (m == null) {
                         StatusText = $"Replay produced no tilt model at {step}.";
-                        Notification.ShowError($"Replay produced no tilt model at step '{step}'.{profileNotChangedNote}");
+                        Notification.ShowError($"Replay produced no sensor-curve-model tilt at step '{step}'. The per-star paraboloid could not be fit.{profileNotChangedNote}");
                         return;
                     }
                     var reading = new StepReading {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
@@ -72,6 +72,29 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         /// clean, equal single-screw moves this is ~1; a large value means the two calibration turns were unequal
         /// (uneven turning / backlash) and the recovered pitch/step size is unreliable. NaN if a magnitude is 0.</summary>
         public double MoveMagnitudeRatio { get; set; }
+
+        /// <summary>Signal-to-noise / reliability of the whole calibration, derived from the per-step tilt vectors.
+        /// Populated by <see cref="TiltCalibrationCalculator.Calibrate"/>.</summary>
+        public TiltCalibrationConfidence Confidence { get; set; }
+    }
+
+    /// <summary>
+    /// How trustworthy a calibration is, derived purely from the six per-step tilt vectors — no fit covariance
+    /// needed. The screw-move magnitudes are the <i>signal</i>; quantities that must be ~0 in a noise-free,
+    /// stationary measurement are <i>noise probes</i>: turning all screws inward equally is a pure piston (no net
+    /// tilt change vs baseline), and each re-baseline should return to its predecessor (zero drift). When the
+    /// noise probes rival the screw-move signal the recovered geometry is dominated by measurement noise / between
+    /// step drift, no matter how cleanly the screws were turned.
+    /// </summary>
+    public sealed class TiltCalibrationConfidence {
+        public double ScrewMoveSignal { get; set; }               // mean |single-screw move| magnitude (the signal)
+        public double NoiseEstimate { get; set; }                 // RMS of the noise probes below
+        public double SignalToNoise { get; set; }                 // ScrewMoveSignal / NoiseEstimate (Inf if noise 0)
+        public double PredictedAngleUncertaintyDeg { get; set; }  // ~1σ on each recovered screw direction
+        public double AllInwardTiltResidual { get; set; }         // |AllInward − Baseline|, should be ~0 (pure piston)
+        public double Rebaseline1Drift { get; set; }              // |ReBaseline1 − Baseline|, should be ~0
+        public double Rebaseline2Drift { get; set; }              // |ReBaseline2 − ReBaseline1|, should be ~0
+        public bool IsReliable { get; set; }                      // SignalToNoise >= MinReliableSignalToNoise
     }
 
     /// <summary>
@@ -87,6 +110,44 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
     public static class TiltCalibrationCalculator {
 
         public static double NormalizeAngle(double deg) => ((deg % 360) + 360) % 360;
+
+        /// <summary>Below this signal-to-noise the calibration is noise-dominated and should not be trusted/applied.
+        /// At SNR = 2 the screw-move signal is twice the noise floor, giving a recovered-direction 1σ of ~27°.</summary>
+        public const double MinReliableSignalToNoise = 2.0;
+
+        private static double Magnitude(double a, double b) => Math.Sqrt(a * a + b * b);
+
+        /// <summary>
+        /// Estimates how trustworthy the calibration is from the six per-step tilt vectors. See
+        /// <see cref="TiltCalibrationConfidence"/> for the model: screw moves are the signal; the all-inward piston
+        /// residual and the two re-baseline drifts are independent noise probes (each ~0 in an ideal measurement).
+        /// </summary>
+        public static TiltCalibrationConfidence ComputeConfidence(TiltCalibrationInputs inputs) {
+            double s1 = Magnitude(inputs.Screw1.A - inputs.ReBaseline1.A, inputs.Screw1.B - inputs.ReBaseline1.B);
+            double s2 = Magnitude(inputs.Screw2.A - inputs.ReBaseline2.A, inputs.Screw2.B - inputs.ReBaseline2.B);
+            double signal = 0.5 * (s1 + s2);
+
+            double allInward = Magnitude(inputs.AllInward.A - inputs.Baseline.A, inputs.AllInward.B - inputs.Baseline.B);
+            double drift1 = Magnitude(inputs.ReBaseline1.A - inputs.Baseline.A, inputs.ReBaseline1.B - inputs.Baseline.B);
+            double drift2 = Magnitude(inputs.ReBaseline2.A - inputs.ReBaseline1.A, inputs.ReBaseline2.B - inputs.ReBaseline1.B);
+            double noise = Math.Sqrt((allInward * allInward + drift1 * drift1 + drift2 * drift2) / 3.0);
+
+            double snr = noise > 0 ? signal / noise : double.PositiveInfinity;
+            // A screw direction is atan2 of its move vector; transverse noise of ~noise on a signal of ~signal
+            // perturbs that direction by ~atan(noise/signal). Degenerate (no signal) => maximally uncertain.
+            double angleUncertainty = signal > 0 ? Math.Atan2(noise, signal) * 180.0 / Math.PI : 90.0;
+
+            return new TiltCalibrationConfidence {
+                ScrewMoveSignal = signal,
+                NoiseEstimate = noise,
+                SignalToNoise = snr,
+                PredictedAngleUncertaintyDeg = angleUncertainty,
+                AllInwardTiltResidual = allInward,
+                Rebaseline1Drift = drift1,
+                Rebaseline2Drift = drift2,
+                IsReliable = snr >= MinReliableSignalToNoise
+            };
+        }
 
         /// <summary>Curvature (backfocus) sign from the all-screws-inward vs baseline mean-focus delta.</summary>
         public static int ComputeCurvatureSign(double allScrewsMean, double baselineMean) {
@@ -214,7 +275,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 MeasuredHardwareMicrons = RecoverHardwareMicrons(inputs),
                 Screw1DirectionDegrees = NormalizeAngle(Math.Atan2(d1A, -d1B) * 180.0 / Math.PI),
                 Screw2DirectionDegrees = NormalizeAngle(Math.Atan2(d2A, -d2B) * 180.0 / Math.PI),
-                MoveMagnitudeRatio = MoveMagnitudeRatio(d1A, d1B, d2A, d2B)
+                MoveMagnitudeRatio = MoveMagnitudeRatio(d1A, d1B, d2A, d2B),
+                Confidence = ComputeConfidence(inputs)
             };
         }
     }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
@@ -16,6 +16,7 @@ using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
@@ -134,14 +135,50 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         /// <summary>
         /// Resolves a stored step folder against the run root the caller actually selected. Relative entries (the
-        /// current format) are rebased onto <paramref name="runRootFolder"/>; absolute entries (legacy files) are
-        /// honored as-is. Mirrors the headless <c>TestApp</c> resolver so in-app and offline replay agree.
+        /// current format) are rebased onto <paramref name="runRootFolder"/>. Absolute entries (legacy files, or a
+        /// run captured under a different volume/path than where <c>metadata.json</c> now lives) are honored as-is
+        /// when they still exist; otherwise their tail is rebased onto the selected run root so a moved/copied run
+        /// stays replayable. Mirrors the headless <c>TestApp</c> resolver so in-app and offline replay agree.
         /// </summary>
         public static string ResolveStepFolder(string runRootFolder, string storedFolder) {
-            if (string.IsNullOrEmpty(storedFolder) || string.IsNullOrEmpty(runRootFolder) || Path.IsPathRooted(storedFolder)) {
+            if (string.IsNullOrEmpty(storedFolder) || string.IsNullOrEmpty(runRootFolder)) {
                 return storedFolder;
             }
-            return Path.GetFullPath(Path.Combine(runRootFolder, storedFolder));
+            if (!Path.IsPathRooted(storedFolder)) {
+                return Path.GetFullPath(Path.Combine(runRootFolder, storedFolder));
+            }
+            // Absolute, and present on this machine: honor it (the common live-replay case).
+            if (Directory.Exists(storedFolder)) {
+                return storedFolder;
+            }
+            // Absolute but missing — the run was moved/copied to a different drive than the captured path. Rebase
+            // the portion after the run-root folder (e.g. TiltCalibration_<id>) onto the selected run root; fall
+            // back to the last two segments (<NN_Step>\AutoFocus_<timestamp>), the wizard's save structure.
+            return RebaseAbsoluteStepFolder(runRootFolder, storedFolder) ?? storedFolder;
+        }
+
+        private static string RebaseAbsoluteStepFolder(string runRootFolder, string storedFolder) {
+            var segments = storedFolder.Split(new[] { '\\', '/' }, StringSplitOptions.RemoveEmptyEntries);
+            string TryTail(IEnumerable<string> tailSegments) {
+                var tail = tailSegments.ToArray();
+                if (tail.Length == 0) {
+                    return null;
+                }
+                var candidate = Path.GetFullPath(Path.Combine(runRootFolder, Path.Combine(tail)));
+                return Directory.Exists(candidate) ? candidate : null;
+            }
+
+            var rootLeaf = Path.GetFileName(Path.TrimEndingDirectorySeparator(runRootFolder));
+            if (!string.IsNullOrEmpty(rootLeaf)) {
+                int idx = Array.FindLastIndex(segments, s => string.Equals(s, rootLeaf, StringComparison.OrdinalIgnoreCase));
+                if (idx >= 0 && idx < segments.Length - 1) {
+                    var afterRoot = TryTail(segments.Skip(idx + 1));
+                    if (afterRoot != null) {
+                        return afterRoot;
+                    }
+                }
+            }
+            return segments.Length >= 2 ? TryTail(segments.Skip(segments.Length - 2)) : null;
         }
 
         public void Validate() {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltScrewGeometry.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltScrewGeometry.cs
@@ -49,6 +49,23 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         }
 
         /// <summary>
+        /// Exact inverse of <see cref="PlaneGradientToPhysical"/>: convert a physical best-focus tilt gradient
+        /// (focuser microns of travel per micron of sensor displacement — e.g. the per-star paraboloid's Gx/Gy)
+        /// into tilt-plane coefficients (A, B) in focuser steps per normalized image coordinate over [-0.5, 0.5].
+        /// This lets the robust per-star sensor-model tilt feed the same screw-calibration math the 4-corner plane
+        /// uses, so the wizard can consume the better estimator without changing downstream geometry.
+        /// </summary>
+        public static (double a, double b) PhysicalGradientToPlane(
+            double gx, double gy, double focuserStepMicrons, double sensorWidthMicrons, double sensorHeightMicrons) {
+            if (focuserStepMicrons <= 0) {
+                return (double.NaN, double.NaN);
+            }
+            var a = gx * sensorWidthMicrons / focuserStepMicrons;
+            var b = gy * sensorHeightMicrons / focuserStepMicrons;
+            return (a, b);
+        }
+
+        /// <summary>
         /// Per-screw axial move (microns) that cancels the given best-focus tilt gradient,
         /// evaluated at the screw location: δ = -(gx·x + gy·y). Positive = the direction
         /// returned here is the sensor-axial displacement to apply at that screw.

--- a/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
@@ -13,8 +13,10 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using NINA.Core.Enum;
+using NINA.Core.Model;
 using NINA.Core.Utility;
 using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.Inspection;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.StarDetection;
 using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
@@ -187,11 +189,13 @@ namespace TestApp {
 
             var perStep = new List<StepResult>(orderedRuns.Count);
             foreach (var run in orderedRuns) {
-                Console.WriteLine($"Measuring tilt for {run.Step} ({Path.GetFileName(run.Folder)}) ...");
+                Console.WriteLine($"Measuring 4-corner tilt for {run.Step} ({Path.GetFileName(run.Folder)}, {run.Frames.Count} frames × 5 regions) ...");
+                var sw4c = System.Diagnostics.Stopwatch.StartNew();
                 var stepResult = await MeasureTiltAsync(run, detector, detectionParams, regions, fRatio,
                     metadata.FocuserStepSizeMicrons, metadata.PixelSizeMicrons, starDetectionOptions.MeasurementAverage,
                     profileService, alglibAPI, afOptions.HyperbolicFitModel).ConfigureAwait(false);
                 perStep.Add(stepResult);
+                Console.WriteLine($"    [4-corner {run.Step}] done in {sw4c.ElapsedMilliseconds} ms");
                 Console.WriteLine($"    A={F(stepResult.Gradient.A)}, B={F(stepResult.Gradient.B)}, " +
                     $"direction={F(NormalizeAngle(Math.Atan2(stepResult.Gradient.A, -stepResult.Gradient.B) * 180.0 / Math.PI))}°, " +
                     $"tilt={F(stepResult.TiltAngleDeg)}°, mean={F(stepResult.Gradient.MeanFocuserPosition)}");
@@ -218,7 +222,42 @@ namespace TestApp {
             };
             var calibration = TiltCalibrationCalculator.Calibrate(inputs);
 
-            WriteReport(outDir, metadata, optimizationSource, perStep, inputs, calibration);
+            // Alternative estimator: measure each step's tilt from the robust per-star paraboloid (Gx/Gy) and run the
+            // SAME calibration on it, to see how the "use the sensor-model tilt" rewire behaves on this exact data.
+            var paraboloidSteps = new List<ParaboloidStepResult>(orderedRuns.Count);
+            foreach (var run in orderedRuns) {
+                Console.WriteLine($"Paraboloid (per-star) tilt for {run.Step} ...");
+                var mean = byStep[run.Step].Gradient.MeanFocuserPosition;
+                var ps = await MeasureTiltViaParaboloidAsync(run, detector, detectionParams, metadata.FocuserStepSizeMicrons,
+                    metadata.PixelSizeMicrons, mean, profileService, inspectorOptions, afOptions, alglibAPI).ConfigureAwait(false);
+                paraboloidSteps.Add(ps);
+                Console.WriteLine(ps.Fitted
+                    ? $"    A={F(ps.Gradient.A)}, B={F(ps.Gradient.B)}, stars={ps.StarsInModel}, R²={F(ps.RSquared)}"
+                    : $"    paraboloid fit FAILED: {ps.Status}");
+            }
+            TiltCalibrationResult paraboloidCalibration = null;
+            if (paraboloidSteps.All(p => p.Fitted)) {
+                var pbyStep = paraboloidSteps.ToDictionary(s => s.Step, StringComparer.OrdinalIgnoreCase);
+                var pinputs = new TiltCalibrationInputs {
+                    ScrewCount = metadata.NumberOfScrews,
+                    Baseline = pbyStep["Baseline"].Gradient,
+                    AllInward = pbyStep["AllInward"].Gradient,
+                    ReBaseline1 = pbyStep["ReBaseline1"].Gradient,
+                    Screw1 = pbyStep["Screw1"].Gradient,
+                    ReBaseline2 = pbyStep["ReBaseline2"].Gradient,
+                    Screw2 = pbyStep["Screw2"].Gradient,
+                    ImageWidthPixels = imageSize.Width,
+                    ImageHeightPixels = imageSize.Height,
+                    PixelSizeMicrons = metadata.PixelSizeMicrons,
+                    FocuserStepMicrons = metadata.FocuserStepSizeMicrons,
+                    ScrewRadiusMillimeters = metadata.ScrewRadiusMillimeters,
+                    CalibrationAppliedAmount = metadata.CalibrationAppliedAmount,
+                    IsStepperAdjustment = inputs.IsStepperAdjustment
+                };
+                paraboloidCalibration = TiltCalibrationCalculator.Calibrate(pinputs);
+            }
+
+            WriteReport(outDir, metadata, optimizationSource, perStep, inputs, calibration, paraboloidSteps, paraboloidCalibration);
             Console.WriteLine($"Wrote tilt_summary.txt and tilt_summary.json to {outDir}");
         }
 
@@ -487,6 +526,102 @@ namespace TestApp {
             }
         }
 
+        // Per-step result of the alternative estimator: the robust per-star paraboloid tilt (Gx/Gy), converted to
+        // the same (A, B) plane units as the 4-corner result so the same screw-calibration math can consume it.
+        private sealed class ParaboloidStepResult {
+            public string Step;
+            public TiltGradient Gradient;   // A/B from the paraboloid Gx/Gy; Mean carried over from the 4-corner step
+            public int StarsInModel;
+            public double RSquared;
+            public double TiltAngleDeg;
+            public bool Fitted;
+            public string Status;           // why the fit failed, when !Fitted
+        }
+
+        /// <summary>
+        /// Measures one step's tilt via the production per-star sensor-model paraboloid (the robust, outlier-rejected,
+        /// curvature-aware estimator), instead of the 4-corner region plane. Detects each frame full-sensor, drives
+        /// <see cref="SensorModel.RegisterStarsAndFit"/> (image: null, exactly like bank-verify), then converts the
+        /// fitted tilt gradient Gx/Gy to plane (A, B) via <see cref="TiltScrewGeometry.PhysicalGradientToPlane"/>.
+        /// The piston (Mean focuser position) is carried over from <paramref name="fourCornerMean"/> since it is
+        /// estimator-independent. Returns a non-fitted result (with a reason) when the field is too star-poor.
+        /// </summary>
+        private static async Task<ParaboloidStepResult> MeasureTiltViaParaboloidAsync(
+            RunStep run, StarDetector detector, StarDetectorParams baseParams, double focuserStepMicrons,
+            double pixelSizeMicrons, double fourCornerMean, ProfileService profileService,
+            InspectorOptions inspectorOptions, AutoFocusOptions afOptions, IAlglibAPI alglibAPI) {
+
+            var mats = await LoadRunMatsAsync(run, profileService).ConfigureAwait(false);
+            try {
+                var imageSize = new DrawingSize(mats[0].Mat.Width, mats[0].Mat.Height);
+                var sensorFrames = new List<SensorDetectedStars>(mats.Count);
+                baseParams.Region = StarDetectionRegion.Full;
+                int fi = 0;
+                foreach (var (focuser, _, mat) in mats) {
+                    var swDet = System.Diagnostics.Stopwatch.StartNew();
+                    using var frameCopy = mat.Clone();
+                    var result = await detector.Detect(frameCopy, baseParams, progress: null, CancellationToken.None).ConfigureAwait(false);
+                    var stars = result.DetectedStars ?? new List<Star>();
+                    var starList = stars.Select(HocusFocusStarDetection.ToDetectedStar)
+                        .OrderBy(s => s.Position.Y * (long)imageSize.Width + s.Position.X).ToList();
+                    sensorFrames.Add(new SensorDetectedStars(
+                        focuser, new HocusFocusStarDetectionResult { StarList = starList, ImageSize = imageSize }, image: null));
+                    Console.WriteLine($"    [paraboloid {run.Step}] full-sensor detect {++fi}/{mats.Count} focuser {focuser}: {starList.Count} stars ({swDet.ElapsedMilliseconds} ms)");
+                }
+
+                int stepSize = InferStepSize(run.Frames.Select(f => f.Focuser));
+                var sortedFoc = run.Frames.Select(f => (double)f.Focuser).OrderBy(x => x).ToList();
+                double finalFocus = sortedFoc[sortedFoc.Count / 2];
+
+                var sensorModel = new SensorModel(profileService, inspectorOptions, afOptions, alglibAPI);
+                // Headless: route registration/fit messages to the logger instead of the UI-bound
+                // RegistrationAndFitReport collection. Without this, Report() marshals to the WPF dispatcher with a
+                // blocking Send, which deadlocks against TestApp's main thread (it blocks on the async command), and
+                // it only fires on the incomplete-RANSAC-alignment path — i.e. exactly the donut-heavy tilt steps.
+                sensorModel.RegistrationReportSink = m => Logger.Info($"[paraboloid {run.Step}] {m}");
+                try {
+                    Console.WriteLine($"    [paraboloid {run.Step}] registering + fitting {sensorFrames.Sum(f => f.StarDetectionResult.StarList.Count)} stars across {sensorFrames.Count} frames (RANSAC={inspectorOptions.UseRANSAC}) ...");
+                    var swFit = System.Diagnostics.Stopwatch.StartNew();
+                    // The headless fit can hang on degenerate (donut-heavy, RANSAC-failed) frames, so bound it: run on a
+                    // worker with a cancellation token and a hard WhenAny cutoff; report a timeout rather than blocking.
+                    // Cutoff is env-configurable (TILT_FIT_TIMEOUT_SEC) so a deadlock investigation can extend it and
+                    // capture a managed stack dump of the hung worker before it is abandoned.
+                    int fitTimeoutSec = int.TryParse(Environment.GetEnvironmentVariable("TILT_FIT_TIMEOUT_SEC"), out var t) && t > 0 ? t : 45;
+                    using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(fitTimeoutSec));
+                    var fitTask = Task.Run(() => sensorModel.RegisterStarsAndFit(
+                        sensorFrames, imageSize, focuserSizeMicrons: focuserStepMicrons, finalFocusPosition: finalFocus,
+                        pixelSize: pixelSizeMicrons, progress: new Progress<ApplicationStatus>(), stepSize: stepSize,
+                        ct: cts.Token));
+                    if (await Task.WhenAny(fitTask, Task.Delay(TimeSpan.FromSeconds(fitTimeoutSec + 5))).ConfigureAwait(false) != fitTask) {
+                        Console.WriteLine($"    [paraboloid {run.Step}] fit TIMED OUT (>{fitTimeoutSec}s) — abandoning and moving on");
+                        return new ParaboloidStepResult { Step = run.Step, Fitted = false, Status = $"fit timed out (>{fitTimeoutSec}s)" };
+                    }
+                    var (fit, _) = await fitTask.ConfigureAwait(false);
+                    Console.WriteLine($"    [paraboloid {run.Step}] fit done in {swFit.ElapsedMilliseconds} ms (stars in model: {fit?.StarsInModel ?? 0})");
+                    if (fit == null) {
+                        return new ParaboloidStepResult { Step = run.Step, Fitted = false, Status = "fit returned null" };
+                    }
+                    var sensorW = imageSize.Width * pixelSizeMicrons;
+                    var sensorH = imageSize.Height * pixelSizeMicrons;
+                    var (a, b) = TiltScrewGeometry.PhysicalGradientToPlane(fit.Gx, fit.Gy, focuserStepMicrons, sensorW, sensorH);
+                    return new ParaboloidStepResult {
+                        Step = run.Step,
+                        Gradient = new TiltGradient(a, b, fourCornerMean),
+                        StarsInModel = fit.StarsInModel,
+                        RSquared = fit.GoodnessOfFit,
+                        TiltAngleDeg = fit.Theta * 180.0 / Math.PI,
+                        Fitted = true
+                    };
+                } catch (Exception ex) {
+                    return new ParaboloidStepResult { Step = run.Step, Fitted = false, Status = ex.Message };
+                }
+            } finally {
+                foreach (var (_, _, mat) in mats) {
+                    mat?.Dispose();
+                }
+            }
+        }
+
         /// <summary>Fits a hyperbolic focus curve to the per-region (focuser, HFR) points and returns the curve
         /// minimum (final focus position) + R². Uses the profile's hyperbolic fit model; unweighted for robustness
         /// headless. Returns (NaN, NaN) on too few points or a failed solve.</summary>
@@ -553,7 +688,8 @@ namespace TestApp {
 
         private static void WriteReport(
             string outDir, TiltCalibrationMetadata metadata, string optimizationSource, List<StepResult> perStep,
-            TiltCalibrationInputs inputs, TiltCalibrationResult calibration) {
+            TiltCalibrationInputs inputs, TiltCalibrationResult calibration,
+            List<ParaboloidStepResult> paraboloidSteps, TiltCalibrationResult paraboloidCalibration) {
 
             bool isStepper = inputs.IsStepperAdjustment;
             double groundTruthHardware = isStepper ? metadata.StepperStepSizeMicrons : metadata.ScrewThreadPitchMicrons;
@@ -604,6 +740,39 @@ namespace TestApp {
             Line($"Curvature (backfocus) inward sign: {calibration.CurvatureSign:+0;-0}");
             Line();
 
+            var conf = calibration.Confidence;
+            Line("Calibration confidence (signal vs noise from the per-step tilt vectors):");
+            Line($"  Screw-move signal: {F(conf.ScrewMoveSignal)}   Noise floor: {F(conf.NoiseEstimate)}   SNR: {F(conf.SignalToNoise)}");
+            Line($"  Noise probes (should be « the signal) — AllInward piston residual: {F(conf.AllInwardTiltResidual)}, " +
+                $"re-baseline drift 1/2: {F(conf.Rebaseline1Drift)}/{F(conf.Rebaseline2Drift)}");
+            Line($"  Predicted screw-direction uncertainty: ±{F(conf.PredictedAngleUncertaintyDeg)}°");
+            if (!conf.IsReliable) {
+                Line($"  NOTE: SNR {F(conf.SignalToNoise)} is below {F(TiltCalibrationCalculator.MinReliableSignalToNoise)} — the calibration is " +
+                    "noise-dominated (insufficient or unstable signal). Re-capture on a star-rich field with a finer step; " +
+                    "the recovered screw geometry from this run should not be applied.");
+            }
+            Line();
+
+            // Alternative estimator: the per-star paraboloid tilt (the "calibrate from the sensor-model tilt" rewire).
+            Line("Per-star paraboloid tilt (alternative estimator — the robust sensor-model Gx/Gy):");
+            Line($"  {"Step",-12} {"A",10} {"B",10} {"stars",6} {"R²",7}  status");
+            foreach (var ps in paraboloidSteps) {
+                Line(ps.Fitted
+                    ? $"  {ps.Step,-12} {F(ps.Gradient.A),10} {F(ps.Gradient.B),10} {ps.StarsInModel,6} {F(ps.RSquared),7}  ok"
+                    : $"  {ps.Step,-12} {"—",10} {"—",10} {"—",6} {"—",7}  FAILED: {ps.Status}");
+            }
+            if (paraboloidCalibration?.Confidence != null) {
+                var pc = paraboloidCalibration.Confidence;
+                Line($"  Paraboloid calibration: SNR {F(pc.SignalToNoise)} (vs 4-corner {F(conf.SignalToNoise)}), " +
+                    $"screw gap {F(paraboloidCalibration.RawAngleDiffDegrees)}° (ideal {(metadata.NumberOfScrews == 3 ? "120" : "90")}°), " +
+                    $"move ratio {F(paraboloidCalibration.MoveMagnitudeRatio)}×, reliable={pc.IsReliable}");
+            } else {
+                int fitted = paraboloidSteps.Count(p => p.Fitted);
+                Line($"  Paraboloid calibration not computed — only {fitted}/{paraboloidSteps.Count} steps fitted. " +
+                    "The per-star model needs ≥9 stars matched across ≥5 frames; this field is too star-poor for it.");
+            }
+            Line();
+
             // Verdicts. The screw-1 angle and hardware checks need ground truth that a wizard-written metadata.json
             // does not carry; when absent they are reported "n/a" and do not fail the run.
             bool angleProvided = !double.IsNaN(metadata.ExpectedPositionAngleScrew1Deg);
@@ -616,9 +785,11 @@ namespace TestApp {
                 Line("  NOTE: the two screw turns produced very unequal tilt changes — the recovered hardware/angles " +
                     "are unreliable. Re-capture turning each screw the same amount.");
             }
+            bool confidenceOk = conf.IsReliable;
             string V(bool ok, bool provided) => !provided ? "n/a" : (ok ? "PASS" : "FAIL");
             Line($"VERDICT: Screw1 angle {V(angleOk, angleProvided)}, angle separation {(gapOk ? "PASS" : "FAIL")}, " +
-                $"hardware {V(hardwareOk, hardwareProvided)}, move balance {(magnitudeOk ? "PASS" : "FAIL")}");
+                $"hardware {V(hardwareOk, hardwareProvided)}, move balance {(magnitudeOk ? "PASS" : "FAIL")}, " +
+                $"confidence {(confidenceOk ? "PASS" : "FAIL")}");
 
             File.WriteAllText(Path.Combine(outDir, "tilt_summary.txt"), sb.ToString());
 
@@ -649,11 +820,19 @@ namespace TestApp {
                     groundTruthHardwareMicrons = groundTruthHardware,
                     hardwarePctDelta
                 },
-                verdict = new { angleOk, gapOk, hardwareOk, magnitudeOk }
+                confidence = conf,
+                paraboloid = new {
+                    perStep = paraboloidSteps.Select(p => new {
+                        p.Step, p.Fitted, p.Status, p.StarsInModel, p.RSquared,
+                        A = p.Gradient.A, B = p.Gradient.B, p.TiltAngleDeg
+                    }),
+                    calibration = paraboloidCalibration
+                },
+                verdict = new { angleOk, gapOk, hardwareOk, magnitudeOk, confidenceOk }
             };
             File.WriteAllText(Path.Combine(outDir, "tilt_summary.json"), JsonConvert.SerializeObject(json, MetadataJsonSettings));
 
-            if (!angleOk || !gapOk || !hardwareOk || !magnitudeOk) {
+            if (!angleOk || !gapOk || !hardwareOk || !magnitudeOk || !confidenceOk) {
                 Environment.ExitCode = 3;
             }
         }

--- a/docs/tilt-calibration-noise-design.md
+++ b/docs/tilt-calibration-noise-design.md
@@ -1,0 +1,158 @@
+# Tilt-Adapter Calibration Noise — Root-Cause Diagnosis
+
+**Status:** diagnosis (design spec). Implementation plan: `plans/tilt-calibration-noise-plan.md`.
+**Dataset:** `D:\Tilt Calibration Bank\astrodet_6\TiltCalibration_20260628_115023` (astrodet profile, 3-screw).
+**Date:** 2026-06-29.
+
+## Context
+
+A 6-step Tilt Adapter Wizard calibration on the already-calibrated **astrodet** profile produced a poor result:
+the sensor models at the three "baseline" steps (which represent the *same* neutral screw state) came out very
+different, and the recovered screw geometry was unreliable. The user reports turning the screws carefully. This
+document explains **why**, from the saved data, the source code, and an empirical replay of the run.
+
+**Headline:** the calibration is **noise-limited — the measurement noise floor is as large as the screw-move
+signal (SNR ≈ 1)**, and the noise originates in a chain that starts with a **star-poor, too-coarsely-sampled
+focus sweep** and is then **amplified by a structurally fragile 4-corner tilt estimator** and **contaminated by
+real between-step drift**. The screws are not the problem — the data confirms the two turns were clean
+(`moveMagnitudeRatio` = 1.0016). No amount of careful turning fixes a measurement whose noise ≈ its signal.
+
+## How a tilt measurement is computed (the chain)
+
+1. An autofocus run sweeps the focuser over 7–8 positions and detects stars in each frame.
+2. The sensor is split into **5 regions** (center + 4 corners). For each region, all its stars' HFRs are pooled
+   into one HFR-vs-position curve and a hyperbola minimum gives that region's best-focus position.
+3. **`TiltPlaneModel.Create`** (`AutoFocus/TiltModel.cs:132-165`) fits a plane `z = A·x + B·y + c` through the **4
+   corner** best-focus positions (center excluded) — **4 points, 3 parameters, 1 residual DOF, no weighting, no
+   outlier rejection, no curvature term.** `(A,B)` is the tilt vector the wizard calibrates from.
+4. The wizard derives screw geometry purely from how `(A,B)` *changes* between steps: each screw =
+   `Screw_i − ReBaseline_i`, screw direction = `atan2(dA, −dB)` (`TiltCalibrationCalculator.cs:118-219`).
+
+Separately and on the same frames, a **per-star tilted paraboloid** (`Inspection/SensorParaboloidModel.cs`) is
+fit over *all* matched stars with winsorized outlier rejection and per-star σ weighting. It has its own tilt
+gradient `Gx/Gy` **and** a curvature term — but the wizard harvests **only its curvature**
+(`PopulateCurvature`, `TiltAdapterWizardVM.cs:946-951`) and **discards its tilt** (`:860-862` reads the 4-corner
+`A/B` instead). So the rich, robust tilt estimate is computed every step and thrown away.
+
+## Root cause, in layers
+
+### Layer 0 — the soil: a star-poor field sampled too coarsely near focus
+`TestApp focus-sweep` on all six runs (per-position star counts, whole sensor):
+
+| Run (best focus) | star count vs focuser position | positions with ≥5 stars |
+|---|---|---|
+| Baseline (~579) | 54:1 229:2 404:11 **579:23** 754:10 929:1 1104:1 | 3 |
+| AllInward (~609) | 0:1 84:1 259:9 **434:32** 609:26 784:5 959:1 1134:**0** | 3 |
+| ReBaseline1 (~600) | 144:1 319:5 494:26 **669:28** 844:7 1019:1 1194:**0** | 3 |
+| Screw1 (~619) | 94:1 269:6 444:19 **619:34** 794:8 969:1 1144:1 | 3 |
+| ReBaseline2 (~584) | 59:1 234:1 409:9 **584:26** 759:13 934:4 1109:1 | 3 |
+| Screw2 (~635) | 110:1 285:7 460:25 **635:38** 810:6 985:1 1160:1 | 3 |
+
+Peak star count is only **~23–38 across the whole sensor**, and only **~3 of 7–8 positions** carry >5 stars; the
+defocused wings collapse to **0–1**. With the step size of **175** (≈ 626 µm/step ≈ ~23× the critical focus
+zone), stars are only detectable within ~±1–2 steps of focus, so the sweep effectively has **~3 usable points**.
+Consequences:
+- Each of the 4 corner quadrants gets only **~5–6 stars over ~3 positions** → its pooled best-focus is poorly
+  constrained and moves with the exact star set detected.
+- The per-star paraboloid needs **≥5 matched detections per star** (`SensorModel.cs:660`); almost no star is
+  detectable in ≥5 of these positions, so the curvature fit runs on a marginal sample → it blows up (curvature
+  radius came out 56 mm on Baseline, +17,279 µm sag at screw radius = **4.6× the entire focuser sweep** —
+  physically impossible).
+
+### Layer 1 — the amplifier: the 4-corner estimator (1 DOF, no robustness)
+A 3-parameter plane through 4 noisy corner positions has **1 degree of freedom and no outlier rejection**, so a
+single off corner maps almost 1:1 into `(A,B)`. Combined with Layer 0, tiny differences in which ~5 stars land in
+a quadrant swing the tilt vector wildly. The robust per-star tilt (`Gx/Gy`, with the center pinned by default via
+`FixedSensorCenter=true`, and an already-computed uncertainty `ThetaStdError`) would average over *all* stars and
+model curvature — but it is discarded.
+
+### Layer 2 — the differencing: variance adds, nothing averages it down
+Each screw signal subtracts two independent noisy 4-corner fits, so their variances add; and
+`MeasurementAverageCount = 1` means no per-step averaging. The strongest repeatability guard is therefore inert.
+
+### Layer 3 — real between-step drift
+Mean focuser position across the three baselines marches **monotonically** 591 → 599.6 → 609.8 (~67 µm over the
+8-minute session) — not random fit noise, but thermal / focuser-backlash / adapter-creep / seeing. Because every
+screw move is a *difference taken ~90–180 s apart*, this non-stationarity lands directly in the signal. **A better
+estimator does not fix this** — a longer per-step average would actually make it worse.
+
+## Empirical evidence
+
+### From the saved metadata (SNR ≈ 1)
+| Check | Expected | Measured | Verdict |
+|---|---|---|---|
+| 3 baselines (identical neutral state) | same (A,B) | RMS scatter **±8.0** units | noise ≈ 8 |
+| AllInward = pure piston → zero tilt change | ~0 | **20.6** units | null-move noise ≈ 20 |
+| Two screws physically 120° apart | 120° | **63.7°** (`rawAngleDiffDegrees`) | 56° error = 1.7σ of ±33° |
+| Screw-move signal | — | **13.9** units | **≈ the noise → SNR ≈ 1** |
+| `moveMagnitudeRatio` (turn evenness) | ~1 | **1.0016** | turns were clean — user's care confirmed |
+
+Re-baseline drift guard (`EvaluateRebaselineDrift`) fires at **134%** and **74%** of the screw move (threshold
+50%); angle-gap guard at **56°** deviation (threshold 30°). Both are advisory only; calibration proceeds and snaps
+the 63.7° gap onto the ideal 120° lattice, emitting confident screw angles built on SNR≈1 data.
+
+### From replaying the run (`TestApp tilt`, 3× identical)
+- **Deterministic but fragile:** three replays were byte-for-byte identical, yet the replay's per-step `(A,B)` are
+  **completely different from the live wizard's** on the *same frames* (e.g. Baseline live (−2.1, 24.1) vs replay
+  (23.5, 12.9); replay calibration gap **247.7°**, `moveMagnitudeRatio` **4.42×**). Two faithful, deterministic
+  analyses of identical frames disagree wildly — direct proof of Layer-1 sensitivity, amplified by Layer 0.
+- **R² ≈ 1.00 everywhere is false confidence:** every region in every step fit at R² 0.96–1.00. The curves are
+  smooth; the *minima* are unstable because they rest on ~5 stars. Curve-fit quality is **not** the problem.
+- **One corner drives each vector:** replay Baseline corners were TL 566, TR 575, BL 565, **BR 602** → that lone
+  off corner produces A≈23, B≈13.
+- **Side finding:** the `TestApp tilt` validator does not reproduce the live wizard's numbers (different
+  detection settings/fit path). The tooling is not faithful enough to validate wizard changes (Layer-0 star
+  poverty makes the two diverge). The Step 3 fix — one shared robust estimator — resolves this too.
+
+## Answer: should there be ≥6 focus points instead of 5?
+
+**Raw point count is not the binding constraint here — points-with-stars-near-focus is.** This run already used
+**7–8** positions, but only ~3 carried usable stars. The per-star paraboloid's **5-detection minimum** can't be
+met when stars are detectable in only ~3 positions, so a 6th *coarse* point (at a 0–1-star wing) barely helps.
+The real lever is a **finer step near focus** so more positions land in the detectable window:
+- At step 175, ~3 of 7 positions have stars. A step of ~**80–100** would put ~5–6 positions in the usable range,
+  letting stars reach the 5-detection threshold and giving each corner region a real curve.
+- Keep ≥6 positions as a floor, but **prioritize step size and a star-rich field over raw count.**
+
+## Remediation (prioritized; detail in the plan)
+
+1. **Operational, do tonight (biggest immediate win):** calibrate on a **star-rich field**; use a **finer step**
+   (~80–100) so ≥5 positions carry stars; raise `MeasurementAverageCount` (e.g. 3) understanding it fights
+   *fit* noise not *drift*; add thermal-settle + focuser-backlash before each step and minimize time between a
+   screw step and its re-baseline to suppress Layer-3 drift.
+2. **Structural (highest accuracy):** calibrate from the per-star paraboloid tilt `Gx/Gy` (robust, curvature-aware,
+   identifiable, already computed and discarded) instead of the 4-corner OLS — mostly wiring + a units
+   conversion; bound/regularize curvature so a junk value can't inflate the tilt. One shared estimator for wizard
+   + live guidance + the validator.
+3. **Guards + confidence:** propagate the existing `ThetaStdError` into a per-step σ → a **calibration SNR** and
+   predicted screw-angle uncertainty; make the drift/angle guards prominent and **gate "Apply"** on low SNR /
+   high drift.
+4. **Validation tooling:** bootstrap the per-region/per-star points to report an A/B uncertainty + SNR from a
+   single run; dump per-corner residuals and per-star plane-fit residuals; make `TestApp tilt` faithful to the
+   wizard; run a bank-wide repeatability pass.
+
+## Verification status
+
+- Built TestApp (Windows dotnet); fixed a path-portability bug in `TiltCalibrationMetadata.ResolveStepFolder`
+  that blocked replay of runs captured under a different drive.
+- Ran `TestApp tilt` (3× — deterministic) and `TestApp focus-sweep` on all 6 runs; all numbers above are measured.
+
+## Implemented so far (verified)
+
+- **Calibration confidence / SNR gate (Step 4):** `TiltCalibrationCalculator.ComputeConfidence` derives a
+  signal-to-noise (screw-move signal vs the AllInward-piston + re-baseline-drift noise probes), surfaced in the
+  `TestApp tilt` report + verdict and as a wizard warning (`HasConfidenceWarning`, DataTemplates.xaml). On this
+  run it correctly reports **SNR 0.73–0.81 (< 2) → confidence FAIL**, ±~51–54° predicted screw-direction error,
+  with a "re-capture on a star-rich field with a finer step; do not apply" note. Unit-tested incl. a regression
+  lock on this run's values.
+- **Structural foundation (Step 3):** `TiltScrewGeometry.PhysicalGradientToPlane` (exact inverse of
+  `PlaneGradientToPhysical`) converts the robust per-star paraboloid tilt `Gx/Gy` into the `(A,B)` units the
+  calibration math consumes — so the wizard can be switched to the better estimator without changing downstream
+  geometry. Round-trip unit-tested. (Live rewire deferred until a star-rich run exists to validate it end-to-end.)
+- Full suite green: **1623 passed, 0 failed**.
+
+## Recommended next acquisition (no code needed)
+
+Re-run one calibration on a **star-rich field** with a **finer step (~80–100)**, thermally settled, screws turned
+the same amount. This is the highest-leverage action and produces the star-rich dataset needed to validate the
+structural estimator swap (Step 3 live wiring) and the bootstrap tooling (Step 5).

--- a/plans/sensor-model-finer-sweep-plan.md
+++ b/plans/sensor-model-finer-sweep-plan.md
@@ -1,0 +1,66 @@
+# Future Plan: Higher-Density Focus Sweeps for Sensor-Model / Tilt Runs
+
+## Context
+
+Tilt / sensor-model calibration on the `astrodet_6` run is **noise-limited**. Measured calibration SNR (screw-move
+signal vs the AllInward-piston + re-baseline-drift noise probes):
+
+| Estimator | SNR | Screw 1→2 gap |
+|---|---|---|
+| 4-corner OLS (current wizard) | **0.73** | 247.7° |
+| Per-star paraboloid `Gx/Gy` (the structural rewire, Step 3) | **1.61** | 130.2° |
+| + donut-aware σ down-weighting (lever 1) | _TBD_ | _TBD_ |
+
+Reliability bar is **SNR ≥ 2**. The paraboloid rewire more than doubled SNR but is still short, and the remaining
+limiter is the **per-image donut scatter** (per-star R² ≈ 0.35–0.60). The donut noise exists because the sweep
+spans ~±500 focuser steps from focus at **step 175** (≈ 626 µm ≈ ~23× the critical focus zone), so the extreme
+frames are huge, partial, overlapping donuts (focuser 54/229/1104) that (a) measure HFR unreliably and (b) fail
+RANSAC alignment. The per-star fit is also coarsely sampled near focus (~3 usable points).
+
+**Idea (this plan): run sensor-model / tilt AF sweeps at half the step size and ~twice the step count** to boost
+the per-star signal — more measurements per star (variance ↓ ~1/√N) and finer near-focus resolution (better
+vertex localization), with proportionally more points landing in the well-behaved (tight-PSF) zone rather than the
+donut tails. This must be validated on a **new capture** — it cannot be simulated from the existing 175-step frames.
+
+## Hypothesis
+
+Halving the step (~175 → ~88) and doubling the count (7–8 → ~15) — same total range, 2× sampling density —
+roughly doubles the per-star signal and sharpens near-focus sampling, lifting the calibration SNR over the
+reliability bar. Secondary variant to test: **finer step with a slightly shorter range** (fewer extreme-donut
+frames) vs **same range with 2× density** (more total signal) — measure which wins.
+
+## Plan
+
+1. **Sweep-cadence override for sensor-model/tilt runs.** The inspector AF sweep already supports overrides
+   (`InspectorOptions.StepCount` / `StepSize`, default −1 = profile; applied in `InspectorVM` ~1038-1045; engine
+   reads them in `AutoFocusEngine.cs:2256-2264`). Expose a sensor-model/tilt "high-density sweep" preset (or let the
+   Tilt Adapter Wizard request a finer StepSize + larger StepCount) so calibration can sample finer than the
+   profile's normal AF without changing day-to-day autofocus.
+2. **Wizard wiring.** Add a wizard option (or default for tilt calibration) to capture each of the six steps at the
+   finer cadence. Persist the cadence used into `metadata.json` so replays/comparisons are reproducible.
+3. **Capture cost note.** 2× exposures/run × 6 steps ≈ 2× calibration time. Surface the trade-off; consider
+   defaulting to finer step only within a bounded near-focus range and sparse sampling beyond it.
+
+## Validation
+
+- Re-capture one tilt calibration at the finer cadence on the same optical train; run
+  `TestApp tilt --dataset <run>` and compare **calibration SNR, screw 1→2 gap, move-magnitude ratio, and per-star
+  R²/stars-in-model** against the 175-step `astrodet_6` baseline. **Target: paraboloid SNR ≥ 2 (reliable).**
+- Bank-validate the sensor-model fit (`running-af-bank-validation` skill / `TestApp bank-verify` sensor-fit
+  metrics) at the finer cadence to confirm no regression and to characterise the signal gain across the bank.
+- Confirm the finer sweep also improves RANSAC alignment (more near-focus, tight-PSF frames → more frames align,
+  fewer wide-radius fallbacks).
+
+## Interactions (stack with the other fixes)
+
+- **Step 3 (paraboloid rewire):** the finer sweep feeds the robust estimator more, better-conditioned points.
+- **Lever 1 (donut-aware σ):** down-weights whatever donut tails remain; complementary, not redundant.
+- **SNR gate (Step 4):** the same metric scores the new capture and tells the user whether the finer cadence
+  cleared the bar.
+- **Drift:** more exposures lengthen each step → more thermal/backlash drift *between* differenced steps; pair the
+  finer cadence with thermal-settle + backlash compensation (Step 6) and minimise inter-step time.
+
+## Status
+
+Future experiment — **requires a new capture** at the finer cadence. No code is blocked on it; the
+override/preset wiring (steps 1–2) can be built ahead of the capture and validated on the bank.

--- a/plans/tilt-calibration-noise-plan.md
+++ b/plans/tilt-calibration-noise-plan.md
@@ -1,0 +1,219 @@
+# Tilt-Adapter Calibration Noise — Diagnosis & Remediation Plan
+
+## Context
+
+The user ran a 6-step Tilt Adapter Wizard calibration on the already-calibrated **astrodet** profile
+(`D:\Tilt Calibration Bank\astrodet_6\TiltCalibration_20260628_115023`) and the result is poor: the sensor
+models at the three "baseline" steps are very different even though they should be identical. The user was
+careful turning the screws and wants to understand **why** — root cause, from all angles — and specifically
+whether the per-star focus curves should use **≥6 points instead of 5**.
+
+**Headline finding (already strongly evidenced by the saved data + code):** the calibration is
+**noise-limited — the measurement noise floor is as large as the screw-move signal (SNR ≈ 1)**. The screws are
+not the problem; the data confirms the two turns were clean. The problem is upstream, in how the per-step tilt
+vector is measured. There are **two distinct noise sources** that must be separated: (a) a structurally fragile
+tilt-plane *estimator*, and (b) real *between-step physical drift* (thermal / focuser backlash / adapter creep)
+that contaminates a measurement built entirely from differences taken ~90–180 s apart.
+
+The 6 steps are: **Baseline → AllInward → ReBaseline1 → Screw1 → ReBaseline2 → Screw2**. The "3 baselines" are
+Baseline / ReBaseline1 / ReBaseline2 — all the *same* neutral screw state, so they must measure the same tilt.
+
+---
+
+## Root-cause diagnosis (the "why")
+
+### Evidence the calibration is noise-dominated (from this one run's `metadata.json`)
+
+| Check | Expected | Measured | Verdict |
+|---|---|---|---|
+| 3 baselines (identical neutral state) | same (A,B) | RMS scatter **±8.0** units; tilt angle 0.089°→0.316° | noise floor ≈ 8 |
+| **AllInward** = all screws in equally = pure piston → **zero tilt change** | ~0 | **20.6** units of tilt change | null-move noise ≈ 20 |
+| Two screws are physically **120° apart** | 120° apart | **63.7°** apart (`rawAngleDiffDegrees`) | 56° error = 1.7σ of predicted ±33° |
+| Screw-move **signal** | — | **13.9** units (both screws) | **≈ the noise → SNR ≈ 1** |
+| `moveMagnitudeRatio` (turn evenness) | ~1.0 | **1.0016** | turns were *clean* — user's care confirmed |
+
+Predicted vs observed angle error lines up exactly: transverse σ ≈ 5.7 on a 13.9-unit vector ⇒ per-move
+direction σ ≈ 23°, ⇒ ±33° on the screw-to-screw difference. Measured 63.7° (vs 120°) is 1.7σ — fully explained
+by noise. **No amount of careful screw-turning fixes an SNR≈1 measurement.**
+
+Corroborating signatures:
+- **Curvature term is fitting noise, not optics.** Across the 3 baselines `curvatureRadiusMillimeters` =
+  56 / 713 / 1112 mm (20× swing, sign flip); Baseline reports **+17,279 µm** curvature at screw radius — **4.6× the
+  entire focuser sweep** (~3,760 µm). Real Petzval curvature is constant; this is the unbounded paraboloid fit
+  absorbing outliers.
+- **Run-to-run repeatability is poor at the profile level:** applied `astrodet.tilt.json` (4 runs, 2026-06-13)
+  used `screwThreadPitchMicrons` = 400; this run *measured* 453 — a 13% drift in a fixed mechanical constant.
+- **The wizard's own guards already fire** (advisory only): re-baseline drift **134%** and **74%** of the screw
+  move (threshold 50%, `EvaluateRebaselineDrift`, `TiltAdapterWizardVM.cs:1186-1208`); angle-gap deviation 56°
+  (threshold 30°, `ValidateCalibrationQuality`, `:1161-1182`). `MeasurementAverageCount` = **1** disables the
+  repeatability guard entirely.
+
+### Mechanism — why the per-step tilt vector (A,B) is so noisy
+
+The entire screw calibration is derived purely from how the tilt vector **(A,B)** changes between steps
+(`TiltCalibrationCalculator.Calibrate/ComputeScrewAngles`, `TiltCalibrationCalculator.cs:118-219`: each screw =
+`Screw_i − ReBaseline_i`, then `atan2(dA,−dB)`). That (A,B) is fragile by construction:
+
+1. **4-corner OLS, 1 degree of freedom, zero robustness** — `TiltPlaneModel.Create`
+   (`AutoFocus/TiltModel.cs:132-165`) fits a 3-parameter plane (A, B, intercept) through **only 4 corner-region
+   best-focus positions** (center region excluded), unweighted, no outlier rejection, **no curvature term**. Each
+   corner is one region's hyperbola minimum aggregating that quadrant's stars. With 4 points for 3 params, any
+   per-corner focus error propagates ~1:1 into A/B, and there is nothing to average it down.
+2. **Two models that disagree and aren't cross-checked.** The metadata mixes outputs of *two independent fits*:
+   `tiltPlaneA/B` from the 4-corner OLS above, but `curvatureRadius…/curvatureEffect…` from a **separate per-star
+   tilted-paraboloid** (`Inspection/SensorParaboloidModel.cs` + `SensorModel.cs`). The paraboloid *does* have
+   robust winsorized rejection and per-star σ weighting — but its **curvature is totally unbounded/unregularized**
+   (`SensorParaboloidModel.cs:398-418`), its quadratic column is ill-conditioned (~1e-6 coeff over ~1e7-scale x²),
+   and its **free center (X0,Y0) is confounded with the tilt gradient** (non-identifiable; the solver returns a
+   null covariance for exactly this case, `NonLinearLeastSquaresSolver.cs:452-456`). So the rich, robust model is
+   *not* what the wizard calibrates from, and the live Inspector guidance (which *does* use the paraboloid Gx/Gy)
+   can diverge from the calibration.
+3. **Differencing doubles the variance.** Each screw signal subtracts two independent noisy plane fits; with
+   `MeasurementAverageCount = 1` nothing averages it down.
+4. **Real, time-correlated between-step drift.** Mean focuser position across the three baselines drifts
+   **monotonically** 591 → 599.6 → 609.8 (~67 µm over 8 min) — that is *not* random fit noise (random noise isn't
+   monotonic); it is thermal / focuser-backlash / tilt-adapter creep / seeing. Because every screw move is a
+   *difference taken ~90–180 s apart*, this non-stationarity lands directly in the signal. **This is why
+   simply averaging more frames per step will not fix it** (longer steps → more drift between the differenced
+   steps).
+
+### Process layer
+The wizard detected the failure (drift + angle warnings) but the warnings are advisory; calibration proceeds and
+**snaps the noisy 63.7° onto the ideal 120° lattice** (`ComputeScrewAngles`, `:126-130`), emitting
+confident-looking screw angles built on SNR≈1 data — which then drive every later screw-turn recommendation.
+
+---
+
+## Answer: should there be ≥6 focus points instead of 5?
+
+**Yes as a floor — but it is not what made *this* run noisy** (this run already used **7–8** focuser positions,
+step 175). Precise picture:
+
+- The **calibration-critical tilt plane** uses **region** curves that need only **3 points** and pool all stars
+  in a quadrant (`AutoFocusEngine.cs:112`), so raw focuser-point count is *not* its bottleneck.
+- The **per-star paraboloid** (curvature) has a hard **min-5-matched-detections-per-star** guard
+  (`SensorModel.cs:624,660`). At exactly 5 positions a star must be detected in *every* frame to qualify; one
+  defocus dropout drops it from the model. **≥6 positions lets stars survive a dropout** → more stars, more
+  stable curvature. So ≥6 (ideally 7–9) is good practice, and step 175 (~23× the critical focus zone) is coarse
+  near focus — denser near-focus sampling helps per-curve vertex precision more than raw count does.
+- Net: keep ≥6 as a floor, but the dominant levers for *this* failure are the structural fit, averaging where
+  drift permits, and killing the between-step drift — not 5→6.
+
+---
+
+## Execution plan
+
+> Plan-mode note: Step 1 needs a Windows build, so it runs first on execution. Deliverables get filed per project
+> convention: the diagnosis as a **design spec** `docs/tilt-calibration-noise-design.md`, this plan as
+> `plans/tilt-calibration-noise-plan.md`.
+
+### Step 1 — Empirically confirm the diagnosis (replay this saved run)
+
+Build TestApp via Windows `dotnet.exe` (per the WSL build note), then:
+
+> **Done:** fixed a path-portability bug that blocked replay — `TiltCalibrationMetadata.ResolveStepFolder` honored
+> stored *absolute* run-folder paths as-is and never checked existence, so this run (captured under `H:\…`, now on
+> `D:\…`) was unreplayable. It now rebases a missing absolute path's tail onto the selected run root (fixes both
+> offline TestApp and in-app wizard replay). Belongs to Step 5's tooling hardening.
+
+1. **Tilt replay** — confirms per-step (A,B) match metadata, exposes per-corner fit quality:
+   ```
+   TestApp.exe tilt --dataset "D:\Tilt Calibration Bank\astrodet_6\TiltCalibration_20260628_115023"
+   ```
+   Inspect `tilt_summary.json`: per-step `regionRSquared` (C/TL/TR/BL/BR) and `regionPositions`, calibrated
+   angles, recovered pitch, PASS/FAIL. **Look for:** corners with low R² or sparse stars in specific steps =
+   where the 4-corner plane is being corrupted. (`TestApp/TiltCalibrationRunner.cs`.)
+2. **Focus-sweep per run** — quantifies dropout/sparsity behind each region curve:
+   ```
+   TestApp.exe focus-sweep --dataset <each of the 6 AutoFocus_* run folders>
+   ```
+   Shows star count + HFR spread + rejection reasons vs focuser position. **Look for:** star count collapsing at
+   the defocused extremes and any quadrant that is chronically star-poor.
+3. Record the measured numbers; separate the **fit-noise** component (per-corner R², star counts) from the
+   **drift** component (monotonic mean-focus march, the 134%/74% rebaseline drift). The random fit-noise σ is
+   quantified by the bootstrap added in Step 5 (replay alone is deterministic).
+
+### Step 2 — Write the diagnosis design doc
+
+`docs/tilt-calibration-noise-design.md`: everything above + the Step-1 measured numbers. This is the primary
+"understand why" deliverable.
+
+### Step 3 — Structural: calibrate from the sensor model's tilt term *(highest accuracy win)*
+
+**Key realization (validated against code): the robust tilt estimate already exists and is computed on every
+measurement — the wizard just throws it away.** The per-star `SensorParaboloidModel` carries a tilt gradient
+`Gx/Gy` (`SensorParaboloidModel.cs:162-166, 286-288`) fit over *all* matched stars with winsorized outlier
+rejection + per-star 1/σ² weighting and an explicit curvature term, and — because `FixedSensorCenter` defaults
+**true** (`InspectorOptions.cs:66,98`) — its center is pinned so `Gx/Gy` is a clean, identifiable tilt-at-center
+(the tilt↔center confounding only bites when the center floats). It is computed during each wizard step but only
+its *curvature* is harvested (`PopulateCurvature`, `TiltAdapterWizardVM.cs:946-951`); calibration instead reads
+the crude 4-corner `TiltModel` (`:860-862`).
+
+So the fix is mostly **wiring + a units conversion**, not new math:
+- Have the wizard calibrate from the paraboloid tilt gradient (`Gx/Gy`) instead of `TiltPlaneModel` 4-corner A/B
+  (`TiltAdapterWizardVM.cs:855-880`). Convert `Gx` (focuser-µm per sensor-µm) → the calibration's `A/B`
+  (focuser-steps per normalized [-0.5,0.5] coord) — a linear scale by sensor width/height, pixel size, focuser
+  step; or refactor `TiltCalibrationCalculator` to take a physical gradient directly so wizard + live guidance
+  share one quantity. Keep the 4-corner value as a cross-check/fallback when the paraboloid is unavailable
+  (needs ≥9 pts / ≥10 stars).
+- **Bound/regularize curvature** `K` so a non-physical value (we saw 56 mm radius) can't inflate `Gx` variance
+  when stars are clustered/few (`SensorParaboloidModel.cs:398-430`); ensure the paraboloid is actually computed
+  during the wizard (it was for this run; make it unconditional for calibration, independent of the display
+  `SensorCurveModelEnabled` toggle).
+- Reuse existing machinery: `SolveWinsorizedResiduals`, per-star σ weighting, `RejectionTest`, `MedianMAD`.
+- Fix the minor winsor-band-centered-on-zero bug (`NonLinearLeastSquaresSolver.cs:124-135`).
+- Key files: `TiltAdapterWizard/TiltAdapterWizardVM.cs`, `TiltAdapterWizard/TiltCalibrationCalculator.cs`,
+  `Inspection/SensorModel.cs`, `Inspection/SensorParaboloidModel.cs`, `Utility/NonLinearLeastSquaresSolver.cs`,
+  `AutoFocus/TiltModel.cs` (fallback/cross-check).
+- **Honest scope:** this removes the *estimator-noise* component only; the between-step *drift* component
+  (Step 6) is orthogonal and unaffected by a better fit.
+
+### Step 4 — Actionable guards + a calibration-confidence number
+
+- The paraboloid **already computes `ThetaStdError`** (1σ tilt-angle SE via the delta method from the fit
+  covariance, `SensorParaboloidModel.cs:198,222-248`). Propagate it into a **per-step (A,B) σ** → a **calibration
+  SNR** (signal = screw-move magnitude, noise = combined per-step σ) and a **predicted screw-angle uncertainty**;
+  surface these in the wizard summary. Largely consume-what-exists.
+- Make the existing advisory guards (`ValidateCalibrationQuality`, `EvaluateRebaselineDrift`) **prominent and
+  gate "Apply"** when drift ratio > 0.5 or SNR below threshold; recommend re-running. (`TiltAdapterWizardVM.cs:1161-1208`,
+  plus the wizard XAML.)
+
+### Step 5 — Validation tooling (so every change is measurable)
+
+Extend `TestApp/TiltCalibrationRunner.cs`:
+- **Bootstrap** the per-region/per-star points and refit to report an A/B uncertainty + calibration SNR from a
+  single dataset (this is what gives the random fit-noise σ that deterministic replay can't).
+- Dump **per-corner residuals**, per-region R², and (new) **per-star plane-fit residuals** (currently no per-star
+  dump exists in TestApp).
+- A bank-wide repeatability pass across the other runs (`astrodet`, `cwhite`, the four `2026-06-21` runs) to
+  characterize the noise floor generally and as a regression baseline.
+
+### Step 6 — Operational / acquisition knobs *(empirically the biggest immediate win)*
+
+Focus-sweep showed the dataset is **star-poor** (peak ~23–38 stars whole-sensor; only ~3 of 7–8 positions carry
+>5 stars; wings 0–1) — the soil under all the noise. The user can act on this with **no code change**:
+- **Star-rich field + detection sensitivity:** point at a denser field for calibration; the per-corner fit needs
+  many stars per quadrant. Re-tune detection for more survivors if the field can't be richer.
+- **Finer step near focus:** at step 175 only ~3 positions have stars. Step ~**80–100** puts ~5–6 positions in
+  the detectable window → stars reach the per-star 5-detection minimum, regions get real curves. **This is the
+  true content of the "≥6 points" question** — points-with-stars, governed by step size, not raw count.
+- **Averaging with the drift caveat:** raise `MeasurementAverageCount` (e.g. 3) — beats *fit* noise, not *drift*.
+- **Kill drift:** thermal-settle + focuser-backlash move before each step; minimize time between a screw step and
+  its re-baseline; optionally drift-correct each screw move using its bracketing rebaselines.
+- Any new persisted option needs a control in `Resources/OptionsDataTemplates.xaml` (project invariant).
+
+> **Recommendation surfaced by Step 1:** re-acquire one calibration on a star-rich field with a finer step
+> *before* investing in the structural refactor — it may largely resolve the problem, and a good run is the test
+> data needed to validate Steps 3–5 against.
+
+---
+
+## Verification
+
+- **Empirical (Step 1):** replay reproduces the metadata per-step (A,B); per-region R² / focus-sweep reveal which
+  corners/steps are weak and confirm extreme-defocus dropout.
+- **Step 3/5:** the bootstrap SNR on this run should rise materially after the robust fit; re-deriving the screw
+  angles should move the 63.7° gap toward 120° (or honestly report that this dataset is too noisy to calibrate).
+- **Guards (Step 4):** this run must be flagged (and "Apply" gated) by the new drift/SNR checks.
+- **Regression:** `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo` must stay green after
+  every code change (project invariant). Bank-wide repeatability pass (Step 5) before/after the structural change.


### PR DESCRIPTION
## Summary

Investigates why tilt-adapter calibration produced inconsistent baselines on a saved run (`astrodet_6`), then lands the diagnosis, the high-confidence fixes, **and** the structural rewire — the wizard now calibrates from the per-star sensor-curve model's tilt instead of the fragile 4-corner region plane.

**Root cause:** the calibration is **noise-limited** (calibration SNR ~0.73). The per-step tilt vector that drove the screw geometry was a 3-parameter plane through just **4 corner regions** (1 DOF, no robustness, no curvature term), and the heavily-defocused **donut** frames at the sweep extremes inject HFR noise and fail RANSAC alignment. The screws were turned cleanly (move-magnitude ratio 1.0016) — the bottleneck is upstream of the screws.

## What's in this PR

**Structural rewire (changes the live estimator)**
- The Tilt Adapter Wizard now derives each step's tilt from the **per-star sensor-curve model** (`inspector.SensorModel.SensorModelResult.TiltPlaneModel`, built from the paraboloid `Gx/Gy` by `CreateTiltPlaneModel`), in both the live measurement loop and Replay — **never** the 4-corner plane. If the paraboloid can't be fit (too few stars), the step fails rather than falling back.
- `InspectorVM.ForceSensorCurveModelGeneration` (transient flag) + `ResolveSensorCurveModelEnabled()` let the wizard **force** the paraboloid to be generated even when the display option is off. The flag is set only around each analysis call and restored immediately (no leak).
- Validated headlessly in the TestApp comparison: the paraboloid estimator lifts **SNR 0.73 → 1.61** and the screw gap **247.7° → 130°** on `astrodet_6`. `CreateTiltPlaneModel` is the exact same `Gx/Gy → (A,B)` mapping as the tested `PhysicalGradientToPlane`, so the live path is mathematically equivalent to that result.

**Other live-plugin fixes**
- **Calibration confidence / SNR gate** — `TiltCalibrationCalculator.ComputeConfidence`: screw-move signal vs the AllInward-piston + re-baseline-drift noise probes + a predicted screw-direction uncertainty + an `IsReliable` flag (SNR ≥ 2). Wizard warning (`HasConfidenceWarning`, red banner) + TestApp verdict. Flags this run (SNR 0.73) as do-not-apply.
- **Donut-aware per-star σ** (`SensorModel.EstimateHfrStdDev`) — SNR floor 1.0 → 0.2 + 3× for contaminated detections. Sensor-model/tilt fit only. **Bank-verified: no regression** (max |ΔR²| 0.0016 / 19 runs).
- **Headless deadlock fix** — `RegisterStarsAndFit`'s `Report()` does a blocking WPF-dispatcher `Send` from a worker; deadlocks when the caller blocks the main thread, only on the incomplete-RANSAC-alignment (donut) path. TestApp tilt runner now sets `RegistrationReportSink`. Root-caused from a managed thread dump.
- **`ResolveStepFolder`** — replay runs captured under a different drive than where `metadata.json` now lives.

**Tooling / docs**
- TestApp `tilt`: 4-corner vs per-star-paraboloid comparison + the confidence report + a bounded fit timeout.
- `docs/tilt-calibration-noise-design.md`, `plans/tilt-calibration-noise-plan.md`, `plans/sensor-model-finer-sweep-plan.md` (future half-step / 2×-steps experiment).

## ⚠️ Validation needed before merge
The structural rewire **changes every user's live calibration estimator**. It's mathematically equivalent to the validated TestApp result and the full unit suite passes, but it needs an **in-NINA smoke test**: run the Tilt Adapter Wizard (and Replay) with the sensor model force-generated, confirm the per-step tilt populates from the paraboloid and the screw guidance looks sane. The wizard warning banner and the deadlock path are also worth eyeballing in-app.

## Not in this PR (future)
- The finer/denser sweep capture experiment (`plans/sensor-model-finer-sweep-plan.md`) — the highest-leverage lever; needs a new capture.

## Testing
- Unit suite: **1623 pass**.
- Bank A/B sensor-R² regression check on the donut-aware σ: no regression.
- TestApp `tilt` replay reproduces the diagnosis, the confidence verdict, and the 4-corner-vs-paraboloid comparison on `astrodet_6`.

## Reviewer note
This run is still below the SNR ≥ 2 bar even with the paraboloid (1.61), so the bottom line for the actual calibration is unchanged: **re-acquire star-rich, thermally settled, with a finer sweep, and don't apply this run's screw geometry.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
