### PR TITLE
docs: restructure Quick Start around an autofocus-first workflow

### DIFF
--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -9,9 +9,9 @@ also builds a full sensor tilt-and-curvature model so you can quantify and corre
 the field.
 
 !!! tip "New here? Start with the Quick Start"
-    The **[Quick Start](quick-start.md)** walks you from a fresh install through setting up detection,
-    autofocus, and annotation, optimizing star detection, and checking your rig for tilt and backfocus
-    errors, linking to the deeper reference pages as you go.
+    The **[Quick Start](quick-start.md)** walks you from a fresh install to a tuned autofocus setup:
+    get a first run working, save your runs, tune star detection against a saved run, and know exactly
+    what to share if you need help. It links to the deeper reference pages as you go.
 
 ![Star field with accepted stars circled in green and rejected detections in pink, each accepted star labeled with its measured HFR](assets/figures/annotation-overlay.png){ width=620 }
 
@@ -51,8 +51,8 @@ and **Autofocus** dropdowns.
 
 ## How this documentation is organized
 
-- **[Quick Start](quick-start.md)** — the recommended first-run path: set up detection, autofocus, and
-  annotation, optimize, then check for tilt and backfocus.
+- **[Quick Start](quick-start.md)** — the recommended first-run path: get autofocus working, save your
+  runs, then tune star detection from a saved run.
 - **[Overview](overview/index.md)** — a tour of star detection, annotation, autofocus, and the tilt /
   aberration inspector, with the concepts and figures behind each.
 - **[Star Detection Settings](settings/index.md)** — a complete reference for every star-detection

--- a/documentation/docs/quick-start.md
+++ b/documentation/docs/quick-start.md
@@ -1,8 +1,9 @@
 # Quick Start
 
-This guide takes you from a fresh install of Hocus Focus to a tuned star detector, a working autofocus
-setup, and a first check of your sensor for tilt and backfocus errors. Each step links to the deeper
-reference page if you want the full detail.
+This guide takes you from a fresh install of Hocus Focus to a working, tuned autofocus setup. The order
+matters: get a basic autofocus running first, turn on saving, capture a run to disk, then let the
+Optimization Wizard tune star detection against that saved run. Each step links to a deeper reference
+page if you want the full detail.
 
 !!! note "Before you start"
     Install the plugin first. In NINA, open **Plugins → Available**, find **Hocus Focus**, and install
@@ -10,14 +11,14 @@ reference page if you want the full detail.
 
 ## 1. Tell NINA about your rig
 
-Several Hocus Focus features derive their starting points from your image scale, so get two things right
-first: your **pixel scale** and how far your **focuser moves per step**.
+Two rig numbers matter to several Hocus Focus features, so get them right first: your pixel scale and
+how far your focuser moves per step.
 
 - **Pixel size** (microns) — NINA's **Options → Equipment → Camera** tab. Usually filled in by the
   camera driver; confirm it matches your sensor.
 - **Focal length** (mm) — NINA's **Options → Equipment → Telescope** tab. Together with pixel size this
-  gives your pixel scale (arcsec/px), which the detector and the Simple-mode [Pixel Scale
-  preset](settings/advanced-debug.md#pixel-scale) use.
+  gives your pixel scale (arcsec/px). The detector uses it directly, and knowing it tells you which
+  Simple-mode [Pixel Scale preset](settings/advanced-debug.md#pixel-scale) to pick.
 - **Focuser Step Size** — set this in the
   [Aberration Inspector options](overview/tilt-aberration-inspector.md#inspector-options) (the inspector
   panel, not the main Options page). This tells the inspector how far the focuser moves per step, in
@@ -28,93 +29,138 @@ first: your **pixel scale** and how far your **focuser moves per step**.
 Turn on the parts you want. Go to **Options → Imaging → Image Options** and, in the dropdowns, select
 **Hocus Focus** for:
 
-![The Image Options dropdowns set to Hocus Focus for Star Detector, Star Annotator, and Autofocus](assets/screenshots/image-options-all.png){ width=510 }
-
-*Set Star Detector, Star Annotator, and Autofocus to Hocus Focus in Options, Imaging, Image Options.*
-
 - **Star Detector** — the improved detector (see [Star Detection](overview/star-detection.md)).
 - **Star Annotator** — the customizable overlay (see [Star Annotation](overview/star-annotation.md)).
 - **Autofocus** — the concurrent autofocus engine (see [Autofocus](overview/autofocus.md)).
+
+![The Image Options dropdowns set to Hocus Focus for Star Detector, Star Annotator, and Autofocus](assets/screenshots/image-options-all.png){ width=510 }
+
+*Set Star Detector, Star Annotator, and Autofocus to Hocus Focus in Options, Imaging, Image Options.*
 
 !!! note "Some features need both"
     The autofocus engine and the Aberration Inspector require Hocus Focus to be selected for both
     **Autofocus** and **Star Detector**. You can otherwise mix and match, for example keeping only the detector.
 
-## 3. Optimize star detection
+## 3. Get a first autofocus working
 
-The detector ships with sensible defaults, but the [Optimization Wizard](optimization/index.md) tunes it
-to *your* rig by replaying a saved autofocus run and searching for the settings that produce the
-cleanest, most repeatable focus curve. Launch it from the top of the **Star Detection** options page.
+Aim for a run that completes and finds a believable best-focus position. It does not have to be a great
+fit yet, and there is no need to hand-tune detection settings chasing one: tuning is the Optimization
+Wizard's job (step 6), and it works from data you capture in the next two steps.
 
-You will choose **what to optimize for** on the start page:
+Two groups of settings matter:
 
-- **Autofocus repeatability** (the default) — the everyday choice. It tunes detection so your autofocus
-  curves are tight and your best-focus position is repeatable run to run.
-- **Optimize for aberration inspection** — tunes instead to **recover many more stars across the whole
-  frame**, which is what the tilt/curvature model in step 4 needs, while keeping the focus curve usable.
-  Use this when you are about to run a Detailed Analysis.
+- **The Simple-mode presets**, on the plugin's **Star Detector** tab (NINA's options → **Plugins** →
+  **Hocus Focus**). Leave **Advanced Mode** off. Set
+  [**Pixel Scale**](settings/advanced-debug.md#pixel-scale) (**Wide Field**, **Typical**, or
+  **Long Focal Length**) to match your rig, raise
+  [**Noise Level**](settings/advanced-debug.md#noise-level) if your sensor is noisy, and leave
+  [**Focus Range**](settings/advanced-debug.md#focus-range) at **Typical**.
+- **NINA's own focuser settings** (**Options → Equipment → Focuser**): the autofocus exposure time,
+  step size, and initial offset steps. Size the sweep so it brackets focus decisively: at the outermost
+  points stars should be visibly bloated, with HFR roughly three times its in-focus value, and about
+  four points on each side of the minimum.
 
-The wizard searches from the default settings and reports its improvement **relative to your current
-settings**; it will never hand back a result worse than what you have today. You can feed it a
-[saved autofocus run](overview/autofocus.md) (recommended; see step 6) or run a fresh one. After it
-finishes you can **Continue optimizing** for another pass or accept the result.
+Get roughly focused first (a Bahtinov mask or a careful manual pass is fine), then run an autofocus from
+the **Auto Focus** panel in NINA's **Imaging** tab. A working run sweeps the focuser, traces a V-shaped
+HFR curve, fits a model through it, and moves to the fitted minimum:
+
+![A real autofocus HFR V-curve with a hyperbolic fit through the measured focus points](assets/screenshots/autofocus-vcurve-real.png){ width=620 }
+
+*What success looks like: a V with a fitted minimum. Some scatter and a merely decent fit are fine at
+this stage.*
+
+If the curve looks flat, the step size is too small. If stars vanish at the ends of the sweep, the step
+size is too large; reduce it, or set **Focus Range** to **Wide Range** so heavily defocused donut stars
+are still detected. If few stars are found even near focus, increase the exposure time. Narrowband
+filters in particular can need much longer autofocus exposures at first; the tip in step 6 shows how to
+work back down.
+
+→ Full detail: [Autofocus](overview/autofocus.md).
+
+## 4. Turn on Save and choose a folder
+
+On the plugin's **Auto Focus** tab, turn on **Save** and set **Save Path** to a folder you have created
+for this purpose. The folder must already exist: if it does not, autofocus still runs, but NINA shows a
+warning and nothing is saved.
+
+![The Hocus Focus Auto Focus options tab](assets/screenshots/autofocus-options.png){ width=402 }
+
+*The Auto Focus tab; the Save Path field appears once Save is turned on.*
+
+Every autofocus run now writes a complete record of itself to a new `AutoFocus_<date>_<time>` folder
+under that path: the focus images themselves, the star-detection results, and the stretched annotated
+frames. A saved run is replayable: Hocus Focus can re-run detection and curve fitting on it later, with
+different settings, without touching the telescope.
+
+## 5. Run autofocus again
+
+Run another autofocus, exactly as in step 3. The run itself is no different; the point is to capture a
+real run from your rig to disk. One good run is enough to continue; a couple more from the same optical
+setup (same camera, scope, and filter) give you a spare to pick from, and more data to share if you
+ever need help.
+
+## 6. Tune star detection with the Optimization Wizard
+
+Now hand the saved run to the [Optimization Wizard](optimization/index.md). It replays your run while
+searching for the detection settings that produce the cleanest, most repeatable focus curve, and it
+never returns a result worse than your current settings.
+
+1. Launch the wizard from the top of the **Star Detection** options page.
+2. Choose your saved run as the source and keep the default objective, autofocus repeatability (leave
+   **Optimize for aberration inspection** off).
+3. When the search finishes, review the improvement (reported relative to your current settings), press
+   **Continue optimizing** for another pass if you like, and accept the result. Adopt the recommended
+   [autofocus step size](optimization/step-size.md) it offers alongside the settings.
+
+The search re-runs star detection on every frame of your run for each candidate it evaluates, so it is
+computationally expensive and can take a while on a slow imaging computer.
+
+!!! tip "Run the wizard on another machine"
+    The wizard works entirely from the saved folder, so it does not have to run on your imaging
+    computer. Copy the `AutoFocus_*` folder to a faster machine with NINA and Hocus Focus installed, run
+    the wizard there, and press **Export** on the Star Detection options page. Back on the imaging
+    computer, **Import** the exported `.json` file, review exactly what will change, and apply. See
+    [exporting and importing settings](settings/index.md#exporting-and-importing-star-detection-settings).
+
+!!! tip "Narrowband filters: start long, then shorten"
+    Through a narrowband filter, autofocus may need long exposures before enough stars appear. Get your
+    first working autofocus that way, capture saved runs, and optimize. Then shorten the exposure as far
+    as autofocus keeps working; a properly tuned detector can handle much fainter stars than the
+    defaults. Save a run at the shorter exposure and optimize once more. The wizard tunes against the
+    run you feed it, so make the final pass use the exposure time, filter, and settings you will
+    actually autofocus with during imaging.
 
 → Full detail: [Star Detection Optimization](optimization/index.md).
 
-## 4. Check for tilt and backfocus
+## 7. If you run into trouble
 
-Open the **Aberration Inspector** dockable panel and run a **Detailed Analysis**. It performs an
-autofocus across the center and corners of the sensor at once and reports **tilt**, **backfocus** (the
-center-to-corner offset), and **field curvature**. A lighter **Simple Analysis** takes a single
-exposure to show an FWHM contour map and an eccentricity vector field for a quick look.
+Saved runs replay deterministically, so sharing one lets the plugin author reproduce exactly what your
+rig did, frame by frame. If autofocus misbehaves or a result looks wrong:
 
-Turn on **Sensor Curve Model Enabled** if you want curvature and centering numbers (not just a corner-vs-center
-tilt plane), for example when you intend to physically correct tilt. How that model is fit is covered
-in [Sensor Model Fitting](overview/sensor-model.md).
+1. Upload the saved run folders (the `AutoFocus_<date>_<time>` folders under your **Save Path**) to a
+   cloud storage provider such as Dropbox or Google Drive.
+2. Post a download link in the **#hocus-focus** channel on the NINA
+   [Discord server](https://discord.com/invite/rWRbVbw), with a short note about what you expected and
+   what happened instead.
 
-→ Full detail: [Tilt &amp; Aberration Inspector](overview/tilt-aberration-inspector.md).
+A replayable run is far more useful than a screenshot of the curve: it carries the actual frames and
+detection results, not just a picture of them.
 
-## 5. If you have a tilt adapter, calibrate it
+## Where to go next
 
-The inspector can turn its tilt measurement into **concrete screw-turn (or stepper-step) guidance**,
-but only after the **Tilt Adapter Wizard** has learned where each screw sits relative to your sensor and
-how far a turn moves it.
+With autofocus working and tuned, the same detector and saved-run machinery feed the rest of the plugin:
 
-1. Pick your adapter from the **Device** preset list (or **Manual** to enter the
-   [hardware values](overview/tilt-adapter-wizard.md#hardware-model-and-device-presets)
-   yourself: thread pitch, screw radius, screw count).
-2. Run the guided **calibration loop** to map the screws into image space. By default it is four
-   steps (a baseline, screw 1, a re-baseline, screw 2); the screw moves are prompted as clockwise
-   or counter-clockwise turns, and each step ends with a measurement. Turn on **Measure direction**
-   to add two steps that also measure which way the screws move the adapter.
-3. Know your adapter already? Use
-   [**Manual Calibration Entry**](overview/tilt-adapter-wizard.md#manual-calibration-entry) in the
-   wizard to type in the screw-1 angle instead of running the loop.
-
-Once calibrated, the inspector's adjustment chart tells you exactly which screw to turn and by how much.
-
-→ Full detail: [Tilt Adapter Wizard](overview/tilt-adapter-wizard.md).
-
-## 6. Save an autofocus run, then replay it to tune during the day
-
-You do not need clear skies to improve your settings. Save a real autofocus run once, then replay it
-indoors as many times as you like with different settings.
-
-1. **Save a run.** On the **Auto Focus** options page, turn on **Save** and set a **Save Path**. Every
-   autofocus run then writes its images, star-detection results, and annotated frames to that folder.
-2. **Replay it.** Point the [Optimization Wizard](optimization/index.md) (or the Aberration Inspector's
-   **Replay** button) at a saved run. The engine re-fits the curve from the saved frames
-   deterministically, so a re-fit reproduces the same per-position HFR every time. That lets you compare
-   settings without touching the telescope.
-
-This replay loop is the fastest way to tune detection: optimize, label any missed or false stars,
-re-optimize, and repeat, all from your desk.
-
-!!! tip "Tune on a fast machine, image on another"
-    The optimizer runs entirely from saved frames, so it does not need to run on your imaging computer. Copy a
-    saved autofocus run to a faster desktop, run the [Optimization Wizard](optimization/index.md) there, then use
-    **Export** on the Star Detection options page to write the tuned settings to a `.json` file. **Import** that file
-    on the imaging computer to apply them, after confirming exactly what will change. See
-    [exporting and importing settings](settings/index.md#exporting-and-importing-star-detection-settings).
-
-→ Full detail: [Autofocus](overview/autofocus.md) and [Star Detection Optimization](optimization/index.md).
+- **Check your sensor for tilt and backfocus.** Open the **Aberration Inspector** dockable panel and run
+  a **Detailed Analysis**: an autofocus across the center and corners of the sensor at once, reporting
+  tilt, backfocus error, and field curvature. Consider first re-running the
+  [Optimization Wizard](optimization/index.md) with **Optimize for aberration inspection** turned on: it
+  tunes detection to recover many more stars across the whole frame, which is what the tilt model needs.
+  → [Tilt &amp; Aberration Inspector](overview/tilt-aberration-inspector.md)
+- **If you have a tilt adapter, calibrate it.** The **Tilt Adapter Wizard** learns where each screw sits
+  relative to your sensor and how far a turn moves it, turning tilt measurements into concrete
+  screw-turn guidance. → [Tilt Adapter Wizard](overview/tilt-adapter-wizard.md)
+- **Customize the annotation overlay**: colors, fonts, and what gets drawn over accepted and rejected
+  stars. → [Star Annotation](overview/star-annotation.md)
+- **Go deeper on the settings.** Every detection knob, and everything the optimizer searches over, is
+  documented in [Star Detection Settings](settings/index.md) and
+  [Star Detection Optimization](optimization/index.md).


### PR DESCRIPTION
## Summary
- Rewrite the Quick Start around the crucial first steps: get a basic autofocus working (a great fit not required), turn on **Save** with a chosen folder, run autofocus again to capture a run to disk, then tune star detection against that saved run with the Optimization Wizard — optionally on another machine via settings Export/Import (linked).
- Add a troubleshooting step: upload the saved `AutoFocus_<date>_<time>` folders to a cloud storage provider (Dropbox, Google Drive) and post a download link in the **#hocus-focus** channel on the NINA Discord.
- Add a narrowband tip: start with long exposures, optimize, shorten the exposure while autofocus still works, then optimize again with the settings used for live autofocus during imaging.
- Condense the old tilt/adapter walkthrough steps into a "Where to go next" section and update the home page's two Quick Start descriptions to match.

## Verification
- `mkdocs build --strict` passes with no warnings.
- Technical-writer review pass: all UI labels, save-folder behavior (`AutoFocusEngine.InitializeSave`), preset names, wizard claims, links, anchors, and screenshots verified against source; findings applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)