### PR TITLE
docs: fix broken curvature LaTeX, drop confessional heading, apply adversarial-review findings

### DIFF
--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -20,7 +20,7 @@ tilt-and-curvature model so you can quantify and correct aberrations across the 
 ## Key features
 
 - **[Improved star detection](overview/star-detection.md)** — accurate, gradient-aware HFR measurement
-  plus optional Gaussian and Moffat-4 PSF fitting for eccentricity and FWHM, with simple defaults and an
+  plus optional Gaussian and Moffat 4.0 PSF fitting for eccentricity and FWHM, with simple defaults and an
   advanced mode for fine tuning.
 - **[Customizable star annotation](overview/star-annotation.md)** — configurable colors and fonts, with
   dynamic reloading of annotations without re-running detection.

--- a/documentation/docs/optimization/af-curve-fitting.md
+++ b/documentation/docs/optimization/af-curve-fitting.md
@@ -1,7 +1,7 @@
 # From Focus Frames to a Score
 
-The optimization wizard does not score your settings on a single image. It scores them on a whole
-**auto-focus run**, a sweep of frames taken across a range of focuser positions. For each candidate
+The Star Detection Optimization Wizard does not score your settings on a single image. It scores them on a whole
+**autofocus run**, a sweep of frames taken across a range of focuser positions. For each candidate
 set of detection parameters, the wizard detects stars on every frame, rebuilds the HFR-vs-focuser
 curve those frames imply, fits it, and reads how *sharp and trustworthy* the resulting best-focus
 estimate is. That single number is what the search maximizes.
@@ -27,7 +27,7 @@ The work for one candidate parameter bundle, on one run, is done by `RunEvaluati
 4. **Score it.** Feed \(\sigma_{\text{focus}}\), the star counts, \(R^2\), and reduced \(\chi^2\)
    into the objective's sub-scores.
 
-![Auto-focus HFR V-curve with a hyperbolic fit, the best-focus minimum, and the sigma_focus uncertainty band](../assets/figures/af-vcurve.png){ width=620 }
+![Autofocus HFR V-curve with a hyperbolic fit, the best-focus minimum, and the sigma_focus uncertainty band](../assets/figures/af-vcurve.png){ width=620 }
 
 *A run's pooled HFR points (one per focuser position, with error bars) and the fitted curve. The
 fit's minimum is the estimated best-focus position; the shaded band is \(\sigma_{\text{focus}}\), the
@@ -37,8 +37,8 @@ narrower.*
 !!! note
     The wizard loads each saved exposure once (rendered, no detection), then re-runs detection on the
     already-loaded frames for every candidate. The fit configuration (step size, weighting,
-    outlier-rejection count and confidence) is taken from the run's own auto-focus options, so the
-    wizard's curve fit matches the auto-focus engine's fit exactly. The optimizer is not changing how
+    outlier-rejection count and confidence) is taken from the run's own autofocus options, so the
+    wizard's curve fit matches the autofocus engine's fit exactly. The optimizer is not changing how
     you focus; it is changing how cleanly the stars are measured.
 
 ## Step 1 — detect, then aggregate each frame
@@ -62,7 +62,7 @@ as the resulting fit (see the star-count term, \(S_{\text{stars}}\), in
 ## Step 2 — pool frames at the same focuser position
 
 Frames captured at the same focuser position are merged into one curve point using the same semantics
-as the auto-focus engine: the point's HFR is the **mean** of the per-frame measures, and its error
+as the autofocus engine: the point's HFR is the **mean** of the per-frame measures, and its error
 bar is the **SEM-pooled** standard deviation: the per-frame \(\sigma\)s combined and divided by the
 square root of the number of contributing frames. Iterating in ascending focuser position keeps the
 fit input deterministic. The result is one scatter point (focuser position, pooled HFR, pooled error)
@@ -71,7 +71,7 @@ per **distinct** focuser position.
 ## Step 3 — fit the focus curve
 
 With at least **3 distinct focuser positions**, the wizard runs the same "best fit" model selection
-the auto-focus engine uses (`AlglibHyperbolicFitting.SelectBestModel`): it tries the candidate models
+the autofocus engine uses (`AlglibHyperbolicFitting.SelectBestModel`): it tries the candidate models
 and lets the winner compete on merit, rather than forcing a single shape (see
 [Hyperbolic Curve Fitting](../overview/hyperbola-fitting.md) for the model family and the Hybrid
 selection rules). From the winning fit it reads:
@@ -142,7 +142,7 @@ rather than the fit; it is covered alongside the full weighting in
 ## A byproduct: the recommended step size
 
 The same winning fit also drives the wizard's **step-size recommendation**, which is reported (and
-applied on confirm) but is *not* part of the score. The idea is to size the auto-focus step so a sweep
+applied on confirm) but is *not* part of the score. The idea is to size the autofocus step so a sweep
 lands roughly 3–4 measurement points on each side of focus inside the "focus-sensitive" band, the
 region where HFR climbs from its minimum to about three times the minimum, which carries the most slope and
 therefore the most information.

--- a/documentation/docs/optimization/index.md
+++ b/documentation/docs/optimization/index.md
@@ -20,7 +20,7 @@ confirm, and the toggle is fully reversible.
 
 ## What the wizard does
 
-At its core the wizard drives a derivative-free search engine, the `StarDetectionOptimizer`. The
+The wizard drives a derivative-free search engine, the `StarDetectionOptimizer`. The
 **same** engine runs in the live wizard and in the offline `TestApp optimize` harness, so results are
 reproducible and the optimizer can be exercised without launching NINA.
 

--- a/documentation/docs/optimization/objective-function.md
+++ b/documentation/docs/optimization/objective-function.md
@@ -52,7 +52,7 @@ their own sections below.
     The weights above are the default, autofocus-tuned objective. When you select **"Optimize for
     Aberration Inspection"** on the wizard's start page, the optimizer swaps in a star-count-favoring
     objective (`ObjectiveConstants.ForAberrationInspection`) that recovers far more stars across the
-    frame — what a [tilt / curvature model](../overview/tilt-aberration-inspector.md) needs — while a
+    frame (what a [tilt / curvature model](../overview/tilt-aberration-inspector.md) needs), while a
     fit guard tied to your current settings' \(\sigma_{\text{focus}}\) keeps the focus curve usable.
     The structure of the score (the sub-scores below) is unchanged; only the weighting differs.
 
@@ -186,7 +186,7 @@ a sub-score.
 
 ## \(S_{\text{defocus-precision}}\) — the defocus junk penalty
 
-The three sub-scores above are combined by a weighted **average**. The defocus-precision term is different: it
+The sub-scores above are combined by a weighted **average**. The defocus-precision term is different: it
 is a **multiplicative** penalty in \([0.5, 1.0]\) applied after the weighted sum. It guards the optional
 defocus-aware gates (which relax distortion/centering to recover bloated donut stars) from being abused to
 flood near-focus frames with junk.
@@ -227,8 +227,8 @@ Two properties make this safe:
 strength 0.5 down to a floor of 0.5.*
 
 !!! warning "The defocus-aware gates are opt-in"
-    With the gates off (default) this penalty is inert and the objective is identical to the three-term
-    version. It exists so the optimizer can safely explore turning the gates on — recovering bloated donuts on
+    With the gates off (default) this penalty is inert and the objective is identical to the weighted-average
+    form above. It exists so the optimizer can safely explore turning the gates on — recovering bloated donuts on
     the extremes — without learning to manufacture spurious near-focus stars.
 
 ## \(S_{\text{hfr-outlier}}\) — the bright-blob penalty

--- a/documentation/docs/optimization/search-variables.md
+++ b/documentation/docs/optimization/search-variables.md
@@ -1,6 +1,6 @@
 # Search Variables — the Curated Search Space
 
-The optimizer does **not** tune every star-detection parameter. It tunes a deliberately small, **curated set** of knobs that have the largest, most predictable effect on the autofocus curve, and it leaves everything else at your profile's current values. Keeping the search space small is what lets a derivative-free search converge inside a fixed evaluation budget (`MaxEvaluations = 400`).
+The optimizer does **not** tune every star-detection parameter. It tunes a deliberately small, **curated set** of knobs that have the largest, most predictable effect on the autofocus curve, and it leaves everything else at your profile's current values. Keeping the search space small is what lets a derivative-free search converge inside a fixed evaluation budget (`MaxEvaluations = 250` by default, raised to `400` when *Recover out-of-focus donut stars* is enabled).
 
 This page is the reference for that curated set: every variable, its bounds, the setting it maps to, the two *synthetic* variables that drive more than one parameter at once, how values are quantized, and the EARLY/LATE split that makes the search fast.
 
@@ -28,7 +28,7 @@ Each row is one tunable axis. **Type** governs quantization (see [Quantization r
 | `DefocusAwareGates` | Boolean (synthetic) | 0 | 1 | — | Two gate-relaxation params at once (see below) |
 | `DefocusAwareStructure` | Integer (synthetic) | 0 | 4 | 1 | Defocus-aware structure flag + layer boost (see below) |
 
-That is **14** axes. Several bounds are open-ended in the detector (there is no hard UI validation range), so the wizard applies pragmatic heuristic limits. For example, `Sensitivity` was widened from a 20 to a 50 ceiling and `StarClippingMultiplier` to a `[0.25, 10]` range because rich star fields kept pinning the older, tighter bounds. The two highest-impact axes, `Sensitivity` and `StarClippingMultiplier`, are also the pair the search grids over first in its coarse Phase A (see [search algorithm](search-algorithm.md)).
+That is the **12** always-on axes. The two synthetic rows in the table above (`DefocusAwareGates`, `DefocusAwareStructure`) plus seven further defocus-tuning knobs (`DefocusDistortionSizeReference`, `DefocusDistortionMinFactor`, `DefocusCenteringToleranceFactor`, `DonutMorphCloseSize`, `DonutMinAnnularityHoleFraction`, `DonutMaxStreakEccentricity`, `DonutSaturationBloomRadius`) are added only when *Recover out-of-focus donut stars* is enabled, taking the curated set to **21** axes; with that master toggle off (the default) the optimizer never touches any defocus parameter. Several bounds are open-ended in the detector (there is no hard UI validation range), so the wizard applies pragmatic heuristic limits. For example, `Sensitivity` was widened from a 20 to a 50 ceiling and `StarClippingMultiplier` to a `[0.25, 10]` range because rich star fields kept pinning the older, tighter bounds. The two highest-impact axes, `Sensitivity` and `StarClippingMultiplier`, are also the pair the search grids over first in its coarse Phase A (see [search algorithm](search-algorithm.md)).
 
 ## The two synthetic variables
 

--- a/documentation/docs/overview/autofocus.md
+++ b/documentation/docs/overview/autofocus.md
@@ -1,6 +1,6 @@
 # Autofocus
 
-Hocus Focus replaces NINA's built-in autofocus engine with a star-detection-driven routine that sweeps the focuser, measures Half-Flux Radius (HFR) on every frame, fits a curve to the resulting V-shape, and moves to the modelled best-focus position. It is the same star detector you tune elsewhere in the plugin, now feeding a more careful curve-fitting and validation pipeline.
+Hocus Focus replaces NINA's built-in autofocus engine with a star-detection-driven routine that sweeps the focuser, measures Half-Flux Radius (HFR) on every frame, fits a curve to the resulting V-shape, and moves to the modeled best-focus position. It is the same star detector you tune elsewhere in the plugin, now feeding a more careful curve-fitting and validation pipeline.
 
 ## What it does, and why it is better
 
@@ -99,7 +99,7 @@ All tooltips below are quoted verbatim from the plugin UI.
 Every HFR measurement comes from the same Hocus Focus star detector documented in [Star detection](star-detection.md), run with autofocus-specific overrides:
 
 - **Profile-driven parameters.** Sensitivity, noise reduction, and the brightest-stars count are taken from NINA's profile (Image and Focuser settings), and the run is flagged as autofocus mode.
-- **Region of interest.** When NINA's inner-crop ratio is below 1 and the camera is not subsampling, detection is restricted to that central crop; otherwise the full frame is analysed. If the camera supports hardware subsampling with the inner crop enabled, the engine reads out only that central rectangle.
+- **Region of interest.** When NINA's inner-crop ratio is below 1 and the camera is not subsampling, detection is restricted to that central crop; otherwise the full frame is analyzed. If the camera supports hardware subsampling with the inner crop enabled, the engine reads out only that central rectangle.
 - **Per-region detection.** For multi-region runs the detector measures HFR only inside each region's boundary, and the per-region results are saved separately.
 - **Replay with cache reuse.** When replaying a saved run, the engine can reuse the cached star-detection result if the detector version and region key still match, falling back to fresh detection otherwise, so you can re-fit a curve with new options without re-running hardware. Replay decodes the saved frames deterministically (concurrent image loads are serialized), so a re-fit reproduces the same per-position HFR every time rather than occasionally pairing two positions with an identical value.
 - **The measurement.** From each detection it takes the median HFR (`AverageHFR`) as the point value and the per-star HFR standard deviation (`HFRStdDev`) as the measurement \(\sigma\) fed into the weighted curve fit.

--- a/documentation/docs/overview/index.md
+++ b/documentation/docs/overview/index.md
@@ -2,7 +2,7 @@
 
 Hocus Focus is a plugin for [NINA](https://nighttime-imaging.eu/) that, in the words of its own description, provides **"Improved Star Detection, Star Annotation, Auto Focus, and Tilt Correction for NINA."** It replaces or augments NINA's built-in star handling and auto-focus routines with a more accurate star detector, a fully customizable annotator, a concurrent auto-focus engine, and an aberration inspector that measures backfocus and sensor-tilt errors.
 
-The plugin is deliberately modular. Per its documentation, you "can use the new Star Detector or Annotator without requiring both"; keep whichever pieces you like and leave the rest on NINA's defaults. The features are wired in under **Options → Imaging → Image Options**, where installing the plugin adds **Star Annotator** and **Auto Focus** dropdowns; select **"Hocus Focus"** in those to turn the features on.
+The plugin is deliberately modular. Per its documentation, you "can use the new Star Detector or Annotator without requiring both"; keep whichever pieces you like and leave the rest on NINA's defaults. The features are wired in under **Options → Imaging → Image Options**, where installing the plugin adds **Star Detection**, **Star Annotator**, and **Auto Focus** dropdowns; select **"Hocus Focus"** in those to turn the features on.
 
 !!! note "Requirements"
 

--- a/documentation/docs/overview/sensor-model.md
+++ b/documentation/docs/overview/sensor-model.md
@@ -291,7 +291,7 @@ The fitted parameters are converted into the quantities the panel displays.
 |---|---|
 | **Tilt** | The angle \(\theta = \arctan\sqrt{G_x^2 + G_y^2}\), in degrees, with its one-sigma error. |
 | **Tilt effect** | Half the spread of the planar term across the four sensor corners: the worst-case best-focus offset, in microns, caused purely by tilt. |
-| **Curvature radius** | \(R = 1 / (2000\,|K|)\) millimeters. Larger is flatter (and better), with its one-sigma error. |
+| **Curvature radius** | \(R = 1 / (2000\,\lvert K \rvert)\) millimeters. Larger is flatter (and better), with its one-sigma error. |
 | **Curvature effect** | The curvature term evaluated at a corner: the corner-to-center offset, in microns, caused purely by field curvature. |
 | **Critical focus** | \(\text{CFZ} = 2.44\,F^2 \cdot 0.55\) microns, from the telescope focal ratio \(F\). The tolerance the other effects are graded against. |
 | **Centering** | The optical-center offsets \(X_0, Y_0\); flagged when either exceeds ten pixels. |

--- a/documentation/docs/overview/star-annotation.md
+++ b/documentation/docs/overview/star-annotation.md
@@ -82,12 +82,12 @@ This is where annotation earns its keep. The detector records, per frame, the bo
 
 | Toggle | Default color | What it reveals |
 |---|---|---|
-| Show Distorted | Green, 50% | *"Whether to show the failed stars that were too distorted"* — candidates whose box-fill / aspect ratio failed the distortion gate. (The gate/reason is "Too Distorted", but the toggle is **Show Distorted**.) |
-| Show Degenerate | Green, 50% | *"Whether to show the failed degenerate stars"* — too few pixels or too little contrast to fit. |
+| Show Distorted | Green, 50% | *"Whether to show the failed stars that were too distorted"*. Candidates whose box-fill / aspect ratio failed the distortion gate. (The gate/reason is "Too Distorted", but the toggle is **Show Distorted**.) |
+| Show Degenerate | Green, 50% | *"Whether to show the failed degenerate stars"*. Too few pixels or too little contrast to fit. |
 | Show Saturated | Green, 50% | *"Whether to show the partially-saturated stars that were processed with masked pixels"*. Grouped here with rejection diagnostics, but saturated stars are **kept** (measured with their saturated pixels masked during PSF fitting), not rejected. |
-| Show Low Sensitivity | Green, 50% | *"Whether to show the failed low sensitivity stars"* — signal too weak relative to background and noise. |
-| Show Not Centered | Green, 50% | *"Whether to show the failed not centered stars"* — centroid fell outside the centering tolerance. |
-| Show Too Flat | Green, 50% | *"Whether to show the failed too flat stars"* — peak too close to the local background. |
+| Show Low Sensitivity | Green, 50% | *"Whether to show the failed low sensitivity stars"*. Signal too weak relative to background and noise. |
+| Show Not Centered | Green, 50% | *"Whether to show the failed not centered stars"*. Centroid fell outside the centering tolerance. |
+| Show Too Flat | Green, 50% | *"Whether to show the failed too flat stars"*. Peak too close to the local background. |
 | Show Contaminated | Magenta, 50% | Marks stars flagged by the contamination test (neighbor, gradient, or hot column). |
 
 Each toggle has a companion color setting (Distorted Box Color, Degenerate Box Color, Saturated Box Color, Low Sensitivity Box Color, Not Centered Box Color, Too Flat Box Color, Contaminated Box Color); the six rejection-gate colors all share the tooltip *"The color of the failed star bounding box"*.

--- a/documentation/docs/overview/star-detection.md
+++ b/documentation/docs/overview/star-detection.md
@@ -18,7 +18,7 @@ heavily defocused donuts. Hocus Focus addresses these head-on:
   sky gradients do not drown faint stars or create spurious blobs.
 - **The background is modeled as a tilted plane per star**, not a single number, so a one-sided gradient
   under a star no longer biases its centroid, flux, or HFR.
-- **Contamination is detected gradient-robustly.** A neighboring star bleeding into one side of the
+- **Contamination is detected even under a background gradient**, so a neighboring star bleeding into one side of the
   measurement annulus is flagged and (by default) removed, instead of quietly corrupting the HFR.
 - **Multiple independent acceptance gates** reject clipped, distorted, off-center, flat, dim, and
   contaminated candidates, each tracked as a named rejection count you can inspect.
@@ -81,7 +81,7 @@ donut stars survive the subtraction. See [Structure Detection](../settings/struc
 
 The smoothed structure map is thresholded into foreground (star) vs. background. The threshold is the
 structure map's median plus a **noise-clipping multiplier** times an estimated noise sigma, where the sigma
-comes from a Kappa-Sigma (an iterative clip-at-k·σ robust noise estimate) noise estimate on the noise-reduced image:
+comes from a Kappa-Sigma noise estimate (an iterative clip-at-k·σ robust estimate) on the noise-reduced image:
 
 \[
 T = \text{median} + k_\sigma \cdot \sigma_{\text{noise}}

--- a/documentation/docs/overview/tilt-adapter-wizard.md
+++ b/documentation/docs/overview/tilt-adapter-wizard.md
@@ -84,16 +84,16 @@ adapter's **physical hardware model**:
 
 | Hardware field | Meaning |
 |---|---|
-| **Adjustment Type** | Whether the adapter is adjusted by **Screws** (reported in turns) or **Stepper Motors** (reported in steps). |
-| **Thread Pitch** | Axial microns the sensor moves per full screw turn; used when Adjustment Type is Screws. |
-| **Stepper Step Size** | Axial microns per stepper step; used when Adjustment Type is Stepper Motors. |
-| **Screw Radius** | Distance of each adjuster from the sensor center, in millimeters; converts a tilt *angle* into an axial movement at the screw. |
+| **Adjustment type** | Whether the adapter is adjusted by **Screws** (reported in turns) or **Stepper Motors** (reported in steps). |
+| **Thread pitch (µm/turn)** | Axial microns the sensor moves per full screw turn; used when Adjustment type is Screws. |
+| **Step size (µm/step)** | Axial microns per stepper step; used when Adjustment type is Stepper Motors. |
+| **Screw radius (mm)** | Distance of each adjuster from the sensor center, in millimeters; converts a tilt *angle* into an axial movement at the screw. |
 
 **Device presets.** Rather than entering those numbers by hand, pick your adapter from the **Device**
 list. Choosing a preset pre-fills and locks the hardware fields to the manufacturer's values. The
 built-in presets are:
 
-| Device | Adjustment | Adjusters | Thread Pitch (µm/turn) | Stepper Step (µm) | Screw Radius (mm) |
+| Device | Adjustment | Adjusters | Thread Pitch (µm/turn) | Step size (µm) | Screw Radius (mm) |
 |---|---|---|---|---|---|
 | Neumann CTU XT48 | Screws | 3 | 400 | — | 44 |
 | ASG Photon Cage - 78mm | Screws | 4 | 212 | — | 44 |

--- a/documentation/docs/quick-start.md
+++ b/documentation/docs/quick-start.md
@@ -10,8 +10,8 @@ reference page if you want the full detail.
 
 ## 1. Tell NINA about your rig
 
-Several Hocus Focus features derive their starting points from your image scale, so it is worth getting
-two things right first: your **pixel scale** and how far your **focuser moves per step**.
+Several Hocus Focus features derive their starting points from your image scale, so get two things right
+first: your **pixel scale** and how far your **focuser moves per step**.
 
 - **Pixel size** (microns) — NINA's **Options → Equipment → Camera** tab. Usually filled in by the
   camera driver; confirm it matches your sensor.
@@ -90,7 +90,7 @@ Once calibrated, the inspector's adjustment chart tells you exactly which screw 
 
 → Full detail: [Tilt Adapter Wizard](overview/tilt-adapter-wizard.md).
 
-## 6. Pro-tip: save an autofocus run, then replay it to tune during the day
+## 6. Save an autofocus run, then replay it to tune during the day
 
 You do not need clear skies to improve your settings. Save a real autofocus run once, then replay it
 indoors as many times as you like with different settings.

--- a/documentation/docs/settings/acceptance-gates.md
+++ b/documentation/docs/settings/acceptance-gates.md
@@ -208,9 +208,6 @@ Because near-focus candidates stay at or below the size reference, they keep the
 !!! tip "When this helps"
     Enable it when you deliberately collect autofocus frames far from focus (wide sweeps) and see donut stars dropped as **Too Distorted** or **Not Centered** at the sweep extremes. It does nothing for near-focus imaging frames, and it should stay off there so the strict gates keep filtering noise. If even heavily defocused stars never appear as candidates at all (not merely rejected), that is a structure-detection problem, not a gate problem; see Defocus-Aware Structure on the [Structure detection](structure-detection.md) page.
 
-!!! warning
-    The three tuning values below are consulted **only while Defocus-Aware Gates is enabled**. With the toggle off they have no effect.
-
 ### Defocus Size Reference
 
 > Tuning knob for the Defocus-Aware Gates (only used while they are enabled). The candidate bounding-box size (in pixels, the larger of width/height) at or below which the strict gate thresholds still apply; larger candidates get the relaxed thresholds. Shared by both the distortion and centering relaxations. Lower it to relax smaller stars; raise it to keep more of the strict behavior. Default 30.

--- a/documentation/docs/settings/advanced-debug.md
+++ b/documentation/docs/settings/advanced-debug.md
@@ -244,11 +244,6 @@ Saves additional in-memory debug data during detection.
 - **Default:** Off
 - **Range:** On / Off
 
-!!! warning "Leave this off for normal use"
-
-    Debug Mode exists for diagnosing detection, not for routine imaging. As the tooltip says, keep it off
-    unless you are actively tuning and want to inspect structure maps.
-
 ## Save Intermediate
 
 Writes a file for each step of the detection pipeline so you can inspect exactly what the detector saw.

--- a/documentation/docs/settings/donut-aware.md
+++ b/documentation/docs/settings/donut-aware.md
@@ -59,7 +59,7 @@ recovered, 22x the default, at 0.93 precision.*
 So a donut run wants the [low, adaptive floor](adaptive-binarization.md) *and* the donut-aware gates together,
 not either alone.
 
-## Honest limit
+## What it does not recover
 
 Faint pure-ring donuts with no core stay noise-limited for everyone. Hocus Focus catches the brighter cored
 donuts and misses the faint rings, and a naive matched filter over-detects them. When a star is that far out of

--- a/documentation/docs/settings/index.md
+++ b/documentation/docs/settings/index.md
@@ -149,7 +149,7 @@ You don't normally need to think about this when using NINA, since it changes wh
 
 !!! note "Profile-scoped and auto-saved"
 
-    All star-detection settings are stored per NINA profile. Switching profiles re-derives Simple-mode settings from that profile's presets. There is also a **Reset to defaults** action that restores every parameter to its shipped value (Simple mode, Typical presets, PSF modeling on with Moffat 4.0, and so on) and clears any optimized snapshot.
+    All star-detection settings are stored per NINA profile. Switching profiles re-derives Simple-mode settings from that profile's presets. There is also a **Reset Defaults** action that restores every parameter to its shipped value (Simple mode, Typical presets, PSF modeling on with Moffat 4.0, and so on) and clears any optimized snapshot.
 
 ## Reference sub-pages
 

--- a/documentation/docs/settings/psf-modeling.md
+++ b/documentation/docs/settings/psf-modeling.md
@@ -34,7 +34,7 @@ Star detection first finds candidates, measures each star's centroid and **HFR**
 
 ## Fit PSF
 
-**Fit PSF** (property `ModelPSF`) — master switch that turns PSF fitting on or off for detected stars.
+**Fit PSF** (property `ModelPSF`) is the master switch that turns PSF fitting on or off for detected stars.
 
 > Whether to fit PSF models to detected stars. This is required for FWHM and Eccentricity
 

--- a/documentation/docs/settings/structure-detection.md
+++ b/documentation/docs/settings/structure-detection.md
@@ -24,8 +24,8 @@ The detector removes large-scale structure with an **à-trous (dyadic) B3-spline
 |---|---|---|---|
 | Structure Layers | 4 | integer > 0 | Wavelet layers kept; structures larger than ~\(2^{\text{layers}}\) px are removed as background. More layers keep larger (e.g. defocused) stars. |
 | Defocus-Aware Structure | Off | On / Off | When on, removes background more coarsely so heavily-defocused donut stars survive and form candidates. Off ⇒ detection unchanged. |
-| Structure Layer Boost | 0 | 0 – 6 | Extra wavelet layers added *only* while Defocus-Aware Structure is on. Higher ⇒ coarser removal ⇒ bigger donuts survive. |
-| Structure Dilation Size | 3 | 3 – 30 px | Diameter of the morphological filter that grows candidate blobs in the structure map. |
+| Structure Layer Boost | 0 | 0–6 | Extra wavelet layers added *only* while Defocus-Aware Structure is on. Higher ⇒ coarser removal ⇒ bigger donuts survive. |
+| Structure Dilation Size | 3 | 3–30 px | Diameter of the morphological filter that grows candidate blobs in the structure map. |
 | Structure Dilation Iterations | 0 | ≥ 0 | How many times the dilation is applied. 0 disables dilation. |
 
 ## Structure Layers
@@ -66,12 +66,12 @@ The strength knob for Defocus-Aware Structure: how many extra wavelet layers to 
 
 > Only used while Defocus-Aware Structure is enabled. The number of extra wavelet layers added when removing large-scale structure, making the removal coarser so larger defocused donuts survive and form candidates. 0 means no change (identical to the feature being off). Raise it (1–6) if very out-of-focus stars never appear; raising it too far can let nebulosity/background structure leak in as false candidates. Default 0.
 
-**Default:** 0. **Range:** 0 – 6 (validated).
+**Default:** 0. **Range:** 0–6 (validated).
 
 Each extra layer roughly doubles the size scale that is preserved rather than erased, so a boost of \(n\) keeps structures up to about \(2^{(\text{StructureLayers}+n)}\) px.
 
 !!! tip "When to adjust"
-    **Raise it 1 – 6** when very out-of-focus stars never appear, increasing it gradually until they do. **Leave it at 0** unless Defocus-Aware Structure is enabled. It is ignored while that toggle is off. It can hurt when pushed too high: a coarser residual leaves more large-scale structure behind, so nebulosity and background gradients start registering as false candidates.
+    **Raise it 1–6** when very out-of-focus stars never appear, increasing it gradually until they do. **Leave it at 0** unless Defocus-Aware Structure is enabled. It is ignored while that toggle is off. It can hurt when pushed too high: a coarser residual leaves more large-scale structure behind, so nebulosity and background gradients start registering as false candidates.
 
 ## Structure Dilation Size
 
@@ -79,7 +79,7 @@ The diameter of the morphological filter used to grow candidate blobs in the str
 
 > During star detection a structure map is generated containing potential star pixels that are above the background noise threshold. This parameter defines the size of gaussian morphology filter used to dilate the structure map. Consider increasing this value if bounding boxes are not large enough around stars, which may be more likely at very high focal lengths.
 
-**Default:** 3. **Range:** 3 – 30 px (validated; the setter also enforces a minimum of 3).
+**Default:** 3. **Range:** 3–30 px (validated; the setter also enforces a minimum of 3).
 
 Internally this is the diameter of an elliptical structuring element passed to OpenCV's morphological dilation. It has **no effect** unless **Structure Dilation Iterations** is at least 1; dilation only runs when the iteration count is positive.
 


### PR DESCRIPTION
## What & why

You spotted two documentation defects — the confessional **"Honest limit"** heading (an AI-writer tell) and a broken **Curvature-radius** table cell showing literal `(R = 1 / (2000\,` — and asked to (1) teach the adversarial doc reviewer to catch both classes, (2) re-review, and (3) apply the fixes.

I enhanced the reviewer, re-swept the whole manual (28 pages), and applied every finding that survived an adversarial verification pass.

## Reviewer enhancement (tooling, not in this repo)

The adversarial doc reviewer's **style lens** now flags confessional / self-aware "honesty" framing (`Honest limit`, `To be fair`, `let's be honest`, …), and a **new formatting/rendering lens** hunts broken math: the top check is a raw `|` inside table-cell math (Markdown parses it as a column separator and truncates the cell), plus unbalanced `\(`/`\)` and malformed tables. Every raw finding is then handed to an independent skeptic that tries to refute it.

Result: **36 raw → 24 confirmed** (12 refuted as established house voice). Whole-manual `mkdocs build --strict` passes.

## The two you flagged

- **`overview/sensor-model.md`** — Curvature-radius cell: `\(R = 1 / (2000\,|K|)\)` → `\(R = 1 / (2000\,\lvert K \rvert)\)`. The raw `|K|` pipes split the table cell and dumped broken LaTeX; `\lvert…\rvert` is the bar notation the manual already uses (`hyperbola-fitting.md`). A whole-manual scan found no other table-cell math pipe.
- **`settings/donut-aware.md`** — `## Honest limit` → `## What it does not recover` (body unchanged). It was the only confessional heading in the manual.

## Also surfaced by the sweep

**Factual (code-verified):**
- `optimization/search-variables.md` — `MaxEvaluations = 400` → `250` by default (400 only with donut recovery on); "14 axes" → 12 always-on / 21 with donut recovery.
- `optimization/objective-function.md` — stale "three sub-scores" / "three-term version" → weighted average of the four base terms.
- `overview/index.md` — plugin adds **three** dropdowns; Star Detection was omitted.
- `settings/index.md` — "Reset to defaults" → exact label **Reset Defaults**.
- `overview/tilt-adapter-wizard.md`, `index.md` — exact in-app labels (Adjustment type / Thread pitch / Step size / Screw radius; **Moffat 4.0**).

**House-voice / AI-tell consistency:** em-dash cluster in the star-annotation rejection table, buzzword "gradient-robustly", `Pro-tip:` and `At its core` openers, "it is worth getting" filler, British-spelling drift (modelled/analysed), spaced-en-dash ranges, and two restatement admonitions removed.

## Verification

- `mkdocs build --strict` → exit 0 (no broken links/anchors/nav).
- Whole-manual programmatic check: no pipe inside any single table-cell math span and no unbalanced math delimiters on any table row.
- Docs-only change; the C# unit suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
