### PR TITLE
Restore v3 BrightnessSensitivity for WideRange/LongFocalLength Simple presets

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionOptionsTests.cs
@@ -147,11 +147,10 @@ public class StarDetectionOptionsTests {
     }
 
     [Test]
-    public void SimpleMode_PixelScaleLongFocalLength_IncreasesSensitivity() {
-        // Longer focal length spreads star flux over more pixels, so detection must be MORE sensitive than
-        // Typical. BrightnessSensitivity is a threshold where SMALLER = more sensitive (regression guard for
-        // the previously-inverted sign: it used to be raised to 12, making LongFocalLength LESS sensitive).
-        // INTERIM (v3.0.0.26 revert): 10.0 unscaled base, deltas 2.0 (F4 sensitivityScale disabled).
+    public void SimpleMode_PixelScaleLongFocalLength_IsStricterThanTypical() {
+        // Longer focal length spreads star flux over more pixels; the preset RAISES BrightnessSensitivity to
+        // reject faint fragments that would corrupt the HFR median (BrightnessSensitivity is a threshold where
+        // SMALLER = more sensitive, so a HIGHER value = stricter). Matches v3.0.0.26 (see design doc §14).
         var (typical, _, _) = Build();
         typical.UseAdvanced = false;
         typical.Simple_PixelScale = PixelScaleEnum.Typical;
@@ -164,8 +163,8 @@ public class StarDetectionOptionsTests {
 
         Assert.Multiple(() => {
             Assert.That(typical.BrightnessSensitivity, Is.EqualTo(10.0));
-            Assert.That(longFl.BrightnessSensitivity, Is.EqualTo(8.0));
-            Assert.That(longFl.BrightnessSensitivity, Is.LessThan(typical.BrightnessSensitivity));
+            Assert.That(longFl.BrightnessSensitivity, Is.EqualTo(12.0));
+            Assert.That(longFl.BrightnessSensitivity, Is.GreaterThan(typical.BrightnessSensitivity));
         });
     }
 
@@ -179,11 +178,10 @@ public class StarDetectionOptionsTests {
     }
 
     [Test]
-    public void SimpleMode_FocusRangeWideRange_IncreasesSensitivity() {
-        // WideRange targets faint/defocused stars, so it must make detection MORE sensitive than Typical.
-        // BrightnessSensitivity is a threshold where SMALLER = more sensitive (regression guard for the
-        // previously-inverted sign: it used to be raised to 12, making WideRange LESS sensitive).
-        // INTERIM (v3.0.0.26 revert): 10.0 unscaled base, deltas 2.0 (F4 sensitivityScale disabled).
+    public void SimpleMode_FocusRangeWideRange_IsStricterThanTypical() {
+        // WideRange reaches heavier defocus, where small noise / donut-fragment detections (tiny HFRs) would
+        // corrupt the median HFR, so the preset RAISES BrightnessSensitivity to reject them (a threshold where
+        // SMALLER = more sensitive, so a HIGHER value = stricter). Matches v3.0.0.26 (see design doc §14).
         var (typical, _, _) = Build();
         typical.UseAdvanced = false;
         typical.Simple_PixelScale = PixelScaleEnum.Typical;
@@ -196,8 +194,8 @@ public class StarDetectionOptionsTests {
 
         Assert.Multiple(() => {
             Assert.That(typical.BrightnessSensitivity, Is.EqualTo(10.0));
-            Assert.That(wide.BrightnessSensitivity, Is.EqualTo(8.0));
-            Assert.That(wide.BrightnessSensitivity, Is.LessThan(typical.BrightnessSensitivity));
+            Assert.That(wide.BrightnessSensitivity, Is.EqualTo(12.0));
+            Assert.That(wide.BrightnessSensitivity, Is.GreaterThan(typical.BrightnessSensitivity));
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
@@ -148,9 +148,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             BrightnessSensitivity = 10.0 * sensitivityScale;
             if (Simple_FocusRange == FocusRangeEnum.WideRange) {
                 StructureLayers += 1;
-                // As we get further from focus, we want to be more sensitive as the chance for bad data
-                // increases. BrightnessSensitivity is a threshold where SMALLER = more sensitive, so we LOWER it.
-                BrightnessSensitivity -= 2.0 * sensitivityScale;
+                // WideRange reaches heavier defocus, where small noise / donut-fragment detections (tiny HFRs)
+                // would corrupt the median HFR. BrightnessSensitivity is a threshold where SMALLER = more sensitive,
+                // so we RAISE it to reject those fragments (matches v3.0.0.26; see the design doc §14 for evidence).
+                BrightnessSensitivity += 2.0 * sensitivityScale;
             }
 
             MinStarBoundingBoxSize = 5;
@@ -162,9 +163,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             } else if (Simple_PixelScale == PixelScaleEnum.LongFocalLength) {
                 StructureLayers += 1;
                 MinStarBoundingBoxSize += 1;
-                // Longer focal length spreads star flux over more pixels, so we want to be more sensitive.
-                // BrightnessSensitivity is a threshold where SMALLER = more sensitive, so we LOWER it.
-                BrightnessSensitivity -= 2.0 * sensitivityScale;
+                // Longer focal length spreads star flux over more pixels. RAISE BrightnessSensitivity (SMALLER =
+                // more sensitive) to reject faint fragments that would corrupt the HFR median (matches v3.0.0.26; §14).
+                BrightnessSensitivity += 2.0 * sensitivityScale;
             }
 
             if (HotpixelThresholdingEnabled && HotpixelFiltering) {

--- a/docs/simple-mode-upgrade-hardening-design.md
+++ b/docs/simple-mode-upgrade-hardening-design.md
@@ -263,6 +263,8 @@ Replaying SorenVance's saved AF run through the plugin ("Replay Saved AF", his f
 
 **Bearing on §13:** the original live `cand=1 / 0-star` collapse remains a separate (likely runtime) event that does not reproduce on replay — but the `BS=2` F4 default **does** independently degrade AF on his defocused frames, so the detector settings *are* implicated in the AF-quality failure, contrary to §13's stronger "not settings" wording. Net: the interim revert (NC=4 **and** BS=10) is warranted on its own merits, and the runtime `cand=1` question is now secondary.
 
+**Follow-up applied (whole grid now matches v3):** the `BrightnessSensitivity` WideRange/LongFocalLength deltas were flipped back to v3's `+= 2.0` (stricter: WideRange or LongFL → 12, both together → 14), so the **entire** Simple-mode BS grid now equals v3.0.0.26 — not just the Typical default. The two guard tests were renamed `SimpleMode_*_IsStricterThanTypical` and assert the raised value. This reverses the v4 "more sensitive at defocus" direction, which — per the mechanism above — admitted the small fragments that corrupt the HFR median exactly where WideRange is used (wide/defocused sweeps). NoiseClipping was already `4` for all combinations in both versions.
+
 ## Appendix — provenance
 
 Diagnosis and the mechanism/hardening study were produced by a multi-agent workflow (`simple-mode-upgrade-hardening`, run `wf_4b4844cb-71c`): a code-grounded mechanism investigation (v4 vs `release/v3.0.0.26`) plus five hardening lenses, each adversarially verified against the source before synthesis. Code anchors above were cited by those agents against the current tree; re-verify line numbers before implementing.


### PR DESCRIPTION
## Restore v3 BrightnessSensitivity for the WideRange / LongFocalLength Simple presets

Follow-up to #135 / v4.0.0.4. That interim revert fixed the **Typical** default (`BS=10`) but left the WideRange/LongFocalLength deltas at v4's flipped `-=` sign, so those presets were still *looser* than v3 — the opposite of what the replay evidence wants.

| Focus Range / Pixel Scale | v3.0.0.26 | v4.0.0.4 | this PR |
|---|---|---|---|
| Typical (default) | 10 | 10 | 10 |
| WideRange **or** LongFocalLength | 12 | 8 | **12** |
| WideRange + LongFocalLength | 14 | 6 | **14** |

Now the **entire** Simple-mode `BrightnessSensitivity` grid matches v3.0.0.26 (`NoiseClipping` was already `4` for all combinations).

### Why
v4 flipped v3's `+= 2.0` to `-= 2.0` on the theory that v3's sign was a bug ("more sensitive at defocus"). The SorenVance replay (design doc §14) showed the reverse: at defocus a **lower** BS admits small noise / donut-fragment detections whose tiny HFRs drag the **median HFR** down and skew autofocus — and WideRange is precisely the preset for wide/defocused sweeps, where that's worst. So **stricter (higher BS) is correct** for those presets.

### Tests
The two guard tests `SimpleMode_{FocusRangeWideRange,PixelScaleLongFocalLength}_IncreasesSensitivity` (which enforced the looser v4 direction) are renamed `_IsStricterThanTypical` and now assert `BS=12 > Typical's 10`. **Full suite: 1754 passed / 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
