### PR TITLE
fix(tilt): reproducible tilt calibration replay (full detection snapshot + overlay parity)

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -5,6 +5,7 @@ using NINA.Equipment.Interfaces.Mediator;
 using NINA.Image.ImageAnalysis;
 using NINA.Image.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
 using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
@@ -15,7 +16,12 @@ using NSubstitute;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
+// Import just the one type — the StarDetection.Optimization namespace also defines a WizardStep that would
+// collide with TiltAdapterWizard.WizardStep used elsewhere in this fixture.
+using OptimizedStarDetectionSettings = NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.OptimizedStarDetectionSettings;
 
 namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
 
@@ -886,6 +892,58 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 Assert.That(drift, Does.Contain("MicronsPerFocuserStep"));
                 Assert.That(drift, Does.Not.Contain("FocalRatio"));
             });
+        }
+
+        [Test]
+        public void OverlayOptimizedSettings_AppliesEveryCuratedKnob_SoTheReplayOverlayCannotDriftFromTheDto() {
+            // Reproducibility guard: every detection knob a run persists in OptimizedStarDetectionSettings must be
+            // reapplied by the tilt replay overlay. A knob present in the DTO but missing from OverlayOptimizedSettings
+            // silently leaks the live-profile value on replay — the LocallyAdaptiveBinarization / AdaptiveNoiseBlockSize
+            // regression that made a replayed calibration disagree with the run it was captured from.
+            var metadataOnly = new HashSet<string> {
+                nameof(OptimizedStarDetectionSettings.CreatedAtUtc),
+                nameof(OptimizedStarDetectionSettings.RunCount),
+                nameof(OptimizedStarDetectionSettings.BaselineJ),
+                nameof(OptimizedStarDetectionSettings.FinalJ),
+                nameof(OptimizedStarDetectionSettings.RecommendedStepSize),
+                nameof(OptimizedStarDetectionSettings.RecommendedOffsetSteps),
+                nameof(OptimizedStarDetectionSettings.SchemaVersion),
+            };
+            var curatedKnobs = typeof(OptimizedStarDetectionSettings)
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(p => p.CanRead && p.CanWrite && !metadataOnly.Contains(p.Name))
+                .ToList();
+            Assert.That(curatedKnobs, Is.Not.Empty, "Expected OptimizedStarDetectionSettings to expose curated knobs");
+
+            // Give each knob a sentinel that differs from a fresh snapshot's default (bools default false, ints default
+            // 0 except AdaptiveNoiseBlockSize=128, doubles default 0.0), so a copied knob is provably distinguishable
+            // from one the overlay left untouched.
+            var dto = new OptimizedStarDetectionSettings();
+            for (int i = 0; i < curatedKnobs.Count; i++) {
+                curatedKnobs[i].SetValue(dto, SentinelFor(curatedKnobs[i].PropertyType, i));
+            }
+
+            var snapshot = new StarDetectionSettingsSnapshot();
+            TiltAdapterWizardVM.OverlayOptimizedSettings(snapshot, dto);
+
+            var snapshotType = typeof(StarDetectionSettingsSnapshot);
+            Assert.Multiple(() => {
+                foreach (var knob in curatedKnobs) {
+                    var snapProp = snapshotType.GetProperty(knob.Name, BindingFlags.Public | BindingFlags.Instance);
+                    Assert.That(snapProp, Is.Not.Null, $"StarDetectionSettingsSnapshot has no '{knob.Name}' to receive the curated knob");
+                    if (snapProp != null) {
+                        Assert.That(snapProp.GetValue(snapshot), Is.EqualTo(knob.GetValue(dto)),
+                            $"OverlayOptimizedSettings did not copy '{knob.Name}' onto the replay snapshot");
+                    }
+                }
+            });
+        }
+
+        private static object SentinelFor(Type type, int index) {
+            if (type == typeof(bool)) return true;              // fresh snapshot bools default to false
+            if (type == typeof(int)) return 1000 + index;       // != 0 and != AdaptiveNoiseBlockSize's 128 default
+            if (type == typeof(double)) return 100.0 + index;   // != 0.0
+            throw new NotSupportedException($"Add a sentinel for curated knob type {type} in the OverlayOptimizedSettings guard test");
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -939,6 +939,21 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             });
         }
 
+        [Test]
+        public void BuildTiltReplayDetectionOverride_PrefersRunLevelFullSnapshot_OverCuratedOverlay() {
+            // A run that stored the full snapshot pins detection directly from it, instead of overlaying only the
+            // curated subset onto the live profile. (Tilt captures never emit per-step AutoFocusReplayMetadata, so
+            // this run-level snapshot is the effective full-pin path for tilt replays.)
+            var fullSnapshot = new StarDetectionSettingsSnapshot { BrightnessSensitivity = 42, LocallyAdaptiveBinarization = true };
+            var metadata = new TiltCalibrationMetadata { StarDetectionSnapshot = fullSnapshot };
+            // A folder with no AutoFocus replay metadata.json, so the per-step branch is skipped.
+            var noPerStepMetadata = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "hf-tilt-no-replay-metadata");
+
+            var result = TiltAdapterWizardVM.BuildTiltReplayDetectionOverride(noPerStepMetadata, metadata);
+
+            Assert.That(result, Is.SameAs(fullSnapshot));
+        }
+
         private static object SentinelFor(Type type, int index) {
             if (type == typeof(bool)) return true;              // fresh snapshot bools default to false
             if (type == typeof(int)) return 1000 + index;       // != 0 and != AdaptiveNoiseBlockSize's 128 default

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationMetadataTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationMetadataTests.cs
@@ -1,3 +1,4 @@
+using NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay;
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
 using NUnit.Framework;
 using System;
@@ -166,6 +167,24 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             // A folder on a different volume can't be made relative; keep it absolute rather than emit "..\..".
             var other = @"D:\external\01_Baseline\AutoFocus_x";
             Assert.That(TiltCalibrationMetadata.ToRelativeStepFolder(@"C:\runs\run1", other), Is.EqualTo(other));
+        }
+
+        [Test]
+        public void StarDetectionSnapshot_RoundTrips() {
+            var meta = new TiltCalibrationMetadata {
+                NumberOfScrews = 3, ScrewRadiusMillimeters = 44, PixelSizeMicrons = 3.76,
+                FocuserStepSizeMicrons = 3.6, CalibrationAppliedAmount = 1.0,
+                StarDetectionSnapshot = new StarDetectionSettingsSnapshot {
+                    BrightnessSensitivity = 42.5, LocallyAdaptiveBinarization = true, AdaptiveNoiseBlockSize = 256
+                }
+            };
+            var back = TiltCalibrationMetadata.Deserialize(meta.Serialize());
+            Assert.That(back.StarDetectionSnapshot, Is.Not.Null);
+            Assert.Multiple(() => {
+                Assert.That(back.StarDetectionSnapshot.BrightnessSensitivity, Is.EqualTo(42.5).Within(1e-9));
+                Assert.That(back.StarDetectionSnapshot.LocallyAdaptiveBinarization, Is.True);
+                Assert.That(back.StarDetectionSnapshot.AdaptiveNoiseBlockSize, Is.EqualTo(256));
+            });
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -1075,6 +1075,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     inspector.InspectorOptions, HocusFocusPlugin.AutoFocusOptions,
                     profileService.ActiveProfile.TelescopeSettings.FocalRatio,
                     profileService.ActiveProfile.TelescopeSettings.FocalLength),
+                // Full detection config so a replay pins every knob, not just the curated OptimizedStarDetectionSettings.
+                StarDetectionSnapshot = StarDetectionSettingsSnapshot.FromOptions(HocusFocusPlugin.StarDetectionOptions),
                 RunStepMapping = new List<TiltRunStepMapping>(),
                 PerStep = new List<TiltPerStepResult>()
             };
@@ -1940,15 +1942,21 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         }
 
         /// <summary>
-        /// Builds a detached, in-memory capture-time star-detection snapshot for the no-mutation tilt replay. Prefers
-        /// the full per-step replay <c>metadata.json</c> (runs captured after that feature shipped); falls back, for
-        /// older tilt runs, to overlaying the curated <see cref="OptimizedStarDetectionSettings"/> onto a snapshot of
-        /// the current options — reproducing the legacy "apply optimized settings" behavior without mutating the
-        /// profile. Returns null when there is nothing to override (the replay then uses current settings).
+        /// Builds a detached, in-memory capture-time star-detection override for the no-mutation tilt replay.
+        /// Resolution order: a per-step replay <c>metadata.json</c> if present (tilt captures don't currently emit
+        /// one); then the run-level full <see cref="TiltCalibrationMetadata.StarDetectionSnapshot"/>, which pins every
+        /// knob; then, for older runs, overlaying the curated <see cref="OptimizedStarDetectionSettings"/> onto a
+        /// snapshot of the current options (legacy "apply optimized settings" behavior, without mutating the profile).
+        /// Returns null when there is nothing to override (the replay then uses current settings).
         /// </summary>
-        private static IStarDetectionOptions BuildTiltReplayDetectionOverride(string stepFolder, TiltCalibrationMetadata tiltMetadata) {
+        internal static IStarDetectionOptions BuildTiltReplayDetectionOverride(string stepFolder, TiltCalibrationMetadata tiltMetadata) {
             if (AutoFocusReplayMetadata.TryLoad(stepFolder, out var replayMetadata, out _) && replayMetadata.StarDetection != null) {
                 return replayMetadata.StarDetection;
+            }
+            // Run-level full snapshot (all 53 knobs) — the effective full-pin path, since tilt captures don't emit
+            // per-step replay metadata. Preferred over the curated overlay so no non-curated knob leaks from the profile.
+            if (tiltMetadata?.StarDetectionSnapshot != null) {
+                return tiltMetadata.StarDetectionSnapshot;
             }
             var optimized = tiltMetadata?.OptimizedStarDetectionSettings;
             if (optimized == null) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -1961,8 +1961,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         // Overlays the curated optimized-settings subset onto a snapshot, mirroring
         // StarDetectionOptions.ApplyOptimizedSnapshotToLiveProperties (the curated knobs win; the rest keep the
-        // snapshot's current-options values).
-        private static void OverlayOptimizedSettings(StarDetectionSettingsSnapshot snapshot, OptimizedStarDetectionSettings s) {
+        // snapshot's current-options values). Internal so OverlayOptimizedSettings_AppliesEveryCuratedKnob can guard
+        // it against silently dropping a knob that OptimizedStarDetectionSettings persists.
+        internal static void OverlayOptimizedSettings(StarDetectionSettingsSnapshot snapshot, OptimizedStarDetectionSettings s) {
             snapshot.BrightnessSensitivity = s.BrightnessSensitivity;
             snapshot.StarClippingMultiplier = s.StarClippingMultiplier;
             snapshot.NoiseClippingMultiplier = s.NoiseClippingMultiplier;
@@ -1983,6 +1984,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             snapshot.StructureLayerBoost = s.StructureLayerBoost;
             snapshot.DefocusAwareDonutDetection = s.DefocusAwareDonutDetection;
             snapshot.DonutMorphCloseSize = s.DonutMorphCloseSize;
+            snapshot.LocallyAdaptiveBinarization = s.LocallyAdaptiveBinarization;
+            snapshot.AdaptiveNoiseBlockSize = s.AdaptiveNoiseBlockSize;
             snapshot.DonutMinAnnularityHoleFraction = s.DonutMinAnnularityHoleFraction;
             snapshot.DonutMaxStreakEccentricity = s.DonutMaxStreakEccentricity;
             snapshot.DonutSaturationBloomRadius = s.DonutSaturationBloomRadius;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
@@ -12,6 +12,7 @@
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay;
 using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
 using System;
 using System.Collections.Generic;
@@ -130,6 +131,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public List<TiltRunStepMapping> RunStepMapping { get; set; }
         public OptimizedStarDetectionSettings OptimizedStarDetectionSettings { get; set; }
         public TiltMeasurementContext MeasurementContext { get; set; }
+
+        // Full capture-time star-detection configuration (all knobs, not just the curated optimizer subset), so a
+        // replay pins detection exactly. Null on runs saved before this shipped — they fall back to the curated
+        // OptimizedStarDetectionSettings overlay. Settings are constant across a run, so one run-level snapshot suffices.
+        public StarDetectionSettingsSnapshot StarDetectionSnapshot { get; set; }
 
         // ---- Results ----
         public List<TiltPerStepResult> PerStep { get; set; }

--- a/docs/tilt-replay-reproducibility-design.md
+++ b/docs/tilt-replay-reproducibility-design.md
@@ -1,0 +1,150 @@
+# Tilt Calibration Replay Reproducibility — Design
+
+## Problem
+
+Two people replayed the **same** saved tilt-calibration run
+(`TiltCalibration_20260705_120026`, a 3-screw adapter) and got materially different "Calibration
+Complete" results:
+
+| | Screw 1 | measured µm/turn (nominal 400) | quality warning |
+|---|---|---|---|
+| astrodet (v4.0.0.1) | 81.9° | 523 (+30.8%) | unequal moves, gap 17.7° |
+| local (dev) | 67.1° | 418.7 (+4.7%) | none |
+| saved `calibration` block in the folder | 66.0° | 352 | (ratio 5.48 → would warn) |
+
+Worse, the folder **cannot reproduce its own saved numbers**, and astrodet's *own* machine
+produced two different answers (66.0° and 81.9°) from the same frames at different points in one
+session. A replay is expected to be deterministic; it is not.
+
+## How the wizard actually "replays"
+
+The replay does **not** re-use the saved per-step tilt planes. For each step it re-runs the entire
+measurement pipeline on the saved FITS:
+
+```
+star detection  →  RANSAC alignment across the focus sweep  →  per-star focus curves
+              →  paraboloid sensor-model fit (SensorModel.FitParaboloidModel)
+              →  tilt plane A/B  →  screw angles / µm-per-turn / warning (TiltCalibrationCalculator)
+```
+
+Entry point: `TiltAdapterWizardVM` replay loop → `inspector.AnalyzeAutoFocusFromSavedPath(folder, token, detectionOverride)`.
+
+The **only immutable input is the FITS pixels.** Everything else — star-detection settings, focuser
+step size, f-ratio — is read from live state at replay time unless explicitly pinned.
+
+### Units (why angles and µm/turn behave differently)
+
+`CreateTiltPlaneModel` builds the plane from `sensorModel.TiltAt(±w/2, ±h/2) / focuserStepSizeMicrons`,
+so **A/B are in focuser _steps_** and the fit's focuser size cancels out of them. Consequences:
+
+- **Screw angles** = `atan2(A, −B)` on per-step A/B deltas → depend only on the **star set** (the
+  direction of each screw's tilt change). Invariant to focuser step and pixel size.
+- **Measured µm/turn** = `0.5·(δ1+δ2)/applied`, `δ = |ΔG|·leverArm` → scales linearly with the
+  **geometry focuser step** used in `RunCalibrationMath`, on top of the star-set magnitude.
+- **f-ratio does not enter the gradient at all** (`SensorParaboloidSolver` never takes it); it only
+  scales downstream physical-effect microns. It is a red herring for angles and µm/turn.
+
+So a wrong star set rotates the angles *and* rescales µm/turn; a wrong focuser step rescales µm/turn
+only.
+
+## Root cause
+
+The recovered tilt is dominated by **which stars the detector admits**, and the detector's star set
+is not pinned to capture time. Evidence from astrodet's NINA log, same `04_Screw1` frame:
+
+| run | detected → in-fit stars | paraboloid RMS / GoD | result |
+|---|---|---|---|
+| tight | 1055 → 590 | 10.3 µm / 0.97 | 66.0° / 352 µm |
+| permissive | 2132 → 1434 | 56.0 µm / 0.82 | 81.9° / 523 µm |
+
+The permissive pass roughly **doubled** the star count with low-SNR/spurious detections (RANSAC
+putative-match fractions fell to 2–8%), which **quintupled the fit RMS** and corrupted the tilt
+plane — most visibly for the weak screw-2 signal in this dataset. Both runs are the same machine,
+same plugin build, same f-ratio; only the detection differed.
+
+Pinning is incomplete in three layers:
+
+1. **The pipeline re-detects rather than replaying stored stars.** Nothing records the actual stars
+   used at capture, so the answer is only as reproducible as the detection settings.
+2. **The persisted `optimizedStarDetectionSettings` is a curated subset** — 25 of the 53 knobs in the
+   full `StarDetectionSettingsSnapshot`. The remaining ~28 (the `UseAdvanced`/`UseOptimizedSettings`
+   mode flags, the `Simple_*` preset baseline the curated knobs overlay onto, contamination
+   rejection, PSF/HFR fitting, structure dilation, saturation handling) are read live from the
+   replaying profile.
+3. **The legacy overlay dropped two curated knobs it did have** —
+   `LocallyAdaptiveBinarization` and `AdaptiveNoiseBlockSize` were absent from
+   `TiltAdapterWizardVM.OverlayOptimizedSettings`, though the canonical
+   `StarDetectionOptions.ApplyOptimizedSnapshotToLiveProperties` applies them and the metadata stores
+   them. Adaptive binarization is exactly the switch that halves/doubles detected-star count in
+   vignetted/gradient fields, so an unpinned value is high-leverage. **(Fixed — see below.)**
+
+Focuser step adds an orthogonal µm/turn-only error for legacy folders: those predate the
+`MeasurementContext` capture, so on replay the sensor-model focuser size falls back to the live
+`InspectorOptions.MicronsPerFocuserStep` rather than the captured 3.6.
+
+Newer runs are already better off: runs captured after the replay-metadata feature write a per-step
+`AutoFocusReplayMetadata.StarDetection` holding the **full** 53-field snapshot, and
+`BuildTiltReplayDetectionOverride` prefers it. astrodet's folder predates that, so it falls back to
+the curated overlay.
+
+## Operational guidance (until reproducibility is fully fixed)
+
+For the specific run above, the local result is the accurate one because its detector kept only real
+stars. To get the clean result, a user should align their live star detection with the run's saved
+`optimizedStarDetectionSettings` — in particular **enable Locally Adaptive Binarization** (the
+capture used it; it suppresses the spurious detections that inflate the fit). Note that even the
+clean answer tripped the weak-screw-2 warning at capture; a recalibration with larger, more equal
+screw turns is more robust regardless of detection settings.
+
+## Fix ladder
+
+### 1. Overlay parity — DONE
+
+Added the two missing assignments to `OverlayOptimizedSettings` so it once again mirrors
+`ApplyOptimizedSnapshotToLiveProperties`, plus a reflection guard test
+(`OverlayOptimizedSettings_AppliesEveryCuratedKnob_...`) that fails if any curated
+`OptimizedStarDetectionSettings` knob is not copied onto the replay snapshot — so the two apply
+paths cannot silently drift again.
+
+### 2. Persist the full detection snapshot at run level — PROPOSED (primary)
+
+Detection settings are constant across the steps of a single calibration run, so a **run-level**
+snapshot is sufficient — no per-step storage is needed.
+
+- When saving a tilt run, persist the complete `StarDetectionSettingsSnapshot` (all 53 fields,
+  via `StarDetectionSettingsSnapshot.FromOptions`) in `metadata.json`, alongside the existing
+  curated `optimizedStarDetectionSettings` (which stays for the optimizer/UI).
+- On replay, when this full snapshot is present, use it directly as the detection override — do not
+  overlay the curated subset onto the live profile. This closes the ~28 non-curated knobs.
+- Fallback order for `BuildTiltReplayDetectionOverride`: per-step `AutoFocusReplayMetadata.StarDetection`
+  (already the richest) → run-level full snapshot (new) → curated-overlay-on-live (legacy, now correct)
+  → live profile (with the existing "no stored settings" warning).
+
+### 3. Focuser step / geometry — already pinned, no change needed
+
+An earlier draft proposed pinning the captured focuser step for the geometry too. On closer analysis
+this is unnecessary for the wizard's screw outputs:
+
+- A/B are in focuser **steps** (`CreateTiltPlaneModel` divides `TiltAt` microns by
+  `focuserStepSizeMicrons`), so the sensor-model **fit's** focuser size cancels and does not affect
+  screw angles or µm/turn.
+- The only focuser step that scales µm/turn is the **geometry** step in `RunCalibrationMath`, and the
+  "use saved geometry" replay mode already passes `metadata.FocuserStepSizeMicrons`. The "use current
+  geometry" mode intentionally uses the live step.
+
+So the motivating µm/turn difference (418.7 vs 352) is a **detection** difference — it also changed
+the screw-move ratio (5.48 → ≤1.5), which a common focuser-step rescale cannot do — and is fully
+addressed by #2. No code change here.
+
+### Out of scope: persisting detected stars
+
+Storing the registered star table and re-fitting from it would make replay bit-identical regardless
+of detector version, but it is deliberately **not** pursued: #2 pins the settings that drive
+detection, which is sufficient, and re-running detection keeps replay honest to the current detector.
+
+## Decision
+
+Ship #1 now (small, guarded). #2 is the real reproducibility fix — run-level (settings are constant
+across a run) and backward-compatible: folders without the full snapshot degrade to the now-correct
+legacy overlay path. Focuser-step geometry is already pinned in saved-geometry mode (#3). Persisting
+detected stars is out of scope.

--- a/docs/tilt-replay-reproducibility-design.md
+++ b/docs/tilt-replay-reproducibility-design.md
@@ -82,10 +82,12 @@ Focuser step adds an orthogonal µm/turn-only error for legacy folders: those pr
 `MeasurementContext` capture, so on replay the sensor-model focuser size falls back to the live
 `InspectorOptions.MicronsPerFocuserStep` rather than the captured 3.6.
 
-Newer runs are already better off: runs captured after the replay-metadata feature write a per-step
-`AutoFocusReplayMetadata.StarDetection` holding the **full** 53-field snapshot, and
-`BuildTiltReplayDetectionOverride` prefers it. astrodet's folder predates that, so it falls back to
-the curated overlay.
+`BuildTiltReplayDetectionOverride` has a branch that *would* prefer a per-step
+`AutoFocusReplayMetadata.StarDetection` (the full 53-field snapshot), but **tilt captures do not emit
+per-step replay `metadata.json`** — verified across the whole calibration bank, where the only
+`metadata.json` is the run-level tilt file (the AF engine's `WriteReplayMetadata` is gated on a save
+folder / method the tilt capture path does not satisfy). So *every* tilt replay falls through to the
+curated overlay today, regardless of plugin version.
 
 ## Operational guidance (until reproducibility is fully fixed)
 
@@ -116,9 +118,12 @@ snapshot is sufficient — no per-step storage is needed.
   curated `optimizedStarDetectionSettings` (which stays for the optimizer/UI).
 - On replay, when this full snapshot is present, use it directly as the detection override — do not
   overlay the curated subset onto the live profile. This closes the ~28 non-curated knobs.
-- Fallback order for `BuildTiltReplayDetectionOverride`: per-step `AutoFocusReplayMetadata.StarDetection`
-  (already the richest) → run-level full snapshot (new) → curated-overlay-on-live (legacy, now correct)
-  → live profile (with the existing "no stored settings" warning).
+- Override resolution order in `BuildTiltReplayDetectionOverride`: per-step
+  `AutoFocusReplayMetadata.StarDetection` (kept, though tilt captures don't currently emit it) →
+  **run-level full snapshot (new — the effective full-pin path for tilt)** → curated-overlay-on-live
+  (legacy runs, now correct after #1) → live profile (with the existing "no stored settings" warning).
+- Because the snapshot serializes only when present, existing folders (no snapshot) deserialize it to
+  `null` and degrade to the legacy overlay — no schema bump needed.
 
 ### 3. Focuser step / geometry — already pinned, no change needed
 


### PR DESCRIPTION
## Summary

Makes Tilt Adapter Wizard replays reproducible. Replaying a saved run re-runs the whole measurement
pipeline (star detection → paraboloid fit → tilt plane), so the result depends on the star-detection
settings in force at replay time. Two gaps let those settings drift from capture, so the same folder
produced different screw angles / µm-per-turn across machines and sessions (one machine reported
81.9° / 523 µm-per-turn with a quality warning, another 67.1° / 418.7 clean, from identical frames).

## Changes

**1. Overlay parity fix** — `OverlayOptimizedSettings` silently omitted `LocallyAdaptiveBinarization`
and `AdaptiveNoiseBlockSize`, so even a "use captured settings" replay kept the live profile's
binarization mode. Adaptive-vs-global binarization is exactly what swings detected-star count ~2×,
which corrupts the paraboloid fit and moves the outputs. Resynced with the canonical
`StarDetectionOptions.ApplyOptimizedSnapshotToLiveProperties`.

**2. Pin the full detection snapshot at run level** — the curated `OptimizedStarDetectionSettings`
persists only 25 of 53 detection knobs; the rest (mode flags, Simple-mode baseline, contamination,
PSF/HFR, dilation, saturation) leaked from the live profile. Tilt captures never emit per-step
`AutoFocus` replay metadata (verified across the whole calibration bank — only the run-level
`metadata.json` exists), so the curated overlay was the *only* pinning. Now the full
`StarDetectionSettingsSnapshot` (all 53 knobs) is persisted once at run level and preferred on
replay. Run-level because settings are constant across a run; backward-compatible because older
folders deserialize the snapshot to `null` and fall back to the (now-correct) curated overlay — no
schema bump.

## Tests (TDD, each verified RED → GREEN)

- `OverlayOptimizedSettings_AppliesEveryCuratedKnob_…` — reflection guard: the overlay must copy
  every curated knob (failed on the two omitted ones before #1).
- `BuildTiltReplayDetectionOverride_PrefersRunLevelFullSnapshot_…` — replay prefers the run-level
  snapshot over the curated overlay.
- `StarDetectionSnapshot_RoundTrips` — the snapshot persists through the tilt `metadata.json`.

Full suite green: **1708 passed, 0 failed**.

## Design

`docs/tilt-replay-reproducibility-design.md` — root cause (re-detect pipeline, the 25-of-53 subset,
step-unit derivation showing angles are focuser-step invariant so a wrong star set is the driver),
plus what was explicitly **not** done: focuser-step geometry is already pinned in saved-geometry
mode, and persisting raw detected stars is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cYTpEUkujEumx6jbLVpeX
