### PR TITLE
fix(ui): legible review-toolbar labels; live optimizer readout reports σ

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationSummaryTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationSummaryTests.cs
@@ -66,6 +66,55 @@ public class OptimizationSummaryTests {
         });
     }
 
+    // ---- Live progress readout ---------------------------------------------------------------------------
+    // It must never contradict the summary. The summary headlines σ (FocusPrecisionText → SigmaText), so the
+    // live line reports σ too — never a percent of the objective J, whose relative deltas are ~1e-5 on a
+    // saturated run (e.g. 0.999939 → 0.999919) and therefore always round to "0%".
+
+    [Test]
+    public void LiveImprovementText_StillSearching_UntilBestBeatsTheBaselineJ() {
+        // gateBaselineJ is the stricter of the pass's own baseline and the user's current settings (see
+        // StarDetectionOptimizerWizardVM.ProgressGateJ), so the live line can never promise an improvement the
+        // results page — which judges against the current settings — then retracts.
+        Assert.Multiple(() => {
+            Assert.That(OptimizationSummary.LiveImprovementText(gateBaselineJ: 0.9, bestJ: 0.0, baselineSigma: 2.20, bestSigma: double.NaN),
+                Is.EqualTo("Searching for a better fit…"), "no incumbent yet");
+            Assert.That(OptimizationSummary.LiveImprovementText(gateBaselineJ: 0.9, bestJ: 0.9, baselineSigma: 2.20, bestSigma: 1.50),
+                Is.EqualTo("Searching for a better fit…"), "a tie is not an improvement");
+            Assert.That(OptimizationSummary.LiveImprovementText(gateBaselineJ: 0.99994, bestJ: 0.99992, baselineSigma: 2.20, bestSigma: 1.50),
+                Is.EqualTo("Searching for a better fit…"),
+                "the saturated-plateau case: a tighter σ must NOT be advertised while J is below the current settings");
+            // The Continue pass: the incumbent beats the prior round (0.999919) but not the current settings
+            // (0.999939). ProgressGateJ hands us the stricter of the two, so nothing is claimed — matching the
+            // results page, which keeps Current and shows "could not improve on your current settings".
+            Assert.That(OptimizationSummary.LiveImprovementText(gateBaselineJ: 0.999939, bestJ: 0.999925, baselineSigma: 2.20, bestSigma: 2.05),
+                Is.EqualTo("Searching for a better fit…"));
+        });
+    }
+
+    [Test]
+    public void LiveImprovementText_ShowsSigmaBeforeAfter_WhenTightened() {
+        // Same F2 σ pair the summary's SigmaText shows, so the two agree digit for digit.
+        Assert.That(OptimizationSummary.LiveImprovementText(gateBaselineJ: 0.90, bestJ: 0.91, baselineSigma: 2.20, bestSigma: 1.85),
+            Is.EqualTo("Best so far: σ 2.20 → 1.85"));
+    }
+
+    [Test]
+    public void LiveImprovementText_FoundBetterSettings_WhenJImprovesWithoutTighteningSigma() {
+        // J can improve on star count alone (the aberration-inspection objective trades σ for stars), and σ may
+        // be missing entirely on a degenerate fit. Neither may render as a σ pair — that would read as a σ win.
+        Assert.Multiple(() => {
+            Assert.That(OptimizationSummary.LiveImprovementText(gateBaselineJ: 0.90, bestJ: 0.91, baselineSigma: 2.20, bestSigma: 2.40),
+                Is.EqualTo("Found better settings so far"), "σ got worse");
+            Assert.That(OptimizationSummary.LiveImprovementText(gateBaselineJ: 0.90, bestJ: 0.91, baselineSigma: 2.201, bestSigma: 2.199),
+                Is.EqualTo("Found better settings so far"), "σ inside SigmaText's 'unchanged' band");
+            Assert.That(OptimizationSummary.LiveImprovementText(gateBaselineJ: 0.90, bestJ: 0.91, baselineSigma: double.NaN, bestSigma: 1.50),
+                Is.EqualTo("Found better settings so far"), "no baseline σ");
+            Assert.That(OptimizationSummary.LiveImprovementText(gateBaselineJ: 0.90, bestJ: 0.91, baselineSigma: 2.20, bestSigma: double.NaN),
+                Is.EqualTo("Found better settings so far"), "no incumbent σ");
+        });
+    }
+
     [Test]
     public void SigmaText_NonFinite_FallsBackToBaseText_NoTighterOrUnchanged() {
         var s = new OptimizationSummary { SeedSigmaFocus = double.NaN, BestSigmaFocus = 1.0 }.SigmaText;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerTests.cs
@@ -268,6 +268,25 @@ public class StarDetectionOptimizerTests {
     }
 
     [Test]
+    public async Task Optimize_ReportsIncumbentSigmaFocus() {
+        // The wizard's live readout shows σ (focus precision) rather than a percent of J, so every progress report
+        // must carry the σ OF THE CURRENT INCUMBENT — the same σ BuildSummaryAsync later recomputes for BestParams.
+        var progress = new SynchronousProgress<OptimizationProgress>();
+        var variables = OptimizerVariable.CreateCuratedSet();
+        var result = await new StarDetectionOptimizer().OptimizeAsync(Seed(), variables, SyntheticEvaluator(), DefaultSettings(), progress, CancellationToken.None);
+
+        var last = progress.Reports.Last();
+        Assert.Multiple(() => {
+            Assert.That(progress.Reports.All(r => double.IsFinite(r.BestSigmaFocus)), Is.True,
+                "every report carries the incumbent's σ");
+            Assert.That(last.BestSigmaFocus, Is.EqualTo(SyntheticRunFor(result.BestParams).SigmaFocus).Within(1e-9),
+                "the final report's σ is the σ of the params the optimizer returns");
+            Assert.That(last.BestSigmaFocus, Is.LessThan(SyntheticRunFor(Seed()).SigmaFocus),
+                "this landscape ties higher J to tighter σ, so the incumbent's σ beats the seed's");
+        });
+    }
+
+    [Test]
     public async Task Optimize_ChangedVariables_OnlyListsDifferences() {
         var variables = OptimizerVariable.CreateCuratedSet();
         var seed = Seed();

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -189,7 +189,8 @@ public class StarDetectionOptimizerWizardVMTests {
         Func<IReadOnlyList<FrameReviewDescriptor>, StarDetectorParams, IProgress<RunLoadProgress>, CancellationToken, Task<List<FrameReview>>> frameReviewBuilder = null,
         Func<bool> isCameraConnected = null,
         Func<bool> isFocuserConnected = null,
-        IAutoFocusEngine autoFocusEngine = null) {
+        IAutoFocusEngine autoFocusEngine = null,
+        OptimizerSettings optimizerSettings = null) {
         options ??= Substitute.For<IStarDetectionOptions>();
         profileService ??= Substitute.For<IProfileService>();
         return new StarDetectionOptimizerWizardVM(
@@ -199,7 +200,7 @@ public class StarDetectionOptimizerWizardVMTests {
             autoFocusEngine: autoFocusEngine ?? Substitute.For<IAutoFocusEngine>(),
             folderPicker: () => @"C:\fake\attempt",
             region: StarDetectionRegion.Full,
-            optimizerSettings: new OptimizerSettings { MaxEvaluations = 200, CoarseGridLevels = 4, StepFloorFraction = 0.125 },
+            optimizerSettings: optimizerSettings ?? new OptimizerSettings { MaxEvaluations = 200, CoarseGridLevels = 4, StepFloorFraction = 0.125 },
             frameReviewBuilder: frameReviewBuilder,
             isCameraConnected: isCameraConnected,
             isFocuserConnected: isFocuserConnected);
@@ -971,12 +972,72 @@ public class StarDetectionOptimizerWizardVMTests {
         await vm.StartAsync(CancellationToken.None);
         vm.IsOptimizedVariant = true;            // read the optimized best regardless of the default selection
         var priorBestJ = vm.Result.BestJ;
+        var priorBestSigma = vm.Summary.BestSigmaFocus;
+        Assume.That(double.IsFinite(priorBestSigma), "the σ assertion below is only meaningful for a finite σ");
 
         await vm.ContinueOptimizationCommand.ExecuteAsync(null);
 
-        // The live "improved ~X%" baseline for a Continue pass is the PRIOR round's best (the seed for this pass),
-        // not the initial current-settings baseline — so ProgressSeedJ tracks where the last round left off.
-        Assert.That(vm.ProgressSeedJ, Is.EqualTo(priorBestJ).Within(1e-9));
+        // The live baseline for a Continue pass is the PRIOR round's best (the seed for this pass), not the initial
+        // current-settings baseline — so ProgressSeedJ/ProgressSeedSigma track where the last round left off, and the
+        // live "σ before → after" reads as the leg the continued search is adding to the summary's σ trajectory.
+        Assert.Multiple(() => {
+            Assert.That(vm.ProgressSeedJ, Is.EqualTo(priorBestJ).Within(1e-9));
+            Assert.That(vm.ProgressSeedSigma, Is.EqualTo(priorBestSigma).Within(1e-9));
+        });
+    }
+
+    [Test]
+    public async Task Continue_LiveImprovementGate_StaysAtCurrentSettings_WhenThePriorRoundLostToThem() {
+        // A Continue pass may be seeded from a round that never beat the user's current settings —
+        // CanContinueOptimization does not require OptimizerImprovedOverCurrent. Gating the live line on that losing
+        // round alone would let it announce a win while the results page still reports "could not improve on your
+        // current settings", so ProgressGateJ takes the stricter of the pass baseline and the current-settings J.
+        //
+        // Fixture: the current settings sit ON the synthetic optimum (Sensitivity 10) and the optimizer gets a
+        // one-evaluation budget, so it never leaves its seed (Sensitivity 2) and finishes strictly below current.
+        var vm = NewVM(
+            LoaderReturning(SeedBaselineSplitRun(baselineSensitivity: 10), SeedBaselineSplitRun(baselineSensitivity: 10)),
+            frameReviewBuilder: new FakeReviewBuilder().Build,
+            optimizerSettings: new OptimizerSettings { MaxEvaluations = 1, CoarseGridLevels = 4, StepFloorFraction = 0.125 });
+        vm.SourcePaths[0] = @"C:\gate-run";
+
+        await vm.StartAsync(CancellationToken.None);
+        var currentSettingsJ = vm.Summary.SeedJ;   // BuildSummaryAsync sets SeedJ = currentBaselineJ
+        vm.IsOptimizedVariant = true;
+        var priorBestJ = vm.Result.BestJ;
+
+        Assert.Multiple(() => {
+            Assert.That(priorBestJ, Is.LessThan(currentSettingsJ), "the fixture must produce a round that LOSES to current");
+            Assert.That(vm.OptimizerImprovedOverCurrent, Is.False, "so the results page keeps Current");
+            Assert.That(vm.CanContinueOptimization, Is.True, "and Continue is still offered");
+        });
+
+        await vm.ContinueOptimizationCommand.ExecuteAsync(null);
+
+        Assert.Multiple(() => {
+            // The σ pair is still measured from the prior round (the leg this pass is adding)…
+            Assert.That(vm.ProgressSeedJ, Is.EqualTo(priorBestJ).Within(1e-9));
+            // …but the CLAIM gate is the current settings, the same baseline OptimizerImprovedOverCurrent uses.
+            Assert.That(vm.ProgressGateJ, Is.EqualTo(currentSettingsJ).Within(1e-12));
+            Assert.That(vm.ProgressGateJ, Is.GreaterThan(vm.ProgressSeedJ),
+                "gating on the losing prior round would let the live line promise what the page withholds");
+        });
+    }
+
+    [Test]
+    public async Task Start_LiveSigmaBaseline_IsTheCurrentSettingsSigma() {
+        // The summary's "Focus precision" row anchors at the CURRENT settings' σ (Summary.SeedSigmaFocus). The live
+        // readout must anchor at the same value, or the σ pair it shows mid-run won't match the summary's.
+        var vm = NewVM(new RecordingLoader(), frameReviewBuilder: new FakeReviewBuilder().Build);
+        vm.SourcePaths[0] = @"C:\sigma-run";
+
+        await vm.StartAsync(CancellationToken.None);
+        vm.IsOptimizedVariant = true;
+
+        Assert.Multiple(() => {
+            Assert.That(double.IsFinite(vm.ProgressSeedSigma), Is.True, "a baseline σ was measured");
+            Assert.That(vm.ProgressSeedSigma, Is.EqualTo(vm.Summary.SeedSigmaFocus).Within(1e-9));
+        });
     }
 
     // ---- Optimize for aberration inspection -------------------------------------------------------------
@@ -1541,4 +1602,5 @@ public class StarDetectionOptimizerWizardVMTests {
         vm.SelectedVariant = OptimizationVariant.Optimized;
         Assert.That(vm.HasStarCountChanges, Is.False, "the comparison only shows on the feedback variant");
     }
+
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Review/AutoFocusFrameReviewControl.xaml
@@ -103,7 +103,21 @@
                         <Border x:Name="Bd" Background="#FFD7DCE3" BorderBrush="#FF9AA5B3" BorderThickness="1"
                                 CornerRadius="3" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="True">
                             <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
-                                              TextElement.Foreground="{TemplateBinding Foreground}" />
+                                              TextElement.Foreground="{TemplateBinding Foreground}">
+                                <ContentPresenter.Resources>
+                                    <!--  A string Content is rendered by a TextBlock the ContentPresenter generates, and
+                                          NINA.WPF.Base ships a KEYLESS TextBlock style (Resources/Styles/TextBlock.xaml,
+                                          BasedOn StandardTextBlock => Foreground = PrimaryBrush) in Application.Resources.
+                                          A style setter outranks the inherited TextElement.Foreground above, so the label
+                                          painted in the theme's near-white text colour on this fixed light fill (~1.25:1).
+                                          The empty style below is found first (nearest dictionary wins the implicit-style
+                                          lookup) and carries no Foreground, so the inherited value — the button's own
+                                          Foreground, enabled or disabled — reaches the glyph again. The white TextBlock
+                                          style further down this file was never the culprit: a control-scope implicit
+                                          style does not reach template-generated content at all.  -->
+                                    <Style TargetType="TextBlock" />
+                                </ContentPresenter.Resources>
+                            </ContentPresenter>
                         </Border>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsMouseOver" Value="True">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/FrameReviewControl.xaml
@@ -179,7 +179,21 @@
                         <Border x:Name="Bd" Background="#FFD7DCE3" BorderBrush="#FF9AA5B3" BorderThickness="1"
                                 CornerRadius="3" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="True">
                             <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
-                                              TextElement.Foreground="{TemplateBinding Foreground}" />
+                                              TextElement.Foreground="{TemplateBinding Foreground}">
+                                <ContentPresenter.Resources>
+                                    <!--  A string Content is rendered by a TextBlock the ContentPresenter generates, and
+                                          NINA.WPF.Base ships a KEYLESS TextBlock style (Resources/Styles/TextBlock.xaml,
+                                          BasedOn StandardTextBlock => Foreground = PrimaryBrush) in Application.Resources.
+                                          A style setter outranks the inherited TextElement.Foreground above, so the label
+                                          painted in the theme's near-white text colour on this fixed light fill (~1.25:1).
+                                          The empty style below is found first (nearest dictionary wins the implicit-style
+                                          lookup) and carries no Foreground, so the inherited value — the button's own
+                                          Foreground, enabled or disabled — reaches the glyph again. The white TextBlock
+                                          style further down this file was never the culprit: a control-scope implicit
+                                          style does not reach template-generated content at all.  -->
+                                    <Style TargetType="TextBlock" />
+                                </ContentPresenter.Resources>
+                            </ContentPresenter>
                         </Border>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsMouseOver" Value="True">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/Review/StarReviewControl.xaml
@@ -178,7 +178,21 @@
                         <Border x:Name="Bd" Background="#FFD7DCE3" BorderBrush="#FF9AA5B3" BorderThickness="1"
                                 CornerRadius="3" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="True">
                             <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
-                                              TextElement.Foreground="{TemplateBinding Foreground}" />
+                                              TextElement.Foreground="{TemplateBinding Foreground}">
+                                <ContentPresenter.Resources>
+                                    <!--  A string Content is rendered by a TextBlock the ContentPresenter generates, and
+                                          NINA.WPF.Base ships a KEYLESS TextBlock style (Resources/Styles/TextBlock.xaml,
+                                          BasedOn StandardTextBlock => Foreground = PrimaryBrush) in Application.Resources.
+                                          A style setter outranks the inherited TextElement.Foreground above, so the label
+                                          painted in the theme's near-white text colour on this fixed light fill (~1.25:1).
+                                          The empty style below is found first (nearest dictionary wins the implicit-style
+                                          lookup) and carries no Foreground, so the inherited value — the button's own
+                                          Foreground, enabled or disabled — reaches the glyph again. The white TextBlock
+                                          style further down this file was never the culprit: a control-scope implicit
+                                          style does not reach template-generated content at all.  -->
+                                    <Style TargetType="TextBlock" />
+                                </ContentPresenter.Resources>
+                            </ContentPresenter>
                         </Border>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsMouseOver" Value="True">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizer.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizer.cs
@@ -44,6 +44,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public int MaxEvaluations { get; set; }
         public double BestJ { get; set; }
         public double SeedJ { get; set; }
+
+        /// <summary>Mean focus σ of the current incumbent, aggregated over the runs that produced a finite σ (the
+        /// same aggregation the wizard's summary applies to the winning params). NaN when no run yielded one. The
+        /// wizard's live readout shows this, not a percent of <see cref="BestJ"/>, so it agrees with the summary.</summary>
+        public double BestSigmaFocus { get; set; } = double.NaN;
+
         public string Phase { get; set; }
     }
 
@@ -114,7 +120,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             var bestTheta = (double[])theta0.Clone();
             var bestJ = seedJ;
 
-            ctx.Report("Seed", bestJ, seedJ);
+            ctx.Report("Seed", bestTheta, bestJ, seedJ);
 
             // Phase A — coarse grid over the two highest-impact axes.
             (bestTheta, bestJ) = await ctx.CoarseGrid(bestTheta, bestJ, seedJ).ConfigureAwait(false);
@@ -159,6 +165,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             private readonly IProgress<OptimizationProgress> progress;
             private readonly CancellationToken token;
             private readonly Dictionary<string, double> memo = new Dictionary<string, double>(StringComparer.Ordinal);
+
+            // σ of every evaluated candidate, keyed exactly like <see cref="memo"/>. Filled alongside J on a cache
+            // miss (free — the metrics are already in hand) so a Report can look up the incumbent's σ without
+            // re-evaluating, and without threading a second value through every search stage.
+            private readonly Dictionary<string, double> memoSigma = new Dictionary<string, double>(StringComparer.Ordinal);
 
             // Phase-B staging partition (T14): the curated axes split into EARLY (members of
             // StarDetector.EarlyCacheKeyProperties — each move both rebuilds AND evicts the per-frame early
@@ -236,18 +247,41 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 }
 
                 memo[key] = j;
+                memoSigma[key] = MeanFiniteSigmaFocus(runMetrics);
                 return j;
             }
+
+            /// <summary>Mean σ over the runs that produced a finite focus σ; NaN when none did. Mirrors the wizard's
+            /// baseline/best σ aggregation so the reported σ is directly comparable to the summary's.</summary>
+            private static double MeanFiniteSigmaFocus(IReadOnlyList<RunEvaluationMetrics> runMetrics) {
+                if (runMetrics == null) {
+                    return double.NaN;
+                }
+                var sum = 0.0;
+                var count = 0;
+                foreach (var m in runMetrics) {
+                    if (double.IsFinite(m.SigmaFocus)) {
+                        sum += m.SigmaFocus;
+                        count++;
+                    }
+                }
+                return count > 0 ? sum / count : double.NaN;
+            }
+
+            /// <summary>The memoized σ of an already-evaluated point. NaN if it was never evaluated.</summary>
+            private double SigmaFor(double[] theta) =>
+                memoSigma.TryGetValue(StarDetector.ComputeCacheKey(Materialize(theta)), out var s) ? s : double.NaN;
 
             /// <summary>True once the eval budget is spent. We never start an evaluation past the cap.</summary>
             public bool BudgetExhausted => Evaluations >= settings.MaxEvaluations;
 
-            public void Report(string phase, double bestJ, double seedJ) {
+            public void Report(string phase, double[] bestTheta, double bestJ, double seedJ) {
                 progress?.Report(new OptimizationProgress {
                     Evaluations = Evaluations,
                     MaxEvaluations = settings.MaxEvaluations,
                     BestJ = bestJ,
                     SeedJ = seedJ,
+                    BestSigmaFocus = SigmaFor(bestTheta),
                     Phase = phase
                 });
             }
@@ -281,7 +315,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                         }
                     }
                 }
-                Report("CoarseGrid", bestJ, seedJ);
+                Report("CoarseGrid", bestTheta, bestJ, seedJ);
                 return (bestTheta, bestJ);
             }
 
@@ -339,7 +373,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     }
                 }
 
-                Report("PatternSearch", bestJ, seedJ);
+                Report("PatternSearch", bestTheta, bestJ, seedJ);
                 return (bestTheta, bestJ);
             }
 
@@ -395,7 +429,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                         // Accept the single best strictly-improving move and re-sweep from there.
                         bestTheta = improvedTheta;
                         bestJ = improvedJ;
-                        Report("PatternSearch", bestJ, seedJ);
+                        Report("PatternSearch", bestTheta, bestJ, seedJ);
                     } else {
                         // No improving move: refine the subset's Continuous steps and sweep again.
                         HalveContinuousSteps(steps, axisIndices);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -128,6 +128,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// <summary>Plain-language offset-steps readout (same before→after / "(unchanged)" convention).</summary>
         public string OffsetStepsText => FormatRecommendation(CurrentOffsetSteps, RecommendedOffsetSteps);
 
+        /// <summary>Minimum strictly-positive J margin for a result to count as beating the baseline it is measured
+        /// against. Just above double round-off so a true tie (e.g. the StartFromCurrentSettings path returning
+        /// current unchanged) reads as "no improvement".</summary>
+        public const double ImprovementEpsilon = 1e-9;
+
+        /// <summary>σ moves smaller than this are "unchanged": they vanish at the F2 precision every σ readout uses.</summary>
+        public const double SigmaUnchangedTolerance = 0.005;
+
         /// <summary>Focus-precision readout: "{seed} → {best}" with a "(~N% tighter)" suffix when σ improved
         /// (σ is the focus-curve sigma — lower is tighter/better).</summary>
         public string SigmaText {
@@ -135,7 +143,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 // "2.20 (unchanged)" when σ is effectively the same before/after (compared at the F2 precision
                 // shown), else "{seed} → {best}" with a "(~N% tighter)" suffix when it improved.
                 if (double.IsFinite(SeedSigmaFocus) && double.IsFinite(BestSigmaFocus)
-                    && Math.Abs(SeedSigmaFocus - BestSigmaFocus) < 0.005) {
+                    && Math.Abs(SeedSigmaFocus - BestSigmaFocus) < SigmaUnchangedTolerance) {
                     return $"{BestSigmaFocus:F2} (unchanged)";
                 }
                 var baseText = $"{SeedSigmaFocus:F2} → {BestSigmaFocus:F2}";
@@ -208,6 +216,41 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             var pct = (improved - baseline) / Math.Abs(baseline) * 100.0;
             return pct > 0.0 ? pct : 0.0;
         }
+
+        /// <summary>
+        /// The live, plain-language readout shown under the progress bar while the search runs. It reports the
+        /// incumbent's focus precision as the same "{seed:F2} → {best:F2}" σ pair the results page headlines
+        /// (<see cref="SigmaText"/>), so the two can never disagree.
+        ///
+        /// <para>It deliberately does NOT report a percentage of the objective J. J is a saturating score in [0, 1]
+        /// that already sits near its ceiling on a decent setup — a real run reads 0.999939 → 0.999919 — so a
+        /// J-relative percent is ~1e-5 and always renders as "0%", which contradicted the results page's
+        /// "(~N% tighter)".</para>
+        ///
+        /// <para>The improvement gate is the J comparison, not the σ one: an incumbent may hold a tighter σ while
+        /// still scoring below the user's current settings (the saturated plateau the Wtie tie-breaker exists for),
+        /// and that run ends on "kept your current settings". Gating on J is what keeps the live line from promising
+        /// an improvement the results page then withholds.</para>
+        ///
+        /// <para><paramref name="gateBaselineJ"/> is therefore the STRICTER of the pass's own baseline and the user's
+        /// current-settings J — see <c>StarDetectionOptimizerWizardVM.ProgressGateJ</c>. The σ pair shown is measured
+        /// from <paramref name="baselineSigma"/>, which is the pass's own baseline (the current settings on a fresh
+        /// Start, the prior round's best on a Continue pass).</para>
+        ///
+        /// Pure — unit-tested.
+        /// </summary>
+        public static string LiveImprovementText(double gateBaselineJ, double bestJ, double baselineSigma, double bestSigma) {
+            if (!(bestJ > gateBaselineJ + ImprovementEpsilon)) {
+                return "Searching for a better fit…";
+            }
+            if (double.IsFinite(baselineSigma) && double.IsFinite(bestSigma)
+                && baselineSigma - bestSigma >= SigmaUnchangedTolerance) {
+                return $"Best so far: σ {baselineSigma:F2} → {bestSigma:F2}";
+            }
+            // J improved without a visible σ gain — more stars under the aberration-inspection reweight, or a
+            // degenerate fit with no σ. Say so plainly rather than print a σ pair that reads as a focus win.
+            return "Found better settings so far";
+        }
     }
 
     /// <summary>
@@ -240,9 +283,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         private const int DonutMaxEvaluations = 400;
 
         // Minimum strictly-positive J margin for the optimized result to count as beating the user's current settings
-        // (drives OptimizerImprovedOverCurrent / the default-to-Current guard). Just above double round-off so a true
-        // tie (e.g. the StartFromCurrentSettings path returning current unchanged) reads as "no improvement".
-        private const double ImprovementEpsilon = 1e-9;
+        // (drives OptimizerImprovedOverCurrent / the default-to-Current guard). Shared with the live readout's gate so
+        // the progress line and the results page agree on what counts as an improvement.
+        private const double ImprovementEpsilon = OptimizationSummary.ImprovementEpsilon;
 
         // The review-build seam: given the snapshotted frame descriptors + the params to detect with, produces the
         // per-frame FrameReviews the StarReviewVM renders. Production wires FrameReviewBuilder over a real
@@ -294,6 +337,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         // improvement readouts (summary SeedJ + live ProgressSeedJ). Set in StartAsync (and the re-optimize path)
         // before the optimize + summary steps.
         private double currentBaselineJ;
+
+        // σ of the user's CURRENT settings, measured alongside currentBaselineJ in ComputeBaselineJAsync (it already
+        // needs the mean σ to anchor the aberration-inspection fit guard). This is the summary's SeedSigmaFocus, and
+        // the "before" the live readout counts from — so the σ pair shown mid-run matches the results page.
+        private double currentBaselineSigma = double.NaN;
 
         /// <summary>
         /// MEF/T5 convenience constructor: wires the real collaborators from the plugin singletons + mediators.
@@ -702,15 +750,40 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             private set { progressBestJ = value; RaisePropertyChanged(); RaisePropertyChanged(nameof(ProgressImprovementText)); }
         }
 
-        /// <summary>Live, plain-language improvement readout shown during the search (no jargon "J"): how much
-        /// better the best result found so far is than the user's current settings. Computed from the objective
-        /// score but never labeled as such.</summary>
-        public string ProgressImprovementText {
-            get {
-                var pct = OptimizationSummary.PercentBetter(progressSeedJ, progressBestJ);
-                return pct > 0.0 ? $"Detection improved ~{pct:F0}% so far" : "Searching for a better fit…";
-            }
+        private double progressSeedSigma = double.NaN;
+
+        /// <summary>The σ the live readout counts from: the current settings' σ for a fresh Start (matching the
+        /// summary's "Focus precision" baseline), or the prior round's best σ for a Continue pass.</summary>
+        public double ProgressSeedSigma {
+            get => progressSeedSigma;
+            private set { progressSeedSigma = value; RaisePropertyChanged(); RaisePropertyChanged(nameof(ProgressImprovementText)); }
         }
+
+        private double progressBestSigma = double.NaN;
+
+        /// <summary>σ of the search's current incumbent, straight off <see cref="OptimizationProgress.BestSigmaFocus"/>.</summary>
+        public double ProgressBestSigma {
+            get => progressBestSigma;
+            private set { progressBestSigma = value; RaisePropertyChanged(); RaisePropertyChanged(nameof(ProgressImprovementText)); }
+        }
+
+        /// <summary>The J the live readout must beat before it claims anything: the stricter of this pass's own
+        /// baseline (<see cref="ProgressSeedJ"/>) and the user's current settings (currentBaselineJ).
+        ///
+        /// <para>They coincide on a fresh Start. They do NOT on a "Continue optimizing" pass, whose baseline is the
+        /// prior round's best — and the prior round is allowed to have finished BELOW the current settings, since
+        /// <see cref="CanContinueOptimization"/> does not require <see cref="OptimizerImprovedOverCurrent"/>. Gating
+        /// on the prior round alone would let the live line announce a win over that (losing) round while the results
+        /// page, which judges <see cref="OptimizerImprovedOverCurrent"/> against the current settings, still reports
+        /// "could not improve on your current settings". Taking the max keeps the live claim at least as strict as
+        /// the page's verdict on every path.</para></summary>
+        public double ProgressGateJ => Math.Max(progressSeedJ, currentBaselineJ);
+
+        /// <summary>Live, plain-language readout shown during the search (no jargon "J"): the focus precision of the
+        /// best result found so far, as the same σ pair the results page headlines. See
+        /// <see cref="OptimizationSummary.LiveImprovementText"/> for why it reports σ rather than a percent of J.</summary>
+        public string ProgressImprovementText =>
+            OptimizationSummary.LiveImprovementText(ProgressGateJ, progressBestJ, progressSeedSigma, progressBestSigma);
 
         private string phase;
 
@@ -1278,6 +1351,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             SetProgress(null, 0, 0);
             ProgressSeedJ = 0;
             ProgressBestJ = 0;
+            ProgressSeedSigma = double.NaN;
+            ProgressBestSigma = double.NaN;
             // A fresh run invalidates any prior review snapshot/labels (they belonged to the previous result).
             if (ReviewVM != null) {
                 ReviewVM.PropertyChanged -= OnReviewLabelsChanged;
@@ -1327,6 +1402,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 //     Computed once here (cheap: the guard just warmed the current-settings contexts).
                 currentBaselineJ = await ComputeBaselineJAsync(loadedRuns, token).ConfigureAwait(true);
                 ProgressSeedJ = currentBaselineJ;
+                ProgressSeedSigma = currentBaselineSigma;
 
                 // 3. Optimize — off the UI thread, progress marshaled back. OptimizeAsync always returns a
                 // non-null result; it signals cancellation by throwing OperationCanceledException (caught below).
@@ -1598,6 +1674,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // bounds the fit relative to the measured current-settings σ; otherwise the standard objective. The same
             // constants are then handed to the optimizer (OptimizeAsync), so the baseline J and BestJ are comparable.
             var currentSigma = sigmaCount > 0 ? sigmaSum / sigmaCount : double.NaN;
+            currentBaselineSigma = currentSigma;
             objectiveConstants = OptimizeForAberrationInspection
                 ? ObjectiveConstants.ForAberrationInspection(currentSigma)
                 : new ObjectiveConstants();
@@ -1612,7 +1689,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// narrowed/curated axes it produced; otherwise it uses the first run's seed and the full curated set.</summary>
         private async Task<OptimizationResult> OptimizeAsync(IReadOnlyList<LoadedRun> runs, CancellationToken token,
             StarDetectorParams seedOverride = null, IReadOnlyList<OptimizerVariable> variablesOverride = null,
-            double? progressBaselineJOverride = null) {
+            double? progressBaselineJOverride = null, double? progressBaselineSigmaOverride = null) {
             // All runs share the same camera/optics, so the search starts from the first run's seed (or the override).
             // With StartFromCurrentSettings, seed from the current settings (Baseline) to refine them rather than the
             // fully-default params. The warm-start override (feedback path) always wins.
@@ -1634,12 +1711,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 ProgressCurrent = p.Evaluations;
                 ProgressTotal = p.MaxEvaluations;
                 ProgressBestJ = p.BestJ;
-                // The displayed baseline is the user's CURRENT settings (currentBaselineJ) for a fresh Start/feedback
-                // pass — not the optimizer's default seed J (p.SeedJ) — so the live "improved ~X%" reads vs current and
-                // matches the summary. A "Continue optimizing" pass overrides it with the PRIOR ROUND's best (the seed
-                // for that pass) so the live readout reflects the gain the continued search is making, not the total
-                // gain since the initial baseline.
+                ProgressBestSigma = p.BestSigmaFocus;
+                // The displayed baseline is the user's CURRENT settings (currentBaselineJ / currentBaselineSigma) for a
+                // fresh Start/feedback pass — not the optimizer's default seed J (p.SeedJ) — so the live readout reads
+                // vs current and matches the summary. A "Continue optimizing" pass overrides both with the PRIOR ROUND's
+                // best (the seed for that pass) so the live readout reflects the gain the continued search is making,
+                // not the total gain since the initial baseline. J gates whether an improvement is claimed at all; σ is
+                // what gets shown.
                 ProgressSeedJ = progressBaselineJOverride ?? currentBaselineJ;
+                ProgressSeedSigma = progressBaselineSigmaOverride ?? currentBaselineSigma;
                 Phase = FriendlyPhase(p.Phase);
             });
 
@@ -2059,6 +2139,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             SetProgress(null, 0, 0);
             ProgressSeedJ = 0;
             ProgressBestJ = 0;
+            ProgressSeedSigma = double.NaN;
+            ProgressBestSigma = double.NaN;
             IsBusy = true;
 
             cts?.Dispose();
@@ -2181,9 +2263,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // The seed for this pass is the CURRENT Optimized best (captured before any UI churn). optimizedResult is
             // not cleared by this path, so this stays valid through the reload.
             var seedForContinue = optimizedResult.BestParams;
-            // The prior round's best J is the live-improvement baseline for THIS pass: the user wants "improved ~X%"
-            // to read relative to where the last round left off, not the initial current-settings baseline.
+            // The prior round's best J/σ are the live baseline for THIS pass: the user wants the readout to measure the
+            // leg the continued search is adding, relative to where the last round left off, not the total gain since
+            // the initial current-settings baseline. That mirrors the summary, whose σ trajectory appends this pass as
+            // the next stage of "baseline → R1 → R2 → …".
             var seedForContinueJ = optimizedResult.BestJ;
+            var seedForContinueSigma = optimizedSummary?.BestSigmaFocus ?? double.NaN;
 
             ErrorMessage = null;
             SetProgress(null, 0, 0);
@@ -2191,6 +2276,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // the first frame and deterministic for tests; ProgressBestJ stays 0 so it starts at "Searching…".
             ProgressSeedJ = seedForContinueJ;
             ProgressBestJ = 0;
+            ProgressSeedSigma = seedForContinueSigma;
+            ProgressBestSigma = double.NaN;
             IsBusy = true;
 
             cts?.Dispose();
@@ -2222,9 +2309,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
                 // Another optimize pass seeded from the prior best; variablesOverride=null ⇒ OptimizeAsync builds a
                 // fresh CreateCuratedSet(seedForContinue) with reset step scale. The progress baseline override makes
-                // the live "improved ~X%" read vs the prior round's best rather than the current-settings baseline.
+                // the live readout measure this pass against the prior round's best rather than the current baseline.
                 var optimizeResult = await OptimizeAsync(reloaded, token, seedForContinue,
-                    progressBaselineJOverride: seedForContinueJ).ConfigureAwait(true);
+                    progressBaselineJOverride: seedForContinueJ,
+                    progressBaselineSigmaOverride: seedForContinueSigma).ConfigureAwait(true);
                 var built = await BuildSummaryAsync(reloaded, optimizeResult, token).ConfigureAwait(true);
 
                 // The latest pass REPLACES the Optimized variant (chart + Accept follow it); append the trajectory stage.


### PR DESCRIPTION
Two reported UI bugs.

## 1. Review Frames toolbar labels were unreadable

`Fit / ◀ Prev / Next ▶ / Close` (and `Undo`/`Redo` in the star review) painted in the NINA theme's text colour on the button style's fixed light `#D7DCE3` fill — **~1.02:1 contrast**.

The plugin's own white `TextBlock` style is *not* the culprit: a control-scope implicit style never reaches the `TextBlock` a `ContentPresenter` generates for string `Content`. `NINA.WPF.Base` ships a **keyless** `<Style TargetType="TextBlock">` (`Resources/Styles/TextBlock.xaml`, `BasedOn StandardTextBlock` → `Foreground = PrimaryBrush`) in `Application.Resources`, and that one does. As a style setter (**precedence 8**) it outranks the `ContentPresenter`'s **inherited** `TextElement.Foreground` (**precedence 11**), so the TemplateBound near-black never reached the glyph — nor did the disabled trigger's `#C9CED6`.

Fix: shadow it with an empty `<Style TargetType="TextBlock" />` inside `ContentPresenter.Resources`. The nearest dictionary wins the implicit-style lookup and carries no `Foreground`, so the button's own colour applies again.

Verified by rendering the **real** `HF_ReviewToolbarButton` markup against NINA's **real** dictionary:

| | glyph | fill | contrast |
|---|---|---|---|
| before | `#DEDEDE` (PrimaryBrush) | `#D7DCE3` | 1.02:1 |
| after | `#15181C` | `#D7DCE3` | 12.92:1 |

Disabled labels return to the intended `#C9CED6`. All three copies of the template are fixed. The combos are unaffected — their `ItemTemplate` sets `Foreground="Black"` as a local value.

## 2. "Detection improved ~0% so far" contradicted the summary

The live line printed a percentage of the objective `J`. `J` is a saturating `[0,1]` score already at its ceiling on a decent setup — a real run reads `0.999939 → 0.999919` — so the relative delta is ~1e-5 and always floors to `0%` under `F0`. The results page instead headlines focus precision σ (`2.20 → 1.85 (~16% tighter)`). Two different quantities; no rounding change could reconcile them.

The incumbent's mean `SigmaFocus` is now threaded through `OptimizationProgress` (memoised alongside `J`, so **no extra evaluations**), and the live line shows the same σ pair the summary does:

```
Best so far: σ 2.20 → 1.85
```

**The claim is gated on J, not σ.** On the saturated plateau an incumbent can hold a tighter σ while still scoring below the user's current settings — that run ends on *"kept your current settings"*. `ProgressGateJ` takes the stricter of the pass baseline and the current-settings J, because a **Continue** pass may be seeded from a round that lost to current (`CanContinueOptimization` does not require `OptimizerImprovedOverCurrent`); gating on that losing round alone would let the live line promise what the page then withholds. When J improves without a visible σ gain (aberration-inspection trading σ for stars, or a degenerate fit with no σ) it says `Found better settings so far` rather than printing a σ pair that would read as a focus win.

## Tests

`dotnet test` — **1754 passed, 0 failed**. Seven new tests: the three `LiveImprovementText` branches, the Continue-pass gate, the optimizer reporting the incumbent's σ, and the live σ baselines matching the summary's on both Start and Continue. The Continue-gate test was confirmed to fail against the pre-fix gate (`0.9528` vs current `0.9943`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXQ1X1HHuVb7Z4EUCAvGji