### PR TITLE
feat(tilt): vector CW/CCW rotation icons and clearer adapter diagram

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -2835,7 +2835,7 @@
                                   element so the conventions are read before the table.  -->
                             <TextBlock
                                 Margin="5,4,5,2"
-                                Text="{Binding TiltGuidance.DirectionLegend}"
+                                controls:IconizedText.Text="{Binding TiltGuidance.DirectionLegend}"
                                 TextWrapping="Wrap"
                                 Visibility="{Binding TiltGuidance.HasDirectionLegend, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                             <!--  No measurement yet  -->
@@ -2987,26 +2987,26 @@
                                 <TextBlock Grid.Row="0" Grid.Column="3" HorizontalAlignment="Center" FontWeight="SemiBold" Text="Screw 3" />
                                 <TextBlock Grid.Row="0" Grid.Column="4" HorizontalAlignment="Center" FontWeight="SemiBold" Text="Screw 4"
                                     Visibility="{Binding TiltGuidance.HasFourScrews, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
-                                <!--  Tilt amounts  -->
+                                <!--  Tilt amounts — ⟳/⟲ in the bound strings render as icons via IconizedText  -->
                                 <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Text="Tilt" />
-                                <TextBlock Grid.Row="1" Grid.Column="1" HorizontalAlignment="Center" Text="{Binding TiltGuidance.Screw1TiltAmount}" />
-                                <TextBlock Grid.Row="1" Grid.Column="2" HorizontalAlignment="Center" Text="{Binding TiltGuidance.Screw2TiltAmount}" />
-                                <TextBlock Grid.Row="1" Grid.Column="3" HorizontalAlignment="Center" Text="{Binding TiltGuidance.Screw3TiltAmount}" />
-                                <TextBlock Grid.Row="1" Grid.Column="4" HorizontalAlignment="Center" Text="{Binding TiltGuidance.Screw4TiltAmount}"
+                                <TextBlock Grid.Row="1" Grid.Column="1" HorizontalAlignment="Center" controls:IconizedText.Text="{Binding TiltGuidance.Screw1TiltAmount}" />
+                                <TextBlock Grid.Row="1" Grid.Column="2" HorizontalAlignment="Center" controls:IconizedText.Text="{Binding TiltGuidance.Screw2TiltAmount}" />
+                                <TextBlock Grid.Row="1" Grid.Column="3" HorizontalAlignment="Center" controls:IconizedText.Text="{Binding TiltGuidance.Screw3TiltAmount}" />
+                                <TextBlock Grid.Row="1" Grid.Column="4" HorizontalAlignment="Center" controls:IconizedText.Text="{Binding TiltGuidance.Screw4TiltAmount}"
                                     Visibility="{Binding TiltGuidance.HasFourScrews, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
-                                <!--  Backfocus amounts  -->
+                                <!--  Backfocus amounts — ⟳/⟲ render as icons via IconizedText  -->
                                 <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Text="Backfocus" />
-                                <TextBlock Grid.Row="2" Grid.Column="1" HorizontalAlignment="Center" Text="{Binding TiltGuidance.Screw1BackfocusAmount}" />
-                                <TextBlock Grid.Row="2" Grid.Column="2" HorizontalAlignment="Center" Text="{Binding TiltGuidance.Screw2BackfocusAmount}" />
-                                <TextBlock Grid.Row="2" Grid.Column="3" HorizontalAlignment="Center" Text="{Binding TiltGuidance.Screw3BackfocusAmount}" />
-                                <TextBlock Grid.Row="2" Grid.Column="4" HorizontalAlignment="Center" Text="{Binding TiltGuidance.Screw4BackfocusAmount}"
+                                <TextBlock Grid.Row="2" Grid.Column="1" HorizontalAlignment="Center" controls:IconizedText.Text="{Binding TiltGuidance.Screw1BackfocusAmount}" />
+                                <TextBlock Grid.Row="2" Grid.Column="2" HorizontalAlignment="Center" controls:IconizedText.Text="{Binding TiltGuidance.Screw2BackfocusAmount}" />
+                                <TextBlock Grid.Row="2" Grid.Column="3" HorizontalAlignment="Center" controls:IconizedText.Text="{Binding TiltGuidance.Screw3BackfocusAmount}" />
+                                <TextBlock Grid.Row="2" Grid.Column="4" HorizontalAlignment="Center" controls:IconizedText.Text="{Binding TiltGuidance.Screw4BackfocusAmount}"
                                     Visibility="{Binding TiltGuidance.HasFourScrews, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
-                                <!--  Total  -->
+                                <!--  Total — ⟳/⟲ render as icons via IconizedText; SemiBold on the cell carries to the Run  -->
                                 <TextBlock Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" FontWeight="SemiBold" Text="Total" />
-                                <TextBlock Grid.Row="3" Grid.Column="1" HorizontalAlignment="Center" FontWeight="SemiBold" Text="{Binding TiltGuidance.Screw1TotalAmount}" />
-                                <TextBlock Grid.Row="3" Grid.Column="2" HorizontalAlignment="Center" FontWeight="SemiBold" Text="{Binding TiltGuidance.Screw2TotalAmount}" />
-                                <TextBlock Grid.Row="3" Grid.Column="3" HorizontalAlignment="Center" FontWeight="SemiBold" Text="{Binding TiltGuidance.Screw3TotalAmount}" />
-                                <TextBlock Grid.Row="3" Grid.Column="4" HorizontalAlignment="Center" FontWeight="SemiBold" Text="{Binding TiltGuidance.Screw4TotalAmount}"
+                                <TextBlock Grid.Row="3" Grid.Column="1" HorizontalAlignment="Center" FontWeight="SemiBold" controls:IconizedText.Text="{Binding TiltGuidance.Screw1TotalAmount}" />
+                                <TextBlock Grid.Row="3" Grid.Column="2" HorizontalAlignment="Center" FontWeight="SemiBold" controls:IconizedText.Text="{Binding TiltGuidance.Screw2TotalAmount}" />
+                                <TextBlock Grid.Row="3" Grid.Column="3" HorizontalAlignment="Center" FontWeight="SemiBold" controls:IconizedText.Text="{Binding TiltGuidance.Screw3TotalAmount}" />
+                                <TextBlock Grid.Row="3" Grid.Column="4" HorizontalAlignment="Center" FontWeight="SemiBold" controls:IconizedText.Text="{Binding TiltGuidance.Screw4TotalAmount}"
                                     Visibility="{Binding TiltGuidance.HasFourScrews, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                             </Grid>
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Controls/IconizedText.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Controls/IconizedText.cs
@@ -1,0 +1,87 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Media;
+
+namespace NINA.Joko.Plugins.HocusFocus.Controls {
+
+    /// <summary>
+    /// Attached property that renders a bound string into a <see cref="TextBlock"/>'s inline run,
+    /// substituting the screw-rotation sentinels ⟳ (U+27F3) / ⟲ (U+27F2) with the crisp vector
+    /// icons HF_RotationCwSVG / HF_RotationCcwSVG. Every other character — including the adapter
+    /// MOTION arrows ⬆⬇↑↓ and the em-dash "—" — passes through unchanged as text.
+    ///
+    /// The VMs keep emitting the glyphs (so their strings stay unit-testable); this control is the
+    /// single place that turns those sentinels into legible icons. Use it in place of Text=, e.g.
+    /// <c>controls:IconizedText.Text="{Binding SomeGlyphBearingString}"</c>. The icon inherits the
+    /// TextBlock's Foreground and tracks its FontSize (sampled when Text changes).
+    /// </summary>
+    public static class IconizedText {
+
+        public static readonly DependencyProperty TextProperty =
+            DependencyProperty.RegisterAttached(
+                "Text", typeof(string), typeof(IconizedText),
+                new PropertyMetadata(null, OnTextChanged));
+
+        public static string GetText(DependencyObject o) => (string)o.GetValue(TextProperty);
+
+        public static void SetText(DependencyObject o, string v) => o.SetValue(TextProperty, v);
+
+        private static void OnTextChanged(DependencyObject o, DependencyPropertyChangedEventArgs e) {
+            if (o is not TextBlock tb) {
+                return;
+            }
+
+            tb.Inlines.Clear();
+            var s = e.NewValue as string;
+            if (string.IsNullOrEmpty(s)) {
+                return;
+            }
+
+            var buffer = new StringBuilder();
+            foreach (var ch in s) {
+                if (ch == '⟳' || ch == '⟲') { // ⟳ / ⟲ only
+                    if (buffer.Length > 0) {
+                        tb.Inlines.Add(new Run(buffer.ToString()));
+                        buffer.Clear();
+                    }
+                    tb.Inlines.Add(BuildIcon(tb, ch == '⟳' ? "HF_RotationCwSVG" : "HF_RotationCcwSVG"));
+                } else {
+                    buffer.Append(ch); // ⬆⬇↑↓ and everything else pass through as text
+                }
+            }
+            if (buffer.Length > 0) {
+                tb.Inlines.Add(new Run(buffer.ToString()));
+            }
+        }
+
+        private static InlineUIContainer BuildIcon(TextBlock tb, string resourceKey) {
+            // Render a touch larger than the surrounding text: the rotation direction has to be
+            // readable at inline sizes, and a glyph-sized icon loses the arrowhead.
+            double size = (tb.FontSize > 0 ? tb.FontSize : 12) + 2;
+            var path = new System.Windows.Shapes.Path {
+                Data = tb.TryFindResource(resourceKey) as Geometry,
+                Stretch = Stretch.Uniform,
+                Width = size,
+                Height = size,
+                Fill = tb.Foreground,
+                Margin = new Thickness(1, 0, 1, 0),
+                SnapsToDevicePixels = true
+            };
+            return new InlineUIContainer(path) { BaselineAlignment = BaselineAlignment.Center };
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
@@ -26,8 +26,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new release build of a plugin
-[assembly: AssemblyVersion("3.0.0.37")]
-[assembly: AssemblyFileVersion("3.0.0.37")]
+[assembly: AssemblyVersion("4.0.0.0")]
+[assembly: AssemblyFileVersion("4.0.0.0")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("Hocus Focus")]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
@@ -42,23 +42,24 @@
     <hfconverters:EmptyCollectionToVisibilityConverter x:Key="HF_EmptyCollectionToVisibilityCollapsedConverter" />
 
     <!--
-        Clockwise rotation icon: a ~300° filled annular arc (outer r=34, inner r=22 about center
-        50,50) opening at the top, capped by a LARGE triangular arrowhead whose tip points clockwise
-        (up-and-right). The oversized head is deliberate — it makes the turn direction legible even
-        at ~14 px inline, which the old ⟳ glyph was not. Pairs with HF_RotationCcwSVG. Consume as a
-        Path with Stretch="Uniform" and a themed Fill.
+        Clockwise rotation icon: a filled ring (outer r=32, inner r=22 about center 50,50) open near
+        the lower-right, plus a separate LARGE triangular arrowhead at ~120° (4–5 o'clock) whose tip
+        points clockwise (down-and-left, tangent to the ring). The oversized head placed on the arc
+        is deliberate — it keeps the turn direction legible even at ~14 px inline, which the old ⟳
+        glyph was not. Pairs with HF_RotationCcwSVG. Consume as a Path with Stretch="Uniform" and a
+        themed Fill.
     -->
     <GeometryGroup x:Key="HF_RotationCwSVG">
-        <PathGeometry Figures="M 67,20.56 A 34,34 0 1 1 33,20.56 L 29,13.63 L 46.1,22.34 L 43,37.88 L 39,30.95 A 22,22 0 1 0 61,30.95 Z" />
+        <PathGeometry Figures="M 47.21,81.88 A 32,32 0 1 1 77.71,66 L 69.05,61 A 22,22 0 1 0 48.08,71.92 Z M 84.64,70 L 64.38,79.1 L 62.12,57 Z" />
     </GeometryGroup>
 
     <!--
         Counter-clockwise rotation icon: the horizontal mirror (x → 100−x) of HF_RotationCwSVG, so
-        the arrowhead points counter-clockwise (up-and-left). Arc sweep flags are inverted relative
-        to the CW variant because mirroring reverses the winding. Replaces the ⟲ glyph.
+        the arrowhead sits at ~240° (7–8 o'clock) and points counter-clockwise. Arc sweep flags are
+        inverted relative to the CW variant because mirroring reverses the winding. Replaces the ⟲ glyph.
     -->
     <GeometryGroup x:Key="HF_RotationCcwSVG">
-        <PathGeometry Figures="M 33,20.56 A 34,34 0 1 0 67,20.56 L 71,13.63 L 53.9,22.34 L 57,37.88 L 61,30.95 A 22,22 0 1 1 39,30.95 Z" />
+        <PathGeometry Figures="M 52.79,81.88 A 32,32 0 1 0 22.29,66 L 30.95,61 A 22,22 0 1 1 51.92,71.92 Z M 15.36,70 L 35.62,79.1 L 37.88,57 Z" />
     </GeometryGroup>
 
     <!--

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
@@ -42,6 +42,26 @@
     <hfconverters:EmptyCollectionToVisibilityConverter x:Key="HF_EmptyCollectionToVisibilityCollapsedConverter" />
 
     <!--
+        Clockwise rotation icon: a ~300° filled annular arc (outer r=34, inner r=22 about center
+        50,50) opening at the top, capped by a LARGE triangular arrowhead whose tip points clockwise
+        (up-and-right). The oversized head is deliberate — it makes the turn direction legible even
+        at ~14 px inline, which the old ⟳ glyph was not. Pairs with HF_RotationCcwSVG. Consume as a
+        Path with Stretch="Uniform" and a themed Fill.
+    -->
+    <GeometryGroup x:Key="HF_RotationCwSVG">
+        <PathGeometry Figures="M 67,20.56 A 34,34 0 1 1 33,20.56 L 29,13.63 L 46.1,22.34 L 43,37.88 L 39,30.95 A 22,22 0 1 0 61,30.95 Z" />
+    </GeometryGroup>
+
+    <!--
+        Counter-clockwise rotation icon: the horizontal mirror (x → 100−x) of HF_RotationCwSVG, so
+        the arrowhead points counter-clockwise (up-and-left). Arc sweep flags are inverted relative
+        to the CW variant because mirroring reverses the winding. Replaces the ⟲ glyph.
+    -->
+    <GeometryGroup x:Key="HF_RotationCcwSVG">
+        <PathGeometry Figures="M 33,20.56 A 34,34 0 1 0 67,20.56 L 71,13.63 L 53.9,22.34 L 57,37.88 L 61,30.95 A 22,22 0 1 1 39,30.95 Z" />
+    </GeometryGroup>
+
+    <!--
         AF focus chart used by the Tilt Adapter Wizard to show live measurement feedback.
         DataContext must be InspectorVM. Shows per-region focus curves; callers control visibility.
     -->

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -164,7 +164,7 @@
             Foreground="{StaticResource PrimaryBrush}"
             Opacity="0.8"
             TextWrapping="Wrap"
-            controls:IconizedText.Text="Rectangle = image as shown in NINA (top = top of image). 0° points up; angles increase clockwise ⟳." />
+            controls:IconizedText.Text="Rectangle = image as shown in NINA. 0° points up; angles increase clockwise ⟳." />
         </StackPanel>
     </DataTemplate>
 
@@ -505,7 +505,7 @@
                         <ComboBox
                             Grid.Row="2"
                             Grid.Column="1"
-                            MinWidth="180"
+                            MinWidth="130"
                             VerticalAlignment="Center"
                             SelectedValuePath="Tag"
                             SelectedValue="{Binding CwMovesAdapterTowardObjective}">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -2,6 +2,7 @@
     x:Class="NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard.DataTemplates"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="clr-namespace:NINA.Joko.Plugins.HocusFocus.Controls"
     xmlns:ninactrl="clr-namespace:NINA.CustomControlLibrary;assembly=NINA.CustomControlLibrary"
     xmlns:rules="clr-namespace:NINA.Core.Utility.ValidationRules;assembly=NINA.Core"
     xmlns:s="clr-namespace:System;assembly=mscorlib"
@@ -31,6 +32,7 @@
           • Screw circles: radius 75 from center, 24×24 circles
     -->
     <DataTemplate x:Key="HF_TiltScrewDiagram">
+        <StackPanel>
         <Canvas Width="200" Height="200">
             <!--  Sensor rectangle — 3:2 aspect ratio, 90×60  -->
             <Rectangle
@@ -124,7 +126,46 @@
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
+
+            <!--  Orientation markers (Style A) — anchored only in screw-free zones: the central-top
+                  band (x∈[93,115], y∈[43,56]) and the rectangle interior are empty for all 3- and
+                  4-screw layouts and any calibration rotation, so they never collide with a screw
+                  circle. The clockwise cue lives in the caption below (collision-proof).  -->
+            <!--  0° = straight up: up-chevron + label just below the 12-o'clock screw  -->
+            <Path
+                Canvas.Left="93"
+                Canvas.Top="46"
+                Width="14"
+                Height="10"
+                Data="M0,10 L7,0 L14,10 Z"
+                Fill="{StaticResource PrimaryBrush}"
+                Stretch="Uniform" />
+            <TextBlock
+                Canvas.Left="110"
+                Canvas.Top="43"
+                FontSize="10"
+                Foreground="{StaticResource PrimaryBrush}"
+                Text="0°" />
+            <!--  The rectangle depicts IMAGE orientation, not the physical adapter  -->
+            <TextBlock
+                Canvas.Left="70"
+                Canvas.Top="74"
+                FontSize="9"
+                Foreground="{StaticResource PrimaryBrush}"
+                Opacity="0.75"
+                Text="top of image" />
         </Canvas>
+        <!--  Caption: states all three orientation facts; the clockwise icon renders inline (via the
+              ⟳ sentinel) here where it cannot collide with a rotated screw circle.  -->
+        <TextBlock
+            MaxWidth="200"
+            Margin="0,4,0,0"
+            FontSize="10"
+            Foreground="{StaticResource PrimaryBrush}"
+            Opacity="0.8"
+            TextWrapping="Wrap"
+            controls:IconizedText.Text="Rectangle = image as shown in NINA (top = top of image). 0° points up; angles increase clockwise ⟳." />
+        </StackPanel>
     </DataTemplate>
 
     <!--
@@ -178,7 +219,42 @@
                         </Style.Triggers>
                     </Style>
                 </UniformGrid.Style>
-                <TextBlock HorizontalAlignment="Center" Text="Screws CW" />
+                <!--  Screw-turn label: "Screws ⟳" for manual screws, "Screws + steps" for steppers  -->
+                <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <StackPanel.Style>
+                            <Style TargetType="StackPanel">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsStepperAdjustment}" Value="True">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </StackPanel.Style>
+                        <TextBlock VerticalAlignment="Center" Text="Screws" />
+                        <Path
+                            Width="14"
+                            Height="14"
+                            Margin="2,0,0,0"
+                            VerticalAlignment="Center"
+                            Data="{StaticResource HF_RotationCwSVG}"
+                            Fill="{StaticResource PrimaryBrush}"
+                            Stretch="Uniform" />
+                    </StackPanel>
+                    <TextBlock VerticalAlignment="Center" Text="Screws + steps">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsStepperAdjustment}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Grid>
                 <TextBlock HorizontalAlignment="Center">
                     <Run Text="Curvature " /><Run Text="{Binding CurvatureSignDescription, Mode=OneWay}" />
                 </TextBlock>
@@ -383,13 +459,49 @@
                             Text="Adds one standard autofocus before every measurement sweep to re-center focus. Turn on if focus drifts between steps (e.g., temperature) or your focuser starts far from focus."
                             TextWrapping="Wrap" />
 
-                        <TextBlock
+                        <!--  Direction label: "Screw ⟳ moves adapter" for screws, "+ steps move adapter"
+                              for steppers. Kept short so the row does not crowd the combo box.  -->
+                        <Grid
                             Grid.Row="2"
                             Grid.Column="0"
                             Margin="0,2,5,2"
                             VerticalAlignment="Center"
-                            Text="{Binding CwDirectionLabel}"
-                            ToolTip="Whether tightening moves the adapter toward the camera or the objective depends on its design (push vs pull screws). Sets the direction of backfocus/curvature guidance." />
+                            ToolTip="Whether tightening moves the adapter toward the camera or the objective depends on its design (push vs pull screws). Sets the direction of backfocus/curvature guidance.">
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <StackPanel.Style>
+                                    <Style TargetType="StackPanel">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsStepperAdjustment}" Value="True">
+                                                <Setter Property="Visibility" Value="Collapsed" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </StackPanel.Style>
+                                <TextBlock VerticalAlignment="Center" Text="Screw" />
+                                <Path
+                                    Width="14"
+                                    Height="14"
+                                    Margin="2,0,2,0"
+                                    VerticalAlignment="Center"
+                                    Data="{StaticResource HF_RotationCwSVG}"
+                                    Fill="{StaticResource PrimaryBrush}"
+                                    Stretch="Uniform" />
+                                <TextBlock VerticalAlignment="Center" Text="moves adapter" />
+                            </StackPanel>
+                            <TextBlock VerticalAlignment="Center" Text="+ steps move adapter">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsStepperAdjustment}" Value="True">
+                                                <Setter Property="Visibility" Value="Visible" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+                        </Grid>
                         <ComboBox
                             Grid.Row="2"
                             Grid.Column="1"
@@ -407,12 +519,12 @@
                                     </Style.Triggers>
                                 </Style>
                             </ComboBox.Style>
-                            <ComboBoxItem Content="Toward the camera — outward">
+                            <ComboBoxItem Content="Toward the camera">
                                 <ComboBoxItem.Tag>
                                     <s:Boolean>False</s:Boolean>
                                 </ComboBoxItem.Tag>
                             </ComboBoxItem>
-                            <ComboBoxItem Content="Toward the objective — inward">
+                            <ComboBoxItem Content="Toward the objective">
                                 <ComboBoxItem.Tag>
                                     <s:Boolean>True</s:Boolean>
                                 </ComboBoxItem.Tag>
@@ -886,7 +998,7 @@
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
                                     <UniformGrid Columns="3">
-                                        <TextBlock Text="{Binding StepDescription}" />
+                                        <TextBlock controls:IconizedText.Text="{Binding StepDescription}" />
                                         <TextBlock Text="{Binding Direction, StringFormat={}{0:F1}°}" />
                                         <TextBlock Text="{Binding TiltAngleDisplay}" />
                                     </UniformGrid>
@@ -932,7 +1044,7 @@
                                             </Style>
                                         </Border.Style>
                                         <UniformGrid Columns="4">
-                                            <TextBlock Text="{Binding StepDescription}" />
+                                            <TextBlock controls:IconizedText.Text="{Binding StepDescription}" />
                                             <TextBlock Text="{Binding Label}" />
                                             <TextBlock Text="{Binding Direction, StringFormat={}{0:F1}°}" />
                                             <TextBlock Text="{Binding TiltAngleDisplay}" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -780,9 +780,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
         }
 
+        // The visible direction-row label is now composed in XAML (a "Screw ⟳ moves adapter" /
+        // "+ steps move adapter" icon+text row). This property is retained because a profile swap
+        // must still raise it (TiltAdapterWizardVMTests asserts the notification); the strings below
+        // are kept aligned with the XAML wording for any future textual use.
         public string CwDirectionLabel => IsStepperAdjustment
-            ? "Applying + steps moves the adapter"
-            : "Turning screws clockwise moves the adapter";
+            ? "+ steps move adapter"
+            : "Screw turn moves adapter";
 
         public string CurvatureSignProvenance =>
             tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured

--- a/plans/tilt-adapter-icon-ux-plan.md
+++ b/plans/tilt-adapter-icon-ux-plan.md
@@ -1,0 +1,253 @@
+# Tilt Adapter UI: vector rotation icons + diagram clarity
+
+> On execution, copy this file into the repo as `plans/tilt-adapter-icon-ux-plan.md` (project convention: implementation plans live in `plans/`). This copy lives in the plan-mode scratch path only because that is the sole file editable during planning.
+
+## Context
+
+User-facing feedback on the HocusFocus **Tilt Adapter** UI:
+
+1. The clockwise/counter-clockwise turn indicators are Unicode glyphs `⟳` (U+27F3) / `⟲` (U+27F2). They are small, low-resolution, and hard to read the direction of. Replace them with crisp vector (WPF `Path`/`Geometry`) icons.
+2. The tilt-adapter screw diagram is confusing. Make it clear that (a) the rectangle depicts **image** orientation — its top = the top of the image as displayed in NINA, not the physical adapter; (b) **0° points straight up**; (c) **angles increase clockwise**.
+3. On the diagram's calibration-info block, replace the literal text "CW" in "Screws CW" with the clockwise icon.
+4. On the wizard Measurement section, shorten the over-long direction row: label → "Screw \<CW icon\> moves adapter", and shorten the combo-box values to "Toward the objective" / "Toward the camera" (drop the "— inward"/"— outward" suffixes).
+
+**Decisions confirmed with the user:**
+- **Scope of glyph → icon replacement: comprehensive.** Beyond the two wizard labels (items 3 & 4) and the diagram, also convert the **Aberration Inspector "Tilt Adapter Guidance" panel** (direction legend + the 12 per-screw Tilt/Backfocus/Total amount cells) and the **wizard step-summary rows** ("Screw 1 ⟳, Screw 3 ⟲").
+- **Diagram clarification style: on-canvas markers + caption** (Style A).
+
+Outcome: users get legible, unambiguous rotation icons everywhere a screw turn is shown, and the diagram self-explains its image-space orientation convention.
+
+## Key design choice — how icons get into text
+
+The `⟳`/`⟲` glyphs are **baked into bound strings** produced by the VMs (`FormatAmount`, `BuildDirectionLegend`, `StepDescription`), several of them mid-sentence and unit-tested for exact string content. Rather than restructure every VM property and rewrite the tests, introduce **one small attached property** that renders a string's `⟳`/`⟲` characters as inline vector icons. The VM strings keep the glyphs **as rendering sentinels**; the user only ever sees the icons; tests stay green.
+
+- Two motion arrows `⬆⬇↑↓` (adapter-plate motion, a different concept) are **left as text** — the attached property only converts `⟳`/`⟲`.
+- Do **not** touch `CurvatureSignDescription` (uses ↑/↓ motion-adjacent glyphs, intentional).
+
+Fixed short labels that need a screw-vs-stepper wording switch (items 3 & 4) use a plain `StackPanel`(text + `Path`) with a `DataTrigger`, not the attached property — cleaner for a two-word label with a hardware-conditional variant.
+
+---
+
+## Implementation
+
+### 1. New icon geometries — `Resources/OptionsDataTemplates.xaml` (CORE)
+
+Add two filled circular-arrow `GeometryGroup` resources near the top of the shared dictionary (every area dictionary merges this file, so they resolve app-wide). Follow the house `…SVG` convention with a documenting comment (mirror `StarDetectionResultsSVG`). Coordinate box 0..100, center (50,50), ~300° annular arc (outer r≈34, inner r≈22) + triangular arrowhead; default `FillRule` (Nonzero).
+
+```xml
+<!-- Clockwise rotation icon: ~300° filled annular arc opening at top, capped by an
+     arrowhead whose tip points clockwise. Pairs with HF_RotationCcwSVG. Stretch="Uniform". -->
+<GeometryGroup x:Key="HF_RotationCwSVG">
+    <PathGeometry Figures="M 67,20.56 A 34,34 0 1 1 33,20.56 L 30,15.36 L 44.18,22.61 L 42,36.14 L 39,30.95 A 22,22 0 1 0 61,30.95 Z" />
+</GeometryGroup>
+
+<!-- Counter-clockwise rotation icon: horizontal mirror (x→100−x) of HF_RotationCwSVG;
+     arrowhead points counter-clockwise. Arc sweep flags inverted vs the CW variant. -->
+<GeometryGroup x:Key="HF_RotationCcwSVG">
+    <PathGeometry Figures="M 33,20.56 A 34,34 0 1 0 67,20.56 L 70,15.36 L 55.82,22.61 L 58,36.14 L 61,30.95 A 22,22 0 1 1 39,30.95 Z" />
+</GeometryGroup>
+```
+
+The path figures above are a computed starting point — **open the file in a XAML previewer (or run NINA) and nudge the arrowhead wing offsets** if the head looks thin. Consume as (house pattern from `Options.xaml`):
+
+```xml
+<Path Width="14" Height="14" Stretch="Uniform" VerticalAlignment="Center"
+      Data="{StaticResource HF_RotationCwSVG}" Fill="{StaticResource PrimaryBrush}" />
+```
+
+Use `PrimaryBrush` on surfaces (the diagram already themes with it); `ButtonForegroundBrush` only for icons on buttons. Set `Fill` at the use-site, not in a shared style.
+
+### 2. `IconizedText` attached property — `Controls/IconizedText.cs` (new; infra for the comprehensive sites)
+
+Renders a bound string into a `TextBlock`'s `Inlines`, converting `⟳`/`⟲` to inline vector icons and passing everything else (incl. `⬆⬇↑↓` and the em-dash "—") through as text. Namespace `NINA.Joko.Plugins.HocusFocus.Controls` (already imported as `xmlns:controls` in `AutoFocus/DataTemplates.xaml` and `OptionsDataTemplates.xaml`).
+
+```csharp
+public static class IconizedText {
+    public static readonly DependencyProperty TextProperty =
+        DependencyProperty.RegisterAttached("Text", typeof(string), typeof(IconizedText),
+            new PropertyMetadata(null, OnTextChanged));
+    public static string GetText(DependencyObject o) => (string)o.GetValue(TextProperty);
+    public static void SetText(DependencyObject o, string v) => o.SetValue(TextProperty, v);
+
+    private static void OnTextChanged(DependencyObject o, DependencyPropertyChangedEventArgs e) {
+        if (o is not TextBlock tb) return;
+        tb.Inlines.Clear();
+        var s = e.NewValue as string;
+        if (string.IsNullOrEmpty(s)) return;
+        var buf = new StringBuilder();
+        foreach (var ch in s) {
+            if (ch == '⟳' || ch == '⟲') {                 // ⟳ / ⟲ only
+                if (buf.Length > 0) { tb.Inlines.Add(new Run(buf.ToString())); buf.Clear(); }
+                tb.Inlines.Add(BuildIcon(tb, ch == '⟳' ? "HF_RotationCwSVG" : "HF_RotationCcwSVG"));
+            } else {
+                buf.Append(ch);
+            }
+        }
+        if (buf.Length > 0) tb.Inlines.Add(new Run(buf.ToString()));
+    }
+
+    private static InlineUIContainer BuildIcon(TextBlock tb, string key) {
+        double size = tb.FontSize > 0 ? tb.FontSize : 12;
+        var path = new System.Windows.Shapes.Path {
+            Data = tb.TryFindResource(key) as Geometry,
+            Stretch = Stretch.Uniform, Width = size, Height = size,
+            Fill = tb.Foreground, Margin = new Thickness(1, 0, 1, 0),
+            SnapsToDevicePixels = true
+        };
+        return new InlineUIContainer(path) { BaselineAlignment = BaselineAlignment.Center };
+    }
+}
+```
+
+Notes / known limits: icon `Fill` inherits the TextBlock `Foreground`; size tracks `FontSize` at parse time (re-parses on `Text` change, not on a later `FontSize` change — fine for our fixed sizes); `TryFindResource` null → empty Path (safe); `TextWrapping="Wrap"` still works. Add a one-line comment at each producing VM method noting "⟳/⟲ are rendered as vector icons by IconizedText".
+
+### 3. Diagram clarity — Style A in `HF_TiltScrewDiagram` (`TiltAdapterWizard/DataTemplates.xaml` ~L33-128) (CORE, XAML-only)
+
+Wrap the existing `Canvas` in a `StackPanel` so **both** consumers (saved-calibration ~L559-569 and complete-step ~L1060-1069) update automatically. No VM change.
+
+**Collision-safe zones** (screws sit on the radius-75 ring; canonical centers: 3-screw 0/120/240°, 4-screw 0/90/180/270°): the **rectangle interior** and the **central-top band** `x∈[93,115], y∈[43,56]` are empty for all rotations (to reach that low `y`, a screw must swing far to the side in `x`). Anchor markers only there; keep the possibly-colliding CW cue in the caption.
+
+Add inside the `Canvas` (after the existing rectangle / crosshairs / screw items):
+
+```xml
+<!-- 0° = straight up: up-chevron + label in the always-empty central-top band -->
+<Path Canvas.Left="93" Canvas.Top="46" Width="14" Height="10" Stretch="Uniform"
+      Fill="{StaticResource PrimaryBrush}" Data="M0,10 L7,0 L14,10 Z" />
+<TextBlock Canvas.Left="110" Canvas.Top="43" FontSize="10"
+           Foreground="{StaticResource PrimaryBrush}" Text="0°" />
+<!-- "top of image" hint inside the rectangle near its top edge (rect interior is screw-free) -->
+<TextBlock Canvas.Left="70" Canvas.Top="74" FontSize="9" Opacity="0.75"
+           Foreground="{StaticResource PrimaryBrush}" Text="top of image" />
+```
+
+Then, below the `Canvas`, a caption that words all three facts and carries the clockwise **icon** inline (collision-proof, via `IconizedText` using the `⟳` sentinel):
+
+```xml
+<TextBlock MaxWidth="200" Margin="0,4,0,0" FontSize="10" Opacity="0.8" TextWrapping="Wrap"
+           Foreground="{StaticResource PrimaryBrush}"
+           controls:IconizedText.Text="Rectangle = image as shown in NINA (top = top of image). 0° points up; angles increase clockwise ⟳." />
+```
+
+Add `xmlns:controls="clr-namespace:NINA.Joko.Plugins.HocusFocus.Controls"` to the wizard dictionary root (it is not currently imported there). If the implementer prefers the CW arrow strictly on-canvas at the top, the only collision-safe spot is tight — verify against a rotated calibration first; the caption is the reliable fallback and is kept regardless.
+
+### 4. Item 3 — "Screws CW" → "Screws \<CW icon\>" in `HF_TiltScrewCalibrationInfo` (~L181) (CORE)
+
+DataContext is the wizard VM (`Content="{Binding}"`), so `IsStepperAdjustment` binds. Replace the single `<TextBlock Text="Screws CW" />` with a screw/stepper toggle (this file's idiom is `DataTrigger`, not converters):
+
+```xml
+<Grid HorizontalAlignment="Center" VerticalAlignment="Center">
+  <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+    <StackPanel.Style>
+      <Style TargetType="StackPanel">
+        <Setter Property="Visibility" Value="Visible" />
+        <Style.Triggers>
+          <DataTrigger Binding="{Binding IsStepperAdjustment}" Value="True">
+            <Setter Property="Visibility" Value="Collapsed" />
+          </DataTrigger>
+        </Style.Triggers>
+      </Style>
+    </StackPanel.Style>
+    <TextBlock Text="Screws" VerticalAlignment="Center" />
+    <Path Width="14" Height="14" Margin="2,0,0,0" Stretch="Uniform" VerticalAlignment="Center"
+          Data="{StaticResource HF_RotationCwSVG}" Fill="{StaticResource PrimaryBrush}" />
+  </StackPanel>
+  <TextBlock Text="+ steps" VerticalAlignment="Center">
+    <TextBlock.Style>
+      <Style TargetType="TextBlock">
+        <Setter Property="Visibility" Value="Collapsed" />
+        <Style.Triggers>
+          <DataTrigger Binding="{Binding IsStepperAdjustment}" Value="True">
+            <Setter Property="Visibility" Value="Visible" />
+          </DataTrigger>
+        </Style.Triggers>
+      </Style>
+    </TextBlock.Style>
+  </TextBlock>
+</Grid>
+```
+
+### 5. Item 4 — direction-row label + ComboBox (`TiltAdapterWizard/DataTemplates.xaml` ~L386-420) (CORE)
+
+Replace the `CwDirectionLabel`-bound TextBlock (L386-392) with the same screw/stepper toggle, keeping its `Grid.Row="2" Grid.Column="0"`, margin, and existing `ToolTip`:
+
+```xml
+<Grid Grid.Row="2" Grid.Column="0" Margin="0,2,5,2" VerticalAlignment="Center"
+      ToolTip="Whether tightening moves the adapter toward the camera or the objective depends on its design (push vs pull screws). Sets the direction of backfocus/curvature guidance.">
+  <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+    <StackPanel.Style>
+      <Style TargetType="StackPanel">
+        <Setter Property="Visibility" Value="Visible" />
+        <Style.Triggers>
+          <DataTrigger Binding="{Binding IsStepperAdjustment}" Value="True">
+            <Setter Property="Visibility" Value="Collapsed" />
+          </DataTrigger>
+        </Style.Triggers>
+      </Style>
+    </StackPanel.Style>
+    <TextBlock Text="Screw" VerticalAlignment="Center" />
+    <Path Width="14" Height="14" Margin="2,0,2,0" Stretch="Uniform" VerticalAlignment="Center"
+          Data="{StaticResource HF_RotationCwSVG}" Fill="{StaticResource PrimaryBrush}" />
+    <TextBlock Text="moves adapter" VerticalAlignment="Center" />
+  </StackPanel>
+  <TextBlock Text="+ steps move adapter" VerticalAlignment="Center">
+    <TextBlock.Style>
+      <Style TargetType="TextBlock">
+        <Setter Property="Visibility" Value="Collapsed" />
+        <Style.Triggers>
+          <DataTrigger Binding="{Binding IsStepperAdjustment}" Value="True">
+            <Setter Property="Visibility" Value="Visible" />
+          </DataTrigger>
+        </Style.Triggers>
+      </Style>
+    </TextBlock.Style>
+  </TextBlock>
+</Grid>
+```
+
+Shorten the two ComboBox items (L410, L415) — keep the `Tag` bools and order:
+
+```xml
+<ComboBoxItem Content="Toward the camera"><ComboBoxItem.Tag><s:Boolean>False</s:Boolean></ComboBoxItem.Tag></ComboBoxItem>
+<ComboBoxItem Content="Toward the objective"><ComboBoxItem.Tag><s:Boolean>True</s:Boolean></ComboBoxItem.Tag></ComboBoxItem>
+```
+
+**Constraint:** `CwDirectionLabel` (VM L783-785) is no longer bound but **must be retained** — `TiltAdapterWizardVMTests.cs:694` asserts it is raised on a profile swap; keep the property and its `RaisePropertyChanged` calls (L266, L312). Optionally shorten its return strings for consistency (no test asserts the value).
+
+### 6. Inspector guidance panel — legend + 12 amount cells (`AutoFocus/DataTemplates.xaml`) (comprehensive)
+
+Pure presentational swap `Text=` → `controls:IconizedText.Text=`; no VM/test change (`controls` is already imported here):
+- Legend TextBlock (~L2836-2840): `controls:IconizedText.Text="{Binding TiltGuidance.DirectionLegend}"` (keeps `TextWrapping`; `⬆` passes through, `⟳` becomes an icon; stepper legend has no `⟳`).
+- The 12 amount cells (~L2992-2996 Tilt, L2999-3003 Backfocus, L3006-3010 Total): change each `Text="{Binding TiltGuidance.ScrewNXxxAmount}"` to `controls:IconizedText.Text="{Binding …}"`, preserving each cell's `Grid.Row/Column`, `HorizontalAlignment`, `Visibility`, and the Total row's `FontWeight="SemiBold"` (the emitted `Run` inherits it). Em-dash and "+N steps" cells render as plain text.
+
+Leave the separate motion-arrow row (`ScrewNTiltArrow`/`ScrewNBackfocusArrow`, `⬆⬇↑↓`) as plain `Text=` — unchanged.
+
+### 7. Wizard step-summary rows (`TiltAdapterWizard/DataTemplates.xaml`) (comprehensive)
+
+The two `ItemsControl ItemsSource="{Binding StepMeasurementSummary}"` render `StepDescription` at ~L889 and ~L935. Change both `<TextBlock Text="{Binding StepDescription}" />` → `controls:IconizedText.Text="{Binding StepDescription}"`. `StepDescription(...)` in the VM is unchanged (glyphs stay as sentinels), so `StepDescription_UsesRotationGlyphs` stays green. (Same `xmlns:controls` added in step 3.)
+
+---
+
+## Files to modify
+
+| File | Change |
+|---|---|
+| `Resources/OptionsDataTemplates.xaml` | Add `HF_RotationCwSVG` / `HF_RotationCcwSVG` geometries |
+| `Controls/IconizedText.cs` | **New** attached property |
+| `TiltAdapterWizard/DataTemplates.xaml` | Add `xmlns:controls`; Style A diagram; item 3 label; item 4 label + combo; step-summary rows |
+| `AutoFocus/DataTemplates.xaml` | Legend + 12 amount cells → `IconizedText.Text` |
+| `TiltAdapterWizard/TiltAdapterWizardVM.cs` | Retain `CwDirectionLabel` (optionally shorten its strings); add sentinel comments |
+
+**Do not change:** `TiltScrewGuidanceRow.cs` (`FormatAmount`/`BuildDirectionLegend` keep sentinels), `InspectorVM` guidance population, `CurvatureSignDescription`, the motion-arrow row, or the `RebuildDiagram` math. No test files change on this route.
+
+## Testing & verification
+
+1. **Build + unit tests** (project invariant — must pass, no skips):
+   ```
+   dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo
+   ```
+   Expect all green with no test edits (VM strings unchanged). If a glyph-asserting test fails, it means a VM string was altered unintentionally — fix the cause.
+2. **Visual verification in NINA** (icons must be legible and directions unambiguous — the whole point). Per `.claude/docs/nina-mcp-screenshots.md`, capture via the Windows MCP:
+   - Tilt Adapter Wizard panel: the diagram (0° up-chevron, "top of image" hint, caption with CW icon read correctly for a 3-screw and a 4-screw calibration), the "Screws \<CW\>" calibration row, and the shortened "Screw \<CW\> moves adapter" row + combo. Toggle a stepper adapter to confirm the "+ steps" variants show.
+   - Aberration Inspector "Tilt Adapter Guidance": the legend CW icon, and the per-screw amount cells rendering `1.25 <CW icon>` / `0.50 <CCW icon>`; confirm the em-dash and stepper "+N steps" cells still render plainly and the Total row stays bold.
+   - Confirm CW vs CCW are visually distinguishable at the rendered small size; tune the geometry arrowhead if not.
+3. **Regression glance:** confirm motion arrows (`⬆⬇↑↓`) are unchanged and no icon appears where they render.


### PR DESCRIPTION
## Summary

Replaces the small, hard-to-discern ⟳/⟲ Unicode turn glyphs with **bold vector rotation icons**, and clarifies the tilt-adapter screw diagram. Addresses UI feedback on the Tilt Adapter Wizard and the Aberration Inspector guidance panel.

## Changes

- **New rotation icons** `HF_RotationCwSVG` / `HF_RotationCcwSVG` (`Resources/OptionsDataTemplates.xaml`) — a near-full ring with a large arrowhead, legible even at inline sizes where the old glyph was not.
- **`Controls/IconizedText.cs`** (new) — an attached property that renders the ⟳/⟲ sentinels in bound strings as inline vector icons. The VMs keep emitting the glyphs, so **no VM/test changes were required**. Applied to:
  - the Aberration Inspector "Tilt Adapter Guidance" **legend + 12 per-screw Tilt/Backfocus/Total amount cells**;
  - the wizard **step-summary rows**.
- **Tilt diagram** — on-canvas markers + caption clarifying that the rectangle is **image** orientation (top = top of image in NINA), **0° = straight up**, and **angles increase clockwise**. Markers are placed only in screw-free zones (verified for 3- and 4-screw layouts and rotated calibrations).
- **"Screws CW"** label → "Screws \<cw icon\>" (shows "Screws + steps" for stepper adapters).
- **Direction-row label** → "Screw \<cw icon\> moves adapter" (stepper: "+ steps move adapter"); combo-box values trimmed to **"Toward the camera" / "Toward the objective"**.
- **Bump `AssemblyVersion` / `AssemblyFileVersion` → `4.0.0.0`.**

Motion arrows (⬆⬇↑↓) are intentionally left unchanged — they denote adapter-plate motion, not screw rotation.

## Testing

- `dotnet test` (Windows/WSL): **1684 passed, 0 failed**.
- Build: **0 errors**.
- Visual: the icon geometry and Style-A diagram were rendered offline from the actual geometry — icons read as clearly directional at 14–80 px and diagram markers are collision-free. A live in-NINA screenshot pass is still recommended to confirm the real theme.

Design/implementation notes: `plans/tilt-adapter-icon-ux-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY7tgXMHkF9EbvPAHry7RA
