### PR TITLE
Improve signal in tilt calibration and sensor modeling

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorOptionsTests.cs
@@ -25,6 +25,8 @@ public class InspectorOptionsTests {
         Assert.Multiple(() => {
             Assert.That(options.StepCount, Is.EqualTo(-1));
             Assert.That(options.StepSize, Is.EqualTo(-1));
+            Assert.That(options.SignalAmplification, Is.EqualTo(2));
+            Assert.That(options.CenterFocuserBeforeRun, Is.True);
             Assert.That(options.FramesPerPoint, Is.EqualTo(-1));
             Assert.That(options.TimeoutSeconds, Is.EqualTo(-1));
             Assert.That(options.SimpleExposureSeconds, Is.EqualTo(-1));
@@ -59,6 +61,8 @@ public class InspectorOptionsTests {
         var (options, store, _) = Build();
         options.StepCount = 5;
         options.StepSize = 50;
+        options.SignalAmplification = 3;
+        options.CenterFocuserBeforeRun = false;
         options.FramesPerPoint = 3;
         options.NumRegionsWide = 9;
         options.SimpleExposureSeconds = 2.5;
@@ -87,6 +91,8 @@ public class InspectorOptionsTests {
         Assert.Multiple(() => {
             Assert.That(store.Snapshot[nameof(InspectorOptions.StepCount)], Is.EqualTo(5));
             Assert.That(store.Snapshot[nameof(InspectorOptions.StepSize)], Is.EqualTo(50));
+            Assert.That(store.Snapshot[nameof(InspectorOptions.SignalAmplification)], Is.EqualTo(3));
+            Assert.That(store.Snapshot[nameof(InspectorOptions.CenterFocuserBeforeRun)], Is.False);
             Assert.That(store.Snapshot[nameof(InspectorOptions.FramesPerPoint)], Is.EqualTo(3));
             Assert.That(store.Snapshot[nameof(InspectorOptions.SimpleExposureSeconds)], Is.EqualTo(2.5));
             Assert.That(store.Snapshot[nameof(InspectorOptions.DetailedAnalysisExposureSeconds)], Is.EqualTo(4.0));
@@ -136,6 +142,17 @@ public class InspectorOptionsTests {
         Assert.That(options.CornersROI, Is.EqualTo(expected));
     }
 
+    [TestCase(-5, 1)]
+    [TestCase(0, 1)]
+    [TestCase(1, 1)]
+    [TestCase(2, 2)]
+    [TestCase(4, 4)]
+    public void SignalAmplification_ClampsToAtLeastOne(int assigned, int expected) {
+        var (options, _, _) = Build();
+        options.SignalAmplification = assigned;
+        Assert.That(options.SignalAmplification, Is.EqualTo(expected));
+    }
+
     [Test]
     public void BrightnessToleranceHint_ReflectsPreviousRunBrightnessDiff() {
         var (options, _, _) = Build();
@@ -165,6 +182,8 @@ public class InspectorOptionsTests {
         options.NumRegionsWide = 10;
         options.SensorROI = 0.5;
         options.MouseOnChartsEnabled = false;
+        options.SignalAmplification = 4;
+        options.CenterFocuserBeforeRun = false;
 
         options.ResetDefaults();
 
@@ -174,10 +193,14 @@ public class InspectorOptionsTests {
             Assert.That(options.SensorROI, Is.EqualTo(1.0));
             Assert.That(options.MouseOnChartsEnabled, Is.True);
             Assert.That(options.InterpolationAmount, Is.EqualTo(InterpolationAmountEnum.Medium));
+            Assert.That(options.SignalAmplification, Is.EqualTo(2));
+            Assert.That(options.CenterFocuserBeforeRun, Is.True);
         });
     }
 
     [TestCase(nameof(InspectorOptions.StepCount), 4)]
+    [TestCase(nameof(InspectorOptions.SignalAmplification), 3)]
+    [TestCase(nameof(InspectorOptions.CenterFocuserBeforeRun), false)]
     [TestCase(nameof(InspectorOptions.LoopingExposureAnalysisEnabled), true)]
     [TestCase(nameof(InspectorOptions.MicronsPerFocuserStep), 2.5)]
     [TestCase(nameof(InspectorOptions.SensorROI), 0.6)]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMTests.cs
@@ -118,6 +118,49 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
         }
 
         [Test]
+        public void ApplySignalAmplification_LiveRun_DividesStepSizeAndMultipliesStepCount() {
+            var options = new AutoFocusEngineOptions { AutoFocusInitialOffsetSteps = 4, AutoFocusStepSize = 100 };
+            InspectorVM.ApplySignalAmplification(options, signalAmplification: 2, isLiveCapture: true);
+            Assert.Multiple(() => {
+                Assert.That(options.AutoFocusInitialOffsetSteps, Is.EqualTo(8));
+                Assert.That(options.AutoFocusStepSize, Is.EqualTo(50));
+            });
+        }
+
+        [TestCase(1)]   // factor of 1 disables amplification
+        [TestCase(0)]   // clamped to 1 -> no-op
+        [TestCase(-3)]  // clamped to 1 -> no-op
+        public void ApplySignalAmplification_FactorOfOneOrLess_IsNoOp(int amp) {
+            var options = new AutoFocusEngineOptions { AutoFocusInitialOffsetSteps = 4, AutoFocusStepSize = 100 };
+            InspectorVM.ApplySignalAmplification(options, signalAmplification: amp, isLiveCapture: true);
+            Assert.Multiple(() => {
+                Assert.That(options.AutoFocusInitialOffsetSteps, Is.EqualTo(4));
+                Assert.That(options.AutoFocusStepSize, Is.EqualTo(100));
+            });
+        }
+
+        [Test]
+        public void ApplySignalAmplification_Replay_IsNoOp() {
+            // On replay the saved frames' focuser positions are fixed, so amplification must not change the sweep.
+            var options = new AutoFocusEngineOptions { AutoFocusInitialOffsetSteps = 4, AutoFocusStepSize = 100 };
+            InspectorVM.ApplySignalAmplification(options, signalAmplification: 3, isLiveCapture: false);
+            Assert.Multiple(() => {
+                Assert.That(options.AutoFocusInitialOffsetSteps, Is.EqualTo(4));
+                Assert.That(options.AutoFocusStepSize, Is.EqualTo(100));
+            });
+        }
+
+        [Test]
+        public void ApplySignalAmplification_StepSizeFloorsAtOne() {
+            var options = new AutoFocusEngineOptions { AutoFocusInitialOffsetSteps = 5, AutoFocusStepSize = 1 };
+            InspectorVM.ApplySignalAmplification(options, signalAmplification: 4, isLiveCapture: true);
+            Assert.Multiple(() => {
+                Assert.That(options.AutoFocusInitialOffsetSteps, Is.EqualTo(20));
+                Assert.That(options.AutoFocusStepSize, Is.EqualTo(1));
+            });
+        }
+
+        [Test]
         public void HasInspectorRegionLayout_RequiresFullSixRegionGrid() {
             // The region report indexes RegionHFRs[1..5], so fewer than 6 regions (e.g. a reprocessed single-region
             // regular-AF run) must be rejected — the guard that turns the old IndexOutOfRange crash into a clean log.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
@@ -8,6 +8,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
 
         public int StepCount { get; set; }
         public int StepSize { get; set; }
+        public int SignalAmplification { get; set; } = 2;
+        public bool CenterFocuserBeforeRun { get; set; } = true;
         public int FramesPerPoint { get; set; }
         public int TimeoutSeconds { get; set; }
         public int NumRegionsWide { get; set; } = 7;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -27,6 +27,8 @@
     <TextBlock x:Key="StepCount_Tooltip" Text="The minimum number of data points needed on each side of the AutoFocus curve minimum. Uses the value set for AutoFocus if blank" />
     <TextBlock x:Key="StepSize_Tooltip" Text="How many focuser steps in between each data point when doing an AutoFocus. Uses the value set for AutoFocus if blank" />
     <TextBlock x:Key="FramesPerPoint_Tooltip" Text="How many exposures to average together for each focuser point. Uses the value set for AutoFocus if blank" />
+    <TextBlock x:Key="SignalAmplification_Tooltip" Text="Increases the resolution and signal of sensor-model / tilt calibration runs by capturing more, finer-spaced focuser points. The focuser step size is divided by this factor and the number of steps multiplied by it, so the sweep covers the same range with more points (and smaller defocus jumps between adjacent frames, which makes star alignment more reliable). Default 2. Set to 1 to disable. Applies to live captures only, not when replaying saved frames." />
+    <TextBlock x:Key="CenterFocuserBeforeRun_Tooltip" Text="When on (default), a quick standard AutoFocus is run before each live sensor-model / tilt calibration sweep to center the focuser at best focus. The detailed sweep then brackets focus symmetrically, which reduces extreme one-sided defocus frames that fail to align. Has no effect when replaying saved frames." />
     <TextBlock x:Key="AutoFocusTimeoutSeconds_Tooltip" Text="How long, in seconds, after which AutoFocus should time out and fail. Uses the value set for AutoFocus if blank" />
     <TextBlock x:Key="NumRegionsWide_Tooltip" Text="How many cells wide to divide the sensor pixels when generating a grid of eccentricity vectors. This value must be an odd, positive integer, and the height will be calculated proportionally from it based on the sensor resolution" />
     <TextBlock x:Key="MicronsPerFocuserStep_Tooltip" Text="How much the focuser moves per step, in microns. If this is set, the adjustment chart will include adjustments in microns" />
@@ -1414,6 +1416,7 @@
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
                             <RowDefinition Style="{StaticResource HideOnInterpolationOff}" />
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
@@ -1754,8 +1757,50 @@
                             <CheckBox Margin="5,0,0,0" IsChecked="{Binding InspectorOptions.FixedSensorCenter}" />
                         </StackPanel>
 
-                        <Expander
+                        <TextBlock
                             Grid.Row="7"
+                            Grid.Column="0"
+                            Margin="5"
+                            VerticalAlignment="Center"
+                            Text="Signal Amplification"
+                            ToolTip="{StaticResource SignalAmplification_Tooltip}" />
+                        <ninactrl:UnitTextBox
+                            Grid.Row="7"
+                            Grid.Column="1"
+                            MinWidth="40"
+                            VerticalAlignment="Center"
+                            HorizontalContentAlignment="Left"
+                            VerticalContentAlignment="Center"
+                            Foreground="{StaticResource PrimaryBrush}"
+                            TextAlignment="Left"
+                            ToolTip="{StaticResource SignalAmplification_Tooltip}"
+                            Unit="x">
+                            <Binding
+                                Mode="TwoWay"
+                                Path="InspectorOptions.SignalAmplification"
+                                UpdateSourceTrigger="LostFocus" />
+                        </ninactrl:UnitTextBox>
+
+                        <TextBlock
+                            Grid.Row="7"
+                            Grid.Column="2"
+                            Margin="5"
+                            VerticalAlignment="Center"
+                            Text="Center Focuser First"
+                            ToolTip="{StaticResource CenterFocuserBeforeRun_Tooltip}" />
+                        <StackPanel
+                            Grid.Row="7"
+                            Grid.Column="3"
+                            Orientation="Horizontal">
+                            <CheckBox
+                                Margin="5,0,0,0"
+                                VerticalAlignment="Center"
+                                IsChecked="{Binding InspectorOptions.CenterFocuserBeforeRun}"
+                                ToolTip="{StaticResource CenterFocuserBeforeRun_Tooltip}" />
+                        </StackPanel>
+
+                        <Expander
+                            Grid.Row="8"
                             Grid.ColumnSpan="4"
                             VerticalAlignment="Center"
                             Header="Experimental">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
@@ -48,6 +48,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         private void InitializeOptions() {
             stepCount = optionsAccessor.GetValueInt32(nameof(StepCount), -1);
             stepSize = optionsAccessor.GetValueInt32(nameof(StepSize), -1);
+            signalAmplification = Math.Max(1, optionsAccessor.GetValueInt32(nameof(SignalAmplification), 2));
+            centerFocuserBeforeRun = optionsAccessor.GetValueBoolean(nameof(CenterFocuserBeforeRun), true);
             framesPerPoint = optionsAccessor.GetValueInt32(nameof(FramesPerPoint), -1);
             timeoutSeconds = optionsAccessor.GetValueInt32(nameof(TimeoutSeconds), -1);
             simpleExposureSeconds = optionsAccessor.GetValueDouble(nameof(SimpleExposureSeconds), -1);
@@ -81,6 +83,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         public void ResetDefaults() {
             StepCount = -1;
             StepSize = -1;
+            SignalAmplification = 2;
+            CenterFocuserBeforeRun = true;
             FramesPerPoint = -1;
             TimeoutSeconds = -1;
             SimpleExposureSeconds = -1;
@@ -128,6 +132,40 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 if (stepSize != value) {
                     stepSize = value;
                     optionsAccessor.SetValueInt32(nameof(StepSize), stepSize);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        // Signal amplification factor for sensor-model / tilt calibration sweeps: divides the focuser step size and
+        // multiplies the step count by this factor, so a live run captures more, finer-spaced points over the same
+        // range. More points => more signal and smaller defocus jumps between adjacent frames (easier RANSAC
+        // alignment). Clamped to >= 1; 1 disables amplification. Applied only to live captures, never on replay.
+        private int signalAmplification = 2;
+
+        public int SignalAmplification {
+            get => signalAmplification;
+            set {
+                var clamped = Math.Max(1, value);
+                if (signalAmplification != clamped) {
+                    signalAmplification = clamped;
+                    optionsAccessor.SetValueInt32(nameof(SignalAmplification), signalAmplification);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        // When on (default), a quick standard autofocus is run before each live sensor-model / tilt sweep to center
+        // the focuser at best focus, so the sweep brackets focus symmetrically (fewer extreme one-sided defocus
+        // frames that fail to align). No effect on replay of saved frames.
+        private bool centerFocuserBeforeRun = true;
+
+        public bool CenterFocuserBeforeRun {
+            get => centerFocuserBeforeRun;
+            set {
+                if (centerFocuserBeforeRun != value) {
+                    centerFocuserBeforeRun = value;
+                    optionsAccessor.SetValueBoolean(nameof(CenterFocuserBeforeRun), centerFocuserBeforeRun);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -420,13 +420,18 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     // Pre-center the focuser at best focus before the detailed multi-region sweep, so the sweep
                     // brackets focus symmetrically. This reduces extreme one-sided defocus frames that fail RANSAC
                     // alignment and improves the per-star paraboloid fit the tilt is read from. A plain (single-region)
-                    // AutoFocus is run on a SEPARATE engine — no inspector chart wiring, no save, profile step
-                    // size/count (NOT signal-amplified; a quick coarse centering pass is sufficient). Failure is
-                    // non-fatal: the detailed run proceeds from the current focuser position.
+                    // AutoFocus is run on a SEPARATE engine — no inspector chart wiring. It uses GetOptions() (profile
+                    // step size/count), so it is deliberately NOT signal-amplified: the finer steps are only needed for
+                    // the sensor-model run, a quick coarse centering pass is sufficient. The centering run is NEVER
+                    // saved (Save forced off, independent of the global AutoFocus save toggle and of any saveOverride):
+                    // only the actual sensor-model / per-tilt-step run that follows is persisted. Failure is non-fatal:
+                    // the detailed run proceeds from the current focuser position.
                     if (inspectorOptions.CenterFocuserBeforeRun) {
                         try {
                             var centeringEngine = autoFocusEngineFactory.Create();
                             var centeringOptions = centeringEngine.GetOptions();
+                            centeringOptions.Save = false;
+                            centeringOptions.PreserveExposures = false;
                             this.progress.Report(new ApplicationStatus() { Status = "Centering focuser before sensor model run" });
                             var centeringResult = await centeringEngine.Run(centeringOptions, imagingFilter, localAnalyzeCts.Token, this.progress);
                             if (centeringResult == null || !centeringResult.Succeeded) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -416,6 +416,29 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     ResetErrors();
                     ResetExposureAnalysis();
                     LastSaveFolder = null;
+
+                    // Pre-center the focuser at best focus before the detailed multi-region sweep, so the sweep
+                    // brackets focus symmetrically. This reduces extreme one-sided defocus frames that fail RANSAC
+                    // alignment and improves the per-star paraboloid fit the tilt is read from. A plain (single-region)
+                    // AutoFocus is run on a SEPARATE engine — no inspector chart wiring, no save, profile step
+                    // size/count (NOT signal-amplified; a quick coarse centering pass is sufficient). Failure is
+                    // non-fatal: the detailed run proceeds from the current focuser position.
+                    if (inspectorOptions.CenterFocuserBeforeRun) {
+                        try {
+                            var centeringEngine = autoFocusEngineFactory.Create();
+                            var centeringOptions = centeringEngine.GetOptions();
+                            this.progress.Report(new ApplicationStatus() { Status = "Centering focuser before sensor model run" });
+                            var centeringResult = await centeringEngine.Run(centeringOptions, imagingFilter, localAnalyzeCts.Token, this.progress);
+                            if (centeringResult == null || !centeringResult.Succeeded) {
+                                Logger.Warning("Centering AutoFocus did not succeed; continuing the sensor-model run from the current focuser position.");
+                            }
+                        } catch (OperationCanceledException) {
+                            throw;
+                        } catch (Exception ex) {
+                            Logger.Warning($"Centering AutoFocus failed: {ex.Message}; continuing the sensor-model run from the current focuser position.");
+                        }
+                    }
+
                     var result = await autoFocusEngine.RunWithRegions(options, imagingFilter, regions, localAnalyzeCts.Token, this.progress);
                     if (result == null) {
                         InspectorErrorText = "AutoFocus Analysis Failed";
@@ -1052,6 +1075,10 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             if (inspectorOptions.StepSize > 0 && savedAutoFocusAttempt != null) {
                 options.AutoFocusStepSize = inspectorOptions.StepSize;
             }
+            // Signal amplification: capture more, finer-spaced points over the same sweep range by dividing the step
+            // size and multiplying the step count by the factor. Only meaningful for LIVE captures — a replay re-uses
+            // the saved frames' fixed focuser positions (savedAutoFocusAttempt != null), so those stay untouched.
+            ApplySignalAmplification(options, inspectorOptions.SignalAmplification, isLiveCapture: savedAutoFocusAttempt == null);
             if (inspectorOptions.TimeoutSeconds > 0) {
                 options.AutoFocusTimeout = TimeSpan.FromSeconds(inspectorOptions.TimeoutSeconds);
             }
@@ -1068,6 +1095,18 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 options.PreserveExposures = true;
             }
             return options;
+        }
+
+        // Applies the Signal Amplification factor to a live sensor-model / tilt sweep: divides the focuser step size
+        // and multiplies the step count by the factor, so the same sweep range is covered with more, finer-spaced
+        // points (more signal, smaller defocus jumps between adjacent frames). No-op at factor <= 1 or on replay
+        // (isLiveCapture == false), since replay re-uses the saved frames' fixed focuser positions. Internal for tests.
+        internal static void ApplySignalAmplification(AutoFocusEngineOptions options, int signalAmplification, bool isLiveCapture) {
+            var amp = Math.Max(1, signalAmplification);
+            if (amp > 1 && isLiveCapture) {
+                options.AutoFocusInitialOffsetSteps *= amp;
+                options.AutoFocusStepSize = Math.Max(1, (int)Math.Round(options.AutoFocusStepSize / (double)amp));
+            }
         }
 
         private StarDetectionRegion GetAutoFocusRegion(AutoFocusEngineOptions options) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
@@ -835,6 +835,11 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
         // the frame forms at least this many triangles. Only ever runs for frames that all earlier passes failed.
         private const double maxEscalationSizePortion = 0.35;
         private const int minEscalationFrameTriangles = 12;
+        // Hard cap on the stars fed into the escalation's triangle builds. The DENSE reference build is O(k^2)/O(k^3)
+        // in stars-within-box, so a star-rich reference frame at a large box would explode into millions of triangles
+        // (observed: a multi-thousand-star bank run hung for hours). The brightest ~120 stars are more than enough to
+        // register a sparse failed frame's handful of stars, and capping bounds the triangle count regardless of box.
+        private const int maxEscalationStars = 120;
 
         private int AlignStarsWithRANSAC(
             List<SensorDetectedStars> allDetectedStars,
@@ -1132,6 +1137,14 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             transform = Matrix3x2.Identity;
             putativeMatches = 0;
             boxUsed = referenceBox;
+            // Bound the O(k^2)/O(k^3) dense-triangle cost (see maxEscalationStars): use only the brightest stars. This
+            // is the failure path only, so the normal passes still triangulate the full star set.
+            if (referenceStars.Count > maxEscalationStars) {
+                referenceStars = referenceStars.OrderByDescending(p => p.NormalisedBrightness).Take(maxEscalationStars).ToList();
+            }
+            if (frameStars.Count > maxEscalationStars) {
+                frameStars = frameStars.OrderByDescending(p => p.NormalisedBrightness).Take(maxEscalationStars).ToList();
+            }
             int maxBox = (int)(maxEscalationSizePortion * Math.Min(imageSize.Width, imageSize.Height));
             // Math.Max(box + 1, ...) guarantees the box strictly grows each step so the loop always terminates,
             // even for a degenerate tiny reference box where (int)(box * 1.5) could otherwise stall.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
@@ -840,6 +840,12 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
         // (observed: a multi-thousand-star bank run hung for hours). The brightest ~120 stars are more than enough to
         // register a sparse failed frame's handful of stars, and capping bounds the triangle count regardless of box.
         private const int maxEscalationStars = 120;
+        // Work budget for a single box's putative-triangle match. The match is O(refTriangles x frameTriangles) in the
+        // k-d tree's per-query allocation, and even with the 120-star cap BOTH dense sets can reach ~C(120,3) triangles
+        // at a large box, so their product is only cheap when the failing frame is sparse (the design case). If a
+        // failing frame is itself star-rich, the product would blow up; skip the match once it would exceed this budget
+        // (and stop escalating, since a larger box only grows both sets), so a pathological frame cannot stall the run.
+        private const long maxEscalationMatchWork = 200_000_000L;
 
         private int AlignStarsWithRANSAC(
             List<SensorDetectedStars> allDetectedStars,
@@ -1154,6 +1160,13 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                     continue;   // still too sparse at this box; grow further
                 }
                 var refDense = RANSACRegistration.BuildStarTriangles(imageSize, referenceStars, box, false, true);
+                // The putative match below is O(refDense x frameDense) in the k-d tree's per-query allocation. Both
+                // sets are bounded per box by the star cap, but a star-rich FAILING frame can still make their product
+                // enormous at a large box. Bail before the match once the product would exceed the work budget; larger
+                // boxes only grow both sets, so stop escalating rather than continue.
+                if ((long)refDense.Count * frameDense.Count > maxEscalationMatchWork) {
+                    break;
+                }
                 var (src, dst) = RANSACRegistration.GeneratePutativeMatchesUsingSimilarTriangles(
                     frameDense, refDense, status, maxShapeDistanceStrict);
                 if (dst.Count < 20) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
@@ -828,6 +828,14 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
         private const double maxShapeDistanceStrict = 0.02;
         private const double maxShapeDistanceRelaxed = 0.05;
 
+        // Box-escalation fallback (TryAlignWithBoxEscalation). A heavily-defocused frame has few stars spread far
+        // apart, so at the reference's (small) search box almost no triples fall within it and RANSAC starves. These
+        // bound a last-resort retry that re-triangulates the frame + a dense reference at progressively LARGER boxes:
+        // grow the box up to this portion of the image's smaller side, ~1.5x per step, attempting an alignment once
+        // the frame forms at least this many triangles. Only ever runs for frames that all earlier passes failed.
+        private const double maxEscalationSizePortion = 0.35;
+        private const int minEscalationFrameTriangles = 12;
+
         private int AlignStarsWithRANSAC(
             List<SensorDetectedStars> allDetectedStars,
             System.Drawing.Size imageSize,
@@ -1001,8 +1009,19 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                         allDetectedStars[imageIndex].HasBeenAligned = true;
                         Logger.Info($"Image {imageIndex}: aligned on dense-reference retry ({retryDst.Count} putative matches; sparse-ref error was: {ex.Message})");
                     } catch (Exception ex2) {
-                        Logger.Info($"Image {imageIndex}: Error: {ex.Message}; dense-reference retry also failed: {ex2.Message}");
-                        allDetectedStars[imageIndex].HasBeenAligned = false;
+                        // Final fallback: ESCALATE the search box for this sparse frame (and a dense reference at the
+                        // same box) so it can form enough triangles to register. The reference-box triangulation
+                        // starves heavily-defocused frames whose few stars are spread far apart; a larger box restores
+                        // the corresponding triangles. The plate-scale guard inside guards against a wrong transform.
+                        if (TryAlignWithBoxEscalation(referenceStars.ToList(), theseStars.ToList(), imageSize, maxTriangleSize, status, progress, out var escTransform, out var escMatches, out var escBox)) {
+                            ApplyAlignmentTransform(imageIndex, escTransform);
+                            imagesAligned++;
+                            allDetectedStars[imageIndex].HasBeenAligned = true;
+                            Logger.Info($"Image {imageIndex}: aligned on box-escalation retry (box {escBox}, {escMatches} putative matches; sparse/dense-ref errors were: {ex.Message} / {ex2.Message})");
+                        } else {
+                            Logger.Info($"Image {imageIndex}: Error: {ex.Message}; dense-reference retry also failed: {ex2.Message}; box escalation also failed");
+                            allDetectedStars[imageIndex].HasBeenAligned = false;
+                        }
                     }
                 }
             }
@@ -1090,6 +1109,67 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             Logger.Info($"RANSAC alignment: {imagesAligned} / {allDetectedStars.Count} images were successfully aligned");
             stopwatch.RecordEntry("RANSAC alignment");
             return imagesAligned;
+        }
+
+        // Last-resort alignment for a heavily-defocused frame that the reference-box triangulation cannot register:
+        // such a frame has few stars spread far apart, so at the reference's (small) search box almost no triples
+        // fall within it (often 1-2 triangles) and RANSAC starves — and the dense-reference retry and neighbor
+        // chaining reuse that SAME box, so they starve too. This re-triangulates BOTH the frame and a DENSE reference
+        // at progressively LARGER boxes until the frame forms enough triangles, restoring the corresponding triangles
+        // a transform needs. The 0.9-1.1 plate-scale guard (frames in one AF run share scale; defocus doesn't rescale
+        // the field) still rejects a degenerate fit, so a larger box cannot admit a wrong transform. Returns the
+        // transform, the putative-match count, and the box that worked. Runs ONLY for frames every earlier pass failed.
+        private bool TryAlignWithBoxEscalation(
+                List<Point2D> referenceStars,
+                List<Point2D> frameStars,
+                System.Drawing.Size imageSize,
+                int referenceBox,
+                ApplicationStatus status,
+                IProgress<ApplicationStatus> progress,
+                out Matrix3x2 transform,
+                out int putativeMatches,
+                out int boxUsed) {
+            transform = Matrix3x2.Identity;
+            putativeMatches = 0;
+            boxUsed = referenceBox;
+            int maxBox = (int)(maxEscalationSizePortion * Math.Min(imageSize.Width, imageSize.Height));
+            // Math.Max(box + 1, ...) guarantees the box strictly grows each step so the loop always terminates,
+            // even for a degenerate tiny reference box where (int)(box * 1.5) could otherwise stall.
+            for (int box = Math.Max(referenceBox + 1, (int)(referenceBox * 1.5)); box <= maxBox; box = Math.Max(box + 1, (int)(box * 1.5))) {
+                var frameDense = RANSACRegistration.BuildStarTriangles(imageSize, frameStars, box, false, false);
+                if (frameDense.Count < minEscalationFrameTriangles) {
+                    continue;   // still too sparse at this box; grow further
+                }
+                var refDense = RANSACRegistration.BuildStarTriangles(imageSize, referenceStars, box, false, true);
+                var (src, dst) = RANSACRegistration.GeneratePutativeMatchesUsingSimilarTriangles(
+                    frameDense, refDense, status, maxShapeDistanceStrict);
+                if (dst.Count < 20) {
+                    foreach (var t in frameDense) {
+                        t.ResetMatch();
+                    }
+                    (src, dst) = RANSACRegistration.GeneratePutativeMatchesUsingSimilarTriangles(
+                        frameDense, refDense, status, maxShapeDistanceRelaxed);
+                }
+                if (dst.Count < 6) {
+                    continue;
+                }
+                try {
+                    var t = inspectorOptions.UseAffineAlignment
+                        ? RANSACRegistration.EstimateAffineTransform(src, dst, status, progress)
+                        : RANSACRegistration.EstimateSimilarityTransform(src, dst, status, progress).ToMatrix3x2();
+                    var scale = Math.Sqrt(Math.Abs(t.GetDeterminant()));
+                    if (scale < 0.9 || scale > 1.1) {
+                        continue;   // degenerate at this box; try a larger one
+                    }
+                    transform = t;
+                    putativeMatches = dst.Count;
+                    boxUsed = box;
+                    return true;
+                } catch {
+                    // RANSAC could not find a consistent transform at this box; escalate further.
+                }
+            }
+            return false;
         }
 
         private static (RegisteredStar[], int) MatchStarsUsingKdTree(

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IInspectorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IInspectorOptions.cs
@@ -47,6 +47,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
     public interface IInspectorOptions : INotifyPropertyChanged {
         int StepCount { get; set; }
         int StepSize { get; set; }
+        int SignalAmplification { get; set; }
+        bool CenterFocuserBeforeRun { get; set; }
         int FramesPerPoint { get; set; }
         int TimeoutSeconds { get; set; }
         int NumRegionsWide { get; set; }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
@@ -26,8 +26,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new release build of a plugin
-[assembly: AssemblyVersion("3.0.0.36")]
-[assembly: AssemblyFileVersion("3.0.0.36")]
+[assembly: AssemblyVersion("3.0.0.37")]
+[assembly: AssemblyFileVersion("3.0.0.37")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("Hocus Focus")]

--- a/documentation/docs/overview/sensor-model.md
+++ b/documentation/docs/overview/sensor-model.md
@@ -137,8 +137,21 @@ Two registration approaches are available, set by **Use RANSAC** (on by default)
   a RANSAC-estimated transform (a similarity transform by default, or an affine one when **Use Affine
   Alignment** is on), so matching stars land almost on top of each other. The nearest-neighbor match
   then runs with a much tighter search radius. This is what keeps matching reliable at the defocused
-  ends of the sweep, where stars are bloated and sparse; it falls back to the wider radius if any frame
-  fails to align.
+  ends of the sweep, where stars are bloated and sparse.
+
+A frame that does not align to the reference on the first pass is retried against a denser set of
+reference triangles, and can also be matched to its nearest already-aligned neighbor, whose similar
+defocus makes its stars easier to match than the sharp reference. A frame stays unplaced when it is
+defocused enough that its few stars sit too far apart to form the small triangles the RANSAC step
+matches on. For that frame, and for a dense copy of the reference, the aligner then rebuilds the
+triangles over a larger box. The box grows by about half each step, up to roughly a third of the shorter
+image dimension, until the frame forms enough triangles to estimate a transform. A plate-scale check
+rejects any transform that would not keep the frame at close to its original scale, so a chance match
+cannot register a frame wrongly. These retries run only for frames the first pass could not place, and
+the box escalation triangulates only the brightest stars (about 120 of them), so a dense field, which
+aligns on the first pass, is neither altered nor slowed. If any frame still cannot be placed, star
+matching for the whole sweep reverts to the wider nearest-neighbor search radius used when RANSAC is
+off.
 
 A star must be matched in **at least five frames** to be fit, so its focus curve has enough points to
 be meaningful.

--- a/documentation/docs/overview/tilt-aberration-inspector.md
+++ b/documentation/docs/overview/tilt-aberration-inspector.md
@@ -93,9 +93,11 @@ outliers are detected and rejected, see [Sensor Model Fitting](sensor-model.md).
 
 !!! note "Frame alignment is robust to heavy defocus"
     Matching stars across frames is hardest at the defocused extremes of the sweep, where stars are
-    bloated and sparse. The matcher chains alignment through neighboring frames and retries against a
-    denser reference rather than giving up, so the "*N frames failed to align*" condition is now rare.
-    If you still hit it, collect more stars on the weak frames (a wider exposure, or the
+    bloated and sparse. The matcher chains alignment through neighboring frames, retries against a
+    denser reference, and escalates its search box for the hardest frames rather than giving up, so the
+    "*N frames failed to align*" condition is now rare. See [cross-frame
+    registration](sensor-model.md#from-stars-to-data-points) for how these fallbacks work. If you still
+    hit it, collect more stars on the weak frames (a wider exposure, or the
     [donut-recovery settings](../settings/acceptance-gates.md#recover-out-of-focus-donut-stars)) and
     re-run.
 
@@ -136,6 +138,8 @@ from the option definitions; descriptions quote the in-app tooltips where one ex
 | **Mouse on Charts** | on | on/off | "Enable mouse events on charts to scroll, pan, and zoom. Disable this if you don't want the charts to intercept mouse actions." |
 | **Step Count** | -1 (auto) | -1 or &gt;0 | "The minimum number of data points needed on each side of the AutoFocus curve minimum. Uses the value set for AutoFocus if blank." |
 | **Step Size** | -1 (auto) | -1 or &gt;0 | "How many focuser steps in between each data point … Uses the value set for AutoFocus if blank." |
+| **Signal Amplification** | 2 | &ge;1 | "Increases the resolution and signal of sensor-model / tilt calibration runs by capturing more, finer-spaced focuser points. The focuser step size is divided by this factor and the number of steps multiplied by it, so the sweep covers the same range with more points (and smaller defocus jumps between adjacent frames, which makes star alignment more reliable) … Set to 1 to disable. Applies to live captures only." |
+| **Center Focuser First** | on | on/off | "When on (default), a quick standard AutoFocus is run before each live sensor-model / tilt calibration sweep to center the focuser at best focus. The detailed sweep then brackets focus symmetrically, which reduces extreme one-sided defocus frames that fail to align. Has no effect when replaying saved frames." |
 | **Frames Per Point** | -1 (auto) | -1 or &ge;1 | "How many exposures to average together for each focuser point. Uses the value set for AutoFocus if blank." |
 | **Timeout (s)** | -1 (auto) | -1 or &gt;0 | "How long, in seconds, after which AutoFocus should time out and fail. Uses the value set for AutoFocus if blank." |
 | **Simple Exposure (s)** | -1 (auto) | -1 or &gt;0 | "How long of an exposure to take for analysis. Defaults to the Auto Focus exposure duration if not set." Sets the exposure for the single-frame Simple Analysis. |

--- a/documentation/docs/overview/tilt-adapter-wizard.md
+++ b/documentation/docs/overview/tilt-adapter-wizard.md
@@ -45,6 +45,18 @@ effect (`ScrewInwardCurvatureSign`: whether turning a screw inward pushes that s
 toward the telescope). To average out seeing, set **Measurements** above 1; the wizard flags
 inconsistent repeats so you can re-run.
 
+!!! tip "Each calibration step runs a full inspector sweep"
+    A calibration measurement is a full sensor-model sweep, so it runs the same alignment and
+    focus-centering steps as a standalone Detailed Analysis. With **Center Focuser First** on (the
+    default), each step re-centers
+    the focuser at best focus before its sweep, so the measurement is not skewed toward one side of
+    focus. **Signal Amplification** gives each step more, finer-spaced focus points for a steadier
+    per-star fit. For a heavily-defocused frame that would otherwise fail to register, the frame aligner
+    escalates its search rather than dropping the frame from that step's model. These help most on faint
+    fields or in poor seeing, and are set under [Inspector
+    options](tilt-aberration-inspector.md#inspector-options). Raising **Measurements** above 1 averages
+    independent repeats on top of them.
+
 !!! note "Set Microns per Focuser Step for the best guidance"
     Per its tooltip, *Microns per Focuser Step* is "how much the focuser moves per step, in microns.
     If this is set, the adjustment chart will include adjustments in microns." Without it, adjustments


### PR DESCRIPTION
## Summary

Three changes that increase signal and alignment reliability of sensor-model and tilt-adapter calibration runs, which are noise-limited at the tail. All three reinforce each other — #2 and #3 reduce the extreme-defocus frames that drive the #1 alignment failures.

### 1. RANSAC box-escalation fallback (`SensorModel.AlignStarsWithRANSAC`)
Heavily-defocused frames have few stars spread far apart, so at the dense reference's small search box almost no triples fall within it (often **1–2 triangles**) and RANSAC starves — and the existing dense-reference retry and neighbor chaining reuse that *same* box, so they starve too. On failure, the new fallback re-triangulates both the frame and a dense reference at progressively larger boxes until the frame forms enough triangles, restoring the corresponding triangles a transform needs. The existing 0.9–1.1 plate-scale guard still rejects degenerate fits. **Runs only for frames every earlier pass already failed, so the happy path is bit-identical.** The escalation's triangle builds are capped to the brightest ~120 stars so a star-rich run can't explode the O(k²) dense build.

### 2. Pre-centering AutoFocus pass (`InspectorVM.AnalyzeAutoFocusImpl`)
Behind a new **`CenterFocuserBeforeRun`** option (default **on**). Before each live sensor-model / tilt sweep, run a quick standard AutoFocus to center the focuser at best focus, so the detailed sweep brackets focus symmetrically — fewer extreme one-sided defocus frames that fail to align, and a better paraboloid fit. The centering run uses profile step size (deliberately **not** signal-amplified) and is **never saved** (`Save`/`PreserveExposures` forced off, independent of the global AF-save toggle and of any per-step `saveOverride`) — only the actual sensor-model / per-tilt-step run is persisted. Runs for the standalone inspector and every live tilt-calibration step (both route through `AnalyzeAutoFocusImpl`); skipped on replay; failure is non-fatal.

### 3. Signal Amplification factor (`InspectorOptions.SignalAmplification`, default **2**)
Divides the focuser step size and multiplies the step count by the factor, so a live run captures more, finer-spaced points over the same range — more signal and smaller defocus jumps between adjacent frames. Applied in `GetAutoFocusEngineOptions` for **live captures only**; replay is untouched.

Both new options surface in the main Aberration Inspector **"Options"** panel (`AutoFocus/DataTemplates.xaml`), not the Experimental section.

## Validation

**Target dataset** `D:\Tilt Calibration Bank\astrodet_6\...` (astrodet profile, the run from the request), replayed with the optimized detection settings the calibration actually used:

| Step | Before | After |
|---|---|---|
| 01_Baseline | 5 / 7 aligned | **7 / 7** |
| 04_Screw1 | 5 / 7 aligned | **7 / 7** |
| other 4 steps | 7/7 or 8/8 | unchanged |

The two previously-failing frames per step were sparse (~30 stars, 1–2 triangles); box-escalation recovers them. The dataset's overall calibration SNR stays ~0.73 because its coarse 175-step spacing is fundamentally noise-limited — exactly what #2/#3 address for *future* captures.

**Full AF-bank C0 verification** (`bank-verify`, all 19 runs × NC 2/3/4 vs the prior committed report) — **zero regressions, broad improvement**:

- **Detection determinism**: on every run with unchanged alignment, `recallHigh` and `precision` are **bit-identical** to baseline → the change provably does not touch star detection.
- **Alignment**: box-escalation rescued frames across the bank — mufti **3→7**, toml999 **5→9**, timmer **5→9**, Panos **3→6**, cwhite_2026 **7→9**, LinwoodFocus/sensitivity_example2 3→5, and others. **No run lost a frame** in any config.
- **Sensor fit**: R² stable or better on rescued runs (e.g. timmer 0.882→0.945, toml999 0.426→0.440); cwhite_2026 9/9 sR² 0.850 unchanged. Panos's nominal 1.0→0.983 is an overfit 3-star fit becoming a robust 31-star fit.
- **No hang, no crash, 0 failed runs.** (An earlier uncapped build hung for hours building a million-triangle dense reference on a star-rich run; the brightest-120-star cap fixes that with no loss of recovery quality.)

**Unit tests**: **1636 pass**, including new coverage for the amplification mapping (live ×factor, no-op at factor 1 / on replay, step-size floor) and option persistence/clamp/reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
