### PR TITLE
fix(tilt): post device-info updates so NINA can shut down

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TestDoubles/RecordingApplicationDispatcher.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TestDoubles/RecordingApplicationDispatcher.cs
@@ -7,10 +7,14 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles {
     /// Runs dispatched actions inline (like <see cref="SynchronousApplicationDispatcher"/>) but counts how many times
     /// <c>DispatchSynchronizationContext</c> was invoked, so tests can assert that a code path actually marshals UI work
     /// through the dispatcher instead of touching commands/collections directly on the calling thread.
+    /// <see cref="PostCount"/> tracks the non-blocking variant separately, so tests can pin which paths must never
+    /// block the calling thread on the UI thread.
     /// </summary>
     internal sealed class RecordingApplicationDispatcher : IApplicationDispatcher {
 
         public int DispatchCount { get; private set; }
+
+        public int PostCount { get; private set; }
 
         public void DispatchSynchronizationContext(Action action) {
             DispatchCount++;
@@ -20,6 +24,11 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles {
         public T DispatchSynchronizationContext<T>(Func<T> func) {
             DispatchCount++;
             return func();
+        }
+
+        public void PostSynchronizationContext(Action action) {
+            PostCount++;
+            action();
         }
 
         public T GetResource<T>(string name, T fallback) => fallback;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TestDoubles/SynchronousApplicationDispatcher.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TestDoubles/SynchronousApplicationDispatcher.cs
@@ -9,6 +9,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles {
 
         public T DispatchSynchronizationContext<T>(Func<T> func) => func();
 
+        public void PostSynchronizationContext(Action action) => action();
+
         public T GetResource<T>(string name, T fallback) => fallback;
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -178,14 +178,14 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             // notifications must now flow through the dispatcher so they are marshaled to the UI thread.
             var dispatcher = new RecordingApplicationDispatcher();
             var (vm, _, _, _) = Build(dispatcher: dispatcher);
-            var before = dispatcher.DispatchCount;
+            var before = dispatcher.PostCount;
 
             Task.Run(() => {
                 vm.UpdateDeviceInfo(new CameraInfo { Connected = true });
                 vm.UpdateDeviceInfo(new FocuserInfo { Connected = true });
             }).GetAwaiter().GetResult();
 
-            Assert.That(dispatcher.DispatchCount - before, Is.GreaterThanOrEqualTo(2));
+            Assert.That(dispatcher.PostCount - before, Is.GreaterThanOrEqualTo(2));
         }
 
         [Test]
@@ -195,12 +195,34 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             // not via a separate dispatch per notify site.
             var dispatcher = new RecordingApplicationDispatcher();
             var (vm, _, _, _) = Build(dispatcher: dispatcher);
-            var before = dispatcher.DispatchCount;
+            var before = dispatcher.PostCount;
 
             vm.UpdateDeviceInfo(new CameraInfo { Connected = true });
 
-            Assert.That(dispatcher.DispatchCount - before, Is.EqualTo(1),
+            Assert.That(dispatcher.PostCount - before, Is.EqualTo(1),
                 "UpdateDeviceInfo(CameraInfo) should marshal exactly once at the consumer boundary");
+        }
+
+        [Test]
+        public void UpdateDeviceInfo_MarshalsWithoutBlockingTheBroadcastThread() {
+            // NINA hang on exit: ApplicationDeviceConnectionVM.Shutdown() blocks the UI thread inside
+            // AsyncContext.Run (which never pumps the WPF dispatcher) while awaiting CameraVM/FocuserVM to
+            // disconnect. Those disconnects await their DeviceUpdateTimer, whose in-flight callback is what
+            // broadcasts device info into this consumer. Marshaling with a blocking Invoke therefore parks the
+            // timer on a UI thread that is itself waiting for the timer — a deadlock. Post, never block.
+            var dispatcher = new RecordingApplicationDispatcher();
+            var (vm, _, _, _) = Build(dispatcher: dispatcher);
+
+            vm.UpdateDeviceInfo(new CameraInfo { Connected = true });
+            vm.UpdateDeviceInfo(new FocuserInfo { Connected = true });
+
+            Assert.Multiple(() => {
+                Assert.That(dispatcher.PostCount, Is.EqualTo(2), "each device-info broadcast marshals by posting");
+                Assert.That(dispatcher.DispatchCount, Is.Zero,
+                    "the device-broadcast path must never block the calling thread on the UI thread");
+                Assert.That(vm.CameraInfo.Connected, Is.True);
+                Assert.That(vm.FocuserInfo.Connected, Is.True);
+            });
         }
 
         [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/ApplicationDispatcherTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/ApplicationDispatcherTests.cs
@@ -1,10 +1,57 @@
 using NINA.Joko.Plugins.HocusFocus.Utility;
 using NUnit.Framework;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Threading;
 
 namespace NINA.Joko.Plugins.HocusFocus.Tests.Utility {
 
     [TestFixture]
     public class ApplicationDispatcherTests {
+
+        /// <summary>
+        /// A real WPF <see cref="Dispatcher"/> on a live thread that is deliberately NOT pumping. This is the exact
+        /// state NINA's UI thread is in during shutdown: <c>ApplicationDeviceConnectionVM.Shutdown()</c> blocks it
+        /// inside <c>Nito.AsyncEx.AsyncContext.Run</c>, which pumps its own queue and never the WPF dispatcher. The
+        /// dispatcher is alive and has NOT begun shutting down, so <c>HasShutdownStarted</c> is still false.
+        /// </summary>
+        private sealed class NonPumpingDispatcherThread : IDisposable {
+            private readonly Thread thread;
+            private readonly ManualResetEventSlim created = new ManualResetEventSlim();
+            private readonly ManualResetEventSlim pump = new ManualResetEventSlim();
+            private bool disposed;
+
+            public NonPumpingDispatcherThread() {
+                thread = new Thread(() => {
+                    Dispatcher = Dispatcher.CurrentDispatcher;
+                    created.Set();
+                    pump.Wait();
+                    Dispatcher.Run();
+                });
+                thread.IsBackground = true;
+                thread.SetApartmentState(ApartmentState.STA);
+                thread.Start();
+                created.Wait();
+            }
+
+            public Dispatcher Dispatcher { get; private set; }
+
+            public int ThreadId => thread.ManagedThreadId;
+
+            /// <summary>Lets the dispatcher start pumping, draining whatever was queued while it was blocked.</summary>
+            public void StartPumping() => pump.Set();
+
+            public void Dispose() {
+                if (disposed) return;
+                disposed = true;
+                StartPumping();
+                Dispatcher.BeginInvokeShutdown(DispatcherPriority.Normal);
+                thread.Join(TimeSpan.FromSeconds(10));
+                created.Dispose();
+                pump.Dispose();
+            }
+        }
 
         // F13: when no WPF Application/Dispatcher is available (headless / early startup / test host), the cached
         // dispatcher is null. DispatchSynchronizationContext must fall back to inline invocation rather than
@@ -25,6 +72,97 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Utility {
             int result = 0;
             Assert.DoesNotThrow(() => result = sut.DispatchSynchronizationContext(() => 42));
             Assert.That(result, Is.EqualTo(42));
+        }
+
+        [Test]
+        public void PostSynchronizationContext_RunsInlineWhenNoDispatcherAvailable() {
+            var sut = new ApplicationDispatcher();
+            var ran = false;
+
+            Assert.DoesNotThrow(() => sut.PostSynchronizationContext(() => ran = true));
+            Assert.That(ran, Is.True);
+        }
+
+        // Characterizes the mechanics of the shutdown deadlock: the blocking variant waits for the dispatcher to
+        // pump. Any code path that a shutdown-blocked UI thread transitively waits on must therefore never use it.
+        [Test]
+        public void DispatchSynchronizationContext_BlocksWhileDispatcherIsNotPumping() {
+            using var ui = new NonPumpingDispatcherThread();
+            var sut = new ApplicationDispatcher(ui.Dispatcher);
+
+            var blocked = Task.Run(() => sut.DispatchSynchronizationContext(() => { }));
+
+            Assert.That(blocked.Wait(TimeSpan.FromMilliseconds(500)), Is.False,
+                "DispatchSynchronizationContext is a blocking Invoke and cannot complete while the dispatcher is idle");
+
+            ui.StartPumping();
+            Assert.That(blocked.Wait(TimeSpan.FromSeconds(10)), Is.True,
+                "once the dispatcher pumps, the blocked Invoke drains");
+        }
+
+        // Regression (NINA hang on exit): FocuserVM/CameraVM's DeviceUpdateTimer broadcasts device info on a
+        // threadpool thread, and ApplicationDeviceConnectionVM.Shutdown() awaits that timer to stop while the UI
+        // thread is blocked and not pumping. A consumer that marshals with a blocking Invoke never returns, so the
+        // timer never stops and shutdown deadlocks. Posting breaks the cycle.
+        [Test]
+        public void PostSynchronizationContext_DoesNotBlockWhileDispatcherIsNotPumping() {
+            using var ui = new NonPumpingDispatcherThread();
+            var sut = new ApplicationDispatcher(ui.Dispatcher);
+
+            var posted = Task.Run(() => sut.PostSynchronizationContext(() => { }));
+
+            Assert.That(posted.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "PostSynchronizationContext must return without waiting for the dispatcher to pump");
+        }
+
+        [Test]
+        public void PostSynchronizationContext_RunsActionOnDispatcherThreadOncePumping() {
+            using var ui = new NonPumpingDispatcherThread();
+            var sut = new ApplicationDispatcher(ui.Dispatcher);
+            var ran = new ManualResetEventSlim();
+            var ranOnThreadId = 0;
+
+            sut.PostSynchronizationContext(() => {
+                ranOnThreadId = Environment.CurrentManagedThreadId;
+                ran.Set();
+            });
+
+            Assert.That(ran.IsSet, Is.False, "the posted action must not run until the dispatcher pumps");
+
+            ui.StartPumping();
+
+            Assert.That(ran.Wait(TimeSpan.FromSeconds(10)), Is.True, "the posted action should run once pumping");
+            Assert.That(ranOnThreadId, Is.EqualTo(ui.ThreadId), "the action must run on the dispatcher's own thread");
+        }
+
+        [Test]
+        public void PostSynchronizationContext_RunsInlineWhenAlreadyOnDispatcherThread() {
+            using var ui = new NonPumpingDispatcherThread();
+            var sut = new ApplicationDispatcher(ui.Dispatcher);
+            ui.StartPumping();
+
+            var ranBeforePostReturned = false;
+            ui.Dispatcher.Invoke(() => {
+                var ran = false;
+                sut.PostSynchronizationContext(() => ran = true);
+                ranBeforePostReturned = ran;
+            });
+
+            Assert.That(ranBeforePostReturned, Is.True,
+                "on the dispatcher thread the action should run inline rather than being queued behind pending work");
+        }
+
+        // F14, post variant: BeginInvoke on a shut-down dispatcher throws InvalidOperationException on the calling
+        // (device-broadcast) thread. Drop the UI-bound work instead of crashing the broadcast.
+        [Test]
+        public void PostSynchronizationContext_DropsWorkWhenDispatcherHasShutDown() {
+            var ui = new NonPumpingDispatcherThread();
+            var sut = new ApplicationDispatcher(ui.Dispatcher);
+            ui.Dispose();
+
+            var ran = false;
+            Assert.DoesNotThrow(() => sut.PostSynchronizationContext(() => ran = true));
+            Assert.That(ran, Is.False, "work bound for a dead dispatcher is dropped, not run on the calling thread");
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IApplicationDispatcher.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IApplicationDispatcher.cs
@@ -20,6 +20,14 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
 
         T DispatchSynchronizationContext<T>(Func<T> func);
 
+        /// <summary>
+        /// Queues <paramref name="action"/> onto the UI thread and returns immediately, without waiting for it to run.
+        /// Use this instead of <see cref="DispatchSynchronizationContext(Action)"/> on any path the UI thread may
+        /// transitively wait on — notably NINA's device-info broadcasts, which run on a DeviceUpdateTimer that
+        /// application shutdown awaits while the UI thread is blocked and not pumping.
+        /// </summary>
+        void PostSynchronizationContext(Action action);
+
         T GetResource<T>(string name, T fallback);
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -448,11 +448,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public void UpdateDeviceInfo(CameraInfo deviceInfo) {
             // Marshal the whole update (state mutation + notifications) once at the consumer boundary so individual
             // setters need not each remember to wrap, and the high-frequency background broadcast is not blocked (F15).
-            OnUIThread(() => CameraInfo = deviceInfo);
+            PostToUIThread(() => CameraInfo = deviceInfo);
         }
 
         public void UpdateDeviceInfo(FocuserInfo deviceInfo) {
-            OnUIThread(() => FocuserInfo = deviceInfo);
+            PostToUIThread(() => FocuserInfo = deviceInfo);
         }
 
         public void UpdateEndAutoFocusRun(AutoFocusInfo info) {
@@ -2099,6 +2099,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // UI thread. DispatchSynchronizationContext is a synchronous Send with a same-context fast path, so calling
         // this from the UI thread is free and calling it from a DeviceMediator background broadcast marshals safely.
         private void OnUIThread(Action action) => applicationDispatcher.DispatchSynchronizationContext(action);
+
+        // Fire-and-forget marshaling for NINA's device-info broadcasts. Those arrive on the CameraVM/FocuserVM
+        // DeviceUpdateTimer, and ApplicationDeviceConnectionVM.Shutdown() awaits that timer to stop while the UI
+        // thread is blocked inside AsyncContext.Run — which pumps its own queue, never the WPF dispatcher. A
+        // blocking OnUIThread here would wait on a UI thread that is waiting on us: NINA hangs on exit. Only the
+        // UI cares about the result (bindings + CanExecute), so queueing it is sufficient.
+        private void PostToUIThread(Action action) => applicationDispatcher.PostSynchronizationContext(action);
 
         private void NotifyCommandsCanExecuteChanged() => OnUIThread(NotifyCommandsCanExecuteChangedCore);
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/ApplicationDispatcher.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/ApplicationDispatcher.cs
@@ -22,7 +22,16 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
         // Capture the WPF dispatcher directly. CheckAccess() lets us detect the UI thread reliably (a self-built
         // DispatcherSynchronizationContext never reference-equals the one WPF installs, so the old fast path never
         // fired — F12). The handle is null in headless/early-startup/test hosts, in which case we invoke inline (F13).
-        private readonly Dispatcher dispatcher = Application.Current?.Dispatcher;
+        private readonly Dispatcher dispatcher;
+
+        public ApplicationDispatcher() : this(Application.Current?.Dispatcher) {
+        }
+
+        // Lets a test drive a real dispatcher whose thread is alive but not pumping — the state NINA's UI thread is
+        // in during shutdown, and the one that makes a blocking Invoke deadlock.
+        public ApplicationDispatcher(Dispatcher dispatcher) {
+            this.dispatcher = dispatcher;
+        }
 
         public void DispatchSynchronizationContext(Action action) {
             // No dispatcher (headless/test host) or already on the UI thread: run inline (F12 fast path, F13 fallback).
@@ -61,6 +70,27 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
                 return default;
             } catch (InvalidOperationException) {
                 return default;
+            }
+        }
+
+        public void PostSynchronizationContext(Action action) {
+            if (dispatcher == null || dispatcher.CheckAccess()) {
+                action();
+                return;
+            }
+
+            if (dispatcher.HasShutdownStarted || dispatcher.HasShutdownFinished) {
+                return;
+            }
+
+            try {
+                // Queue and return. A blocking Invoke here would park the caller on a UI thread that may itself be
+                // waiting on the caller — e.g. shutdown awaits the DeviceUpdateTimer whose broadcast lands here.
+                dispatcher.BeginInvoke(action);
+            } catch (OperationCanceledException) {
+                // Dispatcher shut down between the check above and the BeginInvoke; nothing to do.
+            } catch (InvalidOperationException) {
+                // Same race: "The Dispatcher has been shut down" surfaced as InvalidOperationException.
             }
         }
 


### PR DESCRIPTION
## Problem

NINA hangs on exit whenever the camera or focuser is connected. Caught it live with `dotnet-stack` against the hung process; two samples ~90s apart were byte-identical, and the NINA log stopped mid-shutdown after disconnecting Dome and Flat Device, never reaching Camera/Focuser.

Three threads form the cycle:

- **UI thread** — `MainWindow.OnClosing` → `ApplicationVM.Closing()` → `ApplicationDeviceConnectionVM.Shutdown()` → `Nito.AsyncEx.AsyncContext.Run(...)`. `AsyncContext.Run` blocks the UI thread and pumps *its own* `BlockingCollection` queue, never the WPF Dispatcher queue. The shutdown task it's waiting on awaits `CameraVM.Disconnect()` / `FocuserVM.Disconnect()`, each of which awaits its `DeviceUpdateTimer` to stop.
- **Two threadpool threads** — the very `DeviceUpdateTimer` callbacks shutdown is waiting on. Both fan out through `DeviceMediator.Broadcast` into `TiltAdapterWizardVM.UpdateDeviceInfo`, which marshaled to the UI thread with a **blocking** `Dispatcher.Invoke` and parked on `DispatcherOperationEvent.WaitOne()`.

So the UI thread waits for the disconnects, the disconnects wait for the update timers, and the update timers wait for a UI thread that will never pump again.

The existing `HasShutdownStarted || HasShutdownFinished` guard in `ApplicationDispatcher` doesn't help: WPF only begins dispatcher shutdown *after* the windows close, so during `OnClosing` both flags are still false, the guard passes, and `Invoke` blocks.

This is **not** a regression from 5a4a9ee. The prior implementation called `DispatcherSynchronizationContext.Send(...)`, which is also a blocking `Invoke` underneath. Latent bug, exposed whenever both devices are connected at exit.

## Fix

Marshal the device-broadcast path by *posting* instead of *blocking*: a new `IApplicationDispatcher.PostSynchronizationContext`, backed by `Dispatcher.BeginInvoke`, with the same null / already-on-UI-thread / dispatcher-shut-down guards as the blocking variant. `UpdateDeviceInfo` uses it for both overloads.

Nothing in `UpdateDeviceInfo` needs a return value or a happens-before guarantee — it assigns a property and re-evaluates `CanExecute`, both purely for bindings — and dispatcher queue ordering is FIFO at the same priority, so device updates stay in order.

`TiltAdapterWizardVM` is the only HocusFocus device consumer with this pattern; `InspectorVM.UpdateDeviceInfo` just assigns and lets `RaisePropertyChanged` marshal.

## Scope

Deliberately one change. `OnUIThread` stays blocking for the wizard's other call sites, which run on the wizard's own tasks and read state back. `Dispose()` is left alone — adding `RemoveConsumer` there is a genuine cleanup, but it's unrelated to the deadlock and could reenter the mediator mid-broadcast. Separate PR if wanted.

## Testing

Suite green: **1741 passed, 0 failed** (was 1734; 7 new tests).

Both new guards were mutation-tested rather than merely observed to pass:

- Reverting the call site to the blocking `OnUIThread` fails `UpdateDeviceInfo_MarshalsWithoutBlockingTheBroadcastThread` — *"the device-broadcast path must never block the calling thread on the UI thread."*
- Swapping `BeginInvoke` back to `Invoke` fails `PostSynchronizationContext_DoesNotBlockWhileDispatcherIsNotPumping` — *"must return without waiting for the dispatcher to pump."*

The dispatcher tests drive a **real WPF `Dispatcher` on a live thread that is deliberately not pumping** — the exact state NINA's UI thread is in during shutdown, with `HasShutdownStarted` still false. That reproduces the deadlock condition rather than simulating it.

Not yet done: running the patched plugin inside NINA and quitting with camera + focuser connected. Evidence here is unit-level plus the live stacks from the hung process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)