### PR TITLE
Tilt calibration: surface confidence (SNR/σ/pitch±) and add replay fidelity

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -827,5 +827,31 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 options.Received().IsCalibrated = true;
             });
         }
+
+        [Test]
+        public void Confidence_DisplayProperties_PopulatedAfterCalibration() {
+            var (vm, _, _, _) = Build(screwCount: 3);
+            // Seed 6 step readings with a clean, unequal-enough pair so pitch σ > 0 (values in A,B plane units).
+            vm.SeedStepReading(WizardStep.Baseline, -9.5, 16.3, 7049);
+            vm.SeedStepReading(WizardStep.AllInward, -15.9, 14.5, 6957);
+            vm.SeedStepReading(WizardStep.ReBaseline1, -9.5, 16.3, 7049);
+            vm.SeedStepReading(WizardStep.Screw1, 11.7, 8.9, 7013);
+            vm.SeedStepReading(WizardStep.ReBaseline2, -9.5, 16.3, 7049);
+            vm.SeedStepReading(WizardStep.Screw2, -8.6, 40.3, 7016);
+            // The seed path bypasses the inspector/profile, so supply the sensor geometry a live run reads + a
+            // paraboloid tilt-plane model (RunCalibrationMath reads only its ImageSize) so the hardware-recovery
+            // branch runs. These seeds recover a positive per-turn pitch that is clearly unequal per screw
+            // (delta1 ≈ 242, delta2 ≈ 363 µm/turn → pitch σ ≈ 61 µm/turn > 0), so PitchUncertaintyDisplay is non-empty.
+            var tiltPlane = new TiltPlaneModel(new System.Drawing.Size(6248, 4176), fRatio: 7,
+                a: 0, b: 0, c: 0, mean: 7000, focuserStepSizeMicrons: 3.6,
+                centerPosition: 7000, topLeftPosition: 7000, topRightPosition: 7000,
+                bottomLeftPosition: 7000, bottomRightPosition: 7000);
+            vm.RunCalibrationForTest(radiusMm: 44, pixelSizeMicrons: 3.76, focuserStepMicrons: 3.6, tiltPlaneOverride: tiltPlane);
+            Assert.Multiple(() => {
+                Assert.That(vm.HasConfidenceInfo, Is.True);
+                Assert.That(vm.ConfidenceSummaryDisplay, Does.Contain("Signal-to-noise"));
+                Assert.That(vm.PitchUncertaintyDisplay, Does.Contain("±"));
+            });
+        }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -853,5 +853,28 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 Assert.That(vm.PitchUncertaintyDisplay, Does.Contain("±"));
             });
         }
+
+        [Test]
+        public void CaptureMeasurementContext_ReadsInspectorAndProfileValues() {
+            var inspector = Substitute.For<IInspectorOptions>();
+            inspector.MicronsPerFocuserStep.Returns(3.6);
+            inspector.UseRANSAC.Returns(true);
+            inspector.AcceptableRSquaredMin.Returns(0.8);
+            inspector.SensorROI.Returns(1.0); inspector.CornersROI.Returns(1.0);
+            var af = Substitute.For<IAutoFocusOptions>();
+            af.WeightedHyperbolicFitEnabled.Returns(true);
+            af.MaxOutlierRejections.Returns(3);
+            af.OutlierRejectionConfidence.Returns(0.9);
+            af.HyperbolicFitModel.Returns(HyperbolicFitModel.Hybrid);
+
+            var ctx = TiltAdapterWizardVM.CaptureMeasurementContext(inspector, af, fRatio: 7, focalLengthMm: 703);
+
+            Assert.Multiple(() => {
+                Assert.That(ctx.MicronsPerFocuserStep, Is.EqualTo(3.6));
+                Assert.That(ctx.FocalRatio, Is.EqualTo(7));
+                Assert.That(ctx.HyperbolicFitModel, Is.EqualTo("Hybrid"));
+                Assert.That(ctx.UseRANSAC, Is.True);
+            });
+        }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -876,5 +876,16 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 Assert.That(ctx.UseRANSAC, Is.True);
             });
         }
+
+        [Test]
+        public void MeasurementContextDrift_ListsChangedFields() {
+            var captured = new TiltMeasurementContext { MicronsPerFocuserStep = 3.6, FocalRatio = 7, UseRANSAC = true };
+            var current  = new TiltMeasurementContext { MicronsPerFocuserStep = 0.26, FocalRatio = 7, UseRANSAC = true };
+            var drift = TiltAdapterWizardVM.DescribeMeasurementContextDrift(captured, current);
+            Assert.Multiple(() => {
+                Assert.That(drift, Does.Contain("MicronsPerFocuserStep"));
+                Assert.That(drift, Does.Not.Contain("FocalRatio"));
+            });
+        }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -131,17 +131,22 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         }
 
         [Test]
-        public void StepInstructions_DiffersByScrewCountAtAllScrewsStep() {
+        public void StepInstructions_BaselineLabelsExactScrewCount() {
             var (vm3, _, _, _) = Build(screwCount: 3);
             var (vm4, _, _, _) = Build(screwCount: 4);
 
-            // Manually advance to AllScrews via reflection-free path: update via PropertyChanged on options
-            // is ineffective for CurrentStep. Use only what we can verify at Baseline first.
-            // Baseline instructions are screw-count independent.
+            // The Baseline (first) step names the exact screws to label — the screw configuration
+            // is already known here, so it must not offer the "(or 1–4 for a 4-screw adapter)" hedge.
             var b3 = vm3.StepInstructions;
             var b4 = vm4.StepInstructions;
-            Assert.That(b3, Is.EqualTo(b4));
-            Assert.That(b3, Does.Contain("baseline"));
+            Assert.Multiple(() => {
+                Assert.That(b3, Does.Contain("Label your screws 1, 2, and 3 in a consistent clockwise order"));
+                Assert.That(b4, Does.Contain("Label your screws 1, 2, 3, and 4 in a consistent clockwise order"));
+                Assert.That(b3, Does.Not.Contain("4-screw"));
+                Assert.That(b4, Does.Not.Contain("3-screw"));
+                Assert.That(b3, Is.Not.EqualTo(b4));
+                Assert.That(b3, Does.Contain("baseline"));
+            });
         }
 
         [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
@@ -167,6 +167,38 @@ public class TiltCalibrationCalculatorTests {
     }
 
     [Test]
+    public void PitchUncertainty_IsHalfTheDifferenceOfPerScrewMoves() {
+        // Two single-screw moves of clearly unequal magnitude along different axes.
+        var inputs = new TiltCalibrationInputs {
+            ScrewCount = 3,
+            ReBaseline1 = new TiltGradient(0, 0, 0),
+            Screw1 = new TiltGradient(20, 0, 0),      // move along A
+            ReBaseline2 = new TiltGradient(0, 0, 0),
+            Screw2 = new TiltGradient(0, 10, 0),      // move along B
+            ImageWidthPixels = 6248, ImageHeightPixels = 4176,
+            PixelSizeMicrons = 3.76, FocuserStepMicrons = 3.6,
+            ScrewRadiusMillimeters = 44, CalibrationAppliedAmount = 1.0, IsStepperAdjustment = false
+        };
+        var (measured, d1, d2) = TiltCalibrationCalculator.RecoverHardwareDetailed(inputs);
+        Assert.Multiple(() => {
+            Assert.That(measured, Is.EqualTo(0.5 * (d1 + d2)).Within(1e-9));
+            var result = TiltCalibrationCalculator.Calibrate(inputs);
+            Assert.That(result.PitchUncertaintyMicrons, Is.EqualTo(Math.Abs(d1 - d2) / 2.0).Within(1e-9));
+            Assert.That(result.PitchUncertaintyMicrons, Is.GreaterThan(0));
+        });
+    }
+
+    [Test]
+    public void PitchUncertainty_IsNaN_WhenHardwareUncomputable() {
+        var inputs = new TiltCalibrationInputs {
+            ScrewCount = 3, ScrewRadiusMillimeters = 0 /* invalid */,
+            CalibrationAppliedAmount = 1.0, PixelSizeMicrons = 3.76, FocuserStepMicrons = 3.6,
+            ImageWidthPixels = 6248, ImageHeightPixels = 4176
+        };
+        Assert.That(TiltCalibrationCalculator.Calibrate(inputs).PitchUncertaintyMicrons, Is.NaN);
+    }
+
+    [Test]
     public void MoveMagnitudeRatio_OneForEqualMoves_GrowsWithImbalance() {
         // Two equal-magnitude moves -> ratio 1; a 3x longer second move -> ratio 3.
         Assert.Multiple(() => {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationMetadataTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationMetadataTests.cs
@@ -78,6 +78,28 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         }
 
         [Test]
+        public void MeasurementContext_RoundTrips() {
+            var meta = new TiltCalibrationMetadata {
+                NumberOfScrews = 3, ScrewRadiusMillimeters = 44, PixelSizeMicrons = 3.76,
+                FocuserStepSizeMicrons = 3.6, CalibrationAppliedAmount = 1.0,
+                MeasurementContext = new TiltMeasurementContext {
+                    MicronsPerFocuserStep = 3.6, FocalRatio = 7, FocalLengthMm = 703,
+                    UseRANSAC = true, FixedSensorCenter = false, AstigmaticCurvatureEnabled = false,
+                    AcceptableRSquaredMin = 0.8, WeightedHyperbolicFitEnabled = true,
+                    MaxOutlierRejections = 3, OutlierRejectionConfidence = 0.9,
+                    HyperbolicFitModel = "Hybrid", SensorROI = 1.0, CornersROI = 1.0
+                }
+            };
+            var back = TiltCalibrationMetadata.Deserialize(meta.Serialize());
+            Assert.Multiple(() => {
+                Assert.That(back.MeasurementContext.MicronsPerFocuserStep, Is.EqualTo(3.6).Within(1e-9));
+                Assert.That(back.MeasurementContext.FocalRatio, Is.EqualTo(7).Within(1e-9));
+                Assert.That(back.MeasurementContext.HyperbolicFitModel, Is.EqualTo("Hybrid"));
+                Assert.That(back.MeasurementContext.UseRANSAC, Is.True);
+            });
+        }
+
+        [Test]
         public void IsStepperAdjustment_FalseForScrews() {
             var md = new TiltCalibrationMetadata { AdjustmentType = "Screws" };
             Assert.That(md.IsStepperAdjustment, Is.False);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationMetadataTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationMetadataTests.cs
@@ -59,6 +59,25 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         }
 
         [Test]
+        public void ResultRecord_RoundTripsConfidenceFields() {
+            var meta = new TiltCalibrationMetadata {
+                NumberOfScrews = 3, ScrewRadiusMillimeters = 44, PixelSizeMicrons = 3.76,
+                FocuserStepSizeMicrons = 3.6, CalibrationAppliedAmount = 1.0,
+                Calibration = new TiltCalibrationResultRecord {
+                    Screw1AngleDegrees = 67.1, SignalToNoise = 2.16,
+                    PredictedAngleUncertaintyDeg = 24.9, PitchUncertaintyMicrons = 43.0, ConfidenceIsReliable = true
+                }
+            };
+            var back = TiltCalibrationMetadata.Deserialize(meta.Serialize());
+            Assert.Multiple(() => {
+                Assert.That(back.Calibration.SignalToNoise, Is.EqualTo(2.16).Within(1e-9));
+                Assert.That(back.Calibration.PredictedAngleUncertaintyDeg, Is.EqualTo(24.9).Within(1e-9));
+                Assert.That(back.Calibration.PitchUncertaintyMicrons, Is.EqualTo(43.0).Within(1e-9));
+                Assert.That(back.Calibration.ConfidenceIsReliable, Is.True);
+            });
+        }
+
+        [Test]
         public void IsStepperAdjustment_FalseForScrews() {
             var md = new TiltCalibrationMetadata { AdjustmentType = "Screws" };
             Assert.That(md.IsStepperAdjustment, Is.False);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -551,6 +551,10 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         // its robust tilt. Transient and not persisted; the wizard sets it only for the duration of each analysis call.
         public bool ForceSensorCurveModelGeneration { get; set; }
 
+        // Transient replay overrides for the sensor-model inputs otherwise read live (null = use profile/inspector).
+        public double? SensorModelFocuserSizeOverrideMicrons { get; set; }
+        public double? SensorModelFRatioOverride { get; set; }
+
         private bool ResolveSensorCurveModelEnabled() =>
             inspectorOptions.SensorCurveModelEnabled || ForceSensorCurveModelGeneration;
 
@@ -575,7 +579,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             // Resolve the definitive review request from the SAME flag that gates this block (capture-time flag on replay).
             frameReviewRequestedForRun = IsFrameReviewRequested(inspectorOptions.FrameReviewEnabled, sensorCurveModelEnabled);
             if (sensorCurveModelEnabled) {
-                double focuserSizeMicrons = InspectorOptions.MicronsPerFocuserStep;
+                double focuserSizeMicrons = SensorModelFocuserSizeOverrideMicrons ?? InspectorOptions.MicronsPerFocuserStep;
                 if (double.IsNaN(focuserSizeMicrons) || focuserSizeMicrons <= 0.0) {
                     if (!focuserStepSizeWarningShowed) {
                         Notification.ShowWarning("Focuser Step Size not set. Assuming 1 micron per focuser step. This message won't be shown again.");
@@ -589,7 +593,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 try {
                     await SensorModel.UpdateModel(
                         FullSensorDetectedStars,
-                        fRatio: profileService.ActiveProfile.TelescopeSettings.FocalRatio,
+                        fRatio: SensorModelFRatioOverride ?? profileService.ActiveProfile.TelescopeSettings.FocalRatio,
                         focuserSizeMicrons: focuserSizeMicrons,
                         finalFocusPosition: finalFocuserPosition,
                         stepSize: result.StepSize,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Controls/IconizedText.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Controls/IconizedText.cs
@@ -77,10 +77,15 @@ namespace NINA.Joko.Plugins.HocusFocus.Controls {
                 Stretch = Stretch.Uniform,
                 Width = size,
                 Height = size,
-                Fill = tb.Foreground,
                 Margin = new Thickness(1, 0, 1, 0),
                 SnapsToDevicePixels = true
             };
+            // Bind the fill to the TextBlock's Foreground so the icon always tracks the resolved theme
+            // brush. A one-time snapshot (Fill = tb.Foreground) can freeze to the near-black default if
+            // it runs before the theme brush resolves; the Run text inherits Foreground dynamically, but
+            // a Shape's Fill does not — so without this binding the icon goes dim/invisible in dark theme.
+            path.SetBinding(System.Windows.Shapes.Shape.FillProperty,
+                new System.Windows.Data.Binding { Source = tb, Path = new PropertyPath(TextBlock.ForegroundProperty) });
             return new InlineUIContainer(path) { BaselineAlignment = BaselineAlignment.Center };
         }
     }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -1164,6 +1164,23 @@
                             TextWrapping="Wrap" />
                     </Border>
 
+                    <!--  Calibration confidence — always shown once a calibration exists (SNR + screw-direction σ).
+                          The red do-not-apply warning above (HasConfidenceWarning) still fires separately at SNR < 2.  -->
+                    <TextBlock Margin="0,0,0,5" TextWrapping="Wrap"
+                        Foreground="{StaticResource PrimaryBrush}"
+                        Text="{Binding ConfidenceSummaryDisplay}">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasConfidenceInfo}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
                     <Grid Margin="0,5,0,5" HorizontalAlignment="Stretch">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
@@ -1201,6 +1218,7 @@
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="{Binding MeasuredHardwareDisplay}" />
                                 <TextBlock Margin="8,0,0,0" Opacity="0.7" Text="{Binding HardwareDeltaDisplay}" />
+                                <TextBlock Margin="8,0,0,0" Opacity="0.7" Text="{Binding PitchUncertaintyDisplay}" />
                             </StackPanel>
                             <TextBlock Text="Saved" />
                             <TextBlock Text="{Binding SavedHardwareDisplay}" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -1108,6 +1108,23 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             };
         }
 
+        // Human-readable list of context fields that differ between capture and the current profile (empty if none).
+        internal static string DescribeMeasurementContextDrift(TiltMeasurementContext captured, TiltMeasurementContext current) {
+            if (captured == null || current == null) return string.Empty;
+            var diffs = new List<string>();
+            void D(string name, double a, double b) { if (!(double.IsNaN(a) && double.IsNaN(b)) && Math.Abs(a - b) > 1e-9) diffs.Add($"{name} ({a:0.###} → {b:0.###})"); }
+            void B(string name, bool a, bool b) { if (a != b) diffs.Add($"{name} ({a} → {b})"); }
+            D("MicronsPerFocuserStep", captured.MicronsPerFocuserStep, current.MicronsPerFocuserStep);
+            D("FocalRatio", captured.FocalRatio, current.FocalRatio);
+            D("AcceptableRSquaredMin", captured.AcceptableRSquaredMin, current.AcceptableRSquaredMin);
+            B("UseRANSAC", captured.UseRANSAC, current.UseRANSAC);
+            B("FixedSensorCenter", captured.FixedSensorCenter, current.FixedSensorCenter);
+            B("WeightedHyperbolicFit", captured.WeightedHyperbolicFitEnabled, current.WeightedHyperbolicFitEnabled);
+            if (!string.Equals(captured.HyperbolicFitModel, current.HyperbolicFitModel, StringComparison.Ordinal))
+                diffs.Add($"HyperbolicFitModel ({captured.HyperbolicFitModel} → {current.HyperbolicFitModel})");
+            return string.Join(", ", diffs);
+        }
+
         private double EffectiveFocuserStepMicrons() {
             var v = inspector.InspectorOptions?.MicronsPerFocuserStep ?? -1;
             if (v > 0) return v;
@@ -1808,6 +1825,21 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             StatusText = string.Empty;
 
             bool completed = false;
+            var ctx = metadata.MeasurementContext;
+            var prevFocuserOverride = inspector.SensorModelFocuserSizeOverrideMicrons;
+            var prevFRatioOverride = inspector.SensorModelFRatioOverride;
+            if (mode.ApplyCaptureTimeOverridePerStep && ctx != null) {
+                if (!double.IsNaN(ctx.MicronsPerFocuserStep) && ctx.MicronsPerFocuserStep > 0)
+                    inspector.SensorModelFocuserSizeOverrideMicrons = ctx.MicronsPerFocuserStep;
+                if (!double.IsNaN(ctx.FocalRatio) && ctx.FocalRatio > 0)
+                    inspector.SensorModelFRatioOverride = ctx.FocalRatio;
+                var currentCtx = CaptureMeasurementContext(inspector.InspectorOptions, HocusFocusPlugin.AutoFocusOptions,
+                    profileService.ActiveProfile.TelescopeSettings.FocalRatio,
+                    profileService.ActiveProfile.TelescopeSettings.FocalLength);
+                var drift = DescribeMeasurementContextDrift(ctx, currentCtx);
+                if (!string.IsNullOrEmpty(drift))
+                    Notification.ShowWarning($"Replaying with captured measurement settings; your current profile differs: {drift}.");
+            }
             try {
                 foreach (var step in replaySteps) {
                     token.ThrowIfCancellationRequested();
@@ -1897,6 +1929,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 // never touches the profile either.
                 isReplaying = false;
                 IsMeasuring = false;
+                inspector.SensorModelFocuserSizeOverrideMicrons = prevFocuserOverride;
+                inspector.SensorModelFRatioOverride = prevFRatioOverride;
                 // A successful replay ends on the Complete panel (like a live run); a failed/cancelled replay
                 // returns to the idle config panel so the user can retry instead of being stuck mid-run.
                 if (!completed) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -113,6 +113,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         private double calibrationAppliedAmount = 1.0;
         private double measuredHardwareMicrons = double.NaN;
+        private TiltCalibrationConfidence lastConfidence;
+        private double pitchUncertaintyMicrons = double.NaN;
         private double calibrationPixelSizeMicrons;
         private double calibrationFocuserStepMicrons;
         private double calibrationScrewRadiusMm;
@@ -860,6 +862,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // rows — the same state Restart clears) that would otherwise describe the previous run next
             // to a manually entered calibration.
             measuredHardwareMicrons = double.NaN;
+            lastConfidence = null;
+            pitchUncertaintyMicrons = double.NaN;
             lastRawAngleDiff = double.NaN;
             lastMoveMagnitudeRatio = double.NaN;
             HasWarning = false;
@@ -920,6 +924,18 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public string CalibrationFocuserStepDisplay => calibrationFocuserStepMicrons > 0 ? $"{calibrationFocuserStepMicrons:0.###} µm" : "—";
         public string CalibrationScrewRadiusDisplay => calibrationScrewRadiusMm > 0 ? $"{calibrationScrewRadiusMm:0.##} mm" : "not set";
         public string CalibrationAppliedAmountDisplay => IsStepperAdjustment ? $"{calibrationAppliedAmount:0.##} steps" : $"{calibrationAppliedAmount:0.##} turns";
+
+        public bool HasConfidenceInfo => lastConfidence != null;
+
+        public bool ConfidenceIsReliable => lastConfidence?.IsReliable ?? false;
+
+        public string ConfidenceSummaryDisplay =>
+            lastConfidence == null ? string.Empty :
+            $"Signal-to-noise {lastConfidence.SignalToNoise:F1} · screw-direction ±{lastConfidence.PredictedAngleUncertaintyDeg:F0}°";
+
+        public string PitchUncertaintyDisplay =>
+            double.IsNaN(pitchUncertaintyMicrons) ? string.Empty :
+            $"± {pitchUncertaintyMicrons:F0} µm/{(IsStepperAdjustment ? "step" : "turn")}";
 
         // Config-panel bindings. They wrap the persisted options, presenting thread pitch in mm and
         // showing 0 for the unset (-1) sentinel so the textboxes read cleanly.
@@ -1152,11 +1168,17 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         private static string StepFolderName(WizardStep step) => $"{(int)step + 1:00}_{step}";
 
+        // Test seam: RunCalibrationForTest injects the tilt plane a live run would get from the inspector so the
+        // hardware-recovery path is exercisable without running the paraboloid fit. Always null in production, so
+        // CalibrationTiltPlane below is byte-for-byte the live inspector chain.
+        private TiltPlaneModel calibrationTiltPlaneOverrideForTest;
+
         // The wizard calibrates from the per-star sensor-curve model's tilt (the paraboloid Gx/Gy, expressed as a
         // TiltPlaneModel by SensorModelAberrationResult.CreateTiltPlaneModel) — NEVER the 4-corner region plane. The
         // sensor model is force-generated around each measurement (inspector.ForceSensorCurveModelGeneration); this is
         // null when the paraboloid could not be fit (too few stars), in which case the measurement fails.
-        private TiltPlaneModel CalibrationTiltPlane => inspector.SensorModel?.SensorModelResult?.TiltPlaneModel;
+        private TiltPlaneModel CalibrationTiltPlane =>
+            calibrationTiltPlaneOverrideForTest ?? inspector.SensorModel?.SensorModelResult?.TiltPlaneModel;
 
         // Runs the aberration inspector MeasurementAverageCount times, averages the tilt plane, appends summary
         // rows + the consistency warning, and captures the per-step field-curvature characterization. When saving
@@ -1374,6 +1396,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             SaveAFRuns = false; // saving must be re-enabled explicitly for each run
             stepReadings.Clear();
             measuredHardwareMicrons = double.NaN;
+            lastConfidence = null;
+            pitchUncertaintyMicrons = double.NaN;
             lastRawAngleDiff = double.NaN;
             lastMoveMagnitudeRatio = double.NaN;
             runRootFolder = null;
@@ -1475,6 +1499,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
             // Recover the adapter hardware (µm/turn or µm/step).
             measuredHardwareMicrons = double.NaN;
+            lastConfidence = null;
+            pitchUncertaintyMicrons = double.NaN;
             calibrationScrewRadiusMm = radiusMm;
             calibrationPixelSizeMicrons = pixelSize;
             calibrationFocuserStepMicrons = fStep;
@@ -1501,7 +1527,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     CalibrationAppliedAmount = appliedAmount,
                     IsStepperAdjustment = isStepper
                 };
-                double measured = TiltCalibrationCalculator.RecoverHardwareMicrons(inputs);
+                var (measured, hwDelta1, hwDelta2) = TiltCalibrationCalculator.RecoverHardwareDetailed(inputs);
+                pitchUncertaintyMicrons = double.IsNaN(hwDelta1) ? double.NaN : Math.Abs(hwDelta1 - hwDelta2) / 2.0;
                 if (!double.IsNaN(measured)) {
                     measuredHardwareMicrons = measured;
                     if (isStepper) {
@@ -1513,7 +1540,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
 
             EvaluateRebaselineDrift();
-            EvaluateCalibrationConfidence(TiltCalibrationCalculator.ComputeConfidence(new TiltCalibrationInputs {
+            lastConfidence = TiltCalibrationCalculator.ComputeConfidence(new TiltCalibrationInputs {
                 ScrewCount = screwCount,
                 Baseline = measuredCurvature ? new TiltGradient(a.A, a.B, a.Mean) : default,
                 AllInward = measuredCurvature ? new TiltGradient(b.A, b.B, b.Mean) : default,
@@ -1523,7 +1550,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 Screw2 = new TiltGradient(f.A, f.B, f.Mean),
                 HasCurvatureMeasurement = measuredCurvature,
                 FallbackCurvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign
-            }));
+            });
+            EvaluateCalibrationConfidence(lastConfidence);
             RaiseHardwareSummaryChanged();
         }
 
@@ -1536,6 +1564,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             RaisePropertyChanged(nameof(CalibrationFocuserStepDisplay));
             RaisePropertyChanged(nameof(CalibrationScrewRadiusDisplay));
             RaisePropertyChanged(nameof(CalibrationAppliedAmountDisplay));
+            RaisePropertyChanged(nameof(HasConfidenceInfo));
+            RaisePropertyChanged(nameof(ConfidenceIsReliable));
+            RaisePropertyChanged(nameof(ConfidenceSummaryDisplay));
+            RaisePropertyChanged(nameof(PitchUncertaintyDisplay));
             OnUIThread(() => ((RelayCommand)UseMeasuredHardwareCommand).NotifyCanExecuteChanged());
         }
 
@@ -1623,6 +1655,27 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // stay private — this is the only external write path.
         internal void SeedStepReading(WizardStep step, double a, double b, double mean) {
             stepReadings[step] = new StepReading { A = a, B = b, Mean = mean };
+        }
+
+        // Test seam: run the calibration math over the seeded step readings (mirrors NextStep -> Complete). The
+        // optional overrides supply the sensor geometry a live run reads from the inspector/profile + the paraboloid
+        // tilt-plane model (all of which the seed path bypasses), so RunCalibrationMath's hardware-recovery + pitch
+        // branch can run under test.
+        internal void RunCalibrationForTest(
+            double? radiusMm = null, double? pixelSizeMicrons = null, double? focuserStepMicrons = null,
+            TiltPlaneModel tiltPlaneOverride = null) {
+            calibrationTiltPlaneOverrideForTest = tiltPlaneOverride;
+            try {
+                RunCalibrationMath(
+                    tiltAdapterOptions.ScrewCount,
+                    radiusMm ?? tiltAdapterOptions.ScrewRadiusMillimeters,
+                    pixelSizeMicrons ?? profileService.ActiveProfile.CameraSettings.PixelSize,
+                    focuserStepMicrons ?? EffectiveFocuserStepMicrons(),
+                    calibrationAppliedAmount,
+                    IsStepperAdjustment);
+            } finally {
+                calibrationTiltPlaneOverrideForTest = null;
+            }
         }
 
         // ---- Replay -----------------------------------------------------------------------------------------
@@ -1916,7 +1969,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 CurvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign,
                 MeasuredHardwareMicrons = measuredHardwareMicrons,
                 RawAngleDiffDegrees = lastRawAngleDiff,
-                MoveMagnitudeRatio = lastMoveMagnitudeRatio
+                MoveMagnitudeRatio = lastMoveMagnitudeRatio,
+                SignalToNoise = lastConfidence?.SignalToNoise ?? double.NaN,
+                PredictedAngleUncertaintyDeg = lastConfidence?.PredictedAngleUncertaintyDeg ?? double.NaN,
+                PitchUncertaintyMicrons = pitchUncertaintyMicrons,
+                ConfidenceIsReliable = lastConfidence?.IsReliable ?? false,
             };
             WriteMetadata();
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -639,7 +639,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             bool four = screwCount == 4;
             switch (step) {
                 case WizardStep.Baseline:
-                    return "Label your screws 1, 2, and 3 (or 1–4 for a 4-screw adapter) in a consistent clockwise order. " +
+                    return (four
+                            ? "Label your screws 1, 2, 3, and 4 in a consistent clockwise order. "
+                            : "Label your screws 1, 2, and 3 in a consistent clockwise order. ") +
                         "Screw 1 does NOT need to be at any particular clock position — the wizard determines each screw's actual " +
                         "position from the measurements.\n\nEnsure all screws are at their starting position, then click Run Measurement to take a baseline reading.";
                 case WizardStep.AllInward:

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -1071,6 +1071,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 CalibrationAppliedAmount = calibrationAppliedAmount,
                 MeasurementAverageCount = Math.Max(1, tiltAdapterOptions.MeasurementAverageCount),
                 OptimizedStarDetectionSettings = CaptureDetectionSettings(),
+                MeasurementContext = CaptureMeasurementContext(
+                    inspector.InspectorOptions, HocusFocusPlugin.AutoFocusOptions,
+                    profileService.ActiveProfile.TelescopeSettings.FocalRatio,
+                    profileService.ActiveProfile.TelescopeSettings.FocalLength),
                 RunStepMapping = new List<TiltRunStepMapping>(),
                 PerStep = new List<TiltPerStepResult>()
             };
@@ -1082,6 +1086,26 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             var p = HocusFocusStarDetection.BuildStarDetectorParams(HocusFocusPlugin.StarDetectionOptions);
             return OptimizedStarDetectionSettings.FromParams(p, runCount: 0, baselineJ: 0.0, finalJ: 0.0,
                 recommendedStepSize: 0, recommendedOffsetSteps: 0);
+        }
+
+        // Snapshot the live inputs the sensor-model measurement reads, so a replay can restore or warn on drift.
+        internal static TiltMeasurementContext CaptureMeasurementContext(
+            IInspectorOptions inspector, IAutoFocusOptions af, double fRatio, double focalLengthMm) {
+            return new TiltMeasurementContext {
+                MicronsPerFocuserStep = inspector.MicronsPerFocuserStep,
+                FocalRatio = fRatio,
+                FocalLengthMm = focalLengthMm,
+                UseRANSAC = inspector.UseRANSAC,
+                FixedSensorCenter = inspector.FixedSensorCenter,
+                AstigmaticCurvatureEnabled = inspector.AstigmaticCurvatureEnabled,
+                AcceptableRSquaredMin = inspector.AcceptableRSquaredMin,
+                WeightedHyperbolicFitEnabled = af.WeightedHyperbolicFitEnabled,
+                MaxOutlierRejections = af.MaxOutlierRejections,
+                OutlierRejectionConfidence = af.OutlierRejectionConfidence,
+                HyperbolicFitModel = af.HyperbolicFitModel.ToString(),
+                SensorROI = inspector.SensorROI,
+                CornersROI = inspector.CornersROI
+            };
         }
 
         private double EffectiveFocuserStepMicrons() {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
@@ -84,6 +84,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         /// (uneven turning / backlash) and the recovered pitch/step size is unreliable. NaN if a magnitude is 0.</summary>
         public double MoveMagnitudeRatio { get; set; }
 
+        /// <summary>Half the absolute difference of the two single-screw recovered pitches (µm/turn or µm/step).
+        /// This is the physical-space 1σ on the recovered hardware — it captures screw-to-screw disagreement the
+        /// (A,B) <see cref="MoveMagnitudeRatio"/> misses because the plane→physical conversion is anisotropic.
+        /// NaN when the hardware is uncomputable.</summary>
+        public double PitchUncertaintyMicrons { get; set; }
+
         /// <summary>Signal-to-noise / reliability of the whole calibration, derived from the per-step tilt vectors.
         /// Populated by <see cref="TiltCalibrationCalculator.Calibrate"/>.</summary>
         public TiltCalibrationConfidence Confidence { get; set; }
@@ -238,14 +244,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             return (s1, s2, s3, s4);
         }
 
-        /// <summary>
-        /// Recovers the adapter hardware (µm per turn for screws, µm per step for steppers) from the two
-        /// single-screw moves' tilt-plane gradient changes and the known applied turns/steps. Mirrors the wizard's
-        /// CalculateAndSaveHardware: convert each gradient change to a physical gradient, derive the per-screw axial
-        /// move via the adapter lever arm, average the two, and divide by the applied amount. Returns NaN when any
-        /// required input is non-positive or the result is non-positive.
-        /// </summary>
-        public static double RecoverHardwareMicrons(TiltCalibrationInputs inputs) {
+        /// <summary>Per-screw recovered hardware: the average (µm/turn or µm/step) plus each screw's own recovered
+        /// value (delta_i / applied). Same math as the wizard's CalculateAndSaveHardware. All three are NaN when any
+        /// input is non-positive or the average is non-positive.</summary>
+        public static (double measured, double delta1PerApplied, double delta2PerApplied) RecoverHardwareDetailed(TiltCalibrationInputs inputs) {
             double pixelSize = inputs.PixelSizeMicrons;
             double fStep = inputs.FocuserStepMicrons;
             double radiusMm = inputs.ScrewRadiusMillimeters;
@@ -253,7 +255,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             double sensorW = inputs.ImageWidthPixels * pixelSize;
             double sensorH = inputs.ImageHeightPixels * pixelSize;
             if (radiusMm <= 0 || applied <= 0 || pixelSize <= 0 || fStep <= 0 || sensorW <= 0 || sensorH <= 0) {
-                return double.NaN;
+                return (double.NaN, double.NaN, double.NaN);
             }
 
             double radiusMicrons = radiusMm * 1000.0;
@@ -273,10 +275,20 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
             double measured = 0.5 * (delta1 + delta2) / applied;
             if (double.IsNaN(measured) || measured <= 0) {
-                return double.NaN;
+                return (double.NaN, double.NaN, double.NaN);
             }
-            return measured;
+            return (measured, delta1 / applied, delta2 / applied);
         }
+
+        /// <summary>
+        /// Recovers the adapter hardware (µm per turn for screws, µm per step for steppers) from the two
+        /// single-screw moves' tilt-plane gradient changes and the known applied turns/steps. Mirrors the wizard's
+        /// CalculateAndSaveHardware: convert each gradient change to a physical gradient, derive the per-screw axial
+        /// move via the adapter lever arm, average the two, and divide by the applied amount. See
+        /// <see cref="RecoverHardwareDetailed"/>. Returns NaN when any required input is non-positive or the result
+        /// is non-positive.
+        /// </summary>
+        public static double RecoverHardwareMicrons(TiltCalibrationInputs inputs) => RecoverHardwareDetailed(inputs).measured;
 
         /// <summary>
         /// Drift of a re-baseline relative to its reference, as a fraction of the subsequent screw-move magnitude.
@@ -301,6 +313,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             double d2B = inputs.Screw2.B - inputs.ReBaseline2.B;
 
             var (s1, s2, s3, s4, rawDiff) = ComputeScrewAngles(d1A, d1B, d2A, d2B, inputs.ScrewCount);
+            var (measuredHardware, delta1PerApplied, delta2PerApplied) = RecoverHardwareDetailed(inputs);
 
             return new TiltCalibrationResult {
                 Screw1AngleDegrees = s1,
@@ -313,7 +326,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 CurvatureSign = inputs.HasCurvatureMeasurement
                     ? ComputeCurvatureSign(inputs.AllInward.MeanFocuserPosition, inputs.Baseline.MeanFocuserPosition)
                     : inputs.FallbackCurvatureSign,
-                MeasuredHardwareMicrons = RecoverHardwareMicrons(inputs),
+                MeasuredHardwareMicrons = measuredHardware,
+                PitchUncertaintyMicrons = double.IsNaN(delta1PerApplied)
+                    ? double.NaN
+                    : Math.Abs(delta1PerApplied - delta2PerApplied) / 2.0,
                 Screw1DirectionDegrees = NormalizeAngle(Math.Atan2(d1A, -d1B) * 180.0 / Math.PI),
                 Screw2DirectionDegrees = NormalizeAngle(Math.Atan2(d2A, -d2B) * 180.0 / Math.PI),
                 MoveMagnitudeRatio = MoveMagnitudeRatio(d1A, d1B, d2A, d2B),

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
@@ -67,6 +67,25 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public bool ConfidenceIsReliable { get; set; }
     }
 
+    /// <summary>Snapshot of the profile/inspector inputs the tilt measurement reads from live state, so a replay
+    /// can reproduce the original calibration (or warn when the current profile has drifted). HyperbolicFitModel
+    /// is stored as its enum name for forward-compatibility.</summary>
+    public sealed class TiltMeasurementContext {
+        public double MicronsPerFocuserStep { get; set; } = double.NaN;
+        public double FocalRatio { get; set; } = double.NaN;
+        public double FocalLengthMm { get; set; } = double.NaN;
+        public bool UseRANSAC { get; set; }
+        public bool FixedSensorCenter { get; set; }
+        public bool AstigmaticCurvatureEnabled { get; set; }
+        public double AcceptableRSquaredMin { get; set; } = double.NaN;
+        public bool WeightedHyperbolicFitEnabled { get; set; }
+        public int MaxOutlierRejections { get; set; }
+        public double OutlierRejectionConfidence { get; set; } = double.NaN;
+        public string HyperbolicFitModel { get; set; }
+        public double SensorROI { get; set; } = double.NaN;
+        public double CornersROI { get; set; } = double.NaN;
+    }
+
     /// <summary>
     /// Serialization unit for a saved Tilt Adapter calibration run, shared by the live wizard (writer + replay)
     /// and the headless <c>TestApp tilt</c> validator so a wizard-saved run replays both in-app and offline.
@@ -110,6 +129,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // ---- Replay payload ----
         public List<TiltRunStepMapping> RunStepMapping { get; set; }
         public OptimizedStarDetectionSettings OptimizedStarDetectionSettings { get; set; }
+        public TiltMeasurementContext MeasurementContext { get; set; }
 
         // ---- Results ----
         public List<TiltPerStepResult> PerStep { get; set; }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
@@ -59,6 +59,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public double MeasuredHardwareMicrons { get; set; }
         public double RawAngleDiffDegrees { get; set; }
         public double MoveMagnitudeRatio { get; set; }
+
+        // ---- Confidence (persisted so a saved/replayed run carries its reliability) ----
+        public double SignalToNoise { get; set; } = double.NaN;
+        public double PredictedAngleUncertaintyDeg { get; set; } = double.NaN;
+        public double PitchUncertaintyMicrons { get; set; } = double.NaN;
+        public bool ConfidenceIsReliable { get; set; }
     }
 
     /// <summary>
@@ -70,7 +76,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
     /// </summary>
     public sealed class TiltCalibrationMetadata {
 
-        public const int CurrentSchemaVersion = 1;
+        public const int CurrentSchemaVersion = 2;
 
         /// <summary>The six discrete measurement steps, in capture order. Same for 3- and 4-screw adapters.</summary>
         public static readonly string[] StepOrder = {

--- a/Joko.NINA.Plugins/TestApp/DiagnosticUtil.cs
+++ b/Joko.NINA.Plugins/TestApp/DiagnosticUtil.cs
@@ -10,6 +10,7 @@
 
 #endregion "copyright"
 
+using NINA.Core.Enum;
 using NINA.Image.FileFormat.FITS;
 using NINA.Image.FileFormat.XISF;
 using NINA.Image.ImageAnalysis;
@@ -22,6 +23,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Media;
 
 namespace TestApp {
 
@@ -51,8 +53,13 @@ namespace TestApp {
         /// <summary>
         /// Loads an image file as a CV_32F Mat normalized to [0,1]. .tif/.tiff are read directly; .xisf/.fits/.fit
         /// go through NINA's loaders (which need a profile). profileService may be null for .tif-only callers.
+        ///
+        /// When <paramref name="debayerToLuminance"/> is true and the loaded frame is bayered, it is debayered to a
+        /// luminance Mat — the SAME representation the live app feeds star detection when ImageSettings.DebayerImage
+        /// is on (see <c>StarDetector.PrepareSrcImageFromRenderedImage</c>). Headless runners otherwise detect on the
+        /// raw Bayer mosaic, which biases the per-star sensor-model tilt the Tilt Adapter Wizard calibrates from.
         /// </summary>
-        public static async Task<Mat> LoadFloatMat(string path, IProfileService profileService) {
+        public static async Task<Mat> LoadFloatMat(string path, IProfileService profileService, bool debayerToLuminance = false) {
             var ext = Path.GetExtension(path).ToLowerInvariant();
             if (ext == ".tif" || ext == ".tiff") {
                 using var src = new Mat(path, ImreadModes.Unchanged);
@@ -66,12 +73,36 @@ namespace TestApp {
                 }
                 var factory = new ImageDataFactory(profileService, new StubBehaviorSelector<IStarDetection>(new StubStarDetection()), new StubBehaviorSelector<IStarAnnotator>());
                 var uri = new Uri(Path.GetFullPath(path));
+                // The second arg is isBayered. Loading with false (the raw-mosaic default the other runners use)
+                // clears IsBayered and drops the CFA pattern, which would silently skip the debayer path below.
+                // When the caller wants luminance, load AS bayered so the CFA pattern is populated for the debayer.
                 IImageData imageData = ext == ".xisf"
-                    ? await XISF.Load(uri, false, factory, CancellationToken.None)
-                    : await FITS.Load(uri, false, factory, CancellationToken.None);
+                    ? await XISF.Load(uri, debayerToLuminance, factory, CancellationToken.None)
+                    : await FITS.Load(uri, debayerToLuminance, factory, CancellationToken.None);
+                if (debayerToLuminance && imageData.Properties.IsBayered) {
+                    return DebayerToLuminanceMat(imageData);
+                }
                 return CvImageUtility.ToOpenCVMat(imageData);
             }
             throw new NotSupportedException($"Unsupported image extension '{ext}'. Supported: .tif/.tiff, .xisf, .fits/.fit");
+        }
+
+        /// <summary>
+        /// Debayers a bayered <see cref="IImageData"/> to a luminance Mat, mirroring the detector's own
+        /// <c>StarDetector.PrepareSrcImageFromRenderedImage</c> conversion (CFA → 16-bit luminance) so the headless
+        /// representation matches the live app. The concrete CFA pattern comes from the frame's own metadata (the
+        /// FITS BAYERPAT), defaulting to RGGB when the metadata reports none but the properties say bayered.
+        /// </summary>
+        private static Mat DebayerToLuminanceMat(IImageData imageData) {
+            var props = imageData.Properties;
+            var sensorType = imageData.MetaData?.Camera?.SensorType ?? SensorType.RGGB;
+            if (sensorType == SensorType.Monochrome) {
+                sensorType = SensorType.RGGB;
+            }
+            var bitmapSource = ImageUtility.CreateSourceFromArray(imageData.Data, props, PixelFormats.Gray16);
+            var debayered = ImageUtility.Debayer(bitmapSource, pf: System.Drawing.Imaging.PixelFormat.Format16bppGrayScale,
+                saveColorChannels: false, saveLumChannel: true, bayerPattern: sensorType);
+            return CvImageUtility.ToOpenCVMat(debayered.Data.Lum, bpp: props.BitDepth, width: props.Width, height: props.Height);
         }
     }
 }

--- a/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
@@ -96,6 +96,10 @@ namespace TestApp {
 
             var profileId = DiagnosticUtil.GetArg(args, "--profile-id");
             bool reoptimize = DiagnosticUtil.HasFlag(args, "--reoptimize");
+            // Match the live app: when the profile debayers (ImageSettings.DebayerImage), detection runs on the
+            // debayered luminance, not the raw Bayer mosaic. The wizard's per-star sensor-model tilt is sensitive
+            // to this, so replaying a bayered run faithfully requires it.
+            bool debayer = DiagnosticUtil.HasFlag(args, "--debayer");
             int? maxEvals = null;
             var maxEvalsArg = DiagnosticUtil.GetArg(args, "--max-evals");
             if (!string.IsNullOrWhiteSpace(maxEvalsArg)) {
@@ -178,10 +182,11 @@ namespace TestApp {
             // optimizer is forced via --reoptimize. The result is applied only to this transient params object.
             var (detectionParams, optimizationSource) = await ResolveDetectionParamsAsync(
                 metadata, metadataPath, outDir, reoptimize, maxEvals, orderedRuns,
-                profileService, starDetectionOptions, afOptions, alglibAPI, pixelScale).ConfigureAwait(false);
+                profileService, starDetectionOptions, afOptions, alglibAPI, pixelScale, debayer).ConfigureAwait(false);
             Console.WriteLine($"Detection params: source={optimizationSource}, Sensitivity={F(detectionParams.Sensitivity)}, " +
                 $"StarClippingMultiplier={F(detectionParams.StarClippingMultiplier)}, StructureLayers={detectionParams.StructureLayers}, " +
                 $"DefocusAwareDonutDetection={detectionParams.DefocusAwareDonutDetection}");
+            Console.WriteLine($"Debayer bayered frames to luminance (match live app): {debayer}");
 
             // Measure the tilt plane for each run.
             var detector = new StarDetector(alglibAPI);
@@ -194,7 +199,7 @@ namespace TestApp {
                 var sw4c = System.Diagnostics.Stopwatch.StartNew();
                 var stepResult = await MeasureTiltAsync(run, detector, detectionParams, regions, fRatio,
                     metadata.FocuserStepSizeMicrons, metadata.PixelSizeMicrons, starDetectionOptions.MeasurementAverage,
-                    profileService, alglibAPI, afOptions.HyperbolicFitModel).ConfigureAwait(false);
+                    profileService, alglibAPI, afOptions.HyperbolicFitModel, debayer).ConfigureAwait(false);
                 perStep.Add(stepResult);
                 Console.WriteLine($"    [4-corner {run.Step}] done in {sw4c.ElapsedMilliseconds} ms");
                 Console.WriteLine($"    A={F(stepResult.Gradient.A)}, B={F(stepResult.Gradient.B)}, " +
@@ -236,7 +241,7 @@ namespace TestApp {
                 Console.WriteLine($"Paraboloid (per-star) tilt for {run.Step} ...");
                 var mean = byStep[run.Step].Gradient.MeanFocuserPosition;
                 var ps = await MeasureTiltViaParaboloidAsync(run, detector, detectionParams, metadata.FocuserStepSizeMicrons,
-                    metadata.PixelSizeMicrons, mean, profileService, inspectorOptions, afOptions, alglibAPI).ConfigureAwait(false);
+                    metadata.PixelSizeMicrons, mean, profileService, inspectorOptions, afOptions, alglibAPI, debayer).ConfigureAwait(false);
                 paraboloidSteps.Add(ps);
                 Console.WriteLine(ps.Fitted
                     ? $"    A={F(ps.Gradient.A)}, B={F(ps.Gradient.B)}, stars={ps.StarsInModel}, R²={F(ps.RSquared)}"
@@ -363,7 +368,7 @@ namespace TestApp {
         private static async Task<(StarDetectorParams Params, string Source)> ResolveDetectionParamsAsync(
             TiltCalibrationMetadata metadata, string metadataPath, string outDir, bool reoptimize, int? maxEvals,
             List<RunStep> orderedRuns, ProfileService profileService, StarDetectionOptions starDetectionOptions,
-            AutoFocusOptions afOptions, AlglibAPI alglibAPI, double pixelScale) {
+            AutoFocusOptions afOptions, AlglibAPI alglibAPI, double pixelScale, bool debayer) {
 
             StarDetectorParams ApplyAfContext(StarDetectorParams p) {
                 p.PixelScale = pixelScale;
@@ -400,7 +405,7 @@ namespace TestApp {
             var loaded = new List<(RunStep Run, List<(int Focuser, Mat Mat)> Frames, RunEvaluationData Data)>();
             try {
                 foreach (var run in orderedRuns) {
-                    var mats = await LoadRunMatsAsync(run, profileService).ConfigureAwait(false);
+                    var mats = await LoadRunMatsAsync(run, profileService, debayer).ConfigureAwait(false);
                     var frames = mats.Select(m => new RunFrame { FrameId = m.Path, FocuserPosition = m.Focuser, Image = m.Mat }).ToList();
                     var stepSize = InferStepSize(run.Frames.Select(f => f.Focuser));
                     var fitConfig = new RunFitConfig {
@@ -512,9 +517,9 @@ namespace TestApp {
         private static async Task<StepResult> MeasureTiltAsync(
             RunStep run, StarDetector detector, StarDetectorParams baseParams, List<StarDetectionRegion> regions,
             double fRatio, double focuserStepMicrons, double pixelSizeMicrons, MeasurementAverageEnum measurementAverage,
-            ProfileService profileService, IAlglibAPI alglibAPI, HyperbolicFitModel hyperbolicModel) {
+            ProfileService profileService, IAlglibAPI alglibAPI, HyperbolicFitModel hyperbolicModel, bool debayer) {
 
-            var mats = await LoadRunMatsAsync(run, profileService).ConfigureAwait(false);
+            var mats = await LoadRunMatsAsync(run, profileService, debayer).ConfigureAwait(false);
             try {
                 var imageSize = new DrawingSize(mats[0].Mat.Width, mats[0].Mat.Height);
 
@@ -587,9 +592,9 @@ namespace TestApp {
         private static async Task<ParaboloidStepResult> MeasureTiltViaParaboloidAsync(
             RunStep run, StarDetector detector, StarDetectorParams baseParams, double focuserStepMicrons,
             double pixelSizeMicrons, double fourCornerMean, ProfileService profileService,
-            InspectorOptions inspectorOptions, AutoFocusOptions afOptions, IAlglibAPI alglibAPI) {
+            InspectorOptions inspectorOptions, AutoFocusOptions afOptions, IAlglibAPI alglibAPI, bool debayer) {
 
-            var mats = await LoadRunMatsAsync(run, profileService).ConfigureAwait(false);
+            var mats = await LoadRunMatsAsync(run, profileService, debayer).ConfigureAwait(false);
             try {
                 var imageSize = new DrawingSize(mats[0].Mat.Width, mats[0].Mat.Height);
                 var sensorFrames = new List<SensorDetectedStars>(mats.Count);
@@ -690,10 +695,10 @@ namespace TestApp {
 
         // ---- Image loading + regions ----------------------------------------------------------------------
 
-        private static async Task<List<(int Focuser, string Path, Mat Mat)>> LoadRunMatsAsync(RunStep run, ProfileService profileService) {
+        private static async Task<List<(int Focuser, string Path, Mat Mat)>> LoadRunMatsAsync(RunStep run, ProfileService profileService, bool debayer) {
             var result = new List<(int, string, Mat)>(run.Frames.Count);
             foreach (var (focuser, path) in run.Frames.OrderBy(f => f.Focuser)) {
-                var mat = await DiagnosticUtil.LoadFloatMat(path, profileService).ConfigureAwait(false);
+                var mat = await DiagnosticUtil.LoadFloatMat(path, profileService, debayer).ConfigureAwait(false);
                 result.Add((focuser, path, mat));
             }
             return result;
@@ -938,6 +943,7 @@ namespace TestApp {
             Console.Error.WriteLine("  --profile-id (default active) NINA profile id (settings + focal length).");
             Console.Error.WriteLine("  --out        (default %LOCALAPPDATA%\\NINA\\Logs\\hf-diag\\tilt\\<timestamp>) output directory.");
             Console.Error.WriteLine("  --reoptimize force re-running star-detection optimization and overwrite the stored settings in metadata.");
+            Console.Error.WriteLine("  --debayer    debayer bayered frames to luminance before detection (matches the live app when the profile debayers); required to reproduce the wizard's per-star sensor-model tilt on a bayered run.");
             Console.Error.WriteLine("  --max-evals  (optional) override the optimizer's MaxEvaluations budget.");
             Console.Error.WriteLine("Metadata lives at <parent>/<datasetName>.tilt.json; a template is written if it is missing.");
         }

--- a/docs/tilt-calibration-error-bounds-design.md
+++ b/docs/tilt-calibration-error-bounds-design.md
@@ -1,0 +1,157 @@
+# Tilt-Adapter Calibration — Error Bounds & Reproducibility (RESOLVED)
+
+**Subject calibration:** `D:\Tilt Calibration Bank\astrodet_6_2\TiltCalibration_20260705_120026`
+(3-screw, screws mode, ASI2600MC Duo 6248×4176 RGGB, nominal pitch 400 µm/turn, screw 1 physically 60°)
+**Wizard result (Default profile, "use captured/stored settings"):** screw 1 = 67.1°, pitch = 418.7 µm/turn.
+**Repro:** `scratchpad/wizard_bounds.py` reconstructs the wizard exactly from the NINA replay log
+(`20260705-073652-3.3.0.1048…`), which records the per-step sensor-model fits.
+
+## TL;DR
+
+- The wizard's calibration is **reconstructed exactly** (67.10° / 418.7 µm) from the per-step paraboloid
+  Gx/Gy in the NINA log — so the wizard's numbers are fully explained and **correct**.
+- **Error bounds on the wizard's actual calibration:** screw angle **67.1° ± ~3.6°** (internal spacing) up to
+  **±25°** (the wizard's own all-inward noise model, SNR 2.16); **pitch 419 ± ~43 µm/turn (±10%)**; curvature
+  sign −1, robust. It is a **reliable** calibration (move ratio 1.14, near-ideal 112.8° spacing) — unlike the
+  stale saved `metadata.json` (ratio 5.48), which my first analysis wrongly used.
+- The headless `TestApp tilt` validator **cannot reproduce the wizard** because its detection differs
+  (raw-Bayer / imperfect-debayer + independent RANSAC → different Gx/Gy). **Debayering was a red herring.**
+  The right move is to consume the wizard's logged tilt planes, not re-detect headlessly.
+
+## 1. How the wizard's numbers arise (from the NINA log)
+
+The replay logs, per step, `Building Sensor Model … Image size (6248×4176)`, RANSAC per-frame star counts,
+and `Solved surface model: {Gx, Gy, …}. Stars: N`. The six steps in order give:
+
+| step | Gx | Gy | stars | GoD |
+|---|---|---|---|---|
+| Baseline | −1.429e-4 | 4.078e-4 | 707 | 0.95 |
+| AllInward | −2.931e-4 | 2.959e-4 | 696 | 0.93 |
+| ReBaseline1 | (= Baseline, reused frames) | | 707 | |
+| Screw1 | 2.213e-4 | 2.169e-4 | 685 | 0.87 |
+| ReBaseline2 | (= Baseline) | | 707 | |
+| Screw2 | −1.636e-4 | 9.125e-4 | 616 | 0.97 |
+
+Feeding these through the calibrator reproduces **screw1 = 67.10°, pitch = 418.7 µm/turn** — the UI values.
+
+### The `MicronsPerFocuserStep = 0.26` subtlety (not a calibration bug, but a profile misconfig)
+
+The log shows the sensor model ran with `Focuser Size (0.26)` — your Default profile's inspector
+`MicronsPerFocuserStep` — not the 3.6 µm the metadata/UI show. This **cancels in the tilt plane**
+(A = Gx·W/f; Gx already scales with f), so the plane and the fStep-independent **screw angles are correct**,
+and hardware recovery (which uses the real 3.6 µm) yields the correct pitch. Confirmation: a *consistent*
+0.26 would give an absurd ~30 µm/turn; 3.6 gives 418.7 ≈ the 400 nominal, so 3.6 is the true focuser step and
+**0.26 is a stale inspector value**. It does **not** corrupt the tilt calibration, but it *would* corrupt any
+inspector display that uses focuserSizeMicrons non-cancelling (tilt-effect µm, backfocus µm, curvature radius)
+— worth fixing separately.
+
+## 2. Error bounds on the wizard's actual calculated values
+
+| value | estimate | 1σ bound | basis |
+|---|---|---|---|
+| Screw 1 / 2 / 3 | 67.1 / 187.1 / 307.1° | **± 3.6°** … **± 25°** | equal-spacing residual (−7.2° off 120°) … all-inward noise model |
+| Pitch | 419 µm/turn | **± 43 (±10%)** | two screws imply 376 vs 462 µm/turn (ratio 1.23) |
+| Curvature sign | −1 | robust | Z0 margin −25 µm |
+
+- **Reliability:** signal 32.7 vs all-inward residual 15.2 → **SNR 2.16** (just above the 2.0 "reliable" gate),
+  so the wizard shows no low-confidence warning, but its own predicted screw-direction σ is **±25°**. The
+  tight spacing bound (±3.6°) and the noise bound (±25°) bracket the real error: the physical **60°** is
+  **+7.1°** from 67.1° — 2.0σ on the tight bound, 0.3σ on the noise bound. So the angle is good to **~±7°**
+  realistically, not ±3.6°.
+- **Pitch** 418.7 is **+4.7% vs the 400 nominal** — comfortably inside the ±10% bound. Trustworthy to ~±10–15%.
+
+These supersede every earlier bound in this doc's history: the first (±16.8°/±65%) used stale metadata; the
+"4-corner 301 µm" and "paraboloid 77°/380" were headless estimators that don't match the wizard.
+
+## 3. Why headless reproduction failed (and the real validator fix)
+
+`TestApp tilt` re-detects the frames headlessly and runs the sensor model with `image:null`. Its Gx/Gy differ
+from the app's (raw-Bayer vs debayered detection, plus independent RANSAC), and the per-star fit is unstable
+headless (paraboloid swung 77°→27° between raw and my debayer). Adding `--debayer` (implemented, opt-in) made
+detection use luminance but did **not** converge — debayering was not the difference. **The faithful path is
+to consume the wizard's logged tilt planes** (as done here), or to drive the full app image/sensor-model
+pipeline. The `--debayer` flag remains a partial, correct improvement (matches the app's detection
+representation) but is not sufficient alone and is incomplete (skips the CFA hot-pixel step).
+
+## 4. Recommendation for the UI
+
+- **Surface the wizard's own uncertainty** (`Confidence.PredictedAngleUncertaintyDeg`, here ±25°, and SNR
+  2.16) next to the result — always, not only on the SNR<2 warning. It is honest and already computed.
+- **Show pitch as ±~10%** and gate its reliability on the **physical** delta ratio (1.23 here), not the (A,B)
+  ratio.
+- **Persist the confidence block + the focuser-step actually used** into `metadata.json`, so a replay under a
+  profile with a stale `MicronsPerFocuserStep` (the 0.26 here) is detectable.
+- **Fix the validator** to consume logged/stored tilt planes (or the full pipeline) rather than re-detect — it
+  currently cannot reproduce the wizard on bayered runs.
+
+## 5. Saved `metadata.json` calibration ≠ replay — different inputs, not a math bug
+
+The saved `calibration` block (screw1 **65.99°**, pitch **352**, move ratio **5.48**, SNR **1.05 = unreliable**)
+differs sharply from the replay (**67.1° / 418.7**, ratio **1.14**, SNR **2.16 = reliable**). This is **not a
+calculation bug** — the calibrator reproduces the replay exactly (§1). It is **different persisted metadata /
+replay conditions**:
+
+- **The move-magnitude ratio is focuser-step-independent** (f cancels in `m1/m2`), so 5.48 vs 1.14 is a genuine
+  **detection/estimator difference** between capture and replay — the two runs fit the saved frames
+  *differently*. The saved `perStep` was therefore produced under a different measurement context (detection
+  state / sensor-model behavior / possibly an older build) than a replay applies.
+- metadata.json persists geometry + the optimized detection settings, but the saved `perStep`/`calibration` is
+  only a **historical snapshot** ("stored for reference; re-derived from the per-step readings"). A replay does
+  **not** reuse it — it re-measures the sensor-model tilt from the frames using **current** profile/inspector
+  state, so it legitimately diverges.
+- Net: **do not trust the saved `calibration` block** — here it captured an *unreliable* run (ratio 5.48). The
+  saved run is not reproducible from the stored artifacts, which is the gap §6 closes.
+
+## 6. Replay reproducibility — measurement context to persist (design extension)
+
+**Problem.** `SensorModel.UpdateModel` reads `InspectorOptions.MicronsPerFocuserStep` (`InspectorVM.cs:578`, the
+stale **0.26** here) and `profile.TelescopeSettings.FocalRatio` (`:592`) from **live state**, and the AF
+curve-fit + sensor-model fit read more live options. metadata.json persists none of these, so a replay under a
+different profile reproduces neither the saved calibration nor a prior replay.
+
+**Fix.** Add a `MeasurementContext` block to `TiltCalibrationMetadata`, captured at save time from the values
+actually used, and have replay **apply it transiently** (like the existing capture-time detection-settings
+override — never mutating the profile). Then in-app replay and `TestApp tilt` both become deterministic and
+faithful.
+
+**Fields to persist** (verify the complete set against the measurement path at implementation):
+
+| field | source today | why it matters |
+|---|---|---|
+| `MicronsPerFocuserStep` | `InspectorOptions` (`:578`) | sensor-model Z scale; must equal the real focuser step |
+| `FocalRatio` | profile (`:592`) | sensor-model + tilt-angle |
+| `FocalLengthMm` | profile | detection pixel scale |
+| `UseRANSAC`, `FixedSensorCenter`, `AstigmaticCurvatureEnabled`, `AcceptableRSquaredMin` | `InspectorOptions` | paraboloid registration/fit |
+| `WeightedHyperbolicFitEnabled`, `MaxOutlierRejections`, `OutlierRejectionConfidence`, `HyperbolicFitModel` | `AutoFocusOptions` | per-region focus minima |
+| `SensorROI`, `CornersROI` | `InspectorOptions` | region geometry (4-corner path) |
+| *(already persisted)* screws/type, pitch/step, radius, pixel, focuserStep, appliedAmount, measurementAverage, `OptimizedStarDetectionSettings`, `runStepMapping` | metadata | geometry + detection |
+
+**Also:** persist the computed `Confidence` block and a `SchemaVersion` bump; on replay, if the current
+profile's `MicronsPerFocuserStep`/`FocalRatio` differ from the persisted context, **warn** that the replay used
+captured settings (so the 0.26-style drift is visible). This is what lets a saved run be re-scored honestly.
+
+## 7. UI confidence surfacing — what a spec needs
+
+Expands §4. To write the spec we need these **decisions** (yours) and **prerequisites** (code):
+
+**Decisions**
+1. *Which metrics* to show: SNR + reliable/unreliable; `PredictedAngleUncertaintyDeg` (±25° here); per-screw
+   angle ±; pitch ±. All, or a subset?
+2. *When*: always, or only the existing SNR<2 warning? (Recommend: always show a compact confidence line;
+   escalate to the red warning at SNR<2.)
+3. *Where* in the "Calibration Complete" panel: a summary confidence row, a ± next to each screw angle, a ±
+   next to the pitch, or a combination?
+4. *Visual treatment + thresholds*: green/amber/red keyed to SNR (and/or predicted σ)? Threshold values +
+   wording.
+5. *Apply gating*: keep the hard "do not apply" at SNR<2; add a softer caution band above it?
+6. *Pitch reliability metric*: switch the gate to the **physical** delta ratio (delta1/delta2 = 1.23 here)
+   instead of the (A,B) `MoveMagnitudeRatio` (which under-reports it)?
+
+**Prerequisites (code the spec depends on)**
+- Compute a **pitch ±** from delta1/delta2 (new — today only the (A,B) ratio exists).
+- Decide per-screw angle ± vs a single global `PredictedAngleUncertaintyDeg`.
+- **Persist the `Confidence` block** in metadata.json (§6) so saved/replayed runs carry it.
+- Bind new fields in `Resources`/`TiltAdapterWizard/DataTemplates.xaml`.
+- Optional: the focuser-step-drift warning from §6.
+
+Once (1)–(6) are decided, this is a self-contained spec + plan.

--- a/docs/tilt-wizard-diagram-orientation-design.md
+++ b/docs/tilt-wizard-diagram-orientation-design.md
@@ -1,0 +1,72 @@
+# Tilt Adapter Wizard — screw-angle ↔ tilt-effect orientation
+
+**Status:** Investigation complete (root cause found, verified). Fix not yet applied.
+**Date:** 2026-07-04
+**Trigger:** User reports, refined across two messages:
+1. "The orientation in the tilt adapter calibration wizard is vertically flipped — 0° comes out of the bottom of the image instead of the top."
+2. (with screenshot) "The user believes when they turn **Screw #2** it actually moves the **top** instead of the bottom."
+
+NINA renders images with (0,0) at top-left, y-down. Angle convention: degrees CW from straight up (0°=top, 90°=right, 180°=bottom, 270°=left).
+
+## TL;DR
+
+Both reports are the **same root defect** seen under the two adapter-direction settings, on a rig that physically behaves as a **"CW moves adapter toward the objective" (−1)** rig:
+
+- The single persisted field `TiltAdapterOptions.ScrewNAngleDegrees` is consumed **raw** as *both* the **physical screw position** (the wizard diagram) *and* the **response direction** (the inspector guidance). These differ by exactly **180° on −1 rigs**, 0° on the default +1 rig.
+- **Screenshot config** (direction = "Toward the camera" = default +1, *assumed*, manual entry): the diagram is **correct** (screw 2 genuinely at 180°/bottom), but the guidance/tilt-effect is **180°-inverted** if the rig is really −1 → "turn screw 2, the top moves."
+- **Set direction = "Toward the objective" (−1)** to fix the guidance → the diagram then draws screws 180° from their physical positions → the "0° comes out the bottom" symptom.
+- You **cannot make both correct** with one raw-consumed field. That is the real defect.
+
+There is **no rendering-math bug** and **no universal forward-physics sign bug**. The diagram trig `cy = 100 − 75·cosθ` is correct y-down (0° → top). The recent sign-convention commits (`93c52dd`, `81ff1dd`) did not flip the default.
+
+## The two roles of `ScrewNAngleDegrees`
+
+| Consumer | Code | Needs |
+|---|---|---|
+| Wizard diagram | `RebuildDiagram` plots raw `ScrewNAngleDegrees` via `cx=100+75·sinθ, cy=100−75·cosθ` (`TiltAdapterWizardVM.cs:1938-1949`); labeled "Rectangle = image as shown in NINA. 0° points up" / "top of image" (`DataTemplates.xaml:156,167`) | **physical** image position |
+| Inspector guidance | `turns[i] = (2/n)(−A·sinθ + B·cosθ)`, arrow motion `= −σ·turns` (`InspectorVM.cs:1901-1923`); "the stored response-convention screw angle … takes NO sign factor" (`TiltScrewGeometry.cs:106-114`) | **response direction** (where a CW turn drives best-focus high) |
+
+`PhysicalToStoredAngle(physical, sign)` (`TiltScrewGeometry.cs:176-180`) adds **180°** when `sign == −1` (`CurvatureSignWhenCwMovesAdapterTowardObjective`, L150), else 0°. Self-inverse. Manual entry applies it once at Apply (`TiltAdapterWizardVM.cs:841`); wizard-measured runs store `atan2(dA,−dB)` (the measured response) directly. So the stored field is **response-convention**, which equals the physical angle only on +1 rigs.
+
+## Verified numeric traces (physical layout: screw 1 @60°, screw 2 @180°/bottom, screw 3 @300°)
+
+**Case B — screenshot (direction = +1 "toward the camera", assumed):**
+- `PhysicalToStoredAngle(60,+1)` → offset 0 → stored 60; `ComputeManualScrewAngles(60,CW,3)` → **60 / 180 / 300** (matches the info panel).
+- Diagram: screw 2 @180° → `cy = 100 − 75·cos180° = 175` → **bottom** = correct physical position.
+- Guidance reads 60/180/300 as *response* angles. On a true −1 rig, screw 2's real response is 180+180 = **0° (top)**, so the guidance/effect for the bottom screw is 180° inverted → **"turn screw 2, the top moves."**
+
+**Case A — direction correctly set to −1 ("toward the objective"):**
+- `PhysicalToStoredAngle(60,−1)` → offset 180 → stored 240; `ComputeManualScrewAngles(240,CW,3)` → **240 / 0 / 120**.
+- Guidance reads 240/0/120 = physical+180 = the correct response angles → **guidance correct**.
+- Diagram: screw 2 stored 0° → `cy = 25` → **top**, but screw 2 is physically at the bottom → **diagram 180°-flipped** ("0° comes out the bottom").
+
+One field, two masters: fixing one flips the other by 180° on −1 rigs.
+
+## Is "screw 2 moves the top" proof of a −1 rig? (Important nuance)
+
+**Not by itself.** Turning one screw of a 3-screw adapter pivots the plane about the line of the other two (lever arm 1.5·R, `TiltScrewGeometry.cs:128-131`), and the **fitted tilt plane the inspector displays is symmetric top↔bottom about field center** — so the opposite side visibly changing is **normal see-saw physics**, independent of the curvature sign. "The top moved" alone does not diagnose −1.
+
+The genuine −1 signature is **directional**: following the guidance moves tilt the **wrong way** / the side that goes high is opposite what the wizard predicts. That comes from the 180° response offset, not a "which side moved more" argument.
+
+**Definitive test:** run a **6-step "Measure direction" calibration** — it measures the true response of each screw and removes the assumption. Equivalently, check whether following the guidance reduces or worsens the measured tilt.
+
+## Config vs. bug
+
+- The **guidance inversion** (report 2) is a **configuration/assumption mismatch**, not a code bug: direction is `ScrewInwardCurvatureSignIsMeasured == false` here (`TiltAdapterWizardVM.cs:849`; screenshot "Direction is assumed / Curvature ↑ assumed"). The math is correct for whatever σ it's told. **User remedy:** measure the direction (6-step) or set "Toward the objective" and re-Apply (conversion is not retroactive, `TiltAdapterWizardVM.cs:839-841`).
+- The **diagram vs. guidance duality** is a **genuine design defect**: even after correctly setting the direction, the diagram will misplace screws by 180° on −1 rigs (Case A). The wizard diagram is untested (`RebuildDiagram` / `ScrewDiagramItems` have zero test references), which is why it went unnoticed.
+
+## Durable fix (decouple the two angles)
+
+Keep the guidance consuming the response-convention angle (do not change), and make every **image-space display** convert to physical first (self-inverse `PhysicalToStoredAngle`):
+
+- **Diagram** — `RebuildDiagram` (`TiltAdapterWizardVM.cs:1938-1943`): convert each `ScrewNAngleDegrees` via `PhysicalToStoredAngle(angle, ScrewInwardCurvatureSign)` before plotting.
+- **Info panel** — `DataTemplates.xaml:181/185/189/204` binds raw stored angles (prints e.g. "210.0°"); needs a converter or a VM-exposed `PhysicalScrewNAngleDegrees` so it prints the physical angle.
+- **Regression test:** assert that a −1-rig calibration with a physically-top screw renders its `TiltScrewDiagramItem` at canvas-top (`Y ≈ 25 − 12`), not bottom.
+
+This makes the diagram/info panel always show physical image positions (matching their labels) while the guidance stays correct — resolving both reports. It does **not** change any tilt/backfocus math.
+
+Caveat: this fixes the *display*. The underlying user problem in the screenshot is still that the **direction is assumed wrong**; the guidance is only correct once the direction is measured/set. The display fix and the "measure your direction" guidance are complementary.
+
+## Evidence index
+
+`TiltScrewGeometry.cs:150,153-167,176-180` (sign anchor, default=+1, PhysicalToStoredAngle) · `TiltAdapterWizardVM.cs:841-849,1938-1949` (manual store, diagram) · `InspectorVM.cs:1901-1923` (guidance turns/arrows) · `TiltCalibrationCalculator.cs:231-238` (ComputeManualScrewAngles) · `TiltModel.cs:91-111` (B<0 for top-high; y-down) · `DataTemplates.xaml:156,167,181-204` (diagram labels, info panel) · commits `93c52dd` (additive anchor), `81ff1dd` (sign restricted to backfocus; manual-entry convention).

--- a/plans/tilt-calibration-confidence-and-replay-fidelity-plan.md
+++ b/plans/tilt-calibration-confidence-and-replay-fidelity-plan.md
@@ -1,0 +1,650 @@
+# Tilt Calibration — Confidence Surfacing & Replay Fidelity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface the tilt calibration's already-computed confidence (SNR, screw-direction σ, and a new pitch ±) in the wizard UI and persist it; and persist the measurement context so a saved run can be replayed faithfully (and drift warned).
+
+**Architecture:** Two phases. Phase 1 (presentation + persistence) adds a per-screw-move pitch uncertainty to the pure `TiltCalibrationCalculator`, retains the `TiltCalibrationConfidence` on the VM, exposes always-on display properties, renders them in the "Calibration Complete" panel, and persists a confidence block in `metadata.json`. Phase 2 (reproducibility) adds a `MeasurementContext` block to `TiltCalibrationMetadata`, captures it at save, and — on replay — restores the sensor-model focuser-size/f-ratio via a transient override and warns when the current profile drifts from the captured context. Both phases follow the plugin's existing patterns; no profile mutation.
+
+**Tech Stack:** C# / .NET 8 (windows), NUnit 4 + NSubstitute tests, CommunityToolkit.Mvvm, WPF/XAML, Newtonsoft.Json (camelCase). Design record: `docs/tilt-calibration-error-bounds-design.md` (§6, §7).
+
+**Design decisions locked (user-approved):** always-show a compact confidence line, escalate to the existing red "do not apply" warning at SNR<2; show a single global screw-direction σ (not per-screw — dof=1); show pitch ±; gate pitch reliability on the physical delta ratio; keep the hard SNR<2 apply-block.
+
+**Conventions:** run the full suite after every change: `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`. Commit with the privacy email per CLAUDE.md. On WSL, `dotnet` is `"/mnt/c/Program Files/dotnet/dotnet.exe"`.
+
+## File Structure
+
+**Phase 1**
+- Modify `Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs` — add `RecoverHardwareDetailed` + `TiltCalibrationResult.PitchUncertaintyMicrons`.
+- Modify `Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs` — add confidence fields to `TiltCalibrationResultRecord`; bump `CurrentSchemaVersion`.
+- Modify `Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs` — retain confidence + pitch σ; add display properties; persist in `FinalizeMetadata`.
+- Modify `Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml` — always-on confidence line + pitch ±.
+- Tests: `Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/{TiltCalibrationCalculatorTests,TiltCalibrationMetadataTests,TiltAdapterWizardVMTests}.cs`.
+
+**Phase 2**
+- Modify `TiltCalibrationMetadata.cs` — add `MeasurementContext` class + property.
+- Modify `TiltAdapterWizardVM.cs` — `CaptureMeasurementContext` helper + wire into `BuildInitialMetadata`; replay drift warning; transient focuser/fRatio override.
+- Modify `AutoFocus/InspectorVM.cs` — consult transient focuser-size/f-ratio overrides at the sensor-model call.
+- Tests: `TiltCalibrationMetadataTests.cs`, `TiltAdapterWizardVMTests.cs`.
+
+---
+
+# Phase 1 — Confidence surfacing & persistence
+
+### Task 1: Pitch uncertainty in the pure calculator
+
+**Files:**
+- Modify: `Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs` (`RecoverHardwareMicrons` 248-279; `TiltCalibrationResult` 69-90; `Calibrate` 297-322)
+- Test: `Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TiltCalibrationCalculatorTests.cs`:
+
+```csharp
+[Test]
+public void PitchUncertainty_IsHalfTheDifferenceOfPerScrewMoves() {
+    // Two single-screw moves of clearly unequal magnitude along different axes.
+    var inputs = new TiltCalibrationInputs {
+        ScrewCount = 3,
+        ReBaseline1 = new TiltGradient(0, 0, 0),
+        Screw1 = new TiltGradient(20, 0, 0),      // move along A
+        ReBaseline2 = new TiltGradient(0, 0, 0),
+        Screw2 = new TiltGradient(0, 10, 0),      // move along B
+        ImageWidthPixels = 6248, ImageHeightPixels = 4176,
+        PixelSizeMicrons = 3.76, FocuserStepMicrons = 3.6,
+        ScrewRadiusMillimeters = 44, CalibrationAppliedAmount = 1.0, IsStepperAdjustment = false
+    };
+    var (measured, d1, d2) = TiltCalibrationCalculator.RecoverHardwareDetailed(inputs);
+    Assert.Multiple(() => {
+        Assert.That(measured, Is.EqualTo(0.5 * (d1 + d2)).Within(1e-9));
+        var result = TiltCalibrationCalculator.Calibrate(inputs);
+        Assert.That(result.PitchUncertaintyMicrons, Is.EqualTo(Math.Abs(d1 - d2) / 2.0).Within(1e-9));
+        Assert.That(result.PitchUncertaintyMicrons, Is.GreaterThan(0));
+    });
+}
+
+[Test]
+public void PitchUncertainty_IsNaN_WhenHardwareUncomputable() {
+    var inputs = new TiltCalibrationInputs {
+        ScrewCount = 3, ScrewRadiusMillimeters = 0 /* invalid */,
+        CalibrationAppliedAmount = 1.0, PixelSizeMicrons = 3.76, FocuserStepMicrons = 3.6,
+        ImageWidthPixels = 6248, ImageHeightPixels = 4176
+    };
+    Assert.That(TiltCalibrationCalculator.Calibrate(inputs).PitchUncertaintyMicrons, Is.NaN);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `"/mnt/c/Program Files/dotnet/dotnet.exe" test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter PitchUncertainty`
+Expected: FAIL — `RecoverHardwareDetailed` and `PitchUncertaintyMicrons` don't exist (compile error).
+
+- [ ] **Step 3: Add the field to `TiltCalibrationResult`**
+
+In `TiltCalibrationCalculator.cs`, inside `TiltCalibrationResult` (after `MoveMagnitudeRatio`, ~line 85):
+
+```csharp
+        /// <summary>Half the absolute difference of the two single-screw recovered pitches (µm/turn or µm/step).
+        /// This is the physical-space 1σ on the recovered hardware — it captures screw-to-screw disagreement the
+        /// (A,B) <see cref="MoveMagnitudeRatio"/> misses because the plane→physical conversion is anisotropic.
+        /// NaN when the hardware is uncomputable.</summary>
+        public double PitchUncertaintyMicrons { get; set; }
+```
+
+- [ ] **Step 4: Add `RecoverHardwareDetailed` and delegate `RecoverHardwareMicrons` to it**
+
+Replace the body of `RecoverHardwareMicrons` (248-279) so the math lives in a detailed variant:
+
+```csharp
+        /// <summary>Per-screw recovered hardware: the average (µm/turn or µm/step) plus each screw's own recovered
+        /// value (delta_i / applied). Same math as the wizard's CalculateAndSaveHardware. All three are NaN when any
+        /// input is non-positive or the average is non-positive.</summary>
+        public static (double measured, double delta1PerApplied, double delta2PerApplied) RecoverHardwareDetailed(TiltCalibrationInputs inputs) {
+            double pixelSize = inputs.PixelSizeMicrons;
+            double fStep = inputs.FocuserStepMicrons;
+            double radiusMm = inputs.ScrewRadiusMillimeters;
+            double applied = inputs.CalibrationAppliedAmount;
+            double sensorW = inputs.ImageWidthPixels * pixelSize;
+            double sensorH = inputs.ImageHeightPixels * pixelSize;
+            if (radiusMm <= 0 || applied <= 0 || pixelSize <= 0 || fStep <= 0 || sensorW <= 0 || sensorH <= 0) {
+                return (double.NaN, double.NaN, double.NaN);
+            }
+            double radiusMicrons = radiusMm * 1000.0;
+            int n = inputs.ScrewCount;
+            double d1A = inputs.Screw1.A - inputs.ReBaseline1.A;
+            double d1B = inputs.Screw1.B - inputs.ReBaseline1.B;
+            double d2A = inputs.Screw2.A - inputs.ReBaseline2.A;
+            double d2B = inputs.Screw2.B - inputs.ReBaseline2.B;
+            var (g1x, g1y) = TiltScrewGeometry.PlaneGradientToPhysical(d1A, d1B, fStep, sensorW, sensorH);
+            var (g2x, g2y) = TiltScrewGeometry.PlaneGradientToPhysical(d2A, d2B, fStep, sensorW, sensorH);
+            double delta1 = TiltScrewGeometry.CalibrationAxialMoveMicrons(g1x, g1y, n, radiusMicrons);
+            double delta2 = TiltScrewGeometry.CalibrationAxialMoveMicrons(g2x, g2y, n, radiusMicrons);
+            double measured = 0.5 * (delta1 + delta2) / applied;
+            if (double.IsNaN(measured) || measured <= 0) {
+                return (double.NaN, double.NaN, double.NaN);
+            }
+            return (measured, delta1 / applied, delta2 / applied);
+        }
+
+        /// <summary>Recovers the adapter hardware (µm/turn for screws, µm/step for steppers). See
+        /// <see cref="RecoverHardwareDetailed"/>. NaN when uncomputable.</summary>
+        public static double RecoverHardwareMicrons(TiltCalibrationInputs inputs) => RecoverHardwareDetailed(inputs).measured;
+```
+
+- [ ] **Step 5: Set `PitchUncertaintyMicrons` in `Calibrate`**
+
+In `Calibrate` (297-322), replace `MeasuredHardwareMicrons = RecoverHardwareMicrons(inputs),` (line 316) with:
+
+```csharp
+                MeasuredHardwareMicrons = RecoverHardwareDetailed(inputs) is var (hw, hd1, hd2)
+                    ? hw : double.NaN,
+                PitchUncertaintyMicrons = RecoverHardwareDetailed(inputs) is var (_, pd1, pd2) && !double.IsNaN(pd1)
+                    ? Math.Abs(pd1 - pd2) / 2.0 : double.NaN,
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `"/mnt/c/Program Files/dotnet/dotnet.exe" test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter PitchUncertainty`
+Expected: PASS (2 tests). Then run the full suite to confirm no regressions.
+
+- [ ] **Step 7: Commit**
+
+```bash
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit -am "feat(tilt): expose per-screw pitch uncertainty from the calibration calculator" \
+  --author="George Hilios <322725+ghilios@users.noreply.github.com>"
+```
+
+### Task 2: Persist the confidence block in metadata.json
+
+**Files:**
+- Modify: `TiltCalibrationMetadata.cs` (`TiltCalibrationResultRecord` 53-62; `CurrentSchemaVersion` 73)
+- Modify: `TiltAdapterWizardVM.cs` (`FinalizeMetadata` 1909-1922)
+- Test: `TiltCalibrationMetadataTests.cs`
+
+- [ ] **Step 1: Write the failing round-trip test**
+
+Add to `TiltCalibrationMetadataTests.cs`:
+
+```csharp
+[Test]
+public void ResultRecord_RoundTripsConfidenceFields() {
+    var meta = new TiltCalibrationMetadata {
+        NumberOfScrews = 3, ScrewRadiusMillimeters = 44, PixelSizeMicrons = 3.76,
+        FocuserStepSizeMicrons = 3.6, CalibrationAppliedAmount = 1.0,
+        Calibration = new TiltCalibrationResultRecord {
+            Screw1AngleDegrees = 67.1, SignalToNoise = 2.16,
+            PredictedAngleUncertaintyDeg = 24.9, PitchUncertaintyMicrons = 43.0, ConfidenceIsReliable = true
+        }
+    };
+    var back = TiltCalibrationMetadata.Deserialize(meta.Serialize());
+    Assert.Multiple(() => {
+        Assert.That(back.Calibration.SignalToNoise, Is.EqualTo(2.16).Within(1e-9));
+        Assert.That(back.Calibration.PredictedAngleUncertaintyDeg, Is.EqualTo(24.9).Within(1e-9));
+        Assert.That(back.Calibration.PitchUncertaintyMicrons, Is.EqualTo(43.0).Within(1e-9));
+        Assert.That(back.Calibration.ConfidenceIsReliable, Is.True);
+    });
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `… --filter ResultRecord_RoundTripsConfidenceFields` → FAIL (fields don't exist).
+
+- [ ] **Step 3: Add fields to `TiltCalibrationResultRecord`**
+
+In `TiltCalibrationMetadata.cs`, inside `TiltCalibrationResultRecord` (after `MoveMagnitudeRatio`, ~line 61):
+
+```csharp
+        // ---- Confidence (persisted so a saved/replayed run carries its reliability) ----
+        public double SignalToNoise { get; set; } = double.NaN;
+        public double PredictedAngleUncertaintyDeg { get; set; } = double.NaN;
+        public double PitchUncertaintyMicrons { get; set; } = double.NaN;
+        public bool ConfidenceIsReliable { get; set; }
+```
+
+- [ ] **Step 4: Bump the schema version**
+
+In `TiltCalibrationMetadata.cs:73` change `public const int CurrentSchemaVersion = 1;` to `= 2;`.
+
+- [ ] **Step 5: Populate in `FinalizeMetadata`**
+
+In `TiltAdapterWizardVM.cs`, `FinalizeMetadata` (1909-1922), extend the `TiltCalibrationResultRecord` initializer with (using the VM fields added in Task 3):
+
+```csharp
+        SignalToNoise = lastConfidence?.SignalToNoise ?? double.NaN,
+        PredictedAngleUncertaintyDeg = lastConfidence?.PredictedAngleUncertaintyDeg ?? double.NaN,
+        PitchUncertaintyMicrons = pitchUncertaintyMicrons,
+        ConfidenceIsReliable = lastConfidence?.IsReliable ?? false,
+```
+
+(Task 3 introduces `lastConfidence` and `pitchUncertaintyMicrons`. If executing tasks strictly in order, do Task 3 before Step 5 compiles.)
+
+- [ ] **Step 6: Run round-trip test + full suite → PASS. Commit.**
+
+```bash
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit -am "feat(tilt): persist calibration confidence block in metadata.json (schema v2)" \
+  --author="George Hilios <322725+ghilios@users.noreply.github.com>"
+```
+
+### Task 3: Retain confidence on the VM and expose display properties
+
+**Files:**
+- Modify: `TiltAdapterWizardVM.cs` — fields near 115-120; `RunCalibrationMath` (1504, 1516); `RaiseHardwareSummaryChanged` 1530-1540; clear sites `Restart` 1376-1378, `ApplyManualCalibration` 862-864, `StartAsync` 995-1010.
+- Test: `TiltAdapterWizardVMTests.cs`
+
+- [ ] **Step 1: Write the failing VM test**
+
+Add to `TiltAdapterWizardVMTests.cs` (mirror existing seed-based tests — use `SeedStepReading` + the private calibration entry the other tests use; follow the pattern already used by `StepInstructionsText_*`/seed tests in this file):
+
+```csharp
+[Test]
+public void Confidence_DisplayProperties_PopulatedAfterCalibration() {
+    var (vm, _, _, _) = Build(screwCount: 3);
+    // Seed 6 step readings with a clean, unequal-enough pair so pitch σ > 0 (values in A,B plane units).
+    vm.SeedStepReading(WizardStep.Baseline, -9.5, 16.3, 7049);
+    vm.SeedStepReading(WizardStep.AllInward, -15.9, 14.5, 6957);
+    vm.SeedStepReading(WizardStep.ReBaseline1, -9.5, 16.3, 7049);
+    vm.SeedStepReading(WizardStep.Screw1, 11.7, 8.9, 7013);
+    vm.SeedStepReading(WizardStep.ReBaseline2, -9.5, 16.3, 7049);
+    vm.SeedStepReading(WizardStep.Screw2, -8.6, 40.3, 7016);
+    vm.RunCalibrationForTest(); // test seam added in Step 3
+    Assert.Multiple(() => {
+        Assert.That(vm.HasConfidenceInfo, Is.True);
+        Assert.That(vm.ConfidenceSummaryDisplay, Does.Contain("Signal-to-noise"));
+        Assert.That(vm.PitchUncertaintyDisplay, Does.Contain("±"));
+    });
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `… --filter Confidence_DisplayProperties_PopulatedAfterCalibration` → FAIL (members missing).
+
+- [ ] **Step 3: Add fields, a test seam, capture, properties, and clearing**
+
+In `TiltAdapterWizardVM.cs`:
+
+3a. Add fields next to `measuredHardwareMicrons` (~115-120):
+
+```csharp
+        private TiltCalibrationConfidence lastConfidence;
+        private double pitchUncertaintyMicrons = double.NaN;
+```
+
+3b. In `RunCalibrationMath`, replace the hardware line (1504) `double measured = TiltCalibrationCalculator.RecoverHardwareMicrons(inputs);` with:
+
+```csharp
+                var (measured, hwDelta1, hwDelta2) = TiltCalibrationCalculator.RecoverHardwareDetailed(inputs);
+                pitchUncertaintyMicrons = double.IsNaN(hwDelta1) ? double.NaN : Math.Abs(hwDelta1 - hwDelta2) / 2.0;
+```
+
+3c. In `RunCalibrationMath`, capture the confidence: change line 1516 from `EvaluateCalibrationConfidence(TiltCalibrationCalculator.ComputeConfidence(new TiltCalibrationInputs {` to compute-then-store:
+
+```csharp
+            lastConfidence = TiltCalibrationCalculator.ComputeConfidence(new TiltCalibrationInputs {
+                ScrewCount = screwCount,
+                Baseline = measuredCurvature ? new TiltGradient(a.A, a.B, a.Mean) : default,
+                AllInward = measuredCurvature ? new TiltGradient(b.A, b.B, b.Mean) : default,
+                ReBaseline1 = new TiltGradient(c.A, c.B, c.Mean),
+                Screw1 = new TiltGradient(d.A, d.B, d.Mean),
+                ReBaseline2 = new TiltGradient(e.A, e.B, e.Mean),
+                Screw2 = new TiltGradient(f.A, f.B, f.Mean),
+                HasCurvatureMeasurement = measuredCurvature,
+                FallbackCurvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign
+            });
+            EvaluateCalibrationConfidence(lastConfidence);
+```
+
+3d. Add display properties (near the other display properties, ~895-922):
+
+```csharp
+        public bool HasConfidenceInfo => lastConfidence != null;
+
+        public bool ConfidenceIsReliable => lastConfidence?.IsReliable ?? false;
+
+        public string ConfidenceSummaryDisplay =>
+            lastConfidence == null ? string.Empty :
+            $"Signal-to-noise {lastConfidence.SignalToNoise:F1} · screw-direction ±{lastConfidence.PredictedAngleUncertaintyDeg:F0}°";
+
+        public string PitchUncertaintyDisplay =>
+            double.IsNaN(pitchUncertaintyMicrons) ? string.Empty :
+            $"± {pitchUncertaintyMicrons:F0} µm/{(IsStepperAdjustment ? "step" : "turn")}";
+```
+
+3e. Add the raises to `RaiseHardwareSummaryChanged` (before the `OnUIThread(...)` line, ~1539):
+
+```csharp
+            RaisePropertyChanged(nameof(HasConfidenceInfo));
+            RaisePropertyChanged(nameof(ConfidenceIsReliable));
+            RaisePropertyChanged(nameof(ConfidenceSummaryDisplay));
+            RaisePropertyChanged(nameof(PitchUncertaintyDisplay));
+```
+
+3f. Clear in `Restart` (1376-1378), `ApplyManualCalibration` (862-864), and `StartAsync` (995-1010) — add alongside the existing `measuredHardwareMicrons = double.NaN;` resets:
+
+```csharp
+            lastConfidence = null;
+            pitchUncertaintyMicrons = double.NaN;
+```
+
+3g. Add the test seam near `SeedStepReading` (1624): a public wrapper that runs the same calibration entry the Complete step uses. Confirm the exact private method name in `NextStep` (1357 calls `RunCalibrationMath(...)`); expose:
+
+```csharp
+        // Test seam: run the calibration math over the seeded step readings (mirrors NextStep -> Complete).
+        internal void RunCalibrationForTest() => RunCalibrationMath(
+            tiltAdapterOptions.ScrewCount, tiltAdapterOptions.ScrewRadiusMillimeters,
+            profileService.ActiveProfile.CameraSettings.PixelSize, EffectiveFocuserStepMicrons(),
+            calibrationAppliedAmount, IsStepperAdjustment);
+```
+
+(Signature confirmed at 1439: `RunCalibrationMath(int screwCount, double radiusMm, double pixelSize, double fStep, double appliedAmount, bool isStepper)`.)
+
+- [ ] **Step 4: Run the VM test + full suite → PASS. Commit.**
+
+```bash
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit -am "feat(tilt): retain calibration confidence + pitch σ on the wizard VM" \
+  --author="George Hilios <322725+ghilios@users.noreply.github.com>"
+```
+
+### Task 4: Render confidence line + pitch ± in the Complete panel
+
+**Files:**
+- Modify: `TiltAdapterWizard/DataTemplates.xaml` — `HF_TiltScrewCalibrationInfo` (append after 261); measured-hardware block (1201-1204).
+- Verification: manual (XAML has no unit tests).
+
+- [ ] **Step 1: Add the always-on confidence line** to `HF_TiltScrewCalibrationInfo` (inside its root `StackPanel`, after the curvature row's closing tag ~line 261):
+
+```xml
+                <!--  Confidence summary — always shown once a calibration exists (SNR + screw-direction σ);
+                      the red do-not-apply warning (HasConfidenceWarning) still fires separately at SNR < 2.  -->
+                <TextBlock Margin="0,6,0,0" TextWrapping="Wrap"
+                    Text="{Binding ConfidenceSummaryDisplay}">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding HasConfidenceInfo}" Value="True">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+```
+
+- [ ] **Step 2: Add the pitch ±** next to `MeasuredHardwareDisplay` — extend the horizontal `StackPanel` (1201-1204) with a third `TextBlock` after `HardwareDeltaDisplay`:
+
+```xml
+                    <TextBlock Margin="8,0,0,0" Opacity="0.7" Text="{Binding PitchUncertaintyDisplay}" />
+```
+
+- [ ] **Step 3: Manual verification**
+
+Build the plugin (Debug installs it): `"/mnt/c/Program Files/dotnet/dotnet.exe" build Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Joko.NINA.Plugins.HocusFocus.csproj -c Debug --nologo`. In NINA, open the Tilt Adapter Wizard and run/replay a calibration; confirm the "Calibration Complete" panel shows "Signal-to-noise X.X · screw-direction ±NN°" and the measured hardware shows "± NN µm/turn". Confirm the red SNR<2 warning still appears when applicable.
+
+- [ ] **Step 4: Run full suite (unchanged) → PASS. Commit.**
+
+```bash
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit -am "feat(tilt): show confidence line and pitch ± in the Calibration Complete panel" \
+  --author="George Hilios <322725+ghilios@users.noreply.github.com>"
+```
+
+---
+
+# Phase 2 — Replay fidelity (measurement context)
+
+### Task 5: `MeasurementContext` metadata block
+
+**Files:**
+- Modify: `TiltCalibrationMetadata.cs` — add class + property.
+- Test: `TiltCalibrationMetadataTests.cs`
+
+- [ ] **Step 1: Write the failing round-trip test**
+
+```csharp
+[Test]
+public void MeasurementContext_RoundTrips() {
+    var meta = new TiltCalibrationMetadata {
+        NumberOfScrews = 3, ScrewRadiusMillimeters = 44, PixelSizeMicrons = 3.76,
+        FocuserStepSizeMicrons = 3.6, CalibrationAppliedAmount = 1.0,
+        MeasurementContext = new TiltMeasurementContext {
+            MicronsPerFocuserStep = 3.6, FocalRatio = 7, FocalLengthMm = 703,
+            UseRANSAC = true, FixedSensorCenter = false, AstigmaticCurvatureEnabled = false,
+            AcceptableRSquaredMin = 0.8, WeightedHyperbolicFitEnabled = true,
+            MaxOutlierRejections = 3, OutlierRejectionConfidence = 0.9,
+            HyperbolicFitModel = "Hybrid", SensorROI = 1.0, CornersROI = 1.0
+        }
+    };
+    var back = TiltCalibrationMetadata.Deserialize(meta.Serialize());
+    Assert.Multiple(() => {
+        Assert.That(back.MeasurementContext.MicronsPerFocuserStep, Is.EqualTo(3.6).Within(1e-9));
+        Assert.That(back.MeasurementContext.FocalRatio, Is.EqualTo(7).Within(1e-9));
+        Assert.That(back.MeasurementContext.HyperbolicFitModel, Is.EqualTo("Hybrid"));
+        Assert.That(back.MeasurementContext.UseRANSAC, Is.True);
+    });
+}
+```
+
+- [ ] **Step 2: Run → FAIL (`TiltMeasurementContext` missing).**
+
+- [ ] **Step 3: Add the class + property** in `TiltCalibrationMetadata.cs`:
+
+```csharp
+    /// <summary>Snapshot of the profile/inspector inputs the tilt measurement reads from live state, so a replay
+    /// can reproduce the original calibration (or warn when the current profile has drifted). HyperbolicFitModel
+    /// is stored as its enum name for forward-compatibility.</summary>
+    public sealed class TiltMeasurementContext {
+        public double MicronsPerFocuserStep { get; set; } = double.NaN;
+        public double FocalRatio { get; set; } = double.NaN;
+        public double FocalLengthMm { get; set; } = double.NaN;
+        public bool UseRANSAC { get; set; }
+        public bool FixedSensorCenter { get; set; }
+        public bool AstigmaticCurvatureEnabled { get; set; }
+        public double AcceptableRSquaredMin { get; set; } = double.NaN;
+        public bool WeightedHyperbolicFitEnabled { get; set; }
+        public int MaxOutlierRejections { get; set; }
+        public double OutlierRejectionConfidence { get; set; } = double.NaN;
+        public string HyperbolicFitModel { get; set; }
+        public double SensorROI { get; set; } = double.NaN;
+        public double CornersROI { get; set; } = double.NaN;
+    }
+```
+
+And add to `TiltCalibrationMetadata` in the replay-payload region (after `OptimizedStarDetectionSettings`, ~line 106):
+
+```csharp
+        public TiltMeasurementContext MeasurementContext { get; set; }
+```
+
+- [ ] **Step 4: Run round-trip test + full suite → PASS. Commit.**
+
+```bash
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit -am "feat(tilt): add MeasurementContext to tilt calibration metadata" \
+  --author="George Hilios <322725+ghilios@users.noreply.github.com>"
+```
+
+### Task 6: Capture the measurement context at save
+
+**Files:**
+- Modify: `TiltAdapterWizardVM.cs` — `CaptureMeasurementContext` helper; `BuildInitialMetadata` 1046-1061.
+- Test: `TiltAdapterWizardVMTests.cs`
+
+- [ ] **Step 1: Write the failing test** (a static, dependency-injected capture helper is testable without the VM):
+
+```csharp
+[Test]
+public void CaptureMeasurementContext_ReadsInspectorAndProfileValues() {
+    var inspector = Substitute.For<IInspectorOptions>();
+    inspector.MicronsPerFocuserStep.Returns(3.6);
+    inspector.UseRANSAC.Returns(true);
+    inspector.AcceptableRSquaredMin.Returns(0.8);
+    inspector.SensorROI.Returns(1.0); inspector.CornersROI.Returns(1.0);
+    var af = Substitute.For<IAutoFocusOptions>();
+    af.WeightedHyperbolicFitEnabled.Returns(true);
+    af.MaxOutlierRejections.Returns(3);
+    af.OutlierRejectionConfidence.Returns(0.9);
+    af.HyperbolicFitModel.Returns(HyperbolicFitModel.Hybrid);
+
+    var ctx = TiltAdapterWizardVM.CaptureMeasurementContext(inspector, af, fRatio: 7, focalLengthMm: 703);
+
+    Assert.Multiple(() => {
+        Assert.That(ctx.MicronsPerFocuserStep, Is.EqualTo(3.6));
+        Assert.That(ctx.FocalRatio, Is.EqualTo(7));
+        Assert.That(ctx.HyperbolicFitModel, Is.EqualTo("Hybrid"));
+        Assert.That(ctx.UseRANSAC, Is.True);
+    });
+}
+```
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Add the static helper** in `TiltAdapterWizardVM.cs` (near `BuildInitialMetadata`):
+
+```csharp
+        // Snapshot the live inputs the sensor-model measurement reads, so a replay can restore or warn on drift.
+        internal static TiltMeasurementContext CaptureMeasurementContext(
+            IInspectorOptions inspector, IAutoFocusOptions af, double fRatio, double focalLengthMm) {
+            return new TiltMeasurementContext {
+                MicronsPerFocuserStep = inspector.MicronsPerFocuserStep,
+                FocalRatio = fRatio,
+                FocalLengthMm = focalLengthMm,
+                UseRANSAC = inspector.UseRANSAC,
+                FixedSensorCenter = inspector.FixedSensorCenter,
+                AstigmaticCurvatureEnabled = inspector.AstigmaticCurvatureEnabled,
+                AcceptableRSquaredMin = inspector.AcceptableRSquaredMin,
+                WeightedHyperbolicFitEnabled = af.WeightedHyperbolicFitEnabled,
+                MaxOutlierRejections = af.MaxOutlierRejections,
+                OutlierRejectionConfidence = af.OutlierRejectionConfidence,
+                HyperbolicFitModel = af.HyperbolicFitModel.ToString(),
+                SensorROI = inspector.SensorROI,
+                CornersROI = inspector.CornersROI
+            };
+        }
+```
+
+- [ ] **Step 4: Wire into `BuildInitialMetadata`** (add to the initializer, after `OptimizedStarDetectionSettings = CaptureDetectionSettings(),`):
+
+```csharp
+        MeasurementContext = CaptureMeasurementContext(
+            inspector.InspectorOptions, HocusFocusPlugin.AutoFocusOptions,
+            profileService.ActiveProfile.TelescopeSettings.FocalRatio,
+            profileService.ActiveProfile.TelescopeSettings.FocalLength),
+```
+
+`HocusFocusPlugin.AutoFocusOptions` (static `IAutoFocusOptions`) is the AF-options accessor — the same singleton pattern `CaptureDetectionSettings()` uses for `HocusFocusPlugin.StarDetectionOptions`.
+
+- [ ] **Step 5: Run test + full suite → PASS. Commit.**
+
+```bash
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit -am "feat(tilt): capture measurement context when saving a calibration run" \
+  --author="George Hilios <322725+ghilios@users.noreply.github.com>"
+```
+
+### Task 7: Replay — restore focuser size/f-ratio + warn on drift
+
+**Files:**
+- Modify: `AutoFocus/InspectorVM.cs` — transient overrides consulted at 578/592.
+- Modify: `TiltAdapterWizardVM.cs` — `ReplayAsync` 1638-1829; a static drift-compare helper.
+- Test: `TiltAdapterWizardVMTests.cs` (drift helper only; the inspector wiring is manual).
+
+- [ ] **Step 1: Write the failing drift-helper test**
+
+```csharp
+[Test]
+public void MeasurementContextDrift_ListsChangedFields() {
+    var captured = new TiltMeasurementContext { MicronsPerFocuserStep = 3.6, FocalRatio = 7, UseRANSAC = true };
+    var current  = new TiltMeasurementContext { MicronsPerFocuserStep = 0.26, FocalRatio = 7, UseRANSAC = true };
+    var drift = TiltAdapterWizardVM.DescribeMeasurementContextDrift(captured, current);
+    Assert.Multiple(() => {
+        Assert.That(drift, Does.Contain("MicronsPerFocuserStep"));
+        Assert.That(drift, Does.Not.Contain("FocalRatio"));
+    });
+}
+```
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Add the drift helper** in `TiltAdapterWizardVM.cs`:
+
+```csharp
+        // Human-readable list of context fields that differ between capture and the current profile (empty if none).
+        internal static string DescribeMeasurementContextDrift(TiltMeasurementContext captured, TiltMeasurementContext current) {
+            if (captured == null || current == null) return string.Empty;
+            var diffs = new List<string>();
+            void D(string name, double a, double b) { if (!(double.IsNaN(a) && double.IsNaN(b)) && Math.Abs(a - b) > 1e-9) diffs.Add($"{name} ({a:0.###} → {b:0.###})"); }
+            void B(string name, bool a, bool b) { if (a != b) diffs.Add($"{name} ({a} → {b})"); }
+            D("MicronsPerFocuserStep", captured.MicronsPerFocuserStep, current.MicronsPerFocuserStep);
+            D("FocalRatio", captured.FocalRatio, current.FocalRatio);
+            D("AcceptableRSquaredMin", captured.AcceptableRSquaredMin, current.AcceptableRSquaredMin);
+            B("UseRANSAC", captured.UseRANSAC, current.UseRANSAC);
+            B("FixedSensorCenter", captured.FixedSensorCenter, current.FixedSensorCenter);
+            B("WeightedHyperbolicFit", captured.WeightedHyperbolicFitEnabled, current.WeightedHyperbolicFitEnabled);
+            if (!string.Equals(captured.HyperbolicFitModel, current.HyperbolicFitModel, StringComparison.Ordinal))
+                diffs.Add($"HyperbolicFitModel ({captured.HyperbolicFitModel} → {current.HyperbolicFitModel})");
+            return string.Join(", ", diffs);
+        }
+```
+
+- [ ] **Step 4: Add transient sensor-model overrides in `InspectorVM.cs`**
+
+Add public nullable transients (near `ForceSensorCurveModelGeneration` 552):
+
+```csharp
+        // Transient replay overrides for the sensor-model inputs otherwise read live (null = use profile/inspector).
+        public double? SensorModelFocuserSizeOverrideMicrons { get; set; }
+        public double? SensorModelFRatioOverride { get; set; }
+```
+
+Consult them at the sensor-model call. Change line 578 to `double focuserSizeMicrons = SensorModelFocuserSizeOverrideMicrons ?? InspectorOptions.MicronsPerFocuserStep;` and line 592's `fRatio:` argument to `fRatio: SensorModelFRatioOverride ?? profileService.ActiveProfile.TelescopeSettings.FocalRatio,`.
+
+- [ ] **Step 5: Set/clear the overrides + warn in `ReplayAsync`**
+
+In `TiltAdapterWizardVM.cs` `ReplayAsync`, when `mode.ApplyCaptureTimeOverridePerStep` and `metadata.MeasurementContext != null`, before the replay loop (1735) set the inspector overrides from the captured context, and restore them in a `finally`:
+
+```csharp
+        var ctx = metadata.MeasurementContext;
+        var prevFocuserOverride = inspector.SensorModelFocuserSizeOverrideMicrons;
+        var prevFRatioOverride = inspector.SensorModelFRatioOverride;
+        if (mode.ApplyCaptureTimeOverridePerStep && ctx != null) {
+            if (!double.IsNaN(ctx.MicronsPerFocuserStep) && ctx.MicronsPerFocuserStep > 0)
+                inspector.SensorModelFocuserSizeOverrideMicrons = ctx.MicronsPerFocuserStep;
+            if (!double.IsNaN(ctx.FocalRatio) && ctx.FocalRatio > 0)
+                inspector.SensorModelFRatioOverride = ctx.FocalRatio;
+            var currentCtx = CaptureMeasurementContext(inspector.InspectorOptions, HocusFocusPlugin.AutoFocusOptions,
+                profileService.ActiveProfile.TelescopeSettings.FocalRatio,
+                profileService.ActiveProfile.TelescopeSettings.FocalLength);
+            var drift = DescribeMeasurementContextDrift(ctx, currentCtx);
+            if (!string.IsNullOrEmpty(drift))
+                Notification.ShowWarning($"Replaying with captured measurement settings; your current profile differs: {drift}.");
+        }
+```
+
+Wrap the existing replay `foreach` in `try { … } finally { inspector.SensorModelFocuserSizeOverrideMicrons = prevFocuserOverride; inspector.SensorModelFRatioOverride = prevFRatioOverride; }`.
+
+- [ ] **Step 6: Run drift test + full suite → PASS.**
+
+- [ ] **Step 7: Manual verification**
+
+Build the plugin. In NINA, replay `TiltCalibration_20260705_120026` with "use captured/stored settings" under a profile whose inspector `MicronsPerFocuserStep` ≠ the captured value; confirm the drift warning lists `MicronsPerFocuserStep`, and that the calibration now uses the captured focuser size (angles unchanged — they are focuser-step-independent — but the sensor-model log shows the captured value).
+
+- [ ] **Step 8: Commit**
+
+```bash
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit -am "feat(tilt): restore captured focuser size/f-ratio on replay and warn on profile drift" \
+  --author="George Hilios <322725+ghilios@users.noreply.github.com>"
+```
+
+---
+
+## Notes / follow-ups (out of scope here)
+
+- **Full fit-option restore.** This plan restores focuser size + f-ratio and *warns* on the remaining drift (RANSAC/weighting/ROI/etc.). Transiently applying every fit option during replay (so a replay bit-reproduces capture) is a larger change — track separately if bit-exact replay is required.
+- **TestApp `tilt`** could consume `MeasurementContext` + the logged tilt planes to reproduce the wizard headlessly (it currently cannot on bayered runs); separate from this plan.


### PR DESCRIPTION
## Summary

Surfaces the Tilt Adapter Wizard's already-computed calibration **confidence** in the UI and persists it, and adds **replay fidelity** so a saved run can be reproduced faithfully (and warns when the current profile has drifted). Implements `plans/tilt-calibration-confidence-and-replay-fidelity-plan.md` (design: `docs/tilt-calibration-error-bounds-design.md`).

### Phase 1 — Confidence surfacing & persistence
- **Calculator:** `TiltCalibrationCalculator.RecoverHardwareDetailed` exposes each screw's recovered pitch; `TiltCalibrationResult.PitchUncertaintyMicrons` = ½·|Δ| of the two single-screw moves (physical-space 1σ the `MoveMagnitudeRatio` misses).
- **Persistence:** confidence block (SNR, screw-direction σ, pitch σ, reliability) added to `TiltCalibrationResultRecord` in `metadata.json` (schema v2), populated from the VM at save.
- **VM:** the calibration confidence + pitch σ are retained on the wizard VM with always-on display properties (`HasConfidenceInfo`, `ConfidenceSummaryDisplay`, `PitchUncertaintyDisplay`).
- **UI:** the "Calibration Complete" panel shows a compact confidence line (`Signal-to-noise X.X · screw-direction ±NN°`) and appends the pitch ± to the measured-hardware row. The existing red "do-not-apply" warning (SNR < 2) still fires independently.

### Phase 2 — Replay fidelity (measurement context)
- **Metadata:** new `TiltMeasurementContext` block snapshots the profile/inspector inputs the sensor-model measurement reads from live state (focuser step, f-ratio, RANSAC/weighting/ROI/fit-model, …), captured at save.
- **Replay:** when replaying with captured settings, the sensor-model focuser size + f-ratio are restored via transient `InspectorVM` overrides (no profile mutation; restored in `finally`), and a drift warning lists any context fields that differ from the current profile.

## Testing
- Full unit suite green after every task — **1705 passing, 0 failing** at the tip.
- Two manual verifications in NINA (per plan): (1) confidence line + pitch ± render correctly in the Complete panel and the red SNR<2 warning is preserved; (2) replay with captured settings shows the drift warning and uses the captured focuser size (angles unchanged — they're focuser-step-independent), with the profile left untouched afterward.

## Notes for reviewers
- **Two incidental UI fixes surfaced during manual verification** of Phase 1:
  - The always-on confidence line was relocated from the shared `HF_TiltScrewCalibrationInfo` sub-template into Panel C directly — inside the `ContentControl`-hosted sub-template it didn't surface; and it now uses `PrimaryBrush` so it's legible in the dark theme.
  - `fix(controls)`: `IconizedText` now binds the inline rotation-icon fill to the TextBlock's `Foreground` instead of snapshotting it (the snapshot froze to near-black before the theme brush resolved). Fixes a pre-existing dark-theme visibility bug for the ⟳/⟲ glyph in the tilt wizard **and** the AF tilt-guidance panel.
- **Two pre-existing working-tree changes** unrelated to the plan were committed separately at the base of the branch to keep the task commits clean: `fix(tilt): name the exact screw count in wizard Baseline instructions` and `feat(testapp): add --debayer …`.
- A `TiltMeasurementContext` for replay is added only where testable/needed; a test-only seam (`RunCalibrationForTest`, `CalibrationTiltPlaneOverrideForTest`) was added so the VM confidence/pitch path is exercised without the inspector pipeline. Production behavior is byte-for-byte unchanged (overrides are null in production).

## Out of scope (tracked as follow-ups in the plan)
- Bit-exact replay of every fit option (this restores focuser size + f-ratio and *warns* on the rest).
- Headless `TestApp tilt` consuming `MeasurementContext` on bayered runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
