### PR TITLE
fix(af): stage report temp file outside the watched directory

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/PathUtilityTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/PathUtilityTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using NINA.Joko.Plugins.HocusFocus.Utility;
 using NUnit.Framework;
 
@@ -10,6 +11,16 @@ public class PathUtilityTests {
 
     private static string Combine(params string[] parts) =>
         string.Join(Path.DirectorySeparatorChar.ToString(), parts);
+
+    private static string NewRoot() {
+        var root = Path.Combine(Path.GetTempPath(), "hf-atomic-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static void Cleanup(string root) {
+        try { Directory.Delete(root, recursive: true); } catch { }
+    }
 
     [Test]
     public void GetRelativePath_ChildOfFromPath_ReturnsRelativeChild() {
@@ -50,7 +61,8 @@ public class PathUtilityTests {
 
     [Test]
     public void WriteAllTextAtomic_WritesContent_AndLeavesNoTempFile() {
-        var dir = Path.Combine(Path.GetTempPath(), "hf-atomic-" + Guid.NewGuid().ToString("N"));
+        var root = NewRoot();
+        var dir = Path.Combine(root, "AutoFocus");
         Directory.CreateDirectory(dir);
         try {
             var path = Path.Combine(dir, "2026-07-03--22-53-42.json");
@@ -63,13 +75,14 @@ public class PathUtilityTests {
                 Assert.That(Directory.GetFiles(dir), Has.Length.EqualTo(1));
             });
         } finally {
-            try { Directory.Delete(dir, recursive: true); } catch { }
+            Cleanup(root);
         }
     }
 
     [Test]
     public void WriteAllTextAtomic_OverwritesExistingFile() {
-        var dir = Path.Combine(Path.GetTempPath(), "hf-atomic-" + Guid.NewGuid().ToString("N"));
+        var root = NewRoot();
+        var dir = Path.Combine(root, "AutoFocus");
         Directory.CreateDirectory(dir);
         try {
             var path = Path.Combine(dir, "report.json");
@@ -78,12 +91,92 @@ public class PathUtilityTests {
 
             Assert.That(File.ReadAllText(path), Is.EqualTo("new"));
         } finally {
-            try { Directory.Delete(dir, recursive: true); } catch { }
+            Cleanup(root);
+        }
+    }
+
+    [Test]
+    public void WriteAllTextAtomic_StagesTempFileOutsideTargetDirectory() {
+        var root = NewRoot();
+        var reportDir = Path.Combine(root, "AutoFocus");
+        Directory.CreateDirectory(reportDir);
+        try {
+            PathUtility.WriteAllTextAtomic(Path.Combine(reportDir, "report.json"), "{\"ok\":true}");
+
+            var expectedStaging = Path.Combine(root, "AutoFocus" + PathUtility.TempDirectorySuffix);
+            Assert.Multiple(() => {
+                Assert.That(
+                    Directory.GetFiles(reportDir),
+                    Has.Length.EqualTo(1),
+                    "the watched directory must only ever contain the final report");
+                Assert.That(
+                    Directory.Exists(expectedStaging),
+                    Is.True,
+                    "the temp file must be staged in a sibling directory so the publish is a cross-directory rename");
+                Assert.That(Directory.GetFiles(expectedStaging), Is.Empty, "staging directory should be left empty");
+            });
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    [Test]
+    public void WriteAllTextAtomic_ExplicitTempDirectory_IsUsedAndLeftEmpty() {
+        var root = NewRoot();
+        var reportDir = Path.Combine(root, "AutoFocus");
+        var stagingDir = Path.Combine(root, "staging");
+        Directory.CreateDirectory(reportDir);
+        try {
+            var path = Path.Combine(reportDir, "report.json");
+            PathUtility.WriteAllTextAtomic(path, "hello", stagingDir);
+
+            Assert.Multiple(() => {
+                Assert.That(File.ReadAllText(path), Is.EqualTo("hello"));
+                Assert.That(Directory.Exists(stagingDir), Is.True, "explicit staging directory should be created on demand");
+                Assert.That(Directory.GetFiles(stagingDir), Is.Empty, "staging directory should be left empty");
+            });
+        } finally {
+            Cleanup(root);
         }
     }
 
     [Test]
     public void WriteAllTextAtomic_NullPath_Throws() {
         Assert.That(() => PathUtility.WriteAllTextAtomic(null, "x"), Throws.TypeOf<ArgumentNullException>());
+    }
+
+    [Test]
+    public void WriteAllTextAtomic_RaisesCreatedEvent_OnNinaStyleWatcher() {
+        var root = NewRoot();
+        var reportDir = Path.Combine(root, "AutoFocus");
+        Directory.CreateDirectory(reportDir);
+        try {
+            using var createdSignal = new ManualResetEventSlim(false);
+            string createdName = null;
+
+            // Mirrors NINA core's AutoFocusToolVM.reportFileWatcher exactly.
+            using (var watcher = new FileSystemWatcher {
+                Path = reportDir,
+                NotifyFilter = NotifyFilters.FileName,
+                Filter = "*.json",
+                IncludeSubdirectories = false
+            }) {
+                watcher.Created += (_, e) => { createdName = e.Name; createdSignal.Set(); };
+                watcher.EnableRaisingEvents = true;
+
+                PathUtility.WriteAllTextAtomic(Path.Combine(reportDir, "report.json"), "{\"ok\":true}");
+
+                Assert.That(
+                    createdSignal.Wait(TimeSpan.FromSeconds(10)),
+                    Is.True,
+                    "NINA's AutoFocusToolVM subscribes only to Created/Deleted. Staging the temp file inside the "
+                    + "watched directory turns the publish into an intra-directory rename, which Windows reports as "
+                    + "Renamed, so the AF chart dropdown never updates until restart.");
+            }
+
+            Assert.That(createdName, Is.EqualTo("report.json"));
+        } finally {
+            Cleanup(root);
+        }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/PathUtility.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/PathUtility.cs
@@ -54,32 +54,66 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
         }
 
         /// <summary>
-        /// Writes text to <paramref name="path"/> atomically: the content is written to a sibling temp file which
-        /// is then renamed into place, so a concurrent reader never observes a half-written file or an open write
-        /// handle on the final path.
+        /// The suffix appended to a target directory's name to form the default staging directory.
         /// </summary>
+        public const string TempDirectorySuffix = ".hf-tmp";
+
+        /// <summary>
+        /// Writes text to <paramref name="path"/> atomically: the content is written to a temp file in a
+        /// staging directory outside the target directory, which is then renamed into place, so a concurrent
+        /// reader never observes a half-written file or an open write handle on the final path.
+        /// </summary>
+        /// <param name="path">The destination file.</param>
+        /// <param name="contents">The content to write.</param>
+        /// <param name="tempDirectory">
+        /// Staging directory for the temp file. It MUST be on the same volume as <paramref name="path"/> for the
+        /// rename to be atomic, and MUST NOT be the target directory itself (see remarks). Defaults to a sibling
+        /// of the target directory named <c>&lt;targetDirName&gt;<see cref="TempDirectorySuffix"/></c>.
+        /// </param>
         /// <remarks>
-        /// A plain <see cref="File.WriteAllText(string, string)"/> keeps a <see cref="FileAccess.Write"/> handle
-        /// open on the destination while serializing. NINA core's <c>AutoFocusToolVM.LoadChart</c> watches the
-        /// AutoFocus report directory and immediately <c>File.OpenText</c>s new reports with
-        /// <see cref="FileShare.Read"/>; that share mode does not admit the still-open write access, so the read
-        /// fails with a sharing violation ("being used by another process"). Writing a temp file and renaming means
-        /// the final report never has an open write handle, eliminating the race. The temp file carries a
-        /// non-<c>.json</c> extension so a directory watcher filtering on the real extension does not wake on it.
+        /// Two separate hazards are in play, and both must be respected.
+        /// <para>
+        /// First: a plain <see cref="File.WriteAllText(string, string)"/> keeps a <see cref="FileAccess.Write"/>
+        /// handle open on the destination. NINA core's <c>AutoFocusToolVM</c> watches the AutoFocus report
+        /// directory and immediately <c>File.OpenText</c>s new reports with <see cref="FileShare.Read"/>; that
+        /// share mode does not admit the still-open write access, so the read fails with a sharing violation
+        /// ("being used by another process"). Staging the content in a temp file and renaming it into place means
+        /// the final report never has an open write handle.
+        /// </para>
+        /// <para>
+        /// Second: the staging file must live OUTSIDE the target directory. Windows reports an intra-directory
+        /// rename as <c>FILE_ACTION_RENAMED_OLD_NAME</c>/<c>FILE_ACTION_RENAMED_NEW_NAME</c>, which .NET raises as
+        /// <see cref="FileSystemWatcher.Renamed"/> — not <see cref="FileSystemWatcher.Created"/>. NINA's watcher
+        /// subscribes only to Created and Deleted, so a same-directory rename publishes a report that NINA never
+        /// notices until it restarts. Renaming in from another directory makes the destination observe
+        /// <c>FILE_ACTION_ADDED</c>, which raises Created. Because the source and destination share a volume, the
+        /// move remains a true atomic rename rather than a copy.
+        /// </para>
+        /// <para>
+        /// Keeping the temp file out of the target directory also means a process crash between the write and the
+        /// rename cannot strand a <c>.tmp</c> file where NINA's unfiltered
+        /// <c>Directory.GetFiles(ReportDirectory)</c> would list it as a bogus chart.
+        /// </para>
         /// </remarks>
-        public static void WriteAllTextAtomic(string path, string contents) {
+        public static void WriteAllTextAtomic(string path, string contents, string tempDirectory = null) {
             if (string.IsNullOrEmpty(path)) {
                 throw new ArgumentNullException(nameof(path));
             }
 
-            var directory = Path.GetDirectoryName(path);
-            // The temp file MUST live in the same directory (volume) as the target so File.Move is a true atomic
-            // rename rather than a copy+delete.
-            var tempPath = Path.Combine(directory ?? string.Empty, Path.GetFileNameWithoutExtension(path) + "." + Guid.NewGuid().ToString("N") + ".tmp");
+            var fullPath = Path.GetFullPath(path);
+            var targetDirectory = Path.GetDirectoryName(fullPath);
+            var stagingDirectory = string.IsNullOrEmpty(tempDirectory)
+                ? GetDefaultTempDirectory(targetDirectory)
+                : tempDirectory;
+            Directory.CreateDirectory(stagingDirectory);
+
+            var tempPath = Path.Combine(
+                stagingDirectory,
+                Path.GetFileNameWithoutExtension(fullPath) + "." + Guid.NewGuid().ToString("N") + ".tmp");
             try {
                 File.WriteAllText(tempPath, contents);
                 // overwrite: a stale report from the same second (filenames are second-resolution) must not block it.
-                File.Move(tempPath, path, overwrite: true);
+                File.Move(tempPath, fullPath, overwrite: true);
             } catch {
                 // Best-effort cleanup so a failed rename doesn't strand a temp file; preserve the original error.
                 try {
@@ -89,6 +123,21 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
                 } catch { }
                 throw;
             }
+        }
+
+        /// <summary>
+        /// A sibling of <paramref name="targetDirectory"/>, which is guaranteed to be on the same volume (same
+        /// parent) and outside the target directory regardless of whether a watcher sets IncludeSubdirectories.
+        /// Falls back to the target directory itself when it is a volume root and therefore has no sibling; in
+        /// that degenerate case the write is still atomic but no Created event is raised.
+        /// </summary>
+        private static string GetDefaultTempDirectory(string targetDirectory) {
+            var parent = Path.GetDirectoryName(targetDirectory);
+            if (string.IsNullOrEmpty(parent)) {
+                return targetDirectory;
+            }
+
+            return Path.Combine(parent, Path.GetFileName(targetDirectory) + TempDirectorySuffix);
         }
 
         private static string AppendDirectorySeparatorChar(string path) {

--- a/docs/autofocus-report-watcher-design.md
+++ b/docs/autofocus-report-watcher-design.md
@@ -1,0 +1,155 @@
+# AutoFocus report atomic write vs. NINA's report-directory watcher
+
+## Status
+
+Root cause **confirmed** (code inspection + empirical test on Windows). Fix **proposed, not yet implemented**.
+
+## Symptom
+
+After an AutoFocus run completes, the new report does not appear in NINA's AutoFocus chart
+dropdown. It only shows up after NINA is restarted. The report file itself is written correctly
+and the calibration data is unaffected.
+
+## Root cause
+
+Commit `8beeed5` ("fix(af): write AutoFocus reports atomically to avoid chart-load IOException")
+introduced `PathUtility.WriteAllTextAtomic`, which writes the report to a temp file **in the same
+directory** as the target and then renames it into place:
+
+```csharp
+// PathUtility.cs:75-82
+var directory = Path.GetDirectoryName(path);
+var tempPath = Path.Combine(directory ?? string.Empty, ... + ".tmp");
+File.WriteAllText(tempPath, contents);
+File.Move(tempPath, path, overwrite: true);
+```
+
+Windows' `ReadDirectoryChangesW` reports an **intra-directory** rename as the pair
+`FILE_ACTION_RENAMED_OLD_NAME` / `FILE_ACTION_RENAMED_NEW_NAME`. .NET surfaces that as
+`FileSystemWatcher.Renamed` — **not** `Created`.
+
+NINA's `AutoFocusToolVM` (`NINA/ViewModel/Imaging/AutoFocusToolVM.cs:88-96`) builds its watcher with
+`NotifyFilter = NotifyFilters.FileName`, `Filter = "*.json"`, and subscribes to **only** `Created`
+and `Deleted`. There is no `Renamed` handler, so the report never enters `ChartList`. It appears
+only on the next startup, when `InitializeChartList()` re-enumerates the directory.
+
+That is exactly the reported behaviour.
+
+### Empirical confirmation
+
+Run on Windows (PowerShell 7.5.8) against a `FileSystemWatcher` configured identically to NINA's
+(`NotifyFilter = FileName`, `Filter = *.json`, `IncludeSubdirectories = false`):
+
+| Write strategy | Event(s) raised on the `.json` target |
+|---|---|
+| `File.WriteAllText` directly (what NINA core does) | `Created` |
+| **same-dir `.tmp` + `File.Move`** — *today's plugin code* | **`Renamed`** ← no `Created`, dropdown never updates |
+| same-dir `.tmp` + `File.Move(overwrite)` onto an **existing** target | **`Deleted`** + `Renamed` ← actively *removes* the entry |
+| temp in a **subdirectory** of the watched dir + `File.Move` | `Created` |
+| temp in a **sibling directory** + `File.Move` | `Created` |
+| temp in a sibling dir + `File.Move(overwrite)` onto existing target | `Deleted` + `Created` |
+| `CreateHardLink(temp → final)` then delete temp | `Created` |
+| `File.Copy(temp → final)` | `Created` |
+
+A cross-directory move on the same volume was verified to be a **true atomic rename, not a
+copy+delete** — the NTFS file ID is preserved across the move:
+
+```
+File ID before move (sibling dir): 0x00000000000000000028000000135128
+File ID after  move (watched dir): 0x00000000000000000028000000135128
+```
+
+The rename pair is only emitted when *both* endpoints are inside the watch scope. Move the temp
+file out of the watched directory and the destination sees `FILE_ACTION_ADDED` instead.
+
+## Two further defects found in the same code
+
+1. **The overwrite path deletes the dropdown entry.** With the temp file in the watched directory,
+   `File.Move(..., overwrite: true)` onto an existing report raises `Deleted` + `Renamed`. NINA's
+   `ReportFileWatcher_Deleted` removes the chart from `ChartList` and nothing re-adds it. Report
+   filenames are second-resolution, and the two `InspectorVM` write sites
+   (`InspectorVM.cs:1473`, `InspectorVM.cs:1532`) don't include the profile GUID at all, so a
+   same-second collision is plausible.
+
+2. **A stranded `.tmp` becomes a bogus dropdown entry.** The temp file lives in `ReportDirectory`,
+   and `AutoFocusToolVM.InitializeChartList()` calls `Directory.GetFiles(ReportDirectory)` with **no
+   filter** — every file, not just `*.json`. If the process dies between `WriteAllText` and
+   `File.Move`, the leftover `.tmp` is listed as a chart at the next startup. (`CoreUtil.DirectoryCleanup`
+   only prunes at 180 days.)
+
+Both disappear once the temp file lives outside `ReportDirectory`.
+
+## The constraint that rules out the obvious fixes
+
+The original `IOException` that `8beeed5` fixed is real and cannot be worked around from the writer
+side. NINA reads the report with `File.OpenText`, i.e. `FileAccess.Read` + **`FileShare.Read`**.
+Windows' share check requires the *reader's* share mode to admit the *writer's* existing access:
+`FileShare.Read` does not admit `FileAccess.Write`. So **any** open write handle on the final path
+at the moment NINA reacts to `Created` is a sharing violation — and `Created` fires the instant the
+file is created, before content is written. Widening the writer's `FileShare` cannot help.
+
+So the fix must satisfy both:
+
+- **(a)** the final path must be *created* (`FILE_ACTION_ADDED`), not renamed into existence; and
+- **(b)** it must already hold complete content, with no write handle, at the moment it is created.
+
+Only a rename/link of an already-complete file from **outside the watch scope** does both.
+
+## Options
+
+| # | Approach | `Created` fires | No write-handle race | Verdict |
+|---|---|---|---|---|
+| A | Revert to `File.WriteAllText` (match NINA core, `AutoFocusVM.cs:491`) | yes | **no** | Reject — reintroduces the observed `IOException` |
+| B | **Keep `File.Move`, put the temp file outside the watched directory** | yes | yes | **Recommended** |
+| C | `CreateHardLink(temp → final)`, then delete temp | yes | yes | Works, but needs P/Invoke and is NTFS-only. Unnecessary given B |
+| D | `File.Copy(temp → final)` | yes | **no** | Reject — destination is created *then* written; same race, worse |
+| E | Upstream: add a `Renamed` handler to `AutoFocusToolVM` | n/a | n/a | Correct long-term; do **in addition**, doesn't help until NINA ships it |
+
+### Recommended: option B
+
+Change `WriteAllTextAtomic` so the temp file is created in a directory that is on the same volume as
+the target (so `File.Move` stays a true atomic rename) but outside the watched directory.
+
+Candidate temp locations:
+
+- **Sibling of the target directory** (e.g. `%LOCALAPPDATA%\NINA\AutoFocus.hf-tmp\`) — same parent,
+  therefore same volume; out of the watch scope regardless of `IncludeSubdirectories`. **Preferred.**
+- Subdirectory of the target directory (e.g. `ReportDirectory\.hf-tmp\`) — same volume trivially, and
+  verified to raise `Created` today. But it is out of scope *only because* NINA sets
+  `IncludeSubdirectories = false`; if core ever flips that flag we silently regress to `Renamed`.
+- `Path.GetTempPath()` — **reject**. It may sit on a different volume, in which case `File.Move`
+  degrades to copy+delete and loses atomicity (or throws).
+
+Proposed signature, keeping the utility general:
+
+```csharp
+public static void WriteAllTextAtomic(string path, string contents, string tempDirectory = null)
+```
+
+Default `tempDirectory` to the sibling `<targetDirName>.hf-tmp`, creating it on demand. If the target
+directory has no parent (a drive root), fall back to the target directory itself and document that the
+fallback does not produce a `Created` event.
+
+Note the residual behaviour under B: overwriting an existing report raises `Deleted` + `Created`, so
+NINA removes and re-adds the entry. That is correct, and strictly better than today's `Deleted` +
+`Renamed` (which removes it permanently).
+
+## Verification plan
+
+- **Regression test (the important one):** a unit test that runs a real `FileSystemWatcher` configured
+  exactly like NINA's (`NotifyFilter = FileName`, `Filter = "*.json"`, `IncludeSubdirectories = false`)
+  over the target directory, calls `WriteAllTextAtomic`, and asserts a **`Created`** event is raised for
+  the target. This is the assertion that was missing and would have caught the bug.
+  Caveat: `FileSystemWatcher` semantics differ on Linux (inotify) — gate or run this on Windows, which is
+  the only supported target (`net8.0-windows7.0`).
+- Assert no temp file is ever created inside the target directory (guards defect 2 above).
+- Keep the existing `PathUtilityTests` coverage: content correctness, no stranded temp, overwrite.
+- Manual: run an AutoFocus in NINA and confirm the new chart appears in the dropdown without a restart.
+
+## Follow-ups (do not bundle)
+
+- Upstream PR to NINA: subscribe `AutoFocusToolVM.reportFileWatcher.Renamed` (and treat it as a create),
+  so core is robust against any writer that publishes reports by atomic rename. Also consider filtering
+  `InitializeChartList`'s `Directory.GetFiles` to `*.json`.
+- `InspectorVM`'s two report paths omit the profile GUID, so `IsAutofocusForCurrentProfile` falls through
+  to `true` and those reports are listed under *every* profile. Separate bug.

--- a/plans/autofocus-report-watcher-plan.md
+++ b/plans/autofocus-report-watcher-plan.md
@@ -1,0 +1,467 @@
+# AutoFocus Report Watcher Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `PathUtility.WriteAllTextAtomic` stage its temp file outside the target directory so that NINA's `FileSystemWatcher` raises `Created` (not `Renamed`) for new AutoFocus reports, restoring live updates of the AF chart dropdown.
+
+**Architecture:** Windows reports an intra-directory rename as `RENAMED_OLD_NAME`/`RENAMED_NEW_NAME`, which .NET surfaces as `FileSystemWatcher.Renamed`. NINA's `AutoFocusToolVM` subscribes only to `Created`/`Deleted`. Moving the staging file to a **sibling** directory of the target (same parent ⇒ same volume ⇒ `File.Move` remains a true atomic rename, verified via preserved NTFS file ID) makes the destination see `FILE_ACTION_ADDED` instead, which raises `Created`. Content is complete and no write handle is open at that instant, so the original sharing-violation `IOException` stays fixed. The change is confined to `PathUtility`; a defaulted `tempDirectory` parameter keeps all three call sites untouched.
+
+**Tech Stack:** C# / .NET 8.0-windows7.0, NUnit 4.4.0, `System.IO.FileSystemWatcher`.
+
+**Design spec:** `docs/autofocus-report-watcher-design.md`
+
+---
+
+## Environment Notes (read first)
+
+There is **no `dotnet` in WSL** and the test project targets `net8.0-windows7.0`. Tests must be run on the
+Windows side via the `mcp__windows-mcp__PowerShell` tool, against the repo over the WSL share.
+
+Test command (use `timeout: 600`):
+
+```powershell
+Set-Location '\\wsl.localhost\Ubuntu-20.04\home\ghilios\src\hocus-focus'
+dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~PathUtilityTests"
+```
+
+Full-suite command (Project Invariant: run after every code change), also `timeout: 600`:
+
+```powershell
+Set-Location '\\wsl.localhost\Ubuntu-20.04\home\ghilios\src\hocus-focus'
+dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo
+```
+
+Baseline as of writing: `--filter FullyQualifiedName~PathUtilityTests` ⇒ **Passed! Failed: 0, Passed: 8**.
+
+Git: never push to `develop`. Work on branch `ghilios/af-report-watcher-created-event`. Commit with the
+privacy email (exact command given in each commit step).
+
+---
+
+## File Structure
+
+- **Modify:** `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/PathUtility.cs`
+  Sole responsibility change: `WriteAllTextAtomic` gains an optional `tempDirectory`, defaults it to a
+  sibling of the target directory, and its `<remarks>` are corrected (they currently assert a rationale
+  that is the actual bug).
+- **Modify:** `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/PathUtilityTests.cs`
+  Adds the watcher regression test plus temp-location tests; existing atomic-write tests are restructured
+  to clean up the new sibling temp directory.
+
+No call sites change: `InspectorVM.cs:1476`, `InspectorVM.cs:1536`, `HocusFocusVM.cs:456` all keep calling
+`WriteAllTextAtomic(path, reportText)`.
+
+---
+
+## Task 1: Regression test — the watcher must see `Created`
+
+This is the assertion that was missing and would have caught the bug. It reproduces NINA's exact watcher
+configuration (`AutoFocusToolVM.cs:88-96`).
+
+**Files:**
+- Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/PathUtilityTests.cs`
+
+- [ ] **Step 1: Create the branch**
+
+```bash
+cd /home/ghilios/src/hocus-focus
+git checkout -b ghilios/af-report-watcher-created-event
+```
+
+- [ ] **Step 2: Add the test helpers and the failing regression test**
+
+In `PathUtilityTests.cs`, replace the `using` block at the top of the file with:
+
+```csharp
+using System;
+using System.IO;
+using System.Threading;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NUnit.Framework;
+```
+
+Then add these two private helpers directly beneath the existing `Combine` helper:
+
+```csharp
+    private static string NewRoot() {
+        var root = Path.Combine(Path.GetTempPath(), "hf-atomic-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static void Cleanup(string root) {
+        try { Directory.Delete(root, recursive: true); } catch { }
+    }
+```
+
+And append this test to the class (before the closing brace):
+
+```csharp
+    [Test]
+    public void WriteAllTextAtomic_RaisesCreatedEvent_OnNinaStyleWatcher() {
+        var root = NewRoot();
+        var reportDir = Path.Combine(root, "AutoFocus");
+        Directory.CreateDirectory(reportDir);
+        try {
+            using var createdSignal = new ManualResetEventSlim(false);
+            string createdName = null;
+
+            // Mirrors NINA core's AutoFocusToolVM.reportFileWatcher exactly.
+            using (var watcher = new FileSystemWatcher {
+                Path = reportDir,
+                NotifyFilter = NotifyFilters.FileName,
+                Filter = "*.json",
+                IncludeSubdirectories = false
+            }) {
+                watcher.Created += (_, e) => { createdName = e.Name; createdSignal.Set(); };
+                watcher.EnableRaisingEvents = true;
+
+                PathUtility.WriteAllTextAtomic(Path.Combine(reportDir, "report.json"), "{\"ok\":true}");
+
+                Assert.That(
+                    createdSignal.Wait(TimeSpan.FromSeconds(10)),
+                    Is.True,
+                    "NINA's AutoFocusToolVM subscribes only to Created/Deleted. Staging the temp file inside the "
+                    + "watched directory turns the publish into an intra-directory rename, which Windows reports as "
+                    + "Renamed, so the AF chart dropdown never updates until restart.");
+            }
+
+            Assert.That(createdName, Is.EqualTo("report.json"));
+        } finally {
+            Cleanup(root);
+        }
+    }
+```
+
+- [ ] **Step 3: Run the test to verify it fails (RED)**
+
+```powershell
+Set-Location '\\wsl.localhost\Ubuntu-20.04\home\ghilios\src\hocus-focus'
+dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~WriteAllTextAtomic_RaisesCreatedEvent_OnNinaStyleWatcher"
+```
+
+Expected: **FAIL** — `Failed: 1`, with the assertion message above (the wait times out after 10 s because
+the current code raises `Renamed`, never `Created`).
+
+Do **not** proceed to Task 2 until you have observed this failure.
+
+---
+
+## Task 2: Stage the temp file outside the target directory
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/PathUtility.cs:56-92`
+
+- [ ] **Step 1: Replace `WriteAllTextAtomic` and its doc comment**
+
+Replace the entire block from the `/// <summary>` above `WriteAllTextAtomic` through the closing brace of
+`WriteAllTextAtomic` with:
+
+```csharp
+        /// <summary>
+        /// The suffix appended to a target directory's name to form the default staging directory.
+        /// </summary>
+        public const string TempDirectorySuffix = ".hf-tmp";
+
+        /// <summary>
+        /// Writes text to <paramref name="path"/> atomically: the content is written to a temp file in a
+        /// staging directory outside the target directory, which is then renamed into place, so a concurrent
+        /// reader never observes a half-written file or an open write handle on the final path.
+        /// </summary>
+        /// <param name="path">The destination file.</param>
+        /// <param name="contents">The content to write.</param>
+        /// <param name="tempDirectory">
+        /// Staging directory for the temp file. It MUST be on the same volume as <paramref name="path"/> for the
+        /// rename to be atomic, and MUST NOT be the target directory itself (see remarks). Defaults to a sibling
+        /// of the target directory named <c>&lt;targetDirName&gt;<see cref="TempDirectorySuffix"/></c>.
+        /// </param>
+        /// <remarks>
+        /// Two separate hazards are in play, and both must be respected.
+        /// <para>
+        /// First: a plain <see cref="File.WriteAllText(string, string)"/> keeps a <see cref="FileAccess.Write"/>
+        /// handle open on the destination. NINA core's <c>AutoFocusToolVM</c> watches the AutoFocus report
+        /// directory and immediately <c>File.OpenText</c>s new reports with <see cref="FileShare.Read"/>; that
+        /// share mode does not admit the still-open write access, so the read fails with a sharing violation
+        /// ("being used by another process"). Staging the content in a temp file and renaming it into place means
+        /// the final report never has an open write handle.
+        /// </para>
+        /// <para>
+        /// Second: the staging file must live OUTSIDE the target directory. Windows reports an intra-directory
+        /// rename as <c>FILE_ACTION_RENAMED_OLD_NAME</c>/<c>FILE_ACTION_RENAMED_NEW_NAME</c>, which .NET raises as
+        /// <see cref="FileSystemWatcher.Renamed"/> — not <see cref="FileSystemWatcher.Created"/>. NINA's watcher
+        /// subscribes only to Created and Deleted, so a same-directory rename publishes a report that NINA never
+        /// notices until it restarts. Renaming in from another directory makes the destination observe
+        /// <c>FILE_ACTION_ADDED</c>, which raises Created. Because the source and destination share a volume, the
+        /// move remains a true atomic rename rather than a copy.
+        /// </para>
+        /// <para>
+        /// Keeping the temp file out of the target directory also means a process crash between the write and the
+        /// rename cannot strand a <c>.tmp</c> file where NINA's unfiltered
+        /// <c>Directory.GetFiles(ReportDirectory)</c> would list it as a bogus chart.
+        /// </para>
+        /// </remarks>
+        public static void WriteAllTextAtomic(string path, string contents, string tempDirectory = null) {
+            if (string.IsNullOrEmpty(path)) {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            var fullPath = Path.GetFullPath(path);
+            var targetDirectory = Path.GetDirectoryName(fullPath);
+            var stagingDirectory = string.IsNullOrEmpty(tempDirectory)
+                ? GetDefaultTempDirectory(targetDirectory)
+                : tempDirectory;
+            Directory.CreateDirectory(stagingDirectory);
+
+            var tempPath = Path.Combine(
+                stagingDirectory,
+                Path.GetFileNameWithoutExtension(fullPath) + "." + Guid.NewGuid().ToString("N") + ".tmp");
+            try {
+                File.WriteAllText(tempPath, contents);
+                // overwrite: a stale report from the same second (filenames are second-resolution) must not block it.
+                File.Move(tempPath, fullPath, overwrite: true);
+            } catch {
+                // Best-effort cleanup so a failed rename doesn't strand a temp file; preserve the original error.
+                try {
+                    if (File.Exists(tempPath)) {
+                        File.Delete(tempPath);
+                    }
+                } catch { }
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// A sibling of <paramref name="targetDirectory"/>, which is guaranteed to be on the same volume (same
+        /// parent) and outside the target directory regardless of whether a watcher sets IncludeSubdirectories.
+        /// Falls back to the target directory itself when it is a volume root and therefore has no sibling; in
+        /// that degenerate case the write is still atomic but no Created event is raised.
+        /// </summary>
+        private static string GetDefaultTempDirectory(string targetDirectory) {
+            var parent = Path.GetDirectoryName(targetDirectory);
+            if (string.IsNullOrEmpty(parent)) {
+                return targetDirectory;
+            }
+
+            return Path.Combine(parent, Path.GetFileName(targetDirectory) + TempDirectorySuffix);
+        }
+```
+
+- [ ] **Step 2: Run the regression test to verify it passes (GREEN)**
+
+```powershell
+Set-Location '\\wsl.localhost\Ubuntu-20.04\home\ghilios\src\hocus-focus'
+dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~WriteAllTextAtomic_RaisesCreatedEvent_OnNinaStyleWatcher"
+```
+
+Expected: **PASS** — `Failed: 0, Passed: 1`.
+
+---
+
+## Task 3: Cover the temp-file location and the explicit `tempDirectory`
+
+The existing atomic-write tests pass `dir` as the target directory, so the new default staging directory
+becomes `<dir>.hf-tmp` — a sibling that their `finally` block does not delete. They must be restructured to
+create a root, or they leak a directory into `%TEMP%` on every run.
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/PathUtilityTests.cs`
+
+- [ ] **Step 1: Restructure the two existing atomic-write tests to use a root directory**
+
+Replace `WriteAllTextAtomic_WritesContent_AndLeavesNoTempFile` and `WriteAllTextAtomic_OverwritesExistingFile`
+in their entirety with:
+
+```csharp
+    [Test]
+    public void WriteAllTextAtomic_WritesContent_AndLeavesNoTempFile() {
+        var root = NewRoot();
+        var dir = Path.Combine(root, "AutoFocus");
+        Directory.CreateDirectory(dir);
+        try {
+            var path = Path.Combine(dir, "2026-07-03--22-53-42.json");
+            PathUtility.WriteAllTextAtomic(path, "{\"ok\":true}");
+
+            Assert.Multiple(() => {
+                Assert.That(File.ReadAllText(path), Is.EqualTo("{\"ok\":true}"));
+                // The rename must clean up after itself: no leftover temp file, and the final file keeps its extension.
+                Assert.That(Directory.GetFiles(dir, "*.tmp"), Is.Empty, "no temp file should remain after an atomic write");
+                Assert.That(Directory.GetFiles(dir), Has.Length.EqualTo(1));
+            });
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    [Test]
+    public void WriteAllTextAtomic_OverwritesExistingFile() {
+        var root = NewRoot();
+        var dir = Path.Combine(root, "AutoFocus");
+        Directory.CreateDirectory(dir);
+        try {
+            var path = Path.Combine(dir, "report.json");
+            File.WriteAllText(path, "old");
+            PathUtility.WriteAllTextAtomic(path, "new");
+
+            Assert.That(File.ReadAllText(path), Is.EqualTo("new"));
+        } finally {
+            Cleanup(root);
+        }
+    }
+```
+
+- [ ] **Step 2: Add the temp-location tests**
+
+Append to the class:
+
+```csharp
+    [Test]
+    public void WriteAllTextAtomic_StagesTempFileOutsideTargetDirectory() {
+        var root = NewRoot();
+        var reportDir = Path.Combine(root, "AutoFocus");
+        Directory.CreateDirectory(reportDir);
+        try {
+            PathUtility.WriteAllTextAtomic(Path.Combine(reportDir, "report.json"), "{\"ok\":true}");
+
+            var expectedStaging = Path.Combine(root, "AutoFocus" + PathUtility.TempDirectorySuffix);
+            Assert.Multiple(() => {
+                Assert.That(
+                    Directory.GetFiles(reportDir),
+                    Has.Length.EqualTo(1),
+                    "the watched directory must only ever contain the final report");
+                Assert.That(
+                    Directory.Exists(expectedStaging),
+                    Is.True,
+                    "the temp file must be staged in a sibling directory so the publish is a cross-directory rename");
+                Assert.That(Directory.GetFiles(expectedStaging), Is.Empty, "staging directory should be left empty");
+            });
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    [Test]
+    public void WriteAllTextAtomic_ExplicitTempDirectory_IsUsedAndLeftEmpty() {
+        var root = NewRoot();
+        var reportDir = Path.Combine(root, "AutoFocus");
+        var stagingDir = Path.Combine(root, "staging");
+        Directory.CreateDirectory(reportDir);
+        try {
+            var path = Path.Combine(reportDir, "report.json");
+            PathUtility.WriteAllTextAtomic(path, "hello", stagingDir);
+
+            Assert.Multiple(() => {
+                Assert.That(File.ReadAllText(path), Is.EqualTo("hello"));
+                Assert.That(Directory.Exists(stagingDir), Is.True, "explicit staging directory should be created on demand");
+                Assert.That(Directory.GetFiles(stagingDir), Is.Empty, "staging directory should be left empty");
+            });
+        } finally {
+            Cleanup(root);
+        }
+    }
+```
+
+- [ ] **Step 3: Run the whole `PathUtilityTests` fixture**
+
+```powershell
+Set-Location '\\wsl.localhost\Ubuntu-20.04\home\ghilios\src\hocus-focus'
+dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~PathUtilityTests"
+```
+
+Expected: **PASS** — `Failed: 0, Passed: 12` (8 pre-existing + 3 new + 1 regression test from Task 1).
+
+---
+
+## Task 4: Full suite, then commit
+
+**Files:** none (verification + commit)
+
+- [ ] **Step 1: Run the full test suite (Project Invariant)**
+
+```powershell
+Set-Location '\\wsl.localhost\Ubuntu-20.04\home\ghilios\src\hocus-focus'
+dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo
+```
+
+Expected: `Failed: 0`. If anything fails, fix the cause — do not skip or mark tests expected-to-fail.
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /home/ghilios/src/hocus-focus
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/PathUtility.cs \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/PathUtilityTests.cs \
+        docs/autofocus-report-watcher-design.md \
+        plans/autofocus-report-watcher-plan.md
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" -F- <<'EOF'
+fix(af): stage report temp file outside the watched directory
+
+WriteAllTextAtomic staged its temp file as a sibling in the target directory and
+renamed it into place. Windows reports an intra-directory rename as
+FILE_ACTION_RENAMED_OLD_NAME/FILE_ACTION_RENAMED_NEW_NAME, which .NET raises as
+FileSystemWatcher.Renamed. NINA core's AutoFocusToolVM subscribes only to Created
+and Deleted, so every AutoFocus report published since the atomic-write change was
+invisible in the AF chart dropdown until NINA restarted and re-enumerated the
+directory.
+
+Stage the temp file in a sibling directory of the target instead. The destination
+then observes FILE_ACTION_ADDED and raises Created. Sharing the parent directory
+guarantees the same volume, so File.Move remains a true atomic rename (verified:
+the NTFS file id survives the move), and the final report still never carries an
+open write handle -- the sharing-violation IOException that motivated the atomic
+write stays fixed.
+
+Two latent defects go away with it: overwriting a same-second report used to raise
+Deleted + Renamed, which removed the chart entry and never re-added it; and a temp
+file stranded by a crash could no longer be listed as a bogus chart by NINA's
+unfiltered Directory.GetFiles(ReportDirectory).
+
+Add a regression test that drives NINA's exact watcher configuration and asserts a
+Created event is raised.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+```
+
+- [ ] **Step 3: Push and open a PR**
+
+```bash
+cd /home/ghilios/src/hocus-focus
+git push -u origin ghilios/af-report-watcher-created-event
+gh pr create --base develop --title "fix(af): stage report temp file outside the watched directory" --body "$(cat <<'EOF'
+## Summary
+
+New AutoFocus reports did not appear in NINA's AF chart dropdown until NINA was restarted.
+
+`PathUtility.WriteAllTextAtomic` staged its temp file inside the target directory and renamed it into place. Windows reports an intra-directory rename as a `RENAMED_OLD_NAME`/`RENAMED_NEW_NAME` pair, which .NET surfaces as `FileSystemWatcher.Renamed`. NINA core's `AutoFocusToolVM` subscribes only to `Created` and `Deleted`, so the report was written correctly and then ignored.
+
+The fix stages the temp file in a **sibling** directory of the target. The destination then sees `FILE_ACTION_ADDED` → `Created`. Same parent means same volume, so `File.Move` is still a true atomic rename (verified: the NTFS file id is preserved across the move), and the final report still never has an open write handle — so the sharing-violation `IOException` that motivated the atomic write remains fixed.
+
+Two latent defects are fixed along the way:
+- Overwriting a same-second report raised `Deleted` + `Renamed`, which *removed* the chart entry and never re-added it.
+- A `.tmp` stranded by a crash sat in `ReportDirectory`, which NINA lists via an unfiltered `Directory.GetFiles`, producing a bogus chart entry.
+
+Design spec: `docs/autofocus-report-watcher-design.md`
+
+## Test plan
+
+- New regression test drives NINA's exact watcher config (`NotifyFilter = FileName`, `Filter = "*.json"`, `IncludeSubdirectories = false`) and asserts `Created` fires. It fails on the old code and passes on the new.
+- New tests cover the sibling staging directory and the explicit `tempDirectory` override.
+- Full suite green.
+
+## Follow-ups (not in this PR)
+
+- Upstream NINA: `AutoFocusToolVM` should also handle `Renamed`, so core is robust against any writer that publishes by atomic rename.
+- `InspectorVM`'s two report paths omit the profile GUID, so those reports list under every profile.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Out of Scope (do not bundle)
+
+- Upstream PR to NINA adding a `Renamed` handler to `AutoFocusToolVM`.
+- Adding the profile GUID to `InspectorVM`'s two report filenames.


### PR DESCRIPTION
## Summary

New AutoFocus reports did not appear in NINA's AF chart dropdown until NINA was restarted.

`PathUtility.WriteAllTextAtomic` staged its temp file inside the target directory and renamed it into place. Windows reports an intra-directory rename as a `RENAMED_OLD_NAME`/`RENAMED_NEW_NAME` pair, which .NET surfaces as `FileSystemWatcher.Renamed`. NINA core's `AutoFocusToolVM` subscribes only to `Created` and `Deleted`, so the report was written correctly and then ignored.

The fix stages the temp file in a **sibling** directory of the target. The destination then sees `FILE_ACTION_ADDED` → `Created`. Same parent means same volume, so `File.Move` is still a true atomic rename (verified: the NTFS file id is preserved across the move), and the final report still never has an open write handle — so the sharing-violation `IOException` that motivated the atomic write remains fixed.

Two latent defects are fixed along the way:
- Overwriting a same-second report raised `Deleted` + `Renamed`, which *removed* the chart entry and never re-added it.
- A `.tmp` stranded by a crash sat in `ReportDirectory`, which NINA lists via an unfiltered `Directory.GetFiles`, producing a bogus chart entry.

Design spec: `docs/autofocus-report-watcher-design.md`

## Test plan

- New regression test drives NINA's exact watcher config (`NotifyFilter = FileName`, `Filter = "*.json"`, `IncludeSubdirectories = false`) and asserts `Created` fires. Verified it fails on the old code (10 s timeout) and passes on the new (18 ms).
- New tests cover the sibling staging directory and the explicit `tempDirectory` override.
- Full suite green: 1713 passed, 0 failed.

## Follow-ups (not in this PR)

- Upstream NINA: `AutoFocusToolVM` should also handle `Renamed`, so core is robust against any writer that publishes by atomic rename.
- `InspectorVM`'s two report paths omit the profile GUID, so those reports list under every profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)