### PR TITLE
Add OGMA tilt adapter presets

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterDevicePresetTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterDevicePresetTests.cs
@@ -94,6 +94,71 @@ public class TiltAdapterDevicePresetTests {
     }
 
     [Test]
+    public void OgmaZTilter3Point_HasDocumentedValues() {
+        var preset = TiltAdapterDevicePreset.ByName("OGMA Z'Tilter - 3-point configuration");
+        Assert.Multiple(() => {
+            Assert.That(preset.IsManual, Is.False);
+            Assert.That(preset.ScrewCount, Is.EqualTo(3));
+            Assert.That(preset.AdjustmentType, Is.EqualTo(TiltAdjustmentType.Screws));
+            Assert.That(preset.ThreadPitchMicrons, Is.EqualTo(450));
+            Assert.That(preset.StepperStepSizeMicrons, Is.EqualTo(-1));
+            Assert.That(preset.ScrewRadiusMillimeters, Is.EqualTo(48.9));
+        });
+    }
+
+    [Test]
+    public void OgmaZTilter4Point_HasDocumentedValues() {
+        var preset = TiltAdapterDevicePreset.ByName("OGMA Z'Tilter - 4-point configuration");
+        Assert.Multiple(() => {
+            Assert.That(preset.IsManual, Is.False);
+            Assert.That(preset.ScrewCount, Is.EqualTo(4));
+            Assert.That(preset.AdjustmentType, Is.EqualTo(TiltAdjustmentType.Screws));
+            Assert.That(preset.ThreadPitchMicrons, Is.EqualTo(450));
+            Assert.That(preset.StepperStepSizeMicrons, Is.EqualTo(-1));
+            Assert.That(preset.ScrewRadiusMillimeters, Is.EqualTo(48.9));
+        });
+    }
+
+    [Test]
+    public void OgmaOTilter_HasDocumentedValues() {
+        var preset = TiltAdapterDevicePreset.ByName("OGMA O'Tilter");
+        Assert.Multiple(() => {
+            Assert.That(preset.IsManual, Is.False);
+            Assert.That(preset.ScrewCount, Is.EqualTo(3));
+            Assert.That(preset.AdjustmentType, Is.EqualTo(TiltAdjustmentType.Screws));
+            Assert.That(preset.ThreadPitchMicrons, Is.EqualTo(450));
+            Assert.That(preset.StepperStepSizeMicrons, Is.EqualTo(-1));
+            Assert.That(preset.ScrewRadiusMillimeters, Is.EqualTo(43.25));
+        });
+    }
+
+    [Test]
+    public void OgmaPlusTilterOagPro3Point_HasDocumentedValues() {
+        var preset = TiltAdapterDevicePreset.ByName("OGMA +Tilter / OAG Pro - 3-point configuration");
+        Assert.Multiple(() => {
+            Assert.That(preset.IsManual, Is.False);
+            Assert.That(preset.ScrewCount, Is.EqualTo(3));
+            Assert.That(preset.AdjustmentType, Is.EqualTo(TiltAdjustmentType.Screws));
+            Assert.That(preset.ThreadPitchMicrons, Is.EqualTo(450));
+            Assert.That(preset.StepperStepSizeMicrons, Is.EqualTo(-1));
+            Assert.That(preset.ScrewRadiusMillimeters, Is.EqualTo(40));
+        });
+    }
+
+    [Test]
+    public void OgmaPlusTilterOagPro4Point_HasDocumentedValues() {
+        var preset = TiltAdapterDevicePreset.ByName("OGMA +Tilter / OAG Pro - 4-point configuration");
+        Assert.Multiple(() => {
+            Assert.That(preset.IsManual, Is.False);
+            Assert.That(preset.ScrewCount, Is.EqualTo(4));
+            Assert.That(preset.AdjustmentType, Is.EqualTo(TiltAdjustmentType.Screws));
+            Assert.That(preset.ThreadPitchMicrons, Is.EqualTo(450));
+            Assert.That(preset.StepperStepSizeMicrons, Is.EqualTo(-1));
+            Assert.That(preset.ScrewRadiusMillimeters, Is.EqualTo(40));
+        });
+    }
+
+    [Test]
     public void ByName_UnknownFallsBackToManual() {
         Assert.That(TiltAdapterDevicePreset.ByName("does-not-exist"), Is.SameAs(TiltAdapterDevicePreset.Manual));
         Assert.That(TiltAdapterDevicePreset.ByName(null), Is.SameAs(TiltAdapterDevicePreset.Manual));

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterDevicePreset.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterDevicePreset.cs
@@ -75,6 +75,23 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             new TiltAdapterDevicePreset(
                 "ASG Electronic EAT - ZWO 461", isManual: false, screwCount: 4, adjustmentType: TiltAdjustmentType.StepperMotors,
                 threadPitchMicrons: -1, stepperStepSizeMicrons: 1.8, screwRadiusMillimeters: 62.75),
+
+            // OGMA series
+            new TiltAdapterDevicePreset(
+                "OGMA Z'Tilter - 3-point configuration", isManual: false, screwCount: 3, adjustmentType: TiltAdjustmentType.Screws,
+                threadPitchMicrons: 450, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 48.9),
+            new TiltAdapterDevicePreset(
+                "OGMA Z'Tilter - 4-point configuration", isManual: false, screwCount: 4, adjustmentType: TiltAdjustmentType.Screws,
+                threadPitchMicrons: 450, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 48.9),
+            new TiltAdapterDevicePreset(
+                "OGMA O'Tilter", isManual: false, screwCount: 3, adjustmentType: TiltAdjustmentType.Screws,
+                threadPitchMicrons: 450, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 43.25),
+            new TiltAdapterDevicePreset(
+                "OGMA +Tilter / OAG Pro - 3-point configuration", isManual: false, screwCount: 3, adjustmentType: TiltAdjustmentType.Screws,
+                threadPitchMicrons: 450, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 40),
+            new TiltAdapterDevicePreset(
+                "OGMA +Tilter / OAG Pro - 4-point configuration", isManual: false, screwCount: 4, adjustmentType: TiltAdjustmentType.Screws,
+                threadPitchMicrons: 450, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 40),
         };
 
         public static TiltAdapterDevicePreset ByName(string name) =>

--- a/documentation/docs/overview/tilt-adapter-wizard.md
+++ b/documentation/docs/overview/tilt-adapter-wizard.md
@@ -141,6 +141,11 @@ built-in presets are:
 | ASG Electronic EAT - 90mm | Stepper Motors | 4 | — | 1.8 | 55 |
 | ASG Photon Cage - ZWO 461 | Screws | 4 | 212 | — | 54 |
 | ASG Electronic EAT - ZWO 461 | Stepper Motors | 4 | — | 1.8 | 62.75 |
+| OGMA Z'Tilter - 3-point configuration | Screws | 3 | 450 | — | 48.9 |
+| OGMA Z'Tilter - 4-point configuration | Screws | 4 | 450 | — | 48.9 |
+| OGMA O'Tilter | Screws | 3 | 450 | — | 43.25 |
+| OGMA +Tilter / OAG Pro - 3-point configuration | Screws | 3 | 450 | — | 40 |
+| OGMA +Tilter / OAG Pro - 4-point configuration | Screws | 4 | 450 | — | 40 |
 
 The ASG Photon Cage adjusters are 120 TPI, which is 211.7 µm per full turn (the manufacturer rounds
 this to ~212). For the motorized EAT units the Screw Radius column is the radius of the motors from


### PR DESCRIPTION
## Summary

Adds built-in device presets for the following OGMA tilt adjusters:

* OGMA Z'Tilter — 3-point configuration
* OGMA Z'Tilter — 4-point configuration
* OGMA O'Tilter
* OGMA +Tilter / OAG Pro — 3-point configuration
* OGMA +Tilter / OAG Pro — 4-point configuration

Also updates the Tilt Adapter Wizard documentation and adds tests for the new presets.

## Testing

* Ran the full test suite successfully.
* Verified the new preset values and adjuster configurations.

Closes #138
