### PR TITLE
v4.0.0.2: scale AF timeout with Signal Amplification; fix overlapping star-detection options

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMTests.cs
@@ -127,26 +127,39 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
             });
         }
 
+        [Test]
+        public void ApplySignalAmplification_LiveRun_MultipliesTimeoutByFactor() {
+            // Amplification multiplies the exposure count (more, finer-spaced points), so the autofocus timeout must
+            // grow by the same factor or the longer sweep would time out. Scaling the per-run options override keeps
+            // this off the persisted timeout — no mutate-then-restore.
+            var options = new AutoFocusEngineOptions { AutoFocusTimeout = System.TimeSpan.FromSeconds(120) };
+            InspectorVM.ApplySignalAmplification(options, signalAmplification: 3, isLiveCapture: true);
+            Assert.That(options.AutoFocusTimeout, Is.EqualTo(System.TimeSpan.FromSeconds(360)));
+        }
+
         [TestCase(1)]   // factor of 1 disables amplification
         [TestCase(0)]   // clamped to 1 -> no-op
         [TestCase(-3)]  // clamped to 1 -> no-op
         public void ApplySignalAmplification_FactorOfOneOrLess_IsNoOp(int amp) {
-            var options = new AutoFocusEngineOptions { AutoFocusInitialOffsetSteps = 4, AutoFocusStepSize = 100 };
+            var options = new AutoFocusEngineOptions { AutoFocusInitialOffsetSteps = 4, AutoFocusStepSize = 100, AutoFocusTimeout = System.TimeSpan.FromSeconds(120) };
             InspectorVM.ApplySignalAmplification(options, signalAmplification: amp, isLiveCapture: true);
             Assert.Multiple(() => {
                 Assert.That(options.AutoFocusInitialOffsetSteps, Is.EqualTo(4));
                 Assert.That(options.AutoFocusStepSize, Is.EqualTo(100));
+                Assert.That(options.AutoFocusTimeout, Is.EqualTo(System.TimeSpan.FromSeconds(120)));
             });
         }
 
         [Test]
         public void ApplySignalAmplification_Replay_IsNoOp() {
-            // On replay the saved frames' focuser positions are fixed, so amplification must not change the sweep.
-            var options = new AutoFocusEngineOptions { AutoFocusInitialOffsetSteps = 4, AutoFocusStepSize = 100 };
+            // On replay the saved frames' focuser positions are fixed, so amplification must not change the sweep — and
+            // the fixed exposure count means the timeout must not grow either.
+            var options = new AutoFocusEngineOptions { AutoFocusInitialOffsetSteps = 4, AutoFocusStepSize = 100, AutoFocusTimeout = System.TimeSpan.FromSeconds(120) };
             InspectorVM.ApplySignalAmplification(options, signalAmplification: 3, isLiveCapture: false);
             Assert.Multiple(() => {
                 Assert.That(options.AutoFocusInitialOffsetSteps, Is.EqualTo(4));
                 Assert.That(options.AutoFocusStepSize, Is.EqualTo(100));
+                Assert.That(options.AutoFocusTimeout, Is.EqualTo(System.TimeSpan.FromSeconds(120)));
             });
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Resources/OptionsDataTemplatesLayoutTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Resources/OptionsDataTemplatesLayoutTests.cs
@@ -1,0 +1,66 @@
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Xml.Linq;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Resources {
+
+    // Guards the hand-authored options grids in OptionsDataTemplates.xaml against a whole class of layout bug:
+    // every option is one label (Grid.Column="0") plus its editor, and the grids place children by explicit
+    // Grid.Row (source order != visual order), so a mistyped/duplicated Grid.Row silently renders two options on
+    // top of each other. Regression: "Exclude Saturated Stars From HFR" was added at Grid.Row="35", colliding with
+    // "Contamination Sensitivity" already on row 35. This test parses the XAML and fails if any grid has two
+    // column-0 children on the same row.
+    [TestFixture]
+    public class OptionsDataTemplatesLayoutTests {
+
+        private static readonly XNamespace Presentation = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
+
+        private static XDocument LoadOptionsDataTemplates([CallerFilePath] string thisFile = null) {
+            // thisFile: <repo>/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Resources/OptionsDataTemplatesLayoutTests.cs
+            var testsProjectDir = Directory.GetParent(Path.GetDirectoryName(thisFile)).FullName;
+            var xamlPath = Path.GetFullPath(Path.Combine(
+                testsProjectDir, "..", "Joko.NINA.Plugins.HocusFocus", "Resources", "OptionsDataTemplates.xaml"));
+            Assert.That(File.Exists(xamlPath), Is.True, $"Could not locate OptionsDataTemplates.xaml at '{xamlPath}'");
+            return XDocument.Load(xamlPath);
+        }
+
+        [Test]
+        public void OptionGrids_NoTwoColumnZeroControlsShareARow() {
+            var doc = LoadOptionsDataTemplates();
+            var collisions = new List<string>();
+
+            foreach (var grid in doc.Descendants(Presentation + "Grid")) {
+                var labelsByRow = new Dictionary<string, List<string>>();
+                foreach (var child in grid.Elements()) {
+                    // Skip property-element children (e.g. Grid.RowDefinitions, Grid.Resources, Grid.ColumnDefinitions).
+                    if (child.Name.LocalName.Contains('.')) {
+                        continue;
+                    }
+                    // Attached properties are unprefixed attributes (no namespace); absent Row/Column default to 0.
+                    var column = (string)child.Attribute("Grid.Column") ?? "0";
+                    if (column != "0") {
+                        continue;
+                    }
+                    var row = (string)child.Attribute("Grid.Row") ?? "0";
+                    var label = (string)child.Attribute("Text") ?? $"<{child.Name.LocalName}>";
+                    if (!labelsByRow.TryGetValue(row, out var list)) {
+                        list = new List<string>();
+                        labelsByRow[row] = list;
+                    }
+                    list.Add(label);
+                }
+
+                collisions.AddRange(labelsByRow
+                    .Where(kv => kv.Value.Count > 1)
+                    .Select(kv => $"Grid.Row={kv.Key}: {string.Join(" | ", kv.Value)}"));
+            }
+
+            Assert.That(collisions, Is.Empty,
+                "Two column-0 controls share a grid row, so they render on top of each other:\n" +
+                string.Join("\n", collisions));
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -1122,13 +1122,16 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             if (inspectorOptions.StepSize > 0 && savedAutoFocusAttempt != null) {
                 options.AutoFocusStepSize = inspectorOptions.StepSize;
             }
-            // Signal amplification: capture more, finer-spaced points over the same sweep range by dividing the step
-            // size and multiplying the step count by the factor. Only meaningful for LIVE captures — a replay re-uses
-            // the saved frames' fixed focuser positions (savedAutoFocusAttempt != null), so those stay untouched.
-            ApplySignalAmplification(options, inspectorOptions.SignalAmplification, isLiveCapture: savedAutoFocusAttempt == null);
+            // Resolve the base autofocus timeout (inspector override, else the profile default GetOptions already put
+            // on the options) BEFORE amplification, so signal amplification scales the resolved value by its factor.
             if (inspectorOptions.TimeoutSeconds > 0) {
                 options.AutoFocusTimeout = TimeSpan.FromSeconds(inspectorOptions.TimeoutSeconds);
             }
+            // Signal amplification: capture more, finer-spaced points over the same sweep range by dividing the step
+            // size and multiplying the step count by the factor, and scale the autofocus timeout by that same factor so
+            // the longer sweep does not time out. Only meaningful for LIVE captures — a replay re-uses the saved frames'
+            // fixed focuser positions (savedAutoFocusAttempt != null), so those stay untouched.
+            ApplySignalAmplification(options, inspectorOptions.SignalAmplification, isLiveCapture: savedAutoFocusAttempt == null);
             if (inspectorOptions.DetailedAnalysisExposureSeconds > 0) {
                 options.OverrideAutoFocusExposureTime = TimeSpan.FromSeconds(inspectorOptions.DetailedAnalysisExposureSeconds);
             }
@@ -1146,13 +1149,17 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
         // Applies the Signal Amplification factor to a live sensor-model / tilt sweep: divides the focuser step size
         // and multiplies the step count by the factor, so the same sweep range is covered with more, finer-spaced
-        // points (more signal, smaller defocus jumps between adjacent frames). No-op at factor <= 1 or on replay
-        // (isLiveCapture == false), since replay re-uses the saved frames' fixed focuser positions. Internal for tests.
+        // points (more signal, smaller defocus jumps between adjacent frames). Those extra points multiply the sweep's
+        // exposure count, so the autofocus timeout is scaled by the same factor to keep the longer sweep from timing
+        // out. The timeout is scaled on the per-run options override (never the persisted AutoFocusTimeoutSeconds), so
+        // there is nothing to restore afterward. No-op at factor <= 1 or on replay (isLiveCapture == false), since
+        // replay re-uses the saved frames' fixed focuser positions. Internal for tests.
         internal static void ApplySignalAmplification(AutoFocusEngineOptions options, int signalAmplification, bool isLiveCapture) {
             var amp = Math.Max(1, signalAmplification);
             if (amp > 1 && isLiveCapture) {
                 options.AutoFocusInitialOffsetSteps *= amp;
                 options.AutoFocusStepSize = Math.Max(1, (int)Math.Round(options.AutoFocusStepSize / (double)amp));
+                options.AutoFocusTimeout *= amp;
             }
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
@@ -26,8 +26,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new release build of a plugin
-[assembly: AssemblyVersion("4.0.0.1")]
-[assembly: AssemblyFileVersion("4.0.0.1")]
+[assembly: AssemblyVersion("4.0.0.2")]
+[assembly: AssemblyFileVersion("4.0.0.2")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("Hocus Focus")]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
@@ -1101,11 +1101,12 @@
 
                 <RowDefinition Style="{StaticResource ShowOnUseAdvanced}" />
 
-                <!-- 33 -->
+                <!--  34: Measurement Averaging (always visible); 35: Exclude Saturated Stars From HFR;
+                      36: Contamination Sensitivity; 37: Reject Contaminated Stars (35-37 advanced-only).  -->
                 <RowDefinition />
                 <RowDefinition Style="{StaticResource ShowOnUseAdvanced}" />
                 <RowDefinition Style="{StaticResource ShowOnUseAdvanced}" />
-                <RowDefinition />
+                <RowDefinition Style="{StaticResource ShowOnUseAdvanced}" />
 
                 <!--  38: Debug Mode (always visible); 39: Intermediate Path (only with Save Intermediate on)  -->
                 <RowDefinition />
@@ -1397,13 +1398,13 @@
             </ninactrl:UnitTextBox>
 
             <TextBlock
-                Grid.Row="35"
+                Grid.Row="36"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Contamination Sensitivity"
                 ToolTip="{StaticResource ContaminationSensitivity_Tooltip}" />
             <ninactrl:UnitTextBox
-                Grid.Row="35"
+                Grid.Row="36"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"
@@ -1423,13 +1424,13 @@
             </ninactrl:UnitTextBox>
 
             <TextBlock
-                Grid.Row="36"
+                Grid.Row="37"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Reject Contaminated Stars"
                 ToolTip="{StaticResource RejectContaminatedStars_Tooltip}" />
             <CheckBox
-                Grid.Row="36"
+                Grid.Row="37"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"


### PR DESCRIPTION
## Summary

Two changes for the **4.0.0.2** release.

### 1. Scale the autofocus timeout with the Signal Amplification factor
The sensor-model / tilt-calibration **Signal Amplification** factor multiplies the sweep's step count (and divides the step size), so the sweep captures N× more exposures over the same range. The autofocus timeout was left unscaled, so a high amplification factor could time the sweep out mid-run.

`ApplySignalAmplification` now also multiplies the **per-run** `AutoFocusEngineOptions.AutoFocusTimeout` by the same factor (live captures only — replay reuses the saved frames' fixed positions, so it stays a no-op there). Because the timeout is scaled on the per-run options override, there is nothing to restore afterward — no mutate-then-restore in finalize. The base timeout (inspector override, else profile default) is now resolved *before* amplification so the resolved value is what gets scaled.

Assembly version bumped to `4.0.0.2`.

### 2. Fix overlapping Advanced star-detection options
"Exclude Saturated Stars From HFR" had been added on `Grid.Row="35"`, the row already occupied by "Contamination Sensitivity", so the two options rendered on top of each other in the Advanced star-detection panel.

Each option now gets its own row: **Exclude Saturated Stars From HFR → 35** (right after Measurement Averaging), **Contamination Sensitivity → 36**, **Reject Contaminated Stars → 37** — filling the previously-empty row 37, whose `RowDefinition` becomes advanced-only so the relocated toggle keeps its visibility.

## Testing
- Full suite: **1710 passed**, 0 failed (3 benchmarks skipped).
- New tests, each verified RED → GREEN:
  - `ApplySignalAmplification_LiveRun_MultipliesTimeoutByFactor` (+ no-op guards for factor ≤ 1 and replay).
  - `OptionGrids_NoTwoColumnZeroControlsShareARow` — parses `OptionsDataTemplates.xaml` and fails if any grid places two column-0 controls on the same `Grid.Row` (the invariant this bug violated).
- Plugin builds clean (XAML/BAML compiles, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cYTpEUkujEumx6jbLVpeX
