### PR TITLE
Tilt calibration & sensor model UX improvements

### DIFF
--- a/.claude/docs/tilt-domain.md
+++ b/.claude/docs/tilt-domain.md
@@ -21,6 +21,10 @@ Each screw has a physical orientation relative to the sensor that determines how
 
 Example: a screw at 0° (straight up from center) — turning it inward tilts the sensor plane along the vertical axis, pushing the top of the sensor away from the telescope.
 
+## Guidance arrows vs rotation glyphs
+
+The inspector's Tilt Adapter Guidance table uses two glyph vocabularies that answer different questions. The ⬆/⬇ arrows describe adapter-plate **motion** (⬆ = that corner moves toward the objective) — pure physics, identical on every rig. The ⟳/⟲ glyphs (screws) and +/− step signs (steppers) on the numeric rows carry the rig-specific **rotation** that produces that motion, which depends on the adapter's direction setting (`ScrewInwardCurvatureSign`). Never present ⬆/⬇ as a rotation. The full contract and sign derivations are in `docs/tilt-guidance-motion-arrows-design.md`.
+
 ## Image mirroring
 
 Camera images may be mirrored horizontally and/or vertically depending on the optical train (e.g., a star diagonal introduces a mirror). **Do not assume that screws numbered clockwise around the physical adapter will appear clockwise around the sensor image.** The screw orientations must be determined from the actual image coordinates after accounting for any mirroring. Plans and features that involve tilt correction must track orientation in image-space, not physical-space.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorOptionsTests.cs
@@ -254,6 +254,36 @@ public class InspectorOptionsTests {
     }
 
     [Test]
+    public void StepCount_ContaminatedByOldTimeoutBug_ResetsToDefaultAndHealsStore() {
+        // Profiles written by builds with the old TimeoutSeconds bug can hold a timeout value (e.g. 300)
+        // under the StepCount key. Load must reset it to -1 (use profile default) AND write the
+        // correction back through the accessor so the store is healed.
+        var profile = Substitute.For<IProfileService>();
+        var store = new InMemoryPluginOptionsAccessor();
+        store.SetValueInt32(nameof(InspectorOptions.StepCount), 300);
+
+        var options = new InspectorOptions(profile, store);
+
+        Assert.Multiple(() => {
+            Assert.That(options.StepCount, Is.EqualTo(-1));
+            Assert.That(store.GetValueInt32(nameof(InspectorOptions.StepCount), -999), Is.EqualTo(-1));
+        });
+    }
+
+    [TestCase(-1)]
+    [TestCase(4)]
+    [TestCase(20)]
+    public void StepCount_PlausibleStoredValues_SurviveLoadUnchanged(int stored) {
+        var profile = Substitute.For<IProfileService>();
+        var store = new InMemoryPluginOptionsAccessor();
+        store.SetValueInt32(nameof(InspectorOptions.StepCount), stored);
+
+        var options = new InspectorOptions(profile, store);
+
+        Assert.That(options.StepCount, Is.EqualTo(stored));
+    }
+
+    [Test]
     public void TimeoutSeconds_PersistsUnderItsOwnKey() {
         var (options, store, _) = Build();
         options.TimeoutSeconds = 120;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorOptionsTests.cs
@@ -26,7 +26,7 @@ public class InspectorOptionsTests {
             Assert.That(options.StepCount, Is.EqualTo(-1));
             Assert.That(options.StepSize, Is.EqualTo(-1));
             Assert.That(options.SignalAmplification, Is.EqualTo(2));
-            Assert.That(options.CenterFocuserBeforeRun, Is.True);
+            Assert.That(options.CenterFocuserBeforeRun, Is.False);
             Assert.That(options.FramesPerPoint, Is.EqualTo(-1));
             Assert.That(options.TimeoutSeconds, Is.EqualTo(-1));
             Assert.That(options.SimpleExposureSeconds, Is.EqualTo(-1));
@@ -62,7 +62,7 @@ public class InspectorOptionsTests {
         options.StepCount = 5;
         options.StepSize = 50;
         options.SignalAmplification = 3;
-        options.CenterFocuserBeforeRun = false;
+        options.CenterFocuserBeforeRun = true;
         options.FramesPerPoint = 3;
         options.NumRegionsWide = 9;
         options.SimpleExposureSeconds = 2.5;
@@ -92,7 +92,7 @@ public class InspectorOptionsTests {
             Assert.That(store.Snapshot[nameof(InspectorOptions.StepCount)], Is.EqualTo(5));
             Assert.That(store.Snapshot[nameof(InspectorOptions.StepSize)], Is.EqualTo(50));
             Assert.That(store.Snapshot[nameof(InspectorOptions.SignalAmplification)], Is.EqualTo(3));
-            Assert.That(store.Snapshot[nameof(InspectorOptions.CenterFocuserBeforeRun)], Is.False);
+            Assert.That(store.Snapshot[nameof(InspectorOptions.CenterFocuserBeforeRun)], Is.True);
             Assert.That(store.Snapshot[nameof(InspectorOptions.FramesPerPoint)], Is.EqualTo(3));
             Assert.That(store.Snapshot[nameof(InspectorOptions.SimpleExposureSeconds)], Is.EqualTo(2.5));
             Assert.That(store.Snapshot[nameof(InspectorOptions.DetailedAnalysisExposureSeconds)], Is.EqualTo(4.0));
@@ -183,7 +183,7 @@ public class InspectorOptionsTests {
         options.SensorROI = 0.5;
         options.MouseOnChartsEnabled = false;
         options.SignalAmplification = 4;
-        options.CenterFocuserBeforeRun = false;
+        options.CenterFocuserBeforeRun = true;
 
         options.ResetDefaults();
 
@@ -194,13 +194,13 @@ public class InspectorOptionsTests {
             Assert.That(options.MouseOnChartsEnabled, Is.True);
             Assert.That(options.InterpolationAmount, Is.EqualTo(InterpolationAmountEnum.Medium));
             Assert.That(options.SignalAmplification, Is.EqualTo(2));
-            Assert.That(options.CenterFocuserBeforeRun, Is.True);
+            Assert.That(options.CenterFocuserBeforeRun, Is.False);
         });
     }
 
     [TestCase(nameof(InspectorOptions.StepCount), 4)]
     [TestCase(nameof(InspectorOptions.SignalAmplification), 3)]
-    [TestCase(nameof(InspectorOptions.CenterFocuserBeforeRun), false)]
+    [TestCase(nameof(InspectorOptions.CenterFocuserBeforeRun), true)]
     [TestCase(nameof(InspectorOptions.LoopingExposureAnalysisEnabled), true)]
     [TestCase(nameof(InspectorOptions.MicronsPerFocuserStep), 2.5)]
     [TestCase(nameof(InspectorOptions.SensorROI), 0.6)]
@@ -251,6 +251,23 @@ public class InspectorOptionsTests {
         options.ResetDefaults();
 
         Assert.That(options.AcceptableRSquaredMin, Is.EqualTo(0.05));
+    }
+
+    [Test]
+    public void TimeoutSeconds_PersistsUnderItsOwnKey() {
+        var (options, store, _) = Build();
+        options.TimeoutSeconds = 120;
+        Assert.Multiple(() => {
+            Assert.That(store.GetValueInt32(nameof(InspectorOptions.TimeoutSeconds), -999), Is.EqualTo(120));
+            Assert.That(store.GetValueInt32(nameof(InspectorOptions.StepCount), -999), Is.EqualTo(-999),
+                "TimeoutSeconds must not clobber the StepCount key");
+        });
+    }
+
+    [Test]
+    public void CenterFocuserBeforeRun_DefaultsToOff() {
+        var (options, _, _) = Build();
+        Assert.That(options.CenterFocuserBeforeRun, Is.False);
     }
 
     [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMBehavioralTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMBehavioralTests.cs
@@ -2,6 +2,8 @@ using NINA.Equipment.Equipment.MyCamera;
 using NINA.Equipment.Equipment.MyFocuser;
 using NINA.Equipment.Equipment.MyTelescope;
 using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.Inspection;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
 using NINA.Profile.Interfaces;
 using NSubstitute;
@@ -146,10 +148,10 @@ public class InspectorVMBehavioralTests {
     [Test]
     public void TiltGuidance_CalibratedButUnmeasured_ShowsNoDirectionLegend() {
         // The legend is gated in RebuildTiltGuidance: it renders only when the rows it annotates exist
-        // (HasTiltGuidance / HasNumericGuidance). Driving those true needs a fitted tilt/sensor model,
-        // which would take heavy scaffolding — so this pins the reachable half of the gate: with a
+        // (HasTiltGuidance / HasNumericGuidance). This pins the suppression half of the gate: with a
         // valid calibration and a non-zero sign but no measurement, the legend must stay hidden even
-        // though BuildDirectionLegend would produce text for that sign.
+        // though BuildDirectionLegend would produce text for that state. The positive half (legend
+        // rendered once rows exist) is pinned by TiltGuidance_SigmaFlip_FlipsMotionArrowsNotTiltGlyphs.
         var bundle = new MediatorBundle();
         bundle.TiltAdapterOptions.IsCalibrated.Returns(true);
         bundle.TiltAdapterOptions.ScrewCount.Returns(3);
@@ -160,12 +162,114 @@ public class InspectorVMBehavioralTests {
 
         Assert.Multiple(() => {
             Assert.That(vm.HasTiltAdapterCalibration, Is.True, "precondition: the calibration is valid");
-            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: false, curvatureSign: 1, signIsMeasured: false), Is.Not.Empty,
-                "precondition: the legend text itself would be non-empty for this sign");
+            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: false, signIsMeasured: false), Is.Not.Empty,
+                "precondition: the legend text itself would be non-empty for this state");
             Assert.That(vm.TiltGuidance.HasTiltGuidance, Is.False, "no measurement -> no arrow rows");
             Assert.That(vm.TiltGuidance.HasNumericGuidance, Is.False, "no sensor model -> no numeric rows");
             Assert.That(vm.TiltGuidance.DirectionLegend, Is.Empty, "the gate must suppress the legend when no rows exist");
             Assert.That(vm.TiltGuidance.HasDirectionLegend, Is.False);
+        });
+    }
+
+    [Test]
+    public void TiltGuidance_SigmaFlip_FlipsMotionArrowsNotTiltGlyphs() {
+        // The σ-flip matrix from docs/tilt-guidance-motion-arrows-design.md, run with identical model
+        // inputs at σ = +1 then σ = −1:
+        //   • tilt MOTION arrows  = −σ·turns            → FLIP with σ
+        //   • backfocus MOTION arrow = sign(CurvatureEffectMicrons) — rig-independent physics → IDENTICAL
+        //   • tilt rotation glyph = sign(TiltMicrons)   → IDENTICAL
+        //   • backfocus rotation glyph = sign(σ·BackfocusMicrons) → FLIPS with σ
+        // This is the robustness property: a wrong direction setting can flip an arrow OR a glyph,
+        // but never both of the same row, so the two vocabularies cannot contradict each other.
+        // Also pinned here: the defensive σ = 0 fallback (renders as the default +1) and the
+        // legend's positive path (rows rendered ⇒ the fixed legend text renders).
+        var bundle = new MediatorBundle();
+        bundle.TiltAdapterOptions.IsCalibrated.Returns(true);
+        bundle.TiltAdapterOptions.ScrewCount.Returns(3);
+        bundle.TiltAdapterOptions.CalibratedScrewCount.Returns(3);
+        bundle.TiltAdapterOptions.ScrewInwardCurvatureSign.Returns(1);
+        bundle.TiltAdapterOptions.Screw1AngleDegrees.Returns(0.0);
+        bundle.TiltAdapterOptions.Screw2AngleDegrees.Returns(120.0);
+        bundle.TiltAdapterOptions.Screw3AngleDegrees.Returns(240.0);
+        bundle.TiltAdapterOptions.AdjustmentType.Returns(TiltAdjustmentType.Screws);
+        bundle.TiltAdapterOptions.ThreadPitchMicrons.Returns(100.0);
+        bundle.TiltAdapterOptions.ScrewRadiusMillimeters.Returns(30.0);
+
+        var vm = bundle.BuildInspectorVM();
+
+        // Tilt plane with a pure +Y gradient (A = 0, B = 10): screw 1 (top, θ = 0°) gets the largest
+        // CW-positive correction turns (+6.67; screws 2/3 get −3.33), so it is the observation point.
+        var imageSize = new System.Drawing.Size(1000, 1000);
+        var tiltPlane = TiltPlaneModel.Create(
+            imageSize: imageSize, fRatio: 5.0, focuserStepSizeMicrons: 1.0,
+            centerFocuser: 5.0, topLeftFocuser: 0.0, topRightFocuser: 0.0,
+            bottomLeftFocuser: 10.0, bottomRightFocuser: 10.0);
+        vm.TiltModel.SelectedTiltHistoryModel = new SensorTiltHistoryModel(
+            historyId: 1, tiltPlaneModel: tiltPlane, backfocusFocuserPositionDelta: 0.0);
+
+        // Fitted paraboloid with positive curvature (K > 0) and the same +Y tilt gradient: the corner
+        // curvature effect is 1e-5·(2000² + 2000²) = +80 µm (≥ the 50 µm large-arrow threshold), and
+        // screw 1's corrections are tilt = +30 µm (0.30 turns CW) / backfocus = −9000 µm (−90 turns).
+        var paraboloid = new SensorParaboloidModel(x0: 0, y0: 0, z0: 0, gx: 0, gy: 1e-3, k: 1e-5);
+        vm.SensorModel.SelectedTiltHistoryModel = new SensorParaboloidTiltHistoryModel(
+            historyId: 1, imageSize: imageSize, pixelSizeMicrons: 4.0, fRatio: 5.0,
+            focuserSizeMicrons: 1.0, finalFocusPosition: 0.0, tiltEffectMicrons: 0.0,
+            curvatureEffectMicrons: 0.0, autoFocusOffset: 0.0, tiltPlaneModel: null,
+            sensorModel: paraboloid);
+
+        TiltAdapterGuidanceVM Rebuild() {
+            bundle.TiltAdapterOptions.PropertyChanged += Raise.Event<PropertyChangedEventHandler>(
+                bundle.TiltAdapterOptions, new PropertyChangedEventArgs(nameof(ITiltAdapterOptions.ScrewInwardCurvatureSign)));
+            return vm.TiltGuidance;
+        }
+
+        var plusSigma = Rebuild();
+        bundle.TiltAdapterOptions.ScrewInwardCurvatureSign.Returns(-1);
+        var minusSigma = Rebuild();
+        bundle.TiltAdapterOptions.ScrewInwardCurvatureSign.Returns(0);
+        var zeroSigma = Rebuild();
+
+        Assert.Multiple(() => {
+            Assert.That(vm.SensorModel.DisplayedSensorModel, Is.Not.Null, "precondition: the sensor model injection must stick");
+            Assert.That(vm.SensorModel.SensorModelResult.CurvatureEffectMicrons, Is.EqualTo(80.0).Within(1e-6),
+                "precondition: positive curvature effect above the large-arrow threshold");
+            Assert.That(plusSigma.HasTiltGuidance, Is.True, "precondition: tilt arrow row rendered");
+            Assert.That(plusSigma.HasBackfocusRow, Is.True, "precondition: backfocus arrow row rendered");
+            Assert.That(plusSigma.HasNumericGuidance, Is.True, "precondition: numeric rows rendered");
+
+            // On a default (σ = +1) rig CW moves the adapter toward the camera; screw 1 needs a CW
+            // rotation, so its MOTION is toward the camera: ⬇ under the fixed "⬆ = toward the
+            // objective" legend. Flipping σ flips the motion the same rotation produces.
+            Assert.That(plusSigma.Screw1TiltArrow, Is.EqualTo("⬇"), "σ=+1: CW-needed screw moves toward the camera");
+            Assert.That(minusSigma.Screw1TiltArrow, Is.EqualTo("⬆"), "tilt MOTION arrows flip with σ");
+
+            // Positive curvature effect ⇒ the local best-focus position must decrease ⇒ the adapter
+            // moves toward the objective — identical on every rig.
+            Assert.That(plusSigma.Screw1BackfocusArrow, Is.EqualTo("⬆"), "effect > 0 ⇒ toward the objective");
+            Assert.That(minusSigma.Screw1BackfocusArrow, Is.EqualTo("⬆"), "backfocus MOTION arrow is σ-independent");
+
+            // Rotation glyphs are the inverse matrix: tilt rotation is σ-free, backfocus rotation flips.
+            Assert.That(plusSigma.Screw1TiltAmount, Is.EqualTo("0.30 ⟳"));
+            Assert.That(minusSigma.Screw1TiltAmount, Is.EqualTo("0.30 ⟳"), "tilt rotation glyph is σ-independent");
+            Assert.That(plusSigma.Screw1BackfocusAmount, Is.EqualTo("90.00 ⟲"));
+            Assert.That(minusSigma.Screw1BackfocusAmount, Is.EqualTo("90.00 ⟳"), "backfocus rotation glyph flips with σ");
+
+            // Defensive σ = 0 (unreachable from persisted options): resolves to
+            // TiltScrewGeometry.DefaultScrewInwardCurvatureSign (+1), so the guidance renders
+            // exactly as the σ = +1 run — arrows and glyphs alike — rather than suppressing rows.
+            Assert.That(zeroSigma.HasTiltGuidance, Is.True, "σ=0 must not suppress the tilt arrows");
+            Assert.That(zeroSigma.HasBackfocusRow, Is.True, "σ=0 must not suppress the backfocus arrows");
+            Assert.That(zeroSigma.Screw1TiltArrow, Is.EqualTo(plusSigma.Screw1TiltArrow));
+            Assert.That(zeroSigma.Screw1BackfocusArrow, Is.EqualTo(plusSigma.Screw1BackfocusArrow));
+            Assert.That(zeroSigma.Screw1TiltAmount, Is.EqualTo(plusSigma.Screw1TiltAmount));
+            Assert.That(zeroSigma.Screw1BackfocusAmount, Is.EqualTo(plusSigma.Screw1BackfocusAmount));
+            Assert.That(zeroSigma.Screw1TotalAmount, Is.EqualTo(plusSigma.Screw1TotalAmount));
+
+            // Legend positive path: rows exist, so the fixed screws legend renders, with the
+            // "(assumed)" suffix because the fixture never marks the direction as wizard-measured.
+            Assert.That(plusSigma.HasDirectionLegend, Is.True, "rows rendered ⇒ legend rendered");
+            Assert.That(plusSigma.DirectionLegend, Is.EqualTo(
+                "⬆ = adapter moves toward the objective · ⟳ = clockwise (tighten) · amounts in turns (assumed — set or measure in the Tilt Adapter Wizard)"));
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMBehavioralTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMBehavioralTests.cs
@@ -3,8 +3,10 @@ using NINA.Equipment.Equipment.MyFocuser;
 using NINA.Equipment.Equipment.MyTelescope;
 using NINA.Joko.Plugins.HocusFocus.AutoFocus;
 using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NINA.Profile.Interfaces;
 using NSubstitute;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 
@@ -138,6 +140,77 @@ public class InspectorVMBehavioralTests {
             Assert.That(vm.SensorModel, Is.Not.Null);
             Assert.That(vm.TiltGuidance, Is.Not.Null);
             Assert.That(vm.InspectorOptions, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public void TiltGuidance_CalibratedButUnmeasured_ShowsNoDirectionLegend() {
+        // The legend is gated in RebuildTiltGuidance: it renders only when the rows it annotates exist
+        // (HasTiltGuidance / HasNumericGuidance). Driving those true needs a fitted tilt/sensor model,
+        // which would take heavy scaffolding — so this pins the reachable half of the gate: with a
+        // valid calibration and a non-zero sign but no measurement, the legend must stay hidden even
+        // though BuildDirectionLegend would produce text for that sign.
+        var bundle = new MediatorBundle();
+        bundle.TiltAdapterOptions.IsCalibrated.Returns(true);
+        bundle.TiltAdapterOptions.ScrewCount.Returns(3);
+        bundle.TiltAdapterOptions.CalibratedScrewCount.Returns(3);
+        bundle.TiltAdapterOptions.ScrewInwardCurvatureSign.Returns(1);
+
+        var vm = bundle.BuildInspectorVM();
+
+        Assert.Multiple(() => {
+            Assert.That(vm.HasTiltAdapterCalibration, Is.True, "precondition: the calibration is valid");
+            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: false, curvatureSign: 1, signIsMeasured: false), Is.Not.Empty,
+                "precondition: the legend text itself would be non-empty for this sign");
+            Assert.That(vm.TiltGuidance.HasTiltGuidance, Is.False, "no measurement -> no arrow rows");
+            Assert.That(vm.TiltGuidance.HasNumericGuidance, Is.False, "no sensor model -> no numeric rows");
+            Assert.That(vm.TiltGuidance.DirectionLegend, Is.Empty, "the gate must suppress the legend when no rows exist");
+            Assert.That(vm.TiltGuidance.HasDirectionLegend, Is.False);
+        });
+    }
+
+    [Test]
+    public void SignalAmplificationSummary_RefreshesOnInPlaceFocuserSettingEdits() {
+        // The summary reads the ACTIVE profile's FocuserSettings; editing those values in place
+        // (no profile swap) must re-raise it, filtered to the two properties it consumes.
+        var bundle = new MediatorBundle();
+        var vm = bundle.BuildInspectorVM();
+        var settings = bundle.ProfileService.ActiveProfile.FocuserSettings;
+
+        int relevant = CountChanges(vm, nameof(InspectorVM.SignalAmplificationSummary), () => {
+            settings.PropertyChanged += Raise.Event<PropertyChangedEventHandler>(
+                settings, new PropertyChangedEventArgs(nameof(IFocuserSettings.AutoFocusInitialOffsetSteps)));
+            settings.PropertyChanged += Raise.Event<PropertyChangedEventHandler>(
+                settings, new PropertyChangedEventArgs(nameof(IFocuserSettings.AutoFocusNumberOfFramesPerPoint)));
+            settings.PropertyChanged += Raise.Event<PropertyChangedEventHandler>(
+                settings, new PropertyChangedEventArgs(nameof(IFocuserSettings.AutoFocusExposureTime))); // filtered out
+        });
+        Assert.That(relevant, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void SignalAmplificationSummary_RehooksFocuserSettingsOnProfileChange() {
+        var bundle = new MediatorBundle();
+        var vm = bundle.BuildInspectorVM();
+        var oldSettings = bundle.ProfileService.ActiveProfile.FocuserSettings;
+
+        var newProfile = Substitute.For<IProfile>();
+        bundle.ProfileService.ActiveProfile.Returns(newProfile);
+        bundle.ProfileService.ProfileChanged += Raise.Event<EventHandler>(bundle.ProfileService, EventArgs.Empty);
+        var newSettings = newProfile.FocuserSettings;
+
+        int fromNew = CountChanges(vm, nameof(InspectorVM.SignalAmplificationSummary), () => {
+            newSettings.PropertyChanged += Raise.Event<PropertyChangedEventHandler>(
+                newSettings, new PropertyChangedEventArgs(nameof(IFocuserSettings.AutoFocusInitialOffsetSteps)));
+        });
+        int fromOld = CountChanges(vm, nameof(InspectorVM.SignalAmplificationSummary), () => {
+            oldSettings.PropertyChanged += Raise.Event<PropertyChangedEventHandler>(
+                oldSettings, new PropertyChangedEventArgs(nameof(IFocuserSettings.AutoFocusInitialOffsetSteps)));
+        });
+
+        Assert.Multiple(() => {
+            Assert.That(fromNew, Is.EqualTo(1), "the new profile's settings must be hooked");
+            Assert.That(fromOld, Is.Zero, "the previous profile's settings must be unhooked");
         });
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMTests.cs
@@ -161,6 +161,29 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
         }
 
         [Test]
+        public void EstimateImagesPerRun_UsesOverridesThenProfileFallbacks() {
+            Assert.Multiple(() => {
+                // StepCount/FramesPerPoint unset (-1) => profile values; amp 2 doubles offset steps.
+                Assert.That(InspectorVM.EstimateImagesPerRun(-1, -1, 2, 4, 1), Is.EqualTo((17, 17)));
+                // Explicit overrides win over profile values.
+                Assert.That(InspectorVM.EstimateImagesPerRun(3, 2, 1, 4, 1), Is.EqualTo((7, 14)));
+                // Unknown when neither source is positive.
+                Assert.That(InspectorVM.EstimateImagesPerRun(-1, 1, 2, 0, 1), Is.EqualTo((0, 0)));
+            });
+        }
+
+        [Test]
+        public void BuildSignalAmplificationSummary_DescribesImageCount() {
+            var text = InspectorVM.BuildSignalAmplificationSummary(-1, -1, 2, 4, 1);
+            Assert.Multiple(() => {
+                Assert.That(text, Does.Contain("~17 images"));
+                Assert.That(text, Does.Contain("17 focus positions"));
+                Assert.That(text, Does.Contain("1 runs a regular autofocus"));
+            });
+            Assert.That(InspectorVM.BuildSignalAmplificationSummary(-1, -1, 2, 0, 0), Is.Empty);
+        }
+
+        [Test]
         public void HasInspectorRegionLayout_RequiresFullSixRegionGrid() {
             // The region report indexes RegionHFRs[1..5], so fewer than 6 regions (e.g. a reprocessed single-region
             // regular-AF run) must be rejected — the guard that turns the old IndexOutOfRange crash into a clean log.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/TiltAdapterGuidanceVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/TiltAdapterGuidanceVMTests.cs
@@ -1,4 +1,5 @@
 using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
 using NUnit.Framework;
 
 namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus;
@@ -25,17 +26,51 @@ public class TiltAdapterGuidanceVMTests {
     }
 
     [Test]
-    public void FormatTotal_AddsInOutDirection() {
+    public void FormatTotal_Screws_UsesClockwiseWording() {
         Assert.Multiple(() => {
-            Assert.That(TiltAdapterGuidanceVM.FormatTotal(0.95, steps: false, hasDirection: true), Is.EqualTo("0.95 turns IN"));
-            Assert.That(TiltAdapterGuidanceVM.FormatTotal(-0.30, steps: false, hasDirection: true), Is.EqualTo("0.30 turns OUT"));
-            Assert.That(TiltAdapterGuidanceVM.FormatTotal(119.6, steps: true, hasDirection: true), Is.EqualTo("120 steps IN"));
+            Assert.That(TiltAdapterGuidanceVM.FormatTotal(1.25, steps: false, hasDirection: true), Is.EqualTo("1.25 turns CW"));
+            Assert.That(TiltAdapterGuidanceVM.FormatTotal(-0.5, steps: false, hasDirection: true), Is.EqualTo("0.50 turns CCW"));
+            Assert.That(TiltAdapterGuidanceVM.FormatTotal(0.75, steps: false, hasDirection: false), Is.EqualTo("0.75 turns"));
+            Assert.That(TiltAdapterGuidanceVM.FormatTotal(0.001, steps: false, hasDirection: true), Is.EqualTo("—"));
         });
     }
 
     [Test]
-    public void FormatTotal_NoDirection_ShowsMagnitudeOnly() {
-        Assert.That(TiltAdapterGuidanceVM.FormatTotal(0.95, steps: false, hasDirection: false), Is.EqualTo("0.95 turns"));
+    public void FormatTotal_Steppers_UsesSignedSteps() {
+        Assert.Multiple(() => {
+            Assert.That(TiltAdapterGuidanceVM.FormatTotal(35.2, steps: true, hasDirection: true), Is.EqualTo("+35 steps"));
+            Assert.That(TiltAdapterGuidanceVM.FormatTotal(-35.2, steps: true, hasDirection: true), Is.EqualTo("−35 steps"));
+            Assert.That(TiltAdapterGuidanceVM.FormatTotal(12.0, steps: true, hasDirection: false), Is.EqualTo("12 steps"));
+            Assert.That(TiltAdapterGuidanceVM.FormatTotal(0.2, steps: true, hasDirection: true), Is.EqualTo("—"));
+        });
+    }
+
+    // Pins the abs-before-sign ordering: the near-zero check and step rounding operate on the
+    // magnitude, so negative near-zero values collapse to "—" and 0.5 steps rounds away from zero.
+    [TestCase(-0.2, true, "—")]
+    [TestCase(-0.004, false, "—")]
+    [TestCase(0.5, true, "+1 steps")]
+    [TestCase(0.4, true, "—")]
+    public void FormatTotal_NearZeroAndBoundary_TakesAbsBeforeSign(double amount, bool steps, string expected) {
+        Assert.That(TiltAdapterGuidanceVM.FormatTotal(amount, steps, hasDirection: true), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void BuildDirectionLegend_DescribesAdapterMotionAndProvenance() {
+        int cwInwardSign = TiltScrewGeometry.CurvatureSignForCwDirection(true);
+        int cwOutwardSign = TiltScrewGeometry.CurvatureSignForCwDirection(false);
+        Assert.Multiple(() => {
+            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: false, cwOutwardSign, signIsMeasured: true),
+                Is.EqualTo("⬆ = clockwise (adapter moves toward the camera)"));
+            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: false, cwInwardSign, signIsMeasured: true),
+                Is.EqualTo("⬆ = clockwise (adapter moves toward the objective)"));
+            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: true, cwOutwardSign, signIsMeasured: false),
+                Is.EqualTo("⬆ = + steps (adapter moves toward the camera) (assumed — set or measure in the Tilt Adapter Wizard)"));
+            // The "(assumed …)" suffix is provenance-only — not coupled to the steps unit.
+            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: false, cwOutwardSign, signIsMeasured: false),
+                Is.EqualTo("⬆ = clockwise (adapter moves toward the camera) (assumed — set or measure in the Tilt Adapter Wizard)"));
+            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: false, 0, signIsMeasured: false), Is.Empty);
+        });
     }
 
     // The Screw 4 backfocus arrow is shown only when the adapter has four screws AND the backfocus row

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/TiltAdapterGuidanceVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/TiltAdapterGuidanceVMTests.cs
@@ -73,6 +73,18 @@ public class TiltAdapterGuidanceVMTests {
         });
     }
 
+    // A fresh guidance object must carry no legend: the legend gate in InspectorVM.RebuildTiltGuidance
+    // relies on this default — DirectionLegend is only assigned when guidance rows exist, so the
+    // unassigned state must render nothing (HasDirectionLegend gates the XAML row).
+    [Test]
+    public void FreshGuidance_HasNoDirectionLegend() {
+        var vm = new TiltAdapterGuidanceVM();
+        Assert.Multiple(() => {
+            Assert.That(vm.DirectionLegend, Is.Empty);
+            Assert.That(vm.HasDirectionLegend, Is.False);
+        });
+    }
+
     // The Screw 4 backfocus arrow is shown only when the adapter has four screws AND the backfocus row
     // is active. This gating bool lets the XAML use a single plain Visibility binding (like every other
     // cell) instead of a MultiDataTrigger that failed to re-apply on the whole-object guidance swap.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/TiltAdapterGuidanceVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/TiltAdapterGuidanceVMTests.cs
@@ -1,5 +1,4 @@
 using NINA.Joko.Plugins.HocusFocus.AutoFocus;
-using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
 using NUnit.Framework;
 
 namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus;
@@ -8,68 +7,42 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus;
 public class TiltAdapterGuidanceVMTests {
 
     [Test]
-    public void FormatMagnitude_Screws_ShowsTwoDecimalTurns() {
+    public void FormatAmount_Screws_ShowsMagnitudeWithRotationGlyph() {
         Assert.Multiple(() => {
-            Assert.That(TiltAdapterGuidanceVM.FormatMagnitude(0.75, steps: false), Is.EqualTo("0.75 turns"));
-            Assert.That(TiltAdapterGuidanceVM.FormatMagnitude(-0.301, steps: false), Is.EqualTo("0.30 turns"));
-            Assert.That(TiltAdapterGuidanceVM.FormatMagnitude(0.0, steps: false), Is.EqualTo("—"));
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(1.25, steps: false), Is.EqualTo("1.25 ⟳"));
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(-0.5, steps: false), Is.EqualTo("0.50 ⟲"));
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(0.001, steps: false), Is.EqualTo("—"));
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(-0.004, steps: false), Is.EqualTo("—"));
+            // Floor boundary: the dash threshold equals the smallest value that renders, so a
+            // misleading "0.00 ⟳" can never be displayed.
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(0.005, steps: false), Is.EqualTo("0.01 ⟳"));
         });
     }
 
     [Test]
-    public void FormatMagnitude_Steppers_RoundsToWholeSteps() {
+    public void FormatAmount_Steppers_ShowsSignedSteps() {
         Assert.Multiple(() => {
-            Assert.That(TiltAdapterGuidanceVM.FormatMagnitude(119.6, steps: true), Is.EqualTo("120 steps"));
-            Assert.That(TiltAdapterGuidanceVM.FormatMagnitude(-120.4, steps: true), Is.EqualTo("120 steps"));
-            Assert.That(TiltAdapterGuidanceVM.FormatMagnitude(0.4, steps: true), Is.EqualTo("—"));
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(35.2, steps: true), Is.EqualTo("+35 steps"));
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(-35.2, steps: true), Is.EqualTo("−35 steps"));
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(0.5, steps: true), Is.EqualTo("+1 steps"));
+            // Rounding is away-from-zero on BOTH sides of zero (|amount| is rounded, then signed).
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(-0.5, steps: true), Is.EqualTo("−1 steps"));
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(0.4, steps: true), Is.EqualTo("—"));
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(-0.2, steps: true), Is.EqualTo("—"));
         });
     }
 
     [Test]
-    public void FormatTotal_Screws_UsesClockwiseWording() {
+    public void BuildDirectionLegend_IsFixedTextWithProvenanceSuffix() {
         Assert.Multiple(() => {
-            Assert.That(TiltAdapterGuidanceVM.FormatTotal(1.25, steps: false, hasDirection: true), Is.EqualTo("1.25 turns CW"));
-            Assert.That(TiltAdapterGuidanceVM.FormatTotal(-0.5, steps: false, hasDirection: true), Is.EqualTo("0.50 turns CCW"));
-            Assert.That(TiltAdapterGuidanceVM.FormatTotal(0.75, steps: false, hasDirection: false), Is.EqualTo("0.75 turns"));
-            Assert.That(TiltAdapterGuidanceVM.FormatTotal(0.001, steps: false, hasDirection: true), Is.EqualTo("—"));
-        });
-    }
-
-    [Test]
-    public void FormatTotal_Steppers_UsesSignedSteps() {
-        Assert.Multiple(() => {
-            Assert.That(TiltAdapterGuidanceVM.FormatTotal(35.2, steps: true, hasDirection: true), Is.EqualTo("+35 steps"));
-            Assert.That(TiltAdapterGuidanceVM.FormatTotal(-35.2, steps: true, hasDirection: true), Is.EqualTo("−35 steps"));
-            Assert.That(TiltAdapterGuidanceVM.FormatTotal(12.0, steps: true, hasDirection: false), Is.EqualTo("12 steps"));
-            Assert.That(TiltAdapterGuidanceVM.FormatTotal(0.2, steps: true, hasDirection: true), Is.EqualTo("—"));
-        });
-    }
-
-    // Pins the abs-before-sign ordering: the near-zero check and step rounding operate on the
-    // magnitude, so negative near-zero values collapse to "—" and 0.5 steps rounds away from zero.
-    [TestCase(-0.2, true, "—")]
-    [TestCase(-0.004, false, "—")]
-    [TestCase(0.5, true, "+1 steps")]
-    [TestCase(0.4, true, "—")]
-    public void FormatTotal_NearZeroAndBoundary_TakesAbsBeforeSign(double amount, bool steps, string expected) {
-        Assert.That(TiltAdapterGuidanceVM.FormatTotal(amount, steps, hasDirection: true), Is.EqualTo(expected));
-    }
-
-    [Test]
-    public void BuildDirectionLegend_DescribesAdapterMotionAndProvenance() {
-        int cwInwardSign = TiltScrewGeometry.CurvatureSignForCwDirection(true);
-        int cwOutwardSign = TiltScrewGeometry.CurvatureSignForCwDirection(false);
-        Assert.Multiple(() => {
-            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: false, cwOutwardSign, signIsMeasured: true),
-                Is.EqualTo("⬆ = clockwise (adapter moves toward the camera)"));
-            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: false, cwInwardSign, signIsMeasured: true),
-                Is.EqualTo("⬆ = clockwise (adapter moves toward the objective)"));
-            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: true, cwOutwardSign, signIsMeasured: false),
-                Is.EqualTo("⬆ = + steps (adapter moves toward the camera) (assumed — set or measure in the Tilt Adapter Wizard)"));
-            // The "(assumed …)" suffix is provenance-only — not coupled to the steps unit.
-            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: false, cwOutwardSign, signIsMeasured: false),
-                Is.EqualTo("⬆ = clockwise (adapter moves toward the camera) (assumed — set or measure in the Tilt Adapter Wizard)"));
-            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: false, 0, signIsMeasured: false), Is.Empty);
+            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: false, signIsMeasured: true),
+                Is.EqualTo("⬆ = adapter moves toward the objective · ⟳ = clockwise (tighten) · amounts in turns"));
+            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: false, signIsMeasured: false),
+                Is.EqualTo("⬆ = adapter moves toward the objective · ⟳ = clockwise (tighten) · amounts in turns (assumed — set or measure in the Tilt Adapter Wizard)"));
+            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: true, signIsMeasured: true),
+                Is.EqualTo("⬆ = adapter moves toward the objective · steps are signed as in the wizard prompts"));
+            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: true, signIsMeasured: false),
+                Is.EqualTo("⬆ = adapter moves toward the objective · steps are signed as in the wizard prompts (assumed — set or measure in the Tilt Adapter Wizard)"));
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
@@ -9,7 +9,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
         public int StepCount { get; set; }
         public int StepSize { get; set; }
         public int SignalAmplification { get; set; } = 2;
-        public bool CenterFocuserBeforeRun { get; set; } = true;
+        public bool CenterFocuserBeforeRun { get; set; } = false;
         public int FramesPerPoint { get; set; }
         public int TimeoutSeconds { get; set; }
         public int NumRegionsWide { get; set; } = 7;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs
@@ -31,13 +31,38 @@ public class TiltAdapterOptionsTests {
             Assert.That(options.Screw4AngleDegrees, Is.NaN);
             Assert.That(options.CalibratedScrewCount, Is.EqualTo(0));
             Assert.That(options.MeasurementAverageCount, Is.EqualTo(1));
-            Assert.That(options.ScrewInwardCurvatureSign, Is.EqualTo(0));
+            Assert.That(options.ScrewInwardCurvatureSign, Is.EqualTo(TiltScrewGeometry.DefaultScrewInwardCurvatureSign));
             Assert.That(options.AdjustmentType, Is.EqualTo(TiltAdjustmentType.Screws));
             Assert.That(options.ThreadPitchMicrons, Is.EqualTo(-1.0));
             Assert.That(options.StepperStepSizeMicrons, Is.EqualTo(-1.0));
             Assert.That(options.ScrewRadiusMillimeters, Is.EqualTo(-1.0));
             Assert.That(options.DeviceName, Is.EqualTo("Manual"));
+            Assert.That(options.ScrewInwardCurvatureSignIsMeasured, Is.False);
+            Assert.That(options.MeasureCurvatureDuringCalibration, Is.False);
+            Assert.That(options.CalibrationIsManual, Is.False);
         });
+    }
+
+    [Test]
+    public void NewOptions_RoundTripThroughAccessor() {
+        var (options, store, _) = Build();
+        options.ScrewInwardCurvatureSignIsMeasured = true;
+        options.MeasureCurvatureDuringCalibration = true;
+        options.CalibrationIsManual = true;
+        Assert.Multiple(() => {
+            Assert.That(store.GetValueBoolean(nameof(TiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured), false), Is.True);
+            Assert.That(store.GetValueBoolean(nameof(TiltAdapterOptions.MeasureCurvatureDuringCalibration), false), Is.True);
+            Assert.That(store.GetValueBoolean(nameof(TiltAdapterOptions.CalibrationIsManual), false), Is.True);
+        });
+    }
+
+    [Test]
+    public void PersistedCurvatureSign_WinsOverDefault() {
+        var profile = Substitute.For<IProfileService>();
+        var store = new InMemoryPluginOptionsAccessor();
+        store.SetValueInt32(nameof(TiltAdapterOptions.ScrewInwardCurvatureSign), -1);
+        var options = new TiltAdapterOptions(profile, store);
+        Assert.That(options.ScrewInwardCurvatureSign, Is.EqualTo(-1));
     }
 
     [Test]
@@ -92,7 +117,10 @@ public class TiltAdapterOptionsTests {
     [TestCase(nameof(TiltAdapterOptions.Screw4AngleDegrees), 359.9)]
     [TestCase(nameof(TiltAdapterOptions.CalibratedScrewCount), 3)]
     [TestCase(nameof(TiltAdapterOptions.MeasurementAverageCount), 7)]
-    [TestCase(nameof(TiltAdapterOptions.ScrewInwardCurvatureSign), 1)]
+    [TestCase(nameof(TiltAdapterOptions.ScrewInwardCurvatureSign), -1)]
+    [TestCase(nameof(TiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured), true)]
+    [TestCase(nameof(TiltAdapterOptions.MeasureCurvatureDuringCalibration), true)]
+    [TestCase(nameof(TiltAdapterOptions.CalibrationIsManual), true)]
     [TestCase(nameof(TiltAdapterOptions.AdjustmentType), TiltAdjustmentType.StepperMotors)]
     [TestCase(nameof(TiltAdapterOptions.ThreadPitchMicrons), 500.0)]
     [TestCase(nameof(TiltAdapterOptions.StepperStepSizeMicrons), 1.25)]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -475,21 +475,22 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         }
 
         [Test]
-        public void StepDescription_ArrowsFollowClockwiseUpConvention() {
-            // Summary-row arrows must match the guidance legend (⬆ = clockwise / + steps): the
-            // perturbation steps are CLOCKWISE moves per StepInstructionsText, so they carry ↑;
-            // the re-baseline undo moves are counter-clockwise and carry ↓.
+        public void StepDescription_UsesRotationGlyphs() {
+            // Summary-row glyphs must match the guidance legend (⟳ = clockwise / + steps,
+            // ⟲ = counter-clockwise / − steps): the perturbation steps are CLOCKWISE moves per
+            // StepInstructionsText, so they carry ⟳; the re-baseline undo moves carry ⟲.
             var (vm3, _, _, _) = Build(screwCount: 3);
             var (vm4, _, _, _) = Build(screwCount: 4);
             Assert.Multiple(() => {
                 Assert.That(vm3.StepDescription(WizardStep.Baseline), Is.EqualTo("Baseline"));
-                Assert.That(vm3.StepDescription(WizardStep.AllInward), Is.EqualTo("All screws ↑"));
-                Assert.That(vm3.StepDescription(WizardStep.ReBaseline1), Is.EqualTo("Re-baseline (all ↓)"));
-                Assert.That(vm3.StepDescription(WizardStep.Screw1), Is.EqualTo("Screw 1 ↑"));
-                Assert.That(vm3.StepDescription(WizardStep.Screw2), Is.EqualTo("Screw 2 ↑"));
-                Assert.That(vm4.StepDescription(WizardStep.Screw1), Is.EqualTo("Screw 1 ↑, Screw 3 ↓"));
-                Assert.That(vm4.StepDescription(WizardStep.ReBaseline2), Is.EqualTo("Re-baseline (Screw 1 ↓, Screw 3 ↑)"));
-                Assert.That(vm4.StepDescription(WizardStep.Screw2), Is.EqualTo("Screw 2 ↑, Screw 4 ↓"));
+                Assert.That(vm3.StepDescription(WizardStep.AllInward), Is.EqualTo("All screws ⟳"));
+                Assert.That(vm3.StepDescription(WizardStep.ReBaseline1), Is.EqualTo("Re-baseline (all ⟲)"));
+                Assert.That(vm3.StepDescription(WizardStep.Screw1), Is.EqualTo("Screw 1 ⟳"));
+                Assert.That(vm3.StepDescription(WizardStep.ReBaseline2), Is.EqualTo("Re-baseline (Screw 1 ⟲)"));
+                Assert.That(vm3.StepDescription(WizardStep.Screw2), Is.EqualTo("Screw 2 ⟳"));
+                Assert.That(vm4.StepDescription(WizardStep.Screw1), Is.EqualTo("Screw 1 ⟳, Screw 3 ⟲"));
+                Assert.That(vm4.StepDescription(WizardStep.ReBaseline2), Is.EqualTo("Re-baseline (Screw 1 ⟲, Screw 3 ⟳)"));
+                Assert.That(vm4.StepDescription(WizardStep.Screw2), Is.EqualTo("Screw 2 ⟳, Screw 4 ⟲"));
             });
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -43,13 +43,14 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 tiltAdapterOptions: Substitute.For<ITiltAdapterOptions>());
         }
 
-        private static (TiltAdapterWizardVM vm, ITiltAdapterOptions options, ICameraMediator camera, IFocuserMediator focuser) Build(int screwCount = 3, IApplicationDispatcher dispatcher = null) {
+        private static (TiltAdapterWizardVM vm, ITiltAdapterOptions options, ICameraMediator camera, IFocuserMediator focuser) Build(int screwCount = 3, IApplicationDispatcher dispatcher = null, System.Action<ITiltAdapterOptions> configureOptions = null) {
             var profileService = Substitute.For<IProfileService>();
             var camera = Substitute.For<ICameraMediator>();
             var focuser = Substitute.For<IFocuserMediator>();
             var options = Substitute.For<ITiltAdapterOptions>();
             options.ScrewCount.Returns(screwCount);
             options.MeasurementAverageCount.Returns(1);
+            configureOptions?.Invoke(options);
             var inspector = BuildInspector();
             var vm = new TiltAdapterWizardVM(
                 profileService: profileService,
@@ -397,8 +398,11 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         }
 
         [Test]
-        public void ApplyManualCalibration_WritesCalibrationState() {
+        public void ApplyManualCalibration_WritesCalibrationState_PositiveSignStoresPhysicalAngles() {
+            // On +1 rigs the stored response-convention angles coincide with the physical angles the
+            // user typed, so 30° places the clockwise-numbered screws at 30/150/270.
             var (vm, options, _, _) = Build(screwCount: 3);
+            options.ScrewInwardCurvatureSign.Returns(1);
             vm.ManualScrew1AngleDegrees = 30;
             vm.ManualNumberingClockwise = true;
 
@@ -418,6 +422,46 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 options.Received().LastMeasuredThreadPitchMicrons = -1;
                 options.Received().LastMeasuredStepperStepSizeMicrons = -1;
             });
+        }
+
+        [Test]
+        public void ApplyManualCalibration_NegativeSign_ConvertsPhysicalToResponseConvention() {
+            // On −1 rigs a CW turn drives the tilt gradient opposite the physical screw direction, so
+            // the stored (response-convention) angles are the typed physical angle + 180°: wizard runs
+            // persist response-convention angles and the guidance math consumes them, so a manual
+            // entry must convert or its arrows would invert on these rigs.
+            var (vm, options, _, _) = Build(screwCount: 3);
+            options.ScrewInwardCurvatureSign.Returns(-1);
+            vm.ManualScrew1AngleDegrees = 30;
+            vm.ManualNumberingClockwise = true;
+
+            vm.ApplyManualCalibration();
+
+            Assert.Multiple(() => {
+                options.Received().Screw1AngleDegrees = 210;
+                options.Received().Screw2AngleDegrees = 330;
+                options.Received().Screw3AngleDegrees = 90;
+                options.Received().Screw4AngleDegrees = double.NaN;
+                options.Received().CalibratedScrewCount = 3;
+                options.Received().IsCalibrated = true;
+            });
+        }
+
+        [Test]
+        public void Constructor_PrefillsManualAngleAsPhysical() {
+            // Stored calibration angles are response-convention; the manual-entry field holds the
+            // PHYSICAL image angle, so the pre-fill must convert back (the conversion is self-inverse).
+            var (vmNeg, _, _, _) = Build(screwCount: 3, configureOptions: o => {
+                o.Screw1AngleDegrees.Returns(210.0);
+                o.ScrewInwardCurvatureSign.Returns(-1);
+            });
+            Assert.That(vmNeg.ManualScrew1AngleDegrees, Is.EqualTo(30).Within(1e-9));
+
+            var (vmPos, _, _, _) = Build(screwCount: 3, configureOptions: o => {
+                o.Screw1AngleDegrees.Returns(210.0);
+                o.ScrewInwardCurvatureSign.Returns(1);
+            });
+            Assert.That(vmPos.ManualScrew1AngleDegrees, Is.EqualTo(210).Within(1e-9));
         }
 
         [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -13,6 +13,8 @@ using NINA.Profile.Interfaces;
 using NINA.WPF.Base.Interfaces.Mediator;
 using NSubstitute;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
@@ -502,6 +504,210 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             var (vm, _, _, _) = Build();
             // No failure has occurred, so the retry button is disabled even though we're on a measurement step.
             Assert.That(vm.RetryMeasurementCommand.CanExecute(null), Is.False);
+        }
+
+        // --- Measurement-consistency warning lifetime ---
+
+        private static readonly List<(double A, double B, double Mean)> InconsistentReadings =
+            new List<(double A, double B, double Mean)> { (0.0, 0.0, 1000.0), (0.1, 0.1, 1000.0) };
+
+        [Test]
+        public void MeasurementConsistencyWarning_SurvivesStepAdvance() {
+            // The warning is raised at the end of a successful averaged measurement, after which the wizard
+            // immediately advances to the next step. If NextStep cleared it, it could never be seen — it must
+            // survive the advance and show on the next step's screen.
+            var (vm, _, _, _) = Build();
+            vm.StartCommand.Execute(null);
+
+            // Real warning path: two repeats whose (A, B) deviate from the average by more than the 0.02 threshold.
+            vm.AppendSummaryRows(InconsistentReadings, "Baseline", latestModel: null, count: 2, avgA: 0.05, avgB: 0.05);
+            Assert.That(vm.HasMeasurementConsistencyWarning, Is.True, "precondition: the averaged measurement raised the warning");
+
+            vm.NextStep();
+
+            Assert.Multiple(() => {
+                Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Screw1));
+                Assert.That(vm.HasMeasurementConsistencyWarning, Is.True, "the warning must survive the step advance");
+                Assert.That(vm.MeasurementConsistencyWarningText, Does.Contain("max deviation"));
+            });
+        }
+
+        [Test]
+        public void MeasurementConsistencyWarning_ClearedWhenANewRunStarts() {
+            // The surviving warning describes the previous step's repeats; starting a fresh wizard run (like
+            // starting the next measurement) must clear it.
+            var (vm, _, _, _) = Build();
+            vm.AppendSummaryRows(InconsistentReadings, "Baseline", latestModel: null, count: 2, avgA: 0.05, avgB: 0.05);
+            Assert.That(vm.HasMeasurementConsistencyWarning, Is.True);
+
+            vm.StartCommand.Execute(null);
+
+            Assert.Multiple(() => {
+                Assert.That(vm.HasMeasurementConsistencyWarning, Is.False);
+                Assert.That(vm.MeasurementConsistencyWarningText, Is.Empty);
+            });
+        }
+
+        // --- Profile switch refreshes direction controls (real options + broadcast reload) ---
+
+        [Test]
+        public void ProfileChanged_RefreshesDirectionControlsAndManualPrefill() {
+            // TiltAdapterOptions reloads its values on ProfileChanged and raises a broadcast PropertyChanged that
+            // the VM's per-name filters miss. The VM's own ProfileChanged handler must therefore re-raise the
+            // direction/provenance/prompt wrappers and re-run the manual-entry pre-fill, or the controls keep
+            // showing the previous profile's state (and re-selecting the stale value would overwrite the new
+            // profile's measured sign).
+            var profileService = Substitute.For<IProfileService>();
+            var store = new InMemoryPluginOptionsAccessor();
+            var options = new TiltAdapterOptions(profileService, store);
+            // Old profile: measured "CW moves the adapter toward the objective" (stored sign −1 per the empirical
+            // anchor) with a calibrated screw 1 at stored angle 210° (physical 30° on a −1 rig).
+            options.ScrewInwardCurvatureSign = -1;
+            options.ScrewInwardCurvatureSignIsMeasured = true;
+            options.Screw1AngleDegrees = 210.0;
+            options.IsCalibrated = true;
+            options.CalibratedScrewCount = 3;
+
+            var vm = new TiltAdapterWizardVM(
+                profileService: profileService,
+                applicationStatusMediator: Substitute.For<IApplicationStatusMediator>(),
+                cameraMediator: Substitute.For<ICameraMediator>(),
+                focuserMediator: Substitute.For<IFocuserMediator>(),
+                inspector: BuildInspector(),
+                applicationDispatcher: new SynchronousApplicationDispatcher(),
+                tiltAdapterOptions: options);
+            Assert.Multiple(() => {
+                Assert.That(vm.CwMovesAdapterTowardObjective, Is.True, "precondition: old profile's direction");
+                Assert.That(vm.ManualScrew1AngleDegrees, Is.EqualTo(30).Within(1e-9), "precondition: ctor pre-fill");
+            });
+
+            // The new profile stores the opposite (assumed) direction and a different screw-1 angle.
+            store.Clear();
+            store.SetValueInt32(nameof(ITiltAdapterOptions.ScrewInwardCurvatureSign), 1);
+            store.SetValueBoolean(nameof(ITiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured), false);
+            store.SetValueDouble(nameof(ITiltAdapterOptions.Screw1AngleDegrees), 90.0);
+
+            var raised = new List<string>();
+            vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+            profileService.ProfileChanged += Raise.Event<EventHandler>(profileService, EventArgs.Empty);
+
+            Assert.Multiple(() => {
+                Assert.That(vm.CwMovesAdapterTowardObjective, Is.False, "the getter reads the new profile's sign");
+                Assert.That(raised, Does.Contain(nameof(vm.CwMovesAdapterTowardObjective)));
+                Assert.That(raised, Does.Contain(nameof(vm.CurvatureSignDescription)));
+                Assert.That(raised, Does.Contain(nameof(vm.CurvatureSignProvenance)));
+                Assert.That(raised, Does.Contain(nameof(vm.CwDirectionLabel)));
+                Assert.That(raised, Does.Contain(nameof(vm.HasCurvatureCalibration)));
+                Assert.That(raised, Does.Contain(nameof(vm.IsCalibrationValid)));
+                Assert.That(raised, Does.Contain(nameof(vm.StepInstructions)));
+                Assert.That(raised, Does.Contain(nameof(vm.BaselineRecoveryInstructions)));
+                // The manual pre-fill re-runs against the new profile: sign +1 stores physical angles unchanged.
+                Assert.That(vm.ManualScrew1AngleDegrees, Is.EqualTo(90).Within(1e-9));
+                Assert.That(raised, Does.Contain(nameof(vm.ManualScrew1AngleDegrees)));
+            });
+        }
+
+        // --- 4-step / 6-step VM sequencing through the real NextStep ---
+
+        [Test]
+        public void NextStep_FourStepFlow_SkipsCurvatureStepsAndCompletes() {
+            var (vm, _, _, _) = Build(configureOptions: o => o.MeasureCurvatureDuringCalibration.Returns(false));
+            vm.StartCommand.Execute(null);
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Baseline));
+
+            // Seed a reading per measurement step as a real run would before each advance.
+            vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw1, 0.5, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw2, -0.25, 0.433, 1000.0);
+
+            vm.NextStep();
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Screw1), "from Baseline the 4-step flow goes straight to Screw1, not AllInward");
+            vm.NextStep();
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.ReBaseline2));
+            vm.NextStep();
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Screw2));
+            vm.NextStep();
+            Assert.Multiple(() => {
+                Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Complete), "from Screw2 the 4-step wizard completes");
+                Assert.That(vm.IsComplete, Is.True);
+            });
+        }
+
+        [Test]
+        public void NextStep_SixStepFlow_WalksAllCurvatureStepsAndCompletes() {
+            var (vm, _, _, _) = Build(configureOptions: o => o.MeasureCurvatureDuringCalibration.Returns(true));
+            vm.StartCommand.Execute(null);
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Baseline));
+
+            vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.AllInward, 0.0, 0.0, 1010.0);
+            vm.SeedStepReading(WizardStep.ReBaseline1, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw1, 0.5, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw2, -0.25, 0.433, 1000.0);
+
+            var walked = new List<WizardStep> { vm.CurrentStep };
+            for (int i = 0; i < 6; i++) {
+                vm.NextStep();
+                walked.Add(vm.CurrentStep);
+            }
+
+            Assert.That(walked, Is.EqualTo(new[] {
+                WizardStep.Baseline, WizardStep.AllInward, WizardStep.ReBaseline1,
+                WizardStep.Screw1, WizardStep.ReBaseline2, WizardStep.Screw2, WizardStep.Complete }));
+        }
+
+        // --- Curvature-sign persistence semantics at run completion ---
+
+        [Test]
+        public void CompletingSixStepRun_WritesMeasuredCurvatureSignFromMeans() {
+            var (vm, options, _, _) = Build(configureOptions: o => o.MeasureCurvatureDuringCalibration.Returns(true));
+            vm.StartCommand.Execute(null);
+
+            // AllInward mean focus (990) below baseline (1000) => ComputeCurvatureSign(990, 1000) = −1.
+            vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.AllInward, 0.0, 0.0, 990.0);
+            vm.SeedStepReading(WizardStep.ReBaseline1, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw1, 0.5, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw2, -0.25, 0.433, 1000.0);
+            options.ClearReceivedCalls();
+
+            for (int i = 0; i < 6; i++) {
+                vm.NextStep();
+            }
+
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Complete));
+            Assert.Multiple(() => {
+                options.Received().ScrewInwardCurvatureSign = -1;
+                options.Received().ScrewInwardCurvatureSignIsMeasured = true;
+                options.Received().IsCalibrated = true;
+            });
+        }
+
+        [Test]
+        public void CompletingFourStepRun_DoesNotTouchCurvatureSign() {
+            var (vm, options, _, _) = Build(configureOptions: o => o.MeasureCurvatureDuringCalibration.Returns(false));
+            vm.StartCommand.Execute(null);
+
+            vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw1, 0.5, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw2, -0.25, 0.433, 1000.0);
+            options.ClearReceivedCalls();
+
+            for (int i = 0; i < 4; i++) {
+                vm.NextStep();
+            }
+
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Complete));
+            Assert.Multiple(() => {
+                // Without the AllInward probe the configured/assumed sign must be left untouched.
+                options.DidNotReceive().ScrewInwardCurvatureSign = Arg.Any<int>();
+                options.DidNotReceive().ScrewInwardCurvatureSignIsMeasured = Arg.Any<bool>();
+                options.Received().IsCalibrated = true;
+            });
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -235,14 +235,16 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         }
 
         [Test]
-        public void CurvatureSignDescription_ArrowMatchesSign() {
+        public void CurvatureSignDescription_ArrowMatchesSign_AndCarriesProvenance() {
             var (vm, options, _, _) = Build();
 
             options.ScrewInwardCurvatureSign.Returns(1);
-            Assert.That(vm.CurvatureSignDescription, Is.EqualTo("↑"));
+            options.ScrewInwardCurvatureSignIsMeasured.Returns(true);
+            Assert.That(vm.CurvatureSignDescription, Is.EqualTo("↑ (measured)"));
 
             options.ScrewInwardCurvatureSign.Returns(-1);
-            Assert.That(vm.CurvatureSignDescription, Is.EqualTo("↓"));
+            options.ScrewInwardCurvatureSignIsMeasured.Returns(false);
+            Assert.That(vm.CurvatureSignDescription, Is.EqualTo("↓ (assumed)"));
 
             options.ScrewInwardCurvatureSign.Returns(0);
             Assert.That(vm.CurvatureSignDescription, Is.Empty);
@@ -314,26 +316,129 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
 
         [Test]
         public void BaselineRecoveryText_PerturbedSteps_DescribeUndoingTheMove() {
-            // 3-screw: undo only the moved screw.
+            // 3-screw: undo only the moved screw (CW/CCW vocabulary — never "inward/outward").
             Assert.Multiple(() => {
-                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.AllInward, 3), Does.Contain("ALL screws back OUT"));
-                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.Screw1, 3), Does.Contain("screw 1 back OUT"));
-                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.Screw2, 3), Does.Contain("screw 2 back OUT"));
+                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.AllInward, 3, false, 1.0), Does.Contain("ALL screws back COUNTER-CLOCKWISE"));
+                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.Screw1, 3, false, 1.0), Does.Contain("screw 1 back COUNTER-CLOCKWISE"));
+                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.Screw2, 3, false, 1.0), Does.Contain("screw 2 back COUNTER-CLOCKWISE"));
             });
             // 4-screw: the opposing screw is undone too.
             Assert.Multiple(() => {
-                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.Screw1, 4), Does.Contain("screw 3 back IN"));
-                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.Screw2, 4), Does.Contain("screw 4 back IN"));
+                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.Screw1, 4, false, 1.0), Does.Contain("screw 3 back CLOCKWISE"));
+                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.Screw2, 4, false, 1.0), Does.Contain("screw 4 back CLOCKWISE"));
+            });
+            // Steppers: signed steps (U+2212 minus for undo).
+            Assert.Multiple(() => {
+                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.AllInward, 3, true, 2.0), Does.Contain("−2 steps to every motor"));
+                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.Screw1, 4, true, 2.0), Does.Contain("−2 steps to motor 1").And.Contain("+2 steps to motor 3"));
             });
         }
 
         [Test]
         public void BaselineRecoveryText_BaselineSteps_SayAlreadyAtBaseline() {
             Assert.Multiple(() => {
-                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.Baseline, 3), Does.Contain("already be at the baseline"));
-                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.ReBaseline1, 3), Does.Contain("already be at the baseline"));
-                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.ReBaseline2, 4), Does.Contain("already be at the baseline"));
+                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.Baseline, 3, false, 1.0), Does.Contain("already be at the baseline"));
+                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.ReBaseline1, 3, false, 1.0), Does.Contain("already be at the baseline"));
+                Assert.That(TiltAdapterWizardVM.BaselineRecoveryText(WizardStep.ReBaseline2, 4, false, 1.0), Does.Contain("already be at the baseline"));
             });
+        }
+
+        // --- 4-step / 6-step sequencing, reworded prompts, sweep summary (Task 8) ---
+
+        [Test]
+        public void GetMeasurementSteps_FourStepFlowSkipsCurvatureSteps() {
+            Assert.Multiple(() => {
+                Assert.That(TiltAdapterWizardVM.GetMeasurementSteps(measureCurvature: true), Is.EqualTo(new[] {
+                    WizardStep.Baseline, WizardStep.AllInward, WizardStep.ReBaseline1,
+                    WizardStep.Screw1, WizardStep.ReBaseline2, WizardStep.Screw2 }));
+                Assert.That(TiltAdapterWizardVM.GetMeasurementSteps(measureCurvature: false), Is.EqualTo(new[] {
+                    WizardStep.Baseline, WizardStep.Screw1, WizardStep.ReBaseline2, WizardStep.Screw2 }));
+            });
+        }
+
+        [Test]
+        public void StepInstructionsText_Screws_UsesClockwiseWordingAndAmount() {
+            Assert.Multiple(() => {
+                Assert.That(TiltAdapterWizardVM.StepInstructionsText(WizardStep.Baseline, 3, isStepper: false, appliedAmount: 1.0),
+                    Does.Contain("consistent clockwise order").And.Contain("starting position"));
+                Assert.That(TiltAdapterWizardVM.StepInstructionsText(WizardStep.AllInward, 3, false, 1.0),
+                    Does.Contain("ALL screws CLOCKWISE (tighten) exactly 1 full turn"));
+                Assert.That(TiltAdapterWizardVM.StepInstructionsText(WizardStep.ReBaseline1, 3, false, 1.0),
+                    Does.Contain("COUNTER-CLOCKWISE (loosen) exactly 1 full turn"));
+                Assert.That(TiltAdapterWizardVM.StepInstructionsText(WizardStep.Screw1, 4, false, 1.0),
+                    Does.Contain("screw 1 CLOCKWISE").And.Contain("screw 3 COUNTER-CLOCKWISE"));
+                Assert.That(TiltAdapterWizardVM.StepInstructionsText(WizardStep.Screw2, 3, false, 1.5),
+                    Does.Contain("screw 2 CLOCKWISE exactly 1.5 turns"));
+            });
+        }
+
+        [Test]
+        public void StepInstructionsText_Steppers_UsesSignedSteps() {
+            Assert.Multiple(() => {
+                Assert.That(TiltAdapterWizardVM.StepInstructionsText(WizardStep.AllInward, 3, isStepper: true, appliedAmount: 2.0),
+                    Does.Contain("+2 steps to EVERY motor"));
+                Assert.That(TiltAdapterWizardVM.StepInstructionsText(WizardStep.ReBaseline2, 3, true, 2.0),
+                    Does.Contain("−2 steps to motor 1"));
+                Assert.That(TiltAdapterWizardVM.StepInstructionsText(WizardStep.Screw1, 4, true, 2.0),
+                    Does.Contain("+2 steps to motor 1").And.Contain("−2 steps to motor 3"));
+            });
+        }
+
+        [Test]
+        public void BuildSweepSummary_CountsSweepsAndImages() {
+            // 4 steps × 2 averaged measurements = 8 sweeps; profile: 4 offset steps, 1 frame, amp 2 => 17 images/run.
+            var text = TiltAdapterWizardVM.BuildSweepSummary(4, 2, -1, -1, 2, 4, 1);
+            Assert.Multiple(() => {
+                Assert.That(text, Does.Contain("~17 images"));
+                Assert.That(text, Does.Contain("8 sweeps"));
+                Assert.That(text, Does.Contain("136 images total"));
+            });
+            Assert.That(TiltAdapterWizardVM.BuildSweepSummary(4, 1, -1, -1, 2, 0, 0), Is.Empty);
+        }
+
+        [Test]
+        public void ApplyManualCalibration_WritesCalibrationState() {
+            var (vm, options, _, _) = Build(screwCount: 3);
+            vm.ManualScrew1AngleDegrees = 30;
+            vm.ManualNumberingClockwise = true;
+
+            vm.ApplyManualCalibration();
+
+            Assert.Multiple(() => {
+                options.Received().Screw1AngleDegrees = 30;
+                options.Received().Screw2AngleDegrees = 150;
+                options.Received().Screw3AngleDegrees = 270;
+                options.Received().Screw4AngleDegrees = double.NaN;
+                options.Received().CalibratedScrewCount = 3;
+                options.Received().IsCalibrated = true;
+                options.Received().ScrewInwardCurvatureSignIsMeasured = false;
+                options.Received().CalibrationIsManual = true;
+                // A manual entry must invalidate the previous wizard run's measured hardware (the
+                // inspector's pitch-mismatch warning compares against these): -1 = the unset sentinel.
+                options.Received().LastMeasuredThreadPitchMicrons = -1;
+                options.Received().LastMeasuredStepperStepSizeMicrons = -1;
+            });
+        }
+
+        [Test]
+        public void CwMovesAdapterTowardObjective_RoundTripsThroughSign() {
+            var (vm, options, _, _) = Build();
+
+            options.ScrewInwardCurvatureSign.Returns(0);
+            vm.CwMovesAdapterTowardObjective = true;
+            Assert.Multiple(() => {
+                options.Received().ScrewInwardCurvatureSign = TiltScrewGeometry.CurvatureSignForCwDirection(true);
+                options.Received().ScrewInwardCurvatureSignIsMeasured = false;
+            });
+
+            vm.CwMovesAdapterTowardObjective = false;
+            options.Received().ScrewInwardCurvatureSign = TiltScrewGeometry.CurvatureSignForCwDirection(false);
+
+            // The getter maps a stored sign back through the pinned empirical constant.
+            options.ScrewInwardCurvatureSign.Returns(TiltScrewGeometry.CurvatureSignForCwDirection(true));
+            Assert.That(vm.CwMovesAdapterTowardObjective, Is.True);
+            options.ScrewInwardCurvatureSign.Returns(TiltScrewGeometry.CurvatureSignForCwDirection(false));
+            Assert.That(vm.CwMovesAdapterTowardObjective, Is.False);
         }
 
         [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -45,8 +45,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 tiltAdapterOptions: Substitute.For<ITiltAdapterOptions>());
         }
 
-        private static (TiltAdapterWizardVM vm, ITiltAdapterOptions options, ICameraMediator camera, IFocuserMediator focuser) Build(int screwCount = 3, IApplicationDispatcher dispatcher = null, System.Action<ITiltAdapterOptions> configureOptions = null) {
-            var profileService = Substitute.For<IProfileService>();
+        private static (TiltAdapterWizardVM vm, ITiltAdapterOptions options, ICameraMediator camera, IFocuserMediator focuser) Build(int screwCount = 3, IApplicationDispatcher dispatcher = null, System.Action<ITiltAdapterOptions> configureOptions = null, IProfileService profileService = null) {
+            profileService ??= Substitute.For<IProfileService>();
             var camera = Substitute.For<ICameraMediator>();
             var focuser = Substitute.For<IFocuserMediator>();
             var options = Substitute.For<ITiltAdapterOptions>();
@@ -447,6 +447,100 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 options.Received().CalibratedScrewCount = 3;
                 options.Received().IsCalibrated = true;
             });
+        }
+
+        [Test]
+        public void ApplyManualCalibration_NonFiniteAngle_WritesNothing() {
+            // WPF double bindings can push NaN; the guard must refuse to persist any calibration
+            // state (IsCalibrated over garbage angles would corrupt guidance until recalibrated).
+            var (vm, options, _, _) = Build(screwCount: 3);
+            options.ScrewInwardCurvatureSign.Returns(1);
+            vm.ManualScrew1AngleDegrees = double.NaN;
+            options.ClearReceivedCalls();
+
+            vm.ApplyManualCalibration();
+
+            Assert.Multiple(() => {
+                options.DidNotReceive().Screw1AngleDegrees = Arg.Any<double>();
+                options.DidNotReceive().Screw2AngleDegrees = Arg.Any<double>();
+                options.DidNotReceive().Screw3AngleDegrees = Arg.Any<double>();
+                options.DidNotReceive().Screw4AngleDegrees = Arg.Any<double>();
+                options.DidNotReceive().CalibratedScrewCount = Arg.Any<int>();
+                options.DidNotReceive().IsCalibrated = Arg.Any<bool>();
+                options.DidNotReceive().ScrewInwardCurvatureSignIsMeasured = Arg.Any<bool>();
+                options.DidNotReceive().CalibrationIsManual = Arg.Any<bool>();
+                options.DidNotReceive().LastMeasuredThreadPitchMicrons = Arg.Any<double>();
+                options.DidNotReceive().LastMeasuredStepperStepSizeMicrons = Arg.Any<double>();
+            });
+        }
+
+        [Test]
+        public void StepDescription_ArrowsFollowClockwiseUpConvention() {
+            // Summary-row arrows must match the guidance legend (⬆ = clockwise / + steps): the
+            // perturbation steps are CLOCKWISE moves per StepInstructionsText, so they carry ↑;
+            // the re-baseline undo moves are counter-clockwise and carry ↓.
+            var (vm3, _, _, _) = Build(screwCount: 3);
+            var (vm4, _, _, _) = Build(screwCount: 4);
+            Assert.Multiple(() => {
+                Assert.That(vm3.StepDescription(WizardStep.Baseline), Is.EqualTo("Baseline"));
+                Assert.That(vm3.StepDescription(WizardStep.AllInward), Is.EqualTo("All screws ↑"));
+                Assert.That(vm3.StepDescription(WizardStep.ReBaseline1), Is.EqualTo("Re-baseline (all ↓)"));
+                Assert.That(vm3.StepDescription(WizardStep.Screw1), Is.EqualTo("Screw 1 ↑"));
+                Assert.That(vm3.StepDescription(WizardStep.Screw2), Is.EqualTo("Screw 2 ↑"));
+                Assert.That(vm4.StepDescription(WizardStep.Screw1), Is.EqualTo("Screw 1 ↑, Screw 3 ↓"));
+                Assert.That(vm4.StepDescription(WizardStep.ReBaseline2), Is.EqualTo("Re-baseline (Screw 1 ↓, Screw 3 ↑)"));
+                Assert.That(vm4.StepDescription(WizardStep.Screw2), Is.EqualTo("Screw 2 ↑, Screw 4 ↓"));
+            });
+        }
+
+        [Test]
+        public void WizardSweepSummary_RefreshesOnInPlaceFocuserSettingEdits() {
+            // The summary reads the ACTIVE profile's FocuserSettings; editing those values in place
+            // (no profile swap) must re-raise it, filtered to the two properties it consumes.
+            var profileService = Substitute.For<IProfileService>();
+            var (vm, _, _, _) = Build(profileService: profileService);
+            var settings = profileService.ActiveProfile.FocuserSettings;
+
+            var raised = new List<string>();
+            vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+            settings.PropertyChanged += Raise.Event<System.ComponentModel.PropertyChangedEventHandler>(
+                settings, new System.ComponentModel.PropertyChangedEventArgs(nameof(IFocuserSettings.AutoFocusInitialOffsetSteps)));
+            Assert.That(raised, Does.Contain(nameof(vm.WizardSweepSummary)));
+
+            raised.Clear();
+            settings.PropertyChanged += Raise.Event<System.ComponentModel.PropertyChangedEventHandler>(
+                settings, new System.ComponentModel.PropertyChangedEventArgs(nameof(IFocuserSettings.AutoFocusNumberOfFramesPerPoint)));
+            Assert.That(raised, Does.Contain(nameof(vm.WizardSweepSummary)));
+
+            raised.Clear();
+            settings.PropertyChanged += Raise.Event<System.ComponentModel.PropertyChangedEventHandler>(
+                settings, new System.ComponentModel.PropertyChangedEventArgs(nameof(IFocuserSettings.AutoFocusExposureTime)));
+            Assert.That(raised, Does.Not.Contain(nameof(vm.WizardSweepSummary)), "unrelated focuser settings must not re-raise the summary");
+        }
+
+        [Test]
+        public void WizardSweepSummary_RehooksFocuserSettingsOnProfileChange() {
+            var profileService = Substitute.For<IProfileService>();
+            var (vm, _, _, _) = Build(profileService: profileService);
+            var oldSettings = profileService.ActiveProfile.FocuserSettings;
+
+            var newProfile = Substitute.For<IProfile>();
+            profileService.ActiveProfile.Returns(newProfile);
+            profileService.ProfileChanged += Raise.Event<EventHandler>(profileService, EventArgs.Empty);
+            var newSettings = newProfile.FocuserSettings;
+
+            var raised = new List<string>();
+            vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+            newSettings.PropertyChanged += Raise.Event<System.ComponentModel.PropertyChangedEventHandler>(
+                newSettings, new System.ComponentModel.PropertyChangedEventArgs(nameof(IFocuserSettings.AutoFocusInitialOffsetSteps)));
+            Assert.That(raised, Does.Contain(nameof(vm.WizardSweepSummary)), "the new profile's settings must be hooked");
+
+            raised.Clear();
+            oldSettings.PropertyChanged += Raise.Event<System.ComponentModel.PropertyChangedEventHandler>(
+                oldSettings, new System.ComponentModel.PropertyChangedEventArgs(nameof(IFocuserSettings.AutoFocusInitialOffsetSteps)));
+            Assert.That(raised, Does.Not.Contain(nameof(vm.WizardSweepSummary)), "the previous profile's settings must be unhooked");
         }
 
         [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
@@ -367,4 +367,77 @@ public class TiltCalibrationCalculatorTests {
         Assert.That(r.Confidence, Is.Not.Null);
         Assert.That(r.Confidence.IsReliable, Is.True); // clean synthetic moves, zero drift
     }
+
+    [Test]
+    public void Calibrate_WithoutCurvatureMeasurement_PassesFallbackSignThrough() {
+        // 4-step run: Baseline/AllInward were never measured. The baseline reading is supplied in
+        // the ReBaseline1 slot (it is the screw-1 reference); Baseline/AllInward stay default.
+        var baseline = new TiltGradient(0, 0, 1000);
+        var inputs = new TiltCalibrationInputs {
+            ScrewCount = 3,
+            HasCurvatureMeasurement = false,
+            FallbackCurvatureSign = -1,
+            ReBaseline1 = baseline,
+            Screw1 = SingleScrewReading(0, 400, 3),
+            ReBaseline2 = baseline,
+            Screw2 = SingleScrewReading(120, 400, 3),
+            ImageWidthPixels = ImgW,
+            ImageHeightPixels = ImgH,
+            PixelSizeMicrons = PixelSize,
+            FocuserStepMicrons = FStep,
+            ScrewRadiusMillimeters = RadiusMm,
+            CalibrationAppliedAmount = 1.0,
+            IsStepperAdjustment = false
+        };
+        var result = TiltCalibrationCalculator.Calibrate(inputs);
+        Assert.Multiple(() => {
+            Assert.That(result.CurvatureSign, Is.EqualTo(-1));
+            Assert.That(result.Screw1AngleDegrees, Is.EqualTo(0).Within(1e-6));
+            Assert.That(result.Screw2AngleDegrees, Is.EqualTo(120).Within(1e-6));
+            Assert.That(result.MeasuredHardwareMicrons, Is.EqualTo(400).Within(1e-6));
+        });
+    }
+
+    [Test]
+    public void ComputeConfidence_WithoutCurvatureMeasurement_UsesOnlyRebaseline2Drift() {
+        var baseline = new TiltGradient(0, 0, 1000);
+        var drifted = new TiltGradient(0.01, 0, 1000); // ReBaseline2 drifts by 0.01 from ReBaseline1
+        var inputs = new TiltCalibrationInputs {
+            ScrewCount = 3,
+            HasCurvatureMeasurement = false,
+            ReBaseline1 = baseline,
+            Screw1 = new TiltGradient(0.10, 0, 1000),
+            ReBaseline2 = drifted,
+            Screw2 = new TiltGradient(0.01, 0.10, 1000)
+        };
+        var confidence = TiltCalibrationCalculator.ComputeConfidence(inputs);
+        Assert.Multiple(() => {
+            // signal = mean(|0.10|, |0.10|) = 0.10; noise = |ReBaseline2 - ReBaseline1| = 0.01
+            Assert.That(confidence.ScrewMoveSignal, Is.EqualTo(0.10).Within(1e-9));
+            Assert.That(confidence.NoiseEstimate, Is.EqualTo(0.01).Within(1e-9));
+            Assert.That(confidence.SignalToNoise, Is.EqualTo(10.0).Within(1e-9));
+            Assert.That(confidence.AllInwardTiltResidual, Is.NaN);
+            Assert.That(confidence.Rebaseline1Drift, Is.NaN);
+            Assert.That(confidence.Rebaseline2Drift, Is.EqualTo(0.01).Within(1e-9));
+            Assert.That(confidence.IsReliable, Is.True);
+        });
+    }
+
+    [TestCase(30.0, true, 3, 30.0, 150.0, 270.0, double.NaN)]
+    [TestCase(30.0, false, 3, 30.0, 270.0, 150.0, double.NaN)]
+    [TestCase(350.0, true, 4, 350.0, 80.0, 170.0, 260.0)]
+    [TestCase(10.0, false, 4, 10.0, 280.0, 190.0, 100.0)]
+    [TestCase(-30.0, true, 3, 330.0, 90.0, 210.0, double.NaN)]  // out-of-range input normalized into [0, 360)
+    [TestCase(370.0, true, 3, 10.0, 130.0, 250.0, double.NaN)]
+    public void ComputeManualScrewAngles_PlacesEqualSpacingWithWinding(
+        double screw1, bool clockwise, int screwCount, double e1, double e2, double e3, double e4) {
+        var (s1, s2, s3, s4) = TiltCalibrationCalculator.ComputeManualScrewAngles(screw1, clockwise, screwCount);
+        Assert.Multiple(() => {
+            Assert.That(s1, Is.EqualTo(e1).Within(1e-9));
+            Assert.That(s2, Is.EqualTo(e2).Within(1e-9));
+            Assert.That(s3, Is.EqualTo(e3).Within(1e-9));
+            if (double.IsNaN(e4)) Assert.That(s4, Is.NaN);
+            else Assert.That(s4, Is.EqualTo(e4).Within(1e-9));
+        });
+    }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltScrewGeometryTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltScrewGeometryTests.cs
@@ -147,14 +147,51 @@ public class TiltScrewGeometryTests {
 
     [TestCase(1)]
     [TestCase(-1)]
-    public void InwardAdjustment_SignMatchesLegacyBackfocusRule(int curvatureSign) {
+    public void SignedTotalAdjustment_BackfocusComponentMatchesLegacyBackfocusRule(int curvatureSign) {
         // Legacy backfocus arrow: needsInward = curvatureEffect * sign < 0, where curvatureEffect is
-        // the curvature deviation (= -correction). So needsInward <=> sign * correction > 0.
+        // the curvature deviation (= -correction). So needsInward <=> sign * correction > 0. With no
+        // tilt component, the signed total must reproduce that rule for the backfocus correction.
         double curvatureDeviation = 42.0;        // positive deviation
         double correction = -curvatureDeviation; // correction cancels it
-        double inward = TiltScrewGeometry.InwardAdjustment(correction, unitMicrons: 500.0, curvatureSign: curvatureSign);
+        double signed = TiltScrewGeometry.SignedTotalAdjustment(0.0, correction, unitMicrons: 500.0, curvatureSign: curvatureSign);
         bool legacyNeedsInward = curvatureDeviation * curvatureSign < 0;
-        Assert.That(inward > 0, Is.EqualTo(legacyNeedsInward));
+        Assert.That(signed > 0, Is.EqualTo(legacyNeedsInward));
+    }
+
+    [Test]
+    public void SignedTotalAdjustment_AppliesSignOnlyToBackfocus() {
+        Assert.Multiple(() => {
+            // The tilt component is already direction-encoded by the stored response-convention
+            // screw angle; only the backfocus component takes the curvature sign.
+            Assert.That(TiltScrewGeometry.SignedTotalAdjustment(300, 100, 100, -1), Is.EqualTo(2.0).Within(1e-12)); // (300 − 100)/100
+            Assert.That(TiltScrewGeometry.SignedTotalAdjustment(300, 100, 100, +1), Is.EqualTo(4.0).Within(1e-12)); // (300 + 100)/100
+            // Unknown sign (0) treats backfocus as +1; callers then display magnitude only.
+            Assert.That(TiltScrewGeometry.SignedTotalAdjustment(300, 100, 100, 0), Is.EqualTo(4.0).Within(1e-12));
+            // Non-positive unit is invalid.
+            Assert.That(TiltScrewGeometry.SignedTotalAdjustment(300, 100, 0, 1), Is.NaN);
+            // REGRESSION PIN (critical sign bug): a pure-tilt correction must render the same
+            // rotational direction on every rig — the curvature sign must NOT touch it.
+            Assert.That(TiltScrewGeometry.SignedTotalAdjustment(300, 0, 100, -1), Is.EqualTo(3.0).Within(1e-12));
+            Assert.That(TiltScrewGeometry.SignedTotalAdjustment(300, 0, 100, +1), Is.EqualTo(3.0).Within(1e-12));
+        });
+    }
+
+    [Test]
+    public void PhysicalToStoredAngle_RoundTripsAndFlipsOnNegativeSign() {
+        Assert.Multiple(() => {
+            // +1 rigs: a CW turn drives the tilt gradient along the physical screw direction,
+            // so stored (response-convention) and physical angles coincide.
+            Assert.That(TiltScrewGeometry.PhysicalToStoredAngle(30, +1), Is.EqualTo(30).Within(1e-12));
+            // −1 rigs (CW moves the adapter toward the objective): the response is inverted,
+            // so stored = physical + 180°.
+            Assert.That(TiltScrewGeometry.PhysicalToStoredAngle(30, -1), Is.EqualTo(210).Within(1e-12));
+            // Self-inverse: applying the conversion to a stored angle recovers the physical one.
+            Assert.That(TiltScrewGeometry.PhysicalToStoredAngle(210, -1), Is.EqualTo(30).Within(1e-12));
+            // Unknown sign (0) resolves to the default direction (+1 ⇒ identity).
+            Assert.That(TiltScrewGeometry.PhysicalToStoredAngle(30, 0), Is.EqualTo(30).Within(1e-12));
+            // Result is normalized to [0, 360).
+            Assert.That(TiltScrewGeometry.PhysicalToStoredAngle(-30, -1), Is.EqualTo(150).Within(1e-12));
+        });
     }
 
     [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltScrewGeometryTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltScrewGeometryTests.cs
@@ -199,4 +199,24 @@ public class TiltScrewGeometryTests {
         var (a, b) = TiltScrewGeometry.PhysicalGradientToPlane(0.01, 0.02, 0.0, 1000, 1000);
         Assert.That(double.IsNaN(a) && double.IsNaN(b), Is.True);
     }
+
+    [Test]
+    public void CurvatureSignForCwDirection_MatchesEmpiricalAnchor() {
+        Assert.Multiple(() => {
+            // Pinned to the empirically verified mapping (see TiltScrewGeometry comment): moving
+            // the adapter toward the objective DECREASES the curvature effect (user measurement,
+            // 2026-07-02), so CW-toward-objective => CW lowers the effect => -1. If this fails
+            // after an intentional flip, update BOTH the constant comment and this test.
+            Assert.That(TiltScrewGeometry.CurvatureSignWhenCwMovesAdapterTowardObjective, Is.EqualTo(-1));
+            Assert.That(TiltScrewGeometry.CurvatureSignForCwDirection(cwMovesAdapterTowardObjective: true), Is.EqualTo(-1));
+            Assert.That(TiltScrewGeometry.CurvatureSignForCwDirection(cwMovesAdapterTowardObjective: false), Is.EqualTo(1));
+            Assert.That(TiltScrewGeometry.CwMovesAdapterTowardObjectiveForSign(-1), Is.True);
+            Assert.That(TiltScrewGeometry.CwMovesAdapterTowardObjectiveForSign(1), Is.False);
+            // Default assumption: CW moves the adapter outward (toward the camera), so the default
+            // stored sign is +1 (CW raises the curvature effect) — equivalently, adapter motion
+            // toward the objective decreases it, the originally requested default behavior.
+            Assert.That(TiltScrewGeometry.DefaultScrewInwardCurvatureSign,
+                Is.EqualTo(TiltScrewGeometry.CurvatureSignForCwDirection(false)));
+        });
+    }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -2970,6 +2970,15 @@
                                     Visibility="{Binding TiltGuidance.HasFourScrews, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                             </Grid>
 
+                            <!--  Direction legend: what ⬆ / CW / + steps mean for this adapter  -->
+                            <TextBlock
+                                Margin="5,4,5,0"
+                                FontStyle="Italic"
+                                Opacity="0.7"
+                                Text="{Binding TiltGuidance.DirectionLegend}"
+                                TextWrapping="Wrap"
+                                Visibility="{Binding TiltGuidance.HasDirectionLegend, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+
                             <!--  Saved-vs-measured pitch mismatch warning  -->
                             <Border
                                 Margin="5,6,5,0"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -2832,6 +2832,13 @@
                         </TextBlock>
                         <!--  Calibrated guidance branch  -->
                         <StackPanel Visibility="{Binding HasTiltAdapterCalibration, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                            <!--  Direction legend: ⬆/⬇ = adapter motion, ⟳/⟲ = screw rotation. First
+                                  element so the conventions are read before the table.  -->
+                            <TextBlock
+                                Margin="5,4,5,2"
+                                Text="{Binding TiltGuidance.DirectionLegend}"
+                                TextWrapping="Wrap"
+                                Visibility="{Binding TiltGuidance.HasDirectionLegend, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                             <!--  No measurement yet  -->
                             <TextBlock
                                 Margin="5"
@@ -2958,7 +2965,7 @@
                                     Visibility="{Binding TiltGuidance.HasFourScrewBackfocus, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                             </Grid>
 
-                            <!--  Precise numeric adjustments (turns / steps) — shown when adapter hardware is configured  -->
+                            <!--  Precise numeric adjustments, each with its rotation glyph / step sign — shown when adapter hardware is configured  -->
                             <Grid
                                 Margin="5,8,5,0"
                                 Visibility="{Binding TiltGuidance.HasNumericGuidance, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
@@ -3003,15 +3010,6 @@
                                 <TextBlock Grid.Row="3" Grid.Column="4" HorizontalAlignment="Center" FontWeight="SemiBold" Text="{Binding TiltGuidance.Screw4TotalAmount}"
                                     Visibility="{Binding TiltGuidance.HasFourScrews, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                             </Grid>
-
-                            <!--  Direction legend: what ⬆ / CW / + steps mean for this adapter  -->
-                            <TextBlock
-                                Margin="5,4,5,0"
-                                FontStyle="Italic"
-                                Opacity="0.7"
-                                Text="{Binding TiltGuidance.DirectionLegend}"
-                                TextWrapping="Wrap"
-                                Visibility="{Binding TiltGuidance.HasDirectionLegend, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
 
                             <!--  Saved-vs-measured pitch mismatch warning  -->
                             <Border

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -28,7 +28,7 @@
     <TextBlock x:Key="StepSize_Tooltip" Text="How many focuser steps in between each data point when doing an AutoFocus. Uses the value set for AutoFocus if blank" />
     <TextBlock x:Key="FramesPerPoint_Tooltip" Text="How many exposures to average together for each focuser point. Uses the value set for AutoFocus if blank" />
     <TextBlock x:Key="SignalAmplification_Tooltip" Text="Increases the resolution and signal of sensor-model / tilt calibration runs by capturing more, finer-spaced focuser points. The focuser step size is divided by this factor and the number of steps multiplied by it, so the sweep covers the same range with more points (and smaller defocus jumps between adjacent frames, which makes star alignment more reliable). Default 2. Set to 1 to disable. Applies to live captures only, not when replaying saved frames." />
-    <TextBlock x:Key="CenterFocuserBeforeRun_Tooltip" Text="When on (default), a quick standard AutoFocus is run before each live sensor-model / tilt calibration sweep to center the focuser at best focus. The detailed sweep then brackets focus symmetrically, which reduces extreme one-sided defocus frames that fail to align. Has no effect when replaying saved frames." />
+    <TextBlock x:Key="CenterFocuserBeforeRun_Tooltip" Text="When on, a quick standard AutoFocus is run before each live sensor-model / tilt calibration sweep to center the focuser at best focus. The detailed sweep then brackets focus symmetrically, which reduces extreme one-sided defocus frames that fail to align. Off by default; it adds an extra AutoFocus run to every sweep. Has no effect when replaying saved frames." />
     <TextBlock x:Key="AutoFocusTimeoutSeconds_Tooltip" Text="How long, in seconds, after which AutoFocus should time out and fail. Uses the value set for AutoFocus if blank" />
     <TextBlock x:Key="NumRegionsWide_Tooltip" Text="How many cells wide to divide the sensor pixels when generating a grid of eccentricity vectors. This value must be an odd, positive integer, and the height will be calculated proportionally from it based on the sensor resolution" />
     <TextBlock x:Key="MicronsPerFocuserStep_Tooltip" Text="How much the focuser moves per step, in microns. If this is set, the adjustment chart will include adjustments in microns" />
@@ -1391,6 +1391,83 @@
                             VerticalAlignment="Center"
                             Text="Keep frames for Review" />
                     </StackPanel>
+
+                    <!--  Sweep-cost settings: kept out of the Options expander because they directly
+                          control how long every sensor-model / tilt-calibration run takes.  -->
+                    <Grid
+                        Grid.Row="4"
+                        Grid.ColumnSpan="4"
+                        Margin="0,4,0,0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            Margin="5"
+                            VerticalAlignment="Center"
+                            Text="Signal Amplification"
+                            ToolTip="{StaticResource SignalAmplification_Tooltip}" />
+                        <ninactrl:UnitTextBox
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            MinWidth="40"
+                            VerticalAlignment="Center"
+                            HorizontalContentAlignment="Left"
+                            VerticalContentAlignment="Center"
+                            Foreground="{StaticResource PrimaryBrush}"
+                            TextAlignment="Left"
+                            ToolTip="{StaticResource SignalAmplification_Tooltip}"
+                            Unit="x">
+                            <Binding
+                                Mode="TwoWay"
+                                Path="InspectorOptions.SignalAmplification"
+                                UpdateSourceTrigger="LostFocus" />
+                        </ninactrl:UnitTextBox>
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="2"
+                            MaxWidth="400"
+                            Margin="10,5,5,5"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            FontStyle="Italic"
+                            Opacity="0.7"
+                            Text="{Binding SignalAmplificationSummary}"
+                            TextWrapping="Wrap" />
+                        <TextBlock
+                            Grid.Row="1"
+                            Grid.Column="0"
+                            Margin="5"
+                            VerticalAlignment="Center"
+                            Text="Center Focuser First"
+                            ToolTip="{StaticResource CenterFocuserBeforeRun_Tooltip}" />
+                        <CheckBox
+                            Grid.Row="1"
+                            Grid.Column="1"
+                            Margin="5,0,0,0"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            IsChecked="{Binding InspectorOptions.CenterFocuserBeforeRun}"
+                            ToolTip="{StaticResource CenterFocuserBeforeRun_Tooltip}" />
+                        <TextBlock
+                            Grid.Row="1"
+                            Grid.Column="2"
+                            MaxWidth="400"
+                            Margin="10,5,5,5"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            FontStyle="Italic"
+                            Opacity="0.7"
+                            Text="Runs one standard autofocus to center the focuser before each measurement sweep. Turn on if your focuser drifts between runs or starts far from best focus; leave off to save time."
+                            TextWrapping="Wrap" />
+                    </Grid>
                 </Grid>
                 <Expander
                     Grid.Row="1"
@@ -1408,7 +1485,6 @@
                             </Style>
                         </Grid.Resources>
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
@@ -1757,50 +1833,8 @@
                             <CheckBox Margin="5,0,0,0" IsChecked="{Binding InspectorOptions.FixedSensorCenter}" />
                         </StackPanel>
 
-                        <TextBlock
-                            Grid.Row="7"
-                            Grid.Column="0"
-                            Margin="5"
-                            VerticalAlignment="Center"
-                            Text="Signal Amplification"
-                            ToolTip="{StaticResource SignalAmplification_Tooltip}" />
-                        <ninactrl:UnitTextBox
-                            Grid.Row="7"
-                            Grid.Column="1"
-                            MinWidth="40"
-                            VerticalAlignment="Center"
-                            HorizontalContentAlignment="Left"
-                            VerticalContentAlignment="Center"
-                            Foreground="{StaticResource PrimaryBrush}"
-                            TextAlignment="Left"
-                            ToolTip="{StaticResource SignalAmplification_Tooltip}"
-                            Unit="x">
-                            <Binding
-                                Mode="TwoWay"
-                                Path="InspectorOptions.SignalAmplification"
-                                UpdateSourceTrigger="LostFocus" />
-                        </ninactrl:UnitTextBox>
-
-                        <TextBlock
-                            Grid.Row="7"
-                            Grid.Column="2"
-                            Margin="5"
-                            VerticalAlignment="Center"
-                            Text="Center Focuser First"
-                            ToolTip="{StaticResource CenterFocuserBeforeRun_Tooltip}" />
-                        <StackPanel
-                            Grid.Row="7"
-                            Grid.Column="3"
-                            Orientation="Horizontal">
-                            <CheckBox
-                                Margin="5,0,0,0"
-                                VerticalAlignment="Center"
-                                IsChecked="{Binding InspectorOptions.CenterFocuserBeforeRun}"
-                                ToolTip="{StaticResource CenterFocuserBeforeRun_Tooltip}" />
-                        </StackPanel>
-
                         <Expander
-                            Grid.Row="8"
+                            Grid.Row="7"
                             Grid.ColumnSpan="4"
                             VerticalAlignment="Center"
                             Header="Experimental">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
@@ -45,8 +45,21 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             RaiseAllPropertiesChanged();
         }
 
+        // StepCount is a per-side AF offset-step count: -1 = use the profile's AutoFocus value, real
+        // values are small (single/double digits). Neither the setter nor the UI (a plain HintTextBox)
+        // constrains it, so 50 is a generous sanity bound used only to catch corrupted stores.
+        private const int MaxPlausibleStepCount = 50;
+
         private void InitializeOptions() {
             stepCount = optionsAccessor.GetValueInt32(nameof(StepCount), -1);
+            // Profiles written by builds with the old TimeoutSeconds bug (it persisted under the
+            // StepCount key) can hold a timeout value (e.g. 300) here. Reset implausible values to -1
+            // and write the correction back so the store is healed once instead of on every load.
+            if (stepCount < -1 || stepCount > MaxPlausibleStepCount) {
+                Logger.Warning($"InspectorOptions.StepCount loaded an implausible value ({stepCount}) — likely a TimeoutSeconds value written under the StepCount key by an older build. Resetting to -1 (use the profile's AutoFocus value).");
+                stepCount = -1;
+                optionsAccessor.SetValueInt32(nameof(StepCount), stepCount);
+            }
             stepSize = optionsAccessor.GetValueInt32(nameof(StepSize), -1);
             signalAmplification = Math.Max(1, optionsAccessor.GetValueInt32(nameof(SignalAmplification), 2));
             centerFocuserBeforeRun = optionsAccessor.GetValueBoolean(nameof(CenterFocuserBeforeRun), false);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
@@ -49,7 +49,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             stepCount = optionsAccessor.GetValueInt32(nameof(StepCount), -1);
             stepSize = optionsAccessor.GetValueInt32(nameof(StepSize), -1);
             signalAmplification = Math.Max(1, optionsAccessor.GetValueInt32(nameof(SignalAmplification), 2));
-            centerFocuserBeforeRun = optionsAccessor.GetValueBoolean(nameof(CenterFocuserBeforeRun), true);
+            centerFocuserBeforeRun = optionsAccessor.GetValueBoolean(nameof(CenterFocuserBeforeRun), false);
             framesPerPoint = optionsAccessor.GetValueInt32(nameof(FramesPerPoint), -1);
             timeoutSeconds = optionsAccessor.GetValueInt32(nameof(TimeoutSeconds), -1);
             simpleExposureSeconds = optionsAccessor.GetValueDouble(nameof(SimpleExposureSeconds), -1);
@@ -84,7 +84,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             StepCount = -1;
             StepSize = -1;
             SignalAmplification = 2;
-            CenterFocuserBeforeRun = true;
+            CenterFocuserBeforeRun = false;
             FramesPerPoint = -1;
             TimeoutSeconds = -1;
             SimpleExposureSeconds = -1;
@@ -155,10 +155,10 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             }
         }
 
-        // When on (default), a quick standard autofocus is run before each live sensor-model / tilt sweep to center
+        // When on, a quick standard autofocus is run before each live sensor-model / tilt sweep to center
         // the focuser at best focus, so the sweep brackets focus symmetrically (fewer extreme one-sided defocus
-        // frames that fail to align). No effect on replay of saved frames.
-        private bool centerFocuserBeforeRun = true;
+        // frames that fail to align). Off by default — it adds a full AF run to every sweep. No effect on replay.
+        private bool centerFocuserBeforeRun = false;
 
         public bool CenterFocuserBeforeRun {
             get => centerFocuserBeforeRun;
@@ -191,7 +191,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             set {
                 if (timeoutSeconds != value) {
                     timeoutSeconds = value;
-                    optionsAccessor.SetValueInt32(nameof(StepCount), timeoutSeconds);
+                    optionsAccessor.SetValueInt32(nameof(TimeoutSeconds), timeoutSeconds);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -1142,8 +1142,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             var (points, images) = EstimateImagesPerRun(stepCount, framesPerPoint, signalAmplification, profileOffsetSteps, profileFramesPerPoint);
             if (images <= 0) return string.Empty;
             int frames = framesPerPoint > 0 ? framesPerPoint : profileFramesPerPoint;
-            return $"Each auto focus run will capture ~{images} images ({points} focus positions × {frames} exposure{(frames == 1 ? "" : "s")} each). " +
-                "Higher values collect more, finer-spaced points for a steadier fit on weak signal; 1 runs a regular autofocus (fastest).";
+            return $"Each autofocus run will capture ~{images} images ({points} focus positions × {frames} exposure{(frames == 1 ? "" : "s")} each). " +
+                "Higher values collect more, finer-spaced points for a steadier fit on weak signal; a value of 1 runs a regular autofocus (fastest).";
         }
 
         public string SignalAmplificationSummary =>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -1886,6 +1886,17 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
             FillNumericGuidance(guidance, n);
 
+            // Direction legend only when the arrows/totals it annotates are actually on screen
+            // (the arrows grid is gated by HasTiltGuidance, the numeric totals by HasNumericGuidance).
+            // Otherwise the calibrated-but-unmeasured state would show a legend right under
+            // "Run a measurement to see guidance." with nothing to explain.
+            if (guidance.HasTiltGuidance || guidance.HasNumericGuidance) {
+                guidance.DirectionLegend = TiltAdapterGuidanceVM.BuildDirectionLegend(
+                    steps: tiltAdapterOptions.AdjustmentType == TiltAdjustmentType.StepperMotors,
+                    curvatureSign: tiltAdapterOptions.ScrewInwardCurvatureSign,
+                    signIsMeasured: tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured);
+            }
+
             TiltGuidance = guidance;
             RaisePropertyChanged(nameof(TiltGuidance));
         }
@@ -1894,7 +1905,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
         // Populate the precise per-screw turn/step amounts from the fitted paraboloid model and the
         // configured adapter hardware. Magnitudes are direction-indicated by the existing arrows; the
-        // total carries an explicit IN/OUT word. Everything is computed in axial best-focus microns
+        // total carries an explicit direction (CW/CCW or +/− steps). Everything is computed in axial best-focus microns
         // (tilt = -TiltAt, backfocus = -CurvatureAt) then divided by the saved pitch/step size — there
         // is no square root, the curvature term is already a length.
         private void FillNumericGuidance(TiltAdapterGuidanceVM guidance, int n) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -101,6 +101,21 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         // is instantiated directly here, mirroring HocusFocusPlugin — used to show the modal Review Frames dialog.
         private readonly IWindowServiceFactory windowServiceFactory = new WindowServiceFactory();
 
+        // SignalAmplificationSummary reads the ACTIVE profile's FocuserSettings; these track the settings
+        // object currently subscribed so in-place edits refresh the summary and profile swaps re-hook cleanly.
+        private readonly System.ComponentModel.PropertyChangedEventHandler focuserSettingsHandler;
+        private IFocuserSettings hookedFocuserSettings;
+
+        private void HookActiveProfileFocuserSettings() {
+            if (hookedFocuserSettings != null) {
+                hookedFocuserSettings.PropertyChanged -= focuserSettingsHandler;
+            }
+            hookedFocuserSettings = profileService?.ActiveProfile?.FocuserSettings;
+            if (hookedFocuserSettings != null) {
+                hookedFocuserSettings.PropertyChanged += focuserSettingsHandler;
+            }
+        }
+
         [ImportingConstructor]
         public InspectorVM(
             IProfileService profileService,
@@ -177,7 +192,21 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     RaisePropertyChanged(nameof(SignalAmplificationSummary));
                 }
             };
-            profileService.ProfileChanged += (s, e) => RaisePropertyChanged(nameof(SignalAmplificationSummary));
+            // SignalAmplificationSummary also reads the active profile's FocuserSettings (offset steps /
+            // frames per point), which the user can edit in place without swapping profiles —
+            // ProfileChanged alone would leave the summary stale. Track the active profile's
+            // FocuserSettings and re-hook on every profile change (unsubscribe old, subscribe new).
+            focuserSettingsHandler = (s, e) => {
+                if (e.PropertyName == nameof(IFocuserSettings.AutoFocusInitialOffsetSteps) ||
+                    e.PropertyName == nameof(IFocuserSettings.AutoFocusNumberOfFramesPerPoint)) {
+                    RaisePropertyChanged(nameof(SignalAmplificationSummary));
+                }
+            };
+            HookActiveProfileFocuserSettings();
+            profileService.ProfileChanged += (s, e) => {
+                HookActiveProfileFocuserSettings();
+                RaisePropertyChanged(nameof(SignalAmplificationSummary));
+            };
 
             this.tiltAdapterOptions = tiltAdapterOptions;
             TiltGuidance = new TiltAdapterGuidanceVM();

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -170,6 +170,15 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             TiltModel = new TiltModel(inspectorOptions);
             SensorModel = new SensorModel(profileService, inspectorOptions, autoFocusOptions, alglibAPI);
 
+            inspectorOptions.PropertyChanged += (s, e) => {
+                if (e.PropertyName == nameof(IInspectorOptions.SignalAmplification) ||
+                    e.PropertyName == nameof(IInspectorOptions.StepCount) ||
+                    e.PropertyName == nameof(IInspectorOptions.FramesPerPoint)) {
+                    RaisePropertyChanged(nameof(SignalAmplificationSummary));
+                }
+            };
+            profileService.ProfileChanged += (s, e) => RaisePropertyChanged(nameof(SignalAmplificationSummary));
+
             this.tiltAdapterOptions = tiltAdapterOptions;
             TiltGuidance = new TiltAdapterGuidanceVM();
             if (tiltAdapterOptions != null) {
@@ -1113,6 +1122,37 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 options.AutoFocusStepSize = Math.Max(1, (int)Math.Round(options.AutoFocusStepSize / (double)amp));
             }
         }
+
+        // Estimated sweep size for one live sensor-model autofocus run at the given settings.
+        // points ≈ 2·offsetSteps·amp + 1 (the engine can extend a sweep, so callers label it "~");
+        // images = points × framesPerPoint. Returns (0, 0) when the inputs cannot be resolved.
+        internal static (int points, int images) EstimateImagesPerRun(
+            int stepCount, int framesPerPoint, int signalAmplification, int profileOffsetSteps, int profileFramesPerPoint) {
+            int offsetSteps = stepCount > 0 ? stepCount : profileOffsetSteps;
+            int frames = framesPerPoint > 0 ? framesPerPoint : profileFramesPerPoint;
+            if (offsetSteps <= 0 || frames <= 0) return (0, 0);
+            int amp = Math.Max(1, signalAmplification);
+            int points = 2 * offsetSteps * amp + 1;
+            return (points, points * frames);
+        }
+
+        // Prose shown beside the Signal Amplification control. Internal for tests.
+        internal static string BuildSignalAmplificationSummary(
+            int stepCount, int framesPerPoint, int signalAmplification, int profileOffsetSteps, int profileFramesPerPoint) {
+            var (points, images) = EstimateImagesPerRun(stepCount, framesPerPoint, signalAmplification, profileOffsetSteps, profileFramesPerPoint);
+            if (images <= 0) return string.Empty;
+            int frames = framesPerPoint > 0 ? framesPerPoint : profileFramesPerPoint;
+            return $"Each auto focus run will capture ~{images} images ({points} focus positions × {frames} exposure{(frames == 1 ? "" : "s")} each). " +
+                "Higher values collect more, finer-spaced points for a steadier fit on weak signal; 1 runs a regular autofocus (fastest).";
+        }
+
+        public string SignalAmplificationSummary =>
+            BuildSignalAmplificationSummary(
+                inspectorOptions.StepCount,
+                inspectorOptions.FramesPerPoint,
+                inspectorOptions.SignalAmplification,
+                profileService.ActiveProfile.FocuserSettings.AutoFocusInitialOffsetSteps,
+                profileService.ActiveProfile.FocuserSettings.AutoFocusNumberOfFramesPerPoint);
 
         private StarDetectionRegion GetAutoFocusRegion(AutoFocusEngineOptions options) {
             var analysisParams = new StarDetectionParams() {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -1961,7 +1961,6 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             double radiusMicrons = radiusMm * 1000.0;
             int curvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign;
             bool hasDirection = curvatureSign != 0;
-            int signForTotal = hasDirection ? curvatureSign : 1;
 
             var angles = new double[n];
             angles[0] = tiltAdapterOptions.Screw1AngleDegrees;
@@ -1978,8 +1977,13 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     model.Gx, model.Gy, model.Kx, model.Ky, model.X0, model.Y0, angles[i], radiusMicrons);
                 tiltText[i] = TiltAdapterGuidanceVM.FormatMagnitude(corr.TiltMicrons / unitMicrons, steps);
                 backText[i] = TiltAdapterGuidanceVM.FormatMagnitude(corr.BackfocusMicrons / unitMicrons, steps);
-                double totalInward = TiltScrewGeometry.InwardAdjustment(corr.TotalMicrons, unitMicrons, signForTotal);
-                totalText[i] = TiltAdapterGuidanceVM.FormatTotal(totalInward, steps, hasDirection);
+                // The curvature sign applies ONLY to the backfocus component: the tilt component's
+                // direction is already encoded by the stored response-convention screw angle (the same
+                // convention the tilt arrows invert), so multiplying the whole total by the sign would
+                // flip the tilt part on sign = -1 rigs and contradict the arrows.
+                double totalSigned = TiltScrewGeometry.SignedTotalAdjustment(
+                    corr.TiltMicrons, corr.BackfocusMicrons, unitMicrons, curvatureSign);
+                totalText[i] = TiltAdapterGuidanceVM.FormatTotal(totalSigned, steps, hasDirection);
             }
 
             guidance.Screw1TiltAmount = tiltText[0];

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -1887,6 +1887,11 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             var guidance = new TiltAdapterGuidanceVM { ScrewCount = n };
 
             if (HasTiltAdapterCalibration) {
+                // σ resolved for the arrow rows; FillNumericGuidance resolves the same 0→default
+                // rule for the numeric rows.
+                int curvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign;
+                int resolvedSign = curvatureSign == 0 ? TiltScrewGeometry.DefaultScrewInwardCurvatureSign : curvatureSign;
+
                 var tiltPlane = TiltModel?.TiltPlaneModel;
                 if (tiltPlane != null) {
                     double a = tiltPlane.A;
@@ -1898,6 +1903,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                         angles[2] = tiltAdapterOptions.Screw3AngleDegrees;
                         if (n == 4) angles[3] = tiltAdapterOptions.Screw4AngleDegrees;
 
+                        // Per-screw CW-positive correction turns from the tilt plane. The arrows grid
+                        // shows the adapter MOTION those turns produce (⬆ = toward the objective), not
+                        // the rotation itself — the rotation glyphs on the numeric rows carry that.
                         var turns = new double[n];
                         for (int i = 0; i < n; i++) {
                             double theta = angles[i] * Math.PI / 180.0;
@@ -1910,7 +1918,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                             if (maxAbs < GuidanceNoiseThreshold) {
                                 tiltArrows[i] = "—";
                             } else {
-                                double ratio = turns[i] / maxAbs;
+                                // turns[i] is CW-positive (the stored response-convention angles encode
+                                // the rig direction), so adapter MOTION toward the objective = −σ·turns.
+                                double ratio = (-resolvedSign * turns[i]) / maxAbs;
                                 if (ratio >= GuidanceLargeArrowThreshold) tiltArrows[i] = "⬆";
                                 else if (ratio >= GuidanceMinArrowThreshold) tiltArrows[i] = "↑";
                                 else if (ratio <= -GuidanceLargeArrowThreshold) tiltArrows[i] = "⬇";
@@ -1926,12 +1936,12 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     }
                 }
 
-                // Backfocus row: adjust curvature toward 0 using sensor model CurvatureEffectMicrons and ScrewInwardCurvatureSign.
-                // CurvatureEffectMicrons is in focuser-µm at the sensor corner — positive when C > 0.
-                // ScrewInwardCurvatureSign = +1 means turning all screws inward raises curvature; -1 means it lowers it.
-                // To reduce |curvature| toward 0: go inward when curvatureEffect and curvatureSign have opposite signs.
-                int curvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign;
-                if (curvatureSign != 0 && SensorModel?.DisplayedSensorModel != null) {
+                // Backfocus row: adapter MOTION needed to null the curvature effect. Toward the
+                // objective ⇔ the local best-focus position must decrease; the σ in "which rotation
+                // is needed" and the σ in "what a rotation does" cancel, so the motion arrow is
+                // sign(CurvatureEffectMicrons) — rig-independent physics (see
+                // docs/tilt-guidance-motion-arrows-design.md).
+                if (SensorModel?.DisplayedSensorModel != null) {
                     double curvatureEffectMicrons = SensorModel.SensorModelResult.CurvatureEffectMicrons;
                     double absMicrons = Math.Abs(curvatureEffectMicrons);
 
@@ -1939,9 +1949,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     if (absMicrons < BackfocusNoiseThresholdMicrons) {
                         backfocusArrow = "—";
                     } else {
-                        bool needsInward = curvatureEffectMicrons * curvatureSign < 0;
-                        string bigArrow = needsInward ? "⬆" : "⬇";
-                        string smallArrow = needsInward ? "↑" : "↓";
+                        bool towardObjective = curvatureEffectMicrons > 0;
+                        string bigArrow = towardObjective ? "⬆" : "⬇";
+                        string smallArrow = towardObjective ? "↑" : "↓";
                         backfocusArrow = absMicrons >= BackfocusLargeArrowThresholdMicrons ? bigArrow : smallArrow;
                     }
 
@@ -1962,7 +1972,6 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             if (guidance.HasTiltGuidance || guidance.HasNumericGuidance) {
                 guidance.DirectionLegend = TiltAdapterGuidanceVM.BuildDirectionLegend(
                     steps: tiltAdapterOptions.AdjustmentType == TiltAdjustmentType.StepperMotors,
-                    curvatureSign: tiltAdapterOptions.ScrewInwardCurvatureSign,
                     signIsMeasured: tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured);
             }
 
@@ -1973,8 +1982,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         private const double PitchMismatchFraction = 0.15;
 
         // Populate the precise per-screw turn/step amounts from the fitted paraboloid model and the
-        // configured adapter hardware. Magnitudes are direction-indicated by the existing arrows; the
-        // total carries an explicit direction (CW/CCW or +/− steps). Everything is computed in axial best-focus microns
+        // configured adapter hardware. All three rows carry their own rotation direction (⟳/⟲ glyphs
+        // for screws, signed steps for steppers); the arrows grid above describes adapter MOTION
+        // (⬆ = toward the objective), not rotation. Everything is computed in axial best-focus microns
         // (tilt = -TiltAt, backfocus = -CurvatureAt) then divided by the saved pitch/step size — there
         // is no square root, the curvature term is already a length.
         private void FillNumericGuidance(TiltAdapterGuidanceVM guidance, int n) {
@@ -1988,8 +1998,10 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             if (unitMicrons <= 0 || radiusMm <= 0) return;
 
             double radiusMicrons = radiusMm * 1000.0;
+            // σ is never 0 from persisted options (defaulted since the direction-setting feature);
+            // resolve defensively to the assumed default so every row can carry a direction.
             int curvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign;
-            bool hasDirection = curvatureSign != 0;
+            int resolvedSign = curvatureSign == 0 ? TiltScrewGeometry.DefaultScrewInwardCurvatureSign : curvatureSign;
 
             var angles = new double[n];
             angles[0] = tiltAdapterOptions.Screw1AngleDegrees;
@@ -2004,15 +2016,15 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             for (int i = 0; i < n; i++) {
                 var corr = TiltScrewGeometry.ScrewCorrectionMicrons(
                     model.Gx, model.Gy, model.Kx, model.Ky, model.X0, model.Y0, angles[i], radiusMicrons);
-                tiltText[i] = TiltAdapterGuidanceVM.FormatMagnitude(corr.TiltMicrons / unitMicrons, steps);
-                backText[i] = TiltAdapterGuidanceVM.FormatMagnitude(corr.BackfocusMicrons / unitMicrons, steps);
+                tiltText[i] = TiltAdapterGuidanceVM.FormatAmount(corr.TiltMicrons / unitMicrons, steps);
+                backText[i] = TiltAdapterGuidanceVM.FormatAmount(resolvedSign * corr.BackfocusMicrons / unitMicrons, steps);
                 // The curvature sign applies ONLY to the backfocus component: the tilt component's
                 // direction is already encoded by the stored response-convention screw angle (the same
                 // convention the tilt arrows invert), so multiplying the whole total by the sign would
-                // flip the tilt part on sign = -1 rigs and contradict the arrows.
+                // double-apply the rig direction to the tilt part on sign = -1 rigs.
                 double totalSigned = TiltScrewGeometry.SignedTotalAdjustment(
-                    corr.TiltMicrons, corr.BackfocusMicrons, unitMicrons, curvatureSign);
-                totalText[i] = TiltAdapterGuidanceVM.FormatTotal(totalSigned, steps, hasDirection);
+                    corr.TiltMicrons, corr.BackfocusMicrons, unitMicrons, resolvedSign);
+                totalText[i] = TiltAdapterGuidanceVM.FormatAmount(totalSigned, steps);
             }
 
             guidance.Screw1TiltAmount = tiltText[0];

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltScrewGuidanceRow.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltScrewGuidanceRow.cs
@@ -10,6 +10,7 @@
 
 #endregion "copyright"
 
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
 using System;
 
 namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
@@ -42,7 +43,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         public bool UnitsAreSteps { get; set; }
 
         // Per-screw tilt and backfocus magnitudes (direction is shown by the arrows above), and the
-        // signed total with an explicit IN/OUT direction word.
+        // signed total with an explicit direction (CW/CCW turns for screws, +/− steps for steppers).
         public string Screw1TiltAmount { get; set; } = "—";
         public string Screw2TiltAmount { get; set; } = "—";
         public string Screw3TiltAmount { get; set; } = "—";
@@ -62,6 +63,23 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         public string PitchMismatchWarning { get; set; } = string.Empty;
         public bool HasPitchMismatch => !string.IsNullOrEmpty(PitchMismatchWarning);
 
+        // One-line legend tying the arrows/totals to physical adapter motion; empty when unknown.
+        public string DirectionLegend { get; set; } = string.Empty;
+        public bool HasDirectionLegend => !string.IsNullOrEmpty(DirectionLegend);
+
+        /// <summary>
+        /// Legend for the guidance table. The adapter-motion wording comes from the configured or
+        /// measured curvature sign; "(assumed)" flags a sign never measured by the wizard.
+        /// </summary>
+        public static string BuildDirectionLegend(bool steps, int curvatureSign, bool signIsMeasured) {
+            if (curvatureSign == 0) return string.Empty;
+            bool cwTowardObjective = TiltScrewGeometry.CwMovesAdapterTowardObjectiveForSign(curvatureSign);
+            string inwardWord = steps ? "+ steps" : "clockwise";
+            string plateWord = cwTowardObjective ? "toward the objective" : "toward the camera";
+            string assumed = signIsMeasured ? string.Empty : " (assumed — set or measure in the Tilt Adapter Wizard)";
+            return $"⬆ = {inwardWord} (adapter moves {plateWord}){assumed}";
+        }
+
         /// <summary>
         /// Format an unsigned per-screw magnitude. Steppers round to whole steps (the user's choice);
         /// screws show two decimals of a turn. Values that round to nothing render as an em dash.
@@ -76,22 +94,22 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         }
 
         /// <summary>
-        /// Format the signed total adjustment with an explicit IN/OUT direction (positive = inward).
-        /// When the inward direction is not calibrated (<paramref name="hasDirection"/> false) only the
-        /// magnitude is shown.
+        /// Format the signed total adjustment with an explicit direction: clockwise/counter-clockwise
+        /// for screws, signed (+/−) steps for steppers. Positive input = the calibration "inward"
+        /// direction (a CW screw turn / + steps). When no direction is known
+        /// (<paramref name="hasDirection"/> false) only the magnitude is shown.
         /// </summary>
         public static string FormatTotal(double inwardAmount, bool steps, bool hasDirection) {
-            string magnitude;
             if (steps) {
                 long rounded = (long)Math.Round(Math.Abs(inwardAmount), MidpointRounding.AwayFromZero);
                 if (rounded == 0) return "—";
-                magnitude = $"{rounded} steps";
-            } else {
-                if (Math.Abs(inwardAmount) < 0.005) return "—";
-                magnitude = $"{Math.Abs(inwardAmount):0.00} turns";
+                if (!hasDirection) return $"{rounded} steps";
+                return inwardAmount >= 0 ? $"+{rounded} steps" : $"−{rounded} steps";
             }
+            if (Math.Abs(inwardAmount) < 0.005) return "—";
+            string magnitude = $"{Math.Abs(inwardAmount):0.00} turns";
             if (!hasDirection) return magnitude;
-            return $"{magnitude} {(inwardAmount >= 0 ? "IN" : "OUT")}";
+            return $"{magnitude} {(inwardAmount >= 0 ? "CW" : "CCW")}";
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltScrewGuidanceRow.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltScrewGuidanceRow.cs
@@ -10,7 +10,6 @@
 
 #endregion "copyright"
 
-using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
 using System;
 
 namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
@@ -42,8 +41,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         public bool HasNumericGuidance { get; set; }
         public bool UnitsAreSteps { get; set; }
 
-        // Per-screw tilt and backfocus magnitudes (direction is shown by the arrows above), and the
-        // signed total with an explicit direction (CW/CCW turns for screws, +/− steps for steppers).
+        // Per-screw signed adjustments, all three rows carrying their own rotation direction
+        // (⟳/⟲ glyphs for screws, +/− signs for steppers). The arrows grid above describes adapter
+        // MOTION (⬆ = toward the objective), not rotation — the two answer different questions.
         public string Screw1TiltAmount { get; set; } = "—";
         public string Screw2TiltAmount { get; set; } = "—";
         public string Screw3TiltAmount { get; set; } = "—";
@@ -63,53 +63,38 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         public string PitchMismatchWarning { get; set; } = string.Empty;
         public bool HasPitchMismatch => !string.IsNullOrEmpty(PitchMismatchWarning);
 
-        // One-line legend tying the arrows/totals to physical adapter motion; empty when unknown.
+        // One-line legend defining the motion arrows and rotation glyphs; empty until guidance renders.
         public string DirectionLegend { get; set; } = string.Empty;
         public bool HasDirectionLegend => !string.IsNullOrEmpty(DirectionLegend);
 
         /// <summary>
-        /// Legend for the guidance table. The adapter-motion wording comes from the configured or
-        /// measured curvature sign; "(assumed)" flags a sign never measured by the wizard.
+        /// Fixed legend for the guidance table: ⬆/⬇ describe adapter-plate motion (toward the
+        /// objective / toward the camera — pure physics, identical on every rig), and ⟳/⟲ (screws)
+        /// or the +/− step sign (steppers) describe the rig-specific rotation that produces it.
+        /// "(assumed)" flags a direction setting never verified by a wizard measurement.
         /// </summary>
-        public static string BuildDirectionLegend(bool steps, int curvatureSign, bool signIsMeasured) {
-            if (curvatureSign == 0) return string.Empty;
-            bool cwTowardObjective = TiltScrewGeometry.CwMovesAdapterTowardObjectiveForSign(curvatureSign);
-            string inwardWord = steps ? "+ steps" : "clockwise";
-            string plateWord = cwTowardObjective ? "toward the objective" : "toward the camera";
+        public static string BuildDirectionLegend(bool steps, bool signIsMeasured) {
+            string body = steps
+                ? "⬆ = adapter moves toward the objective · steps are signed as in the wizard prompts"
+                : "⬆ = adapter moves toward the objective · ⟳ = clockwise (tighten) · amounts in turns";
             string assumed = signIsMeasured ? string.Empty : " (assumed — set or measure in the Tilt Adapter Wizard)";
-            return $"⬆ = {inwardWord} (adapter moves {plateWord}){assumed}";
+            return body + assumed;
         }
 
         /// <summary>
-        /// Format an unsigned per-screw magnitude. Steppers round to whole steps (the user's choice);
-        /// screws show two decimals of a turn. Values that round to nothing render as an em dash.
+        /// Format a signed per-screw adjustment. Positive = clockwise / the wizard-prompt "+" step
+        /// direction. Screws render the magnitude with a rotation glyph ("1.25 ⟳" / "0.50 ⟲" — units
+        /// live in the legend); steppers render signed whole steps ("+35 steps"). Values that round
+        /// to nothing render as an em dash with no direction mark.
         /// </summary>
-        public static string FormatMagnitude(double amount, bool steps) {
-            double a = Math.Abs(amount);
+        public static string FormatAmount(double signedAmount, bool steps) {
             if (steps) {
-                long rounded = (long)Math.Round(a, MidpointRounding.AwayFromZero);
-                return rounded == 0 ? "—" : $"{rounded} steps";
-            }
-            return a < 0.005 ? "—" : $"{a:0.00} turns";
-        }
-
-        /// <summary>
-        /// Format the signed total adjustment with an explicit direction: clockwise/counter-clockwise
-        /// for screws, signed (+/−) steps for steppers. Positive input = the calibration "inward"
-        /// direction (a CW screw turn / + steps). When no direction is known
-        /// (<paramref name="hasDirection"/> false) only the magnitude is shown.
-        /// </summary>
-        public static string FormatTotal(double inwardAmount, bool steps, bool hasDirection) {
-            if (steps) {
-                long rounded = (long)Math.Round(Math.Abs(inwardAmount), MidpointRounding.AwayFromZero);
+                long rounded = (long)Math.Round(Math.Abs(signedAmount), MidpointRounding.AwayFromZero);
                 if (rounded == 0) return "—";
-                if (!hasDirection) return $"{rounded} steps";
-                return inwardAmount >= 0 ? $"+{rounded} steps" : $"−{rounded} steps";
+                return signedAmount >= 0 ? $"+{rounded} steps" : $"−{rounded} steps";
             }
-            if (Math.Abs(inwardAmount) < 0.005) return "—";
-            string magnitude = $"{Math.Abs(inwardAmount):0.00} turns";
-            if (!hasDirection) return magnitude;
-            return $"{magnitude} {(inwardAmount >= 0 ? "CW" : "CCW")}";
+            if (Math.Abs(signedAmount) < 0.005) return "—";
+            return $"{Math.Abs(signedAmount):0.00} {(signedAmount >= 0 ? "⟳" : "⟲")}";
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltAdapterOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltAdapterOptions.cs
@@ -28,7 +28,21 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         double Screw4AngleDegrees { get; set; }  // double.NaN when 3-screw setup
         int CalibratedScrewCount { get; set; }      // screw count at time of last calibration; 0 = never calibrated
         int MeasurementAverageCount { get; set; }
-        int ScrewInwardCurvatureSign { get; set; } // +1 or -1; 0 = not yet calibrated
+        // Sign of the curvature/backfocus response to a CW ("inward") screw turn: +1 = CW turns
+        // raise the curvature effect, -1 = lower it. Defaults to the assumed mechanical direction
+        // (TiltScrewGeometry.DefaultScrewInwardCurvatureSign); a 6-step wizard run measures it.
+        int ScrewInwardCurvatureSign { get; set; }
+
+        // True only when a wizard run measured ScrewInwardCurvatureSign (Baseline -> AllInward
+        // steps). Cleared when the user edits the direction manually or applies a manual entry.
+        bool ScrewInwardCurvatureSignIsMeasured { get; set; }
+
+        // Include the 2 curvature-direction steps (Baseline + AllInward) in a calibration run:
+        // 6 steps instead of 4. Off by default — the assumed/manual direction is used instead.
+        bool MeasureCurvatureDuringCalibration { get; set; }
+
+        // True when the current calibration came from Manual Calibration Entry, not a wizard run.
+        bool CalibrationIsManual { get; set; }
 
         // Physical adapter hardware model, used to convert focus deviation into absolute
         // screw turns (or stepper steps). -1 = unset.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ninactrl="clr-namespace:NINA.CustomControlLibrary;assembly=NINA.CustomControlLibrary"
+    xmlns:rules="clr-namespace:NINA.Core.Utility.ValidationRules;assembly=NINA.Core"
     xmlns:s="clr-namespace:System;assembly=mscorlib"
     xmlns:interfaces="clr-namespace:NINA.Joko.Plugins.HocusFocus.Interfaces">
     <ResourceDictionary.MergedDictionaries>
@@ -160,8 +161,12 @@
                 <TextBlock HorizontalAlignment="Center" Text="Screw 4" />
                 <TextBlock HorizontalAlignment="Center" Text="{Binding TiltAdapterOptions.Screw4AngleDegrees, StringFormat={}{0:F1}°}" />
             </UniformGrid>
-            <!--  Curvature row — shows the configured/measured direction of the curvature response  -->
-            <UniformGrid Margin="0,2" VerticalAlignment="Center" Columns="2">
+            <!--  Curvature row — the arrow shows how the curvature effect responds to clockwise screw turns  -->
+            <UniformGrid
+                Margin="0,2"
+                VerticalAlignment="Center"
+                Columns="2"
+                ToolTip="The direction of the curvature response to clockwise screw turns (+ steps for stepper motors). Set by the adapter direction in the Measurement settings, or measured by a 6-step calibration run.">
                 <UniformGrid.Style>
                     <Style TargetType="UniformGrid">
                         <Setter Property="Visibility" Value="Collapsed" />
@@ -172,7 +177,7 @@
                         </Style.Triggers>
                     </Style>
                 </UniformGrid.Style>
-                <TextBlock HorizontalAlignment="Center" Text="Screws Inward" />
+                <TextBlock HorizontalAlignment="Center" Text="Screws CW" />
                 <TextBlock HorizontalAlignment="Center">
                     <Run Text="Curvature " /><Run Text="{Binding CurvatureSignDescription, Mode=OneWay}" />
                 </TextBlock>
@@ -576,7 +581,22 @@
                             <UniformGrid Margin="0,2" VerticalAlignment="Center" Columns="2">
                                 <TextBlock VerticalAlignment="Center" Text="Screw 1 angle (°)"
                                     ToolTip="Position angle of screw 1 in the image: 0° = straight up (12 o'clock), increasing clockwise. Remaining screws are placed at equal spacing (120° for 3 screws, 90° for 4)." />
-                                <TextBox MinWidth="60" Text="{Binding ManualScrew1AngleDegrees, UpdateSourceTrigger=LostFocus}" />
+                                <!--  Validation keeps the box in an error state on unparseable/out-of-range text: without it a
+                                      failed LostFocus conversion silently leaves the last valid angle in the VM while the box
+                                      shows the garbage text, and Apply would persist the stale angle.  -->
+                                <TextBox MinWidth="60">
+                                    <TextBox.Text>
+                                        <Binding Path="ManualScrew1AngleDegrees" UpdateSourceTrigger="LostFocus">
+                                            <Binding.ValidationRules>
+                                                <rules:DoubleRangeRule>
+                                                    <rules:DoubleRangeRule.ValidRange>
+                                                        <rules:DoubleRangeChecker Maximum="360" Minimum="0" />
+                                                    </rules:DoubleRangeRule.ValidRange>
+                                                </rules:DoubleRangeRule>
+                                            </Binding.ValidationRules>
+                                        </Binding>
+                                    </TextBox.Text>
+                                </TextBox>
                             </UniformGrid>
                             <UniformGrid Margin="0,2" VerticalAlignment="Center" Columns="2">
                                 <TextBlock VerticalAlignment="Center" Text="Numbering direction"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -2,6 +2,7 @@
     x:Class="NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard.DataTemplates"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ninactrl="clr-namespace:NINA.CustomControlLibrary;assembly=NINA.CustomControlLibrary"
     xmlns:s="clr-namespace:System;assembly=mscorlib"
     xmlns:interfaces="clr-namespace:NINA.Joko.Plugins.HocusFocus.Interfaces">
     <ResourceDictionary.MergedDictionaries>
@@ -128,7 +129,7 @@
         Calibration info rows shared between Panel A and Panel C.
         Matches inspector UniformGrid Columns="2" label+value pattern.
         Screw 4 row collapses for 3-screw setups.
-        Curvature row collapses until curvature sign is calibrated.
+        Curvature row shows the configured/measured direction of the curvature response.
     -->
     <DataTemplate x:Key="HF_TiltScrewCalibrationInfo">
         <StackPanel>
@@ -159,7 +160,7 @@
                 <TextBlock HorizontalAlignment="Center" Text="Screw 4" />
                 <TextBlock HorizontalAlignment="Center" Text="{Binding TiltAdapterOptions.Screw4AngleDegrees, StringFormat={}{0:F1}°}" />
             </UniformGrid>
-            <!--  Curvature row — collapses until curvature sign is calibrated  -->
+            <!--  Curvature row — shows the configured/measured direction of the curvature response  -->
             <UniformGrid Margin="0,2" VerticalAlignment="Center" Columns="2">
                 <UniformGrid.Style>
                     <Style TargetType="UniformGrid">
@@ -301,6 +302,150 @@
                         <TextBox MinWidth="60" Text="{Binding FocuserStepSizeMicronsValue, UpdateSourceTrigger=LostFocus}" />
                     </UniformGrid>
 
+                    <!--  Measurement cost & direction settings (shared Signal Amplification /
+                          Center Focuser First live in InspectorOptions — same values as the
+                          Aberration Inspector's controls)  -->
+                    <TextBlock
+                        Margin="0,10,0,5"
+                        FontWeight="Bold"
+                        Text="Measurement" />
+                    <Grid Margin="0,2">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            Margin="0,2,5,2"
+                            VerticalAlignment="Center"
+                            Text="Signal Amplification"
+                            ToolTip="Increases the resolution and signal of sensor-model / tilt calibration runs by capturing more, finer-spaced focuser points. Set to 1 to disable. Applies to live captures only." />
+                        <ninactrl:UnitTextBox
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            MinWidth="40"
+                            VerticalAlignment="Center"
+                            HorizontalContentAlignment="Left"
+                            VerticalContentAlignment="Center"
+                            Foreground="{StaticResource PrimaryBrush}"
+                            TextAlignment="Left"
+                            Unit="x">
+                            <Binding
+                                Mode="TwoWay"
+                                Path="Inspector.InspectorOptions.SignalAmplification"
+                                UpdateSourceTrigger="LostFocus" />
+                        </ninactrl:UnitTextBox>
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="2"
+                            Margin="8,2,0,2"
+                            VerticalAlignment="Center"
+                            FontStyle="Italic"
+                            Opacity="0.7"
+                            Text="{Binding WizardSweepSummary}"
+                            TextWrapping="Wrap" />
+
+                        <TextBlock
+                            Grid.Row="1"
+                            Grid.Column="0"
+                            Margin="0,2,5,2"
+                            VerticalAlignment="Center"
+                            Text="Center Focuser First"
+                            ToolTip="When on, a quick standard AutoFocus is run before each live sweep to center the focuser at best focus. Off by default. No effect when replaying saved frames." />
+                        <CheckBox
+                            Grid.Row="1"
+                            Grid.Column="1"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            IsChecked="{Binding Inspector.InspectorOptions.CenterFocuserBeforeRun}" />
+                        <TextBlock
+                            Grid.Row="1"
+                            Grid.Column="2"
+                            Margin="8,2,0,2"
+                            VerticalAlignment="Center"
+                            FontStyle="Italic"
+                            Opacity="0.7"
+                            Text="Adds one standard autofocus before every measurement sweep to re-center focus. Turn on if focus drifts between steps (e.g., temperature) or your focuser starts far from focus."
+                            TextWrapping="Wrap" />
+
+                        <TextBlock
+                            Grid.Row="2"
+                            Grid.Column="0"
+                            Margin="0,2,5,2"
+                            VerticalAlignment="Center"
+                            Text="{Binding CwDirectionLabel}"
+                            ToolTip="Whether tightening moves the adapter toward the camera or the objective depends on its design (push vs pull screws). Sets the direction of backfocus/curvature guidance." />
+                        <ComboBox
+                            Grid.Row="2"
+                            Grid.Column="1"
+                            MinWidth="180"
+                            VerticalAlignment="Center"
+                            SelectedValuePath="Tag"
+                            SelectedValue="{Binding CwMovesAdapterTowardObjective}">
+                            <ComboBox.Style>
+                                <Style BasedOn="{StaticResource {x:Type ComboBox}}" TargetType="ComboBox">
+                                    <Setter Property="IsEnabled" Value="True" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding TiltAdapterOptions.MeasureCurvatureDuringCalibration}" Value="True">
+                                            <Setter Property="IsEnabled" Value="False" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </ComboBox.Style>
+                            <ComboBoxItem Content="Toward the camera — outward">
+                                <ComboBoxItem.Tag>
+                                    <s:Boolean>False</s:Boolean>
+                                </ComboBoxItem.Tag>
+                            </ComboBoxItem>
+                            <ComboBoxItem Content="Toward the objective — inward">
+                                <ComboBoxItem.Tag>
+                                    <s:Boolean>True</s:Boolean>
+                                </ComboBoxItem.Tag>
+                            </ComboBoxItem>
+                        </ComboBox>
+                        <TextBlock
+                            Grid.Row="2"
+                            Grid.Column="2"
+                            Margin="8,2,0,2"
+                            VerticalAlignment="Center"
+                            FontStyle="Italic"
+                            Opacity="0.7"
+                            Text="{Binding CurvatureSignProvenance}"
+                            TextWrapping="Wrap" />
+
+                        <TextBlock
+                            Grid.Row="3"
+                            Grid.Column="0"
+                            Margin="0,2,5,2"
+                            VerticalAlignment="Center"
+                            Text="Measure direction"
+                            ToolTip="Include the two curvature-direction steps in the calibration to determine the adapter direction automatically." />
+                        <CheckBox
+                            Grid.Row="3"
+                            Grid.Column="1"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            IsChecked="{Binding TiltAdapterOptions.MeasureCurvatureDuringCalibration}" />
+                        <TextBlock
+                            Grid.Row="3"
+                            Grid.Column="2"
+                            Margin="8,2,0,2"
+                            VerticalAlignment="Center"
+                            FontStyle="Italic"
+                            Opacity="0.7"
+                            Text="Adds 2 extra measurement steps (6 instead of 4 — about 50% longer) to determine the direction automatically. Turn on if you don't know how your adapter behaves, or to verify the setting above."
+                            TextWrapping="Wrap" />
+                    </Grid>
+
                     <!--  Calibrate + Replay side by side  -->
                     <StackPanel Margin="0,8,0,0" Orientation="Horizontal">
                         <Button Command="{Binding StartCommand}">
@@ -382,6 +527,24 @@
                             </Style>
                         </StackPanel.Style>
 
+                        <TextBlock
+                            Margin="0,10,0,0"
+                            FontStyle="Italic"
+                            Opacity="0.7"
+                            Text="Manually entered calibration (not measured by the wizard)."
+                            TextWrapping="Wrap">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding TiltAdapterOptions.CalibrationIsManual}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+
                         <Grid Margin="0,10,0,0" HorizontalAlignment="Stretch">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
@@ -399,6 +562,49 @@
                                 Content="{Binding}" />
                         </Grid>
                     </StackPanel>
+
+                    <!--  Manual calibration entry: writes the same persisted state a wizard run
+                          does (screw angles + calibrated flags), tagged as manually entered.  -->
+                    <Expander Margin="0,10,0,0" Header="Manual Calibration Entry">
+                        <StackPanel Margin="0,5,0,0">
+                            <TextBlock
+                                Margin="0,0,0,5"
+                                FontStyle="Italic"
+                                Opacity="0.7"
+                                Text="If you already know where screw 1 sits, enter it here and skip the wizard. Angles and numbering direction are in image space — mirrors or diagonals in the optical train can flip them relative to the physical adapter. If guidance moves tilt the wrong way, flip the numbering direction. Set the adapter direction in the Measurement settings above if you know it."
+                                TextWrapping="Wrap" />
+                            <UniformGrid Margin="0,2" VerticalAlignment="Center" Columns="2">
+                                <TextBlock VerticalAlignment="Center" Text="Screw 1 angle (°)"
+                                    ToolTip="Position angle of screw 1 in the image: 0° = straight up (12 o'clock), increasing clockwise. Remaining screws are placed at equal spacing (120° for 3 screws, 90° for 4)." />
+                                <TextBox MinWidth="60" Text="{Binding ManualScrew1AngleDegrees, UpdateSourceTrigger=LostFocus}" />
+                            </UniformGrid>
+                            <UniformGrid Margin="0,2" VerticalAlignment="Center" Columns="2">
+                                <TextBlock VerticalAlignment="Center" Text="Numbering direction"
+                                    ToolTip="Whether screws 2 and up proceed clockwise or counter-clockwise from screw 1, as seen in the image." />
+                                <ComboBox MinWidth="120" SelectedValuePath="Tag" SelectedValue="{Binding ManualNumberingClockwise}">
+                                    <ComboBoxItem Content="Clockwise">
+                                        <ComboBoxItem.Tag>
+                                            <s:Boolean>True</s:Boolean>
+                                        </ComboBoxItem.Tag>
+                                    </ComboBoxItem>
+                                    <ComboBoxItem Content="Counter-clockwise">
+                                        <ComboBoxItem.Tag>
+                                            <s:Boolean>False</s:Boolean>
+                                        </ComboBoxItem.Tag>
+                                    </ComboBoxItem>
+                                </ComboBox>
+                            </UniformGrid>
+                            <Button
+                                Margin="0,8,0,0"
+                                HorizontalAlignment="Left"
+                                Command="{Binding ApplyManualCalibrationCommand}">
+                                <TextBlock
+                                    Margin="10,5,10,5"
+                                    Foreground="{StaticResource ButtonForegroundBrush}"
+                                    Text="Apply" />
+                            </Button>
+                        </StackPanel>
+                    </Expander>
                 </StackPanel>
 
                 <!-- Panel B: Active wizard steps (visible when IsWizardRunning && !IsComplete) -->

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -955,6 +955,29 @@
                         <TextBlock Text="{Binding WarningText}" TextWrapping="Wrap" />
                     </Border>
 
+                    <!--  Consistency warning raised by the final step's repeats: it survives the advance to
+                          Complete (the step panel that raised it is already hidden), so it must render here too  -->
+                    <Border
+                        Margin="0,5"
+                        Padding="5"
+                        BorderBrush="{StaticResource NotificationErrorBrush}"
+                        BorderThickness="1">
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasMeasurementConsistencyWarning}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <TextBlock
+                            Foreground="{StaticResource NotificationErrorBrush}"
+                            Text="{Binding MeasurementConsistencyWarningText}"
+                            TextWrapping="Wrap" />
+                    </Border>
+
                     <!--  Re-baseline drift warning (an undo between moves left residual tilt)  -->
                     <Border
                         Margin="0,5"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -571,7 +571,7 @@
                                 Margin="0,0,0,5"
                                 FontStyle="Italic"
                                 Opacity="0.7"
-                                Text="If you already know where screw 1 sits, enter it here and skip the wizard. Angles and numbering direction are in image space — mirrors or diagonals in the optical train can flip them relative to the physical adapter. If guidance moves tilt the wrong way, flip the numbering direction. Set the adapter direction in the Measurement settings above if you know it."
+                                Text="If you already know where screw 1 sits, enter it here and skip the wizard. Angles and numbering direction are in image space — mirrors or diagonals in the optical train can flip them relative to the physical adapter. If guidance moves tilt the wrong way, flip the numbering direction. Set the adapter direction in the Measurement settings above if you know it. If you change the adapter direction setting later, click Apply again."
                                 TextWrapping="Wrap" />
                             <UniformGrid Margin="0,2" VerticalAlignment="Center" Columns="2">
                                 <TextBlock VerticalAlignment="Center" Text="Screw 1 angle (°)"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
@@ -54,7 +54,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             screw4AngleDegrees = optionsAccessor.GetValueDouble(nameof(Screw4AngleDegrees), double.NaN);
             calibratedScrewCount = optionsAccessor.GetValueInt32(nameof(CalibratedScrewCount), 0);
             measurementAverageCount = optionsAccessor.GetValueInt32(nameof(MeasurementAverageCount), 1);
-            screwInwardCurvatureSign = optionsAccessor.GetValueInt32(nameof(ScrewInwardCurvatureSign), 0);
+            screwInwardCurvatureSign = optionsAccessor.GetValueInt32(nameof(ScrewInwardCurvatureSign), TiltScrewGeometry.DefaultScrewInwardCurvatureSign);
+            screwInwardCurvatureSignIsMeasured = optionsAccessor.GetValueBoolean(nameof(ScrewInwardCurvatureSignIsMeasured), false);
+            measureCurvatureDuringCalibration = optionsAccessor.GetValueBoolean(nameof(MeasureCurvatureDuringCalibration), false);
+            calibrationIsManual = optionsAccessor.GetValueBoolean(nameof(CalibrationIsManual), false);
             adjustmentType = optionsAccessor.GetValueEnum(nameof(AdjustmentType), TiltAdjustmentType.Screws);
             threadPitchMicrons = optionsAccessor.GetValueDouble(nameof(ThreadPitchMicrons), -1.0);
             stepperStepSizeMicrons = optionsAccessor.GetValueDouble(nameof(StepperStepSizeMicrons), -1.0);
@@ -177,6 +180,45 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 if (screwInwardCurvatureSign != value) {
                     screwInwardCurvatureSign = value;
                     optionsAccessor.SetValueInt32(nameof(ScrewInwardCurvatureSign), screwInwardCurvatureSign);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool screwInwardCurvatureSignIsMeasured;
+
+        public bool ScrewInwardCurvatureSignIsMeasured {
+            get => screwInwardCurvatureSignIsMeasured;
+            set {
+                if (screwInwardCurvatureSignIsMeasured != value) {
+                    screwInwardCurvatureSignIsMeasured = value;
+                    optionsAccessor.SetValueBoolean(nameof(ScrewInwardCurvatureSignIsMeasured), screwInwardCurvatureSignIsMeasured);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool measureCurvatureDuringCalibration;
+
+        public bool MeasureCurvatureDuringCalibration {
+            get => measureCurvatureDuringCalibration;
+            set {
+                if (measureCurvatureDuringCalibration != value) {
+                    measureCurvatureDuringCalibration = value;
+                    optionsAccessor.SetValueBoolean(nameof(MeasureCurvatureDuringCalibration), measureCurvatureDuringCalibration);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool calibrationIsManual;
+
+        public bool CalibrationIsManual {
+            get => calibrationIsManual;
+            set {
+                if (calibrationIsManual != value) {
+                    calibrationIsManual = value;
+                    optionsAccessor.SetValueBoolean(nameof(CalibrationIsManual), calibrationIsManual);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -1125,19 +1125,19 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         }
 
         // Description shown on each summary row, reflecting the single move performed for the step.
-        // Arrow convention matches the guidance legend (⬆ = clockwise / + steps): ↑ = the screw was
-        // turned CLOCKWISE (+ steps), ↓ = COUNTER-CLOCKWISE (− steps) — screw motion, never
-        // adapter-plate motion. So the perturbation steps (all CW per StepInstructionsText) carry ↑
-        // and the re-baseline undo moves carry ↓. Internal for tests.
+        // Rotation glyphs match the guidance legend (⟳ = clockwise / + steps, ⟲ = counter-clockwise
+        // / − steps) — screw rotation, never adapter-plate motion (⬆/⬇ are reserved for motion in
+        // the guidance table). Perturbation steps (all CW per StepInstructionsText) carry ⟳ and the
+        // re-baseline undo moves carry ⟲. Internal for tests.
         internal string StepDescription(WizardStep step) {
             bool four = tiltAdapterOptions.ScrewCount == 4;
             switch (step) {
                 case WizardStep.Baseline: return "Baseline";
-                case WizardStep.AllInward: return "All screws ↑";
-                case WizardStep.ReBaseline1: return "Re-baseline (all ↓)";
-                case WizardStep.Screw1: return four ? "Screw 1 ↑, Screw 3 ↓" : "Screw 1 ↑";
-                case WizardStep.ReBaseline2: return four ? "Re-baseline (Screw 1 ↓, Screw 3 ↑)" : "Re-baseline (Screw 1 ↓)";
-                case WizardStep.Screw2: return four ? "Screw 2 ↑, Screw 4 ↓" : "Screw 2 ↑";
+                case WizardStep.AllInward: return "All screws ⟳";
+                case WizardStep.ReBaseline1: return "Re-baseline (all ⟲)";
+                case WizardStep.Screw1: return four ? "Screw 1 ⟳, Screw 3 ⟲" : "Screw 1 ⟳";
+                case WizardStep.ReBaseline2: return four ? "Re-baseline (Screw 1 ⟲, Screw 3 ⟳)" : "Re-baseline (Screw 1 ⟲)";
+                case WizardStep.Screw2: return four ? "Screw 2 ⟳, Screw 4 ⟲" : "Screw 2 ⟳";
                 default: return step.ToString();
             }
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -96,6 +96,21 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         private readonly Dictionary<WizardStep, StepReading> stepReadings = new Dictionary<WizardStep, StepReading>();
         private CancellationTokenSource measureCts;
 
+        // WizardSweepSummary reads the ACTIVE profile's FocuserSettings; these track the settings object
+        // currently subscribed so in-place edits refresh the summary and profile swaps re-hook cleanly.
+        private readonly System.ComponentModel.PropertyChangedEventHandler focuserSettingsHandler;
+        private IFocuserSettings hookedFocuserSettings;
+
+        private void HookActiveProfileFocuserSettings() {
+            if (hookedFocuserSettings != null) {
+                hookedFocuserSettings.PropertyChanged -= focuserSettingsHandler;
+            }
+            hookedFocuserSettings = profileService?.ActiveProfile?.FocuserSettings;
+            if (hookedFocuserSettings != null) {
+                hookedFocuserSettings.PropertyChanged += focuserSettingsHandler;
+            }
+        }
+
         private double calibrationAppliedAmount = 1.0;
         private double measuredHardwareMicrons = double.NaN;
         private double calibrationPixelSizeMicrons;
@@ -265,7 +280,20 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 });
             }
 
+            // WizardSweepSummary also reads the active profile's FocuserSettings (offset steps / frames
+            // per point), which the user can edit in place without swapping profiles — ProfileChanged
+            // alone would leave the summary stale. Track the active profile's FocuserSettings and
+            // re-hook on every profile change (unsubscribe old, subscribe new).
+            focuserSettingsHandler = (s, e) => OnUIThread(() => {
+                if (e.PropertyName == nameof(IFocuserSettings.AutoFocusInitialOffsetSteps) ||
+                    e.PropertyName == nameof(IFocuserSettings.AutoFocusNumberOfFramesPerPoint)) {
+                    RaisePropertyChanged(nameof(WizardSweepSummary));
+                }
+            });
+            HookActiveProfileFocuserSettings();
+
             profileService.ProfileChanged += (s, e) => OnUIThread(() => {
+                HookActiveProfileFocuserSettings();
                 RaisePropertyChanged(nameof(PixelSizeMicronsValue));
                 RaisePropertyChanged(nameof(FocuserStepSizeMicronsValue));
                 RaisePropertyChanged(nameof(SelectedDevice));
@@ -1097,15 +1125,19 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         }
 
         // Description shown on each summary row, reflecting the single move performed for the step.
-        private string StepDescription(WizardStep step) {
+        // Arrow convention matches the guidance legend (⬆ = clockwise / + steps): ↑ = the screw was
+        // turned CLOCKWISE (+ steps), ↓ = COUNTER-CLOCKWISE (− steps) — screw motion, never
+        // adapter-plate motion. So the perturbation steps (all CW per StepInstructionsText) carry ↑
+        // and the re-baseline undo moves carry ↓. Internal for tests.
+        internal string StepDescription(WizardStep step) {
             bool four = tiltAdapterOptions.ScrewCount == 4;
             switch (step) {
                 case WizardStep.Baseline: return "Baseline";
-                case WizardStep.AllInward: return "All screws ↓";
-                case WizardStep.ReBaseline1: return "Re-baseline (all ↑)";
-                case WizardStep.Screw1: return four ? "Screw 1 ↓, Screw 3 ↑" : "Screw 1 ↓";
-                case WizardStep.ReBaseline2: return four ? "Re-baseline (Screw 1 ↑, Screw 3 ↓)" : "Re-baseline (Screw 1 ↑)";
-                case WizardStep.Screw2: return four ? "Screw 2 ↓, Screw 4 ↑" : "Screw 2 ↓";
+                case WizardStep.AllInward: return "All screws ↑";
+                case WizardStep.ReBaseline1: return "Re-baseline (all ↓)";
+                case WizardStep.Screw1: return four ? "Screw 1 ↑, Screw 3 ↓" : "Screw 1 ↑";
+                case WizardStep.ReBaseline2: return four ? "Re-baseline (Screw 1 ↓, Screw 3 ↑)" : "Re-baseline (Screw 1 ↓)";
+                case WizardStep.Screw2: return four ? "Screw 2 ↑, Screw 4 ↓" : "Screw 2 ↑";
                 default: return step.ToString();
             }
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -115,11 +115,31 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // screw-move signal (backlash / uneven undo would corrupt the recovered angle/hardware for that screw).
         private const double RebaselineDriftWarnThreshold = 0.5;
 
-        // The six measurement steps in capture order.
-        private static readonly WizardStep[] MeasurementSteps = {
-            WizardStep.Baseline, WizardStep.AllInward, WizardStep.ReBaseline1,
-            WizardStep.Screw1, WizardStep.ReBaseline2, WizardStep.Screw2
-        };
+        // The measurement steps in capture order. The 4-step flow (default) skips the two
+        // curvature-direction steps; the Baseline reading then serves as the screw-1 reference
+        // (the ReBaseline1 role of the 6-step flow).
+        internal static WizardStep[] GetMeasurementSteps(bool measureCurvature) =>
+            measureCurvature
+                ? new[] { WizardStep.Baseline, WizardStep.AllInward, WizardStep.ReBaseline1,
+                          WizardStep.Screw1, WizardStep.ReBaseline2, WizardStep.Screw2 }
+                : new[] { WizardStep.Baseline, WizardStep.Screw1, WizardStep.ReBaseline2, WizardStep.Screw2 };
+
+        // Captured at run start (StartAsync/ReplayAsync) so toggling the option mid-run is inert.
+        private WizardStep[] activeMeasurementSteps = GetMeasurementSteps(measureCurvature: false);
+
+        // Prose for the wizard's Signal Amplification row: per-sweep image estimate plus the total
+        // for the whole calibration at current settings. Internal for tests.
+        internal static string BuildSweepSummary(int stepsInRun, int measurementAverage,
+            int stepCount, int framesPerPoint, int signalAmplification, int profileOffsetSteps, int profileFramesPerPoint) {
+            var (points, imagesPerRun) = InspectorVM.EstimateImagesPerRun(
+                stepCount, framesPerPoint, signalAmplification, profileOffsetSteps, profileFramesPerPoint);
+            if (imagesPerRun <= 0) return string.Empty;
+            int frames = framesPerPoint > 0 ? framesPerPoint : profileFramesPerPoint;
+            int sweeps = stepsInRun * Math.Max(1, measurementAverage);
+            return $"Every calibration step runs a full autofocus sweep of ~{imagesPerRun} images ({points} focus positions × {frames} exposure{(frames == 1 ? "" : "s")}). " +
+                $"At the current settings this calibration will take {sweeps} sweeps ≈ {sweeps * imagesPerRun} images total. " +
+                "Increase for more signal on faint stars; decrease to run faster (1 = a regular autofocus).";
+        }
 
         private struct StepReading {
             public double A;
@@ -177,11 +197,25 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             BrowseSaveFolderCommand = new RelayCommand(BrowseSaveFolder);
             ReplayCommand = new AsyncRelayCommand(ReplayAsync, () => !IsWizardRunning && !IsMeasuring);
             RetryMeasurementCommand = new AsyncRelayCommand(RunMeasurementAsync, () => HasMeasurementFailureChoice && IsOnMeasurementStep && !IsMeasuring && AreDevicesConnected);
+            ApplyManualCalibrationCommand = new RelayCommand(ApplyManualCalibration);
 
             tiltAdapterOptions.PropertyChanged += (s, e) => OnUIThread(() => {
                 if (e.PropertyName == nameof(ITiltAdapterOptions.ScrewInwardCurvatureSign)) {
                     RaisePropertyChanged(nameof(HasCurvatureCalibration));
                     RaisePropertyChanged(nameof(CurvatureSignDescription));
+                    RaisePropertyChanged(nameof(CwMovesAdapterTowardObjective));
+                    RaisePropertyChanged(nameof(CurvatureSignProvenance));
+                }
+                if (e.PropertyName == nameof(ITiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured)) {
+                    RaisePropertyChanged(nameof(CurvatureSignDescription));
+                    RaisePropertyChanged(nameof(CurvatureSignProvenance));
+                }
+                if (e.PropertyName == nameof(ITiltAdapterOptions.MeasureCurvatureDuringCalibration) ||
+                    e.PropertyName == nameof(ITiltAdapterOptions.MeasurementAverageCount)) {
+                    RaisePropertyChanged(nameof(WizardSweepSummary));
+                }
+                if (e.PropertyName == nameof(ITiltAdapterOptions.CalibrationIsManual)) {
+                    RaisePropertyChanged(nameof(IsCalibrationValid));
                 }
                 if (e.PropertyName == nameof(ITiltAdapterOptions.ScrewCount) ||
                     e.PropertyName == nameof(ITiltAdapterOptions.IsCalibrated) ||
@@ -210,9 +244,23 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     RaisePropertyChanged(nameof(ThreadPitchMicronsValue));
                     RaisePropertyChanged(nameof(StepperStepSizeMicronsValue));
                     RaisePropertyChanged(nameof(ScrewRadiusMillimetersValue));
+                    // Adjustment type changes the prompt vocabulary (screw turns vs signed steps).
+                    RaisePropertyChanged(nameof(CwDirectionLabel));
+                    RaisePropertyChanged(nameof(StepInstructions));
+                    RaisePropertyChanged(nameof(BaselineRecoveryInstructions));
                     RaiseHardwareSummaryChanged();
                 }
             });
+
+            if (inspector.InspectorOptions != null) {
+                inspector.InspectorOptions.PropertyChanged += (s, e) => OnUIThread(() => {
+                    if (e.PropertyName == nameof(IInspectorOptions.SignalAmplification) ||
+                        e.PropertyName == nameof(IInspectorOptions.StepCount) ||
+                        e.PropertyName == nameof(IInspectorOptions.FramesPerPoint)) {
+                        RaisePropertyChanged(nameof(WizardSweepSummary));
+                    }
+                });
+            }
 
             profileService.ProfileChanged += (s, e) => OnUIThread(() => {
                 RaisePropertyChanged(nameof(PixelSizeMicronsValue));
@@ -220,10 +268,16 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 RaisePropertyChanged(nameof(SelectedDevice));
                 RaisePropertyChanged(nameof(IsManualDevice));
                 RaisePropertyChanged(nameof(SaveAFRunsPath));
+                RaisePropertyChanged(nameof(WizardSweepSummary));
             });
 
             // Re-assert and lock a persisted device preset on load.
             ApplyDevice(tiltAdapterOptions.DeviceName);
+
+            // Pre-fill the Manual Calibration Entry angle from an existing calibration.
+            if (!double.IsNaN(tiltAdapterOptions.Screw1AngleDegrees)) {
+                manualScrew1AngleDegrees = tiltAdapterOptions.Screw1AngleDegrees;
+            }
 
             RebuildDiagram();
 
@@ -280,7 +334,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public bool IsComplete => currentStep == WizardStep.Complete;
 
         // Steps that end with running the aberration inspector (measurement auto-advances)
-        public bool IsOnMeasurementStep => MeasurementSteps.Contains(currentStep);
+        public bool IsOnMeasurementStep => activeMeasurementSteps.Contains(currentStep);
 
         public bool IsCalibrationValid =>
             tiltAdapterOptions.IsCalibrated &&
@@ -344,10 +398,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // Do nothing
         }
 
-        public string CurvatureSignDescription =>
-            tiltAdapterOptions.ScrewInwardCurvatureSign == 1 ? "↑" :
-            tiltAdapterOptions.ScrewInwardCurvatureSign == -1 ? "↓" :
-            string.Empty;
+        public string CurvatureSignDescription {
+            get {
+                int sign = tiltAdapterOptions.ScrewInwardCurvatureSign;
+                if (sign == 0) return string.Empty;
+                string arrow = sign == 1 ? "↑" : "↓";
+                return tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured ? $"{arrow} (measured)" : $"{arrow} (assumed)";
+            }
+        }
 
         public bool IsMeasuring {
             get => isMeasuring;
@@ -430,7 +488,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public bool IsCurrentStepAtBaseline => StepIsAtBaseline(currentStep);
 
         // Per-step guidance for returning to baseline before retrying, shown in the failure panel.
-        public string BaselineRecoveryInstructions => BaselineRecoveryText(currentStep, tiltAdapterOptions.ScrewCount);
+        public string BaselineRecoveryInstructions =>
+            BaselineRecoveryText(currentStep, tiltAdapterOptions.ScrewCount, IsStepperAdjustment, calibrationAppliedAmount);
 
         public bool HasRebaselineDriftWarning {
             get => hasRebaselineDriftWarning;
@@ -497,35 +556,66 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
         }
 
-        public string StepInstructions {
-            get {
-                int n = tiltAdapterOptions.ScrewCount;
-                switch (currentStep) {
-                    case WizardStep.Baseline:
-                        return "Ensure all screws are at their starting position, then click Run Measurement to take a baseline reading.";
-                    case WizardStep.AllInward:
-                        return "Label your screws 1, 2, and 3 (or 1–4 for a 4-screw adapter) in a consistent clockwise order. " +
-                            "Screw 1 does NOT need to be at any particular clock position — the wizard determines each screw's actual " +
-                            "position from the measurements.\n\nTurn ALL screws INWARD exactly 1 full turn each, then click Run Measurement.";
-                    case WizardStep.ReBaseline1:
-                        return "Turn ALL screws back OUT exactly 1 full turn each, returning to the baseline position, then click Run Measurement.";
-                    case WizardStep.Screw1:
-                        return n == 3
-                            ? "Turn screw 1 INWARD exactly 1 full turn, then click Run Measurement."
-                            : "Turn screw 1 INWARD and screw 3 OUTWARD exactly 1 full turn each, then click Run Measurement.";
-                    case WizardStep.ReBaseline2:
-                        return n == 3
-                            ? "Turn screw 1 back OUT exactly 1 full turn, returning to the baseline position, then click Run Measurement."
-                            : "Turn screw 1 back OUT and screw 3 back IN exactly 1 full turn each, returning to the baseline position, then click Run Measurement.";
-                    case WizardStep.Screw2:
-                        return n == 3
-                            ? "Turn screw 2 INWARD exactly 1 full turn, then click Run Measurement."
-                            : "Turn screw 2 INWARD and screw 4 OUTWARD exactly 1 full turn each, then click Run Measurement.";
-                    case WizardStep.Complete:
-                        return "Restore all screws to their original position.";
-                    default:
-                        return string.Empty;
-                }
+        public string StepInstructions =>
+            StepInstructionsText(currentStep, tiltAdapterOptions.ScrewCount, IsStepperAdjustment, calibrationAppliedAmount);
+
+        // Formats the calibration move amount: "1 full turn" / "1.5 turns" for screws, whole "+N"
+        // magnitude for steppers (sign is added by the caller's wording).
+        internal static string FormatAppliedAmount(bool isStepper, double amount) =>
+            isStepper ? $"{amount:0.##}" : (amount == 1.0 ? "1 full turn" : $"{amount:0.##} turns");
+
+        // All wizard prompts. Screw motion is worded as CLOCKWISE/COUNTER-CLOCKWISE (tighten/loosen)
+        // — never "inward/outward", which this plugin reserves for adapter-plate motion. Stepper
+        // prompts use signed steps; "+" is the direction the guidance later reports as positive.
+        internal static string StepInstructionsText(WizardStep step, int screwCount, bool isStepper, double appliedAmount) {
+            string amt = FormatAppliedAmount(isStepper, appliedAmount);
+            bool four = screwCount == 4;
+            switch (step) {
+                case WizardStep.Baseline:
+                    return "Label your screws 1, 2, and 3 (or 1–4 for a 4-screw adapter) in a consistent clockwise order. " +
+                        "Screw 1 does NOT need to be at any particular clock position — the wizard determines each screw's actual " +
+                        "position from the measurements.\n\nEnsure all screws are at their starting position, then click Run Measurement to take a baseline reading.";
+                case WizardStep.AllInward:
+                    return isStepper
+                        ? $"Apply +{amt} steps to EVERY motor, then click Run Measurement."
+                        : $"Turn ALL screws CLOCKWISE (tighten) exactly {amt} each, then click Run Measurement.";
+                case WizardStep.ReBaseline1:
+                    return isStepper
+                        ? $"Apply −{amt} steps to every motor, returning to the baseline position, then click Run Measurement."
+                        : $"Turn ALL screws back COUNTER-CLOCKWISE (loosen) exactly {amt} each, returning to the baseline position, then click Run Measurement.";
+                case WizardStep.Screw1:
+                    if (isStepper) {
+                        return four
+                            ? $"Apply +{amt} steps to motor 1 and −{amt} steps to motor 3, then click Run Measurement."
+                            : $"Apply +{amt} steps to motor 1, then click Run Measurement.";
+                    }
+                    return four
+                        ? $"Turn screw 1 CLOCKWISE and screw 3 COUNTER-CLOCKWISE exactly {amt} each, then click Run Measurement."
+                        : $"Turn screw 1 CLOCKWISE exactly {amt}, then click Run Measurement.";
+                case WizardStep.ReBaseline2:
+                    if (isStepper) {
+                        return four
+                            ? $"Apply −{amt} steps to motor 1 and +{amt} steps to motor 3, returning to the baseline position, then click Run Measurement."
+                            : $"Apply −{amt} steps to motor 1, returning to the baseline position, then click Run Measurement.";
+                    }
+                    return four
+                        ? $"Turn screw 1 back COUNTER-CLOCKWISE and screw 3 back CLOCKWISE exactly {amt} each, returning to the baseline position, then click Run Measurement."
+                        : $"Turn screw 1 back COUNTER-CLOCKWISE exactly {amt}, returning to the baseline position, then click Run Measurement.";
+                case WizardStep.Screw2:
+                    if (isStepper) {
+                        return four
+                            ? $"Apply +{amt} steps to motor 2 and −{amt} steps to motor 4, then click Run Measurement."
+                            : $"Apply +{amt} steps to motor 2, then click Run Measurement.";
+                    }
+                    return four
+                        ? $"Turn screw 2 CLOCKWISE and screw 4 COUNTER-CLOCKWISE exactly {amt} each, then click Run Measurement."
+                        : $"Turn screw 2 CLOCKWISE exactly {amt}, then click Run Measurement.";
+                case WizardStep.Complete:
+                    return isStepper
+                        ? "Return all motors to their original position."
+                        : "Restore all screws to their original position.";
+                default:
+                    return string.Empty;
             }
         }
 
@@ -544,18 +634,32 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         // Instructions for undoing the current step's screw move to return to baseline (mirrors the ReBaseline /
         // Complete wording in StepInstructions). For a step already at baseline, says so instead.
-        internal static string BaselineRecoveryText(WizardStep step, int screwCount) {
+        internal static string BaselineRecoveryText(WizardStep step, int screwCount, bool isStepper, double appliedAmount) {
+            string amt = FormatAppliedAmount(isStepper, appliedAmount);
+            bool four = screwCount == 4;
             switch (step) {
                 case WizardStep.AllInward:
-                    return "Turn ALL screws back OUT exactly 1 full turn each, returning to the baseline position.";
+                    return isStepper
+                        ? $"Apply −{amt} steps to every motor, returning to the baseline position."
+                        : $"Turn ALL screws back COUNTER-CLOCKWISE exactly {amt} each, returning to the baseline position.";
                 case WizardStep.Screw1:
-                    return screwCount == 3
-                        ? "Turn screw 1 back OUT exactly 1 full turn, returning to the baseline position."
-                        : "Turn screw 1 back OUT and screw 3 back IN exactly 1 full turn each, returning to the baseline position.";
+                    if (isStepper) {
+                        return four
+                            ? $"Apply −{amt} steps to motor 1 and +{amt} steps to motor 3, returning to the baseline position."
+                            : $"Apply −{amt} steps to motor 1, returning to the baseline position.";
+                    }
+                    return four
+                        ? $"Turn screw 1 back COUNTER-CLOCKWISE and screw 3 back CLOCKWISE exactly {amt} each, returning to the baseline position."
+                        : $"Turn screw 1 back COUNTER-CLOCKWISE exactly {amt}, returning to the baseline position.";
                 case WizardStep.Screw2:
-                    return screwCount == 3
-                        ? "Turn screw 2 back OUT exactly 1 full turn, returning to the baseline position."
-                        : "Turn screw 2 back OUT and screw 4 back IN exactly 1 full turn each, returning to the baseline position.";
+                    if (isStepper) {
+                        return four
+                            ? $"Apply −{amt} steps to motor 2 and +{amt} steps to motor 4, returning to the baseline position."
+                            : $"Apply −{amt} steps to motor 2, returning to the baseline position.";
+                    }
+                    return four
+                        ? $"Turn screw 2 back COUNTER-CLOCKWISE and screw 4 back CLOCKWISE exactly {amt} each, returning to the baseline position."
+                        : $"Turn screw 2 back COUNTER-CLOCKWISE exactly {amt}, returning to the baseline position.";
                 default:
                     return "All screws should already be at the baseline (starting) position.";
             }
@@ -570,6 +674,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public ICommand BrowseSaveFolderCommand { get; }
         public ICommand ReplayCommand { get; }
         public ICommand RetryMeasurementCommand { get; }
+        public ICommand ApplyManualCalibrationCommand { get; }
 
         // Known amount the user moves each screw during the per-screw calibration steps (full turns
         // for screws, steps for steppers). Defaults to 1.0 to match the "1 full turn" instructions.
@@ -580,11 +685,126 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     calibrationAppliedAmount = value;
                     RaisePropertyChanged();
                     RaisePropertyChanged(nameof(CalibrationAppliedAmountDisplay));
+                    // The prompts embed the applied amount, so editing it must refresh them.
+                    RaisePropertyChanged(nameof(StepInstructions));
+                    RaisePropertyChanged(nameof(BaselineRecoveryInstructions));
                 }
             }
         }
 
         public bool IsStepperAdjustment => tiltAdapterOptions.AdjustmentType == TiltAdjustmentType.StepperMotors;
+
+        // Mechanical framing of ScrewInwardCurvatureSign: does a CW screw turn (or +steps) move the
+        // adapter plate toward the objective? Editing writes the sign (and marks it assumed); a
+        // 6-step wizard measurement overwrites the sign and this re-reads it.
+        public bool CwMovesAdapterTowardObjective {
+            get {
+                int sign = tiltAdapterOptions.ScrewInwardCurvatureSign;
+                if (sign == 0) sign = TiltScrewGeometry.DefaultScrewInwardCurvatureSign;
+                return TiltScrewGeometry.CwMovesAdapterTowardObjectiveForSign(sign);
+            }
+            set {
+                int sign = TiltScrewGeometry.CurvatureSignForCwDirection(value);
+                if (tiltAdapterOptions.ScrewInwardCurvatureSign != sign) {
+                    tiltAdapterOptions.ScrewInwardCurvatureSign = sign;
+                    tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured = false;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public string CwDirectionLabel => IsStepperAdjustment
+            ? "Applying + steps moves the adapter"
+            : "Turning screws clockwise moves the adapter";
+
+        public string CurvatureSignProvenance => tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured
+            ? "Direction was measured by a calibration run."
+            : "Direction is assumed — enable the measurement below (or run a 6-step calibration) to verify it.";
+
+        private double manualScrew1AngleDegrees;
+
+        // Manual Calibration Entry: screw 1 position angle in degrees, image space, 0° = straight
+        // up (12 o'clock), increasing clockwise — the plugin-wide convention.
+        public double ManualScrew1AngleDegrees {
+            get => manualScrew1AngleDegrees;
+            set {
+                if (manualScrew1AngleDegrees != value) {
+                    manualScrew1AngleDegrees = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool manualNumberingClockwise = true;
+
+        // Whether screws 2..n proceed clockwise from screw 1 in the IMAGE (mirrors can flip it).
+        public bool ManualNumberingClockwise {
+            get => manualNumberingClockwise;
+            set {
+                if (manualNumberingClockwise != value) {
+                    manualNumberingClockwise = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        // Applies a manually entered calibration: same persisted state a wizard run writes, tagged
+        // manual. The curvature sign is whatever the direction setting above holds (assumed).
+        internal void ApplyManualCalibration() {
+            // WPF double bindings can push NaN/Infinity; never persist IsCalibrated over all-NaN angles.
+            if (!double.IsFinite(manualScrew1AngleDegrees)) {
+                Notification.ShowWarning("Enter a valid screw 1 position angle (in degrees) before applying a manual calibration.");
+                return;
+            }
+            int n = tiltAdapterOptions.ScrewCount;
+            var (s1, s2, s3, s4) = TiltCalibrationCalculator.ComputeManualScrewAngles(manualScrew1AngleDegrees, manualNumberingClockwise, n);
+            tiltAdapterOptions.Screw1AngleDegrees = s1;
+            tiltAdapterOptions.Screw2AngleDegrees = s2;
+            tiltAdapterOptions.Screw3AngleDegrees = s3;
+            tiltAdapterOptions.Screw4AngleDegrees = s4;
+            tiltAdapterOptions.CalibratedScrewCount = n;
+            tiltAdapterOptions.IsCalibrated = true;
+            tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured = false;
+            tiltAdapterOptions.CalibrationIsManual = true;
+            // A manual entry supersedes whatever wizard run last measured the hardware — reset to the
+            // unset sentinel (-1, what the options initialize to; PitchMismatchExceeds ignores <= 0) so
+            // the inspector's pitch-mismatch warning can't compare the new adapter's configured pitch
+            // against a stale measurement from a previous adapter.
+            tiltAdapterOptions.LastMeasuredThreadPitchMicrons = -1;
+            tiltAdapterOptions.LastMeasuredStepperStepSizeMicrons = -1;
+            // Clear stale wizard-run display state (measured-hardware panel, per-run warnings, summary
+            // rows — the same state Restart clears) that would otherwise describe the previous run next
+            // to a manually entered calibration.
+            measuredHardwareMicrons = double.NaN;
+            lastRawAngleDiff = double.NaN;
+            lastMoveMagnitudeRatio = double.NaN;
+            HasWarning = false;
+            WarningText = string.Empty;
+            HasMeasurementConsistencyWarning = false;
+            MeasurementConsistencyWarningText = string.Empty;
+            HasRebaselineDriftWarning = false;
+            RebaselineDriftWarningText = string.Empty;
+            HasConfidenceWarning = false;
+            ConfidenceWarningText = string.Empty;
+            ClearSummaryRows();
+            RaiseHardwareSummaryChanged();
+            RebuildDiagram();
+        }
+
+        public string WizardSweepSummary {
+            get {
+                var inspectorOptions = inspector.InspectorOptions;
+                if (inspectorOptions == null) return string.Empty;
+                return BuildSweepSummary(
+                    GetMeasurementSteps(tiltAdapterOptions.MeasureCurvatureDuringCalibration).Length,
+                    tiltAdapterOptions.MeasurementAverageCount,
+                    inspectorOptions.StepCount,
+                    inspectorOptions.FramesPerPoint,
+                    inspectorOptions.SignalAmplification,
+                    profileService.ActiveProfile.FocuserSettings.AutoFocusInitialOffsetSteps,
+                    profileService.ActiveProfile.FocuserSettings.AutoFocusNumberOfFramesPerPoint);
+            }
+        }
 
         public string CalibrationAmountLabel => IsStepperAdjustment ? "Steps applied per screw" : "Turns applied per screw";
 
@@ -710,6 +930,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 }
             }
 
+            activeMeasurementSteps = GetMeasurementSteps(tiltAdapterOptions.MeasureCurvatureDuringCalibration);
             CurrentStep = WizardStep.Baseline;
             IsWizardRunning = true;
             return Task.CompletedTask;
@@ -1019,7 +1240,17 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         }
 
         private void NextStep() {
-            WizardStep next = currentStep + 1;
+            int idx = Array.IndexOf(activeMeasurementSteps, currentStep);
+            if (idx < 0) {
+                // Unreachable via the measurement commands (they gate on IsOnMeasurementStep), but never
+                // fabricate a Complete: that would run the calibration math on default-zero readings and
+                // persist IsCalibrated from garbage. Log loudly and leave the state untouched.
+                Logger.Error($"Tilt calibration: current step {currentStep} is not in the active measurement sequence; ignoring step advance.");
+                return;
+            }
+            WizardStep next = idx == activeMeasurementSteps.Length - 1
+                ? WizardStep.Complete
+                : activeMeasurementSteps[idx + 1];
 
             if (next == WizardStep.Complete) {
                 RunCalibrationMath(
@@ -1112,15 +1343,20 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // by a live run (geometry from the current options/profile) and a replay (geometry from the metadata).
         private void RunCalibrationMath(int screwCount, double radiusMm, double pixelSize, double fStep,
             double appliedAmount, bool isStepper) {
+            bool measuredCurvature = stepReadings.ContainsKey(WizardStep.AllInward);
             var a = Reading(WizardStep.Baseline);
             var b = Reading(WizardStep.AllInward);
-            var c = Reading(WizardStep.ReBaseline1);
+            var c = measuredCurvature ? Reading(WizardStep.ReBaseline1) : Reading(WizardStep.Baseline);
             var d = Reading(WizardStep.Screw1);
             var e = Reading(WizardStep.ReBaseline2);
             var f = Reading(WizardStep.Screw2);
 
-            // Curvature (backfocus) sign from baseline (a) → all-inward (b) mean focus.
-            tiltAdapterOptions.ScrewInwardCurvatureSign = TiltCalibrationCalculator.ComputeCurvatureSign(b.Mean, a.Mean);
+            // Curvature (backfocus) sign from baseline (a) → all-inward (b) mean focus, only when
+            // those steps ran; otherwise the configured/assumed sign is left untouched.
+            if (measuredCurvature) {
+                tiltAdapterOptions.ScrewInwardCurvatureSign = TiltCalibrationCalculator.ComputeCurvatureSign(b.Mean, a.Mean);
+                tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured = true;
+            }
 
             // Screw angles from each move relative to its preceding re-baseline (c→d, e→f).
             double d1A = d.A - c.A, d1B = d.B - c.B;
@@ -1136,6 +1372,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
             tiltAdapterOptions.CalibratedScrewCount = screwCount;
             tiltAdapterOptions.IsCalibrated = true;
+            tiltAdapterOptions.CalibrationIsManual = false;
 
             lastRawAngleDiff = rawDiff;
             lastMoveMagnitudeRatio = TiltCalibrationCalculator.MoveMagnitudeRatio(d1A, d1B, d2A, d2B);
@@ -1151,12 +1388,16 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             if (model != null) {
                 var inputs = new TiltCalibrationInputs {
                     ScrewCount = screwCount,
-                    Baseline = new TiltGradient(a.A, a.B, a.Mean),
-                    AllInward = new TiltGradient(b.A, b.B, b.Mean),
+                    // 4-step runs never measured Baseline/AllInward as curvature probes: leave them default —
+                    // the calculator ignores them when HasCurvatureMeasurement is false (c carries the baseline).
+                    Baseline = measuredCurvature ? new TiltGradient(a.A, a.B, a.Mean) : default,
+                    AllInward = measuredCurvature ? new TiltGradient(b.A, b.B, b.Mean) : default,
                     ReBaseline1 = new TiltGradient(c.A, c.B, c.Mean),
                     Screw1 = new TiltGradient(d.A, d.B, d.Mean),
                     ReBaseline2 = new TiltGradient(e.A, e.B, e.Mean),
                     Screw2 = new TiltGradient(f.A, f.B, f.Mean),
+                    HasCurvatureMeasurement = measuredCurvature,
+                    FallbackCurvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign,
                     ImageWidthPixels = model.ImageSize.Width,
                     ImageHeightPixels = model.ImageSize.Height,
                     PixelSizeMicrons = pixelSize,
@@ -1179,12 +1420,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             EvaluateRebaselineDrift();
             EvaluateCalibrationConfidence(TiltCalibrationCalculator.ComputeConfidence(new TiltCalibrationInputs {
                 ScrewCount = screwCount,
-                Baseline = new TiltGradient(a.A, a.B, a.Mean),
-                AllInward = new TiltGradient(b.A, b.B, b.Mean),
+                Baseline = measuredCurvature ? new TiltGradient(a.A, a.B, a.Mean) : default,
+                AllInward = measuredCurvature ? new TiltGradient(b.A, b.B, b.Mean) : default,
                 ReBaseline1 = new TiltGradient(c.A, c.B, c.Mean),
                 Screw1 = new TiltGradient(d.A, d.B, d.Mean),
                 ReBaseline2 = new TiltGradient(e.A, e.B, e.Mean),
-                Screw2 = new TiltGradient(f.A, f.B, f.Mean)
+                Screw2 = new TiltGradient(f.A, f.B, f.Mean),
+                HasCurvatureMeasurement = measuredCurvature,
+                FallbackCurvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign
             }));
             RaiseHardwareSummaryChanged();
         }
@@ -1232,13 +1475,18 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // Re-baseline drift: each re-baseline (c, e) should return close to the prior state. A large residual
         // relative to the subsequent screw move means backlash / an uneven undo contaminated the calibration.
         private void EvaluateRebaselineDrift() {
+            bool measuredCurvature = stepReadings.ContainsKey(WizardStep.AllInward);
             var a = Reading(WizardStep.Baseline);
-            var c = Reading(WizardStep.ReBaseline1);
+            var c = measuredCurvature ? Reading(WizardStep.ReBaseline1) : Reading(WizardStep.Baseline);
             var d = Reading(WizardStep.Screw1);
             var e = Reading(WizardStep.ReBaseline2);
             var f = Reading(WizardStep.Screw2);
 
-            double drift1 = TiltCalibrationCalculator.RebaselineDriftRatio(c.A - a.A, c.B - a.B, d.A - c.A, d.B - c.B);
+            // In the 4-step flow c IS a (drift1 would be a meaningless 0); the explicit NaN keeps the
+            // warning semantics clean — only the 6-step flow has a re-baseline-1 to evaluate.
+            double drift1 = measuredCurvature
+                ? TiltCalibrationCalculator.RebaselineDriftRatio(c.A - a.A, c.B - a.B, d.A - c.A, d.B - c.B)
+                : double.NaN;
             double drift2 = TiltCalibrationCalculator.RebaselineDriftRatio(e.A - c.A, e.B - c.B, f.A - e.A, f.B - e.B);
 
             var parts = new List<string>(2);
@@ -1319,7 +1567,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             var byStep = (metadata.RunStepMapping ?? new List<TiltRunStepMapping>())
                 .GroupBy(m => m.Step, StringComparer.OrdinalIgnoreCase)
                 .ToDictionary(g => g.Key, g => TiltCalibrationMetadata.ResolveStepFolder(folder, g.Last().Folder), StringComparer.OrdinalIgnoreCase);
-            foreach (var step in MeasurementSteps) {
+            // A run saved without the curvature steps replays as a 4-step run.
+            bool replayHasCurvatureSteps = byStep.ContainsKey(WizardStep.AllInward.ToString());
+            var replaySteps = GetMeasurementSteps(replayHasCurvatureSteps);
+            activeMeasurementSteps = replaySteps;
+            foreach (var step in replaySteps) {
                 if (!byStep.ContainsKey(step.ToString())) {
                     Notification.ShowError($"metadata.json has no saved folder for step '{step}'. Cannot replay.");
                     return;
@@ -1328,7 +1580,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
             // Consolidated replay: one button, three modes resolved by the shared replay-settings modal (seeded from a
             // representative per-step AutoFocus replay snapshot). Cancelling / closing the modal aborts.
-            var representativeStepFolder = byStep[MeasurementSteps.First().ToString()];
+            var representativeStepFolder = byStep[replaySteps.First().ToString()];
             AutoFocusReplayMetadata.TryLoad(representativeStepFolder, out var replayMetadata, out _);
             var choice = await ReplaySettingsPrompt.ShowAsync(windowServiceFactory, replayMetadata, ReplaySettingsPromptTexts.TiltCalibration);
             if (choice == ReplaySettingsChoice.Cancel) {
@@ -1378,7 +1630,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
             bool completed = false;
             try {
-                foreach (var step in MeasurementSteps) {
+                foreach (var step in replaySteps) {
                     token.ThrowIfCancellationRequested();
                     StatusText = $"Replaying {step}...";
                     // Capture-time modes ("use captured in memory" and "update profile") replay each step with its own

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -272,6 +272,37 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 RaisePropertyChanged(nameof(IsManualDevice));
                 RaisePropertyChanged(nameof(SaveAFRunsPath));
                 RaisePropertyChanged(nameof(WizardSweepSummary));
+                // TiltAdapterOptions reloads its values from the new profile in its own ProfileChanged handler
+                // (subscribed before this VM exists, so it runs first), but that reload raises one broadcast
+                // PropertyChanged (null name) that the per-name filters in the options handler above never match.
+                // Every wrapper/derived property must therefore be re-raised here, or the direction controls,
+                // provenance text, prompts, and diagram keep showing the previous profile's state — and re-selecting
+                // the stale direction value would silently overwrite the new profile's measured sign.
+                RaisePropertyChanged(nameof(CwMovesAdapterTowardObjective));
+                RaisePropertyChanged(nameof(CurvatureSignDescription));
+                RaisePropertyChanged(nameof(CurvatureSignProvenance));
+                RaisePropertyChanged(nameof(CwDirectionLabel));
+                RaisePropertyChanged(nameof(HasCurvatureCalibration));
+                RaisePropertyChanged(nameof(IsCalibrationValid));
+                RaisePropertyChanged(nameof(StepInstructions));
+                RaisePropertyChanged(nameof(BaselineRecoveryInstructions));
+                RaisePropertyChanged(nameof(AdjustmentType));
+                RaisePropertyChanged(nameof(IsStepperAdjustment));
+                RaisePropertyChanged(nameof(CalibrationAmountLabel));
+                RaisePropertyChanged(nameof(ThreadPitchMicronsValue));
+                RaisePropertyChanged(nameof(StepperStepSizeMicronsValue));
+                RaisePropertyChanged(nameof(ScrewRadiusMillimetersValue));
+                RaisePropertyChanged(nameof(ShowRunColumn));
+                RaiseHardwareSummaryChanged();
+                RebuildDiagram();
+                // Re-run the manual-entry pre-fill for the new profile's calibration (it was constructor-only):
+                // stored angles are response-convention, the manual field holds the physical image angle, and the
+                // conversion uses the new profile's direction sign. When the new profile has no calibration angle
+                // the previous value is kept, matching the constructor's NaN guard.
+                if (!double.IsNaN(tiltAdapterOptions.Screw1AngleDegrees)) {
+                    ManualScrew1AngleDegrees = TiltScrewGeometry.PhysicalToStoredAngle(
+                        tiltAdapterOptions.Screw1AngleDegrees, tiltAdapterOptions.ScrewInwardCurvatureSign);
+                }
             });
 
             // Re-assert and lock a persisted device preset on load.
@@ -929,6 +960,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             StatusText = string.Empty;
             ClearMeasurementFailureChoice();
             stepReadings.Clear();
+            HasMeasurementConsistencyWarning = false;
+            MeasurementConsistencyWarningText = string.Empty;
             HasRebaselineDriftWarning = false;
             RebaselineDriftWarningText = string.Empty;
             HasConfidenceWarning = false;
@@ -1182,7 +1215,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
         }
 
-        private void AppendSummaryRows(List<(double A, double B, double Mean)> readings, string stepDescription,
+        // Internal for tests (the consistency-warning path is otherwise only reachable through a live inspector run).
+        internal void AppendSummaryRows(List<(double A, double B, double Mean)> readings, string stepDescription,
             TiltPlaneModel latestModel, int count, double avgA, double avgB) {
             for (int i = 0; i < readings.Count; i++) {
                 var (a, b, _) = readings[i];
@@ -1256,7 +1290,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             MeasurementFailureText = string.Empty;
         }
 
-        private void NextStep() {
+        // Internal for tests (the step-advance rule and the end-of-run calibration math are otherwise only
+        // reachable through a live inspector measurement).
+        internal void NextStep() {
             int idx = Array.IndexOf(activeMeasurementSteps, currentStep);
             if (idx < 0) {
                 // Unreachable via the measurement commands (they gate on IsOnMeasurementStep), but never
@@ -1281,8 +1317,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 FinalizeMetadata();
             }
 
-            HasMeasurementConsistencyWarning = false;
-            MeasurementConsistencyWarningText = string.Empty;
+            // The measurement-consistency warning is intentionally NOT cleared here: it is set at the end of a
+            // successful averaged measurement, and NextStep runs immediately afterwards — clearing it here would
+            // hide it before the user ever saw it. It survives onto the next step's screen and is cleared when the
+            // next measurement run starts (RunMeasurementAsync / RunSavedMeasurementAsync) and on Start/Restart/Replay.
             StatusText = string.Empty;
             ClearMeasurementFailureChoice();
             CurrentStep = next;
@@ -1539,6 +1577,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         private StepReading Reading(WizardStep step) =>
             stepReadings.TryGetValue(step, out var r) ? r : default;
+
+        // Test seam: seeds a step reading with the fields the calibration math consumes, so unit tests can
+        // exercise NextStep/RunCalibrationMath without running the inspector. StepReading and stepReadings
+        // stay private — this is the only external write path.
+        internal void SeedStepReading(WizardStep step, double a, double b, double mean) {
+            stepReadings[step] = new StepReading { A = a, B = b, Mean = mean };
+        }
 
         // ---- Replay -----------------------------------------------------------------------------------------
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -214,6 +214,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     e.PropertyName == nameof(ITiltAdapterOptions.MeasurementAverageCount)) {
                     RaisePropertyChanged(nameof(WizardSweepSummary));
                 }
+                if (e.PropertyName == nameof(ITiltAdapterOptions.MeasureCurvatureDuringCalibration)) {
+                    RaisePropertyChanged(nameof(CurvatureSignProvenance));
+                }
                 if (e.PropertyName == nameof(ITiltAdapterOptions.CalibrationIsManual)) {
                     RaisePropertyChanged(nameof(IsCalibrationValid));
                 }
@@ -717,9 +720,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             ? "Applying + steps moves the adapter"
             : "Turning screws clockwise moves the adapter";
 
-        public string CurvatureSignProvenance => tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured
-            ? "Direction was measured by a calibration run."
-            : "Direction is assumed — enable the measurement below (or run a 6-step calibration) to verify it.";
+        public string CurvatureSignProvenance =>
+            tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured
+                ? "Direction was measured by a calibration run."
+                : tiltAdapterOptions.MeasureCurvatureDuringCalibration
+                    ? "Direction will be measured on the next calibration run."
+                    : "Direction is assumed — enable the measurement below (or run a 6-step calibration) to verify it.";
 
         private double manualScrew1AngleDegrees;
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -277,9 +277,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // Re-assert and lock a persisted device preset on load.
             ApplyDevice(tiltAdapterOptions.DeviceName);
 
-            // Pre-fill the Manual Calibration Entry angle from an existing calibration.
+            // Pre-fill the Manual Calibration Entry angle from an existing calibration. Stored angles
+            // are response-convention; the manual field holds the PHYSICAL image angle, so convert
+            // back (PhysicalToStoredAngle is self-inverse) with the current direction sign.
             if (!double.IsNaN(tiltAdapterOptions.Screw1AngleDegrees)) {
-                manualScrew1AngleDegrees = tiltAdapterOptions.Screw1AngleDegrees;
+                manualScrew1AngleDegrees = TiltScrewGeometry.PhysicalToStoredAngle(
+                    tiltAdapterOptions.Screw1AngleDegrees, tiltAdapterOptions.ScrewInwardCurvatureSign);
             }
 
             RebuildDiagram();
@@ -729,8 +732,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         private double manualScrew1AngleDegrees;
 
-        // Manual Calibration Entry: screw 1 position angle in degrees, image space, 0° = straight
-        // up (12 o'clock), increasing clockwise — the plugin-wide convention.
+        // Manual Calibration Entry: screw 1 PHYSICAL position angle in degrees, image space, 0° =
+        // straight up (12 o'clock), increasing clockwise — the plugin-wide convention. Converted to
+        // the wizard's stored response convention on Apply (TiltScrewGeometry.PhysicalToStoredAngle),
+        // using the adapter-direction sign at Apply time.
         public double ManualScrew1AngleDegrees {
             get => manualScrew1AngleDegrees;
             set {
@@ -763,7 +768,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 return;
             }
             int n = tiltAdapterOptions.ScrewCount;
-            var (s1, s2, s3, s4) = TiltCalibrationCalculator.ComputeManualScrewAngles(manualScrew1AngleDegrees, manualNumberingClockwise, n);
+            // The user types the PHYSICAL image angle, but wizard runs persist RESPONSE-convention
+            // angles (the direction a CW turn drives the tilt gradient — 180° from physical on
+            // sign = -1 rigs), and the guidance math consumes stored angles as response-convention.
+            // Convert with the adapter-direction sign in effect now; if the user changes that setting
+            // later they must click Apply again (the conversion is not retroactive).
+            double stored1 = TiltScrewGeometry.PhysicalToStoredAngle(manualScrew1AngleDegrees, tiltAdapterOptions.ScrewInwardCurvatureSign);
+            var (s1, s2, s3, s4) = TiltCalibrationCalculator.ComputeManualScrewAngles(stored1, manualNumberingClockwise, n);
             tiltAdapterOptions.Screw1AngleDegrees = s1;
             tiltAdapterOptions.Screw2AngleDegrees = s2;
             tiltAdapterOptions.Screw3AngleDegrees = s3;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
@@ -36,6 +36,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
     /// The discrete 6-step flow measures: Baseline (a), AllInward (b), ReBaseline1 (c), Screw1 (d), ReBaseline2 (e),
     /// Screw2 (f). Each screw's angle/hardware is derived from the move relative to the re-baseline that immediately
     /// precedes it (c→d for screw 1, e→f for screw 2), so a single physical move is isolated per measurement pair.
+    /// In the 4-step flow (no curvature steps) Baseline/AllInward are unset, HasCurvatureMeasurement is false, and
+    /// the baseline reading occupies the ReBaseline1 slot.
     /// </summary>
     public sealed class TiltCalibrationInputs {
         public int ScrewCount { get; set; }                 // 3 or 4
@@ -52,6 +54,15 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public double ScrewRadiusMillimeters { get; set; }
         public double CalibrationAppliedAmount { get; set; } // turns (screws) or steps (steppers) applied per screw step
         public bool IsStepperAdjustment { get; set; }
+
+        /// <summary>False for a 4-step run that skipped the curvature-direction steps: Baseline and
+        /// AllInward were never measured (leave them default) and the baseline reading is supplied
+        /// in the ReBaseline1 slot, which is the screw-1 reference in both flows.</summary>
+        public bool HasCurvatureMeasurement { get; set; } = true;
+
+        /// <summary>Curvature sign carried into the result when HasCurvatureMeasurement is false
+        /// (the configured/assumed ScrewInwardCurvatureSign; 0 = unknown).</summary>
+        public int FallbackCurvatureSign { get; set; }
     }
 
     /// <summary>Result of calibrating a tilt adapter: per-screw position angles, curvature sign, and recovered hardware.</summary>
@@ -63,7 +74,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public int CalibratedScrewCount { get; set; }
         public bool IsCalibrated { get; set; }
         public double RawAngleDiffDegrees { get; set; }      // measured screw1->screw2 gap before the constrained fit
-        public int CurvatureSign { get; set; }               // +1 / -1
+        public int CurvatureSign { get; set; }               // +1 / -1; 0 = unknown (4-step run whose fallback sign was never configured)
         public double MeasuredHardwareMicrons { get; set; }  // µm/turn (screws) or µm/step (steppers); NaN if uncomputable
         public double Screw1DirectionDegrees { get; set; }   // raw measured direction of screw 1's move (atan2(dA,-dB))
         public double Screw2DirectionDegrees { get; set; }   // raw measured direction of screw 2's move
@@ -79,20 +90,22 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
     }
 
     /// <summary>
-    /// How trustworthy a calibration is, derived purely from the six per-step tilt vectors — no fit covariance
+    /// How trustworthy a calibration is, derived purely from the per-step tilt vectors — no fit covariance
     /// needed. The screw-move magnitudes are the <i>signal</i>; quantities that must be ~0 in a noise-free,
     /// stationary measurement are <i>noise probes</i>: turning all screws inward equally is a pure piston (no net
-    /// tilt change vs baseline), and each re-baseline should return to its predecessor (zero drift). When the
-    /// noise probes rival the screw-move signal the recovered geometry is dominated by measurement noise / between
-    /// step drift, no matter how cleanly the screws were turned.
+    /// tilt change vs baseline), and each re-baseline should return to its predecessor (zero drift). A 6-step run
+    /// has all three noise probes; a 4-step run (no curvature steps) has only the single re-baseline drift, and
+    /// <see cref="AllInwardTiltResidual"/> / <see cref="Rebaseline1Drift"/> are NaN there. When the noise probes
+    /// rival the screw-move signal the recovered geometry is dominated by measurement noise / between step drift,
+    /// no matter how cleanly the screws were turned.
     /// </summary>
     public sealed class TiltCalibrationConfidence {
         public double ScrewMoveSignal { get; set; }               // mean |single-screw move| magnitude (the signal)
         public double NoiseEstimate { get; set; }                 // RMS of the noise probes below
         public double SignalToNoise { get; set; }                 // ScrewMoveSignal / NoiseEstimate (Inf if noise 0)
         public double PredictedAngleUncertaintyDeg { get; set; }  // ~1σ on each recovered screw direction
-        public double AllInwardTiltResidual { get; set; }         // |AllInward − Baseline|, should be ~0 (pure piston)
-        public double Rebaseline1Drift { get; set; }              // |ReBaseline1 − Baseline|, should be ~0
+        public double AllInwardTiltResidual { get; set; }         // |AllInward − Baseline|, should be ~0 (pure piston); NaN for 4-step runs
+        public double Rebaseline1Drift { get; set; }              // |ReBaseline1 − Baseline|, should be ~0; NaN for 4-step runs
         public double Rebaseline2Drift { get; set; }              // |ReBaseline2 − ReBaseline1|, should be ~0
         public bool IsReliable { get; set; }                      // SignalToNoise >= MinReliableSignalToNoise
     }
@@ -118,19 +131,30 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         private static double Magnitude(double a, double b) => Math.Sqrt(a * a + b * b);
 
         /// <summary>
-        /// Estimates how trustworthy the calibration is from the six per-step tilt vectors. See
-        /// <see cref="TiltCalibrationConfidence"/> for the model: screw moves are the signal; the all-inward piston
-        /// residual and the two re-baseline drifts are independent noise probes (each ~0 in an ideal measurement).
+        /// Estimates how trustworthy the calibration is from the per-step tilt vectors. See
+        /// <see cref="TiltCalibrationConfidence"/> for the model: screw moves are the signal; the noise probes are
+        /// independent quantities that are each ~0 in an ideal measurement — the all-inward piston residual and both
+        /// re-baseline drifts in a 6-step run, only the single re-baseline drift in a 4-step run.
         /// </summary>
         public static TiltCalibrationConfidence ComputeConfidence(TiltCalibrationInputs inputs) {
             double s1 = Magnitude(inputs.Screw1.A - inputs.ReBaseline1.A, inputs.Screw1.B - inputs.ReBaseline1.B);
             double s2 = Magnitude(inputs.Screw2.A - inputs.ReBaseline2.A, inputs.Screw2.B - inputs.ReBaseline2.B);
             double signal = 0.5 * (s1 + s2);
 
-            double allInward = Magnitude(inputs.AllInward.A - inputs.Baseline.A, inputs.AllInward.B - inputs.Baseline.B);
-            double drift1 = Magnitude(inputs.ReBaseline1.A - inputs.Baseline.A, inputs.ReBaseline1.B - inputs.Baseline.B);
             double drift2 = Magnitude(inputs.ReBaseline2.A - inputs.ReBaseline1.A, inputs.ReBaseline2.B - inputs.ReBaseline1.B);
-            double noise = Math.Sqrt((allInward * allInward + drift1 * drift1 + drift2 * drift2) / 3.0);
+            double allInward = double.NaN;
+            double drift1 = double.NaN;
+            double noise;
+            if (inputs.HasCurvatureMeasurement) {
+                allInward = Magnitude(inputs.AllInward.A - inputs.Baseline.A, inputs.AllInward.B - inputs.Baseline.B);
+                drift1 = Magnitude(inputs.ReBaseline1.A - inputs.Baseline.A, inputs.ReBaseline1.B - inputs.Baseline.B);
+                noise = Math.Sqrt((allInward * allInward + drift1 * drift1 + drift2 * drift2) / 3.0);
+            } else {
+                // 4-step run: the only available noise probe is the single re-baseline drift. A one-sample noise
+                // estimate makes the IsReliable gate looser than the 6-step RMS-of-3 — an accepted tradeoff of the
+                // shorter flow.
+                noise = drift2;
+            }
 
             double snr = noise > 0 ? signal / noise : double.PositiveInfinity;
             // A screw direction is atan2 of its move vector; transverse noise of ~noise on a signal of ~signal
@@ -197,6 +221,21 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 // Opposite screws are always 180° apart regardless of mirroring.
                 return (theta1, theta2, NormalizeAngle(theta1 + 180.0), NormalizeAngle(theta2 + 180.0), rawDiff);
             }
+        }
+
+        /// <summary>
+        /// Places all screws from a manually entered screw-1 position angle: equal spacing (120° for
+        /// 3 screws; 90° for 4, opposite screws 180° apart), numbered clockwise or counter-clockwise
+        /// around the IMAGE (mirrors/diagonals can flip the physical winding). s4 = NaN for 3 screws.
+        /// </summary>
+        public static (double s1, double s2, double s3, double s4) ComputeManualScrewAngles(
+            double screw1Deg, bool clockwise, int screwCount) {
+            double step = (screwCount == 3 ? 120.0 : 90.0) * (clockwise ? 1.0 : -1.0);
+            double s1 = NormalizeAngle(screw1Deg);
+            double s2 = NormalizeAngle(s1 + step);
+            double s3 = NormalizeAngle(s1 + 2 * step);
+            double s4 = screwCount == 4 ? NormalizeAngle(s1 + 3 * step) : double.NaN;
+            return (s1, s2, s3, s4);
         }
 
         /// <summary>
@@ -271,7 +310,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 CalibratedScrewCount = inputs.ScrewCount,
                 IsCalibrated = true,
                 RawAngleDiffDegrees = rawDiff,
-                CurvatureSign = ComputeCurvatureSign(inputs.AllInward.MeanFocuserPosition, inputs.Baseline.MeanFocuserPosition),
+                CurvatureSign = inputs.HasCurvatureMeasurement
+                    ? ComputeCurvatureSign(inputs.AllInward.MeanFocuserPosition, inputs.Baseline.MeanFocuserPosition)
+                    : inputs.FallbackCurvatureSign,
                 MeasuredHardwareMicrons = RecoverHardwareMicrons(inputs),
                 Screw1DirectionDegrees = NormalizeAngle(Math.Atan2(d1A, -d1B) * 180.0 / Math.PI),
                 Screw2DirectionDegrees = NormalizeAngle(Math.Atan2(d2A, -d2B) * 180.0 / Math.PI),

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
@@ -77,6 +77,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             "Baseline", "AllInward", "ReBaseline1", "Screw1", "ReBaseline2", "Screw2"
         };
 
+        /// <summary>The 4 measurement steps of a run captured without the curvature-direction steps.</summary>
+        public static readonly string[] StepOrderWithoutCurvature = {
+            "Baseline", "Screw1", "ReBaseline2", "Screw2"
+        };
+
         public static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings {
             ContractResolver = new CamelCasePropertyNamesContractResolver(),
             Formatting = Formatting.Indented,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltScrewGeometry.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltScrewGeometry.cs
@@ -109,7 +109,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         /// stored at θ raises the local gradient along +θ by construction of the calibration), so it
         /// takes NO sign factor; the backfocus component is a physical axial requirement from the
         /// curvature model, so the configured/measured curvature sign converts it to a rotation
-        /// direction. A zero sign treats backfocus as +1 (callers then display magnitude only).
+        /// direction. A zero sign treats backfocus as +1 (defensive only — callers pre-resolve σ
+        /// to the default).
         /// </summary>
         public static double SignedTotalAdjustment(double tiltMicrons, double backfocusMicrons, double unitMicrons, int curvatureSign) {
             if (unitMicrons <= 0) return double.NaN;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltScrewGeometry.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltScrewGeometry.cs
@@ -104,14 +104,17 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         }
 
         /// <summary>
-        /// Convert an axial correction (microns) into a signed adjustment in turns (screws) or
-        /// steps (steppers), where positive = turn the screw inward. Inward turning moves the
-        /// sensor axially in the direction given by <paramref name="curvatureSign"/> (= the wizard's
-        /// ScrewInwardCurvatureSign), so the inward amount is curvatureSign·correction / unitMicrons.
+        /// Signed total adjustment in turns/steps, CW/+ positive. The tilt component is already
+        /// direction-encoded by the stored response-convention screw angle (a CW turn of the screw
+        /// stored at θ raises the local gradient along +θ by construction of the calibration), so it
+        /// takes NO sign factor; the backfocus component is a physical axial requirement from the
+        /// curvature model, so the configured/measured curvature sign converts it to a rotation
+        /// direction. A zero sign treats backfocus as +1 (callers then display magnitude only).
         /// </summary>
-        public static double InwardAdjustment(double correctionMicrons, double unitMicrons, int curvatureSign) {
+        public static double SignedTotalAdjustment(double tiltMicrons, double backfocusMicrons, double unitMicrons, int curvatureSign) {
             if (unitMicrons <= 0) return double.NaN;
-            return curvatureSign * correctionMicrons / unitMicrons;
+            int sign = curvatureSign == 0 ? 1 : curvatureSign;
+            return (tiltMicrons + sign * backfocusMicrons) / unitMicrons;
         }
 
         /// <summary>
@@ -161,6 +164,19 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // With the anchor above this makes the default stored sign +1 (CW raises the curvature
         // effect; adapter motion toward the objective decreases it).
         public static int DefaultScrewInwardCurvatureSign => CurvatureSignForCwDirection(false);
+
+        /// <summary>Converts between the physical image angle and the wizard's stored response-convention
+        /// angle (self-inverse): identical when CW raises the curvature effect (+1); 180° apart when CW
+        /// lowers it (−1). A zero sign is treated as the default direction. The condition is written
+        /// against the empirical-anchor constant so an anchor flip keeps the mechanical meaning
+        /// coherent: the 180° offset belongs to the rigs where CW moves the adapter toward the
+        /// objective. NOTE: callers convert with the sign in effect at Apply time — if the adapter
+        /// direction setting changes afterwards, the conversion must be re-applied.</summary>
+        public static double PhysicalToStoredAngle(double angleDegrees, int curvatureSign) {
+            int resolvedSign = curvatureSign == 0 ? DefaultScrewInwardCurvatureSign : curvatureSign;
+            double offset = resolvedSign == CurvatureSignWhenCwMovesAdapterTowardObjective ? 180.0 : 0.0;
+            return TiltCalibrationCalculator.NormalizeAngle(angleDegrees + offset);
+        }
     }
 
     public readonly struct ScrewAxialCorrection {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltScrewGeometry.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltScrewGeometry.cs
@@ -132,6 +132,35 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             if (activeMicrons <= 0 || measuredMicrons <= 0) return false;
             return Math.Abs(activeMicrons - measuredMicrons) / measuredMicrons > fraction;
         }
+
+        // ---- Adapter direction ⇄ curvature sign --------------------------------------------------
+        //
+        // Clockwise (tighten) always advances a screw; the rig-specific unknown is whether that
+        // advance moves the adapter's plate toward the telescope objective ("inward") or toward the
+        // camera ("outward"). ScrewInwardCurvatureSign stores the measurable consequence: the sign
+        // of the curvature-effect response to a CW turn (+1 = raises it).
+        //
+        // EMPIRICAL ANCHOR (user measurement, 2026-07-02): moving the adapter toward the objective
+        // DECREASES the curvature effect. Therefore a rig where CW drives the adapter toward the
+        // objective has CW lowering the effect: sign -1.
+        public const int CurvatureSignWhenCwMovesAdapterTowardObjective = -1;
+
+        /// <summary>The stored curvature sign implied by the mechanical setting.</summary>
+        public static int CurvatureSignForCwDirection(bool cwMovesAdapterTowardObjective) =>
+            cwMovesAdapterTowardObjective
+                ? CurvatureSignWhenCwMovesAdapterTowardObjective
+                : -CurvatureSignWhenCwMovesAdapterTowardObjective;
+
+        /// <summary>The mechanical reading of a stored curvature sign (sign must be non-zero).</summary>
+        public static bool CwMovesAdapterTowardObjectiveForSign(int curvatureSign) =>
+            curvatureSign * CurvatureSignWhenCwMovesAdapterTowardObjective > 0;
+
+        // Default assumption when the direction was never measured or chosen: CW moves the adapter
+        // toward the camera (outward) — the common push-screw design; matches the tilt-domain doc
+        // ("turning a screw inward pushes that corner of the sensor away from the telescope").
+        // With the anchor above this makes the default stored sign +1 (CW raises the curvature
+        // effect; adapter motion toward the objective decreases it).
+        public static int DefaultScrewInwardCurvatureSign => CurvatureSignForCwDirection(false);
     }
 
     public readonly struct ScrewAxialCorrection {

--- a/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
@@ -283,9 +283,25 @@ namespace TestApp {
             // from the explicit mapping when present, else from the discovered folder count.
             string[] expectedSteps;
             if (metadata.RunStepMapping != null && metadata.RunStepMapping.Count > 0) {
-                expectedSteps = metadata.RunStepMapping.Any(m => string.Equals(m.Step, "AllInward", StringComparison.OrdinalIgnoreCase))
-                    ? StepOrder
-                    : TiltCalibrationMetadata.StepOrderWithoutCurvature;
+                bool hasAllInward = metadata.RunStepMapping.Any(m => string.Equals(m.Step, "AllInward", StringComparison.OrdinalIgnoreCase));
+                expectedSteps = hasAllInward ? StepOrder : TiltCalibrationMetadata.StepOrderWithoutCurvature;
+                if (!hasAllInward) {
+                    // A mapping without an "AllInward" entry is treated as a 4-step run, which silently
+                    // ignores any measured curvature-direction data. Entries that are not 4-step names
+                    // (a typo like "AllInwards", or a stray "ReBaseline1" without "AllInward") suggest
+                    // the author intended the 6-step flow — warn instead of guessing.
+                    var anomalous = metadata.RunStepMapping
+                        .Select(m => m.Step)
+                        .Where(s => !TiltCalibrationMetadata.StepOrderWithoutCurvature.Any(k => string.Equals(k, s, StringComparison.OrdinalIgnoreCase)))
+                        .ToList();
+                    if (anomalous.Count > 0) {
+                        Console.Error.WriteLine(
+                            $"WARNING: runStepMapping has no 'AllInward' entry, so this dataset is treated as a 4-step run " +
+                            $"({string.Join(", ", TiltCalibrationMetadata.StepOrderWithoutCurvature)}) and curvature-direction data is ignored. " +
+                            $"Unrecognized 4-step entries: {string.Join(", ", anomalous.Select(s => $"'{s}'"))}. " +
+                            $"If this was meant to be a 6-step run, check the step names in runStepMapping ({string.Join(", ", StepOrder)}).");
+                    }
+                }
             } else if (runFolders.Count == StepOrder.Length) {
                 expectedSteps = StepOrder;
             } else if (runFolders.Count == TiltCalibrationMetadata.StepOrderWithoutCurvature.Length) {

--- a/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
@@ -43,7 +43,8 @@ namespace TestApp {
     /// <summary>
     /// Headless validator for the Tilt Adapter Wizard's calibration. Given a dataset folder containing the 6
     /// saved AF runs the wizard consumes in sequence (Baseline → AllInward → ReBaseline1 → Screw1 → ReBaseline2 →
-    /// Screw2), it measures each
+    /// Screw2) — or the 4 runs of a wizard flow saved without the curvature-direction steps (Baseline → Screw1 →
+    /// ReBaseline2 → Screw2) — it measures each
     /// run's tilt plane, runs the SAME pure <see cref="TiltCalibrationCalculator"/> the live wizard uses, and
     /// reports the computed per-screw position angles + recovered hardware (thread pitch / step size) against
     /// ground-truth metadata stored in a per-dataset JSON file. It can also run (and persist) the star-detection
@@ -164,7 +165,7 @@ namespace TestApp {
             var inspectorOptions = new InspectorOptions(profileService);
             var alglibAPI = new AlglibAPI();
 
-            // Map the run folders to the 4 wizard steps (explicit override in metadata, else folder-name order).
+            // Map the run folders to the wizard steps (explicit override in metadata, else folder-name order).
             var orderedRuns = MapRunsToSteps(metadata, runFolders, datasetDir);
             foreach (var r in orderedRuns) {
                 Console.WriteLine($"  {r.Step,-10} -> {Path.GetFileName(r.Folder)} ({r.Frames.Count} frames, {r.Frames.Select(f => f.Focuser).Distinct().Count()} positions)");
@@ -204,14 +205,20 @@ namespace TestApp {
             // Calibrate using the pure shared calculator.
             var byStep = perStep.ToDictionary(s => s.Step, StringComparer.OrdinalIgnoreCase);
             var imageSize = perStep[0].ImageSize;
+            // A 4-step run (wizard flow without the curvature-direction steps) has no AllInward/ReBaseline1: its
+            // Baseline reading is the screw-1 reference (ReBaseline1 slot), and the curvature sign falls back to
+            // whatever the wizard carried in the metadata (0 = unknown).
+            bool hasCurvatureSteps = byStep.ContainsKey("AllInward");
             var inputs = new TiltCalibrationInputs {
                 ScrewCount = metadata.NumberOfScrews,
-                Baseline = byStep["Baseline"].Gradient,
-                AllInward = byStep["AllInward"].Gradient,
-                ReBaseline1 = byStep["ReBaseline1"].Gradient,
+                Baseline = hasCurvatureSteps ? byStep["Baseline"].Gradient : default,
+                AllInward = hasCurvatureSteps ? byStep["AllInward"].Gradient : default,
+                ReBaseline1 = hasCurvatureSteps ? byStep["ReBaseline1"].Gradient : byStep["Baseline"].Gradient,
                 Screw1 = byStep["Screw1"].Gradient,
                 ReBaseline2 = byStep["ReBaseline2"].Gradient,
                 Screw2 = byStep["Screw2"].Gradient,
+                HasCurvatureMeasurement = hasCurvatureSteps,
+                FallbackCurvatureSign = metadata.Calibration?.CurvatureSign ?? 0,
                 ImageWidthPixels = imageSize.Width,
                 ImageHeightPixels = imageSize.Height,
                 PixelSizeMicrons = metadata.PixelSizeMicrons,
@@ -240,12 +247,14 @@ namespace TestApp {
                 var pbyStep = paraboloidSteps.ToDictionary(s => s.Step, StringComparer.OrdinalIgnoreCase);
                 var pinputs = new TiltCalibrationInputs {
                     ScrewCount = metadata.NumberOfScrews,
-                    Baseline = pbyStep["Baseline"].Gradient,
-                    AllInward = pbyStep["AllInward"].Gradient,
-                    ReBaseline1 = pbyStep["ReBaseline1"].Gradient,
+                    Baseline = hasCurvatureSteps ? pbyStep["Baseline"].Gradient : default,
+                    AllInward = hasCurvatureSteps ? pbyStep["AllInward"].Gradient : default,
+                    ReBaseline1 = hasCurvatureSteps ? pbyStep["ReBaseline1"].Gradient : pbyStep["Baseline"].Gradient,
                     Screw1 = pbyStep["Screw1"].Gradient,
                     ReBaseline2 = pbyStep["ReBaseline2"].Gradient,
                     Screw2 = pbyStep["Screw2"].Gradient,
+                    HasCurvatureMeasurement = hasCurvatureSteps,
+                    FallbackCurvatureSign = metadata.Calibration?.CurvatureSign ?? 0,
                     ImageWidthPixels = imageSize.Width,
                     ImageHeightPixels = imageSize.Height,
                     PixelSizeMicrons = metadata.PixelSizeMicrons,
@@ -270,6 +279,24 @@ namespace TestApp {
         }
 
         private static List<RunStep> MapRunsToSteps(TiltCalibrationMetadata metadata, List<string> runFolders, string datasetDir) {
+            // Runs saved by the 4-step wizard flow have no AllInward/ReBaseline1 steps. Pick the expected step set
+            // from the explicit mapping when present, else from the discovered folder count.
+            string[] expectedSteps;
+            if (metadata.RunStepMapping != null && metadata.RunStepMapping.Count > 0) {
+                expectedSteps = metadata.RunStepMapping.Any(m => string.Equals(m.Step, "AllInward", StringComparison.OrdinalIgnoreCase))
+                    ? StepOrder
+                    : TiltCalibrationMetadata.StepOrderWithoutCurvature;
+            } else if (runFolders.Count == StepOrder.Length) {
+                expectedSteps = StepOrder;
+            } else if (runFolders.Count == TiltCalibrationMetadata.StepOrderWithoutCurvature.Length) {
+                expectedSteps = TiltCalibrationMetadata.StepOrderWithoutCurvature;
+            } else {
+                throw new InvalidOperationException(
+                    $"Expected {StepOrder.Length} run folders ({string.Join(", ", StepOrder)}) or " +
+                    $"{TiltCalibrationMetadata.StepOrderWithoutCurvature.Length} ({string.Join(", ", TiltCalibrationMetadata.StepOrderWithoutCurvature)}) under {datasetDir}, " +
+                    $"but found {runFolders.Count}. Provide an explicit 'runStepMapping' in the metadata to disambiguate.");
+            }
+
             // Build the ordered (step, folder) list.
             List<(string Step, string Folder)> ordered;
             if (metadata.RunStepMapping != null && metadata.RunStepMapping.Count > 0) {
@@ -277,17 +304,12 @@ namespace TestApp {
                     .Select(m => (m.Step, Folder: ResolveFolder(m.Folder, datasetDir)))
                     .ToList();
             } else {
-                if (runFolders.Count != StepOrder.Length) {
-                    throw new InvalidOperationException(
-                        $"Expected exactly {StepOrder.Length} run folders ({string.Join(", ", StepOrder)}) under {datasetDir}, " +
-                        $"but found {runFolders.Count}. Provide an explicit 'runStepMapping' in the metadata to disambiguate.");
-                }
-                ordered = runFolders.Select((f, i) => (StepOrder[i], f)).ToList();
+                ordered = runFolders.Select((f, i) => (expectedSteps[i], f)).ToList();
             }
 
-            // Validate exactly the 4 expected steps are present.
+            // Validate every expected step is present.
             var steps = ordered.Select(o => o.Step).ToList();
-            foreach (var required in StepOrder) {
+            foreach (var required in expectedSteps) {
                 if (!steps.Any(s => string.Equals(s, required, StringComparison.OrdinalIgnoreCase))) {
                     throw new InvalidOperationException($"runStepMapping is missing the '{required}' step.");
                 }
@@ -737,14 +759,31 @@ namespace TestApp {
                 $"(ground truth {F(groundTruthHardware)}, Δ {(double.IsNaN(hardwarePctDelta) ? "n/a" : F(hardwarePctDelta) + "%")})");
             Line($"Screw move magnitude ratio (larger/smaller): {F(calibration.MoveMagnitudeRatio)}× " +
                 "(should be ~1× for two equal calibration turns)");
-            Line($"Curvature (backfocus) inward sign: {calibration.CurvatureSign:+0;-0}");
+            // A measured sign is always ±1; sign 0 is only reachable for a 4-step run whose metadata carried no
+            // fallback sign (and a two-section format would misprint it as "+0"), so spell out the unmeasured cases.
+            string curvatureSignText;
+            if (inputs.HasCurvatureMeasurement) {
+                curvatureSignText = calibration.CurvatureSign.ToString("+0;-0", CultureInfo.InvariantCulture);
+            } else if (calibration.CurvatureSign == 0) {
+                curvatureSignText = "0 (unknown — not measured, no fallback in metadata)";
+            } else {
+                curvatureSignText = calibration.CurvatureSign.ToString("+0;-0", CultureInfo.InvariantCulture) +
+                    " (not measured; carried from metadata)";
+            }
+            Line($"Curvature (backfocus) inward sign: {curvatureSignText}");
             Line();
 
             var conf = calibration.Confidence;
             Line("Calibration confidence (signal vs noise from the per-step tilt vectors):");
             Line($"  Screw-move signal: {F(conf.ScrewMoveSignal)}   Noise floor: {F(conf.NoiseEstimate)}   SNR: {F(conf.SignalToNoise)}");
-            Line($"  Noise probes (should be « the signal) — AllInward piston residual: {F(conf.AllInwardTiltResidual)}, " +
-                $"re-baseline drift 1/2: {F(conf.Rebaseline1Drift)}/{F(conf.Rebaseline2Drift)}");
+            if (inputs.HasCurvatureMeasurement) {
+                Line($"  Noise probes (should be « the signal) — AllInward piston residual: {F(conf.AllInwardTiltResidual)}, " +
+                    $"re-baseline drift 1/2: {F(conf.Rebaseline1Drift)}/{F(conf.Rebaseline2Drift)}");
+            } else {
+                // 4-step run: no curvature-direction steps were captured, so the AllInward residual and first
+                // re-baseline drift do not exist; the single re-baseline drift is the only noise probe.
+                Line($"  Noise probe (should be « the signal) — single re-baseline drift: {F(conf.Rebaseline2Drift)} (4-step run)");
+            }
             Line($"  Predicted screw-direction uncertainty: ±{F(conf.PredictedAngleUncertaintyDeg)}°");
             if (!conf.IsReliable) {
                 Line($"  NOTE: SNR {F(conf.SignalToNoise)} is below {F(TiltCalibrationCalculator.MinReliableSignalToNoise)} — the calibration is " +
@@ -814,6 +853,8 @@ namespace TestApp {
                     calibration.Screw4AngleDegrees,
                     calibration.RawAngleDiffDegrees,
                     calibration.CurvatureSign,
+                    // False for a 4-step run: CurvatureSign was not measured, it is the metadata fallback (0 = unknown).
+                    curvatureSignMeasured = inputs.HasCurvatureMeasurement,
                     calibration.MeasuredHardwareMicrons,
                     calibration.MoveMagnitudeRatio,
                     screw1DeviationDeg = screw1Deviation,
@@ -849,6 +890,11 @@ namespace TestApp {
         // ---- Metadata --------------------------------------------------------------------------------------
 
         private static void WriteMetadataTemplate(string metadataPath, string outDir, List<string> runFolders) {
+            // Seed the template mapping with the step order matching the discovered folder count (4 = the wizard
+            // flow without the curvature-direction steps); the user corrects it if the guess is wrong.
+            var templateStepOrder = runFolders.Count == TiltCalibrationMetadata.StepOrderWithoutCurvature.Length
+                ? TiltCalibrationMetadata.StepOrderWithoutCurvature
+                : StepOrder;
             var template = new TiltCalibrationMetadata {
                 NumberOfScrews = 3,
                 ScrewThreadPitchMicrons = 0,
@@ -861,7 +907,7 @@ namespace TestApp {
                 AdjustmentType = "Screws",
                 StepperStepSizeMicrons = -1,
                 RunStepMapping = runFolders.Select((f, i) => new TiltRunStepMapping {
-                    Step = i < StepOrder.Length ? StepOrder[i] : $"Extra{i}",
+                    Step = i < templateStepOrder.Length ? templateStepOrder[i] : $"Extra{i}",
                     Folder = Path.GetFileName(f)
                 }).ToList(),
                 OptimizedStarDetectionSettings = null
@@ -872,7 +918,7 @@ namespace TestApp {
 
         private static void PrintUsage() {
             Console.Error.WriteLine("Usage: TestApp tilt --dataset <folder> [--profile-id <guid>] [--out <dir>] [--reoptimize] [--max-evals <int>]");
-            Console.Error.WriteLine("  --dataset    (required) folder containing the 6 AF runs (Baseline, AllInward, ReBaseline1, Screw1, ReBaseline2, Screw2).");
+            Console.Error.WriteLine("  --dataset    (required) folder containing the 6 AF runs (Baseline, AllInward, ReBaseline1, Screw1, ReBaseline2, Screw2) — or 4 (Baseline, Screw1, ReBaseline2, Screw2) for a run saved without the curvature-direction steps.");
             Console.Error.WriteLine("  --profile-id (default active) NINA profile id (settings + focal length).");
             Console.Error.WriteLine("  --out        (default %LOCALAPPDATA%\\NINA\\Logs\\hf-diag\\tilt\\<timestamp>) output directory.");
             Console.Error.WriteLine("  --reoptimize force re-running star-detection optimization and overwrite the stored settings in metadata.");

--- a/docs/manual-doc-review-findings.md
+++ b/docs/manual-doc-review-findings.md
@@ -1,0 +1,1063 @@
+# Adversarial doc-review findings — full manual sweep (2026-07-02)
+
+Run during the tilt-calibration-ux branch work. 28 pages reviewed, 95 confirmed findings (each adversarially verified). All findings on the four pages edited by the branch were verified to be PRE-EXISTING; the branch's own doc changes came back clean apart from two small fixes already applied. This report is the backlog for a separate docs-cleanup pass.
+
+
+## index.md (3)
+
+### [high] (style) documentation/docs/index.md line 42: "select **Hocus Focus** in the Star Detection, Star Annotator, and Auto Focus dropdowns"
+
+**Issue:** UI labels do not match the exact in-app text. Both screenshots on this page and in quick-start.md (assets/screenshots/image-options-dropdown.png, image-options-all.png) show the Image options dropdowns labeled "Star Detector", "Star Annotator", and "Autofocus", not "Star Detection" and "Auto Focus". The page even contradicts itself: the image alt text on line 45 correctly says "Star Detector" while the body text two lines above says "Star Detection". The lead-in also says "turn on the star detector and annotator" (two features) but then instructs setting three dropdowns.
+
+**Suggested fix:**
+
+To turn on its features afterward, go to **Options → Imaging → Image Options** and select **Hocus Focus** in the **Star Detector**, **Star Annotator**, and **Autofocus** dropdowns.
+
+### [medium] (style) documentation/docs/index.md line 6: "It measures HFR with a robust, gradient-aware star detector"
+
+**Issue:** "robust" is explicitly on the banned buzzword list in .claude/docs/documentation-style.md ("avoid ... buzzwords ('robust', 'leverage', 'delve', 'powerful')"). It adds nothing that "gradient-aware" and "accurate" (the wording the Key features bullet on line 22 already uses) do not.
+
+**Suggested fix:**
+
+It measures HFR with an accurate, gradient-aware star detector
+
+### [low] (style) documentation/docs/index.md lines 6-9: "It measures HFR with a robust, gradient-aware star detector and fits PSF models to stars for eccentricity and FWHM measurements; lets you swap in just the star detector or just the annotator without taking both; and builds a full sensor tilt-and-curvature model..."
+
+**Issue:** A single 60+ word sentence built as a three-clause parallel semicolon chain (rule-of-three cadence), against the house preference for short declarative sentences. Its middle clause also duplicates the "Mix and match" admonition on lines 33-36 ("You can use the new star detector or the new annotator independently"), so the same fact is stated twice on one page.
+
+**Suggested fix:**
+
+It measures HFR with an accurate, gradient-aware star detector and fits PSF models to stars for eccentricity and FWHM measurements. It also builds a full sensor tilt-and-curvature model so you can quantify and correct aberrations across the field.
+
+
+## optimization/af-curve-fitting.md (3)
+
+### [low] (style) documentation/docs/optimization/af-curve-fitting.md, line 95: "the objective hard-fails it gracefully to a run score of 0"
+
+**Issue:** Self-contradictory phrasing: "hard-fails ... gracefully" mixes two opposite ideas. The house term on objective-function.md is plain "hard-fails" (e.g. "the run hard-fails (J_run = 0)"); the softener reads as AI hedging and muddies the meaning.
+
+**Suggested fix:**
+
+    parameters). A run that thin produces a NaN \(\sigma\). The evaluation does not throw; the
+    objective hard-fails the run to a score of 0. This is why a usable run needs a real
+    sweep, not a couple of frames.
+
+### [low] (style) documentation/docs/optimization/af-curve-fitting.md, line 76: "it tries the candidate models and lets the winner compete on merit"
+
+**Issue:** Garbled logic: the models compete and a winner emerges; the winner does not itself "compete on merit". The sentence as written is nonsensical on a careful read.
+
+**Suggested fix:**
+
+the autofocus engine uses (`AlglibHyperbolicFitting.SelectBestModel`): it tries the candidate models
+and picks the winner on merit, rather than forcing a single shape (see
+
+### [low] (style) documentation/docs/optimization/af-curve-fitting.md, lines 128–136: "\operatorname{clamp}_{[0,1]}(R^2)" and "\tau = 2.0" / "knee \(\tau = 2.0\)" / "\(\tau / \text{reduced }\chi^2\)"
+
+**Issue:** Notation drift from the authoritative objective page this page links to: objective-function.md writes the same formula as \(\operatorname{clip}(R^2)\) with knee \(\chi_\tau = 2.0\). A reader moving between the two pages may think \(\tau\) and \(\chi_\tau\) (or clamp and clip) are different quantities.
+
+**Suggested fix:**
+
+\[
+S_{\text{fit}} = \operatorname{clip}_{[0,1]}(R^2) \cdot \text{penalty}, \qquad
+\text{penalty} = \begin{cases} 1 & \text{reduced }\chi^2 \le \chi_\tau \\[2pt] \dfrac{\chi_\tau}{\text{reduced }\chi^2} & \text{reduced }\chi^2 > \chi_\tau \end{cases}, \quad \chi_\tau = 2.0 .
+\]
+
+![S_fit equals clamped R-squared times a reduced-chi-squared penalty that only bites on the high side](../assets/figures/objective-sfit.png){ width=620 }
+
+*Only the **high** side of reduced \(\chi^2\) is penalized. Star-rich fields routinely produce a
+reduced \(\chi^2\) well below 1 (over-fit-looking but benign), so values at or below the knee
+\(\chi_\tau = 2.0\) carry no penalty at all; above the knee the penalty decays smoothly as \(\chi_\tau / \text{reduced }\chi^2\).*
+
+
+## optimization/index.md (3)
+
+### [medium] (style) documentation/docs/optimization/index.md line 59: "Optimize for Aberration Inspection"
+
+**Issue:** Quoted UI label does not match the exact in-app text. The wizard checkbox in StarDetection/Optimization/DataTemplates.xaml (line 363) reads "Optimize for aberration inspection (favor more stars)" — sentence case, not title case. House convention elsewhere on this page correctly truncates trailing parentheticals (e.g. "Start from my current settings", "Recover out-of-focus donut stars"), but the capitalization must match the app. (objective-function.md lines 52–53 shares the same title-case mismatch; out of this page's scope but should be fixed together.)
+
+**Suggested fix:**
+
+    **"Optimize for aberration inspection"** instead reweights the objective toward **recovering many
+
+### [low] (style) documentation/docs/optimization/index.md lines 82–87: "w_f\,S_{\text{focus}} ... a further term \( w_l = 0.25 \)"
+
+**Issue:** Math-notation drift from the detail pages this section defers to. index.md writes the objective weights lowercase (\( w_f, w_s, w_c, w_{\text{cov}}, w_l \)) while objective-function.md and labels-recall-precision.md, which the very next line links to for "the full breakdown", consistently use uppercase \( W_f, W_s, W_c, W_{\text{cov}} \) and \( W_\ell \). A reader following the link sees the same formula under different symbols.
+
+**Suggested fix:**
+
+Line 82 (display-math body) becomes:
+
+J_{\text{run}} = \frac{W_f\,S_{\text{focus}} + W_s\,S_{\text{stars}} + W_c\,S_{\text{fit}} + W_{\text{cov}}\,S_{\text{cov}}}{W_f + W_s + W_c + W_{\text{cov}}}
+
+Lines 85–87 become:
+
+with default weights \( W_f = 0.55 \) (focus), \( W_s = 0.20 \) (star count), \( W_c = 0.25 \)
+(curve fit), and \( W_{\text{cov}} = 0.05 \) (how well the accepted stars cover the sensor). When
+ground-truth labels are present a further term \( W_\ell = 0.25 \) is added and all weights are
+
+### [low] (style) documentation/docs/optimization/index.md lines 122–124: "see the authoritative design spec, `docs/star-detection-optimization-wizard-design.md`"
+
+**Issue:** Voice/convention drift: this is the only page in the entire manual that points readers at a repo-internal design spec (grep over documentation/docs/ confirms no other page does this), and the path is not part of the published MkDocs site, so a reader of the GitHub Pages manual has nothing to follow. "the authoritative design spec" is also mildly puffy framing.
+
+**Suggested fix:**
+
+For the design rationale behind these choices (why a derivative-free pattern search rather than a
+smooth solver, why these weights, and why these exclusions), see
+`docs/star-detection-optimization-wizard-design.md` in the project repository.
+
+
+## optimization/labels-recall-precision.md (4)
+
+### [medium] (style) documentation/docs/optimization/labels-recall-precision.md lines 6-7, phrase "the objective gains a fourth term"
+
+**Issue:** Terminology drift from the sibling page: objective-function.md (and OptimizationObjective.cs, Wcov = 0.05) documents five additive sub-scores (S_focus, S_stars, S_fit, S_cov, S_label), so calling S_label "a fourth term" contradicts the page it links to. "Additional" avoids re-counting and stays correct if terms change.
+
+**Suggested fix:**
+
+instead of a proxy, you give it ground truth: hand-drawn **labels**. With labels present, the objective gains an
+additional term, \(S_{\text{label}}\), scored directly against the boxes you drew.
+
+### [low] (style) documentation/docs/optimization/labels-recall-precision.md line 9: "Without labels the optimizer runs on the focus / star-count / curve-fit terms alone."
+
+**Issue:** Same drift as above: the label-free objective also includes the region-coverage term (S_cov, weight 0.05) documented on objective-function.md, so the three-term enumeration is incomplete.
+
+**Suggested fix:**
+
+This is entirely optional. Without labels the optimizer runs on the focus / star-count / curve-fit / coverage terms alone.
+
+### [low] (style) documentation/docs/optimization/labels-recall-precision.md lines 35 and 37, bullets "**Recall** — the fraction..." and "**Precision** — the fraction..."
+
+**Issue:** Paired definitional em-dashes; the directly parallel bullets in objective-function.md write these same two definitions as "**Recall** = the fraction..." / "**Precision** = the fraction...". Using "=" removes both em-dashes and makes the two pages' definitions read identically.
+
+**Suggested fix:**
+
+- **Recall** = the fraction of *recall-target* boxes (missed ∪ wrongly-rejected) that now contain at least one
+  accepted star center. If you labeled nothing to recover, recall is 1.0 by definition.
+- **Precision** = the fraction of *should-reject* boxes that now contain **no** accepted star center, i.e. the
+  spurious detection has successfully been excluded. If you labeled no false positives, precision is 1.0.
+
+### [low] (style) documentation/docs/optimization/labels-recall-precision.md line 38: "the spurious detection has successfully been excluded"
+
+**Issue:** "successfully" is a filler adverb (the exclusion either happened or it did not); the sibling page states the same fact without it ("the bad detection has been excluded").
+
+**Suggested fix:**
+
+i.e. the spurious detection has been excluded. If you labeled no false positives, precision is 1.0.
+
+
+## optimization/objective-function.md (5)
+
+### [medium] (style) documentation/docs/optimization/objective-function.md lines 52-53: "When you select **\"Optimize for Aberration Inspection\"** on the wizard's start page"
+
+**Issue:** UI label does not match the exact in-app text. The wizard start-page checkbox (StarDetection/Optimization/DataTemplates.xaml line 363) reads "Optimize for aberration inspection (favor more stars)" — sentence case with a parenthetical, not title case. Note: optimization/index.md shares this same drift, so the fix should ideally be applied section-wide.
+
+**Suggested fix:**
+
+When you select **"Optimize for aberration inspection (favor more stars)"** on the wizard's start page, the optimizer swaps in a star-count-favoring objective
+
+### [medium] (style) documentation/docs/optimization/objective-function.md line 164: "This term reinforces what the **\"Optimize for Aberration Inspection\"** objective already favors"
+
+**Issue:** Second occurrence of the same UI-label mismatch: in-app text is sentence case ("Optimize for aberration inspection"), not title case.
+
+**Suggested fix:**
+
+    This term reinforces what the **"Optimize for aberration inspection"** objective already favors: stars spread
+
+### [medium] (style) documentation/docs/optimization/objective-function.md lines 158-159: "Coverage is allowed to cost a little focus tightness — recovering stars across the frame is worth a minor rise in \\(\\sigma_{\\text{focus}}\\) — but at one-eleventh..."
+
+**Issue:** Paired em-dashes in one sentence — the classic AI-writer tell the house style explicitly bans ("several per paragraph is not" fine). Sibling pages use parentheses for asides like this. This page carries 6 body-prose em-dashes vs 0-2 on every neighbor.
+
+**Suggested fix:**
+
+The weight is deliberately small (0.05). Coverage is allowed to cost a little focus tightness (recovering stars across the frame is worth a minor rise in \(\sigma_{\text{focus}}\)), but at one-eleventh of the focus weight it cannot override the dominant focus term.
+
+### [low] (style) documentation/docs/optimization/objective-function.md lines 229-232, the "!!! warning" admonition: "With the gates off (default) this penalty is inert and the objective is identical to the weighted-average form above. It exists so the optimizer can safely explore turning the gates on — recovering bloated donuts on the extremes — without learning..."
+
+**Issue:** Two problems: the admonition's first sentence restates the "Off is bit-identical" bullet ten lines above (admonitions should add information, not restate the main flow), and the second sentence contains another paired em-dash aside.
+
+**Suggested fix:**
+
+!!! warning "The defocus-aware gates are opt-in"
+    This penalty exists so the optimizer can safely explore turning the gates on (recovering bloated
+    donuts on the extremes) without learning to manufacture spurious near-focus stars.
+
+### [low] (style) documentation/docs/optimization/objective-function.md lines 17-18: "produces a wobbly curve and an uncertain minimum — you would land on a slightly different focuser position every run"
+
+**Issue:** Body-prose em-dash where a colon does the same work; part of the page's above-baseline em-dash density.
+
+**Suggested fix:**
+
+    look pretty but scatters the per-position HFR points produces a wobbly curve and an uncertain minimum:
+    you would land on a slightly different focuser position every run. Minimizing that uncertainty
+
+
+## optimization/search-algorithm.md (4)
+
+### [low] (style) documentation/docs/optimization/search-algorithm.md, lines 168-169: "The recommended auto-focus step size is **derived from the winning fit, not searched** — it is not one of the optimizer's variables."
+
+**Issue:** Body em-dash used for an appositive explanation (a colon reads better and the style guide says not to lean on em-dashes), and "auto-focus" drifts from the folder-standard spelling "autofocus" used across index.md, objective-function.md, step-size.md, and af-curve-fitting.md.
+
+**Suggested fix:**
+
+The recommended autofocus step size is **derived from the winning fit, not searched**: it is not one
+of the optimizer's variables.
+
+### [low] (style) documentation/docs/optimization/search-algorithm.md, line 134: "matching the auto-focus engine's averaging."
+
+**Issue:** Terminology drift: "auto-focus" where every sibling page in this folder writes "autofocus" (e.g. af-curve-fitting.md "the autofocus engine", objective-function.md "the autofocus step size").
+
+**Suggested fix:**
+
+   matching the autofocus engine's averaging.
+
+### [low] (style) documentation/docs/optimization/search-algorithm.md, line 41 (figure caption): "halves the step when a sweep finds nothing — converging on a local optimum."
+
+**Issue:** Body em-dash where a comma serves; the equivalent caption for the same figure on index.md and search-variables.md uses no em-dash.
+
+**Suggested fix:**
+
+*The compass search starts at the seed, probes each axis by \(\pm\)step, steps to the best improving
+neighbor, and halves the step when a sweep finds nothing, converging on a local optimum.*
+
+### [low] (style) documentation/docs/optimization/search-algorithm.md, line 77 (LATE row of the stage table): "everything else — the gate/measure knobs and the synthetic `DefocusAwareGates` switch"
+
+**Issue:** Em-dash inside a table cell introducing an elaboration; a colon is the cleaner house rendering.
+
+**Suggested fix:**
+
+| **LATE** | Re-runs only the cheap gate-and-measure step against an already-built context (a cache hit) | everything else: the gate/measure knobs and the synthetic `DefocusAwareGates` switch |
+
+
+## optimization/search-variables.md (8)
+
+### [high] (style) documentation/docs/optimization/search-variables.md line 78: "The optimizer starts from your **current** profile values (the seed) and only accepts strictly-improving moves, so the result can never be worse than where you started."
+
+**Issue:** Voice/factual drift from neighboring pages and the code. index.md and search-algorithm.md ("Three guarantees") both state the seed is the fully-default detection parameters unless the user enables "Start from my current settings", and StarDetectionOptimizerWizardVM.cs confirms it (`var seed = seedOverride ?? (StartFromCurrentSettings ? runs[0].Baseline : runs[0].Seed)`). Saying the seed is "your current profile values" also mis-attributes the never-worse-than-current guarantee, which actually comes from a separate wizard-level guard, not from seeding at current.
+
+**Suggested fix:**
+
+The optimizer starts from the seed (the **default** detection parameters, or your **current** settings when you choose *"Start from my current settings"*) and only accepts strictly-improving moves, so the result can never score worse than the seed; on top of that, the wizard never hands back a result worse than your current settings (see [search algorithm](search-algorithm.md#three-guarantees)).
+
+### [medium] (style) documentation/docs/optimization/search-variables.md line 41: "The seed reads your current params (both OFF by default), so the baseline is unchanged"
+
+**Issue:** Same seed-provenance drift as line 78 (the seed is the default parameters unless "Start from my current settings" is enabled), plus the informal "params" where the folder's prose consistently uses "parameters" (code font `StarDetectorParams` is reserved for code references).
+
+**Suggested fix:**
+
+The variable reads the distortion flag as its value and writes the same value to both flags. Both flags are OFF in the default seed parameters, so the baseline is unchanged, and the search may flip the pair on if it helps the curve.
+
+### [medium] (style) documentation/docs/optimization/search-variables.md line 3: "and it leaves everything else at your profile's current values"
+
+**Issue:** Inaccurate under the default seeding: non-curated parameters sit at the seed's values (the fully-default parameters, per index.md), and when the optimized snapshot is applied the remaining knobs follow the Simple-mode preset defaults (per OptimizedStarDetectionSettings.cs: "the remaining advanced knobs continue to follow Simple-mode preset defaults when this snapshot is applied"), not the profile's current values.
+
+**Suggested fix:**
+
+It tunes a deliberately small, **curated set** of knobs that have the largest, most predictable effect on the autofocus curve, and it leaves the rest out of the search entirely.
+
+### [medium] (style) documentation/docs/optimization/search-variables.md line 66: "The EARLY-keyed curated variables are: `NoiseClippingMultiplier`, `StructureLayers`, `NoiseReductionRadius`, `HotpixelThresholdingEnabled`, `HotpixelThreshold`, and the synthetic `DefocusAwareStructure` (it shares the early cache-key property name)."
+
+**Issue:** The list omits `DonutMorphCloseSize`, a curated axis (added when *Recover out-of-focus donut stars* is on) that is in `StarDetector.EarlyCacheKeyProperties` (the code comments call it "EARLY morph-close kernel"). Since the list already includes the donut-gated `DefocusAwareStructure`, the omission makes line 67's "LATE axes are everything else" wrongly imply a `DonutMorphCloseSize` move is a cache hit. (search-algorithm.md's EARLY/LATE table shares this omission and should get the same correction.)
+
+**Suggested fix:**
+
+The EARLY-keyed curated variables are: `NoiseClippingMultiplier`, `StructureLayers`, `NoiseReductionRadius`, `HotpixelThresholdingEnabled`, `HotpixelThreshold`, the synthetic `DefocusAwareStructure` (it shares the early cache-key property name), and, when donut recovery is enabled, `DonutMorphCloseSize` (the early morphological close).
+
+### [low] (style) documentation/docs/optimization/search-variables.md line 1: "# Search Variables — the Curated Search Space"
+
+**Issue:** Em-dash in the H1. Section headings in this folder do use "X — y" separators (house style), but no sibling page title does; the established H1 pattern for a title-plus-subtitle is a colon ("Labels: Recall and Precision").
+
+**Suggested fix:**
+
+# Search Variables: The Curated Search Space
+
+### [low] (style) documentation/docs/optimization/search-variables.md line 31: "That is the **12** always-on axes."
+
+**Issue:** Subject–verb agreement: singular "That is" with the plural "12 always-on axes". (The counts themselves check out against OptimizerVariable.cs: 12 base axes, 21 with the donut master on.)
+
+**Suggested fix:**
+
+Those are the **12** always-on axes.
+
+### [low] (style) documentation/docs/optimization/search-variables.md line 54: "which is then **clamped** to `[Lower, Upper]` and **quantized** to a legal value of its type before being stored"
+
+**Issue:** Order contradicts both the code and the page's own next bullet: `OptimizerVariable.Quantize` rounds/thresholds first and then clamps, and line 57 says "`Math.Round(v, AwayFromZero)`, then clamped".
+
+**Suggested fix:**
+
+Every proposal flows through the variable's descriptor as a `double`, which is **quantized** to a legal value of its type and then **clamped** to `[Lower, Upper]` before being stored:
+
+### [low] (style) documentation/docs/optimization/search-variables.md line 50: "so the seed's `J` is unchanged"
+
+**Issue:** Terminology drift: every neighboring page sets the objective symbol in math mode (\(J\), \(J_{\text{run}}\), \(J_{\text{seed}}\)); code font `J` breaks that convention.
+
+**Suggested fix:**
+
+so the seed's \(J\) is unchanged
+
+
+## overview/autofocus.md (1)
+
+### [medium] (style) documentation/docs/overview/autofocus.md, lines 9-14 ("**Multiple curve-fitting models** — hyperbolic ..." through "**HFR-improvement validation** — an optional ...")
+
+**Issue:** Six consecutive bullets use an em-dash as the separator between the bold lead-in and its description. This is the classic AI-writer em-dash cluster (six in one list), and it drifts from the established list style on neighboring pages: star-detection.md and hyperbola-fitting.md use '**Bold lead-in.** Sentence.' (e.g. '**Local background plane.** Pixels in an annulus...', '**Consensus outlier rejection.** Each candidate proposes...') or let the bold phrase flow directly into the sentence with no dash. The house style doc explicitly names leaning on em-dashes as the biggest tell to avoid.
+
+**Suggested fix:**
+
+- **Multiple curve-fitting models.** Hyperbolic (several asymmetric variants), parabolic, and trendline fits, each with a goodness-of-fit rejection gate (\(R^2\) or reduced \(\chi^2\)). See [Hyperbolic Curve Fitting](hyperbola-fitting.md) for the model formulas and when each applies.
+- **Hybrid model selection.** At the end of a run every hyperbolic model is refit and the one with the least expected error for the best-focus position is kept, so each run self-selects its most trustworthy fit.
+- **Weighted fitting.** Each point carries its own measurement uncertainty \(\sigma\) (the per-frame star-HFR scatter), and the fit can weight points by \(1/\sigma^2\) so a noisy point counts for less.
+- **Outlier rejection.** An iterative two-tailed Grubbs test removes points that do not belong on the curve (e.g. a frame ruined by a cloud or satellite).
+- **Stability reporting.** A leave-one-out (LOO) cross-validation estimates how much the best-focus position would move if any single point were dropped.
+- **HFR-improvement validation.** An optional before/after check confirms the run actually made the stars sharper, retrying the run if it did not.
+
+
+## overview/hyperbola-fitting.md (2)
+
+### [low] (style) documentation/docs/overview/hyperbola-fitting.md line 211: "Leave it on **Hybrid**."
+
+**Issue:** The in-app dropdown label is "Hybrid (Best Fit)" (Description attribute in Interfaces/HyperbolicFitModel.cs, rendered verbatim by EnumStaticDescriptionValueConverter). This is the one place the page directly tells the user what to select, so the first actionable mention should use the exact in-app text; the "Hybrid" shorthand elsewhere on the page is fine once anchored.
+
+**Suggested fix:**
+
+Leave it on **Hybrid (Best Fit)**. Across a large bank of real runs no single fixed model wins on every curve, so
+
+### [low] (style) documentation/docs/overview/hyperbola-fitting.md line 217: "**Tilted** is the best fixed asymmetric model"
+
+**Issue:** When recommending which fixed model to pick from the dropdown, the bolded name should match the exact in-app entry "Tilted Hyperbola" (Interfaces/HyperbolicFitModel.cs). The "Tilted" shorthand is fine in descriptive prose (e.g. the Hybrid selector steps) but not in the pick-this-option sentence.
+
+**Suggested fix:**
+
+near-symmetric curves; **Tilted Hyperbola** is the best fixed asymmetric model; **Smooth Blend** suits curves
+
+
+## overview/index.md (6)
+
+### [high] (style) documentation/docs/overview/index.md line 3: "in the words of its own description, provides **\"Improved Star Detection, Star Annotation, Auto Focus, and Tilt Correction for NINA.\"**"
+
+**Issue:** AI-summarizer voice: the manual quotes the plugin's own store blurb ("in the words of its own description") instead of stating the facts natively. Neighboring pages (star-detection.md, autofocus.md, star-annotation.md) open with direct declarative prose; the only house-sanctioned quoting is of exact in-app tooltips. A bolded marketing quote as the opening sentence reads as an AI summarizing a source document rather than writing the manual.
+
+**Suggested fix:**
+
+Hocus Focus is a plugin for [NINA](https://nighttime-imaging.eu/) that provides improved star detection, star annotation, auto focus, and tilt correction. It replaces or augments NINA's built-in star handling and auto-focus routines with a more accurate star detector, a fully customizable annotator, a concurrent auto-focus engine, and an aberration inspector that measures backfocus and sensor-tilt errors.
+
+### [high] (style) documentation/docs/overview/index.md line 5: "Per its documentation, you \"can use the new Star Detector or Annotator without requiring both\""
+
+**Issue:** Same source-narration tell: "Per its documentation" is the manual citing itself, and the scare-quoted fragment is stitched into the sentence. This is voice drift from every neighboring page, which states behavior directly. Also, `select **"Hocus Focus"**` doubles up quotes and bold; house style bolds UI labels without quotation marks.
+
+**Suggested fix:**
+
+The plugin is deliberately modular: the star detector, the annotator, and the auto-focus engine can each be enabled independently, so keep whichever pieces you like and leave the rest on NINA's defaults. The features are wired in under **Options → Imaging → Image Options**, where installing the plugin adds **Star Detection**, **Star Annotator**, and **Auto Focus** dropdowns; select **Hocus Focus** in each to turn that feature on.
+
+### [medium] (style) documentation/docs/overview/index.md line 42: "Start at the Simple level: \"higher accuracy (lower HFR Standard Deviation)\" is available \"if parameters are set properly,\" and the defaults are a reasonable starting point."
+
+**Issue:** Two unattributed quote fragments from the plugin description are stitched into one sentence, producing garbled syntax (X "is available" "if Y,") and continuing the quote-the-blurb pattern. State the claim plainly.
+
+**Suggested fix:**
+
+Start at the Simple level: the defaults are a reasonable starting point, and higher accuracy (lower HFR standard deviation) comes from setting parameters well. Move to Advanced only when you need to correct a specific behavior, and reach for the wizard when you want the settings tuned automatically rather than by hand.
+
+### [medium] (style) documentation/docs/overview/index.md line 34: "Hocus Focus exposes \"simpler configuration, with an advanced mode for fine tuning.\""
+
+**Issue:** Unattributed scare quotes around blurb text, again quoting the plugin description instead of writing native prose. "Simpler" is also a dangling comparative with no attribution left to anchor it.
+
+**Suggested fix:**
+
+Hocus Focus is simple to configure by default, with an advanced mode for fine tuning. There are three levels of control, in increasing order of effort:
+
+### [medium] (style) documentation/docs/overview/index.md line 27: "The inspector estimates **backfocus and tilt errors** by running an auto-focus..."
+
+**Issue:** Reflexive bolding: seven bolded phrases in one paragraph, most of them whole descriptive clauses ("**center and corner regions of the sensor split into a 3×3 grid**", "**replay saved AF runs**") rather than the key terms or UI labels the neighboring pages bold. The paragraph is also one very long sentence.
+
+**Suggested fix:**
+
+The inspector estimates **backfocus and tilt errors** by running an auto-focus and computing AF curves for the center and corner regions of the sensor, split into a 3×3 grid. The result is a full sensor tilt and curvature model, which lets it measure backfocus error even when tilt is present. For single exposures it also generates FWHM contour maps and eccentricity vector fields for a quick visual read, offers a 3D visualization of sensor tilt, and can replay saved AF runs. See [Tilt & Aberration Inspector](tilt-aberration-inspector.md), [Sensor Model Fitting](sensor-model.md) for how the tilt and curvature model is fit, and the [Tilt Adapter Wizard](tilt-adapter-wizard.md) for turning a measured tilt into concrete screw adjustments.
+
+### [low] (style) documentation/docs/overview/index.md line 19: "**customizable colors and fonts** ... **dynamic reloading of annotations without re-running star detection**"
+
+**Issue:** Clause-level bolding of feature descriptions, part of the same reflexive-bolding pattern across the feature-area section.
+
+**Suggested fix:**
+
+The annotator controls how detected stars are drawn on top of an image. It offers customizable colors and fonts for the star overlays, and it can reload annotations dynamically without re-running star detection, so you can restyle the overlay or change what is shown without paying for another detection pass. See [Star Annotation](star-annotation.md).
+
+
+## overview/sensor-model.md (6)
+
+### [medium] (style) documentation/docs/overview/sensor-model.md line 131: "set by **Use RANSAC** (on by default)"
+
+**Issue:** UI label does not match the exact in-app text. The checkbox bound to InspectorOptions.UseRANSAC is labeled "Align images before matching" (AutoFocus/DataTemplates.xaml line ~1873, inside the Experimental expander). "Use RANSAC" is the option's property name, not a label a user can find in the panel. The dependent phrasings "(RANSAC off)" (line 133), "(RANSAC on)" (line 136), and "used when RANSAC is off" (line 153) lean on the same non-existent label. Note: tilt-aberration-inspector.md's options table uses the same wrong name, so fix both pages together.
+
+**Suggested fix:**
+
+In documentation/docs/overview/sensor-model.md:
+
+1. Replace lines 131-132 with:
+Two registration approaches are available, set by **Align images before matching** (on by default) under
+[Inspector options](tilt-aberration-inspector.md#inspector-options):
+
+2. Replace line 134 (start of first bullet) with:
+- **Nearest-neighbor only** (alignment off). Stars are matched directly in their original pixel
+
+3. Replace lines 136-138 (start of second bullet) with:
+- **RANSAC alignment first** (alignment on). Every frame is first transformed onto the reference frame by
+  a RANSAC-estimated transform (a similarity transform by default, or an affine one when **Use affine
+  alignment (diagnostic)** is on), so matching stars land almost on top of each other.
+
+4. Replace the end of the paragraph at lines 152-154 with:
+aligns on the first pass, is neither altered nor slowed. If any frame still cannot be placed, star
+matching for the whole sweep reverts to the wider nearest-neighbor search radius used when alignment
+is off.
+
+Companion fix (per the finding's note) in documentation/docs/overview/tilt-aberration-inspector.md options table, lines 135-136:
+| **Align images before matching** | on | on/off | Align frames with RANSAC before matching stars, improving registration robustness. |
+| **Use affine alignment (diagnostic)** | off | on/off | Use a 6-DOF affine transform (adds shear) instead of similarity; only enabled when alignment is on. |
+
+### [medium] (style) documentation/docs/overview/sensor-model.md line 192: "With **Fixed Sensor Center** on (the default)"
+
+**Issue:** UI label mismatch. The in-app checkbox is labeled "Sensor Centered" (AutoFocus/DataTemplates.xaml line ~1827; the property is FixedSensorCenter). A reader scanning the panel will not find a control called "Fixed Sensor Center". Shared with the inspector page's options table; coordinate the fix.
+
+**Suggested fix:**
+
+- **The center.** With **Sensor Centered** on (the default), \(X_0\) and \(Y_0\) are pinned to
+  zero and the sensor is assumed centered.
+
+### [medium] (style) documentation/docs/overview/sensor-model.md line 245: "below **Acceptable R² Min** (default \(0.05\))"
+
+**Issue:** UI label mismatch. The in-app label for InspectorOptions.AcceptableRSquaredMin is "Min R² (rejection)" (AutoFocus/DataTemplates.xaml line ~2003). "Acceptable R² Min" is derived from the property name and appears nowhere in the panel. Also used in tilt-aberration-inspector.md's options table.
+
+**Suggested fix:**
+
+  when \(R^2\) is below **Min R² (rejection)** (default \(0.05\)) *and* the reduced \(\chi^2\) is also
+  poor (above \(5\)).
+
+### [medium] (style) documentation/docs/overview/sensor-model.md lines 137-138: "when **Use Affine\nAlignment** is on"
+
+**Issue:** UI label mismatch. The in-app checkbox is labeled "Use affine alignment (diagnostic)" (AutoFocus/DataTemplates.xaml line ~1888). The docs' title-cased "Use Affine Alignment" drops the "(diagnostic)" qualifier, which is part of the visible label and signals the option's intent.
+
+**Suggested fix:**
+
+a RANSAC-estimated transform (a similarity transform by default, or an affine one when **Use affine
+  alignment (diagnostic)** is on), so matching stars land almost on top of each other.
+
+### [low] (style) documentation/docs/overview/sensor-model.md line 47: "## 4-Corners Model"
+
+**Issue:** Heading-case drift. Every other heading on this page ("## The sensor surface model", "## From stars to data points", "## Fitting the surface") and in neighboring pages ("## The tilt plane", "## The calibration loop", "## Weighted fitting and robustness") uses sentence case; this is the lone title-case heading, and it also disagrees with the body text's own "4-corners model".
+
+**Suggested fix:**
+
+## The 4-corners model
+
+### [low] (style) documentation/docs/overview/sensor-model.md line 59: "Each corner's **Adjustment Required** is its"
+
+**Issue:** Bolded as if it were an in-app label, but no UI element says "Adjustment Required"; the corresponding DataGrid columns are headed "Adj Steps" and "Adj Microns" (AutoFocus/DataTemplates.xaml lines 3482/3486). The inspector page uses the same phrase, so either tie the prose to the real column names or unbold it on both pages.
+
+**Suggested fix:**
+
+Each corner's required adjustment (the **Adj Steps** / **Adj Microns** columns) is its
+best-focus position minus that mean, reported in focuser steps (and in microns when *Microns per
+Focuser Step* is set).
+
+
+## overview/star-annotation.md (4)
+
+### [low] (style) documentation/docs/overview/star-annotation.md line 3: "which is invaluable when tuning detection or diagnosing focus problems"
+
+**Issue:** "Invaluable" is promotional puffery of the "powerful/robust" family; neighboring pages state what a feature does rather than praising it.
+
+**Suggested fix:**
+
+It is your window into what the detector actually saw, which helps when tuning detection or diagnosing focus problems.
+
+### [low] (style) documentation/docs/overview/star-annotation.md line 118: "Cap labels (**Show All Stars** off, **Maximum Stars** ≈ 200)"
+
+**Issue:** Internal inconsistency: the earlier tip (line 19) advises capping Maximum Stars at "a few dozen", but this recipe says ≈ 200, which is the documented default (line 33) and therefore caps nothing in practice.
+
+**Suggested fix:**
+
+Cap labels (**Show All Stars** off, **Maximum Stars** ≈ 50), then enable the rejection toggles one or two at a time with distinct colors. Walk the gates until the accepted set looks right for your focal ratio and seeing.
+
+### [low] (style) documentation/docs/overview/star-annotation.md lines 112-113: warning after the structure-map paragraph
+
+**Issue:** The warning's first sentence ("a debugging aid for tuning the structure-detection stage") restates line 110 ("exists for algorithm-level tuning rather than routine use"); only "it obscures the underlying image" is new. On a page already carrying 8 admonitions, this one should be folded into the body.
+
+**Suggested fix:**
+
+The mask pixels are blended onto the image in **Structure Map Color** (*"The color of the overlayed structure map"*; magenta/purple, half-transparent by default). This control is only exposed when the detector's debug mode is enabled, since it exists for algorithm-level tuning rather than routine use. Leave it off during normal focusing; the overlay obscures the underlying image.
+
+### [low] (style) documentation/docs/overview/star-annotation.md lines 43 and 102: quoted tooltips "Whether to show the a reticule on each star center" and "Overlays the structure map to aide debugging"
+
+**Issue:** The doc faithfully quotes tooltips that contain typos in the app itself ("the a reticule", "aide debugging" in Resources/OptionsDataTemplates.xaml lines 478 and 494). The doc is correct as verbatim quotation, but readers will attribute the typos to the manual; the fix belongs at the source, then re-quote.
+
+**Suggested fix:**
+
+Apply four exact-string edits (fix the app source first, then re-quote in the doc):
+
+1. Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml line 478 — replace:
+    <TextBlock x:Key="ShowStarCenter_Tooltip" Text="Whether to show the a reticule on each star center" />
+with:
+    <TextBlock x:Key="ShowStarCenter_Tooltip" Text="Whether to show a reticule on each star center" />
+
+2. Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml line 494 — replace:
+    <TextBlock x:Key="ShowStructureMap_Tooltip" Text="Overlays the structure map to aide debugging. Original shows the initial structure map after noise clipping and binarization, and Dilated shows it after dilation has been performed" />
+with:
+    <TextBlock x:Key="ShowStructureMap_Tooltip" Text="Overlays the structure map to aid debugging. Original shows the initial structure map after noise clipping and binarization, and Dilated shows it after dilation has been performed" />
+
+3. documentation/docs/overview/star-annotation.md line 43 — replace:
+| Show Star Center | On | on / off | *"Whether to show the a reticule on each star center"*. |
+with:
+| Show Star Center | On | on / off | *"Whether to show a reticule on each star center"*. |
+
+4. documentation/docs/overview/star-annotation.md line 102 — replace:
+**Show Structure Map** overlays the detector's binary structure mask so you can see exactly which pixels were treated as potential star structure. Its tooltip: *"Overlays the structure map to aide debugging. Original shows the initial structure map after noise clipping and binarization, and Dilated shows it after dilation has been performed"*.
+with:
+**Show Structure Map** overlays the detector's binary structure mask so you can see exactly which pixels were treated as potential star structure. Its tooltip: *"Overlays the structure map to aid debugging. Original shows the initial structure map after noise clipping and binarization, and Dilated shows it after dilation has been performed"*.
+
+
+## overview/star-detection.md (5)
+
+### [medium] (style) documentation/docs/overview/star-detection.md line 142, "Tune with" cell: "min star box size"
+
+**Issue:** Setting name matches nothing in the product or the rest of the manual. The in-app label (OptionsDataTemplates.xaml) and the settings page (settings/acceptance-gates.md) both call it "Min Bounding Box Size"; a reader searching the Advanced list for "min star box size" will not find it.
+
+**Suggested fix:**
+
+| Too small | bounding box width or height below the minimum box size | min bounding box size |
+
+### [low] (style) documentation/docs/overview/star-detection.md lines 144-150, gate table "Tune with" column
+
+**Issue:** The remaining "Tune with" entries are lowercased ("max distortion", "brightness sensitivity", "star center tolerance", "star peak response", "min HFR", "contamination sensitivity") while the in-app labels and every settings page use exact Title Case. House rule: use the exact in-app UI labels.
+
+**Suggested fix:**
+
+| Too distorted | fill ratio (pixels / \(d^2\)) below the max-distortion threshold | Max Distortion |
+| Degenerate | parameters could not be computed | — |
+| Low sensitivity | normalized brightness / noise sigma at or below the sensitivity threshold | Brightness Sensitivity |
+| Not centered | centroid falls outside the centered acceptance sub-box | Star Center Tolerance |
+| Too flat | star median at or above peak-response × peak (a flat blob, not a peaked star) | Star Peak Response |
+| HFR failed / too low | HFR could not be measured, or is at/below the minimum HFR | Min HFR |
+| Contaminated | a one-sided neighbor was detected in the annulus (when rejection is on) | Contamination Sensitivity |
+
+### [low] (style) documentation/docs/overview/star-detection.md line 46: "With *hot-pixel thresholding* enabled"
+
+**Issue:** Italicized as a setting reference, but the in-app label is "Use Hotpixel Thresholding" and settings/hotpixel-saturation.md phrases it as "when **Use Hotpixel Thresholding** is on". "hot-pixel thresholding" matches neither the label's spelling nor its casing.
+
+**Suggested fix:**
+
+(which span many pixels) essentially untouched. With **Use Hotpixel Thresholding** enabled, only pixels that
+
+### [low] (style) documentation/docs/overview/star-detection.md line 83: "a **noise-clipping multiplier**"
+
+**Issue:** Bolded as a setting reference but lowercased and hyphenated; the in-app label and settings/preprocessing.md use "Noise Clipping Multiplier". (Lowercase "noise-clipping floor" as a concept elsewhere is house-consistent and fine.)
+
+**Suggested fix:**
+
+structure map's median plus the **Noise Clipping Multiplier** times an estimated noise sigma, where the sigma
+
+### [low] (style) documentation/docs/overview/star-detection.md line 153: "The *defocus-aware gates* option"
+
+**Issue:** Italicized lowercase reference to the setting the in-app UI and settings/acceptance-gates.md call "Defocus-Aware Gates".
+
+**Suggested fix:**
+
+bounding box, while a streak (a satellite trail or merged pair) fills far less. The **Defocus-Aware Gates**
+
+
+## overview/tilt-aberration-inspector.md (7)
+
+### [high] (style) documentation/docs/overview/tilt-aberration-inspector.md, "Inspector options" table (lines 125-154), e.g. "| **Num Regions Wide** |"
+
+**Issue:** The Setting column uses code-property-derived names instead of the exact in-app labels. The screenshot embedded directly above the table (inspector-options-empty.png) shows the real labels, so the table contradicts its own illustration. Verified against AutoFocus/DataTemplates.xaml: 20 of the 28 rows are wrong.
+
+**Suggested fix:**
+
+Apply these exact replacements in documentation/docs/overview/tilt-aberration-inspector.md:
+
+EDIT 1 — lines 69-71, replace:
+its best-focus position minus the mean, reported in focuser steps (and in microns, if you have set
+*Microns per Focuser Step*).
+with:
+its best-focus position minus the mean, reported in focuser steps (and in microns, if you have set
+*Focuser Step Size*).
+
+EDIT 2 — line 75, replace:
+Enabling **Sensor Curve Model** goes further.
+with:
+Turning on **Sensor Curve Model Enabled** goes further.
+
+EDIT 3 — line 89, replace:
+    Enable **Sensor Curve Model** when you intend to physically correct tilt or want curvature and
+with:
+    Turn on **Sensor Curve Model Enabled** when you intend to physically correct tilt or want curvature and
+
+EDIT 4 — lines 118-119, replace:
+These settings live in the inspector panel (not the main Options page). Defaults and ranges are taken
+from the option definitions; descriptions quote the in-app tooltips where one exists.
+with:
+These settings live in the inspector panel (not the main Options page). Defaults and ranges are taken
+from the option definitions; descriptions quote the in-app tooltips where one exists. The alignment,
+star-matching, outlier-rejection, and save-images settings (plus **Astigmatic field curvature** and
+**Min R² (rejection)**) sit inside an **Experimental** sub-expander within the Options section.
+
+EDIT 5 — replace the full table (lines 125-154) with:
+| Setting | Default | Range | What it does |
+|---|---|---|---|
+| **Eccentricity Grid Width** | 7 | odd, positive | "How many cells wide to divide the sensor pixels when generating a grid of eccentricity vectors … the height will be calculated proportionally." |
+| **Focuser Step Size** | -1 (auto) | -1 or &gt;0 | "How much the focuser moves per step, in microns. If this is set, the adjustment chart will include adjustments in microns." |
+| **Sensor ROI** | 1.0 | 0.1–1.0 | "Uses only a centered portion of the full sensor when evaluating aberration. This is useful if you have a flattener that cannot produce a flat field for your sensor." |
+| **Corners ROI** | 1.0 | 0.1–1.0 | "Reduces the size of the corner regions when performing corners analysis … evaluate only stars closer to the corners than the full 1/9th region. This can be combined with Sensor ROI." |
+| **Sensor Curve Model Enabled** | off | on/off | "Create a paraboloid model of the sensor by creating focus curves for every star. This enables calculation of centering error and curvature … similar to … CCD Inspector." |
+| **Show Sensor Model** | on | on/off | Displays the 3D surface model in the panel. |
+| **Sensor Centered** | on | on/off | "Assume the sensor is perfectly centered in the optical train. If this option is off, the sensor location will be modeled along with the other model parameters." |
+| **Astigmatic field curvature** | off | on/off | "When off (default), field curvature is modeled as rotationally symmetric … Enable to fit independent X and Y curvature, representing the saddle-shaped field of an astigmatic optical train. Adds one free parameter." |
+| **Align images before matching** | on | on/off | Align frames with RANSAC before matching stars, improving registration robustness. |
+| **Use affine alignment (diagnostic)** | off | on/off | Use a 6-DOF affine transform (adds shear) instead of similarity; only enabled when **Align images before matching** is on. |
+| **Outlier rejection** | on | on/off | Drop matched stars whose per-star hyperbolic fit is too poor. |
+| **Match using brightness** | off | on/off | Enable an adaptive search that rejects matched stars whose brightness differs too much. |
+| **Starting Brightness Tolerance** | -1 (auto) | -1 or &ge;0.01 | Starting brightness tolerance for the adaptive match search; -1 starts from the previous run's value. |
+| **Min R² (rejection)** | 0.05 | 0–1 | Minimum model \(R^2\) for acceptance; only triggers rejection when reduced \(\chi^2\) also fails. |
+| **Max Stars Per Region** | -1 (unlimited) | -1 or &gt;0 | Cap on the number of (brightest) stars used per region. |
+| **Eccentricity Color Enabled** | on | on/off | "Enable color on the eccentricity map." |
+| **Mouse Events Enabled** | on | on/off | "Enable mouse events on charts to scroll, pan, and zoom. Disable this if you don't want the charts to intercept mouse actions." |
+| **Steps** | -1 (auto) | -1 or &gt;0 | "The minimum number of data points needed on each side of the AutoFocus curve minimum. Uses the value set for AutoFocus if blank." |
+| **Step Size** | -1 (auto) | -1 or &gt;0 | "How many focuser steps in between each data point … Uses the value set for AutoFocus if blank." |
+| **Signal Amplification** | 2 | &ge;1 | "Increases the resolution and signal of sensor-model / tilt calibration runs by capturing more, finer-spaced focuser points. The focuser step size is divided by this factor and the number of steps multiplied by it, so the sweep covers the same range with more points (and smaller defocus jumps between adjacent frames, which makes star alignment more reliable) … Set to 1 to disable. Applies to live captures only." Sits above the Options expander, with a live estimate of the images each run will capture. |
+| **Center Focuser First** | off | on/off | "When on, a quick standard AutoFocus is run before each live sensor-model / tilt calibration sweep to center the focuser at best focus. The detailed sweep then brackets focus symmetrically, which reduces extreme one-sided defocus frames that fail to align … Has no effect when replaying saved frames." Sits above the Options expander, next to Signal Amplification. |
+| **Exposures per Point** | -1 (auto) | -1 or &ge;1 | "How many exposures to average together for each focuser point. Uses the value set for AutoFocus if blank." |
+| **AutoFocus Timeout** | -1 (auto) | -1 or &gt;0 | "How long, in seconds, after which AutoFocus should time out and fail. Uses the value set for AutoFocus if blank." |
+| **Simple Analysis exposure** (the unlabeled seconds box beside **Take Exposure**) | -1 (auto) | -1 or &gt;0 | "How long of an exposure to take for analysis. Defaults to the Auto Focus exposure duration if not set." Sets the exposure for the single-frame Simple Analysis. |
+| **AutoFocus Exposure** | -1 (auto) | -1 or &gt;0 | Per-frame exposure for a Detailed Analysis sweep; defaults to the AutoFocus exposure duration when blank. Unlike the Simple Analysis exposure box, this sets the per-frame exposure for the multi-frame Detailed Analysis sweep. |
+| **Looping** | off | on/off | "If enabled, repeatedly take and analyze exposures." |
+| **Save annotated images when rerunning a saved autofocus** | off | on/off | Save registered/alignment images when reanalyzing saved runs. |
+| **Save alignment images** | off | on/off | Also save the pre-alignment star-detection images. |
+
+### [medium] (style) documentation/docs/overview/tilt-aberration-inspector.md line 141: "| **Max Stars Per Region** | -1 (unlimited) | -1 or >0 | Cap on the number of (brightest) stars used per region. |"
+
+**Issue:** This row documents a setting that has no control in the inspector panel (MaxStarsPerRegion exists only in IInspectorOptions.cs; no XAML binds it anywhere), contradicting the section lead "These settings live in the inspector panel."
+
+**Suggested fix:**
+
+Delete line 141 from documentation/docs/overview/tilt-aberration-inspector.md — remove this entire table row (no replacement text):
+
+| **Max Stars Per Region** | -1 (unlimited) | -1 or &gt;0 | Cap on the number of (brightest) stars used per region. |
+
+Do not add a substitute note: the option has no control anywhere in the UI (only a persisted-options property consumed by SensorModel.cs), so it does not belong in a section introduced as "These settings live in the inspector panel."
+
+### [medium] (style) documentation/docs/overview/tilt-aberration-inspector.md, "What the inspector measures" table (lines 34-42), e.g. "| **Tilt effect** |" and "| **AutoFocus offset** |"
+
+**Issue:** Row labels do not match the panel's exact text: the app shows "Tilt Effect", "Curvature Effect", "Curvature Radius", "Critical Focus", "Mean Focuser Position", and "Auto Focus Offset" (title case, and "Auto Focus" with a space). This also drifts from tilt-adapter-wizard.md, which already uses "Tilt Effect" and "Curvature Effect".
+
+**Suggested fix:**
+
+| Measurement | What it means (from the panel tooltips) |
+|---|---|
+| **Tilt** | "The angle the sensor is tilted. 0 indicates no tilt, and values here are typically very small." |
+| **Tilt Effect** | "The maximum nominal distance from the corners of the sensor to the center, due purely to the modeled tilt." |
+| **Curvature Effect** | "The nominal distance from the corner of the sensor to the center, due purely to the modeled curvature. Curvature effect is more exaggerated on larger sensors." |
+| **Curvature Radius** | "Near focus, the base of the sensor parabola is close to a sphere. This value represents the radius of that sphere. Larger values indicate flatter curves, which are better." |
+| **Critical Focus** | "The focuser distance a pixel can be from optimal focus before the effects can be noticed. This value increases with larger (slower) F/ratios, which can tolerate more curvature before affecting image quality." |
+| **Mean Focuser Position** | "The weighted mean focuser position under the sensor curve … a focus point where pixels throughout the sensor have minimum absolute distance from optimal focus." |
+| **Auto Focus Offset** | "The number of focuser steps between the AutoFocus position and the Sensor Mean Focuser Position." |
+
+### [low] (style) documentation/docs/overview/tilt-aberration-inspector.md line 98: "the \"*N frames failed to align*\" condition is now rare"
+
+**Issue:** "is now rare" is changelog voice: it describes an improvement relative to an earlier release the manual reader has never seen. The manual should state current behavior.
+
+**Suggested fix:**
+
+escalates its search box for the hardest frames rather than giving up, so the "*N frames failed to align*" condition is rare.
+
+### [low] (style) documentation/docs/overview/tilt-aberration-inspector.md line 94: "!!! note \"Frame alignment is robust to heavy defocus\"" and line 135: "improving registration robustness"
+
+**Issue:** "robust"/"robustness" is on the house buzzword list. Neighboring pages use "robust" only in the statistics term-of-art sense (robust estimators, MAD); these two uses are the generic marketing sense.
+
+**Suggested fix:**
+
+Line 94: replace
+!!! note "Frame alignment is robust to heavy defocus"
+with
+!!! note "Frame alignment holds up under heavy defocus"
+
+Line 135: replace
+| **Use RANSAC** | on | on/off | Align frames with RANSAC before matching stars, improving registration robustness. |
+with
+| **Use RANSAC** | on | on/off | Align frames with RANSAC before matching stars, so matching stays reliable at the defocused ends of the sweep. |
+
+### [low] (style) documentation/docs/overview/tilt-aberration-inspector.md lines 6-8: "Is my backfocus right?* Backfocus is the spacing between the corrector/flattener and the sensor. And, when paired with a tilt-adapter calibration..."
+
+**Issue:** The backfocus definition interrupts the run of rhetorical questions and forces the next sentence to open with "And,", which reads disjointed.
+
+**Suggested fix:**
+
+*Is one corner sharper than the other? Is the field bowed? Is my backfocus right?* (Backfocus is the spacing between the corrector/flattener and the sensor.) When paired with a tilt-adapter calibration, the inspector translates those numbers into concrete screw-turn guidance.
+
+### [low] (style) documentation/docs/overview/tilt-aberration-inspector.md line 156: "!!! tip \"When Sensor ROI / Corners ROI help\""
+
+**Issue:** The tip largely restates the Sensor ROI and Corners ROI tooltips already quoted in the table 25 lines above; only the "keeps a bad corner from polluting the tilt fit" clause is new information. House style says admonitions should add, not restate.
+
+**Suggested fix:**
+
+!!! tip "Sensor ROI protects the tilt fit"
+    Restricting analysis to the well-corrected center (**Sensor ROI**) keeps a corner your
+    flattener cannot correct from polluting the tilt fit.
+
+
+## overview/tilt-adapter-wizard.md (2)
+
+### [medium] (style) documentation/docs/overview/tilt-adapter-wizard.md, lines 35-36: "opposite screws are always 180° apart regardless of mirroring,"
+
+**Issue:** An internal code comment (TiltCalibrationCalculator.cs:221) is quoted verbatim in quotation marks with no attribution. The house voice reserves quotation marks for user-visible text and always attributes it ("Per the tooltip, ...", as in tilt-aberration-inspector.md and the Microns per Focuser Step note on this same page). Presented this way, the quote reads as a citation of UI text the reader could go look for, and quoting one's own source comments is a generated-from-source tell.
+
+**Suggested fix:**
+
+  exploits this: opposite screws are always 180° apart regardless of mirroring, so it measures two
+  screws and places the other two 180° across.
+
+### [low] (style) documentation/docs/overview/tilt-adapter-wizard.md, lines 76-87: !!! tip "Tilt, backfocus, and curvature: what the screws can fix"
+
+**Issue:** This admonition carries two paragraphs of core conceptual content: it defines the Tilt Effect and Curvature Effect and explains the per-screw Tilt and Backfocus guidance amounts shown in the screenshot at the top of the page. The style guide says admonitions should add information that breaks the main flow, not carry it, and this page already has six callouts (siblings: sensor-model 0, tilt-aberration-inspector 3, autofocus 3). Promoting this one to a regular section keeps the text and restores the aside-only role of the remaining callouts.
+
+**Suggested fix:**
+
+## What the screws can fix
+
+The Sensor Model splits the focus surface into two effects. The **Tilt Effect** is the linear
+plane (one side focuses ahead of the opposite side); you null it by moving the screws
+*differentially*, reported as the per-screw **Tilt** amount.
+
+The **Curvature Effect** is the symmetric corners-versus-center bowl. The wizard reads it as a
+spacing error and derives a **backfocus** correction from it, reported as the per-screw
+**Backfocus** amount: turn all screws the same way to move the whole sensor along the optical axis
+(or add spacers for changes beyond the adapter's travel), then re-measure and repeat until the
+Curvature Effect stops dropping. What remains is the residual curvature of a correctly spaced
+system, set by your corrector design and focal ratio; the adapter cannot remove it (a
+better-matched corrector or stopping down does).
+
+
+## quick-start.md (3)
+
+### [medium] (style) documentation/docs/quick-start.md lines 35-37: "- **Star Detection** — the improved detector ... - **Auto Focus** — the concurrent autofocus engine"
+
+**Issue:** UI labels do not match the exact in-app text. The screenshot directly above (assets/screenshots/image-options-all.png) shows the NINA Image options dropdowns labeled "Star Detector", "Star Annotator", and "Autofocus", and the caption on line 33 uses those names, but the bullet list contradicts both by calling them "Star Detection" and "Auto Focus".
+
+**Suggested fix:**
+
+- **Star Detector** — the improved detector (see [Star Detection](overview/star-detection.md)).
+- **Star Annotator** — the customizable overlay (see [Star Annotation](overview/star-annotation.md)).
+- **Autofocus** — the concurrent autofocus engine (see [Autofocus](overview/autofocus.md)).
+
+### [medium] (style) documentation/docs/quick-start.md lines 40-41: "require Hocus Focus to be selected for **both** Auto Focus **and** Star Detection."
+
+**Issue:** Same dropdown-label drift as the bullet list ("Auto Focus" / "Star Detection" instead of the in-app "Autofocus" / "Star Detector"), and the bolding lands on the connectives "both" and "and" instead of the UI labels the reader must find.
+
+**Suggested fix:**
+
+    The autofocus engine and the Aberration Inspector require Hocus Focus to be selected for both
+    **Autofocus** and **Star Detector**. You can otherwise mix and match, for example keeping only the detector.
+
+### [low] (style) documentation/docs/quick-start.md line 51: "- **Default (autofocus repeatability)** — the everyday choice."
+
+**Issue:** "Default (autofocus repeatability)" is bolded in the same style as the exact UI label beside it ("Optimize for Aberration Inspection"), implying an on-screen option with that name; per optimization/index.md the start page actually has a single "Optimize for Aberration Inspection" toggle, and no control is labeled "Default (autofocus repeatability)".
+
+**Suggested fix:**
+
+- **Autofocus repeatability** (the default) — the everyday choice. It tunes detection so your autofocus
+  curves are tight and your best-focus position is repeatable run to run.
+
+
+## settings/acceptance-gates.md (5)
+
+### [medium] (style) documentation/docs/settings/acceptance-gates.md line 249, blockquote beginning "> MASTER toggle for defocus-aware donut detection."
+
+**Issue:** The blockquote presents itself as the verbatim in-app tooltip but omits the parenthetical "(also on the optimizer wizard's start page)" that the actual DefocusAwareDonutDetection_Tooltip contains (Resources/OptionsDataTemplates.xaml line 453). Quoted UI text must match the exact in-app text.
+
+**Suggested fix:**
+
+> MASTER toggle for defocus-aware donut detection (also on the optimizer wizard's start page). When ON, out-of-focus DONUT stars (heavily defocused stars that appear as hollow rings) are recovered: a morphological close reconnects fragmented rings and an annularity test lets a hollow ring pass the distortion gate like a filled disk (detection-only — it never changes HFR). It also unlocks the optimizer to tune ALL defocus-aware settings and to enable diffraction-spike / saturated-bloom suppression. Recommended for telescopes with a central obstruction (Newtonians/SCTs); leave OFF for refractors. Off by default; when OFF, detection is exactly as before.
+
+### [medium] (style) documentation/docs/settings/acceptance-gates.md line 304, blockquote ending "0 means OFF. Default 0."
+
+**Issue:** The quoted Donut Saturation Bloom Radius tooltip is truncated relative to the actual in-app text, which ends "Default 0 (OFF — the optimizer enables it when you label the saturated star's artifacts as should-reject)." (Resources/OptionsDataTemplates.xaml line 459). The dropped clause carries real information about when the optimizer turns the guard on, and the sibling Donut Max Streak Eccentricity quote on this same page keeps its equivalent clause.
+
+**Suggested fix:**
+
+> Only used while Defocus-Aware Donut Detection is on. Rejects candidates whose center lies within this many pixels of a saturated star, removing the bloom/halo fragments around a bright saturated star while keeping the star itself. 0 means OFF. Default 0 (OFF — the optimizer enables it when you label the saturated star's artifacts as should-reject).
+
+### [low] (style) documentation/docs/settings/acceptance-gates.md line 243: "as **\"Recover out-of-focus donut stars.\"**"
+
+**Issue:** The quoted Optimization Wizard checkbox label does not match the exact in-app text, which is "Recover out-of-focus donut stars (reflectors/SCTs)" (StarDetection/Optimization/DataTemplates.xaml line 346); the doc also folds a sentence-ending period inside the quoted label, making it look like part of the UI string.
+
+**Suggested fix:**
+
+[Optimization Wizard](../optimization/index.md)'s start page as **"Recover out-of-focus donut stars (reflectors/SCTs)"**.
+
+### [low] (style) documentation/docs/settings/acceptance-gates.md line 156: "The default of 1.2 is an honest-HFR floor calibrated to the current measurement pipeline; the older 1.5 floor was tuned against noise-inflated faint-star HFRs and is no longer appropriate."
+
+**Issue:** Developer jargon leaking into the user manual: "honest-HFR floor" is lifted from an internal code comment (StarDetectionOptions.cs line 182, "honest-HFR floor... (F3 follow-up)") and is meaningless to a reader; the sentence reads as changelog-speak rather than user guidance. (Note: "honest multiple of the real noise" elsewhere on the page is established product terminology from the tooltip and preprocessing.md, and was deliberately not flagged; "honest-HFR" appears nowhere else in the manual.)
+
+**Suggested fix:**
+
+Leave it at the default for almost all setups. Lower it only if you are extremely undersampled and confident your real stars measure below 1.2 px. Raising it discards the sharpest stars and is rarely useful. The default of 1.2 is calibrated to the current measurement pipeline; older versions defaulted to 1.5, which compensated for noise-inflated HFR measurements of faint stars and is no longer needed.
+
+### [low] (style) documentation/docs/settings/acceptance-gates.md line 56: "Because σ is measured on the same image that is actually sampled for star measurement, the number is an honest multiple of the real noise and behaves consistently across noise-reduction settings."
+
+**Issue:** This body sentence restates the quoted tooltip two lines above nearly verbatim ("...so this value is an honest multiple of the real noise and means the same thing regardless of noise-reduction settings"). The house pattern (e.g. contamination.md) elaborates on the tooltip rather than echoing it; the echo reads as generated padding.
+
+**Suggested fix:**
+
+**Smaller values are more sensitive** (they admit fainter stars); larger values are stricter. Because σ is measured on the image actually sampled for star measurement, the same threshold keeps its meaning whether or not noise reduction is enabled.
+
+
+## settings/adaptive-binarization.md (1)
+
+### [low] (style) documentation/docs/settings/adaptive-binarization.md line 103: "## Reverting to legacy behavior (you should not need to)"
+
+**Issue:** Editorializing parenthetical aside in a heading is a mild self-aware framing and drifts from house heading style. Other parenthetical headings in this folder are descriptive qualifiers ("Tuning workflow (Advanced mode)", "Half-Flux Radius (HFR)"), not asides addressed to the reader. The advice itself is already stated plainly in the section body ("The only reason to do that is to reproduce or compare against the old detector... leave them as they are"), so the aside is redundant.
+
+**Suggested fix:**
+
+## Reverting to legacy behavior
+
+
+## settings/advanced-debug.md (3)
+
+### [medium] (style) documentation/docs/settings/advanced-debug.md, line 263: "> When Save Intermediate is enabled, they are written to this path the next time star detection runs"
+
+**Issue:** Quoted in-app tooltip does not match the actual UI text. The XAML resource SaveIntermediatePath_Tooltip (Resources/OptionsDataTemplates.xaml line 496) reads "When Save Intermediate Files is enabled, ...". Every other blockquote on this page reproduces its tooltip verbatim (even preserving the "due from" grammar slip in the Pixel Scale tooltip), so this one-word paraphrase breaks the page's own convention and the house rule that UI text must match exactly.
+
+**Suggested fix:**
+
+> When Save Intermediate Files is enabled, they are written to this path the next time star detection runs
+
+### [low] (style) documentation/docs/settings/advanced-debug.md, lines 97-98: "watch **Total detected** rise without the spurious/**Structure candidates** counts ballooning"
+
+**Issue:** Garbled compound: "the spurious/**Structure candidates** counts" reads as if the results panel has a "spurious" count, which it does not (index.md lists only Structure candidates, Total detected, and the per-reason rejection counts). It also drifts from the established phrasing in preprocessing.md ("a good move raises **Total detected** while the **Structure candidates** count falls toward it (fewer spurious candidates ...)").
+
+**Suggested fix:**
+
+re-detect and watch **Total detected** rise without the **Structure candidates** count ballooning with spurious candidates in the [Star Detection Results panel](index.md#reading-the-results-the-star-detection-results-panel).
+
+### [low] (style) documentation/docs/settings/advanced-debug.md, lines 84-85: "(Noise-reduction radius: base radius 3/5; +1 is added whenever Hotpixel Thresholding is enabled (the default), so the applied radius is 4/6 (None stays 0 because filtering is off).)"
+
+**Issue:** Triple-nested parentheses (a parenthetical containing two further parentheticals) is over-parenthesized hedging that no sibling page uses; the house voice favors short declarative sentences. The content is fine; the packaging is the tell.
+
+**Suggested fix:**
+
+Noise-reduction radius: the base radius is 3/5; +1 is added whenever Hotpixel Thresholding is enabled (the
+default), so the applied radius is 4/6. None stays 0 because filtering is off.
+
+
+## settings/contamination.md (1)
+
+### [low] (style) documentation/docs/settings/contamination.md line 18 (Settings at a glance table): "0 – 20 (0 disables)"
+
+**Issue:** Spaced en-dash range '0 – 20' drifts from the house convention of unspaced en-dash ranges used in sibling tables and reference lines (e.g. acceptance-gates.md '0–100%', '1–1000', '0.01–1').
+
+**Suggested fix:**
+
+0–20 (0 disables)
+
+
+## settings/donut-aware.md (3)
+
+### [medium] (style) documentation/docs/settings/donut-aware.md line 11: "The whole group is gated by one master toggle."
+
+**Issue:** Terminology drift from acceptance-gates.md and the code: the Defocus-Aware Donut Detection master gates only the donut-recovery knobs (and implies the relaxations); Defocus-Aware Gates and Defocus-Aware Structure are independent toggles that act even with the master off (StarDetector.cs lines 575-580, 1382). The page's own figure caption ("The defocus-aware gates alone relax that gate") contradicts this sentence.
+
+**Suggested fix:**
+
+The donut-recovery knobs are gated by the Defocus-Aware Donut Detection master toggle; Defocus-Aware Gates and Defocus-Aware Structure are independent toggles. The numeric knobs and their full reference live on the
+
+### [low] (style) documentation/docs/settings/donut-aware.md lines 6-7: "The features are off by default; with the master toggle off, detection is identical to having them absent."
+
+**Issue:** Over-attributes the bit-identical guarantee to the master toggle alone. With the master off but Defocus-Aware Gates or Defocus-Aware Structure on, detection differs. The guarantee holds only when all the toggles are off (the default).
+
+**Suggested fix:**
+
+The features are off by default; with all of them off, detection is identical to having them absent.
+
+### [low] (style) documentation/docs/settings/donut-aware.md line 20: "| Donut morph close, annularity, streak, bloom | per knob | ..."
+
+**Issue:** The Setting column uses lowercase shorthand instead of the exact in-app UI labels; the house style requires exact labels and every other row in this table uses them (labels verified in OptionsDataTemplates.xaml and the acceptance-gates.md table).
+
+**Suggested fix:**
+
+| Donut Morph Close Size, Donut Min Annularity Hole Fraction, Donut Max Streak Eccentricity, Donut Saturation Bloom Radius | per knob | [Acceptance Gates](acceptance-gates.md#recover-out-of-focus-donut-stars) |
+
+
+## settings/hotpixel-saturation.md (1)
+
+### [low] (style) documentation/docs/settings/hotpixel-saturation.md, lines 105-106: "!!! note — The same threshold gates two things: the per-image **saturated-pixel count** in the metrics, and the per-star mask applied during PSF fitting. It does not, by itself, reject stars from the accepted set."
+
+**Issue:** Admonition that merely restates the main flow. Every point in this note already appears in the body paragraph under Saturation Threshold (line 97): the per-star mask during PSF fitting ("during PSF fitting it discards every pixel whose raw value is at or above the saturation threshold"), the metrics count ("The count of saturated pixels and saturated stars is tracked in the detection metrics"), and the no-rejection point ("Hocus Focus does **not** reject a partially-saturated star outright"). The house style guide says admonitions should add information that breaks the main flow, not restate it, and the neighboring pages' notes (e.g. preprocessing.md's "Why the default is 2", psf-modeling.md's "HFR is always measured; FWHM is not") all carry new content.
+
+**Suggested fix:**
+
+Delete the `!!! note` block at lines 105-106 together with the blank line that precedes it (line 104). Concretely, replace:
+
+!!! tip "When this helps"
+    Leave the default (99%) for most setups. **Lower** it if your sensor or processing introduces non-linearity or blooming just below the full-well point, so those tainted near-saturation pixels are also excluded from fits. **Raise** it toward 100% only if you are confident your sensor stays linear right up to the clip point and want to keep as many pixels as possible in the fit. Setting it too low needlessly throws away good pixels and can leave too few for a reliable fit.
+
+!!! note
+    The same threshold gates two things: the per-image **saturated-pixel count** in the metrics, and the per-star mask applied during PSF fitting. It does not, by itself, reject stars from the accepted set.
+
+---
+
+with:
+
+!!! tip "When this helps"
+    Leave the default (99%) for most setups. **Lower** it if your sensor or processing introduces non-linearity or blooming just below the full-well point, so those tainted near-saturation pixels are also excluded from fits. **Raise** it toward 100% only if you are confident your sensor stays linear right up to the clip point and want to keep as many pixels as possible in the fit. Setting it too low needlessly throws away good pixels and can leave too few for a reliable fit.
+
+---
+
+
+## settings/index.md (2)
+
+### [low] (style) documentation/docs/settings/index.md line 9: "The star-detection settings live under the star-detection options area."
+
+**Issue:** Tautological sentence that also dodges the exact in-app UI label. The tab is named "Star Detector" (Options.xaml, LblStarDetector), and the page's own screenshot caption already names it; house style requires exact in-app labels.
+
+**Suggested fix:**
+
+Open NINA's options, go to the **Plugins** tab, and select **Hocus Focus**. The star-detection settings live in the **Star Detector** tab. Two top-level switches decide which controls you see:
+
+### [low] (style) documentation/docs/settings/index.md lines 83-84: "**Structure candidates**" and "**Total detected**"
+
+**Issue:** These bolded labels do not match the exact in-app text: the Star Detection Results panel renders "Structure Candidates" and "Total Detected" (AutoFocus/DataTemplates.xaml lines 843 and 831). Note the sentence-case form is repeated in preprocessing.md, structure-detection.md, and advanced-debug.md, so fix manual-wide (or explicitly adopt sentence case) rather than on this page alone; this page is the canonical place that introduces the panel, so it should lead.
+
+**Suggested fix:**
+
+- **Structure Candidates** — bright structures evaluated as potential stars before any gate.
+- **Total Detected** — stars accepted after all gates.
+
+
+## settings/precision-recall.md (3)
+
+### [low] (style) documentation/docs/settings/precision-recall.md, lines 34-35: "It failed on faint subs, and the failure is worth recording so it is not repeated."
+
+**Issue:** "worth recording so it is not repeated" is the "it's worth noting" family of filler plus self-aware meta-narration about the document itself. The section heading ("Why hand-marking every star does not scale") and line 43 ("The lesson shaped the whole method") already carry this purpose, so the clause is redundant throat-clearing.
+
+**Suggested fix:**
+
+The first attempt had a vision model mark every star directly on stretched image tiles. It failed on faint subs. Each tile reaches the model downscaled to roughly a 256-pixel thumbnail, so the model guesses a position and scales it back up.
+
+### [low] (style) documentation/docs/settings/precision-recall.md, line 105: "This split is what turns a recall number into an actionable diagnosis"
+
+**Issue:** "actionable" is buzzword-adjacent ("actionable insights" territory) and adds nothing: the rest of the sentence already states why the split matters (different failure modes call for different fixes). No other page in the manual uses "actionable".
+
+**Suggested fix:**
+
+This split is what turns a recall number into a diagnosis, since a candidate-formation gap and a too-strict gate call for different fixes.
+
+### [low] (style) documentation/docs/settings/precision-recall.md, line 123: "excellent precision (about 0.85) but found only ~19% of the real SNR ≥ 12 stars"
+
+**Issue:** Mixed approximation styles in one sentence: "about 0.85" versus "~19%". The rest of the page's prose uses "about"/"roughly" (e.g. "about 79%", "about 12 pixels"), and the neighboring adaptive-binarization.md reports these same measurements as fractions (0.189, 0.85).
+
+**Suggested fix:**
+
+On a real ZWO ASI6200MM Pro train, Hocus Focus had excellent precision (about 0.85) but found only about 19% of the real SNR ≥ 12 stars.
+
+
+## settings/preprocessing.md (3)
+
+### [medium] (style) documentation/docs/settings/preprocessing.md, line 100 (blockquote "> Makes the structure-map binarization threshold spatially adaptive...")
+
+**Issue:** The quoted Locally Adaptive Binarization tooltip does not match the actual in-app tooltip text. The doc silently drops the parenthetical "— local background median + Noise Clipping Multiplier × local noise σ —" and the final three sentences ("Recovers faint real stars... On by default... EARLY-stage setting."). The house convention is verbatim tooltip quotes: structure-detection.md line 51 and acceptance-gates.md line 282 both keep trailing sentences like "EARLY-stage setting.", and every other blockquote on this page matches OptionsDataTemplates.xaml exactly.
+
+**Suggested fix:**
+
+> Makes the structure-map binarization threshold spatially adaptive. Normally a single global threshold (background median + Noise Clipping Multiplier × global noise σ) is applied across the whole frame, which is too high in clean regions (losing faint stars) and too low in noisy corners (admitting noise). When enabled, the threshold becomes a smooth surface computed from robust local statistics on a coarse block grid — local background median + Noise Clipping Multiplier × local noise σ — so the same Noise Clipping Multiplier is locally fair everywhere. Recovers faint real stars in clean regions while rejecting noise in vignetted/gradient-heavy corners. On by default; turn it off to revert to the single global threshold, which makes detection bit-for-bit identical to the legacy behavior. EARLY-stage setting.
+
+### [low] (style) documentation/docs/settings/preprocessing.md, lines 137-138 ("!!! note / This value has no effect unless Locally Adaptive Binarization is on.")
+
+**Issue:** Admonition that merely restates the main flow: the quoted tooltip nine lines above already opens with "Only used while Locally Adaptive Binarization is on.", and the section is nested under the Locally Adaptive Binarization heading. The style guide says a note should add information that breaks the main flow, not restate it; sister-page notes (structure-detection.md line 18, acceptance-gates.md line 309) all add cross-page routing rather than repeating the section.
+
+**Suggested fix:**
+
+Delete lines 137-139 of documentation/docs/settings/preprocessing.md (the "!!! note" block and its trailing blank line), so the section ends:
+
+The default of 128 px matches the reference detector used to validate the feature.
+
+## Star Clipping Multiplier
+
+### [low] (style) documentation/docs/settings/index.md, line 165 ("- [Advanced & Debug](advanced-debug.md) — measurement averaging, pixel sample size, intermediate files, debug mode.")
+
+**Issue:** Cross-page drift discovered while checking this page against its neighbors: index.md's sub-page list says Pixel Sample Size is documented on Advanced & Debug, but the setting is actually documented on preprocessing.md (advanced-debug.md only mentions it in a preset table), and the Preprocessing bullet on line 159 omits it. Readers following the index will look for the setting on the wrong page.
+
+**Suggested fix:**
+
+Line 159: - [Preprocessing & Noise](preprocessing.md) — hotpixel filtering, noise reduction radius, clipping multipliers, measurement noise reduction, pixel sample size.
+Line 165: - [Advanced & Debug](advanced-debug.md) — measurement averaging, intermediate files, debug mode.
+
+
+## settings/psf-modeling.md (5)
+
+### [medium] (style) documentation/docs/settings/psf-modeling.md lines 113 and 126: "watch the **PSFFitFailed** count in the [Star Detection Results panel]"
+
+**Issue:** UI label mismatch. The Star Detection Results panel row is labeled "PSF Failed" (AutoFocus/DataTemplates.xaml line 1025, Text="PSF Failed"), but both tips tell the reader to look for a bolded **PSFFitFailed** count in that panel. Sibling pages use the exact panel label when pointing at the results panel (e.g. contamination.md: "watch the **Contaminated** rejection count"). The backticked `PSFFitFailed` code references on lines 13 and 94 are fine; only the two panel-facing bolded uses are wrong.
+
+**Suggested fix:**
+
+Line 113: replace "and watch the **PSFFitFailed** count in the [Star Detection Results panel](index.md#reading-the-results-the-star-detection-results-panel) for any change in fit rejections." with "and watch the **PSF Failed** count in the [Star Detection Results panel](index.md#reading-the-results-the-star-detection-results-panel) for any change in fit rejections."
+
+Line 126: replace "and watch the **PSFFitFailed** count in the [Star Detection Results panel](index.md#reading-the-results-the-star-detection-results-panel) for any shift in fit rejections." with "and watch the **PSF Failed** count in the [Star Detection Results panel](index.md#reading-the-results-the-star-detection-results-panel) for any shift in fit rejections."
+
+(Leave the backticked `PSFFitFailed` code references on lines 13 and 94 unchanged.)
+
+### [low] (style) documentation/docs/settings/psf-modeling.md line 53: "**PSF Type** (property `PSFFitType`) — selects which analytic profile is fit to each star."
+
+**Issue:** Em-dash in running prose plus structural drift: every other setting section on this page and on sibling pages opens with a plain declarative sentence ("**Fit PSF** (property `ModelPSF`) is the master switch...", "How finely each star's bounding box is sampled..."; contamination.md: "Sets how large the one-sided asymmetry must be..."). This is the only headline sentence on the page fused with an em-dash fragment. (The "**Moffat 4.0** — ..." bullets on lines 65-68 were deliberately not flagged: the "**Term** — definition" bullet pattern is established house style in index.md, preprocessing.md, and advanced-debug.md.)
+
+**Suggested fix:**
+
+**PSF Type** (property `PSFFitType`) selects which analytic profile is fit to each star.
+
+### [low] (style) documentation/docs/settings/psf-modeling.md line 126: "To gauge the effect, compare reported FWHM/σ stability before and after and watch the **PSFFitFailed** count in the [Star Detection Results panel](...) for any shift in fit rejections."
+
+**Issue:** Boilerplate repetition, an AI-writer tell: this sentence is a near-verbatim duplicate of the evaluation sentence in the PSF Pixel Integration tip 13 lines earlier (line 113, "To judge it, compare reported FWHM/σ stability before and after, and watch the ... count ... for any change in fit rejections"). Two adjacent tips reciting the same recipe reads as generated; state it once and cross-reference.
+
+**Suggested fix:**
+
+    Try it on **noisy frames** or fields with frequent outlier pixels where ordinary fits are being pulled around, and when you want behavior closer to PixInsight's PSF logic. Judge it the same way as PSF Pixel Integration above: FWHM/σ stability before and after, plus the **PSFFitFailed** count. Because it is experimental and slower, **leave it off** by default and enable it deliberately when robustness matters more than speed.
+
+### [low] (style) documentation/docs/settings/psf-modeling.md line 123: "The internal note describes it as \"more robust to noise and outlier pixels.\""
+
+**Issue:** Redundant self-citation: the sentence re-quotes the same tooltip that is already blockquoted verbatim four lines above (line 119). No sibling page re-cites its own blockquote, and "the internal note" is terminology used nowhere else in the manual (other pages just call it the tooltip or let the blockquote speak).
+
+**Suggested fix:**
+
+Fitting to minimize absolute deviation downweights outlier pixels (a hot pixel, a cosmic-ray hit, a nearby star's flux) relative to a least-squares fit, at a modest extra computational cost.
+
+### [low] (style) documentation/docs/settings/psf-modeling.md lines 41, 57, 79, 92, 108, 121, 134: "**Default:** On &nbsp;·&nbsp; **Range:** On / Off"
+
+**Issue:** Separator drift from neighboring pages: the two sibling pages that use an inline Default/Range separator (contamination.md, preprocessing.md) both use the bullet "&nbsp;•&nbsp;"; this page alone uses the middle dot "&nbsp;·&nbsp;" in all seven Default/Range lines.
+
+**Suggested fix:**
+
+Replace every "&nbsp;·&nbsp;" with "&nbsp;•&nbsp;" in documentation/docs/settings/psf-modeling.md. The seven corrected lines are:
+
+Line 41: **Default:** On &nbsp;•&nbsp; **Range:** On / Off
+Line 57: **Default:** Moffat 4.0 &nbsp;•&nbsp; **Range:** Gaussian, Moffat 4.0, Moffat 2.5, Moffat 1.5, Moffat (β fittable)
+Line 79: **Default:** 10 (pixels) &nbsp;•&nbsp; **Range:** integer > 0 (the field validates greater-than-zero; the backing property rejects negatives)
+Line 92: **Default:** 0.9 (R²) &nbsp;•&nbsp; **Range:** (0, 1]. The field validates `0 ≤ value ≤ 1.0`; the backing property rejects values outside the open-low, closed-high interval \((0, 1]\)
+Line 108: **Default:** Off &nbsp;•&nbsp; **Range:** On / Off
+Line 121: **Default:** Off &nbsp;•&nbsp; **Range:** On / Off (property name `UsePSFAbsoluteDeviation`)
+Line 134: **Default:** 100 (stars) &nbsp;•&nbsp; **Range:** integer ≥ 0 (the backing property rejects negatives)
+
+
+## settings/structure-detection.md (2)
+
+### [high] (style) documentation/docs/settings/structure-detection.md, line 35: "At the default of 5 (2⁵=32), structures larger than 32 pixels in size are excluded from structure detection"
+
+**Issue:** The quoted tooltip does not match the exact in-app text. The shipped tooltip (Resources/OptionsDataTemplates.xaml line 436, StructureLayers_Tooltip) reads "At the default of 4 (2⁴=16), structures larger than 16 pixels in size are excluded from structure detection". The page quotes a stale 5/32 version.
+
+**Suggested fix:**
+
+> The number of dyadic (power of 2) layers to include in structure detection. At the default of 4 (2⁴=16), structures larger than 16 pixels in size are excluded from structure detection
+
+### [medium] (style) documentation/docs/settings/structure-detection.md, line 37: "**Default:** 4 (the tooltip's \"5/32 px\" wording describes the scaling relationship; the shipped default is 4, i.e. structures larger than \(2^{4}=16\) px)."
+
+**Issue:** This parenthetical explains away a "5/32 px" tooltip wording that no longer exists in the app (the shipped tooltip already says 4/16), so it currently makes a false claim about the UI text and becomes redundant once the quote on line 35 is corrected.
+
+**Suggested fix:**
+
+**Default:** 4 (structures larger than \(2^{4}=16\) px are removed as background). **Range:** any positive integer (validated as greater than zero).

--- a/docs/tilt-calibration-ux-design.md
+++ b/docs/tilt-calibration-ux-design.md
@@ -1,0 +1,232 @@
+# Tilt Calibration & Sensor Model UX — Design
+
+## Problem
+
+Users complain that Tilt Adapter Calibration and Sensor Model runs take too long. Two duration-extending
+features are on by default and buried in the Aberration Inspector's Options expander, invisible from the
+wizard entirely:
+
+- **Center Focuser First** (`InspectorOptions.CenterFocuserBeforeRun`, default **on**) — a full extra
+  standard autofocus before every live sensor-model sweep. The wizard pays this on every one of its 6
+  measurement steps.
+- **Signal Amplification** (`InspectorOptions.SignalAmplification`, default **2**) — multiplies the sweep
+  point count (offset steps × amp, step size ÷ amp), roughly doubling images per sweep at the default.
+
+In addition, the wizard always runs 6 steps even though the first 2 (Baseline → AllInward) exist only to
+measure the curvature/backfocus direction sign; guidance never states a turn direction (only IN/OUT); and
+there is no way to enter a known calibration manually.
+
+## Decisions confirmed with the user
+
+1. **Shared settings, two surfaces.** Signal Amplification and Center Focuser First remain single
+   `InspectorOptions` values; the wizard binds the same instances (no wizard-specific overrides).
+2. **Direction semantics.** Clockwise always drives a screw inward (hardware fact — right-hand thread).
+   The rig-specific unknown is whether that inward screw motion moves the sensor plate **toward the
+   telescope objective** or **away from it (toward the camera)**. No rotation-direction enum is needed;
+   IN ⇔ CW and OUT ⇔ CCW are fixed wording. The plate-direction unknown is exactly what
+   `ScrewInwardCurvatureSign` already encodes.
+3. **Manual calibration entry** lives in the wizard's pre-run settings panel (collapsed expander), and
+   applying it produces the same persisted calibration state the wizard writes (tagged as manual).
+4. **Stepper guidance uses signed steps** (`+35 steps` / `−35 steps`), positive = inward, matching the
+   convention the wizard prompts establish.
+
+## Feature 1 — Surface the sweep-cost settings
+
+### Behavior changes
+
+- `InspectorOptions.CenterFocuserBeforeRun` default flips **true → false** (both `InitializeOptions()`
+  and `ResetDefaults()`). Existing users who never persisted a value will see the centering AF stop
+  running — intended.
+- `SignalAmplification` default stays 2. No engine behavior changes.
+
+### Aberration Inspector UI (`AutoFocus/DataTemplates.xaml`)
+
+- Remove the "Signal Amplification" and "Center Focuser First" rows from the Options expander (current
+  row 7, ~L1767–1799).
+- Add a new always-visible block **above the Options expander** (between the buttons row and the
+  expander). Two rows, Signal Amplification **first**:
+  - Row layout: label + control on the left (same styles as existing option rows: `ninactrl:UnitTextBox`
+    for amplification, `CheckBox` for centering), and wrapping explanatory prose to the right
+    (`FontStyle="Italic"`, `Opacity="0.7"`, `TextWrapping="Wrap"` — the established prose style).
+- **Signal Amplification prose** (dynamic, new computed VM property, e.g.
+  `InspectorVM.SignalAmplificationSummary`):
+  > "Each auto focus run will capture ~**N** images (**P** focus positions × **F** exposures each). More,
+  > finer-spaced points give a steadier fit for weak signal; set to 1 to run a regular autofocus
+  > (fastest)."
+  Estimate: `P ≈ 2 × offsetSteps × amp + 1`, where `offsetSteps` = `InspectorOptions.StepCount` if > 0
+  else the profile's AF initial offset steps, and `F` = `FramesPerPoint` if > 0 else the profile's
+  frames-per-point. Labeled approximate ("~") because the AF engine can extend a sweep dynamically.
+  Recomputed when `SignalAmplification` / `StepCount` / `FramesPerPoint` / profile change.
+- **Center Focuser First prose** (static):
+  > "Runs one standard autofocus to center the focuser before each measurement sweep. Turn on if your
+  > focuser drifts between runs or starts far from best focus; leave off to save time."
+
+### Tilt Adapter Wizard UI (`TiltAdapterWizard/DataTemplates.xaml`, Panel A)
+
+- New **"Measurement"** bold sub-header after the "Focuser step size" row and before the
+  Calibrate/Replay buttons. Rows in order:
+  1. **Signal Amplification** (bound to the shared `InspectorOptions.SignalAmplification` via a wizard VM
+     passthrough property) with prose to the right, wizard-flavored and dynamic:
+     > "Every calibration step runs a full autofocus sweep of ~**N** images. At the current settings this
+     > calibration will take **S** sweeps ≈ **S×N** images total. Increase for more signal on faint
+     > stars; decrease to run faster (1 = a regular autofocus)."
+     `S` = (4 or 6, per Feature 3) × `MeasurementAverageCount`.
+  2. **Center Focuser First** (shared `InspectorOptions.CenterFocuserBeforeRun`) with prose:
+     > "Adds one standard autofocus before every measurement sweep to re-center focus. Turn on if focus
+     > drifts between steps (e.g., temperature) or your focuser starts far from focus."
+- The wizard VM exposes `IInspectorOptions InspectorOptions => inspector.InspectorOptions` (or
+  equivalent) for binding.
+
+## Feature 2 — Directional screw/stepper guidance (CW/CCW, signed steps)
+
+The numeric guidance pipeline already exists (`InspectorVM.FillNumericGuidance`,
+`TiltScrewGeometry.ScrewCorrectionMicrons` / `InwardAdjustment`,
+`TiltAdapterGuidanceVM.FormatMagnitude` / `FormatTotal`). Changes are wording plus the assumed-direction
+default (Feature 3):
+
+- **Screws:** totals become e.g. `1.25 turns CW (in)` / `0.50 turns CCW (out)`. IN maps to CW
+  unconditionally, per the confirmed hardware fact.
+- **Steppers:** totals become signed steps: `+35 steps (in)` / `−35 steps (out)`, positive = inward —
+  the same "+" the wizard's calibration prompts instruct.
+- Per-screw Tilt/Backfocus cells stay magnitude-only (the arrows carry direction). Add a one-line legend
+  under the guidance table: "⬆ = inward (clockwise)" (steppers: "⬆ = inward (+ steps)").
+- `FormatTotal` (and a new small formatter for the legend) extended and kept as **pure static helpers**
+  for unit testing.
+- Wizard step instructions and baseline-recovery text gain the fixed rotation words:
+  "Turn ALL screws INWARD (clockwise) exactly 1 full turn…", "…back OUT (counter-clockwise)…". For
+  stepper adapters the prompts switch to signed-step phrasing ("apply +N steps to every motor…"),
+  replacing the current turns-only wording, with N = `CalibrationAppliedAmount`.
+- The direction is available whenever calibration is available; because Feature 3 gives
+  `ScrewInwardCurvatureSign` an assumed default, totals always carry a direction word, with an
+  "(assumed)" caveat where the sign is not measured (see below).
+
+## Feature 3 — Curvature calibration becomes opt-in (4-step wizard by default)
+
+### Settings
+
+New/changed persisted options on `TiltAdapterOptions`:
+
+| Option | Type | Default | Meaning |
+|---|---|---|---|
+| `MeasureCurvatureDuringCalibration` | bool | **false** | Include the Baseline + AllInward steps (6-step wizard) to measure the direction sign. |
+| `ScrewInwardCurvatureSign` | int | **−1** (was 0) | Unchanged storage/semantics: +1 = inward turns raise the curvature effect; −1 = lower it. New default = the user-requested assumption "inward decreases curvature". |
+| `ScrewInwardCurvatureSignIsMeasured` | bool | **false** | Provenance: true only when a 6-step wizard run measured the sign. Cleared when the user edits the direction manually or applies manual calibration entry. |
+
+Physical interpretation shown to the user (consistent with `.claude/docs/tilt-domain.md` and the
+standard NINA focuser convention of position increasing = drawtube out): sign **−1** ⇔ "turning screws
+clockwise (inward) moves the sensor plate **away from the objective** — curvature effect decreases";
+sign **+1** ⇔ "…**toward the objective** — curvature effect increases". If a rig's guidance appears
+inverted, flipping this setting (or running the 6-step measurement) corrects it.
+
+### Wizard settings UI (Panel A, in the new "Measurement" section after Feature 1's rows)
+
+1. ComboBox **"Turning screws inward (CW)"** with two entries bound to the sign:
+   - "Moves sensor away from objective — curvature decreases" (−1, default)
+   - "Moves sensor toward objective — curvature increases" (+1)
+   For stepper adapters the label reads **"Applying + steps"** instead. Disabled while
+   `MeasureCurvatureDuringCalibration` is checked (measurement will overwrite it); after a measured run
+   it displays the measured value.
+2. CheckBox **"Measure curvature direction during calibration"** with prose to the right:
+   > "Adds 2 extra measurement steps (6 instead of 4 — about 50% longer) to determine the direction
+   > automatically. Turn on if you don't know how your adapter behaves, or to verify the setting above."
+
+### Wizard sequencing
+
+- When **off** (default): the run performs 4 measurement steps — Baseline → Screw1 → ReBaseline → Screw2
+  — by starting the existing linear sequence at `ReBaseline1` (its instruction text shows baseline
+  wording in this mode). `TiltCalibrationInputs.Baseline`/`AllInward` become optional; `Calibrate()`
+  passes the configured sign through instead of computing it, and `RunCalibrationMath` leaves
+  `ScrewInwardCurvatureSign`/`...IsMeasured` untouched.
+- When **on**: current 6-step behavior; the measured sign is written and `...IsMeasured = true`.
+- Confidence model (`ComputeConfidence`): without the AllInward residual and first re-baseline drift,
+  noise is estimated from the remaining re-baseline drift probe alone (1 probe instead of 3); the SNR
+  threshold and warnings are unchanged. Angle math, hardware recovery (`RecoverHardwareMicrons`),
+  magnitude-ratio and drift checks all use only the c→d / e→f deltas and are unaffected.
+- **Metadata/replay/validator:** `TiltCalibrationMetadata` records which steps ran (`RunStepMapping`
+  already lists them per step). Replaying an old 6-step run still measures the sign; a 4-step run
+  replays as 4 steps. The TestApp validator accepts both.
+- The wizard results panel and saved-calibration panel annotate the curvature row with
+  "(measured)" / "(assumed)" from `ScrewInwardCurvatureSignIsMeasured`.
+
+## Feature 4 — Manual calibration entry
+
+A collapsed **"Manual Calibration Entry"** expander at the bottom of wizard Panel A (below the
+saved-calibration display):
+
+- **Screw 1 position angle (°)** — TextBox, validated; 0° = straight up (12 o'clock) in the *image*,
+  increasing clockwise (the plugin-wide convention). Pre-filled from the current
+  `Screw1AngleDegrees` when a calibration exists.
+- **Screw numbering direction (in the image)** — ComboBox {Clockwise (default), Counter-clockwise}.
+  Remaining screws are placed at equal spacing: 3-screw ±120°; 4-screw ±90° with opposite screws 180°
+  apart — the same layout `ComputeScrewAngles` fits to.
+- The **curvature direction** setting from Feature 3 sits directly above in the same panel and is
+  called out in the expander's prose as the companion setting ("set the direction above if you know
+  it").
+- **Apply** button: writes `Screw1..4AngleDegrees`, `CalibratedScrewCount = ScrewCount`,
+  `IsCalibrated = true`, sets new persisted `CalibrationIsManual = true` (wizard runs set it false),
+  and clears `ScrewInwardCurvatureSignIsMeasured`. Inspector guidance activates immediately.
+- Prose warning (italic style):
+  > "Angles and numbering direction are in image space — mirrors or diagonals in the optical train can
+  > flip them relative to the physical adapter. If guidance moves tilt the wrong way, flip the numbering
+  > direction."
+- The saved-calibration panel shows a "Manually entered" tag when `CalibrationIsManual` is true.
+- Angle placement implemented as a **pure static helper** (e.g.
+  `TiltCalibrationCalculator.ComputeManualScrewAngles(screw1Deg, clockwise, screwCount)`) for unit
+  testing.
+
+## Incidental fix
+
+`InspectorOptions.TimeoutSeconds` setter persists under `nameof(StepCount)` (`InspectorOptions.cs:194`),
+silently corrupting the persisted step count whenever the timeout is edited. Fix the key to
+`nameof(TimeoutSeconds)` (forward-looking only; no migration).
+
+## Options-UI invariant
+
+All new persisted options get visible controls. They live in `TiltAdapterWizard/DataTemplates.xaml`,
+following the existing precedent that `TiltAdapterOptions` controls live in the wizard's own template
+(not `Resources/OptionsDataTemplates.xaml`). The two relocated inspector settings remain in
+`AutoFocus/DataTemplates.xaml`, just outside the Options expander.
+
+## Testing
+
+New/updated NUnit tests (test project links shared sources directly):
+
+- `TiltCalibrationCalculator`: 4-step inputs — sign passthrough, confidence noise fallback (single drift
+  probe), unchanged angle/hardware math; 6-step behavior regression.
+- `ComputeManualScrewAngles`: 3- and 4-screw, CW and CCW winding, wrap-around normalization.
+- `TiltAdapterGuidanceVM.FormatTotal` (+ legend formatter): CW/CCW wording, signed steps, "(assumed)"
+  handling, em-dash small-value behavior.
+- `InspectorOptions`: `CenterFocuserBeforeRun` default false; `TimeoutSeconds` persists under its own
+  key (and no longer clobbers `StepCount`).
+- `TiltAdapterOptions`: new option defaults (`ScrewInwardCurvatureSign` = −1, flags false).
+
+Full suite (`dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`) must pass.
+
+## Documentation deliverables
+
+Update the MkDocs manual (follow `.claude/docs/documentation-style.md`):
+
+- `overview/tilt-adapter-wizard.md` — 4-step default flow, optional 2-step curvature measurement,
+  manual entry, new Measurement section, CW/CCW prompt wording.
+- `overview/tilt-aberration-inspector.md` — relocated Signal Amplification / Center Focuser First
+  (new default), directional guidance wording and legend.
+- `overview/sensor-model.md`, `quick-start.md` — cross-references and defaults.
+
+## Alternatives considered
+
+- **Wizard-specific overrides** for amplification/centering — rejected by user (shared settings).
+- **A rotation-direction enum (CW/CCW = inward)** — rejected: CW⇒screw-inward is fixed by hardware; the
+  only rig-specific sign is the plate direction, already covered by `ScrewInwardCurvatureSign`.
+- **Leaving the direction unset until chosen** — rejected: user wants the inward-decreases default;
+  the "(assumed)" tag plus the IN/OUT word retained next to CW/CCW keeps a wrong assumption visible and
+  recoverable.
+- **Separate dialog for manual entry** — rejected in favor of an inline expander (fewer clicks, less
+  XAML surface).
+- **Up/Down stepper wording** — rejected in favor of signed steps (user choice).
+
+## Out of scope
+
+- Driving stepper motors automatically (the user still applies steps in vendor software).
+- Per-screw thread handedness or preset-carried direction data.
+- Changing the `SignalAmplification` default (stays 2).
+- Migrating historical `StepCount` values corrupted by the `TimeoutSeconds` key bug.

--- a/docs/tilt-calibration-ux-design.md
+++ b/docs/tilt-calibration-ux-design.md
@@ -16,19 +16,31 @@ In addition, the wizard always runs 6 steps even though the first 2 (Baseline �
 measure the curvature/backfocus direction sign; guidance never states a turn direction (only IN/OUT); and
 there is no way to enter a known calibration manually.
 
+## Terminology
+
+Two different motions get called "in/out"; this spec (and all new UI text) keeps them distinct:
+
+- **Screw motion**: clockwise (CW) always advances/tightens a screw — a fixed hardware fact, never a
+  setting. UI text says "clockwise/counter-clockwise (tighten/loosen)", never "in/out", for this.
+- **Adapter motion**: *inward* = the adapter's moving plate travels **toward the telescope objective**
+  (away from the camera); *outward* = toward the camera. Whether a CW screw turn produces inward or
+  outward adapter motion depends on the adapter design (push vs pull screws, spring loading) — **this
+  is the rig-specific configuration that needs a setting.**
+
+The existing wizard prompts use "INWARD" in the screw-motion sense; they will be reworded to
+"clockwise (tighten)" to remove the ambiguity.
+
 ## Decisions confirmed with the user
 
 1. **Shared settings, two surfaces.** Signal Amplification and Center Focuser First remain single
    `InspectorOptions` values; the wizard binds the same instances (no wizard-specific overrides).
-2. **Direction semantics.** Clockwise always drives a screw inward (hardware fact — right-hand thread).
-   The rig-specific unknown is whether that inward screw motion moves the sensor plate **toward the
-   telescope objective** or **away from it (toward the camera)**. No rotation-direction enum is needed;
-   IN ⇔ CW and OUT ⇔ CCW are fixed wording. The plate-direction unknown is exactly what
-   `ScrewInwardCurvatureSign` already encodes.
+2. **Direction semantics.** CW ⇒ screw advances is fixed; the setting captures whether that moves the
+   **adapter** inward (toward objective) or outward (toward camera). Guidance states rotation as
+   CW/CCW (always valid); adapter in/out wording is derived from the setting.
 3. **Manual calibration entry** lives in the wizard's pre-run settings panel (collapsed expander), and
    applying it produces the same persisted calibration state the wizard writes (tagged as manual).
-4. **Stepper guidance uses signed steps** (`+35 steps` / `−35 steps`), positive = inward, matching the
-   convention the wizard prompts establish.
+4. **Stepper guidance uses signed steps** (`+35 steps` / `−35 steps`), where "+" is the step direction
+   the wizard's calibration prompts establish.
 
 ## Feature 1 — Surface the sweep-cost settings
 
@@ -81,24 +93,27 @@ there is no way to enter a known calibration manually.
 
 The numeric guidance pipeline already exists (`InspectorVM.FillNumericGuidance`,
 `TiltScrewGeometry.ScrewCorrectionMicrons` / `InwardAdjustment`,
-`TiltAdapterGuidanceVM.FormatMagnitude` / `FormatTotal`). Changes are wording plus the assumed-direction
-default (Feature 3):
+`TiltAdapterGuidanceVM.FormatMagnitude` / `FormatTotal`). Internally, a positive `InwardAdjustment`
+means "turn the screw in the direction the calibration prompts used" — i.e. CW for screws — so the
+rotation word is a fixed mapping; only adapter in/out wording depends on the Feature 3 setting:
 
-- **Screws:** totals become e.g. `1.25 turns CW (in)` / `0.50 turns CCW (out)`. IN maps to CW
-  unconditionally, per the confirmed hardware fact.
-- **Steppers:** totals become signed steps: `+35 steps (in)` / `−35 steps (out)`, positive = inward —
-  the same "+" the wizard's calibration prompts instruct.
-- Per-screw Tilt/Backfocus cells stay magnitude-only (the arrows carry direction). Add a one-line legend
-  under the guidance table: "⬆ = inward (clockwise)" (steppers: "⬆ = inward (+ steps)").
+- **Screws:** totals become e.g. `1.25 turns CW` / `0.50 turns CCW`.
+- **Steppers:** totals become signed steps: `+35 steps` / `−35 steps`, with the same "+" the wizard's
+  calibration prompts instruct.
+- Per-screw Tilt/Backfocus cells stay magnitude-only (the arrows carry direction). Add a one-line
+  legend under the guidance table stating both conventions, with the adapter direction derived from
+  the Feature 3 setting: e.g. "⬆ = clockwise (adapter moves toward camera)" — steppers:
+  "⬆ = + steps (adapter moves toward camera)".
+- The tilt component's direction comes from the measured screw angles and is independent of the
+  Feature 3 setting; only the backfocus/total components depend on it. When the setting is assumed
+  rather than measured (Feature 3), the guidance shows an "(assumed direction)" annotation.
 - `FormatTotal` (and a new small formatter for the legend) extended and kept as **pure static helpers**
   for unit testing.
-- Wizard step instructions and baseline-recovery text gain the fixed rotation words:
-  "Turn ALL screws INWARD (clockwise) exactly 1 full turn…", "…back OUT (counter-clockwise)…". For
-  stepper adapters the prompts switch to signed-step phrasing ("apply +N steps to every motor…"),
-  replacing the current turns-only wording, with N = `CalibrationAppliedAmount`.
-- The direction is available whenever calibration is available; because Feature 3 gives
-  `ScrewInwardCurvatureSign` an assumed default, totals always carry a direction word, with an
-  "(assumed)" caveat where the sign is not measured (see below).
+- Wizard step instructions and baseline-recovery text are reworded from the ambiguous "INWARD/OUT" to
+  screw-motion terms: "Turn ALL screws CLOCKWISE (tighten) exactly 1 full turn…", "…back
+  COUNTER-CLOCKWISE (loosen)…". For stepper adapters the prompts switch to signed-step phrasing
+  ("apply +N steps to every motor…"), replacing the current turns-only wording, with
+  N = `CalibrationAppliedAmount`.
 
 ## Feature 3 — Curvature calibration becomes opt-in (4-step wizard by default)
 
@@ -108,25 +123,35 @@ New/changed persisted options on `TiltAdapterOptions`:
 
 | Option | Type | Default | Meaning |
 |---|---|---|---|
-| `MeasureCurvatureDuringCalibration` | bool | **false** | Include the Baseline + AllInward steps (6-step wizard) to measure the direction sign. |
-| `ScrewInwardCurvatureSign` | int | **−1** (was 0) | Unchanged storage/semantics: +1 = inward turns raise the curvature effect; −1 = lower it. New default = the user-requested assumption "inward decreases curvature". |
+| `MeasureCurvatureDuringCalibration` | bool | **false** | Include the Baseline + AllInward steps (6-step wizard) to measure the adapter direction. |
+| `ScrewInwardCurvatureSign` | int | **non-zero default** (was 0) | Unchanged storage/semantics: the sign of the focus/curvature response to a CW ("prompt-direction") screw turn, exactly what `ComputeCurvatureSign` measures. Now derived from the mechanical setting below when not measured. |
 | `ScrewInwardCurvatureSignIsMeasured` | bool | **false** | Provenance: true only when a 6-step wizard run measured the sign. Cleared when the user edits the direction manually or applies manual calibration entry. |
 
-Physical interpretation shown to the user (consistent with `.claude/docs/tilt-domain.md` and the
-standard NINA focuser convention of position increasing = drawtube out): sign **−1** ⇔ "turning screws
-clockwise (inward) moves the sensor plate **away from the objective** — curvature effect decreases";
-sign **+1** ⇔ "…**toward the objective** — curvature effect increases". If a rig's guidance appears
-inverted, flipping this setting (or running the 6-step measurement) corrects it.
+The **user-facing setting is mechanical**, per the confirmed framing: does a CW screw turn move the
+adapter inward (toward objective) or outward (toward camera)? It is presented as a two-entry ComboBox
+and stored via `ScrewInwardCurvatureSign` through a **fixed mapping constant** (the physics/focuser
+convention linking adapter motion to the measured focus-shift sign). That constant must be **verified
+empirically during implementation** against a real measured calibration run (saved run metadata records
+the measured sign, and the adapter's mechanical behavior is known for the reference hardware) — it is a
+single boolean that armchair sign-chasing gets wrong too easily.
+
+**Default:** CW ⇒ adapter moves **outward (toward the camera)** — consistent with
+`.claude/docs/tilt-domain.md` ("turning a screw inward pushes that corner of the sensor away from the
+telescope"). If the empirical mapping check shows this default disagrees with the originally requested
+"inward decreases curvature" behavior, the mechanical default wins and the discrepancy is raised for
+review. If a rig's backfocus guidance appears inverted, flipping this setting (or running the 6-step
+measurement) corrects it.
 
 ### Wizard settings UI (Panel A, in the new "Measurement" section after Feature 1's rows)
 
-1. ComboBox **"Turning screws inward (CW)"** with two entries bound to the sign:
-   - "Moves sensor away from objective — curvature decreases" (−1, default)
-   - "Moves sensor toward objective — curvature increases" (+1)
-   For stepper adapters the label reads **"Applying + steps"** instead. Disabled while
-   `MeasureCurvatureDuringCalibration` is checked (measurement will overwrite it); after a measured run
-   it displays the measured value.
-2. CheckBox **"Measure curvature direction during calibration"** with prose to the right:
+1. ComboBox **"Turning screws clockwise moves the adapter"** with two entries:
+   - "Toward the camera — outward" (default)
+   - "Toward the objective — inward"
+   For stepper adapters the label reads **"Applying + steps moves the adapter"** instead. Disabled
+   while `MeasureCurvatureDuringCalibration` is checked (measurement will overwrite it); after a
+   measured run it displays the value inferred from the measurement (the measured sign back-fills this
+   setting through the same fixed mapping).
+2. CheckBox **"Measure adapter direction during calibration"** with prose to the right:
    > "Adds 2 extra measurement steps (6 instead of 4 — about 50% longer) to determine the direction
    > automatically. Turn on if you don't know how your adapter behaves, or to verify the setting above."
 
@@ -145,8 +170,8 @@ inverted, flipping this setting (or running the 6-step measurement) corrects it.
 - **Metadata/replay/validator:** `TiltCalibrationMetadata` records which steps ran (`RunStepMapping`
   already lists them per step). Replaying an old 6-step run still measures the sign; a 4-step run
   replays as 4 steps. The TestApp validator accepts both.
-- The wizard results panel and saved-calibration panel annotate the curvature row with
-  "(measured)" / "(assumed)" from `ScrewInwardCurvatureSignIsMeasured`.
+- The wizard results panel and saved-calibration panel show the adapter direction row with a
+  "(measured)" / "(assumed)" annotation from `ScrewInwardCurvatureSignIsMeasured`.
 
 ## Feature 4 — Manual calibration entry
 
@@ -159,7 +184,7 @@ saved-calibration display):
 - **Screw numbering direction (in the image)** — ComboBox {Clockwise (default), Counter-clockwise}.
   Remaining screws are placed at equal spacing: 3-screw ±120°; 4-screw ±90° with opposite screws 180°
   apart — the same layout `ComputeScrewAngles` fits to.
-- The **curvature direction** setting from Feature 3 sits directly above in the same panel and is
+- The **adapter direction** setting from Feature 3 sits directly above in the same panel and is
   called out in the expander's prose as the companion setting ("set the direction above if you know
   it").
 - **Apply** button: writes `Screw1..4AngleDegrees`, `CalibratedScrewCount = ScrewCount`,
@@ -198,7 +223,9 @@ New/updated NUnit tests (test project links shared sources directly):
   handling, em-dash small-value behavior.
 - `InspectorOptions`: `CenterFocuserBeforeRun` default false; `TimeoutSeconds` persists under its own
   key (and no longer clobbers `StepCount`).
-- `TiltAdapterOptions`: new option defaults (`ScrewInwardCurvatureSign` = −1, flags false).
+- `TiltAdapterOptions`: new option defaults (non-zero `ScrewInwardCurvatureSign`, flags false); the
+  mechanical-setting ↔ stored-sign mapping constant round-trips (one test pinned to the empirically
+  verified value).
 
 Full suite (`dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`) must pass.
 
@@ -217,9 +244,12 @@ Update the MkDocs manual (follow `.claude/docs/documentation-style.md`):
 - **Wizard-specific overrides** for amplification/centering — rejected by user (shared settings).
 - **A rotation-direction enum (CW/CCW = inward)** — rejected: CW⇒screw-inward is fixed by hardware; the
   only rig-specific sign is the plate direction, already covered by `ScrewInwardCurvatureSign`.
-- **Leaving the direction unset until chosen** — rejected: user wants the inward-decreases default;
-  the "(assumed)" tag plus the IN/OUT word retained next to CW/CCW keeps a wrong assumption visible and
-  recoverable.
+- **Leaving the direction unset until chosen** — rejected: a sensible mechanical default plus the
+  "(assumed direction)" annotation keeps a wrong assumption visible and recoverable, and the feature
+  works out of the box.
+- **Phrasing the setting through curvature ("inward decreases curvature")** — rejected after review:
+  it conflates the mechanical rig fact (CW ⇒ adapter in/out, which the user knows) with the optical
+  response (which the code measures); the mechanical phrasing is the one users can answer.
 - **Separate dialog for manual entry** — rejected in favor of an inline expander (fewer clicks, less
   XAML surface).
 - **Up/Down stepper wording** — rejected in favor of signed steps (user choice).

--- a/docs/tilt-calibration-ux-design.md
+++ b/docs/tilt-calibration-ux-design.md
@@ -129,18 +129,22 @@ New/changed persisted options on `TiltAdapterOptions`:
 
 The **user-facing setting is mechanical**, per the confirmed framing: does a CW screw turn move the
 adapter inward (toward objective) or outward (toward camera)? It is presented as a two-entry ComboBox
-and stored via `ScrewInwardCurvatureSign` through a **fixed mapping constant** (the physics/focuser
-convention linking adapter motion to the measured focus-shift sign). That constant must be **verified
-empirically during implementation** against a real measured calibration run (saved run metadata records
-the measured sign, and the adapter's mechanical behavior is known for the reference hardware) — it is a
-single boolean that armchair sign-chasing gets wrong too easily.
+and stored via `ScrewInwardCurvatureSign` through a **fixed mapping constant**.
+
+**Empirical anchor (user measurement, 2026-07-02):** moving the adapter toward the objective
+**decreases** the curvature effect. Combined with the sign's consumer semantics (+1 = a CW turn raises
+the curvature effect), the constant is pinned: CW-toward-objective ⇔ sign **−1**
+(`TiltScrewGeometry.CurvatureSignWhenCwMovesAdapterTowardObjective = -1`).
 
 **Default:** CW ⇒ adapter moves **outward (toward the camera)** — consistent with
 `.claude/docs/tilt-domain.md` ("turning a screw inward pushes that corner of the sensor away from the
-telescope"). If the empirical mapping check shows this default disagrees with the originally requested
-"inward decreases curvature" behavior, the mechanical default wins and the discrepancy is raised for
-review. If a rig's backfocus guidance appears inverted, flipping this setting (or running the 6-step
-measurement) corrects it.
+telescope"). With the anchor above, the default stored sign is **+1**, whose composed behavior is
+exactly the originally requested default: adapter motion inward (toward the objective) decreases the
+curvature effect. An optional implementation-time cross-check compares a wizard-measured rig's sign
+arrow (↑/↓) against its known mechanical direction; a contradiction would indicate the measured and
+manual producers of the sign disagree and must be surfaced rather than papered over. If a rig's
+backfocus guidance appears inverted, flipping this setting (or running the 6-step measurement)
+corrects it.
 
 ### Wizard settings UI (Panel A, in the new "Measurement" section after Feature 1's rows)
 

--- a/docs/tilt-guidance-motion-arrows-design.md
+++ b/docs/tilt-guidance-motion-arrows-design.md
@@ -32,7 +32,7 @@ Robustness property (state it in code comments and pin it in tests): with a **wr
 
 ### Cell formats
 
-- Screws — Tilt `0.75 ⟳`, Backfocus `0.30 ⟲`, Total `1.05 ⟳` (bold, per today's Total styling). **No "turns" word and no "CW"/"CCW" text anywhere** — the glyph alone carries rotation; the legend defines it.
+- Screws — Tilt `0.75 ⟳`, Backfocus `0.30 ⟲`, Total `1.05 ⟳` (bold, per today's Total styling). **No units and no "CW"/"CCW" text in any cell** — today's cells say "0.75 turns"; the unit moves into the legend ("amounts in turns") and the glyph alone carries rotation.
 - Steppers — no rotation glyphs (the motor abstracts rotation). All three rows show **signed steps** in the wizard-prompt convention: Tilt `+35 steps`, Backfocus `−12 steps`, Total `+23 steps`. (Tilt/Backfocus cells were magnitude-only before; they gain the sign so steppers carry the same per-row direction information screws get from glyphs.) Signs: Tilt σ-free, Backfocus σ-signed, Total per `SignedTotalAdjustment` — identical logic to the glyph selection.
 - Below-threshold values keep today's "—" dash behavior (no glyph/sign on a dash).
 
@@ -45,10 +45,10 @@ Unreachable from persisted options since PR #117 (default +1, wizard writes ±1,
 - **Position:** first element under the "Tilt Adapter Guidance" header, above the arrows grid (moved from below the numeric grid).
 - **Style:** regular (non-italic), full opacity — prominence by position *and* weight; wraps.
 - **Text (fixed, no longer varies with σ):**
-  - Screws: `⬆ = adapter moves toward the objective · ⟳ = clockwise (tighten)`
+  - Screws: `⬆ = adapter moves toward the objective · ⟳ = clockwise (tighten) · amounts in turns`
   - Steppers: `⬆ = adapter moves toward the objective · steps are signed as in the wizard prompts`
   - Suffix when σ is not wizard-measured (unchanged rule): ` (assumed — set or measure in the Tilt Adapter Wizard)`.
-- `BuildDirectionLegend` keeps its signature; σ now only drives the assumed-suffix resolution (and the defensive 0→default rule), not the wording.
+- Since the wording no longer depends on σ, `BuildDirectionLegend` drops its `curvatureSign` parameter: `BuildDirectionLegend(bool steps, bool signIsMeasured)`.
 - Visibility gating unchanged: legend renders iff guidance rows render.
 
 ## Vocabulary consistency (wizard step summary)

--- a/docs/tilt-guidance-motion-arrows-design.md
+++ b/docs/tilt-guidance-motion-arrows-design.md
@@ -1,0 +1,79 @@
+# Tilt Guidance: Motion-Anchored Arrows & Rotation Glyphs — Design Spec
+
+**Status:** approved 2026-07-02 (user UI feedback on PR #117's guidance table)
+**Scope:** Aberration Inspector "Tilt Adapter Guidance" section (+ the wizard's step-summary rotation glyphs for vocabulary consistency). Lands as additional commits on PR #117 (`ghilios/tilt-calibration-ux`), since it revises presentation semantics that PR introduced.
+
+## Problem
+
+Three pieces of user feedback on the guidance table shipped in PR #117:
+
+1. The direction legend sits *below* the guidance grids; it should be at the top, prominent.
+2. The legend wording ("⬆ = clockwise (adapter moves toward the camera/objective)") is too complex; it should read simply "up = adapter moves toward the objective".
+3. "CW"/"CCW" text should be replaced by circular-arrow glyphs, and the rotation direction should appear on **all three** numeric rows (Tilt, Backfocus, Total), not just Total.
+
+Feedback 2+3 together imply a semantic re-anchoring, confirmed with the user: the ⬆/⬇ arrows stop meaning *rotation* and start meaning *adapter motion*; the new circular glyphs carry the rotation.
+
+## The contract
+
+Two glyph vocabularies, each answering a different question:
+
+| Glyph | Question it answers | Meaning |
+|---|---|---|
+| ⬆ / ↑ / — / ↓ / ⬇ (arrows grid) | *What must the adapter do at this screw?* | ⬆ = this corner of the adapter plate moves **toward the objective**; ⬇ = toward the camera. Magnitude tiers (large/small/dash) keep today's threshold logic. |
+| ⟳ / ⟲ (numeric grid, screws) | *Which way do I turn this screw?* | ⟳ = clockwise (tighten); ⟲ = counter-clockwise (loosen). U+27F3 / U+27F2 text glyphs. |
+
+Because "adapter moves toward the objective" ⇔ "the local best-focus position decreases" (this is what `ScrewInwardCurvatureSign` σ together with the pinned constant `CurvatureSignWhenCwMovesAdapterTowardObjective = −1` encode — no new empirical input is needed), both vocabularies are computable from existing state:
+
+- **Tilt row** — rotation is σ-free (the calibrated screw angles already encode the rig's response direction): glyph ⟳ iff the CW-positive tilt turns value is positive. Motion needs σ: arrow ⬆ iff `σ · turns[i] < 0`.
+- **Backfocus row** — motion is σ-free (pure curvature physics): arrow ⬆ iff the backfocus correction calls for the local best-focus position to decrease (`BackfocusMicrons < 0` in the correction convention — verify the equivalent expression the VM already computes when implementing). Rotation needs σ: glyph ⟳ iff `σ · BackfocusMicrons > 0`.
+- **Total row** — rotation per the corrected PR #117 formula (`SignedTotalAdjustment`): glyph ⟳ iff `TiltMicrons + σ·BackfocusMicrons > 0`. (No motion arrow — the arrows grid has no Total row; unchanged.)
+
+Robustness property (state it in code comments and pin it in tests): with a **wrong** adapter-direction setting, the tilt *arrows* flip but the tilt *glyphs* stay correct, and the backfocus *arrows* stay correct while the backfocus *glyphs* flip. The old failure mode — two rotation indicators contradicting each other — cannot recur because arrows and glyphs no longer claim to answer the same question. The "(assumed …)" legend suffix remains the flag that σ is unverified.
+
+### Cell formats
+
+- Screws — Tilt `0.75 ⟳`, Backfocus `0.30 ⟲`, Total `1.05 ⟳` (bold, per today's Total styling). **No "turns" word and no "CW"/"CCW" text anywhere** — the glyph alone carries rotation; the legend defines it.
+- Steppers — no rotation glyphs (the motor abstracts rotation). All three rows show **signed steps** in the wizard-prompt convention: Tilt `+35 steps`, Backfocus `−12 steps`, Total `+23 steps`. (Tilt/Backfocus cells were magnitude-only before; they gain the sign so steppers carry the same per-row direction information screws get from glyphs.) Signs: Tilt σ-free, Backfocus σ-signed, Total per `SignedTotalAdjustment` — identical logic to the glyph selection.
+- Below-threshold values keep today's "—" dash behavior (no glyph/sign on a dash).
+
+### Direction unknown (σ = 0)
+
+Unreachable from persisted options since PR #117 (default +1, wizard writes ±1, manual entry preserves the setting). Defensively, resolve `σ = 0 → TiltScrewGeometry.DefaultScrewInwardCurvatureSign` (the same rule `CwMovesAdapterTowardObjective` already uses) and drop the old magnitude-only "hasDirection = false" display path; the formatter parameters simplify accordingly.
+
+## Legend
+
+- **Position:** first element under the "Tilt Adapter Guidance" header, above the arrows grid (moved from below the numeric grid).
+- **Style:** regular (non-italic), full opacity — prominence by position *and* weight; wraps.
+- **Text (fixed, no longer varies with σ):**
+  - Screws: `⬆ = adapter moves toward the objective · ⟳ = clockwise (tighten)`
+  - Steppers: `⬆ = adapter moves toward the objective · steps are signed as in the wizard prompts`
+  - Suffix when σ is not wizard-measured (unchanged rule): ` (assumed — set or measure in the Tilt Adapter Wizard)`.
+- `BuildDirectionLegend` keeps its signature; σ now only drives the assumed-suffix resolution (and the defensive 0→default rule), not the wording.
+- Visibility gating unchanged: legend renders iff guidance rows render.
+
+## Vocabulary consistency (wizard step summary)
+
+PR #117's Fix C set the wizard step-summary Rotation column to ↑ = CW. With ⬆ re-anchored to adapter motion, ↑-as-rotation must not survive anywhere: switch the step-summary rotation glyphs from ↑/↓ to ⟳/⟲ (same `StepDescription` static, same tests updated). The saved-calibration row's "Screws CW → Curvature ↑ (measured)" is out of scope: its arrow denotes the curvature-effect direction, is explicitly labeled, and predates this feedback.
+
+## Out of scope / non-goals
+
+- Merging the arrows grid and numeric grid into one table (kept separate: conceptual vs actionable).
+- Vector/Path icons for the rotation glyphs (Unicode ⟳/⟲ chosen; revisit only if live rendering is poor — ↻/↺ are the lighter-weight fallback).
+- Any change to wizard prompts, TestApp, stored conventions, or the calculator math (presentation-layer only; `SignedTotalAdjustment` remains the single rotation source of truth).
+
+## Files
+
+- `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltScrewGuidanceRow.cs` — formatter statics reworked (glyph/sign selection replaces FormatTotal's CW/CCW text; magnitude formatter gains the rotation/sign variant); legend text fixed.
+- `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs` — `RebuildTiltGuidance` motion-arrow mapping (tilt ×−σ into the existing threshold picker; backfocus σ dropped); `FillNumericGuidance` per-row rotation signs.
+- `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml` — legend relocation and styling.
+- `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs` — step-summary ⟳/⟲ glyphs.
+- Tests: `TiltAdapterGuidanceVMTests.cs`, `TiltAdapterWizardVMTests.cs`, plus an InspectorVM behavioral test for the σ-flip matrix.
+- Docs: `documentation/docs/overview/tilt-aberration-inspector.md` guidance/legend description; grep all docs for `turns CW`, `⬆ = clockwise`, and stale examples.
+
+## Testing requirements
+
+- Formatter statics: glyph/sign selection for all three rows × screws/steppers; dash thresholds; Total loses "turns"/"CW" text.
+- Legend: fixed wording both adapter types; assumed suffix; 0→default resolution.
+- σ-flip matrix (behavioral, σ = ±1 with identical model inputs): tilt arrows flip / tilt glyphs don't; backfocus arrows don't flip / backfocus glyphs do; Total glyph matches `SignedTotalAdjustment` sign.
+- Wizard step-summary glyph update pinned.
+- Full suite green; `mkdocs build --strict` clean.

--- a/documentation/docs/overview/sensor-model.md
+++ b/documentation/docs/overview/sensor-model.md
@@ -304,4 +304,6 @@ tilt adapter removes the tilt (linear) part with differential screw moves, and r
 effect by moving all screws together to change the backfocus spacing (see the
 [Tilt Adapter Wizard](tilt-adapter-wizard.md)); the curvature that remains at the optimal spacing is a
 property of the corrector and focal ratio, addressed with a better-matched corrector or stopping down
-rather than the adapter.
+rather than the adapter. The direction of those all-screws moves comes from the adapter-direction
+setting (or the wizard's optional direction measurement); if the backfocus guidance seems inverted,
+flip that setting.

--- a/documentation/docs/overview/tilt-aberration-inspector.md
+++ b/documentation/docs/overview/tilt-aberration-inspector.md
@@ -108,10 +108,12 @@ Once tilt is measured, a **tilt adapter** lets you correct the linear (tilt-plan
 hardware model, then converts the measured tilt into concrete screw-turn (or stepper-step)
 instructions. See [Tilt Adapter Wizard](tilt-adapter-wizard.md).
 
-Each screw's guidance total carries an explicit direction: `1.25 turns CW` or `0.50 turns CCW` for
-screws, `+35 steps` or `−35 steps` for stepper motors. A legend line under the numbers ties the
-arrows to physical motion, for example "⬆ = clockwise (adapter moves toward the camera)", and is
-marked "(assumed)" until the adapter direction has been measured in the wizard.
+The arrows describe what the adapter must do: ⬆ means that corner of the adapter plate moves toward
+the objective, ⬇ toward the camera — the same on every rig. The numeric rows each carry the screw
+rotation that produces the move: `1.25 ⟳` means 1.25 turns clockwise (tighten), `0.50 ⟲`
+counter-clockwise (loosen); stepper adapters show signed steps (`+35 steps`) matching the wizard's
+prompts. A legend at the top of the section defines both conventions and is marked "(assumed)" until
+the adapter direction has been measured in the wizard.
 
 ## Inspector options
 

--- a/documentation/docs/overview/tilt-aberration-inspector.md
+++ b/documentation/docs/overview/tilt-aberration-inspector.md
@@ -108,6 +108,11 @@ Once tilt is measured, a **tilt adapter** lets you correct the linear (tilt-plan
 hardware model, then converts the measured tilt into concrete screw-turn (or stepper-step)
 instructions. See [Tilt Adapter Wizard](tilt-adapter-wizard.md).
 
+Each screw's guidance total carries an explicit direction: `1.25 turns CW` or `0.50 turns CCW` for
+screws, `+35 steps` or `−35 steps` for stepper motors. A legend line under the numbers ties the
+arrows to physical motion, for example "⬆ = clockwise (adapter moves toward the camera)", and is
+marked "(assumed)" until the adapter direction has been measured in the wizard.
+
 ## Inspector options
 
 These settings live in the inspector panel (not the main Options page). Defaults and ranges are taken
@@ -138,8 +143,8 @@ from the option definitions; descriptions quote the in-app tooltips where one ex
 | **Mouse on Charts** | on | on/off | "Enable mouse events on charts to scroll, pan, and zoom. Disable this if you don't want the charts to intercept mouse actions." |
 | **Step Count** | -1 (auto) | -1 or &gt;0 | "The minimum number of data points needed on each side of the AutoFocus curve minimum. Uses the value set for AutoFocus if blank." |
 | **Step Size** | -1 (auto) | -1 or &gt;0 | "How many focuser steps in between each data point … Uses the value set for AutoFocus if blank." |
-| **Signal Amplification** | 2 | &ge;1 | "Increases the resolution and signal of sensor-model / tilt calibration runs by capturing more, finer-spaced focuser points. The focuser step size is divided by this factor and the number of steps multiplied by it, so the sweep covers the same range with more points (and smaller defocus jumps between adjacent frames, which makes star alignment more reliable) … Set to 1 to disable. Applies to live captures only." |
-| **Center Focuser First** | on | on/off | "When on (default), a quick standard AutoFocus is run before each live sensor-model / tilt calibration sweep to center the focuser at best focus. The detailed sweep then brackets focus symmetrically, which reduces extreme one-sided defocus frames that fail to align. Has no effect when replaying saved frames." |
+| **Signal Amplification** | 2 | &ge;1 | "Increases the resolution and signal of sensor-model / tilt calibration runs by capturing more, finer-spaced focuser points. The focuser step size is divided by this factor and the number of steps multiplied by it, so the sweep covers the same range with more points (and smaller defocus jumps between adjacent frames, which makes star alignment more reliable) … Set to 1 to disable. Applies to live captures only." Sits above the Options expander, with a live estimate of the images each run will capture. |
+| **Center Focuser First** | off | on/off | "When on, a quick standard AutoFocus is run before each live sensor-model / tilt calibration sweep to center the focuser at best focus. The detailed sweep then brackets focus symmetrically, which reduces extreme one-sided defocus frames that fail to align … Has no effect when replaying saved frames." Sits above the Options expander, next to Signal Amplification. |
 | **Frames Per Point** | -1 (auto) | -1 or &ge;1 | "How many exposures to average together for each focuser point. Uses the value set for AutoFocus if blank." |
 | **Timeout (s)** | -1 (auto) | -1 or &gt;0 | "How long, in seconds, after which AutoFocus should time out and fail. Uses the value set for AutoFocus if blank." |
 | **Simple Exposure (s)** | -1 (auto) | -1 or &gt;0 | "How long of an exposure to take for analysis. Defaults to the Auto Focus exposure duration if not set." Sets the exposure for the single-frame Simple Analysis. |

--- a/documentation/docs/overview/tilt-adapter-wizard.md
+++ b/documentation/docs/overview/tilt-adapter-wizard.md
@@ -101,8 +101,10 @@ If you already know where screw 1 sits in the image, you can skip the calibratio
 **Apply** writes the same calibration state a wizard run produces; the saved-calibration panel tags
 it "Manually entered calibration (not measured by the wizard)." The curvature sign comes from the
 adapter direction setting, so guidance stays marked "(assumed)" until a **Measure direction** run
-verifies it. If guidance moves the tilt the wrong way after a manual entry, the numbering direction
-is flipped: switch it and Apply again.
+verifies it. The entered angle is interpreted with the adapter direction setting in effect when you
+click **Apply** — if you change that setting later, click **Apply** again. If guidance moves the
+tilt the wrong way after a manual entry, the numbering direction is flipped: switch it and Apply
+again.
 
 ## Hardware model and device presets
 

--- a/documentation/docs/overview/tilt-adapter-wizard.md
+++ b/documentation/docs/overview/tilt-adapter-wizard.md
@@ -14,7 +14,11 @@ turn moves it. That mapping is established once by the **Tilt Adapter Wizard**.
 
 Screw orientations are stored as angles measured **clockwise from straight up (12 o'clock)**: `0°` is
 the top of the sensor, `90°` is to the right, `180°` is the bottom, `270°` is to the left. The wizard
-stores one angle per screw (`Screw1AngleDegrees` … `Screw4AngleDegrees`).
+stores one angle per screw (`Screw1AngleDegrees` … `Screw4AngleDegrees`). On adapters where a
+clockwise turn moves the plate toward the objective, the stored convention encodes that direction:
+the wizard's diagram and saved-calibration angles read 180° rotated from the screws' physical
+positions in the image, while [Manual Calibration Entry](#manual-calibration-entry) always takes the
+physical angle.
 
 !!! warning "Orientation is tracked in image space, not physically"
     A star diagonal, a mirror, or a rotator can flip the sensor's orientation inside the camera body,
@@ -104,7 +108,8 @@ adapter direction setting, so guidance stays marked "(assumed)" until a **Measur
 verifies it. The entered angle is interpreted with the adapter direction setting in effect when you
 click **Apply** — if you change that setting later, click **Apply** again. If guidance moves the
 tilt the wrong way after a manual entry, the numbering direction is flipped: switch it and Apply
-again.
+again. A wrong adapter direction setting inverts guidance the same way — correct that setting and
+click **Apply** again.
 
 ## Hardware model and device presets
 

--- a/documentation/docs/overview/tilt-adapter-wizard.md
+++ b/documentation/docs/overview/tilt-adapter-wizard.md
@@ -3,8 +3,8 @@
 A measured tilt plane tells you which corners need to move and by how much, but turning a screw moves
 the sensor along that screw's own axis. To convert the [Tilt & Aberration
 Inspector](tilt-aberration-inspector.md) measurement into a concrete instruction (*"turn this screw
-inward ¼ turn"*), the wizard must know where each screw sits relative to the sensor and how far a turn
-moves it. That mapping is established once by the **Tilt Adapter Wizard**.
+clockwise ¼ turn"*), the wizard must know where each screw sits relative to the sensor and how far a
+turn moves it. That mapping is established once by the **Tilt Adapter Wizard**.
 
 ![The Tilt Adapter Guidance table giving the direction and number of turns for each screw](../assets/screenshots/inspector-tilt-guidance.png){ width=620 }
 
@@ -31,31 +31,41 @@ The adapter type is set by the **Screws** field (default `3`).
   Screw 1 at the top (12 o'clock) and numbers the rest clockwise, then solves for the three angles
   with an equal-spacing constraint, splitting measurement error evenly between them.
 - **4-screw adapter**: screws are spaced about `90°` apart and **opposite screws are mechanically
-  coupled**, so adjustments are made in pairs (turn one in while the opposite turns out). The wizard
+  coupled**, so adjustments are made in pairs (tighten one while the opposite loosens). The wizard
   exploits this: "opposite screws are always 180° apart regardless of mirroring," so it measures two
   screws and places the other two 180° across.
 
 ## The calibration loop
 
-The wizard establishes the screw-to-tilt mapping empirically. You take a **baseline** measurement,
-then follow on-screen instructions to turn screws by a known amount (the wizard prompts, e.g., "turn
-ALL screws INWARD exactly 1 full turn each," then per-screw steps), re-measuring after each. From the
-change in the tilt vector \((\Delta A, \Delta B)\) it computes each screw's angle and the sign of its
-effect (`ScrewInwardCurvatureSign`: whether turning a screw inward pushes that side away from or
-toward the telescope). To average out seeing, set **Measurements** above 1; the wizard flags
-inconsistent repeats so you can re-run.
+The wizard establishes the screw-to-tilt mapping empirically. The default run is **four steps**: a
+**baseline** measurement, a screw 1 move, a re-baseline, and a screw 2 move. The move steps prompt
+a known amount of motion, worded as clockwise/counter-clockwise (tighten/loosen) turns for screws
+(e.g., "Turn screw 1 CLOCKWISE exactly 1 full turn") and as signed +/− steps for stepper adapters;
+every step ends with a measurement. From the change in the tilt vector \((\Delta A, \Delta B)\) it
+computes each screw's angle.
+
+The four-step run does not measure which way a clockwise turn moves the adapter. That direction
+comes from the adapter direction setting in the wizard's **Measurement** section, labeled **Turning
+screws clockwise moves the adapter** (or **Applying + steps moves the adapter** for steppers):
+either **Toward the camera — outward** (the default) or **Toward the objective — inward**. Until it
+is measured, guidance marks the direction "(assumed)". To measure it, turn on **Measure direction**:
+this adds two steps (an all-screws-clockwise move plus a return to baseline) that determine the sign
+of the effect (`ScrewInwardCurvatureSign`) from the curvature change, and the saved calibration then
+reports the direction as measured. To average out seeing, set **Measurements** above 1; the wizard
+flags inconsistent repeats so you can re-run.
 
 !!! tip "Each calibration step runs a full inspector sweep"
     A calibration measurement is a full sensor-model sweep, so it runs the same alignment and
-    focus-centering steps as a standalone Detailed Analysis. With **Center Focuser First** on (the
-    default), each step re-centers
-    the focuser at best focus before its sweep, so the measurement is not skewed toward one side of
-    focus. **Signal Amplification** gives each step more, finer-spaced focus points for a steadier
-    per-star fit. For a heavily-defocused frame that would otherwise fail to register, the frame aligner
-    escalates its search rather than dropping the frame from that step's model. These help most on faint
-    fields or in poor seeing, and are set under [Inspector
-    options](tilt-aberration-inspector.md#inspector-options). Raising **Measurements** above 1 averages
-    independent repeats on top of them.
+    focus-centering steps as a standalone Detailed Analysis. **Center Focuser First** (off by
+    default) re-centers the focuser at best focus before each step's sweep, so the measurement is not
+    skewed toward one side of focus. **Signal Amplification** gives each step more, finer-spaced
+    focus points for a steadier per-star fit. Both are editable in the wizard's **Measurement**
+    section (they are the same settings as the [Inspector
+    options](tilt-aberration-inspector.md#inspector-options)), which also shows a live estimate of the
+    images each sweep captures and the total for the whole calibration. For a heavily-defocused frame
+    that would otherwise fail to register, the frame aligner escalates its search rather than dropping
+    the frame from that step's model. These help most on faint fields or in poor seeing. Raising
+    **Measurements** above 1 averages independent repeats on top of them.
 
 !!! note "Set Microns per Focuser Step for the best guidance"
     Per its tooltip, *Microns per Focuser Step* is "how much the focuser moves per step, in microns.
@@ -75,6 +85,24 @@ inconsistent repeats so you can re-run.
     Curvature Effect stops dropping. What remains is the residual curvature of a correctly spaced
     system, set by your corrector design and focal ratio; the adapter cannot remove it (a
     better-matched corrector or stopping down does).
+
+## Manual calibration entry
+
+If you already know where screw 1 sits in the image, you can skip the calibration loop. Open the
+**Manual Calibration Entry** expander in the wizard and enter:
+
+- **Screw 1 angle (°)**: the position angle of screw 1 in the image, using the convention above (0°
+  is straight up, at 12 o'clock, increasing clockwise). The remaining screws are placed at equal
+  spacing: 120° apart for 3 screws, 90° for 4.
+- **Numbering direction**: whether screws 2 and up proceed clockwise or counter-clockwise from
+  screw 1, *as seen in the image*. Mirrors or diagonals in the optical train can flip this relative
+  to the physical adapter, so count the direction on an image if you can.
+
+**Apply** writes the same calibration state a wizard run produces; the saved-calibration panel tags
+it "Manually entered calibration (not measured by the wizard)." The curvature sign comes from the
+adapter direction setting, so guidance stays marked "(assumed)" until a **Measure direction** run
+verifies it. If guidance moves the tilt the wrong way after a manual entry, the numbering direction
+is flipped: switch it and Apply again.
 
 ## Hardware model and device presets
 

--- a/documentation/docs/quick-start.md
+++ b/documentation/docs/quick-start.md
@@ -83,8 +83,13 @@ how far a turn moves it.
 1. Pick your adapter from the **Device** preset list (or **Manual** to enter the
    [hardware values](overview/tilt-adapter-wizard.md#hardware-model-and-device-presets)
    yourself: thread pitch, screw radius, screw count).
-2. Run the guided **calibration loop** (a baseline measurement, then turning the screws by a known
-   amount while the wizard re-measures) to map the screws into image space.
+2. Run the guided **calibration loop** to map the screws into image space. By default it is four
+   steps (a baseline, screw 1, a re-baseline, screw 2); the screw moves are prompted as clockwise
+   or counter-clockwise turns, and each step ends with a measurement. Turn on **Measure direction**
+   to add two steps that also measure which way the screws move the adapter.
+3. Know your adapter already? Use
+   [**Manual Calibration Entry**](overview/tilt-adapter-wizard.md#manual-calibration-entry) in the
+   wizard to type in the screw-1 angle instead of running the loop.
 
 Once calibrated, the inspector's adjustment chart tells you exactly which screw to turn and by how much.
 

--- a/plans/manual-doc-cleanup-plan.md
+++ b/plans/manual-doc-cleanup-plan.md
@@ -1,0 +1,141 @@
+# Manual Documentation Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Burn down the 95 adversarially-confirmed documentation findings in `docs/manual-doc-review-findings.md` across all 27 pages of the MkDocs manual (`documentation/docs/`).
+
+**Architecture:** Docs-only change. The findings file is the work backlog: each finding carries an exact location, the verified issue, and suggested replacement text. Fixes are applied in per-page-group batches, each batch verified with `mkdocs build --strict` and committed separately; a final adversarial-doc-review workflow re-run confirms the backlog is cleared.
+
+**Tech Stack:** MkDocs Material markdown, `mkdocs build --strict`, the repo's `adversarial-doc-review` workflow, git.
+
+---
+
+## Context for a zero-context engineer
+
+- **Repo root:** `/home/ghilios/src/hocus-focus`.
+- **Precondition:** PR #117 (`ghilios/tilt-calibration-ux`) must be **merged into `develop`** before starting — the findings were gathered on that branch and three of the affected pages were edited by it. Branch from up-to-date `develop`:
+  ```bash
+  git checkout develop && git pull && git checkout -b ghilios/manual-doc-cleanup
+  ```
+  **Never push to `develop` directly.**
+- **The backlog:** `docs/manual-doc-review-findings.md` — 95 findings grouped by page, most-severe first within each page. Each finding has `[severity] (lens) location`, an **Issue** paragraph, and a **Suggested fix** (usually exact replacement text). These were produced by a 2-lens-per-page review with 3-vote adversarial verification on 2026-07-02, so false positives were filtered — but they are point-in-time:
+  - **Line numbers in the findings are stale.** Use the quoted text as the anchor, never the line number.
+  - **Re-verify each finding's premise before applying it.** Especially: (a) findings that quote in-app UI labels must be checked against the current XAML (`Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml` and `TiltAdapterWizard/DataTemplates.xaml` — grep for the label text); (b) findings on `overview/tilt-adapter-wizard.md`, `overview/tilt-aberration-inspector.md`, `overview/sensor-model.md`, and `quick-start.md` may have been partially overtaken by PR #117's later commits — if the quoted text no longer exists, mark the finding obsolete in your commit message rather than forcing an edit.
+  - Suggested fixes are suggestions. Where a fix conflicts with the style guide or current code, write the correct fix; do not blindly paste.
+- **Style contract:** read `.claude/docs/documentation-style.md` in full before Task 1. Hard rules: house voice, no confessional/self-aware headings, no raw pipes inside table-cell math, quote only exact in-app UI text, bold UI labels without quotation marks.
+- **Build verification** (run from repo root; config is `mkdocs.yml` at repo root):
+  ```bash
+  mkdocs build --strict
+  ```
+  Must stay clean after every batch. Also run the .NET suite once at the end (project invariant, even for docs-only changes):
+  ```bash
+  dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo
+  ```
+  (On WSL the binary is `dotnet.exe`.)
+- **Committing** (GitHub email privacy — author and committer must both use the noreply address):
+  ```bash
+  GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+    git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" -m "<message>"
+  ```
+
+## Batch procedure (identical for Tasks 1–5)
+
+For the task's listed pages, in order:
+
+1. Open the page's section in `docs/manual-doc-review-findings.md` and the page itself.
+2. For each finding: locate the quoted text in the current page; re-verify the premise (UI-label claims against the XAML; factual claims against the cited code); apply the suggested fix or your corrected variant; if the premise no longer holds, skip and note it.
+3. When two pages share a finding (the findings often say "fix both pages together" — e.g. the `Use RANSAC` → **Align images before matching** rename spans `sensor-model.md` and `tilt-aberration-inspector.md`), apply the shared rename consistently across every occurrence in the batch, and grep the whole manual for stragglers: `grep -rn "Use RANSAC\|Fixed Sensor Center\|Acceptable R² Min" documentation/docs/`.
+4. Run `mkdocs build --strict` → must pass.
+5. Commit the batch.
+
+---
+
+### Task 1: Landing pages — `index.md`, `quick-start.md`, `overview/index.md` (12 findings)
+
+**Files:**
+- Modify: `documentation/docs/index.md` (3 findings)
+- Modify: `documentation/docs/quick-start.md` (3 findings)
+- Modify: `documentation/docs/overview/index.md` (6 findings)
+
+- [ ] **Step 1:** Read `.claude/docs/documentation-style.md` in full.
+- [ ] **Step 2:** Apply the batch procedure to the three pages. Highlights to expect: dropdown labels must match the screenshots (**Star Detector** / **Star Annotator** / **Autofocus**, not "Star Detection"/"Auto Focus"); `overview/index.md` opens with self-citation voice ("in the words of its own description", "Per its documentation") that must be rewritten as direct prose.
+- [ ] **Step 3:** `mkdocs build --strict` → PASS.
+- [ ] **Step 4:** Commit:
+```bash
+git add documentation/docs/index.md documentation/docs/quick-start.md documentation/docs/overview/index.md
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "docs: fix landing-page findings — exact UI labels, direct voice (review batch 1/5)"
+```
+
+---
+
+### Task 2: Detection/AF overview pages — `overview/star-detection.md`, `overview/star-annotation.md`, `overview/autofocus.md`, `overview/hyperbola-fitting.md` (12 findings)
+
+**Files:**
+- Modify: `documentation/docs/overview/star-detection.md` (5), `overview/star-annotation.md` (4), `overview/autofocus.md` (1), `overview/hyperbola-fitting.md` (2)
+
+- [ ] **Step 1:** Apply the batch procedure to the four pages.
+- [ ] **Step 2:** `mkdocs build --strict` → PASS.
+- [ ] **Step 3:** Commit (same env-var pattern): `docs: fix detection/AF overview findings (review batch 2/5)`
+
+---
+
+### Task 3: Tilt/sensor pages — `overview/sensor-model.md`, `overview/tilt-aberration-inspector.md`, `overview/tilt-adapter-wizard.md` (15 findings)
+
+**Files:**
+- Modify: `documentation/docs/overview/sensor-model.md` (6), `overview/tilt-aberration-inspector.md` (7), `overview/tilt-adapter-wizard.md` (2)
+
+These pages were edited after the findings sweep (PR #117 Fix commits) — re-verify every premise. The big items: the inspector options table uses code-property names instead of in-app labels (the findings enumerate exact row replacements — cross-check each against `AutoFocus/DataTemplates.xaml` at HEAD); the **Max Stars Per Region** row documents a control that does not exist in any XAML (delete the row); `sensor-model.md` label renames (**Align images before matching**, **Sensor Centered**, **Min R² (rejection)**, **Use affine alignment (diagnostic)**) must be applied consistently on both pages.
+
+- [ ] **Step 1:** Apply the batch procedure to the three pages.
+- [ ] **Step 2:** Cross-page consistency grep (expect zero hits after the fixes):
+```bash
+grep -rn "Use RANSAC\|Fixed Sensor Center\|Acceptable R² Min\|Max Stars Per Region\|Adjustment Required" documentation/docs/
+```
+- [ ] **Step 3:** `mkdocs build --strict` → PASS.
+- [ ] **Step 4:** Commit: `docs: fix tilt/sensor page findings — in-app labels, table accuracy (review batch 3/5)`
+
+---
+
+### Task 4: Optimization pages — all six `optimization/*.md` (27 findings)
+
+**Files:**
+- Modify: `documentation/docs/optimization/af-curve-fitting.md` (3), `optimization/index.md` (3), `optimization/labels-recall-precision.md` (4), `optimization/objective-function.md` (5), `optimization/search-algorithm.md` (4), `optimization/search-variables.md` (8)
+
+Highlight: `search-variables.md` misstates the optimizer seed (it is the **default** detection parameters unless "Start from my current settings" is enabled — verified against `StarDetectionOptimizerWizardVM.cs`); the never-worse-than-current guarantee is a separate wizard-level guard. The findings give the corrected paragraph.
+
+- [ ] **Step 1:** Apply the batch procedure to the six pages.
+- [ ] **Step 2:** `mkdocs build --strict` → PASS.
+- [ ] **Step 3:** Commit: `docs: fix optimization page findings — seed semantics, guarantees (review batch 4/5)`
+
+---
+
+### Task 5: Settings pages — all eleven `settings/*.md` (29 findings)
+
+**Files:**
+- Modify: `documentation/docs/settings/acceptance-gates.md` (5), `settings/adaptive-binarization.md` (1), `settings/advanced-debug.md` (3), `settings/contamination.md` (1), `settings/donut-aware.md` (3), `settings/hotpixel-saturation.md` (1), `settings/index.md` (2), `settings/precision-recall.md` (3), `settings/preprocessing.md` (3), `settings/psf-modeling.md` (5), `settings/structure-detection.md` (2)
+
+- [ ] **Step 1:** Apply the batch procedure to the eleven pages.
+- [ ] **Step 2:** `mkdocs build --strict` → PASS.
+- [ ] **Step 3:** Commit: `docs: fix settings page findings (review batch 5/5)`
+
+---
+
+### Task 6: Final verification — re-run the adversarial review
+
+- [ ] **Step 1:** Run the .NET suite once (project invariant): `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo` → all green (docs-only branch, so any failure is pre-existing — investigate before proceeding).
+- [ ] **Step 2:** Re-run the repo's adversarial-doc-review workflow over the whole manual. Gotcha: `.claude/workflows/adversarial-doc-review.js` has CRLF line endings, which the Workflow permission dialog rejects — make an LF copy first and invoke by `scriptPath`:
+```bash
+tr -d '\r' < .claude/workflows/adversarial-doc-review.js > "$SCRATCHPAD/adversarial-doc-review.js"
+```
+then `Workflow({scriptPath: "$SCRATCHPAD/adversarial-doc-review.js"})` (a full sweep — passing `args.pages` did not narrow the sweep on the 2026-07-02 run, so expect all pages).
+- [ ] **Step 3:** Triage the re-run's confirmed findings: fix any that are regressions or misses from Tasks 1–5 (amend the relevant batch commit or add a fixup commit); genuinely new/out-of-scope findings get appended to `docs/manual-doc-review-findings.md` with a note.
+- [ ] **Step 4:** Update `docs/manual-doc-review-findings.md` header: add a line noting which findings were applied/obsoleted by this branch, so the file reads as a closed backlog. Commit: `docs: close out manual review backlog; re-review results`
+- [ ] **Step 5:** Push and open a PR:
+```bash
+git push -u origin ghilios/manual-doc-cleanup
+gh pr create --base develop --title "Manual documentation cleanup — adversarial review backlog" --body "Applies the 95 adversarially-confirmed findings in docs/manual-doc-review-findings.md (exact UI labels, factual corrections, house-voice fixes) across all 27 manual pages. Verified with mkdocs --strict per batch and a full adversarial-doc-review re-run.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```

--- a/plans/tilt-calibration-ux-plan.md
+++ b/plans/tilt-calibration-ux-plan.md
@@ -1,0 +1,1711 @@
+# Tilt Calibration & Sensor Model UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the approved spec `docs/tilt-calibration-ux-design.md`: surface the sweep-cost settings (Signal Amplification, Center Focuser First — new default off) in both the Aberration Inspector and the Tilt Adapter Wizard, give screw/stepper guidance explicit CW/CCW and signed-step directions, make the wizard's curvature-direction measurement opt-in (4-step default, 6-step optional), and add manual calibration entry.
+
+**Architecture:** All changes live in the existing HocusFocus plugin (C#/WPF, MEF + CommunityToolkit.Mvvm). Pure math/formatting goes in static helpers (`TiltCalibrationCalculator`, `TiltScrewGeometry`, `TiltAdapterGuidanceVM`, internal statics on the VMs) so it is unit-testable without WPF. Persisted settings follow the existing `PluginOptionsAccessor` pattern. UI is XAML edits to `AutoFocus/DataTemplates.xaml` and `TiltAdapterWizard/DataTemplates.xaml`.
+
+**Tech Stack:** .NET 8 (`net8.0-windows7.0`, builds on Linux/WSL via EnableWindowsTargeting), NUnit 4.4 + NSubstitute, WPF XAML.
+
+---
+
+## Context for a zero-context engineer
+
+- **Repo root:** `/home/ghilios/src/hocus-focus`. Work on branch `ghilios/tilt-calibration-ux` (already exists; the spec is committed there). **Never push to `develop`.**
+- **Build + full test suite** (run after every task; it also compiles the XAML since the sln includes the plugin project):
+  ```bash
+  dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo
+  ```
+  Filtered run for a single fixture:
+  ```bash
+  dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~TiltCalibrationCalculatorTests"
+  ```
+- **Committing** (GitHub email privacy — both author and committer must use the noreply address):
+  ```bash
+  GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+    git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" -m "<message>"
+  ```
+- **Domain terminology (from the spec — keep these distinct in ALL text you write):**
+  - *Screw motion:* clockwise (CW) always advances/tightens a screw. Fixed hardware fact, never a setting. UI text says "clockwise/counter-clockwise (tighten/loosen)".
+  - *Adapter motion:* "inward" = the adapter's moving plate travels toward the telescope objective; "outward" = toward the camera. Whether a CW turn produces inward or outward adapter motion is rig-specific — that is the new setting.
+  - `ScrewInwardCurvatureSign` (existing, persisted): the measured sign of the mean-focus/curvature response to a CW ("prompt-direction") screw turn. `+1` = CW turns raise the curvature effect, `−1` = lower it. The wizard's Baseline→AllInward steps measure it; this plan adds a manual/mechanical way to set it.
+- **The 6-step wizard flow (existing):** Baseline (a) → AllInward (b) → ReBaseline1 (c) → Screw1 (d) → ReBaseline2 (e) → Screw2 (f). Steps a→b exist only to measure the sign. The 4-step flow removes a-as-separate-reference and b: Baseline → Screw1 → ReBaseline2 → Screw2, with the Baseline reading serving as the screw-1 reference (the role `ReBaseline1` plays in the 6-step flow).
+- **Key files:**
+  - `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs` — inspector persisted options
+  - `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs` — sensor-model runs, tilt guidance
+  - `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltScrewGuidanceRow.cs` — `TiltAdapterGuidanceVM` + formatters
+  - `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml` — inspector UI
+  - `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs` — wizard state machine
+  - `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs` (+ `Interfaces/ITiltAdapterOptions.cs`) — wizard persisted options
+  - `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs` — pure calibration math
+  - `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltScrewGeometry.cs` — pure screw geometry
+  - `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs` — saved-run metadata
+  - `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml` — wizard UI
+  - `Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs` — headless validator
+  - Tests live in `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/` (ProjectReference to the plugin; test doubles in `TestDoubles/`, notably `InMemoryPluginOptionsAccessor`).
+- **Line numbers below are pre-change positions.** Each task's edits shift later lines; anchors are given as unique code snippets so you can locate them regardless.
+
+---
+
+### Task 1: InspectorOptions — fix TimeoutSeconds persistence key; flip CenterFocuserBeforeRun default to off
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs`
+- Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorOptionsTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `InspectorOptionsTests.cs` (fixture already has a `Build()` helper returning `(InspectorOptions options, InMemoryPluginOptionsAccessor store, IProfileService profile)`), add:
+
+```csharp
+    [Test]
+    public void TimeoutSeconds_PersistsUnderItsOwnKey() {
+        var (options, store, _) = Build();
+        options.TimeoutSeconds = 120;
+        Assert.Multiple(() => {
+            Assert.That(store.GetValueInt32(nameof(InspectorOptions.TimeoutSeconds), -999), Is.EqualTo(120));
+            Assert.That(store.GetValueInt32(nameof(InspectorOptions.StepCount), -999), Is.EqualTo(-999),
+                "TimeoutSeconds must not clobber the StepCount key");
+        });
+    }
+
+    [Test]
+    public void CenterFocuserBeforeRun_DefaultsToOff() {
+        var (options, _, _) = Build();
+        Assert.That(options.CenterFocuserBeforeRun, Is.False);
+    }
+```
+
+Also update the existing `Defaults_AreLoadedFromAccessor` test: change the line
+`Assert.That(options.CenterFocuserBeforeRun, Is.True);` to `Assert.That(options.CenterFocuserBeforeRun, Is.False);`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~InspectorOptionsTests"`
+Expected: FAIL — `TimeoutSeconds_PersistsUnderItsOwnKey` (StepCount key clobbered) and `CenterFocuserBeforeRun_DefaultsToOff` (currently true).
+
+- [ ] **Step 3: Implement**
+
+In `InspectorOptions.cs`:
+
+1. Line 52, change the default:
+```csharp
+            centerFocuserBeforeRun = optionsAccessor.GetValueBoolean(nameof(CenterFocuserBeforeRun), false);
+```
+2. In `ResetDefaults()` (line 87), change `CenterFocuserBeforeRun = true;` to `CenterFocuserBeforeRun = false;`.
+3. The field declaration + doc comment (lines 158–161) — replace with:
+```csharp
+        // When on, a quick standard autofocus is run before each live sensor-model / tilt sweep to center
+        // the focuser at best focus, so the sweep brackets focus symmetrically (fewer extreme one-sided defocus
+        // frames that fail to align). Off by default — it adds a full AF run to every sweep. No effect on replay.
+        private bool centerFocuserBeforeRun = false;
+```
+4. In the `TimeoutSeconds` setter (line 194), fix the key:
+```csharp
+                    optionsAccessor.SetValueInt32(nameof(TimeoutSeconds), timeoutSeconds);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~InspectorOptionsTests"`
+Expected: PASS. Then run the full suite: `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo` — fix any other test that asserted the old default (search the Tests project for `CenterFocuserBeforeRun`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "fix(inspector): TimeoutSeconds persisted under StepCount key; default Center Focuser First off"
+```
+
+---
+
+### Task 2: Direction-mapping constant in TiltScrewGeometry (USER CHECKPOINT)
+
+The spec requires the mechanical-setting ↔ stored-sign mapping to be **verified empirically, not derived on paper**. This task pins it as a single named constant.
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltScrewGeometry.cs`
+- Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltScrewGeometryTests.cs`
+
+- [ ] **Step 1: STOP — ask the user (blocking checkpoint)**
+
+Ask the user these two questions about a rig they have **measured** with the 6-step wizard:
+
+1. On that adapter, does turning the screws **clockwise** move the adapter plate **toward the objective** or **toward the camera**?
+2. What is the measured curvature sign on that rig? (Visible as the "Screws Inward / Curvature ↑ or ↓" row in the wizard's saved-calibration panel — ↑ = `+1`, ↓ = `−1`; or as `calibration.curvatureSign` in a saved run's `metadata.json`.)
+
+Set the constant so the two answers agree: if CW→objective pairs with measured `+1` (or CW→camera pairs with `−1`), the constant is `+1`; if CW→objective pairs with measured `−1`, the constant is `−1`. **Do not guess. Do not proceed without the user's answer.** Record the rig + date in the comment.
+
+- [ ] **Step 2: Write the failing test**
+
+In `TiltScrewGeometryTests.cs` add (adjust the two `+1/−1` expectations if the user's answer flipped the constant — the test documents the verified truth):
+
+```csharp
+    [Test]
+    public void CurvatureSignForCwDirection_MatchesEmpiricalAnchor() {
+        Assert.Multiple(() => {
+            // Pinned to the empirically verified mapping (see TiltScrewGeometry comment). If this
+            // fails after an intentional flip, update BOTH the constant comment and this test.
+            Assert.That(TiltScrewGeometry.CurvatureSignWhenCwMovesAdapterTowardObjective, Is.EqualTo(1));
+            Assert.That(TiltScrewGeometry.CurvatureSignForCwDirection(cwMovesAdapterTowardObjective: true), Is.EqualTo(1));
+            Assert.That(TiltScrewGeometry.CurvatureSignForCwDirection(cwMovesAdapterTowardObjective: false), Is.EqualTo(-1));
+            Assert.That(TiltScrewGeometry.CwMovesAdapterTowardObjectiveForSign(1), Is.True);
+            Assert.That(TiltScrewGeometry.CwMovesAdapterTowardObjectiveForSign(-1), Is.False);
+            // Default assumption: CW moves the adapter outward (toward the camera).
+            Assert.That(TiltScrewGeometry.DefaultScrewInwardCurvatureSign,
+                Is.EqualTo(TiltScrewGeometry.CurvatureSignForCwDirection(false)));
+        });
+    }
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~TiltScrewGeometryTests"`
+Expected: FAIL with "does not contain a definition for `CurvatureSignWhenCwMovesAdapterTowardObjective`" (compile error counts as the failing state).
+
+- [ ] **Step 4: Implement**
+
+Append inside the `TiltScrewGeometry` class (it is a static geometry helper class in namespace `NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard`):
+
+```csharp
+        // ---- Adapter direction ⇄ curvature sign --------------------------------------------------
+        //
+        // Clockwise (tighten) always advances a screw; the rig-specific unknown is whether that
+        // advance moves the adapter's plate toward the telescope objective ("inward") or toward the
+        // camera ("outward"). ScrewInwardCurvatureSign stores the measurable consequence: the sign
+        // of the mean best-focus / curvature-effect response to a CW turn (+1 = raises it).
+        //
+        // EMPIRICAL ANCHOR (verified <DATE> against <RIG> — fill in from the Task 2 checkpoint):
+        // a plate moving toward the objective forces the focuser to re-focus outward, raising the
+        // mean best-focus position, which ComputeCurvatureSign records as +1.
+        public const int CurvatureSignWhenCwMovesAdapterTowardObjective = 1;
+
+        /// <summary>The stored curvature sign implied by the mechanical setting.</summary>
+        public static int CurvatureSignForCwDirection(bool cwMovesAdapterTowardObjective) =>
+            cwMovesAdapterTowardObjective
+                ? CurvatureSignWhenCwMovesAdapterTowardObjective
+                : -CurvatureSignWhenCwMovesAdapterTowardObjective;
+
+        /// <summary>The mechanical reading of a stored curvature sign (sign must be non-zero).</summary>
+        public static bool CwMovesAdapterTowardObjectiveForSign(int curvatureSign) =>
+            curvatureSign * CurvatureSignWhenCwMovesAdapterTowardObjective > 0;
+
+        // Default assumption when the direction was never measured or chosen: CW moves the adapter
+        // toward the camera (outward) — the common push-screw design; matches the tilt-domain doc
+        // ("turning a screw inward pushes that corner of the sensor away from the telescope").
+        public static int DefaultScrewInwardCurvatureSign => CurvatureSignForCwDirection(false);
+```
+
+Replace `<DATE>` / `<RIG>` with the user's checkpoint answer, and flip the constant to `-1` (and the test's expectations) if that is what the answer implies.
+
+- [ ] **Step 5: Run tests, then commit**
+
+Run: `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~TiltScrewGeometryTests"` → PASS, then the full suite → PASS.
+
+```bash
+git add -A
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "feat(tilt): pin empirically verified adapter-direction <-> curvature-sign mapping"
+```
+
+---
+
+### Task 3: TiltAdapterOptions — new persisted options and new default for the sign
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltAdapterOptions.cs`
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs`
+- Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `TiltAdapterOptionsTests.cs`, update `Defaults_AreLoadedFromAccessor`: change
+`Assert.That(options.ScrewInwardCurvatureSign, Is.EqualTo(0));` to
+`Assert.That(options.ScrewInwardCurvatureSign, Is.EqualTo(TiltScrewGeometry.DefaultScrewInwardCurvatureSign));`
+and add inside the same `Assert.Multiple`:
+
+```csharp
+            Assert.That(options.ScrewInwardCurvatureSignIsMeasured, Is.False);
+            Assert.That(options.MeasureCurvatureDuringCalibration, Is.False);
+            Assert.That(options.CalibrationIsManual, Is.False);
+```
+
+Add a round-trip test:
+
+```csharp
+    [Test]
+    public void NewOptions_RoundTripThroughAccessor() {
+        var (options, store, _) = Build();
+        options.ScrewInwardCurvatureSignIsMeasured = true;
+        options.MeasureCurvatureDuringCalibration = true;
+        options.CalibrationIsManual = true;
+        Assert.Multiple(() => {
+            Assert.That(store.GetValueBoolean(nameof(TiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured), false), Is.True);
+            Assert.That(store.GetValueBoolean(nameof(TiltAdapterOptions.MeasureCurvatureDuringCalibration), false), Is.True);
+            Assert.That(store.GetValueBoolean(nameof(TiltAdapterOptions.CalibrationIsManual), false), Is.True);
+        });
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail** (compile error on the new members)
+
+Run: `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~TiltAdapterOptionsTests"`
+
+- [ ] **Step 3: Implement**
+
+In `ITiltAdapterOptions.cs`, replace line 31 (`int ScrewInwardCurvatureSign { get; set; } // +1 or -1; 0 = not yet calibrated`) with:
+
+```csharp
+        // Sign of the curvature/backfocus response to a CW ("inward") screw turn: +1 = CW turns
+        // raise the curvature effect, -1 = lower it. Defaults to the assumed mechanical direction
+        // (TiltScrewGeometry.DefaultScrewInwardCurvatureSign); a 6-step wizard run measures it.
+        int ScrewInwardCurvatureSign { get; set; }
+
+        // True only when a wizard run measured ScrewInwardCurvatureSign (Baseline -> AllInward
+        // steps). Cleared when the user edits the direction manually or applies a manual entry.
+        bool ScrewInwardCurvatureSignIsMeasured { get; set; }
+
+        // Include the 2 curvature-direction steps (Baseline + AllInward) in a calibration run:
+        // 6 steps instead of 4. Off by default — the assumed/manual direction is used instead.
+        bool MeasureCurvatureDuringCalibration { get; set; }
+
+        // True when the current calibration came from Manual Calibration Entry, not a wizard run.
+        bool CalibrationIsManual { get; set; }
+```
+
+In `TiltAdapterOptions.cs`:
+
+1. In `InitializeOptions()`, replace the `screwInwardCurvatureSign` line and append the new loads:
+```csharp
+            screwInwardCurvatureSign = optionsAccessor.GetValueInt32(nameof(ScrewInwardCurvatureSign), TiltScrewGeometry.DefaultScrewInwardCurvatureSign);
+            screwInwardCurvatureSignIsMeasured = optionsAccessor.GetValueBoolean(nameof(ScrewInwardCurvatureSignIsMeasured), false);
+            measureCurvatureDuringCalibration = optionsAccessor.GetValueBoolean(nameof(MeasureCurvatureDuringCalibration), false);
+            calibrationIsManual = optionsAccessor.GetValueBoolean(nameof(CalibrationIsManual), false);
+```
+2. After the `ScrewInwardCurvatureSign` property (line 183), add three properties following the exact existing pattern:
+```csharp
+        private bool screwInwardCurvatureSignIsMeasured;
+
+        public bool ScrewInwardCurvatureSignIsMeasured {
+            get => screwInwardCurvatureSignIsMeasured;
+            set {
+                if (screwInwardCurvatureSignIsMeasured != value) {
+                    screwInwardCurvatureSignIsMeasured = value;
+                    optionsAccessor.SetValueBoolean(nameof(ScrewInwardCurvatureSignIsMeasured), screwInwardCurvatureSignIsMeasured);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool measureCurvatureDuringCalibration;
+
+        public bool MeasureCurvatureDuringCalibration {
+            get => measureCurvatureDuringCalibration;
+            set {
+                if (measureCurvatureDuringCalibration != value) {
+                    measureCurvatureDuringCalibration = value;
+                    optionsAccessor.SetValueBoolean(nameof(MeasureCurvatureDuringCalibration), measureCurvatureDuringCalibration);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool calibrationIsManual;
+
+        public bool CalibrationIsManual {
+            get => calibrationIsManual;
+            set {
+                if (calibrationIsManual != value) {
+                    calibrationIsManual = value;
+                    optionsAccessor.SetValueBoolean(nameof(CalibrationIsManual), calibrationIsManual);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**, then the full suite. Any existing test asserting `ScrewInwardCurvatureSign == 0` defaults must be updated to the new default (search Tests for `ScrewInwardCurvatureSign`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "feat(tilt): persisted options for assumed direction, opt-in curvature steps, manual-entry provenance"
+```
+
+---
+
+### Task 4: TiltCalibrationCalculator — optional curvature measurement + manual angle placement
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs`
+- Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `TiltCalibrationCalculatorTests.cs` (the fixture has `SingleScrewReading(angleDeg, axialMicrons, n, meanFocuser)` and constants `PixelSize/ImgW/ImgH/FStep/RadiusMm` — reuse them; follow an existing `Calibrate` test for how a full `TiltCalibrationInputs` is built):
+
+```csharp
+    [Test]
+    public void Calibrate_WithoutCurvatureMeasurement_PassesFallbackSignThrough() {
+        // 4-step run: Baseline/AllInward were never measured. The baseline reading is supplied in
+        // the ReBaseline1 slot (it is the screw-1 reference); Baseline/AllInward stay default.
+        var baseline = new TiltGradient(0, 0, 1000);
+        var inputs = new TiltCalibrationInputs {
+            ScrewCount = 3,
+            HasCurvatureMeasurement = false,
+            FallbackCurvatureSign = -1,
+            ReBaseline1 = baseline,
+            Screw1 = SingleScrewReading(0, 400, 3),
+            ReBaseline2 = baseline,
+            Screw2 = SingleScrewReading(120, 400, 3),
+            ImageWidthPixels = ImgW,
+            ImageHeightPixels = ImgH,
+            PixelSizeMicrons = PixelSize,
+            FocuserStepMicrons = FStep,
+            ScrewRadiusMillimeters = RadiusMm,
+            CalibrationAppliedAmount = 1.0,
+            IsStepperAdjustment = false
+        };
+        var result = TiltCalibrationCalculator.Calibrate(inputs);
+        Assert.Multiple(() => {
+            Assert.That(result.CurvatureSign, Is.EqualTo(-1));
+            Assert.That(result.Screw1AngleDegrees, Is.EqualTo(0).Within(1e-6));
+            Assert.That(result.Screw2AngleDegrees, Is.EqualTo(120).Within(1e-6));
+            Assert.That(result.MeasuredHardwareMicrons, Is.EqualTo(400).Within(1e-6));
+        });
+    }
+
+    [Test]
+    public void ComputeConfidence_WithoutCurvatureMeasurement_UsesOnlyRebaseline2Drift() {
+        var baseline = new TiltGradient(0, 0, 1000);
+        var drifted = new TiltGradient(0.01, 0, 1000); // ReBaseline2 drifts by 0.01 from ReBaseline1
+        var inputs = new TiltCalibrationInputs {
+            ScrewCount = 3,
+            HasCurvatureMeasurement = false,
+            ReBaseline1 = baseline,
+            Screw1 = new TiltGradient(0.10, 0, 1000),
+            ReBaseline2 = drifted,
+            Screw2 = new TiltGradient(0.01, 0.10, 1000)
+        };
+        var confidence = TiltCalibrationCalculator.ComputeConfidence(inputs);
+        Assert.Multiple(() => {
+            // signal = mean(|0.10|, |0.10|) = 0.10; noise = |ReBaseline2 - ReBaseline1| = 0.01
+            Assert.That(confidence.ScrewMoveSignal, Is.EqualTo(0.10).Within(1e-9));
+            Assert.That(confidence.NoiseEstimate, Is.EqualTo(0.01).Within(1e-9));
+            Assert.That(confidence.SignalToNoise, Is.EqualTo(10.0).Within(1e-9));
+            Assert.That(confidence.AllInwardTiltResidual, Is.NaN);
+            Assert.That(confidence.Rebaseline1Drift, Is.NaN);
+            Assert.That(confidence.Rebaseline2Drift, Is.EqualTo(0.01).Within(1e-9));
+            Assert.That(confidence.IsReliable, Is.True);
+        });
+    }
+
+    [TestCase(30.0, true, 3, 30.0, 150.0, 270.0, double.NaN)]
+    [TestCase(30.0, false, 3, 30.0, 270.0, 150.0, double.NaN)]
+    [TestCase(350.0, true, 4, 350.0, 80.0, 170.0, 260.0)]
+    [TestCase(10.0, false, 4, 10.0, 280.0, 190.0, 100.0)]
+    public void ComputeManualScrewAngles_PlacesEqualSpacingWithWinding(
+        double screw1, bool clockwise, int screwCount, double e1, double e2, double e3, double e4) {
+        var (s1, s2, s3, s4) = TiltCalibrationCalculator.ComputeManualScrewAngles(screw1, clockwise, screwCount);
+        Assert.Multiple(() => {
+            Assert.That(s1, Is.EqualTo(e1).Within(1e-9));
+            Assert.That(s2, Is.EqualTo(e2).Within(1e-9));
+            Assert.That(s3, Is.EqualTo(e3).Within(1e-9));
+            if (double.IsNaN(e4)) Assert.That(s4, Is.NaN);
+            else Assert.That(s4, Is.EqualTo(e4).Within(1e-9));
+        });
+    }
+```
+
+Note on the 4-screw expectations: with step +90° CW, screws land at s1, s1+90, s1+180, s1+270 (normalized); with −90° CCW at s1, s1−90, s1−180, s1−270. Opposite screws are 180° apart in both cases.
+
+- [ ] **Step 2: Run to verify failure** (compile errors on `HasCurvatureMeasurement`, `FallbackCurvatureSign`, `ComputeManualScrewAngles`).
+
+Run: `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~TiltCalibrationCalculatorTests"`
+
+- [ ] **Step 3: Implement**
+
+In `TiltCalibrationCalculator.cs`:
+
+1. In `TiltCalibrationInputs` (after the `IsStepperAdjustment` property, line 54), add:
+```csharp
+        /// <summary>False for a 4-step run that skipped the curvature-direction steps: Baseline and
+        /// AllInward were never measured (leave them default) and the baseline reading is supplied
+        /// in the ReBaseline1 slot, which is the screw-1 reference in both flows.</summary>
+        public bool HasCurvatureMeasurement { get; set; } = true;
+
+        /// <summary>Curvature sign carried into the result when HasCurvatureMeasurement is false
+        /// (the configured/assumed ScrewInwardCurvatureSign; 0 = unknown).</summary>
+        public int FallbackCurvatureSign { get; set; }
+```
+2. In `ComputeConfidence` (lines 125–150), replace the noise computation (keep the `s1/s2/signal` lines) with:
+```csharp
+            double drift2 = Magnitude(inputs.ReBaseline2.A - inputs.ReBaseline1.A, inputs.ReBaseline2.B - inputs.ReBaseline1.B);
+            double allInward = double.NaN;
+            double drift1 = double.NaN;
+            double noise;
+            if (inputs.HasCurvatureMeasurement) {
+                allInward = Magnitude(inputs.AllInward.A - inputs.Baseline.A, inputs.AllInward.B - inputs.Baseline.B);
+                drift1 = Magnitude(inputs.ReBaseline1.A - inputs.Baseline.A, inputs.ReBaseline1.B - inputs.Baseline.B);
+                noise = Math.Sqrt((allInward * allInward + drift1 * drift1 + drift2 * drift2) / 3.0);
+            } else {
+                // 4-step run: the only available noise probe is the single re-baseline drift.
+                noise = drift2;
+            }
+```
+   (The subsequent `snr`, `angleUncertainty`, and result-object lines are unchanged — they already use `allInward`, `drift1`, `drift2`, `noise`.)
+3. In `Calibrate` (line 274), replace the `CurvatureSign = ...` line with:
+```csharp
+                CurvatureSign = inputs.HasCurvatureMeasurement
+                    ? ComputeCurvatureSign(inputs.AllInward.MeanFocuserPosition, inputs.Baseline.MeanFocuserPosition)
+                    : inputs.FallbackCurvatureSign,
+```
+4. Add the manual-placement helper (near `ComputeScrewAngles`):
+```csharp
+        /// <summary>
+        /// Places all screws from a manually entered screw-1 position angle: equal spacing (120° for
+        /// 3 screws; 90° for 4, opposite screws 180° apart), numbered clockwise or counter-clockwise
+        /// around the IMAGE (mirrors/diagonals can flip the physical winding). s4 = NaN for 3 screws.
+        /// </summary>
+        public static (double s1, double s2, double s3, double s4) ComputeManualScrewAngles(
+            double screw1Deg, bool clockwise, int screwCount) {
+            double step = (screwCount == 3 ? 120.0 : 90.0) * (clockwise ? 1.0 : -1.0);
+            double s1 = NormalizeAngle(screw1Deg);
+            double s2 = NormalizeAngle(s1 + step);
+            double s3 = NormalizeAngle(s1 + 2 * step);
+            double s4 = screwCount == 4 ? NormalizeAngle(s1 + 3 * step) : double.NaN;
+            return (s1, s2, s3, s4);
+        }
+```
+5. Update the `TiltCalibrationInputs` class doc comment (lines 35–39) to mention both flows: append `In the 4-step flow (no curvature steps) Baseline/AllInward are unset, HasCurvatureMeasurement is false, and the baseline reading occupies the ReBaseline1 slot.` to the summary.
+
+- [ ] **Step 4: Run tests** — the fixture filter, then the full suite. PASS required.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "feat(tilt): calculator supports 4-step runs (sign passthrough) and manual screw placement"
+```
+
+---
+
+### Task 5: Directional guidance — CW/CCW totals, signed steps, direction legend
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltScrewGuidanceRow.cs`
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs` (RebuildTiltGuidance)
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml` (legend line)
+- Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/TiltAdapterGuidanceVMTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `TiltAdapterGuidanceVMTests.cs` add (and UPDATE any existing `FormatTotal` tests asserting the old `"IN"/"OUT"` wording to the new expectations below):
+
+```csharp
+    [Test]
+    public void FormatTotal_Screws_UsesClockwiseWording() {
+        Assert.Multiple(() => {
+            Assert.That(TiltAdapterGuidanceVM.FormatTotal(1.25, steps: false, hasDirection: true), Is.EqualTo("1.25 turns CW"));
+            Assert.That(TiltAdapterGuidanceVM.FormatTotal(-0.5, steps: false, hasDirection: true), Is.EqualTo("0.50 turns CCW"));
+            Assert.That(TiltAdapterGuidanceVM.FormatTotal(0.75, steps: false, hasDirection: false), Is.EqualTo("0.75 turns"));
+            Assert.That(TiltAdapterGuidanceVM.FormatTotal(0.001, steps: false, hasDirection: true), Is.EqualTo("—"));
+        });
+    }
+
+    [Test]
+    public void FormatTotal_Steppers_UsesSignedSteps() {
+        Assert.Multiple(() => {
+            Assert.That(TiltAdapterGuidanceVM.FormatTotal(35.2, steps: true, hasDirection: true), Is.EqualTo("+35 steps"));
+            Assert.That(TiltAdapterGuidanceVM.FormatTotal(-35.2, steps: true, hasDirection: true), Is.EqualTo("−35 steps"));
+            Assert.That(TiltAdapterGuidanceVM.FormatTotal(12.0, steps: true, hasDirection: false), Is.EqualTo("12 steps"));
+            Assert.That(TiltAdapterGuidanceVM.FormatTotal(0.2, steps: true, hasDirection: true), Is.EqualTo("—"));
+        });
+    }
+
+    [Test]
+    public void BuildDirectionLegend_DescribesAdapterMotionAndProvenance() {
+        int cwInwardSign = TiltScrewGeometry.CurvatureSignForCwDirection(true);
+        int cwOutwardSign = TiltScrewGeometry.CurvatureSignForCwDirection(false);
+        Assert.Multiple(() => {
+            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: false, cwOutwardSign, signIsMeasured: true),
+                Is.EqualTo("⬆ = clockwise (adapter moves toward the camera)"));
+            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: false, cwInwardSign, signIsMeasured: true),
+                Is.EqualTo("⬆ = clockwise (adapter moves toward the objective)"));
+            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: true, cwOutwardSign, signIsMeasured: false),
+                Is.EqualTo("⬆ = + steps (adapter moves toward the camera) (assumed — set or measure in the Tilt Adapter Wizard)"));
+            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: false, 0, signIsMeasured: false), Is.Empty);
+        });
+    }
+```
+
+Add `using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;` to the test file if missing.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~TiltAdapterGuidanceVMTests"`
+
+- [ ] **Step 3: Implement the formatter changes**
+
+In `TiltScrewGuidanceRow.cs`:
+
+1. Add `using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;` to the usings.
+2. Replace `FormatTotal` (lines 78–95) with:
+```csharp
+        /// <summary>
+        /// Format the signed total adjustment with an explicit direction: clockwise/counter-clockwise
+        /// for screws, signed (+/−) steps for steppers. Positive input = the calibration "inward"
+        /// direction (a CW screw turn / + steps). When no direction is known
+        /// (<paramref name="hasDirection"/> false) only the magnitude is shown.
+        /// </summary>
+        public static string FormatTotal(double inwardAmount, bool steps, bool hasDirection) {
+            if (steps) {
+                long rounded = (long)Math.Round(Math.Abs(inwardAmount), MidpointRounding.AwayFromZero);
+                if (rounded == 0) return "—";
+                if (!hasDirection) return $"{rounded} steps";
+                return inwardAmount >= 0 ? $"+{rounded} steps" : $"−{rounded} steps";
+            }
+            if (Math.Abs(inwardAmount) < 0.005) return "—";
+            string magnitude = $"{Math.Abs(inwardAmount):0.00} turns";
+            if (!hasDirection) return magnitude;
+            return $"{magnitude} {(inwardAmount >= 0 ? "CW" : "CCW")}";
+        }
+```
+3. Add new members after `PitchMismatchWarning`/`HasPitchMismatch` (lines 62–63):
+```csharp
+        // One-line legend tying the arrows/totals to physical adapter motion; empty when unknown.
+        public string DirectionLegend { get; set; } = string.Empty;
+        public bool HasDirectionLegend => !string.IsNullOrEmpty(DirectionLegend);
+
+        /// <summary>
+        /// Legend for the guidance table. The adapter-motion wording comes from the configured or
+        /// measured curvature sign; "(assumed)" flags a sign never measured by the wizard.
+        /// </summary>
+        public static string BuildDirectionLegend(bool steps, int curvatureSign, bool signIsMeasured) {
+            if (curvatureSign == 0) return string.Empty;
+            bool cwTowardObjective = TiltScrewGeometry.CwMovesAdapterTowardObjectiveForSign(curvatureSign);
+            string inwardWord = steps ? "+ steps" : "clockwise";
+            string plateWord = cwTowardObjective ? "toward the objective" : "toward the camera";
+            string assumed = signIsMeasured ? string.Empty : " (assumed — set or measure in the Tilt Adapter Wizard)";
+            return $"⬆ = {inwardWord} (adapter moves {plateWord}){assumed}";
+        }
+```
+
+- [ ] **Step 4: Wire the legend in InspectorVM**
+
+In `InspectorVM.cs`, inside `RebuildTiltGuidance()` — after the backfocus-row block closes (the `if (curvatureSign != 0 && SensorModel?.DisplayedSensorModel != null) { ... }` block ending at line 1884) and still inside the `if (HasTiltAdapterCalibration)` block — add:
+
+```csharp
+                guidance.DirectionLegend = TiltAdapterGuidanceVM.BuildDirectionLegend(
+                    steps: tiltAdapterOptions.AdjustmentType == TiltAdjustmentType.StepperMotors,
+                    curvatureSign: curvatureSign,
+                    signIsMeasured: tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured);
+```
+
+Note `curvatureSign` is already in scope (declared at line 1864). `TiltAdjustmentType` is already resolvable in this file (it uses `TiltAdjustmentType.StepperMotors` at line 1905).
+
+- [ ] **Step 5: Add the legend line to the inspector guidance XAML**
+
+In `AutoFocus/DataTemplates.xaml`, find the numeric-guidance grid's closing tag — the `</Grid>` immediately after the `Screw4TotalAmount` TextBlock (line ~2972), just before the comment `<!--  Saved-vs-measured pitch mismatch warning  -->`. Insert between them:
+
+```xml
+                            <!--  Direction legend: what ⬆ / CW / + steps mean for this adapter  -->
+                            <TextBlock
+                                Margin="5,4,5,0"
+                                FontStyle="Italic"
+                                Opacity="0.7"
+                                Text="{Binding TiltGuidance.DirectionLegend}"
+                                TextWrapping="Wrap"
+                                Visibility="{Binding TiltGuidance.HasDirectionLegend, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+```
+
+- [ ] **Step 6: Run tests** — fixture filter, then full suite (this also compiles the XAML). Update any other failing tests that asserted the old IN/OUT strings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "feat(tilt): CW/CCW and signed-step guidance totals with adapter-direction legend"
+```
+
+---
+
+### Task 6: InspectorVM — dynamic image-count summary for Signal Amplification
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs`
+- Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `InspectorVMTests.cs` add:
+
+```csharp
+        [Test]
+        public void EstimateImagesPerRun_UsesOverridesThenProfileFallbacks() {
+            Assert.Multiple(() => {
+                // StepCount/FramesPerPoint unset (-1) => profile values; amp 2 doubles offset steps.
+                Assert.That(InspectorVM.EstimateImagesPerRun(-1, -1, 2, 4, 1), Is.EqualTo((17, 17)));
+                // Explicit overrides win over profile values.
+                Assert.That(InspectorVM.EstimateImagesPerRun(3, 2, 1, 4, 1), Is.EqualTo((7, 14)));
+                // Unknown when neither source is positive.
+                Assert.That(InspectorVM.EstimateImagesPerRun(-1, 1, 2, 0, 1), Is.EqualTo((0, 0)));
+            });
+        }
+
+        [Test]
+        public void BuildSignalAmplificationSummary_DescribesImageCount() {
+            var text = InspectorVM.BuildSignalAmplificationSummary(-1, -1, 2, 4, 1);
+            Assert.Multiple(() => {
+                Assert.That(text, Does.Contain("~17 images"));
+                Assert.That(text, Does.Contain("17 focus positions"));
+                Assert.That(text, Does.Contain("1 runs a regular autofocus"));
+            });
+            Assert.That(InspectorVM.BuildSignalAmplificationSummary(-1, -1, 2, 0, 0), Is.Empty);
+        }
+```
+
+- [ ] **Step 2: Run to verify failure** (missing members).
+
+Run: `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~InspectorVMTests"`
+
+- [ ] **Step 3: Implement**
+
+In `InspectorVM.cs`, next to `ApplySignalAmplification` (after line 1115), add:
+
+```csharp
+        // Estimated sweep size for one live sensor-model autofocus run at the given settings.
+        // points ≈ 2·offsetSteps·amp + 1 (the engine can extend a sweep, so callers label it "~");
+        // images = points × framesPerPoint. Returns (0, 0) when the inputs cannot be resolved.
+        internal static (int points, int images) EstimateImagesPerRun(
+            int stepCount, int framesPerPoint, int signalAmplification, int profileOffsetSteps, int profileFramesPerPoint) {
+            int offsetSteps = stepCount > 0 ? stepCount : profileOffsetSteps;
+            int frames = framesPerPoint > 0 ? framesPerPoint : profileFramesPerPoint;
+            if (offsetSteps <= 0 || frames <= 0) return (0, 0);
+            int amp = Math.Max(1, signalAmplification);
+            int points = 2 * offsetSteps * amp + 1;
+            return (points, points * frames);
+        }
+
+        // Prose shown beside the Signal Amplification control. Internal for tests.
+        internal static string BuildSignalAmplificationSummary(
+            int stepCount, int framesPerPoint, int signalAmplification, int profileOffsetSteps, int profileFramesPerPoint) {
+            var (points, images) = EstimateImagesPerRun(stepCount, framesPerPoint, signalAmplification, profileOffsetSteps, profileFramesPerPoint);
+            if (images <= 0) return string.Empty;
+            int frames = framesPerPoint > 0 ? framesPerPoint : profileFramesPerPoint;
+            return $"Each auto focus run will capture ~{images} images ({points} focus positions × {frames} exposure{(frames == 1 ? "" : "s")} each). " +
+                "Higher values collect more, finer-spaced points for a steadier fit on weak signal; 1 runs a regular autofocus (fastest).";
+        }
+
+        public string SignalAmplificationSummary =>
+            BuildSignalAmplificationSummary(
+                inspectorOptions.StepCount,
+                inspectorOptions.FramesPerPoint,
+                inspectorOptions.SignalAmplification,
+                profileService.ActiveProfile.FocuserSettings.AutoFocusInitialOffsetSteps,
+                profileService.ActiveProfile.FocuserSettings.AutoFocusNumberOfFramesPerPoint);
+```
+
+In the testing constructor, immediately before the `this.tiltAdapterOptions = tiltAdapterOptions;` line (line ~173), add a change subscription so the prose live-updates:
+
+```csharp
+            inspectorOptions.PropertyChanged += (s, e) => {
+                if (e.PropertyName == nameof(IInspectorOptions.SignalAmplification) ||
+                    e.PropertyName == nameof(IInspectorOptions.StepCount) ||
+                    e.PropertyName == nameof(IInspectorOptions.FramesPerPoint)) {
+                    RaisePropertyChanged(nameof(SignalAmplificationSummary));
+                }
+            };
+            profileService.ProfileChanged += (s, e) => RaisePropertyChanged(nameof(SignalAmplificationSummary));
+```
+
+- [ ] **Step 4: Run tests** — fixture filter, then full suite. PASS required.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "feat(inspector): dynamic image-count summary for Signal Amplification"
+```
+
+---
+
+### Task 7: Inspector XAML — surface the two sweep settings above the Options expander
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml`
+
+No unit tests possible for XAML; the full-suite build compiles it (`dotnet test` builds the sln).
+
+- [ ] **Step 1: Update the CenterFocuserBeforeRun tooltip** (line 31) — the default changed. Replace the resource with:
+
+```xml
+    <TextBlock x:Key="CenterFocuserBeforeRun_Tooltip" Text="When on, a quick standard AutoFocus is run before each live sensor-model / tilt calibration sweep to center the focuser at best focus. The detailed sweep then brackets focus symmetrically, which reduces extreme one-sided defocus frames that fail to align. Off by default; it adds a full AutoFocus run to every sweep. Has no effect when replaying saved frames." />
+```
+
+- [ ] **Step 2: Add the always-visible sweep-settings block**
+
+The buttons grid is `<Grid Grid.Row="0">` opening at line 1181 with its own `<Grid.RowDefinitions>` (two `Auto` rows at lines 1183–1184 — verify the actual count when editing). Append one more `<RowDefinition Height="Auto" />` to that inner list, then insert the following block immediately before the buttons grid's closing `</Grid>` (line ~1394, directly before the `<Expander Grid.Row="1" ... Header="Options">`). Set `Grid.Row` to the new last row index (expected `2`; adjust if the count differs):
+
+```xml
+                    <!--  Sweep-cost settings: kept out of the Options expander because they directly
+                          control how long every sensor-model / tilt-calibration run takes.  -->
+                    <Grid Grid.Row="2" Margin="0,4,0,0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            Margin="5"
+                            VerticalAlignment="Center"
+                            Text="Signal Amplification"
+                            ToolTip="{StaticResource SignalAmplification_Tooltip}" />
+                        <ninactrl:UnitTextBox
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            MinWidth="40"
+                            VerticalAlignment="Center"
+                            HorizontalContentAlignment="Left"
+                            VerticalContentAlignment="Center"
+                            Foreground="{StaticResource PrimaryBrush}"
+                            TextAlignment="Left"
+                            ToolTip="{StaticResource SignalAmplification_Tooltip}"
+                            Unit="x">
+                            <Binding
+                                Mode="TwoWay"
+                                Path="InspectorOptions.SignalAmplification"
+                                UpdateSourceTrigger="LostFocus" />
+                        </ninactrl:UnitTextBox>
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="2"
+                            Margin="10,5,5,5"
+                            VerticalAlignment="Center"
+                            FontStyle="Italic"
+                            Opacity="0.7"
+                            Text="{Binding SignalAmplificationSummary}"
+                            TextWrapping="Wrap" />
+                        <TextBlock
+                            Grid.Row="1"
+                            Grid.Column="0"
+                            Margin="5"
+                            VerticalAlignment="Center"
+                            Text="Center Focuser First"
+                            ToolTip="{StaticResource CenterFocuserBeforeRun_Tooltip}" />
+                        <CheckBox
+                            Grid.Row="1"
+                            Grid.Column="1"
+                            Margin="5,0,0,0"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            IsChecked="{Binding InspectorOptions.CenterFocuserBeforeRun}"
+                            ToolTip="{StaticResource CenterFocuserBeforeRun_Tooltip}" />
+                        <TextBlock
+                            Grid.Row="1"
+                            Grid.Column="2"
+                            Margin="10,5,5,5"
+                            VerticalAlignment="Center"
+                            FontStyle="Italic"
+                            Opacity="0.7"
+                            Text="Runs one standard autofocus to center the focuser before each measurement sweep. Turn on if your focuser drifts between runs or starts far from best focus; leave off to save time."
+                            TextWrapping="Wrap" />
+                    </Grid>
+```
+
+- [ ] **Step 3: Remove the two rows from the Options expander**
+
+Inside the Options expander (opens line 1395):
+1. Delete the "Signal Amplification" label + `UnitTextBox` (lines 1760–1782) and the "Center Focuser First" label + `StackPanel`/CheckBox (lines 1784–1800) — all six elements are `Grid.Row="7"`.
+2. In the expander grid's `<Grid.RowDefinitions>` (lines 1410–1421: nine plain `Auto` rows + one styled `HideOnInterpolationOff` row), delete ONE plain `<RowDefinition Height="Auto" />` so eight plain rows + the styled row remain.
+3. Renumber the two elements that referenced later rows: the `Experimental` expander `Grid.Row="8"` → `Grid.Row="7"`; any active (non-commented) element with `Grid.Row="9"` → `Grid.Row="8"` (the interpolation row's controls are commented out — check before assuming).
+
+- [ ] **Step 4: Build + full suite**
+
+Run: `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`
+Expected: PASS (XAML compiles; no test changes in this task).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "feat(inspector): surface Signal Amplification and Center Focuser First above Options with prose"
+```
+
+---
+
+### Task 8: TiltAdapterWizardVM — 4-step sequencing, direction property, manual entry, sweep summary, reworded prompts
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs`
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs`
+- Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs`
+
+- [ ] **Step 1: Write the failing tests for the new statics**
+
+In `TiltAdapterWizardVMTests.cs` add (namespace `NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard`; the statics need no VM instance):
+
+```csharp
+    [Test]
+    public void GetMeasurementSteps_FourStepFlowSkipsCurvatureSteps() {
+        Assert.Multiple(() => {
+            Assert.That(TiltAdapterWizardVM.GetMeasurementSteps(measureCurvature: true), Is.EqualTo(new[] {
+                WizardStep.Baseline, WizardStep.AllInward, WizardStep.ReBaseline1,
+                WizardStep.Screw1, WizardStep.ReBaseline2, WizardStep.Screw2 }));
+            Assert.That(TiltAdapterWizardVM.GetMeasurementSteps(measureCurvature: false), Is.EqualTo(new[] {
+                WizardStep.Baseline, WizardStep.Screw1, WizardStep.ReBaseline2, WizardStep.Screw2 }));
+        });
+    }
+
+    [Test]
+    public void StepInstructionsText_Screws_UsesClockwiseWordingAndAmount() {
+        Assert.Multiple(() => {
+            Assert.That(TiltAdapterWizardVM.StepInstructionsText(WizardStep.Baseline, 3, isStepper: false, appliedAmount: 1.0),
+                Does.Contain("consistent clockwise order").And.Contain("starting position"));
+            Assert.That(TiltAdapterWizardVM.StepInstructionsText(WizardStep.AllInward, 3, false, 1.0),
+                Does.Contain("ALL screws CLOCKWISE (tighten) exactly 1 full turn"));
+            Assert.That(TiltAdapterWizardVM.StepInstructionsText(WizardStep.ReBaseline1, 3, false, 1.0),
+                Does.Contain("COUNTER-CLOCKWISE (loosen) exactly 1 full turn"));
+            Assert.That(TiltAdapterWizardVM.StepInstructionsText(WizardStep.Screw1, 4, false, 1.0),
+                Does.Contain("screw 1 CLOCKWISE").And.Contain("screw 3 COUNTER-CLOCKWISE"));
+            Assert.That(TiltAdapterWizardVM.StepInstructionsText(WizardStep.Screw2, 3, false, 1.5),
+                Does.Contain("screw 2 CLOCKWISE exactly 1.5 turns"));
+        });
+    }
+
+    [Test]
+    public void StepInstructionsText_Steppers_UsesSignedSteps() {
+        Assert.Multiple(() => {
+            Assert.That(TiltAdapterWizardVM.StepInstructionsText(WizardStep.AllInward, 3, isStepper: true, appliedAmount: 2.0),
+                Does.Contain("+2 steps to EVERY motor"));
+            Assert.That(TiltAdapterWizardVM.StepInstructionsText(WizardStep.ReBaseline2, 3, true, 2.0),
+                Does.Contain("−2 steps to motor 1"));
+            Assert.That(TiltAdapterWizardVM.StepInstructionsText(WizardStep.Screw1, 4, true, 2.0),
+                Does.Contain("+2 steps to motor 1").And.Contain("−2 steps to motor 3"));
+        });
+    }
+
+    [Test]
+    public void BuildSweepSummary_CountsSweepsAndImages() {
+        // 4 steps × 2 averaged measurements = 8 sweeps; profile: 4 offset steps, 1 frame, amp 2 => 17 images/run.
+        var text = TiltAdapterWizardVM.BuildSweepSummary(4, 2, -1, -1, 2, 4, 1);
+        Assert.Multiple(() => {
+            Assert.That(text, Does.Contain("~17 images"));
+            Assert.That(text, Does.Contain("8 sweeps"));
+            Assert.That(text, Does.Contain("136 images total"));
+        });
+        Assert.That(TiltAdapterWizardVM.BuildSweepSummary(4, 1, -1, -1, 2, 0, 0), Is.Empty);
+    }
+```
+
+- [ ] **Step 2: Run to verify failure** (missing statics).
+
+Run: `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~TiltAdapterWizardVMTests"`
+
+- [ ] **Step 3: Implement sequencing**
+
+In `TiltAdapterWizardVM.cs`:
+
+1. Replace the static `MeasurementSteps` field (lines 118–122) with:
+```csharp
+        // The measurement steps in capture order. The 4-step flow (default) skips the two
+        // curvature-direction steps; the Baseline reading then serves as the screw-1 reference
+        // (the ReBaseline1 role of the 6-step flow).
+        internal static WizardStep[] GetMeasurementSteps(bool measureCurvature) =>
+            measureCurvature
+                ? new[] { WizardStep.Baseline, WizardStep.AllInward, WizardStep.ReBaseline1,
+                          WizardStep.Screw1, WizardStep.ReBaseline2, WizardStep.Screw2 }
+                : new[] { WizardStep.Baseline, WizardStep.Screw1, WizardStep.ReBaseline2, WizardStep.Screw2 };
+
+        // Captured at run start (StartAsync/ReplayAsync) so toggling the option mid-run is inert.
+        private WizardStep[] activeMeasurementSteps = GetMeasurementSteps(measureCurvature: false);
+```
+2. `IsOnMeasurementStep` (line 283) → `public bool IsOnMeasurementStep => activeMeasurementSteps.Contains(currentStep);`
+3. In `StartAsync()` (before `CurrentStep = WizardStep.Baseline;`, line 713), add:
+```csharp
+            activeMeasurementSteps = GetMeasurementSteps(tiltAdapterOptions.MeasureCurvatureDuringCalibration);
+```
+4. Rewrite `NextStep()` (lines 1021–1041) — sequence advance is index-based now:
+```csharp
+        private void NextStep() {
+            int idx = Array.IndexOf(activeMeasurementSteps, currentStep);
+            WizardStep next = (idx < 0 || idx == activeMeasurementSteps.Length - 1)
+                ? WizardStep.Complete
+                : activeMeasurementSteps[idx + 1];
+
+            if (next == WizardStep.Complete) {
+                RunCalibrationMath(
+                    tiltAdapterOptions.ScrewCount,
+                    tiltAdapterOptions.ScrewRadiusMillimeters,
+                    profileService.ActiveProfile.CameraSettings.PixelSize,
+                    EffectiveFocuserStepMicrons(),
+                    calibrationAppliedAmount,
+                    IsStepperAdjustment);
+                RebuildDiagram();
+                FinalizeMetadata();
+            }
+
+            HasMeasurementConsistencyWarning = false;
+            MeasurementConsistencyWarningText = string.Empty;
+            StatusText = string.Empty;
+            ClearMeasurementFailureChoice();
+            CurrentStep = next;
+        }
+```
+
+- [ ] **Step 4: Implement the calibration-math branching**
+
+Rewrite the top of `RunCalibrationMath` (lines 1113–1123). The rule: curvature was measured iff an `AllInward` reading exists (works for live runs and replays of old 6-step runs alike). In the 4-step flow the Baseline reading takes the `c` role:
+
+```csharp
+        private void RunCalibrationMath(int screwCount, double radiusMm, double pixelSize, double fStep,
+            double appliedAmount, bool isStepper) {
+            bool measuredCurvature = stepReadings.ContainsKey(WizardStep.AllInward);
+            var a = Reading(WizardStep.Baseline);
+            var b = Reading(WizardStep.AllInward);
+            var c = measuredCurvature ? Reading(WizardStep.ReBaseline1) : Reading(WizardStep.Baseline);
+            var d = Reading(WizardStep.Screw1);
+            var e = Reading(WizardStep.ReBaseline2);
+            var f = Reading(WizardStep.Screw2);
+
+            // Curvature (backfocus) sign from baseline (a) → all-inward (b) mean focus, only when
+            // those steps ran; otherwise the configured/assumed sign is left untouched.
+            if (measuredCurvature) {
+                tiltAdapterOptions.ScrewInwardCurvatureSign = TiltCalibrationCalculator.ComputeCurvatureSign(b.Mean, a.Mean);
+                tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured = true;
+            }
+```
+
+After `tiltAdapterOptions.IsCalibrated = true;` (line 1138) add:
+```csharp
+            tiltAdapterOptions.CalibrationIsManual = false;
+```
+
+Both `TiltCalibrationInputs` constructions in this method (the hardware-recovery one at lines 1152–1167 and the confidence one at lines 1180–1188) get three edits each:
+- `ReBaseline1 = new TiltGradient(c.A, c.B, c.Mean),` (unchanged text — `c` now carries the right reading in both flows), and add:
+```csharp
+                    HasCurvatureMeasurement = measuredCurvature,
+                    FallbackCurvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign,
+```
+
+Rewrite `EvaluateRebaselineDrift` (lines 1234–1256) — drift1 only exists in the 6-step flow:
+
+```csharp
+        private void EvaluateRebaselineDrift() {
+            bool measuredCurvature = stepReadings.ContainsKey(WizardStep.AllInward);
+            var a = Reading(WizardStep.Baseline);
+            var c = measuredCurvature ? Reading(WizardStep.ReBaseline1) : Reading(WizardStep.Baseline);
+            var d = Reading(WizardStep.Screw1);
+            var e = Reading(WizardStep.ReBaseline2);
+            var f = Reading(WizardStep.Screw2);
+
+            double drift1 = measuredCurvature
+                ? TiltCalibrationCalculator.RebaselineDriftRatio(c.A - a.A, c.B - a.B, d.A - c.A, d.B - c.B)
+                : double.NaN;
+            double drift2 = TiltCalibrationCalculator.RebaselineDriftRatio(e.A - c.A, e.B - c.B, f.A - e.A, f.B - e.B);
+
+            var parts = new List<string>(2);
+            if (!double.IsNaN(drift1) && drift1 > RebaselineDriftWarnThreshold) {
+                parts.Add($"re-baseline 1 drifted {drift1 * 100.0:F0}% of the screw-1 move");
+            }
+            if (!double.IsNaN(drift2) && drift2 > RebaselineDriftWarnThreshold) {
+                parts.Add($"re-baseline 2 drifted {drift2 * 100.0:F0}% of the screw-2 move");
+            }
+            HasRebaselineDriftWarning = parts.Count > 0;
+            RebaselineDriftWarningText = parts.Count == 0
+                ? string.Empty
+                : "Re-baseline drift detected: " + string.Join("; ", parts) +
+                    ". The undo between moves left residual tilt (backlash or an uneven turn); consider recalibrating.";
+        }
+```
+
+- [ ] **Step 5: Implement the reworded, testable step instructions**
+
+Replace the `StepInstructions` property (lines 500–530) with a delegating property + static, and extend `BaselineRecoveryText`:
+
+```csharp
+        public string StepInstructions =>
+            StepInstructionsText(currentStep, tiltAdapterOptions.ScrewCount, IsStepperAdjustment, calibrationAppliedAmount);
+
+        // Formats the calibration move amount: "1 full turn" / "1.5 turns" for screws, whole "+N"
+        // magnitude for steppers (sign is added by the caller's wording).
+        internal static string FormatAppliedAmount(bool isStepper, double amount) =>
+            isStepper ? $"{amount:0.##}" : (amount == 1.0 ? "1 full turn" : $"{amount:0.##} turns");
+
+        // All wizard prompts. Screw motion is worded as CLOCKWISE/COUNTER-CLOCKWISE (tighten/loosen)
+        // — never "inward/outward", which this plugin reserves for adapter-plate motion. Stepper
+        // prompts use signed steps; "+" is the direction the guidance later reports as positive.
+        internal static string StepInstructionsText(WizardStep step, int screwCount, bool isStepper, double appliedAmount) {
+            string amt = FormatAppliedAmount(isStepper, appliedAmount);
+            bool four = screwCount == 4;
+            switch (step) {
+                case WizardStep.Baseline:
+                    return "Label your screws 1, 2, and 3 (or 1–4 for a 4-screw adapter) in a consistent clockwise order. " +
+                        "Screw 1 does NOT need to be at any particular clock position — the wizard determines each screw's actual " +
+                        "position from the measurements.\n\nEnsure all screws are at their starting position, then click Run Measurement to take a baseline reading.";
+                case WizardStep.AllInward:
+                    return isStepper
+                        ? $"Apply +{amt} steps to EVERY motor, then click Run Measurement."
+                        : $"Turn ALL screws CLOCKWISE (tighten) exactly {amt} each, then click Run Measurement.";
+                case WizardStep.ReBaseline1:
+                    return isStepper
+                        ? $"Apply −{amt} steps to every motor, returning to the baseline position, then click Run Measurement."
+                        : $"Turn ALL screws back COUNTER-CLOCKWISE (loosen) exactly {amt} each, returning to the baseline position, then click Run Measurement.";
+                case WizardStep.Screw1:
+                    if (isStepper) {
+                        return four
+                            ? $"Apply +{amt} steps to motor 1 and −{amt} steps to motor 3, then click Run Measurement."
+                            : $"Apply +{amt} steps to motor 1, then click Run Measurement.";
+                    }
+                    return four
+                        ? $"Turn screw 1 CLOCKWISE and screw 3 COUNTER-CLOCKWISE exactly {amt} each, then click Run Measurement."
+                        : $"Turn screw 1 CLOCKWISE exactly {amt}, then click Run Measurement.";
+                case WizardStep.ReBaseline2:
+                    if (isStepper) {
+                        return four
+                            ? $"Apply −{amt} steps to motor 1 and +{amt} steps to motor 3, returning to the baseline position, then click Run Measurement."
+                            : $"Apply −{amt} steps to motor 1, returning to the baseline position, then click Run Measurement.";
+                    }
+                    return four
+                        ? $"Turn screw 1 back COUNTER-CLOCKWISE and screw 3 back CLOCKWISE exactly {amt} each, returning to the baseline position, then click Run Measurement."
+                        : $"Turn screw 1 back COUNTER-CLOCKWISE exactly {amt}, returning to the baseline position, then click Run Measurement.";
+                case WizardStep.Screw2:
+                    if (isStepper) {
+                        return four
+                            ? $"Apply +{amt} steps to motor 2 and −{amt} steps to motor 4, then click Run Measurement."
+                            : $"Apply +{amt} steps to motor 2, then click Run Measurement.";
+                    }
+                    return four
+                        ? $"Turn screw 2 CLOCKWISE and screw 4 COUNTER-CLOCKWISE exactly {amt} each, then click Run Measurement."
+                        : $"Turn screw 2 CLOCKWISE exactly {amt}, then click Run Measurement.";
+                case WizardStep.Complete:
+                    return isStepper
+                        ? "Return all motors to their original position."
+                        : "Restore all screws to their original position.";
+                default:
+                    return string.Empty;
+            }
+        }
+```
+
+Update `BaselineRecoveryText` (lines 547–562) to the same vocabulary — new signature `internal static string BaselineRecoveryText(WizardStep step, int screwCount, bool isStepper, double appliedAmount)`:
+
+```csharp
+        internal static string BaselineRecoveryText(WizardStep step, int screwCount, bool isStepper, double appliedAmount) {
+            string amt = FormatAppliedAmount(isStepper, appliedAmount);
+            bool four = screwCount == 4;
+            switch (step) {
+                case WizardStep.AllInward:
+                    return isStepper
+                        ? $"Apply −{amt} steps to every motor, returning to the baseline position."
+                        : $"Turn ALL screws back COUNTER-CLOCKWISE exactly {amt} each, returning to the baseline position.";
+                case WizardStep.Screw1:
+                    if (isStepper) {
+                        return four
+                            ? $"Apply −{amt} steps to motor 1 and +{amt} steps to motor 3, returning to the baseline position."
+                            : $"Apply −{amt} steps to motor 1, returning to the baseline position.";
+                    }
+                    return four
+                        ? $"Turn screw 1 back COUNTER-CLOCKWISE and screw 3 back CLOCKWISE exactly {amt} each, returning to the baseline position."
+                        : $"Turn screw 1 back COUNTER-CLOCKWISE exactly {amt}, returning to the baseline position.";
+                case WizardStep.Screw2:
+                    if (isStepper) {
+                        return four
+                            ? $"Apply −{amt} steps to motor 2 and +{amt} steps to motor 4, returning to the baseline position."
+                            : $"Apply −{amt} steps to motor 2, returning to the baseline position.";
+                    }
+                    return four
+                        ? $"Turn screw 2 back COUNTER-CLOCKWISE and screw 4 back CLOCKWISE exactly {amt} each, returning to the baseline position."
+                        : $"Turn screw 2 back COUNTER-CLOCKWISE exactly {amt}, returning to the baseline position.";
+                default:
+                    return "All screws should already be at the baseline (starting) position.";
+            }
+        }
+```
+
+Update its caller `BaselineRecoveryInstructions` (line 433):
+```csharp
+        public string BaselineRecoveryInstructions =>
+            BaselineRecoveryText(currentStep, tiltAdapterOptions.ScrewCount, IsStepperAdjustment, calibrationAppliedAmount);
+```
+
+The prompts now embed the applied amount, so editing it must refresh them — in the `CalibrationAppliedAmount` setter (lines 576–585), after the existing `RaisePropertyChanged(nameof(CalibrationAppliedAmountDisplay));` add:
+```csharp
+                    RaisePropertyChanged(nameof(StepInstructions));
+                    RaisePropertyChanged(nameof(BaselineRecoveryInstructions));
+```
+
+- [ ] **Step 6: Implement direction property, provenance, manual entry, sweep summary**
+
+1. Replace `CurvatureSignDescription` (lines 347–350) with:
+```csharp
+        public string CurvatureSignDescription {
+            get {
+                int sign = tiltAdapterOptions.ScrewInwardCurvatureSign;
+                if (sign == 0) return string.Empty;
+                string arrow = sign == 1 ? "↑" : "↓";
+                return tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured ? $"{arrow} (measured)" : $"{arrow} (assumed)";
+            }
+        }
+```
+2. Add new properties near `IsStepperAdjustment` (line 587):
+```csharp
+        // Mechanical framing of ScrewInwardCurvatureSign: does a CW screw turn (or +steps) move the
+        // adapter plate toward the objective? Editing writes the sign (and marks it assumed); a
+        // 6-step wizard measurement overwrites the sign and this re-reads it.
+        public bool CwMovesAdapterTowardObjective {
+            get {
+                int sign = tiltAdapterOptions.ScrewInwardCurvatureSign;
+                if (sign == 0) sign = TiltScrewGeometry.DefaultScrewInwardCurvatureSign;
+                return TiltScrewGeometry.CwMovesAdapterTowardObjectiveForSign(sign);
+            }
+            set {
+                int sign = TiltScrewGeometry.CurvatureSignForCwDirection(value);
+                if (tiltAdapterOptions.ScrewInwardCurvatureSign != sign) {
+                    tiltAdapterOptions.ScrewInwardCurvatureSign = sign;
+                    tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured = false;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public string CwDirectionLabel => IsStepperAdjustment
+            ? "Applying + steps moves the adapter"
+            : "Turning screws clockwise moves the adapter";
+
+        public string CurvatureSignProvenance => tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured
+            ? "Direction was measured by a calibration run."
+            : "Direction is assumed — enable the measurement below (or run a 6-step calibration) to verify it.";
+```
+3. Manual entry state + command. Add fields/properties near `CalibrationAppliedAmount` (line 576):
+```csharp
+        private double manualScrew1AngleDegrees;
+
+        // Manual Calibration Entry: screw 1 position angle in degrees, image space, 0° = straight
+        // up (12 o'clock), increasing clockwise — the plugin-wide convention.
+        public double ManualScrew1AngleDegrees {
+            get => manualScrew1AngleDegrees;
+            set {
+                if (manualScrew1AngleDegrees != value) {
+                    manualScrew1AngleDegrees = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool manualNumberingClockwise = true;
+
+        // Whether screws 2..n proceed clockwise from screw 1 in the IMAGE (mirrors can flip it).
+        public bool ManualNumberingClockwise {
+            get => manualNumberingClockwise;
+            set {
+                if (manualNumberingClockwise != value) {
+                    manualNumberingClockwise = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        // Applies a manually entered calibration: same persisted state a wizard run writes, tagged
+        // manual. The curvature sign is whatever the direction setting above holds (assumed).
+        internal void ApplyManualCalibration() {
+            int n = tiltAdapterOptions.ScrewCount;
+            var (s1, s2, s3, s4) = TiltCalibrationCalculator.ComputeManualScrewAngles(manualScrew1AngleDegrees, manualNumberingClockwise, n);
+            tiltAdapterOptions.Screw1AngleDegrees = s1;
+            tiltAdapterOptions.Screw2AngleDegrees = s2;
+            tiltAdapterOptions.Screw3AngleDegrees = s3;
+            tiltAdapterOptions.Screw4AngleDegrees = s4;
+            tiltAdapterOptions.CalibratedScrewCount = n;
+            tiltAdapterOptions.IsCalibrated = true;
+            tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured = false;
+            tiltAdapterOptions.CalibrationIsManual = true;
+            RebuildDiagram();
+        }
+```
+   Declare `public ICommand ApplyManualCalibrationCommand { get; }` with the other commands (line 564+) and initialize it in the constructor next to the others (line ~178): `ApplyManualCalibrationCommand = new RelayCommand(ApplyManualCalibration);`
+   In the constructor, after `ApplyDevice(tiltAdapterOptions.DeviceName);` (line 226), pre-fill from an existing calibration:
+```csharp
+            if (!double.IsNaN(tiltAdapterOptions.Screw1AngleDegrees)) {
+                manualScrew1AngleDegrees = tiltAdapterOptions.Screw1AngleDegrees;
+            }
+```
+4. Sweep summary statics + property (place near `GetMeasurementSteps`):
+```csharp
+        // Prose for the wizard's Signal Amplification row: per-sweep image estimate plus the total
+        // for the whole calibration at current settings. Internal for tests.
+        internal static string BuildSweepSummary(int stepsInRun, int measurementAverage,
+            int stepCount, int framesPerPoint, int signalAmplification, int profileOffsetSteps, int profileFramesPerPoint) {
+            var (points, imagesPerRun) = InspectorVM.EstimateImagesPerRun(
+                stepCount, framesPerPoint, signalAmplification, profileOffsetSteps, profileFramesPerPoint);
+            if (imagesPerRun <= 0) return string.Empty;
+            int frames = framesPerPoint > 0 ? framesPerPoint : profileFramesPerPoint;
+            int sweeps = stepsInRun * Math.Max(1, measurementAverage);
+            return $"Every calibration step runs a full autofocus sweep of ~{imagesPerRun} images ({points} focus positions × {frames} exposure{(frames == 1 ? "" : "s")}). " +
+                $"At the current settings this calibration will take {sweeps} sweeps ≈ {sweeps * imagesPerRun} images total. " +
+                "Increase for more signal on faint stars; decrease to run faster (1 = a regular autofocus).";
+        }
+
+        public string WizardSweepSummary {
+            get {
+                var inspectorOptions = inspector.InspectorOptions;
+                if (inspectorOptions == null) return string.Empty;
+                return BuildSweepSummary(
+                    GetMeasurementSteps(tiltAdapterOptions.MeasureCurvatureDuringCalibration).Length,
+                    tiltAdapterOptions.MeasurementAverageCount,
+                    inspectorOptions.StepCount,
+                    inspectorOptions.FramesPerPoint,
+                    inspectorOptions.SignalAmplification,
+                    profileService.ActiveProfile.FocuserSettings.AutoFocusInitialOffsetSteps,
+                    profileService.ActiveProfile.FocuserSettings.AutoFocusNumberOfFramesPerPoint);
+            }
+        }
+```
+5. Change notifications. In the constructor's `tiltAdapterOptions.PropertyChanged` handler:
+   - Extend the `ScrewInwardCurvatureSign` branch (lines 182–185) to also raise `CwMovesAdapterTowardObjective` and `CurvatureSignProvenance`.
+   - Add a new branch:
+```csharp
+                if (e.PropertyName == nameof(ITiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured)) {
+                    RaisePropertyChanged(nameof(CurvatureSignDescription));
+                    RaisePropertyChanged(nameof(CurvatureSignProvenance));
+                }
+                if (e.PropertyName == nameof(ITiltAdapterOptions.MeasureCurvatureDuringCalibration) ||
+                    e.PropertyName == nameof(ITiltAdapterOptions.MeasurementAverageCount)) {
+                    RaisePropertyChanged(nameof(WizardSweepSummary));
+                }
+                if (e.PropertyName == nameof(ITiltAdapterOptions.CalibrationIsManual)) {
+                    RaisePropertyChanged(nameof(IsCalibrationValid));
+                }
+```
+   - In the `AdjustmentType` branch (lines 202–214), also raise `CwDirectionLabel` and `StepInstructions` and `BaselineRecoveryInstructions` (adjustment type changes the prompt wording).
+   - After the `profileService.ProfileChanged` handler body (lines 217–223), add `RaisePropertyChanged(nameof(WizardSweepSummary));`.
+   - Subscribe to the inspector options for live prose updates, after the tiltAdapterOptions handler (line ~215):
+```csharp
+            if (inspector.InspectorOptions != null) {
+                inspector.InspectorOptions.PropertyChanged += (s, e) => OnUIThread(() => {
+                    if (e.PropertyName == nameof(IInspectorOptions.SignalAmplification) ||
+                        e.PropertyName == nameof(IInspectorOptions.StepCount) ||
+                        e.PropertyName == nameof(IInspectorOptions.FramesPerPoint)) {
+                        RaisePropertyChanged(nameof(WizardSweepSummary));
+                    }
+                });
+            }
+```
+
+- [ ] **Step 7: Replay support for 4-step runs**
+
+1. In `TiltCalibrationMetadata.cs`, after the `StepOrder` array (lines 76–78), add:
+```csharp
+        /// <summary>The 4 measurement steps of a run captured without the curvature-direction steps.</summary>
+        public static readonly string[] StepOrderWithoutCurvature = {
+            "Baseline", "Screw1", "ReBaseline2", "Screw2"
+        };
+```
+2. In `TiltAdapterWizardVM.ReplayAsync`, the three uses of `MeasurementSteps` (lines 1322, 1331, 1381) switch to a locally derived array. After the `byStep` dictionary is built (line ~1321), insert:
+```csharp
+            // A run saved without the curvature steps replays as a 4-step run.
+            bool replayHasCurvatureSteps = byStep.ContainsKey(WizardStep.AllInward.ToString());
+            var replaySteps = GetMeasurementSteps(replayHasCurvatureSteps);
+            activeMeasurementSteps = replaySteps;
+```
+   then replace `foreach (var step in MeasurementSteps)` (validation loop, line 1322) and the replay loop (line 1381) with `foreach (var step in replaySteps)`, and `MeasurementSteps.First()` (line 1331) with `replaySteps.First()`.
+
+- [ ] **Step 8: Run tests** — `--filter "FullyQualifiedName~TiltAdapterWizard"`, then the full suite. Existing wizard tests that assert the old instruction strings or `BaselineRecoveryText(step, screwCount)` signature must be updated to the new wording/signature (search Tests for `BaselineRecoveryText` and `INWARD`).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add -A
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "feat(wizard): 4-step default flow, CW/CCW prompts, manual entry, direction setting, sweep summary"
+```
+
+---
+
+### Task 9: Wizard XAML — Measurement section, direction controls, manual entry, provenance tags
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml`
+
+- [ ] **Step 1: Add the "Measurement" section**
+
+Insert after the "Focuser step size" `UniformGrid` closes (line 302) and before the `<!--  Calibrate + Replay side by side  -->` comment (line 304):
+
+```xml
+                    <!--  Measurement cost & direction settings (shared Signal Amplification /
+                          Center Focuser First live in InspectorOptions — same values as the
+                          Aberration Inspector's controls)  -->
+                    <TextBlock
+                        Margin="0,10,0,5"
+                        FontWeight="Bold"
+                        Text="Measurement" />
+                    <Grid Margin="0,2">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            Margin="0,2,5,2"
+                            VerticalAlignment="Center"
+                            Text="Signal Amplification"
+                            ToolTip="Increases the resolution and signal of sensor-model / tilt calibration runs by capturing more, finer-spaced focuser points. Set to 1 to disable. Applies to live captures only." />
+                        <ninactrl:UnitTextBox
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            MinWidth="40"
+                            VerticalAlignment="Center"
+                            HorizontalContentAlignment="Left"
+                            VerticalContentAlignment="Center"
+                            Foreground="{StaticResource PrimaryBrush}"
+                            TextAlignment="Left"
+                            Unit="x">
+                            <Binding
+                                Mode="TwoWay"
+                                Path="Inspector.InspectorOptions.SignalAmplification"
+                                UpdateSourceTrigger="LostFocus" />
+                        </ninactrl:UnitTextBox>
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="2"
+                            Margin="8,2,0,2"
+                            VerticalAlignment="Center"
+                            FontStyle="Italic"
+                            Opacity="0.7"
+                            Text="{Binding WizardSweepSummary}"
+                            TextWrapping="Wrap" />
+
+                        <TextBlock
+                            Grid.Row="1"
+                            Grid.Column="0"
+                            Margin="0,2,5,2"
+                            VerticalAlignment="Center"
+                            Text="Center Focuser First"
+                            ToolTip="When on, a quick standard AutoFocus is run before each live sweep to center the focuser at best focus. Off by default. No effect when replaying saved frames." />
+                        <CheckBox
+                            Grid.Row="1"
+                            Grid.Column="1"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            IsChecked="{Binding Inspector.InspectorOptions.CenterFocuserBeforeRun}" />
+                        <TextBlock
+                            Grid.Row="1"
+                            Grid.Column="2"
+                            Margin="8,2,0,2"
+                            VerticalAlignment="Center"
+                            FontStyle="Italic"
+                            Opacity="0.7"
+                            Text="Adds one standard autofocus before every measurement sweep to re-center focus. Turn on if focus drifts between steps (e.g., temperature) or your focuser starts far from focus."
+                            TextWrapping="Wrap" />
+
+                        <TextBlock
+                            Grid.Row="2"
+                            Grid.Column="0"
+                            Margin="0,2,5,2"
+                            VerticalAlignment="Center"
+                            Text="{Binding CwDirectionLabel}"
+                            ToolTip="Whether tightening moves the adapter toward the camera or the objective depends on its design (push vs pull screws). Sets the direction of backfocus/curvature guidance." />
+                        <ComboBox
+                            Grid.Row="2"
+                            Grid.Column="1"
+                            MinWidth="180"
+                            VerticalAlignment="Center"
+                            SelectedValuePath="Tag"
+                            SelectedValue="{Binding CwMovesAdapterTowardObjective}">
+                            <ComboBox.Style>
+                                <Style BasedOn="{StaticResource {x:Type ComboBox}}" TargetType="ComboBox">
+                                    <Setter Property="IsEnabled" Value="True" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding TiltAdapterOptions.MeasureCurvatureDuringCalibration}" Value="True">
+                                            <Setter Property="IsEnabled" Value="False" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </ComboBox.Style>
+                            <ComboBoxItem Content="Toward the camera — outward">
+                                <ComboBoxItem.Tag>
+                                    <s:Boolean>False</s:Boolean>
+                                </ComboBoxItem.Tag>
+                            </ComboBoxItem>
+                            <ComboBoxItem Content="Toward the objective — inward">
+                                <ComboBoxItem.Tag>
+                                    <s:Boolean>True</s:Boolean>
+                                </ComboBoxItem.Tag>
+                            </ComboBoxItem>
+                        </ComboBox>
+                        <TextBlock
+                            Grid.Row="2"
+                            Grid.Column="2"
+                            Margin="8,2,0,2"
+                            VerticalAlignment="Center"
+                            FontStyle="Italic"
+                            Opacity="0.7"
+                            Text="{Binding CurvatureSignProvenance}"
+                            TextWrapping="Wrap" />
+
+                        <TextBlock
+                            Grid.Row="3"
+                            Grid.Column="0"
+                            Margin="0,2,5,2"
+                            VerticalAlignment="Center"
+                            Text="Measure direction"
+                            ToolTip="Include the two curvature-direction steps in the calibration to determine the adapter direction automatically." />
+                        <CheckBox
+                            Grid.Row="3"
+                            Grid.Column="1"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            IsChecked="{Binding TiltAdapterOptions.MeasureCurvatureDuringCalibration}" />
+                        <TextBlock
+                            Grid.Row="3"
+                            Grid.Column="2"
+                            Margin="8,2,0,2"
+                            VerticalAlignment="Center"
+                            FontStyle="Italic"
+                            Opacity="0.7"
+                            Text="Adds 2 extra measurement steps (6 instead of 4 — about 50% longer) to determine the direction automatically. Turn on if you don't know how your adapter behaves, or to verify the setting above."
+                            TextWrapping="Wrap" />
+                    </Grid>
+```
+
+Note: the tooltips above are literal text (not `{StaticResource ...}`) on purpose — the `*_Tooltip` resources live in `AutoFocus/DataTemplates.xaml`, which is NOT merged into this file. Also confirm `ninactrl:` is declared in this file's root `ResourceDictionary` element; it is not today, so add the xmlns attribute — copy the exact `xmlns:ninactrl="..."` declaration string from the root element of `AutoFocus/DataTemplates.xaml` (do not guess the assembly name).
+
+- [ ] **Step 2: Add the "Manually entered" tag to the saved-calibration panel**
+
+Inside the saved-calibration `StackPanel` (opens line 373), before the `<Grid Margin="0,10,0,0" ...>` (line 385), insert:
+
+```xml
+                        <TextBlock
+                            Margin="0,10,0,0"
+                            FontStyle="Italic"
+                            Opacity="0.7"
+                            Text="Manually entered calibration (not measured by the wizard)."
+                            TextWrapping="Wrap">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding TiltAdapterOptions.CalibrationIsManual}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+```
+
+(The curvature row's "(measured)/(assumed)" annotation comes for free — it binds `CurvatureSignDescription`, which Task 8 extended.)
+
+- [ ] **Step 3: Add the Manual Calibration Entry expander**
+
+After the saved-calibration `StackPanel` closes (line 401) and before Panel A's closing `</StackPanel>` (line 402), insert:
+
+```xml
+                    <!--  Manual calibration entry: writes the same persisted state a wizard run
+                          does (screw angles + calibrated flags), tagged as manually entered.  -->
+                    <Expander Margin="0,10,0,0" Header="Manual Calibration Entry">
+                        <StackPanel Margin="0,5,0,0">
+                            <TextBlock
+                                Margin="0,0,0,5"
+                                FontStyle="Italic"
+                                Opacity="0.7"
+                                Text="If you already know where screw 1 sits, enter it here and skip the wizard. Angles and numbering direction are in image space — mirrors or diagonals in the optical train can flip them relative to the physical adapter. If guidance moves tilt the wrong way, flip the numbering direction. Set the adapter direction in the Measurement settings above if you know it."
+                                TextWrapping="Wrap" />
+                            <UniformGrid Margin="0,2" VerticalAlignment="Center" Columns="2">
+                                <TextBlock VerticalAlignment="Center" Text="Screw 1 angle (°)"
+                                    ToolTip="Position angle of screw 1 in the image: 0° = straight up (12 o'clock), increasing clockwise. Remaining screws are placed at equal spacing (120° for 3 screws, 90° for 4)." />
+                                <TextBox MinWidth="60" Text="{Binding ManualScrew1AngleDegrees, UpdateSourceTrigger=LostFocus}" />
+                            </UniformGrid>
+                            <UniformGrid Margin="0,2" VerticalAlignment="Center" Columns="2">
+                                <TextBlock VerticalAlignment="Center" Text="Numbering direction"
+                                    ToolTip="Whether screws 2 and up proceed clockwise or counter-clockwise from screw 1, as seen in the image." />
+                                <ComboBox MinWidth="120" SelectedValuePath="Tag" SelectedValue="{Binding ManualNumberingClockwise}">
+                                    <ComboBoxItem Content="Clockwise">
+                                        <ComboBoxItem.Tag>
+                                            <s:Boolean>True</s:Boolean>
+                                        </ComboBoxItem.Tag>
+                                    </ComboBoxItem>
+                                    <ComboBoxItem Content="Counter-clockwise">
+                                        <ComboBoxItem.Tag>
+                                            <s:Boolean>False</s:Boolean>
+                                        </ComboBoxItem.Tag>
+                                    </ComboBoxItem>
+                                </ComboBox>
+                            </UniformGrid>
+                            <Button
+                                Margin="0,8,0,0"
+                                HorizontalAlignment="Left"
+                                Command="{Binding ApplyManualCalibrationCommand}">
+                                <TextBlock
+                                    Margin="10,5,10,5"
+                                    Foreground="{StaticResource ButtonForegroundBrush}"
+                                    Text="Apply" />
+                            </Button>
+                        </StackPanel>
+                    </Expander>
+```
+
+- [ ] **Step 4: Build + full suite**
+
+Run: `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`
+Expected: PASS. (XAML compile errors surface here; the most likely one is a missing `ninactrl` xmlns — see the note in Step 1.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "feat(wizard): Measurement settings section, adapter-direction control, manual calibration entry UI"
+```
+
+---
+
+### Task 10: TestApp TiltCalibrationRunner — accept 4-step runs
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs`
+
+The headless validator currently hard-requires all 6 steps. Make it accept either flow. (No unit tests exist for this Exe-resident file; the linked-in tests don't cover it. Verify by build + a careful read-through.)
+
+- [ ] **Step 1: Implement**
+
+1. In `MapRunsToSteps` (lines 272–316): compute the expected step set instead of always using `StepOrder`:
+```csharp
+            // Runs saved by the 4-step wizard flow have no AllInward/ReBaseline1 steps.
+            string[] expectedSteps;
+            if (metadata.RunStepMapping != null && metadata.RunStepMapping.Count > 0) {
+                expectedSteps = metadata.RunStepMapping.Any(m => string.Equals(m.Step, "AllInward", StringComparison.OrdinalIgnoreCase))
+                    ? StepOrder
+                    : TiltCalibrationMetadata.StepOrderWithoutCurvature;
+            } else {
+                if (runFolders.Count == StepOrder.Length) {
+                    expectedSteps = StepOrder;
+                } else if (runFolders.Count == TiltCalibrationMetadata.StepOrderWithoutCurvature.Length) {
+                    expectedSteps = TiltCalibrationMetadata.StepOrderWithoutCurvature;
+                } else {
+                    throw new InvalidOperationException(
+                        $"Expected {StepOrder.Length} run folders ({string.Join(", ", StepOrder)}) or " +
+                        $"{TiltCalibrationMetadata.StepOrderWithoutCurvature.Length} ({string.Join(", ", TiltCalibrationMetadata.StepOrderWithoutCurvature)}) under {datasetDir}, " +
+                        $"but found {runFolders.Count}. Provide an explicit 'runStepMapping' in the metadata to disambiguate.");
+                }
+            }
+```
+   Then use `expectedSteps` in place of `StepOrder` for the no-mapping ordered list (`ordered = runFolders.Select((f, i) => (expectedSteps[i], f)).ToList();`) and in the required-steps validation loop (`foreach (var required in expectedSteps)`).
+2. In `RunImpl`, both `TiltCalibrationInputs` constructions (lines ~207–225 and the paraboloid one at ~240–258) must handle the short flow. Before the first construction add:
+```csharp
+            bool hasCurvatureSteps = byStep.ContainsKey("AllInward");
+```
+   and in each initializer replace the `Baseline`/`AllInward`/`ReBaseline1` lines with:
+```csharp
+                Baseline = hasCurvatureSteps ? byStep["Baseline"].Gradient : default,
+                AllInward = hasCurvatureSteps ? byStep["AllInward"].Gradient : default,
+                ReBaseline1 = hasCurvatureSteps ? byStep["ReBaseline1"].Gradient : byStep["Baseline"].Gradient,
+                HasCurvatureMeasurement = hasCurvatureSteps,
+                FallbackCurvatureSign = metadata.Calibration?.CurvatureSign ?? 0,
+```
+   (same for the `pbyStep` paraboloid block, keeping `IsStepperAdjustment = inputs.IsStepperAdjustment` etc. as-is). The paraboloid loop iterates `orderedRuns` — that is already only the discovered steps, so nothing else changes.
+3. In `WriteReport`, where `calibration.CurvatureSign` is printed (lines ~740 and ~816), annotate when it was not measured — append the string `" (not measured — carried from metadata)"` when `!inputs.HasCurvatureMeasurement` (the method already receives `inputs`; check the signature and thread it through if not).
+4. Update `PrintUsage` (lines 873–881): change "folder containing the 6 AF runs (Baseline, AllInward, ReBaseline1, Screw1, ReBaseline2, Screw2)" to "folder containing the 6 AF runs (Baseline, AllInward, ReBaseline1, Screw1, ReBaseline2, Screw2) — or 4 (Baseline, Screw1, ReBaseline2, Screw2) for a run saved without the curvature-direction steps".
+
+- [ ] **Step 2: Build + full suite**
+
+Run: `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`
+Expected: PASS (TestApp compiles as part of the sln).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "feat(testapp): tilt calibration validator accepts 4-step runs"
+```
+
+---
+
+### Task 11: Documentation updates
+
+**Files:**
+- Modify: `documentation/docs/overview/tilt-adapter-wizard.md`
+- Modify: `documentation/docs/overview/tilt-aberration-inspector.md`
+- Modify: `documentation/docs/overview/sensor-model.md`
+- Modify: `documentation/docs/quick-start.md`
+
+Read `.claude/docs/documentation-style.md` before editing. Keep the house voice; do not add "Honest limit"-style confessional headings; no raw pipes inside table-cell math.
+
+- [ ] **Step 1: tilt-adapter-wizard.md**
+
+In "The calibration loop" (lines 38–58):
+1. Replace the loop description paragraph (lines 40–46) with one that states: the default run is **4 steps** (baseline, screw 1, re-baseline, screw 2) with prompts worded as **clockwise/counter-clockwise turns** (signed +/− steps for stepper adapters); turning on **Measure direction** adds 2 steps (baseline + all-screws-clockwise) that measure `ScrewInwardCurvatureSign` — otherwise the sign comes from the **adapter direction setting** ("Turning screws clockwise moves the adapter: toward the camera / toward the objective", default toward the camera) and guidance marks it "(assumed)". Keep the existing "Measurements above 1 averages repeats" sentence.
+2. Update the tip block (lines 48–58): Center Focuser First is now **off by default** and both it and Signal Amplification are editable **directly in the wizard's Measurement section** (as well as in the inspector); remove "(the default)" after Center Focuser First.
+3. Add a new `## Manual calibration entry` section (after the calibration-loop section) documenting: enter the screw-1 angle (0° = top of image, clockwise-positive), pick the numbering direction (clockwise/counter-clockwise **in the image** — mirrors can flip it), Apply writes the same calibration state the wizard produces, tagged "manually entered"; the adapter-direction setting supplies the curvature sign.
+
+- [ ] **Step 2: tilt-aberration-inspector.md**
+
+1. In the "Inspector options" table, update the **Signal Amplification** row (line 141) and **Center Focuser First** row (line 142): note both controls now sit **above the Options expander** with explanatory text (including a live image-count estimate), and Center Focuser First's default is **off** ("| **Center Focuser First** | off | on/off | ..."). Rewrite the quoted description to match the new tooltip (drop "(default)").
+2. Search this page for guidance wording that says IN/OUT or "inward/outward" describing **screw turns** (`grep -n "IN/OUT\|inward" documentation/docs/overview/tilt-aberration-inspector.md`) and update: totals now read like `1.25 turns CW` (screws) or `+35 steps` (steppers), a legend line explains what ⬆ means for the adapter ("adapter moves toward the camera/objective"), and an "(assumed)" marker appears until the direction is measured.
+
+- [ ] **Step 3: sensor-model.md**
+
+At the end of the "From fit to physical numbers" paragraph (lines 301–307), after "…(see the [Tilt Adapter Wizard](tilt-adapter-wizard.md))", add one sentence: "The direction of those all-screws moves comes from the adapter-direction setting (or the wizard's optional direction measurement); if the backfocus guidance seems inverted, flip that setting."
+
+- [ ] **Step 4: quick-start.md**
+
+In section 5 (lines 77–91), update item 2 to mention the default 4-step loop and the opt-in direction measurement, and add an item 3: "Know your adapter already? Use **Manual Calibration Entry** in the wizard to type in the screw-1 angle instead of running the loop." Keep the arrow-link lines unchanged.
+
+- [ ] **Step 5: Verify + commit**
+
+Run `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo` (unchanged code, but keep the invariant). Optionally run the repo's `adversarial-doc-review` workflow on the four pages.
+
+```bash
+git add -A
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "docs: 4-step wizard flow, surfaced sweep settings, directional guidance, manual entry"
+```
+
+---
+
+### Task 12: Final verification
+
+- [ ] **Step 1: Full suite** — `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo` → all green.
+- [ ] **Step 2: Spec coverage check** — re-read `docs/tilt-calibration-ux-design.md` section by section and confirm each requirement maps to a landed change (Feature 1 → Tasks 1, 6, 7, 8, 9; Feature 2 → Tasks 5, 8; Feature 3 → Tasks 2, 3, 4, 8, 9, 10; Feature 4 → Tasks 4, 8, 9; incidental fix → Task 1; docs → Task 11).
+- [ ] **Step 3: Grep for leftovers** — `grep -rn "INWARD\|OUTWARD" Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus --include="*.cs" | grep -v obj/` should show no remaining screw-motion prompts using the old vocabulary (adapter-motion usages in comments are fine).
+- [ ] **Step 4: Push the branch and open a PR** against `develop` (never push develop directly):
+```bash
+git push -u origin ghilios/tilt-calibration-ux
+gh pr create --base develop --title "Tilt calibration & sensor model UX improvements" --body "Implements docs/tilt-calibration-ux-design.md: surfaced sweep-cost settings (Center Focuser First now default-off), CW/CCW + signed-step guidance with adapter-direction legend, opt-in curvature measurement (4-step default wizard), manual calibration entry, TimeoutSeconds persistence-key fix.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```

--- a/plans/tilt-calibration-ux-plan.md
+++ b/plans/tilt-calibration-ux-plan.md
@@ -122,39 +122,38 @@ GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.nor
 
 ---
 
-### Task 2: Direction-mapping constant in TiltScrewGeometry (USER CHECKPOINT)
+### Task 2: Direction-mapping constant in TiltScrewGeometry (empirical anchor recorded)
 
-The spec requires the mechanical-setting ↔ stored-sign mapping to be **verified empirically, not derived on paper**. This task pins it as a single named constant.
+The spec requires the mechanical-setting ↔ stored-sign mapping to be **verified empirically, not derived on paper**. The user supplied the anchor on 2026-07-02: **moving the adapter toward the objective decreases the curvature effect** (measured on their rig). Composed with the stored sign's consumer semantics (`InspectorVM.cs` backfocus guidance: `+1` = a CW screw turn raises the curvature effect), this pins the constant at **−1**: a rig where CW moves the adapter toward the objective has CW lowering the curvature effect.
 
 **Files:**
 - Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltScrewGeometry.cs`
 - Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltScrewGeometryTests.cs`
 
-- [ ] **Step 1: STOP — ask the user (blocking checkpoint)**
+- [ ] **Step 1: Optional cross-check (non-blocking; flip if it contradicts)**
 
-Ask the user these two questions about a rig they have **measured** with the 6-step wizard:
-
-1. On that adapter, does turning the screws **clockwise** move the adapter plate **toward the objective** or **toward the camera**?
-2. What is the measured curvature sign on that rig? (Visible as the "Screws Inward / Curvature ↑ or ↓" row in the wizard's saved-calibration panel — ↑ = `+1`, ↓ = `−1`; or as `calibration.curvatureSign` in a saved run's `metadata.json`.)
-
-Set the constant so the two answers agree: if CW→objective pairs with measured `+1` (or CW→camera pairs with `−1`), the constant is `+1`; if CW→objective pairs with measured `−1`, the constant is `−1`. **Do not guess. Do not proceed without the user's answer.** Record the rig + date in the comment.
+If the user's rig has a wizard-measured calibration handy, cross-check the measured path: note the "Screws Inward / Curvature ↑ or ↓" arrow in the wizard's saved-calibration panel (↑ = `+1`, ↓ = `−1`) and which way CW moves that adapter mechanically. The pair must satisfy `measuredSign == CurvatureSignForCwDirection(cwMovesAdapterTowardObjective)` with the constant below. If it does NOT, the wizard's mean-focus measurement disagrees with the curvature-response semantics on that rig — **stop and surface this to the user** (it would mean the sign's two producers disagree, a pre-existing issue bigger than this feature); anchor the constant to the measured path in that case.
 
 - [ ] **Step 2: Write the failing test**
 
-In `TiltScrewGeometryTests.cs` add (adjust the two `+1/−1` expectations if the user's answer flipped the constant — the test documents the verified truth):
+In `TiltScrewGeometryTests.cs` add:
 
 ```csharp
     [Test]
     public void CurvatureSignForCwDirection_MatchesEmpiricalAnchor() {
         Assert.Multiple(() => {
-            // Pinned to the empirically verified mapping (see TiltScrewGeometry comment). If this
-            // fails after an intentional flip, update BOTH the constant comment and this test.
-            Assert.That(TiltScrewGeometry.CurvatureSignWhenCwMovesAdapterTowardObjective, Is.EqualTo(1));
-            Assert.That(TiltScrewGeometry.CurvatureSignForCwDirection(cwMovesAdapterTowardObjective: true), Is.EqualTo(1));
-            Assert.That(TiltScrewGeometry.CurvatureSignForCwDirection(cwMovesAdapterTowardObjective: false), Is.EqualTo(-1));
-            Assert.That(TiltScrewGeometry.CwMovesAdapterTowardObjectiveForSign(1), Is.True);
-            Assert.That(TiltScrewGeometry.CwMovesAdapterTowardObjectiveForSign(-1), Is.False);
-            // Default assumption: CW moves the adapter outward (toward the camera).
+            // Pinned to the empirically verified mapping (see TiltScrewGeometry comment): moving
+            // the adapter toward the objective DECREASES the curvature effect (user measurement,
+            // 2026-07-02), so CW-toward-objective => CW lowers the effect => -1. If this fails
+            // after an intentional flip, update BOTH the constant comment and this test.
+            Assert.That(TiltScrewGeometry.CurvatureSignWhenCwMovesAdapterTowardObjective, Is.EqualTo(-1));
+            Assert.That(TiltScrewGeometry.CurvatureSignForCwDirection(cwMovesAdapterTowardObjective: true), Is.EqualTo(-1));
+            Assert.That(TiltScrewGeometry.CurvatureSignForCwDirection(cwMovesAdapterTowardObjective: false), Is.EqualTo(1));
+            Assert.That(TiltScrewGeometry.CwMovesAdapterTowardObjectiveForSign(-1), Is.True);
+            Assert.That(TiltScrewGeometry.CwMovesAdapterTowardObjectiveForSign(1), Is.False);
+            // Default assumption: CW moves the adapter outward (toward the camera), so the default
+            // stored sign is +1 (CW raises the curvature effect) — equivalently, adapter motion
+            // toward the objective decreases it, the originally requested default behavior.
             Assert.That(TiltScrewGeometry.DefaultScrewInwardCurvatureSign,
                 Is.EqualTo(TiltScrewGeometry.CurvatureSignForCwDirection(false)));
         });
@@ -176,12 +175,12 @@ Append inside the `TiltScrewGeometry` class (it is a static geometry helper clas
         // Clockwise (tighten) always advances a screw; the rig-specific unknown is whether that
         // advance moves the adapter's plate toward the telescope objective ("inward") or toward the
         // camera ("outward"). ScrewInwardCurvatureSign stores the measurable consequence: the sign
-        // of the mean best-focus / curvature-effect response to a CW turn (+1 = raises it).
+        // of the curvature-effect response to a CW turn (+1 = raises it).
         //
-        // EMPIRICAL ANCHOR (verified <DATE> against <RIG> — fill in from the Task 2 checkpoint):
-        // a plate moving toward the objective forces the focuser to re-focus outward, raising the
-        // mean best-focus position, which ComputeCurvatureSign records as +1.
-        public const int CurvatureSignWhenCwMovesAdapterTowardObjective = 1;
+        // EMPIRICAL ANCHOR (user measurement, 2026-07-02): moving the adapter toward the objective
+        // DECREASES the curvature effect. Therefore a rig where CW drives the adapter toward the
+        // objective has CW lowering the effect: sign -1.
+        public const int CurvatureSignWhenCwMovesAdapterTowardObjective = -1;
 
         /// <summary>The stored curvature sign implied by the mechanical setting.</summary>
         public static int CurvatureSignForCwDirection(bool cwMovesAdapterTowardObjective) =>
@@ -196,10 +195,10 @@ Append inside the `TiltScrewGeometry` class (it is a static geometry helper clas
         // Default assumption when the direction was never measured or chosen: CW moves the adapter
         // toward the camera (outward) — the common push-screw design; matches the tilt-domain doc
         // ("turning a screw inward pushes that corner of the sensor away from the telescope").
+        // With the anchor above this makes the default stored sign +1 (CW raises the curvature
+        // effect; adapter motion toward the objective decreases it).
         public static int DefaultScrewInwardCurvatureSign => CurvatureSignForCwDirection(false);
 ```
-
-Replace `<DATE>` / `<RIG>` with the user's checkpoint answer, and flip the constant to `-1` (and the test's expectations) if that is what the answer implies.
 
 - [ ] **Step 5: Run tests, then commit**
 

--- a/plans/tilt-guidance-motion-arrows-plan.md
+++ b/plans/tilt-guidance-motion-arrows-plan.md
@@ -1,0 +1,320 @@
+# Tilt Guidance Motion Arrows & Rotation Glyphs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `docs/tilt-guidance-motion-arrows-design.md`: re-anchor the guidance ⬆/⬇ arrows to adapter motion (⬆ = toward the objective, fixed on every rig), put ⟳/⟲ rotation glyphs on all three numeric rows, and move a simplified legend to the top of the guidance section.
+
+**Architecture:** Presentation-layer only. One new pure formatter static (`FormatAmount`) replaces `FormatMagnitude`/`FormatTotal`; `BuildDirectionLegend` becomes fixed-text; `InspectorVM.RebuildTiltGuidance`/`FillNumericGuidance` compute motion signs and per-row rotation signs from existing state (σ = `ScrewInwardCurvatureSign`); the wizard step summary swaps its ↑/↓ rotation glyphs for ⟳/⟲ so ⬆-as-rotation survives nowhere. No calculator, storage, prompt, or TestApp changes.
+
+**Tech Stack:** .NET 8 (`net8.0-windows7.0`), NUnit 4.4 + NSubstitute, WPF XAML, MkDocs.
+
+---
+
+## Context for a zero-context engineer
+
+- **Repo root:** `/home/ghilios/src/hocus-focus`. Work on branch `ghilios/tilt-calibration-ux` (already checked out; PR #117 is open on it — these are additional commits). **Never push to `develop`.**
+- **Build + full test suite** (run after every task; on WSL the binary is `dotnet.exe`; it also compiles the XAML):
+  ```bash
+  dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo
+  ```
+  Baseline at plan time: 1688 passed / 0 failed.
+- **Committing** (author and committer must both use the noreply address):
+  ```bash
+  GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+    git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" -m "<message>"
+  ```
+- **Domain semantics (read `docs/tilt-guidance-motion-arrows-design.md` first — it is the contract):**
+  - σ = `ITiltAdapterOptions.ScrewInwardCurvatureSign` ∈ {+1, −1} (0 unreachable from options; resolve defensively to `TiltScrewGeometry.DefaultScrewInwardCurvatureSign`). +1 = a clockwise screw turn raises the curvature effect.
+  - "Adapter moves toward the objective" ⇔ the local best-focus position decreases. Consequences used below (derivations in the design spec):
+    - Tilt motion sign = `−σ × (CW-positive tilt turns value)`.
+    - Backfocus motion is σ-free: ⬆ (toward objective) ⇔ `CurvatureEffectMicrons > 0` (the σ in "rotation needed" and the σ in "what rotation does" cancel).
+    - Rotation signs: Tilt `sign(TiltMicrons)` (σ-free); Backfocus `sign(σ·BackfocusMicrons)`; Total `sign(TiltMicrons + σ·BackfocusMicrons)` (= `SignedTotalAdjustment`).
+  - Glyphs: ⟳ = U+27F3 (clockwise/tighten), ⟲ = U+27F2 (counter-clockwise/loosen). The em dash "—" and minus "−" (U+2212) in snippets are intentional — copy exactly.
+- **Line numbers below are positions at plan time** — use the quoted code as anchors.
+
+---
+
+### Task 1: Formatter statics — `FormatAmount` and the fixed-text legend
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltScrewGuidanceRow.cs`
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs` (only the two call sites that must change to keep the build green: the legend call and the three `FormatMagnitude`/`FormatTotal` row calls)
+- Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/TiltAdapterGuidanceVMTests.cs`
+
+- [ ] **Step 1: Rewrite the formatter tests (failing first).** In `TiltAdapterGuidanceVMTests.cs`, DELETE these tests: `FormatMagnitude_Screws_ShowsTwoDecimalTurns`, `FormatMagnitude_Steppers_RoundsToWholeSteps`, `FormatTotal_Screws_UsesClockwiseWording`, `FormatTotal_Steppers_UsesSignedSteps`, `FormatTotal_NearZeroAndBoundary_TakesAbsBeforeSign` (and its TestCase attributes), and `BuildDirectionLegend_DescribesAdapterMotionAndProvenance`. ADD:
+
+```csharp
+    [Test]
+    public void FormatAmount_Screws_ShowsMagnitudeWithRotationGlyph() {
+        Assert.Multiple(() => {
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(1.25, steps: false), Is.EqualTo("1.25 ⟳"));
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(-0.5, steps: false), Is.EqualTo("0.50 ⟲"));
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(0.001, steps: false), Is.EqualTo("—"));
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(-0.004, steps: false), Is.EqualTo("—"));
+        });
+    }
+
+    [Test]
+    public void FormatAmount_Steppers_ShowsSignedSteps() {
+        Assert.Multiple(() => {
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(35.2, steps: true), Is.EqualTo("+35 steps"));
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(-35.2, steps: true), Is.EqualTo("−35 steps"));
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(0.5, steps: true), Is.EqualTo("+1 steps"));
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(0.4, steps: true), Is.EqualTo("—"));
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(-0.2, steps: true), Is.EqualTo("—"));
+        });
+    }
+
+    [Test]
+    public void BuildDirectionLegend_IsFixedTextWithProvenanceSuffix() {
+        Assert.Multiple(() => {
+            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: false, signIsMeasured: true),
+                Is.EqualTo("⬆ = adapter moves toward the objective · ⟳ = clockwise (tighten) · amounts in turns"));
+            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: false, signIsMeasured: false),
+                Is.EqualTo("⬆ = adapter moves toward the objective · ⟳ = clockwise (tighten) · amounts in turns (assumed — set or measure in the Tilt Adapter Wizard)"));
+            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: true, signIsMeasured: true),
+                Is.EqualTo("⬆ = adapter moves toward the objective · steps are signed as in the wizard prompts"));
+            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: true, signIsMeasured: false),
+                Is.EqualTo("⬆ = adapter moves toward the objective · steps are signed as in the wizard prompts (assumed — set or measure in the Tilt Adapter Wizard)"));
+        });
+    }
+```
+Keep `FreshGuidance_HasNoDirectionLegend` unchanged.
+
+- [ ] **Step 2: Run to verify failure.** `dotnet.exe test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~TiltAdapterGuidanceVMTests"` → FAIL (compile errors: `FormatAmount` missing, `BuildDirectionLegend` wrong arity).
+
+- [ ] **Step 3: Implement in `TiltScrewGuidanceRow.cs`.** Replace `BuildDirectionLegend` (lines ~70–81), `FormatMagnitude` (~83–94), and `FormatTotal` (~96–113) with:
+
+```csharp
+        /// <summary>
+        /// Fixed legend for the guidance table: ⬆/⬇ describe adapter-plate motion (toward the
+        /// objective / toward the camera — pure physics, identical on every rig), and ⟳/⟲ (screws)
+        /// or the +/− step sign (steppers) describe the rig-specific rotation that produces it.
+        /// "(assumed)" flags a direction setting never verified by a wizard measurement.
+        /// </summary>
+        public static string BuildDirectionLegend(bool steps, bool signIsMeasured) {
+            string body = steps
+                ? "⬆ = adapter moves toward the objective · steps are signed as in the wizard prompts"
+                : "⬆ = adapter moves toward the objective · ⟳ = clockwise (tighten) · amounts in turns";
+            string assumed = signIsMeasured ? string.Empty : " (assumed — set or measure in the Tilt Adapter Wizard)";
+            return body + assumed;
+        }
+
+        /// <summary>
+        /// Format a signed per-screw adjustment. Positive = clockwise / the wizard-prompt "+" step
+        /// direction. Screws render the magnitude with a rotation glyph ("1.25 ⟳" / "0.50 ⟲" — units
+        /// live in the legend); steppers render signed whole steps ("+35 steps"). Values that round
+        /// to nothing render as an em dash with no direction mark.
+        /// </summary>
+        public static string FormatAmount(double signedAmount, bool steps) {
+            if (steps) {
+                long rounded = (long)Math.Round(Math.Abs(signedAmount), MidpointRounding.AwayFromZero);
+                if (rounded == 0) return "—";
+                return signedAmount >= 0 ? $"+{rounded} steps" : $"−{rounded} steps";
+            }
+            if (Math.Abs(signedAmount) < 0.005) return "—";
+            return $"{Math.Abs(signedAmount):0.00} {(signedAmount >= 0 ? "⟳" : "⟲")}";
+        }
+```
+
+Also update the two stale comments on the field blocks: line ~45 (`// Per-screw tilt and backfocus magnitudes (direction is shown by the arrows above), and the` / `// signed total with an explicit direction (CW/CCW turns for screws, +/− steps for steppers).`) becomes:
+
+```csharp
+        // Per-screw signed adjustments, all three rows carrying their own rotation direction
+        // (⟳/⟲ glyphs for screws, +/− signs for steppers). The arrows grid above describes adapter
+        // MOTION (⬆ = toward the objective), not rotation — the two answer different questions.
+```
+and line ~66 (`// One-line legend tying the arrows/totals to physical adapter motion; empty when unknown.`) becomes `// One-line legend defining the motion arrows and rotation glyphs; empty until guidance renders.`
+
+- [ ] **Step 4: Keep the build green — minimal `InspectorVM.cs` call-site fixes.** In `FillNumericGuidance` (~line 2004–2016), replace the loop body's three formatter calls (semantics land properly in Task 2; this step only restores compilation with equivalent-for-σ=+1 behavior):
+
+```csharp
+                var corr = TiltScrewGeometry.ScrewCorrectionMicrons(
+                    model.Gx, model.Gy, model.Kx, model.Ky, model.X0, model.Y0, angles[i], radiusMicrons);
+                tiltText[i] = TiltAdapterGuidanceVM.FormatAmount(corr.TiltMicrons / unitMicrons, steps);
+                backText[i] = TiltAdapterGuidanceVM.FormatAmount(resolvedSign * corr.BackfocusMicrons / unitMicrons, steps);
+                // The curvature sign applies ONLY to the backfocus component: the tilt component's
+                // direction is already encoded by the stored response-convention screw angle (the same
+                // convention the tilt arrows invert), so multiplying the whole total by the sign would
+                // flip the tilt part on sign = -1 rigs and contradict the arrows.
+                double totalSigned = TiltScrewGeometry.SignedTotalAdjustment(
+                    corr.TiltMicrons, corr.BackfocusMicrons, unitMicrons, resolvedSign);
+                totalText[i] = TiltAdapterGuidanceVM.FormatAmount(totalSigned, steps);
+```
+and above the loop replace
+```csharp
+            int curvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign;
+            bool hasDirection = curvatureSign != 0;
+```
+with
+```csharp
+            // σ is never 0 from persisted options (defaulted since the direction-setting feature);
+            // resolve defensively to the assumed default so every row can carry a direction.
+            int curvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign;
+            int resolvedSign = curvatureSign == 0 ? TiltScrewGeometry.DefaultScrewInwardCurvatureSign : curvatureSign;
+```
+In `RebuildTiltGuidance` (~line 1962–1967), update the legend call:
+```csharp
+            if (guidance.HasTiltGuidance || guidance.HasNumericGuidance) {
+                guidance.DirectionLegend = TiltAdapterGuidanceVM.BuildDirectionLegend(
+                    steps: tiltAdapterOptions.AdjustmentType == TiltAdjustmentType.StepperMotors,
+                    signIsMeasured: tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured);
+            }
+```
+
+- [ ] **Step 5: Run the fixture filter → PASS, then the full suite.** Expect the wizard/inspector suites green; if any other test referenced `FormatMagnitude`/`FormatTotal` (grep the Tests project), update it to `FormatAmount` with the new expected strings and report it.
+
+- [ ] **Step 6: Commit:**
+```bash
+git add -A
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "feat(tilt): rotation-glyph amount formatter and fixed-text guidance legend"
+```
+
+---
+
+### Task 2: InspectorVM — motion-anchored arrows
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs` (`RebuildTiltGuidance`, ~lines 1883–1971)
+- Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMBehavioralTests.cs`
+
+- [ ] **Step 1: Write the failing σ-flip behavioral test.** Read `InspectorVMBehavioralTests.cs` first — `TiltGuidance_CalibratedButUnmeasured_ShowsNoDirectionLegend` (added recently) shows how the fixture builds an InspectorVM via `BuildInspectorVM`/MediatorBundle and drives `RebuildTiltGuidance` state. Determine whether the fixture can also inject a `TiltModel.TiltPlaneModel` (for tilt arrows) and a `SensorModel` result (for the backfocus arrow + numeric rows).
+  - **If it can** (preferred): add a test that runs the same guidance rebuild twice — identical model inputs, options mock returning σ = +1 then σ = −1 — and asserts the matrix: `Screw1TiltArrow` FLIPS between the runs; `Screw1BackfocusArrow` is IDENTICAL between the runs; `Screw1TiltAmount`'s glyph is IDENTICAL; `Screw1BackfocusAmount`'s glyph FLIPS. Name it `TiltGuidance_SigmaFlip_FlipsMotionArrowsNotTiltGlyphs`.
+  - **If injecting a fitted model requires scaffolding the fixture doesn't have**: instead assert the backfocus-arrow σ-independence and tilt-arrow σ-dependence at whatever level the fixture DOES reach, and pin the remaining mapping with a comment in the production code referencing the design spec. State in your report which branch you took and why.
+- [ ] **Step 2: Run to verify the new test fails** (arrows currently rotation-anchored: tilt arrows do NOT flip with σ; backfocus arrows DO).
+- [ ] **Step 3: Implement in `RebuildTiltGuidance`.**
+  1. Hoist the sign resolution above the tilt block (before `var tiltPlane = ...`, ~line 1890):
+```csharp
+                // σ resolved once for the whole rebuild; see FillNumericGuidance for the 0 rule.
+                int curvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign;
+                int resolvedSign = curvatureSign == 0 ? TiltScrewGeometry.DefaultScrewInwardCurvatureSign : curvatureSign;
+```
+     (Delete the now-duplicate `int curvatureSign = ...` declaration at ~line 1933; `FillNumericGuidance` keeps its own locals.)
+  2. Tilt arrows become motion-anchored — replace the classifier input (~line 1913):
+```csharp
+                                // turns[i] is CW-positive (the stored response-convention angles encode
+                                // the rig direction), so adapter MOTION toward the objective = −σ·turns.
+                                double ratio = (-resolvedSign * turns[i]) / maxAbs;
+```
+     (Only this line changes; thresholds and glyph tiers stay.) Update the comment above the `turns` loop (~1901) to note the arrows show adapter motion, ⬆ = toward the objective.
+  3. Backfocus arrows drop σ — replace the block at ~lines 1929–1946 with:
+```csharp
+                // Backfocus row: adapter MOTION needed to null the curvature effect. Toward the
+                // objective ⇔ the local best-focus position must decrease; the σ in "which rotation
+                // is needed" and the σ in "what a rotation does" cancel, so the motion arrow is
+                // sign(CurvatureEffectMicrons) — rig-independent physics (see the design spec).
+                if (SensorModel?.DisplayedSensorModel != null) {
+                    double curvatureEffectMicrons = SensorModel.SensorModelResult.CurvatureEffectMicrons;
+                    double absMicrons = Math.Abs(curvatureEffectMicrons);
+
+                    string backfocusArrow;
+                    if (absMicrons < BackfocusNoiseThresholdMicrons) {
+                        backfocusArrow = "—";
+                    } else {
+                        bool towardObjective = curvatureEffectMicrons > 0;
+                        string bigArrow = towardObjective ? "⬆" : "⬇";
+                        string smallArrow = towardObjective ? "↑" : "↓";
+                        backfocusArrow = absMicrons >= BackfocusLargeArrowThresholdMicrons ? bigArrow : smallArrow;
+                    }
+
+                    guidance.Screw1BackfocusArrow = backfocusArrow;
+                    guidance.Screw2BackfocusArrow = backfocusArrow;
+                    guidance.Screw3BackfocusArrow = backfocusArrow;
+                    if (n == 4) guidance.Screw4BackfocusArrow = backfocusArrow;
+                    guidance.HasBackfocusRow = true;
+                }
+```
+     Sanity-check the `towardObjective` polarity yourself before committing: with `CurvatureEffectMicrons > 0`, the per-screw correction `BackfocusMicrons = −(kx·cx²+ky·cy²)` is negative = the local best-focus position must decrease = toward the objective ⇒ ⬆. If your reading of the model's sign conventions disagrees, STOP and report rather than guessing.
+  4. Update the stale `FillNumericGuidance` doc comment (~1975–1979): the total no longer "carries an explicit direction (CW/CCW or +/− steps)" — all three rows carry a rotation glyph / signed steps, and the arrows above are adapter motion.
+- [ ] **Step 4: Run the new test → PASS, then the full suite → all green.** The legend-gating behavioral test must still pass unchanged.
+- [ ] **Step 5: Commit:**
+```bash
+git add -A
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "feat(tilt): guidance arrows describe adapter motion; rotation carried by per-row glyphs"
+```
+
+---
+
+### Task 3: Wizard step summary uses ⟳/⟲
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs` (`StepDescription`, ~lines 1127–1143)
+- Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs` (`StepDescription_ArrowsFollowClockwiseUpConvention`)
+
+- [ ] **Step 1: Update the pinning test (failing first).** Rename `StepDescription_ArrowsFollowClockwiseUpConvention` to `StepDescription_UsesRotationGlyphs` and change every expected `↑` to `⟳` and `↓` to `⟲` (both 3- and 4-screw cases; e.g. `"All screws ⟳"`, `"Re-baseline (all ⟲)"`, `"Screw 1 ⟳, Screw 3 ⟲"`).
+- [ ] **Step 2: Run to verify it fails**, filter `FullyQualifiedName~StepDescription_UsesRotationGlyphs`.
+- [ ] **Step 3: Implement.** In `StepDescription`, replace `↑` → `⟳` and `↓` → `⟲` in all five case strings, and replace the method comment with:
+```csharp
+        // Description shown on each summary row, reflecting the single move performed for the step.
+        // Rotation glyphs match the guidance legend (⟳ = clockwise / + steps, ⟲ = counter-clockwise
+        // / − steps) — screw rotation, never adapter-plate motion (⬆/⬇ are reserved for motion in
+        // the guidance table). Perturbation steps (all CW per StepInstructionsText) carry ⟳ and the
+        // re-baseline undo moves carry ⟲. Internal for tests.
+```
+- [ ] **Step 4: Run the filter → PASS, then the full suite → all green.**
+- [ ] **Step 5: Commit:**
+```bash
+git add -A
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "feat(wizard): step-summary rotation glyphs match the guidance legend"
+```
+
+---
+
+### Task 4: XAML — legend to the top, prominent
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml`
+
+- [ ] **Step 1: Move the legend.** Delete the legend TextBlock currently after the numeric grid (~lines 3007–3014, anchored by the comment `<!--  Direction legend: what ⬆ / CW / + steps mean for this adapter  -->`). Insert this block inside the calibrated-guidance StackPanel as its FIRST child — immediately after `<StackPanel Visibility="{Binding HasTiltAdapterCalibration, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">` and before the `<!--  No measurement yet  -->` TextBlock:
+
+```xml
+                            <!--  Direction legend: ⬆/⬇ = adapter motion, ⟳/⟲ = screw rotation. First
+                                  element so the conventions are read before the table.  -->
+                            <TextBlock
+                                Margin="5,4,5,2"
+                                Text="{Binding TiltGuidance.DirectionLegend}"
+                                TextWrapping="Wrap"
+                                Visibility="{Binding TiltGuidance.HasDirectionLegend, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+```
+  Note the deliberate styling change vs the old block: no `FontStyle="Italic"`, no `Opacity="0.7"` — prominence per the design spec. The `HasDirectionLegend` gating is unchanged, so the "Run a measurement to see guidance." placeholder state still shows no legend.
+- [ ] **Step 2: Also fix the numeric-grid header comment** (~line 2961): `<!--  Precise numeric adjustments (turns / steps) — shown when adapter hardware is configured  -->` → `<!--  Precise numeric adjustments, each with its rotation glyph / step sign — shown when adapter hardware is configured  -->`.
+- [ ] **Step 3: Build + full suite** (compiles the XAML) → all green.
+- [ ] **Step 4: Commit:**
+```bash
+git add -A
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "feat(inspector): guidance legend moves to the top of the section, non-italic"
+```
+
+---
+
+### Task 5: Docs + follow-up-plan touch-up + final verification
+
+**Files:**
+- Modify: `documentation/docs/overview/tilt-aberration-inspector.md`
+- Modify: `plans/tilt-ux-polish-plan.md` (screenshot expectations reference the now-obsolete "turns CW" layout)
+- Check (grep only): all of `documentation/docs/`
+
+- [ ] **Step 1: Rewrite the guidance-presentation paragraph** in `tilt-aberration-inspector.md` ("Correcting tilt with a tilt adapter" section — locate it with `grep -n "turns CW" documentation/docs/overview/tilt-aberration-inspector.md`). Replace the sentences describing totals/legend (added by PR #117) with wording that matches the new UI; keep the surrounding house voice:
+
+  > The arrows describe what the adapter must do: ⬆ means that corner of the adapter plate moves toward the objective, ⬇ toward the camera — the same on every rig. The numeric rows each carry the screw rotation that produces the move: `1.25 ⟳` means 1.25 turns clockwise (tighten), `0.50 ⟲` counter-clockwise (loosen); stepper adapters show signed steps (`+35 steps`) matching the wizard's prompts. A legend at the top of the section defines both conventions and is marked "(assumed)" until the adapter direction has been measured in the wizard.
+
+  Adapt the splice points to the actual current paragraph — do not duplicate content it already states (e.g. the "(assumed)" sentence exists today; merge rather than repeat).
+- [ ] **Step 2: Sweep for stale examples:** `grep -rn "turns CW\|turns CCW\|⬆ = clockwise\|⬆ = + steps" documentation/docs/` → update every hit to the new vocabulary (expected hits: the inspector page; possibly the wizard page tip block). `grep -rn "1.25 turns" documentation/docs/` for stray examples.
+- [ ] **Step 3: Touch up `plans/tilt-ux-polish-plan.md`** Task 5: change the `inspector-tilt-guidance.png` expectation text `(currently shows the pre-#117 IN/OUT guidance table; must show CW/CCW totals + the direction legend line)` to `(currently shows the pre-#117 IN/OUT guidance table; must show the motion-anchored arrows, per-row rotation glyphs, and the legend at the top of the section)`.
+- [ ] **Step 4: Verify:** `mkdocs build --strict` (from repo root) → clean; full suite → all green.
+- [ ] **Step 5: Commit and push (updates PR #117):**
+```bash
+git add -A
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "docs: motion-anchored guidance arrows and rotation glyphs"
+git push
+```

--- a/plans/tilt-ux-polish-plan.md
+++ b/plans/tilt-ux-polish-plan.md
@@ -153,7 +153,7 @@ The wizard's Measurement section carries literal-text copies of the inspector's 
 Requires: Windows machine, NINA with the branch-built plugin installed, windows-mcp. **Read `.claude/docs/nina-mcp-screenshots.md` first and follow its capture/annotate pipeline exactly** (it defines the build-install steps, capture resolution, theme, and file conventions).
 
 **Files:**
-- Replace: `documentation/docs/assets/screenshots/inspector-tilt-guidance.png` (currently shows the pre-#117 IN/OUT guidance table; must show CW/CCW totals + the direction legend line)
+- Replace: `documentation/docs/assets/screenshots/inspector-tilt-guidance.png` (currently shows the pre-#117 IN/OUT guidance table; must show the motion-anchored arrows, per-row rotation glyphs, and the legend at the top of the section)
 - Replace: `documentation/docs/assets/screenshots/inspector-options-empty.png` (must show the new always-visible sweep-settings block above the Options expander)
 - Create: `documentation/docs/assets/screenshots/wizard-measurement-section.png` (the wizard's Measurement section incl. the adapter-direction ComboBox) — embed it in `documentation/docs/overview/tilt-adapter-wizard.md` in "The calibration loop" section, after the paragraph introducing the Measurement section, MkDocs image syntax matching the page's existing images (`{ width=620 }`).
 - Modify: `documentation/docs/overview/tilt-adapter-wizard.md` (embed line for the new screenshot)

--- a/plans/tilt-ux-polish-plan.md
+++ b/plans/tilt-ux-polish-plan.md
@@ -1,0 +1,178 @@
+# Tilt UX Polish & Screenshot Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close out the cosmetic/UX items deliberately deferred from PR #117's reviews (stale label on profile swap, dirty-input Apply, "Measurements"/"Measurement" label collision, duplicated tooltips) and refresh the manual screenshots that PR #117's UI changes made stale.
+
+**Architecture:** Small, independent C#/XAML polish changes on the existing HocusFocus plugin patterns (CommunityToolkit.Mvvm, PluginOptionsAccessor), each TDD'd where a test can pin it; then a Windows-side session (NINA + windows-mcp) that runtime-verifies the XAML-only changes and captures new screenshots per the repo's capture pipeline.
+
+**Tech Stack:** .NET 8 (`net8.0-windows7.0`), NUnit 4.4 + NSubstitute, WPF XAML, MkDocs, Windows MCP screenshot pipeline (`.claude/docs/nina-mcp-screenshots.md`).
+
+---
+
+## Context for a zero-context engineer
+
+- **Repo root:** `/home/ghilios/src/hocus-focus`.
+- **Precondition:** PR #117 (`ghilios/tilt-calibration-ux`) merged into `develop`. Branch from up-to-date develop:
+  ```bash
+  git checkout develop && git pull && git checkout -b ghilios/tilt-ux-polish
+  ```
+  **Never push to `develop` directly.** Task 5 additionally requires the Windows machine with NINA, the windows-mcp server, and a locally built plugin installed (see `.claude/docs/nina-mcp-screenshots.md`).
+- **Build + full test suite** (run after every task; on WSL the binary is `dotnet.exe`):
+  ```bash
+  dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo
+  ```
+- **Committing** (author and committer must both use the noreply address):
+  ```bash
+  GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+    git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" -m "<message>"
+  ```
+- **Key files:**
+  - `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs` — wizard VM; its `profileService.ProfileChanged` handler already re-raises a block of wrapper properties inside `OnUIThread`.
+  - `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml` — wizard UI (Manual Calibration Entry expander; the "Measurements" label at ~line 283; Measurement section with literal tooltips).
+  - `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml` — inspector UI; defines `SignalAmplification_Tooltip` / `CenterFocuserBeforeRun_Tooltip` resources near the top.
+  - Tests: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs` (has a `Build()` fixture; profile-change tests exist from PR #117 — follow their style).
+- **Non-goals (decided during PR #117 reviews — do not do these):** renaming `WizardStep` enum members (serialized in saved-run metadata); surfacing physical vs stored screw angles in the saved-calibration panel (needs a design pass first — brainstorm before implementing); a setter-level `StepCount` clamp (load-time healing shipped in #117 is sufficient); an upper clamp on `SignalAmplification` (finding was refuted).
+
+---
+
+### Task 1: `CalibrationAppliedAmountDisplay` refreshes on profile switch
+
+A profile swap that changes `AdjustmentType` (screws ↔ steppers) leaves this one label's turns/steps vocabulary stale — it was the only wrapper property missed by PR #117's ProfileChanged re-raise block.
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs`
+- Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs`
+
+- [ ] **Step 1: Write the failing test.** Locate the existing PR #117 profile-change test (search the test file for `ProfileChanged`) and add a sibling following its exact fixture pattern:
+```csharp
+    [Test]
+    public void ProfileChanged_RaisesCalibrationAppliedAmountDisplay() {
+        var (vm, options, profileService) = Build(); // adapt to the fixture's actual signature/style
+        var raised = new List<string>();
+        vm.PropertyChanged += (s, e) => raised.Add(e.PropertyName);
+        profileService.ProfileChanged += Raise.Event<EventHandler>(profileService, EventArgs.Empty); // match the existing test's raise style
+        Assert.That(raised, Does.Contain(nameof(TiltAdapterWizardVM.CalibrationAppliedAmountDisplay)));
+    }
+```
+- [ ] **Step 2: Run to verify it fails.** `dotnet.exe test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~ProfileChanged_RaisesCalibrationAppliedAmountDisplay"` → FAIL (property not raised).
+- [ ] **Step 3: Implement.** In the wizard VM's `profileService.ProfileChanged` handler, add one line in the existing re-raise block, next to `RaisePropertyChanged(nameof(CalibrationAmountLabel));`:
+```csharp
+                    RaisePropertyChanged(nameof(CalibrationAppliedAmountDisplay));
+```
+- [ ] **Step 4: Run the filtered test → PASS, then the full suite → all green.**
+- [ ] **Step 5: Commit:** `fix(wizard): refresh CalibrationAppliedAmountDisplay vocabulary on profile switch`
+
+---
+
+### Task 2: Disable manual-entry Apply while the angle box has a validation error
+
+PR #117 added a 0–360 `DoubleRangeRule` to the Screw 1 angle TextBox, so garbage input shows the red error adorner — but Apply still persists the last valid VM value. Disable Apply while the box is in error.
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml`
+
+- [ ] **Step 1: Name the TextBox.** In the Manual Calibration Entry expander, add `x:Name="ManualScrew1AngleBox"` to the Screw-1-angle `TextBox` (the one whose binding carries the `DoubleRangeRule`).
+- [ ] **Step 2: Gate the Apply button.** Replace the Apply `Button`'s opening tag content so it carries a style trigger (keep the existing `Command` and inner `TextBlock` exactly as-is):
+```xml
+                            <Button
+                                Margin="0,8,0,0"
+                                HorizontalAlignment="Left"
+                                Command="{Binding ApplyManualCalibrationCommand}">
+                                <Button.Style>
+                                    <Style BasedOn="{StaticResource {x:Type Button}}" TargetType="Button">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding ElementName=ManualScrew1AngleBox, Path=(Validation.HasError)}" Value="True">
+                                                <Setter Property="IsEnabled" Value="False" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Button.Style>
+                                <TextBlock
+                                    Margin="10,5,10,5"
+                                    Foreground="{StaticResource ButtonForegroundBrush}"
+                                    Text="Apply" />
+                            </Button>
+```
+  (Verify the file's Button style resource key by looking at how sibling buttons set styles; use `BasedOn` exactly as sibling styled controls do so the NINA theme is preserved.)
+- [ ] **Step 3: Build + full suite** (compiles the XAML): `dotnet.exe test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo` → all green. Runtime behavior (button actually greys out on garbage input) is verified in Task 5's NINA session — note this in the commit body.
+- [ ] **Step 4: Commit:** `fix(wizard): disable manual-calibration Apply while the angle input is invalid`
+
+---
+
+### Task 3: Resolve the "Measurements" / "Measurement" label collision
+
+The `MeasurementAverageCount` field labeled **Measurements** sits a few rows above the new bold **Measurement** section header — two adjacent measurement-named things with different meanings.
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml` (label at ~line 283 — anchor on `Text="Measurements"`)
+- Modify: `documentation/docs/overview/tilt-adapter-wizard.md` (two `**Measurements**` occurrences, ~lines 58 and 72)
+
+- [ ] **Step 1:** In the XAML, change `Text="Measurements"` to `Text="Measurements to average"` (keep its ToolTip; extend the tooltip's first sentence if it doesn't already say the value is a per-step repeat count).
+- [ ] **Step 2:** Update both doc occurrences: `set **Measurements** above 1` → `set **Measurements to average** above 1`, and `Raising **Measurements** above 1` → `Raising **Measurements to average** above 1`. Grep for stragglers: `grep -rn '\*\*Measurements\*\*' documentation/docs/` → expect zero hits afterwards.
+- [ ] **Step 3:** `mkdocs build --strict` → PASS; full suite → all green.
+- [ ] **Step 4: Commit:** `fix(wizard): rename Measurements label to avoid collision with the Measurement section`
+
+---
+
+### Task 4: Consolidate the shared Signal Amplification / Center Focuser First tooltips
+
+The wizard's Measurement section carries literal-text copies of the inspector's `SignalAmplification_Tooltip` / `CenterFocuserBeforeRun_Tooltip` resources, and they have already drifted. Move both to a shared merged dictionary so there is one source of truth.
+
+**Files:**
+- Create: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/SharedTooltips.xaml`
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml`
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml`
+- Modify (probably): `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Joko.NINA.Plugins.HocusFocus.csproj` — check whether XAML pages are globbed or listed; add the new Page item if listed explicitly.
+
+- [ ] **Step 1:** Create `Resources/SharedTooltips.xaml` containing exactly the two `TextBlock` resources currently defined near the top of `AutoFocus/DataTemplates.xaml` (`x:Key="SignalAmplification_Tooltip"`, `x:Key="CenterFocuserBeforeRun_Tooltip"`), using the inspector wording as canon:
+```xml
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!--  Tooltips shared by the Aberration Inspector and the Tilt Adapter Wizard (single source of truth).  -->
+    <TextBlock x:Key="SignalAmplification_Tooltip" Text="[copy the exact current Text from AutoFocus/DataTemplates.xaml]" />
+    <TextBlock x:Key="CenterFocuserBeforeRun_Tooltip" Text="[copy the exact current Text from AutoFocus/DataTemplates.xaml]" />
+</ResourceDictionary>
+```
+  (The bracketed placeholders are copy instructions, not content to invent — lift the two `Text` attributes verbatim from `AutoFocus/DataTemplates.xaml` at HEAD.)
+- [ ] **Step 2:** In BOTH `AutoFocus/DataTemplates.xaml` and `TiltAdapterWizard/DataTemplates.xaml`, add at the top of the root `ResourceDictionary`:
+```xml
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/NINA.Joko.Plugins.HocusFocus;component/Resources/SharedTooltips.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+```
+  Then delete the two now-duplicate resource definitions from `AutoFocus/DataTemplates.xaml`, and in the wizard's Measurement section replace the two literal `ToolTip="..."` attributes with `ToolTip="{StaticResource SignalAmplification_Tooltip}"` / `ToolTip="{StaticResource CenterFocuserBeforeRun_Tooltip}"`. If `StaticResource` fails to resolve at XAML-compile time from the merged dictionary, switch those references to `DynamicResource` and note it.
+- [ ] **Step 3:** Full suite (compiles both XAML files) → all green. **Runtime verification is mandatory in Task 5** (pack-URI merged dictionaries only fully resolve when the plugin loads in NINA): if Task 5 shows missing tooltips or a load failure, revert this task's commit rather than shipping broken resources.
+- [ ] **Step 4: Commit:** `refactor(ui): single shared source for Signal Amplification / Center Focuser First tooltips`
+
+---
+
+### Task 5: Windows session — runtime verification + screenshot refresh
+
+Requires: Windows machine, NINA with the branch-built plugin installed, windows-mcp. **Read `.claude/docs/nina-mcp-screenshots.md` first and follow its capture/annotate pipeline exactly** (it defines the build-install steps, capture resolution, theme, and file conventions).
+
+**Files:**
+- Replace: `documentation/docs/assets/screenshots/inspector-tilt-guidance.png` (currently shows the pre-#117 IN/OUT guidance table; must show CW/CCW totals + the direction legend line)
+- Replace: `documentation/docs/assets/screenshots/inspector-options-empty.png` (must show the new always-visible sweep-settings block above the Options expander)
+- Create: `documentation/docs/assets/screenshots/wizard-measurement-section.png` (the wizard's Measurement section incl. the adapter-direction ComboBox) — embed it in `documentation/docs/overview/tilt-adapter-wizard.md` in "The calibration loop" section, after the paragraph introducing the Measurement section, MkDocs image syntax matching the page's existing images (`{ width=620 }`).
+- Modify: `documentation/docs/overview/tilt-adapter-wizard.md` (embed line for the new screenshot)
+
+- [ ] **Step 1: Runtime-verify Tasks 2 and 4.** In the running NINA: type garbage into the Screw 1 angle box → red adorner appears AND Apply greys out (Task 2); hover the wizard's Signal Amplification and Center Focuser First labels → tooltips render (Task 4). If Task 4's tooltips are missing, revert that commit (per Task 4 Step 3) before capturing screenshots.
+- [ ] **Step 2: Capture the three screenshots** per the pipeline doc. For `inspector-tilt-guidance.png` a calibrated profile with a completed measurement (or a replayed saved run) is needed so the guidance table + legend render — the pipeline doc's NINA navigation map covers loading a saved AF run.
+- [ ] **Step 3: Embed the new image** in `tilt-adapter-wizard.md` and verify all three images render: `mkdocs build --strict` → PASS, then `mkdocs serve` and eyeball the three pages.
+- [ ] **Step 4:** Full suite (invariant) → all green.
+- [ ] **Step 5: Commit:** `docs: refresh tilt guidance/options screenshots; add wizard Measurement section capture`
+
+---
+
+### Task 6: Push + PR
+
+- [ ] **Step 1:** Full suite one final time → all green; `mkdocs build --strict` → PASS.
+- [ ] **Step 2:**
+```bash
+git push -u origin ghilios/tilt-ux-polish
+gh pr create --base develop --title "Tilt UX polish: deferred review minors + screenshot refresh" --body "Closes out the cosmetic items deferred from PR #117's reviews: profile-swap label refresh, invalid-input Apply gating, Measurements label rename, shared tooltip source; refreshes the manual screenshots the new UI made stale.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```


### PR DESCRIPTION
Implements docs/tilt-calibration-ux-design.md: surfaced sweep-cost settings (Center Focuser First now default-off), CW/CCW + signed-step guidance with adapter-direction legend, opt-in curvature measurement (4-step default wizard), manual calibration entry, TimeoutSeconds persistence-key fix.

## Highlights
- **4-step default calibration** (baseline, screw 1, re-baseline, screw 2); the two curvature-direction steps are opt-in via **Measure direction**. The direction otherwise comes from a new mechanical adapter-direction setting ("Turning screws clockwise moves the adapter: toward the camera / toward the objective") with "(assumed)/(measured)" provenance everywhere it is consumed.
- **Directional guidance**: totals read `1.25 turns CW` / `+35 steps`; a legend ties arrows to physical adapter motion. Wizard prompts reworded to CLOCKWISE/COUNTER-CLOCKWISE (tighten/loosen) and signed steps.
- **Sweep-cost settings surfaced**: Signal Amplification and Center Focuser First (now off by default) sit above the inspector's Options expander and in a new wizard Measurement section, with live image-count estimates.
- **Manual Calibration Entry**: type the screw-1 position angle and numbering direction instead of running the loop.
- **TestApp** validator accepts 4-step datasets.

## Verification
- TDD throughout; suite grew 1638 → 1688 tests, all green.
- Every task went through implementer + spec-compliance + code-quality subagent reviews.
- A final adversarial multi-agent review (9 lenses, 3 skeptics per finding) confirmed 18 findings — including one **critical** pre-existing sign inversion the new UI would have surfaced (guidance totals applied the curvature sign to the tilt component, inverting totals vs arrows on CW-toward-objective rigs). All 18 are fixed in the last three commits; the sign fix was re-verified by independent derivation.
- Docs updated (mkdocs strict build clean); spec-coverage audit maps every design-spec requirement to a landed change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)