### PR TITLE
feat(af): optionally annotate the displayed image during an auto focus run

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusEngineTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusEngineTests.cs
@@ -48,8 +48,32 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
                 imagingMediator: Substitute.For<IImagingMediator>(),
                 imageDataFactory: Substitute.For<IImageDataFactory>(),
                 starDetectionSelector: starDetectionSelector ?? Substitute.For<IPluggableBehaviorSelector<IStarDetection>>(),
+                starAnnotatorSelector: Substitute.For<IPluggableBehaviorSelector<IStarAnnotator>>(),
                 autoFocusOptions: autoFocusOptions ?? Substitute.For<IAutoFocusOptions>(),
+                starAnnotatorOptions: Substitute.For<IStarAnnotatorOptions>(),
                 alglibAPI: new AlglibAPI());
+        }
+
+        // The live-display annotation gate. Every input must be true for the overlay to be drawn; each false case below
+        // pins one reason the overlay is suppressed.
+        [Test]
+        public void ShouldAnnotateAutoFocusDisplay_AllConditionsMet_ReturnsTrue() {
+            Assert.That(
+                AutoFocusEngine.ShouldAnnotateAutoFocusDisplay(
+                    annotateDuringAutoFocus: true, showAnnotations: true, isFullFrameRegion: true, isLiveRun: true, frameIsCurrentlyDisplayed: true),
+                Is.True);
+        }
+
+        [TestCase(false, true, true, true, true, TestName = "ShouldAnnotateAutoFocusDisplay_OptionOff_ReturnsFalse")]
+        [TestCase(true, false, true, true, true, TestName = "ShouldAnnotateAutoFocusDisplay_MasterSwitchOff_ReturnsFalse")]
+        [TestCase(true, true, false, true, true, TestName = "ShouldAnnotateAutoFocusDisplay_MultiRegionRun_ReturnsFalse")]
+        [TestCase(true, true, true, false, true, TestName = "ShouldAnnotateAutoFocusDisplay_ReplayRun_ReturnsFalse")]
+        [TestCase(true, true, true, true, false, TestName = "ShouldAnnotateAutoFocusDisplay_StaleFrame_ReturnsFalse")]
+        public void ShouldAnnotateAutoFocusDisplay_AnyConditionUnmet_ReturnsFalse(
+            bool annotateDuringAutoFocus, bool showAnnotations, bool isFullFrameRegion, bool isLiveRun, bool frameIsCurrentlyDisplayed) {
+            Assert.That(
+                AutoFocusEngine.ShouldAnnotateAutoFocusDisplay(annotateDuringAutoFocus, showAnnotations, isFullFrameRegion, isLiveRun, frameIsCurrentlyDisplayed),
+                Is.False);
         }
 
         [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarAnnotatorOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarAnnotatorOptionsTests.cs
@@ -26,7 +26,7 @@ public class StarAnnotatorOptionsTests {
         var (options, _, _) = Build();
         Assert.Multiple(() => {
             Assert.That(options.ShowAnnotations, Is.True);
-            Assert.That(options.ShowAnnotationsDuringAutoFocus, Is.False);
+            Assert.That(options.ShowAnnotationsDuringAutoFocus, Is.True);
             Assert.That(options.ShowAllStars, Is.True);
             Assert.That(options.MaxStars, Is.EqualTo(200));
             Assert.That(options.ShowStarBounds, Is.True);
@@ -54,7 +54,7 @@ public class StarAnnotatorOptionsTests {
     public void Setters_PersistToAccessor() {
         var (options, store, _) = Build();
         options.ShowAnnotations = false;
-        options.ShowAnnotationsDuringAutoFocus = true;
+        options.ShowAnnotationsDuringAutoFocus = false;
         options.ShowAllStars = false;
         options.MaxStars = 50;
         options.ShowStarBounds = false;
@@ -85,7 +85,7 @@ public class StarAnnotatorOptionsTests {
 
         Assert.Multiple(() => {
             Assert.That(store.Snapshot["ShowAnnotations"], Is.False);
-            Assert.That(store.Snapshot["ShowAnnotationsDuringAutoFocus"], Is.True);
+            Assert.That(store.Snapshot["ShowAnnotationsDuringAutoFocus"], Is.False);
             Assert.That(store.Snapshot["ShowAllStars"], Is.False);
             Assert.That(store.Snapshot["MaxStars"], Is.EqualTo(50));
             Assert.That(store.Snapshot["ShowStarBounds"], Is.False);
@@ -117,7 +117,7 @@ public class StarAnnotatorOptionsTests {
     }
 
     [TestCase(nameof(StarAnnotatorOptions.ShowAnnotations), false)]
-    [TestCase(nameof(StarAnnotatorOptions.ShowAnnotationsDuringAutoFocus), true)]
+    [TestCase(nameof(StarAnnotatorOptions.ShowAnnotationsDuringAutoFocus), false)]
     [TestCase(nameof(StarAnnotatorOptions.ShowAllStars), false)]
     [TestCase(nameof(StarAnnotatorOptions.MaxStars), 25)]
     [TestCase(nameof(StarAnnotatorOptions.ShowStarBounds), false)]
@@ -148,7 +148,7 @@ public class StarAnnotatorOptionsTests {
         var (options, _, _) = Build();
         options.MaxStars = 5;
         options.ShowAnnotations = false;
-        options.ShowAnnotationsDuringAutoFocus = true;
+        options.ShowAnnotationsDuringAutoFocus = false;
         options.ShowStructureMap = ShowStructureMapEnum.Original;
         options.AnnotationFontFamily = new FontFamily("Tahoma");
 
@@ -157,7 +157,7 @@ public class StarAnnotatorOptionsTests {
         Assert.Multiple(() => {
             Assert.That(options.MaxStars, Is.EqualTo(200));
             Assert.That(options.ShowAnnotations, Is.True);
-            Assert.That(options.ShowAnnotationsDuringAutoFocus, Is.False);
+            Assert.That(options.ShowAnnotationsDuringAutoFocus, Is.True);
             Assert.That(options.ShowStructureMap, Is.EqualTo(ShowStructureMapEnum.None));
             Assert.That(options.AnnotationFontFamily.FamilyNames.Values, Does.Contain("Arial"));
         });

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarAnnotatorOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarAnnotatorOptionsTests.cs
@@ -26,6 +26,7 @@ public class StarAnnotatorOptionsTests {
         var (options, _, _) = Build();
         Assert.Multiple(() => {
             Assert.That(options.ShowAnnotations, Is.True);
+            Assert.That(options.ShowAnnotationsDuringAutoFocus, Is.False);
             Assert.That(options.ShowAllStars, Is.True);
             Assert.That(options.MaxStars, Is.EqualTo(200));
             Assert.That(options.ShowStarBounds, Is.True);
@@ -53,6 +54,7 @@ public class StarAnnotatorOptionsTests {
     public void Setters_PersistToAccessor() {
         var (options, store, _) = Build();
         options.ShowAnnotations = false;
+        options.ShowAnnotationsDuringAutoFocus = true;
         options.ShowAllStars = false;
         options.MaxStars = 50;
         options.ShowStarBounds = false;
@@ -83,6 +85,7 @@ public class StarAnnotatorOptionsTests {
 
         Assert.Multiple(() => {
             Assert.That(store.Snapshot["ShowAnnotations"], Is.False);
+            Assert.That(store.Snapshot["ShowAnnotationsDuringAutoFocus"], Is.True);
             Assert.That(store.Snapshot["ShowAllStars"], Is.False);
             Assert.That(store.Snapshot["MaxStars"], Is.EqualTo(50));
             Assert.That(store.Snapshot["ShowStarBounds"], Is.False);
@@ -114,6 +117,7 @@ public class StarAnnotatorOptionsTests {
     }
 
     [TestCase(nameof(StarAnnotatorOptions.ShowAnnotations), false)]
+    [TestCase(nameof(StarAnnotatorOptions.ShowAnnotationsDuringAutoFocus), true)]
     [TestCase(nameof(StarAnnotatorOptions.ShowAllStars), false)]
     [TestCase(nameof(StarAnnotatorOptions.MaxStars), 25)]
     [TestCase(nameof(StarAnnotatorOptions.ShowStarBounds), false)]
@@ -144,6 +148,7 @@ public class StarAnnotatorOptionsTests {
         var (options, _, _) = Build();
         options.MaxStars = 5;
         options.ShowAnnotations = false;
+        options.ShowAnnotationsDuringAutoFocus = true;
         options.ShowStructureMap = ShowStructureMapEnum.Original;
         options.AnnotationFontFamily = new FontFamily("Tahoma");
 
@@ -152,6 +157,7 @@ public class StarAnnotatorOptionsTests {
         Assert.Multiple(() => {
             Assert.That(options.MaxStars, Is.EqualTo(200));
             Assert.That(options.ShowAnnotations, Is.True);
+            Assert.That(options.ShowAnnotationsDuringAutoFocus, Is.False);
             Assert.That(options.ShowStructureMap, Is.EqualTo(ShowStructureMapEnum.None));
             Assert.That(options.AnnotationFontFamily.FamilyNames.Values, Does.Contain("Arial"));
         });

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
@@ -57,7 +57,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         private readonly IImagingMediator imagingMediator;
         private readonly IImageDataFactory imageDataFactory;
         private readonly IPluggableBehaviorSelector<IStarDetection> starDetectionSelector;
+        private readonly IPluggableBehaviorSelector<IStarAnnotator> starAnnotatorSelector;
         private readonly IAutoFocusOptions autoFocusOptions;
+        private readonly IStarAnnotatorOptions starAnnotatorOptions;
         private readonly IAlglibAPI alglibAPI;
 
         public AutoFocusEngine(
@@ -69,7 +71,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             IImagingMediator imagingMediator,
             IImageDataFactory imageDataFactory,
             IPluggableBehaviorSelector<IStarDetection> starDetectionSelector,
+            IPluggableBehaviorSelector<IStarAnnotator> starAnnotatorSelector,
             IAutoFocusOptions autoFocusOptions,
+            IStarAnnotatorOptions starAnnotatorOptions,
             IAlglibAPI alglibAPI) {
             this.profileService = profileService;
             this.cameraMediator = cameraMediator;
@@ -79,7 +83,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             this.guiderMediator = guiderMediator;
             this.imageDataFactory = imageDataFactory;
             this.starDetectionSelector = starDetectionSelector;
+            this.starAnnotatorSelector = starAnnotatorSelector;
             this.autoFocusOptions = autoFocusOptions;
+            this.starAnnotatorOptions = starAnnotatorOptions;
             this.alglibAPI = alglibAPI;
         }
 
@@ -534,6 +540,24 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             return AutoFocusFailureMode.None;
         }
 
+        // Whether this frame's star detection should be drawn onto the live imaging display. Pure/static so the gate is
+        // unit-testable without the full sweep harness.
+        //
+        // showAnnotations is checked here rather than left to the annotator: GenerateAnnotatedImage no-ops when the master
+        // switch is off, so testing it up front skips the (expensive) full-frame render entirely. The overlay is limited to
+        // plain full-frame runs (isFullFrameRegion) because a multi-region run - the Aberration Inspector, the Tilt Adapter
+        // Wizard - would have every region racing to paint the one display. Replay runs are excluded (isLiveRun) because
+        // their bounded prefetch prepares frames ahead of analysis, so frameIsCurrentlyDisplayed would reject most of them;
+        // the Review Frames UI already re-renders those overlays on demand.
+        internal static bool ShouldAnnotateAutoFocusDisplay(
+            bool annotateDuringAutoFocus,
+            bool showAnnotations,
+            bool isFullFrameRegion,
+            bool isLiveRun,
+            bool frameIsCurrentlyDisplayed) {
+            return annotateDuringAutoFocus && showAnnotations && isFullFrameRegion && isLiveRun && frameIsCurrentlyDisplayed;
+        }
+
         private class AutoFocusState {
 
             public AutoFocusState(
@@ -583,6 +607,46 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             public List<Task> AnalysisTasks { get; private set; } = new List<Task>();
             public AsyncAutoResetEvent MeasurementCompleteEvent { get; private set; }
             public string SaveFolder { get; set; } = "";
+
+            // The IRenderedImage most recently handed to imagingMediator.PrepareImage - i.e. the frame currently on the
+            // imaging display. Written in PrepareExposure, read by the live-annotation stale-frame guard: analyses of
+            // different frames overlap (ExposureSemaphore allows MaxConcurrent), so a slow detection must not paint its
+            // overlay over a newer frame. Reference reads/writes are atomic; volatile for visibility across those tasks.
+            private volatile IRenderedImage lastDisplayedRenderedImage;
+
+            public IRenderedImage LastDisplayedRenderedImage {
+                get => lastDisplayedRenderedImage;
+                set => lastDisplayedRenderedImage = value;
+            }
+
+            // Fire-and-forget annotation renders spawned by MaybeDisplayAutoFocusAnnotation. Drained at run teardown so a
+            // late SetImage can never paint over the next, non-AutoFocus image.
+            private readonly List<Task> displayAnnotationTasks = new List<Task>();
+
+            public void TrackDisplayAnnotationTask(Task task) {
+                lock (StatesLock) {
+                    displayAnnotationTasks.Add(task);
+                }
+            }
+
+            public Task[] SnapshotDisplayAnnotationTasks() {
+                lock (StatesLock) {
+                    return displayAnnotationTasks.ToArray();
+                }
+            }
+
+            // At most one annotation render is in flight at a time. Analyses of different frames overlap, and until now
+            // IStarAnnotator.GetAnnotatedImage was only ever called from NINA's display pipeline, which serializes it. Two
+            // concurrent AutoFocus renders would both queue a full-frame conversion+draw AND race the annotator's own
+            // previousParams/previousResult/previousAnnotatedImageRef triple (which drives its live re-annotation on an
+            // option change). Dropping the newcomer rather than queueing it is right: the in-flight render is for this
+            // frame or a newer one, and a superseded render is discarded by the stale-frame re-check anyway. Under normal
+            // AutoFocus (exposure time greatly exceeds render time) this never contends.
+            private int annotationRenderInFlight;
+
+            public bool TryClaimAnnotationRender() => Interlocked.CompareExchange(ref annotationRenderInFlight, 1, 0) == 0;
+
+            public void ReleaseAnnotationRender() => Interlocked.Exchange(ref annotationRenderInFlight, 0);
 
             private volatile int measurementsInProgress;
             public int MeasurementsInProgress { get => measurementsInProgress; }
@@ -742,6 +806,10 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     imageState.PreservedExposure = image;
                 }
 
+                // cacheSource is non-null only on the replay path (RerunImpl always constructs one), so it doubles as the
+                // live/replay discriminator.
+                MaybeDisplayAutoFocusAnnotation(state, regionState, image, analysisParams, analysisResult, isLiveRun: cacheSource == null, token: token);
+
                 Logger.Debug($"Current Focus - Position: {imageState.FocuserPosition}, HFR: {analysisResult.AverageHFR}");
                 return new MeasureAndError() { Measure = analysisResult.AverageHFR, Stdev = analysisResult.HFRStdDev };
             } else {
@@ -762,6 +830,73 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 var analysisResult = await analysis.Measure(image, analysisParams, progress: null, token);
                 return new MeasureAndError() { Measure = analysisResult.AverageContrast, Stdev = analysisResult.ContrastStdev };
             }
+        }
+
+        /// <summary>
+        /// Best-effort: draw this frame's star detection onto the live imaging display, reusing the detection auto focus
+        /// already ran rather than paying for a second one. Never throws (annotation must not fail an AF measurement) and
+        /// never blocks the caller - the render is a full-frame 16→8bpp conversion plus draw, so keeping it off the
+        /// measurement path leaves AF timing and the ExposureSemaphore slot untouched. The spawned task is tracked on the
+        /// state and drained at run teardown.
+        ///
+        /// annotationParams is only consulted by the annotator when the result is NOT a HocusFocusStarDetectionResult (the
+        /// HF result carries its own DetectorParams.Region for the ROI). This is the region==null branch, where
+        /// analysisParams carries the correct UseROI/InnerCropRatio/OuterCropRatio for NINA's built-in annotator.
+        /// </summary>
+        private void MaybeDisplayAutoFocusAnnotation(
+            AutoFocusState state,
+            AutoFocusRegionState regionState,
+            IRenderedImage image,
+            StarDetectionParams annotationParams,
+            StarDetectionResult analysisResult,
+            bool isLiveRun,
+            CancellationToken token) {
+            var originalImage = image?.OriginalImage;
+            if (originalImage == null) {
+                return;
+            }
+
+            if (!ShouldAnnotateAutoFocusDisplay(
+                    annotateDuringAutoFocus: starAnnotatorOptions.ShowAnnotationsDuringAutoFocus,
+                    showAnnotations: starAnnotatorOptions.ShowAnnotations,
+                    isFullFrameRegion: regionState.Region == null,
+                    isLiveRun: isLiveRun,
+                    frameIsCurrentlyDisplayed: ReferenceEquals(state.LastDisplayedRenderedImage, image))) {
+                return;
+            }
+
+            var annotator = starAnnotatorSelector.GetBehavior();
+            if (annotator == null) {
+                return;
+            }
+
+            if (!state.TryClaimAnnotationRender()) {
+                Logger.Trace("Skipping auto focus display annotation - another render is already in flight");
+                return;
+            }
+
+            // Mirrors NINA's RenderedImage.DetectStars. The Hocus Focus annotator ignores this in favor of its own MaxStars
+            // option, but a different selected annotator (e.g. NINA's built-in) honors it.
+            var maxStars = profileService.ActiveProfile.ImageSettings.AnnotateUnlimitedStars ? -1 : 200;
+
+            // The token is deliberately not passed to Task.Run: the delegate owns cancellation so its catch always runs.
+            var annotationTask = Task.Run(async () => {
+                try {
+                    var annotatedImage = await annotator.GetAnnotatedImage(annotationParams, analysisResult, originalImage, maxStars, token);
+
+                    // Re-check after the render: a newer frame may have been prepared and displayed in the meantime.
+                    if (annotatedImage != null && !token.IsCancellationRequested && ReferenceEquals(state.LastDisplayedRenderedImage, image)) {
+                        imagingMediator.SetImage(annotatedImage);
+                    }
+                } catch (OperationCanceledException) {
+                    // Auto focus was cancelled mid-render. Nothing to display.
+                } catch (Exception e) {
+                    Logger.Error(e, "Failed to render star detection annotations onto the auto focus display");
+                } finally {
+                    state.ReleaseAnnotationRender();
+                }
+            });
+            state.TrackDisplayAnnotationTask(annotationTask);
         }
 
         private async Task<IExposureData> TakeExposure(AutoFocusState state, int focuserPosition, CancellationToken token, IProgress<ApplicationStatus> progress) {
@@ -1017,7 +1152,12 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             }
 
             var prepareParameters = new PrepareImageParameters(autoStretch: autoStretch, detectStars: false);
-            return await imagingMediator.PrepareImage(imageData, prepareParameters, token);
+            var preparedImage = await imagingMediator.PrepareImage(imageData, prepareParameters, token);
+
+            // This is what NINA assigns to ImageControlVM.RenderedImage, so recording it here gives the live-annotation
+            // stale-frame guard an exact "is this frame still on screen" test. Single choke point for live and replay.
+            state.LastDisplayedRenderedImage = preparedImage;
+            return preparedImage;
         }
 
         private async Task AnalyzeExposure(
@@ -1742,6 +1882,16 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     Notification.ShowError($"Auto Focus Failure. {ex.Message}");
                     Logger.Error("Failure during AutoFocus", ex);
                 } finally {
+                    // Never let a live-display annotation outlive the run: a late SetImage would paint an auto focus frame
+                    // over whatever image is shown next. Each task already swallows its own exceptions.
+                    if (autoFocusState != null) {
+                        try {
+                            await Task.WhenAll(autoFocusState.SnapshotDisplayAnnotationTasks());
+                        } catch (Exception ex) {
+                            Logger.Warning($"Failure draining auto focus display annotations. {ex.Message}");
+                        }
+                    }
+
                     try {
                         await PerformPostAutoFocusActions(
                             successfulAutoFocus: completed, initialFocusPosition: autoFocusState?.InitialFocuserPosition, imagingFilter: imagingFilter, restoreTempComp: tempComp,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngineFactory.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngineFactory.cs
@@ -29,7 +29,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         private readonly IImagingMediator imagingMediator;
         private readonly IImageDataFactory imageDataFactory;
         private readonly IPluggableBehaviorSelector<IStarDetection> starDetectionSelector;
+        private readonly IPluggableBehaviorSelector<IStarAnnotator> starAnnotatorSelector;
         private readonly IAutoFocusOptions autoFocusOptions;
+        private readonly IStarAnnotatorOptions starAnnotatorOptions;
         private readonly IAlglibAPI alglibAPI;
 
         public AutoFocusEngineFactory(
@@ -41,7 +43,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             IImagingMediator imagingMediator,
             IImageDataFactory imageDataFactory,
             IPluggableBehaviorSelector<IStarDetection> starDetectionSelector,
+            IPluggableBehaviorSelector<IStarAnnotator> starAnnotatorSelector,
             IAutoFocusOptions autoFocusOptions,
+            IStarAnnotatorOptions starAnnotatorOptions,
             IAlglibAPI alglibAPI) {
             this.profileService = profileService;
             this.cameraMediator = cameraMediator;
@@ -51,7 +55,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             this.guiderMediator = guiderMediator;
             this.imageDataFactory = imageDataFactory;
             this.starDetectionSelector = starDetectionSelector;
+            this.starAnnotatorSelector = starAnnotatorSelector;
             this.autoFocusOptions = autoFocusOptions;
+            this.starAnnotatorOptions = starAnnotatorOptions;
             this.alglibAPI = alglibAPI;
         }
 
@@ -65,7 +71,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 imagingMediator,
                 imageDataFactory,
                 starDetectionSelector,
+                starAnnotatorSelector,
                 autoFocusOptions,
+                starAnnotatorOptions,
                 alglibAPI);
         }
     }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/HocusFocusPlugin.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/HocusFocusPlugin.cs
@@ -80,7 +80,8 @@ namespace NINA.Joko.Plugins.HocusFocus {
             IImageDataFactory imageDataFactory,
             IImageSaveMediator imageSaveMediator,
             IOptionsVM options,
-            IPluggableBehaviorSelector<IStarDetection> starDetectionSelector) {
+            IPluggableBehaviorSelector<IStarDetection> starDetectionSelector,
+            IPluggableBehaviorSelector<IStarAnnotator> starAnnotatorSelector) {
             this.profileService = profileService;
             this.cameraMediator = cameraMediator;
             this.focuserMediator = focuserMediator;
@@ -121,7 +122,9 @@ namespace NINA.Joko.Plugins.HocusFocus {
                     imagingMediator,
                     imageDataFactory,
                     starDetectionSelector,
+                    starAnnotatorSelector,
                     AutoFocusOptions,
+                    StarAnnotatorOptions,
                     AlglibAPI);
             }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarAnnotatorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarAnnotatorOptions.cs
@@ -77,6 +77,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
 
     public interface IStarAnnotatorOptions : INotifyPropertyChanged {
         bool ShowAnnotations { get; set; }
+        bool ShowAnnotationsDuringAutoFocus { get; set; }
         bool ShowAllStars { get; set; }
         int MaxStars { get; set; }
         bool ShowStarBounds { get; set; }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
@@ -487,6 +487,7 @@
     <TextBlock x:Key="PixelSampleSize_Tooltip" Text="When calculating star centers and HFR, we sample values between pixels using bilinear interpolation to improve accuracy. The optimal sample size depends on whether and how much your optical system is undersampling. Increase to 1 if you are perfectly- or over-sampled, and consider lowering it below 0.5 if you are more than 2x undersampled. This value must be between 25 and 100, inclusive" />
     <TextBlock x:Key="DebugMode_Tooltip" Text="Enables debug mode, which saves additional data useful for debugging. Keep this off unless you're tuning star detection and want to view structure maps." />
     <TextBlock x:Key="ShowAnnotations_Tooltip" Text="Toggles the annotations on/off" />
+    <TextBlock x:Key="ShowAnnotationsDuringAutoFocus_Tooltip" Text="Draws the annotations on the displayed image during an Auto Focus run, so you can watch star detection as the sweep progresses. Requires Show Annotations. Applies to normal auto focus only, not to the Aberration Inspector or a replayed run." />
     <TextBlock x:Key="ShowAllStars_Tooltip" Text="Whether to annotate all stars" />
     <TextBlock x:Key="MaxStars_Tooltip" Text="The maximum number of stars to annotate (the brightest ones)" />
     <TextBlock x:Key="ShowStarBounds_Tooltip" Text="Whether to draw the bounding box or ellipse around the star" />
@@ -2367,6 +2368,7 @@
                 <RowDefinition />
                 <RowDefinition />
                 <RowDefinition />
+                <RowDefinition />
             </Grid.RowDefinitions>
             <TextBlock
                 Grid.Row="0"
@@ -2387,10 +2389,25 @@
                 Grid.Row="1"
                 Grid.Column="0"
                 VerticalAlignment="Center"
+                Text="Annotate During Auto Focus"
+                ToolTip="{StaticResource ShowAnnotationsDuringAutoFocus_Tooltip}" />
+            <CheckBox
+                Grid.Row="1"
+                Grid.Column="1"
+                MinWidth="80"
+                Margin="5,5,0,0"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                IsChecked="{Binding ShowAnnotationsDuringAutoFocus}"
+                ToolTip="{StaticResource ShowAnnotationsDuringAutoFocus_Tooltip}" />
+            <TextBlock
+                Grid.Row="2"
+                Grid.Column="0"
+                VerticalAlignment="Center"
                 Text="Show All Stars"
                 ToolTip="{StaticResource ShowAllStars_Tooltip}" />
             <CheckBox
-                Grid.Row="1"
+                Grid.Row="2"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"
@@ -2399,14 +2416,14 @@
                 IsChecked="{Binding ShowAllStars}"
                 ToolTip="{StaticResource ShowAllStars_Tooltip}" />
             <TextBlock
-                Grid.Row="2"
+                Grid.Row="3"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Maximum Stars"
                 ToolTip="{StaticResource MaxStars_Tooltip}"
                 Visibility="{Binding ShowAllStars, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}" />
             <ninactrl:UnitTextBox
-                Grid.Row="2"
+                Grid.Row="3"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"
@@ -2422,13 +2439,13 @@
                 </Binding>
             </ninactrl:UnitTextBox>
             <TextBlock
-                Grid.Row="3"
+                Grid.Row="4"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Show Star Bounds"
                 ToolTip="{StaticResource ShowStarBounds_Tooltip}" />
             <CheckBox
-                Grid.Row="3"
+                Grid.Row="4"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"
@@ -2437,7 +2454,7 @@
                 IsChecked="{Binding ShowStarBounds}"
                 ToolTip="{StaticResource ShowStarBounds_Tooltip}" />
             <TextBlock
-                Grid.Row="4"
+                Grid.Row="5"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Star Bounds Type"
@@ -2445,7 +2462,7 @@
                 Visibility="{Binding ShowStarBounds, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
             <ComboBox
                 Name="PART_StarBoundsTypeList"
-                Grid.Row="4"
+                Grid.Row="5"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"
@@ -2456,14 +2473,14 @@
                 ToolTip="{StaticResource StarBoundsType_Tooltip}"
                 Visibility="{Binding ShowStarBounds, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
             <TextBlock
-                Grid.Row="5"
+                Grid.Row="6"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Star Bounds Color"
                 ToolTip="{StaticResource StarBoundsColor_Tooltip}"
                 Visibility="{Binding ShowStarBounds, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
             <xceed:ColorPicker
-                Grid.Row="5"
+                Grid.Row="6"
                 Grid.Column="1"
                 Width="80"
                 Margin="5,5,0,0"
@@ -2474,14 +2491,14 @@
                 Visibility="{Binding ShowStarBounds, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
 
             <TextBlock
-                Grid.Row="6"
+                Grid.Row="7"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Show Property"
                 ToolTip="{StaticResource ShowAnnotationType_Tooltip}" />
             <ComboBox
                 Name="PART_ShowAnnotationTypeList"
-                Grid.Row="6"
+                Grid.Row="7"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"
@@ -2498,13 +2515,13 @@
             </ComboBox>
 
             <TextBlock
-                Grid.Row="7"
+                Grid.Row="8"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Property Font"
                 Visibility="{Binding ShowAnnotationType, Converter={StaticResource HF_ShowAnnotationTypeToVisibilityConverter}}" />
             <StackPanel
-                Grid.Row="7"
+                Grid.Row="8"
                 Grid.Column="1"
                 Orientation="Horizontal"
                 Visibility="{Binding ShowAnnotationType, Converter={StaticResource HF_ShowAnnotationTypeToVisibilityConverter}}">
@@ -2551,14 +2568,14 @@
             </StackPanel>
 
             <TextBlock
-                Grid.Row="8"
+                Grid.Row="9"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Property Color"
                 ToolTip="{StaticResource AnnotationColor_Tooltip}"
                 Visibility="{Binding ShowAnnotationType, Converter={StaticResource HF_ShowAnnotationTypeToVisibilityConverter}}" />
             <xceed:ColorPicker
-                Grid.Row="8"
+                Grid.Row="9"
                 Grid.Column="1"
                 Width="80"
                 Margin="5,5,0,0"
@@ -2569,13 +2586,13 @@
                 Visibility="{Binding ShowAnnotationType, Converter={StaticResource HF_ShowAnnotationTypeToVisibilityConverter}}" />
 
             <TextBlock
-                Grid.Row="9"
+                Grid.Row="10"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Show ROI"
                 ToolTip="{StaticResource ShowROI_Tooltip}" />
             <CheckBox
-                Grid.Row="9"
+                Grid.Row="10"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"
@@ -2584,14 +2601,14 @@
                 IsChecked="{Binding ShowROI}"
                 ToolTip="{StaticResource ShowROI_Tooltip}" />
             <TextBlock
-                Grid.Row="10"
+                Grid.Row="11"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="ROI Color"
                 ToolTip="{StaticResource ROIColor_Tooltip}"
                 Visibility="{Binding ShowROI, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
             <xceed:ColorPicker
-                Grid.Row="10"
+                Grid.Row="11"
                 Grid.Column="1"
                 Width="80"
                 Margin="5,5,0,0"
@@ -2601,13 +2618,13 @@
                 ToolTip="{StaticResource ROIColor_Tooltip}"
                 Visibility="{Binding ShowROI, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
             <TextBlock
-                Grid.Row="11"
+                Grid.Row="12"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Show Star Center"
                 ToolTip="{StaticResource ShowStarCenter_Tooltip}" />
             <CheckBox
-                Grid.Row="11"
+                Grid.Row="12"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"
@@ -2616,14 +2633,14 @@
                 IsChecked="{Binding ShowStarCenter}"
                 ToolTip="{StaticResource ShowStarCenter_Tooltip}" />
             <TextBlock
-                Grid.Row="12"
+                Grid.Row="13"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Star Center Color"
                 ToolTip="{StaticResource StarCenterColor_Tooltip}"
                 Visibility="{Binding ShowStarCenter, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
             <xceed:ColorPicker
-                Grid.Row="12"
+                Grid.Row="13"
                 Grid.Column="1"
                 Width="80"
                 Margin="5,5,0,0"
@@ -2634,13 +2651,13 @@
                 Visibility="{Binding ShowStarCenter, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
 
             <TextBlock
-                Grid.Row="13"
+                Grid.Row="14"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Show Distorted"
                 ToolTip="{StaticResource ShowTooDistorted_Tooltip}" />
             <CheckBox
-                Grid.Row="13"
+                Grid.Row="14"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"
@@ -2649,14 +2666,14 @@
                 IsChecked="{Binding ShowTooDistorted}"
                 ToolTip="{StaticResource ShowTooDistorted_Tooltip}" />
             <TextBlock
-                Grid.Row="14"
+                Grid.Row="15"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Distorted Box Color"
                 ToolTip="{StaticResource TooDistortedColor_Tooltip}"
                 Visibility="{Binding ShowTooDistorted, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
             <xceed:ColorPicker
-                Grid.Row="14"
+                Grid.Row="15"
                 Grid.Column="1"
                 Width="80"
                 Margin="5,5,0,0"
@@ -2667,13 +2684,13 @@
                 Visibility="{Binding ShowTooDistorted, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
 
             <TextBlock
-                Grid.Row="15"
+                Grid.Row="16"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Show Degenerate"
                 ToolTip="{StaticResource ShowDegenerate_Tooltip}" />
             <CheckBox
-                Grid.Row="15"
+                Grid.Row="16"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"
@@ -2682,14 +2699,14 @@
                 IsChecked="{Binding ShowDegenerate}"
                 ToolTip="{StaticResource ShowDegenerate_Tooltip}" />
             <TextBlock
-                Grid.Row="16"
+                Grid.Row="17"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Degenerate Box Color"
                 ToolTip="{StaticResource DegenerateColor_Tooltip}"
                 Visibility="{Binding ShowDegenerate, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
             <xceed:ColorPicker
-                Grid.Row="16"
+                Grid.Row="17"
                 Grid.Column="1"
                 Width="80"
                 Margin="5,5,0,0"
@@ -2700,13 +2717,13 @@
                 Visibility="{Binding ShowDegenerate, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
 
             <TextBlock
-                Grid.Row="17"
+                Grid.Row="18"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Show Saturated"
                 ToolTip="{StaticResource ShowSaturated_Tooltip}" />
             <CheckBox
-                Grid.Row="17"
+                Grid.Row="18"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"
@@ -2715,14 +2732,14 @@
                 IsChecked="{Binding ShowSaturated}"
                 ToolTip="{StaticResource ShowSaturated_Tooltip}" />
             <TextBlock
-                Grid.Row="18"
+                Grid.Row="19"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Saturated Box Color"
                 ToolTip="{StaticResource SaturatedColor_Tooltip}"
                 Visibility="{Binding ShowSaturated, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
             <xceed:ColorPicker
-                Grid.Row="18"
+                Grid.Row="19"
                 Grid.Column="1"
                 Width="80"
                 Margin="5,5,0,0"
@@ -2733,13 +2750,13 @@
                 Visibility="{Binding ShowSaturated, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
 
             <TextBlock
-                Grid.Row="19"
+                Grid.Row="20"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Show Low Sensitivity"
                 ToolTip="{StaticResource ShowLowSensitivity_Tooltip}" />
             <CheckBox
-                Grid.Row="19"
+                Grid.Row="20"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"
@@ -2748,14 +2765,14 @@
                 IsChecked="{Binding ShowLowSensitivity}"
                 ToolTip="{StaticResource ShowLowSensitivity_Tooltip}" />
             <TextBlock
-                Grid.Row="20"
+                Grid.Row="21"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Low Sensitivity Box Color"
                 ToolTip="{StaticResource LowSensitivityColor_Tooltip}"
                 Visibility="{Binding ShowLowSensitivity, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
             <xceed:ColorPicker
-                Grid.Row="20"
+                Grid.Row="21"
                 Grid.Column="1"
                 Width="80"
                 Margin="5,5,0,0"
@@ -2766,13 +2783,13 @@
                 Visibility="{Binding ShowLowSensitivity, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
 
             <TextBlock
-                Grid.Row="21"
+                Grid.Row="22"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Show Not Centered"
                 ToolTip="{StaticResource ShowNotCentered_Tooltip}" />
             <CheckBox
-                Grid.Row="21"
+                Grid.Row="22"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"
@@ -2781,14 +2798,14 @@
                 IsChecked="{Binding ShowNotCentered}"
                 ToolTip="{StaticResource ShowNotCentered_Tooltip}" />
             <TextBlock
-                Grid.Row="22"
+                Grid.Row="23"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Not Centered Box Color"
                 ToolTip="{StaticResource NotCenteredColor_Tooltip}"
                 Visibility="{Binding ShowNotCentered, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
             <xceed:ColorPicker
-                Grid.Row="22"
+                Grid.Row="23"
                 Grid.Column="1"
                 Width="80"
                 Margin="5,5,0,0"
@@ -2799,13 +2816,13 @@
                 Visibility="{Binding ShowNotCentered, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
 
             <TextBlock
-                Grid.Row="23"
+                Grid.Row="24"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Show Too Flat"
                 ToolTip="{StaticResource ShowTooFlat_Tooltip}" />
             <CheckBox
-                Grid.Row="23"
+                Grid.Row="24"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"
@@ -2814,14 +2831,14 @@
                 IsChecked="{Binding ShowTooFlat}"
                 ToolTip="{StaticResource ShowTooFlat_Tooltip}" />
             <TextBlock
-                Grid.Row="24"
+                Grid.Row="25"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Too Flat Box Color"
                 ToolTip="{StaticResource TooFlatColor_Tooltip}"
                 Visibility="{Binding ShowTooFlat, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
             <xceed:ColorPicker
-                Grid.Row="24"
+                Grid.Row="25"
                 Grid.Column="1"
                 Width="80"
                 Margin="5,5,0,0"
@@ -2832,13 +2849,13 @@
                 Visibility="{Binding ShowTooFlat, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
 
             <TextBlock
-                Grid.Row="25"
+                Grid.Row="26"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Show Contaminated"
                 ToolTip="{StaticResource ShowContaminated_Tooltip}" />
             <CheckBox
-                Grid.Row="25"
+                Grid.Row="26"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"
@@ -2847,14 +2864,14 @@
                 IsChecked="{Binding ShowContaminated}"
                 ToolTip="{StaticResource ShowContaminated_Tooltip}" />
             <TextBlock
-                Grid.Row="26"
+                Grid.Row="27"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Contaminated Box Color"
                 ToolTip="{StaticResource ContaminatedColor_Tooltip}"
                 Visibility="{Binding ShowContaminated, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
             <xceed:ColorPicker
-                Grid.Row="26"
+                Grid.Row="27"
                 Grid.Column="1"
                 Width="80"
                 Margin="5,5,0,0"
@@ -2865,7 +2882,7 @@
                 Visibility="{Binding ShowContaminated, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
 
             <TextBlock
-                Grid.Row="27"
+                Grid.Row="28"
                 Grid.Column="0"
                 VerticalAlignment="Center"
                 Text="Show Structure Map"
@@ -2873,7 +2890,7 @@
                 Visibility="{Binding DetectorOptions.DebugMode, Converter={BoolToVisibilityConverter}}" />
             <ComboBox
                 Name="PART_ShowStructureMapList"
-                Grid.Row="27"
+                Grid.Row="28"
                 Grid.Column="1"
                 MinWidth="80"
                 Margin="5,5,0,0"
@@ -2884,7 +2901,7 @@
                 ToolTip="{StaticResource ShowStructureMap_Tooltip}"
                 Visibility="{Binding DetectorOptions.DebugMode, Converter={BoolToVisibilityConverter}}" />
             <TextBlock
-                Grid.Row="28"
+                Grid.Row="29"
                 Grid.Column="0"
                 Margin="5,5,0,0"
                 VerticalAlignment="Center"
@@ -2898,7 +2915,7 @@
                 </TextBlock.Visibility>
             </TextBlock>
             <xceed:ColorPicker
-                Grid.Row="28"
+                Grid.Row="29"
                 Grid.Column="1"
                 Width="80"
                 Margin="5,5,0,0"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarAnnotatorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarAnnotatorOptions.cs
@@ -48,6 +48,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
 
         private void InitializeOptions() {
             showAnnotations = optionsAccessor.GetValueBoolean("ShowAnnotations", true);
+            showAnnotationsDuringAutoFocus = optionsAccessor.GetValueBoolean("ShowAnnotationsDuringAutoFocus", false);
             showAllStars = optionsAccessor.GetValueBoolean("ShowAllStars", true);
             maxStars = optionsAccessor.GetValueInt32("MaxStars", 200);
             showStarBounds = optionsAccessor.GetValueBoolean("ShowStarBounds", true);
@@ -81,6 +82,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
 
         public void ResetDefaults() {
             ShowAnnotations = true;
+            ShowAnnotationsDuringAutoFocus = false;
             ShowAllStars = false;
             MaxStars = 200;
             ShowStarBounds = true;
@@ -120,6 +122,19 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                 if (showAnnotations != value) {
                     showAnnotations = value;
                     optionsAccessor.SetValueBoolean("ShowAnnotations", showAnnotations);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool showAnnotationsDuringAutoFocus;
+
+        public bool ShowAnnotationsDuringAutoFocus {
+            get => showAnnotationsDuringAutoFocus;
+            set {
+                if (showAnnotationsDuringAutoFocus != value) {
+                    showAnnotationsDuringAutoFocus = value;
+                    optionsAccessor.SetValueBoolean("ShowAnnotationsDuringAutoFocus", value);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarAnnotatorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarAnnotatorOptions.cs
@@ -48,7 +48,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
 
         private void InitializeOptions() {
             showAnnotations = optionsAccessor.GetValueBoolean("ShowAnnotations", true);
-            showAnnotationsDuringAutoFocus = optionsAccessor.GetValueBoolean("ShowAnnotationsDuringAutoFocus", false);
+            showAnnotationsDuringAutoFocus = optionsAccessor.GetValueBoolean("ShowAnnotationsDuringAutoFocus", true);
             showAllStars = optionsAccessor.GetValueBoolean("ShowAllStars", true);
             maxStars = optionsAccessor.GetValueInt32("MaxStars", 200);
             showStarBounds = optionsAccessor.GetValueBoolean("ShowStarBounds", true);
@@ -82,7 +82,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
 
         public void ResetDefaults() {
             ShowAnnotations = true;
-            ShowAnnotationsDuringAutoFocus = false;
+            ShowAnnotationsDuringAutoFocus = true;
             ShowAllStars = false;
             MaxStars = 200;
             ShowStarBounds = true;

--- a/Joko.NINA.Plugins/TestApp/Program.cs
+++ b/Joko.NINA.Plugins/TestApp/Program.cs
@@ -325,6 +325,7 @@ namespace TestApp {
             public static StaticStarAnnotatorOptions CreateDefault() {
                 return new StaticStarAnnotatorOptions() {
                     ShowAnnotations = true,
+                    ShowAnnotationsDuringAutoFocus = true,
                     ShowAllStars = true,
                     MaxStars = 200,
                     ShowStarBounds = true,

--- a/Joko.NINA.Plugins/TestApp/Program.cs
+++ b/Joko.NINA.Plugins/TestApp/Program.cs
@@ -290,6 +290,7 @@ namespace TestApp {
 
         public class StaticStarAnnotatorOptions : BaseINPC, IStarAnnotatorOptions {
             public bool ShowAnnotations { get; set; }
+            public bool ShowAnnotationsDuringAutoFocus { get; set; }
             public bool ShowAllStars { get; set; }
             public int MaxStars { get; set; }
             public bool ShowStarBounds { get; set; }

--- a/documentation/docs/overview/star-annotation.md
+++ b/documentation/docs/overview/star-annotation.md
@@ -13,6 +13,8 @@ The annotator converts the displayed image to an 8-bit grayscale canvas, draws e
 
 If **Show Annotations** is off, the annotator returns the image untouched, and nothing else in this page applies until you turn it back on.
 
+Auto Focus is the exception: it measures each frame with its own detection pass and shows the frame unannotated. Turn on **Annotate During Auto Focus** and it overlays that same detection — the very stars that produced the HFR point — onto each frame as the sweep runs.
+
 By default the annotator draws *every* detected star. If you turn **Show All Stars** off, it keeps only the **Maximum Stars** brightest stars (sorted by average brightness) and labels those. The rejection boxes described later are drawn from the detector's metrics independently of this limit, so they always appear in full when their toggle is on.
 
 !!! tip "When this helps"
@@ -29,6 +31,7 @@ These controls govern the always-on overlay drawn for accepted stars. ("Property
 | Setting | Default | Range / values | What it does |
 |---|---|---|---|
 | Show Annotations | On | on / off | Master switch. *"Toggles the annotations on/off"*. When off, the unmodified image is returned. |
+| Annotate During Auto Focus | Off | on / off | Draws the overlay on the displayed image during an Auto Focus run, so you can watch star detection as the sweep progresses. Requires **Show Annotations**. Applies to a normal auto focus only — not to the Aberration Inspector's multi-region run, nor to a replayed run. |
 | Show All Stars | On | on / off | *"Whether to annotate all stars"*. When off, only the brightest **Maximum Stars** are labeled. |
 | Maximum Stars | 200 | ≥ 1 | *"The maximum number of stars to annotate (the brightest ones)"*. Only applies when **Show All Stars** is off. |
 | Show Star Bounds | On | on / off | *"Whether to draw the bounding box or ellipse around the star"*. |

--- a/documentation/docs/overview/star-annotation.md
+++ b/documentation/docs/overview/star-annotation.md
@@ -13,7 +13,7 @@ The annotator converts the displayed image to an 8-bit grayscale canvas, draws e
 
 If **Show Annotations** is off, the annotator returns the image untouched, and nothing else in this page applies until you turn it back on.
 
-Auto Focus is the exception: it measures each frame with its own detection pass and shows the frame unannotated. Turn on **Annotate During Auto Focus** and it overlays that same detection — the very stars that produced the HFR point — onto each frame as the sweep runs.
+Auto Focus works a little differently: it measures each frame with its own detection pass, and **Annotate During Auto Focus** overlays that same detection — the very stars that produced the HFR point — onto each frame as the sweep runs. It is on by default; turn it off to watch the sweep on unmarked frames.
 
 By default the annotator draws *every* detected star. If you turn **Show All Stars** off, it keeps only the **Maximum Stars** brightest stars (sorted by average brightness) and labels those. The rejection boxes described later are drawn from the detector's metrics independently of this limit, so they always appear in full when their toggle is on.
 
@@ -31,7 +31,7 @@ These controls govern the always-on overlay drawn for accepted stars. ("Property
 | Setting | Default | Range / values | What it does |
 |---|---|---|---|
 | Show Annotations | On | on / off | Master switch. *"Toggles the annotations on/off"*. When off, the unmodified image is returned. |
-| Annotate During Auto Focus | Off | on / off | Draws the overlay on the displayed image during an Auto Focus run, so you can watch star detection as the sweep progresses. Requires **Show Annotations**. Applies to a normal auto focus only — not to the Aberration Inspector's multi-region run, nor to a replayed run. |
+| Annotate During Auto Focus | On | on / off | Draws the overlay on the displayed image during an Auto Focus run, so you can watch star detection as the sweep progresses. Requires **Show Annotations**. Applies to a normal auto focus only — not to the Aberration Inspector's multi-region run, nor to a replayed run. |
 | Show All Stars | On | on / off | *"Whether to annotate all stars"*. When off, only the brightest **Maximum Stars** are labeled. |
 | Maximum Stars | 200 | ≥ 1 | *"The maximum number of stars to annotate (the brightest ones)"*. Only applies when **Show All Stars** is off. |
 | Show Star Bounds | On | on / off | *"Whether to draw the bounding box or ellipse around the star"*. |

--- a/plans/af-live-annotations-plan.md
+++ b/plans/af-live-annotations-plan.md
@@ -6,7 +6,7 @@ During an auto-focus run HocusFocus displays every captured frame on NINA's imag
 
 The suppression is structural, not a flag. `AutoFocusEngine.PrepareExposure` calls `imagingMediator.PrepareImage(..., detectStars: false)`, so NINA's display pipeline runs neither detection nor `IStarAnnotator.GetAnnotatedImage`. Meanwhile the engine runs its *own* `IStarDetection.Detect` for the HFR measurement and throws the result at the AF curve — it never reaches the annotator. (Per-frame annotated TIFFs were removed in `ee9c5eb`; the Review-Frames UI re-renders overlays after the fact.)
 
-The outcome we want: a new, off-by-default star-annotator option — **"Annotate During Auto Focus"**, placed immediately after "Show Annotations" — that overlays the AF run's *actual* detection result onto the displayed frame, live, as each frame is measured. We reuse the detection AF already computed rather than running a second one, so the overlay shows exactly the stars that produced the HFR point.
+The outcome we want: a new star-annotator option — **"Annotate During Auto Focus"**, placed immediately after "Show Annotations" — that overlays the AF run's *actual* detection result onto the displayed frame, live, as each frame is measured. We reuse the detection AF already computed rather than running a second one, so the overlay shows exactly the stars that produced the HFR point.
 
 **Scope (decided):** live AF only, and only plain full-frame runs. Replay (`Rerun` over saved frames) is suppressed — its bounded prefetch prepares frames ahead of analysis, so the stale-frame guard would reject most of them and the overlay would appear erratically; Review Frames already covers that case. Multi-region runs (Aberration Inspector, Tilt Adapter Wizard) are suppressed too, so nine regions never fight over one display.
 
@@ -39,8 +39,8 @@ Add `bool ShowAnnotationsDuringAutoFocus { get; set; }` immediately after `ShowA
 
 Four touch points, mirroring `ShowAnnotations` exactly (`GetValueBoolean`/`SetValueBoolean`):
 
-- `InitializeOptions()` after line 50: `showAnnotationsDuringAutoFocus = optionsAccessor.GetValueBoolean("ShowAnnotationsDuringAutoFocus", false);`
-- `ResetDefaults()` after line 83: `ShowAnnotationsDuringAutoFocus = false;`
+- `InitializeOptions()` after line 50: `showAnnotationsDuringAutoFocus = optionsAccessor.GetValueBoolean("ShowAnnotationsDuringAutoFocus", true);`
+- `ResetDefaults()` after line 83: `ShowAnnotationsDuringAutoFocus = true;`
 - Backing field + property after the `ShowAnnotations` block (line 126), with the `if (x != value)` guard, `SetValueBoolean`, `RaisePropertyChanged()`.
 
 Do **not** add it to `AutoFocusFrameReviewVM.OverlayAffectingProperties` — that set governs the separate Review-Frames re-render.
@@ -122,7 +122,7 @@ An end-to-end engine test asserting `SetImage` was called is feasible but heavy 
 Add one row to the **Display options** table, directly after the "Show Annotations" row (line 31):
 
 ```markdown
-| Annotate During Auto Focus | Off | on / off | Draws the overlay on the live image during a plain Auto Focus run, so you can watch star detection as the sweep progresses. Requires **Show Annotations**. Off by default. |
+| Annotate During Auto Focus | On | on / off | Draws the overlay on the live image during a plain Auto Focus run, so you can watch star detection as the sweep progresses. Requires **Show Annotations**. On by default. |
 ```
 
 Follow `.claude/docs/documentation-style.md`. The page's opening paragraph already claims "The AutoFocus engine … pick[s] the active annotator through `IPluggableBehaviorSelector<IStarAnnotator>`" — after this change that becomes true for the first time, so no correction is needed there.

--- a/plans/af-live-annotations-plan.md
+++ b/plans/af-live-annotations-plan.md
@@ -1,0 +1,138 @@
+# Show star-detection annotations during Auto Focus
+
+## Context
+
+During an auto-focus run HocusFocus displays every captured frame on NINA's imaging view, but never with the star-detection overlay — so the user can't see which stars the detector actually found, where the ROI landed, or which candidates were rejected, at the moment it matters most (while the sweep is running and focus is visibly changing).
+
+The suppression is structural, not a flag. `AutoFocusEngine.PrepareExposure` calls `imagingMediator.PrepareImage(..., detectStars: false)`, so NINA's display pipeline runs neither detection nor `IStarAnnotator.GetAnnotatedImage`. Meanwhile the engine runs its *own* `IStarDetection.Detect` for the HFR measurement and throws the result at the AF curve — it never reaches the annotator. (Per-frame annotated TIFFs were removed in `ee9c5eb`; the Review-Frames UI re-renders overlays after the fact.)
+
+The outcome we want: a new, off-by-default star-annotator option — **"Annotate During Auto Focus"**, placed immediately after "Show Annotations" — that overlays the AF run's *actual* detection result onto the displayed frame, live, as each frame is measured. We reuse the detection AF already computed rather than running a second one, so the overlay shows exactly the stars that produced the HFR point.
+
+**Scope (decided):** live AF only, and only plain full-frame runs. Replay (`Rerun` over saved frames) is suppressed — its bounded prefetch prepares frames ahead of analysis, so the stale-frame guard would reject most of them and the overlay would appear erratically; Review Frames already covers that case. Multi-region runs (Aberration Inspector, Tilt Adapter Wizard) are suppressed too, so nine regions never fight over one display.
+
+## Approach
+
+After AF's own detection completes in `EvaluateExposure`, hand the result to the selected `IStarAnnotator` and push the annotated bitmap to the display via **`imagingMediator.SetImage(BitmapSource)`** — an existing NINA API (`ImagingVM.SetImage` → `ImageControl.Image = img`) that the engine can reach through the `imagingMediator` it already holds. No `IImageControlVM` import is needed.
+
+Two NINA facts this rests on (verified against the NINA source at `/mnt/c/Users/ghili/src/nina`; those files are Windows-1252, read with `iconv -f WINDOWS-1252 -t UTF-8`):
+
+- `RenderedImage.DetectStars(annotateImage: true, …)` annotates by calling `starAnnotator.GetAnnotatedImage(p, result, this.OriginalImage, maxStars, token)` and assigning the result to `Image`. So `OriginalImage` — the stretched, un-annotated bitmap — is the correct thing to pass, and `SetImage` is the correct place to put the answer.
+- `PluggableBehaviorSelector`'s constructor takes only `(profileService, ninaDefault)`; plugin behaviors are appended later by the loader. So importing `IPluggableBehaviorSelector<IStarAnnotator>` into the plugin manifest cannot eagerly construct `HocusFocusStarAnnotator` (which reads the static `HocusFocusPlugin.StarAnnotatorOptions` in its importing constructor). The manifest already imports the `IStarDetection` selector the same way.
+
+### Stale-frame guard
+
+`AutoFocusState.ExposureSemaphore` permits `MaxConcurrent` in-flight analyses, so frame N's detection can finish *after* frame N+1 has already been displayed. Without a guard, a late `SetImage` would paint a stale overlay. Track the most recently prepared `IRenderedImage` on `AutoFocusState` and `ReferenceEquals`-check it before painting.
+
+This also aligns `HocusFocusStarAnnotator`'s own live re-annotation guard (`previousAnnotatedImageRef` vs `imageControlVM.RenderedImage.OriginalImage`): `SetImage` writes only `Image`, never `RenderedImage`, so toggling an annotator option mid-run correctly re-renders the current AF frame.
+
+### Fire-and-forget, with a drain
+
+`GenerateAnnotatedImage` does a full-frame 16→8bpp conversion plus draw (tens to hundreds of ms). Awaiting it inline would sit on the HFR measurement path and hold the `ExposureSemaphore` slot longer, changing AF timing. Instead spawn it on a background task, track the task on `AutoFocusState`, and drain the tracked tasks in `RunImpl`'s `finally` so a late `SetImage` can never clobber the next non-AF image.
+
+## Changes
+
+### 1. `Interfaces/IStarAnnotatorOptions.cs`
+
+Add `bool ShowAnnotationsDuringAutoFocus { get; set; }` immediately after `ShowAnnotations` (line 79).
+
+### 2. `StarDetection/StarAnnotatorOptions.cs`
+
+Four touch points, mirroring `ShowAnnotations` exactly (`GetValueBoolean`/`SetValueBoolean`):
+
+- `InitializeOptions()` after line 50: `showAnnotationsDuringAutoFocus = optionsAccessor.GetValueBoolean("ShowAnnotationsDuringAutoFocus", false);`
+- `ResetDefaults()` after line 83: `ShowAnnotationsDuringAutoFocus = false;`
+- Backing field + property after the `ShowAnnotations` block (line 126), with the `if (x != value)` guard, `SetValueBoolean`, `RaisePropertyChanged()`.
+
+Do **not** add it to `AutoFocusFrameReviewVM.OverlayAffectingProperties` — that set governs the separate Review-Frames re-render.
+
+### 3. `AutoFocus/AutoFocusEngine.cs`
+
+**Constructor (lines 63–84).** Add two dependencies after `starDetectionSelector`:
+`IPluggableBehaviorSelector<IStarAnnotator> starAnnotatorSelector` and `IStarAnnotatorOptions starAnnotatorOptions`, with matching readonly fields. All needed usings are already present (`NINA.Core.Interfaces`, `NINA.Image.ImageAnalysis`, `…HocusFocus.Interfaces`, `System.Windows.Media.Imaging`).
+
+**`AutoFocusState`** (near the other fields, ~line 560). Add a `volatile IRenderedImage` holding the most recently prepared frame, exposed as `LastDisplayedRenderedImage`; and a `List<Task>` of spawned annotation renders guarded by the existing `StatesLock`, with `TrackDisplayAnnotationTask(Task)` / `SnapshotDisplayAnnotationTasks()` (mirroring how `AnalysisTasks` is handled).
+
+**`PrepareExposure(state, IImageData, token)` (lines 1012–1021).** Capture the return of `imagingMediator.PrepareImage(...)` into a local, assign it to `state.LastDisplayedRenderedImage`, then return it. This inner overload is the single choke point for both live and replay paths, and its return value is exactly what NINA assigns to `ImageControlVM.RenderedImage`.
+
+**Pure gate**, placed beside the other `internal static` decision helpers (~line 464–524, next to `ShouldRetryFromCalculatedPoint`) so it is unit-testable in isolation:
+
+```csharp
+internal static bool ShouldAnnotateAutoFocusDisplay(
+    bool annotateDuringAutoFocus, bool showAnnotations,
+    bool isFullFrameRegion, bool isLiveRun, bool frameIsCurrentlyDisplayed)
+```
+
+returning the conjunction. `showAnnotations` is included because `GenerateAnnotatedImage` no-ops when the master switch is off — checking it up front skips the render entirely.
+
+**Side-effecting helper** `MaybeDisplayAutoFocusAnnotation(state, regionState, image, annotationParams, analysisResult, isLiveRun, token)`, placed after `EvaluateExposure` (~line 765). It:
+
+- returns if `image?.OriginalImage` is null, or the gate says no;
+- resolves `starAnnotatorSelector.GetBehavior()` (null-check it);
+- computes `maxStars` as `profileService.ActiveProfile.ImageSettings.AnnotateUnlimitedStars ? -1 : 200`, mirroring `RenderedImage.DetectStars`. The HocusFocus annotator ignores this in favour of its own `MaxStars` option, but NINA's built-in annotator honours it;
+- spawns `Task.Run` (do **not** pass the token to `Task.Run` — let the delegate own cancellation so its `catch` always runs) that awaits `GetAnnotatedImage(annotationParams, analysisResult, image.OriginalImage, maxStars, token)`, **re-checks** `ReferenceEquals(state.LastDisplayedRenderedImage, image)` after the async render, then calls `imagingMediator.SetImage(annotated)`;
+- swallows `OperationCanceledException` and logs any other exception via `Logger.Error` — annotation must never fail an AF measurement;
+- registers the task with `state.TrackDisplayAnnotationTask(...)`.
+
+**Call site.** In `EvaluateExposure`'s `STARHFR` branch, after the `PreserveExposures` block (line 743) and before the closing `Logger.Debug`/`return`:
+
+```csharp
+MaybeDisplayAutoFocusAnnotation(state, regionState, image, analysisParams, analysisResult,
+    isLiveRun: cacheSource == null, token);
+```
+
+- `isFullFrameRegion` inside the gate is `regionState.Region == null`. `AutoFocusState`'s constructor (line 552) creates exactly one `AutoFocusRegionState(this, 0, null, …)` when `regions == null`, and `RunWithRegions` always supplies non-null regions — so `Region == null` is the exact discriminator for a plain single-region run, and it implies `RegionIndex == 0`.
+- `cacheSource == null` is a reliable live/replay discriminator: `RerunImpl` constructs a `SavedDetectionCacheSource` unconditionally (line 1999) and the live path never passes one.
+- Passing `analysisParams` is correct for this branch: with `Region == null`, the HocusFocus detector returns a `HocusFocusStarDetectionResult` (whose `DetectorParams.Region` drives ROI drawing, and `p` is ignored), while NINA's built-in detector returns a plain `StarDetectionResult`, for which the annotator reads `p.UseROI / InnerCropRatio / OuterCropRatio` — which `analysisParams` carries.
+
+The `CONTRASTDETECTION` branch and the `Statistics` early return do no star detection and need nothing.
+
+**Teardown drain.** In `RunImpl`'s outer `finally` (line 1744), before the `PerformPostAutoFocusActions` try, `await Task.WhenAll(autoFocusState.SnapshotDisplayAnnotationTasks())` inside a `try`/`catch`. `RunImpl` is already `async`. `RerunImpl` needs nothing — replay spawns no annotation tasks.
+
+**Thread affinity is fine.** `ImagingVM.SetImage` just assigns `ImageControl.Image`; the setter assigns the field, calls `ResizeRectangleToImageSize` only when `ShowBahtinovAnalyzer` is true, and raises `PropertyChanged` (WPF marshals binding updates). `GenerateAnnotatedImage` returns a `Freeze()`d `BitmapSource`. Precedent: `HocusFocusStarAnnotator.cs:68` already assigns `imageControlVM.Image` from a `Task.Run`, and NINA's own `ProcessAndUpdateImage` sets `Image` off the UI thread.
+
+### 4. `AutoFocus/AutoFocusEngineFactory.cs` and `HocusFocusPlugin.cs`
+
+Thread the two new dependencies through. The factory mirrors the engine's constructor; `HocusFocusPlugin`'s `[ImportingConstructor]` (lines 73–83) gains `IPluggableBehaviorSelector<IStarAnnotator> starAnnotatorSelector`, and the `AutoFocusEngineFactory` construction (lines 115–125) passes it plus the existing static `StarAnnotatorOptions` (already assigned at lines 99–101, before the factory). **Keep the argument order identical across engine, factory, and this call site.**
+
+### 5. `Resources/OptionsDataTemplates.xaml`
+
+All edits confined to the tooltip block and the `HocusFocus_StarAnnotator_Options` template (lines 2334–2917). The template above it numbers rows up to 40 — do not touch it.
+
+- After line 489, a `ShowAnnotationsDuringAutoFocus_Tooltip` `TextBlock` resource, alongside the other `*_Tooltip` keys.
+- Add one `<RowDefinition />` to the block at lines 2341–2369 (29 → 30).
+- Insert the label + `CheckBox` (`IsChecked="{Binding ShowAnnotationsDuringAutoFocus}"`, `Text="Annotate During Auto Focus"`) at `Grid.Row="1"`, between the Show Annotations block (ends 2385) and Show All Stars (starts 2386), copying the Show Annotations markup verbatim for margins/alignment.
+- **Renumber every `Grid.Row` from 1..28 → 2..29** in lines 2386–2915. Work in **descending** order (28→29, then 27→28, …, 1→2) so no intermediate value collides. The two `Grid.Row="0"` at 2372/2378 stay. Highest existing value is 28 at lines 2887/2901.
+
+### 6. `TestApp/Program.cs`
+
+`StaticStarAnnotatorOptions` (line 291) implements the interface, so it needs `public bool ShowAnnotationsDuringAutoFocus { get; set; }` after line 292 — a required compile fix. `CreateDefault()` needs no entry (`false` is the default). TestApp constructs neither `AutoFocusEngine` nor `AutoFocusEngineFactory`, and `new HocusFocusStarAnnotator(...)` at line 248 is unchanged.
+
+`Tests/TestDoubles/MediatorBundle.cs` already exposes `StarAnnotatorOptions` and `StarAnnotatorSelector` NSubstitute doubles and builds VMs (not the engine), so it needs no change.
+
+### 7. Tests
+
+`Tests/StarDetection/StarAnnotatorOptionsTests.cs` — add the new option to all four existing tests, matching their established shape: an `Is.False` assert in `Defaults_AreLoadedFromAccessor`; a set + `store.Snapshot[...]` assert in `Setters_PersistToAccessor`; a `[TestCase(nameof(StarAnnotatorOptions.ShowAnnotationsDuringAutoFocus), true)]` on `Setter_RaisesPropertyChanged`; and a set-then-reset assert in `ResetDefaults_RestoresDocumentedDefaults`.
+
+`Tests/AutoFocus/AutoFocusEngineTests.cs` — update the `Build(...)` helper (lines 38–53) with the two new constructor arguments (`Substitute.For<...>()`; no new usings needed). Add table-driven tests for `ShouldAnnotateAutoFocusDisplay`: one all-true case, and one case per false branch (option off, `ShowAnnotations` off, multi-region, replay, stale frame). This matches how `ShouldRetryFromCalculatedPoint` / `EvaluateHfrImprovement` are already tested.
+
+An end-to-end engine test asserting `SetImage` was called is feasible but heavy (fake `IStarDetection`, an `IRenderedImage` with `RawImageData`/`OriginalImage`, an `IStarAnnotator` double) and races on the fire-and-forget task. The pure gate carries the logic; skip it.
+
+### 8. `documentation/docs/overview/star-annotation.md`
+
+Add one row to the **Display options** table, directly after the "Show Annotations" row (line 31):
+
+```markdown
+| Annotate During Auto Focus | Off | on / off | Draws the overlay on the live image during a plain Auto Focus run, so you can watch star detection as the sweep progresses. Requires **Show Annotations**. Off by default. |
+```
+
+Follow `.claude/docs/documentation-style.md`. The page's opening paragraph already claims "The AutoFocus engine … pick[s] the active annotator through `IPluggableBehaviorSelector<IStarAnnotator>`" — after this change that becomes true for the first time, so no correction is needed there.
+
+## Verification
+
+1. **Unit tests.** Per `.claude/docs`, there is no `dotnet` in WSL — run on the Windows side against the WSL path, with a generous timeout:
+   `dotnet test '\\wsl.localhost\Ubuntu-20.04\home\ghilios\src\hocus-focus\Joko.NINA.Plugins\Joko.NINA.Plugins.sln' -c Debug --nologo` (timeout 600).
+   Everything must pass, including the new `StarAnnotatorOptions` and `ShouldAnnotateAutoFocusDisplay` cases. Never mark a test expected-to-fail to get green.
+2. **XAML renumbering sanity.** After editing, confirm the annotator template has exactly 30 `RowDefinition`s and that `Grid.Row` values 0–29 each appear exactly twice within lines 2334–2917 (except the rows whose label/control pairing legitimately differs, e.g. the font-size row) — a stray duplicate silently stacks two controls on one row.
+3. **Live behavior in NINA** (Windows MCP; see `.claude/docs/nina-mcp-screenshots.md`). Options → HocusFocus → Star Annotator: confirm "Annotate During Auto Focus" renders directly under "Show Annotations", unchecked. Run an auto focus with it **off** — frames display clean, as today. Turn it **on**, run auto focus again — each displayed frame shows star bounds, centers, labels, and the ROI box from that frame's own detection. While the sweep is running, toggle e.g. "Star Bounds Type": the current frame's overlay should re-render live (this exercises the annotator's `previousAnnotatedImageRef` guard lining up with `SetImage`).
+4. **Non-regression on the suppressed paths.** With the option on, run the Aberration Inspector and a saved-run replay: neither should paint an overlay on the imaging view, and Review Frames must still render its own overlays normally.
+5. **No late paint.** With the option on, finish an AF run and immediately take a normal snapshot exposure. The snapshot must not be overwritten by a trailing annotated AF frame — this is what the `RunImpl` drain protects.


### PR DESCRIPTION
## What

Adds a persisted star-annotator option, **"Annotate During Auto Focus"** (default **on**), placed directly after "Show Annotations". Each auto-focus frame is displayed with the star-detection overlay drawn on it.

## Why

Auto focus displayed every captured frame unannotated, so you couldn't see which stars the detector found, where the ROI landed, or which candidates were rejected — at the moment it matters most, while the sweep is running and focus is visibly changing.

The suppression was structural, not a flag. `AutoFocusEngine.PrepareExposure` calls `imagingMediator.PrepareImage(..., detectStars: false)`, so NINA's display pipeline runs neither detection nor `IStarAnnotator.GetAnnotatedImage`. Meanwhile the engine runs its *own* `IStarDetection.Detect` for the HFR measurement and never hands the result to an annotator. (Per-frame annotated TIFFs were removed in `ee9c5eb`; Review Frames re-renders overlays after the fact.)

## How

After AF's own detection completes in `EvaluateExposure`, the result is handed to the selected `IStarAnnotator` and the annotated bitmap is pushed to the display via **`imagingMediator.SetImage`** — existing NINA plumbing (`ImagingVM.SetImage` → `ImageControl.Image`), reachable through the mediator the engine already holds. No `IImageControlVM` import, and **no second detection pass**: the overlay shows exactly the stars that produced the HFR point.

`AutoFocusEngine` / `AutoFocusEngineFactory` gain `IPluggableBehaviorSelector<IStarAnnotator>` + `IStarAnnotatorOptions`, threaded through `HocusFocusPlugin`.

### Scope

Live, plain full-frame runs only.

- **Multi-region runs** (Aberration Inspector, Tilt Adapter Wizard) are excluded — otherwise every region races to paint the one display. Discriminator: `regionState.Region == null`.
- **Replay** is excluded. Its bounded prefetch (`maxPrefetch = max(2, min(4, ProcessorCount))`) prepares — and therefore displays — up to four frames *ahead* of the one being analyzed, so the frame on screen is rarely the frame being measured; the stale-frame guard would reject nearly all of them and the overlay would flicker in erratically. Review Frames already re-renders those overlays on demand. Discriminator: `cacheSource == null`.

### Concurrency

Analyses of different frames overlap (`ExposureSemaphore` admits `MaxConcurrent`), so three guards:

1. **Stale-frame guard.** `AutoFocusState` tracks the most recently prepared `IRenderedImage` — verified to be exactly the object NINA assigns to `ImageControlVM.RenderedImage` — and the overlay is painted only if that frame is still on screen, re-checked *after* the async render.
2. **One render in flight.** `GetAnnotatedImage` was previously only ever called from NINA's display pipeline, which serializes it behind `ImageControlVM`'s semaphore. Two concurrent AF renders would queue redundant full-frame conversions *and* race the annotator's `previousParams`/`previousResult`/`previousAnnotatedImageRef` triple. The newcomer is dropped rather than queued (a superseded render is discarded by the stale-frame check anyway).
3. **Teardown drain.** Spawned renders are awaited in `RunImpl`'s `finally`, so a late `SetImage` can never paint an AF frame over whatever image is shown next.

Rendering is fire-and-forget (a full-frame 16→8bpp convert + draw shouldn't sit on the measurement path or hold an `ExposureSemaphore` slot), and it can never fail a measurement — cancellation and exceptions are swallowed and logged.

## Verification

- `dotnet test` — **1748 pass**, including new `StarAnnotatorOptions` cases and table-driven coverage of the pure `ShouldAnnotateAutoFocusDisplay` gate (one case per suppression reason).
- XAML: the annotator template's hand-numbered grid went 29 → 30 rows; asserted programmatically that rows 0–29 each appear exactly twice.
- **Live NINA run** against the Sky Simulator:
  - Plugin composes with **zero MEF errors** — the riskiest part, since the manifest gained a new `IPluggableBehaviorSelector<IStarAnnotator>` import that no unit test covers.
  - Checkbox renders directly under "Show Annotations"; rows below it unshifted.
  - Sweep frames show star bounds, center reticules, and HFR labels.
  - The run failed its R² gate (0.61 — the simulator's defocus curve, not this change), which usefully exercised the **failure** path: `PerformPostAutoFocusActions` still ran, so the drain neither hung nor threw.
  - A post-AF snapshot was *not* clobbered: its overlay came from a fresh detection (HFR 1.354, 181 stars) versus AF's last frame (HFR 7.25, 50 stars).

## Notes

- Default is **on**. Profiles that already stored a value for the key keep it; only profiles that never set it pick up the new default.
- Not added to `AutoFocusFrameReviewVM.OverlayAffectingProperties` — that set governs the separate Review-Frames re-render.
- Docs updated in `documentation/docs/overview/star-annotation.md`; plan in `plans/af-live-annotations-plan.md`.
- Rebased onto `develop` after #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXQ1X1HHuVb7Z4EUCAvGji