### PR TITLE
feat(optimizer): show the live auto-focus curve during a Live-source run

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/LiveAutoFocusChartVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/LiveAutoFocusChartVMTests.cs
@@ -1,0 +1,335 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Enum;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NINA.WPF.Base.Utility.AutoFocus;
+using NINA.WPF.Base.ViewModel.AutoFocus;
+using NSubstitute;
+using NUnit.Framework;
+using OxyPlot;
+using System;
+using System.Collections.Immutable;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Optimization;
+
+/// <summary>
+/// Unit tests for the wizard's live auto-focus chart: which engine events it plots, how it selects the one fit the
+/// profile uses, how it finalizes the best-focus point + σ(focus) bar, and that its subscription lifecycle is
+/// symmetric. The engine is an NSubstitute double whose events are raised directly — no hardware, no images.
+/// </summary>
+[TestFixture]
+public class LiveAutoFocusChartVMTests {
+
+    /// <summary>A hyperbolic fit with a preset minimum and uncertainty, so the final-point error bar can be
+    /// exercised without running a real solve (a real fit cannot be made to report a non-finite σ(focus)).</summary>
+    private sealed class StubHyperbolicFit : AlglibHyperbolicFitting {
+
+        public StubHyperbolicFit(DataPoint minimum, double minimumStdError, double leaveOneOutStdError) {
+            Minimum = minimum;
+            MinimumStdError = minimumStdError;
+            LeaveOneOutStdError = leaveOneOutStdError;
+            Fitting = x => x;
+        }
+
+        protected override int ParameterCount => 4;
+
+        protected override bool TryComputeInitialState(out double[] initialGuess, out double[] lowerBounds, out double[] upperBounds, out double[] scale) {
+            initialGuess = lowerBounds = upperBounds = scale = null;
+            return false;
+        }
+
+        protected override double ModelValue(double[] parameters, double x) => 0.0;
+
+        protected override DataPoint ComputeMinimum(double[] parameters) => Minimum;
+
+        protected override string FormatExpression(double[] parameters) => string.Empty;
+    }
+
+    private static AutoFocusFitting Fittings(
+        AFCurveFittingEnum curveFitting,
+        AFMethodEnum method = AFMethodEnum.STARHFR,
+        HyperbolicFitting hyperbolic = null) =>
+        new AutoFocusFitting {
+            Method = method,
+            CurveFittingType = curveFitting,
+            HyperbolicFitting = hyperbolic ?? new StubHyperbolicFit(new DataPoint(10000, 1.5), 12.0, 8.0),
+            QuadraticFitting = new QuadraticFitting { Fitting = x => x },
+            GaussianFitting = new GaussianFitting { Fitting = x => x },
+            // Two real trend lines, as the engine's CurveFittingResult produces them.
+            TrendlineFitting = new TrendlineFitting().Calculate(
+                new[] {
+                    new OxyPlot.Series.ScatterErrorPoint(9800, 3.0, 0, 0.1),
+                    new OxyPlot.Series.ScatterErrorPoint(9900, 2.0, 0, 0.1),
+                    new OxyPlot.Series.ScatterErrorPoint(10000, 1.5, 0, 0.1),
+                    new OxyPlot.Series.ScatterErrorPoint(10100, 2.0, 0, 0.1),
+                    new OxyPlot.Series.ScatterErrorPoint(10200, 3.0, 0, 0.1)
+                },
+                AFMethodEnum.STARHFR.ToString())
+        };
+
+    private static AutoFocusMeasurementPointCompletedEventArgs Point(
+        int focuserPosition,
+        double hfr,
+        int regionIndex = 0,
+        AutoFocusFitting fittings = null,
+        AutoFocusRegionPoint[] rejected = null) =>
+        new AutoFocusMeasurementPointCompletedEventArgs {
+            FocuserPosition = focuserPosition,
+            RegionIndex = regionIndex,
+            Measurement = new MeasureAndError { Measure = hfr, Stdev = 0.1 },
+            Fittings = fittings ?? Fittings(AFCurveFittingEnum.TRENDHYPERBOLIC),
+            RejectedPoints = rejected ?? Array.Empty<AutoFocusRegionPoint>()
+        };
+
+    private static AutoFocusRegionPoint Rejected(int focuserPosition, double hfr) =>
+        new AutoFocusRegionPoint { FocuserPosition = focuserPosition, Measurement = new MeasureAndError { Measure = hfr, Stdev = 0.1 } };
+
+    private static AutoFocusCompletedEventArgs Completed(HyperbolicFitting hyperbolic, double finalPosition = 1005, double finalHfr = 2.9) =>
+        new AutoFocusCompletedEventArgs {
+            RegionHFRs = ImmutableList.Create(new AutoFocusRegionHFR {
+                EstimatedFinalFocuserPosition = finalPosition,
+                EstimatedFinalHFR = finalHfr,
+                Fittings = Fittings(AFCurveFittingEnum.HYPERBOLIC, hyperbolic: hyperbolic),
+                RejectedPoints = Array.Empty<AutoFocusRegionPoint>()
+            })
+        };
+
+    private static (LiveAutoFocusChartVM Chart, IAutoFocusEngine Engine) NewAttachedChart() {
+        var engine = Substitute.For<IAutoFocusEngine>();
+        var chart = new LiveAutoFocusChartVM();
+        chart.Attach(engine);
+        return (chart, engine);
+    }
+
+    [Test]
+    public void MeasurementPointCompleted_Region0_AddsPointLineAndSelectsActiveFit() {
+        var (chart, engine) = NewAttachedChart();
+
+        engine.MeasurementPointCompleted += Raise.EventWith(Point(10000, 1.5));
+
+        Assert.Multiple(() => {
+            Assert.That(chart.FocusPoints, Has.Count.EqualTo(1));
+            Assert.That(chart.PlotFocusPoints, Has.Count.EqualTo(1));
+            // TRENDHYPERBOLIC => the hyperbolic curve, plus both trend lines.
+            Assert.That(chart.CurveFitting, Is.Not.Null);
+            Assert.That(chart.LeftTrendFitting, Is.Not.Null);
+            Assert.That(chart.RightTrendFitting, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public void MeasurementPointCompleted_PureHyperbolic_LeavesTrendFittingsNull() {
+        var (chart, engine) = NewAttachedChart();
+
+        engine.MeasurementPointCompleted += Raise.EventWith(Point(10000, 1.5, fittings: Fittings(AFCurveFittingEnum.HYPERBOLIC)));
+
+        Assert.Multiple(() => {
+            Assert.That(chart.CurveFitting, Is.Not.Null);
+            Assert.That(chart.LeftTrendFitting, Is.Null, "a non-trend profile must not draw trend lines");
+            Assert.That(chart.RightTrendFitting, Is.Null);
+        });
+    }
+
+    [Test]
+    public void MeasurementPointCompleted_ContrastDetection_SelectsGaussianCurve() {
+        var (chart, engine) = NewAttachedChart();
+        var fittings = Fittings(AFCurveFittingEnum.HYPERBOLIC, method: AFMethodEnum.CONTRASTDETECTION);
+
+        engine.MeasurementPointCompleted += Raise.EventWith(Point(10000, 1.5, fittings: fittings));
+
+        Assert.Multiple(() => {
+            Assert.That(chart.CurveFitting, Is.SameAs(fittings.GaussianFitting.Fitting));
+            Assert.That(chart.LeftTrendFitting, Is.Null);
+        });
+    }
+
+    [Test]
+    public void MeasurementPointCompleted_TrendlinesOnly_HasTrendsButNoCurve() {
+        var (chart, engine) = NewAttachedChart();
+
+        engine.MeasurementPointCompleted += Raise.EventWith(Point(10000, 1.5, fittings: Fittings(AFCurveFittingEnum.TRENDLINES)));
+
+        Assert.Multiple(() => {
+            Assert.That(chart.CurveFitting, Is.Null, "a pure-trendlines profile fits no curve");
+            Assert.That(chart.LeftTrendFitting, Is.Not.Null);
+            Assert.That(chart.RightTrendFitting, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public void MeasurementPointCompleted_NonZeroRegion_IsIgnored() {
+        var (chart, engine) = NewAttachedChart();
+
+        engine.MeasurementPointCompleted += Raise.EventWith(Point(10000, 1.5, regionIndex: 1));
+
+        Assert.Multiple(() => {
+            Assert.That(chart.FocusPoints, Is.Empty);
+            Assert.That(chart.PlotFocusPoints, Is.Empty);
+            Assert.That(chart.CurveFitting, Is.Null);
+        });
+    }
+
+    [Test]
+    public void MeasurementPointCompleted_RebuildsRejectedOverlayEachPoint() {
+        var (chart, engine) = NewAttachedChart();
+
+        engine.MeasurementPointCompleted += Raise.EventWith(Point(10000, 1.5, rejected: new[] { Rejected(9800, 3.0), Rejected(10200, 3.1) }));
+        Assert.That(chart.PlotRejectedFocusPoints, Has.Count.EqualTo(2));
+
+        // The next point's overlay REPLACES the previous one rather than accumulating.
+        engine.MeasurementPointCompleted += Raise.EventWith(Point(10100, 1.6, rejected: new[] { Rejected(9800, 3.0) }));
+        Assert.That(chart.PlotRejectedFocusPoints, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void MeasurementPointCompleted_PointsAreSortedByFocuserPosition() {
+        var (chart, engine) = NewAttachedChart();
+
+        engine.MeasurementPointCompleted += Raise.EventWith(Point(10200, 3.0));
+        engine.MeasurementPointCompleted += Raise.EventWith(Point(9800, 3.1));
+        engine.MeasurementPointCompleted += Raise.EventWith(Point(10000, 1.5));
+
+        Assert.That(new[] { chart.PlotFocusPoints[0].X, chart.PlotFocusPoints[1].X, chart.PlotFocusPoints[2].X },
+            Is.EqualTo(new[] { 9800.0, 10000.0, 10200.0 }));
+    }
+
+    [Test]
+    public void Started_ClearsAPriorAttempt() {
+        var (chart, engine) = NewAttachedChart();
+        engine.MeasurementPointCompleted += Raise.EventWith(Point(10000, 1.5));
+
+        engine.Started += Raise.EventWith(new AutoFocusStartedEventArgs());
+
+        Assert.Multiple(() => {
+            Assert.That(chart.FocusPoints, Is.Empty);
+            Assert.That(chart.CurveFitting, Is.Null);
+        });
+    }
+
+    [Test]
+    public void IterationFailed_ClearsAllSeriesSoTheRetryStartsClean() {
+        var (chart, engine) = NewAttachedChart();
+        engine.MeasurementPointCompleted += Raise.EventWith(Point(10000, 1.5, rejected: new[] { Rejected(9800, 3.0) }));
+        engine.MeasurementPointCompleted += Raise.EventWith(Point(10100, 1.6, rejected: new[] { Rejected(9800, 3.0) }));
+
+        engine.IterationFailed += Raise.EventWith(new AutoFocusFailedEventArgs());
+
+        Assert.Multiple(() => {
+            Assert.That(chart.FocusPoints, Is.Empty);
+            Assert.That(chart.PlotFocusPoints, Is.Empty);
+            Assert.That(chart.PlotRejectedFocusPoints, Is.Empty);
+            Assert.That(chart.PlotFinalFocusPointWithError, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void Completed_SetsFinalFocusPointAndSigmaErrorBar() {
+        var (chart, engine) = NewAttachedChart();
+        var fit = new StubHyperbolicFit(new DataPoint(1005, 2.9), minimumStdError: 12.0, leaveOneOutStdError: 8.0);
+
+        engine.Completed += Raise.EventWith(Completed(fit));
+
+        Assert.Multiple(() => {
+            Assert.That(chart.FinalFocusPoint.X, Is.EqualTo(1005));
+            Assert.That(chart.FinalFocusPoint.Y, Is.EqualTo(2.9));
+            Assert.That(chart.PlotFinalFocusPointWithError, Has.Count.EqualTo(1));
+            Assert.That(chart.PlotFinalFocusPointWithError[0].ErrorX, Is.EqualTo(12.0));
+        });
+    }
+
+    [Test]
+    public void Completed_NonFiniteMinimumStdError_FallsBackToLeaveOneOut() {
+        var (chart, engine) = NewAttachedChart();
+        var fit = new StubHyperbolicFit(new DataPoint(1005, 2.9), minimumStdError: double.NaN, leaveOneOutStdError: 8.0);
+
+        engine.Completed += Raise.EventWith(Completed(fit));
+
+        Assert.That(chart.PlotFinalFocusPointWithError[0].ErrorX, Is.EqualTo(8.0));
+    }
+
+    [Test]
+    public void Completed_NoUncertaintyEstimate_DrawsNoErrorBar() {
+        var (chart, engine) = NewAttachedChart();
+        var fit = new StubHyperbolicFit(new DataPoint(1005, 2.9), minimumStdError: double.NaN, leaveOneOutStdError: double.NaN);
+
+        engine.Completed += Raise.EventWith(Completed(fit));
+
+        Assert.Multiple(() => {
+            Assert.That(chart.FinalFocusPoint.X, Is.EqualTo(1005), "the best-focus marker still shows");
+            Assert.That(chart.PlotFinalFocusPointWithError, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void Failed_WithRegions_SyncsTheSameFinalState() {
+        var (chart, engine) = NewAttachedChart();
+        var fit = new StubHyperbolicFit(new DataPoint(1005, 2.9), minimumStdError: 12.0, leaveOneOutStdError: 8.0);
+        var failed = new AutoFocusFailedEventArgs { RegionHFRs = Completed(fit).RegionHFRs };
+
+        engine.Failed += Raise.EventWith(failed);
+
+        Assert.Multiple(() => {
+            Assert.That(chart.FinalFocusPoint.X, Is.EqualTo(1005));
+            Assert.That(chart.PlotFinalFocusPointWithError, Has.Count.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void Completed_EmptyRegionHFRs_IsNoOp() {
+        var (chart, engine) = NewAttachedChart();
+
+        Assert.DoesNotThrow(() => engine.Completed += Raise.EventWith(new AutoFocusCompletedEventArgs { RegionHFRs = ImmutableList<AutoFocusRegionHFR>.Empty }));
+        Assert.DoesNotThrow(() => engine.Failed += Raise.EventWith(new AutoFocusFailedEventArgs()));
+
+        Assert.Multiple(() => {
+            Assert.That(chart.FinalFocusPoint.X, Is.EqualTo(-1.0), "the sentinel is untouched");
+            Assert.That(chart.PlotFinalFocusPointWithError, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void Detach_StopsReceivingUpdates() {
+        var (chart, engine) = NewAttachedChart();
+
+        chart.Detach();
+        engine.MeasurementPointCompleted += Raise.EventWith(Point(10000, 1.5));
+
+        Assert.That(chart.FocusPoints, Is.Empty);
+    }
+
+    [Test]
+    public void Detach_IsIdempotent() {
+        var (chart, _) = NewAttachedChart();
+
+        Assert.DoesNotThrow(() => { chart.Detach(); chart.Detach(); chart.Dispose(); });
+    }
+
+    [Test]
+    public void Attach_Twice_DoesNotDoubleSubscribe() {
+        var (chart, engine) = NewAttachedChart();
+
+        chart.Attach(engine);
+        engine.MeasurementPointCompleted += Raise.EventWith(Point(10000, 1.5));
+
+        Assert.That(chart.FocusPoints, Has.Count.EqualTo(1), "a re-attach must not register the handlers twice");
+    }
+
+    [Test]
+    public void Attach_NullEngine_IsIgnored() {
+        var chart = new LiveAutoFocusChartVM();
+
+        Assert.DoesNotThrow(() => chart.Attach(null));
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -16,7 +16,9 @@ using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
 using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review;
 using NINA.Joko.Plugins.HocusFocus.Utility;
 using NINA.Profile.Interfaces;
+using NINA.WPF.Base.ViewModel.AutoFocus;
 using NSubstitute;
+using NSubstitute.Core;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -186,14 +188,15 @@ public class StarDetectionOptimizerWizardVMTests {
         IProfileService profileService = null,
         Func<IReadOnlyList<FrameReviewDescriptor>, StarDetectorParams, IProgress<RunLoadProgress>, CancellationToken, Task<List<FrameReview>>> frameReviewBuilder = null,
         Func<bool> isCameraConnected = null,
-        Func<bool> isFocuserConnected = null) {
+        Func<bool> isFocuserConnected = null,
+        IAutoFocusEngine autoFocusEngine = null) {
         options ??= Substitute.For<IStarDetectionOptions>();
         profileService ??= Substitute.For<IProfileService>();
         return new StarDetectionOptimizerWizardVM(
             profileService,
             options,
             loader,
-            autoFocusEngine: Substitute.For<IAutoFocusEngine>(),
+            autoFocusEngine: autoFocusEngine ?? Substitute.For<IAutoFocusEngine>(),
             folderPicker: () => @"C:\fake\attempt",
             region: StarDetectionRegion.Full,
             optimizerSettings: new OptimizerSettings { MaxEvaluations = 200, CoarseGridLevels = 4, StepFloorFraction = 0.125 },
@@ -1180,6 +1183,93 @@ public class StarDetectionOptimizerWizardVMTests {
         Assert.Multiple(() => {
             Assert.That(vm.ErrorMessage, Does.Contain("focuser").IgnoreCase);
             Assert.That(vm.CurrentStep, Is.Not.EqualTo(WizardStep.Summary));
+        });
+    }
+
+    // ---- Live auto-focus chart -------------------------------------------------------------------------
+    //
+    // A bare Substitute.For<IAutoFocusEngine>() returns null from GetOptions(), which RunLiveAttemptAsync
+    // dereferences (options.Save) — so every test that actually reaches the live run must stub it, along with
+    // Run(...) returning a SaveFolder the fake loader will accept. The connection probes are stubbed connected
+    // so the pre-flight check passes, and UseCurrentSettings skips the optimization pass we are not testing.
+    private static IAutoFocusEngine LiveEngine(Func<CallInfo, AutoFocusResult> onRun) {
+        var engine = Substitute.For<IAutoFocusEngine>();
+        engine.GetOptions().Returns(_ => new AutoFocusEngineOptions());
+        engine.Run(default, default, default, default).ReturnsForAnyArgs(ci => Task.FromResult(onRun(ci)));
+        return engine;
+    }
+
+    private static StarDetectionOptimizerWizardVM NewLiveVM(IAutoFocusEngine engine) {
+        var vm = NewVM(LoaderReturning(GoodRun()), isCameraConnected: () => true, isFocuserConnected: () => true, autoFocusEngine: engine);
+        vm.SourceMode = SourceMode.Live;
+        vm.OptimizeMode = WizardOptimizeMode.UseCurrentSettings;
+        return vm;
+    }
+
+    [Test]
+    public async Task ReplayMode_NeverShowsTheLiveChart() {
+        var vm = NewVM(LoaderReturning(GoodRun()));
+        var everShown = false;
+        vm.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(vm.ShowLiveChart) && vm.ShowLiveChart) { everShown = true; } };
+        vm.SourcePaths[0] = @"C:\run1";
+
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(everShown, Is.False, "a replay has no live run to chart");
+            Assert.That(vm.ShowLiveChart, Is.False);
+            Assert.That(vm.LiveChart, Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task LiveMode_ShowsChartDuringTheRunAndTearsItDownAfter() {
+        StarDetectionOptimizerWizardVM vm = null;
+        var shownDuringRun = false;
+        var chartDuringRun = (LiveAutoFocusChartVM)null;
+        var engine = LiveEngine(_ => {
+            shownDuringRun = vm.ShowLiveChart;
+            chartDuringRun = vm.LiveChart;
+            return new AutoFocusResult { Succeeded = true, SaveFolder = @"C:\live\attempt" };
+        });
+        vm = NewLiveVM(engine);
+
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(shownDuringRun, Is.True, "the chart is up while the auto-focus is in flight");
+            Assert.That(chartDuringRun, Is.Not.Null);
+            Assert.That(vm.ShowLiveChart, Is.False, "and is gone once the run ends");
+            Assert.That(vm.LiveChart, Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task LiveMode_ChartIsDetachedWhenTheRunThrows() {
+        StarDetectionOptimizerWizardVM vm = null;
+        var chartDuringRun = (LiveAutoFocusChartVM)null;
+        var engine = LiveEngine(_ => {
+            chartDuringRun = vm.LiveChart;
+            throw new InvalidOperationException("focuser exploded");
+        });
+        vm = NewLiveVM(engine);
+
+        await vm.StartAsync(CancellationToken.None);
+
+        // The failed run leaves no chart behind, and the engine no longer feeds the one it had.
+        engine.MeasurementPointCompleted += Raise.EventWith(new AutoFocusMeasurementPointCompletedEventArgs {
+            RegionIndex = 0,
+            FocuserPosition = 10000,
+            Measurement = new MeasureAndError { Measure = 1.5, Stdev = 0.1 },
+            Fittings = new AutoFocusFitting(),
+            RejectedPoints = Array.Empty<AutoFocusRegionPoint>()
+        });
+
+        Assert.Multiple(() => {
+            Assert.That(vm.ErrorMessage, Does.Contain("focuser exploded"));
+            Assert.That(vm.LiveChart, Is.Null);
+            Assert.That(vm.ShowLiveChart, Is.False);
+            Assert.That(chartDuringRun.FocusPoints, Is.Empty, "the detached chart receives nothing further");
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -90,6 +90,83 @@
         </oxy:Plot>
     </DataTemplate>
 
+    <!--  Live auto-focus curve, streamed into the progress panel while the wizard's Live source runs a fresh
+          auto-focus. Unlike the OptimizationCurve chart above, the axes AUTO-SCALE (MinimumPadding/MaximumPadding,
+          no explicit bounds) exactly as the AF pane's chart does: points arrive one at a time, so the plot must
+          rescale as the sweep widens rather than being pinned to bounds computed from the first point or two.
+          The VM exposes only the ONE fit the profile uses (plus the two trend lines when the curve fitting is
+          trend-based), so each annotation is a single FunctionAnnotation and a null Equation simply draws nothing.  -->
+    <DataTemplate DataType="{x:Type local:LiveAutoFocusChartVM}">
+        <oxy:Plot
+            Background="{StaticResource BackgroundBrush}"
+            PlotAreaBackground="{StaticResource BackgroundBrush}"
+            PlotAreaBorderColor="{Binding Path=Color, Source={StaticResource BorderBrush}}"
+            TextColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}">
+            <oxy:Plot.Axes>
+                <oxy:LinearAxis
+                    AxislineColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
+                    IsPanEnabled="False"
+                    IsZoomEnabled="False"
+                    MajorGridlineColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}, Converter={StaticResource SetAlphaToColorConverter}, ConverterParameter=60}"
+                    MajorGridlineStyle="LongDash"
+                    MaximumPadding="0.1"
+                    MinimumPadding="0.1"
+                    Position="Left"
+                    TextColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
+                    TicklineColor="{Binding Path=Color, Source={StaticResource SecondaryBrush}}"
+                    Title="HFR" />
+                <oxy:LinearAxis
+                    AxislineColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
+                    IsPanEnabled="False"
+                    IsZoomEnabled="False"
+                    MajorGridlineColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}, Converter={StaticResource SetAlphaToColorConverter}, ConverterParameter=60}"
+                    MajorGridlineStyle="LongDash"
+                    MaximumPadding="0.1"
+                    MinimumPadding="0.1"
+                    Position="Bottom"
+                    TextColor="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
+                    TicklineColor="{Binding Path=Color, Source={StaticResource SecondaryBrush}}"
+                    Title="Focuser position" />
+            </oxy:Plot.Axes>
+            <oxy:Plot.Series>
+                <oxy:ScatterErrorSeries
+                    ErrorBarColor="{Binding Path=Color, Source={StaticResource NotificationErrorBrush}}"
+                    ErrorBarStopWidth="2"
+                    ErrorBarStrokeThickness="2"
+                    ItemsSource="{Binding FocusPoints}"
+                    MarkerFill="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
+                    MarkerType="Circle"
+                    TrackerFormatString="Focuser: {2:0}, HFR: {4:0.000}" />
+                <oxy:LineSeries Color="{Binding Path=Color, Source={StaticResource SecondaryBrush}}" ItemsSource="{Binding PlotFocusPoints}" />
+                <!--  Points the outlier rejection dropped from the fit.  -->
+                <oxy:ScatterSeries
+                    ItemsSource="{Binding PlotRejectedFocusPoints}"
+                    MarkerSize="8"
+                    MarkerStroke="Red"
+                    MarkerStrokeThickness="2"
+                    MarkerType="Cross" />
+                <!--  Horizontal error bar (ErrorX = σ(focus), or the leave-one-out fallback) on the final point.  -->
+                <oxy:ScatterErrorSeries
+                    ErrorBarColor="{Binding Path=Color, Source={StaticResource NotificationErrorBrush}}"
+                    ErrorBarStopWidth="4"
+                    ErrorBarStrokeThickness="2"
+                    ItemsSource="{Binding PlotFinalFocusPointWithError}"
+                    MarkerType="None" />
+            </oxy:Plot.Series>
+            <oxy:Plot.Annotations>
+                <oxy:FunctionAnnotation Color="{Binding Path=Color, Source={StaticResource SecondaryBrush}}" Equation="{Binding CurveFitting}" />
+                <oxy:FunctionAnnotation Color="{Binding Path=Color, Source={StaticResource SecondaryBrush}, Converter={StaticResource SetAlphaToColorConverter}, ConverterParameter=140}" Equation="{Binding LeftTrendFitting}" />
+                <oxy:FunctionAnnotation Color="{Binding Path=Color, Source={StaticResource SecondaryBrush}, Converter={StaticResource SetAlphaToColorConverter}, ConverterParameter=140}" Equation="{Binding RightTrendFitting}" />
+                <oxy:PointAnnotation
+                    Fill="{Binding Path=Color, Source={StaticResource NotificationErrorBrush}}"
+                    Shape="Diamond"
+                    Stroke="{Binding Path=Color, Source={StaticResource NotificationErrorBrush}}"
+                    X="{Binding FinalFocusPoint.X}"
+                    Y="{Binding FinalFocusPoint.Y}" />
+            </oxy:Plot.Annotations>
+        </oxy:Plot>
+    </DataTemplate>
+
     <!--  Fitted focus graph for a registered star WITH an accepted fit (Review Frames hover): plain scatter (NO error
           bars — each point is a single detection, so there is no sample spread) + the fitted curve + best-focus marker.  -->
     <DataTemplate DataType="{x:Type review:FrameReviewFocusGraph}">
@@ -219,6 +296,12 @@
                 <Style TargetType="Grid">
                     <Setter Property="Width" Value="640" />
                     <Style.Triggers>
+                        <!--  Wider while the live auto-focus curve is streaming, so it gets the same room the
+                              results-page chart does. Mutually exclusive with the two triggers below (a live run
+                              is on the Acquire step).  -->
+                        <DataTrigger Binding="{Binding ShowLiveChart}" Value="True">
+                            <Setter Property="Width" Value="820" />
+                        </DataTrigger>
                         <!--  Wider on the results page so the auto-focus curve chart has room…  -->
                         <DataTrigger Binding="{Binding IsSummary}" Value="True">
                             <Setter Property="Width" Value="820" />
@@ -401,6 +484,15 @@
                         HorizontalAlignment="Center"
                         FontWeight="Bold"
                         Text="{Binding Phase}" />
+                    <!--  The live auto-focus curve, streaming while the Live source runs its fresh auto-focus.
+                          Collapsed in Saved Auto-Focus (replay), where there is no live run to chart, and again as
+                          soon as the run ends and "Loading frames" takes over.  -->
+                    <Border
+                        Height="240"
+                        Margin="0,0,0,10"
+                        Visibility="{Binding ShowLiveChart, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                        <ContentControl Content="{Binding LiveChart}" />
+                    </Border>
                     <ProgressBar
                         Height="18"
                         IsIndeterminate="{Binding IsProgressIndeterminate}"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/LiveAutoFocusChartVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/LiveAutoFocusChartVM.cs
@@ -1,0 +1,276 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Enum;
+using NINA.Core.Utility;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.WPF.Base.ViewModel.AutoFocus;
+using OxyPlot;
+using OxyPlot.Series;
+using System;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
+
+    /// <summary>
+    /// The auto-focus curve streamed live while the wizard's Live source runs a fresh auto-focus. It mirrors the
+    /// chart half of <see cref="AutoFocus.HocusFocusVM"/> — the same measured points, connecting line, rejected
+    /// overlay, fitted curve and final-point σ(focus) bar — with none of its collaborators: no mediators, no
+    /// report generation, no focuser broadcast, no frame-review retention. The wizard owns its own
+    /// <see cref="IAutoFocusEngine"/> instance, so those side effects belong to the AF pane's run, not this one.
+    ///
+    /// <para>Unlike the AF pane, only the ONE fit the user's profile actually uses is exposed
+    /// (<see cref="CurveFitting"/>, plus the two trend lines when the curve-fitting type is trend-based),
+    /// selected exactly as <see cref="AutoFocus.InspectorVM"/> does. The pane instead renders all four fits and
+    /// hides the inactive ones by routing every annotation's colour through AFFittingToColorConverter; picking the
+    /// active fit here keeps the chart template as small as the sibling OptimizationCurve one.</para>
+    ///
+    /// <para>Threading: the engine raises its events on worker threads. The four collections are
+    /// <see cref="AsyncObservableCollection{T}"/>, which marshals CollectionChanged to the dispatcher — but only
+    /// to the dispatcher captured when the collection is CONSTRUCTED. This VM must therefore be constructed on the
+    /// UI thread. It is: StartCommand is an AsyncRelayCommand and the StartAsync → AcquireAsync →
+    /// RunLiveAttemptAsync chain is UI-affine throughout (ConfigureAwait(true), no Task.Run before construction).
+    /// Wrapping acquisition in a Task.Run would silently break this.</para>
+    /// </summary>
+    public sealed class LiveAutoFocusChartVM : BaseINPC, IDisposable {
+        private static readonly FocusPointComparer focusPointComparer = new FocusPointComparer();
+        private static readonly PlotPointComparer plotPointComparer = new PlotPointComparer();
+
+        /// <summary>Sentinel for "no final focus point yet" — off the left of any real focuser range, so the
+        /// diamond annotation sits outside the plotted data (mirrors InspectorVM.ClearPlots).</summary>
+        private static readonly DataPoint NoFinalFocusPoint = new DataPoint(-1.0d, 0.0d);
+
+        private IAutoFocusEngine engine;
+
+        /// <summary>Measured HFR per focuser position, with the star-ensemble scatter as a vertical error bar.</summary>
+        public AsyncObservableCollection<ScatterErrorPoint> FocusPoints { get; } = new AsyncObservableCollection<ScatterErrorPoint>();
+
+        /// <summary>The same points as a plain line series, connecting the measurements in focuser order.</summary>
+        public AsyncObservableCollection<DataPoint> PlotFocusPoints { get; } = new AsyncObservableCollection<DataPoint>();
+
+        /// <summary>Points the outlier rejection dropped from the fit, drawn as crosses.</summary>
+        public AsyncObservableCollection<ScatterPoint> PlotRejectedFocusPoints { get; } = new AsyncObservableCollection<ScatterPoint>();
+
+        /// <summary>A single point at the fitted best focus, carrying σ(focus) as a horizontal error bar. Empty
+        /// until the run completes, and for fits that cannot estimate the uncertainty.</summary>
+        public AsyncObservableCollection<ScatterErrorPoint> PlotFinalFocusPointWithError { get; } = new AsyncObservableCollection<ScatterErrorPoint>();
+
+        private Func<double, double> curveFitting;
+
+        /// <summary>The fitted curve (focuser position → HFR) for the profile's auto-focus method and curve-fitting
+        /// type. Null before enough points exist to fit, and for a pure-trendlines profile, which has no curve.</summary>
+        public Func<double, double> CurveFitting {
+            get => curveFitting;
+            private set { curveFitting = value; RaisePropertyChanged(); }
+        }
+
+        private Func<double, double> leftTrendFitting;
+
+        /// <summary>The left-hand trend line as a function, or null when the profile's curve fitting is not
+        /// trend-based. Exposed as a function rather than as slope/offset bindings on a LineAnnotation because a
+        /// null TrendlineFitting would bind slope=0, offset=0 and draw a spurious horizontal line at y=0, whereas
+        /// a FunctionAnnotation with a null Equation draws nothing.</summary>
+        public Func<double, double> LeftTrendFitting {
+            get => leftTrendFitting;
+            private set { leftTrendFitting = value; RaisePropertyChanged(); }
+        }
+
+        private Func<double, double> rightTrendFitting;
+
+        /// <summary>The right-hand trend line as a function. See <see cref="LeftTrendFitting"/>.</summary>
+        public Func<double, double> RightTrendFitting {
+            get => rightTrendFitting;
+            private set { rightTrendFitting = value; RaisePropertyChanged(); }
+        }
+
+        private DataPoint finalFocusPoint = NoFinalFocusPoint;
+
+        /// <summary>The calculated best-focus position and its estimated HFR, set when the run finishes.</summary>
+        public DataPoint FinalFocusPoint {
+            get => finalFocusPoint;
+            private set { finalFocusPoint = value; RaisePropertyChanged(); }
+        }
+
+        /// <summary>
+        /// Subscribes to <paramref name="engine"/> and starts streaming its curve. Idempotent: attaching twice
+        /// detaches first, so the handlers are never registered more than once. Clears any prior run's points.
+        /// </summary>
+        public void Attach(IAutoFocusEngine engine) {
+            if (engine == null) {
+                return;
+            }
+            Detach();
+            this.engine = engine;
+            Clear();
+            engine.Started += OnStarted;
+            engine.MeasurementPointCompleted += OnMeasurementPointCompleted;
+            engine.IterationFailed += OnIterationFailed;
+            engine.Completed += OnCompleted;
+            engine.Failed += OnFailed;
+        }
+
+        /// <summary>Unsubscribes from the engine. Idempotent, and safe to call from a finally on any exit path —
+        /// without it the engine would keep this VM (and the wizard) alive through its event handlers.</summary>
+        public void Detach() {
+            if (engine == null) {
+                return;
+            }
+            engine.Started -= OnStarted;
+            engine.MeasurementPointCompleted -= OnMeasurementPointCompleted;
+            engine.IterationFailed -= OnIterationFailed;
+            engine.Completed -= OnCompleted;
+            engine.Failed -= OnFailed;
+            engine = null;
+        }
+
+        public void Dispose() => Detach();
+
+        /// <summary>Resets the chart to its empty state.</summary>
+        public void Clear() {
+            ClearSeries();
+            CurveFitting = null;
+            LeftTrendFitting = null;
+            RightTrendFitting = null;
+        }
+
+        private void ClearSeries() {
+            FocusPoints.Clear();
+            PlotFocusPoints.Clear();
+            PlotRejectedFocusPoints.Clear();
+            PlotFinalFocusPointWithError.Clear();
+            FinalFocusPoint = NoFinalFocusPoint;
+        }
+
+        private void OnStarted(object sender, AutoFocusStartedEventArgs e) => Clear();
+
+        /// <summary>Each completed focuser position: append the measurement, rebuild the rejected overlay from the
+        /// step's current outlier set, and re-point the fit to the intermediate curve. Region 0 is the only region
+        /// the wizard's plain Run() produces; the guard mirrors the AF pane.</summary>
+        private void OnMeasurementPointCompleted(object sender, AutoFocusMeasurementPointCompletedEventArgs e) {
+            if (e.RegionIndex != 0) {
+                return;
+            }
+
+            FocusPoints.AddSorted(new ScatterErrorPoint(e.FocuserPosition, e.Measurement.Measure, 0, AutoFocusEngine.SafeDisplayError(e.Measurement.Stdev)), focusPointComparer);
+            PlotFocusPoints.AddSorted(new DataPoint(e.FocuserPosition, e.Measurement.Measure), plotPointComparer);
+            SyncRejectedPoints(e.RejectedPoints);
+            SyncFittings(e.Fittings);
+        }
+
+        /// <summary>An attempt failed and the engine is about to retry: wipe the plot so the next attempt's points
+        /// aren't drawn on top of the abandoned ones (mirrors the AF pane).</summary>
+        private void OnIterationFailed(object sender, AutoFocusFailedEventArgs e) => ClearSeries();
+
+        private void OnCompleted(object sender, AutoFocusCompletedEventArgs e) => SyncFinalState(e);
+
+        private void OnFailed(object sender, AutoFocusFailedEventArgs e) => SyncFinalState(e);
+
+        /// <summary>
+        /// Re-syncs the chart to the run's FINALIZED region fit, which carries the values the per-point
+        /// intermediate fit lacks (the selected hyperbolic model, σ(focus), leave-one-out stability) and the
+        /// model-fair consensus rejected set. A failed run can finish with no regions at all, so guard for it.
+        /// </summary>
+        private void SyncFinalState(AutoFocusFinishedEventArgsBase e) {
+            if (e.RegionHFRs == null || e.RegionHFRs.Count == 0) {
+                return;
+            }
+
+            var firstRegion = e.RegionHFRs[0];
+            FinalFocusPoint = new DataPoint(firstRegion.EstimatedFinalFocuserPosition, firstRegion.EstimatedFinalHFR);
+            SyncFittings(firstRegion.Fittings);
+            SyncRejectedPoints(firstRegion.RejectedPoints);
+            RefreshFinalFocusPointError(firstRegion.Fittings);
+        }
+
+        private void SyncRejectedPoints(AutoFocusRegionPoint[] rejectedPoints) {
+            PlotRejectedFocusPoints.Clear();
+            if (rejectedPoints == null) {
+                return;
+            }
+            foreach (var rejected in rejectedPoints) {
+                PlotRejectedFocusPoints.Add(new ScatterPoint(rejected.FocuserPosition, rejected.Measurement.Measure));
+            }
+        }
+
+        private void SyncFittings(AutoFocusFitting fittings) {
+            CurveFitting = GetCurveFitting(fittings);
+            LeftTrendFitting = GetTrendFitting(fittings, left: true);
+            RightTrendFitting = GetTrendFitting(fittings, left: false);
+        }
+
+        /// <summary>
+        /// Rebuilds <see cref="PlotFinalFocusPointWithError"/> from the finalized hyperbolic fit: one point at the
+        /// best-focus minimum with σ(focus) as a horizontal error bar, falling back to the leave-one-out stability
+        /// when σ(focus) could not be propagated. Leaves the series empty — drawing nothing — for non-hyperbolic
+        /// fits and when neither uncertainty estimate exists. Mirrors HocusFocusVM.RefreshFinalFocusPointError.
+        /// </summary>
+        private void RefreshFinalFocusPointError(AutoFocusFitting fittings) {
+            PlotFinalFocusPointWithError.Clear();
+            if (!(fittings?.HyperbolicFitting is AlglibHyperbolicFitting alglibFit)) {
+                return;
+            }
+            var minimum = alglibFit.Minimum;
+            if (!double.IsFinite(minimum.X)) {
+                return;
+            }
+            var errorX = alglibFit.MinimumStdError;
+            if (!double.IsFinite(errorX) || errorX <= 0.0) {
+                errorX = alglibFit.LeaveOneOutStdError; // σ(focus) unavailable (degenerate fit) → use LOO stability
+            }
+            if (!double.IsFinite(errorX) || errorX <= 0.0) {
+                return;
+            }
+            PlotFinalFocusPointWithError.Add(new ScatterErrorPoint(minimum.X, minimum.Y, errorX, 0.0));
+        }
+
+        /// <summary>The one fitted curve the profile's method + curve-fitting type actually uses. Mirrors
+        /// InspectorVM.GetCurveFitting; a pure-trendlines profile has no curve, only the two trend lines.</summary>
+        private static Func<double, double> GetCurveFitting(AutoFocusFitting fittings) {
+            if (fittings == null) {
+                return null;
+            }
+            if (fittings.Method == AFMethodEnum.CONTRASTDETECTION) {
+                return fittings.GaussianFitting?.Fitting;
+            }
+            if (fittings.CurveFittingType == AFCurveFittingEnum.PARABOLIC || fittings.CurveFittingType == AFCurveFittingEnum.TRENDPARABOLIC) {
+                return fittings.QuadraticFitting?.Fitting;
+            }
+            if (fittings.CurveFittingType == AFCurveFittingEnum.HYPERBOLIC || fittings.CurveFittingType == AFCurveFittingEnum.TRENDHYPERBOLIC) {
+                return fittings.HyperbolicFitting?.Fitting;
+            }
+            return null;
+        }
+
+        /// <summary>One side's trend line as y = slope·x + offset, or null when the profile's curve fitting is not
+        /// trend-based (the gate InspectorVM.GetLineFitting applies).</summary>
+        private static Func<double, double> GetTrendFitting(AutoFocusFitting fittings, bool left) {
+            if (fittings == null || fittings.Method != AFMethodEnum.STARHFR) {
+                return null;
+            }
+            if (fittings.CurveFittingType != AFCurveFittingEnum.TRENDLINES
+                && fittings.CurveFittingType != AFCurveFittingEnum.TRENDPARABOLIC
+                && fittings.CurveFittingType != AFCurveFittingEnum.TRENDHYPERBOLIC) {
+                return null;
+            }
+            var trend = left ? fittings.TrendlineFitting?.LeftTrend : fittings.TrendlineFitting?.RightTrend;
+            if (trend == null) {
+                return null;
+            }
+            var slope = trend.Slope;
+            var offset = trend.Offset;
+            if (!double.IsFinite(slope) || !double.IsFinite(offset)) {
+                return null;
+            }
+            return x => slope * x + offset;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -508,6 +508,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     sourceMode = value;
                     RaisePropertyChanged();
                     RaisePropertyChanged(nameof(IsReplay));
+                    RaisePropertyChanged(nameof(ShowLiveChart));
                     // Live needs no paths (Start enabled); Saved disables Start until paths are filled.
                     StartCommand.NotifyCanExecuteChanged();
                 }
@@ -717,6 +718,20 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             get => phase;
             private set { phase = value; RaisePropertyChanged(); }
         }
+
+        private LiveAutoFocusChartVM liveChart;
+
+        /// <summary>The streaming auto-focus curve, non-null only while a live auto-focus run is in flight.
+        /// Created and torn down by <see cref="RunLiveAttemptAsync"/>.</summary>
+        public LiveAutoFocusChartVM LiveChart {
+            get => liveChart;
+            private set { liveChart = value; RaisePropertyChanged(); RaisePropertyChanged(nameof(ShowLiveChart)); }
+        }
+
+        /// <summary>Whether the progress panel shows the live auto-focus chart. The chart is only ever created on
+        /// the Live path, so the SourceMode check is redundant by construction — it is here to make the invariant
+        /// the requirement states ("never in Saved Auto-Focus") explicit and directly testable.</summary>
+        public bool ShowLiveChart => SourceMode == SourceMode.Live && liveChart != null;
 
         #endregion Progress
 
@@ -1472,7 +1487,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
         /// <summary>
         /// Triggers a live auto-focus run that saves its frames, then returns the saved attempt folder so the run
-        /// converges onto the same replay path. Kept minimal — hardware-dependent, manually verified later (T6).
+        /// converges onto the same replay path. For the duration of the run a <see cref="LiveAutoFocusChartVM"/> is
+        /// attached to the engine and published on <see cref="LiveChart"/>, so the progress panel streams the focus
+        /// curve instead of showing a bare marching bar. Replay never reaches here, hence never shows a chart.
         /// </summary>
         private async Task<string> RunLiveAttemptAsync(CancellationToken token) {
             if (autoFocusEngine == null) {
@@ -1481,8 +1498,22 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             Phase = "Running live auto-focus";
             var options = autoFocusEngine.GetOptions();
             options.Save = true; // ensure frames land on disk so we can load them like a replay
-            var afResult = await autoFocusEngine.Run(options, null, token, null).ConfigureAwait(true);
-            return afResult?.SaveFolder;
+
+            // Constructed here, on the UI thread — the chart's collections capture the dispatcher they are created
+            // on in order to marshal the engine's worker-thread events. See the LiveAutoFocusChartVM class doc.
+            var chart = new LiveAutoFocusChartVM();
+            chart.Attach(autoFocusEngine);
+            LiveChart = chart;
+            try {
+                var afResult = await autoFocusEngine.Run(options, null, token, null).ConfigureAwait(true);
+                return afResult?.SaveFolder;
+            } finally {
+                // Detach on every exit — success, engine failure, and cancellation alike — so the engine never
+                // holds this wizard alive through the chart's event handlers. Clearing LiveChart collapses the
+                // chart before the "Loading frames" phase takes over the progress panel.
+                chart.Detach();
+                LiveChart = null;
+            }
         }
 
         /// <summary>
@@ -2356,6 +2387,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             runStopwatch.Stop();
             cts?.Dispose();
             cts = null;
+            // Closing the window mid-run does not cancel the in-flight auto-focus, so sever the engine → chart →
+            // wizard subscription explicitly; the run finishes on its own and plots nowhere.
+            liveChart?.Detach();
+            liveChart = null;
         }
 
         private void Back() {


### PR DESCRIPTION
## Context

The Star Detection Optimizer Wizard's **Live Auto-Focus** source triggers a fresh auto-focus run and then optimizes star detection against the frames it saved. That run was a black box: `RunLiveAttemptAsync` called `autoFocusEngine.Run(options, null, token, null)` — no event subscriptions, no progress — so the user watched an indeterminate marching bar for several minutes with no idea whether the sweep was producing a sane HFR curve.

Meanwhile the engine already streams exactly this data. `IAutoFocusEngine.MeasurementPointCompleted` fires once per focuser position with the measurement, the rejected outliers, and a cloned `AutoFocusFitting`; both the AF dock (`HocusFocusVM`) and the Aberration Inspector consume it to draw a live curve.

## What changed

`LiveAutoFocusChartVM` (new) subscribes to `Started` / `MeasurementPointCompleted` / `IterationFailed` / `Completed` / `Failed` and owns the OxyPlot-feeding collections: measured points with HFR error bars, the connecting line, the rejected-outlier crosses, and the final best-focus point with its σ(focus) bar (falling back to leave-one-out stability). It is the chart half of `HocusFocusVM` with none of its collaborators — no mediators, no JSON report, no focuser broadcast, no frame-review retention. The wizard drives its own engine instance, so those side effects belong to the AF pane's run, not this one.

`RunLiveAttemptAsync` creates it, attaches it, publishes it on `LiveChart`, and detaches in a `finally` — success, engine throw, and cancellation alike — so the engine never holds the wizard alive through the chart's handlers. `Dispose()` detaches too, since closing the window mid-run does not cancel the in-flight auto-focus.

Two deliberate departures from the reference AF pane:

- **One active fit, not four.** The engine computes trendline, quadratic, hyperbolic *and* gaussian on every point. The AF pane renders all four annotations and hides the inactive ones by routing each `Color` through NINA's app-level `AFFittingToColorConverter`. Instead the VM selects the fit the profile actually uses (mirroring `InspectorVM.GetCurveFitting`) and exposes it as a `Func<double,double>`, so the template needs a single `FunctionAnnotation` — same shape as the sibling `OptimizationCurve` template already in this file, and one less resource dependency.
- **Trend lines as `Func`s, not slope/intercept.** A null `TrendlineFitting` would silently bind `Slope=0, Intercept=0` and draw a spurious horizontal line at y=0; a `FunctionAnnotation` with a null `Equation` draws nothing.

The chart is visible **only while the live run is in flight**, and **never in Saved Auto-Focus (replay)** — `ShowLiveChart` requires both `SourceMode == Live` and a non-null chart, which is only ever created on the Live path. The wizard widens to 820px while it is up (matching the results page); the progress bar stays indeterminate.

No persisted option is added, so `Resources/OptionsDataTemplates.xaml` is untouched.

## Testing

Full suite green: **1734 passed, 0 failed**, including 21 new tests — 18 covering the chart VM (region-0 filtering, per-fit selection across STARHFR/CONTRASTDETECTION and each curve-fitting type, rejected-overlay rebuild, point sorting, iteration-failed clear, final-point σ with LOO fallback, empty `RegionHFRs` guard, attach/detach idempotence) and 3 covering the wizard's chart lifecycle (replay never shows it; live shows then tears down; a throwing run leaves it detached).

Note for future test authors: a bare `Substitute.For<IAutoFocusEngine>()` returns `null` from `GetOptions()`, which `RunLiveAttemptAsync` dereferences. No existing test reached that line, so the new Live tests stub it.

## Manual verification

Driven end-to-end in NINA against the Sky Simulator camera + simulator focuser:

- **Replay**: window stays 640px, no chart at any phase.
- **Live**: window widens to 820px; the chart appears under the "Running live auto-focus" heading with the bar still marching below it; points accumulate one per focuser position with error bars; the axes auto-rescale from the empty default to the real focuser range (24700–25800); the chart collapses the moment the run ends and "Loading frames" takes over.

Not directly observed: the fitted-curve annotation drawn on the *live* chart mid-sweep — both runs completed before a late-sweep screenshot landed. Points and connecting line are confirmed; the curve is inferred from the AF pane using the identical `FunctionAnnotation`/`Func` binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXQ1X1HHuVb7Z4EUCAvGji