### PR TITLE
fix(af): region-0-only HFR-improvement gate, richer failure diagnostics, atomic report writes

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusEngineTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusEngineTests.cs
@@ -441,6 +441,123 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
             });
         }
 
+        // --- HFR-improvement gate (region-0-only validation) ---
+        // The whole-run HFR-improvement check now gates on region 0 only; EvaluateHfrImprovement is the pure
+        // decision for a single region, unit-tested here since the full sweep can't be driven through the mocks.
+
+        [Test]
+        public void EvaluateHfrImprovement_FinalHfrNull_ReturnsFinalHfrMissing() {
+            Assert.That(AutoFocusEngine.EvaluateHfrImprovement(new MeasureAndError { Measure = 2.5 }, null, 0.1),
+                Is.EqualTo(AutoFocusEngine.AutoFocusFailureMode.FinalHfrMissing));
+        }
+
+        [Test]
+        public void EvaluateHfrImprovement_FinalHfrZero_ReturnsFinalHfrMissing() {
+            Assert.That(AutoFocusEngine.EvaluateHfrImprovement(new MeasureAndError { Measure = 2.5 }, new MeasureAndError { Measure = 0.0 }, 0.1),
+                Is.EqualTo(AutoFocusEngine.AutoFocusFailureMode.FinalHfrMissing));
+        }
+
+        [Test]
+        public void EvaluateHfrImprovement_InitialHfrZero_FinalOk_ReturnsInitialHfrFailed() {
+            // The incident's shape: a zero initial HFR with a healthy final HFR. Only fatal now when it's region 0.
+            Assert.That(AutoFocusEngine.EvaluateHfrImprovement(new MeasureAndError { Measure = 0.0 }, new MeasureAndError { Measure = 2.5 }, 0.1),
+                Is.EqualTo(AutoFocusEngine.AutoFocusFailureMode.InitialHfrFailed));
+        }
+
+        [Test]
+        public void EvaluateHfrImprovement_InitialHfrNull_FinalOk_ReturnsInitialHfrFailed() {
+            Assert.That(AutoFocusEngine.EvaluateHfrImprovement(null, new MeasureAndError { Measure = 2.5 }, 0.1),
+                Is.EqualTo(AutoFocusEngine.AutoFocusFailureMode.InitialHfrFailed));
+        }
+
+        [Test]
+        public void EvaluateHfrImprovement_FinalWorseBeyondThreshold_ReturnsHfrRegression() {
+            // initial 3.0, threshold 0.1 => reject when final > 3.3.
+            Assert.That(AutoFocusEngine.EvaluateHfrImprovement(new MeasureAndError { Measure = 3.0 }, new MeasureAndError { Measure = 3.4 }, 0.1),
+                Is.EqualTo(AutoFocusEngine.AutoFocusFailureMode.HfrRegression));
+        }
+
+        [Test]
+        public void EvaluateHfrImprovement_FinalWithinThreshold_ReturnsNone() {
+            // 3.3 == 3.0 * 1.1 exactly => accepted (strictly-greater rejection).
+            Assert.That(AutoFocusEngine.EvaluateHfrImprovement(new MeasureAndError { Measure = 3.0 }, new MeasureAndError { Measure = 3.3 }, 0.1),
+                Is.EqualTo(AutoFocusEngine.AutoFocusFailureMode.None));
+        }
+
+        [Test]
+        public void EvaluateHfrImprovement_FinalImproves_ReturnsNone() {
+            Assert.That(AutoFocusEngine.EvaluateHfrImprovement(new MeasureAndError { Measure = 3.0 }, new MeasureAndError { Measure = 2.5 }, 0.1),
+                Is.EqualTo(AutoFocusEngine.AutoFocusFailureMode.None));
+        }
+
+        // --- HFR-improvement validation failure diagnostics (expanded logging) ---
+        // The generic "Failed assessing HFR at the initial position" named neither the region nor the reason.
+        // DescribeHfrValidationFailure builds the enriched log line; verify it classifies the three causes and
+        // echoes the region index so a user can cross-reference the detector's "Region: N" lines.
+
+        [Test]
+        public void DescribeHfrValidationFailure_ZeroHfrFiniteStdev_SaysNoStars() {
+            // Genuine zero-star detection: EvaluateExposure returns {Measure: 0, Stdev: 0 (finite)}. This is the
+            // real incident — region 3 had <=1 usable star in the initial frame.
+            var subs = new List<MeasureAndError> { new MeasureAndError { Measure = 0.0, Stdev = 0.0 } };
+            var msg = AutoFocusEngine.DescribeHfrValidationFailure("initial position", 3, new MeasureAndError { Measure = 0.0, Stdev = 0.0 }, subs, framesPerPoint: 1);
+
+            Assert.Multiple(() => {
+                Assert.That(msg, Does.Contain("initial position"));
+                Assert.That(msg, Does.Contain("Region 3"));
+                Assert.That(msg, Does.Contain("found no usable stars"));
+                Assert.That(msg, Does.Contain("Measured HFR=0.00"));
+                Assert.That(msg, Does.Contain("sub-frames 1/1"));
+                Assert.That(msg, Does.Contain("Region: 3"), "must point the reader at the detector's Region line");
+                Assert.That(msg, Does.Not.Contain("NaN"));
+            });
+        }
+
+        [Test]
+        public void DescribeHfrValidationFailure_ZeroHfrNaNStdev_SaysAnalysisError() {
+            // AnalyzeExposure's catch injects {Measure: 0, Stdev: NaN} when detection threw for a sub-frame.
+            var subs = new List<MeasureAndError> { new MeasureAndError { Measure = 0.0, Stdev = double.NaN } };
+            var msg = AutoFocusEngine.DescribeHfrValidationFailure("final focus point", 2, new MeasureAndError { Measure = 0.0, Stdev = double.NaN }, subs, framesPerPoint: 1);
+
+            Assert.Multiple(() => {
+                Assert.That(msg, Does.Contain("final focus point"));
+                Assert.That(msg, Does.Contain("Region 2"));
+                Assert.That(msg, Does.Contain("analysis errored"));
+                Assert.That(msg, Does.Contain("σ=NaN"));
+            });
+        }
+
+        [Test]
+        public void DescribeHfrValidationFailure_NullHfr_SaysMeasurementIncomplete() {
+            // Null averaged HFR means the sub-frame loop never reached FramesPerPoint.
+            var subs = new List<MeasureAndError> { new MeasureAndError { Measure = 2.5, Stdev = 0.3 } };
+            var msg = AutoFocusEngine.DescribeHfrValidationFailure("initial position", 4, null, subs, framesPerPoint: 3);
+
+            Assert.Multiple(() => {
+                Assert.That(msg, Does.Contain("Region 4"));
+                Assert.That(msg, Does.Contain("no averaged HFR was recorded"));
+                Assert.That(msg, Does.Contain("1 of 3 sub-frame(s) completed"));
+                Assert.That(msg, Does.Contain("Measured HFR=null"));
+            });
+        }
+
+        [Test]
+        public void DescribeHfrValidationFailure_MultiFrame_ListsEachSubMeasurement() {
+            var subs = new List<MeasureAndError> {
+                new MeasureAndError { Measure = 0.0, Stdev = 0.0 },
+                new MeasureAndError { Measure = 0.0, Stdev = double.NaN },
+            };
+            var msg = AutoFocusEngine.DescribeHfrValidationFailure("initial position", 5, new MeasureAndError { Measure = 0.0, Stdev = 0.0 }, subs, framesPerPoint: 2);
+
+            Assert.Multiple(() => {
+                Assert.That(msg, Does.Contain("sub-frames 2/2"));
+                Assert.That(msg, Does.Contain("0.00 (σ=0.00)"));
+                Assert.That(msg, Does.Contain("0.00 (σ=NaN)"));
+                // Any NaN sub-frame means an analysis error dominated the classification.
+                Assert.That(msg, Does.Contain("analysis errored on 1 of 2"));
+            });
+        }
+
         private sealed class TempDir : IDisposable {
             public string Path { get; }
             public TempDir() {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/PathUtilityTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/PathUtilityTests.cs
@@ -47,4 +47,43 @@ public class PathUtilityTests {
             () => PathUtility.GetRelativePath(@"C:\foo", null),
             Throws.TypeOf<ArgumentNullException>());
     }
+
+    [Test]
+    public void WriteAllTextAtomic_WritesContent_AndLeavesNoTempFile() {
+        var dir = Path.Combine(Path.GetTempPath(), "hf-atomic-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try {
+            var path = Path.Combine(dir, "2026-07-03--22-53-42.json");
+            PathUtility.WriteAllTextAtomic(path, "{\"ok\":true}");
+
+            Assert.Multiple(() => {
+                Assert.That(File.ReadAllText(path), Is.EqualTo("{\"ok\":true}"));
+                // The rename must clean up after itself: no leftover temp file, and the final file keeps its extension.
+                Assert.That(Directory.GetFiles(dir, "*.tmp"), Is.Empty, "no temp file should remain after an atomic write");
+                Assert.That(Directory.GetFiles(dir), Has.Length.EqualTo(1));
+            });
+        } finally {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    [Test]
+    public void WriteAllTextAtomic_OverwritesExistingFile() {
+        var dir = Path.Combine(Path.GetTempPath(), "hf-atomic-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try {
+            var path = Path.Combine(dir, "report.json");
+            File.WriteAllText(path, "old");
+            PathUtility.WriteAllTextAtomic(path, "new");
+
+            Assert.That(File.ReadAllText(path), Is.EqualTo("new"));
+        } finally {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    [Test]
+    public void WriteAllTextAtomic_NullPath_Throws() {
+        Assert.That(() => PathUtility.WriteAllTextAtomic(null, "x"), Throws.TypeOf<ArgumentNullException>());
+    }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
@@ -474,6 +474,66 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             return calculatedPoint >= 0 && calculatedPoint != currentSweepCenter;
         }
 
+        // Builds the diagnostic explaining WHY the HFR-improvement validation rejected a region. The generic
+        // "Failed assessing HFR at the initial position" gave no way to tell which region failed or why; this
+        // names the region (the same integer the detector logs as "Region: N") and distinguishes the three
+        // causes recoverable from the region's measurement data:
+        //   - hfr == null            -> the sub-frame loop never reached FramesPerPoint (capture/analysis
+        //                               incomplete for this region, e.g. cancellation).
+        //   - Measure == 0, σ finite -> the detector ran but found no usable stars (AverageHFR stayed 0; see
+        //                               HocusFocusStarDetection's "hfrStars.Count > 1" guard).
+        //   - Measure == 0, σ = NaN  -> exposure analysis threw for a sub-frame (AnalyzeExposure's catch injects
+        //                               {Measure: 0, Stdev: NaN}).
+        // Pure/static so it is unit-testable in the same style as ShouldRetryFromCalculatedPoint.
+        internal static string DescribeHfrValidationFailure(
+            string phase,
+            int regionIndex,
+            MeasureAndError? hfr,
+            IReadOnlyList<MeasureAndError> subMeasurements,
+            int framesPerPoint) {
+            var subCount = subMeasurements?.Count ?? 0;
+            var nanCount = subMeasurements?.Count(m => double.IsNaN(m.Stdev)) ?? 0;
+
+            string cause;
+            if (!hfr.HasValue) {
+                cause = $"no averaged HFR was recorded ({subCount} of {framesPerPoint} sub-frame(s) completed; capture/analysis did not finish for this region)";
+            } else if (hfr.Value.Measure == 0.0) {
+                cause = nanCount > 0
+                    ? $"HFR measured 0 - exposure analysis errored on {nanCount} of {subCount} sub-frame(s) (σ=NaN)"
+                    : $"HFR measured 0 - the detector found no usable stars in this region across {subCount} sub-frame(s)";
+            } else {
+                // Defensive: the two call sites only invoke this on null-or-zero, but never assert a false reason.
+                cause = $"HFR {hfr.Value.Measure:0.00} was rejected";
+            }
+
+            var hfrText = hfr.HasValue ? hfr.Value.Measure.ToString("0.00") : "null";
+            var subList = subCount == 0
+                ? ""
+                : " [" + string.Join(", ", subMeasurements.Select(m =>
+                    $"{m.Measure:0.00} (σ={(double.IsNaN(m.Stdev) ? "NaN" : m.Stdev.ToString("0.00"))})")) + "]";
+
+            return $"Failed assessing HFR at the {phase} for Region {regionIndex}: {cause}. " +
+                   $"Measured HFR={hfrText}; sub-frames {subCount}/{framesPerPoint}{subList}. " +
+                   $"Cross-reference the \"Region: {regionIndex}\" star-detection lines.";
+        }
+
+        // The single-region HFR-improvement decision. Returns the specific rejection mode, or None when the region
+        // passes. The whole-run validation gates on region 0 only (see ValidateCalculatedFocusPosition), so a
+        // transient dropout in a corner/sub-region cannot discard an otherwise-good autofocus. Pure/static so the
+        // gate is unit-testable without the full sweep harness.
+        internal static AutoFocusFailureMode EvaluateHfrImprovement(MeasureAndError? initialHfr, MeasureAndError? finalHfr, double improvementThreshold) {
+            if (!finalHfr.HasValue || finalHfr.Value.Measure == 0.0) {
+                return AutoFocusFailureMode.FinalHfrMissing;
+            }
+            if (!initialHfr.HasValue || initialHfr.Value.Measure == 0.0) {
+                return AutoFocusFailureMode.InitialHfrFailed;
+            }
+            if (finalHfr.Value.Measure > initialHfr.Value.Measure * (1.0 + improvementThreshold)) {
+                return AutoFocusFailureMode.HfrRegression;
+            }
+            return AutoFocusFailureMode.None;
+        }
+
         private class AutoFocusState {
 
             public AutoFocusState(
@@ -515,6 +575,10 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             public AutoFocusFailureMode LastFailureMode { get; set; } = AutoFocusFailureMode.None;
             public int LastCalculatedFocusPoint { get; set; } = -1;
 
+            // Region index that tripped the last validation failure (HFR-improvement checks), so the metadata.json
+            // FailureReason can name it. Null when the failure has no single associated region.
+            public int? LastFailureRegionIndex { get; set; } = null;
+
             public List<Task> InitialHFRTasks { get; private set; } = new List<Task>();
             public List<Task> AnalysisTasks { get; private set; } = new List<Task>();
             public AsyncAutoResetEvent MeasurementCompleteEvent { get; private set; }
@@ -536,6 +600,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 ResetFocusMeasurements();
                 LastFailureMode = AutoFocusFailureMode.None;
                 LastCalculatedFocusPoint = -1;
+                LastFailureRegionIndex = null;
                 ImageNumber = 0;
                 ++AttemptNumber;
             }
@@ -1563,30 +1628,33 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             }
 
             if (autoFocusState.Options.AutoFocusMethod == AFMethodEnum.STARHFR && autoFocusState.Options.ValidateHfrImprovement) {
-                foreach (var autoFocusRegionState in autoFocusState.FocusRegionStates) {
-                    lock (autoFocusRegionState.SubMeasurementsLock) {
-                        if (!autoFocusRegionState.FinalHFR.HasValue || autoFocusRegionState.FinalHFR.Value.Measure == 0.0) {
-                            Logger.Warning("Failed assessing HFR at the final focus point");
-                            Notification.ShowWarning("Failed assessing HFR at the final focus point");
-                            autoFocusState.LastFailureMode = AutoFocusFailureMode.FinalHfrMissing;
-                            return false;
+                // Gate on region 0 — the primary/full-frame region that drives the focus decision — ONLY. A
+                // transient dropout in a corner/sub-region (e.g. one initial frame where a region momentarily
+                // detects no usable stars) must not discard an otherwise-good autofocus. This mirrors the
+                // region-0-only early guard in StartBlindFocusPoints. Every region's HFR is still logged by the
+                // detector for diagnosis; corner dropouts are simply non-fatal here.
+                var primaryRegionState = autoFocusState.FocusRegionStates[0];
+                lock (primaryRegionState.SubMeasurementsLock) {
+                    var hfrFailureMode = EvaluateHfrImprovement(primaryRegionState.InitialHFR, primaryRegionState.FinalHFR, autoFocusState.Options.HFRImprovementThreshold);
+                    if (hfrFailureMode != AutoFocusFailureMode.None) {
+                        autoFocusState.LastFailureMode = hfrFailureMode;
+                        autoFocusState.LastFailureRegionIndex = primaryRegionState.RegionIndex;
+                        switch (hfrFailureMode) {
+                            case AutoFocusFailureMode.FinalHfrMissing:
+                                Logger.Warning(DescribeHfrValidationFailure("final focus point", primaryRegionState.RegionIndex, primaryRegionState.FinalHFR, primaryRegionState.FinalHFRSubMeasurements, autoFocusState.Options.FramesPerPoint));
+                                Notification.ShowWarning($"Failed assessing HFR at the final focus point (Region {primaryRegionState.RegionIndex}). See log for details.");
+                                break;
+                            case AutoFocusFailureMode.InitialHfrFailed:
+                                Logger.Warning(DescribeHfrValidationFailure("initial position", primaryRegionState.RegionIndex, primaryRegionState.InitialHFR, primaryRegionState.InitialHFRSubMeasurements, autoFocusState.Options.FramesPerPoint));
+                                Notification.ShowWarning($"Failed assessing HFR at the initial position (Region {primaryRegionState.RegionIndex}). See log for details.");
+                                break;
+                            case AutoFocusFailureMode.HfrRegression:
+                                Logger.Warning($"New focus point HFR {primaryRegionState.FinalHFR?.Measure} is significantly worse than original HFR {primaryRegionState.InitialHFR?.Measure}");
+                                Notification.ShowWarning(string.Format(Loc.Instance["LblAutoFocusNewWorseThanOriginal"], primaryRegionState.FinalHFR?.Measure, primaryRegionState.InitialHFR?.Measure));
+                                autoFocusState.LastCalculatedFocusPoint = calculatedFocusPoint;
+                                break;
                         }
-                        if (!autoFocusRegionState.InitialHFR.HasValue || autoFocusRegionState.InitialHFR.Value.Measure == 0.0) {
-                            Logger.Warning("Failed assessing HFR at the initial position");
-                            Notification.ShowWarning("Failed assessing HFR at the initial position");
-                            autoFocusState.LastFailureMode = AutoFocusFailureMode.InitialHfrFailed;
-                            return false;
-                        }
-
-                        var finalHfr = autoFocusRegionState.FinalHFR?.Measure;
-                        var initialHFR = autoFocusRegionState.InitialHFR?.Measure;
-                        if (finalHfr > (initialHFR * (1.0 + autoFocusState.Options.HFRImprovementThreshold))) {
-                            Logger.Warning($"New focus point HFR {finalHfr} is significantly worse than original HFR {initialHFR}");
-                            Notification.ShowWarning(string.Format(Loc.Instance["LblAutoFocusNewWorseThanOriginal"], finalHfr, initialHFR));
-                            autoFocusState.LastFailureMode = AutoFocusFailureMode.HfrRegression;
-                            autoFocusState.LastCalculatedFocusPoint = calculatedFocusPoint;
-                            return false;
-                        }
+                        return false;
                     }
                 }
             }
@@ -2159,21 +2227,31 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         }
 
         // Short human-readable reason for the metadata.json failure record, derived from the validation failure mode.
-        private static string FailureReasonText(AutoFocusFailureMode mode) {
+        // When the failure is attributable to a single region (the HFR-improvement checks), its index is appended so
+        // the replay record is self-describing; appended only when non-null to stay backward-compatible.
+        private static string FailureReasonText(AutoFocusFailureMode mode, int? regionIndex = null) {
+            string baseText;
             switch (mode) {
                 case AutoFocusFailureMode.HfrRegression:
-                    return "Final HFR worse than original";
+                    baseText = "Final HFR worse than original";
+                    break;
                 case AutoFocusFailureMode.FinalPointOutOfBounds:
-                    return "Calculated focus point outside the swept range";
+                    baseText = "Calculated focus point outside the swept range";
+                    break;
                 case AutoFocusFailureMode.FitQuality:
-                    return "Fit/data quality rejected (low R²/χ² or insufficient stars)";
+                    baseText = "Fit/data quality rejected (low R²/χ² or insufficient stars)";
+                    break;
                 case AutoFocusFailureMode.InitialHfrFailed:
-                    return "Initial HFR measurement failed";
+                    baseText = "Initial HFR measurement failed";
+                    break;
                 case AutoFocusFailureMode.FinalHfrMissing:
-                    return "Final HFR measurement failed";
+                    baseText = "Final HFR measurement failed";
+                    break;
                 default:
-                    return "AutoFocus failed";
+                    baseText = "AutoFocus failed";
+                    break;
             }
+            return regionIndex.HasValue ? $"{baseText}; Region {regionIndex.Value}" : baseText;
         }
 
         private void OnCompleted(
@@ -2242,7 +2320,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             TimeSpan duration) {
             // A failed run is still saved with a metadata.json (flagged as failed) so it can be inspected/replayed —
             // unlike OnIterationFailed, which is a mid-run retry boundary, this is the terminal failure.
-            WriteReplayMetadata(state, succeeded: false, failureReason: FailureReasonText(state.LastFailureMode));
+            WriteReplayMetadata(state, succeeded: false, failureReason: FailureReasonText(state.LastFailureMode, state.LastFailureRegionIndex));
             Failed?.Invoke(this, GetFailedEventArgs(state, temperature, duration));
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/HocusFocusVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/HocusFocusVM.cs
@@ -451,7 +451,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
                 var reportText = JsonConvert.SerializeObject(report, Formatting.Indented);
                 string path = Path.Combine(ReportDirectory, $"{DateTime.Now:yyyy-MM-dd--HH-mm-ss}--{profileService.ActiveProfile.Id}.json");
-                File.WriteAllText(path, reportText);
+                // Atomic write: NINA core watches ReportDirectory and File.OpenText's new reports; a plain
+                // File.WriteAllText's open write handle races that reader into a sharing-violation IOException.
+                PathUtility.WriteAllTextAtomic(path, reportText);
                 return report;
             } catch (Exception ex) {
                 Logger.Error(ex);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -1460,7 +1460,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
             var reportText = JsonConvert.SerializeObject(regionReports[0], Formatting.Indented);
             string path = Path.Combine(HocusFocusVM.ReportDirectory, DateTime.Now.ToString("yyyy-MM-dd--HH-mm-ss") + ".json");
-            File.WriteAllText(path, reportText);
+            // Atomic write: NINA core watches ReportDirectory and File.OpenText's new reports; a plain
+            // File.WriteAllText's open write handle races that reader into a sharing-violation IOException.
+            PathUtility.WriteAllTextAtomic(path, reportText);
 
             var firstRegionReport = regionReports[0];
             var autoFocusInfo = new AutoFocusInfo(firstRegionReport.Temperature, firstRegionReport.CalculatedFocusPoint.Position, firstRegionReport.Filter, firstRegionReport.Timestamp);
@@ -1517,7 +1519,10 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             var report = GenerateReportForRegion(e, 0);
             var reportText = JsonConvert.SerializeObject(report, Formatting.Indented);
             string path = Path.Combine(HocusFocusVM.ReportDirectory, DateTime.Now.ToString("yyyy-MM-dd--HH-mm-ss") + ".json");
-            File.WriteAllText(path, reportText);
+            // Atomic write (see the success-path write above): avoids the ReportDirectory read-while-write race
+            // with NINA core's AutoFocusToolVM.LoadChart. This is the exact site that produced the reported
+            // IOException on the AF-failed path.
+            PathUtility.WriteAllTextAtomic(path, reportText);
         }
 
         private HocusFocusReport GenerateReportForRegion(AutoFocusFinishedEventArgsBase e, int regionIndex) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
@@ -26,8 +26,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new release build of a plugin
-[assembly: AssemblyVersion("4.0.0.0")]
-[assembly: AssemblyFileVersion("4.0.0.0")]
+[assembly: AssemblyVersion("4.0.0.1")]
+[assembly: AssemblyFileVersion("4.0.0.1")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("Hocus Focus")]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/HocusFocusStarDetection.cs
@@ -686,24 +686,31 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             // curve point when enough unsaturated stars remain. When nothing is saturated this is the full starList,
             // so AverageHFR/HFRStdDev are bit-identical.
             var hfrStars = StarsForHfrAggregation(starList, detectorParams.ExcludeSaturatedStarsFromHFR, detectorParams.SaturationThreshold);
-            if (hfrStars.Count > 1) {
-                if (detectorParams.MeasurementAverage == MeasurementAverageEnum.MeanOutliers) {
+            // AverageHFR/HFRStdDev need at least 2 usable stars to be meaningful; with 0 or 1 they stay 0 (a
+            // rejected curve point), which preserves the fit inputs exactly.
+            string hfrDispersionLabel;
+            if (detectorParams.MeasurementAverage == MeasurementAverageEnum.MeanOutliers) {
+                hfrDispersionLabel = "HFR σ";
+                if (hfrStars.Count > 1) {
                     result.AverageHFR = hfrStars.Average(s => s.HFR);
                     var hfrVariance = hfrStars.Sum(s => (s.HFR - result.AverageHFR) * (s.HFR - result.AverageHFR)) / (hfrStars.Count - 1);
                     result.HFRStdDev = Math.Sqrt(hfrVariance);
-
-                    if (!detectorParams.SuppressInfoLogging) {
-                        Logger.Info($"Average HFR: {result.AverageHFR}, HFR σ: {result.HFRStdDev}, Detected Stars {result.StarList.Count}, Region: {result?.Region.Index ?? 0}");
-                    }
-                } else {
+                }
+            } else {
+                hfrDispersionLabel = "HFR MAD";
+                if (hfrStars.Count > 1) {
                     var (hfrMedian, hfrMAD) = hfrStars.Select(s => s.HFR).MedianMAD();
                     result.AverageHFR = hfrMedian;
                     result.HFRStdDev = hfrMAD;
-
-                    if (!detectorParams.SuppressInfoLogging) {
-                        Logger.Info($"Average HFR: {result.AverageHFR}, HFR MAD: {result.HFRStdDev}, Detected Stars {result.StarList.Count}, Region: {result?.Region.Index ?? 0}");
-                    }
                 }
+            }
+
+            // Log EVERY region's result — including regions with too few usable stars, where AverageHFR stays 0 —
+            // so a region that dropped out (e.g. a transient no-star frame) is visible in the log rather than
+            // silently absent. Previously this line lived inside the "count > 1" guard, so a 0/1-star region logged
+            // nothing and its downstream HFR-validation failure had to be inferred from the missing line.
+            if (!detectorParams.SuppressInfoLogging) {
+                Logger.Info($"Average HFR: {result.AverageHFR}, {hfrDispersionLabel}: {result.HFRStdDev}, Detected Stars {result.StarList.Count}, Region: {result.Region?.Index ?? 0}");
             }
             result.DebugData = starDetectorResult.DebugData;
             result.Metrics = starDetectorResult.Metrics;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/PathUtility.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/PathUtility.cs
@@ -53,6 +53,44 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
             return relativePath;
         }
 
+        /// <summary>
+        /// Writes text to <paramref name="path"/> atomically: the content is written to a sibling temp file which
+        /// is then renamed into place, so a concurrent reader never observes a half-written file or an open write
+        /// handle on the final path.
+        /// </summary>
+        /// <remarks>
+        /// A plain <see cref="File.WriteAllText(string, string)"/> keeps a <see cref="FileAccess.Write"/> handle
+        /// open on the destination while serializing. NINA core's <c>AutoFocusToolVM.LoadChart</c> watches the
+        /// AutoFocus report directory and immediately <c>File.OpenText</c>s new reports with
+        /// <see cref="FileShare.Read"/>; that share mode does not admit the still-open write access, so the read
+        /// fails with a sharing violation ("being used by another process"). Writing a temp file and renaming means
+        /// the final report never has an open write handle, eliminating the race. The temp file carries a
+        /// non-<c>.json</c> extension so a directory watcher filtering on the real extension does not wake on it.
+        /// </remarks>
+        public static void WriteAllTextAtomic(string path, string contents) {
+            if (string.IsNullOrEmpty(path)) {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            var directory = Path.GetDirectoryName(path);
+            // The temp file MUST live in the same directory (volume) as the target so File.Move is a true atomic
+            // rename rather than a copy+delete.
+            var tempPath = Path.Combine(directory ?? string.Empty, Path.GetFileNameWithoutExtension(path) + "." + Guid.NewGuid().ToString("N") + ".tmp");
+            try {
+                File.WriteAllText(tempPath, contents);
+                // overwrite: a stale report from the same second (filenames are second-resolution) must not block it.
+                File.Move(tempPath, path, overwrite: true);
+            } catch {
+                // Best-effort cleanup so a failed rename doesn't strand a temp file; preserve the original error.
+                try {
+                    if (File.Exists(tempPath)) {
+                        File.Delete(tempPath);
+                    }
+                } catch { }
+                throw;
+            }
+        }
+
         private static string AppendDirectorySeparatorChar(string path) {
             // Append a slash only if the path is a directory and does not have a slash.
             if (!Path.HasExtension(path) &&

--- a/docs/initial-hfr-validation-diagnostics-design.md
+++ b/docs/initial-hfr-validation-diagnostics-design.md
@@ -1,0 +1,163 @@
+# Initial-HFR validation failure — diagnosis and logging expansion
+
+## Context
+
+During a Tilt Adapter calibration **baseline** autofocus run (`TiltCalibration_20260703_225028/01_Baseline`),
+the run failed with two log entries a user reported:
+
+1. `WARNING AutoFocusEngine.cs ValidateCalculatedFocusPosition:1575 Failed assessing HFR at the initial position`
+2. `ERROR AutoFocusToolVM.cs LoadChart:327 Failed to load autofocus chart — System.IO.IOException: The process
+   cannot access the file 'C:\Users\Detle\AppData\Local\NINA\AutoFocus\2026-07-03--22-53-42.json' because it is
+   being used by another process.`
+
+The two failures are **independent**. Neither is a star-detection or curve-fit problem — the autofocus sweep and
+fit were excellent (all 7 regions chose Symmetric hyperbolic models; calculated point 7236 → 7241 after the +5
+offset, well inside the swept 6998–7498 range; final-validation HFR ≈ 2.67).
+
+## Failure #2 — "Failed assessing HFR at the initial position" (the real rejection)
+
+### What the check actually does
+
+`ValidateHfrImprovement` compares the HFR at the **final** (calculated) focus position against the HFR at the
+**initial** focuser position and rejects the run if focus did not improve. The per-region validation loop
+(`AutoFocusEngine.cs:1565–1592`) requires **every** region to have *both* a valid final HFR **and** a valid
+initial HFR. The failing branch is:
+
+```csharp
+if (!autoFocusRegionState.InitialHFR.HasValue || autoFocusRegionState.InitialHFR.Value.Measure == 0.0) {
+    Logger.Warning("Failed assessing HFR at the initial position");   // line 1575
+    ...
+    autoFocusState.LastFailureMode = AutoFocusFailureMode.InitialHfrFailed;
+    return false;
+}
+```
+
+The message names neither the region nor the reason, so the log cannot tell you *why*.
+
+### Root cause (from the full log)
+
+The **initial** frame at focuser 7248 (`\initial\01_..._Focuser7248.fits`, 22:51:16) was anomalously star-poor.
+Its per-region detection lines were:
+
+| Region | 0 | 1 | 2 | 3 | 4 | 5 | 6 |
+|--------|---|---|---|---|---|---|---|
+| Stars  | 19 | 30 | 51 | **— (≤1 usable)** | 33 | 12 | 19 |
+
+**Region 3 logged no HFR line for the initial frame** because it had ≤1 usable star. Both the `AverageHFR`
+assignment *and* the summary log line in `BuildStarDetectionResult` are gated on `hfrStars.Count > 1`
+(`HocusFocusStarDetection.cs:689`); with ≤1 usable star, `AverageHFR` stays at its default **0.0** and nothing is
+logged. (A `StarDetectionResult` object was still created and stored — this is "no usable-star HFR", not a
+missing result.) For comparison, the *same* focuser position 7248 during the sweep 70 s later
+(`\attempt01\06_..._Focuser7248.fits`) produced 88–104 stars per sub-region and **837** in the full frame — a
+~44× jump at identical focus. HFR of the stars that *were* detected in the initial frame was normal (≈2.6), so
+this is a transient acquisition/transparency event (thin cloud, dew, gust), not defocus, trailing, or a detector
+regression.
+
+The chain that turned "region 3 had ≤1 usable star in one frame" into a whole-run failure:
+
+1. `EvaluateExposure` returned `Measure = analysisResult.AverageHFR = 0.0` **directly** (`:681`) for region 3 —
+   it did *not* throw, so the `AnalyzeExposure` catch (`:973–978`, which would also yield `Measure = 0.0`) was
+   not the path here; the `hfrStars.Count > 1` guard left `AverageHFR` at 0.0.
+2. `StartAutoFocusPoint` (`:1014`) dispatches an analysis task for **every** region, so
+   `InitialHFRMeasurementAction` (`:906`) ran for region 3, appended the 0.0 sub-measurement, reached
+   `FramesPerPoint` (1), and set `region3.InitialHFR = { Measure: 0.0 }` (a value, **not** null — but line 1574
+   rejects on either `null` *or* `Measure == 0.0`, so the distinction does not change the outcome).
+3. The early guard in `StartBlindFocusPoints` (`:1069`) only inspects **region 0** (`InitialHFR == 0.0`), which
+   was a healthy 2.60, so it did not fire.
+4. The full sweep ran (~2 min), all fits succeeded, the final-validation image was captured — and only then did
+   the per-region loop (`:1574`) reach region 3, see `Measure == 0.0`, and reject the run as `InitialHfrFailed`.
+5. `InitialHfrFailed` is **not** eligible for the re-centered retry (`ShouldRetryFromCalculatedPoint`,
+   `:464–475`), so that path did not fire. More importantly, even the *standard* attempt-count reattempt
+   (`:1293`) could not have rescued this run: `StartInitialFocusPoints` (`:1056`) only re-measures the initial
+   HFR when **region 0's** `InitialHFR` is null — region 0 was a valid 2.60, so region 3's cached `0.0` would
+   never be re-measured and every reattempt would fail identically at line 1574.
+
+**Net:** one transient zero-star region in the single initial frame discarded an otherwise-perfect autofocus,
+and the generic log line gave no way to see that region 3 (and only region 3, and only at the initial position)
+was responsible.
+
+## Failure #1 — the IOException (cosmetic, plugin-caused, separate)
+
+`%LOCALAPPDATA%\NINA\AutoFocus\2026-07-03--22-53-42.json` is written by the **plugin** on the AF-failed path:
+`InspectorVM.AutoFocusEngine_Failed` (`InspectorVM.cs:1519`) does `File.WriteAllText(ReportDirectory\<ts>.json)`
+where `ReportDirectory = Path.Combine(CoreUtil.APPLICATIONTEMPPATH, "AutoFocus")` (`HocusFocusVM.cs:96`). The
+filename has **no** profile-GUID suffix, which distinguishes it from `HocusFocusVM.GenerateReport`
+(`…--{profileId}.json`, `:453`) and matches the log exactly.
+
+NINA core's `AutoFocusToolVM` watches that directory and, on a new report, calls `LoadChart()` →
+`File.OpenText(newest)`. `File.OpenText` opens with `FileAccess.Read, FileShare.Read`; while `File.WriteAllText`
+still holds its `FileAccess.Write` handle open, the reader's share mode does not admit the existing write access,
+so Windows raises `ERROR_SHARING_VIOLATION` → the `IOException`. It is intermittent (depends on whether the
+watcher's read lands during the write) and affects only the **chart display** — calibration data is unaffected.
+
+**Mitigation (plugin side) — *implemented*:** `PathUtility.WriteAllTextAtomic` serializes to a sibling temp file
+(non-`.json` extension so the watcher ignores it), then `File.Move(tmp, path, overwrite: true)` renames it into
+place, so the final report never has an open write handle. Applied to the three writes that target the watched
+`ReportDirectory` (`InspectorVM.cs` success + failed paths, `HocusFocusVM.GenerateReport`); the per-attempt
+writes under the user's AF save folder are unwatched and left as-is. Note the reader is NINA core — changing the
+*writer's* `FileShare` cannot help, because the failing check is the reader's fixed `FileShare.Read` refusing the
+writer's `Write` access; only removing the concurrent write handle resolves it.
+
+## Changes
+
+Status: **all implemented** (`AutoFocusEngine.cs`, `HocusFocusStarDetection.cs`, `PathUtility.cs`,
+`InspectorVM.cs`, `HocusFocusVM.cs` + tests; full suite green — 1698 passed).
+
+### 1. Robustness: gate the HFR-improvement check on region 0 only — *implemented*
+
+The whole-run HFR-improvement validation now checks **region 0** (the primary/full-frame region that drives the
+focus decision) only, instead of looping over every region. A transient dropout in a corner/sub-region — exactly
+the incident, where region 3 momentarily detected ≤1 usable star — is now **non-fatal** and cannot discard an
+otherwise-good autofocus. This mirrors the region-0-only early guard already in `StartBlindFocusPoints` (`:1069`),
+so region 0's own bad initial HFR still fails fast there.
+
+The three-way decision is extracted into a pure, unit-tested `EvaluateHfrImprovement(initialHfr, finalHfr,
+threshold)` returning the specific `AutoFocusFailureMode` (`FinalHfrMissing` / `InitialHfrFailed` /
+`HfrRegression`) or `None`; the call site branches on it for the per-mode log/notification/state.
+
+### 2. Log every region at the detector — *implemented*
+
+`BuildStarDetectionResult` (`HocusFocusStarDetection.cs`) previously wrote its `Average HFR … Region: N` line
+**inside** the `hfrStars.Count > 1` guard, so a region with 0–1 usable stars logged nothing — which is why region
+3 was silently absent and its failure had to be inferred. The `AverageHFR`/`HFRStdDev` computation stays guarded
+(so those values, and the fit inputs, are bit-identical), but the log line now always emits (respecting
+`SuppressInfoLogging`). Region 3 with 0 stars now logs `Average HFR: 0, HFR MAD: 0, Detected Stars 0, Region: 3`.
+
+### 3. Log the reason for the HFR-validation failure — *implemented*
+
+The two generic warnings are replaced by a per-region diagnostic from a pure, unit-tested helper
+`DescribeHfrValidationFailure(phase, regionIndex, hfr, subMeasurements, framesPerPoint)`, reporting the region
+index (cross-references the detector's `Region: N` lines), the phase, `null` vs `Measure == 0`, and the per-sub-
+frame `Measure`+σ. The `σ` is the tell for the zero case: finite `σ` = detector found no usable stars
+(`{Measure:0, Stdev:0}`, `:681`); `σ = NaN` = analysis threw (`{Measure:0, Stdev:NaN}`, `AnalyzeExposure` catch
+`:976`). The `Notification` toast is a short form (`… (Region N). See log for details.`). Example:
+
+```
+Failed assessing HFR at the initial position for Region 0: HFR measured 0 - the detector found no usable stars
+in this region across 1 sub-frame(s). Measured HFR=0.00; sub-frames 1/1 [0.00 (σ=0.00)]. Cross-reference the
+"Region: 0" star-detection lines.
+```
+
+### 4. Carry the region into `metadata.json`'s `FailureReason` — *implemented*
+
+`AutoFocusState` gained `LastFailureRegionIndex` (set at each HFR-validation failure return);
+`FailureReasonText(mode, int? regionIndex)` appends `"; Region N"` when present (append-only, so the existing
+round-trip test still holds), making the replay record self-describing.
+
+### Not kept
+
+An earlier capture-time warning in `InitialHFRMeasurementAction` was removed: with region-0-only gating, region 0
+already fails fast in `StartBlindFocusPoints`, and change #2 makes every region visible at capture time — so the
+extra warning was redundant and its "Failed…" wording would have been misleading for the now-non-fatal corner
+regions.
+
+## Tests
+
+- `EvaluateHfrImprovement` — the region-0 gate decision across all branches (final null/zero → `FinalHfrMissing`;
+  initial null/zero → `InitialHfrFailed`; final worse-beyond-threshold → `HfrRegression`; within-threshold and
+  improved → `None`). Written test-first (watched the stub fail before implementing).
+- `DescribeHfrValidationFailure` — null-vs-zero, finite-σ (no stars) vs NaN-σ (analysis error), multi-frame list,
+  and region/phase echo, in the existing pure-helper style in `AutoFocusEngineTests.cs`.
+- `PathUtility.WriteAllTextAtomic` — content round-trips, no leftover temp file, overwrites existing, null guard.
+- Full suite (`dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`): **1698 passed, 0 failed**.
+  The detector-equivalence tests still pass, confirming change #2 left `AverageHFR`/`HFRStdDev` bit-identical.


### PR DESCRIPTION
## Summary

Investigates and fixes two failures a user hit during a **tilt-adapter baseline** autofocus run. They are
unrelated; neither is a star-detection or fit problem — the sweep and fit were excellent (final HFR 2.67).

1. **`Failed assessing HFR at the initial position`** — the run's *initial* frame at focuser 7248 was transiently
   star-poor (full-frame **19** stars vs **837** at the same position 70 s later; normal HFR, so it's a
   transparency/cloud transient, not defocus). Region 3 detected ≤1 usable star, so its initial HFR came back
   `0`. The per-region HFR-improvement check then discarded the *whole* otherwise-successful run over that one
   corner-region dropout — and the generic log line named neither the region nor the reason, so the culprit had
   to be inferred from a *missing* log line.
2. **Chart-load `IOException`** (cosmetic) — the plugin writes its AF report with `File.WriteAllText` into the
   directory NINA core watches; NINA's `AutoFocusToolVM.LoadChart` then `File.OpenText`s it mid-write and hits a
   sharing violation. Chart display only; calibration data is unaffected.

## Changes

**Robustness — gate on region 0 only** (`AutoFocusEngine.cs`)
- The HFR-improvement validation now checks **region 0** (the primary/full-frame region that drives the focus
  decision) only, instead of looping over every region. Transient corner/sub-region dropouts are **non-fatal** —
  they can no longer discard a good autofocus. Mirrors the existing region-0-only early guard in
  `StartBlindFocusPoints`, so region 0's own bad initial HFR still fails fast.
- Extracted the decision into a pure, unit-tested `EvaluateHfrImprovement(initialHfr, finalHfr, threshold)`.

**Diagnostics — never infer again**
- **Log every region** at the detector (`HocusFocusStarDetection.cs`): the `Average HFR … Region: N` line was
  inside the `hfrStars.Count > 1` guard, so a 0/1-star region logged nothing (why region 3 was invisible). The
  `AverageHFR`/`HFRStdDev` computation stays guarded — **fit inputs are bit-identical** (detector-equivalence
  tests confirm) — but the log line now always emits. Region 3 with 0 stars logs
  `Average HFR: 0, HFR MAD: 0, Detected Stars 0, Region: 3`.
- **Log the failure reason** via a pure `DescribeHfrValidationFailure` helper: region index (cross-references the
  `Region: N` detector lines), phase, `null` vs `Measure == 0`, and per-sub-frame `Measure`+σ (finite σ = no
  usable stars; `σ = NaN` = analysis error). Notification is a short form; the region is also carried into
  `metadata.json`'s `FailureReason`.

**IOException — atomic report writes** (`PathUtility.WriteAllTextAtomic`, `InspectorVM.cs`, `HocusFocusVM.cs`)
- Write to a sibling temp file (non-`.json` extension) then `File.Move`/rename into place, so the final report
  never has an open write handle. Applied to the three writes targeting the watched `ReportDirectory`.

## Testing

- `EvaluateHfrImprovement` written test-first (watched a `None`-returning stub fail on 5/7 cases before
  implementing); covers all branches.
- `DescribeHfrValidationFailure` and `PathUtility.WriteAllTextAtomic` unit-tested.
- **Full suite: 1698 passed, 0 failed.** Detector-equivalence tests pass, confirming the always-log change did
  not perturb detection.

Design notes / full root-cause writeup: `docs/initial-hfr-validation-diagnostics-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY7tgXMHkF9EbvPAHry7RA
