### PR TITLE
refactor(autofocus): remove dead Fast Focus Mode options

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusOptionsTests.cs
@@ -24,12 +24,6 @@ public class AutoFocusOptionsTests {
         var (options, _, _) = Build();
         Assert.Multiple(() => {
             Assert.That(options.MaxConcurrent, Is.EqualTo(0));
-            Assert.That(options.FastFocusModeEnabled, Is.False);
-            Assert.That(options.FastStepSize, Is.EqualTo(1));
-            Assert.That(options.FastOffsetSteps, Is.EqualTo(4));
-            Assert.That(options.FastThreshold_Celcius, Is.EqualTo(5));
-            Assert.That(options.FastThreshold_FocuserPosition, Is.EqualTo(100));
-            Assert.That(options.FastThreshold_Seconds, Is.EqualTo((int)TimeSpan.FromMinutes(60).TotalSeconds));
             Assert.That(options.AutoFocusTimeoutSeconds, Is.EqualTo((int)TimeSpan.FromMinutes(10).TotalSeconds));
             Assert.That(options.ValidateHfrImprovement, Is.True);
             Assert.That(options.HFRImprovementThreshold, Is.EqualTo(0.15));
@@ -48,12 +42,6 @@ public class AutoFocusOptionsTests {
     public void Setters_PersistToAccessor() {
         var (options, store, _) = Build();
         options.MaxConcurrent = 4;
-        options.FastFocusModeEnabled = true;
-        options.FastStepSize = 3;
-        options.FastOffsetSteps = 6;
-        options.FastThreshold_Celcius = 7;
-        options.FastThreshold_FocuserPosition = 250;
-        options.FastThreshold_Seconds = 1800;
         options.AutoFocusTimeoutSeconds = 900;
         options.ValidateHfrImprovement = false;
         options.HFRImprovementThreshold = 0.25;
@@ -68,12 +56,6 @@ public class AutoFocusOptionsTests {
 
         Assert.Multiple(() => {
             Assert.That(store.Snapshot["MaxConcurrent"], Is.EqualTo(4));
-            Assert.That(store.Snapshot["FastFocusModeEnabled"], Is.True);
-            Assert.That(store.Snapshot["FastStepSize"], Is.EqualTo(3));
-            Assert.That(store.Snapshot["FastOffsetSteps"], Is.EqualTo(6));
-            Assert.That(store.Snapshot["FastThreshold_Celcius"], Is.EqualTo(7));
-            Assert.That(store.Snapshot["FastThreshold_FocuserPosition"], Is.EqualTo(250));
-            Assert.That(store.Snapshot["FastThreshold_Seconds"], Is.EqualTo(1800));
             Assert.That(store.Snapshot["AutoFocusTimeoutSeconds"], Is.EqualTo(900));
             Assert.That(store.Snapshot["ValidateHfrImprovement"], Is.False);
             Assert.That(store.Snapshot["HFRImprovementThreshold"], Is.EqualTo(0.25));
@@ -92,7 +74,6 @@ public class AutoFocusOptionsTests {
     public void ResetDefaults_RestoresDocumentedDefaults() {
         var (options, _, _) = Build();
         options.MaxConcurrent = 8;
-        options.FastFocusModeEnabled = true;
         options.HFRImprovementThreshold = 0.99;
         options.Save = true;
         options.KeepFramesForReview = true;
@@ -102,7 +83,6 @@ public class AutoFocusOptionsTests {
 
         Assert.Multiple(() => {
             Assert.That(options.MaxConcurrent, Is.EqualTo(0));
-            Assert.That(options.FastFocusModeEnabled, Is.False);
             Assert.That(options.HFRImprovementThreshold, Is.EqualTo(0.15));
             Assert.That(options.Save, Is.False);
             Assert.That(options.KeepFramesForReview, Is.False);
@@ -113,9 +93,6 @@ public class AutoFocusOptionsTests {
     }
 
     [TestCase(nameof(AutoFocusOptions.MaxConcurrent), 4)]
-    [TestCase(nameof(AutoFocusOptions.FastFocusModeEnabled), true)]
-    [TestCase(nameof(AutoFocusOptions.FastStepSize), 5)]
-    [TestCase(nameof(AutoFocusOptions.FastThreshold_Celcius), 7)]
     [TestCase(nameof(AutoFocusOptions.AutoFocusTimeoutSeconds), 1200)]
     [TestCase(nameof(AutoFocusOptions.ValidateHfrImprovement), false)]
     [TestCase(nameof(AutoFocusOptions.HFRImprovementThreshold), 0.5)]
@@ -134,18 +111,6 @@ public class AutoFocusOptionsTests {
         var prop = typeof(AutoFocusOptions).GetProperty(propertyName);
         prop.SetValue(options, Convert.ChangeType(newValue, prop.PropertyType));
         Assert.That(raised, Does.Contain(propertyName));
-    }
-
-    [Test]
-    public void FastOffsetSteps_RejectsValuesLessThanTwo() {
-        var (options, _, _) = Build();
-        Assert.Throws<ArgumentException>(() => options.FastOffsetSteps = 1);
-    }
-
-    [TestCase(-1)]
-    public void FastThreshold_SecondsRejectsNegative(int v) {
-        var (options, _, _) = Build();
-        Assert.Throws<ArgumentException>(() => options.FastThreshold_Seconds = v);
     }
 
     [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
@@ -45,12 +45,6 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
         public event PropertyChangedEventHandler PropertyChanged;
 
         public int MaxConcurrent { get; set; }
-        public bool FastFocusModeEnabled { get; set; }
-        public int FastStepSize { get; set; }
-        public int FastOffsetSteps { get; set; }
-        public int FastThreshold_Seconds { get; set; }
-        public int FastThreshold_Celcius { get; set; }
-        public int FastThreshold_FocuserPosition { get; set; }
         public bool ValidateHfrImprovement { get; set; }
         public double HFRImprovementThreshold { get; set; }
         public int AutoFocusTimeoutSeconds { get; set; }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusOptions.cs
@@ -50,12 +50,6 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
         private void InitializeOptions() {
             maxConcurrent = optionsAccessor.GetValueInt32("MaxConcurrent", 0);
-            fastFocusModeEnabled = optionsAccessor.GetValueBoolean("FastFocusModeEnabled", false);
-            fastStepSize = optionsAccessor.GetValueInt32("FastStepSize", 1);
-            fastOffsetSteps = optionsAccessor.GetValueInt32("FastOffsetSteps", 4);
-            fastThreshold_Celcius = optionsAccessor.GetValueInt32("FastThreshold_Celcius", 5);
-            fastThreshold_FocuserPosition = optionsAccessor.GetValueInt32("FastThreshold_FocuserPosition", 100);
-            fastThreshold_Seconds = optionsAccessor.GetValueInt32("FastThreshold_Seconds", (int)TimeSpan.FromMinutes(60).TotalSeconds);
             autoFocusTimeoutSeconds = optionsAccessor.GetValueInt32("AutoFocusTimeoutSeconds", (int)TimeSpan.FromMinutes(10).TotalSeconds);
             validateHfrImprovement = optionsAccessor.GetValueBoolean("ValidateHfrImprovement", true);
             hfrImprovementThreshold = optionsAccessor.GetValueDouble("HFRImprovementThreshold", 0.15);
@@ -74,12 +68,6 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
         public void ResetDefaults() {
             maxConcurrent = 0;
-            FastFocusModeEnabled = false;
-            FastStepSize = 1;
-            FastOffsetSteps = 4;
-            FastThreshold_Celcius = 5;
-            FastThreshold_FocuserPosition = 100;
-            FastThreshold_Seconds = (int)TimeSpan.FromMinutes(60).TotalSeconds;
             AutoFocusTimeoutSeconds = (int)TimeSpan.FromMinutes(10).TotalSeconds;
             ValidateHfrImprovement = true;
             HFRImprovementThreshold = 0.15;
@@ -104,100 +92,6 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 if (maxConcurrent != value) {
                     maxConcurrent = value;
                     optionsAccessor.SetValueInt32("MaxConcurrent", maxConcurrent);
-                    RaisePropertyChanged();
-                }
-            }
-        }
-
-        private bool fastFocusModeEnabled;
-
-        public bool FastFocusModeEnabled {
-            get => fastFocusModeEnabled;
-            set {
-                if (fastFocusModeEnabled != value) {
-                    fastFocusModeEnabled = value;
-                    optionsAccessor.SetValueBoolean("FastFocusModeEnabled", value);
-                    RaisePropertyChanged();
-                }
-            }
-        }
-
-        private int fastStepSize;
-
-        public int FastStepSize {
-            get => fastStepSize;
-            set {
-                if (fastStepSize != value) {
-                    fastStepSize = value;
-                    optionsAccessor.SetValueInt32("FastStepSize", fastStepSize);
-                    RaisePropertyChanged();
-                }
-            }
-        }
-
-        private int fastOffsetSteps;
-
-        public int FastOffsetSteps {
-            get => fastOffsetSteps;
-            set {
-                if (fastOffsetSteps != value) {
-                    if (value <= 1) {
-                        throw new ArgumentException("FastOffsetSteps must be at least 2", "FastOffsetSteps");
-                    }
-
-                    fastOffsetSteps = value;
-                    optionsAccessor.SetValueInt32("FastOffsetSteps", fastOffsetSteps);
-                    RaisePropertyChanged();
-                }
-            }
-        }
-
-        private int fastThreshold_Seconds;
-
-        public int FastThreshold_Seconds {
-            get => fastThreshold_Seconds;
-            set {
-                if (fastThreshold_Seconds != value) {
-                    if (value < 0) {
-                        throw new ArgumentException("FastThreshold_Seconds must be non-negative", "FastThreshold_Seconds");
-                    }
-
-                    fastThreshold_Seconds = value;
-                    optionsAccessor.SetValueInt32("FastThreshold_Seconds", fastThreshold_Seconds);
-                    RaisePropertyChanged();
-                }
-            }
-        }
-
-        private int fastThreshold_Celcius;
-
-        public int FastThreshold_Celcius {
-            get => fastThreshold_Celcius;
-            set {
-                if (fastThreshold_Celcius != value) {
-                    if (value < 0) {
-                        throw new ArgumentException("FastThreshold_Celcius must be non-negative", "FastThreshold_Celcius");
-                    }
-
-                    fastThreshold_Celcius = value;
-                    optionsAccessor.SetValueInt32("FastThreshold_Celcius", fastThreshold_Celcius);
-                    RaisePropertyChanged();
-                }
-            }
-        }
-
-        private int fastThreshold_FocuserPosition;
-
-        public int FastThreshold_FocuserPosition {
-            get => fastThreshold_FocuserPosition;
-            set {
-                if (fastThreshold_FocuserPosition != value) {
-                    if (value < 0) {
-                        throw new ArgumentException("FastThreshold_FocuserPosition must be non-negative", "FastThreshold_FocuserPosition");
-                    }
-
-                    fastThreshold_FocuserPosition = value;
-                    optionsAccessor.SetValueInt32("FastThreshold_FocuserPosition", fastThreshold_FocuserPosition);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IAutoFocusOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IAutoFocusOptions.cs
@@ -14,12 +14,6 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
 
     public interface IAutoFocusOptions {
         int MaxConcurrent { get; set; }
-        bool FastFocusModeEnabled { get; set; }
-        int FastStepSize { get; set; }
-        int FastOffsetSteps { get; set; }
-        int FastThreshold_Seconds { get; set; }
-        int FastThreshold_Celcius { get; set; }
-        int FastThreshold_FocuserPosition { get; set; }
         bool ValidateHfrImprovement { get; set; }
         double HFRImprovementThreshold { get; set; }
         int AutoFocusTimeoutSeconds { get; set; }


### PR DESCRIPTION
## Summary

Removes the abandoned **Fast Focus Mode** options, which were declared, persisted, and unit-tested but had **no consumer** anywhere — no engine, view model, or XAML reads them, and there's no UI control to set them. Enabling "fast focus mode" or changing any of these values had zero runtime effect.

Removed (all 6):
- `FastFocusModeEnabled`
- `FastStepSize`
- `FastOffsetSteps`
- `FastThreshold_Seconds`
- `FastThreshold_Celcius`
- `FastThreshold_FocuserPosition`

## Changes

| File | What |
|---|---|
| `Interfaces/IAutoFocusOptions.cs` | Dropped the 6 interface members |
| `AutoFocus/AutoFocusOptions.cs` | Removed fields, properties, `InitializeOptions()` loads, and `ResetDefaults()` lines |
| `Tests/Inspection/FakeSensorModelOptions.cs` | Removed the 6 stub properties from the `IAutoFocusOptions` test double |
| `Tests/AutoFocus/AutoFocusOptionsTests.cs` | Removed Fast\* assertions from `Defaults`/`Setters`/`ResetDefaults`, the 3 Fast\* `[TestCase]`s, and the two Fast\*-only validation tests |

Net: **153 deletions**, no production behavior change.

## Notes

- **No settings migration needed** — any orphaned `FastFocusModeEnabled`/etc. keys left in a user's profile option store are simply never read again (harmless).
- No options-UI template changes: these options never had a UI control (part of why they were dead — a violation of the repo's "every persisted option needs a UI control" invariant, now resolved by removal).
- `using System;` remains valid in both edited source files (`TimeSpan`/`ArgumentException`/`ArgumentNullException` still used elsewhere).

## Testing

Full suite green: **1749 passed, 0 failed** (3 pre-existing benchmarks skipped). Only pre-existing, unrelated warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013emnWAzJBXXqWZqqRx76QC