### PR TITLE
Motorized tilt adapter automation (ASG EAT) — T1–T14

### DIFF
--- a/.claude/docs/mvvm-patterns.md
+++ b/.claude/docs/mvvm-patterns.md
@@ -79,6 +79,45 @@ private readonly IProgress<ApplicationStatus> progress;
 // Created via: ProgressFactory.Create(applicationStatusMediator, "Aberration Inspector")
 ```
 
+## UI Threading & Dispatcher Marshaling
+
+VMs are driven from **three** kinds of threads: the UI thread (user actions, ctor), awaited task
+continuations (AF/analysis/calibration runs), and **background timers/broadcasts** (NINA's DeviceUpdateTimer
+device-info push; the tilt-device connection service's `cp` poll). Getting the marshaling wrong causes either a
+cross-thread **crash** or a **deadlock/hang** — both have bitten this codebase. Rules:
+
+- **`RaisePropertyChanged` is auto-marshaled by WPF data binding; `ICommand` requery is NOT.**
+  `IRelayCommand.NotifyCanExecuteChanged()` raises through `CanExecuteChangedEventManager`, which **throws
+  `InvalidOperationException` ("The calling thread cannot access this object…") off the UI thread.** Any
+  `NotifyCanExecuteChanged()` reachable from a non-UI thread must be marshaled.
+
+- **Marshal via `IApplicationDispatcher` — and default to the NON-blocking `PostSynchronizationContext`
+  (`BeginInvoke`).** Reach for the blocking `DispatchSynchronizationContext` (`Invoke`) **only** when the action
+  must complete before the method returns (e.g. the next step reads the value) **and** the caller is a task the
+  UI awaits — never a background timer/poll. A blocking `Invoke` from a background thread onto a busy or
+  tearing-down UI thread **deadlocks** (the UI thread may be laying out a tab, or, at shutdown, awaiting the very
+  timer that is trying to Invoke). Both dispatch methods run inline when already on the UI thread (and in tests,
+  where the dispatcher is null) — so UI-thread callers and unit tests are unaffected either way.
+  - Precedents: `InspectorVM.RefreshCommandStates` / `RebuildTiltGuidance` **Post** (they are reachable from the
+    `cp`-poll thread via `tiltAdapterOptions.PropertyChanged`); `NotifyReviewFramesAvailabilityChanged` **Dispatch**
+    (only ever called from an awaited analysis task).
+
+- **Watch what fires a subscribed `PropertyChanged` on a background thread.** An options setter written from a
+  poll/broadcast thread (e.g. `EatTiltMotionController` persists `TiltDeviceShadowPositions` during a `cp` poll)
+  runs every subscriber — including a `… .PropertyChanged += (s,e) => Rebuild()` handler — on **that** thread. So
+  `Rebuild()` must be background-safe (no blocking Invoke).
+
+- **Shared device / simulator state belongs in the shared options, not a per-VM field.** State that both a
+  background/automation writer and the UI mutate (e.g. per-screw net counters driven by *both* manual clicks and
+  the `SimulatedTiltActuator`) must live on the shared `*Options` object and be observed via INPC, so every VM
+  instance and every writer stay in lockstep. A per-VM field silently desyncs when a second VM or an automated
+  path bypasses it. (See `ICameraSimulatorOptions.SimNetAxialMicrons`.)
+
+- **Status-bar lines don't clear themselves.** `IProgress<ApplicationStatus>` shows the *last* reported status
+  until something reports an empty one. After a transient operation (a device move, a recovery sweep), clear it in
+  a `finally`: `progress.Report(new ApplicationStatus { Status = string.Empty })`, or the last message lingers in
+  NINA's bottom-left corner after the command finishes.
+
 ## Error Handling
 
 Custom domain exceptions extend `Exception` directly:

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMAutomaticAdjustmentTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMAutomaticAdjustmentTests.cs
@@ -1,0 +1,1026 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.Inspection;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
+using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NINA.Core.Utility.SerialCommunication;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus;
+
+// T14 (Inspector "Automatic Adjustment" end-to-end): SAFETY-CRITICAL feature -- these tests are the
+// backstop for the design doc's "[CRITICAL GATE]" (device-linked calibration) and user decision #9
+// (one adjustment per measurement, no auto-looping). Two layers:
+//   1. Pure `internal static` helper tests (canExecute gate, per-screw targets, plan preview, worsening
+//      check) -- directly unit-testable, no VM needed.
+//   2. A VM-level harness (mirrors InspectorVMBehavioralTests) driving AutomaticAdjustmentCommand through
+//      a REAL TiltDeviceConnectionService (built via its internal test ctor, exactly like
+//      TiltDeviceConnectionServiceTests) wired to an NSubstitute ITiltMotionController, with the
+//      dialog-showing and confirm-prompt steps replaced by injectable fakes (TiltDeviceAdjustmentPrompt.ShowAsync
+//      opens a real WPF window and cannot run headless; AnalyzeAutoFocus needs a working AutoFocus engine and
+//      is exercised elsewhere) -- see InspectorVM's showAdjustmentPromptAsync/confirmPromptAsync/reRunAnalysisAsync.
+[TestFixture]
+[Apartment(System.Threading.ApartmentState.STA)]
+public class InspectorVMAutomaticAdjustmentTests {
+
+    // ======================================================================================================
+    // Pure static helpers
+    // ======================================================================================================
+
+    #region IsCalibrationDeviceLinked
+
+    [Test]
+    public void IsCalibrationDeviceLinked_NullOptions_ReturnsFalse() {
+        Assert.That(InspectorVM.IsCalibrationDeviceLinked(null), Is.False);
+    }
+
+    [TestCase("", "ASG Electronic EAT - 90mm", false, TestName = "EmptyLinkedMarker")]
+    [TestCase(null, "ASG Electronic EAT - 90mm", false, TestName = "NullLinkedMarker")]
+    [TestCase("ASG Electronic EAT - 90mm", "ASG Electronic EAT - ZWO 461", false, TestName = "MismatchedPreset")]
+    [TestCase("ASG Electronic EAT - 90mm", "ASG Electronic EAT - 90mm", true, TestName = "MatchingNonEmpty")]
+    public void IsCalibrationDeviceLinked_VariousCombinations(string linked, string deviceName, bool expected) {
+        var options = Substitute.For<ITiltAdapterOptions>();
+        options.DeviceLinkedCalibrationDeviceName.Returns(linked);
+        options.DeviceName.Returns(deviceName);
+        Assert.That(InspectorVM.IsCalibrationDeviceLinked(options), Is.EqualTo(expected));
+    }
+
+    #endregion
+
+    #region CanExecuteAutomaticAdjustment
+
+    [Test]
+    public void CanExecuteAutomaticAdjustment_AllGatesSatisfied_ReturnsTrue() {
+        Assert.That(InspectorVM.CanExecuteAutomaticAdjustment(
+            serviceConnected: true, controllerAvailable: true, deviceLinked: true, calibrationIsReliable: true,
+            hasNumericGuidance: true, isOperationActive: false, currentGeneration: 1, lastExecutedGeneration: 0),
+            Is.True);
+    }
+
+    [Test]
+    public void CanExecuteAutomaticAdjustment_NotConnected_ReturnsFalse() {
+        Assert.That(InspectorVM.CanExecuteAutomaticAdjustment(
+            serviceConnected: false, controllerAvailable: true, deviceLinked: true, calibrationIsReliable: true,
+            hasNumericGuidance: true, isOperationActive: false, currentGeneration: 1, lastExecutedGeneration: 0),
+            Is.False);
+    }
+
+    [Test]
+    public void CanExecuteAutomaticAdjustment_NoController_ReturnsFalse() {
+        Assert.That(InspectorVM.CanExecuteAutomaticAdjustment(
+            serviceConnected: true, controllerAvailable: false, deviceLinked: true, calibrationIsReliable: true,
+            hasNumericGuidance: true, isOperationActive: false, currentGeneration: 1, lastExecutedGeneration: 0),
+            Is.False);
+    }
+
+    [Test]
+    public void CanExecuteAutomaticAdjustment_NotDeviceLinked_ReturnsFalse() {
+        Assert.That(InspectorVM.CanExecuteAutomaticAdjustment(
+            serviceConnected: true, controllerAvailable: true, deviceLinked: false, calibrationIsReliable: true,
+            hasNumericGuidance: true, isOperationActive: false, currentGeneration: 1, lastExecutedGeneration: 0),
+            Is.False);
+    }
+
+    // [CRITICAL GATE] The second half of the automation gate: a device-linked calibration that failed its
+    // own confidence/quality check must still be blocked -- device-linked is necessary but not sufficient.
+    [Test]
+    public void CanExecuteAutomaticAdjustment_CalibrationNotReliable_ReturnsFalse() {
+        Assert.That(InspectorVM.CanExecuteAutomaticAdjustment(
+            serviceConnected: true, controllerAvailable: true, deviceLinked: true, calibrationIsReliable: false,
+            hasNumericGuidance: true, isOperationActive: false, currentGeneration: 1, lastExecutedGeneration: 0),
+            Is.False);
+    }
+
+    [Test]
+    public void CanExecuteAutomaticAdjustment_NoNumericGuidance_ReturnsFalse() {
+        Assert.That(InspectorVM.CanExecuteAutomaticAdjustment(
+            serviceConnected: true, controllerAvailable: true, deviceLinked: true, calibrationIsReliable: true,
+            hasNumericGuidance: false, isOperationActive: false, currentGeneration: 1, lastExecutedGeneration: 0),
+            Is.False);
+    }
+
+    [Test]
+    public void CanExecuteAutomaticAdjustment_OperationActive_ReturnsFalse() {
+        Assert.That(InspectorVM.CanExecuteAutomaticAdjustment(
+            serviceConnected: true, controllerAvailable: true, deviceLinked: true, calibrationIsReliable: true,
+            hasNumericGuidance: true, isOperationActive: true, currentGeneration: 1, lastExecutedGeneration: 0),
+            Is.False);
+    }
+
+    [Test]
+    public void CanExecuteAutomaticAdjustment_GenerationAlreadyExecuted_ReturnsFalse() {
+        Assert.That(InspectorVM.CanExecuteAutomaticAdjustment(
+            serviceConnected: true, controllerAvailable: true, deviceLinked: true, calibrationIsReliable: true,
+            hasNumericGuidance: true, isOperationActive: false, currentGeneration: 1, lastExecutedGeneration: 1),
+            Is.False);
+    }
+
+    [Test]
+    public void CanExecuteAutomaticAdjustment_NoMeasurementYet_BothGenerationsZero_ReturnsFalse() {
+        Assert.That(InspectorVM.CanExecuteAutomaticAdjustment(
+            serviceConnected: true, controllerAvailable: true, deviceLinked: true, calibrationIsReliable: true,
+            hasNumericGuidance: true, isOperationActive: false, currentGeneration: 0, lastExecutedGeneration: 0),
+            Is.False);
+    }
+
+    #endregion
+
+    #region BuildPerScrewTargets
+
+    private static ITiltAdapterOptions NewFourScrewOptions() {
+        var options = Substitute.For<ITiltAdapterOptions>();
+        options.ScrewCount.Returns(4);
+        options.AdjustmentType.Returns(TiltAdjustmentType.StepperMotors);
+        options.StepperStepSizeMicrons.Returns(1.8);
+        options.ScrewRadiusMillimeters.Returns(55.0);
+        options.Screw1AngleDegrees.Returns(0.0);
+        options.Screw2AngleDegrees.Returns(90.0);
+        options.Screw3AngleDegrees.Returns(180.0);
+        options.Screw4AngleDegrees.Returns(270.0);
+        options.ScrewInwardCurvatureSign.Returns(1);
+        return options;
+    }
+
+    // The whole point of this helper is that automation reads targets straight off the fitted model --
+    // NEVER off the formatted display strings FillNumericGuidance builds for the guidance table -- so this
+    // asserts equality against TiltScrewTargets.ComputePerScrewTargets directly (the same call InspectorVM
+    // makes), not against any formatted text.
+    [Test]
+    public void BuildPerScrewTargets_MatchesTiltScrewTargetsDirectly_NotDisplayStrings() {
+        var options = NewFourScrewOptions();
+        var model = new SensorParaboloidModel(x0: 3.0, y0: -2.0, z0: 0, gx: 0.0015, gy: -0.0007, k: 4e-6);
+
+        var (sPerScrew, unitMicrons) = InspectorVM.BuildPerScrewTargets(model, options);
+
+        var angles = new[] { 0.0, 90.0, 180.0, 270.0 };
+        var expected = TiltScrewTargets.ComputePerScrewTargets(
+            model.Gx, model.Gy, model.Kx, model.Ky, model.X0, model.Y0,
+            angles, 55.0 * 1000.0, 1.8, 1);
+
+        Assert.Multiple(() => {
+            Assert.That(unitMicrons, Is.EqualTo(1.8));
+            Assert.That(sPerScrew, Has.Length.EqualTo(4));
+            for (int i = 0; i < 4; i++) {
+                Assert.That(sPerScrew[i], Is.EqualTo(expected[i].TotalSteps).Within(1e-9), $"screw {i + 1}");
+            }
+        });
+    }
+
+    [Test]
+    public void BuildPerScrewTargets_ThreeScrewAdapter_Throws() {
+        var options = NewFourScrewOptions();
+        options.ScrewCount.Returns(3);
+        var model = new SensorParaboloidModel(0, 0, 0, 0.001, 0, 0);
+        Assert.Throws<InvalidOperationException>(() => InspectorVM.BuildPerScrewTargets(model, options));
+    }
+
+    [Test]
+    public void BuildPerScrewTargets_UnconfiguredUnitSize_Throws() {
+        var options = NewFourScrewOptions();
+        options.StepperStepSizeMicrons.Returns(-1.0);
+        var model = new SensorParaboloidModel(0, 0, 0, 0.001, 0, 0);
+        Assert.Throws<InvalidOperationException>(() => InspectorVM.BuildPerScrewTargets(model, options));
+    }
+
+    [Test]
+    public void BuildPerScrewTargets_UnconfiguredRadius_Throws() {
+        var options = NewFourScrewOptions();
+        options.ScrewRadiusMillimeters.Returns(-1.0);
+        var model = new SensorParaboloidModel(0, 0, 0, 0.001, 0, 0);
+        Assert.Throws<InvalidOperationException>(() => InspectorVM.BuildPerScrewTargets(model, options));
+    }
+
+    [Test]
+    public void BuildPerScrewTargets_NaNScrewAngle_Throws() {
+        var options = NewFourScrewOptions();
+        options.Screw4AngleDegrees.Returns(double.NaN);
+        var model = new SensorParaboloidModel(0, 0, 0, 0.001, 0, 0);
+        Assert.Throws<InvalidOperationException>(() => InspectorVM.BuildPerScrewTargets(model, options));
+    }
+
+    [Test]
+    public void BuildPerScrewTargets_NullModel_Throws() {
+        Assert.Throws<ArgumentNullException>(() => InspectorVM.BuildPerScrewTargets(null, NewFourScrewOptions()));
+    }
+
+    [Test]
+    public void BuildPerScrewTargets_NullOptions_Throws() {
+        var model = new SensorParaboloidModel(0, 0, 0, 0.001, 0, 0);
+        Assert.Throws<ArgumentNullException>(() => InspectorVM.BuildPerScrewTargets(model, null));
+    }
+
+    // T14 fix D: options.ScrewInwardCurvatureSign is never persisted as 0 in practice, but if it ever were,
+    // the planner (this method) and the displayed guidance table (FillNumericGuidance) must resolve it
+    // IDENTICALLY -- otherwise the plan a user approves in the dialog could silently differ from the numbers
+    // they saw in the guidance table.
+    [Test]
+    public void BuildPerScrewTargets_ZeroSign_ResolvesToDefaultSign_LikeFillNumericGuidance() {
+        var options = NewFourScrewOptions();
+        options.ScrewInwardCurvatureSign.Returns(0);
+        var model = new SensorParaboloidModel(x0: 3.0, y0: -2.0, z0: 0, gx: 0.0015, gy: -0.0007, k: 4e-6);
+
+        var (sPerScrew, unitMicrons) = InspectorVM.BuildPerScrewTargets(model, options);
+
+        var angles = new[] { 0.0, 90.0, 180.0, 270.0 };
+        var expected = TiltScrewTargets.ComputePerScrewTargets(
+            model.Gx, model.Gy, model.Kx, model.Ky, model.X0, model.Y0,
+            angles, 55.0 * 1000.0, 1.8, TiltScrewGeometry.DefaultScrewInwardCurvatureSign);
+
+        Assert.Multiple(() => {
+            Assert.That(unitMicrons, Is.EqualTo(1.8));
+            Assert.That(sPerScrew, Has.Length.EqualTo(4));
+            for (int i = 0; i < 4; i++) {
+                Assert.That(sPerScrew[i], Is.EqualTo(expected[i].TotalSteps).Within(1e-9), $"screw {i + 1}");
+            }
+        });
+    }
+
+    #endregion
+
+    #region BuildPlanPreview
+
+    // s -> a=(s1-s3)/2=10, b=(s2-s4)/2=-3 -> two diagonal moves (ra != +-rb): DiagonalA(10), DiagonalB(-3),
+    // in that order out of TiltMovePlanner.Plan. Used to prove BuildPlanPreview shows the CONTROLLER's
+    // ordering, not the planner's original order.
+    private static readonly double[] TwoMoveTargets = { 10.0, -3.0, -10.0, 3.0 };
+
+    [Test]
+    public void BuildPlanPreview_NoLimitViolation_UsesControllerOrderedMoves() {
+        var controller = Substitute.For<ITiltMotionController>();
+        controller.OrderForMinimalPeakExcursion(Arg.Any<IReadOnlyList<TiltAdapterMove>>())
+            .Returns(ci => ((IReadOnlyList<TiltAdapterMove>)ci.Arg<IReadOnlyList<TiltAdapterMove>>()).Reverse().ToList());
+
+        var preview = InspectorVM.BuildPlanPreview(TwoMoveTargets, includeTilt: true, includeBackfocus: true, unitMicrons: 1.8, maxStepsPerCommand: 500, controller);
+
+        Assert.Multiple(() => {
+            Assert.That(preview.HardLimitViolated, Is.False);
+            Assert.That(preview.Plan.Moves, Has.Count.EqualTo(2));
+            Assert.That(preview.Plan.Moves[0].Axis, Is.EqualTo(TiltMoveAxis.DiagonalB), "must reflect the controller's (reversed) order, not the planner's original order");
+            Assert.That(preview.Plan.Moves[1].Axis, Is.EqualTo(TiltMoveAxis.DiagonalA));
+        });
+    }
+
+    [Test]
+    public void BuildPlanPreview_LimitException_ReturnsUnorderedMovesWithHardLimitFlag() {
+        var controller = Substitute.For<ITiltMotionController>();
+        controller.OrderForMinimalPeakExcursion(Arg.Any<IReadOnlyList<TiltAdapterMove>>())
+            .Returns(ci => throw new TiltDeviceLimitException("excursion exceeded"));
+
+        var preview = InspectorVM.BuildPlanPreview(TwoMoveTargets, includeTilt: true, includeBackfocus: true, unitMicrons: 1.8, maxStepsPerCommand: 500, controller);
+
+        Assert.Multiple(() => {
+            Assert.That(preview.HardLimitViolated, Is.True);
+            Assert.That(preview.LimitWarning, Does.Contain("excursion exceeded"));
+            Assert.That(preview.Plan.Moves, Has.Count.EqualTo(2), "the unordered plan must still be shown so the dialog can display it");
+        });
+    }
+
+    [Test]
+    public void BuildPlanPreview_ResidualsTwistAndDurationCarryOverUnaffectedByOrdering() {
+        var controller = Substitute.For<ITiltMotionController>();
+        controller.OrderForMinimalPeakExcursion(Arg.Any<IReadOnlyList<TiltAdapterMove>>())
+            .Returns(ci => ((IReadOnlyList<TiltAdapterMove>)ci.Arg<IReadOnlyList<TiltAdapterMove>>()).Reverse().ToList());
+
+        var unordered = TiltMovePlanner.Plan(TwoMoveTargets, includeTilt: true, includeBackfocus: true, unitMicrons: 1.8, maxStepsPerCommand: 500);
+        var preview = InspectorVM.BuildPlanPreview(TwoMoveTargets, includeTilt: true, includeBackfocus: true, unitMicrons: 1.8, maxStepsPerCommand: 500, controller);
+
+        Assert.Multiple(() => {
+            Assert.That(preview.Plan.ResidualMicronsPerCorner, Is.EqualTo(unordered.ResidualMicronsPerCorner));
+            Assert.That(preview.Plan.TwistResidualSteps, Is.EqualTo(unordered.TwistResidualSteps));
+            Assert.That(preview.Plan.EstimatedSeconds, Is.EqualTo(unordered.EstimatedSeconds));
+        });
+    }
+
+    #endregion
+
+    #region TiltMagnitude / TiltWorsened
+
+    [Test]
+    public void TiltMagnitude_ComputesSqrtGxSquaredPlusGySquared() {
+        var model = new SensorParaboloidModel(0, 0, 0, gx: 3.0, gy: 4.0, k: 0);
+        Assert.That(InspectorVM.TiltMagnitude(model), Is.EqualTo(5.0).Within(1e-9));
+    }
+
+    [Test]
+    public void TiltMagnitude_NullModel_ReturnsNaN() {
+        Assert.That(InspectorVM.TiltMagnitude(null), Is.NaN);
+    }
+
+    [TestCase(0.10, 0.10, false, TestName = "TiltWorsened_Unchanged")]
+    [TestCase(0.10, 0.08, false, TestName = "TiltWorsened_Improved")]
+    [TestCase(0.10, 0.105, false, TestName = "TiltWorsened_TinyUptickWithinMargin")]
+    [TestCase(0.10, 0.16, true, TestName = "TiltWorsened_MeaningfullyWorse")]
+    public void TiltWorsened_VariousDeltas(double before, double after, bool expected) {
+        Assert.That(InspectorVM.TiltWorsened(before, after), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void TiltWorsened_NearZeroBefore_RequiresAbsoluteFloorNotJustRelativeMargin() {
+        // A purely-relative test would flag ANY increase off a near-zero baseline as "worse" by a huge
+        // relative factor. The absolute floor prevents that until the increase itself is non-negligible.
+        Assert.Multiple(() => {
+            Assert.That(InspectorVM.TiltWorsened(1e-8, 5e-8), Is.False);
+            Assert.That(InspectorVM.TiltWorsened(1e-8, 1e-3), Is.True);
+        });
+    }
+
+    [Test]
+    public void TiltWorsened_NaNInputs_ReturnsFalse() {
+        Assert.Multiple(() => {
+            Assert.That(InspectorVM.TiltWorsened(double.NaN, 1.0), Is.False);
+            Assert.That(InspectorVM.TiltWorsened(1.0, double.NaN), Is.False);
+        });
+    }
+
+    #endregion
+
+    #region FirstMoveFailureMeansDeviceUntouched / DescribeFirstMoveFailureNotification
+
+    // T14 fix: per EatTiltMotionController's exception taxonomy (see its ExecuteMoveAsync XML doc), only
+    // TiltDeviceLimitException is thrown BEFORE any device I/O -- everything else on the first move means a
+    // command may already have been sent and the device's position is ambiguous. These pure-helper tests are
+    // the only way to verify the notification text directly: NINA.Core.Utility.Notification.Notification is
+    // a no-op in a headless test process (Application.Current == null -> its internal manager stays null), so
+    // nothing in the VM-level harness below can observe the actual message text.
+
+    [Test]
+    public void FirstMoveFailureMeansDeviceUntouched_LimitException_ReturnsTrue() {
+        Assert.That(InspectorVM.FirstMoveFailureMeansDeviceUntouched(new TiltDeviceLimitException("exceeds cap")), Is.True);
+    }
+
+    [Test]
+    public void FirstMoveFailureMeansDeviceUntouched_CommandFailedException_ReturnsFalse() {
+        Assert.That(InspectorVM.FirstMoveFailureMeansDeviceUntouched(new TiltDeviceCommandFailedException("ack timeout")), Is.False);
+    }
+
+    [Test]
+    public void FirstMoveFailureMeansDeviceUntouched_SerialPortClosedException_ReturnsFalse() {
+        Assert.That(InspectorVM.FirstMoveFailureMeansDeviceUntouched(new SerialPortClosedException("unplugged")), Is.False);
+    }
+
+    [Test]
+    public void FirstMoveFailureMeansDeviceUntouched_UnexpectedException_ReturnsFalse() {
+        Assert.That(InspectorVM.FirstMoveFailureMeansDeviceUntouched(new InvalidOperationException("boom")), Is.False);
+    }
+
+    [Test]
+    public void DescribeFirstMoveFailureNotification_LimitException_SaysNothingWasSent() {
+        var message = InspectorVM.DescribeFirstMoveFailureNotification(new TiltDeviceLimitException("exceeds cap"), "a device travel limit was violated (exceeds cap)");
+        Assert.Multiple(() => {
+            Assert.That(message, Does.Contain("Nothing was sent to the device."));
+            Assert.That(message, Does.Not.Contain("UNCERTAIN"));
+        });
+    }
+
+    [TestCaseSource(nameof(AmbiguousFirstMoveExceptions))]
+    public void DescribeFirstMoveFailureNotification_AmbiguousException_DoesNotClaimNothingWasSent(Exception failure) {
+        var message = InspectorVM.DescribeFirstMoveFailureNotification(failure, "ack timeout");
+        Assert.Multiple(() => {
+            Assert.That(message, Does.Not.Contain("Nothing was sent"), "must not mislabel an ambiguous device state as safe");
+            Assert.That(message, Does.Contain("UNCERTAIN"), "must surface the ambiguous-state message instead");
+            Assert.That(message, Does.Contain("vendor app").Or.Contain("disconnect and reconnect"));
+        });
+    }
+
+    private static IEnumerable<Exception> AmbiguousFirstMoveExceptions() {
+        yield return new TiltDeviceCommandFailedException("ack timeout");
+        yield return new SerialPortClosedException("unplugged");
+    }
+
+    #endregion
+
+    // ======================================================================================================
+    // VM-level harness
+    // ======================================================================================================
+
+    private sealed class FakeTimeSource : ITiltDeviceTimeSource {
+        public DateTimeOffset UtcNow { get; set; } = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        public event EventHandler Tick;
+        public void Dispose() {
+        }
+    }
+
+    private static TiltAdapterMove Move(TiltMoveAxis axis, int steps, TiltMoveGroup group, string description) =>
+        new TiltAdapterMove(axis, steps, group, description);
+
+    private sealed class AdjustmentFixture {
+        public const string PresetName = "ASG Electronic EAT - 90mm";
+
+        public MediatorBundle Bundle { get; } = new MediatorBundle();
+        public ITiltMotionController Controller { get; }
+        public TiltDeviceConnectionService Service { get; }
+
+        // Every move ExecuteMoveAsync was called with, in call order (forward moves AND revert moves alike).
+        public List<TiltAdapterMove> ExecutedMoves { get; } = new();
+
+        public List<(string Message, string Title)> ConfirmPrompts { get; } = new();
+        public Queue<bool> ConfirmAnswers { get; } = new();
+
+        public TiltDeviceAdjustmentChoice NextChoice { get; set; } = TiltDeviceAdjustmentChoice.Cancelled;
+        public int ShowPromptCallCount { get; private set; }
+
+        public bool ReRunResult { get; set; } = true;
+        public int ReRunCallCount { get; private set; }
+        public Action OnReRun { get; set; }
+
+        // Per-move failure injection: return non-null to make that ExecuteMoveAsync call fail. Matched by
+        // reference for forward moves, by (axis, steps) for the freshly-constructed inverse moves reverts send.
+        public Func<TiltAdapterMove, Exception> FailureForMove { get; set; }
+
+        public AdjustmentFixture() {
+            Controller = Substitute.For<ITiltMotionController>();
+            Controller.ConnectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+            Controller.QueryPositionsAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(TiltDevicePositions.Unknown));
+            Controller.ExecuteMoveAsync(Arg.Any<TiltAdapterMove>(), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>())
+                .Returns(ci => {
+                    var move = ci.Arg<TiltAdapterMove>();
+                    ExecutedMoves.Add(move);
+                    var ex = FailureForMove?.Invoke(move);
+                    return ex != null ? Task.FromException(ex) : Task.CompletedTask;
+                });
+
+            var time = new FakeTimeSource();
+            Service = new TiltDeviceConnectionService(Bundle.ProfileService, Bundle.TiltAdapterOptions, (name, opts) => Controller, time);
+
+            Bundle.TiltAdapterOptions.ScrewCount.Returns(4);
+            Bundle.TiltAdapterOptions.CalibratedScrewCount.Returns(4);
+            Bundle.TiltAdapterOptions.IsCalibrated.Returns(true);
+            Bundle.TiltAdapterOptions.DeviceName.Returns(PresetName);
+            Bundle.TiltAdapterOptions.DeviceLinkedCalibrationDeviceName.Returns(PresetName);
+            // The reliability gate defaults to reliable so every existing scenario in this fixture (which is
+            // about the OTHER gates) keeps exercising a calibration that would otherwise be automation-trusted;
+            // ReliabilityGateTests below overrides this to false to exercise the gate itself.
+            Bundle.TiltAdapterOptions.CalibrationIsReliable.Returns(true);
+            Bundle.TiltAdapterOptions.AdjustmentType.Returns(TiltAdjustmentType.StepperMotors);
+            Bundle.TiltAdapterOptions.StepperStepSizeMicrons.Returns(1.8);
+            Bundle.TiltAdapterOptions.ScrewRadiusMillimeters.Returns(55.0);
+            Bundle.TiltAdapterOptions.Screw1AngleDegrees.Returns(0.0);
+            Bundle.TiltAdapterOptions.Screw2AngleDegrees.Returns(90.0);
+            Bundle.TiltAdapterOptions.Screw3AngleDegrees.Returns(180.0);
+            Bundle.TiltAdapterOptions.Screw4AngleDegrees.Returns(270.0);
+            Bundle.TiltAdapterOptions.TiltDeviceMaxStepsPerCommand.Returns(500);
+            Bundle.TiltAdapterOptions.ScrewInwardCurvatureSign.Returns(1);
+        }
+
+        public Task ConnectAsync() => Service.ConnectAsync(PresetName, "COM5", CancellationToken.None);
+
+        private Task<bool> ConfirmPromptAsync(string message, string title) {
+            ConfirmPrompts.Add((message, title));
+            return Task.FromResult(ConfirmAnswers.Count > 0 && ConfirmAnswers.Dequeue());
+        }
+
+        private Task<TiltDeviceAdjustmentChoice> ShowPromptAsync(
+            Func<bool, bool, TiltDevicePlanPreview> replanner, bool screwInwardCurvatureSignIsMeasured, string pitchMismatchWarning, bool positionsUnknown) {
+            ShowPromptCallCount++;
+            return Task.FromResult(NextChoice);
+        }
+
+        // Set by BuildVM below -- ReRunAnalysisAsync needs it to simulate a completed analysis's effect on
+        // measurementGeneration (see the T14 fix B comment there), but the delegate is captured by
+        // MediatorBundle.BuildInspectorVM before the VM instance exists.
+        private InspectorVM vm;
+
+        private Task<bool> ReRunAnalysisAsync(CancellationToken ct) {
+            ReRunCallCount++;
+            OnReRun?.Invoke();
+            if (ReRunResult) {
+                // Fix B (T14): production's reRunAnalysisAsync ultimately calls AnalyzeAutoFocusResult, which
+                // increments measurementGeneration once per COMPLETED analysis (see its doc comment). This fake
+                // must mirror that -- otherwise the worsening-triggered-revert bug this fixture exists to catch
+                // (lastExecutedMeasurementGeneration left pointing at the STALE, pre-revert generation while the
+                // re-run has already moved measurementGeneration forward) is invisible to every test here.
+                vm.MeasurementGenerationForTest++;
+            }
+            return Task.FromResult(ReRunResult);
+        }
+
+        public InspectorVM BuildVM() {
+            vm = Bundle.BuildInspectorVM(Service, ConfirmPromptAsync, ShowPromptAsync, ReRunAnalysisAsync);
+            return vm;
+        }
+
+        // Seeds a valid, minimal sensor model and forces a RebuildTiltGuidance pass (mirrors
+        // InspectorVMBehavioralTests.TiltGuidance_SigmaFlip_FlipsMotionArrowsNotTiltGlyphs's pattern: set the
+        // model directly on SensorModel, then raise tiltAdapterOptions.PropertyChanged to trigger the rebuild
+        // InspectorVM only does in response to that event) so HasNumericGuidance becomes true.
+        public void SeedValidModel(InspectorVM vm, double gx = 0.001, double gy = 0.0, double k = 0.0) {
+            var imageSize = new System.Drawing.Size(1000, 1000);
+            var paraboloid = new SensorParaboloidModel(x0: 0, y0: 0, z0: 0, gx: gx, gy: gy, k: k);
+            vm.SensorModel.SelectedTiltHistoryModel = new SensorParaboloidTiltHistoryModel(
+                historyId: 1, imageSize: imageSize, pixelSizeMicrons: 4.0, fRatio: 5.0,
+                focuserSizeMicrons: 1.0, finalFocusPosition: 0.0, tiltEffectMicrons: 0.0,
+                curvatureEffectMicrons: 0.0, autoFocusOffset: 0.0, tiltPlaneModel: null,
+                sensorModel: paraboloid);
+            Bundle.TiltAdapterOptions.PropertyChanged += Raise.Event<PropertyChangedEventHandler>(
+                Bundle.TiltAdapterOptions, new PropertyChangedEventArgs(nameof(ITiltAdapterOptions.IsCalibrated)));
+        }
+    }
+
+    // --- canExecute gates (live VM) -----------------------------------------------------------------------
+
+    [Test]
+    public void Disconnected_CannotExecute() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm);
+        vm.MeasurementGenerationForTest = 1;
+
+        Assert.Multiple(() => {
+            Assert.That(vm.IsTiltDeviceConnected, Is.False);
+            Assert.That(vm.AutomaticAdjustmentCommand.CanExecute(null), Is.False);
+        });
+    }
+
+    [Test]
+    public void ConnectedButNotDeviceLinked_CannotExecute_RemediationShown() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm);
+        vm.MeasurementGenerationForTest = 1;
+        fx.Bundle.TiltAdapterOptions.DeviceLinkedCalibrationDeviceName.Returns(string.Empty);
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        Assert.Multiple(() => {
+            Assert.That(vm.IsTiltDeviceConnected, Is.True, "precondition");
+            Assert.That(vm.AutomaticAdjustmentCommand.CanExecute(null), Is.False);
+            Assert.That(vm.AutomaticAdjustmentRemediationVisible, Is.True);
+            Assert.That(vm.AutomaticAdjustmentRemediationText, Does.Contain("Re-run calibration"));
+        });
+    }
+
+    [Test]
+    public void ConnectedDeviceLinkedToADifferentPreset_CannotExecute() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm);
+        vm.MeasurementGenerationForTest = 1;
+        fx.Bundle.TiltAdapterOptions.DeviceLinkedCalibrationDeviceName.Returns("ASG Electronic EAT - ZWO 461");
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        Assert.That(vm.AutomaticAdjustmentCommand.CanExecute(null), Is.False);
+    }
+
+    // [CRITICAL GATE] T14 canExecute must be FALSE when CalibrationIsReliable=false even though the
+    // calibration IS device-linked and connected -- device-linked is necessary but not sufficient; a
+    // noise-dominated calibration must never drive unattended automation.
+    [Test]
+    public void ConnectedAndDeviceLinked_ButNotReliable_CannotExecute_RemediationShown() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm);
+        vm.MeasurementGenerationForTest = 1;
+        fx.Bundle.TiltAdapterOptions.CalibrationIsReliable.Returns(false);
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        Assert.Multiple(() => {
+            Assert.That(vm.IsTiltDeviceConnected, Is.True, "precondition");
+            Assert.That(InspectorVM.IsCalibrationDeviceLinked(fx.Bundle.TiltAdapterOptions), Is.True, "precondition: still device-linked");
+            Assert.That(vm.AutomaticAdjustmentCommand.CanExecute(null), Is.False);
+            Assert.That(vm.AutomaticAdjustmentRemediationVisible, Is.True);
+            Assert.That(vm.AutomaticAdjustmentRemediationText, Does.Contain("low-confidence"));
+        });
+    }
+
+    [Test]
+    public void WizardOperationActive_CannotExecute_ReEnablesOnRelease() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm);
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        Assert.That(vm.AutomaticAdjustmentCommand.CanExecute(null), Is.True, "precondition");
+
+        var token = fx.Service.TryBeginOperation("wizard calibration");
+        Assert.That(token, Is.Not.Null);
+        Assert.That(vm.AutomaticAdjustmentCommand.CanExecute(null), Is.False);
+
+        token.Dispose();
+        Assert.That(vm.AutomaticAdjustmentCommand.CanExecute(null), Is.True);
+    }
+
+    [Test]
+    public void NoNumericGuidance_CannotExecute() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        // Deliberately no SeedValidModel call -- HasNumericGuidance stays false.
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+
+        Assert.Multiple(() => {
+            Assert.That(vm.TiltGuidance.HasNumericGuidance, Is.False);
+            Assert.That(vm.AutomaticAdjustmentCommand.CanExecute(null), Is.False);
+        });
+    }
+
+    [Test]
+    public void NoFreshMeasurementYet_CannotExecute() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm);
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        // MeasurementGenerationForTest left at its default (0) -- no analysis has completed yet.
+
+        Assert.That(vm.AutomaticAdjustmentCommand.CanExecute(null), Is.False);
+    }
+
+    [Test]
+    public void AllGatesSatisfied_CanExecute() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm);
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        Assert.That(vm.AutomaticAdjustmentCommand.CanExecute(null), Is.True);
+    }
+
+    // --- Dialog cancel / empty plan: measurement not consumed ---------------------------------------------
+
+    [Test]
+    public void DialogCancel_NoMovesExecuted_MeasurementNotConsumed() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm);
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        fx.NextChoice = TiltDeviceAdjustmentChoice.Cancelled;
+
+        vm.AutomaticAdjustmentCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+        Assert.Multiple(() => {
+            Assert.That(fx.ExecutedMoves, Is.Empty);
+            Assert.That(vm.LastExecutedMeasurementGenerationForTest, Is.EqualTo(0));
+            Assert.That(vm.AutomaticAdjustmentCommand.CanExecute(null), Is.True, "cancel must not consume the measurement");
+        });
+    }
+
+    [Test]
+    public void ApprovedEmptyPlan_IsNoOp_MeasurementNotConsumed() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm);
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        var emptyPlan = new TiltAdapterMovePlan(Array.Empty<TiltAdapterMove>(), new double[4], twistResidualSteps: 0, estimatedSeconds: 0);
+        fx.NextChoice = TiltDeviceAdjustmentChoice.Proceeded(true, true, emptyPlan);
+
+        vm.AutomaticAdjustmentCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+        Assert.Multiple(() => {
+            Assert.That(fx.ExecutedMoves, Is.Empty);
+            Assert.That(vm.LastExecutedMeasurementGenerationForTest, Is.EqualTo(0));
+            Assert.That(vm.AutomaticAdjustmentCommand.CanExecute(null), Is.True, "an approved no-op must not consume the measurement");
+        });
+    }
+
+    // --- Approved plan: executed in order, measurement consumed, stale lockout --------------------------------
+
+    [Test]
+    public void ApprovedPlan_MovesExecutedInOrder_MeasurementConsumed() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm);
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        var moveA = Move(TiltMoveAxis.DiagonalA, 40, TiltMoveGroup.Tilt, "A");
+        var moveB = Move(TiltMoveAxis.EdgeVertical, 12, TiltMoveGroup.Tilt, "B");
+        var moveC = Move(TiltMoveAxis.Backfocus, -8, TiltMoveGroup.Backfocus, "C");
+        var plan = new TiltAdapterMovePlan(new[] { moveA, moveB, moveC }, new double[4], twistResidualSteps: 0, estimatedSeconds: 30);
+        fx.NextChoice = TiltDeviceAdjustmentChoice.Proceeded(true, true, plan);
+        fx.ConfirmAnswers.Enqueue(false); // decline the "re-run to confirm" prompt
+
+        vm.AutomaticAdjustmentCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+        Assert.Multiple(() => {
+            Assert.That(fx.ExecutedMoves, Has.Count.EqualTo(3));
+            Assert.That(fx.ExecutedMoves[0], Is.SameAs(moveA));
+            Assert.That(fx.ExecutedMoves[1], Is.SameAs(moveB));
+            Assert.That(fx.ExecutedMoves[2], Is.SameAs(moveC));
+            Assert.That(vm.LastExecutedMeasurementGenerationForTest, Is.EqualTo(1), "consumed once execution started");
+            Assert.That(vm.AutomaticAdjustmentCommand.CanExecute(null), Is.False, "the same measurement cannot drive a second plan");
+            Assert.That(fx.ReRunCallCount, Is.EqualTo(0), "declining the re-run prompt must not invoke it");
+        });
+    }
+
+    [Test]
+    public void StaleGeneration_DirectReExecution_IsIgnored_FreshMeasurementReEnables() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm);
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        var move = Move(TiltMoveAxis.Backfocus, 10, TiltMoveGroup.Backfocus, "bf");
+        var plan = new TiltAdapterMovePlan(new[] { move }, new double[4], 0, 10);
+        fx.NextChoice = TiltDeviceAdjustmentChoice.Proceeded(true, true, plan);
+        fx.ConfirmAnswers.Enqueue(false); // decline re-run
+
+        vm.AutomaticAdjustmentCommand.ExecuteAsync(null).GetAwaiter().GetResult(); // first execution consumes generation 1
+        Assert.That(vm.AutomaticAdjustmentCommand.CanExecute(null), Is.False, "precondition: measurement consumed");
+        fx.ExecutedMoves.Clear();
+        int promptCallsBefore = fx.ShowPromptCallCount;
+
+        // Directly invoke again (a second click, or any programmatic re-invocation): the defensive re-check
+        // inside RunAutomaticAdjustmentAsync itself -- not just the disabled button -- must refuse. A second
+        // execution off the same measurement must be impossible.
+        vm.AutomaticAdjustmentCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+        Assert.Multiple(() => {
+            Assert.That(fx.ExecutedMoves, Is.Empty, "no moves may be sent off a stale measurement");
+            Assert.That(fx.ShowPromptCallCount, Is.EqualTo(promptCallsBefore), "must not even show the approval dialog again");
+        });
+
+        // A fresh measurement (a new completed analysis) re-enables it.
+        vm.MeasurementGenerationForTest = 2;
+        Assert.That(vm.AutomaticAdjustmentCommand.CanExecute(null), Is.True);
+    }
+
+    // --- Re-run on accept ---------------------------------------------------------------------------------
+
+    [Test]
+    public void SuccessfulExecution_ReRunAccepted_InvokesReRun_NoWorseningPromptWhenUnchanged() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm);
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        var move = Move(TiltMoveAxis.Backfocus, 10, TiltMoveGroup.Backfocus, "bf");
+        var plan = new TiltAdapterMovePlan(new[] { move }, new double[4], 0, 10);
+        fx.NextChoice = TiltDeviceAdjustmentChoice.Proceeded(true, true, plan);
+        fx.ConfirmAnswers.Enqueue(true); // accept "re-run to confirm"
+        fx.ReRunResult = true; // the model is not touched by the fake re-run -> unchanged tilt -> not worsened
+
+        vm.AutomaticAdjustmentCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+        Assert.Multiple(() => {
+            Assert.That(fx.ReRunCallCount, Is.EqualTo(1));
+            Assert.That(fx.ConfirmPrompts, Has.Count.EqualTo(1), "no worsening-revert prompt should follow an unchanged/improved result");
+        });
+    }
+
+    [Test]
+    public void SuccessfulExecution_ReRunDeclined_DoesNotInvokeReRun() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm);
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        var move = Move(TiltMoveAxis.Backfocus, 10, TiltMoveGroup.Backfocus, "bf");
+        var plan = new TiltAdapterMovePlan(new[] { move }, new double[4], 0, 10);
+        fx.NextChoice = TiltDeviceAdjustmentChoice.Proceeded(true, true, plan);
+        fx.ConfirmAnswers.Enqueue(false);
+
+        vm.AutomaticAdjustmentCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+        Assert.That(fx.ReRunCallCount, Is.EqualTo(0));
+    }
+
+    // --- Worsening check ------------------------------------------------------------------------------------
+
+    [Test]
+    public void ReRunConfirmed_TiltWorsened_WarnsAndRevertsOnConfirm() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm, gx: 0.001, gy: 0.0); // before magnitude = 0.001
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        var move = Move(TiltMoveAxis.Backfocus, 10, TiltMoveGroup.Backfocus, "bf");
+        var plan = new TiltAdapterMovePlan(new[] { move }, new double[4], 0, 10);
+        fx.NextChoice = TiltDeviceAdjustmentChoice.Proceeded(true, true, plan);
+        fx.ConfirmAnswers.Enqueue(true); // accept the re-run
+        fx.ConfirmAnswers.Enqueue(true); // accept the worsening-revert offer
+        // The fake re-run "measures" a substantially worse tilt (10x the magnitude) before completing.
+        fx.OnReRun = () => fx.SeedValidModel(vm, gx: 0.01, gy: 0.0);
+
+        vm.AutomaticAdjustmentCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+        Assert.Multiple(() => {
+            Assert.That(fx.ConfirmPrompts.Any(p => p.Title.Contains("Worsened")), Is.True, "the worsening-revert prompt must be shown");
+            // 1 forward move + 1 revert (the inverse of `move`).
+            Assert.That(fx.ExecutedMoves, Has.Count.EqualTo(2));
+            Assert.That(fx.ExecutedMoves[1].Axis, Is.EqualTo(move.Axis));
+            Assert.That(fx.ExecutedMoves[1].Steps, Is.EqualTo(-move.Steps));
+        });
+    }
+
+    // T14 fix B: the confirming re-run above already moves measurementGeneration forward (a genuinely
+    // completed analysis), but that analysis was of the PRE-revert (still-bad) state -- once the revert has
+    // ALSO happened, lastExecutedMeasurementGeneration must be bumped to match, or canExecute would
+    // immediately re-enable Automatic Adjustment against the stale, now-reverted DisplayedSensorModel that
+    // was captured before the revert ever ran.
+    [Test]
+    public void ReRunConfirmed_TiltWorsened_RevertConfirmed_MeasurementConsumed_ReEnablesOnlyAfterFreshAnalysis() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm, gx: 0.001, gy: 0.0); // before magnitude = 0.001
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        var move = Move(TiltMoveAxis.Backfocus, 10, TiltMoveGroup.Backfocus, "bf");
+        var plan = new TiltAdapterMovePlan(new[] { move }, new double[4], 0, 10);
+        fx.NextChoice = TiltDeviceAdjustmentChoice.Proceeded(true, true, plan);
+        fx.ConfirmAnswers.Enqueue(true); // accept the re-run
+        fx.ConfirmAnswers.Enqueue(true); // accept the worsening-revert offer
+        // The fake re-run "measures" a substantially worse tilt (10x the magnitude) before completing; this
+        // also bumps measurementGeneration to 2 (see ReRunAnalysisAsync's fake behavior above).
+        fx.OnReRun = () => fx.SeedValidModel(vm, gx: 0.01, gy: 0.0);
+
+        vm.AutomaticAdjustmentCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+        Assert.Multiple(() => {
+            Assert.That(fx.ExecutedMoves, Has.Count.EqualTo(2), "precondition: the revert actually ran");
+            Assert.That(vm.LastExecutedMeasurementGenerationForTest, Is.EqualTo(2), "consumed against the CURRENT (post-revert) generation, not the stale pre-revert one");
+            Assert.That(vm.AutomaticAdjustmentCommand.CanExecute(null), Is.False,
+                "must stay disabled against the just-consumed, now-reverted measurement -- re-enabling here would let a second plan over-correct an already-reverted device");
+        });
+
+        // A genuinely NEW completed analysis (generation 3) re-enables it, exactly like the non-revert case.
+        vm.MeasurementGenerationForTest = 3;
+        Assert.That(vm.AutomaticAdjustmentCommand.CanExecute(null), Is.True, "a fresh post-revert analysis must re-enable Automatic Adjustment");
+    }
+
+    [Test]
+    public void ReRunConfirmed_TiltWorsened_DeclinedRevert_LeavesMovesInPlace() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm, gx: 0.001, gy: 0.0);
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        var move = Move(TiltMoveAxis.Backfocus, 10, TiltMoveGroup.Backfocus, "bf");
+        var plan = new TiltAdapterMovePlan(new[] { move }, new double[4], 0, 10);
+        fx.NextChoice = TiltDeviceAdjustmentChoice.Proceeded(true, true, plan);
+        fx.ConfirmAnswers.Enqueue(true);  // accept the re-run
+        fx.ConfirmAnswers.Enqueue(false); // DECLINE the worsening-revert offer
+        fx.OnReRun = () => fx.SeedValidModel(vm, gx: 0.01, gy: 0.0);
+
+        vm.AutomaticAdjustmentCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+        Assert.That(fx.ExecutedMoves, Has.Count.EqualTo(1), "declining the revert offer must leave the applied move(s) in place");
+    }
+
+    // --- Mid-plan failure: journal + revert ----------------------------------------------------------------
+
+    [Test]
+    public void MidPlanFailure_JournalHoldsAppliedMoves_RevertExecutesInverseInReverseOrder() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm);
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        var moveA = Move(TiltMoveAxis.DiagonalA, 40, TiltMoveGroup.Tilt, "A");
+        var moveB = Move(TiltMoveAxis.DiagonalB, -12, TiltMoveGroup.Tilt, "B");
+        var moveC = Move(TiltMoveAxis.Backfocus, 8, TiltMoveGroup.Backfocus, "C");
+        var plan = new TiltAdapterMovePlan(new[] { moveA, moveB, moveC }, new double[4], 0, 30);
+        fx.NextChoice = TiltDeviceAdjustmentChoice.Proceeded(true, true, plan);
+        fx.FailureForMove = m => ReferenceEquals(m, moveC) ? new TiltDeviceCommandFailedException("ack timeout") : null;
+        fx.ConfirmAnswers.Enqueue(true); // confirm revert
+
+        vm.AutomaticAdjustmentCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+        Assert.Multiple(() => {
+            // Forward: A, B succeed; C is attempted and throws (journal = [A, B]).
+            Assert.That(fx.ExecutedMoves, Has.Count.EqualTo(5), "3 forward attempts + 2 successful reverts");
+            Assert.That(fx.ExecutedMoves[0], Is.SameAs(moveA));
+            Assert.That(fx.ExecutedMoves[1], Is.SameAs(moveB));
+            Assert.That(fx.ExecutedMoves[2], Is.SameAs(moveC));
+            // Revert in REVERSE order of the journal [A, B]: inverse(B) then inverse(A).
+            Assert.That(fx.ExecutedMoves[3].Axis, Is.EqualTo(moveB.Axis));
+            Assert.That(fx.ExecutedMoves[3].Steps, Is.EqualTo(-moveB.Steps));
+            Assert.That(fx.ExecutedMoves[4].Axis, Is.EqualTo(moveA.Axis));
+            Assert.That(fx.ExecutedMoves[4].Steps, Is.EqualTo(-moveA.Steps));
+            // Consumed even though it failed -- execution started (>= 1 move sent).
+            Assert.That(vm.LastExecutedMeasurementGenerationForTest, Is.EqualTo(1));
+            Assert.That(vm.AutomaticAdjustmentCommand.CanExecute(null), Is.False);
+            Assert.That(fx.ReRunCallCount, Is.EqualTo(0), "a failed execution must not offer the re-run confirm");
+        });
+    }
+
+    [Test]
+    public void MidPlanFailure_FirstMoveThrowsLimitException_NothingSent_MeasurementNotConsumed() {
+        // A TiltDeviceLimitException on the very FIRST move means nothing was ever sent (the check runs
+        // before any device I/O) -- no revert offer, and the measurement is NOT consumed.
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm);
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        var move = Move(TiltMoveAxis.Backfocus, 10, TiltMoveGroup.Backfocus, "bf");
+        var plan = new TiltAdapterMovePlan(new[] { move }, new double[4], 0, 10);
+        fx.NextChoice = TiltDeviceAdjustmentChoice.Proceeded(true, true, plan);
+        fx.FailureForMove = m => new TiltDeviceLimitException("would exceed max excursion");
+
+        vm.AutomaticAdjustmentCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+        Assert.Multiple(() => {
+            Assert.That(fx.ExecutedMoves, Has.Count.EqualTo(1), "the move was attempted (and rejected) but nothing physical happened");
+            Assert.That(fx.ConfirmPrompts, Is.Empty, "no revert should ever be offered when nothing was sent");
+            Assert.That(vm.LastExecutedMeasurementGenerationForTest, Is.EqualTo(0), "execution never started -- the measurement is not consumed");
+            Assert.That(vm.AutomaticAdjustmentCommand.CanExecute(null), Is.True, "the button must stay enabled for another attempt off this same measurement");
+        });
+    }
+
+    // T14 fix: unlike TiltDeviceLimitException above, a TiltDeviceCommandFailedException or
+    // SerialPortClosedException on the FIRST move means a command may have already been sent -- the journal
+    // stays empty (nothing was CONFIRMED successful) so the measurement-consumption bookkeeping is unchanged,
+    // but see DescribeFirstMoveFailureNotification_AmbiguousException_DoesNotClaimNothingWasSent above for the
+    // notification-text half of this fix (unobservable at this VM level since Notification is a no-op headless).
+    [TestCaseSource(nameof(AmbiguousFirstMoveExceptions))]
+    public void MidPlanFailure_FirstMoveThrowsAmbiguousException_NoRevertOffered_MeasurementNotConsumed(Exception firstMoveFailure) {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm);
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        var move = Move(TiltMoveAxis.Backfocus, 10, TiltMoveGroup.Backfocus, "bf");
+        var plan = new TiltAdapterMovePlan(new[] { move }, new double[4], 0, 10);
+        fx.NextChoice = TiltDeviceAdjustmentChoice.Proceeded(true, true, plan);
+        fx.FailureForMove = m => firstMoveFailure;
+
+        vm.AutomaticAdjustmentCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+        Assert.Multiple(() => {
+            Assert.That(fx.ExecutedMoves, Has.Count.EqualTo(1), "the move was attempted and may have been sent before failing");
+            Assert.That(fx.ConfirmPrompts, Is.Empty, "there is nothing in the journal to revert (the ambiguity is handled by the notification text, not an automated revert)");
+            Assert.That(vm.LastExecutedMeasurementGenerationForTest, Is.EqualTo(0), "the journal is still empty -- consumption bookkeeping is unaffected by this fix");
+            Assert.That(vm.AutomaticAdjustmentCommand.CanExecute(null), Is.True, "the button must stay enabled for another attempt off this same measurement");
+        });
+    }
+
+    [Test]
+    public void MidPlanFailure_RevertItselfFails_StopsAfterFirstFailedRevert() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm);
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        var moveA = Move(TiltMoveAxis.DiagonalA, 40, TiltMoveGroup.Tilt, "A");
+        var moveB = Move(TiltMoveAxis.DiagonalB, -12, TiltMoveGroup.Tilt, "B");
+        var moveC = Move(TiltMoveAxis.Backfocus, 8, TiltMoveGroup.Backfocus, "C");
+        var plan = new TiltAdapterMovePlan(new[] { moveA, moveB, moveC }, new double[4], 0, 30);
+        fx.NextChoice = TiltDeviceAdjustmentChoice.Proceeded(true, true, plan);
+        // C fails to send; the revert of B (the first move reverted) ALSO fails.
+        fx.FailureForMove = m => {
+            if (ReferenceEquals(m, moveC)) return new TiltDeviceCommandFailedException("ack timeout");
+            if (m.Axis == moveB.Axis && m.Steps == -moveB.Steps) return new TiltDeviceCommandFailedException("revert ack timeout");
+            return null;
+        };
+        fx.ConfirmAnswers.Enqueue(true); // confirm revert
+
+        Assert.DoesNotThrow(() => vm.AutomaticAdjustmentCommand.ExecuteAsync(null).GetAwaiter().GetResult());
+
+        Assert.Multiple(() => {
+            // A, B, C forward (3) + ONE revert attempt (inverse(B), which fails) -- inverse(A) must NEVER be
+            // attempted once state is dirty.
+            Assert.That(fx.ExecutedMoves, Has.Count.EqualTo(4));
+            Assert.That(fx.ExecutedMoves[3].Axis, Is.EqualTo(moveB.Axis));
+            Assert.That(fx.ExecutedMoves[3].Steps, Is.EqualTo(-moveB.Steps));
+            Assert.That(fx.ExecutedMoves.Any(m => m.Axis == moveA.Axis && m.Steps == -moveA.Steps), Is.False,
+                "revert must stop after its first failure -- inverse(A) must never be attempted once state is dirty");
+        });
+    }
+
+    [Test]
+    public void MidPlanFailure_RevertDeclined_LeavesAppliedMovesInPlace() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm);
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        var moveA = Move(TiltMoveAxis.DiagonalA, 40, TiltMoveGroup.Tilt, "A");
+        var moveB = Move(TiltMoveAxis.Backfocus, 8, TiltMoveGroup.Backfocus, "B");
+        var plan = new TiltAdapterMovePlan(new[] { moveA, moveB }, new double[4], 0, 20);
+        fx.NextChoice = TiltDeviceAdjustmentChoice.Proceeded(true, true, plan);
+        fx.FailureForMove = m => ReferenceEquals(m, moveB) ? new TiltDeviceCommandFailedException("ack timeout") : null;
+        fx.ConfirmAnswers.Enqueue(false); // DECLINE revert
+
+        vm.AutomaticAdjustmentCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+        Assert.That(fx.ExecutedMoves, Has.Count.EqualTo(2), "declining revert must not send any inverse moves");
+    }
+
+    [Test]
+    public void MidPlanFailure_OperationCanceledException_TreatedAsFailure_JournalPreserved() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm);
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        var moveA = Move(TiltMoveAxis.DiagonalA, 40, TiltMoveGroup.Tilt, "A");
+        var moveB = Move(TiltMoveAxis.Backfocus, 8, TiltMoveGroup.Backfocus, "B");
+        var plan = new TiltAdapterMovePlan(new[] { moveA, moveB }, new double[4], 0, 20);
+        fx.NextChoice = TiltDeviceAdjustmentChoice.Proceeded(true, true, plan);
+        fx.FailureForMove = m => ReferenceEquals(m, moveB) ? new OperationCanceledException("cancelled") : null;
+        fx.ConfirmAnswers.Enqueue(true);
+
+        vm.AutomaticAdjustmentCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+        Assert.Multiple(() => {
+            Assert.That(fx.ExecutedMoves, Has.Count.EqualTo(3), "A + B(throws) forward, then 1 revert of A");
+            Assert.That(fx.ExecutedMoves[2].Axis, Is.EqualTo(moveA.Axis));
+            Assert.That(fx.ExecutedMoves[2].Steps, Is.EqualTo(-moveA.Steps));
+            Assert.That(vm.LastExecutedMeasurementGenerationForTest, Is.EqualTo(1));
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMAutomaticAdjustmentTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMAutomaticAdjustmentTests.cs
@@ -492,7 +492,7 @@ public class InspectorVMAutomaticAdjustmentTests {
         }
 
         private Task<TiltDeviceAdjustmentChoice> ShowPromptAsync(
-            Func<bool, bool, TiltDevicePlanPreview> replanner, bool screwInwardCurvatureSignIsMeasured, string pitchMismatchWarning, bool positionsUnknown) {
+            Func<bool, bool, TiltDevicePlanPreview> replanner, bool screwInwardCurvatureSignIsMeasured, string pitchMismatchWarning, bool positionsUnknown, double unitMicrons) {
             ShowPromptCallCount++;
             return Task.FromResult(NextChoice);
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/SimulatedEatTransportTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/SimulatedEatTransportTests.cs
@@ -1,0 +1,160 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.CameraSimulator;
+using NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
+using NINA.Profile.Interfaces;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.CameraSimulator;
+
+/// <summary>
+/// The transport is the seam that lets the entire UNCHANGED EAT controller stack run against the simulator. The
+/// unit tests pin its contract against a substitute actuator (cp reply parses, move commands decode to the right
+/// wizard-order effect, acks succeed); the integration test drives a real actuator through a real, unmodified
+/// <see cref="EatTiltMotionController"/> to prove the whole chain works end to end.
+/// </summary>
+[TestFixture]
+public class SimulatedEatTransportTests {
+
+    private static readonly TimeSpan AnyTimeout = TimeSpan.FromSeconds(5);
+
+    private static ISimulatedTiltActuator Actuator(int[] positions = null) {
+        var actuator = Substitute.For<ISimulatedTiltActuator>();
+        actuator.GetPerMotorPositions().Returns(positions ?? new[] { 0, 0, 0, 0 });
+        return actuator;
+    }
+
+    [Test]
+    public async Task OpenAsync_SetsIsOpen_Close_ClearsIt() {
+        var transport = new SimulatedEatTransport(Actuator());
+        Assert.That(transport.IsOpen, Is.False);
+        await transport.OpenAsync("Simulator", CancellationToken.None);
+        Assert.That(transport.IsOpen, Is.True);
+        transport.Close();
+        Assert.That(transport.IsOpen, Is.False);
+    }
+
+    [Test]
+    public async Task SendAsync_Cp_ReturnsPositionsParseableByEatResponses() {
+        var transport = new SimulatedEatTransport(Actuator(new[] { 10, 20, 30, 40 }));
+
+        var exchange = await transport.SendAsync("cp", AnyTimeout, CancellationToken.None);
+        var positions = EatResponses.ParseCpPositions(exchange);
+
+        Assert.Multiple(() => {
+            Assert.That(exchange.TimedOut, Is.False);
+            Assert.That(positions.Known, Is.True);
+            Assert.That(positions.PerMotorSteps, Is.EqualTo(new[] { 10, 20, 30, 40 }));
+        });
+    }
+
+    // "tr,5" (DiagonalA, +5) -> wizard-order per-corner effect (+5, 0, -5, 0).
+    // "tl,5" (DiagonalB, +5) -> (0, +5, 0, -5). "bf,150" (Backfocus) -> (150,150,150,150).
+    [TestCase("tr,5", 5.0, 0.0, -5.0, 0.0)]
+    [TestCase("tl,5", 0.0, 5.0, 0.0, -5.0)]
+    [TestCase("bf,150", 150.0, 150.0, 150.0, 150.0)]
+    [TestCase("tr,-5", -5.0, 0.0, 5.0, 0.0)]
+    public async Task SendAsync_MoveWire_AppliesWizardOrderEffect(string wire, double s0, double s1, double s2, double s3) {
+        var actuator = Actuator();
+        var transport = new SimulatedEatTransport(actuator);
+
+        await transport.SendAsync(wire, AnyTimeout, CancellationToken.None);
+
+        actuator.Received(1).ApplyWizardScrewSteps(Arg.Is<IReadOnlyList<double>>(v =>
+            v != null && v.Count == 4 && v[0] == s0 && v[1] == s1 && v[2] == s2 && v[3] == s3));
+    }
+
+    [Test]
+    public async Task SendAsync_Move_ReturnsSuccessAck() {
+        var transport = new SimulatedEatTransport(Actuator());
+        var exchange = await transport.SendAsync("tr,5", AnyTimeout, CancellationToken.None);
+        Assert.That(EatResponses.ParseMoveAck(exchange), Is.True);
+    }
+
+    [Test]
+    public void SendAsync_UnparseableCommand_Throws() {
+        var transport = new SimulatedEatTransport(Actuator());
+        Assert.ThrowsAsync<ArgumentException>(() => transport.SendAsync("zz,5", AnyTimeout, CancellationToken.None));
+    }
+
+    [Test]
+    public void SendAsync_NullCommand_Throws() {
+        var transport = new SimulatedEatTransport(Actuator());
+        Assert.ThrowsAsync<ArgumentNullException>(() => transport.SendAsync(null, AnyTimeout, CancellationToken.None));
+    }
+
+    [Test]
+    public void Constructor_NullActuator_Throws() {
+        Assert.Throws<ArgumentNullException>(() => new SimulatedEatTransport(null));
+    }
+
+    // ---- Integration: real actuator through the REAL, UNCHANGED EatTiltMotionController ----------------
+
+    private static CameraSimulatorOptions BuildSimOptions() {
+        var profileService = Substitute.For<IProfileService>();
+        var options = new CameraSimulatorOptions(profileService, new InMemoryPluginOptionsAccessor(),
+            new InspectorOptions(profileService, new InMemoryPluginOptionsAccessor()));
+        options.SimScrewCount = 4;
+        options.SimScrew1AngleDegrees = 45.0;
+        options.SimScrew2AngleDegrees = 135.0;
+        options.SimScrew3AngleDegrees = 225.0;
+        options.SimScrew4AngleDegrees = 315.0;
+        options.SimScrewInwardCurvatureSign = 1;
+        options.SimAdjustmentType = TiltAdjustmentType.StepperMotors;
+        options.SimStepperStepSizeMicrons = 1.8;
+        options.SimScrewRadiusMillimeters = 55.0;
+        options.EnableAberrations = true;
+        return options;
+    }
+
+    private static ITiltAdapterOptions BuildTiltOptions() {
+        var options = Substitute.For<ITiltAdapterOptions>();
+        options.TiltDeviceMaxStepsPerCommand.Returns(200);
+        options.TiltDeviceMaxExcursionSteps.Returns(500);
+        options.TiltDeviceSettleSeconds.Returns(0.0);
+        return options;
+    }
+
+    [Test]
+    public async Task Integration_RealActuator_ThroughUnchangedController() {
+        var simOptions = BuildSimOptions();
+        var actuator = new SimulatedTiltActuator(simOptions, new RecordingApplicationDispatcher());
+        var controller = new EatTiltMotionController(new SimulatedEatTransport(actuator), BuildTiltOptions());
+
+        await controller.ConnectAsync("Simulator", CancellationToken.None);
+        Assert.That(controller.Connected, Is.True);
+        Assert.That(controller.AbsolutePositionsKnown, Is.True, "the simulated cp reply always parses, so positions are known");
+
+        var tiltBefore = simOptions.TiltAmountMicrons;
+        var move = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 50, TiltMoveGroup.Tilt, "tr,50");
+        await controller.ExecuteMoveAsync(move, null, CancellationToken.None);
+
+        var positions = await controller.QueryPositionsAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            // DiagonalA +50 -> device order [50, 0, 0, -50] (TR, TL, BR, BL).
+            Assert.That(positions.PerMotorSteps, Is.EqualTo(new[] { 50, 0, 0, -50 }));
+            Assert.That(simOptions.TiltAmountMicrons, Is.Not.EqualTo(tiltBefore), "the move must fold into the simulator's injected tilt");
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/SimulatedTiltActuatorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/SimulatedTiltActuatorTests.cs
@@ -1,0 +1,168 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.CameraSimulator;
+using NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NINA.Profile.Interfaces;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.CameraSimulator;
+
+/// <summary>
+/// The actuator is the software stand-in for the EAT's four motors. These tests pin the two index orders it
+/// bridges (wizard-order moves in, device-order counters out), that it folds through the shared, sign-verified
+/// <see cref="SimulatedTiltInjection"/> (so tilt vs backfocus stay separated), and that it stays faithful even
+/// when the geometry can't render (a real motor still turns). The convergence physics itself is pinned by the
+/// VM/capstone tests through the same Fold; here we assert the actuator drives that path correctly.
+/// </summary>
+[TestFixture]
+public class SimulatedTiltActuatorTests {
+
+    private const double StepMicrons = 1.8;
+    private const double RadiusMillimeters = 55.0;
+
+    private static CameraSimulatorOptions BuildOptions() {
+        var profileService = Substitute.For<IProfileService>();
+        return new CameraSimulatorOptions(profileService, new InMemoryPluginOptionsAccessor(),
+            new InspectorOptions(profileService, new InMemoryPluginOptionsAccessor()));
+    }
+
+    /// <summary>A valid 4-corner stepper EAT-like config: square screw angles, matching radius/step size.</summary>
+    private static CameraSimulatorOptions ConfiguredEat(int curvatureSign = 1) {
+        var options = BuildOptions();
+        options.SimScrewCount = 4;
+        options.SimScrew1AngleDegrees = 45.0;
+        options.SimScrew2AngleDegrees = 135.0;
+        options.SimScrew3AngleDegrees = 225.0;
+        options.SimScrew4AngleDegrees = 315.0;
+        options.SimScrewInwardCurvatureSign = curvatureSign;
+        options.SimAdjustmentType = TiltAdjustmentType.StepperMotors;
+        options.SimStepperStepSizeMicrons = StepMicrons;
+        options.SimScrewRadiusMillimeters = RadiusMillimeters;
+        options.EnableAberrations = true;
+        return options;
+    }
+
+    private static SimulatedTiltActuator NewActuator(CameraSimulatorOptions options, out RecordingApplicationDispatcher dispatcher) {
+        dispatcher = new RecordingApplicationDispatcher();
+        return new SimulatedTiltActuator(options, dispatcher);
+    }
+
+    [Test]
+    public void GetPerMotorPositions_StartsAtZero() {
+        var actuator = NewActuator(ConfiguredEat(), out _);
+        Assert.That(actuator.GetPerMotorPositions(), Is.EqualTo(new[] { 0, 0, 0, 0 }));
+    }
+
+    [Test]
+    public void ApplyWizardScrewSteps_AdvancesCountersInDeviceOrder() {
+        var actuator = NewActuator(ConfiguredEat(), out _);
+
+        // Wizard-order diagonal-A move "tr,5": PerCornerSteps = (+5, 0, -5, 0). Device order (TR,TL,BR,BL) is the
+        // permutation [w0, w1, w3, w2] = [5, 0, 0, -5].
+        actuator.ApplyWizardScrewSteps(new[] { 5.0, 0.0, -5.0, 0.0 });
+        Assert.That(actuator.GetPerMotorPositions(), Is.EqualTo(new[] { 5, 0, 0, -5 }));
+
+        // Backfocus "bf,3": (+3,+3,+3,+3) -> device [3,3,3,3], accumulating onto the previous state.
+        actuator.ApplyWizardScrewSteps(new[] { 3.0, 3.0, 3.0, 3.0 });
+        Assert.That(actuator.GetPerMotorPositions(), Is.EqualTo(new[] { 8, 3, 3, -2 }));
+    }
+
+    [Test]
+    public void ApplyWizardScrewSteps_MarshalsFoldThroughDispatcher() {
+        var actuator = NewActuator(ConfiguredEat(), out var dispatcher);
+        actuator.ApplyWizardScrewSteps(new[] { 5.0, 0.0, -5.0, 0.0 });
+        Assert.That(dispatcher.DispatchCount, Is.EqualTo(1), "the optical fold must be marshalled onto the UI thread");
+    }
+
+    [Test]
+    public void ApplyWizardScrewSteps_DiagonalPair_ChangesTiltNotBackfocus() {
+        var options = ConfiguredEat();
+        var actuator = new SimulatedTiltActuator(options, new RecordingApplicationDispatcher());
+
+        actuator.ApplyWizardScrewSteps(new[] { 50.0, 0.0, -50.0, 0.0 }); // pure diagonal -> pure tilt, piston 0
+
+        Assert.Multiple(() => {
+            Assert.That(options.TiltAmountMicrons, Is.GreaterThan(0.0), "a diagonal move must inject tilt");
+            Assert.That(options.BackfocusErrorMicrons, Is.EqualTo(0.0).Within(1e-9), "a symmetric diagonal move has zero piston -> no backfocus change");
+        });
+    }
+
+    [Test]
+    public void ApplyWizardScrewSteps_BackfocusAllMotors_ChangesBackfocusNotTilt() {
+        var options = ConfiguredEat();
+        var actuator = new SimulatedTiltActuator(options, new RecordingApplicationDispatcher());
+
+        actuator.ApplyWizardScrewSteps(new[] { 50.0, 50.0, 50.0, 50.0 }); // uniform -> pure piston, zero gradient
+
+        Assert.Multiple(() => {
+            Assert.That(options.BackfocusErrorMicrons, Is.Not.EqualTo(0.0), "a backfocus move must inject a backfocus error");
+            Assert.That(options.TiltAmountMicrons, Is.EqualTo(0.0).Within(1e-9), "a uniform move has zero gradient -> no tilt change");
+        });
+    }
+
+    [Test]
+    public void ApplyWizardScrewSteps_ApplyThenInverse_ReturnsToBaseline() {
+        var options = ConfiguredEat();
+        var actuator = new SimulatedTiltActuator(options, new RecordingApplicationDispatcher());
+
+        actuator.ApplyWizardScrewSteps(new[] { 50.0, 0.0, -50.0, 0.0 });
+        actuator.ApplyWizardScrewSteps(new[] { -50.0, 0.0, 50.0, 0.0 }); // exact inverse
+
+        Assert.Multiple(() => {
+            Assert.That(actuator.GetPerMotorPositions(), Is.EqualTo(new[] { 0, 0, 0, 0 }), "counters must return to baseline");
+            Assert.That(options.TiltAmountMicrons, Is.EqualTo(0.0).Within(1e-6), "injected tilt must return to baseline");
+            Assert.That(options.BackfocusErrorMicrons, Is.EqualTo(0.0).Within(1e-6), "injected backfocus must return to baseline");
+        });
+    }
+
+    [Test]
+    public void ApplyWizardScrewSteps_UnbuildableGeometry_StillTracksPositions_SkipsFold() {
+        var options = ConfiguredEat();
+        options.SimScrewRadiusMillimeters = 0.0; // radius <= 0 -> BuildAdapter returns null, fold is skipped
+        var actuator = new SimulatedTiltActuator(options, new RecordingApplicationDispatcher());
+
+        actuator.ApplyWizardScrewSteps(new[] { 50.0, 0.0, -50.0, 0.0 });
+
+        Assert.Multiple(() => {
+            Assert.That(actuator.GetPerMotorPositions(), Is.EqualTo(new[] { 50, 0, 0, -50 }), "counters advance even when geometry can't render");
+            Assert.That(options.TiltAmountMicrons, Is.EqualTo(0.0).Within(1e-9), "no optical effect when the plane can't be built");
+        });
+    }
+
+    [Test]
+    public void ApplyWizardScrewSteps_WrongLength_Throws() {
+        var actuator = NewActuator(ConfiguredEat(), out _);
+        Assert.Throws<ArgumentException>(() => actuator.ApplyWizardScrewSteps(new[] { 1.0, 2.0, 3.0 }));
+    }
+
+    [Test]
+    public void ApplyWizardScrewSteps_Null_Throws() {
+        var actuator = NewActuator(ConfiguredEat(), out _);
+        Assert.Throws<ArgumentNullException>(() => actuator.ApplyWizardScrewSteps(null));
+    }
+
+    [Test]
+    public void Constructor_NullOptions_Throws() {
+        Assert.Throws<ArgumentNullException>(() => new SimulatedTiltActuator(null, new RecordingApplicationDispatcher()));
+    }
+
+    [Test]
+    public void Constructor_NullDispatcher_Throws() {
+        Assert.Throws<ArgumentNullException>(() => new SimulatedTiltActuator(ConfiguredEat(), null));
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/SimulatedTiltActuatorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/SimulatedTiltActuatorTests.cs
@@ -145,6 +145,30 @@ public class SimulatedTiltActuatorTests {
     }
 
     [Test]
+    public void ApplyWizardScrewSteps_AccumulatesSharedNetCounters() {
+        var options = ConfiguredEat();
+        var actuator = new SimulatedTiltActuator(options, new RecordingApplicationDispatcher());
+
+        actuator.ApplyWizardScrewSteps(new[] { 150.0, 150.0, 150.0, 150.0 }); // bf,150 -> +150 steps per screw
+
+        // Net is stored in axial µm (steps x step size), the same convention the manual panel's "Net" strip uses.
+        Assert.That(options.SimNetAxialMicrons,
+            Is.EqualTo(new[] { 150 * StepMicrons, 150 * StepMicrons, 150 * StepMicrons, 150 * StepMicrons }).Within(1e-9),
+            "the shared net counters must reflect the automated move");
+    }
+
+    [Test]
+    public void ApplyWizardScrewSteps_Net_InverseReturnsToZero() {
+        var options = ConfiguredEat();
+        var actuator = new SimulatedTiltActuator(options, new RecordingApplicationDispatcher());
+
+        actuator.ApplyWizardScrewSteps(new[] { 50.0, 0.0, -50.0, 0.0 });
+        actuator.ApplyWizardScrewSteps(new[] { -50.0, 0.0, 50.0, 0.0 });
+
+        Assert.That(options.SimNetAxialMicrons, Is.EqualTo(new[] { 0.0, 0.0, 0.0, 0.0 }).Within(1e-9));
+    }
+
+    [Test]
     public void ApplyWizardScrewSteps_WrongLength_Throws() {
         var actuator = NewActuator(ConfiguredEat(), out _);
         Assert.Throws<ArgumentException>(() => actuator.ApplyWizardScrewSteps(new[] { 1.0, 2.0, 3.0 }));

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TestDoubles/MediatorBundle.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TestDoubles/MediatorBundle.cs
@@ -9,10 +9,15 @@ using NINA.Image.ImageAnalysis;
 using NINA.Image.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.AutoFocus;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt;
 using NINA.Joko.Plugins.HocusFocus.Utility;
 using NINA.Profile.Interfaces;
 using NINA.WPF.Base.Interfaces.Mediator;
 using NSubstitute;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
 
@@ -64,7 +69,11 @@ internal sealed class MediatorBundle {
         return this;
     }
 
-    public InspectorVM BuildInspectorVM() {
+    public InspectorVM BuildInspectorVM(
+        TiltDeviceConnectionService tiltDeviceConnectionService = null,
+        Func<string, string, Task<bool>> confirmPromptAsync = null,
+        Func<Func<bool, bool, TiltDevicePlanPreview>, bool, string, bool, Task<TiltDeviceAdjustmentChoice>> showAdjustmentPromptAsync = null,
+        Func<CancellationToken, Task<bool>> reRunAnalysisAsync = null) {
         return new InspectorVM(
             profileService: ProfileService,
             applicationStatusMediator: ApplicationStatusMediator,
@@ -83,7 +92,11 @@ internal sealed class MediatorBundle {
             starAnnotatorSelector: StarAnnotatorSelector,
             applicationDispatcher: ApplicationDispatcher,
             alglibAPI: AlglibAPI,
-            tiltAdapterOptions: TiltAdapterOptions);
+            tiltAdapterOptions: TiltAdapterOptions,
+            tiltDeviceConnectionService: tiltDeviceConnectionService,
+            confirmPromptAsync: confirmPromptAsync,
+            showAdjustmentPromptAsync: showAdjustmentPromptAsync,
+            reRunAnalysisAsync: reRunAnalysisAsync);
     }
 
     public HocusFocusVM BuildHocusFocusVM() {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TestDoubles/MediatorBundle.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TestDoubles/MediatorBundle.cs
@@ -72,7 +72,7 @@ internal sealed class MediatorBundle {
     public InspectorVM BuildInspectorVM(
         TiltDeviceConnectionService tiltDeviceConnectionService = null,
         Func<string, string, Task<bool>> confirmPromptAsync = null,
-        Func<Func<bool, bool, TiltDevicePlanPreview>, bool, string, bool, Task<TiltDeviceAdjustmentChoice>> showAdjustmentPromptAsync = null,
+        Func<Func<bool, bool, TiltDevicePlanPreview>, bool, string, bool, double, Task<TiltDeviceAdjustmentChoice>> showAdjustmentPromptAsync = null,
         Func<CancellationToken, Task<bool>> reRunAnalysisAsync = null) {
         return new InspectorVM(
             profileService: ProfileService,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatCommandsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatCommandsTests.cs
@@ -1,0 +1,181 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Globalization;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterDevices.AsgEat;
+
+[TestFixture]
+public class EatCommandsTests {
+
+    // Expected strings below are hard-coded literals copied from the plan/design mnemonic table, NOT
+    // computed from the same lookup tables EatCommands.cs uses internally -- that would be tautological
+    // and could not catch a wrong mnemonic baked into the implementation.
+
+    // --- SignedArgument encoding: always the positive mnemonic, sign rides on the value. ---
+
+    [TestCase(TiltMoveAxis.DiagonalA, 5, "tr,5")]
+    [TestCase(TiltMoveAxis.DiagonalA, -5, "tr,-5")]
+    [TestCase(TiltMoveAxis.DiagonalB, 5, "tl,5")]
+    [TestCase(TiltMoveAxis.DiagonalB, -5, "tl,-5")]
+    [TestCase(TiltMoveAxis.EdgeVertical, 7, "tp,7")]
+    [TestCase(TiltMoveAxis.EdgeVertical, -7, "tp,-7")]
+    [TestCase(TiltMoveAxis.EdgeHorizontal, 2, "rt,2")]
+    [TestCase(TiltMoveAxis.EdgeHorizontal, -2, "rt,-2")]
+    [TestCase(TiltMoveAxis.Backfocus, 4, "bf,4")]
+    [TestCase(TiltMoveAxis.Backfocus, -4, "bf,-4")]
+    public void Format_SignedArgument_ProducesExactWireString(TiltMoveAxis axis, int steps, string expected) {
+        var actual = EatCommands.Format(axis, steps, EatSignEncoding.SignedArgument);
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    // --- OppositeMnemonic encoding: positive -> positive mnemonic + magnitude; negative -> opposite
+    // mnemonic + magnitude. Backfocus stays signed even here (no opposite mnemonic exists). ---
+
+    [TestCase(TiltMoveAxis.DiagonalA, 5, "tr,5")]
+    [TestCase(TiltMoveAxis.DiagonalA, -5, "bl,5")]
+    [TestCase(TiltMoveAxis.DiagonalB, 5, "tl,5")]
+    [TestCase(TiltMoveAxis.DiagonalB, -5, "br,5")]
+    [TestCase(TiltMoveAxis.EdgeVertical, 7, "tp,7")]
+    [TestCase(TiltMoveAxis.EdgeVertical, -7, "bt,7")]
+    [TestCase(TiltMoveAxis.EdgeHorizontal, 2, "rt,2")]
+    [TestCase(TiltMoveAxis.EdgeHorizontal, -2, "lt,2")]
+    [TestCase(TiltMoveAxis.Backfocus, 4, "bf,4")]
+    [TestCase(TiltMoveAxis.Backfocus, -4, "bf,-4")]
+    public void Format_OppositeMnemonic_ProducesExactWireString(TiltMoveAxis axis, int steps, string expected) {
+        var actual = EatCommands.Format(axis, steps, EatSignEncoding.OppositeMnemonic);
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    // --- The blocking-sign invariant: negative Backfocus is ALWAYS "bf,-N", under BOTH encodings. This is
+    // the one sign unknown that is truly blocking (no opposite mnemonic exists for bf on the real device);
+    // a future encoding flip (e.g. during T15) must not be able to silently break it. ---
+
+    [TestCase(EatSignEncoding.SignedArgument)]
+    [TestCase(EatSignEncoding.OppositeMnemonic)]
+    public void Format_NegativeBackfocus_AlwaysUsesSignedArgument_UnderBothEncodings(EatSignEncoding encoding) {
+        var actual = EatCommands.Format(TiltMoveAxis.Backfocus, -3, encoding);
+        Assert.That(actual, Is.EqualTo("bf,-3"));
+    }
+
+    [TestCase(EatSignEncoding.SignedArgument)]
+    [TestCase(EatSignEncoding.OppositeMnemonic)]
+    public void Format_PositiveBackfocus_UsesBfMnemonic_UnderBothEncodings(EatSignEncoding encoding) {
+        var actual = EatCommands.Format(TiltMoveAxis.Backfocus, 3, encoding);
+        Assert.That(actual, Is.EqualTo("bf,3"));
+    }
+
+    // --- TiltAdapterMove overload delegates to (axis, steps). ---
+
+    [Test]
+    public void Format_TiltAdapterMoveOverload_DelegatesToAxisSteps() {
+        var move = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 5, TiltMoveGroup.Tilt, "tr,5");
+        var actual = EatCommands.Format(move, EatSignEncoding.SignedArgument);
+        Assert.That(actual, Is.EqualTo("tr,5"));
+    }
+
+    [Test]
+    public void Format_TiltAdapterMoveOverload_NegativeDiagonalUnderOppositeMnemonic() {
+        var move = new TiltAdapterMove(TiltMoveAxis.DiagonalA, -5, TiltMoveGroup.Tilt, "bl,5");
+        var actual = EatCommands.Format(move, EatSignEncoding.OppositeMnemonic);
+        Assert.That(actual, Is.EqualTo("bl,5"));
+    }
+
+    [Test]
+    public void Format_TiltAdapterMoveOverload_NullMove_Throws() {
+        Assert.Throws<ArgumentNullException>(() => EatCommands.Format(null, EatSignEncoding.SignedArgument));
+    }
+
+    [Test]
+    public void Format_TiltAdapterMoveOverload_DefaultEncoding_UsesDefaultSignEncoding() {
+        var move = new TiltAdapterMove(TiltMoveAxis.DiagonalA, -5, TiltMoveGroup.Tilt, "tr,-5");
+        var actual = EatCommands.Format(move);
+        Assert.That(actual, Is.EqualTo(EatCommands.DefaultSignEncoding == EatSignEncoding.SignedArgument ? "tr,-5" : "bl,5"));
+    }
+
+    // --- Default encoding constant: pinned to SignedArgument per the plan (LIVE-CAPTURE: T15 confirms/flips). ---
+
+    [Test]
+    public void DefaultSignEncoding_IsSignedArgument() {
+        Assert.That(EatCommands.DefaultSignEncoding, Is.EqualTo(EatSignEncoding.SignedArgument));
+    }
+
+    // --- PositionQuery. ---
+
+    [Test]
+    public void PositionQuery_ReturnsCp() {
+        Assert.That(EatCommands.PositionQuery(), Is.EqualTo("cp"));
+    }
+
+    // --- steps == 0: documented behavior is to throw, since the planner never emits a zero-magnitude move
+    // and a silent "no-op" wire command would be an ambiguous, untested code path on real hardware. ---
+
+    [TestCase(EatSignEncoding.SignedArgument)]
+    [TestCase(EatSignEncoding.OppositeMnemonic)]
+    public void Format_ZeroSteps_Throws(EatSignEncoding encoding) {
+        Assert.Throws<ArgumentException>(() => EatCommands.Format(TiltMoveAxis.DiagonalA, 0, encoding));
+    }
+
+    [Test]
+    public void Format_ZeroStepsBackfocus_AlsoThrows() {
+        Assert.Throws<ArgumentException>(() => EatCommands.Format(TiltMoveAxis.Backfocus, 0, EatSignEncoding.SignedArgument));
+    }
+
+    // --- Culture-invariant wire formatting: negative values must always use ASCII '-' (U+002D), never a
+    // culture's alternate negative sign glyph. Under .NET 8's ICU-backed globalization, some cultures format
+    // the minus sign as U+2212 (MINUS SIGN) rather than ASCII '-'; if that leaked into a plain culture-
+    // sensitive interpolation, the ASG EAT device -- which parses raw wire bytes -- would receive a corrupted
+    // command. This test does not rely on any particular CI machine's installed ICU/locale data: it builds an
+    // explicit CultureInfo whose NegativeSign is forced to U+2212 and installs it as CurrentCulture for the
+    // duration, so the assertion is deterministic everywhere. Against the old ($"{positiveMnemonic},{steps}")
+    // formatting this fails (the command would contain U+2212 instead of '-'); it passes once every
+    // value-formatting return site uses FormattableString.Invariant. ---
+
+    [Test]
+    public void Format_NegativeValues_UseAsciiMinusSign_RegardlessOfCurrentCulture() {
+        const string nonAsciiMinusSign = "−"; // U+2212 MINUS SIGN
+        var originalCulture = CultureInfo.CurrentCulture;
+        try {
+            var hostileCulture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+            hostileCulture.NumberFormat.NegativeSign = nonAsciiMinusSign;
+            CultureInfo.CurrentCulture = hostileCulture;
+
+            var signedArgument = EatCommands.Format(TiltMoveAxis.DiagonalA, -5, EatSignEncoding.SignedArgument);
+            var backfocus = EatCommands.Format(TiltMoveAxis.Backfocus, -3, EatSignEncoding.SignedArgument);
+
+            Assert.Multiple(() => {
+                Assert.That(signedArgument, Is.EqualTo("tr,-5"));
+                Assert.That(signedArgument, Does.Not.Contain(nonAsciiMinusSign));
+                Assert.That(backfocus, Is.EqualTo("bf,-3"));
+                Assert.That(backfocus, Does.Not.Contain(nonAsciiMinusSign));
+            });
+        } finally {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    // --- Unknown axis / encoding guard. ---
+
+    [Test]
+    public void Format_UnknownAxis_Throws() {
+        Assert.Throws<ArgumentOutOfRangeException>(() => EatCommands.Format((TiltMoveAxis)999, 5, EatSignEncoding.SignedArgument));
+    }
+
+    [Test]
+    public void Format_UnknownEncoding_Throws() {
+        Assert.Throws<ArgumentOutOfRangeException>(() => EatCommands.Format(TiltMoveAxis.DiagonalA, 5, (EatSignEncoding)999));
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatCommandsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatCommandsTests.cs
@@ -178,4 +178,139 @@ public class EatCommandsTests {
     public void Format_UnknownEncoding_Throws() {
         Assert.Throws<ArgumentOutOfRangeException>(() => EatCommands.Format(TiltMoveAxis.DiagonalA, 5, (EatSignEncoding)999));
     }
+
+    // --- TryParse: the exact inverse of Format. The strongest guarantee we want is a round-trip, but round-
+    // tripping ALONE (parse(format(x)) == x) can't catch a table that is wrong in the SAME way in both
+    // directions, so the wire strings fed to TryParse below are the same hard-coded literals used in the
+    // Format tests (copied from the mnemonic table), not values produced by Format at test time. ---
+
+    [TestCase("tr,5", TiltMoveAxis.DiagonalA, 5)]
+    [TestCase("tr,-5", TiltMoveAxis.DiagonalA, -5)]
+    [TestCase("tl,5", TiltMoveAxis.DiagonalB, 5)]
+    [TestCase("tl,-5", TiltMoveAxis.DiagonalB, -5)]
+    [TestCase("tp,7", TiltMoveAxis.EdgeVertical, 7)]
+    [TestCase("tp,-7", TiltMoveAxis.EdgeVertical, -7)]
+    [TestCase("rt,2", TiltMoveAxis.EdgeHorizontal, 2)]
+    [TestCase("rt,-2", TiltMoveAxis.EdgeHorizontal, -2)]
+    [TestCase("bf,4", TiltMoveAxis.Backfocus, 4)]
+    [TestCase("bf,-4", TiltMoveAxis.Backfocus, -4)]
+    public void TryParse_SignedArgument_DecodesExactMove(string wire, TiltMoveAxis expectedAxis, int expectedSteps) {
+        var ok = EatCommands.TryParse(wire, out var axis, out var steps, EatSignEncoding.SignedArgument);
+        Assert.Multiple(() => {
+            Assert.That(ok, Is.True);
+            Assert.That(axis, Is.EqualTo(expectedAxis));
+            Assert.That(steps, Is.EqualTo(expectedSteps));
+        });
+    }
+
+    [TestCase("tr,5", TiltMoveAxis.DiagonalA, 5)]
+    [TestCase("bl,5", TiltMoveAxis.DiagonalA, -5)]
+    [TestCase("tl,5", TiltMoveAxis.DiagonalB, 5)]
+    [TestCase("br,5", TiltMoveAxis.DiagonalB, -5)]
+    [TestCase("tp,7", TiltMoveAxis.EdgeVertical, 7)]
+    [TestCase("bt,7", TiltMoveAxis.EdgeVertical, -7)]
+    [TestCase("rt,2", TiltMoveAxis.EdgeHorizontal, 2)]
+    [TestCase("lt,2", TiltMoveAxis.EdgeHorizontal, -2)]
+    [TestCase("bf,4", TiltMoveAxis.Backfocus, 4)]
+    [TestCase("bf,-4", TiltMoveAxis.Backfocus, -4)]
+    public void TryParse_OppositeMnemonic_DecodesExactMove(string wire, TiltMoveAxis expectedAxis, int expectedSteps) {
+        var ok = EatCommands.TryParse(wire, out var axis, out var steps, EatSignEncoding.OppositeMnemonic);
+        Assert.Multiple(() => {
+            Assert.That(ok, Is.True);
+            Assert.That(axis, Is.EqualTo(expectedAxis));
+            Assert.That(steps, Is.EqualTo(expectedSteps));
+        });
+    }
+
+    // Round-trip closure over the whole vocabulary under both encodings: TryParse(Format(axis,steps,enc),enc)
+    // recovers (axis, steps) exactly. Backfocus is included precisely because it is the one axis whose negative
+    // is signed under BOTH encodings.
+    [TestCase(TiltMoveAxis.DiagonalA, 5, EatSignEncoding.SignedArgument)]
+    [TestCase(TiltMoveAxis.DiagonalA, -5, EatSignEncoding.SignedArgument)]
+    [TestCase(TiltMoveAxis.DiagonalB, 12, EatSignEncoding.SignedArgument)]
+    [TestCase(TiltMoveAxis.DiagonalB, -12, EatSignEncoding.SignedArgument)]
+    [TestCase(TiltMoveAxis.EdgeVertical, 3, EatSignEncoding.SignedArgument)]
+    [TestCase(TiltMoveAxis.EdgeVertical, -3, EatSignEncoding.SignedArgument)]
+    [TestCase(TiltMoveAxis.EdgeHorizontal, 8, EatSignEncoding.SignedArgument)]
+    [TestCase(TiltMoveAxis.EdgeHorizontal, -8, EatSignEncoding.SignedArgument)]
+    [TestCase(TiltMoveAxis.Backfocus, 150, EatSignEncoding.SignedArgument)]
+    [TestCase(TiltMoveAxis.Backfocus, -150, EatSignEncoding.SignedArgument)]
+    [TestCase(TiltMoveAxis.DiagonalA, 5, EatSignEncoding.OppositeMnemonic)]
+    [TestCase(TiltMoveAxis.DiagonalA, -5, EatSignEncoding.OppositeMnemonic)]
+    [TestCase(TiltMoveAxis.DiagonalB, 12, EatSignEncoding.OppositeMnemonic)]
+    [TestCase(TiltMoveAxis.DiagonalB, -12, EatSignEncoding.OppositeMnemonic)]
+    [TestCase(TiltMoveAxis.EdgeVertical, 3, EatSignEncoding.OppositeMnemonic)]
+    [TestCase(TiltMoveAxis.EdgeVertical, -3, EatSignEncoding.OppositeMnemonic)]
+    [TestCase(TiltMoveAxis.EdgeHorizontal, 8, EatSignEncoding.OppositeMnemonic)]
+    [TestCase(TiltMoveAxis.EdgeHorizontal, -8, EatSignEncoding.OppositeMnemonic)]
+    [TestCase(TiltMoveAxis.Backfocus, 150, EatSignEncoding.OppositeMnemonic)]
+    [TestCase(TiltMoveAxis.Backfocus, -150, EatSignEncoding.OppositeMnemonic)]
+    public void TryParse_RoundTripsFormat(TiltMoveAxis axis, int steps, EatSignEncoding encoding) {
+        var wire = EatCommands.Format(axis, steps, encoding);
+        var ok = EatCommands.TryParse(wire, out var parsedAxis, out var parsedSteps, encoding);
+        Assert.Multiple(() => {
+            Assert.That(ok, Is.True, $"'{wire}' should parse");
+            Assert.That(parsedAxis, Is.EqualTo(axis));
+            Assert.That(parsedSteps, Is.EqualTo(steps));
+        });
+    }
+
+    // Default encoding overload parses SignedArgument (pinned to the same DefaultSignEncoding as Format).
+    [Test]
+    public void TryParse_DefaultEncoding_ParsesSignedArgument() {
+        var ok = EatCommands.TryParse("tr,-5", out var axis, out var steps);
+        Assert.Multiple(() => {
+            Assert.That(ok, Is.True);
+            Assert.That(axis, Is.EqualTo(TiltMoveAxis.DiagonalA));
+            Assert.That(steps, Is.EqualTo(-5));
+        });
+    }
+
+    // An opposite-corner mnemonic is not a legal command under SignedArgument (Format never emits one there),
+    // so TryParse must reject it rather than silently guessing the axis.
+    [Test]
+    public void TryParse_OppositeMnemonicUnderSignedArgument_ReturnsFalse() {
+        var ok = EatCommands.TryParse("bl,5", out _, out _, EatSignEncoding.SignedArgument);
+        Assert.That(ok, Is.False);
+    }
+
+    [TestCase("bf,-3", EatSignEncoding.SignedArgument)]
+    [TestCase("bf,-3", EatSignEncoding.OppositeMnemonic)]
+    public void TryParse_NegativeBackfocus_DecodesSigned_UnderBothEncodings(string wire, EatSignEncoding encoding) {
+        var ok = EatCommands.TryParse(wire, out var axis, out var steps, encoding);
+        Assert.Multiple(() => {
+            Assert.That(ok, Is.True);
+            Assert.That(axis, Is.EqualTo(TiltMoveAxis.Backfocus));
+            Assert.That(steps, Is.EqualTo(-3));
+        });
+    }
+
+    [Test]
+    public void TryParse_PositionQuery_ReturnsFalse() {
+        Assert.That(EatCommands.TryParse("cp", out _, out _), Is.False);
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("tr")]
+    [TestCase("tr,")]
+    [TestCase("tr,x")]
+    [TestCase("zz,5")]
+    [TestCase("tr,5,6")]
+    [TestCase(",5")]
+    public void TryParse_Malformed_ReturnsFalse(string wire) {
+        Assert.That(EatCommands.TryParse(wire, out _, out _), Is.False);
+    }
+
+    // Whitespace tolerance: mnemonic/value are trimmed, so a padded command still decodes.
+    [Test]
+    public void TryParse_WithSurroundingWhitespace_Decodes() {
+        var ok = EatCommands.TryParse(" tr , 5 ", out var axis, out var steps);
+        Assert.Multiple(() => {
+            Assert.That(ok, Is.True);
+            Assert.That(axis, Is.EqualTo(TiltMoveAxis.DiagonalA));
+            Assert.That(steps, Is.EqualTo(5));
+        });
+    }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatHardwareIntegrationTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatHardwareIntegrationTests.cs
@@ -1,0 +1,170 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterDevices.AsgEat;
+
+/// <summary>
+/// MANUAL, HARDWARE-IN-THE-LOOP integration test for the real ASG EAT (firmware 7.1.0) over serial. It is
+/// <see cref="ExplicitAttribute"/> and category "HardwareIntegration", so it NEVER runs in the normal unit
+/// suite (`dotnet test` with no filter skips it); run it deliberately with, e.g.:
+///   dotnet test --filter "FullyQualifiedName~EatHardwareIntegrationTests"
+///
+/// It drives the FULL production stack -- <see cref="EatTiltMotionController"/> over the real
+/// <see cref="EatSerialTransport"/> -- against the physical device on <see cref="Port"/>. It connects, reads
+/// the current positions, then exercises every move mnemonic this plugin depends on (each of the five axes,
+/// once forward and once reversed), asserting the device's reported per-motor positions after every command,
+/// and finally asserts the device ends exactly where it started. Each move persists to the device's EEPROM,
+/// so a clean pass leaves the hardware unchanged.
+///
+/// <para>Progress is written LIVE (one flushed line per step) to <see cref="ProgressLogPath"/> as well as to
+/// NUnit's <see cref="TestContext.Progress"/>, so an observer can tail the file while the test runs.</para>
+///
+/// <para>MACHINE-SPECIFIC by design (per the manual-test request): the COM port and the progress-log path are
+/// hardcoded below for the current bench setup. Adjust them for a different machine.</para>
+/// </summary>
+[TestFixture]
+[Explicit("Requires a real ASG EAT physically connected on COM7. Moves real motors and writes device EEPROM.")]
+[Category("HardwareIntegration")]
+public class EatHardwareIntegrationTests {
+
+    // --- MACHINE-SPECIFIC constants (manual test) ---------------------------------------------------------
+    private const string Port = "COM7";
+    // Windows path; tail it from WSL at /mnt/c/Users/ghili/eat-probe/integration-progress.log while running.
+    private const string ProgressLogPath = @"C:\Users\ghili\eat-probe\integration-progress.log";
+
+    // Small, reversible probe magnitude (<= 10 steps, per the capture constraints).
+    private const int N = 5;
+
+    private static readonly CancellationToken None = CancellationToken.None;
+
+    [Test]
+    public async Task FullMnemonicRoundTrip_OnRealDevice_ReturnsToStartingPositions() {
+        ResetProgressLog();
+        Progress($"=== ASG EAT hardware integration test — port {Port}, step size {N} ===");
+
+        // Generous limits: the device's counters sit around 600, and this test only nudges them by +/-N; we
+        // do not want the software soft-limits to interfere with a protocol/wire validation run.
+        var options = Substitute.For<ITiltAdapterOptions>();
+        options.TiltDeviceMaxStepsPerCommand.Returns(1000);
+        options.TiltDeviceMaxExcursionSteps.Returns(1_000_000);
+        options.TiltDeviceSettleSeconds.Returns(0.0);
+        // TiltDeviceShadowPositions is left to NSubstitute's auto-backing (starts null -> shadow unseeded;
+        // ConnectAsync's 'cp' seeds it from the real device).
+
+        var controller = new EatTiltMotionController(options);
+        var moveProgress = new ActionProgress(s => Progress($"    device: {s}"));
+
+        try {
+            Progress($"Connecting (opens {Port}, resets the Arduino, drains the boot banner, sends 'cp')...");
+            await controller.ConnectAsync(Port, None);
+            Assert.That(controller.Connected, Is.True, "controller should report Connected after ConnectAsync");
+            Assert.That(controller.AbsolutePositionsKnown, Is.True,
+                "the 'cp' response at connect should have parsed, seeding known absolute positions");
+
+            var start = await ReadPositionsAsync(controller, "start");
+
+            // Each axis, once forward (+N) and once reversed (-N). The forward move uses the axis's positive
+            // mnemonic (tr/tl/tp/rt/bf); the reverse uses the SAME mnemonic with a negative signed argument
+            // (SignedArgument encoding, confirmed on hardware) -- so the opposite mnemonics (bl/br/bt/lt),
+            // which this plugin never emits, are intentionally NOT exercised.
+            // Expected per-motor deltas are in DEVICE motor order [TR, TL, BR, BL] and are an INDEPENDENT
+            // oracle (hardcoded from the confirmed physical corner effects), not derived from the code
+            // under test.
+            var axes = new[] {
+                (Axis: TiltMoveAxis.DiagonalA,      Name: "DiagonalA",      Delta: new[] { +N, 0, 0, -N }),
+                (Axis: TiltMoveAxis.DiagonalB,      Name: "DiagonalB",      Delta: new[] { 0, +N, -N, 0 }),
+                (Axis: TiltMoveAxis.EdgeVertical,   Name: "EdgeVertical",   Delta: new[] { +N, +N, -N, -N }),
+                (Axis: TiltMoveAxis.EdgeHorizontal, Name: "EdgeHorizontal", Delta: new[] { +N, -N, +N, -N }),
+                (Axis: TiltMoveAxis.Backfocus,      Name: "Backfocus",      Delta: new[] { +N, +N, +N, +N }),
+            };
+
+            foreach (var (axis, name, delta) in axes) {
+                var group = axis == TiltMoveAxis.Backfocus ? TiltMoveGroup.Backfocus : TiltMoveGroup.Tilt;
+
+                var before = await ReadPositionsAsync(controller, $"{name}: before");
+
+                var forward = new TiltAdapterMove(axis, +N, group, $"{name} +{N}");
+                Progress($"{name}: sending +{N}  (wire '{EatCommands.Format(forward)}')");
+                await controller.ExecuteMoveAsync(forward, moveProgress, None);
+                var after = await ReadPositionsAsync(controller, $"{name}: after +{N}");
+                var expected = Add(before, delta);
+                Progress($"    expected [{Join(expected)}]  (device order TR,TL,BR,BL)");
+                Assert.That(after, Is.EqualTo(expected),
+                    $"{name} +{N}: device positions after the forward move [TR,TL,BR,BL]");
+
+                var reverse = new TiltAdapterMove(axis, -N, group, $"{name} -{N}");
+                Progress($"{name}: reversing -{N}  (wire '{EatCommands.Format(reverse)}')");
+                await controller.ExecuteMoveAsync(reverse, moveProgress, None);
+                var back = await ReadPositionsAsync(controller, $"{name}: after -{N}");
+                Assert.That(back, Is.EqualTo(before),
+                    $"{name} -{N}: reversing must restore the pre-move positions");
+            }
+
+            var end = await ReadPositionsAsync(controller, "end");
+            Assert.That(end, Is.EqualTo(start),
+                "the device must end at exactly the positions it started at (net-zero across the whole run)");
+            Progress($"=== PASS — all five axes exercised; positions restored: [{Join(start)}] -> [{Join(end)}] ===");
+        } finally {
+            try {
+                await controller.DisconnectAsync(None);
+                Progress("Disconnected.");
+            } catch (Exception ex) {
+                Progress($"Disconnect error (ignored): {ex.Message}");
+            }
+        }
+    }
+
+    private static async Task<int[]> ReadPositionsAsync(EatTiltMotionController controller, string label) {
+        var positions = await controller.QueryPositionsAsync(None);
+        Assert.That(positions.Known, Is.True, $"'cp' at '{label}' should have returned known positions");
+        var arr = positions.PerMotorSteps.ToArray();
+        Progress($"    {label}: [{Join(arr)}]  (device order TR,TL,BR,BL)");
+        return arr;
+    }
+
+    private static int[] Add(int[] a, int[] b) => a.Zip(b, (x, y) => x + y).ToArray();
+
+    private static string Join(int[] a) => string.Join(", ", a);
+
+    private static void ResetProgressLog() {
+        try {
+            Directory.CreateDirectory(Path.GetDirectoryName(ProgressLogPath));
+            File.WriteAllText(ProgressLogPath, $"[{DateTime.Now:HH:mm:ss.fff}] --- run start ---{Environment.NewLine}");
+        } catch { /* best-effort */ }
+    }
+
+    private static void Progress(string message) {
+        var line = $"[{DateTime.Now:HH:mm:ss.fff}] {message}";
+        TestContext.Progress.WriteLine(line);
+        try {
+            File.AppendAllText(ProgressLogPath, line + Environment.NewLine); // open+close flushes for live tailing
+        } catch { /* best-effort */ }
+    }
+
+    /// <summary>Synchronous <see cref="IProgress{T}"/> so device progress lines are logged in order, inline.</summary>
+    private sealed class ActionProgress : IProgress<string> {
+        private readonly Action<string> report;
+        public ActionProgress(Action<string> report) => this.report = report;
+        public void Report(string value) => report(value);
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatResponsesTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatResponsesTests.cs
@@ -1,0 +1,149 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using NINA.Core.Utility.SerialCommunication;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterDevices.AsgEat;
+
+// These tests pin EatResponses' PARSING CONTRACT (tolerant success/failure rules, the four-integer `cp`
+// extraction shape, the throw-with-raw-lines-included behavior) -- NOT the real ASG EAT wire format, which
+// is unknown until plan task T15's live hardware capture. Every fixture string below is an ASSUMED
+// stand-in (// LIVE-CAPTURE:), not a real captured device response; T15 replaces them with real transcripts
+// without needing to change ParseMoveAck's or ParseCpPositions' signatures.
+[TestFixture]
+public class EatResponsesTests {
+
+    // --- ParseMoveAck: tolerant on TimedOut only (no ack/error text recognized yet). ---
+
+    [Test]
+    public void ParseMoveAck_NotTimedOut_ReturnsTrue() {
+        // LIVE-CAPTURE: "OK" is an assumed placeholder ack line -- the real ack text (if any) is unknown
+        // until T15. ParseMoveAck does not currently inspect line content at all; this fixture exists only
+        // to show a plausible non-timed-out exchange.
+        var exchange = new EatRawExchange("tr,50", new[] { "OK" }, timedOut: false);
+        Assert.That(EatResponses.ParseMoveAck(exchange), Is.True);
+    }
+
+    [Test]
+    public void ParseMoveAck_NotTimedOut_NoLinesAtAll_StillReturnsTrue() {
+        // A quiet-period completion with zero lines (the device produced no output at all before going
+        // quiet) is still tolerated as success -- this is exactly the "move produces no terminating
+        // response" case the plan calls out; EatResponses treats it as success by default pre-T15.
+        var exchange = new EatRawExchange("bf,10", Array.Empty<string>(), timedOut: false);
+        Assert.That(EatResponses.ParseMoveAck(exchange), Is.True);
+    }
+
+    [Test]
+    public void ParseMoveAck_TimedOut_ReturnsFalse() {
+        var exchange = new EatRawExchange("tr,50", Array.Empty<string>(), timedOut: true);
+        Assert.That(EatResponses.ParseMoveAck(exchange), Is.False);
+    }
+
+    [Test]
+    public void ParseMoveAck_TimedOut_WithPartialLines_StillReturnsFalse() {
+        // Even if some lines trickled in before the overall timeout fired, TimedOut still wins -- partial
+        // data is not evidence of success under the tolerant policy.
+        var exchange = new EatRawExchange("tr,50", new[] { "partial" }, timedOut: true);
+        Assert.That(EatResponses.ParseMoveAck(exchange), Is.False);
+    }
+
+    [Test]
+    public void ParseMoveAck_NullExchange_Throws() {
+        Assert.Throws<ArgumentNullException>(() => EatResponses.ParseMoveAck(null));
+    }
+
+    // --- ParseCpPositions: assumed layout is "first four integers found, in order, across the raw lines". ---
+
+    [Test]
+    public void ParseCpPositions_FourIntegers_OnePerLine_ParsesInDeviceMotorOrder() {
+        // LIVE-CAPTURE: assumes one integer per line, no other content -- real framing (single line vs
+        // multiple, delimiter) unconfirmed until T15.
+        var exchange = new EatRawExchange("cp", new[] { "100", "200", "300", "400" }, timedOut: false);
+
+        var positions = EatResponses.ParseCpPositions(exchange);
+
+        Assert.Multiple(() => {
+            Assert.That(positions.Known, Is.True);
+            // Device motor order 1..4 = TR, TL, BR, BL (TiltDevicePositions' own contract).
+            Assert.That(positions.PerMotorSteps, Is.EqualTo(new[] { 100, 200, 300, 400 }));
+        });
+    }
+
+    [Test]
+    public void ParseCpPositions_FourIntegers_SingleCommaDelimitedLine_Parses() {
+        // LIVE-CAPTURE: assumes a single comma-delimited reply line is also a plausible layout -- the
+        // extraction is delimiter-agnostic (any non-digit run separates tokens) so both plausible layouts
+        // parse the same way without EatResponses needing to guess which one the real device uses.
+        var exchange = new EatRawExchange("cp", new[] { "cp,100,200,-300,400" }, timedOut: false);
+
+        var positions = EatResponses.ParseCpPositions(exchange);
+
+        Assert.That(positions.PerMotorSteps, Is.EqualTo(new[] { 100, 200, -300, 400 }));
+    }
+
+    [Test]
+    public void ParseCpPositions_NegativeValues_ParsedWithSign() {
+        var exchange = new EatRawExchange("cp", new[] { "-5", "0", "10", "-20" }, timedOut: false);
+
+        var positions = EatResponses.ParseCpPositions(exchange);
+
+        Assert.That(positions.PerMotorSteps, Is.EqualTo(new[] { -5, 0, 10, -20 }));
+    }
+
+    [Test]
+    public void ParseCpPositions_MoreThanFourIntegers_TakesFirstFour() {
+        // Tolerant: extra numeric noise (e.g. a leading echo of the command, or a trailing checksum) does
+        // not prevent extraction -- only the first four found are used.
+        var exchange = new EatRawExchange("cp", new[] { "cp", "100,200,300,400,999" }, timedOut: false);
+
+        var positions = EatResponses.ParseCpPositions(exchange);
+
+        Assert.That(positions.PerMotorSteps, Is.EqualTo(new[] { 100, 200, 300, 400 }));
+    }
+
+    [Test]
+    public void ParseCpPositions_FewerThanFourIntegers_ThrowsInvalidDeviceResponseException_WithRawLinesInMessage() {
+        var exchange = new EatRawExchange("cp", new[] { "100", "200" }, timedOut: false);
+
+        var ex = Assert.Throws<InvalidDeviceResponseException>(() => EatResponses.ParseCpPositions(exchange));
+
+        Assert.Multiple(() => {
+            Assert.That(ex.Message, Does.Contain("100"));
+            Assert.That(ex.Message, Does.Contain("200"));
+        });
+    }
+
+    [Test]
+    public void ParseCpPositions_NoLinesAtAll_ThrowsInvalidDeviceResponseException() {
+        // Expected to happen ROUTINELY pre-T15 (e.g. a TimedOut exchange with zero lines) -- callers (T7's
+        // EatTiltMotionController) treat this as "positions unknown", not a crash; this test just pins that
+        // the parser itself throws rather than silently returning a bogus TiltDevicePositions.
+        var exchange = new EatRawExchange("cp", Array.Empty<string>(), timedOut: true);
+
+        Assert.Throws<InvalidDeviceResponseException>(() => EatResponses.ParseCpPositions(exchange));
+    }
+
+    [Test]
+    public void ParseCpPositions_NonNumericLines_ThrowsInvalidDeviceResponseException() {
+        var exchange = new EatRawExchange("cp", new[] { "ERR", "unexpected" }, timedOut: false);
+
+        Assert.Throws<InvalidDeviceResponseException>(() => EatResponses.ParseCpPositions(exchange));
+    }
+
+    [Test]
+    public void ParseCpPositions_NullExchange_Throws() {
+        Assert.Throws<ArgumentNullException>(() => EatResponses.ParseCpPositions(null));
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatResponsesTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatResponsesTests.cs
@@ -142,6 +142,72 @@ public class EatResponsesTests {
         Assert.Throws<InvalidDeviceResponseException>(() => EatResponses.ParseCpPositions(exchange));
     }
 
+    // --- ParseCpPositions: the REAL device format (ASG EAT firmware 7.1.0), captured from hardware. ---
+    // See docs/asg-eat-serial-protocol-design.md. The four positions are bare integer lines wrapped between
+    // "***Get Current Positions***" and "***End Current Positions***", in WIRE order [TL, TR, BL, BR], amid
+    // {UI|SET|...} chatter; the parser reorders them into device motor order [TR, TL, BR, BL].
+
+    [Test]
+    public void ParseCpPositions_RealMarkedBlock_ReordersWireTLTRBLBR_ToDeviceTRTLBRBL() {
+        // Wire block [TL, TR, BL, BR] = [10, 20, 30, 40] -> device order [TR, TL, BR, BL] = [20, 10, 40, 30].
+        var exchange = new EatRawExchange("cp", new[] {
+            "{UI|SET|ready_light.IndicatorColor=Red}",
+            "{UI|SET|TR_curr_position.Text=20}",
+            "***Get Current Positions***",
+            "10",   // TL
+            "20",   // TR
+            "30",   // BL
+            "40",   // BR
+            "***End Current Positions***",
+            "{UI|SET|ready_light.IndicatorColor=green}",
+            "***Action Processed***",
+        }, timedOut: false);
+
+        var positions = EatResponses.ParseCpPositions(exchange);
+
+        Assert.Multiple(() => {
+            Assert.That(positions.Known, Is.True);
+            Assert.That(positions.PerMotorSteps, Is.EqualTo(new[] { 20, 10, 40, 30 }));
+        });
+    }
+
+    [Test]
+    public void ParseCpPositions_RealMarkedBlock_IgnoresUiChatterIntegersBeforeTheBlock() {
+        // The {UI|SET|..._input.Text=0} lines contain integers (0) BEFORE the block. A naive "first four
+        // integers" scan would return [0,0,0,0]; the marker-aware parser must instead take the block values.
+        var exchange = new EatRawExchange("cp", new[] {
+            "{UI|SET|TR_input.Text=0}",
+            "{UI|SET|TL_input.Text=0}",
+            "{UI|SET|BR_input.Text=0}",
+            "{UI|SET|BL_input.Text=0}",
+            "***Get Current Positions***",
+            "600",  // TL
+            "605",  // TR
+            "595",  // BL
+            "600",  // BR
+            "***End Current Positions***",
+        }, timedOut: false);
+
+        var positions = EatResponses.ParseCpPositions(exchange);
+
+        // Device order [TR, TL, BR, BL] = [605, 600, 600, 595].
+        Assert.That(positions.PerMotorSteps, Is.EqualTo(new[] { 605, 600, 600, 595 }));
+    }
+
+    [Test]
+    public void ParseCpPositions_MarkerPresentButFewerThanFourIntegers_Throws() {
+        // A real-device marker with a malformed body is a genuine parse failure -- must NOT silently fall back
+        // to scanning {UI|SET|...} integers for a bogus answer.
+        var exchange = new EatRawExchange("cp", new[] {
+            "***Get Current Positions***",
+            "600",
+            "605",
+            "***End Current Positions***",
+        }, timedOut: false);
+
+        Assert.Throws<InvalidDeviceResponseException>(() => EatResponses.ParseCpPositions(exchange));
+    }
+
     [Test]
     public void ParseCpPositions_NullExchange_Throws() {
         Assert.Throws<ArgumentNullException>(() => EatResponses.ParseCpPositions(null));

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatSerialTransportTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatSerialTransportTests.cs
@@ -1,0 +1,412 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Collections.Generic;
+using System.IO.Ports;
+using System.Threading;
+using System.Threading.Tasks;
+using NINA.Core.Utility.SerialCommunication;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterDevices.AsgEat;
+
+// These tests pin the CONTRACT of EatSerialTransport -- the port config, the read-loop's quiet-period vs
+// overall-timeout race, exception propagation, and single-flight-command serialization -- NOT the (still
+// unknown) ASG EAT wire format. Fixture strings used to fake device responses are arbitrary placeholders;
+// none of this asserts anything about what the real device actually sends (that's EatResponsesTests' job,
+// and even there the fixtures are marked ASSUMED/LIVE-CAPTURE, replaced with real captures in plan task T15).
+[TestFixture]
+public class EatSerialTransportTests {
+
+    // NSubstitute gotcha (documented, not a bug in our code): once a member has been configured to throw,
+    // calling `substitute.Member().Returns(...)` a SECOND time to reconfigure it actually re-invokes the
+    // FIRST configured behavior (and throws) as a side effect of making that call. To let tests freely swap
+    // ReadLine's behavior after OpenAsync's boot-banner drain has already run (which needs its own default
+    // "no banner" behavior), ReadLine is configured on the substitute exactly ONCE, delegating to this
+    // mutable indirection instead -- reassigning ReadLineBehavior.Next is a plain field write, not another
+    // NSubstitute configuration call, so it can't trigger the gotcha.
+    private sealed class ReadLineBehavior {
+        public Func<string> Next = () => throw new TimeoutException();
+    }
+
+    private static (ISerialPortProvider Provider, ISerialPort Port, ReadLineBehavior ReadLine) MakeFakeProvider() {
+        var provider = Substitute.For<ISerialPortProvider>();
+        var port = Substitute.For<ISerialPort>();
+        provider.GetSerialPort(
+            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<Parity>(), Arg.Any<int>(), Arg.Any<StopBits>(),
+            Arg.Any<Handshake>(), Arg.Any<bool>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>())
+            .Returns(port);
+
+        // No boot banner by default -- every poll during OpenAsync's post-open settle drain times out
+        // immediately so tests don't need to wait out the full settle window themselves. Tests that care
+        // about SendAsync's own read behavior reassign readLine.Next AFTER OpenAsync completes.
+        var readLine = new ReadLineBehavior();
+        port.ReadLine().Returns(_ => readLine.Next());
+        return (provider, port, readLine);
+    }
+
+    // --- OpenAsync: exact port config + explicit DTR. ---
+
+    [Test]
+    public async Task OpenAsync_CallsGetSerialPort_WithExactEatPortConfig() {
+        var (provider, port, _) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+
+        await transport.OpenAsync("COM7", CancellationToken.None);
+
+        provider.Received(1).GetSerialPort(
+            "COM7",
+            9600,
+            Parity.None,
+            8,
+            StopBits.One,
+            Handshake.XOnXOff,
+            Arg.Any<bool>(),
+            Arg.Any<string>(),
+            Arg.Any<int>(),
+            // WriteTimeout must exceed the longest legitimate move (5-10 s, per the plan's device facts) --
+            // assert it's generously beyond that, without pinning the exact LIVE-CAPTURE-tunable value.
+            Arg.Is<int>(writeTimeoutMs => writeTimeoutMs > 10_000));
+    }
+
+    [Test]
+    public async Task OpenAsync_OpensThePort_AndSetsDtrEnableExplicitly() {
+        var (provider, port, _) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+
+        await transport.OpenAsync("COM7", CancellationToken.None);
+
+        port.Received(1).Open();
+        // NSubstitute auto-implements interface property get/set, so reading it back after OpenAsync
+        // confirms the transport set it explicitly (independent of whatever the fake provider itself did
+        // with the constructor-style parameter). Compared against the named constant -- not a literal
+        // `true` -- so a future T15 flip of the assumed default doesn't break this "DTR is set explicitly"
+        // contract test.
+        Assert.That(port.DtrEnable, Is.EqualTo(EatSerialTransport.DefaultDtrEnable));
+    }
+
+    [Test]
+    public async Task OpenAsync_SetsIsOpenTrue() {
+        var (provider, _, _) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+
+        Assert.That(transport.IsOpen, Is.False);
+        await transport.OpenAsync("COM7", CancellationToken.None);
+        Assert.That(transport.IsOpen, Is.True);
+    }
+
+    [Test]
+    public void Constructor_NullProvider_Throws() {
+        Assert.Throws<ArgumentNullException>(() => new EatSerialTransport(null));
+    }
+
+    [Test]
+    public void DefaultConstructor_DoesNotThrow() {
+        // Uses the real production SerialPortProvider; we never call OpenAsync on it (no real hardware in
+        // this test run), so this only confirms the production wiring constructs successfully.
+        Assert.DoesNotThrow(() => new EatSerialTransport());
+    }
+
+    // --- OpenAsync: double-open guard + half-open-on-failure. ---
+
+    [Test]
+    public async Task OpenAsync_WhenAlreadyOpen_ThrowsAndDoesNotOverwriteTheExistingPort() {
+        var (provider, port, _) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+        await transport.OpenAsync("COM7", CancellationToken.None);
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await transport.OpenAsync("COM7", CancellationToken.None));
+
+        // The double-open guard must reject BEFORE ever asking the provider for a second port -- the
+        // original (still-open) port is left completely untouched.
+        provider.Received(1).GetSerialPort(
+            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<Parity>(), Arg.Any<int>(), Arg.Any<StopBits>(),
+            Arg.Any<Handshake>(), Arg.Any<bool>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>());
+        Assert.That(transport.IsOpen, Is.True);
+        port.DidNotReceive().Close();
+    }
+
+    [Test]
+    public void OpenAsync_StepAfterPortOpenThrows_ClosesThePortAndLeavesTransportClosed() {
+        var (provider, port, readLine) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+        // Force the post-open boot-banner drain to fail with something other than the tolerated
+        // TimeoutException -- e.g. the port reporting itself closed mid-drain.
+        readLine.Next = () => throw new InvalidOperationException("port closed mid-drain");
+
+        Assert.ThrowsAsync<SerialPortClosedException>(async () =>
+            await transport.OpenAsync("COM7", CancellationToken.None));
+
+        // Half-open on failure: the port must be closed and IsOpen must never report true for a failed open.
+        Assert.That(transport.IsOpen, Is.False);
+        port.Received(1).Close();
+    }
+
+    [Test]
+    public void OpenAsync_StepAfterPortOpenThrows_AllowsARetryAfterward() {
+        var (provider, port, readLine) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+        readLine.Next = () => throw new InvalidOperationException("port closed mid-drain");
+
+        Assert.ThrowsAsync<SerialPortClosedException>(async () =>
+            await transport.OpenAsync("COM7", CancellationToken.None));
+
+        // A failed open must not leave IsOpen == true (which would make every subsequent OpenAsync hit the
+        // double-open guard forever) -- a fresh OpenAsync must be able to proceed normally.
+        readLine.Next = () => throw new TimeoutException(); // no banner this time
+        Assert.DoesNotThrowAsync(async () => await transport.OpenAsync("COM7", CancellationToken.None));
+        Assert.That(transport.IsOpen, Is.True);
+    }
+
+    // --- Close: idempotent. ---
+
+    [Test]
+    public void Close_WhenNeverOpened_DoesNotThrow() {
+        var transport = new EatSerialTransport(Substitute.For<ISerialPortProvider>());
+        Assert.DoesNotThrow(() => transport.Close());
+    }
+
+    [Test]
+    public async Task Close_ClosesThePort_AndIsIdempotent_AndClearsIsOpen() {
+        var (provider, port, _) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+        await transport.OpenAsync("COM7", CancellationToken.None);
+
+        transport.Close();
+        transport.Close(); // second call must not throw
+
+        port.Received(1).Close();
+        Assert.That(transport.IsOpen, Is.False);
+    }
+
+    // --- SendAsync: writes + collects lines; command not open guard. ---
+
+    [Test]
+    public void SendAsync_BeforeOpen_Throws() {
+        var transport = new EatSerialTransport(Substitute.For<ISerialPortProvider>());
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await transport.SendAsync("cp", TimeSpan.FromSeconds(1), CancellationToken.None));
+    }
+
+    [Test]
+    public async Task SendAsync_WritesCommandPlusTerminator() {
+        var (provider, port, _) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+        await transport.OpenAsync("COM7", CancellationToken.None);
+
+        await transport.SendAsync("cp", TimeSpan.FromMilliseconds(300), CancellationToken.None);
+
+        port.Received(1).Write(Arg.Is<string>(s => s.StartsWith("cp", StringComparison.Ordinal) && s.Length > "cp".Length));
+    }
+
+    [Test]
+    public async Task SendAsync_NoResponseWithinOverallTimeout_ReturnsTimedOutTrue_DoesNotThrow() {
+        var (provider, port, readLine) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+        await transport.OpenAsync("COM7", CancellationToken.None);
+        readLine.Next = () => throw new TimeoutException(); // silent device, e.g. a move in progress
+
+        EatRawExchange exchange = null;
+        Assert.DoesNotThrowAsync(async () =>
+            exchange = await transport.SendAsync("bf,10", TimeSpan.FromMilliseconds(300), CancellationToken.None));
+
+        Assert.Multiple(() => {
+            Assert.That(exchange, Is.Not.Null);
+            Assert.That(exchange.TimedOut, Is.True);
+            Assert.That(exchange.Lines, Is.Empty);
+            Assert.That(exchange.Command, Is.EqualTo("bf,10"));
+        });
+    }
+
+    [Test]
+    public async Task SendAsync_CollectsLinesUntilQuietPeriod_ReturnsTimedOutFalse_AndReturnsEarly() {
+        var (provider, port, readLine) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+        await transport.OpenAsync("COM7", CancellationToken.None);
+
+        var callCount = 0;
+        readLine.Next = () => {
+            callCount++;
+            return callCount switch {
+                1 => "OK",
+                2 => "cp,100,200,300,400",
+                _ => throw new TimeoutException()
+            };
+        };
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        // A generous overall budget -- the quiet-period race should end the exchange well before this
+        // elapses, which the elapsed-time assertion below verifies.
+        var exchange = await transport.SendAsync("cp", TimeSpan.FromSeconds(10), CancellationToken.None);
+        sw.Stop();
+
+        Assert.Multiple(() => {
+            Assert.That(exchange.TimedOut, Is.False);
+            Assert.That(exchange.Lines, Is.EqualTo(new[] { "OK", "cp,100,200,300,400" }));
+            Assert.That(sw.Elapsed, Is.LessThan(TimeSpan.FromSeconds(5)),
+                "the quiet-period race should end the exchange well before the 10s overall budget elapses");
+        });
+    }
+
+    [Test]
+    public void SendAsync_PortClosedDuringRead_PropagatesSerialPortClosedException_NotSwallowed() {
+        var (provider, port, readLine) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+        transport.OpenAsync("COM7", CancellationToken.None).GetAwaiter().GetResult();
+        readLine.Next = () => throw new InvalidOperationException("port closed");
+
+        Assert.ThrowsAsync<SerialPortClosedException>(async () =>
+            await transport.SendAsync("cp", TimeSpan.FromSeconds(1), CancellationToken.None));
+    }
+
+    [Test]
+    public void SendAsync_PortClosedDuringWrite_PropagatesSerialPortClosedException_NotSwallowed() {
+        var (provider, port, _) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+        transport.OpenAsync("COM7", CancellationToken.None).GetAwaiter().GetResult();
+        port.When(p => p.Write(Arg.Any<string>())).Do(_ => throw new InvalidOperationException("port closed"));
+
+        Assert.ThrowsAsync<SerialPortClosedException>(async () =>
+            await transport.SendAsync("cp", TimeSpan.FromSeconds(1), CancellationToken.None));
+    }
+
+    [Test]
+    public void SendAsync_WriteTimesOut_PropagatesAsHardFailure_NotSwallowed() {
+        var (provider, port, _) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+        transport.OpenAsync("COM7", CancellationToken.None).GetAwaiter().GetResult();
+        port.When(p => p.Write(Arg.Any<string>())).Do(_ => throw new TimeoutException("write timeout"));
+
+        // A write timeout must propagate as a hard failure -- unlike a read timeout, it must NOT be
+        // swallowed/converted into a tolerant EatRawExchange.
+        Assert.ThrowsAsync<TimeoutException>(async () =>
+            await transport.SendAsync("cp", TimeSpan.FromSeconds(1), CancellationToken.None));
+    }
+
+    [Test]
+    public async Task SendAsync_WritesOnABackgroundThread_NotTheCallerThread() {
+        var (provider, port, _) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+        await transport.OpenAsync("COM7", CancellationToken.None);
+
+        var callerThreadId = Thread.CurrentThread.ManagedThreadId;
+        int? writeThreadId = null;
+        port.When(p => p.Write(Arg.Any<string>())).Do(_ => writeThreadId = Thread.CurrentThread.ManagedThreadId);
+
+        // A synchronous inline Write() could block the caller (e.g. the UI thread) for up to WriteTimeout
+        // under an XON/XOFF stall -- it must be offloaded, mirroring the already-offloaded read.
+        await transport.SendAsync("cp", TimeSpan.FromMilliseconds(300), CancellationToken.None);
+
+        Assert.That(writeThreadId, Is.Not.Null);
+        Assert.That(writeThreadId, Is.Not.EqualTo(callerThreadId));
+    }
+
+    [Test]
+    public async Task SendAsync_ConcurrentCloseDuringRead_DoesNotThrowNullReferenceException() {
+        var (provider, port, readLine) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+        await transport.OpenAsync("COM7", CancellationToken.None);
+
+        var readStarted = new ManualResetEventSlim(false);
+        var releaseRead = new ManualResetEventSlim(false);
+        var readCallCount = 0;
+        readLine.Next = () => {
+            // Only the FIRST poll blocks and then returns a line; every subsequent poll times out so the
+            // quiet-period race ends the exchange after that one line instead of looping until the 5s
+            // overall budget (which would otherwise return thousands of "OK" lines).
+            if (Interlocked.Increment(ref readCallCount) == 1) {
+                readStarted.Set();
+                releaseRead.Wait(TimeSpan.FromSeconds(10));
+                return "OK";
+            }
+            throw new TimeoutException();
+        };
+
+        var sendTask = transport.SendAsync("cp", TimeSpan.FromSeconds(5), CancellationToken.None);
+        Assert.That(readStarted.Wait(TimeSpan.FromSeconds(5)), Is.True, "the read loop should have started");
+
+        // Close the transport (nulling the serialPort field) WHILE the read above is still in flight.
+        // SendAsync snapshotted the port into a local before dispatching the read, so the in-flight read
+        // must complete cleanly against that snapshot instead of NRE-ing on the now-null field.
+        transport.Close();
+        releaseRead.Set();
+
+        EatRawExchange exchange = null;
+        Assert.DoesNotThrowAsync(async () => exchange = await sendTask);
+        Assert.That(exchange.Lines, Is.EqualTo(new[] { "OK" }));
+    }
+
+    [Test]
+    public async Task SendAsync_AlreadyCancelledToken_ThrowsWithoutWriting() {
+        var (provider, port, _) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+        await transport.OpenAsync("COM7", CancellationToken.None);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.CatchAsync<OperationCanceledException>(async () =>
+            await transport.SendAsync("cp", TimeSpan.FromSeconds(1), cts.Token));
+        port.DidNotReceive().Write(Arg.Any<string>());
+    }
+
+    // --- Single-flight: only one command in flight at a time. ---
+
+    [Test]
+    public async Task SendAsync_SerializesConcurrentCalls_SecondDoesNotWriteUntilFirstCompletes() {
+        var (provider, port, readLine) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+        await transport.OpenAsync("COM7", CancellationToken.None);
+
+        var firstReadStarted = new ManualResetEventSlim(false);
+        var releaseFirstRead = new ManualResetEventSlim(false);
+        var writeOrder = new List<string>();
+        var readCallCount = 0;
+
+        port.When(p => p.Write(Arg.Any<string>())).Do(callInfo => {
+            lock (writeOrder) {
+                // The written string includes the transport's appended line terminator; strip it so this
+                // test can assert on the plain command text (the terminator itself is a separate,
+                // LIVE-CAPTURE-marked concern covered by SendAsync_WritesCommandPlusTerminator).
+                writeOrder.Add(((string)callInfo[0]).TrimEnd('\r', '\n'));
+            }
+        });
+        readLine.Next = () => {
+            var count = Interlocked.Increment(ref readCallCount);
+            if (count == 1) {
+                firstReadStarted.Set();
+                releaseFirstRead.Wait(TimeSpan.FromSeconds(10));
+            }
+            throw new TimeoutException();
+        };
+
+        var firstTask = transport.SendAsync("first", TimeSpan.FromMilliseconds(500), CancellationToken.None);
+        Assert.That(firstReadStarted.Wait(TimeSpan.FromSeconds(5)), Is.True, "first command's read loop should have started");
+
+        var secondTask = transport.SendAsync("second", TimeSpan.FromMilliseconds(200), CancellationToken.None);
+        await Task.Delay(150);
+        lock (writeOrder) {
+            Assert.That(writeOrder, Does.Not.Contain("second"),
+                "the second command must not be written while the first is still in flight (the semaphore should block it)");
+        }
+
+        releaseFirstRead.Set();
+        await Task.WhenAll(firstTask, secondTask);
+
+        lock (writeOrder) {
+            Assert.That(writeOrder, Is.EqualTo(new[] { "first", "second" }));
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatSerialTransportTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatSerialTransportTests.cs
@@ -49,10 +49,19 @@ public class EatSerialTransportTests {
             Arg.Any<Handshake>(), Arg.Any<bool>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>())
             .Returns(port);
 
-        // No boot banner by default -- every poll during OpenAsync's post-open settle drain times out
-        // immediately so tests don't need to wait out the full settle window themselves. Tests that care
-        // about SendAsync's own read behavior reassign readLine.Next AFTER OpenAsync completes.
+        // Default boot banner: emit the terminating "FW:" line once, then go quiet -- so OpenAsync's boot-banner
+        // drain stops promptly (on the FW: marker) instead of waiting out the full settle cap. Tests that care
+        // about SendAsync's own read behavior reassign readLine.Next AFTER OpenAsync completes; tests that force
+        // the drain to fail reassign it (to throw) BEFORE calling OpenAsync.
         var readLine = new ReadLineBehavior();
+        var emittedBanner = false;
+        readLine.Next = () => {
+            if (!emittedBanner) {
+                emittedBanner = true;
+                return "FW:7.1.0";
+            }
+            throw new TimeoutException();
+        };
         port.ReadLine().Returns(_ => readLine.Next());
         return (provider, port, readLine);
     }
@@ -72,7 +81,8 @@ public class EatSerialTransportTests {
             Parity.None,
             8,
             StopBits.One,
-            Handshake.XOnXOff,
+            // Handshake.None -- confirmed against firmware 7.1.0 (an Arduino Uno with no software flow control).
+            Handshake.None,
             Arg.Any<bool>(),
             Arg.Any<string>(),
             Arg.Any<int>(),
@@ -166,7 +176,8 @@ public class EatSerialTransportTests {
 
         // A failed open must not leave IsOpen == true (which would make every subsequent OpenAsync hit the
         // double-open guard forever) -- a fresh OpenAsync must be able to proceed normally.
-        readLine.Next = () => throw new TimeoutException(); // no banner this time
+        var reopenedBanner = false;
+        readLine.Next = () => { if (!reopenedBanner) { reopenedBanner = true; return "FW:7.1.0"; } throw new TimeoutException(); };
         Assert.DoesNotThrowAsync(async () => await transport.OpenAsync("COM7", CancellationToken.None));
         Assert.That(transport.IsOpen, Is.True);
     }
@@ -258,6 +269,86 @@ public class EatSerialTransportTests {
             Assert.That(exchange.Lines, Is.EqualTo(new[] { "OK", "cp,100,200,300,400" }));
             Assert.That(sw.Elapsed, Is.LessThan(TimeSpan.FromSeconds(5)),
                 "the quiet-period race should end the exchange well before the 10s overall budget elapses");
+        });
+    }
+
+    // --- Boot-banner drain + terminal-sentinel completion (confirmed against firmware 7.1.0). ---
+
+    [Test]
+    public async Task OpenAsync_DrainsBootBannerUntilFwLine_ThenFirstCommandSeesOnlyPostBannerLines() {
+        var (provider, port, readLine) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+        // The Arduino is silent for ~1.5s after the reset-on-open, then streams a banner ending in "FW:...".
+        // The drain must wait through the silence and consume the banner up to and including the FW: line, so
+        // the FIRST real command sees only its own response, not leftover banner lines.
+        var script = new Queue<Func<string>>(new Func<string>[] {
+            () => throw new TimeoutException(),               // still resetting (silent)
+            () => "Initialize Setup",
+            () => "{UI|SET|ready_light.On=True}",
+            () => "FW:7.1.0",                                 // banner end -> drain stops here
+            () => "***Action Processed***",                   // belongs to the first real command ('cp')
+            () => throw new TimeoutException(),
+        });
+        readLine.Next = () => script.Count > 0 ? script.Dequeue()() : throw new TimeoutException();
+
+        await transport.OpenAsync("COM7", CancellationToken.None);
+        var exchange = await transport.SendAsync("cp", TimeSpan.FromSeconds(2), CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(exchange.TimedOut, Is.False);
+            Assert.That(exchange.Lines, Is.EqualTo(new[] { "***Action Processed***" }),
+                "the boot banner must be fully drained before the first command's read begins");
+        });
+    }
+
+    [Test]
+    public async Task SendAsync_ReturnsExactlyAtMoveCompleteSentinel_WithoutReadingPast() {
+        var (provider, port, readLine) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+        await transport.OpenAsync("COM7", CancellationToken.None);
+        // A real move streams heartbeats then a terminating "***finished movement***". The read loop must
+        // return the instant it sees that sentinel -- not wait out a quiet window, and not read past it.
+        var script = new Queue<Func<string>>(new Func<string>[] {
+            () => "start_cmd: tr",
+            () => "***moving***",
+            () => "***moving***",
+            () => "***finished movement***",                 // terminal sentinel -> return here
+            () => "SHOULD_NOT_BE_READ",
+        });
+        readLine.Next = () => script.Count > 0 ? script.Dequeue()() : throw new TimeoutException();
+
+        // A generous 30s budget: if completion depended on the overall timeout rather than the sentinel, this
+        // would either hang or read past the sentinel.
+        var exchange = await transport.SendAsync("tr,5", TimeSpan.FromSeconds(30), CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(exchange.TimedOut, Is.False);
+            Assert.That(exchange.Lines[exchange.Lines.Count - 1], Is.EqualTo("***finished movement***"),
+                "the exchange must end exactly at the terminal sentinel");
+            Assert.That(exchange.Lines, Does.Not.Contain("SHOULD_NOT_BE_READ"));
+        });
+    }
+
+    [Test]
+    public async Task SendAsync_ReturnsOnQueryCompleteSentinel_IgnoringInterleavedUiChatter() {
+        var (provider, port, readLine) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+        await transport.OpenAsync("COM7", CancellationToken.None);
+        var script = new Queue<Func<string>>(new Func<string>[] {
+            () => "{UI|SET|ready_light.IndicatorColor=Red}",
+            () => "***Get Current Positions***",
+            () => "600",
+            () => "***End Current Positions***",
+            () => "***Action Processed***",                   // query terminal sentinel -> return here
+            () => throw new TimeoutException(),
+        });
+        readLine.Next = () => script.Count > 0 ? script.Dequeue()() : throw new TimeoutException();
+
+        var exchange = await transport.SendAsync("cp", TimeSpan.FromSeconds(30), CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(exchange.TimedOut, Is.False);
+            Assert.That(exchange.Lines[exchange.Lines.Count - 1], Is.EqualTo("***Action Processed***"));
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatTiltMotionControllerTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatTiltMotionControllerTests.cs
@@ -1,0 +1,648 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NINA.Core.Utility.SerialCommunication;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterDevices.AsgEat;
+
+// Safety-critical: every test here guards the last line of software defense between the plugin and an
+// EEPROM-persisted, physically-damaging motor move. Expected per-corner/per-motor vectors are hand-derived
+// from the design doc's generator table and the T7 wizard-index -> device-motor permutation, never computed
+// from the implementation under test on both sides of an assertion.
+[TestFixture]
+public class EatTiltMotionControllerTests {
+
+    // --- Test doubles / builders -------------------------------------------------------------------------
+
+    private static IEatTransport NewTransport() {
+        var transport = Substitute.For<IEatTransport>();
+        transport.OpenAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+        // Default: any command acks immediately with no lines. For "cp" specifically this means
+        // ParseCpPositions finds zero integers and throws InvalidDeviceResponseException -- i.e. the
+        // GUARANTEED pre-T15 "positions unknown" case is the test default; tests that need a real position
+        // reading call WithCpResponse. For any move command this means ParseMoveAck (= !TimedOut) succeeds
+        // by default; tests that need a failed/timed-out ack call WithTimedOutResponse for that exact wire
+        // string (configured AFTER this default so it takes precedence for matching calls).
+        transport.SendAsync(Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => Task.FromResult(new EatRawExchange((string)callInfo[0], Array.Empty<string>(), timedOut: false)));
+        return transport;
+    }
+
+    private static void WithCpResponse(IEatTransport transport, params int[] values) {
+        var line = string.Join(",", values);
+        transport.SendAsync("cp", Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new EatRawExchange("cp", new[] { line }, timedOut: false)));
+    }
+
+    private static void WithUnparseableCpResponse(IEatTransport transport) {
+        transport.SendAsync("cp", Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new EatRawExchange("cp", Array.Empty<string>(), timedOut: false)));
+    }
+
+    private static void WithTimedOutResponse(IEatTransport transport, string command) {
+        transport.SendAsync(command, Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new EatRawExchange(command, Array.Empty<string>(), timedOut: true)));
+    }
+
+    private static ITiltAdapterOptions NewOptions(int maxStepsPerCommand = 200, int maxExcursionSteps = 500, double settleSeconds = 0) {
+        var options = Substitute.For<ITiltAdapterOptions>();
+        options.TiltDeviceMaxStepsPerCommand = maxStepsPerCommand;
+        options.TiltDeviceMaxExcursionSteps = maxExcursionSteps;
+        options.TiltDeviceSettleSeconds = settleSeconds;
+        return options;
+    }
+
+    // Synchronous IProgress<T> double: System.Progress<T> posts through a SynchronizationContext (often
+    // asynchronously), which would make a "cancel from inside the progress callback" test non-deterministic.
+    // This invokes the callback inline, exactly when EatTiltMotionController calls Report(...).
+    private sealed class SyncProgress : IProgress<string> {
+        private readonly Action<string> action;
+        public SyncProgress(Action<string> action) => this.action = action;
+        public void Report(string value) => action(value);
+    }
+
+    // --- Constructors -------------------------------------------------------------------------------------
+
+    [Test]
+    public void Constructor_NullTransport_Throws() {
+        Assert.Throws<ArgumentNullException>(() => new EatTiltMotionController(null, NewOptions()));
+    }
+
+    [Test]
+    public void Constructor_NullOptions_Throws() {
+        Assert.Throws<ArgumentNullException>(() => new EatTiltMotionController(Substitute.For<IEatTransport>(), null));
+    }
+
+    [Test]
+    public void ProductionConstructor_DoesNotThrow() {
+        Assert.DoesNotThrow(() => new EatTiltMotionController(NewOptions()));
+    }
+
+    [Test]
+    public void Capabilities_DeclaresFourCornerCoupled_NoPerScrewIndependent() {
+        var controller = new EatTiltMotionController(NewTransport(), NewOptions());
+        Assert.Multiple(() => {
+            Assert.That(controller.Capabilities.Topology, Is.EqualTo(TiltDeviceTopology.FourCornerCoupled));
+            Assert.That(controller.Capabilities.SupportsPerScrewIndependent, Is.False);
+            Assert.That(controller.Capabilities.SupportedAxes, Is.EquivalentTo(new[] {
+                TiltMoveAxis.DiagonalA, TiltMoveAxis.DiagonalB, TiltMoveAxis.EdgeVertical, TiltMoveAxis.EdgeHorizontal, TiltMoveAxis.Backfocus
+            }));
+        });
+    }
+
+    // --- ConnectAsync ---------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task ConnectAsync_SendsCp() {
+        var transport = NewTransport();
+        var controller = new EatTiltMotionController(transport, NewOptions());
+
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+
+        await transport.Received(1).SendAsync("cp", Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ConnectAsync_CpParses_CachesPositions_SeedsShadow_SetsAbsolutePositionsKnownTrue() {
+        var transport = NewTransport();
+        WithCpResponse(transport, 10, -20, 30, -40);
+        var options = NewOptions();
+        var controller = new EatTiltMotionController(transport, options);
+
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(controller.Connected, Is.True);
+            Assert.That(controller.AbsolutePositionsKnown, Is.True);
+        });
+        var expected = EatTiltMotionController.SerializeShadowPositions(true, new[] { 10, -20, 30, -40 });
+        Assert.That(options.TiltDeviceShadowPositions, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ConnectAsync_CpDoesNotParse_StillConnects_SetsAbsolutePositionsKnownFalse() {
+        var transport = NewTransport(); // default: 'cp' has zero integers -> unparseable
+        var controller = new EatTiltMotionController(transport, NewOptions());
+
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(controller.Connected, Is.True, "must still connect even though 'cp' did not parse");
+            Assert.That(controller.AbsolutePositionsKnown, Is.False);
+        });
+    }
+
+    [Test]
+    public void ConnectAsync_CpDoesNotParse_DoesNotZeroAPreviouslyPersistedShadow() {
+        var options = NewOptions();
+        // Simulate a previously-persisted, trusted shadow from an earlier session (e.g. a prior connect
+        // that DID parse 'cp').
+        var persisted = EatTiltMotionController.SerializeShadowPositions(true, new[] { 5, 6, 7, 8 });
+        options.TiltDeviceShadowPositions = persisted;
+
+        var transport = NewTransport(); // 'cp' unparseable this session
+        var controller = new EatTiltMotionController(transport, options);
+
+        controller.ConnectAsync("COM5", CancellationToken.None).GetAwaiter().GetResult();
+
+        // The plugin NEVER zeroes the shadow -- only the confidence flag changes. The persisted numeric
+        // counters must be exactly what was loaded (the confidence flag flips to invalid=false, but the
+        // stored option string itself was never overwritten by this failed connect).
+        Assert.That(options.TiltDeviceShadowPositions, Is.EqualTo(persisted));
+        Assert.That(controller.AbsolutePositionsKnown, Is.False);
+    }
+
+    [Test]
+    public void ConnectAsync_EmptyPortName_Throws() {
+        var controller = new EatTiltMotionController(NewTransport(), NewOptions());
+        Assert.ThrowsAsync<ArgumentException>(async () => await controller.ConnectAsync("", CancellationToken.None));
+    }
+
+    // --- DisconnectAsync --------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task DisconnectAsync_ClosesTransport_SetsConnectedFalse() {
+        var transport = NewTransport();
+        var controller = new EatTiltMotionController(transport, NewOptions());
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+
+        await controller.DisconnectAsync(CancellationToken.None);
+
+        Assert.That(controller.Connected, Is.False);
+        transport.Received(1).Close();
+    }
+
+    // --- ExecuteMoveAsync: formatting + sending ------------------------------------------------------------
+
+    [Test]
+    public async Task ExecuteMoveAsync_FormatsCorrectWireCommand_AndSends() {
+        var transport = NewTransport();
+        var controller = new EatTiltMotionController(transport, NewOptions());
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+        transport.ClearReceivedCalls();
+
+        var move = new TiltAdapterMove(TiltMoveAxis.Backfocus, 37, TiltMoveGroup.Backfocus, "bf test");
+        await controller.ExecuteMoveAsync(move, null, CancellationToken.None);
+
+        await transport.Received(1).SendAsync("bf,37", Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ExecuteMoveAsync_NotConnected_Throws() {
+        var controller = new EatTiltMotionController(NewTransport(), NewOptions());
+        var move = new TiltAdapterMove(TiltMoveAxis.Backfocus, 10, TiltMoveGroup.Backfocus, "bf");
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await controller.ExecuteMoveAsync(move, null, CancellationToken.None));
+    }
+
+    [Test]
+    public void ExecuteMoveAsync_NullMove_Throws() {
+        var controller = new EatTiltMotionController(NewTransport(), NewOptions());
+        Assert.ThrowsAsync<ArgumentNullException>(async () => await controller.ExecuteMoveAsync(null, null, CancellationToken.None));
+    }
+
+    // --- ExecuteMoveAsync: cap violation => NO send ---------------------------------------------------------
+
+    [Test]
+    public async Task ExecuteMoveAsync_ExceedsMaxStepsPerCommand_ThrowsBeforeSending() {
+        var transport = NewTransport();
+        var controller = new EatTiltMotionController(transport, NewOptions(maxStepsPerCommand: 50));
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+        transport.ClearReceivedCalls();
+
+        var move = new TiltAdapterMove(TiltMoveAxis.Backfocus, 51, TiltMoveGroup.Backfocus, "too big");
+
+        Assert.ThrowsAsync<TiltDeviceLimitException>(async () => await controller.ExecuteMoveAsync(move, null, CancellationToken.None));
+        await transport.DidNotReceive().SendAsync(Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ExecuteMoveAsync_ExactlyAtCap_DoesNotThrow() {
+        var transport = NewTransport();
+        var controller = new EatTiltMotionController(transport, NewOptions(maxStepsPerCommand: 50, maxExcursionSteps: 500));
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+
+        var move = new TiltAdapterMove(TiltMoveAxis.Backfocus, 50, TiltMoveGroup.Backfocus, "exactly at cap");
+
+        Assert.DoesNotThrowAsync(async () => await controller.ExecuteMoveAsync(move, null, CancellationToken.None));
+    }
+
+    // --- ExecuteMoveAsync: excursion violation (incl. intermediate) => NO send -----------------------------
+
+    [Test]
+    public async Task ExecuteMoveAsync_ExceedsMaxExcursion_ThrowsBeforeSending_ShadowUnchanged() {
+        var transport = NewTransport();
+        WithCpResponse(transport, 0, 0, 0, 0);
+        var options = NewOptions(maxStepsPerCommand: 200, maxExcursionSteps: 40);
+        var controller = new EatTiltMotionController(transport, options);
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+        var shadowBefore = options.TiltDeviceShadowPositions;
+        transport.ClearReceivedCalls();
+
+        var move = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 45, TiltMoveGroup.Tilt, "too far");
+
+        Assert.ThrowsAsync<TiltDeviceLimitException>(async () => await controller.ExecuteMoveAsync(move, null, CancellationToken.None));
+        await transport.DidNotReceive().SendAsync(Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+        Assert.That(options.TiltDeviceShadowPositions, Is.EqualTo(shadowBefore));
+    }
+
+    [Test]
+    public async Task ExecuteMoveAsync_SecondMoveWouldExceedExcursionAtIntermediateState_ThrowsBeforeSending() {
+        // moveA alone is within the excursion cap; moveA THEN moveB would push a shared motor beyond it.
+        // moveB's own validation (using the shadow AFTER moveA already succeeded) must catch this.
+        var transport = NewTransport();
+        WithCpResponse(transport, 0, 0, 0, 0);
+        var options = NewOptions(maxStepsPerCommand: 200, maxExcursionSteps: 50);
+        var controller = new EatTiltMotionController(transport, options);
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+
+        var moveA = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 40, TiltMoveGroup.Tilt, "A"); // TR=+40, BL=-40 (within 50)
+        await controller.ExecuteMoveAsync(moveA, null, CancellationToken.None);
+        transport.ClearReceivedCalls();
+
+        var moveB = new TiltAdapterMove(TiltMoveAxis.Backfocus, 20, TiltMoveGroup.Backfocus, "B"); // would push TR to 60, BL to -20
+
+        Assert.ThrowsAsync<TiltDeviceLimitException>(async () => await controller.ExecuteMoveAsync(moveB, null, CancellationToken.None));
+        await transport.DidNotReceive().SendAsync(Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+    }
+
+    // --- ExecuteMoveAsync: shadow updates ONLY on success ---------------------------------------------------
+
+    [Test]
+    public async Task ExecuteMoveAsync_AckTimesOut_ThrowsCommandFailed_ShadowUnchanged() {
+        var transport = NewTransport();
+        WithCpResponse(transport, 0, 0, 0, 0);
+        var options = NewOptions();
+        var controller = new EatTiltMotionController(transport, options);
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+        var shadowBefore = options.TiltDeviceShadowPositions;
+
+        var move = new TiltAdapterMove(TiltMoveAxis.Backfocus, 20, TiltMoveGroup.Backfocus, "will time out");
+        WithTimedOutResponse(transport, EatCommands.Format(move));
+
+        Assert.ThrowsAsync<TiltDeviceCommandFailedException>(async () => await controller.ExecuteMoveAsync(move, null, CancellationToken.None));
+        Assert.That(options.TiltDeviceShadowPositions, Is.EqualTo(shadowBefore));
+    }
+
+    // FINDING 1 regression lock: a write timeout (EatSerialTransport.SendAsync throwing TimeoutException,
+    // which it deliberately does NOT swallow -- see its WriteCommand remarks) must be classified as
+    // TiltDeviceCommandFailedException, exactly like an ack timeout/failure, and must NOT advance the shadow.
+    [Test]
+    public async Task ExecuteMoveAsync_SendThrowsTimeoutException_ThrowsCommandFailed_ShadowUnchanged() {
+        var transport = NewTransport();
+        WithCpResponse(transport, 0, 0, 0, 0);
+        var options = NewOptions();
+        var controller = new EatTiltMotionController(transport, options);
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+        var shadowBefore = options.TiltDeviceShadowPositions;
+
+        var move = new TiltAdapterMove(TiltMoveAxis.Backfocus, 20, TiltMoveGroup.Backfocus, "write timeout");
+        var wire = EatCommands.Format(move);
+        // Simulate EatSerialTransport's own write-timeout behavior: SendAsync's returned Task faults with
+        // TimeoutException rather than completing with a tolerant EatRawExchange.
+        transport.SendAsync(wire, Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<EatRawExchange>(new TimeoutException("write timeout")));
+
+        var ex = Assert.ThrowsAsync<TiltDeviceCommandFailedException>(async () =>
+            await controller.ExecuteMoveAsync(move, null, CancellationToken.None));
+
+        Assert.Multiple(() => {
+            Assert.That(ex.InnerException, Is.InstanceOf<TimeoutException>());
+            Assert.That(options.TiltDeviceShadowPositions, Is.EqualTo(shadowBefore));
+        });
+    }
+
+    // FINDING 1 regression lock: a propagated SerialPortClosedException during a move must NOT be
+    // reclassified/wrapped -- T9's port-unplug handling depends on catching it by its own type -- and must
+    // also leave the shadow unchanged.
+    [Test]
+    public async Task ExecuteMoveAsync_SendThrowsSerialPortClosedException_PropagatesUnwrapped_ShadowUnchanged() {
+        var transport = NewTransport();
+        WithCpResponse(transport, 0, 0, 0, 0);
+        var options = NewOptions();
+        var controller = new EatTiltMotionController(transport, options);
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+        var shadowBefore = options.TiltDeviceShadowPositions;
+
+        var move = new TiltAdapterMove(TiltMoveAxis.Backfocus, 20, TiltMoveGroup.Backfocus, "unplugged");
+        var wire = EatCommands.Format(move);
+        transport.SendAsync(wire, Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<EatRawExchange>(
+                new SerialPortClosedException("unplugged mid-move", new InvalidOperationException("port closed"))));
+
+        Assert.ThrowsAsync<SerialPortClosedException>(async () =>
+            await controller.ExecuteMoveAsync(move, null, CancellationToken.None));
+        Assert.That(options.TiltDeviceShadowPositions, Is.EqualTo(shadowBefore));
+    }
+
+    // FINDING 2 regression lock: connecting with an UNPARSEABLE 'cp' (AbsolutePositionsKnown == false,
+    // shadow seeded from zero/persisted) must NOT disable excursion protection -- it must still be enforced
+    // against the best-estimate shadow, accumulated from zero across successive moves.
+    [Test]
+    public async Task ExecuteMoveAsync_PositionsUnknown_ExcursionStillEnforced_AccumulatingFromZero() {
+        var transport = NewTransport(); // default: 'cp' unparseable
+        var options = NewOptions(maxStepsPerCommand: 200, maxExcursionSteps: 50);
+        var controller = new EatTiltMotionController(transport, options);
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+        Assert.That(controller.AbsolutePositionsKnown, Is.False, "precondition: 'cp' must not have parsed");
+
+        // Accumulate per-motor position toward the excursion cap via successive within-cap moves (Backfocus
+        // moves all four motors equally -- see ExecuteMoveAsync_Success_AdvancesAndPersistsShadow above).
+        var move1 = new TiltAdapterMove(TiltMoveAxis.Backfocus, 20, TiltMoveGroup.Backfocus, "step 1"); // -> 20
+        await controller.ExecuteMoveAsync(move1, null, CancellationToken.None);
+        var move2 = new TiltAdapterMove(TiltMoveAxis.Backfocus, 20, TiltMoveGroup.Backfocus, "step 2"); // -> 40
+        await controller.ExecuteMoveAsync(move2, null, CancellationToken.None);
+        transport.ClearReceivedCalls();
+
+        // A third move of the same size would push every motor from 40 to 60, exceeding the 50-step cap.
+        var move3 = new TiltAdapterMove(TiltMoveAxis.Backfocus, 20, TiltMoveGroup.Backfocus, "step 3 - over the line");
+
+        Assert.ThrowsAsync<TiltDeviceLimitException>(async () => await controller.ExecuteMoveAsync(move3, null, CancellationToken.None));
+        await transport.DidNotReceive().SendAsync(Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+        Assert.That(controller.AbsolutePositionsKnown, Is.False, "must remain degraded; excursion enforcement being active must not itself confirm positions");
+    }
+
+    [Test]
+    public async Task ExecuteMoveAsync_Success_AdvancesAndPersistsShadow() {
+        var transport = NewTransport();
+        WithCpResponse(transport, 0, 0, 0, 0);
+        var options = NewOptions();
+        var controller = new EatTiltMotionController(transport, options);
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+
+        var move = new TiltAdapterMove(TiltMoveAxis.Backfocus, 20, TiltMoveGroup.Backfocus, "bf");
+        await controller.ExecuteMoveAsync(move, null, CancellationToken.None);
+
+        var expected = EatTiltMotionController.SerializeShadowPositions(true, new[] { 20, 20, 20, 20 });
+        Assert.That(options.TiltDeviceShadowPositions, Is.EqualTo(expected));
+    }
+
+    // --- Wizard -> device-motor permutation ------------------------------------------------------------------
+
+    [Test]
+    public void PermuteWizardToDeviceMotorOrder_AppliesExactMapping() {
+        var wizard = new double[] { 1, 2, 3, 4 };
+        var result = EatTiltMotionController.PermuteWizardToDeviceMotorOrder(wizard);
+        // motor1(TR)<-wizard1, motor2(TL)<-wizard2, motor3(BR)<-wizard4, motor4(BL)<-wizard3.
+        Assert.That(result, Is.EqualTo(new double[] { 1, 2, 4, 3 }));
+    }
+
+    [Test]
+    public void PermuteWizardToDeviceMotorOrder_WrongLength_Throws() {
+        Assert.Throws<ArgumentException>(() => EatTiltMotionController.PermuteWizardToDeviceMotorOrder(new double[] { 1, 2, 3 }));
+    }
+
+    [Test]
+    public async Task ExecuteMoveAsync_DiagonalAMove_UpdatesShadowAtTRAndBL_NotTLOrBR() {
+        var transport = NewTransport();
+        WithCpResponse(transport, 0, 0, 0, 0);
+        var options = NewOptions();
+        var controller = new EatTiltMotionController(transport, options);
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+
+        // DiagonalA(+45) in WIZARD space is (wizard1=+45, wizard2=0, wizard3=-45, wizard4=0). Permuted to
+        // DEVICE order this lands on motor1(TR)<-wizard1=+45 and motor4(BL)<-wizard3=-45 -- NOT motor3(BR).
+        // A naive, unpermuted "wizard order == device order" implementation would incorrectly move BR
+        // instead of BL here (wizard3 sits at array index 2, which is BR's position in device order).
+        var move = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 45, TiltMoveGroup.Tilt, "diagonal A");
+        await controller.ExecuteMoveAsync(move, null, CancellationToken.None);
+
+        var expected = EatTiltMotionController.SerializeShadowPositions(true, new[] { 45, 0, 0, -45 });
+        Assert.That(options.TiltDeviceShadowPositions, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ExecuteMoveAsync_DiagonalBMove_UpdatesShadowAtTLAndBR_NotTROrBL() {
+        var transport = NewTransport();
+        WithCpResponse(transport, 0, 0, 0, 0);
+        var options = NewOptions();
+        var controller = new EatTiltMotionController(transport, options);
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+
+        // DiagonalB(+30) in WIZARD space is (wizard1=0, wizard2=+30, wizard3=0, wizard4=-30). Permuted to
+        // DEVICE order this lands on motor2(TL)<-wizard2=+30 and motor3(BR)<-wizard4=-30 -- NOT motor4(BL).
+        var move = new TiltAdapterMove(TiltMoveAxis.DiagonalB, 30, TiltMoveGroup.Tilt, "diagonal B");
+        await controller.ExecuteMoveAsync(move, null, CancellationToken.None);
+
+        var expected = EatTiltMotionController.SerializeShadowPositions(true, new[] { 0, 30, -30, 0 });
+        Assert.That(options.TiltDeviceShadowPositions, Is.EqualTo(expected));
+    }
+
+    // --- Cancellation: between commands only ---------------------------------------------------------------
+
+    [Test]
+    public async Task ExecuteMoveAsync_CancellationRequestedViaProgressDuringMove_StillCompletesCurrentMove() {
+        var transport = NewTransport();
+        var controller = new EatTiltMotionController(transport, NewOptions());
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+        transport.ClearReceivedCalls();
+
+        using var cts = new CancellationTokenSource();
+        var move = new TiltAdapterMove(TiltMoveAxis.Backfocus, 10, TiltMoveGroup.Backfocus, "move1");
+        var progress = new SyncProgress(_ => cts.Cancel()); // fires synchronously, BEFORE the send completes
+
+        // No abort capability on the device -- ExecuteMoveAsync must ignore the caller's token for the
+        // actual exchange, so this call must complete normally despite ct flipping to cancelled mid-call.
+        Assert.DoesNotThrowAsync(async () => await controller.ExecuteMoveAsync(move, progress, cts.Token));
+
+        await transport.Received(1).SendAsync("bf,10", Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ExecuteMoveAsync_TokenCancelledAfterFirstMove_SkipsSecondMove_WithoutSending() {
+        var transport = NewTransport();
+        var controller = new EatTiltMotionController(transport, NewOptions());
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+        transport.ClearReceivedCalls();
+
+        using var cts = new CancellationTokenSource();
+        var move1 = new TiltAdapterMove(TiltMoveAxis.Backfocus, 10, TiltMoveGroup.Backfocus, "move1");
+        var move2 = new TiltAdapterMove(TiltMoveAxis.Backfocus, 5, TiltMoveGroup.Backfocus, "move2");
+
+        await controller.ExecuteMoveAsync(move1, null, cts.Token);
+        cts.Cancel(); // caller decides to stop AFTER move1 completed, BEFORE starting move2
+
+        Assert.ThrowsAsync<OperationCanceledException>(async () => await controller.ExecuteMoveAsync(move2, null, cts.Token));
+        // Only move1's send happened -- move2's entry check throws before any validation or I/O.
+        await transport.Received(1).SendAsync(Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+    }
+
+    // --- QueryPositionsAsync ---------------------------------------------------------------------------------
+
+    [Test]
+    public void QueryPositionsAsync_NotConnected_Throws() {
+        var controller = new EatTiltMotionController(NewTransport(), NewOptions());
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await controller.QueryPositionsAsync(CancellationToken.None));
+    }
+
+    [Test]
+    public async Task QueryPositionsAsync_CpParses_ReconcilesShadow_ReturnsKnownPositions() {
+        var transport = NewTransport();
+        var controller = new EatTiltMotionController(transport, NewOptions());
+        await controller.ConnectAsync("COM5", CancellationToken.None); // degraded: 'cp' didn't parse at connect
+        Assert.That(controller.AbsolutePositionsKnown, Is.False);
+
+        WithCpResponse(transport, 5, 6, 7, 8);
+        var positions = await controller.QueryPositionsAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(positions.Known, Is.True);
+            Assert.That(positions.PerMotorSteps, Is.EqualTo(new[] { 5, 6, 7, 8 }));
+            Assert.That(controller.AbsolutePositionsKnown, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task QueryPositionsAsync_CpDoesNotParse_ReturnsUnknown_LeavesShadowUntouched() {
+        var transport = NewTransport();
+        WithCpResponse(transport, 1, 2, 3, 4);
+        var options = NewOptions();
+        var controller = new EatTiltMotionController(transport, options);
+        await controller.ConnectAsync("COM5", CancellationToken.None); // seeds a valid shadow [1,2,3,4]
+        Assert.That(controller.AbsolutePositionsKnown, Is.True);
+        var shadowBefore = options.TiltDeviceShadowPositions;
+
+        WithUnparseableCpResponse(transport);
+        var positions = await controller.QueryPositionsAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(positions.Known, Is.False);
+            // A single failed poll is a no-op -- it must NOT retroactively invalidate an already-trusted shadow.
+            Assert.That(controller.AbsolutePositionsKnown, Is.True);
+            Assert.That(options.TiltDeviceShadowPositions, Is.EqualTo(shadowBefore));
+        });
+    }
+
+    // --- Shadow serialization format --------------------------------------------------------------------------
+
+    [Test]
+    public void ShadowPositions_SerializeThenParse_RoundTrips() {
+        var serialized = EatTiltMotionController.SerializeShadowPositions(true, new[] { 10, -20, 30, -40 });
+        bool ok = EatTiltMotionController.TryParseShadowPositions(serialized, out var valid, out var steps);
+        Assert.Multiple(() => {
+            Assert.That(ok, Is.True);
+            Assert.That(valid, Is.True);
+            Assert.That(steps, Is.EqualTo(new[] { 10, -20, 30, -40 }));
+        });
+    }
+
+    [Test]
+    public void ShadowPositions_SerializeInvalidFlag_RoundTrips() {
+        var serialized = EatTiltMotionController.SerializeShadowPositions(false, new[] { 0, 0, 0, 0 });
+        bool ok = EatTiltMotionController.TryParseShadowPositions(serialized, out var valid, out var steps);
+        Assert.Multiple(() => {
+            Assert.That(ok, Is.True);
+            Assert.That(valid, Is.False);
+            Assert.That(steps, Is.EqualTo(new[] { 0, 0, 0, 0 }));
+        });
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("garbage")]
+    [TestCase("1;2;3;4")]
+    [TestCase("2;1;2;3;4")]
+    [TestCase("1;a;2;3;4")]
+    public void ShadowPositions_TryParse_MalformedInput_ReturnsFalse(string input) {
+        bool ok = EatTiltMotionController.TryParseShadowPositions(input, out _, out _);
+        Assert.That(ok, Is.False);
+    }
+
+    [Test]
+    public void SerializeShadowPositions_WrongLength_Throws() {
+        Assert.Throws<ArgumentException>(() => EatTiltMotionController.SerializeShadowPositions(true, new[] { 1, 2, 3 }));
+    }
+
+    // --- OrderForMinimalPeakExcursion --------------------------------------------------------------------------
+
+    [Test]
+    public async Task OrderForMinimalPeakExcursion_PicksOrderingWithSmallestPeak() {
+        var transport = NewTransport();
+        WithCpResponse(transport, 0, 0, 0, 0);
+        var options = NewOptions(maxStepsPerCommand: 100, maxExcursionSteps: 50);
+        var controller = new EatTiltMotionController(transport, options);
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+
+        // moveA alone spikes TR to 55 (> 50). moveB alone is small. Applying B THEN A never spikes past 45;
+        // applying A THEN B spikes to 55 first. The final combined state (45) is identical either way.
+        var moveA = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 55, TiltMoveGroup.Tilt, "A");
+        var moveB = new TiltAdapterMove(TiltMoveAxis.DiagonalA, -10, TiltMoveGroup.Tilt, "B");
+
+        var order = controller.OrderForMinimalPeakExcursion(new[] { moveA, moveB });
+
+        Assert.That(order, Is.EqualTo(new[] { moveB, moveA }));
+
+        // Executing in the returned order must never violate the excursion limit at any intermediate/final state.
+        foreach (var move in order) {
+            await controller.ExecuteMoveAsync(move, null, CancellationToken.None);
+        }
+    }
+
+    [Test]
+    public async Task OrderForMinimalPeakExcursion_NoValidOrdering_Throws() {
+        var transport = NewTransport();
+        WithCpResponse(transport, 0, 0, 0, 0);
+        var options = NewOptions(maxStepsPerCommand: 100, maxExcursionSteps: 50);
+        var controller = new EatTiltMotionController(transport, options);
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+
+        // Neither move ALONE exceeds the 50-step excursion cap (45 <= 50), but both push the SAME motor
+        // further in the SAME direction, so their combined effect (90) exceeds it regardless of which is
+        // sent first -- a genuine "no ordering escapes it" case, not just a single oversized move.
+        var moveA = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 45, TiltMoveGroup.Tilt, "A");
+        var moveB = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 45, TiltMoveGroup.Tilt, "B");
+
+        Assert.Throws<TiltDeviceLimitException>(() => controller.OrderForMinimalPeakExcursion(new[] { moveA, moveB }));
+    }
+
+    [Test]
+    public void OrderForMinimalPeakExcursion_MoveExceedsCap_ThrowsRegardlessOfOrdering() {
+        var controller = new EatTiltMotionController(NewTransport(), NewOptions(maxStepsPerCommand: 50, maxExcursionSteps: 500));
+        var move = new TiltAdapterMove(TiltMoveAxis.Backfocus, 51, TiltMoveGroup.Backfocus, "too big");
+
+        Assert.Throws<TiltDeviceLimitException>(() => controller.OrderForMinimalPeakExcursion(new[] { move }));
+    }
+
+    [Test]
+    public void OrderForMinimalPeakExcursion_EmptyList_ReturnsEmpty() {
+        var controller = new EatTiltMotionController(NewTransport(), NewOptions());
+        var order = controller.OrderForMinimalPeakExcursion(Array.Empty<TiltAdapterMove>());
+        Assert.That(order, Is.Empty);
+    }
+
+    [Test]
+    public void OrderForMinimalPeakExcursion_Null_Throws() {
+        var controller = new EatTiltMotionController(NewTransport(), NewOptions());
+        Assert.Throws<ArgumentNullException>(() => controller.OrderForMinimalPeakExcursion(null));
+    }
+
+    [Test]
+    public void OrderForMinimalPeakExcursion_IsPure_DoesNotMutateShadow() {
+        var options = NewOptions(maxStepsPerCommand: 100, maxExcursionSteps: 500);
+        var controller = new EatTiltMotionController(NewTransport(), options);
+        var shadowBefore = options.TiltDeviceShadowPositions;
+
+        var moveA = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 10, TiltMoveGroup.Tilt, "A");
+        var moveB = new TiltAdapterMove(TiltMoveAxis.DiagonalB, 5, TiltMoveGroup.Tilt, "B");
+        controller.OrderForMinimalPeakExcursion(new[] { moveA, moveB });
+
+        Assert.That(options.TiltDeviceShadowPositions, Is.EqualTo(shadowBefore));
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatWizardMappingTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatWizardMappingTests.cs
@@ -1,0 +1,241 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Linq;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterDevices.AsgEat;
+
+[TestFixture]
+public class EatWizardMappingTests {
+
+    // Expected per-corner vectors below are HARD-CODED literals derived independently from the wizard's
+    // StepInstructionsText wording (TiltAdapterWizardVM.cs) -- never computed from MoveForStep on either
+    // side of an assertion. A sign error here is exactly the class of bug the plan calls out as the
+    // highest-consequence failure mode (EEPROM-persisted wrong-way motor moves), so this test intentionally
+    // does not trust the implementation to check itself.
+    //
+    // N = 150 is the EAT preset's default CalibrationAppliedAmount; N = 30 is a second, unrelated value used
+    // to make sure the mapping isn't accidentally hard-coded to 150 anywhere.
+
+    [TestCase(150)]
+    [TestCase(30)]
+    public void MoveForStep_Baseline_ReturnsNull(int n) {
+        // "Ensure all screws are at their starting position, then click Run Measurement." -- measurement
+        // only, no move.
+        Assert.That(EatWizardMapping.MoveForStep(WizardStep.Baseline, n), Is.Null);
+    }
+
+    [TestCase(150)]
+    [TestCase(30)]
+    public void MoveForStep_AllInward_MatchesWizardInstruction(int n) {
+        // "Apply +N steps to EVERY motor, then click Run Measurement." -> all four wizard screws +N.
+        var expected = new double[] { n, n, n, n };
+        var move = EatWizardMapping.MoveForStep(WizardStep.AllInward, n);
+        Assert.Multiple(() => {
+            Assert.That(move.Axis, Is.EqualTo(TiltMoveAxis.Backfocus));
+            Assert.That(move.Steps, Is.EqualTo(n));
+            Assert.That(move.Group, Is.EqualTo(TiltMoveGroup.Backfocus));
+            Assert.That(move.PerCornerSteps, Is.EqualTo(expected));
+        });
+    }
+
+    [TestCase(150)]
+    [TestCase(30)]
+    public void MoveForStep_ReBaseline1_MatchesWizardInstruction(int n) {
+        // "Apply -N steps to every motor, returning to the baseline position, then click Run Measurement."
+        var expected = new double[] { -n, -n, -n, -n };
+        var move = EatWizardMapping.MoveForStep(WizardStep.ReBaseline1, n);
+        Assert.Multiple(() => {
+            Assert.That(move.Axis, Is.EqualTo(TiltMoveAxis.Backfocus));
+            Assert.That(move.Steps, Is.EqualTo(-n));
+            Assert.That(move.Group, Is.EqualTo(TiltMoveGroup.Backfocus));
+            Assert.That(move.PerCornerSteps, Is.EqualTo(expected));
+        });
+    }
+
+    [TestCase(150)]
+    [TestCase(30)]
+    public void MoveForStep_Screw1_MatchesWizardInstruction(int n) {
+        // "Apply +N steps to motor 1 and -N steps to motor 3, then click Run Measurement." -> wizard-screw1
+        // +N, wizard-screw3 -N (wizard indices 1..4 at array positions [0..3]).
+        var expected = new double[] { n, 0, -n, 0 };
+        var move = EatWizardMapping.MoveForStep(WizardStep.Screw1, n);
+        Assert.Multiple(() => {
+            Assert.That(move.Axis, Is.EqualTo(TiltMoveAxis.DiagonalA));
+            Assert.That(move.Steps, Is.EqualTo(n));
+            Assert.That(move.Group, Is.EqualTo(TiltMoveGroup.Tilt));
+            Assert.That(move.PerCornerSteps, Is.EqualTo(expected));
+        });
+    }
+
+    [TestCase(150)]
+    [TestCase(30)]
+    public void MoveForStep_ReBaseline2_MatchesWizardInstruction(int n) {
+        // "Apply -N steps to motor 1 and +N steps to motor 3, returning to the baseline position, then
+        // click Run Measurement."
+        var expected = new double[] { -n, 0, n, 0 };
+        var move = EatWizardMapping.MoveForStep(WizardStep.ReBaseline2, n);
+        Assert.Multiple(() => {
+            Assert.That(move.Axis, Is.EqualTo(TiltMoveAxis.DiagonalA));
+            Assert.That(move.Steps, Is.EqualTo(-n));
+            Assert.That(move.Group, Is.EqualTo(TiltMoveGroup.Tilt));
+            Assert.That(move.PerCornerSteps, Is.EqualTo(expected));
+        });
+    }
+
+    [TestCase(150)]
+    [TestCase(30)]
+    public void MoveForStep_Screw2_MatchesWizardInstruction(int n) {
+        // "Apply +N steps to motor 2 and -N steps to motor 4, then click Run Measurement." -> wizard-screw2
+        // +N, wizard-screw4 -N.
+        var expected = new double[] { 0, n, 0, -n };
+        var move = EatWizardMapping.MoveForStep(WizardStep.Screw2, n);
+        Assert.Multiple(() => {
+            Assert.That(move.Axis, Is.EqualTo(TiltMoveAxis.DiagonalB));
+            Assert.That(move.Steps, Is.EqualTo(n));
+            Assert.That(move.Group, Is.EqualTo(TiltMoveGroup.Tilt));
+            Assert.That(move.PerCornerSteps, Is.EqualTo(expected));
+        });
+    }
+
+    [TestCase(150)]
+    [TestCase(30)]
+    public void MoveForStep_Complete_MatchesWizardInstruction(int n) {
+        // "Return all motors to their original position." -- the restore move after Screw2; must be exactly
+        // the move that returns (0,+N,0,-N) back to (0,0,0,0).
+        var expected = new double[] { 0, -n, 0, n };
+        var move = EatWizardMapping.MoveForStep(WizardStep.Complete, n);
+        Assert.Multiple(() => {
+            Assert.That(move.Axis, Is.EqualTo(TiltMoveAxis.DiagonalB));
+            Assert.That(move.Steps, Is.EqualTo(-n));
+            Assert.That(move.Group, Is.EqualTo(TiltMoveGroup.Tilt));
+            Assert.That(move.PerCornerSteps, Is.EqualTo(expected));
+        });
+    }
+
+    [Test]
+    public void MoveForStep_UnknownStep_Throws() {
+        Assert.Throws<ArgumentOutOfRangeException>(() => EatWizardMapping.MoveForStep((WizardStep)999, 150));
+    }
+
+    // --- Inverse relationships: the "Re-Baseline"/"Complete" steps are literally the recovery moves for the
+    // preceding perturbation step. ---
+
+    [TestCase(150)]
+    [TestCase(30)]
+    public void ReBaseline1_IsNegationOfAllInward(int n) {
+        var allInward = EatWizardMapping.MoveForStep(WizardStep.AllInward, n);
+        var reBaseline1 = EatWizardMapping.MoveForStep(WizardStep.ReBaseline1, n);
+        var negated = allInward.PerCornerSteps.Select(v => -v).ToArray();
+        Assert.That(reBaseline1.PerCornerSteps, Is.EqualTo(negated));
+    }
+
+    [TestCase(150)]
+    [TestCase(30)]
+    public void ReBaseline2_IsNegationOfScrew1(int n) {
+        var screw1 = EatWizardMapping.MoveForStep(WizardStep.Screw1, n);
+        var reBaseline2 = EatWizardMapping.MoveForStep(WizardStep.ReBaseline2, n);
+        var negated = screw1.PerCornerSteps.Select(v => -v).ToArray();
+        Assert.That(reBaseline2.PerCornerSteps, Is.EqualTo(negated));
+    }
+
+    [TestCase(150)]
+    [TestCase(30)]
+    public void Complete_IsNegationOfScrew2(int n) {
+        var screw2 = EatWizardMapping.MoveForStep(WizardStep.Screw2, n);
+        var complete = EatWizardMapping.MoveForStep(WizardStep.Complete, n);
+        var negated = screw2.PerCornerSteps.Select(v => -v).ToArray();
+        Assert.That(complete.PerCornerSteps, Is.EqualTo(negated));
+    }
+
+    // --- Full-sequence-returns-to-baseline: the cumulative device position after the executed 6-step
+    // sequence (Baseline itself moves nothing) must be exactly (0,0,0,0). If this fails, the mapping is
+    // wrong and must not ship -- see the plan's mandatory sequence trace. ---
+
+    [TestCase(150)]
+    [TestCase(30)]
+    public void FullSequence_SumsToZeroPerCorner(int n) {
+        var executedSteps = new[] {
+            WizardStep.AllInward,
+            WizardStep.ReBaseline1,
+            WizardStep.Screw1,
+            WizardStep.ReBaseline2,
+            WizardStep.Screw2,
+            WizardStep.Complete,
+        };
+
+        var total = new double[] { 0, 0, 0, 0 };
+        foreach (var step in executedSteps) {
+            var move = EatWizardMapping.MoveForStep(step, n);
+            for (int i = 0; i < 4; i++) {
+                total[i] += move.PerCornerSteps[i];
+            }
+        }
+
+        Assert.That(total, Is.EqualTo(new double[] { 0, 0, 0, 0 }));
+    }
+
+    // --- InverseMove ---
+
+    [Test]
+    public void InverseMove_NegatesSteps_PreservesAxisAndGroup() {
+        var move = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 42, TiltMoveGroup.Tilt, "forward move");
+        var inverse = EatWizardMapping.InverseMove(move);
+        Assert.Multiple(() => {
+            Assert.That(inverse.Axis, Is.EqualTo(TiltMoveAxis.DiagonalA));
+            Assert.That(inverse.Steps, Is.EqualTo(-42));
+            Assert.That(inverse.Group, Is.EqualTo(TiltMoveGroup.Tilt));
+        });
+    }
+
+    [Test]
+    public void InverseMove_OfNegativeSteps_ProducesPositiveSteps() {
+        var move = new TiltAdapterMove(TiltMoveAxis.Backfocus, -17, TiltMoveGroup.Backfocus, "backward move");
+        var inverse = EatWizardMapping.InverseMove(move);
+        Assert.That(inverse.Steps, Is.EqualTo(17));
+    }
+
+    [Test]
+    public void InverseMove_PerCornerSteps_IsNegationOfOriginal() {
+        var move = new TiltAdapterMove(TiltMoveAxis.EdgeVertical, 6, TiltMoveGroup.Tilt, "edge move");
+        var inverse = EatWizardMapping.InverseMove(move);
+        var negated = move.PerCornerSteps.Select(v => -v).ToArray();
+        Assert.That(inverse.PerCornerSteps, Is.EqualTo(negated));
+    }
+
+    [Test]
+    public void InverseMove_Null_ReturnsNull() {
+        Assert.That(EatWizardMapping.InverseMove(null), Is.Null);
+    }
+
+    // --- CornerLabelForWizardScrew ---
+
+    [TestCase(1, "TR")]
+    [TestCase(2, "TL")]
+    [TestCase(3, "BL")]
+    [TestCase(4, "BR")]
+    public void CornerLabelForWizardScrew_ReturnsExpectedLabel(int wizardScrew, string expected) {
+        Assert.That(EatWizardMapping.CornerLabelForWizardScrew(wizardScrew), Is.EqualTo(expected));
+    }
+
+    [TestCase(0)]
+    [TestCase(5)]
+    [TestCase(-1)]
+    public void CornerLabelForWizardScrew_OutOfRange_Throws(int wizardScrew) {
+        Assert.Throws<ArgumentOutOfRangeException>(() => EatWizardMapping.CornerLabelForWizardScrew(wizardScrew));
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptVMTests.cs
@@ -89,9 +89,10 @@ public class TiltDeviceAdjustmentPromptVMTests {
             Assert.That(vm.Moves[1].GroupLabel, Is.EqualTo("Backfocus"));
             Assert.That(vm.HasMoves, Is.True);
             Assert.That(vm.HasNoMoves, Is.False);
-            Assert.That(vm.MoveCountText, Is.EqualTo("2 commands"));
+            Assert.That(vm.MoveCountText, Is.EqualTo("2 moves"));
+            Assert.That(vm.ProceedButtonText, Is.EqualTo("Send 2 moves"));
             Assert.That(vm.EstimatedDurationText, Is.EqualTo("~20 s"));
-            Assert.That(vm.CornerResiduals.Select(r => r.Label), Is.EqualTo(new[] { "Screw 1", "Screw 2", "Screw 3", "Screw 4" }));
+            Assert.That(vm.CornerResiduals.Select(r => r.Label), Is.EqualTo(new[] { "Screw 1 (TR)", "Screw 2 (TL)", "Screw 3 (BL)", "Screw 4 (BR)" }));
             Assert.That(vm.CornerResiduals.Select(r => r.ValueText), Is.EqualTo(new[] { "+0.9 µm", "-0.9 µm", "0.0 µm", "+1.3 µm" }));
             Assert.That(vm.ProceedCommand.CanExecute(null), Is.True);
         });
@@ -127,7 +128,7 @@ public class TiltDeviceAdjustmentPromptVMTests {
             Assert.That(replanner.Calls, Is.EqualTo(new[] { (true, true), (false, true) }));
             Assert.That(vm.Moves, Has.Count.EqualTo(1));
             Assert.That(vm.Moves[0].WireCommand, Is.EqualTo("bf,12"));
-            Assert.That(vm.MoveCountText, Is.EqualTo("1 command"));
+            Assert.That(vm.MoveCountText, Is.EqualTo("1 move"));
             Assert.That(vm.EstimatedDurationText, Is.EqualTo("~10 s"));
             Assert.That(vm.CornerResiduals.Select(r => r.ValueText), Is.EqualTo(new[] { "+2.0 µm", "-2.0 µm", "+2.0 µm", "-2.0 µm" }));
             Assert.That(raised, Does.Contain(nameof(vm.ApplyTilt)));
@@ -381,7 +382,8 @@ public class TiltDeviceAdjustmentPromptVMTests {
         Assert.Multiple(() => {
             Assert.That(vm.HasMoves, Is.False);
             Assert.That(vm.HasNoMoves, Is.True);
-            Assert.That(vm.MoveCountText, Is.EqualTo("No commands"));
+            Assert.That(vm.MoveCountText, Is.EqualTo("No moves"));
+            Assert.That(vm.ProceedButtonText, Is.EqualTo("Proceed"));
             Assert.That(vm.EstimatedDurationText, Is.EqualTo("0 s"));
         });
     }
@@ -451,6 +453,75 @@ public class TiltDeviceAdjustmentPromptVMTests {
         var move = new TiltAdapterMove(TiltMoveAxis.Backfocus, 150, TiltMoveGroup.Backfocus, "x");
         Assert.That(TiltDeviceAdjustmentPromptVM.BuildSemanticText(move),
             Is.EqualTo("All four screws +150 steps together — changes backfocus (sensor spacing), not tilt."));
+    }
+
+    [Test]
+    public void ProceedDisabledReason_ExplainsBothGroupsOff_ButNotWhenEnabledOrHardLimited() {
+        var replanner = new RecordingReplanner {
+            Produce = (_, _) => new TiltDevicePlanPreview(
+                MakePlan(moves: new[] { Move(TiltMoveAxis.DiagonalA, 10, TiltMoveGroup.Tilt) }), false, null),
+        };
+        var vm = BuildVM(replanner);
+
+        // Enabled: no reason shown.
+        Assert.That(vm.ProceedDisabledReason, Is.Empty);
+        Assert.That(vm.ProceedDisabledReasonVisible, Is.False);
+
+        // Both groups off: explain why Proceed is disabled.
+        vm.ApplyTilt = false;
+        vm.ApplyBackfocus = false;
+        Assert.Multiple(() => {
+            Assert.That(vm.ProceedCommand.CanExecute(null), Is.False);
+            Assert.That(vm.ProceedDisabledReason, Is.EqualTo("Select at least one correction to apply."));
+            Assert.That(vm.ProceedDisabledReasonVisible, Is.True);
+        });
+    }
+
+    [Test]
+    public void ProceedDisabledReason_EmptyWhenHardLimited_RedPanelExplainsInstead() {
+        var replanner = new RecordingReplanner {
+            Produce = (_, _) => new TiltDevicePlanPreview(
+                MakePlan(moves: new[] { Move(TiltMoveAxis.DiagonalA, 500, TiltMoveGroup.Tilt) }),
+                hardLimitViolated: true, limitWarning: "Too far."),
+        };
+        var vm = BuildVM(replanner);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.ProceedCommand.CanExecute(null), Is.False);
+            Assert.That(vm.ProceedDisabledReason, Is.Empty, "the red hard-limit panel already explains this");
+            Assert.That(vm.ProceedDisabledReasonVisible, Is.False);
+        });
+    }
+
+    [Test]
+    public void MoveRow_AssumedDirection_FlagsOnlyBackfocusRow_WhenSignUnmeasured() {
+        var replanner = new RecordingReplanner {
+            Produce = (_, _) => new TiltDevicePlanPreview(
+                MakePlan(moves: new[] {
+                    Move(TiltMoveAxis.DiagonalA, 10, TiltMoveGroup.Tilt),
+                    Move(TiltMoveAxis.Backfocus, 8, TiltMoveGroup.Backfocus),
+                }), false, null),
+        };
+
+        var unmeasured = BuildVM(replanner, signMeasured: false);
+        Assert.Multiple(() => {
+            Assert.That(unmeasured.Moves[0].AssumedDirection, Is.False, "tilt rows are never direction-assumed");
+            Assert.That(unmeasured.Moves[1].AssumedDirection, Is.True, "the backfocus row carries the assumed-direction tag");
+        });
+
+        var measured = BuildVM(replanner, signMeasured: true);
+        Assert.That(measured.Moves[1].AssumedDirection, Is.False, "measured sign ⇒ no assumed-direction tag");
+    }
+
+    [Test]
+    public void CornerResiduals_AppendPhysicalCornerToEachScrew() {
+        var replanner = new RecordingReplanner {
+            Produce = (_, _) => new TiltDevicePlanPreview(
+                MakePlan(residualMicrons: new[] { 0.0, 0.0, 0.0, 0.0 }), false, null),
+        };
+        var vm = BuildVM(replanner);
+        Assert.That(vm.CornerResiduals.Select(r => r.Label),
+            Is.EqualTo(new[] { "Screw 1 (TR)", "Screw 2 (TL)", "Screw 3 (BL)", "Screw 4 (BR)" }));
     }
 
     [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptVMTests.cs
@@ -54,8 +54,9 @@ public class TiltDeviceAdjustmentPromptVMTests {
         RecordingReplanner replanner,
         bool signMeasured = true,
         string pitchMismatchWarning = null,
-        bool positionsUnknown = false) =>
-        new TiltDeviceAdjustmentPromptVM(replanner.Replan, signMeasured, pitchMismatchWarning, positionsUnknown);
+        bool positionsUnknown = false,
+        double unitMicrons = 0.0) =>
+        new TiltDeviceAdjustmentPromptVM(replanner.Replan, signMeasured, pitchMismatchWarning, positionsUnknown, unitMicrons);
 
     [Test]
     public void Ctor_NullReplanner_Throws() {
@@ -320,6 +321,28 @@ public class TiltDeviceAdjustmentPromptVMTests {
         }
     }
 
+    [Test]
+    public void TwistWarning_TranslatesStepsToMicrons_WhenUnitKnown() {
+        var replanner = new RecordingReplanner {
+            Produce = (_, _) => new TiltDevicePlanPreview(MakePlan(twistResidualSteps: 3.0), false, null),
+        };
+        // 3 steps × 1.8 µm/step = 5.4 µm across the sensor.
+        var vm = BuildVM(replanner, unitMicrons: 1.8);
+        Assert.Multiple(() => {
+            Assert.That(vm.TwistWarningText, Does.Contain("+3.0 steps"));
+            Assert.That(vm.TwistWarningText, Does.Contain("5.4 µm"));
+        });
+    }
+
+    [Test]
+    public void TwistWarning_OmitsMicrons_WhenUnitUnknown() {
+        var replanner = new RecordingReplanner {
+            Produce = (_, _) => new TiltDevicePlanPreview(MakePlan(twistResidualSteps: 3.0), false, null),
+        };
+        var vm = BuildVM(replanner, unitMicrons: 0.0);
+        Assert.That(vm.TwistWarningText, Does.Not.Contain("µm"));
+    }
+
     [TestCase(false, true, true)]
     [TestCase(false, false, false)]
     [TestCase(true, true, false)]
@@ -419,9 +442,10 @@ public class TiltDeviceAdjustmentPromptVMTests {
 
     [Test]
     public void BuildSemanticText_CornerMove_ListsBothDiagonalScrewsWithSigns() {
+        // The move kind ("Corner") is in the row badge, so the text does not repeat it.
         var move = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 142, TiltMoveGroup.Tilt, "x");
         Assert.That(TiltDeviceAdjustmentPromptVM.BuildSemanticText(move),
-            Is.EqualTo("Corner move — Screw 1 +142, Screw 3 -142 steps"));
+            Is.EqualTo("Screw 1 +142, Screw 3 -142 steps"));
     }
 
     [Test]
@@ -429,7 +453,7 @@ public class TiltDeviceAdjustmentPromptVMTests {
         // DiagonalA,-142 => PerCornerSteps (-142,0,+142,0): screw 3 positive, screw 1 negative.
         var move = new TiltAdapterMove(TiltMoveAxis.DiagonalA, -142, TiltMoveGroup.Tilt, "x");
         Assert.That(TiltDeviceAdjustmentPromptVM.BuildSemanticText(move),
-            Is.EqualTo("Corner move — Screw 3 +142, Screw 1 -142 steps"));
+            Is.EqualTo("Screw 3 +142, Screw 1 -142 steps"));
     }
 
     [Test]
@@ -437,7 +461,7 @@ public class TiltDeviceAdjustmentPromptVMTests {
         // EdgeVertical,+20 => (+1,+1,-1,-1): screws 1 & 2 together, 3 & 4 together the other way.
         var move = new TiltAdapterMove(TiltMoveAxis.EdgeVertical, 20, TiltMoveGroup.Tilt, "x");
         Assert.That(TiltDeviceAdjustmentPromptVM.BuildSemanticText(move),
-            Is.EqualTo("Side move — Screws 1 & 2 +20, Screws 3 & 4 -20 steps"));
+            Is.EqualTo("Screws 1 & 2 +20, Screws 3 & 4 -20 steps"));
     }
 
     [Test]
@@ -445,14 +469,14 @@ public class TiltDeviceAdjustmentPromptVMTests {
         // EdgeHorizontal,+20 => (+1,-1,-1,+1): screws 1 & 4 together, 2 & 3 the other way.
         var move = new TiltAdapterMove(TiltMoveAxis.EdgeHorizontal, 20, TiltMoveGroup.Tilt, "x");
         Assert.That(TiltDeviceAdjustmentPromptVM.BuildSemanticText(move),
-            Is.EqualTo("Side move — Screws 1 & 4 +20, Screws 2 & 3 -20 steps"));
+            Is.EqualTo("Screws 1 & 4 +20, Screws 2 & 3 -20 steps"));
     }
 
     [Test]
     public void BuildSemanticText_Backfocus_SaysAllFourTogether() {
         var move = new TiltAdapterMove(TiltMoveAxis.Backfocus, 150, TiltMoveGroup.Backfocus, "x");
         Assert.That(TiltDeviceAdjustmentPromptVM.BuildSemanticText(move),
-            Is.EqualTo("All four screws +150 steps together — changes backfocus (sensor spacing), not tilt."));
+            Is.EqualTo("All four screws +150 steps together"));
     }
 
     [Test]
@@ -534,7 +558,7 @@ public class TiltDeviceAdjustmentPromptVMTests {
 
         Assert.Multiple(() => {
             Assert.That(vm.Moves[0].MoveKindLabel, Is.EqualTo("Corner"));
-            Assert.That(vm.Moves[0].SemanticText, Is.EqualTo("Corner move — Screw 2 +30, Screw 4 -30 steps"));
+            Assert.That(vm.Moves[0].SemanticText, Is.EqualTo("Screw 2 +30, Screw 4 -30 steps"));
             // The exact wire command is still available (demoted to an auditability chip in the UI).
             Assert.That(vm.Moves[0].WireCommand, Is.EqualTo("tl,30"));
         });

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptVMTests.cs
@@ -1,0 +1,408 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterDevices.Prompt;
+
+[TestFixture]
+public class TiltDeviceAdjustmentPromptVMTests {
+
+    private static TiltAdapterMove Move(TiltMoveAxis axis, int steps, TiltMoveGroup group) =>
+        new TiltAdapterMove(axis, steps, group, $"Test move {axis} {steps}");
+
+    private static TiltAdapterMovePlan MakePlan(
+        IReadOnlyList<TiltAdapterMove> moves = null,
+        double[] residualMicrons = null,
+        double twistResidualSteps = 0.0,
+        double estimatedSeconds = 0.0) =>
+        new TiltAdapterMovePlan(
+            moves ?? Array.Empty<TiltAdapterMove>(),
+            residualMicrons ?? new double[4],
+            twistResidualSteps,
+            estimatedSeconds);
+
+    /// <summary>Replanner test double: records every (includeTilt, includeBackfocus) call and delegates to Produce.</summary>
+    private sealed class RecordingReplanner {
+        public readonly List<(bool IncludeTilt, bool IncludeBackfocus)> Calls = new();
+
+        public Func<bool, bool, TiltDevicePlanPreview> Produce { get; set; } =
+            (_, _) => new TiltDevicePlanPreview(MakePlan(), hardLimitViolated: false, limitWarning: null);
+
+        public TiltDevicePlanPreview Replan(bool includeTilt, bool includeBackfocus) {
+            Calls.Add((includeTilt, includeBackfocus));
+            return Produce(includeTilt, includeBackfocus);
+        }
+    }
+
+    private static TiltDeviceAdjustmentPromptVM BuildVM(
+        RecordingReplanner replanner,
+        bool signMeasured = true,
+        string pitchMismatchWarning = null,
+        bool positionsUnknown = false) =>
+        new TiltDeviceAdjustmentPromptVM(replanner.Replan, signMeasured, pitchMismatchWarning, positionsUnknown);
+
+    [Test]
+    public void Ctor_NullReplanner_Throws() {
+        Assert.Throws<ArgumentNullException>(() => new TiltDeviceAdjustmentPromptVM(null, true, null, false));
+    }
+
+    [Test]
+    public void Ctor_ComputesInitialPreview_WithBothGroupsOn() {
+        var replanner = new RecordingReplanner {
+            Produce = (_, _) => new TiltDevicePlanPreview(
+                MakePlan(
+                    moves: new[] {
+                        Move(TiltMoveAxis.DiagonalA, 150, TiltMoveGroup.Tilt),
+                        Move(TiltMoveAxis.Backfocus, -20, TiltMoveGroup.Backfocus),
+                    },
+                    residualMicrons: new[] { 0.9, -0.9, 0.0, 1.26 },
+                    estimatedSeconds: 20),
+                hardLimitViolated: false,
+                limitWarning: null),
+        };
+        var vm = BuildVM(replanner);
+
+        Assert.Multiple(() => {
+            Assert.That(replanner.Calls, Is.EqualTo(new[] { (true, true) }));
+            Assert.That(vm.ApplyTilt, Is.True);
+            Assert.That(vm.ApplyBackfocus, Is.True);
+            Assert.That(vm.Moves, Has.Count.EqualTo(2));
+            Assert.That(vm.Moves[0].WireCommand, Is.EqualTo("tr,150"));
+            Assert.That(vm.Moves[0].GroupLabel, Is.EqualTo("Tilt"));
+            Assert.That(vm.Moves[1].WireCommand, Is.EqualTo("bf,-20"));
+            Assert.That(vm.Moves[1].GroupLabel, Is.EqualTo("Backfocus"));
+            Assert.That(vm.HasMoves, Is.True);
+            Assert.That(vm.HasNoMoves, Is.False);
+            Assert.That(vm.MoveCountText, Is.EqualTo("2 commands"));
+            Assert.That(vm.EstimatedDurationText, Is.EqualTo("~20 s"));
+            Assert.That(vm.CornerResiduals.Select(r => r.Label), Is.EqualTo(new[] { "Screw 1", "Screw 2", "Screw 3", "Screw 4" }));
+            Assert.That(vm.CornerResiduals.Select(r => r.ValueText), Is.EqualTo(new[] { "+0.9 µm", "-0.9 µm", "0.0 µm", "+1.3 µm" }));
+            Assert.That(vm.ProceedCommand.CanExecute(null), Is.True);
+        });
+    }
+
+    [Test]
+    public void ToggleTiltOff_ReplansWithNewFlags_AndRefreshesMovesResidualsDuration() {
+        var replanner = new RecordingReplanner {
+            Produce = (includeTilt, _) => includeTilt
+                ? new TiltDevicePlanPreview(
+                    MakePlan(
+                        moves: new[] {
+                            Move(TiltMoveAxis.DiagonalB, -25, TiltMoveGroup.Tilt),
+                            Move(TiltMoveAxis.Backfocus, 12, TiltMoveGroup.Backfocus),
+                        },
+                        residualMicrons: new[] { 0.5, 0.5, 0.5, 0.5 },
+                        estimatedSeconds: 20),
+                    false, null)
+                : new TiltDevicePlanPreview(
+                    MakePlan(
+                        moves: new[] { Move(TiltMoveAxis.Backfocus, 12, TiltMoveGroup.Backfocus) },
+                        residualMicrons: new[] { 2.0, -2.0, 2.0, -2.0 },
+                        estimatedSeconds: 10),
+                    false, null),
+        };
+        var vm = BuildVM(replanner);
+        var raised = new List<string>();
+        vm.PropertyChanged += (object s, PropertyChangedEventArgs e) => raised.Add(e.PropertyName);
+
+        vm.ApplyTilt = false;
+
+        Assert.Multiple(() => {
+            Assert.That(replanner.Calls, Is.EqualTo(new[] { (true, true), (false, true) }));
+            Assert.That(vm.Moves, Has.Count.EqualTo(1));
+            Assert.That(vm.Moves[0].WireCommand, Is.EqualTo("bf,12"));
+            Assert.That(vm.MoveCountText, Is.EqualTo("1 command"));
+            Assert.That(vm.EstimatedDurationText, Is.EqualTo("~10 s"));
+            Assert.That(vm.CornerResiduals.Select(r => r.ValueText), Is.EqualTo(new[] { "+2.0 µm", "-2.0 µm", "+2.0 µm", "-2.0 µm" }));
+            Assert.That(raised, Does.Contain(nameof(vm.ApplyTilt)));
+            Assert.That(raised, Does.Contain(nameof(vm.Moves)));
+            Assert.That(raised, Does.Contain(nameof(vm.CornerResiduals)));
+            Assert.That(raised, Does.Contain(nameof(vm.EstimatedDurationText)));
+        });
+    }
+
+    [Test]
+    public void ToggleToSameValue_DoesNotReplan() {
+        var replanner = new RecordingReplanner();
+        var vm = BuildVM(replanner);
+
+        vm.ApplyTilt = true;
+        vm.ApplyBackfocus = true;
+
+        Assert.That(replanner.Calls, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void BothGroupsOff_ProceedDisabled_ReenabledWhenAGroupComesBackOn() {
+        var replanner = new RecordingReplanner();
+        var vm = BuildVM(replanner);
+
+        vm.ApplyTilt = false;
+        vm.ApplyBackfocus = false;
+        Assert.That(vm.ProceedCommand.CanExecute(null), Is.False);
+
+        vm.ApplyBackfocus = true;
+        Assert.That(vm.ProceedCommand.CanExecute(null), Is.True);
+    }
+
+    [Test]
+    public void HardLimitViolated_DisablesProceed_AndSurfacesWarning() {
+        const string warning = "Motor 2 would exceed the configured max excursion (300 steps).";
+        var replanner = new RecordingReplanner {
+            Produce = (_, _) => new TiltDevicePlanPreview(
+                MakePlan(moves: new[] { Move(TiltMoveAxis.DiagonalA, 500, TiltMoveGroup.Tilt) }),
+                hardLimitViolated: true,
+                limitWarning: warning),
+        };
+        var vm = BuildVM(replanner);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.ProceedCommand.CanExecute(null), Is.False);
+            Assert.That(vm.HardLimitViolated, Is.True);
+            Assert.That(vm.HardLimitWarningVisible, Is.True);
+            Assert.That(vm.SoftLimitWarningVisible, Is.False);
+            Assert.That(vm.LimitWarningText, Is.EqualTo(warning));
+        });
+    }
+
+    [Test]
+    public void HardLimitViolated_WithEmptyWarningText_StillShowsFallbackExplanation() {
+        var replanner = new RecordingReplanner {
+            Produce = (_, _) => new TiltDevicePlanPreview(MakePlan(), hardLimitViolated: true, limitWarning: null),
+        };
+        var vm = BuildVM(replanner);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.ProceedCommand.CanExecute(null), Is.False);
+            Assert.That(vm.HardLimitWarningVisible, Is.True);
+            Assert.That(vm.LimitWarningText, Is.Not.Empty);
+        });
+    }
+
+    [Test]
+    public void SoftLimitWarning_ShownWithoutDisablingProceed() {
+        const string warning = "Positions are near the configured excursion limit.";
+        var replanner = new RecordingReplanner {
+            Produce = (_, _) => new TiltDevicePlanPreview(
+                MakePlan(moves: new[] { Move(TiltMoveAxis.DiagonalA, 10, TiltMoveGroup.Tilt) }),
+                hardLimitViolated: false,
+                limitWarning: warning),
+        };
+        var vm = BuildVM(replanner);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.ProceedCommand.CanExecute(null), Is.True);
+            Assert.That(vm.HardLimitWarningVisible, Is.False);
+            Assert.That(vm.SoftLimitWarningVisible, Is.True);
+            Assert.That(vm.LimitWarningText, Is.EqualTo(warning));
+        });
+    }
+
+    [Test]
+    public void HardLimitCleared_ByTogglingAGroupOff_ReenablesProceed() {
+        var replanner = new RecordingReplanner {
+            Produce = (includeTilt, _) => includeTilt
+                ? new TiltDevicePlanPreview(
+                    MakePlan(moves: new[] { Move(TiltMoveAxis.DiagonalA, 500, TiltMoveGroup.Tilt) }),
+                    hardLimitViolated: true,
+                    limitWarning: "Too far.")
+                : new TiltDevicePlanPreview(MakePlan(), hardLimitViolated: false, limitWarning: null),
+        };
+        var vm = BuildVM(replanner);
+        Assert.That(vm.ProceedCommand.CanExecute(null), Is.False);
+
+        vm.ApplyTilt = false;
+
+        Assert.Multiple(() => {
+            Assert.That(vm.ProceedCommand.CanExecute(null), Is.True);
+            Assert.That(vm.HardLimitWarningVisible, Is.False);
+        });
+    }
+
+    [Test]
+    public void Proceed_ResolvesChoice_WithCurrentTogglesAndDisplayedPlan() {
+        var tiltOnlyPlan = MakePlan(moves: new[] { Move(TiltMoveAxis.DiagonalA, 30, TiltMoveGroup.Tilt) });
+        var bothPlan = MakePlan(moves: new[] {
+            Move(TiltMoveAxis.DiagonalA, 30, TiltMoveGroup.Tilt),
+            Move(TiltMoveAxis.Backfocus, 5, TiltMoveGroup.Backfocus),
+        });
+        var replanner = new RecordingReplanner {
+            Produce = (_, includeBackfocus) => new TiltDevicePlanPreview(
+                includeBackfocus ? bothPlan : tiltOnlyPlan, false, null),
+        };
+        var vm = BuildVM(replanner);
+        var closeRaised = 0;
+        vm.RequestClose += (s, e) => closeRaised++;
+
+        vm.ApplyBackfocus = false;
+        vm.ProceedCommand.Execute(null);
+
+        Assert.That(vm.Choice.IsCompleted, Is.True);
+        var choice = vm.Choice.Result;
+        Assert.Multiple(() => {
+            Assert.That(choice.Proceed, Is.True);
+            Assert.That(choice.ApplyTilt, Is.True);
+            Assert.That(choice.ApplyBackfocus, Is.False);
+            Assert.That(choice.FinalPlan, Is.SameAs(tiltOnlyPlan));
+            Assert.That(closeRaised, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void Cancel_ResolvesProceedFalse_AndRaisesRequestClose() {
+        var vm = BuildVM(new RecordingReplanner());
+        var closeRaised = 0;
+        vm.RequestClose += (s, e) => closeRaised++;
+
+        vm.CancelCommand.Execute(null);
+
+        Assert.That(vm.Choice.IsCompleted, Is.True);
+        var choice = vm.Choice.Result;
+        Assert.Multiple(() => {
+            Assert.That(choice.Proceed, Is.False);
+            Assert.That(choice.FinalPlan, Is.Null);
+            Assert.That(closeRaised, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void Dispose_WithoutExplicitPick_ResolvesCancel() {
+        var vm = BuildVM(new RecordingReplanner());
+
+        vm.Dispose();
+
+        Assert.That(vm.Choice.IsCompleted, Is.True);
+        Assert.That(vm.Choice.Result.Proceed, Is.False);
+    }
+
+    [Test]
+    public void Dispose_AfterProceed_KeepsProceedResult() {
+        var vm = BuildVM(new RecordingReplanner());
+
+        vm.ProceedCommand.Execute(null);
+        vm.Dispose();
+
+        Assert.That(vm.Choice.Result.Proceed, Is.True);
+    }
+
+    [TestCase(0.0, false)]
+    [TestCase(0.4, false)]
+    [TestCase(-0.99, false)]
+    [TestCase(1.0, true)]
+    [TestCase(-1.3, true)]
+    public void TwistWarning_VisibleIffAtLeastOneStepOfTwist(double twistSteps, bool expectedVisible) {
+        var replanner = new RecordingReplanner {
+            Produce = (_, _) => new TiltDevicePlanPreview(
+                MakePlan(twistResidualSteps: twistSteps), false, null),
+        };
+        var vm = BuildVM(replanner);
+
+        Assert.That(vm.TwistWarningVisible, Is.EqualTo(expectedVisible));
+        if (expectedVisible) {
+            Assert.That(vm.TwistWarningText, Does.Contain("twist"));
+        }
+    }
+
+    [TestCase(false, true, true)]
+    [TestCase(false, false, false)]
+    [TestCase(true, true, false)]
+    [TestCase(true, false, false)]
+    public void AssumedDirectionWarning_VisibleIffUnmeasuredAndBackfocusMovePresent(
+        bool signMeasured, bool planHasBackfocusMove, bool expectedVisible) {
+        var moves = planHasBackfocusMove
+            ? new[] { Move(TiltMoveAxis.Backfocus, 8, TiltMoveGroup.Backfocus) }
+            : new[] { Move(TiltMoveAxis.DiagonalA, 8, TiltMoveGroup.Tilt) };
+        var replanner = new RecordingReplanner {
+            Produce = (_, _) => new TiltDevicePlanPreview(MakePlan(moves: moves), false, null),
+        };
+        var vm = BuildVM(replanner, signMeasured: signMeasured);
+
+        Assert.That(vm.AssumedDirectionWarningVisible, Is.EqualTo(expectedVisible));
+    }
+
+    [Test]
+    public void AssumedDirectionWarning_ClearsWhenBackfocusToggledOff() {
+        var replanner = new RecordingReplanner {
+            Produce = (_, includeBackfocus) => new TiltDevicePlanPreview(
+                MakePlan(moves: includeBackfocus
+                    ? new[] { Move(TiltMoveAxis.Backfocus, 8, TiltMoveGroup.Backfocus) }
+                    : Array.Empty<TiltAdapterMove>()),
+                false, null),
+        };
+        var vm = BuildVM(replanner, signMeasured: false);
+        Assert.That(vm.AssumedDirectionWarningVisible, Is.True);
+
+        vm.ApplyBackfocus = false;
+
+        Assert.That(vm.AssumedDirectionWarningVisible, Is.False);
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void PositionsUnknownWarning_TracksCtorFlag(bool positionsUnknown) {
+        var vm = BuildVM(new RecordingReplanner(), positionsUnknown: positionsUnknown);
+
+        Assert.That(vm.PositionsUnknownWarningVisible, Is.EqualTo(positionsUnknown));
+    }
+
+    [Test]
+    public void PitchMismatchWarning_ShownIffTextProvided() {
+        const string warning = "Saved step size (1.8 µm/step) differs from the wizard's last measured value (2.4 µm/step).";
+        var withWarning = BuildVM(new RecordingReplanner(), pitchMismatchWarning: warning);
+        var withoutWarning = BuildVM(new RecordingReplanner(), pitchMismatchWarning: null);
+
+        Assert.Multiple(() => {
+            Assert.That(withWarning.PitchMismatchWarningVisible, Is.True);
+            Assert.That(withWarning.PitchMismatchWarning, Is.EqualTo(warning));
+            Assert.That(withoutWarning.PitchMismatchWarningVisible, Is.False);
+        });
+    }
+
+    [Test]
+    public void EmptyPlan_ShowsNoMovesState() {
+        var vm = BuildVM(new RecordingReplanner());
+
+        Assert.Multiple(() => {
+            Assert.That(vm.HasMoves, Is.False);
+            Assert.That(vm.HasNoMoves, Is.True);
+            Assert.That(vm.MoveCountText, Is.EqualTo("No commands"));
+            Assert.That(vm.EstimatedDurationText, Is.EqualTo("0 s"));
+        });
+    }
+
+    [TestCase(0.0, "0 s")]
+    [TestCase(-5.0, "0 s")]
+    [TestCase(9.2, "~10 s")]
+    [TestCase(30.0, "~30 s")]
+    [TestCase(59.0, "~59 s")]
+    [TestCase(59.5, "~1 min")]
+    [TestCase(60.0, "~1 min")]
+    [TestCase(95.0, "~1 min 35 s")]
+    [TestCase(120.0, "~2 min")]
+    public void FormatDuration_IsHumanFriendly_AndRoundsUp(double seconds, string expected) {
+        Assert.That(TiltDeviceAdjustmentPromptVM.FormatDuration(seconds), Is.EqualTo(expected));
+    }
+
+    [TestCase(0.94, "+0.9 µm")]
+    [TestCase(-1.26, "-1.3 µm")]
+    [TestCase(0.0, "0.0 µm")]
+    public void FormatResidualMicrons_IsSignedOneDecimal(double microns, string expected) {
+        Assert.That(TiltDeviceAdjustmentPromptVM.FormatResidualMicrons(microns), Is.EqualTo(expected));
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptVMTests.cs
@@ -405,4 +405,67 @@ public class TiltDeviceAdjustmentPromptVMTests {
     public void FormatResidualMicrons_IsSignedOneDecimal(double microns, string expected) {
         Assert.That(TiltDeviceAdjustmentPromptVM.FormatResidualMicrons(microns), Is.EqualTo(expected));
     }
+
+    [TestCase(TiltMoveAxis.DiagonalA, "Corner")]
+    [TestCase(TiltMoveAxis.DiagonalB, "Corner")]
+    [TestCase(TiltMoveAxis.EdgeVertical, "Side")]
+    [TestCase(TiltMoveAxis.EdgeHorizontal, "Side")]
+    [TestCase(TiltMoveAxis.Backfocus, "Backfocus")]
+    public void BuildMoveKindLabel_MapsAxisToKind(TiltMoveAxis axis, string expected) {
+        Assert.That(TiltDeviceAdjustmentPromptVM.BuildMoveKindLabel(axis), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void BuildSemanticText_CornerMove_ListsBothDiagonalScrewsWithSigns() {
+        var move = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 142, TiltMoveGroup.Tilt, "x");
+        Assert.That(TiltDeviceAdjustmentPromptVM.BuildSemanticText(move),
+            Is.EqualTo("Corner move — Screw 1 +142, Screw 3 -142 steps"));
+    }
+
+    [Test]
+    public void BuildSemanticText_CornerMove_NegativeSteps_FlipsWhichScrewGoesPositive() {
+        // DiagonalA,-142 => PerCornerSteps (-142,0,+142,0): screw 3 positive, screw 1 negative.
+        var move = new TiltAdapterMove(TiltMoveAxis.DiagonalA, -142, TiltMoveGroup.Tilt, "x");
+        Assert.That(TiltDeviceAdjustmentPromptVM.BuildSemanticText(move),
+            Is.EqualTo("Corner move — Screw 3 +142, Screw 1 -142 steps"));
+    }
+
+    [Test]
+    public void BuildSemanticText_SideMove_GroupsTheTwoScrewsMovingTheSameDirection() {
+        // EdgeVertical,+20 => (+1,+1,-1,-1): screws 1 & 2 together, 3 & 4 together the other way.
+        var move = new TiltAdapterMove(TiltMoveAxis.EdgeVertical, 20, TiltMoveGroup.Tilt, "x");
+        Assert.That(TiltDeviceAdjustmentPromptVM.BuildSemanticText(move),
+            Is.EqualTo("Side move — Screws 1 & 2 +20, Screws 3 & 4 -20 steps"));
+    }
+
+    [Test]
+    public void BuildSemanticText_EdgeHorizontal_GroupsScrews1And4() {
+        // EdgeHorizontal,+20 => (+1,-1,-1,+1): screws 1 & 4 together, 2 & 3 the other way.
+        var move = new TiltAdapterMove(TiltMoveAxis.EdgeHorizontal, 20, TiltMoveGroup.Tilt, "x");
+        Assert.That(TiltDeviceAdjustmentPromptVM.BuildSemanticText(move),
+            Is.EqualTo("Side move — Screws 1 & 4 +20, Screws 2 & 3 -20 steps"));
+    }
+
+    [Test]
+    public void BuildSemanticText_Backfocus_SaysAllFourTogether() {
+        var move = new TiltAdapterMove(TiltMoveAxis.Backfocus, 150, TiltMoveGroup.Backfocus, "x");
+        Assert.That(TiltDeviceAdjustmentPromptVM.BuildSemanticText(move),
+            Is.EqualTo("All four screws +150 steps together — changes backfocus (sensor spacing), not tilt."));
+    }
+
+    [Test]
+    public void Moves_ExposeSemanticTextAndKind_ForBinding() {
+        var replanner = new RecordingReplanner {
+            Produce = (_, _) => new TiltDevicePlanPreview(
+                MakePlan(moves: new[] { Move(TiltMoveAxis.DiagonalB, 30, TiltMoveGroup.Tilt) }), false, null),
+        };
+        var vm = BuildVM(replanner);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.Moves[0].MoveKindLabel, Is.EqualTo("Corner"));
+            Assert.That(vm.Moves[0].SemanticText, Is.EqualTo("Corner move — Screw 2 +30, Screw 4 -30 steps"));
+            // The exact wire command is still available (demoted to an auditability chip in the UI).
+            Assert.That(vm.Moves[0].WireCommand, Is.EqualTo("tl,30"));
+        });
+    }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/TiltAdapterMoveTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/TiltAdapterMoveTests.cs
@@ -1,0 +1,220 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterDevices;
+
+[TestFixture]
+public class TiltAdapterMoveTests {
+
+    // The generator table from the design doc's "Core algorithm" section, copied exactly. This is the
+    // correctness anchor for the whole feature: a sign error here means an EEPROM-persisted wrong-way
+    // motor move on real hardware.
+    private static readonly Dictionary<TiltMoveAxis, double[]> ExpectedUnitEffect = new Dictionary<TiltMoveAxis, double[]> {
+        [TiltMoveAxis.DiagonalA] = new double[] { 1, 0, -1, 0 },
+        [TiltMoveAxis.DiagonalB] = new double[] { 0, 1, 0, -1 },
+        [TiltMoveAxis.EdgeVertical] = new double[] { 1, 1, -1, -1 },
+        [TiltMoveAxis.EdgeHorizontal] = new double[] { 1, -1, -1, 1 },
+        [TiltMoveAxis.Backfocus] = new double[] { 1, 1, 1, 1 },
+    };
+
+    private static IEnumerable<TiltMoveAxis> AllAxes => Enum.GetValues(typeof(TiltMoveAxis)).Cast<TiltMoveAxis>();
+
+    [TestCaseSource(nameof(AllAxes))]
+    public void UnitEffect_MatchesGeneratorTableForEveryAxis(TiltMoveAxis axis) {
+        var effect = TiltAdapterMove.UnitEffect(axis);
+        Assert.That(effect, Is.EqualTo(ExpectedUnitEffect[axis]));
+    }
+
+    [TestCaseSource(nameof(AllAxes))]
+    public void PerCornerSteps_PositiveSteps_EqualsUnitEffectTimesSteps(TiltMoveAxis axis) {
+        const int steps = 5;
+        var move = new TiltAdapterMove(axis, steps, TiltMoveGroup.Tilt, "positive test move");
+        var expected = ExpectedUnitEffect[axis].Select(e => e * steps).ToArray();
+        Assert.That(move.PerCornerSteps, Is.EqualTo(expected));
+    }
+
+    [TestCaseSource(nameof(AllAxes))]
+    public void PerCornerSteps_NegativeSteps_EqualsUnitEffectTimesSteps(TiltMoveAxis axis) {
+        const int steps = -3;
+        var move = new TiltAdapterMove(axis, steps, TiltMoveGroup.Tilt, "negative test move");
+        var expected = ExpectedUnitEffect[axis].Select(e => e * steps).ToArray();
+        Assert.That(move.PerCornerSteps, Is.EqualTo(expected));
+    }
+
+    // Explicit worked examples from the plan/design, pinned verbatim as a regression lock in addition to
+    // the generic per-axis loop above.
+    [Test]
+    public void DiagonalA_PlusFive_ProducesDocumentedExample() {
+        var move = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 5, TiltMoveGroup.Tilt, "tr,5");
+        Assert.That(move.PerCornerSteps, Is.EqualTo(new double[] { 5, 0, -5, 0 }));
+    }
+
+    [Test]
+    public void EdgeVertical_MinusThree_ProducesDocumentedExample() {
+        var move = new TiltAdapterMove(TiltMoveAxis.EdgeVertical, -3, TiltMoveGroup.Tilt, "bt,3");
+        Assert.That(move.PerCornerSteps, Is.EqualTo(new double[] { -3, -3, 3, 3 }));
+    }
+
+    [Test]
+    public void Backfocus_PlusTwo_ProducesDocumentedExample() {
+        var move = new TiltAdapterMove(TiltMoveAxis.Backfocus, 2, TiltMoveGroup.Backfocus, "bf,2");
+        Assert.That(move.PerCornerSteps, Is.EqualTo(new double[] { 2, 2, 2, 2 }));
+    }
+
+    [Test]
+    public void Constructor_StoresAxisStepsGroupAndDescription() {
+        var move = new TiltAdapterMove(TiltMoveAxis.EdgeHorizontal, -7, TiltMoveGroup.Tilt, "rt,-7");
+        Assert.Multiple(() => {
+            Assert.That(move.Axis, Is.EqualTo(TiltMoveAxis.EdgeHorizontal));
+            Assert.That(move.Steps, Is.EqualTo(-7));
+            Assert.That(move.Group, Is.EqualTo(TiltMoveGroup.Tilt));
+            Assert.That(move.Description, Is.EqualTo("rt,-7"));
+        });
+    }
+
+    [Test]
+    public void PerCornerSteps_AlwaysHasFourElements() {
+        foreach (var axis in AllAxes) {
+            var move = new TiltAdapterMove(axis, 1, TiltMoveGroup.Tilt, "length check");
+            Assert.That(move.PerCornerSteps, Has.Count.EqualTo(4), $"axis {axis}");
+        }
+    }
+
+    [Test]
+    public void UnitEffect_UnknownAxis_Throws() {
+        Assert.Throws<ArgumentOutOfRangeException>(() => TiltAdapterMove.UnitEffect((TiltMoveAxis)999));
+    }
+
+    // --- Immutability ---
+    //
+    // TiltAdapterMove has no array-valued constructor parameter (PerCornerSteps is always computed
+    // internally from Axis/Steps), so "defensive copy" here means: the returned collections cannot be
+    // mutated by the caller, even via a downcast to a mutable collection interface. This is the property
+    // that actually matters for hardware safety — nothing external can corrupt the generator table or a
+    // move's computed per-corner effect after construction.
+
+    [Test]
+    public void UnitEffect_ReturnedCollection_ThrowsOnMutationAttempt() {
+        var effect = TiltAdapterMove.UnitEffect(TiltMoveAxis.DiagonalA);
+        var asList = effect as IList<double>;
+        Assert.That(asList, Is.Not.Null, "Expected a read-only wrapper implementing IList<double>.");
+        Assert.Throws<NotSupportedException>(() => asList[0] = 999);
+    }
+
+    [Test]
+    public void UnitEffect_CalledTwice_ReturnsTableWithSameValues() {
+        var first = TiltAdapterMove.UnitEffect(TiltMoveAxis.EdgeVertical);
+        var second = TiltAdapterMove.UnitEffect(TiltMoveAxis.EdgeVertical);
+        Assert.That(second, Is.EqualTo(first));
+    }
+
+    [Test]
+    public void PerCornerSteps_ReturnedCollection_ThrowsOnMutationAttempt() {
+        var move = new TiltAdapterMove(TiltMoveAxis.DiagonalB, 4, TiltMoveGroup.Tilt, "mutation test");
+        var asList = move.PerCornerSteps as IList<double>;
+        Assert.That(asList, Is.Not.Null, "Expected a read-only wrapper implementing IList<double>.");
+        Assert.Throws<NotSupportedException>(() => asList[0] = 999);
+    }
+
+    [Test]
+    public void PerCornerSteps_IsNotTheSameReferenceAsUnitEffectTable() {
+        var move = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 1, TiltMoveGroup.Tilt, "reference test");
+        Assert.That(move.PerCornerSteps, Is.Not.SameAs(TiltAdapterMove.UnitEffect(TiltMoveAxis.DiagonalA)));
+    }
+}
+
+[TestFixture]
+public class TiltAdapterMovePlanTests {
+
+    private static TiltAdapterMove[] SampleMoves() => new[] {
+        new TiltAdapterMove(TiltMoveAxis.DiagonalA, 5, TiltMoveGroup.Tilt, "tr,5"),
+        new TiltAdapterMove(TiltMoveAxis.Backfocus, -2, TiltMoveGroup.Backfocus, "bf,-2"),
+    };
+
+    [Test]
+    public void Constructor_StoresAllFieldsIntact() {
+        var moves = SampleMoves();
+        var residuals = new double[] { 0.1, -0.2, 0.3, -0.4 };
+
+        var plan = new TiltAdapterMovePlan(moves, residuals, twistResidualSteps: 1.25, estimatedSeconds: 20.0);
+
+        Assert.Multiple(() => {
+            Assert.That(plan.Moves, Is.EqualTo(moves));
+            Assert.That(plan.ResidualMicronsPerCorner, Is.EqualTo(residuals));
+            Assert.That(plan.TwistResidualSteps, Is.EqualTo(1.25));
+            Assert.That(plan.EstimatedSeconds, Is.EqualTo(20.0));
+        });
+    }
+
+    [Test]
+    public void Constructor_DefensivelyCopiesMoves_SourceArrayMutationDoesNotAffectPlan() {
+        var moves = SampleMoves();
+        var originalFirstMove = moves[0];
+        var replacementMove = new TiltAdapterMove(TiltMoveAxis.DiagonalB, 9, TiltMoveGroup.Tilt, "tl,9");
+        var residuals = new double[] { 0.1, 0.2, 0.3, 0.4 };
+
+        var plan = new TiltAdapterMovePlan(moves, residuals, twistResidualSteps: 0, estimatedSeconds: 10);
+
+        // Mutate the caller's arrays after construction.
+        moves[0] = replacementMove;
+        residuals[0] = 999.0;
+
+        Assert.Multiple(() => {
+            Assert.That(plan.Moves[0], Is.SameAs(originalFirstMove), "Plan's Moves must not reflect post-construction mutation of the source array.");
+            Assert.That(plan.ResidualMicronsPerCorner[0], Is.EqualTo(0.1), "Plan's residuals must not reflect post-construction mutation of the source array.");
+        });
+    }
+
+    [Test]
+    public void Constructor_ReturnedCollections_AreNotTheSameReferenceAsSourceArrays() {
+        var moves = SampleMoves();
+        var residuals = new double[] { 0, 0, 0, 0 };
+
+        var plan = new TiltAdapterMovePlan(moves, residuals, twistResidualSteps: 0, estimatedSeconds: 0);
+
+        Assert.Multiple(() => {
+            Assert.That(plan.Moves, Is.Not.SameAs(moves));
+            Assert.That(plan.ResidualMicronsPerCorner, Is.Not.SameAs(residuals));
+        });
+    }
+
+    [Test]
+    public void Moves_ReturnedCollection_ThrowsOnMutationAttempt() {
+        var plan = new TiltAdapterMovePlan(SampleMoves(), new double[] { 0, 0, 0, 0 }, 0, 0);
+        var asList = plan.Moves as IList<TiltAdapterMove>;
+        Assert.That(asList, Is.Not.Null, "Expected a read-only wrapper implementing IList<TiltAdapterMove>.");
+        Assert.Throws<NotSupportedException>(() => asList[0] = null);
+    }
+
+    [Test]
+    public void ResidualMicronsPerCorner_ReturnedCollection_ThrowsOnMutationAttempt() {
+        var plan = new TiltAdapterMovePlan(SampleMoves(), new double[] { 0, 0, 0, 0 }, 0, 0);
+        var asList = plan.ResidualMicronsPerCorner as IList<double>;
+        Assert.That(asList, Is.Not.Null, "Expected a read-only wrapper implementing IList<double>.");
+        Assert.Throws<NotSupportedException>(() => asList[0] = 999);
+    }
+
+    [Test]
+    public void Constructor_NullCollections_ProduceEmptyReadOnlyCollections() {
+        var plan = new TiltAdapterMovePlan(null, null, twistResidualSteps: 0, estimatedSeconds: 0);
+        Assert.Multiple(() => {
+            Assert.That(plan.Moves, Is.Empty);
+            Assert.That(plan.ResidualMicronsPerCorner, Is.Empty);
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/TiltDeviceConnectionServiceTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/TiltDeviceConnectionServiceTests.cs
@@ -134,6 +134,76 @@ public class TiltDeviceConnectionServiceTests {
         await second.Received(1).ConnectAsync("COM2", Arg.Any<CancellationToken>());
     }
 
+    // --- Simulated-port routing (connect to the camera simulator instead of a serial device) ----------
+
+    private static (TiltDeviceConnectionService service, List<ITiltMotionController> registryControllers, ITiltMotionController simController)
+            BuildWithSimulator() {
+        var profile = Substitute.For<IProfileService>();
+        var options = Substitute.For<ITiltAdapterOptions>();
+        var time = new FakeTiltDeviceTimeSource();
+        var registryControllers = new List<ITiltMotionController>();
+
+        ITiltMotionController Registry(string presetName, ITiltAdapterOptions opts) {
+            var controller = NewControllerSubstitute();
+            registryControllers.Add(controller);
+            return controller;
+        }
+
+        var simController = NewControllerSubstitute();
+        var service = new TiltDeviceConnectionService(profile, options, Registry, time, () => simController);
+        return (service, registryControllers, simController);
+    }
+
+    [Test]
+    public async Task ConnectAsync_SentinelPort_UsesSimulatedFactory_NotRegistry() {
+        var (service, registryControllers, simController) = BuildWithSimulator();
+
+        await service.ConnectAsync("ASG Electronic EAT - 90mm", SimulatedTiltPort.PortName, CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(service.Connected, Is.True);
+            Assert.That(service.Controller, Is.SameAs(simController));
+            Assert.That(registryControllers, Is.Empty, "the serial registry factory must NOT be used for the Simulator port");
+        });
+        await simController.Received(1).ConnectAsync(SimulatedTiltPort.PortName, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ConnectAsync_RealPort_UsesRegistryFactory_NotSimulator() {
+        var (service, registryControllers, simController) = BuildWithSimulator();
+
+        await service.ConnectAsync("ASG Electronic EAT - 90mm", "COM7", CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(service.Controller, Is.SameAs(registryControllers[0]));
+            Assert.That(service.Controller, Is.Not.SameAs(simController));
+        });
+        await registryControllers[0].Received(1).ConnectAsync("COM7", Arg.Any<CancellationToken>());
+    }
+
+    // Documents the inert fallback: a host that wired no simulator factory (every existing caller) treats the
+    // sentinel like any other port name and routes it through the registry -- so existing behavior is unchanged.
+    [Test]
+    public async Task ConnectAsync_SentinelPort_NoSimulatorFactory_FallsBackToRegistry() {
+        var (service, _, _, controllers) = Build();
+
+        await service.ConnectAsync("ASG Electronic EAT - 90mm", SimulatedTiltPort.PortName, CancellationToken.None);
+
+        Assert.That(service.Controller, Is.SameAs(controllers[0]));
+        await controllers[0].Received(1).ConnectAsync(SimulatedTiltPort.PortName, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public void SimulatedTiltPort_IsSimulator_MatchesOnlyTheSentinel() {
+        Assert.Multiple(() => {
+            Assert.That(SimulatedTiltPort.PortName, Is.EqualTo("Simulator"));
+            Assert.That(SimulatedTiltPort.IsSimulator("Simulator"), Is.True);
+            Assert.That(SimulatedTiltPort.IsSimulator("COM3"), Is.False);
+            Assert.That(SimulatedTiltPort.IsSimulator(null), Is.False);
+            Assert.That(SimulatedTiltPort.IsSimulator("simulator"), Is.False, "sentinel match is case-sensitive");
+        });
+    }
+
     // Regression lock (fix #4): if the controller's own ConnectAsync throws AFTER it may have already
     // opened the underlying port, ConnectAsync must best-effort disconnect the controller before rethrowing
     // -- otherwise the COM port is leaked and the NEXT connect attempt fails with "port in use".

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/TiltDeviceConnectionServiceTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/TiltDeviceConnectionServiceTests.cs
@@ -422,6 +422,49 @@ public class TiltDeviceConnectionServiceTests {
         Assert.That(raised, Is.True, "Must resume firing normally once the lease is released and a full idle window elapses.");
     }
 
+    // Regression lock (T9 fix E): EndOperation used to release the lock / clear isOperationActive and only
+    // THEN call RecordUserActivity() -- a timer tick landing in that window (for a lease held past the idle
+    // timeout, e.g. a long T11 calibration run) would see isOperationActive == false together with a STALE
+    // LastActivityUtc and fire one spurious idle-disconnect prompt right as the operation ends. The fix
+    // reorders RecordUserActivity() to run BEFORE isOperationActive is cleared.
+    //
+    // FakeTiltDeviceTimeSource.Advance is single-threaded, so it can't land a tick "in the middle of" a
+    // synchronous method by wall-clock race the way the real Timer could -- but EndOperation raises
+    // PropertyChanged(IsOperationActive) synchronously partway through its own body (AFTER the flag clear in
+    // both the old and new ordering), which gives a precise, deterministic hook: firing a Tick from inside
+    // that notification lands exactly on the boundary the fix moves RecordUserActivity() across, so this
+    // reproduces the bug on the pre-fix ordering and proves it's gone on the fixed ordering.
+    [Test]
+    public async Task EndOperation_TickLandingAsOperationEnds_DoesNotRaiseSpuriousIdlePrompt() {
+        var (service, _, time, _) = Build();
+        await service.ConnectAsync("preset", "COM3", CancellationToken.None);
+
+        // Hold the lease well past the idle timeout (T11-style long calibration run) so LastActivityUtc,
+        // stamped when the lease began, is already stale by the time it ends.
+        var token = service.TryBeginOperation("long calibration");
+        Assert.That(token, Is.Not.Null);
+        time.Advance(TiltDeviceConnectionService.IdleTimeout + TimeSpan.FromMinutes(5));
+
+        bool raised = false;
+        service.IdlePromptRequested += (s, e) => raised = true;
+
+        void OnPropertyChanged(object s, System.ComponentModel.PropertyChangedEventArgs e) {
+            if (e.PropertyName == nameof(TiltDeviceConnectionService.IsOperationActive) && !service.IsOperationActive) {
+                // Zero-delta Advance still fires Tick synchronously at the current (already-past-threshold)
+                // virtual time -- simulating a timer tick landing right here, mid-EndOperation.
+                time.Advance(TimeSpan.Zero);
+            }
+        }
+        service.PropertyChanged += OnPropertyChanged;
+        try {
+            token.Dispose(); // -> EndOperation(), synchronously raising the INPC above partway through.
+        } finally {
+            service.PropertyChanged -= OnPropertyChanged;
+        }
+
+        Assert.That(raised, Is.False, "a tick landing exactly as the operation ends must not see stale activity and fire a spurious idle prompt");
+    }
+
     // Regression lock (fix #1): the idle-prompt check-and-set must be atomic. FakeTiltDeviceTimeSource.Advance
     // is single-threaded, so it cannot itself reproduce the race (a real System.Threading.Timer can re-enter
     // its callback on another pool thread if a previous tick hasn't returned) -- this test instead fires the

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/TiltDeviceConnectionServiceTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/TiltDeviceConnectionServiceTests.cs
@@ -1,0 +1,465 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
+using NINA.Profile.Interfaces;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterDevices;
+
+[TestFixture]
+public class TiltDeviceConnectionServiceTests {
+
+    // Deterministic ITiltDeviceTimeSource test double: UtcNow is a plain settable clock, and Advance()
+    // moves it forward then fires Tick synchronously once — no real Timer, no real wall-clock wait. Because
+    // the service computes due-ness from (now - storedTimestamp) rather than counting ticks, a single big
+    // Advance(30 minutes) and many small Advance(5 seconds) calls both drive the service correctly.
+    private sealed class FakeTiltDeviceTimeSource : ITiltDeviceTimeSource {
+        public DateTimeOffset UtcNow { get; private set; } = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        public event EventHandler Tick;
+
+        public void Advance(TimeSpan delta) {
+            UtcNow += delta;
+            Tick?.Invoke(this, EventArgs.Empty);
+        }
+
+        public void Dispose() {
+        }
+    }
+
+    private static ITiltMotionController NewControllerSubstitute() {
+        var controller = Substitute.For<ITiltMotionController>();
+        controller.ConnectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+        controller.DisconnectAsync(Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+        controller.QueryPositionsAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(TiltDevicePositions.Unknown));
+        return controller;
+    }
+
+    private static (TiltDeviceConnectionService service, IProfileService profile, FakeTiltDeviceTimeSource time, List<ITiltMotionController> createdControllers) Build() {
+        var profile = Substitute.For<IProfileService>();
+        var options = Substitute.For<ITiltAdapterOptions>();
+        var time = new FakeTiltDeviceTimeSource();
+        var createdControllers = new List<ITiltMotionController>();
+
+        ITiltMotionController Factory(string presetName, ITiltAdapterOptions opts) {
+            var controller = NewControllerSubstitute();
+            createdControllers.Add(controller);
+            return controller;
+        }
+
+        var service = new TiltDeviceConnectionService(profile, options, Factory, time);
+        return (service, profile, time, createdControllers);
+    }
+
+    // --- Connect / Disconnect -------------------------------------------------------------------------
+
+    [Test]
+    public async Task ConnectAsync_SetsConnectedAndController_RaisesINPC() {
+        var (service, _, _, controllers) = Build();
+        var raised = new List<string>();
+        service.PropertyChanged += (s, e) => raised.Add(e.PropertyName);
+
+        await service.ConnectAsync("ASG Electronic EAT - 90mm", "COM5", CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(service.Connected, Is.True);
+            Assert.That(service.Controller, Is.SameAs(controllers[0]));
+            Assert.That(raised, Does.Contain(nameof(TiltDeviceConnectionService.Connected)));
+            Assert.That(raised, Does.Contain(nameof(TiltDeviceConnectionService.Controller)));
+        });
+        await controllers[0].Received(1).ConnectAsync("COM5", Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task DisconnectAsync_ClearsConnectedAndController_RaisesINPC() {
+        var (service, _, _, controllers) = Build();
+        await service.ConnectAsync("preset", "COM3", CancellationToken.None);
+
+        var raised = new List<string>();
+        service.PropertyChanged += (s, e) => raised.Add(e.PropertyName);
+
+        await service.DisconnectAsync();
+
+        Assert.Multiple(() => {
+            Assert.That(service.Connected, Is.False);
+            Assert.That(service.Controller, Is.Null);
+            Assert.That(raised, Does.Contain(nameof(TiltDeviceConnectionService.Connected)));
+            Assert.That(raised, Does.Contain(nameof(TiltDeviceConnectionService.Controller)));
+        });
+        await controllers[0].Received(1).DisconnectAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task DisconnectAsync_WhenNotConnected_IsSafeNoOp() {
+        var (service, _, _, _) = Build();
+        Assert.DoesNotThrowAsync(async () => await service.DisconnectAsync());
+        Assert.That(service.Connected, Is.False);
+    }
+
+    // Documented choice: Connect-while-connected tears down the existing controller/session first, then
+    // connects fresh under the newly requested preset/port (rather than no-op-if-same or throwing). This
+    // lets "Connect" double as "reconnect" (e.g. a different COM port) without a separate Disconnect click.
+    [Test]
+    public async Task ConnectAsync_WhileConnected_DisconnectsOldControllerThenReconnects() {
+        var (service, _, _, controllers) = Build();
+        await service.ConnectAsync("preset-a", "COM1", CancellationToken.None);
+        var first = controllers[0];
+
+        await service.ConnectAsync("preset-b", "COM2", CancellationToken.None);
+
+        Assert.That(controllers, Has.Count.EqualTo(2));
+        var second = controllers[1];
+
+        Assert.Multiple(() => {
+            Assert.That(service.Connected, Is.True);
+            Assert.That(service.Controller, Is.SameAs(second));
+        });
+        await first.Received(1).DisconnectAsync(Arg.Any<CancellationToken>());
+        await second.Received(1).ConnectAsync("COM2", Arg.Any<CancellationToken>());
+    }
+
+    // Regression lock (fix #4): if the controller's own ConnectAsync throws AFTER it may have already
+    // opened the underlying port, ConnectAsync must best-effort disconnect the controller before rethrowing
+    // -- otherwise the COM port is leaked and the NEXT connect attempt fails with "port in use".
+    [Test]
+    public async Task ConnectAsync_ControllerConnectThrows_DisconnectsControllerBeforeRethrowing_AndStaysDisconnected() {
+        var profile = Substitute.For<IProfileService>();
+        var options = Substitute.For<ITiltAdapterOptions>();
+        var time = new FakeTiltDeviceTimeSource();
+        var controller = Substitute.For<ITiltMotionController>();
+        controller.ConnectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new InvalidOperationException("port already in use")));
+        controller.DisconnectAsync(Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+
+        var service = new TiltDeviceConnectionService(profile, options, (presetName, opts) => controller, time);
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await service.ConnectAsync("preset", "COM3", CancellationToken.None));
+
+        await controller.Received(1).DisconnectAsync(Arg.Any<CancellationToken>());
+        Assert.That(service.Connected, Is.False);
+    }
+
+    [Test]
+    public void ConnectAsync_ControllerConnectThrows_SecondaryDisconnectErrorIsSwallowed_OriginalThrows() {
+        var profile = Substitute.For<IProfileService>();
+        var options = Substitute.For<ITiltAdapterOptions>();
+        var time = new FakeTiltDeviceTimeSource();
+        var controller = Substitute.For<ITiltMotionController>();
+        controller.ConnectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new InvalidOperationException("original connect failure")));
+        controller.DisconnectAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new Exception("secondary disconnect failure")));
+
+        var service = new TiltDeviceConnectionService(profile, options, (presetName, opts) => controller, time);
+
+        // The ORIGINAL connect failure must be what surfaces to the caller, not the secondary cleanup error.
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await service.ConnectAsync("preset", "COM3", CancellationToken.None));
+        Assert.That(ex.Message, Is.EqualTo("original connect failure"));
+    }
+
+    // --- Operation-token exclusivity -------------------------------------------------------------------
+
+    [Test]
+    public void TryBeginOperation_SecondCallWhileActive_ReturnsNull() {
+        var (service, _, _, _) = Build();
+
+        var first = service.TryBeginOperation("wizard calibration");
+        Assert.That(first, Is.Not.Null);
+        Assert.That(service.IsOperationActive, Is.True);
+
+        var second = service.TryBeginOperation("inspector adjustment");
+        Assert.That(second, Is.Null);
+
+        first.Dispose();
+    }
+
+    [Test]
+    public void TryBeginOperation_DisposeReleases_AllowsNewOperation() {
+        var (service, _, _, _) = Build();
+
+        var first = service.TryBeginOperation("wizard calibration");
+        first.Dispose();
+
+        Assert.That(service.IsOperationActive, Is.False);
+
+        var second = service.TryBeginOperation("inspector adjustment");
+        Assert.That(second, Is.Not.Null);
+        second.Dispose();
+    }
+
+    [Test]
+    public void OperationToken_DoubleDispose_IsSafeAndDoesNotOverReleaseTheLease() {
+        var (service, _, _, _) = Build();
+
+        var token = service.TryBeginOperation("op");
+        token.Dispose();
+        Assert.DoesNotThrow(() => token.Dispose());
+        Assert.That(service.IsOperationActive, Is.False);
+
+        // A second lease must be obtainable exactly once — proves the double Dispose() didn't leave the
+        // underlying hardware lock over-released (which would let two operations be "active" at once).
+        var a = service.TryBeginOperation("a");
+        Assert.That(a, Is.Not.Null);
+        var b = service.TryBeginOperation("b");
+        Assert.That(b, Is.Null);
+        a.Dispose();
+    }
+
+    // --- Profile change ---------------------------------------------------------------------------------
+
+    [Test]
+    public async Task ProfileChanged_ForcesDisconnect() {
+        var (service, profile, _, controllers) = Build();
+        await service.ConnectAsync("preset", "COM3", CancellationToken.None);
+
+        profile.ProfileChanged += Raise.Event<EventHandler>(profile, EventArgs.Empty);
+        await service.LastForcedDisconnectTask;
+
+        Assert.That(service.Connected, Is.False);
+        await controllers[0].Received(1).DisconnectAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ProfileChanged_WhileOperationActive_WaitsForOperationToRelease() {
+        var (service, profile, _, _) = Build();
+        await service.ConnectAsync("preset", "COM3", CancellationToken.None);
+        var token = service.TryBeginOperation("calibration");
+        Assert.That(token, Is.Not.Null);
+
+        profile.ProfileChanged += Raise.Event<EventHandler>(profile, EventArgs.Empty);
+
+        // The forced disconnect must not proceed while the operation lease is held.
+        Assert.That(service.Connected, Is.True, "Must not disconnect mid-operation.");
+
+        token.Dispose();
+        await service.LastForcedDisconnectTask;
+
+        Assert.That(service.Connected, Is.False, "Must disconnect once the operation lease is released.");
+    }
+
+    // --- Position polling --------------------------------------------------------------------------------
+
+    [Test]
+    public async Task Poll_AdvancingPollInterval_QueriesPositionsAndUpdatesState() {
+        var (service, _, time, controllers) = Build();
+        await service.ConnectAsync("preset", "COM3", CancellationToken.None);
+        var controller = controllers[0];
+
+        var known = new TiltDevicePositions(new[] { 10, 20, 30, 40 }, known: true);
+        controller.QueryPositionsAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(known));
+
+        time.Advance(TiltDeviceConnectionService.PollInterval);
+
+        Assert.Multiple(() => {
+            Assert.That(service.PositionsKnown, Is.True);
+            Assert.That(service.CurrentPositions, Is.EqualTo(new[] { 10, 20, 30, 40 }));
+        });
+        await controller.Received(1).QueryPositionsAsync(Arg.Any<CancellationToken>());
+
+        // Flip back to Known == false: PositionsKnown must track the latest poll, not stick at true.
+        controller.QueryPositionsAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(TiltDevicePositions.Unknown));
+        time.Advance(TiltDeviceConnectionService.PollInterval);
+        Assert.That(service.PositionsKnown, Is.False);
+    }
+
+    [Test]
+    public async Task Poll_QueryThrows_SetsPositionsUnknownWithoutCrashingPollLoop() {
+        var (service, _, time, controllers) = Build();
+        await service.ConnectAsync("preset", "COM3", CancellationToken.None);
+        var controller = controllers[0];
+
+        var known = new TiltDevicePositions(new[] { 1, 2, 3, 4 }, known: true);
+        controller.QueryPositionsAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(known));
+        time.Advance(TiltDeviceConnectionService.PollInterval);
+        Assert.That(service.PositionsKnown, Is.True);
+
+        controller.QueryPositionsAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<TiltDevicePositions>(new InvalidOperationException("cp response unparseable")));
+
+        Assert.DoesNotThrow(() => time.Advance(TiltDeviceConnectionService.PollInterval));
+        Assert.That(service.PositionsKnown, Is.False);
+
+        // The poll loop itself must have survived the throw: a subsequent tick still polls normally.
+        controller.QueryPositionsAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(known));
+        time.Advance(TiltDeviceConnectionService.PollInterval);
+        Assert.That(service.PositionsKnown, Is.True);
+    }
+
+    [Test]
+    public async Task Poll_PausesWhileOperationActive_ResumesAfterDispose() {
+        var (service, _, time, controllers) = Build();
+        await service.ConnectAsync("preset", "COM3", CancellationToken.None);
+        var controller = controllers[0];
+        controller.ClearReceivedCalls();
+
+        var token = service.TryBeginOperation("calibration");
+        Assert.That(token, Is.Not.Null);
+
+        time.Advance(TiltDeviceConnectionService.PollInterval);
+        await controller.DidNotReceive().QueryPositionsAsync(Arg.Any<CancellationToken>());
+
+        token.Dispose();
+
+        time.Advance(TiltDeviceConnectionService.PollInterval);
+        await controller.Received(1).QueryPositionsAsync(Arg.Any<CancellationToken>());
+    }
+
+    // --- Idle tracking ------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task Idle_ThirtyMinutesNoActivity_RaisesPromptExactlyOnce() {
+        var (service, _, time, _) = Build();
+        await service.ConnectAsync("preset", "COM3", CancellationToken.None);
+
+        int raiseCount = 0;
+        service.IdlePromptRequested += (s, e) => raiseCount++;
+
+        // Many small (poll-cadence) ticks past the idle threshold; polling happens on every one of them.
+        for (int i = 0; i < 400; i++) { // 400 * 5s = 2000s > 1800s (30 min)
+            time.Advance(TiltDeviceConnectionService.PollInterval);
+        }
+
+        Assert.That(raiseCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Idle_PollingTicksDoNotResetIdleTimer() {
+        var (service, _, time, _) = Build();
+        await service.ConnectAsync("preset", "COM3", CancellationToken.None);
+
+        bool raised = false;
+        service.IdlePromptRequested += (s, e) => raised = true;
+
+        // Advance to just under 30 minutes with a poll-cadence tick (which itself performs a poll). If
+        // polling incorrectly counted as activity, the subsequent small advance would never reach the
+        // (now pushed-out) idle deadline.
+        time.Advance(TiltDeviceConnectionService.IdleTimeout - TimeSpan.FromSeconds(1));
+        Assert.That(raised, Is.False, "Must not fire before the idle timeout elapses.");
+
+        time.Advance(TimeSpan.FromSeconds(2));
+        Assert.That(raised, Is.True, "Must fire once idle timeout elapses, unaffected by intervening polling.");
+    }
+
+    [Test]
+    public async Task KeepConnectedResetIdle_ResetsTimerAndDoesNotDisconnect() {
+        var (service, _, time, _) = Build();
+        await service.ConnectAsync("preset", "COM3", CancellationToken.None);
+
+        int raiseCount = 0;
+        service.IdlePromptRequested += (s, e) => raiseCount++;
+
+        time.Advance(TiltDeviceConnectionService.IdleTimeout);
+        Assert.That(raiseCount, Is.EqualTo(1));
+
+        service.KeepConnectedResetIdle();
+
+        time.Advance(TimeSpan.FromSeconds(1));
+        Assert.That(raiseCount, Is.EqualTo(1), "Must not immediately re-raise after being kept connected.");
+
+        time.Advance(TiltDeviceConnectionService.IdleTimeout);
+        Assert.That(raiseCount, Is.EqualTo(2), "Must re-arm and fire again after a full new idle window.");
+
+        Assert.That(service.Connected, Is.True, "Keep-connected must not disconnect.");
+    }
+
+    [Test]
+    public async Task ConfirmIdleDisconnectAsync_Disconnects() {
+        var (service, _, time, controllers) = Build();
+        await service.ConnectAsync("preset", "COM3", CancellationToken.None);
+
+        time.Advance(TiltDeviceConnectionService.IdleTimeout);
+        Assert.That(service.Connected, Is.True, "The prompt firing must not itself disconnect.");
+
+        await service.ConfirmIdleDisconnectAsync();
+
+        Assert.That(service.Connected, Is.False);
+        await controllers[0].Received(1).DisconnectAsync(Arg.Any<CancellationToken>());
+    }
+
+    // Regression lock (fix #5): T11's hands-off calibration run holds an operation lease for a whole
+    // multi-command plan that can legitimately exceed 30 minutes -- the idle prompt must not fire while it
+    // is held, however far past the threshold virtual time advances.
+    [Test]
+    public async Task Idle_SuppressedWhileOperationActive_EvenWellPastThreshold() {
+        var (service, _, time, _) = Build();
+        await service.ConnectAsync("preset", "COM3", CancellationToken.None);
+
+        var token = service.TryBeginOperation("hands-off calibration");
+        Assert.That(token, Is.Not.Null);
+
+        bool raised = false;
+        service.IdlePromptRequested += (s, e) => raised = true;
+
+        time.Advance(TiltDeviceConnectionService.IdleTimeout + TimeSpan.FromMinutes(10));
+        Assert.That(raised, Is.False, "Idle prompt must be suppressed for the entire duration of an active operation lease.");
+
+        // EndOperation() itself records activity, so releasing the lease resets the idle clock -- a small
+        // subsequent advance must not immediately fire either.
+        token.Dispose();
+        time.Advance(TimeSpan.FromSeconds(1));
+        Assert.That(raised, Is.False, "Releasing the lease resets the idle timer; must not fire immediately.");
+
+        // But a full new idle window after release must still fire normally -- suppression must not be sticky.
+        time.Advance(TiltDeviceConnectionService.IdleTimeout);
+        Assert.That(raised, Is.True, "Must resume firing normally once the lease is released and a full idle window elapses.");
+    }
+
+    // Regression lock (fix #1): the idle-prompt check-and-set must be atomic. FakeTiltDeviceTimeSource.Advance
+    // is single-threaded, so it cannot itself reproduce the race (a real System.Threading.Timer can re-enter
+    // its callback on another pool thread if a previous tick hasn't returned) -- this test instead fires the
+    // SAME Tick event concurrently from many threads once virtual time is already past the idle threshold,
+    // which exercises the exact TOCTOU window (concurrent CheckIdle invocations racing the outstanding-flag
+    // check-and-set) that the fix guards.
+    private sealed class ConcurrentTickTimeSource : ITiltDeviceTimeSource {
+        public DateTimeOffset UtcNow { get; set; }
+        public event EventHandler Tick;
+        public void FireTick() => Tick?.Invoke(this, EventArgs.Empty);
+        public void Dispose() {
+        }
+    }
+
+    [Test]
+    public async Task Idle_ConcurrentTicksPastThreshold_RaisesPromptExactlyOnce() {
+        var profile = Substitute.For<IProfileService>();
+        var options = Substitute.For<ITiltAdapterOptions>();
+        var time = new ConcurrentTickTimeSource { UtcNow = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero) };
+        var service = new TiltDeviceConnectionService(profile, options, (presetName, opts) => NewControllerSubstitute(), time);
+        await service.ConnectAsync("preset", "COM3", CancellationToken.None);
+
+        time.UtcNow += TiltDeviceConnectionService.IdleTimeout + TimeSpan.FromSeconds(1);
+
+        int raiseCount = 0;
+        service.IdlePromptRequested += (s, e) => Interlocked.Increment(ref raiseCount);
+
+        const int concurrency = 8;
+        var barrier = new Barrier(concurrency);
+        var tasks = new Task[concurrency];
+        for (int i = 0; i < concurrency; i++) {
+            tasks[i] = Task.Run(() => {
+                barrier.SignalAndWait();
+                time.FireTick();
+            });
+        }
+        await Task.WhenAll(tasks);
+
+        Assert.That(raiseCount, Is.EqualTo(1));
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/TiltMotionControllerRegistryTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/TiltMotionControllerRegistryTests.cs
@@ -13,7 +13,9 @@
 using System;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterDevices;
@@ -65,13 +67,16 @@ public class TiltMotionControllerRegistryTests {
         Assert.Throws<ArgumentException>(() => TiltMotionControllerRegistry.Create("Not A Real Device", null));
     }
 
-    // The real EatTiltMotionController factory is wired in T7; until then Create() for either EAT preset
-    // must throw NotImplementedException from the placeholder — pinning this makes T7's flip to a real
-    // controller a visible, intended change to this test (it will start failing until updated).
+    // T7 flip: the real EatTiltMotionController factory is now wired for both EAT presets (this test used
+    // to pin the placeholder NotImplementedException prior to T7 -- that placeholder is gone).
     [TestCase("ASG Electronic EAT - 90mm")]
     [TestCase("ASG Electronic EAT - ZWO 461")]
-    public void Create_EatPreset_PlaceholderThrowsNotImplemented(string presetName) {
-        Assert.Throws<NotImplementedException>(() => TiltMotionControllerRegistry.Create(presetName, null));
+    public void Create_EatPreset_ReturnsRealEatTiltMotionController(string presetName) {
+        var options = Substitute.For<ITiltAdapterOptions>();
+
+        var controller = TiltMotionControllerRegistry.Create(presetName, options);
+
+        Assert.That(controller, Is.InstanceOf<EatTiltMotionController>());
     }
 
     [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/TiltMotionControllerRegistryTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/TiltMotionControllerRegistryTests.cs
@@ -1,0 +1,149 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterDevices;
+
+[TestFixture]
+public class TiltMotionControllerRegistryTests {
+
+    [TestCase("ASG Electronic EAT - 90mm")]
+    [TestCase("ASG Electronic EAT - ZWO 461")]
+    public void IsMotorized_TrueForEatPresetNames(string presetName) {
+        Assert.That(TiltMotionControllerRegistry.IsMotorized(presetName), Is.True);
+    }
+
+    [TestCase("Manual")]
+    [TestCase("ASG Photon Cage - 90mm")]
+    [TestCase("Some Unknown Device")]
+    public void IsMotorized_FalseForNonMotorizedOrUnknownNames(string presetName) {
+        Assert.That(TiltMotionControllerRegistry.IsMotorized(presetName), Is.False);
+    }
+
+    [Test]
+    public void IsMotorized_NullName_ReturnsFalse() {
+        Assert.That(TiltMotionControllerRegistry.IsMotorized(null), Is.False);
+    }
+
+    // Invariant guard: any future TiltAdapterDevicePreset with AdjustmentType == StepperMotors MUST be
+    // registered here, and no non-stepper preset may be. This makes it impossible to add a new motorized
+    // preset without also wiring a registry entry (even a placeholder) — forgetting one fails this test.
+    [Test]
+    public void IsMotorized_MatchesStepperMotorsAdjustmentType_ForEveryKnownPreset() {
+        Assert.Multiple(() => {
+            foreach (var preset in TiltAdapterDevicePreset.All) {
+                bool expectedMotorized = preset.AdjustmentType == TiltAdjustmentType.StepperMotors;
+                Assert.That(
+                    TiltMotionControllerRegistry.IsMotorized(preset.Name),
+                    Is.EqualTo(expectedMotorized),
+                    $"Preset \"{preset.Name}\" (AdjustmentType={preset.AdjustmentType}) registry mismatch.");
+            }
+        });
+    }
+
+    [Test]
+    public void Create_UnregisteredName_Throws() {
+        Assert.Throws<ArgumentException>(() => TiltMotionControllerRegistry.Create("Manual", null));
+    }
+
+    [Test]
+    public void Create_UnknownName_Throws() {
+        Assert.Throws<ArgumentException>(() => TiltMotionControllerRegistry.Create("Not A Real Device", null));
+    }
+
+    // The real EatTiltMotionController factory is wired in T7; until then Create() for either EAT preset
+    // must throw NotImplementedException from the placeholder — pinning this makes T7's flip to a real
+    // controller a visible, intended change to this test (it will start failing until updated).
+    [TestCase("ASG Electronic EAT - 90mm")]
+    [TestCase("ASG Electronic EAT - ZWO 461")]
+    public void Create_EatPreset_PlaceholderThrowsNotImplemented(string presetName) {
+        Assert.Throws<NotImplementedException>(() => TiltMotionControllerRegistry.Create(presetName, null));
+    }
+
+    [Test]
+    public void MotorizedPresetNames_ContainsExactlyBothEatPresets() {
+        Assert.That(TiltMotionControllerRegistry.MotorizedPresetNames, Is.EquivalentTo(new[] {
+            "ASG Electronic EAT - 90mm",
+            "ASG Electronic EAT - ZWO 461",
+        }));
+    }
+}
+
+[TestFixture]
+public class TiltDeviceCapabilitiesTests {
+
+    [Test]
+    public void Constructor_StoresTopologyAndFlags() {
+        var caps = new TiltDeviceCapabilities(
+            TiltDeviceTopology.FourCornerCoupled,
+            new[] { TiltMoveAxis.DiagonalA, TiltMoveAxis.Backfocus },
+            supportsPerScrewIndependent: false);
+
+        Assert.Multiple(() => {
+            Assert.That(caps.Topology, Is.EqualTo(TiltDeviceTopology.FourCornerCoupled));
+            Assert.That(caps.SupportedAxes, Is.EqualTo(new[] { TiltMoveAxis.DiagonalA, TiltMoveAxis.Backfocus }));
+            Assert.That(caps.SupportsPerScrewIndependent, Is.False);
+        });
+    }
+
+    [Test]
+    public void Constructor_DefensivelyCopiesAxisList() {
+        var axes = new System.Collections.Generic.List<TiltMoveAxis> { TiltMoveAxis.DiagonalA };
+        var caps = new TiltDeviceCapabilities(TiltDeviceTopology.FourCornerCoupled, axes, false);
+
+        axes.Add(TiltMoveAxis.Backfocus);
+
+        Assert.That(caps.SupportedAxes, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void Constructor_NullAxisList_ProducesEmptyCollection() {
+        var caps = new TiltDeviceCapabilities(TiltDeviceTopology.FourCornerCoupled, null, false);
+        Assert.That(caps.SupportedAxes, Is.Empty);
+    }
+}
+
+[TestFixture]
+public class TiltDevicePositionsTests {
+
+    [Test]
+    public void Constructor_StoresPerMotorStepsAndKnown() {
+        var positions = new TiltDevicePositions(new[] { 1, 2, 3, 4 }, known: true);
+        Assert.Multiple(() => {
+            Assert.That(positions.PerMotorSteps, Is.EqualTo(new[] { 1, 2, 3, 4 }));
+            Assert.That(positions.Known, Is.True);
+        });
+    }
+
+    [Test]
+    public void Constructor_DefensivelyCopiesPerMotorSteps() {
+        var steps = new System.Collections.Generic.List<int> { 1, 2, 3, 4 };
+        var positions = new TiltDevicePositions(steps, known: true);
+
+        steps[0] = 999;
+
+        Assert.That(positions.PerMotorSteps[0], Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Unknown_HasEmptyStepsAndKnownFalse() {
+        Assert.Multiple(() => {
+            Assert.That(TiltDevicePositions.Unknown.Known, Is.False);
+            Assert.That(TiltDevicePositions.Unknown.PerMotorSteps, Is.Empty);
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/TiltMovePlannerTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/TiltMovePlannerTests.cs
@@ -1,0 +1,481 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterDevices;
+
+[TestFixture]
+public class TiltMovePlannerTests {
+
+    // Builds a per-screw target vector s = (s1, s2, s3, s4) from the orthogonal components
+    // (a, b, f, t) via the design doc's reconstruction formulas: s1=a+f+t, s2=b+f-t, s3=-a+f+t,
+    // s4=-b+f-t. Used throughout to construct precise, hand-verifiable test inputs rather than
+    // reverse-engineering s by hand for every case.
+    private static double[] BuildS(double a, double b, double f, double t) =>
+        new[] { a + f + t, b + f - t, -a + f + t, -b + f - t };
+
+    private static readonly Random Rng = new Random(20260714);
+
+    // --- Decompose recovery ---
+
+    [Test]
+    public void Decompose_PureAntisymmetricTilt_RecoversExactAAndB_ZeroFAndT() {
+        var s = new double[] { 6.0, -3.5, -6.0, 3.5 }; // (a, -a-pattern)=(a,b,-a,-b) with a=6, b=-3.5
+
+        var (a, b, f, t) = TiltMovePlanner.Decompose(s);
+
+        Assert.Multiple(() => {
+            Assert.That(a, Is.EqualTo(6.0).Within(1e-12));
+            Assert.That(b, Is.EqualTo(-3.5).Within(1e-12));
+            Assert.That(f, Is.EqualTo(0.0).Within(1e-12));
+            Assert.That(t, Is.EqualTo(0.0).Within(1e-12));
+        });
+    }
+
+    [Test]
+    public void Decompose_Uniform_RecoversFOnly() {
+        var s = new double[] { 7.25, 7.25, 7.25, 7.25 };
+
+        var (a, b, f, t) = TiltMovePlanner.Decompose(s);
+
+        Assert.Multiple(() => {
+            Assert.That(f, Is.EqualTo(7.25).Within(1e-12));
+            Assert.That(a, Is.EqualTo(0.0).Within(1e-12));
+            Assert.That(b, Is.EqualTo(0.0).Within(1e-12));
+            Assert.That(t, Is.EqualTo(0.0).Within(1e-12));
+        });
+    }
+
+    [Test]
+    public void Decompose_BuildSRoundTrips_ForGeneralComponents() {
+        var s = BuildS(a: 2.5, b: -4.25, f: 3.0, t: 0.75);
+
+        var (a, b, f, t) = TiltMovePlanner.Decompose(s);
+
+        Assert.Multiple(() => {
+            Assert.That(a, Is.EqualTo(2.5).Within(1e-12));
+            Assert.That(b, Is.EqualTo(-4.25).Within(1e-12));
+            Assert.That(f, Is.EqualTo(3.0).Within(1e-12));
+            Assert.That(t, Is.EqualTo(0.75).Within(1e-12));
+        });
+    }
+
+    [Test]
+    public void Decompose_WrongLength_Throws() {
+        Assert.Throws<ArgumentException>(() => TiltMovePlanner.Decompose(new double[] { 1, 2, 3 }));
+    }
+
+    [Test]
+    public void Decompose_Null_Throws() {
+        Assert.Throws<ArgumentException>(() => TiltMovePlanner.Decompose(null));
+    }
+
+    // --- RoundToStep ---
+
+    [TestCase(4.6, 5)]
+    [TestCase(5.4, 5)]
+    [TestCase(-4.6, -5)]
+    [TestCase(2.5, 3)]   // ties away from zero, not banker's rounding
+    [TestCase(-2.5, -3)]
+    [TestCase(0.49, 0)]
+    [TestCase(-0.49, 0)]
+    public void RoundToStep_MatchesAwayFromZeroConvention(double value, int expected) {
+        Assert.That(TiltMovePlanner.RoundToStep(value), Is.EqualTo(expected));
+    }
+
+    // --- Single-edge merge vs two-diagonal general case ---
+
+    [Test]
+    public void Plan_RaEqualsRb_ProducesOneEdgeVerticalMove() {
+        // a=4.6, b=5.4 -> ra=5, rb=5 (equal, nonzero) -> ONE EdgeVertical(5) move, not two diagonals.
+        var s = BuildS(a: 4.6, b: 5.4, f: 0, t: 0);
+
+        var plan = TiltMovePlanner.Plan(s, includeTilt: true, includeBackfocus: true, unitMicrons: 1.0);
+
+        Assert.That(plan.Moves, Has.Count.EqualTo(1));
+        var move = plan.Moves[0];
+        Assert.Multiple(() => {
+            Assert.That(move.Axis, Is.EqualTo(TiltMoveAxis.EdgeVertical));
+            Assert.That(move.Steps, Is.EqualTo(5));
+            Assert.That(move.Group, Is.EqualTo(TiltMoveGroup.Tilt));
+        });
+    }
+
+    [Test]
+    public void Plan_RaEqualsNegativeRb_ProducesOneEdgeHorizontalMove() {
+        // a=5, b=-5 -> ra=5, rb=-5 -> ONE EdgeHorizontal(5) move.
+        var s = BuildS(a: 5, b: -5, f: 0, t: 0);
+
+        var plan = TiltMovePlanner.Plan(s, includeTilt: true, includeBackfocus: true, unitMicrons: 1.0);
+
+        Assert.That(plan.Moves, Has.Count.EqualTo(1));
+        var move = plan.Moves[0];
+        Assert.Multiple(() => {
+            Assert.That(move.Axis, Is.EqualTo(TiltMoveAxis.EdgeHorizontal));
+            Assert.That(move.Steps, Is.EqualTo(5));
+            Assert.That(move.Group, Is.EqualTo(TiltMoveGroup.Tilt));
+        });
+    }
+
+    [Test]
+    public void Plan_UnequalNonzeroComponents_ProducesTwoDiagonals_NotForcedIntoOneEdge() {
+        // a=3.4, b=2.4 -> ra=3, rb=2 -> TWO diagonals (never force a common magnitude to save a move).
+        var s = BuildS(a: 3.4, b: 2.4, f: 0, t: 0);
+
+        var plan = TiltMovePlanner.Plan(s, includeTilt: true, includeBackfocus: true, unitMicrons: 1.0);
+
+        Assert.That(plan.Moves, Has.Count.EqualTo(2));
+        Assert.That(plan.Moves.Select(m => m.Axis), Is.EquivalentTo(new[] { TiltMoveAxis.DiagonalA, TiltMoveAxis.DiagonalB }));
+        var diagA = plan.Moves.Single(m => m.Axis == TiltMoveAxis.DiagonalA);
+        var diagB = plan.Moves.Single(m => m.Axis == TiltMoveAxis.DiagonalB);
+        Assert.Multiple(() => {
+            Assert.That(diagA.Steps, Is.EqualTo(3));
+            Assert.That(diagB.Steps, Is.EqualTo(2));
+            Assert.That(diagA.Group, Is.EqualTo(TiltMoveGroup.Tilt));
+            Assert.That(diagB.Group, Is.EqualTo(TiltMoveGroup.Tilt));
+        });
+    }
+
+    [Test]
+    public void Plan_OnlyOneComponentNonzero_ProducesSingleDiagonal() {
+        var sOnlyA = BuildS(a: 4, b: 0, f: 0, t: 0);
+        var sOnlyB = BuildS(a: 0, b: -6, f: 0, t: 0);
+
+        var planA = TiltMovePlanner.Plan(sOnlyA, includeTilt: true, includeBackfocus: true, unitMicrons: 1.0);
+        var planB = TiltMovePlanner.Plan(sOnlyB, includeTilt: true, includeBackfocus: true, unitMicrons: 1.0);
+
+        Assert.Multiple(() => {
+            Assert.That(planA.Moves, Has.Count.EqualTo(1));
+            Assert.That(planA.Moves[0].Axis, Is.EqualTo(TiltMoveAxis.DiagonalA));
+            Assert.That(planA.Moves[0].Steps, Is.EqualTo(4));
+
+            Assert.That(planB.Moves, Has.Count.EqualTo(1));
+            Assert.That(planB.Moves[0].Axis, Is.EqualTo(TiltMoveAxis.DiagonalB));
+            Assert.That(planB.Moves[0].Steps, Is.EqualTo(-6));
+        });
+    }
+
+    // --- Total move count bound (property-style over random inputs) ---
+
+    [Test]
+    public void Plan_TotalMoveCount_NeverExceedsThree_ForRandomInputs() {
+        for (int i = 0; i < 500; ++i) {
+            var s = RandomS(range: 50.0);
+            var plan = TiltMovePlanner.Plan(s, includeTilt: true, includeBackfocus: true, unitMicrons: 1.8);
+            Assert.That(plan.Moves.Count, Is.LessThanOrEqualTo(3), $"Iteration {i}: s=[{string.Join(",", s)}]");
+        }
+    }
+
+    // --- Sub-step targets -> zero moves ---
+
+    [Test]
+    public void Plan_AllComponentsUnderHalfStep_ProducesZeroMoves() {
+        var s = BuildS(a: 0.4, b: -0.3, f: 0.2, t: 0.1);
+
+        var plan = TiltMovePlanner.Plan(s, includeTilt: true, includeBackfocus: true, unitMicrons: 1.0);
+
+        Assert.That(plan.Moves, Is.Empty);
+    }
+
+    // --- Off-center-curvature leakage regression (command-space split guarantee) ---
+
+    [Test]
+    public void Plan_OffCenterCurvatureLeakage_AsymmetricPartLandsInTiltGroup_MeanCapturedByBackfocus() {
+        // Nonzero mean (backfocus) AND an asymmetric linear part (as off-center curvature would
+        // produce): a=2 (leaked linear term), b=0, f=10 (mean/backfocus), t=0.
+        var s = BuildS(a: 2, b: 0, f: 10, t: 0); // s = (12, 10, 8, 10)
+
+        var plan = TiltMovePlanner.Plan(s, includeTilt: true, includeBackfocus: true, unitMicrons: 1.0);
+
+        Assert.That(plan.Moves, Has.Count.EqualTo(2));
+        var tiltMove = plan.Moves.Single(m => m.Group == TiltMoveGroup.Tilt);
+        var bfMove = plan.Moves.Single(m => m.Group == TiltMoveGroup.Backfocus);
+        Assert.Multiple(() => {
+            Assert.That(tiltMove.Axis, Is.EqualTo(TiltMoveAxis.DiagonalA));
+            Assert.That(tiltMove.Steps, Is.EqualTo(2), "The asymmetric leakage term must land in the tilt group, not be dropped.");
+            Assert.That(bfMove.Axis, Is.EqualTo(TiltMoveAxis.Backfocus));
+            Assert.That(bfMove.Steps, Is.EqualTo(10), "The mean must be captured by the backfocus group.");
+        });
+    }
+
+    // --- Residual math ---
+
+    [Test]
+    public void Plan_ResidualMicronsPerCorner_MatchesAppliedMinusTargetTimesUnit_WorkedExample() {
+        // a=4.6, b=5.4, f=0, t=0 -> ra=5, rb=5 -> EdgeVertical(5) -> applied=(5,5,-5,-5).
+        var s = BuildS(a: 4.6, b: 5.4, f: 0, t: 0);
+        const double unitMicrons = 1.8;
+
+        var plan = TiltMovePlanner.Plan(s, includeTilt: true, includeBackfocus: true, unitMicrons: unitMicrons);
+
+        var applied = new double[] { 5, 5, -5, -5 };
+        var expectedResidual = new double[4];
+        for (int i = 0; i < 4; ++i) {
+            expectedResidual[i] = (applied[i] - s[i]) * unitMicrons;
+        }
+
+        Assert.That(plan.ResidualMicronsPerCorner, Is.EqualTo(expectedResidual).Within(1e-9));
+    }
+
+    [Test]
+    public void Plan_TwistOnlyInput_ProducesZeroMoves_ResidualReflectsUnreachableTwist_TwistResidualCarriesT() {
+        const double t = 0.7;
+        var s = new double[] { t, -t, t, -t }; // pure twist, a=b=f=0
+
+        var plan = TiltMovePlanner.Plan(s, includeTilt: true, includeBackfocus: true, unitMicrons: 1.8);
+
+        Assert.Multiple(() => {
+            Assert.That(plan.Moves, Is.Empty, "Twist is never planned; a pure-twist target produces zero moves.");
+            Assert.That(plan.TwistResidualSteps, Is.EqualTo(t).Within(1e-12));
+            for (int i = 0; i < 4; ++i) {
+                Assert.That(plan.ResidualMicronsPerCorner[i], Is.EqualTo((0.0 - s[i]) * 1.8).Within(1e-9), $"corner {i}");
+            }
+        });
+    }
+
+    // --- Twist reported, never planned ---
+
+    [Test]
+    public void Plan_NonzeroTwist_NeverProducesAMoveThatChangesT_AcrossGroupToggles() {
+        var s = BuildS(a: 3, b: -2, f: 4, t: 1.3);
+        var (_, _, _, expectedT) = TiltMovePlanner.Decompose(s);
+
+        var allGroups = TiltMovePlanner.Plan(s, includeTilt: true, includeBackfocus: true, unitMicrons: 1.0);
+        var tiltOnly = TiltMovePlanner.Plan(s, includeTilt: true, includeBackfocus: false, unitMicrons: 1.0);
+        var bfOnly = TiltMovePlanner.Plan(s, includeTilt: false, includeBackfocus: true, unitMicrons: 1.0);
+        var neither = TiltMovePlanner.Plan(s, includeTilt: false, includeBackfocus: false, unitMicrons: 1.0);
+
+        // No move axis (DiagonalA/B, EdgeVertical/Horizontal, Backfocus) has any component of t (all
+        // generators are combinations of a, b, f only — see TiltAdapterMove's unit-effect table), so
+        // TwistResidualSteps must be the same raw t regardless of which groups were applied.
+        Assert.Multiple(() => {
+            Assert.That(allGroups.TwistResidualSteps, Is.EqualTo(expectedT).Within(1e-12));
+            Assert.That(tiltOnly.TwistResidualSteps, Is.EqualTo(expectedT).Within(1e-12));
+            Assert.That(bfOnly.TwistResidualSteps, Is.EqualTo(expectedT).Within(1e-12));
+            Assert.That(neither.TwistResidualSteps, Is.EqualTo(expectedT).Within(1e-12));
+        });
+    }
+
+    // --- Group toggles ---
+
+    [Test]
+    public void Plan_IncludeBackfocusFalse_DropsBfMove_ResidualReflectsUnappliedBackfocus() {
+        var s = BuildS(a: 3, b: 0, f: 5, t: 0); // s = (8, 5, 2, 5)
+
+        var plan = TiltMovePlanner.Plan(s, includeTilt: true, includeBackfocus: false, unitMicrons: 1.0);
+
+        Assert.That(plan.Moves.Any(m => m.Group == TiltMoveGroup.Backfocus), Is.False);
+        Assert.That(plan.Moves, Has.Count.EqualTo(1));
+        Assert.That(plan.Moves[0].Axis, Is.EqualTo(TiltMoveAxis.DiagonalA));
+
+        // applied=(3,0,-3,0); residual = applied - s = (-5,-5,-5,-5) -- the missing backfocus of 5 on every corner.
+        var expected = new double[] { -5, -5, -5, -5 };
+        Assert.That(plan.ResidualMicronsPerCorner, Is.EqualTo(expected).Within(1e-9));
+    }
+
+    [Test]
+    public void Plan_IncludeTiltFalse_DropsDiagonalAndEdgeMoves_ResidualReflectsUnappliedTilt() {
+        var s = BuildS(a: 3, b: 0, f: 5, t: 0); // s = (8, 5, 2, 5)
+
+        var plan = TiltMovePlanner.Plan(s, includeTilt: false, includeBackfocus: true, unitMicrons: 1.0);
+
+        Assert.That(plan.Moves.Any(m => m.Group == TiltMoveGroup.Tilt), Is.False);
+        Assert.That(plan.Moves, Has.Count.EqualTo(1));
+        Assert.That(plan.Moves[0].Axis, Is.EqualTo(TiltMoveAxis.Backfocus));
+
+        // applied=(5,5,5,5); residual = applied - s = (-3,0,3,0) -- the missing DiagonalA of 3.
+        var expected = new double[] { -3, 0, 3, 0 };
+        Assert.That(plan.ResidualMicronsPerCorner, Is.EqualTo(expected).Within(1e-9));
+    }
+
+    [Test]
+    public void Plan_BothGroupsFalse_ProducesZeroMoves_ResidualEqualsNegativeTargetTimesUnit() {
+        var s = BuildS(a: 3, b: -2, f: 5, t: 0.4);
+        const double unitMicrons = 1.8;
+
+        var plan = TiltMovePlanner.Plan(s, includeTilt: false, includeBackfocus: false, unitMicrons: unitMicrons);
+
+        Assert.That(plan.Moves, Is.Empty);
+        for (int i = 0; i < 4; ++i) {
+            Assert.That(plan.ResidualMicronsPerCorner[i], Is.EqualTo(-s[i] * unitMicrons).Within(1e-9), $"corner {i}");
+        }
+    }
+
+    // --- Cap-splitting ---
+
+    [Test]
+    public void SplitStepsForCap_450With200Cap_ProducesThreeChunksSummingCorrectly() {
+        var chunks = TiltMovePlanner.SplitStepsForCap(450, 200);
+
+        Assert.That(chunks, Is.EqualTo(new[] { 200, 200, 50 }));
+        Assert.That(chunks.Sum(), Is.EqualTo(450));
+    }
+
+    [Test]
+    public void SplitStepsForCap_NegativeMagnitude_PreservesSignInEveryChunk() {
+        var chunks = TiltMovePlanner.SplitStepsForCap(-450, 200);
+
+        Assert.That(chunks, Is.EqualTo(new[] { -200, -200, -50 }));
+        Assert.That(chunks.Sum(), Is.EqualTo(-450));
+    }
+
+    [Test]
+    public void SplitStepsForCap_WithinCap_ReturnsSingleUnsplitValue() {
+        var chunks = TiltMovePlanner.SplitStepsForCap(150, 200);
+        Assert.That(chunks, Is.EqualTo(new[] { 150 }));
+    }
+
+    [Test]
+    public void SplitStepsForCap_ZeroOrNegativeCap_Throws() {
+        Assert.Throws<ArgumentOutOfRangeException>(() => TiltMovePlanner.SplitStepsForCap(100, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => TiltMovePlanner.SplitStepsForCap(100, -5));
+    }
+
+    [Test]
+    public void Plan_MoveExceedingCap_SplitsIntoMultipleSameAxisMoves_AfterMinimalDecomposition() {
+        // a=450, b=0, f=0 -> minimal decomposition is ONE DiagonalA(450) move; cap-splitting then
+        // splits that single move into ceil(450/200)=3 same-axis moves: 200, 200, 50.
+        var s = BuildS(a: 450, b: 0, f: 0, t: 0);
+
+        var plan = TiltMovePlanner.Plan(s, includeTilt: true, includeBackfocus: true, unitMicrons: 1.0, maxStepsPerCommand: 200);
+
+        Assert.That(plan.Moves, Has.Count.EqualTo(3));
+        Assert.That(plan.Moves.Select(m => m.Axis), Is.All.EqualTo(TiltMoveAxis.DiagonalA));
+        Assert.That(plan.Moves.Select(m => m.Steps), Is.EqualTo(new[] { 200, 200, 50 }));
+        Assert.That(plan.Moves.Sum(m => m.Steps), Is.EqualTo(450));
+        Assert.That(plan.Moves.Select(m => m.Group), Is.All.EqualTo(TiltMoveGroup.Tilt));
+    }
+
+    [Test]
+    public void Plan_CapSplitting_DoesNotChangeAppliedTotalOrResidual() {
+        var s = BuildS(a: 450, b: 0, f: 0, t: 0);
+        const double unitMicrons = 1.8;
+
+        var uncapped = TiltMovePlanner.Plan(s, includeTilt: true, includeBackfocus: true, unitMicrons: unitMicrons);
+        var capped = TiltMovePlanner.Plan(s, includeTilt: true, includeBackfocus: true, unitMicrons: unitMicrons, maxStepsPerCommand: 200);
+
+        Assert.That(capped.ResidualMicronsPerCorner, Is.EqualTo(uncapped.ResidualMicronsPerCorner).Within(1e-9));
+    }
+
+    [Test]
+    public void Plan_MaxStepsPerCommandLessThanOne_Throws() {
+        var s = BuildS(a: 1, b: 1, f: 1, t: 0);
+        Assert.Throws<ArgumentOutOfRangeException>(() => TiltMovePlanner.Plan(s, true, true, 1.0, maxStepsPerCommand: 0));
+    }
+
+    // --- EstimatedSeconds ---
+
+    [Test]
+    public void Plan_EstimatedSeconds_EqualsMoveCountTimesPerMoveSeconds() {
+        var s = BuildS(a: 450, b: 0, f: 3, t: 0);
+
+        var plan = TiltMovePlanner.Plan(s, includeTilt: true, includeBackfocus: true, unitMicrons: 1.0, maxStepsPerCommand: 200, perMoveSeconds: 12.5);
+
+        Assert.That(plan.EstimatedSeconds, Is.EqualTo(plan.Moves.Count * 12.5).Within(1e-9));
+    }
+
+    // --- Validation ---
+
+    [Test]
+    public void Plan_WrongLengthInput_Throws() {
+        Assert.Throws<ArgumentException>(() => TiltMovePlanner.Plan(new double[] { 1, 2, 3 }, true, true, 1.0));
+    }
+
+    // --- Property-style random check: applied == reconstruction from rounded (ra,rb,rf); residual == (applied-s)*unit ---
+
+    [Test]
+    public void Plan_RandomInputs_AppliedMatchesRoundedReconstruction_AndResidualIsConsistent() {
+        for (int i = 0; i < 500; ++i) {
+            var s = RandomS(range: 30.0);
+            const double unitMicrons = 1.8;
+
+            var plan = TiltMovePlanner.Plan(s, includeTilt: true, includeBackfocus: true, unitMicrons: unitMicrons);
+
+            var (a, b, f, _) = TiltMovePlanner.Decompose(s);
+            int ra = TiltMovePlanner.RoundToStep(a);
+            int rb = TiltMovePlanner.RoundToStep(b);
+            int rf = TiltMovePlanner.RoundToStep(f);
+
+            // Reconstruction from rounded components via the same a/b/f -> corner formula as BuildS
+            // (with t=0, since twist is never applied): applied1=ra+rf, applied2=rb+rf, applied3=-ra+rf, applied4=-rb+rf.
+            var expectedApplied = new double[] { ra + rf, rb + rf, -ra + rf, -rb + rf };
+
+            var actualApplied = new double[4];
+            foreach (var move in plan.Moves) {
+                for (int c = 0; c < 4; ++c) {
+                    actualApplied[c] += move.PerCornerSteps[c];
+                }
+            }
+
+            Assert.That(actualApplied, Is.EqualTo(expectedApplied).Within(1e-9), $"Iteration {i}: s=[{string.Join(",", s)}]");
+
+            for (int c = 0; c < 4; ++c) {
+                double expectedResidual = (expectedApplied[c] - s[c]) * unitMicrons;
+                Assert.That(plan.ResidualMicronsPerCorner[c], Is.EqualTo(expectedResidual).Within(1e-9), $"Iteration {i}, corner {c}");
+            }
+        }
+    }
+
+    private static double[] RandomS(double range) {
+        return new[] {
+            (Rng.NextDouble() * 2 - 1) * range,
+            (Rng.NextDouble() * 2 - 1) * range,
+            (Rng.NextDouble() * 2 - 1) * range,
+            (Rng.NextDouble() * 2 - 1) * range,
+        };
+    }
+}
+
+[TestFixture]
+public class FourCornerCoupledPlannerTests {
+
+    [Test]
+    public void Plan_DelegatesToTiltMovePlanner_ProducesIdenticalResultForSameInputs() {
+        var s = new double[] { 8, 5, 2, 5 };
+        var planner = new FourCornerCoupledPlanner();
+
+        var viaInstance = planner.Plan(s, includeTilt: true, includeBackfocus: true, unitMicrons: 1.8, maxStepsPerCommand: 100, perMoveSeconds: 8);
+        var viaStatic = TiltMovePlanner.Plan(s, includeTilt: true, includeBackfocus: true, unitMicrons: 1.8, maxStepsPerCommand: 100, perMoveSeconds: 8);
+
+        Assert.Multiple(() => {
+            Assert.That(viaInstance.Moves.Select(m => (m.Axis, m.Steps, m.Group)),
+                Is.EqualTo(viaStatic.Moves.Select(m => (m.Axis, m.Steps, m.Group))));
+            Assert.That(viaInstance.ResidualMicronsPerCorner, Is.EqualTo(viaStatic.ResidualMicronsPerCorner));
+            Assert.That(viaInstance.TwistResidualSteps, Is.EqualTo(viaStatic.TwistResidualSteps));
+            Assert.That(viaInstance.EstimatedSeconds, Is.EqualTo(viaStatic.EstimatedSeconds));
+        });
+    }
+
+    [Test]
+    public void Plan_UsesDefaultParameters_WhenNotSpecified() {
+        var s = new double[] { 1, 1, 1, 1 }; // pure backfocus of 1
+        var planner = new FourCornerCoupledPlanner();
+
+        var plan = planner.Plan(s, includeTilt: true, includeBackfocus: true, unitMicrons: 1.0);
+
+        Assert.That(plan.Moves, Has.Count.EqualTo(1));
+        Assert.That(plan.Moves[0].Axis, Is.EqualTo(TiltMoveAxis.Backfocus));
+        Assert.That(plan.Moves[0].Steps, Is.EqualTo(1));
+        Assert.That(plan.EstimatedSeconds, Is.EqualTo(10)); // default perMoveSeconds
+    }
+
+    [Test]
+    public void IsAssignableToInterface() {
+        ITiltMovePlanner planner = new FourCornerCoupledPlanner();
+        Assert.That(planner, Is.Not.Null);
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterDevicePresetTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterDevicePresetTests.cs
@@ -13,6 +13,7 @@ public class TiltAdapterDevicePresetTests {
             Assert.That(TiltAdapterDevicePreset.Manual.IsManual, Is.True);
             Assert.That(TiltAdapterDevicePreset.Manual.Name, Is.EqualTo("Manual"));
             Assert.That(TiltAdapterDevicePreset.All[0], Is.SameAs(TiltAdapterDevicePreset.Manual));
+            Assert.That(TiltAdapterDevicePreset.Manual.DefaultCalibrationAmount, Is.EqualTo(1.0));
         });
     }
 
@@ -25,6 +26,7 @@ public class TiltAdapterDevicePresetTests {
             Assert.That(preset.AdjustmentType, Is.EqualTo(TiltAdjustmentType.Screws));
             Assert.That(preset.ThreadPitchMicrons, Is.EqualTo(400));
             Assert.That(preset.ScrewRadiusMillimeters, Is.EqualTo(44));
+            Assert.That(preset.DefaultCalibrationAmount, Is.EqualTo(1.0));
         });
     }
 
@@ -38,6 +40,7 @@ public class TiltAdapterDevicePresetTests {
             Assert.That(preset.ThreadPitchMicrons, Is.EqualTo(212));
             Assert.That(preset.StepperStepSizeMicrons, Is.EqualTo(-1));
             Assert.That(preset.ScrewRadiusMillimeters, Is.EqualTo(44));
+            Assert.That(preset.DefaultCalibrationAmount, Is.EqualTo(1.0));
         });
     }
 
@@ -51,6 +54,7 @@ public class TiltAdapterDevicePresetTests {
             Assert.That(preset.ThreadPitchMicrons, Is.EqualTo(212));
             Assert.That(preset.StepperStepSizeMicrons, Is.EqualTo(-1));
             Assert.That(preset.ScrewRadiusMillimeters, Is.EqualTo(50));
+            Assert.That(preset.DefaultCalibrationAmount, Is.EqualTo(1.0));
         });
     }
 
@@ -64,6 +68,7 @@ public class TiltAdapterDevicePresetTests {
             Assert.That(preset.ThreadPitchMicrons, Is.EqualTo(-1));
             Assert.That(preset.StepperStepSizeMicrons, Is.EqualTo(1.8));
             Assert.That(preset.ScrewRadiusMillimeters, Is.EqualTo(55));
+            Assert.That(preset.DefaultCalibrationAmount, Is.EqualTo(150));
         });
     }
 
@@ -77,6 +82,7 @@ public class TiltAdapterDevicePresetTests {
             Assert.That(preset.ThreadPitchMicrons, Is.EqualTo(212));
             Assert.That(preset.StepperStepSizeMicrons, Is.EqualTo(-1));
             Assert.That(preset.ScrewRadiusMillimeters, Is.EqualTo(54));
+            Assert.That(preset.DefaultCalibrationAmount, Is.EqualTo(1.0));
         });
     }
 
@@ -90,6 +96,7 @@ public class TiltAdapterDevicePresetTests {
             Assert.That(preset.ThreadPitchMicrons, Is.EqualTo(-1));
             Assert.That(preset.StepperStepSizeMicrons, Is.EqualTo(1.8));
             Assert.That(preset.ScrewRadiusMillimeters, Is.EqualTo(62.75));
+            Assert.That(preset.DefaultCalibrationAmount, Is.EqualTo(150));
         });
     }
 
@@ -162,5 +169,18 @@ public class TiltAdapterDevicePresetTests {
     public void ByName_UnknownFallsBackToManual() {
         Assert.That(TiltAdapterDevicePreset.ByName("does-not-exist"), Is.SameAs(TiltAdapterDevicePreset.Manual));
         Assert.That(TiltAdapterDevicePreset.ByName(null), Is.SameAs(TiltAdapterDevicePreset.Manual));
+    }
+
+    [Test]
+    public void DefaultCalibrationAmount_Is150ForStepperPresetsAnd1ForEveryOtherPreset() {
+        // 150 steps for both ASG Electronic EAT (stepper-motor) presets; 1 full turn for Manual and
+        // every screw-thread preset. Iterates the live All list so a future preset addition is forced
+        // to make an explicit choice rather than silently inheriting a wrong default.
+        Assert.Multiple(() => {
+            foreach (var preset in TiltAdapterDevicePreset.All) {
+                double expected = preset.AdjustmentType == TiltAdjustmentType.StepperMotors ? 150.0 : 1.0;
+                Assert.That(preset.DefaultCalibrationAmount, Is.EqualTo(expected), $"preset '{preset.Name}'");
+            }
+        });
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs
@@ -42,7 +42,7 @@ public class TiltAdapterOptionsTests {
             Assert.That(options.CalibrationIsManual, Is.False);
             Assert.That(options.TiltDeviceSerialPortName, Is.EqualTo(""));
             Assert.That(options.TiltDeviceMaxStepsPerCommand, Is.EqualTo(200));
-            Assert.That(options.TiltDeviceMaxExcursionSteps, Is.EqualTo(500));
+            Assert.That(options.TiltDeviceMaxExcursionSteps, Is.EqualTo(2000));
             Assert.That(options.TiltDeviceSettleSeconds, Is.EqualTo(3.0));
             Assert.That(options.DeviceLinkedCalibrationDeviceName, Is.EqualTo(""));
             Assert.That(options.CalibrationIsReliable, Is.False);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs
@@ -45,6 +45,7 @@ public class TiltAdapterOptionsTests {
             Assert.That(options.TiltDeviceMaxExcursionSteps, Is.EqualTo(500));
             Assert.That(options.TiltDeviceSettleSeconds, Is.EqualTo(3.0));
             Assert.That(options.DeviceLinkedCalibrationDeviceName, Is.EqualTo(""));
+            Assert.That(options.CalibrationIsReliable, Is.False);
             Assert.That(options.TiltDeviceShadowPositions, Is.EqualTo(""));
             Assert.That(options.CalibrationAppliedAmount, Is.EqualTo(-1.0));
         });
@@ -80,6 +81,7 @@ public class TiltAdapterOptionsTests {
         options.TiltDeviceMaxExcursionSteps = 900;
         options.TiltDeviceSettleSeconds = 4.5;
         options.DeviceLinkedCalibrationDeviceName = "ASG Electronic EAT - 90mm";
+        options.CalibrationIsReliable = true;
         options.TiltDeviceShadowPositions = "{\"positions\":[10,20,30,40],\"valid\":true}";
         options.CalibrationAppliedAmount = 150.0;
 
@@ -93,6 +95,7 @@ public class TiltAdapterOptionsTests {
             Assert.That(reloaded.TiltDeviceMaxExcursionSteps, Is.EqualTo(900));
             Assert.That(reloaded.TiltDeviceSettleSeconds, Is.EqualTo(4.5));
             Assert.That(reloaded.DeviceLinkedCalibrationDeviceName, Is.EqualTo("ASG Electronic EAT - 90mm"));
+            Assert.That(reloaded.CalibrationIsReliable, Is.True);
             Assert.That(reloaded.TiltDeviceShadowPositions, Is.EqualTo("{\"positions\":[10,20,30,40],\"valid\":true}"));
             Assert.That(reloaded.CalibrationAppliedAmount, Is.EqualTo(150.0));
         });
@@ -165,6 +168,7 @@ public class TiltAdapterOptionsTests {
     [TestCase(nameof(TiltAdapterOptions.TiltDeviceMaxExcursionSteps), 900)]
     [TestCase(nameof(TiltAdapterOptions.TiltDeviceSettleSeconds), 4.5)]
     [TestCase(nameof(TiltAdapterOptions.DeviceLinkedCalibrationDeviceName), "ASG Electronic EAT - 90mm")]
+    [TestCase(nameof(TiltAdapterOptions.CalibrationIsReliable), true)]
     [TestCase(nameof(TiltAdapterOptions.TiltDeviceShadowPositions), "{\"positions\":[1,2,3,4],\"valid\":true}")]
     [TestCase(nameof(TiltAdapterOptions.CalibrationAppliedAmount), 150.0)]
     public void Setter_RaisesPropertyChanged(string propertyName, object newValue) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs
@@ -40,6 +40,13 @@ public class TiltAdapterOptionsTests {
             Assert.That(options.ScrewInwardCurvatureSignIsMeasured, Is.False);
             Assert.That(options.MeasureCurvatureDuringCalibration, Is.False);
             Assert.That(options.CalibrationIsManual, Is.False);
+            Assert.That(options.TiltDeviceSerialPortName, Is.EqualTo(""));
+            Assert.That(options.TiltDeviceMaxStepsPerCommand, Is.EqualTo(200));
+            Assert.That(options.TiltDeviceMaxExcursionSteps, Is.EqualTo(500));
+            Assert.That(options.TiltDeviceSettleSeconds, Is.EqualTo(3.0));
+            Assert.That(options.DeviceLinkedCalibrationDeviceName, Is.EqualTo(""));
+            Assert.That(options.TiltDeviceShadowPositions, Is.EqualTo(""));
+            Assert.That(options.CalibrationAppliedAmount, Is.EqualTo(-1.0));
         });
     }
 
@@ -63,6 +70,32 @@ public class TiltAdapterOptionsTests {
         store.SetValueInt32(nameof(TiltAdapterOptions.ScrewInwardCurvatureSign), -1);
         var options = new TiltAdapterOptions(profile, store);
         Assert.That(options.ScrewInwardCurvatureSign, Is.EqualTo(-1));
+    }
+
+    [Test]
+    public void TiltDeviceOptions_PersistAndRoundTripThroughNewInstance() {
+        var (options, store, profile) = Build();
+        options.TiltDeviceSerialPortName = "COM5";
+        options.TiltDeviceMaxStepsPerCommand = 75;
+        options.TiltDeviceMaxExcursionSteps = 900;
+        options.TiltDeviceSettleSeconds = 4.5;
+        options.DeviceLinkedCalibrationDeviceName = "ASG Electronic EAT - 90mm";
+        options.TiltDeviceShadowPositions = "{\"positions\":[10,20,30,40],\"valid\":true}";
+        options.CalibrationAppliedAmount = 150.0;
+
+        // Re-read through a brand-new TiltAdapterOptions over the same backing store, confirming the
+        // values actually round-trip through the accessor rather than just being held in memory.
+        var reloaded = new TiltAdapterOptions(profile, store);
+
+        Assert.Multiple(() => {
+            Assert.That(reloaded.TiltDeviceSerialPortName, Is.EqualTo("COM5"));
+            Assert.That(reloaded.TiltDeviceMaxStepsPerCommand, Is.EqualTo(75));
+            Assert.That(reloaded.TiltDeviceMaxExcursionSteps, Is.EqualTo(900));
+            Assert.That(reloaded.TiltDeviceSettleSeconds, Is.EqualTo(4.5));
+            Assert.That(reloaded.DeviceLinkedCalibrationDeviceName, Is.EqualTo("ASG Electronic EAT - 90mm"));
+            Assert.That(reloaded.TiltDeviceShadowPositions, Is.EqualTo("{\"positions\":[10,20,30,40],\"valid\":true}"));
+            Assert.That(reloaded.CalibrationAppliedAmount, Is.EqualTo(150.0));
+        });
     }
 
     [Test]
@@ -127,6 +160,13 @@ public class TiltAdapterOptionsTests {
     [TestCase(nameof(TiltAdapterOptions.StepperStepSizeMicrons), 1.25)]
     [TestCase(nameof(TiltAdapterOptions.ScrewRadiusMillimeters), 21.0)]
     [TestCase(nameof(TiltAdapterOptions.DeviceName), "Neumann CTU XT48")]
+    [TestCase(nameof(TiltAdapterOptions.TiltDeviceSerialPortName), "COM5")]
+    [TestCase(nameof(TiltAdapterOptions.TiltDeviceMaxStepsPerCommand), 75)]
+    [TestCase(nameof(TiltAdapterOptions.TiltDeviceMaxExcursionSteps), 900)]
+    [TestCase(nameof(TiltAdapterOptions.TiltDeviceSettleSeconds), 4.5)]
+    [TestCase(nameof(TiltAdapterOptions.DeviceLinkedCalibrationDeviceName), "ASG Electronic EAT - 90mm")]
+    [TestCase(nameof(TiltAdapterOptions.TiltDeviceShadowPositions), "{\"positions\":[1,2,3,4],\"valid\":true}")]
+    [TestCase(nameof(TiltAdapterOptions.CalibrationAppliedAmount), 150.0)]
     public void Setter_RaisesPropertyChanged(string propertyName, object newValue) {
         var (options, _, _) = Build();
         var raised = new List<string>();

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -8,6 +8,7 @@ using NINA.Image.ImageAnalysis;
 using NINA.Image.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.AutoFocus;
 using NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay;
+using NINA.Joko.Plugins.HocusFocus.CameraSimulator;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
@@ -108,7 +109,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         private static (TiltAdapterWizardVM vm, ITiltAdapterOptions options, TiltDeviceConnectionService service,
             ITiltMotionController controller, FakeTiltDeviceTimeSource time, List<string> requestedPresets)
             BuildMotorized(string deviceName = "ASG Electronic EAT - 90mm",
-                Func<Task<bool>> confirmIdleDisconnectAsync = null, TiltDevicePositions polledPositions = null) {
+                Func<Task<bool>> confirmIdleDisconnectAsync = null, TiltDevicePositions polledPositions = null,
+                ICameraSimulatorOptions cameraSimulatorOptions = null,
+                Func<string, string, Task<bool>> confirmSimConfigChangeAsync = null) {
             var profile = Substitute.For<IProfileService>();
             var options = Substitute.For<ITiltAdapterOptions>();
             options.ScrewCount.Returns(4);
@@ -140,7 +143,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 tiltAdapterOptions: options,
                 tiltDeviceConnectionService: service,
                 serialPortProvider: ports,
-                confirmIdleDisconnectAsync: confirmIdleDisconnectAsync);
+                confirmIdleDisconnectAsync: confirmIdleDisconnectAsync,
+                cameraSimulatorOptions: cameraSimulatorOptions,
+                confirmSimConfigChangeAsync: confirmSimConfigChangeAsync);
             return (vm, options, service, controller, time, requestedPresets);
         }
 
@@ -1263,16 +1268,23 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                     new ReadOnlyCollection<string>(new[] { "COM3", "COM7" }));
             var (vm, _, _, _) = Build(serialPortProvider: ports);
 
-            Assert.That(vm.AvailablePortNames, Is.EqualTo(new[] { "COM3" }));
+            // The simulated adapter is always prepended to the enumerated serial ports.
+            Assert.That(vm.AvailablePortNames, Is.EqualTo(new[] { "Simulator", "COM3" }));
 
             var raised = new List<string>();
             vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
             vm.RefreshPortsCommand.Execute(null);
 
             Assert.Multiple(() => {
-                Assert.That(vm.AvailablePortNames, Is.EqualTo(new[] { "COM3", "COM7" }));
+                Assert.That(vm.AvailablePortNames, Is.EqualTo(new[] { "Simulator", "COM3", "COM7" }));
                 Assert.That(raised, Does.Contain(nameof(vm.AvailablePortNames)));
             });
+        }
+
+        [Test]
+        public void AvailablePortNames_ContainsSimulatorSentinelFirst() {
+            var (vm, _, _, _, _, _) = BuildMotorized();
+            Assert.That(vm.AvailablePortNames, Is.EqualTo(new[] { "Simulator", "COM3", "COM7" }));
         }
 
         [Test]
@@ -1321,6 +1333,147 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 Assert.That(vm.ConnectDeviceCommand.CanExecute(null), Is.False, "already connected");
                 Assert.That(vm.DisconnectDeviceCommand.CanExecute(null), Is.True);
                 Assert.That(vm.TiltDeviceStatusText, Does.Contain("Connected"));
+            });
+        }
+
+        // --- Simulator port: block-until-active gate, config-match prompt, aberration auto-enable -------------
+
+        // A substitute sim-options that matches the "ASG Electronic EAT - 90mm" preset (4 corners, steppers,
+        // 1.8 µm/step, 55 mm radius), aberrations on.
+        private static ICameraSimulatorOptions MatchingSimOptions(bool aberrationsEnabled = true) {
+            var sim = Substitute.For<ICameraSimulatorOptions>();
+            sim.SimScrewCount.Returns(4);
+            sim.SimAdjustmentType.Returns(TiltAdjustmentType.StepperMotors);
+            sim.SimStepperStepSizeMicrons.Returns(1.8);
+            sim.SimScrewRadiusMillimeters.Returns(55.0);
+            sim.EnableAberrations.Returns(aberrationsEnabled);
+            return sim;
+        }
+
+        private static void ActivateSimulatorCamera(TiltAdapterWizardVM vm) =>
+            vm.UpdateDeviceInfo(new CameraInfo { Connected = true, DeviceId = HocusFocusSimulatorCamera.DeviceId });
+
+        private static void ConnectSimulatorPort(TiltAdapterWizardVM vm) {
+            vm.SelectedPortName = SimulatedTiltPort.PortName;
+            ((AsyncRelayCommand)vm.ConnectDeviceCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+        }
+
+        [Test]
+        public void Connect_SimulatorPort_CameraSimulatorNotActive_DoesNotConnect() {
+            var sim = MatchingSimOptions();
+            var (vm, _, service, controller, _, _) = BuildMotorized(cameraSimulatorOptions: sim);
+            // No camera activated -> CameraInfo defaults to not-connected.
+
+            ConnectSimulatorPort(vm);
+
+            Assert.That(service.Connected, Is.False, "must not connect the sim adapter without the sim camera active");
+            controller.DidNotReceive().ConnectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        }
+
+        [Test]
+        public void Connect_SimulatorPort_WrongActiveCamera_DoesNotConnect() {
+            var sim = MatchingSimOptions();
+            var (vm, _, service, controller, _, _) = BuildMotorized(cameraSimulatorOptions: sim);
+            vm.UpdateDeviceInfo(new CameraInfo { Connected = true, DeviceId = "Some.Other.Camera" });
+
+            ConnectSimulatorPort(vm);
+
+            Assert.That(service.Connected, Is.False);
+            controller.DidNotReceive().ConnectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        }
+
+        [Test]
+        public void Connect_SimulatorPort_ConfigMatches_ConnectsWithoutPrompt() {
+            var sim = MatchingSimOptions();
+            var promptCount = 0;
+            var (vm, _, service, controller, _, _) = BuildMotorized(
+                cameraSimulatorOptions: sim,
+                confirmSimConfigChangeAsync: (m, t) => { promptCount++; return Task.FromResult(true); });
+            ActivateSimulatorCamera(vm);
+
+            ConnectSimulatorPort(vm);
+
+            Assert.Multiple(() => {
+                Assert.That(promptCount, Is.EqualTo(0), "matching config must not prompt");
+                Assert.That(service.Connected, Is.True);
+                controller.Received(1).ConnectAsync(SimulatedTiltPort.PortName, Arg.Any<CancellationToken>());
+            });
+        }
+
+        [Test]
+        public void Connect_SimulatorPort_ConfigDiffers_Yes_WritesSimConfigFromPreset_ThenConnects() {
+            var sim = MatchingSimOptions();
+            sim.SimScrewRadiusMillimeters.Returns(40.0); // mismatch vs the 55 mm preset
+            var (vm, _, service, controller, _, _) = BuildMotorized(
+                cameraSimulatorOptions: sim,
+                confirmSimConfigChangeAsync: (m, t) => Task.FromResult(true));
+            ActivateSimulatorCamera(vm);
+
+            ConnectSimulatorPort(vm);
+
+            Assert.Multiple(() => {
+                sim.Received().SimScrewCount = 4;
+                sim.Received().SimAdjustmentType = TiltAdjustmentType.StepperMotors;
+                sim.Received().SimStepperStepSizeMicrons = 1.8;
+                sim.Received().SimScrewRadiusMillimeters = 55.0;
+                Assert.That(service.Connected, Is.True);
+                controller.Received(1).ConnectAsync(SimulatedTiltPort.PortName, Arg.Any<CancellationToken>());
+            });
+        }
+
+        [Test]
+        public void Connect_SimulatorPort_ConfigDiffers_No_DoesNotConnect_NoWrites() {
+            var sim = MatchingSimOptions();
+            sim.SimAdjustmentType.Returns(TiltAdjustmentType.Screws); // mismatch vs the stepper preset
+            var (vm, _, service, controller, _, _) = BuildMotorized(
+                cameraSimulatorOptions: sim,
+                confirmSimConfigChangeAsync: (m, t) => Task.FromResult(false));
+            ActivateSimulatorCamera(vm);
+
+            ConnectSimulatorPort(vm);
+
+            Assert.Multiple(() => {
+                Assert.That(service.Connected, Is.False, "declining the config change must abort the connect");
+                controller.DidNotReceive().ConnectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+                sim.DidNotReceive().SimScrewRadiusMillimeters = Arg.Any<double>();
+                sim.DidNotReceive().SimAdjustmentType = Arg.Any<TiltAdjustmentType>();
+            });
+        }
+
+        [Test]
+        public void Connect_SimulatorPort_AberrationsDisabled_AutoEnablesAndConnects() {
+            var sim = MatchingSimOptions(aberrationsEnabled: false);
+            var (vm, _, service, _, _, _) = BuildMotorized(
+                cameraSimulatorOptions: sim,
+                confirmSimConfigChangeAsync: (m, t) => Task.FromResult(true));
+            ActivateSimulatorCamera(vm);
+
+            ConnectSimulatorPort(vm);
+
+            Assert.Multiple(() => {
+                sim.Received().EnableAberrations = true;
+                Assert.That(service.Connected, Is.True);
+            });
+        }
+
+        [Test]
+        public void Connect_RealPort_NeverChecksSimConfigOrCameraGate() {
+            var sim = MatchingSimOptions();
+            sim.SimScrewRadiusMillimeters.Returns(40.0); // would mismatch, but a real port must not check it
+            var promptCount = 0;
+            var (vm, _, service, controller, _, _) = BuildMotorized(
+                cameraSimulatorOptions: sim,
+                confirmSimConfigChangeAsync: (m, t) => { promptCount++; return Task.FromResult(true); });
+            // Note: no sim camera activated; a real COM port must connect regardless.
+
+            vm.SelectedPortName = "COM7";
+            ((AsyncRelayCommand)vm.ConnectDeviceCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+
+            Assert.Multiple(() => {
+                Assert.That(promptCount, Is.EqualTo(0), "a real COM port must not trigger the sim config prompt");
+                Assert.That(service.Connected, Is.True);
+                controller.Received(1).ConnectAsync("COM7", Arg.Any<CancellationToken>());
+                sim.DidNotReceive().SimScrewRadiusMillimeters = Arg.Any<double>();
             });
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -335,6 +335,122 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             });
         }
 
+        [Test]
+        public void SelectedDevice_EatPreset_SetsCalibrationAppliedAmountTo150Steps() {
+            // The ASG Electronic EAT stepper adapters default the per-screw calibration applied amount
+            // to 150 steps (TiltAdapterDevicePreset.DefaultCalibrationAmount) so the wizard prompts and
+            // any future hands-off automation start from a sane stepper-scale amount, not 1 (a turn-scale
+            // default that would be a no-op-sized move for a stepper motor).
+            var (vm, options, _, _) = Build();
+            // NSubstitute's auto-implemented DeviceName property starts at null; the ctor's own
+            // re-lock-on-load ApplyDevice(null) call resolves that to Manual and already writes
+            // CalibrationAppliedAmount once (null != "Manual", a "device changed" transition). Clear that
+            // call out so Received(1) below proves the write is caused by the user-driven SelectedDevice
+            // assignment below (a genuine Manual -> EAT transition), not the constructor.
+            options.ClearReceivedCalls();
+
+            vm.SelectedDevice = "ASG Electronic EAT - 90mm";
+
+            options.Received(1).CalibrationAppliedAmount = 150.0;
+        }
+
+        [Test]
+        public void SelectedDevice_ScrewPreset_SetsCalibrationAppliedAmountTo1Turn() {
+            var (vm, options, _, _) = Build();
+            // See comment in SelectedDevice_EatPreset_SetsCalibrationAppliedAmountTo150Steps above.
+            options.ClearReceivedCalls();
+
+            vm.SelectedDevice = "Neumann CTU XT48";
+
+            options.Received(1).CalibrationAppliedAmount = 1.0;
+        }
+
+        [Test]
+        public void SelectedDevice_Manual_ResetsCalibrationAppliedAmountTo1Turn() {
+            // Manual's own DefaultCalibrationAmount is 1.0 (screw-scale), so re-selecting Manual after an
+            // EAT preset must reset the applied amount back to 1, not leave a leftover stepper-scale value
+            // (e.g. 150) on screen — unlike ScrewCount/ThreadPitchMicrons/etc., which Manual leaves alone.
+            var (vm, options, _, _) = Build();
+            // NSubstitute's auto-implemented properties remember the LAST value set through the substitute
+            // (ClearReceivedCalls only clears call-verification history, not that remembered state) — and the
+            // ctor's own ApplyDevice(null) call already left DeviceName at "Manual". So a genuine "away from
+            // Manual" transition has to happen first, or "Manual" -> "Manual" below would be a no-op device
+            // change (correctly, per the fix) and never write CalibrationAppliedAmount at all.
+            vm.SelectedDevice = "ASG Electronic EAT - 90mm";
+            options.ClearReceivedCalls();
+
+            vm.SelectedDevice = "Manual";
+
+            options.Received(1).CalibrationAppliedAmount = 1.0;
+        }
+
+        [Test]
+        public void Constructor_ReAppliesPersistedDevice_DoesNotClobberCalibrationAppliedAmount() {
+            // Regression test for the fix: ApplyDevice is called both from the SelectedDevice setter
+            // (genuine user change) AND from the constructor's re-lock-on-load path
+            // (ApplyDevice(tiltAdapterOptions.DeviceName)). Simulate an app restart where the options
+            // store already has an EAT device persisted from a prior session -- the ctor's call
+            // re-asserts that SAME device, so it must NOT be treated as a device change and must not
+            // clobber the persisted CalibrationAppliedAmount with the preset default.
+            var (vm, options, _, _) = Build(
+                screwCount: 4,
+                configureOptions: o => o.DeviceName.Returns("ASG Electronic EAT - 90mm"));
+
+            options.DidNotReceive().CalibrationAppliedAmount = Arg.Any<double>();
+        }
+
+        [Test]
+        public void Constructor_ReAppliesPersistedDevice_PreservesUserEditedCalibrationAppliedAmount_WithRealOptions() {
+            // End-to-end proof using a REAL TiltAdapterOptions backed by InMemoryPluginOptionsAccessor
+            // (not a substitute): a profile that already has an EAT device selected and a user-customized
+            // applied amount (220, not the preset default of 150) must survive VM construction.
+            var profile = Substitute.For<IProfileService>();
+            var store = new InMemoryPluginOptionsAccessor();
+            store.SetValueString(nameof(TiltAdapterOptions.DeviceName), "ASG Electronic EAT - 90mm");
+            store.SetValueDouble(nameof(TiltAdapterOptions.CalibrationAppliedAmount), 220.0);
+            var options = new TiltAdapterOptions(profile, store);
+            var camera = Substitute.For<ICameraMediator>();
+            var focuser = Substitute.For<IFocuserMediator>();
+            var inspector = BuildInspector();
+
+            var vm = new TiltAdapterWizardVM(
+                profileService: profile,
+                applicationStatusMediator: Substitute.For<IApplicationStatusMediator>(),
+                cameraMediator: camera,
+                focuserMediator: focuser,
+                inspector: inspector,
+                applicationDispatcher: new SynchronousApplicationDispatcher(),
+                tiltAdapterOptions: options);
+
+            Assert.Multiple(() => {
+                Assert.That(options.CalibrationAppliedAmount, Is.EqualTo(220.0));
+                Assert.That(vm.CalibrationAppliedAmount, Is.EqualTo(220.0));
+            });
+        }
+
+        [Test]
+        public void CalibrationAppliedAmount_Getter_ResolvesUnsetToPresetDefault() {
+            // -1 (unset) must resolve to the currently-selected preset's DefaultCalibrationAmount.
+            var (vm, _, _, _) = Build(configureOptions: o => {
+                o.DeviceName.Returns("ASG Electronic EAT - 90mm");
+                o.CalibrationAppliedAmount.Returns(-1.0);
+            });
+
+            Assert.That(vm.CalibrationAppliedAmount, Is.EqualTo(150.0));
+        }
+
+        [Test]
+        public void CalibrationAppliedAmount_Getter_ReturnsZeroAsARealValue() {
+            // Boundary check on the getter's "raw >= 0" resolution branch: 0 is a real (if unusual)
+            // persisted value and must be returned as-is, not treated as "unset" like -1 is.
+            var (vm, _, _, _) = Build(configureOptions: o => {
+                o.DeviceName.Returns("Manual");
+                o.CalibrationAppliedAmount.Returns(0.0);
+            });
+
+            Assert.That(vm.CalibrationAppliedAmount, Is.EqualTo(0.0));
+        }
+
         // --- Failure-choice panel (Change 3) ---
 
         [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -1,4 +1,6 @@
+using CommunityToolkit.Mvvm.Input;
 using NINA.Core.Interfaces;
+using NINA.Core.Utility.SerialCommunication;
 using NINA.Equipment.Equipment.MyCamera;
 using NINA.Equipment.Equipment.MyFocuser;
 using NINA.Equipment.Interfaces.Mediator;
@@ -7,6 +9,8 @@ using NINA.Image.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.AutoFocus;
 using NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
 using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
 using NINA.Joko.Plugins.HocusFocus.Utility;
@@ -16,8 +20,10 @@ using NSubstitute;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 // Import just the one type — the StarDetection.Optimization namespace also defines a WizardStep that would
 // collide with TiltAdapterWizard.WizardStep used elsewhere in this fixture.
@@ -51,7 +57,10 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 tiltAdapterOptions: Substitute.For<ITiltAdapterOptions>());
         }
 
-        private static (TiltAdapterWizardVM vm, ITiltAdapterOptions options, ICameraMediator camera, IFocuserMediator focuser) Build(int screwCount = 3, IApplicationDispatcher dispatcher = null, System.Action<ITiltAdapterOptions> configureOptions = null, IProfileService profileService = null) {
+        private static (TiltAdapterWizardVM vm, ITiltAdapterOptions options, ICameraMediator camera, IFocuserMediator focuser) Build(
+            int screwCount = 3, IApplicationDispatcher dispatcher = null, System.Action<ITiltAdapterOptions> configureOptions = null,
+            IProfileService profileService = null, TiltDeviceConnectionService tiltDeviceService = null,
+            ISerialPortProvider serialPortProvider = null, Func<Task<bool>> confirmIdleDisconnectAsync = null) {
             profileService ??= Substitute.For<IProfileService>();
             var camera = Substitute.For<ICameraMediator>();
             var focuser = Substitute.For<IFocuserMediator>();
@@ -67,8 +76,72 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 focuserMediator: focuser,
                 inspector: inspector,
                 applicationDispatcher: dispatcher ?? new SynchronousApplicationDispatcher(),
-                tiltAdapterOptions: options);
+                tiltAdapterOptions: options,
+                tiltDeviceConnectionService: tiltDeviceService,
+                serialPortProvider: serialPortProvider,
+                confirmIdleDisconnectAsync: confirmIdleDisconnectAsync);
             return (vm, options, camera, focuser);
+        }
+
+        // --- Motorized device connection pane (T10) test rig -------------------------------------------------
+
+        // Deterministic ITiltDeviceTimeSource test double (mirrors TiltDeviceConnectionServiceTests): UtcNow is
+        // a plain settable clock and Advance() moves it forward then fires Tick synchronously once — no real
+        // Timer, no wall-clock wait. Advancing 31 minutes drives the service's idle prompt deterministically.
+        private sealed class FakeTiltDeviceTimeSource : ITiltDeviceTimeSource {
+            public DateTimeOffset UtcNow { get; private set; } = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+            public event EventHandler Tick;
+
+            public void Advance(TimeSpan delta) {
+                UtcNow += delta;
+                Tick?.Invoke(this, EventArgs.Empty);
+            }
+
+            public void Dispose() {
+            }
+        }
+
+        // Builds the VM around a REAL TiltDeviceConnectionService driven by a substitute ITiltMotionController
+        // (via the service's internal factory ctor) and a fake time source — the least invasive substitution
+        // seam: no interface extraction or virtuals on the service, production wiring untouched.
+        private static (TiltAdapterWizardVM vm, ITiltAdapterOptions options, TiltDeviceConnectionService service,
+            ITiltMotionController controller, FakeTiltDeviceTimeSource time, List<string> requestedPresets)
+            BuildMotorized(string deviceName = "ASG Electronic EAT - 90mm",
+                Func<Task<bool>> confirmIdleDisconnectAsync = null, TiltDevicePositions polledPositions = null) {
+            var profile = Substitute.For<IProfileService>();
+            var options = Substitute.For<ITiltAdapterOptions>();
+            options.ScrewCount.Returns(4);
+            options.MeasurementAverageCount.Returns(1);
+            options.DeviceName.Returns(deviceName);
+
+            var controller = Substitute.For<ITiltMotionController>();
+            controller.ConnectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+            controller.DisconnectAsync(Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+            controller.QueryPositionsAsync(Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(polledPositions ?? TiltDevicePositions.Unknown));
+
+            var time = new FakeTiltDeviceTimeSource();
+            var requestedPresets = new List<string>();
+            var service = new TiltDeviceConnectionService(profile, options,
+                (presetName, opts) => { requestedPresets.Add(presetName); return controller; }, time);
+
+            var ports = Substitute.For<ISerialPortProvider>();
+            ports.GetPortNames(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>())
+                .Returns(new ReadOnlyCollection<string>(new[] { "COM3", "COM7" }));
+
+            var vm = new TiltAdapterWizardVM(
+                profileService: profile,
+                applicationStatusMediator: Substitute.For<IApplicationStatusMediator>(),
+                cameraMediator: Substitute.For<ICameraMediator>(),
+                focuserMediator: Substitute.For<IFocuserMediator>(),
+                inspector: BuildInspector(),
+                applicationDispatcher: new SynchronousApplicationDispatcher(),
+                tiltAdapterOptions: options,
+                tiltDeviceConnectionService: service,
+                serialPortProvider: ports,
+                confirmIdleDisconnectAsync: confirmIdleDisconnectAsync);
+            return (vm, options, service, controller, time, requestedPresets);
         }
 
         [Test]
@@ -1090,6 +1163,859 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             var result = TiltAdapterWizardVM.BuildTiltReplayDetectionOverride(noPerStepMetadata, metadata);
 
             Assert.That(result, Is.SameAs(fullSnapshot));
+        }
+
+        // --- Motorized device connection pane (T10) ---
+
+        [Test]
+        public void IsMotorizedDevice_TrueForEatPresets_FalseForManualAndScrewPresets() {
+            // Drives the "Motorized Device Connection" GroupBox visibility: it must appear only for
+            // presets with a registered motion controller (the two EAT presets) and disappear for
+            // Manual and every screw preset.
+            var (vmEat, _, _, _) = Build(configureOptions: o => o.DeviceName.Returns("ASG Electronic EAT - 90mm"));
+            var (vmEat461, _, _, _) = Build(configureOptions: o => o.DeviceName.Returns("ASG Electronic EAT - ZWO 461"));
+            var (vmManual, _, _, _) = Build(configureOptions: o => o.DeviceName.Returns("Manual"));
+            var (vmScrew, _, _, _) = Build(configureOptions: o => o.DeviceName.Returns("ASG Photon Cage - 90mm"));
+
+            Assert.Multiple(() => {
+                Assert.That(vmEat.IsMotorizedDevice, Is.True);
+                Assert.That(vmEat461.IsMotorizedDevice, Is.True);
+                Assert.That(vmManual.IsMotorizedDevice, Is.False);
+                Assert.That(vmScrew.IsMotorizedDevice, Is.False);
+            });
+        }
+
+        [Test]
+        public void SelectedDevice_Change_RaisesIsMotorizedDevice() {
+            // The GroupBox visibility binds to IsMotorizedDevice, so switching presets must re-raise it.
+            var (vm, _, _, _) = Build();
+            var raised = new List<string>();
+            vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+            vm.SelectedDevice = "ASG Electronic EAT - 90mm";
+
+            Assert.Multiple(() => {
+                Assert.That(vm.IsMotorizedDevice, Is.True);
+                Assert.That(raised, Does.Contain(nameof(vm.IsMotorizedDevice)));
+            });
+        }
+
+        [Test]
+        public void SelectedPortName_PersistsToOptions() {
+            var (vm, options, _, _) = Build();
+
+            vm.SelectedPortName = "COM7";
+
+            Assert.Multiple(() => {
+                options.Received().TiltDeviceSerialPortName = "COM7";
+                Assert.That(vm.SelectedPortName, Is.EqualTo("COM7"));
+            });
+        }
+
+        // Fix 4 [MINOR]: WPF's ComboBox Selector coerces SelectedItem (and pushes it back through this
+        // two-way binding) to null when the bound value isn't present in AvailablePortNames -- there is no
+        // "no selection" item in this UI, so a null/empty incoming value can only be that coercion, never a
+        // genuine user choice. It must not wipe a remembered, non-empty persisted port.
+        [Test]
+        public void SelectedPortName_NullFromSelectorCoercion_DoesNotWipePersistedPort() {
+            var (vm, options, _, _) = Build(configureOptions: o => o.TiltDeviceSerialPortName.Returns("COM7"));
+
+            vm.SelectedPortName = null;
+
+            Assert.Multiple(() => {
+                Assert.That(vm.SelectedPortName, Is.EqualTo("COM7"), "the persisted port must survive the coercion");
+                options.DidNotReceive().TiltDeviceSerialPortName = Arg.Any<string>();
+            });
+        }
+
+        [Test]
+        public void SelectedPortName_PersistedPortNotInEnumeratedList_SurvivesAndCanStillConnect() {
+            // BuildMotorized's port provider enumerates only COM3/COM7 (see its ctor below); the persisted
+            // port ("COM9") is a device that is currently unplugged -- not among them.
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.TiltDeviceSerialPortName.Returns("COM9");
+            Assert.That(vm.SelectedPortName, Is.EqualTo("COM9"), "precondition: the persisted port loads normally");
+
+            // Simulates the ComboBox's Selector coercing SelectedItem (and pushing it back through the
+            // two-way binding) to null because "COM9" is absent from AvailablePortNames.
+            vm.SelectedPortName = null;
+
+            Assert.Multiple(() => {
+                Assert.That(vm.SelectedPortName, Is.EqualTo("COM9"), "the persisted port must survive the coercion, not be wiped to empty");
+                options.DidNotReceive().TiltDeviceSerialPortName = Arg.Any<string>();
+                Assert.That(vm.ConnectDeviceCommand.CanExecute(null), Is.True, "a surviving persisted port must still allow connecting");
+            });
+
+            ((AsyncRelayCommand)vm.ConnectDeviceCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+
+            Assert.Multiple(() => {
+                Assert.That(service.Connected, Is.True, "connecting must still work against the unlisted persisted port");
+                controller.Received(1).ConnectAsync("COM9", Arg.Any<CancellationToken>());
+            });
+        }
+
+        [Test]
+        public void AvailablePortNames_EnumeratesLazily_AndRefreshReEnumerates() {
+            var ports = Substitute.For<ISerialPortProvider>();
+            ports.GetPortNames(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>())
+                .Returns(
+                    new ReadOnlyCollection<string>(new[] { "COM3" }),
+                    new ReadOnlyCollection<string>(new[] { "COM3", "COM7" }));
+            var (vm, _, _, _) = Build(serialPortProvider: ports);
+
+            Assert.That(vm.AvailablePortNames, Is.EqualTo(new[] { "COM3" }));
+
+            var raised = new List<string>();
+            vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+            vm.RefreshPortsCommand.Execute(null);
+
+            Assert.Multiple(() => {
+                Assert.That(vm.AvailablePortNames, Is.EqualTo(new[] { "COM3", "COM7" }));
+                Assert.That(raised, Does.Contain(nameof(vm.AvailablePortNames)));
+            });
+        }
+
+        [Test]
+        public void ConnectDeviceCommand_CanExecute_RequiresMotorizedAndPortAndNotConnected() {
+            var (vm, _, _, _, _, _) = BuildMotorized();
+
+            // Motorized but no port selected yet.
+            Assert.Multiple(() => {
+                Assert.That(vm.ConnectDeviceCommand.CanExecute(null), Is.False, "no port selected");
+                Assert.That(vm.DisconnectDeviceCommand.CanExecute(null), Is.False, "not connected");
+            });
+
+            vm.SelectedPortName = "COM3";
+            Assert.That(vm.ConnectDeviceCommand.CanExecute(null), Is.True, "motorized + port + not connected");
+        }
+
+        [Test]
+        public void ConnectDeviceCommand_CanExecute_FalseForNonMotorizedDevice() {
+            // Even with a port persisted, Manual/screw presets have no motion controller to connect.
+            var (vm, _, _, _) = Build(configureOptions: o => {
+                o.DeviceName.Returns("Manual");
+                o.TiltDeviceSerialPortName.Returns("COM3");
+            });
+            Assert.That(vm.ConnectDeviceCommand.CanExecute(null), Is.False);
+        }
+
+        // NOTE: the motorized-pane tests below are deliberately synchronous (GetAwaiter().GetResult() over
+        // fakes whose tasks complete inline): ProgressFactory.Create — called by the InspectorVM/wizard VM
+        // constructors — NREs under the SynchronizationContext NUnit installs for async test methods when
+        // Application.Current is null, which is why every other test in this fixture is synchronous too.
+
+        [Test]
+        public void ConnectDeviceCommand_ConnectsThroughService_AndPersistsPort() {
+            var (vm, options, service, controller, _, requestedPresets) = BuildMotorized();
+            vm.SelectedPortName = "COM7";
+
+            ((AsyncRelayCommand)vm.ConnectDeviceCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+
+            Assert.Multiple(() => {
+                Assert.That(service.Connected, Is.True);
+                Assert.That(vm.IsTiltDeviceConnected, Is.True);
+                Assert.That(requestedPresets, Is.EqualTo(new[] { "ASG Electronic EAT - 90mm" }),
+                    "the service must be asked for the selected device preset's controller");
+                controller.Received(1).ConnectAsync("COM7", Arg.Any<CancellationToken>());
+                options.Received().TiltDeviceSerialPortName = "COM7";
+                Assert.That(vm.ConnectDeviceCommand.CanExecute(null), Is.False, "already connected");
+                Assert.That(vm.DisconnectDeviceCommand.CanExecute(null), Is.True);
+                Assert.That(vm.TiltDeviceStatusText, Does.Contain("Connected"));
+            });
+        }
+
+        [Test]
+        public void DisconnectDeviceCommand_DisconnectsThroughService() {
+            var (vm, _, service, controller, _, _) = BuildMotorized();
+            vm.SelectedPortName = "COM3";
+            ((AsyncRelayCommand)vm.ConnectDeviceCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+            Assert.That(service.Connected, Is.True, "precondition");
+
+            ((AsyncRelayCommand)vm.DisconnectDeviceCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+
+            Assert.Multiple(() => {
+                Assert.That(service.Connected, Is.False);
+                Assert.That(vm.IsTiltDeviceConnected, Is.False);
+                controller.Received(1).DisconnectAsync(Arg.Any<CancellationToken>());
+                Assert.That(vm.TiltDeviceStatusText, Does.Contain("Not connected"));
+                Assert.That(vm.DisconnectDeviceCommand.CanExecute(null), Is.False);
+            });
+        }
+
+        [Test]
+        public void IdlePrompt_ConfirmYes_DisconnectsThroughService() {
+            int promptCount = 0;
+            var (vm, _, service, controller, time, _) = BuildMotorized(
+                confirmIdleDisconnectAsync: () => { promptCount++; return Task.FromResult(true); });
+            vm.SelectedPortName = "COM3";
+            ((AsyncRelayCommand)vm.ConnectDeviceCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+            Assert.That(service.Connected, Is.True, "precondition");
+
+            time.Advance(TimeSpan.FromMinutes(31));
+            Assert.That(vm.LastIdlePromptTask, Is.Not.Null, "the idle prompt handler should have run");
+            vm.LastIdlePromptTask.GetAwaiter().GetResult();
+
+            Assert.Multiple(() => {
+                Assert.That(promptCount, Is.EqualTo(1));
+                Assert.That(service.Connected, Is.False, "Yes must route to ConfirmIdleDisconnectAsync (disconnect)");
+                controller.Received(1).DisconnectAsync(Arg.Any<CancellationToken>());
+            });
+        }
+
+        [Test]
+        public void IdlePrompt_ConfirmNo_KeepsConnected_AndResetsIdleTimer() {
+            int promptCount = 0;
+            var (vm, _, service, controller, time, _) = BuildMotorized(
+                confirmIdleDisconnectAsync: () => { promptCount++; return Task.FromResult(false); });
+            vm.SelectedPortName = "COM3";
+            ((AsyncRelayCommand)vm.ConnectDeviceCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+
+            time.Advance(TimeSpan.FromMinutes(31));
+            vm.LastIdlePromptTask.GetAwaiter().GetResult();
+            Assert.Multiple(() => {
+                Assert.That(promptCount, Is.EqualTo(1));
+                Assert.That(service.Connected, Is.True, "No must route to KeepConnectedResetIdle (stay connected)");
+                controller.DidNotReceive().DisconnectAsync(Arg.Any<CancellationToken>());
+            });
+
+            // KeepConnectedResetIdle restarted the 30-minute window: 29 more minutes -> no new prompt...
+            time.Advance(TimeSpan.FromMinutes(29));
+            Assert.That(promptCount, Is.EqualTo(1), "the idle timer must have been reset by the No answer");
+
+            // ...but 31 minutes past the reset the prompt is re-armed and fires again.
+            time.Advance(TimeSpan.FromMinutes(2));
+            vm.LastIdlePromptTask.GetAwaiter().GetResult();
+            Assert.That(promptCount, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void ScrewPositionDisplays_MapDeviceMotorOrderToCorners_AndShowUnknownOtherwise() {
+            // Service positions come in DEVICE motor order: [0]=TR (motor 1), [1]=TL (motor 2),
+            // [2]=BR (motor 3), [3]=BL (motor 4).
+            var polled = new TiltDevicePositions(new[] { 10, 20, 30, 40 }, known: true);
+            var (vm, _, service, _, time, _) = BuildMotorized(polledPositions: polled);
+
+            Assert.That(vm.ScrewPositionTopRightDisplay, Is.EqualTo("unknown"), "positions unknown before connecting");
+
+            vm.SelectedPortName = "COM3";
+            ((AsyncRelayCommand)vm.ConnectDeviceCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+            time.Advance(TimeSpan.FromSeconds(6)); // > PollInterval; the tick polls and applies positions
+
+            Assert.Multiple(() => {
+                Assert.That(service.PositionsKnown, Is.True, "precondition: the poll applied positions");
+                Assert.That(vm.TiltDevicePositionsKnown, Is.True);
+                Assert.That(vm.ScrewPositionTopRightDisplay, Is.EqualTo("10"));
+                Assert.That(vm.ScrewPositionTopLeftDisplay, Is.EqualTo("20"));
+                Assert.That(vm.ScrewPositionBottomRightDisplay, Is.EqualTo("30"));
+                Assert.That(vm.ScrewPositionBottomLeftDisplay, Is.EqualTo("40"));
+            });
+
+            ((AsyncRelayCommand)vm.DisconnectDeviceCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+            Assert.Multiple(() => {
+                Assert.That(vm.TiltDevicePositionsKnown, Is.False);
+                Assert.That(vm.ScrewPositionTopLeftDisplay, Is.EqualTo("unknown"), "positions reset to unknown on disconnect");
+            });
+        }
+
+        // --- T11: hands-off device-driven calibration ---------------------------------------------------------
+        // All tests below are deliberately synchronous (.GetAwaiter().GetResult()) — see the note above
+        // ConnectDeviceCommand_ConnectsThroughService_AndPersistsPort for why (ProgressFactory.Create NREs
+        // under NUnit's async SynchronizationContext).
+
+        private static void Connect(TiltAdapterWizardVM vm, string port = "COM3") {
+            vm.SelectedPortName = port;
+            ((AsyncRelayCommand)vm.ConnectDeviceCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+        }
+
+        private static void StubSuccessfulMoves(ITiltMotionController controller) {
+            controller.ExecuteMoveAsync(Arg.Any<TiltAdapterMove>(), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>())
+                .Returns(Task.CompletedTask);
+        }
+
+        // Mirrors the seed values the existing 6-step SeedStepReading tests use (e.g. RunCalibrationForTest
+        // regression tests below Constructor_Re...): a distinct, non-degenerate reading per step so
+        // RunCalibrationMath's angle/hardware-recovery math has real signal instead of an all-zero diff.
+        private static Func<WizardStep, CancellationToken, Task<bool>> SeedingMeasurementOverride(TiltAdapterWizardVM vm) {
+            var readings = new Dictionary<WizardStep, (double a, double b, double mean)> {
+                [WizardStep.Baseline] = (0.0, 0.0, 1000.0),
+                [WizardStep.AllInward] = (0.0, 0.0, 1010.0),
+                [WizardStep.ReBaseline1] = (0.0, 0.0, 1000.0),
+                [WizardStep.Screw1] = (0.5, 0.0, 1000.0),
+                [WizardStep.ReBaseline2] = (0.0, 0.0, 1000.0),
+                [WizardStep.Screw2] = (-0.25, 0.433, 1000.0),
+            };
+            return (step, ct) => {
+                var (a, b, mean) = readings[step];
+                vm.SeedStepReading(step, a, b, mean);
+                return Task.FromResult(true);
+            };
+        }
+
+        [TestCase(WizardStep.AllInward, TiltMoveAxis.Backfocus, 150)]
+        [TestCase(WizardStep.ReBaseline1, TiltMoveAxis.Backfocus, -150)]
+        [TestCase(WizardStep.Screw1, TiltMoveAxis.DiagonalA, 150)]
+        [TestCase(WizardStep.ReBaseline2, TiltMoveAxis.DiagonalA, -150)]
+        [TestCase(WizardStep.Screw2, TiltMoveAxis.DiagonalB, 150)]
+        [TestCase(WizardStep.Complete, TiltMoveAxis.DiagonalB, -150)]
+        public void ExecuteDeviceMoveForCurrentStepAsync_EachStep_SendsExpectedMove(WizardStep step, TiltMoveAxis expectedAxis, int expectedSteps) {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            StubSuccessfulMoves(controller);
+            Connect(vm);
+
+            bool result = vm.ExecuteDeviceMoveForCurrentStepAsync(step, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.Multiple(() => {
+                Assert.That(result, Is.True);
+                controller.Received(1).ExecuteMoveAsync(
+                    Arg.Is<TiltAdapterMove>(m => m.Axis == expectedAxis && m.Steps == expectedSteps),
+                    Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+            });
+        }
+
+        [Test]
+        public void ExecuteDeviceMoveForCurrentStepAsync_Baseline_IsNoOp_AndControllerUntouched() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            Connect(vm);
+
+            bool result = vm.ExecuteDeviceMoveForCurrentStepAsync(WizardStep.Baseline, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.Multiple(() => {
+                Assert.That(result, Is.True);
+                controller.DidNotReceive().ExecuteMoveAsync(Arg.Any<TiltAdapterMove>(), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+            });
+        }
+
+        [Test]
+        public void ExecuteDeviceMoveForCurrentStepAsync_ControllerThrows_SendsInverseRecovery_AndSurfacesFailure() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            Connect(vm);
+            controller.ExecuteMoveAsync(
+                    Arg.Is<TiltAdapterMove>(m => m.Axis == TiltMoveAxis.DiagonalA && m.Steps == 150),
+                    Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>())
+                .Returns<Task>(x => throw new InvalidOperationException("boom"));
+            controller.ExecuteMoveAsync(
+                    Arg.Is<TiltAdapterMove>(m => m.Axis == TiltMoveAxis.DiagonalA && m.Steps == -150),
+                    Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>())
+                .Returns(Task.CompletedTask);
+
+            bool result = vm.ExecuteDeviceMoveForCurrentStepAsync(WizardStep.Screw1, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.Multiple(() => {
+                Assert.That(result, Is.False);
+                controller.Received(1).ExecuteMoveAsync(
+                    Arg.Is<TiltAdapterMove>(m => m.Axis == TiltMoveAxis.DiagonalA && m.Steps == -150),
+                    Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+                Assert.That(vm.HasMeasurementFailureChoice, Is.True);
+                Assert.That(vm.MeasurementFailureText, Does.Contain("boom"));
+            });
+        }
+
+        [Test]
+        public void ExecuteDeviceMoveForCurrentStepAsync_LimitException_DoesNotSendSpuriousInverse() {
+            // TiltDeviceLimitException means NOTHING was sent (every soft-limit check runs before any device
+            // I/O) — sending an inverse here would be a spurious, physically real move for a step that never
+            // happened. See EatTiltMotionController.ExecuteMoveAsync's documented exception taxonomy.
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            Connect(vm);
+            controller.ExecuteMoveAsync(Arg.Any<TiltAdapterMove>(), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>())
+                .Returns<Task>(x => throw new TiltDeviceLimitException("refused"));
+
+            bool result = vm.ExecuteDeviceMoveForCurrentStepAsync(WizardStep.Screw1, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.Multiple(() => {
+                Assert.That(result, Is.False);
+                // Exactly one call total: the failed attempt itself, and no recovery/inverse call.
+                controller.Received(1).ExecuteMoveAsync(Arg.Any<TiltAdapterMove>(), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+                Assert.That(vm.HasMeasurementFailureChoice, Is.True);
+                Assert.That(vm.MeasurementFailureText, Does.Contain("Nothing was sent"));
+            });
+        }
+
+        [Test]
+        public void AutoRunAllCommand_CanExecute_RequiresConnectedMotorizedAndValidAppliedAmount() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            Assert.That(vm.AutoRunAllCommand.CanExecute(null), Is.False, "not connected, and applied amount unset (NSubstitute double default 0)");
+
+            options.CalibrationAppliedAmount.Returns(150.0);
+            Connect(vm);
+            Assert.That(vm.AutoRunAllCommand.CanExecute(null), Is.True, "connected + motorized + valid applied amount");
+        }
+
+        [Test]
+        public void AutoRunAll_FourStepFlow_WalksSequence_IncludingCompleteRestoreMove_AndSetsDeviceLinkedMarker() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            StubSuccessfulMoves(controller);
+            Connect(vm);
+            // Connecting defaults this ON (T11 item 4); re-assert false AFTER connecting, so StartAsync (read
+            // fresh at Start) resolves the 4-step flow this test exercises.
+            options.MeasureCurvatureDuringCalibration.Returns(false);
+            vm.MeasurementStepOverrideForTest = SeedingMeasurementOverride(vm);
+
+            ((AsyncRelayCommand)vm.AutoRunAllCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+
+            Assert.Multiple(() => {
+                Assert.That(vm.IsComplete, Is.True);
+                Received.InOrder(() => {
+                    controller.ExecuteMoveAsync(Arg.Is<TiltAdapterMove>(m => m.Axis == TiltMoveAxis.DiagonalA && m.Steps == 150), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+                    controller.ExecuteMoveAsync(Arg.Is<TiltAdapterMove>(m => m.Axis == TiltMoveAxis.DiagonalA && m.Steps == -150), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+                    controller.ExecuteMoveAsync(Arg.Is<TiltAdapterMove>(m => m.Axis == TiltMoveAxis.DiagonalB && m.Steps == 150), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+                    controller.ExecuteMoveAsync(Arg.Is<TiltAdapterMove>(m => m.Axis == TiltMoveAxis.DiagonalB && m.Steps == -150), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+                });
+                options.Received(1).DeviceLinkedCalibrationDeviceName = "ASG Electronic EAT - 90mm";
+            });
+        }
+
+        [Test]
+        public void AutoRunAll_SixStepFlow_WalksFullSequence_IncludingCurvatureSteps() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            options.MeasureCurvatureDuringCalibration.Returns(true); // 6-step flow
+            StubSuccessfulMoves(controller);
+            Connect(vm);
+            vm.MeasurementStepOverrideForTest = SeedingMeasurementOverride(vm);
+
+            ((AsyncRelayCommand)vm.AutoRunAllCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+
+            Assert.Multiple(() => {
+                Assert.That(vm.IsComplete, Is.True);
+                Received.InOrder(() => {
+                    controller.ExecuteMoveAsync(Arg.Is<TiltAdapterMove>(m => m.Axis == TiltMoveAxis.Backfocus && m.Steps == 150), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+                    controller.ExecuteMoveAsync(Arg.Is<TiltAdapterMove>(m => m.Axis == TiltMoveAxis.Backfocus && m.Steps == -150), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+                    controller.ExecuteMoveAsync(Arg.Is<TiltAdapterMove>(m => m.Axis == TiltMoveAxis.DiagonalA && m.Steps == 150), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+                    controller.ExecuteMoveAsync(Arg.Is<TiltAdapterMove>(m => m.Axis == TiltMoveAxis.DiagonalA && m.Steps == -150), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+                    controller.ExecuteMoveAsync(Arg.Is<TiltAdapterMove>(m => m.Axis == TiltMoveAxis.DiagonalB && m.Steps == 150), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+                    controller.ExecuteMoveAsync(Arg.Is<TiltAdapterMove>(m => m.Axis == TiltMoveAxis.DiagonalB && m.Steps == -150), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+                });
+            });
+        }
+
+        [Test]
+        public void AutoRunAll_Cancel_FinishesCurrentStep_ThenRecoversAppliedMovesInReverse() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            StubSuccessfulMoves(controller);
+            Connect(vm);
+            options.MeasureCurvatureDuringCalibration.Returns(false); // re-assert AFTER connecting; see the 4-step-flow test above
+
+            // Cancel while Screw1's measurement is in flight: the move+measurement for Screw1 finishes (device
+            // has no abort), THEN the loop notices cancellation before ReBaseline2's move and recovers.
+            vm.MeasurementStepOverrideForTest = (step, ct) => {
+                vm.SeedStepReading(step, 0.1, 0.0, 1000.0);
+                if (step == WizardStep.Screw1) {
+                    vm.CancelCommand.Execute(null);
+                }
+                return Task.FromResult(true);
+            };
+
+            ((AsyncRelayCommand)vm.AutoRunAllCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+
+            Assert.Multiple(() => {
+                Assert.That(vm.IsComplete, Is.False, "the run must stop before Complete");
+                Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.ReBaseline2), "NextStep already advanced past Screw1 before the cancellation was noticed");
+                // Screw1's move was sent, then its inverse was sent back as recovery.
+                controller.Received(1).ExecuteMoveAsync(Arg.Is<TiltAdapterMove>(m => m.Axis == TiltMoveAxis.DiagonalA && m.Steps == 150), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+                controller.Received(1).ExecuteMoveAsync(Arg.Is<TiltAdapterMove>(m => m.Axis == TiltMoveAxis.DiagonalA && m.Steps == -150), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+                // ReBaseline2/Screw2/Complete's DiagonalB moves must never have been sent.
+                controller.DidNotReceive().ExecuteMoveAsync(Arg.Is<TiltAdapterMove>(m => m.Axis == TiltMoveAxis.DiagonalB), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+                // The lease must be released so the device is available again.
+                Assert.That(service.TryBeginOperation("anything"), Is.Not.Null);
+            });
+        }
+
+        [Test]
+        public void Disconnected_FourStepFlow_NeverTouchesController_AndClearsDeviceLinkedMarker() {
+            // BuildMotorized gives a motorized preset + a real controller mock, but the device is NEVER
+            // connected — the mandatory regression: the manual flow must be byte-for-byte the old flow.
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            vm.MeasurementStepOverrideForTest = SeedingMeasurementOverride(vm);
+
+            vm.StartCommand.Execute(null);
+            while (!vm.IsComplete) {
+                ((AsyncRelayCommand)vm.RunMeasurementCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+            }
+
+            Assert.Multiple(() => {
+                Assert.That(vm.IsComplete, Is.True);
+                controller.DidNotReceive().ExecuteMoveAsync(Arg.Any<TiltAdapterMove>(), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+                options.Received(1).DeviceLinkedCalibrationDeviceName = string.Empty;
+                Assert.That(service.TryBeginOperation("anything"), Is.Not.Null, "a disconnected run must never hold the device operation lease");
+            });
+        }
+
+        [Test]
+        public void Disconnected_StepInstructions_MatchesManualTextExactly_EvenForAMotorizedPreset() {
+            var (vm, options, service, controller, _, _) = BuildMotorized(); // motorized preset, never connected
+            string expected = TiltAdapterWizardVM.StepInstructionsText(WizardStep.Baseline, 4, true, vm.CalibrationAppliedAmount);
+            Assert.That(vm.StepInstructions, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void ConnectedMotorized_StepInstructions_ShowsAutomatedTextInsteadOfManual() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            Connect(vm);
+
+            string manualText = TiltAdapterWizardVM.StepInstructionsText(WizardStep.Baseline, 4, true, vm.CalibrationAppliedAmount);
+            Assert.Multiple(() => {
+                Assert.That(vm.StepInstructions, Is.Not.EqualTo(manualText));
+                Assert.That(vm.StepInstructions, Does.Contain("wizard will drive"));
+            });
+        }
+
+        [Test]
+        public void ConnectedRun_ManualStepByStep_ReachingComplete_SetsDeviceLinkedMarker() {
+            // Drives the 4-step flow via repeated "Run Measurement" clicks (NOT AutoRunAllCommand) to prove
+            // the marker is tied to "connected + device-driven", not specifically to Auto Run All.
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            StubSuccessfulMoves(controller);
+            Connect(vm);
+            options.MeasureCurvatureDuringCalibration.Returns(false); // re-assert AFTER connecting; see the 4-step-flow test above
+            vm.MeasurementStepOverrideForTest = SeedingMeasurementOverride(vm);
+
+            vm.StartCommand.Execute(null);
+            while (!vm.IsComplete) {
+                ((AsyncRelayCommand)vm.RunMeasurementCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+            }
+
+            Assert.Multiple(() => {
+                Assert.That(vm.IsComplete, Is.True);
+                controller.Received(1).ExecuteMoveAsync(Arg.Is<TiltAdapterMove>(m => m.Axis == TiltMoveAxis.DiagonalB && m.Steps == -150), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+                options.Received(1).DeviceLinkedCalibrationDeviceName = "ASG Electronic EAT - 90mm";
+            });
+        }
+
+        // Fix 2 [MAJOR]: a "Use Saved AF" measurement mid-run must drop the run out of device-driven mode --
+        // the marker must CLEAR (not be set) at completion, and no further device moves (including any later
+        // step's move or Complete's restore move) may be sent once this has happened.
+        [Test]
+        public void MeasureStep_SavedAFStepDuringDeviceDrivenRun_ClearsDeviceLinkedMarker_AndSendsNoFurtherDeviceMoves() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            StubSuccessfulMoves(controller);
+            Connect(vm);
+            options.MeasureCurvatureDuringCalibration.Returns(false); // 4-step flow; re-assert AFTER connecting
+            vm.MeasurementStepOverrideForTest = SeedingMeasurementOverride(vm);
+
+            vm.StartCommand.Execute(null);
+            ((AsyncRelayCommand)vm.RunMeasurementCommand).ExecuteAsync(null).GetAwaiter().GetResult(); // Baseline (no move)
+            ((AsyncRelayCommand)vm.RunMeasurementCommand).ExecuteAsync(null).GetAwaiter().GetResult(); // Screw1 (real device move)
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.ReBaseline2), "precondition: past Screw1, mid-run");
+            controller.Received(1).ExecuteMoveAsync(Arg.Is<TiltAdapterMove>(m => m.Axis == TiltMoveAxis.DiagonalA && m.Steps == 150), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+            controller.ClearReceivedCalls();
+
+            // ReBaseline2 measured via "Use Saved AF" instead of a device move -- the run drops out of
+            // device-driven mode from this point on.
+            ((AsyncRelayCommand)vm.UseSavedAFCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+            Assert.Multiple(() => {
+                Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Screw2), "precondition: past ReBaseline2");
+                Assert.That(vm.HasDeviceLinkDroppedWarning, Is.True);
+                controller.DidNotReceive().ExecuteMoveAsync(Arg.Any<TiltAdapterMove>(), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+                Assert.That(service.TryBeginOperation("anything"), Is.Not.Null,
+                    "the exclusive lease must be released the moment the run drops out of device-driven mode");
+            });
+
+            // Screw2 + the Complete transition: even a NORMAL (non-saved) "Run Measurement" click must send no
+            // device move for the remainder of this run, and no Complete restore move either.
+            ((AsyncRelayCommand)vm.RunMeasurementCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+
+            Assert.Multiple(() => {
+                Assert.That(vm.IsComplete, Is.True);
+                controller.DidNotReceive().ExecuteMoveAsync(Arg.Any<TiltAdapterMove>(), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+                options.Received(1).DeviceLinkedCalibrationDeviceName = string.Empty;
+            });
+        }
+
+        [Test]
+        public void MeasureStep_RetryAfterMeasurementFailure_DoesNotResendDeviceMove() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            StubSuccessfulMoves(controller);
+            Connect(vm);
+            // Connecting defaults MeasureCurvatureDuringCalibration ON (T11 item 4); re-assert false here,
+            // AFTER connecting, so StartAsync (which reads it fresh) resolves the 4-step flow (Screw1 is the
+            // second step) — this test only cares about retry-safety, not the curvature-measuring flow.
+            options.MeasureCurvatureDuringCalibration.Returns(false);
+
+            vm.StartCommand.Execute(null);
+            // Advance past Baseline (measurement-only; no device move) so the retry-safety check below is
+            // exercised for a step that actually has a move (Screw1).
+            vm.MeasurementStepOverrideForTest = (step, ct) => { vm.SeedStepReading(step, 0.0, 0.0, 1000.0); return Task.FromResult(true); };
+            ((AsyncRelayCommand)vm.RunMeasurementCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Screw1), "precondition: past Baseline");
+
+            int attempt = 0;
+            vm.MeasurementStepOverrideForTest = (step, ct) => {
+                attempt++;
+                if (attempt == 1) {
+                    return Task.FromResult(false); // first attempt: the move succeeds, the "measurement" fails
+                }
+                vm.SeedStepReading(step, 0.5, 0.0, 1000.0);
+                return Task.FromResult(true);
+            };
+
+            ((AsyncRelayCommand)vm.RunMeasurementCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+            Assert.That(vm.HasMeasurementFailureChoice, Is.True, "precondition: the first attempt's measurement failed");
+
+            ((AsyncRelayCommand)vm.RetryMeasurementCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+
+            Assert.Multiple(() => {
+                Assert.That(vm.HasMeasurementFailureChoice, Is.False);
+                // Sent exactly ONCE despite two measurement attempts -- a retry after a measurement-only
+                // failure must not re-apply the same device move a second time.
+                controller.Received(1).ExecuteMoveAsync(
+                    Arg.Is<TiltAdapterMove>(m => m.Axis == TiltMoveAxis.DiagonalA && m.Steps == 150),
+                    Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+            });
+        }
+
+        [Test]
+        public void StartAsync_DeviceDriven_HoldsOperationTokenForWholeRun_BlockingConcurrentOperations() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            Connect(vm);
+
+            vm.StartCommand.Execute(null);
+
+            Assert.Multiple(() => {
+                Assert.That(vm.IsWizardRunning, Is.True);
+                Assert.That(service.TryBeginOperation("someone else"), Is.Null, "the wizard's own lease must block a concurrent operation");
+            });
+
+            vm.RestartCommand.Execute(null);
+            Assert.That(service.TryBeginOperation("someone else"), Is.Not.Null, "abandoning the run (Restart) must release the lease");
+        }
+
+        [Test]
+        public void StartAsync_DeviceDriven_RefusesWhenAppliedAmountExceedsMaxStepsPerCommand() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(300.0);
+            options.TiltDeviceMaxStepsPerCommand.Returns(200);
+            Connect(vm);
+
+            vm.StartCommand.Execute(null);
+
+            Assert.Multiple(() => {
+                Assert.That(vm.IsWizardRunning, Is.False, "must refuse to start a device-driven run whose applied amount exceeds the configured max steps per command");
+                controller.DidNotReceive().ExecuteMoveAsync(Arg.Any<TiltAdapterMove>(), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+                Assert.That(service.TryBeginOperation("anything"), Is.Not.Null, "no lease should have been acquired");
+            });
+        }
+
+        [Test]
+        public void StartAsync_DeviceDriven_RefusesWhenAppliedAmountExceedsMaxExcursion() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            options.TiltDeviceMaxExcursionSteps.Returns(100);
+            Connect(vm);
+
+            vm.StartCommand.Execute(null);
+
+            Assert.That(vm.IsWizardRunning, Is.False);
+        }
+
+        [Test]
+        public void RunCalibrationForTest_DeviceDriven_SetsDeviceLinkedMarker() {
+            var (vm, options, _, _, _, _) = BuildMotorized();
+            vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw1, 0.5, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw2, -0.25, 0.433, 1000.0);
+
+            vm.RunCalibrationForTest(deviceDriven: true);
+
+            options.Received(1).DeviceLinkedCalibrationDeviceName = "ASG Electronic EAT - 90mm";
+        }
+
+        [Test]
+        public void RunCalibrationForTest_NotDeviceDriven_ClearsDeviceLinkedMarker() {
+            // deviceDriven defaults to false — this is exactly the parameter value ReplayAsync's two
+            // RunCalibrationMath call sites (and a disconnected live run's NextStep call) pass.
+            var (vm, options, _, _) = Build(screwCount: 4);
+            vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw1, 0.5, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw2, -0.25, 0.433, 1000.0);
+
+            vm.RunCalibrationForTest();
+
+            options.Received(1).DeviceLinkedCalibrationDeviceName = string.Empty;
+        }
+
+        // End-to-end ReplayAsync, via the three test seams (SelectReplayFolderForTest / SelectReplaySettingsForTest /
+        // ReplayStepOverrideForTest + CalibrationTiltPlaneOverrideForTest) that stand in for the real FolderBrowserDialog,
+        // the shared WPF replay-settings modal, and the live inspector analysis respectively -- none of which can run
+        // headless. Proves ReplayAsync's own RunCalibrationMath call site (deviceDriven: false, always) actually clears a
+        // PRE-EXISTING device-linked marker, not just that RunCalibrationMath does so in isolation (already covered by
+        // RunCalibrationForTest_NotDeviceDriven_ClearsDeviceLinkedMarker above).
+        [Test]
+        public void ReplayAsync_ClearsAPreExistingDeviceLinkedMarker() {
+            var (vm, options, _, _) = Build(screwCount: 3);
+            // Simulate the marker was set by an earlier, unrelated device-driven calibration.
+            options.DeviceLinkedCalibrationDeviceName = "ASG Electronic EAT - 90mm";
+
+            string runRoot = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "hf-tilt-replay-test-" + Guid.NewGuid().ToString("N"));
+            var stepFolders = new[] { "01_Baseline", "02_Screw1", "03_ReBaseline2", "04_Screw2" };
+            System.IO.Directory.CreateDirectory(runRoot);
+            try {
+                foreach (var stepFolder in stepFolders) {
+                    System.IO.Directory.CreateDirectory(System.IO.Path.Combine(runRoot, stepFolder));
+                }
+                var metadata = new TiltCalibrationMetadata {
+                    NumberOfScrews = 3,
+                    PixelSizeMicrons = 3.76,
+                    FocuserStepSizeMicrons = 3.6,
+                    ScrewRadiusMillimeters = 44,
+                    CalibrationAppliedAmount = 1.0,
+                    RunStepMapping = new List<TiltRunStepMapping> {
+                        new TiltRunStepMapping { Step = "Baseline", Folder = stepFolders[0] },
+                        new TiltRunStepMapping { Step = "Screw1", Folder = stepFolders[1] },
+                        new TiltRunStepMapping { Step = "ReBaseline2", Folder = stepFolders[2] },
+                        new TiltRunStepMapping { Step = "Screw2", Folder = stepFolders[3] },
+                    }
+                };
+                System.IO.File.WriteAllText(System.IO.Path.Combine(runRoot, "metadata.json"), metadata.Serialize());
+
+                var tiltPlane = new TiltPlaneModel(new System.Drawing.Size(6248, 4176), fRatio: 7,
+                    a: 0.1, b: 0.05, c: 0, mean: 7000, focuserStepSizeMicrons: 3.6,
+                    centerPosition: 7000, topLeftPosition: 7000, topRightPosition: 7000,
+                    bottomLeftPosition: 7000, bottomRightPosition: 7000);
+                vm.CalibrationTiltPlaneOverrideForTest = tiltPlane;
+                vm.SelectReplayFolderForTest = _ => runRoot;
+                vm.SelectReplaySettingsForTest = _ => Task.FromResult(ReplaySettingsChoice.UseCurrentSettings);
+                vm.ReplayStepOverrideForTest = (step, ct) => Task.FromResult(true);
+
+                ((AsyncRelayCommand)vm.ReplayCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+
+                Assert.Multiple(() => {
+                    Assert.That(vm.IsComplete, Is.True, "precondition: the replay actually completed (RunCalibrationMath was reached)");
+                    options.Received(1).DeviceLinkedCalibrationDeviceName = string.Empty;
+                });
+            } finally {
+                System.IO.Directory.Delete(runRoot, recursive: true);
+            }
+        }
+
+        [Test]
+        public void ApplyManualCalibrationCommand_ClearsDeviceLinkedMarker() {
+            var (vm, options, _, _) = Build();
+            vm.ManualScrew1AngleDegrees = 30.0;
+
+            vm.ApplyManualCalibrationCommand.Execute(null);
+
+            options.Received(1).DeviceLinkedCalibrationDeviceName = string.Empty;
+        }
+
+        // Fix 1 [CRITICAL GATE, MAJOR]: RunCalibrationMath must persist the confidence result's IsReliable to
+        // ITiltAdapterOptions.CalibrationIsReliable, independent of (in addition to) DeviceLinkedCalibrationDeviceName.
+        [Test]
+        public void RunCalibrationForTest_DeviceDriven_ReliableCalibration_SetsCalibrationIsReliableTrue() {
+            var (vm, options, _, _, _, _) = BuildMotorized();
+            // Clean, equal-magnitude single-screw moves with zero re-baseline drift -> noise probe 0 ->
+            // SignalToNoise = +Infinity -> reliable (mirrors the seed data RunCalibrationForTest_DeviceDriven_SetsDeviceLinkedMarker uses).
+            vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw1, 0.5, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw2, -0.25, 0.433, 1000.0);
+
+            vm.RunCalibrationForTest(deviceDriven: true);
+
+            options.Received(1).CalibrationIsReliable = true;
+        }
+
+        [Test]
+        public void RunCalibrationForTest_DeviceDriven_UnreliableCalibration_SetsCalibrationIsReliableFalse_EvenThoughDeviceLinked() {
+            var (vm, options, _, _, _, _) = BuildMotorized();
+            // ReBaseline2 drifts substantially from Baseline (0.4 of the ~0.5 screw-move signal) instead of
+            // returning to it -> noise probe large relative to signal -> SignalToNoise ~1.25, below
+            // TiltCalibrationCalculator.MinReliableSignalToNoise (2.0) -> not reliable, even though this is
+            // still a completed, connected, device-driven run (device-linked and reliable are independent gates).
+            vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw1, 0.5, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.ReBaseline2, 0.4, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw2, 0.9, 0.0, 1000.0);
+
+            vm.RunCalibrationForTest(deviceDriven: true);
+
+            Assert.Multiple(() => {
+                options.Received(1).CalibrationIsReliable = false;
+                options.Received(1).DeviceLinkedCalibrationDeviceName = "ASG Electronic EAT - 90mm";
+            });
+        }
+
+        [Test]
+        public void ApplyManualCalibrationCommand_SetsCalibrationIsReliableFalse() {
+            // A manual entry has no confidence computation to reuse (no per-step tilt vectors) -- conservative
+            // default: not automation-trusted until a fresh calibration run demonstrably passes its own check.
+            var (vm, options, _, _) = Build();
+            vm.ManualScrew1AngleDegrees = 30.0;
+
+            vm.ApplyManualCalibrationCommand.Execute(null);
+
+            options.Received(1).CalibrationIsReliable = false;
+        }
+
+        [Test]
+        public void ConnectDeviceCommand_Success_DefaultsMeasureCurvatureDuringCalibrationOn_WhenNotAlreadyEnabled() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.MeasureCurvatureDuringCalibration.Returns(false);
+
+            Connect(vm);
+
+            options.Received(1).MeasureCurvatureDuringCalibration = true;
+        }
+
+        [Test]
+        public void ConnectDeviceCommand_Success_DoesNotResendMeasureCurvature_WhenAlreadyTrue() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.MeasureCurvatureDuringCalibration.Returns(true);
+
+            Connect(vm);
+
+            options.DidNotReceive().MeasureCurvatureDuringCalibration = Arg.Any<bool>();
+        }
+
+        // Fix 3 [MINOR]: the on-connect default (T11 item 4, tested above) must never re-force a
+        // deliberately disabled option back on across a disconnect -> reconnect cycle.
+        [Test]
+        public void ConnectDeviceCommand_UserExplicitlyDisabledMeasureCurvature_ReconnectDoesNotReForceOn() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.MeasureCurvatureDuringCalibration.Returns(false);
+
+            Connect(vm); // first (and only) connect that may default it on
+            options.Received(1).MeasureCurvatureDuringCalibration = true;
+
+            // The user deliberately unchecks it (the checkbox binds straight to the option's setter, which
+            // raises PropertyChanged in production; simulate that on the substitute).
+            options.MeasureCurvatureDuringCalibration.Returns(false);
+            options.PropertyChanged += Raise.Event<System.ComponentModel.PropertyChangedEventHandler>(
+                options, new System.ComponentModel.PropertyChangedEventArgs(nameof(ITiltAdapterOptions.MeasureCurvatureDuringCalibration)));
+            options.ClearReceivedCalls();
+
+            ((AsyncRelayCommand)vm.DisconnectDeviceCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+            Connect(vm); // reconnect must NOT re-force the user's explicit choice back on
+
+            options.DidNotReceive().MeasureCurvatureDuringCalibration = Arg.Any<bool>();
+        }
+
+        // First-connect case where the user disables it BEFORE ever connecting: the very first connect must
+        // also respect that (not just reconnects after an earlier default).
+        [Test]
+        public void ConnectDeviceCommand_UserExplicitlyDisabledMeasureCurvature_BeforeFirstConnect_DoesNotForceOn() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.MeasureCurvatureDuringCalibration.Returns(false);
+            options.PropertyChanged += Raise.Event<System.ComponentModel.PropertyChangedEventHandler>(
+                options, new System.ComponentModel.PropertyChangedEventArgs(nameof(ITiltAdapterOptions.MeasureCurvatureDuringCalibration)));
+
+            Connect(vm);
+
+            options.DidNotReceive().MeasureCurvatureDuringCalibration = Arg.Any<bool>();
         }
 
         private static object SentinelFor(Type type, int index) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -614,6 +614,47 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             });
         }
 
+        [TestCase(WizardStep.Baseline, "Baseline Measurement")]
+        [TestCase(WizardStep.AllInward, "All Screws Inward")]
+        [TestCase(WizardStep.ReBaseline1, "Return to Baseline")]
+        [TestCase(WizardStep.Screw1, "Move Screw 1")]
+        [TestCase(WizardStep.ReBaseline2, "Return to Baseline")]
+        [TestCase(WizardStep.Screw2, "Move Screw 2")]
+        [TestCase(WizardStep.Complete, "Calibration Complete")]
+        public void StepTitleText_IsShortPerStepHeader(WizardStep step, string expected) {
+            Assert.That(TiltAdapterWizardVM.StepTitleText(step), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void DeviceStepInstructionsText_AutoRunning_DropsClickImperatives() {
+            // Baseline: manual/connected wording tells the user to click; auto-running does not.
+            Assert.Multiple(() => {
+                Assert.That(TiltAdapterWizardVM.DeviceStepInstructionsText(WizardStep.Baseline, 0, autoRunning: false),
+                    Does.Contain("click Run Measurement"));
+                Assert.That(TiltAdapterWizardVM.DeviceStepInstructionsText(WizardStep.Baseline, 0, autoRunning: true),
+                    Does.Contain("Running automatically").And.Not.Contain("click"));
+
+                // A move step: not auto-running tells the user to click; auto-running is pure status.
+                Assert.That(TiltAdapterWizardVM.DeviceStepInstructionsText(WizardStep.Screw1, 150, autoRunning: false),
+                    Does.Contain("Click Run Measurement"));
+                Assert.That(TiltAdapterWizardVM.DeviceStepInstructionsText(WizardStep.Screw1, 150, autoRunning: true),
+                    Does.StartWith("Running automatically").And.Not.Contain("Click"));
+            });
+        }
+
+        [Test]
+        public void StepProgressDisplay_ReflectsActiveStepCount_4vs6() {
+            // Default (curvature off) is a 4-step run; the counter reads "Step 1 of 4" at Baseline.
+            var (vm4, _, _, _) = Build();
+            Assert.That(vm4.StepProgressDisplay, Is.EqualTo("Step 1 of 4"));
+            Assert.That(vm4.StepTitle, Is.EqualTo("Baseline Measurement"));
+
+            // Enabling curvature measurement makes it a 6-step run once started.
+            var (vm6, _, _, _) = Build(configureOptions: o => o.MeasureCurvatureDuringCalibration.Returns(true));
+            vm6.StartCommand.Execute(null);
+            Assert.That(vm6.StepProgressDisplay, Is.EqualTo("Step 1 of 6"));
+        }
+
         [Test]
         public void BuildSweepSummary_CountsSweepsAndImages() {
             // 4 steps × 2 averaged measurements = 8 sweeps; profile: 4 offset steps, 1 frame, amp 2 => 17 images/run.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -1478,6 +1478,24 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         }
 
         [Test]
+        public void DeviceMove_UpdatesScrewPositionDisplayWithDeltaFromStart() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            // First read is the run baseline (captured before the first move); second is the post-move position.
+            controller.QueryPositionsAsync(Arg.Any<CancellationToken>()).Returns(
+                Task.FromResult(new TiltDevicePositions(new[] { 0, 0, 0, 0 }, known: true)),
+                Task.FromResult(new TiltDevicePositions(new[] { 150, 150, 150, 150 }, known: true)));
+
+            vm.SelectedPortName = "COM3";
+            ((AsyncRelayCommand)vm.ConnectDeviceCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+
+            vm.ExecuteDeviceMoveForCurrentStepAsync(WizardStep.AllInward, CancellationToken.None).GetAwaiter().GetResult();
+
+            // TR = motor 1 = index 0: shows the live position plus the delta from the run's baseline.
+            Assert.That(vm.ScrewPositionTopRightDisplay, Does.Contain("150").And.Contain("Δ").And.Contain("+150"));
+        }
+
+        [Test]
         public void DisconnectDeviceCommand_DisconnectsThroughService() {
             var (vm, _, service, controller, _, _) = BuildMotorized();
             vm.SelectedPortName = "COM3";

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltScrewTargetsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltScrewTargetsTests.cs
@@ -1,0 +1,166 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard;
+
+[TestFixture]
+public class TiltScrewTargetsTests {
+
+    // Representative fitted-paraboloid model params: nonzero Gx/Gy/Kx/Ky (astigmatic) and an
+    // off-center vertex (X0/Y0 != 0) so every term in the formula participates.
+    private const double Gx = 0.0012;
+    private const double Gy = -0.0008;
+    private const double Kx = 1.1e-5;
+    private const double Ky = 1.3e-5;
+    private const double X0 = 150.0;
+    private const double Y0 = -80.0;
+    private const double RadiusMicrons = 60000.0; // 60 mm
+
+    private static readonly double[] Angles4 = { 0.0, 90.0, 180.0, 270.0 };
+    private static readonly double[] Angles3 = { 15.0, 135.0, 255.0 };
+
+    // Independent replication of the PRE-REFACTOR inline formula that used to live in
+    // InspectorVM.FillNumericGuidance (foundation brief item 4), computed via separate calls
+    // rather than through TiltScrewTargets.ComputePerScrewTargets, so comparing against it is not
+    // a tautology:
+    //   tiltSteps  = corr.TiltMicrons / unitMicrons
+    //   backSteps  = resolvedSign * corr.BackfocusMicrons / unitMicrons
+    //   totalSteps = TiltScrewGeometry.SignedTotalAdjustment(corr.TiltMicrons, corr.BackfocusMicrons, unitMicrons, resolvedSign)
+    private static (double tiltSteps, double backSteps, double totalSteps) ExpectedTarget(
+        double angleDegrees, double radiusMicrons, double unitMicrons, int curvatureSign) {
+        int resolvedSign = curvatureSign == 0 ? TiltScrewGeometry.DefaultScrewInwardCurvatureSign : curvatureSign;
+        var corr = TiltScrewGeometry.ScrewCorrectionMicrons(Gx, Gy, Kx, Ky, X0, Y0, angleDegrees, radiusMicrons);
+        double tiltSteps = corr.TiltMicrons / unitMicrons;
+        double backSteps = resolvedSign * corr.BackfocusMicrons / unitMicrons;
+        double totalSteps = TiltScrewGeometry.SignedTotalAdjustment(corr.TiltMicrons, corr.BackfocusMicrons, unitMicrons, resolvedSign);
+        return (tiltSteps, backSteps, totalSteps);
+    }
+
+    [TestCase(1.8, true, 1)]     // stepper unit (e.g. ASG EAT), σ = +1
+    [TestCase(1.8, true, -1)]    // stepper unit, σ = -1
+    [TestCase(212.0, false, 1)]  // screw thread-pitch unit (e.g. ASG Photon Cage), σ = +1
+    public void ComputePerScrewTargets_FourScrews_MatchesHandReplicatedInlineFormula(
+        double unitMicrons, bool steps, int curvatureSign) {
+        var targets = TiltScrewTargets.ComputePerScrewTargets(
+            Gx, Gy, Kx, Ky, X0, Y0, Angles4, RadiusMicrons, unitMicrons, curvatureSign);
+
+        Assert.That(targets.Count, Is.EqualTo(4));
+        Assert.Multiple(() => {
+            for (int i = 0; i < Angles4.Length; i++) {
+                var expected = ExpectedTarget(Angles4[i], RadiusMicrons, unitMicrons, curvatureSign);
+
+                Assert.That(targets[i].TiltSteps, Is.EqualTo(expected.tiltSteps).Within(1e-9), $"screw {i} tilt steps");
+                Assert.That(targets[i].BackfocusSteps, Is.EqualTo(expected.backSteps).Within(1e-9), $"screw {i} backfocus steps");
+                Assert.That(targets[i].TotalSteps, Is.EqualTo(expected.totalSteps).Within(1e-9), $"screw {i} total steps");
+
+                // Regression lock: the strings the pre-refactor inline formula would have formatted.
+                string expectedTiltText = TiltAdapterGuidanceVM.FormatAmount(expected.tiltSteps, steps, TiltGuidanceAngleUnit.Turns);
+                string expectedBackText = TiltAdapterGuidanceVM.FormatAmount(expected.backSteps, steps, TiltGuidanceAngleUnit.Turns);
+                string expectedTotalText = TiltAdapterGuidanceVM.FormatAmount(expected.totalSteps, steps, TiltGuidanceAngleUnit.Turns);
+
+                Assert.That(TiltAdapterGuidanceVM.FormatAmount(targets[i].TiltSteps, steps, TiltGuidanceAngleUnit.Turns), Is.EqualTo(expectedTiltText), $"screw {i} tilt text");
+                Assert.That(TiltAdapterGuidanceVM.FormatAmount(targets[i].BackfocusSteps, steps, TiltGuidanceAngleUnit.Turns), Is.EqualTo(expectedBackText), $"screw {i} backfocus text");
+                Assert.That(TiltAdapterGuidanceVM.FormatAmount(targets[i].TotalSteps, steps, TiltGuidanceAngleUnit.Turns), Is.EqualTo(expectedTotalText), $"screw {i} total text");
+            }
+        });
+    }
+
+    [Test]
+    public void ComputePerScrewTargets_ThreeScrews_MatchesHandReplicatedInlineFormula() {
+        const double unitMicrons = 400.0; // e.g. Neumann CTU XT48 thread pitch
+        const int curvatureSign = -1;
+        var targets = TiltScrewTargets.ComputePerScrewTargets(
+            Gx, Gy, Kx, Ky, X0, Y0, Angles3, RadiusMicrons, unitMicrons, curvatureSign);
+
+        Assert.That(targets.Count, Is.EqualTo(3));
+        Assert.Multiple(() => {
+            for (int i = 0; i < Angles3.Length; i++) {
+                var expected = ExpectedTarget(Angles3[i], RadiusMicrons, unitMicrons, curvatureSign);
+                Assert.That(targets[i].TiltSteps, Is.EqualTo(expected.tiltSteps).Within(1e-9), $"screw {i} tilt steps");
+                Assert.That(targets[i].BackfocusSteps, Is.EqualTo(expected.backSteps).Within(1e-9), $"screw {i} backfocus steps");
+                Assert.That(targets[i].TotalSteps, Is.EqualTo(expected.totalSteps).Within(1e-9), $"screw {i} total steps");
+            }
+        });
+    }
+
+    [Test]
+    public void ComputePerScrewTargets_SigmaFlip_NegatesBackfocusOnly_TiltUnchanged() {
+        const double unitMicrons = 1.8;
+        var plus = TiltScrewTargets.ComputePerScrewTargets(Gx, Gy, Kx, Ky, X0, Y0, Angles4, RadiusMicrons, unitMicrons, curvatureSign: 1);
+        var minus = TiltScrewTargets.ComputePerScrewTargets(Gx, Gy, Kx, Ky, X0, Y0, Angles4, RadiusMicrons, unitMicrons, curvatureSign: -1);
+
+        Assert.Multiple(() => {
+            for (int i = 0; i < Angles4.Length; i++) {
+                // σ multiplies BACKFOCUS ONLY: the tilt component must be bit-for-bit identical.
+                Assert.That(minus[i].TiltSteps, Is.EqualTo(plus[i].TiltSteps).Within(1e-12), $"screw {i} tilt unaffected by σ");
+                // Flipping σ negates the backfocus component.
+                Assert.That(minus[i].BackfocusSteps, Is.EqualTo(-plus[i].BackfocusSteps).Within(1e-9), $"screw {i} backfocus negates");
+                // Total therefore shifts by 2·backfocus(σ=+1)/unit (tilt term is common, backfocus term flips sign).
+                Assert.That(minus[i].TotalSteps, Is.EqualTo(plus[i].TotalSteps - 2.0 * plus[i].BackfocusSteps).Within(1e-9),
+                    $"screw {i} total shifts by 2*backfocus/unit");
+            }
+        });
+    }
+
+    [Test]
+    public void ComputePerScrewTargets_ZeroCurvatureSign_ResolvesToDefault() {
+        const double unitMicrons = 1.8;
+        var zero = TiltScrewTargets.ComputePerScrewTargets(Gx, Gy, Kx, Ky, X0, Y0, Angles4, RadiusMicrons, unitMicrons, curvatureSign: 0);
+        var defaultSign = TiltScrewTargets.ComputePerScrewTargets(
+            Gx, Gy, Kx, Ky, X0, Y0, Angles4, RadiusMicrons, unitMicrons, curvatureSign: TiltScrewGeometry.DefaultScrewInwardCurvatureSign);
+
+        Assert.Multiple(() => {
+            for (int i = 0; i < Angles4.Length; i++) {
+                Assert.That(zero[i].TiltSteps, Is.EqualTo(defaultSign[i].TiltSteps).Within(1e-12));
+                Assert.That(zero[i].BackfocusSteps, Is.EqualTo(defaultSign[i].BackfocusSteps).Within(1e-12));
+                Assert.That(zero[i].TotalSteps, Is.EqualTo(defaultSign[i].TotalSteps).Within(1e-12));
+            }
+        });
+    }
+
+    [Test]
+    public void ComputePerScrewTargets_TotalSign_MatchesWizardPlusConvention() {
+        // Pure curvature (no tilt gradient), isotropic (Kx == Ky) and centered (X0 = Y0 = 0): every
+        // screw sits at the same radius so BackfocusMicrons is identical at every angle, TiltSteps is
+        // exactly 0, and TotalSteps == BackfocusSteps. This isolates the sign convention that
+        // TiltAdapterGuidanceVM.FormatAmount renders as "+"/⟳ (signedAmount >= 0) vs "−"/⟲
+        // (signedAmount < 0) -- the same "CW/+ positive" convention TiltScrewGeometry.SignedTotalAdjustment
+        // documents and the wizard's StepInstructionsText "Turn screw N CLOCKWISE..." prompts use for a
+        // positive applied amount.
+        const double k = 1e-5;
+        const double radius = 10000.0;
+        const double unitMicrons = 1.8;
+
+        var plus = TiltScrewTargets.ComputePerScrewTargets(0, 0, k, k, 0, 0, Angles4, radius, unitMicrons, curvatureSign: 1);
+        var minus = TiltScrewTargets.ComputePerScrewTargets(0, 0, k, k, 0, 0, Angles4, radius, unitMicrons, curvatureSign: -1);
+
+        double expectedBackfocusMicrons = -(k * radius * radius); // -(kx*cx^2 + ky*cy^2), cx^2+cy^2 == R^2 on every screw
+        Assert.Multiple(() => {
+            for (int i = 0; i < Angles4.Length; i++) {
+                Assert.That(plus[i].TiltSteps, Is.EqualTo(0.0).Within(1e-12), $"screw {i}: no tilt gradient -> zero tilt steps");
+
+                Assert.That(plus[i].TotalSteps, Is.EqualTo(expectedBackfocusMicrons / unitMicrons).Within(1e-9), $"screw {i} σ=+1 total");
+                Assert.That(plus[i].TotalSteps, Is.LessThan(0.0), $"screw {i}: σ=+1 total must be negative here");
+                Assert.That(TiltAdapterGuidanceVM.FormatAmount(plus[i].TotalSteps, steps: true, TiltGuidanceAngleUnit.Turns), Does.StartWith("−"), $"screw {i} negative formats with a minus sign");
+
+                Assert.That(minus[i].TotalSteps, Is.EqualTo(-expectedBackfocusMicrons / unitMicrons).Within(1e-9), $"screw {i} σ=-1 total");
+                Assert.That(minus[i].TotalSteps, Is.GreaterThan(0.0), $"screw {i}: σ=-1 total must be positive here");
+                Assert.That(TiltAdapterGuidanceVM.FormatAmount(minus[i].TotalSteps, steps: true, TiltGuidanceAngleUnit.Turns), Does.StartWith("+"), $"screw {i} positive formats with a plus sign (wizard '+' convention)");
+            }
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -3082,6 +3082,28 @@
                                 Visibility="{Binding TiltGuidance.HasPitchMismatch, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
                                 <TextBlock Text="{Binding TiltGuidance.PitchMismatchWarning}" TextWrapping="Wrap" />
                             </Border>
+
+                            <!--  Automatic Adjustment (T14): computes a move plan from this measurement and executes it on the
+                                  connected tilt-adapter device. Only shown while a device is connected; the CRITICAL device-linked
+                                  calibration gate is surfaced as a remediation hint rather than the button when it fails.  -->
+                            <StackPanel
+                                Margin="5,8,5,0"
+                                Visibility="{Binding IsTiltDeviceConnected, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                                <Button
+                                    Height="25"
+                                    HorizontalAlignment="Left"
+                                    Command="{Binding AutomaticAdjustmentCommand}"
+                                    ToolTip="Computes a move plan from this measurement's fitted sensor model, shows an approval dialog listing the exact device commands, and executes it on the connected tilt-adapter device. Disabled until a fresh measurement is available to adjust from, or if the current calibration is not linked to the connected device.">
+                                    <TextBlock Margin="5,0,5,0" Text="Automatic Adjustment" />
+                                </Button>
+                                <TextBlock
+                                    Margin="0,4,0,0"
+                                    FontStyle="Italic"
+                                    TextWrapping="Wrap"
+                                    Foreground="{StaticResource NotificationWarningBrush}"
+                                    Text="{Binding AutomaticAdjustmentRemediationText}"
+                                    Visibility="{Binding AutomaticAdjustmentRemediationVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                            </StackPanel>
                         </StackPanel>
                     </StackPanel>
                 </Expander>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -9,6 +9,7 @@
     xmlns:local="clr-namespace:NINA.Joko.Plugins.HocusFocus.AutoFocus"
     xmlns:afreview="clr-namespace:NINA.Joko.Plugins.HocusFocus.AutoFocus.Review"
     xmlns:replay="clr-namespace:NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay"
+    xmlns:tiltprompt="clr-namespace:NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt"
     xmlns:ninactrl="clr-namespace:NINA.CustomControlLibrary;assembly=NINA.CustomControlLibrary"
     xmlns:ns="clr-namespace:NINA.Core.Locale;assembly=NINA.Core"
     xmlns:oxy="clr-namespace:OxyPlot.Wpf;assembly=OxyPlot.Contrib.Wpf"
@@ -102,6 +103,12 @@
           saved run that has a metadata.json. Implicit DataType template resolved by the WindowService, same as above.  -->
     <DataTemplate DataType="{x:Type replay:ReplaySettingsPromptVM}">
         <replay:ReplaySettingsPromptControl />
+    </DataTemplate>
+
+    <!--  The tilt-device adjustment approval prompt: review/approve the exact motorized tilt-adapter commands before
+          they are sent to the device. Implicit DataType template resolved by the WindowService, same as above.  -->
+    <DataTemplate DataType="{x:Type tiltprompt:TiltDeviceAdjustmentPromptVM}">
+        <tiltprompt:TiltDeviceAdjustmentPromptControl />
     </DataTemplate>
 
     <!--  Shared chart + info "core": the AF plot plus the run's info rows (Time / Position / HFR / Temperature /

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -1192,6 +1192,19 @@
                         </MultiBinding>
                     </FrameworkElement.Tag>
                 </FrameworkElement>
+                <!--  Chart-only gate: like ShowSensorModel, but ALSO false while a sweep is running, so the
+                      Focus Chart shows the 5-curve (Center + 4-corner) view live DURING a sweep and collapses
+                      to the single AF-points curve only after the sweep completes (when the sensor model is
+                      shown). Only the Focus Chart's series/annotations/legend bind to this; every other
+                      sensor-model gate stays on ShowSensorModel.  -->
+                <FrameworkElement x:Name="ShowSingleAfCurve">
+                    <FrameworkElement.Tag>
+                        <MultiBinding Converter="{StaticResource BooleanAndConverter}">
+                            <Binding ElementName="ShowSensorModel" Mode="OneWay" Path="Tag" />
+                            <Binding Converter="{StaticResource HF_InverseBooleanConverter}" Mode="OneWay" Path="IsAnalysisRunning" />
+                        </MultiBinding>
+                    </FrameworkElement.Tag>
+                </FrameworkElement>
                 <FrameworkElement x:Name="ShowLoadedSensorModel">
                     <FrameworkElement.Tag>
                         <MultiBinding Converter="{StaticResource BooleanAndConverter}">
@@ -2292,7 +2305,7 @@
                                     <oxy:ScatterErrorSeries.Visibility>
                                         <Binding
                                             Converter="{StaticResource BooleanToVisibilityCollapsedConverter}"
-                                            ElementName="ShowSensorModel"
+                                            ElementName="ShowSingleAfCurve"
                                             Mode="OneWay"
                                             Path="Tag" />
                                     </oxy:ScatterErrorSeries.Visibility>
@@ -2314,7 +2327,7 @@
                                     <oxy:ScatterErrorSeries.Visibility>
                                         <Binding
                                             Converter="{StaticResource InverseBooleanToVisibilityCollapsedConverter}"
-                                            ElementName="ShowSensorModel"
+                                            ElementName="ShowSingleAfCurve"
                                             Mode="OneWay"
                                             Path="Tag" />
                                     </oxy:ScatterErrorSeries.Visibility>
@@ -2335,7 +2348,7 @@
                                     <oxy:ScatterErrorSeries.Visibility>
                                         <Binding
                                             Converter="{StaticResource InverseBooleanToVisibilityCollapsedConverter}"
-                                            ElementName="ShowSensorModel"
+                                            ElementName="ShowSingleAfCurve"
                                             Mode="OneWay"
                                             Path="Tag" />
                                     </oxy:ScatterErrorSeries.Visibility>
@@ -2356,7 +2369,7 @@
                                     <oxy:ScatterErrorSeries.Visibility>
                                         <Binding
                                             Converter="{StaticResource InverseBooleanToVisibilityCollapsedConverter}"
-                                            ElementName="ShowSensorModel"
+                                            ElementName="ShowSingleAfCurve"
                                             Mode="OneWay"
                                             Path="Tag" />
                                     </oxy:ScatterErrorSeries.Visibility>
@@ -2377,7 +2390,7 @@
                                     <oxy:ScatterErrorSeries.Visibility>
                                         <Binding
                                             Converter="{StaticResource InverseBooleanToVisibilityCollapsedConverter}"
-                                            ElementName="ShowSensorModel"
+                                            ElementName="ShowSingleAfCurve"
                                             Mode="OneWay"
                                             Path="Tag" />
                                     </oxy:ScatterErrorSeries.Visibility>
@@ -2398,7 +2411,7 @@
                                     <oxy:ScatterErrorSeries.Visibility>
                                         <Binding
                                             Converter="{StaticResource InverseBooleanToVisibilityCollapsedConverter}"
-                                            ElementName="ShowSensorModel"
+                                            ElementName="ShowSingleAfCurve"
                                             Mode="OneWay"
                                             Path="Tag" />
                                     </oxy:ScatterErrorSeries.Visibility>
@@ -2419,7 +2432,7 @@
                                             </Binding>
                                             <Binding Path="RegionCurveFittings[0]" />
                                             <Binding
-                                                ElementName="ShowSensorModel"
+                                                ElementName="ShowSingleAfCurve"
                                                 Mode="OneWay"
                                                 Path="Tag" />
                                         </MultiBinding>
@@ -2451,7 +2464,7 @@
                                             <Binding Path="RegionCurveFittings[1]" />
                                             <Binding
                                                 Converter="{StaticResource HF_InverseBooleanConverter}"
-                                                ElementName="ShowSensorModel"
+                                                ElementName="ShowSingleAfCurve"
                                                 Mode="OneWay"
                                                 Path="Tag" />
                                         </MultiBinding>
@@ -2482,7 +2495,7 @@
                                             <Binding Path="RegionCurveFittings[2]" />
                                             <Binding
                                                 Converter="{StaticResource HF_InverseBooleanConverter}"
-                                                ElementName="ShowSensorModel"
+                                                ElementName="ShowSingleAfCurve"
                                                 Mode="OneWay"
                                                 Path="Tag" />
                                         </MultiBinding>
@@ -2513,7 +2526,7 @@
                                             <Binding Path="RegionCurveFittings[3]" />
                                             <Binding
                                                 Converter="{StaticResource HF_InverseBooleanConverter}"
-                                                ElementName="ShowSensorModel"
+                                                ElementName="ShowSingleAfCurve"
                                                 Mode="OneWay"
                                                 Path="Tag" />
                                         </MultiBinding>
@@ -2544,7 +2557,7 @@
                                             <Binding Path="RegionCurveFittings[4]" />
                                             <Binding
                                                 Converter="{StaticResource HF_InverseBooleanConverter}"
-                                                ElementName="ShowSensorModel"
+                                                ElementName="ShowSingleAfCurve"
                                                 Mode="OneWay"
                                                 Path="Tag" />
                                         </MultiBinding>
@@ -2575,7 +2588,7 @@
                                             <Binding Path="RegionCurveFittings[5]" />
                                             <Binding
                                                 Converter="{StaticResource HF_InverseBooleanConverter}"
-                                                ElementName="ShowSensorModel"
+                                                ElementName="ShowSingleAfCurve"
                                                 Mode="OneWay"
                                                 Path="Tag" />
                                         </MultiBinding>
@@ -2608,7 +2621,7 @@
                                             </Binding>
                                             <Binding Converter="{StaticResource HF_IsNotNegativeToBooleanConverter}" Path="RegionFinalFocusPoints[0].X" />
                                             <Binding
-                                                ElementName="ShowSensorModel"
+                                                ElementName="ShowSingleAfCurve"
                                                 Mode="OneWay"
                                                 Path="Tag" />
                                         </MultiBinding>
@@ -2632,7 +2645,7 @@
                                             <Binding Converter="{StaticResource HF_IsNotNegativeToBooleanConverter}" Path="RegionFinalFocusPoints[1].X" />
                                             <Binding
                                                 Converter="{StaticResource HF_InverseBooleanConverter}"
-                                                ElementName="ShowSensorModel"
+                                                ElementName="ShowSingleAfCurve"
                                                 Mode="OneWay"
                                                 Path="Tag" />
                                         </MultiBinding>
@@ -2658,7 +2671,7 @@
                                             <Binding Converter="{StaticResource HF_IsNotNegativeToBooleanConverter}" Path="RegionFinalFocusPoints[2].X" />
                                             <Binding
                                                 Converter="{StaticResource HF_InverseBooleanConverter}"
-                                                ElementName="ShowSensorModel"
+                                                ElementName="ShowSingleAfCurve"
                                                 Mode="OneWay"
                                                 Path="Tag" />
                                         </MultiBinding>
@@ -2684,7 +2697,7 @@
                                             <Binding Converter="{StaticResource HF_IsNotNegativeToBooleanConverter}" Path="RegionFinalFocusPoints[3].X" />
                                             <Binding
                                                 Converter="{StaticResource HF_InverseBooleanConverter}"
-                                                ElementName="ShowSensorModel"
+                                                ElementName="ShowSingleAfCurve"
                                                 Mode="OneWay"
                                                 Path="Tag" />
                                         </MultiBinding>
@@ -2710,7 +2723,7 @@
                                             <Binding Converter="{StaticResource HF_IsNotNegativeToBooleanConverter}" Path="RegionFinalFocusPoints[4].X" />
                                             <Binding
                                                 Converter="{StaticResource HF_InverseBooleanConverter}"
-                                                ElementName="ShowSensorModel"
+                                                ElementName="ShowSingleAfCurve"
                                                 Mode="OneWay"
                                                 Path="Tag" />
                                         </MultiBinding>
@@ -2736,7 +2749,7 @@
                                             <Binding Converter="{StaticResource HF_IsNotNegativeToBooleanConverter}" Path="RegionFinalFocusPoints[5].X" />
                                             <Binding
                                                 Converter="{StaticResource HF_InverseBooleanConverter}"
-                                                ElementName="ShowSensorModel"
+                                                ElementName="ShowSingleAfCurve"
                                                 Mode="OneWay"
                                                 Path="Tag" />
                                         </MultiBinding>
@@ -2766,27 +2779,27 @@
                             BorderThickness="1"
                             IsHitTestVisible="False">
                             <StackPanel Orientation="Vertical">
-                                <StackPanel Margin="0,1" Orientation="Horizontal" Visibility="{Binding ElementName=ShowSensorModel, Path=Tag, Mode=OneWay, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                                <StackPanel Margin="0,1" Orientation="Horizontal" Visibility="{Binding ElementName=ShowSingleAfCurve, Path=Tag, Mode=OneWay, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
                                     <Rectangle Width="12" Height="12" Margin="0,0,6,0" VerticalAlignment="Center" Fill="{StaticResource PrimaryBrush}" />
                                     <TextBlock VerticalAlignment="Center" FontSize="11" Foreground="{StaticResource PrimaryBrush}" Text="AF Points" />
                                 </StackPanel>
-                                <StackPanel Margin="0,1" Orientation="Horizontal" Visibility="{Binding ElementName=ShowSensorModel, Path=Tag, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}">
+                                <StackPanel Margin="0,1" Orientation="Horizontal" Visibility="{Binding ElementName=ShowSingleAfCurve, Path=Tag, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}">
                                     <Rectangle Width="12" Height="12" Margin="0,0,6,0" VerticalAlignment="Center" Fill="{StaticResource PrimaryBrush}" />
                                     <TextBlock VerticalAlignment="Center" FontSize="11" Foreground="{StaticResource PrimaryBrush}" Text="Center" />
                                 </StackPanel>
-                                <StackPanel Margin="0,1" Orientation="Horizontal" Visibility="{Binding ElementName=ShowSensorModel, Path=Tag, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}">
+                                <StackPanel Margin="0,1" Orientation="Horizontal" Visibility="{Binding ElementName=ShowSingleAfCurve, Path=Tag, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}">
                                     <Rectangle Width="12" Height="12" Margin="0,0,6,0" VerticalAlignment="Center" Fill="{StaticResource TopLeftBrush}" />
                                     <TextBlock VerticalAlignment="Center" FontSize="11" Foreground="{StaticResource PrimaryBrush}" Text="Top Left" />
                                 </StackPanel>
-                                <StackPanel Margin="0,1" Orientation="Horizontal" Visibility="{Binding ElementName=ShowSensorModel, Path=Tag, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}">
+                                <StackPanel Margin="0,1" Orientation="Horizontal" Visibility="{Binding ElementName=ShowSingleAfCurve, Path=Tag, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}">
                                     <Rectangle Width="12" Height="12" Margin="0,0,6,0" VerticalAlignment="Center" Fill="{StaticResource TopRightBrush}" />
                                     <TextBlock VerticalAlignment="Center" FontSize="11" Foreground="{StaticResource PrimaryBrush}" Text="Top Right" />
                                 </StackPanel>
-                                <StackPanel Margin="0,1" Orientation="Horizontal" Visibility="{Binding ElementName=ShowSensorModel, Path=Tag, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}">
+                                <StackPanel Margin="0,1" Orientation="Horizontal" Visibility="{Binding ElementName=ShowSingleAfCurve, Path=Tag, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}">
                                     <Rectangle Width="12" Height="12" Margin="0,0,6,0" VerticalAlignment="Center" Fill="{StaticResource BottomLeftBrush}" />
                                     <TextBlock VerticalAlignment="Center" FontSize="11" Foreground="{StaticResource PrimaryBrush}" Text="Bottom Left" />
                                 </StackPanel>
-                                <StackPanel Margin="0,1" Orientation="Horizontal" Visibility="{Binding ElementName=ShowSensorModel, Path=Tag, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}">
+                                <StackPanel Margin="0,1" Orientation="Horizontal" Visibility="{Binding ElementName=ShowSingleAfCurve, Path=Tag, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}">
                                     <Rectangle Width="12" Height="12" Margin="0,0,6,0" VerticalAlignment="Center" Fill="{StaticResource BottomRightBrush}" />
                                     <TextBlock VerticalAlignment="Center" FontSize="11" Foreground="{StaticResource PrimaryBrush}" Text="Bottom Right" />
                                 </StackPanel>
@@ -3089,6 +3102,56 @@
                             <StackPanel
                                 Margin="5,8,5,0"
                                 Visibility="{Binding IsTiltDeviceConnected, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                                <!--  Current per-motor stepper positions for the connected motorized adapter. 2×2
+                                      layout matches the physical corners; device motor numbering TR=1, TL=2, BR=3,
+                                      BL=4; wizard screw numbers per the device-connected calibration convention.  -->
+                                <TextBlock Margin="0,0,0,2" FontWeight="Bold" Text="Motor positions (steps)" />
+                                <Grid Margin="0,0,0,8" HorizontalAlignment="Left" MinWidth="260">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <!--  TL = device motor 2, wizard screw 2  -->
+                                    <Border Grid.Row="0" Grid.Column="0" Margin="0,0,2,2" Padding="6,3"
+                                        BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="3">
+                                        <StackPanel>
+                                            <TextBlock FontWeight="Bold" Text="TL · Motor 2" />
+                                            <TextBlock FontSize="10" Opacity="0.7" Text="Wizard screw 2" />
+                                            <TextBlock Margin="0,2,0,0" Text="{Binding ScrewPositionTopLeftDisplay}" />
+                                        </StackPanel>
+                                    </Border>
+                                    <!--  TR = device motor 1, wizard screw 1  -->
+                                    <Border Grid.Row="0" Grid.Column="1" Margin="2,0,0,2" Padding="6,3"
+                                        BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="3">
+                                        <StackPanel>
+                                            <TextBlock FontWeight="Bold" Text="TR · Motor 1" />
+                                            <TextBlock FontSize="10" Opacity="0.7" Text="Wizard screw 1" />
+                                            <TextBlock Margin="0,2,0,0" Text="{Binding ScrewPositionTopRightDisplay}" />
+                                        </StackPanel>
+                                    </Border>
+                                    <!--  BL = device motor 4, wizard screw 3  -->
+                                    <Border Grid.Row="1" Grid.Column="0" Margin="0,2,2,0" Padding="6,3"
+                                        BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="3">
+                                        <StackPanel>
+                                            <TextBlock FontWeight="Bold" Text="BL · Motor 4" />
+                                            <TextBlock FontSize="10" Opacity="0.7" Text="Wizard screw 3" />
+                                            <TextBlock Margin="0,2,0,0" Text="{Binding ScrewPositionBottomLeftDisplay}" />
+                                        </StackPanel>
+                                    </Border>
+                                    <!--  BR = device motor 3, wizard screw 4  -->
+                                    <Border Grid.Row="1" Grid.Column="1" Margin="2,2,0,0" Padding="6,3"
+                                        BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="3">
+                                        <StackPanel>
+                                            <TextBlock FontWeight="Bold" Text="BR · Motor 3" />
+                                            <TextBlock FontSize="10" Opacity="0.7" Text="Wizard screw 4" />
+                                            <TextBlock Margin="0,2,0,0" Text="{Binding ScrewPositionBottomRightDisplay}" />
+                                        </StackPanel>
+                                    </Border>
+                                </Grid>
                                 <Button
                                     Height="25"
                                     HorizontalAlignment="Left"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -690,7 +690,10 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             // (ctor, tiltAdapterOptions.PropertyChanged, ClearAnalyses) — only a genuinely completed analysis
             // counts as a new measurement.
             measurementGeneration++;
-            AutomaticAdjustmentCommand?.NotifyCanExecuteChanged();
+            // Marshal the requery: AnalyzeAutoFocusResult runs on the analysis background task and
+            // NotifyCanExecuteChanged raises through CanExecuteChangedEventManager, which requires the UI thread
+            // (same reason as RebuildTiltGuidance's own requery above).
+            applicationDispatcher.DispatchSynchronizationContext(() => AutomaticAdjustmentCommand?.NotifyCanExecuteChanged());
             AutoFocusCompleted = true;
             return true;
         }
@@ -2097,16 +2100,24 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     angleUnit: tiltAdapterOptions.AngleDisplayUnit);
             }
 
-            TiltGuidance = guidance;
-            RaisePropertyChanged(nameof(TiltGuidance));
+            // Publish to the UI on the UI thread. RebuildTiltGuidance runs on the analysis background task (via
+            // AnalyzeAutoFocusResult) as well as on the UI thread (ctor, tiltAdapterOptions.PropertyChanged), and
+            // AutomaticAdjustmentCommand.NotifyCanExecuteChanged() raises through CanExecuteChangedEventManager,
+            // which throws when called off the UI thread. DispatchSynchronizationContext is a synchronous Send
+            // with a same-thread fast path, so it runs inline for UI callers and marshals for the background task
+            // — the same pattern NotifyReviewFramesAvailabilityChanged uses.
+            applicationDispatcher.DispatchSynchronizationContext(() => {
+                TiltGuidance = guidance;
+                RaisePropertyChanged(nameof(TiltGuidance));
 
-            // Numeric guidance availability and the device-linked calibration marker (both read from
-            // tiltAdapterOptions, whose PropertyChanged is what drives every call to this method) both feed
-            // Automatic Adjustment's canExecute gate — re-raise its remediation text/visibility and
-            // canExecute here so they never go stale.
-            RaisePropertyChanged(nameof(AutomaticAdjustmentRemediationVisible));
-            RaisePropertyChanged(nameof(AutomaticAdjustmentRemediationText));
-            AutomaticAdjustmentCommand?.NotifyCanExecuteChanged();
+                // Numeric guidance availability and the device-linked calibration marker (both read from
+                // tiltAdapterOptions, whose PropertyChanged is what drives every call to this method) both feed
+                // Automatic Adjustment's canExecute gate — re-raise its remediation text/visibility and
+                // canExecute here so they never go stale.
+                RaisePropertyChanged(nameof(AutomaticAdjustmentRemediationVisible));
+                RaisePropertyChanged(nameof(AutomaticAdjustmentRemediationText));
+                AutomaticAdjustmentCommand?.NotifyCanExecuteChanged();
+            });
         }
 
         private const double PitchMismatchFraction = 0.15;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -120,7 +120,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         // dispatcher that unit tests don't have. Production default delegates to the real dialog
         // (DefaultShowAdjustmentPromptAsync). Signature mirrors TiltDeviceAdjustmentPrompt.ShowAsync minus the
         // windowServiceFactory parameter (fixed to this VM's own windowServiceFactory field in the default).
-        private readonly Func<Func<bool, bool, TiltDevicePlanPreview>, bool, string, bool, Task<TiltDeviceAdjustmentChoice>> showAdjustmentPromptAsync;
+        private readonly Func<Func<bool, bool, TiltDevicePlanPreview>, bool, string, bool, double, Task<TiltDeviceAdjustmentChoice>> showAdjustmentPromptAsync;
 
         // The confirming re-run after a successful adjustment. Injectable so tests can verify "re-run
         // invoked on accept" without exercising the full AutoFocus engine pipeline (AnalyzeAutoFocus requires
@@ -184,7 +184,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             ITiltAdapterOptions tiltAdapterOptions = null,
             TiltDeviceConnectionService tiltDeviceConnectionService = null,
             Func<string, string, Task<bool>> confirmPromptAsync = null,
-            Func<Func<bool, bool, TiltDevicePlanPreview>, bool, string, bool, Task<TiltDeviceAdjustmentChoice>> showAdjustmentPromptAsync = null,
+            Func<Func<bool, bool, TiltDevicePlanPreview>, bool, string, bool, double, Task<TiltDeviceAdjustmentChoice>> showAdjustmentPromptAsync = null,
             Func<CancellationToken, Task<bool>> reRunAnalysisAsync = null) : base(profileService) {
             this.applicationStatusMediator = applicationStatusMediator;
             this.imagingMediator = imagingMediator;
@@ -2233,6 +2233,36 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
         public bool IsTiltDeviceConnected => tiltDeviceConnectionService?.Connected ?? false;
 
+        // Live per-motor stepper positions for the connected motorized adapter, shown in the Tilt Adapter
+        // Guidance section. Device motor order matches the wizard's convention (TR=1, TL=2, BR=3, BL=4); there
+        // is no calibration-run baseline here, so — unlike the wizard — these carry no Δ.
+        public string ScrewPositionTopRightDisplay => TiltDevicePositionDisplay(0);
+
+        public string ScrewPositionTopLeftDisplay => TiltDevicePositionDisplay(1);
+
+        public string ScrewPositionBottomRightDisplay => TiltDevicePositionDisplay(2);
+
+        public string ScrewPositionBottomLeftDisplay => TiltDevicePositionDisplay(3);
+
+        private string TiltDevicePositionDisplay(int deviceMotorIndex) {
+            var svc = tiltDeviceConnectionService;
+            if (svc == null || !svc.PositionsKnown) {
+                return "unknown";
+            }
+            var positions = svc.CurrentPositions;
+            if (positions == null || positions.Count <= deviceMotorIndex) {
+                return "unknown";
+            }
+            return positions[deviceMotorIndex].ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        private void RaiseScrewPositionDisplays() {
+            RaisePropertyChanged(nameof(ScrewPositionTopRightDisplay));
+            RaisePropertyChanged(nameof(ScrewPositionTopLeftDisplay));
+            RaisePropertyChanged(nameof(ScrewPositionBottomRightDisplay));
+            RaisePropertyChanged(nameof(ScrewPositionBottomLeftDisplay));
+        }
+
         /// <summary>
         /// [CRITICAL GATE] Visible remediation hint when connected but the calibration is not linked to the
         /// connected device preset (see <see cref="IsCalibrationDeviceLinked"/>) — OR is linked but did not
@@ -2441,7 +2471,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 Replanner,
                 options.ScrewInwardCurvatureSignIsMeasured,
                 TiltGuidance?.PitchMismatchWarning ?? string.Empty,
-                !service.PositionsKnown);
+                !service.PositionsKnown,
+                unitMicrons);
 
             if (!choice.Proceed) {
                 // Cancel (or window close): no moves may be sent, and — per design doc user decision #9 — the
@@ -2657,8 +2688,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             Func<bool, bool, TiltDevicePlanPreview> replanner,
             bool screwInwardCurvatureSignIsMeasured,
             string pitchMismatchWarning,
-            bool positionsUnknown) {
-            return TiltDeviceAdjustmentPrompt.ShowAsync(windowServiceFactory, replanner, screwInwardCurvatureSignIsMeasured, pitchMismatchWarning, positionsUnknown);
+            bool positionsUnknown,
+            double unitMicrons) {
+            return TiltDeviceAdjustmentPrompt.ShowAsync(windowServiceFactory, replanner, screwInwardCurvatureSignIsMeasured, pitchMismatchWarning, positionsUnknown, unitMicrons);
         }
 
         private void TiltDeviceConnectionService_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e) {
@@ -2669,7 +2701,12 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     e.PropertyName == nameof(TiltDeviceConnectionService.Controller)) {
                     RaisePropertyChanged(nameof(IsTiltDeviceConnected));
                     RaisePropertyChanged(nameof(AutomaticAdjustmentRemediationVisible));
+                    RaiseScrewPositionDisplays();
                     AutomaticAdjustmentCommand?.NotifyCanExecuteChanged();
+                }
+                if (e.PropertyName == nameof(TiltDeviceConnectionService.CurrentPositions) ||
+                    e.PropertyName == nameof(TiltDeviceConnectionService.PositionsKnown)) {
+                    RaiseScrewPositionDisplays();
                 }
                 if (e.PropertyName == nameof(TiltDeviceConnectionService.IsOperationActive)) {
                     AutomaticAdjustmentCommand?.NotifyCanExecuteChanged();

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -2075,21 +2075,22 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             if (n == 4) angles[3] = tiltAdapterOptions.Screw4AngleDegrees;
             if (angles.Any(double.IsNaN)) return;
 
+            // Per-screw signed targets come from the shared helper (also consumed by the motorized
+            // move planner, T14) so the display and the planner can never diverge. The curvature sign
+            // applies ONLY to the backfocus component within the helper: the tilt component's
+            // direction is already encoded by the stored response-convention screw angle (the same
+            // convention the tilt arrows invert), so multiplying the whole total by the sign would
+            // double-apply the rig direction to the tilt part on sign = -1 rigs.
+            var targets = TiltScrewTargets.ComputePerScrewTargets(
+                model.Gx, model.Gy, model.Kx, model.Ky, model.X0, model.Y0, angles, radiusMicrons, unitMicrons, resolvedSign);
+
             var tiltText = new string[n];
             var backText = new string[n];
             var totalText = new string[n];
             for (int i = 0; i < n; i++) {
-                var corr = TiltScrewGeometry.ScrewCorrectionMicrons(
-                    model.Gx, model.Gy, model.Kx, model.Ky, model.X0, model.Y0, angles[i], radiusMicrons);
-                tiltText[i] = TiltAdapterGuidanceVM.FormatAmount(corr.TiltMicrons / unitMicrons, steps, angleUnit);
-                backText[i] = TiltAdapterGuidanceVM.FormatAmount(resolvedSign * corr.BackfocusMicrons / unitMicrons, steps, angleUnit);
-                // The curvature sign applies ONLY to the backfocus component: the tilt component's
-                // direction is already encoded by the stored response-convention screw angle (the same
-                // convention the tilt arrows invert), so multiplying the whole total by the sign would
-                // double-apply the rig direction to the tilt part on sign = -1 rigs.
-                double totalSigned = TiltScrewGeometry.SignedTotalAdjustment(
-                    corr.TiltMicrons, corr.BackfocusMicrons, unitMicrons, resolvedSign);
-                totalText[i] = TiltAdapterGuidanceVM.FormatAmount(totalSigned, steps, angleUnit);
+                tiltText[i] = TiltAdapterGuidanceVM.FormatAmount(targets[i].TiltSteps, steps, angleUnit);
+                backText[i] = TiltAdapterGuidanceVM.FormatAmount(targets[i].BackfocusSteps, steps, angleUnit);
+                totalText[i] = TiltAdapterGuidanceVM.FormatAmount(targets[i].TotalSteps, steps, angleUnit);
             }
 
             guidance.Screw1TiltAmount = tiltText[0];

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -690,10 +690,10 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             // (ctor, tiltAdapterOptions.PropertyChanged, ClearAnalyses) — only a genuinely completed analysis
             // counts as a new measurement.
             measurementGeneration++;
-            // Marshal the requery: AnalyzeAutoFocusResult runs on the analysis background task and
-            // NotifyCanExecuteChanged raises through CanExecuteChangedEventManager, which requires the UI thread
-            // (same reason as RebuildTiltGuidance's own requery above).
-            applicationDispatcher.DispatchSynchronizationContext(() => AutomaticAdjustmentCommand?.NotifyCanExecuteChanged());
+            // Marshal the requery to the UI thread (NotifyCanExecuteChanged raises through
+            // CanExecuteChangedEventManager, which requires it). Non-blocking Post, for the same
+            // deadlock-avoidance reason as RebuildTiltGuidance's publish above.
+            applicationDispatcher.PostSynchronizationContext(() => AutomaticAdjustmentCommand?.NotifyCanExecuteChanged());
             AutoFocusCompleted = true;
             return true;
         }
@@ -2100,13 +2100,17 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     angleUnit: tiltAdapterOptions.AngleDisplayUnit);
             }
 
-            // Publish to the UI on the UI thread. RebuildTiltGuidance runs on the analysis background task (via
-            // AnalyzeAutoFocusResult) as well as on the UI thread (ctor, tiltAdapterOptions.PropertyChanged), and
-            // AutomaticAdjustmentCommand.NotifyCanExecuteChanged() raises through CanExecuteChangedEventManager,
-            // which throws when called off the UI thread. DispatchSynchronizationContext is a synchronous Send
-            // with a same-thread fast path, so it runs inline for UI callers and marshals for the background task
-            // — the same pattern NotifyReviewFramesAvailabilityChanged uses.
-            applicationDispatcher.DispatchSynchronizationContext(() => {
+            // Publish to the UI on the UI thread. RebuildTiltGuidance runs on the UI thread (ctor) but ALSO on
+            // background threads: the analysis task (AnalyzeAutoFocusResult) and — via tiltAdapterOptions
+            // .PropertyChanged (subscribed in the ctor) — the connection service's 'cp' poll thread, because a
+            // poll persists shadow positions back into tiltAdapterOptions. AutomaticAdjustmentCommand
+            // .NotifyCanExecuteChanged() raises through CanExecuteChangedEventManager, which throws off the UI
+            // thread, so this must be marshaled. Use the NON-BLOCKING PostSynchronizationContext (BeginInvoke),
+            // NOT a blocking DispatchSynchronizationContext (Invoke): a blocking Invoke from the poll thread onto
+            // a busy UI thread (e.g. while it lays out the Imaging tab) deadlocks — the same hazard, and the same
+            // fix, as RefreshCommandStates. It still runs inline for UI-thread callers; the requery/publish only
+            // needs to reach the UI eventually, not synchronously.
+            applicationDispatcher.PostSynchronizationContext(() => {
                 TiltGuidance = guidance;
                 RaisePropertyChanged(nameof(TiltGuidance));
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -21,6 +21,7 @@ using NINA.Core.Model;
 using NINA.Core.Model.Equipment;
 using NINA.Core.Utility;
 using NINA.Core.Utility.Notification;
+using NINA.Core.Utility.SerialCommunication;
 using NINA.Core.Utility.WindowService;
 using NINA.Equipment.Equipment;
 using NINA.Equipment.Equipment.MyCamera;
@@ -39,6 +40,9 @@ using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.Scottplot;
 using NINA.Joko.Plugins.HocusFocus.StarDetection;
 using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt;
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
 using NINA.Joko.Plugins.HocusFocus.Utility;
 using NINA.Profile.Interfaces;
@@ -68,6 +72,7 @@ using static NINA.Joko.Plugins.HocusFocus.Inspection.SensorModel;
 using AsyncRelayCommand = CommunityToolkit.Mvvm.Input.AsyncRelayCommand;
 using DrawingColor = System.Drawing.Color;
 using Logger = NINA.Core.Utility.Logger;
+using MyMessageBox = NINA.Core.MyMessageBox.MyMessageBox;
 using RelayCommand = CommunityToolkit.Mvvm.Input.RelayCommand;
 using SPPlot = ScottPlot.Plot;
 using SPVector2 = ScottPlot.Statistics.Vector2;
@@ -98,6 +103,30 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         private readonly IApplicationDispatcher applicationDispatcher;
         private readonly IProgress<ApplicationStatus> progress;
         private readonly ITiltAdapterOptions tiltAdapterOptions;
+
+        // Shared motorized-device connection singleton (HocusFocusPlugin.TiltDeviceConnectionService in
+        // production, injected in tests; null-tolerant so device-less test rigs stay valid — Automatic
+        // Adjustment then degrades to "not connected"/disabled, mirroring TiltAdapterWizardVM's pattern).
+        private readonly TiltDeviceConnectionService tiltDeviceConnectionService;
+
+        // Yes/No confirmation prompt for the Automatic Adjustment flow (re-run to confirm; revert on
+        // mid-plan failure; revert on post-adjustment worsening). Injectable for tests; production default
+        // shows NINA's message box (ShowYesNoPromptAsync), mirroring TiltAdapterWizardVM's confirmIdleDisconnectAsync.
+        private readonly Func<string, string, Task<bool>> confirmPromptAsync;
+
+        // Shows the tilt-device adjustment approval dialog and returns the user's choice. Injectable so tests
+        // can drive the Automatic Adjustment flow (cancel / approve with a specific plan) WITHOUT opening a
+        // real WPF window — TiltDeviceAdjustmentPrompt.ShowAsync's ShowDialog call requires a live UI
+        // dispatcher that unit tests don't have. Production default delegates to the real dialog
+        // (DefaultShowAdjustmentPromptAsync). Signature mirrors TiltDeviceAdjustmentPrompt.ShowAsync minus the
+        // windowServiceFactory parameter (fixed to this VM's own windowServiceFactory field in the default).
+        private readonly Func<Func<bool, bool, TiltDevicePlanPreview>, bool, string, bool, Task<TiltDeviceAdjustmentChoice>> showAdjustmentPromptAsync;
+
+        // The confirming re-run after a successful adjustment. Injectable so tests can verify "re-run
+        // invoked on accept" without exercising the full AutoFocus engine pipeline (AnalyzeAutoFocus requires
+        // a working IAutoFocusEngine/camera/focuser and is exercised on its own elsewhere). Production default
+        // is the real AnalyzeAutoFocus(ct, captureCameraBlock: true).
+        private readonly Func<CancellationToken, Task<bool>> reRunAnalysisAsync;
 
         // WindowServiceFactory is not a MEF export (NINA exposes the concrete type with a default ctor only), so it
         // is instantiated directly here, mirroring HocusFocusPlugin — used to show the modal Review Frames dialog.
@@ -131,7 +160,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             IPluggableBehaviorSelector<IStarDetection> starDetectionSelector,
             IPluggableBehaviorSelector<IStarAnnotator> starAnnotatorSelector)
             : this(profileService, applicationStatusMediator, imagingMediator, cameraMediator, focuserMediator, filterWheelMediator, telescopeMediator, HocusFocusPlugin.StarDetectionOptions, HocusFocusPlugin.StarAnnotatorOptions, HocusFocusPlugin.InspectorOptions, HocusFocusPlugin.AutoFocusOptions, HocusFocusPlugin.AutoFocusEngineFactory,
-                  imageDataFactory, starDetectionSelector, starAnnotatorSelector, HocusFocusPlugin.ApplicationDispatcher, HocusFocusPlugin.AlglibAPI, HocusFocusPlugin.TiltAdapterOptions) {
+                  imageDataFactory, starDetectionSelector, starAnnotatorSelector, HocusFocusPlugin.ApplicationDispatcher, HocusFocusPlugin.AlglibAPI, HocusFocusPlugin.TiltAdapterOptions, HocusFocusPlugin.TiltDeviceConnectionService) {
         }
 
         public InspectorVM(
@@ -152,7 +181,11 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             IPluggableBehaviorSelector<IStarAnnotator> starAnnotatorSelector,
             IApplicationDispatcher applicationDispatcher,
             IAlglibAPI alglibAPI,
-            ITiltAdapterOptions tiltAdapterOptions = null) : base(profileService) {
+            ITiltAdapterOptions tiltAdapterOptions = null,
+            TiltDeviceConnectionService tiltDeviceConnectionService = null,
+            Func<string, string, Task<bool>> confirmPromptAsync = null,
+            Func<Func<bool, bool, TiltDevicePlanPreview>, bool, string, bool, Task<TiltDeviceAdjustmentChoice>> showAdjustmentPromptAsync = null,
+            Func<CancellationToken, Task<bool>> reRunAnalysisAsync = null) : base(profileService) {
             this.applicationStatusMediator = applicationStatusMediator;
             this.imagingMediator = imagingMediator;
             this.cameraMediator = cameraMediator;
@@ -211,10 +244,19 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             };
 
             this.tiltAdapterOptions = tiltAdapterOptions;
+            this.tiltDeviceConnectionService = tiltDeviceConnectionService;
+            this.confirmPromptAsync = confirmPromptAsync ?? ShowYesNoPromptAsync;
+            this.showAdjustmentPromptAsync = showAdjustmentPromptAsync ?? DefaultShowAdjustmentPromptAsync;
+            this.reRunAnalysisAsync = reRunAnalysisAsync ?? (ct => AnalyzeAutoFocus(ct, captureCameraBlock: true));
             TiltGuidance = new TiltAdapterGuidanceVM();
             if (tiltAdapterOptions != null) {
                 tiltAdapterOptions.PropertyChanged += (s, e) => RebuildTiltGuidance();
                 RebuildTiltGuidance();
+            }
+            if (this.tiltDeviceConnectionService != null) {
+                // This VM is a Shared MEF singleton, so this ctor-time subscription intentionally lives for
+                // the whole app run (mirrors TiltAdapterWizardVM's identical subscription).
+                this.tiltDeviceConnectionService.PropertyChanged += TiltDeviceConnectionService_PropertyChanged;
             }
 
             ImageGeometry = (System.Windows.Media.GeometryGroup)dict["InspectorSVG"];
@@ -229,6 +271,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             SlewToZenithWestCommand = new AsyncRelayCommand(() => SlewToZenith(true), canExecute: () => TelescopeInfo.Connected && (slewToZenithTask == null || slewToZenithTask?.Status >= TaskStatus.RanToCompletion));
             CancelSlewToZenithCommand = new RelayCommand(() => slewToZenithCts?.Cancel());
             ReviewFramesCommand = new RelayCommand(ShowFrameReview, canExecute: () => ReviewFramesAvailable);
+            AutomaticAdjustmentCommand = new AsyncRelayCommand(RunAutomaticAdjustmentAsync, CanExecuteAutomaticAdjustmentNow);
         }
 
         private bool AnalysisRunning() {
@@ -638,6 +681,16 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             UpdateBackfocusMeasurements(result);
             TiltModel.UpdateTiltModel(result, fRatio: profileService.ActiveProfile.TelescopeSettings.FocalRatio, backfocusFocuserPositionDelta: BackfocusFocuserPositionDelta);
             RebuildTiltGuidance();
+            // One-adjustment-per-measurement (design doc user decision #9): every COMPLETED analysis that
+            // reaches this point (wizard calibration steps included) is a fresh measurement. Automatic
+            // Adjustment's canExecute requires this counter to be strictly newer than the generation stamped
+            // on the last EXECUTED plan (see AutomaticAdjustmentCommand's canExecute) — so the button stays
+            // disabled after an adjustment until a brand-new analysis completes, and the same measurement can
+            // never drive two plans. Deliberately NOT incremented from RebuildTiltGuidance's other call sites
+            // (ctor, tiltAdapterOptions.PropertyChanged, ClearAnalyses) — only a genuinely completed analysis
+            // counts as a new measurement.
+            measurementGeneration++;
+            AutomaticAdjustmentCommand?.NotifyCanExecuteChanged();
             AutoFocusCompleted = true;
             return true;
         }
@@ -1724,6 +1777,11 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         // RelayCommand (not ICommand) so we can call NotifyCanExecuteChanged when the snapshot becomes (un)available.
         public RelayCommand ReviewFramesCommand { get; private set; }
 
+        // AsyncRelayCommand (not ICommand) so we can call NotifyCanExecuteChanged from the tilt device
+        // service's INPC, RebuildTiltGuidance, and the measurement-generation counter. See the "Tilt Adapter
+        // Automatic Adjustment" region below for the full flow.
+        public AsyncRelayCommand AutomaticAdjustmentCommand { get; private set; }
+
         private readonly object fullSensorDetectedStarsLock = new object();
         private readonly List<SensorDetectedStars> FullSensorDetectedStars = new List<SensorDetectedStars>();
 
@@ -2041,6 +2099,14 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
             TiltGuidance = guidance;
             RaisePropertyChanged(nameof(TiltGuidance));
+
+            // Numeric guidance availability and the device-linked calibration marker (both read from
+            // tiltAdapterOptions, whose PropertyChanged is what drives every call to this method) both feed
+            // Automatic Adjustment's canExecute gate — re-raise its remediation text/visibility and
+            // canExecute here so they never go stale.
+            RaisePropertyChanged(nameof(AutomaticAdjustmentRemediationVisible));
+            RaisePropertyChanged(nameof(AutomaticAdjustmentRemediationText));
+            AutomaticAdjustmentCommand?.NotifyCanExecuteChanged();
         }
 
         private const double PitchMismatchFraction = 0.15;
@@ -2119,6 +2185,481 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     $"Saved {label} ({unitMicrons:0.###} {units}) differs from the wizard's last measured value " +
                     $"({measured:0.###} {units}). Re-run the Tilt Adapter Wizard or update the saved value.";
             }
+        }
+
+        // ==================================================================================================
+        // Tilt Adapter Automatic Adjustment (T14): computes a move plan from the fitted sensor model, gets
+        // user approval via the modal approval dialog, executes it on the connected device with a revert
+        // journal, then offers to re-run the inspector to confirm. SAFETY-CRITICAL — see the design doc's
+        // "[CRITICAL GATE]" note and user decision #9 (one adjustment per measurement).
+        // ==================================================================================================
+
+        // Measurement-generation counter (design doc user decision #9): incremented once per COMPLETED
+        // analysis (see AnalyzeAutoFocusResult, the only place this is incremented). lastExecutedMeasurementGeneration
+        // is stamped with the generation captured at the start of a plan's execution, but only once execution
+        // has actually STARTED (>= 1 move successfully sent) — a dialog Cancel or an approved empty plan never
+        // touch it, so they don't consume the measurement.
+        private int measurementGeneration;
+        private int lastExecutedMeasurementGeneration;
+
+        // Test seams: AnalyzeAutoFocusResult (the only production incrementer of measurementGeneration)
+        // requires a full AutoFocusResult that is impractical to construct in a unit test, so tests drive
+        // and observe the measurement-generation counters directly here instead of running the whole
+        // analysis pipeline.
+        internal int MeasurementGenerationForTest {
+            get => measurementGeneration;
+            set {
+                measurementGeneration = value;
+                AutomaticAdjustmentCommand?.NotifyCanExecuteChanged();
+            }
+        }
+
+        internal int LastExecutedMeasurementGenerationForTest => lastExecutedMeasurementGeneration;
+
+        public bool IsTiltDeviceConnected => tiltDeviceConnectionService?.Connected ?? false;
+
+        /// <summary>
+        /// [CRITICAL GATE] Visible remediation hint when connected but the calibration is not linked to the
+        /// connected device preset (see <see cref="IsCalibrationDeviceLinked"/>) — OR is linked but did not
+        /// pass its own confidence/quality check (<see cref="ITiltAdapterOptions.CalibrationIsReliable"/>).
+        /// </summary>
+        public bool AutomaticAdjustmentRemediationVisible =>
+            IsTiltDeviceConnected &&
+            (!IsCalibrationDeviceLinked(tiltAdapterOptions) || !(tiltAdapterOptions?.CalibrationIsReliable ?? false));
+
+        public string AutomaticAdjustmentRemediationText =>
+            !IsCalibrationDeviceLinked(tiltAdapterOptions)
+                ? "This calibration is not linked to the connected device. Re-run calibration with the device connected."
+                : "This calibration is low-confidence (it did not pass quality validation). Re-run calibration to enable Automatic Adjustment.";
+
+        /// <summary>
+        /// [CRITICAL GATE] True only when the stored calibration was produced by a completed, connected
+        /// hands-off run against the SAME device preset that is now selected — see the design doc's
+        /// "[CRITICAL GATE]" note. A pre-existing manual/replay calibration could have "screw 1" mapped to a
+        /// different physical corner than the connected device's wiring, which would apply corrections
+        /// rotated 90°/180° and worsen tilt unattended. Connecting to the device always uses
+        /// tiltAdapterOptions.DeviceName as the preset name (TiltAdapterWizardVM.ConnectTiltDeviceAsync), so
+        /// DeviceName IS "the connected preset name" whenever the service reports Connected.
+        /// </summary>
+        internal static bool IsCalibrationDeviceLinked(ITiltAdapterOptions options) {
+            if (options == null) return false;
+            string linked = options.DeviceLinkedCalibrationDeviceName;
+            return !string.IsNullOrEmpty(linked) && linked == options.DeviceName;
+        }
+
+        /// <summary>
+        /// Pure canExecute gate for <see cref="AutomaticAdjustmentCommand"/> — every condition the design doc
+        /// and plan require, expressed as plain values so it's directly unit-testable without the VM. See
+        /// <see cref="CanExecuteAutomaticAdjustmentNow"/> for how the live VM/service state feeds this.
+        ///
+        /// <paramref name="calibrationIsReliable"/> is the second half of the "[CRITICAL GATE]" automation
+        /// gate: <see cref="ITiltAdapterOptions.CalibrationIsReliable"/>, persisted by TiltAdapterWizardVM's
+        /// RunCalibrationMath/ApplyManualCalibration from TiltCalibrationCalculator.ComputeConfidence's
+        /// IsReliable. A calibration can be device-linked (the correct wizard-screw &lt;-&gt; device-corner
+        /// correspondence) yet still be noise-dominated (measurement noise rivaling the screw-move signal) —
+        /// both must hold before automation may run unattended.
+        /// </summary>
+        internal static bool CanExecuteAutomaticAdjustment(
+            bool serviceConnected,
+            bool controllerAvailable,
+            bool deviceLinked,
+            bool calibrationIsReliable,
+            bool hasNumericGuidance,
+            bool isOperationActive,
+            int currentGeneration,
+            int lastExecutedGeneration) {
+            return serviceConnected
+                && controllerAvailable
+                && deviceLinked
+                && calibrationIsReliable
+                && hasNumericGuidance
+                && !isOperationActive
+                && currentGeneration > lastExecutedGeneration;
+        }
+
+        private bool CanExecuteAutomaticAdjustmentNow() {
+            var service = tiltDeviceConnectionService;
+            return CanExecuteAutomaticAdjustment(
+                serviceConnected: service?.Connected ?? false,
+                controllerAvailable: service?.Controller != null,
+                deviceLinked: IsCalibrationDeviceLinked(tiltAdapterOptions),
+                calibrationIsReliable: tiltAdapterOptions?.CalibrationIsReliable ?? false,
+                hasNumericGuidance: TiltGuidance?.HasNumericGuidance ?? false,
+                isOperationActive: service?.IsOperationActive ?? false,
+                currentGeneration: measurementGeneration,
+                lastExecutedGeneration: lastExecutedMeasurementGeneration);
+        }
+
+        /// <summary>Dimensionless tilt magnitude sqrt(Gx² + Gy²) — used for the before/after worsening check.</summary>
+        internal static double TiltMagnitude(SensorParaboloidModel model) =>
+            model == null ? double.NaN : Math.Sqrt(model.Gx * model.Gx + model.Gy * model.Gy);
+
+        // A tiny relative uptick is noise, not a real regression: require BOTH a fractional margin (relative
+        // to the "before" magnitude) and an absolute floor (so a near-zero before-magnitude can't make the
+        // relative test trivially satisfied by noise) before calling it "worse".
+        internal const double TiltWorseningRelativeMargin = 0.15;
+        internal const double TiltWorseningAbsoluteFloor = 1e-4;
+
+        /// <summary>True when <paramref name="afterMagnitude"/> is meaningfully larger than <paramref name="beforeMagnitude"/> — see TiltWorseningRelativeMargin/TiltWorseningAbsoluteFloor.</summary>
+        internal static bool TiltWorsened(double beforeMagnitude, double afterMagnitude) {
+            if (double.IsNaN(beforeMagnitude) || double.IsNaN(afterMagnitude)) return false;
+            if (!(afterMagnitude > beforeMagnitude)) return false;
+            double delta = afterMagnitude - beforeMagnitude;
+            double threshold = Math.Max(TiltWorseningAbsoluteFloor, beforeMagnitude * TiltWorseningRelativeMargin);
+            return delta >= threshold;
+        }
+
+        /// <summary>
+        /// Per-screw signed step/turn targets (TiltScrewTargets.ComputePerScrewTargets's TotalSteps) plus the
+        /// resolved unit size, computed directly from the fitted model + adapter options — the exact same
+        /// inputs FillNumericGuidance formats for display, so the planner's targets can never diverge from
+        /// what the guidance table shows. Throws InvalidOperationException for a not-fully-configured/not-4-screw
+        /// adapter (should be unreachable once CanExecuteAutomaticAdjustment has gated on hasNumericGuidance
+        /// and the only device-linkable presets are 4-screw EAT presets, but this guards defensively rather
+        /// than silently computing against a NaN Screw4AngleDegrees).
+        /// </summary>
+        internal static (double[] sPerScrew, double unitMicrons) BuildPerScrewTargets(SensorParaboloidModel model, ITiltAdapterOptions options) {
+            if (model == null) throw new ArgumentNullException(nameof(model));
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            if (options.ScrewCount != 4) {
+                throw new InvalidOperationException("Automatic Adjustment requires a 4-corner coupled device (screw count must be 4).");
+            }
+
+            bool steps = options.AdjustmentType == TiltAdjustmentType.StepperMotors;
+            double unitMicrons = steps ? options.StepperStepSizeMicrons : options.ThreadPitchMicrons;
+            double radiusMm = options.ScrewRadiusMillimeters;
+            if (unitMicrons <= 0 || radiusMm <= 0) {
+                throw new InvalidOperationException("Adapter hardware (unit size / screw radius) is not configured.");
+            }
+
+            var angles = new[] { options.Screw1AngleDegrees, options.Screw2AngleDegrees, options.Screw3AngleDegrees, options.Screw4AngleDegrees };
+            if (angles.Any(double.IsNaN)) {
+                throw new InvalidOperationException("Screw position angles are not fully calibrated.");
+            }
+
+            // Resolve the sign exactly like FillNumericGuidance does (σ is never persisted as 0 since the
+            // direction-setting feature, but resolve defensively to the assumed default here too) — using
+            // the raw options.ScrewInwardCurvatureSign here instead would let the planner's targets diverge
+            // from the guidance table the user actually approved if the sign were ever 0.
+            int curvatureSign = options.ScrewInwardCurvatureSign;
+            int resolvedSign = curvatureSign == 0 ? TiltScrewGeometry.DefaultScrewInwardCurvatureSign : curvatureSign;
+
+            var targets = TiltScrewTargets.ComputePerScrewTargets(
+                model.Gx, model.Gy, model.Kx, model.Ky, model.X0, model.Y0,
+                angles, radiusMm * 1000.0, unitMicrons, resolvedSign);
+            return (targets.Select(t => t.TotalSteps).ToArray(), unitMicrons);
+        }
+
+        /// <summary>
+        /// Builds one replanner invocation's preview: plans the moves for the given group toggles, then asks
+        /// the controller (via the interface — never a downcast) to order them for minimal peak excursion so
+        /// the approval dialog shows the EXACT execution order (WYSIWYG). A TiltDeviceLimitException from the
+        /// ordering call means either a single move exceeds the per-command cap or every ordering would
+        /// exceed the max excursion — surfaced as a blocking preview (unordered moves shown, matching the
+        /// design doc) rather than propagated, so the dialog can display it instead of crashing. Residuals,
+        /// twist, and the time estimate are unaffected by ordering, so they carry over unchanged from the
+        /// original plan.
+        /// </summary>
+        internal static TiltDevicePlanPreview BuildPlanPreview(
+            IReadOnlyList<double> sPerScrew,
+            bool includeTilt,
+            bool includeBackfocus,
+            double unitMicrons,
+            int maxStepsPerCommand,
+            ITiltMotionController controller) {
+            var plan = TiltMovePlanner.Plan(sPerScrew, includeTilt, includeBackfocus, unitMicrons, maxStepsPerCommand);
+            try {
+                var ordered = controller.OrderForMinimalPeakExcursion(plan.Moves);
+                var orderedPlan = new TiltAdapterMovePlan(ordered, plan.ResidualMicronsPerCorner, plan.TwistResidualSteps, plan.EstimatedSeconds);
+                return new TiltDevicePlanPreview(orderedPlan, hardLimitViolated: false, limitWarning: string.Empty);
+            } catch (TiltDeviceLimitException ex) {
+                return new TiltDevicePlanPreview(plan, hardLimitViolated: true, limitWarning: ex.Message);
+            }
+        }
+
+        private async Task RunAutomaticAdjustmentAsync() {
+            // Defensive re-check: canExecute already gates the UI button, but this makes the
+            // one-adjustment-per-measurement invariant hold even if this method is somehow invoked directly
+            // (e.g. programmatically, or a CanExecute/Execute race) — a second execution off the same
+            // measurement must be impossible, not just discouraged by a disabled button.
+            if (!CanExecuteAutomaticAdjustmentNow()) {
+                Logger.Warning("Automatic Adjustment invoked while its gate conditions were not satisfied; ignoring.");
+                return;
+            }
+
+            var service = tiltDeviceConnectionService;
+            var options = tiltAdapterOptions;
+            var controller = service?.Controller;
+            if (service == null || options == null || controller == null) {
+                return;
+            }
+
+            var model = SensorModel?.DisplayedSensorModel;
+            if (model == null) {
+                Notification.ShowError("No fitted sensor model is available for Automatic Adjustment.");
+                return;
+            }
+
+            // Captured up front: this is the measurement the plan below is computed from. It is only marked
+            // "consumed" (see below) once a move belonging to THIS plan has actually been sent — a later
+            // analysis completing while the dialog is open must not let this capture consume a newer
+            // measurement it was never computed from.
+            int capturedGeneration = measurementGeneration;
+
+            double[] sPerScrew;
+            double unitMicrons;
+            try {
+                (sPerScrew, unitMicrons) = BuildPerScrewTargets(model, options);
+            } catch (Exception ex) {
+                Logger.Error(ex, "Automatic Adjustment: failed to compute per-screw targets");
+                Notification.ShowError($"Could not compute the Automatic Adjustment plan: {ex.Message}");
+                return;
+            }
+
+            double beforeTiltMagnitude = TiltMagnitude(model);
+            int maxStepsPerCommand = options.TiltDeviceMaxStepsPerCommand;
+
+            TiltDevicePlanPreview Replanner(bool includeTilt, bool includeBackfocus) =>
+                BuildPlanPreview(sPerScrew, includeTilt, includeBackfocus, unitMicrons, maxStepsPerCommand, controller);
+
+            var choice = await showAdjustmentPromptAsync(
+                Replanner,
+                options.ScrewInwardCurvatureSignIsMeasured,
+                TiltGuidance?.PitchMismatchWarning ?? string.Empty,
+                !service.PositionsKnown);
+
+            if (!choice.Proceed) {
+                // Cancel (or window close): no moves may be sent, and — per design doc user decision #9 — the
+                // measurement is NOT consumed. The button stays enabled for another attempt off this same run.
+                return;
+            }
+
+            var moves = choice.FinalPlan?.Moves ?? Array.Empty<TiltAdapterMove>();
+            if (moves.Count == 0) {
+                // Approved but nothing to do (e.g. every residual rounded to 0 steps): a no-op does not
+                // consume the measurement either — nothing physical happened.
+                Notification.ShowInformation("Automatic Adjustment: no moves were needed for the approved groups.");
+                return;
+            }
+
+            using var operationToken = service.TryBeginOperation("Automatic Adjustment");
+            if (operationToken == null) {
+                Notification.ShowWarning("The tilt adapter device is busy with another operation; try Automatic Adjustment again once it finishes.");
+                return;
+            }
+
+            // Re-check after acquiring the lease: the dialog was open (holding no lease) while the user
+            // reviewed it, so the device could have disconnected, or reconnected to a different controller
+            // instance, in the meantime.
+            if (!service.Connected || !ReferenceEquals(service.Controller, controller)) {
+                Notification.ShowError("The tilt adapter device disconnected before Automatic Adjustment could execute; nothing was sent.");
+                return;
+            }
+
+            // Same re-check window, different hazard: closes a TOCTOU where two Automatic Adjustment
+            // invocations both captured this same generation (e.g. two dialogs opened off the same
+            // measurement) before either had executed. TryBeginOperation above serializes the two, but only
+            // by time, not by generation — if the OTHER invocation already ran to completion and stamped
+            // lastExecutedMeasurementGeneration while this one was waiting on the dialog/lease, this
+            // invocation must not go on to send a second, redundant/over-correcting plan against the same
+            // already-consumed measurement.
+            if (lastExecutedMeasurementGeneration >= capturedGeneration) {
+                Logger.Warning("Automatic Adjustment: this measurement was already consumed by a concurrent invocation; ignoring.");
+                return;
+            }
+
+            var journal = new List<TiltAdapterMove>();
+            Exception failure = null;
+            var moveProgress = new Progress<string>(text => this.progress.Report(new ApplicationStatus { Status = $"Automatic Adjustment: {text}" }));
+
+            for (int i = 0; i < moves.Count; i++) {
+                var move = moves[i];
+                this.progress.Report(new ApplicationStatus { Status = $"Automatic Adjustment: move {i + 1} of {moves.Count} — {move.Description}" });
+                try {
+                    await controller.ExecuteMoveAsync(move, moveProgress, CancellationToken.None);
+                    journal.Add(move);
+                } catch (Exception ex) {
+                    failure = ex;
+                    break;
+                }
+            }
+
+            // Consumed once execution has STARTED (>= 1 move sent), regardless of what happens next (success,
+            // failure, or a later revert) — the same measurement can never drive a second plan.
+            if (journal.Count > 0) {
+                lastExecutedMeasurementGeneration = capturedGeneration;
+                AutomaticAdjustmentCommand?.NotifyCanExecuteChanged();
+            }
+
+            if (failure != null) {
+                Logger.Error(failure, "Automatic Adjustment: move execution failed");
+                await HandleExecutionFailureAsync(controller, journal, failure);
+                return;
+            }
+
+            this.progress.Report(new ApplicationStatus { Status = "Automatic Adjustment: complete" });
+            Notification.ShowInformation($"Automatic Adjustment complete: {journal.Count} move(s) sent.");
+
+            bool confirmRerun = await confirmPromptAsync(
+                "Automatic Adjustment finished sending the approved moves. Re-run the Aberration Inspector to confirm the improvement?",
+                "Confirm Adjustment");
+            if (!confirmRerun) {
+                return;
+            }
+
+            bool analyzed = await reRunAnalysisAsync(CancellationToken.None);
+            if (!analyzed) {
+                Notification.ShowWarning("The confirming Aberration Inspector run did not complete; verify the result manually before adjusting again.");
+                return;
+            }
+
+            var afterModel = SensorModel?.DisplayedSensorModel;
+            double afterTiltMagnitude = TiltMagnitude(afterModel);
+            if (TiltWorsened(beforeTiltMagnitude, afterTiltMagnitude)) {
+                Notification.ShowError(
+                    "Tilt got WORSE after this Automatic Adjustment. This can indicate a stale calibration, a rotated camera/adapter, " +
+                    "or an incorrect curvature-sign setting — investigate before adjusting again.");
+                bool confirmRevert = await confirmPromptAsync(
+                    "Tilt appears WORSE after the moves just applied. Revert them now (send the inverse of each move, in reverse order)?",
+                    "Tilt Worsened — Revert?");
+                if (confirmRevert) {
+                    await RevertJournalAsync(controller, journal, "post-adjustment worsening");
+
+                    // The confirming re-run above incremented measurementGeneration (a new completed
+                    // analysis), but lastExecutedMeasurementGeneration is still stamped with the PRE-revert
+                    // generation this plan was computed from. Left unbumped, the canExecute gate
+                    // (currentGeneration > lastExecutedGeneration) would immediately re-enable the button
+                    // against the STALE, now-reverted DisplayedSensorModel — a second plan computed before
+                    // the user has looked at fresh (post-revert) numbers could over-correct an already-reverted
+                    // device. Consume the confirming measurement so a genuinely NEW analysis is required.
+                    lastExecutedMeasurementGeneration = measurementGeneration;
+                    AutomaticAdjustmentCommand?.NotifyCanExecuteChanged();
+                }
+            }
+        }
+
+        private async Task HandleExecutionFailureAsync(ITiltMotionController controller, List<TiltAdapterMove> journal, Exception failure) {
+            string failureText = DescribeFailure(failure);
+            if (journal.Count == 0) {
+                if (!FirstMoveFailureMeansDeviceUntouched(failure)) {
+                    // Per EatTiltMotionController's exception taxonomy, anything other than
+                    // TiltDeviceLimitException on the FIRST move (TiltDeviceCommandFailedException, a
+                    // propagated SerialPortClosedException, or something unexpected) means a command WAS
+                    // actually sent to the device before the failure — the outcome is ambiguous (an EEPROM
+                    // move may have executed) and the shadow was deliberately NOT advanced. The journal being
+                    // empty here reflects only that no move was confirmed successful, NOT that nothing
+                    // physical happened.
+                    Logger.Error(failure, "Automatic Adjustment: first move failed after a command may have been sent; device state is ambiguous.");
+                }
+                Notification.ShowError(DescribeFirstMoveFailureNotification(failure, failureText));
+                return;
+            }
+
+            Notification.ShowError($"Automatic Adjustment failed after {journal.Count} of its move(s) were sent: {failureText}");
+            bool confirmRevert = await confirmPromptAsync(
+                $"Automatic Adjustment failed after {journal.Count} move(s) were sent: {failureText}\n\nRevert the applied move(s) now (send the inverse of each, in reverse order)?",
+                "Automatic Adjustment Failed");
+            if (confirmRevert) {
+                await RevertJournalAsync(controller, journal, "mid-plan failure");
+            } else {
+                Notification.ShowWarning("The applied move(s) were left in place. Verify the device's position in the vendor app before adjusting again.");
+            }
+        }
+
+        private async Task RevertJournalAsync(ITiltMotionController controller, List<TiltAdapterMove> journal, string context) {
+            for (int i = journal.Count - 1; i >= 0; i--) {
+                var inverse = EatWizardMapping.InverseMove(journal[i]);
+                try {
+                    this.progress.Report(new ApplicationStatus { Status = $"Automatic Adjustment: reverting move {journal.Count - i} of {journal.Count} — {inverse.Description}" });
+                    await controller.ExecuteMoveAsync(inverse, null, CancellationToken.None);
+                } catch (Exception ex) {
+                    // Revert itself failed partway: the device's tracked position can no longer be trusted.
+                    // There is no interface member to force-invalidate a controller's shadow position, so the
+                    // actionable recovery path is the one the controller already implements: ConnectAsync
+                    // always re-queries the device's absolute positions and overwrites the shadow with ground
+                    // truth on a successful parse. Tell the user to use it.
+                    Logger.Error(ex, $"Automatic Adjustment revert ({context}) failed partway through; device position may be inaccurate.");
+                    Notification.ShowError(
+                        $"Revert failed: {ex.Message}. The device's tracked position may now be inaccurate — " +
+                        "disconnect and reconnect the tilt adapter device to resync its position from the hardware before doing anything else.");
+                    return;
+                }
+            }
+            Notification.ShowWarning($"Automatic Adjustment: {journal.Count} move(s) were reverted ({context}).");
+        }
+
+        private static string DescribeFailure(Exception failure) {
+            switch (failure) {
+                case OperationCanceledException _:
+                    return "the operation was cancelled";
+                case TiltDeviceLimitException limitEx:
+                    return $"a device travel limit was violated ({limitEx.Message})";
+                case TiltDeviceCommandFailedException cmdEx:
+                    return cmdEx.Message;
+                case SerialPortClosedException portEx:
+                    return $"the serial port closed unexpectedly ({portEx.Message})";
+                default:
+                    return failure.Message;
+            }
+        }
+
+        /// <summary>
+        /// True only for <see cref="TiltDeviceLimitException"/> -- per EatTiltMotionController's exception
+        /// taxonomy (see its <c>ExecuteMoveAsync</c> XML doc's "Exception taxonomy" section), this is the ONLY
+        /// exception thrown strictly BEFORE any device I/O, so a limit violation on the very first move
+        /// guarantees the device was never touched. Any other exception (<see cref="TiltDeviceCommandFailedException"/>,
+        /// a propagated <see cref="SerialPortClosedException"/>, or something unexpected) means a command may
+        /// already have been sent, even though the journal is empty (nothing was CONFIRMED successful).
+        /// </summary>
+        internal static bool FirstMoveFailureMeansDeviceUntouched(Exception failure) => failure is TiltDeviceLimitException;
+
+        /// <summary>
+        /// The notification text for a failure on the FIRST move of a plan (empty journal) -- see
+        /// <see cref="FirstMoveFailureMeansDeviceUntouched"/> for which branch applies. Extracted as a pure
+        /// helper (mirrors <see cref="DescribeFailure"/>) specifically so the two outcomes are directly
+        /// unit-testable without a live VM/Notification pipeline (Notification is a no-op in headless tests).
+        /// </summary>
+        internal static string DescribeFirstMoveFailureNotification(Exception failure, string failureText) {
+            if (FirstMoveFailureMeansDeviceUntouched(failure)) {
+                return $"Automatic Adjustment failed before any move was sent: {failureText}. Nothing was sent to the device.";
+            }
+            return $"Automatic Adjustment failed on its first move: {failureText}\n\nA command may have already been sent to the device, so its position is now UNCERTAIN — " +
+                "verify the device's position in the vendor app before doing anything else, or disconnect and reconnect the tilt adapter device to force a fresh resync of its position from the hardware.";
+        }
+
+        // Production Yes/No confirmation: NINA's message box (mirrors TiltAdapterWizardVM.ShowIdleDisconnectPromptAsync).
+        // Default answer is No for every caller of confirmPromptAsync in this file — never proceed with an
+        // irreversible hardware action (re-run, revert) just because a dialog was dismissed.
+        private static Task<bool> ShowYesNoPromptAsync(string message, string title) {
+            var result = MyMessageBox.Show(message, title, MessageBoxButton.YesNo, MessageBoxResult.No);
+            return Task.FromResult(result == MessageBoxResult.Yes);
+        }
+
+        // Production adjustment-approval dialog: the real modal (TiltDeviceAdjustmentPrompt.ShowAsync), using
+        // this VM's own windowServiceFactory. See showAdjustmentPromptAsync's field doc for why this is
+        // injectable at all (unit tests cannot open a real WPF window).
+        private Task<TiltDeviceAdjustmentChoice> DefaultShowAdjustmentPromptAsync(
+            Func<bool, bool, TiltDevicePlanPreview> replanner,
+            bool screwInwardCurvatureSignIsMeasured,
+            string pitchMismatchWarning,
+            bool positionsUnknown) {
+            return TiltDeviceAdjustmentPrompt.ShowAsync(windowServiceFactory, replanner, screwInwardCurvatureSignIsMeasured, pitchMismatchWarning, positionsUnknown);
+        }
+
+        private void TiltDeviceConnectionService_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e) {
+            // The service raises INPC from its polling/idle timer threads; marshal without blocking them
+            // (mirrors TiltAdapterWizardVM.TiltDeviceConnectionService_PropertyChanged).
+            applicationDispatcher.PostSynchronizationContext(() => {
+                if (e.PropertyName == nameof(TiltDeviceConnectionService.Connected) ||
+                    e.PropertyName == nameof(TiltDeviceConnectionService.Controller)) {
+                    RaisePropertyChanged(nameof(IsTiltDeviceConnected));
+                    RaisePropertyChanged(nameof(AutomaticAdjustmentRemediationVisible));
+                    AutomaticAdjustmentCommand?.NotifyCanExecuteChanged();
+                }
+                if (e.PropertyName == nameof(TiltDeviceConnectionService.IsOperationActive)) {
+                    AutomaticAdjustmentCommand?.NotifyCanExecuteChanged();
+                }
+            });
         }
 
         private TrendlineFitting GetLineFitting(AutoFocusFitting fitting) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/CameraSimulatorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/CameraSimulatorOptions.cs
@@ -857,5 +857,22 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator {
                 }
             }
         }
+
+        private double[] simNetAxialMicrons = new double[4];
+
+        // Not persisted (an ephemeral session counter, like the pre-existing manual net) and deliberately NOT
+        // routed through optionsAccessor. Copies defensively on get/set so no caller can mutate the backing
+        // array in place and skip the INPC that both SimulatedTiltAdapterVM instances rely on.
+        public double[] SimNetAxialMicrons {
+            get => (double[])simNetAxialMicrons.Clone();
+            set {
+                var next = new double[4];
+                if (value != null) {
+                    Array.Copy(value, next, Math.Min(value.Length, 4));
+                }
+                simNetAxialMicrons = next;
+                RaisePropertyChanged();
+            }
+        }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/HocusFocusSimulatorCamera.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/HocusFocusSimulatorCamera.cs
@@ -135,7 +135,12 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator {
         /// </summary>
         public bool HasSetupDialog => true;
 
-        public string Id => "HocusFocus_SimulatorCamera";
+        /// <summary>The stable device id NINA reports as <c>CameraInfo.DeviceId</c> for this camera. Exposed as a
+        /// constant so callers (e.g. the tilt wizard's "connect the simulator" gate) can identify the active
+        /// camera without a magic string.</summary>
+        public const string DeviceId = "HocusFocus_SimulatorCamera";
+
+        public string Id => DeviceId;
         public string Name => "Hocus Focus Simulator";
         public string DisplayName => Name;
         public string Category => "Hocus Focus";

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/ISimulatedTiltActuator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/ISimulatedTiltActuator.cs
@@ -1,0 +1,40 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System.Collections.Generic;
+
+namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
+
+    /// <summary>
+    /// The seam <c>SimulatedEatTransport</c> drives to make the camera simulator behave like a connected ASG
+    /// EAT. It is the software stand-in for the four physical motors: apply a move (in the wizard's screw-index
+    /// order, the order <see cref="TiltAdapterDevices.TiltAdapterMove.PerCornerSteps"/> uses) and read back the
+    /// per-motor step counters (in the device's motor order, the order a real <c>cp</c> reply uses).
+    /// </summary>
+    public interface ISimulatedTiltActuator {
+
+        /// <summary>
+        /// Applies a move expressed as per-screw signed step counts in WIZARD screw-index order (screws 1..4 at
+        /// [0..3]) — exactly a <see cref="TiltAdapterDevices.TiltAdapterMove.PerCornerSteps"/> vector. Advances
+        /// the per-motor counters and folds the resulting best-focus-surface change into the simulator's injected
+        /// aberration so the next simulated exposure reflects it.
+        /// </summary>
+        void ApplyWizardScrewSteps(IReadOnlyList<double> wizardOrderSteps);
+
+        /// <summary>
+        /// The cumulative per-motor step counters in DEVICE motor order (motor 1..4 = TR, TL, BR, BL at [0..3]),
+        /// i.e. the order a real EAT <c>cp</c> reply reports and the order the controller's shadow tracking and
+        /// the wizard's position display both expect. Always a 4-element array.
+        /// </summary>
+        int[] GetPerMotorPositions();
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedEatTransport.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedEatTransport.cs
@@ -1,0 +1,86 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
+
+    /// <summary>
+    /// A drop-in <see cref="IEatTransport"/> that speaks the ASG EAT command vocabulary but drives a
+    /// <see cref="ISimulatedTiltActuator"/> (the camera simulator) instead of a serial port. It lets the
+    /// entire, UNCHANGED EAT stack — <c>EatTiltMotionController</c> (limits, shadow tracking, wizard↔device
+    /// permutation), <c>EatCommands</c>, <c>EatResponses</c> — run against software, closing the calibration
+    /// loop with no hardware. Because it produces clean, canonical responses the tolerant parsers already
+    /// accept, it needs none of the T15 live-capture wire-format knowledge.
+    ///
+    /// <para><c>cp</c> is answered with the actuator's four device-order counters as a comma-separated line
+    /// (which <see cref="EatResponses.ParseCpPositions"/> reads as the first four integers). Every move command
+    /// is decoded with <see cref="EatCommands.TryParse"/> back into its axis + steps, turned into the wizard-
+    /// order per-corner effect (<see cref="TiltAdapterMove.UnitEffect"/> × steps — the exact vector the
+    /// controller formatted from), applied to the actuator, and acknowledged (an exchange that did not time out,
+    /// which <see cref="EatResponses.ParseMoveAck"/> treats as success).</para>
+    /// </summary>
+    public sealed class SimulatedEatTransport : IEatTransport {
+        private readonly ISimulatedTiltActuator actuator;
+        private bool isOpen;
+
+        public SimulatedEatTransport(ISimulatedTiltActuator actuator) {
+            this.actuator = actuator ?? throw new ArgumentNullException(nameof(actuator));
+        }
+
+        public bool IsOpen => isOpen;
+
+        public Task OpenAsync(string portName, CancellationToken ct) {
+            ct.ThrowIfCancellationRequested();
+            isOpen = true; // The port string is the "Simulator" sentinel; there is no real port to open.
+            return Task.CompletedTask;
+        }
+
+        public void Close() => isOpen = false;
+
+        public Task<EatRawExchange> SendAsync(string command, TimeSpan timeout, CancellationToken ct) {
+            if (command == null) {
+                throw new ArgumentNullException(nameof(command));
+            }
+            ct.ThrowIfCancellationRequested();
+
+            if (command == EatCommands.PositionQuery()) {
+                var positions = actuator.GetPerMotorPositions();
+                var line = string.Join(",", positions.Select(p => p.ToString(CultureInfo.InvariantCulture)));
+                return Task.FromResult(new EatRawExchange(command, new[] { line }, timedOut: false));
+            }
+
+            if (!EatCommands.TryParse(command, out var axis, out var steps)) {
+                // The controller only ever sends 'cp' or EatCommands.Format output, so anything else is a bug.
+                throw new ArgumentException(
+                    $"SimulatedEatTransport received a command it cannot parse: '{command}'. Only 'cp' and EatCommands.Format output are expected.",
+                    nameof(command));
+            }
+
+            var effect = TiltAdapterMove.UnitEffect(axis);
+            var wizardSteps = new double[effect.Count];
+            for (int i = 0; i < wizardSteps.Length; ++i) {
+                wizardSteps[i] = effect[i] * steps;
+            }
+            actuator.ApplyWizardScrewSteps(wizardSteps);
+
+            // Empty, non-timed-out exchange = success ack (EatResponses.ParseMoveAck returns !TimedOut).
+            return Task.FromResult(new EatRawExchange(command, Array.Empty<string>(), timedOut: false));
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltActuator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltActuator.cs
@@ -75,9 +75,32 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
                 }
             }
 
-            // 2) Fold the optical effect into the injected aberration on the UI thread (synchronous), so the next
-            //    simulated exposure sees it. FoldIntoInjection is a no-op when the geometry can't build a plane.
-            dispatcher.DispatchSynchronizationContext(() => FoldIntoInjection(wizardOrderSteps));
+            // 2) On the UI thread (synchronous, so the next simulated exposure sees it): accumulate the shared
+            //    per-screw net counters (so every SimulatedTiltAdapterVM's "Net" strip reflects the automated
+            //    move, exactly as manual clicks do), then fold the optical effect into the injected aberration
+            //    (a no-op when the geometry can't build a plane).
+            dispatcher.DispatchSynchronizationContext(() => {
+                AccumulateNet(wizardOrderSteps);
+                FoldIntoInjection(wizardOrderSteps);
+            });
+        }
+
+        // Accumulate the applied per-screw steps into the shared net counters (axial µm), the same counters the
+        // manual panel's clicks update and the "Net" strip displays. Runs unconditionally (a real motor moves
+        // even when the geometry can't render an optical effect). sim screw i == wizard screw i, so the wizard-
+        // order vector maps straight onto the sim-screw-ordered net array.
+        private void AccumulateNet(IReadOnlyList<double> wizardOrderSteps) {
+            var unit = options.SimAdjustmentType == TiltAdjustmentType.StepperMotors
+                ? options.SimStepperStepSizeMicrons
+                : options.SimThreadPitchMicrons;
+            if (unit <= 0) {
+                return; // Can't scale steps to µm; the Net strip shows 0 in this state anyway.
+            }
+            var net = options.SimNetAxialMicrons;
+            for (int i = 0; i < net.Length && i < wizardOrderSteps.Count; i++) {
+                net[i] += wizardOrderSteps[i] * unit;
+            }
+            options.SimNetAxialMicrons = net;
         }
 
         private void FoldIntoInjection(IReadOnlyList<double> wizardOrderSteps) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltActuator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltActuator.cs
@@ -1,0 +1,124 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
+
+    /// <summary>
+    /// Software stand-in for the ASG EAT's four motors, over the camera simulator. It builds a
+    /// <see cref="SimulatedTiltAdapter"/> from the current <c>Sim*</c> options exactly the way
+    /// <c>SimulatedTiltAdapterVM.RebuildAdapter</c> does, feeds each move's WIZARD-order per-screw steps
+    /// (× the active step size) into <see cref="SimulatedTiltAdapter.ApplyMoves"/>, and folds the result into
+    /// the persisted injected aberration through the shared <see cref="SimulatedTiltInjection.Fold"/> — so the
+    /// automated calibration loop and the manual panel drive the identical, sign-verified math.
+    ///
+    /// <para><b>Two index orders, on purpose.</b> Moves come in WIZARD screw order (screws 1..4), which is the
+    /// order <see cref="SimulatedTiltAdapter.ApplyMoves"/> and the sim's own screw geometry use. The per-motor
+    /// counters returned for <c>cp</c> are kept in DEVICE motor order (TR, TL, BR, BL) via
+    /// <see cref="EatTiltMotionController.PermuteWizardToDeviceMotorOrder"/>, matching a real device's reply and
+    /// the controller's shadow tracking. The counters are advanced on EVERY move (a real motor turns regardless
+    /// of optical effect); the optical fold is skipped only when the sim geometry can't build a valid plane.</para>
+    ///
+    /// <para><b>Threading.</b> Called from the connection service's background move execution. The injected-
+    /// aberration writes are marshalled onto the UI thread via
+    /// <see cref="IApplicationDispatcher.DispatchSynchronizationContext(Action)"/> (synchronous, so the fold is
+    /// committed before the move returns and the next exposure observes it); the two <c>SimulatedTiltAdapterVM</c>
+    /// instances subscribe to <c>CameraSimulatorOptions.PropertyChanged</c>, so the dockable panel reflects
+    /// automated moves live without this class ever touching a VM. The counters are guarded by a lock.</para>
+    /// </summary>
+    public sealed class SimulatedTiltActuator : ISimulatedTiltActuator {
+        private readonly ICameraSimulatorOptions options;
+        private readonly IApplicationDispatcher dispatcher;
+        private readonly object gate = new object();
+        private readonly int[] positions = new int[4]; // DEVICE motor order (TR, TL, BR, BL).
+
+        public SimulatedTiltActuator(ICameraSimulatorOptions options, IApplicationDispatcher dispatcher) {
+            this.options = options ?? throw new ArgumentNullException(nameof(options));
+            this.dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        }
+
+        public int[] GetPerMotorPositions() {
+            lock (gate) {
+                return (int[])positions.Clone();
+            }
+        }
+
+        public void ApplyWizardScrewSteps(IReadOnlyList<double> wizardOrderSteps) {
+            if (wizardOrderSteps == null) {
+                throw new ArgumentNullException(nameof(wizardOrderSteps));
+            }
+            if (wizardOrderSteps.Count != 4) {
+                throw new ArgumentException("Expected 4 wizard-order step values (the EAT is a 4-corner adapter).", nameof(wizardOrderSteps));
+            }
+
+            // 1) Advance the per-motor counters (device order) unconditionally -- a real motor moves regardless of
+            //    whether the sim geometry can render an optical effect, and cp / excursion tracking must stay
+            //    faithful to that. PerCornerSteps entries are integer step counts, so the round is exact.
+            var deviceDelta = EatTiltMotionController.PermuteWizardToDeviceMotorOrder(wizardOrderSteps);
+            lock (gate) {
+                for (int i = 0; i < 4; ++i) {
+                    positions[i] += (int)Math.Round(deviceDelta[i], MidpointRounding.AwayFromZero);
+                }
+            }
+
+            // 2) Fold the optical effect into the injected aberration on the UI thread (synchronous), so the next
+            //    simulated exposure sees it. FoldIntoInjection is a no-op when the geometry can't build a plane.
+            dispatcher.DispatchSynchronizationContext(() => FoldIntoInjection(wizardOrderSteps));
+        }
+
+        private void FoldIntoInjection(IReadOnlyList<double> wizardOrderSteps) {
+            var adapter = BuildAdapter();
+            if (adapter == null || adapter.ScrewCount != wizardOrderSteps.Count) {
+                return; // Unbuildable/incompatible geometry -- counters are already advanced above.
+            }
+
+            var unit = adapter.UnitMicrons;
+            var axialPerScrew = new double[wizardOrderSteps.Count];
+            for (int i = 0; i < axialPerScrew.Length; ++i) {
+                axialPerScrew[i] = wizardOrderSteps[i] * unit;
+            }
+
+            AberrationDelta delta;
+            try {
+                delta = adapter.ApplyMoves(axialPerScrew);
+            } catch (InvalidOperationException) {
+                return; // Collinear screw geometry -- same defensive skip the manual panel makes.
+            }
+
+            SimulatedTiltInjection.Fold(options, delta, adapter.PistonDirectionSign);
+        }
+
+        // Mirrors SimulatedTiltAdapterVM.RebuildAdapter: same angle set, unit selection, mm->µm radius, and the
+        // finite/positive guards. Returns null when the geometry can't build a plane.
+        private SimulatedTiltAdapter BuildAdapter() {
+            var n = options.SimScrewCount == 4 ? 4 : 3;
+            var angles = new[] {
+                options.SimScrew1AngleDegrees, options.SimScrew2AngleDegrees,
+                options.SimScrew3AngleDegrees, options.SimScrew4AngleDegrees
+            }.Take(n).ToArray();
+            var unit = options.SimAdjustmentType == TiltAdjustmentType.StepperMotors
+                ? options.SimStepperStepSizeMicrons
+                : options.SimThreadPitchMicrons;
+            var radiusMicrons = options.SimScrewRadiusMillimeters * 1000.0;
+
+            if (angles.Any(a => !double.IsFinite(a)) || unit <= 0 || radiusMicrons <= 0) {
+                return null;
+            }
+            return new SimulatedTiltAdapter(angles, radiusMicrons, unit, options.SimScrewInwardCurvatureSign);
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltAdapterVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltAdapterVM.cs
@@ -128,7 +128,8 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
 
         private readonly ICameraSimulatorOptions options;
         private readonly ITiltAdapterOptions realAdapter;
-        private readonly double[] netAxialMicrons = new double[4];
+        // Per-screw net counters live on the shared options (options.SimNetAxialMicrons), NOT in a local field,
+        // so automated moves (SimulatedTiltActuator) and every SimulatedTiltAdapterVM instance stay in lockstep.
 
         private SimulatedTiltAdapter adapter;
         private bool derivingAngles;
@@ -384,15 +385,16 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
         /// Per-screw accumulated position since the last re-zero, in axial µm. Stored in µm — not turns — so a
         /// mid-session pitch edit re-scales the display instead of corrupting it.
         /// </summary>
-        public IReadOnlyList<double> NetAxialMicrons => netAxialMicrons.Take(ScrewCount).ToArray();
+        public IReadOnlyList<double> NetAxialMicrons => options.SimNetAxialMicrons.Take(ScrewCount).ToArray();
 
         public string NetPositionText {
             get {
                 var unit = UnitMicrons;
+                var net = options.SimNetAxialMicrons;
                 var sb = new StringBuilder();
                 for (var i = 0; i < ScrewCount; i++) {
                     if (i > 0) sb.Append("  ·  ");
-                    var value = unit > 0 ? netAxialMicrons[i] / unit : 0.0;
+                    var value = unit > 0 ? net[i] / unit : 0.0;
                     sb.Append(CultureInfo.CurrentCulture, $"{i + 1}: {FormatNet(value)}");
                 }
                 return sb.ToString();
@@ -641,9 +643,11 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
             var backfocusBefore = options.BackfocusErrorMicrons;
             var clamped = ApplyDelta(delta);
 
+            var net = options.SimNetAxialMicrons;
             for (var i = 0; i < moves.Length; i++) {
-                netAxialMicrons[i] += moves[i];
+                net[i] += moves[i];
             }
+            options.SimNetAxialMicrons = net;
 
             undoSnapshot = snapshot;
             LastActionText = BuildLastActionText(turn, moves, tiltBefore, backfocusBefore, clamped);
@@ -798,7 +802,7 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
 
         private PanelSnapshot Capture() => new PanelSnapshot(
             options.TiltAmountMicrons, options.TiltAngleDegrees, options.BackfocusErrorMicrons,
-            options.OptimalFocuserPosition, (double[])netAxialMicrons.Clone(), LastActionText);
+            options.OptimalFocuserPosition, options.SimNetAxialMicrons, LastActionText);
 
         /// <summary>Single level: misclicks in a rapid loop must be free, but this is not an edit history.</summary>
         private void Undo() {
@@ -808,7 +812,7 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
             options.TiltAngleDegrees = s.TiltAngleDegrees;
             options.BackfocusErrorMicrons = s.BackfocusErrorMicrons;
             options.OptimalFocuserPosition = s.OptimalFocuserPosition;
-            Array.Copy(s.NetAxialMicrons, netAxialMicrons, netAxialMicrons.Length);
+            options.SimNetAxialMicrons = s.NetAxialMicrons;
             undoSnapshot = null;
             LastActionText = s.LastActionText;
             AfterStateChanged();
@@ -816,7 +820,7 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
 
         /// <summary>Re-bases the counter display only — never the plane. Hence "Re-zero", not "Reset".</summary>
         private void Rezero() {
-            Array.Clear(netAxialMicrons, 0, netAxialMicrons.Length);
+            options.SimNetAxialMicrons = new double[4];
             RaisePropertyChanged(nameof(NetAxialMicrons));
             RaisePropertyChanged(nameof(NetPositionText));
         }
@@ -897,6 +901,13 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
             }
 
             switch (e.PropertyName) {
+                case nameof(ICameraSimulatorOptions.SimNetAxialMicrons):
+                    // Shared net counters changed (a manual click on this or the other panel, or an automated
+                    // move via SimulatedTiltActuator) — refresh only the Net strip, not the whole panel.
+                    RaisePropertyChanged(nameof(NetAxialMicrons));
+                    RaisePropertyChanged(nameof(NetPositionText));
+                    break;
+
                 case nameof(ICameraSimulatorOptions.SimScrewCount):
                 case nameof(ICameraSimulatorOptions.SimScrew1AngleDegrees):
                 case nameof(ICameraSimulatorOptions.SimScrewNumberingClockwise):

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltAdapterVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltAdapterVM.cs
@@ -113,8 +113,10 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
         /// <summary>Passive "expect heavy donuts" warning above this. Extreme states stay legal — Undo is free.</summary>
         private const double ExtremeTiltMicrons = 500.0;
 
-        /// <summary>The persisted bounds of the aberration boxes (Resources/OptionsDataTemplates.xaml).</summary>
-        private const double AberrationBoundMicrons = 10_000.0;
+        /// <summary>The persisted bounds of the aberration boxes (Resources/OptionsDataTemplates.xaml).
+        /// Single-sourced from <see cref="SimulatedTiltInjection.AberrationBoundMicrons"/> so the manual panel and
+        /// the automated actuator clamp to the exact same bound.</summary>
+        private const double AberrationBoundMicrons = SimulatedTiltInjection.AberrationBoundMicrons;
 
         private const double DefaultTurnsPerClick = 0.25;
         private const double DefaultStepsPerClick = 10.0;
@@ -702,53 +704,13 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
         /// raw fitted constant in here is correct only on σ=+1 rigs and silently backwards on the other half —
         /// pinned by SimulatedTiltAdapterVMTests.BackfocusMove_OnOppositeRigs_MovesBackfocusInOppositeDirections.
         /// </summary>
-        private bool ApplyDelta(AberrationDelta delta) {
-            var (halfW, halfH) = SensorHalfDimensionsMicrons();
+        // Delegates to the shared, sign-critical implementation so the manual panel and the automated actuator
+        // fold identically (see SimulatedTiltInjection). Behavior-preserving — the sign/clamp tests are unchanged.
+        private bool ApplyDelta(AberrationDelta delta) =>
+            SimulatedTiltInjection.Fold(options, delta, adapter.PistonDirectionSign);
 
-            // Current gradient from the options' (azimuth, amount) form — the same inversion AberrationSurface uses.
-            var phi = options.TiltAngleDegrees * Math.PI / 180.0;
-            var den = Math.Abs(Math.Cos(phi)) * halfW + Math.Abs(Math.Sin(phi)) * halfH;
-            var g = den > 0 ? options.TiltAmountMicrons / den : 0.0;
-            var gx = g * Math.Cos(phi) + delta.Gx;
-            var gy = g * Math.Sin(phi) + delta.Gy;
-
-            // Back to (azimuth, amount). The amount is a non-negative magnitude by construction — AberrationSurface
-            // rejects a negative one, because direction belongs to the azimuth.
-            var amount = Math.Abs(gx) * halfW + Math.Abs(gy) * halfH;
-            var clamped = amount > AberrationBoundMicrons;
-            options.TiltAmountMicrons = Math.Min(amount, AberrationBoundMicrons);
-            options.TiltAngleDegrees = TiltCalibrationCalculator.NormalizeAngle(Math.Atan2(gy, gx) * 180.0 / Math.PI);
-
-            var pistonMicrons = adapter.PistonDirectionSign * delta.PistonMicrons;
-            if (pistonMicrons != 0.0) {
-                // The sensor moving axially both shifts best focus... Effective, not raw: the raw value is the -1
-                // "unset" sentinel on an uncalibrated Inspector, and the render uses Effective, so converting the
-                // piston with anything else would move best focus somewhere the star field is not defocused about.
-                options.OptimalFocuserPosition += (int)Math.Round(pistonMicrons / options.EffectiveFocuserStepSizeMicrons);
-
-                // ...and violates the optics' backfocus spacing. The curvature responds to the PISTON, not to any
-                // individual screw move, so a corner move (piston 0 by symmetry) correctly leaves it untouched.
-                // The proportionality is fixed by being the exact inverse of the inspector's backfocus row: it asks
-                // for an axial ΔZ0_phys = -CurvatureAt(R) = -K·R² per screw, which must null K exactly, so
-                // ΔK = ΔZ0_phys / R². Equivalently — and this is the independent check that fixes the sign —
-                // ScrewInwardCurvatureSign is DEFINED as the sign of the curvature-effect response to a CW turn,
-                // and a CW turn gives ΔZ0_phys = σ·(+δ), so ΔBackfocusError must carry the sign of σ.
-                var radiusMicrons = options.SimScrewRadiusMillimeters * 1000.0;
-                if (radiusMicrons > 0) {
-                    var backfocus = options.BackfocusErrorMicrons +
-                        pistonMicrons * (halfW * halfW + halfH * halfH) / (radiusMicrons * radiusMicrons);
-                    clamped |= Math.Abs(backfocus) > AberrationBoundMicrons;
-                    options.BackfocusErrorMicrons = Math.Clamp(backfocus, -AberrationBoundMicrons, AberrationBoundMicrons);
-                }
-            }
-
-            return clamped;
-        }
-
-        private (double halfWidth, double halfHeight) SensorHalfDimensionsMicrons() {
-            var sensor = SensorRegistry.Get(options.SensorModel);
-            return (sensor.Width * sensor.PixelSizeMicrons / 2.0, sensor.Height * sensor.PixelSizeMicrons / 2.0);
-        }
+        private (double halfWidth, double halfHeight) SensorHalfDimensionsMicrons() =>
+            SimulatedTiltInjection.SensorHalfDimensionsMicrons(options);
 
         // ---- Feedback --------------------------------------------------------------------------------
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltInjection.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltInjection.cs
@@ -1,0 +1,98 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.CameraSimulator.Sensors;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
+using System;
+
+namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
+
+    /// <summary>
+    /// The single, sign-critical implementation of folding a virtual-adapter <see cref="AberrationDelta"/> into
+    /// the camera simulator's persisted injected aberration. Extracted verbatim from
+    /// <see cref="SimulatedTiltAdapterVM.ApplyDelta"/> so that BOTH ways of driving the virtual adapter -- the
+    /// manual dockable panel (<see cref="SimulatedTiltAdapterVM"/>) and the automated
+    /// <c>SimulatedEatTransport</c>/<c>SimulatedTiltActuator</c> path -- run the exact same gradient-compose +
+    /// piston arithmetic. The closed calibration loop only converges if the injection here is the exact inverse
+    /// of the inspector's guidance; keeping ONE implementation (rather than two that could silently drift) is
+    /// what guarantees that. Pure: reads/writes only <see cref="ICameraSimulatorOptions"/>.
+    /// </summary>
+    public static class SimulatedTiltInjection {
+
+        /// <summary>The persisted bounds of the aberration boxes (Resources/OptionsDataTemplates.xaml).</summary>
+        internal const double AberrationBoundMicrons = 10_000.0;
+
+        /// <summary>Half the physical sensor extents (µm), from the simulator's selected sensor.</summary>
+        internal static (double halfWidth, double halfHeight) SensorHalfDimensionsMicrons(ICameraSimulatorOptions options) {
+            var sensor = SensorRegistry.Get(options.SensorModel);
+            return (sensor.Width * sensor.PixelSizeMicrons / 2.0, sensor.Height * sensor.PixelSizeMicrons / 2.0);
+        }
+
+        /// <summary>
+        /// Fold a screw-move delta into the simulator's injected aberration (design §3.2). Returns true when a
+        /// value had to be clamped to the persisted bounds.
+        ///
+        /// THE SIGN, stated once: <see cref="AberrationDelta"/> is an honest plane fit in the adapter's RESPONSE
+        /// frame. On a σ=−1 rig that frame is a point reflection of the physical one, so the fitted GRADIENT is
+        /// frame-invariant (both the screw position and its displacement flip, and their product does not) and
+        /// Gx/Gy apply raw — but the constant term has no angle to absorb the reflection, so the physical piston
+        /// is <c>PistonDirectionSign · PistonMicrons</c>. This is the same asymmetry the guidance has, where
+        /// <see cref="TiltScrewGeometry.SignedTotalAdjustment"/> applies the curvature sign to its backfocus
+        /// component only; the two cancel, so backfocus guidance converges on both rig directions. Feeding the
+        /// raw fitted constant in here is correct only on σ=+1 rigs and silently backwards on the other half —
+        /// pinned by SimulatedTiltAdapterVMTests.BackfocusMove_OnOppositeRigs_MovesBackfocusInOppositeDirections.
+        /// </summary>
+        public static bool Fold(ICameraSimulatorOptions options, AberrationDelta delta, int pistonDirectionSign) {
+            var (halfW, halfH) = SensorHalfDimensionsMicrons(options);
+
+            // Current gradient from the options' (azimuth, amount) form — the same inversion AberrationSurface uses.
+            var phi = options.TiltAngleDegrees * Math.PI / 180.0;
+            var den = Math.Abs(Math.Cos(phi)) * halfW + Math.Abs(Math.Sin(phi)) * halfH;
+            var g = den > 0 ? options.TiltAmountMicrons / den : 0.0;
+            var gx = g * Math.Cos(phi) + delta.Gx;
+            var gy = g * Math.Sin(phi) + delta.Gy;
+
+            // Back to (azimuth, amount). The amount is a non-negative magnitude by construction — AberrationSurface
+            // rejects a negative one, because direction belongs to the azimuth.
+            var amount = Math.Abs(gx) * halfW + Math.Abs(gy) * halfH;
+            var clamped = amount > AberrationBoundMicrons;
+            options.TiltAmountMicrons = Math.Min(amount, AberrationBoundMicrons);
+            options.TiltAngleDegrees = TiltCalibrationCalculator.NormalizeAngle(Math.Atan2(gy, gx) * 180.0 / Math.PI);
+
+            var pistonMicrons = pistonDirectionSign * delta.PistonMicrons;
+            if (pistonMicrons != 0.0) {
+                // The sensor moving axially both shifts best focus... Effective, not raw: the raw value is the -1
+                // "unset" sentinel on an uncalibrated Inspector, and the render uses Effective, so converting the
+                // piston with anything else would move best focus somewhere the star field is not defocused about.
+                options.OptimalFocuserPosition += (int)Math.Round(pistonMicrons / options.EffectiveFocuserStepSizeMicrons);
+
+                // ...and violates the optics' backfocus spacing. The curvature responds to the PISTON, not to any
+                // individual screw move, so a corner move (piston 0 by symmetry) correctly leaves it untouched.
+                // The proportionality is fixed by being the exact inverse of the inspector's backfocus row: it asks
+                // for an axial ΔZ0_phys = -CurvatureAt(R) = -K·R² per screw, which must null K exactly, so
+                // ΔK = ΔZ0_phys / R². Equivalently — and this is the independent check that fixes the sign —
+                // ScrewInwardCurvatureSign is DEFINED as the sign of the curvature-effect response to a CW turn,
+                // and a CW turn gives ΔZ0_phys = σ·(+δ), so ΔBackfocusError must carry the sign of σ.
+                var radiusMicrons = options.SimScrewRadiusMillimeters * 1000.0;
+                if (radiusMicrons > 0) {
+                    var backfocus = options.BackfocusErrorMicrons +
+                        pistonMicrons * (halfW * halfW + halfH * halfH) / (radiusMicrons * radiusMicrons);
+                    clamped |= Math.Abs(backfocus) > AberrationBoundMicrons;
+                    options.BackfocusErrorMicrons = Math.Clamp(backfocus, -AberrationBoundMicrons, AberrationBoundMicrons);
+                }
+            }
+
+            return clamped;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/HocusFocusPlugin.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/HocusFocusPlugin.cs
@@ -15,6 +15,7 @@ using NINA.Joko.Plugins.HocusFocus.CameraSimulator;
 using NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter;
 using NINA.Joko.Plugins.HocusFocus.Properties;
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
 using NINA.Joko.Plugins.HocusFocus.StarDetection;
 using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
 using NINA.Core.Utility;
@@ -121,6 +122,9 @@ namespace NINA.Joko.Plugins.HocusFocus {
             }
             // Must follow CameraSimulatorOptions: the VM reads it and subscribes to its PropertyChanged.
             SimTiltAdapterVM = new SimulatedTiltAdapterVM(CameraSimulatorOptions);
+            if (TiltDeviceConnectionService == null) {
+                TiltDeviceConnectionService = new TiltDeviceConnectionService(profileService, TiltAdapterOptions);
+            }
             if (AlglibAPI == null) {
                 AlglibAPI = new AlglibAPI();
             }
@@ -291,6 +295,8 @@ namespace NINA.Joko.Plugins.HocusFocus {
         /// geometry live in the options, never in the VM.
         /// </remarks>
         public SimulatedTiltAdapterVM SimTiltAdapterVM { get; private set; }
+
+        public static TiltDeviceConnectionService TiltDeviceConnectionService { get; private set; }
 
         public static AutoFocusEngineFactory AutoFocusEngineFactory { get; private set; }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/HocusFocusPlugin.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/HocusFocusPlugin.cs
@@ -16,6 +16,7 @@ using NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter;
 using NINA.Joko.Plugins.HocusFocus.Properties;
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
 using NINA.Joko.Plugins.HocusFocus.StarDetection;
 using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
 using NINA.Core.Utility;
@@ -123,7 +124,18 @@ namespace NINA.Joko.Plugins.HocusFocus {
             // Must follow CameraSimulatorOptions: the VM reads it and subscribes to its PropertyChanged.
             SimTiltAdapterVM = new SimulatedTiltAdapterVM(CameraSimulatorOptions);
             if (TiltDeviceConnectionService == null) {
-                TiltDeviceConnectionService = new TiltDeviceConnectionService(profileService, TiltAdapterOptions);
+                // The "Simulator" port connects the EAT automation to the camera simulator instead of real
+                // hardware, so the whole calibration/adjustment loop can run with nothing plugged in. A single
+                // shared actuator (created lazily on first Connect) keeps the per-motor counters and injected
+                // aberration coherent across reconnects; the closure runs only at Connect time, by which point
+                // the CameraSimulatorOptions and ApplicationDispatcher statics are both set.
+                SimulatedTiltActuator sharedSimActuator = null;
+                TiltDeviceConnectionService = new TiltDeviceConnectionService(
+                    profileService, TiltAdapterOptions,
+                    simulatedControllerFactory: () => {
+                        sharedSimActuator ??= new SimulatedTiltActuator(CameraSimulatorOptions, ApplicationDispatcher);
+                        return new EatTiltMotionController(new SimulatedEatTransport(sharedSimActuator), TiltAdapterOptions);
+                    });
             }
             if (AlglibAPI == null) {
                 AlglibAPI = new AlglibAPI();

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ICameraSimulatorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ICameraSimulatorOptions.cs
@@ -165,6 +165,13 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         double SimScrewRadiusMillimeters { get; set; }       // screw distance from sensor center
         bool ShowSimulatorTiltAdapterPanel { get; set; }
 
+        // Per-sim-screw accumulated position since the last re-zero, in axial µm (index 0..3 = sim screw 1..4).
+        // Shared, in-memory (NOT persisted) state: the manual panel AND automated moves (SimulatedTiltActuator,
+        // driving a connected simulated EAT) accumulate into the SAME counters, so every SimulatedTiltAdapterVM
+        // instance's "Net" strip reflects both. The getter returns a copy and the setter replaces (copy) + INPC,
+        // so callers cannot mutate the backing array in place.
+        double[] SimNetAxialMicrons { get; set; }
+
         void ResetDefaults();
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltAdapterOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltAdapterOptions.cs
@@ -108,6 +108,20 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         // entry, replay-driven recalculation, and disconnected runs must clear it back to "".
         string DeviceLinkedCalibrationDeviceName { get; set; }
 
+        // [CRITICAL AUTOMATION GATE] True only when the CURRENT stored calibration's own confidence/quality
+        // result (TiltCalibrationCalculator.ComputeConfidence's IsReliable — signal-to-noise across the
+        // per-step tilt vectors) passed. False for a noise-dominated calibration (SNR below
+        // TiltCalibrationCalculator.MinReliableSignalToNoise), a manual entry (ApplyManualCalibration has no
+        // confidence to evaluate), or any completion where reliability could not be established. Automation
+        // (the inspector's Automatic Adjustment, T14, and any future wizard auto-apply) MUST be blocked
+        // whenever this is false, even when the calibration IS device-linked: a device-linked-but-unreliable
+        // calibration is safe to review but not safe to trust unattended. Written at every calibration-math
+        // completion (RunCalibrationMath and ApplyManualCalibration — the same places that set/clear
+        // DeviceLinkedCalibrationDeviceName above); conservative by default (false) whenever reliability
+        // cannot be established. Internal state marker, not a user setting — it needs NO UI control, exactly
+        // like DeviceLinkedCalibrationDeviceName above (also intentionally absent from the options UI).
+        bool CalibrationIsReliable { get; set; }
+
         // Opaque serialized per-motor cumulative step counters + a validity flag, tracking each motor's
         // position relative to its last-known home/reference so absolute travel limits can be enforced
         // across app restarts. "" = no shadow position recorded yet. The serialization format is defined

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltAdapterOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltAdapterOptions.cs
@@ -80,5 +80,44 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         // Persisted (independent of AutoFocusOptions.SavePath) so the location is reused; "" = unset.
         // NOTE: whether saving is ON is a transient per-run toggle on the VM, not persisted here.
         string SaveAFRunsPath { get; set; }
+
+        // --- Motorized tilt-adapter device connection ---
+
+        // Serial port name the tilt-adapter device connects over (e.g. "COM3"). "" = unset.
+        string TiltDeviceSerialPortName { get; set; }
+
+        // Safety cap on the magnitude of a single commanded move, in device steps. Guards against
+        // sending an oversized command to the hardware in one shot.
+        int TiltDeviceMaxStepsPerCommand { get; set; }
+
+        // Safety cap on the total cumulative excursion (in device steps) a motor may travel from its
+        // shadow-tracked home position before automation refuses to move it further.
+        int TiltDeviceMaxExcursionSteps { get; set; }
+
+        // Seconds to wait after a commanded move before treating the device as settled (e.g. before
+        // polling position or issuing the next command).
+        double TiltDeviceSettleSeconds { get; set; }
+
+        // [CRITICAL AUTOMATION GATE] The device preset name (see TiltAdapterDevicePreset) the CURRENT
+        // stored calibration is linked to. "" means the calibration is NOT device-linked (e.g. it came
+        // from manual screw entry, ApplyManualCalibration, or a replay), and hands-off device automation
+        // (the wizard's auto-apply and the inspector's Automatic Adjustment button) MUST be blocked: a
+        // pre-existing manual calibration's screw numbering/orientation may not match how the device's
+        // motors are wired, and applying corrections against the wrong mapping would worsen tilt
+        // unattended. Only a completed hands-off (connected-device) calibration run may set this; manual
+        // entry, replay-driven recalculation, and disconnected runs must clear it back to "".
+        string DeviceLinkedCalibrationDeviceName { get; set; }
+
+        // Opaque serialized per-motor cumulative step counters + a validity flag, tracking each motor's
+        // position relative to its last-known home/reference so absolute travel limits can be enforced
+        // across app restarts. "" = no shadow position recorded yet. The serialization format is defined
+        // and consumed by the device controller; this option only stores/round-trips the raw string.
+        string TiltDeviceShadowPositions { get; set; }
+
+        // Amount the user (or automation) moves each screw/motor during the per-screw calibration steps
+        // (full turns for screws, steps for steppers). -1 = unset, resolved to the selected device
+        // preset's default (TiltAdapterDevicePreset.DefaultCalibrationAmount) — still user-editable
+        // afterward.
+        double CalibrationAppliedAmount { get; set; }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltMotionController.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltMotionController.cs
@@ -1,0 +1,120 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
+
+    /// <summary>
+    /// The rigid-body topology a motorized tilt device implements. Determines which planner (see the
+    /// design doc's "3-corner extensibility" note) can drive it: today only <see cref="FourCornerCoupled"/>
+    /// (the ASG EAT) is implemented; <see cref="ThreeCornerIndependent"/> is a placeholder for a future
+    /// device/planner pair where each screw can be commanded independently.
+    /// </summary>
+    public enum TiltDeviceTopology {
+        FourCornerCoupled,
+        ThreeCornerIndependent
+    }
+
+    /// <summary>
+    /// Immutable description of what a connected <see cref="ITiltMotionController"/> can do. Constructed
+    /// once by the driver (typically from its <c>Capabilities</c> property) and never mutated. Mirrors the
+    /// constructor-assigned, get-only immutability style of <c>TiltAdapterDevicePreset</c>; the incoming
+    /// axis list is defensively copied so the exposed <see cref="SupportedAxes"/> can't be mutated out from
+    /// under the driver after construction.
+    /// </summary>
+    public sealed class TiltDeviceCapabilities {
+
+        public TiltDeviceCapabilities(TiltDeviceTopology topology, IReadOnlyList<TiltMoveAxis> supportedAxes, bool supportsPerScrewIndependent) {
+            Topology = topology;
+            SupportedAxes = new ReadOnlyCollection<TiltMoveAxis>((supportedAxes ?? Array.Empty<TiltMoveAxis>()).ToArray());
+            SupportsPerScrewIndependent = supportsPerScrewIndependent;
+        }
+
+        public TiltDeviceTopology Topology { get; }
+
+        /// <summary>The device move axes (see <see cref="TiltMoveAxis"/>) this device accepts commands on.</summary>
+        public IReadOnlyList<TiltMoveAxis> SupportedAxes { get; }
+
+        /// <summary>
+        /// True if the device can move a single screw/motor independently of the others (a 3-corner
+        /// independent device). The ASG EAT is <c>FourCornerCoupled</c> and declares this <c>false</c> —
+        /// every command moves at least a diagonal or edge pair.
+        /// </summary>
+        public bool SupportsPerScrewIndependent { get; }
+    }
+
+    /// <summary>
+    /// Immutable snapshot of a motorized tilt device's per-motor position counters, as returned by a
+    /// position query (e.g. the ASG EAT's <c>cp</c> command). Device motor order 1..4 = TR, TL, BR, BL
+    /// (see the design doc's "Device corner labels" note — this is the DEVICE's own numbering, distinct
+    /// from the wizard's screw indices used elsewhere in this feature). Mirrors the constructor-assigned,
+    /// get-only immutability style of <c>TiltAdapterDevicePreset</c>.
+    /// </summary>
+    public sealed class TiltDevicePositions {
+
+        public TiltDevicePositions(IReadOnlyList<int> perMotorSteps, bool known) {
+            PerMotorSteps = new ReadOnlyCollection<int>((perMotorSteps ?? Array.Empty<int>()).ToArray());
+            Known = known;
+        }
+
+        /// <summary>Per-motor absolute step counters in DEVICE motor order 1..4 (TR, TL, BR, BL) at [0..3].</summary>
+        public IReadOnlyList<int> PerMotorSteps { get; }
+
+        /// <summary>
+        /// False when the device's positions could not be determined (e.g. the response protocol is not
+        /// yet understood, or the query failed) — callers must not assume <see cref="PerMotorSteps"/> is
+        /// meaningful unless this is true.
+        /// </summary>
+        public bool Known { get; }
+
+        /// <summary>Convenience singleton for "no position information available": empty list, <see cref="Known"/> false.</summary>
+        public static TiltDevicePositions Unknown { get; } = new TiltDevicePositions(Array.Empty<int>(), known: false);
+    }
+
+    /// <summary>
+    /// Abstraction over a connected motorized tilt-adapter device (e.g. the ASG EAT). Implementations own
+    /// the transport (serial or otherwise), command formatting, and any device-specific limits/shadow
+    /// position tracking. Deliberately has NO zero-positions member: per the design doc's user decision
+    /// #5, zeroing screw/motor position counters is the vendor app's job — the plugin never zeroes.
+    /// </summary>
+    public interface ITiltMotionController : INotifyPropertyChanged {
+
+        /// <summary>True while connected to the device. Implementations raise <see cref="INotifyPropertyChanged.PropertyChanged"/> for this property.</summary>
+        bool Connected { get; }
+
+        /// <summary>What this device can do (topology, supported move axes, per-screw independence).</summary>
+        TiltDeviceCapabilities Capabilities { get; }
+
+        /// <summary>Opens the connection to the device over the given port (e.g. "COM3").</summary>
+        Task ConnectAsync(string portName, CancellationToken ct);
+
+        /// <summary>Closes the connection to the device.</summary>
+        Task DisconnectAsync(CancellationToken ct);
+
+        /// <summary>
+        /// Sends the given move to the device and awaits its completion. <paramref name="progress"/>
+        /// receives human-readable status text (e.g. "Move 1 of 3: tr,+50") suitable for direct display.
+        /// </summary>
+        Task ExecuteMoveAsync(TiltAdapterMove move, IProgress<string> progress, CancellationToken ct);
+
+        /// <summary>Queries the device's current per-motor positions.</summary>
+        Task<TiltDevicePositions> QueryPositionsAsync(CancellationToken ct);
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltMotionController.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltMotionController.cs
@@ -116,5 +116,19 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
 
         /// <summary>Queries the device's current per-motor positions.</summary>
         Task<TiltDevicePositions> QueryPositionsAsync(CancellationToken ct);
+
+        /// <summary>
+        /// Orders <paramref name="moves"/> (a small plan) to minimize the peak per-motor excursion across
+        /// every intermediate state, starting from the device's current (shadow-tracked) position.
+        /// Pure/side-effect-free: does not touch device state and sends nothing. Callers (e.g. the
+        /// Aberration Inspector's Automatic Adjustment) call this once to decide send order via the
+        /// interface -- never by downcasting to a concrete driver -- then invoke
+        /// <see cref="ExecuteMoveAsync"/> for each move in the returned order (whose own per-move
+        /// validation remains the defensive, authoritative check). Throws
+        /// <see cref="NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat.TiltDeviceLimitException"/> if
+        /// any move exceeds the per-command cap (no ordering can fix that) or if even the best ordering's
+        /// peak excursion exceeds the configured max -- in either case nothing is sent.
+        /// </summary>
+        IReadOnlyList<TiltAdapterMove> OrderForMinimalPeakExcursion(IReadOnlyList<TiltAdapterMove> moves);
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatCommands.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatCommands.cs
@@ -12,6 +12,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
 
@@ -129,6 +130,62 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
                 default:
                     throw new ArgumentOutOfRangeException(nameof(encoding), encoding, "Unknown sign encoding.");
             }
+        }
+
+        /// <summary>
+        /// The exact inverse of <see cref="Format(TiltMoveAxis, int, EatSignEncoding)"/>: decodes an ASG EAT
+        /// move wire command string (<c>&lt;mnemonic&gt;,&lt;value&gt;</c>) back into its axis + signed step
+        /// count under the same <paramref name="encoding"/>. This is what lets the simulated transport
+        /// (<c>SimulatedEatTransport</c>) recover the move a connected controller just formatted and drive the
+        /// virtual adapter with it -- so the identical mnemonic table is the single source of truth for both
+        /// directions and a round-trip against <see cref="Format"/> is exact by construction.
+        ///
+        /// Returns false (never throws) for anything that is not a move command: the position query
+        /// (<c>cp</c>), a null/blank string, a missing or non-integer value, an unknown mnemonic, or -- under
+        /// <see cref="EatSignEncoding.SignedArgument"/> -- an opposite-corner mnemonic that <see cref="Format"/>
+        /// would never emit in that encoding (e.g. <c>bl,5</c>). Callers that only ever pass this the output of
+        /// <see cref="Format"/> can treat a false return as a programming error.
+        /// </summary>
+        public static bool TryParse(string wire, out TiltMoveAxis axis, out int steps, EatSignEncoding encoding = DefaultSignEncoding) {
+            axis = default;
+            steps = 0;
+            if (string.IsNullOrWhiteSpace(wire)) {
+                return false;
+            }
+
+            var parts = wire.Split(',');
+            if (parts.Length != 2) {
+                return false; // rejects "cp", a bare mnemonic, or a malformed extra-comma command.
+            }
+
+            var mnemonic = parts[0].Trim();
+            if (!int.TryParse(parts[1].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)) {
+                return false;
+            }
+
+            // Positive mnemonic: the SignedArgument path for every axis, the non-negative OppositeMnemonic path,
+            // and Backfocus under both encodings -- in all of these the value already carries the sign.
+            foreach (var kv in PositiveMnemonics) {
+                if (kv.Value == mnemonic) {
+                    axis = kv.Key;
+                    steps = value;
+                    return true;
+                }
+            }
+
+            // Opposite mnemonic: only meaningful under OppositeMnemonic, where Format encodes a negative move as
+            // the opposite corner/edge mnemonic plus the magnitude -- so the recovered step count is negated.
+            if (encoding == EatSignEncoding.OppositeMnemonic) {
+                foreach (var kv in OppositeMnemonics) {
+                    if (kv.Value == mnemonic) {
+                        axis = kv.Key;
+                        steps = -value;
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatCommands.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatCommands.cs
@@ -1,0 +1,134 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Collections.Generic;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
+
+    /// <summary>
+    /// The two candidate strategies the ASG EAT firmware might use to encode a negative move: either the
+    /// mnemonic always stays the axis's positive corner/edge and the sign rides on the numeric argument
+    /// (<c>tr,-5</c>), or the firmware only ever accepts non-negative arguments and the caller must instead
+    /// select the mechanically opposite mnemonic (<c>bl,5</c>). The actual device behavior is UNKNOWN until
+    /// a live hardware capture (plan task T15) — see <see cref="EatCommands.DefaultSignEncoding"/>.
+    /// </summary>
+    public enum EatSignEncoding {
+        SignedArgument,
+        OppositeMnemonic
+    }
+
+    /// <summary>
+    /// Pure formatting module: converts a <see cref="TiltMoveAxis"/> + signed step count into the ASG EAT
+    /// wire command string <c>&lt;mnemonic&gt;,&lt;value&gt;</c>. No I/O — see <c>EatSerialTransport.cs</c>
+    /// for the actual serial send. The mnemonic table below is the correctness anchor for this file: it is
+    /// derived from the device's physical command vocabulary (plan's "Device facts (ASG EAT)" section) and
+    /// must not be edited without re-verifying against that source — a wrong mnemonic here is an
+    /// EEPROM-persisted wrong-way motor move on real hardware.
+    /// </summary>
+    public static class EatCommands {
+
+        // Positive mnemonic per axis (the mnemonic used under EatSignEncoding.SignedArgument, and for
+        // non-negative steps under EatSignEncoding.OppositeMnemonic).
+        private static readonly IReadOnlyDictionary<TiltMoveAxis, string> PositiveMnemonics = new Dictionary<TiltMoveAxis, string> {
+            [TiltMoveAxis.DiagonalA] = "tr",
+            [TiltMoveAxis.DiagonalB] = "tl",
+            [TiltMoveAxis.EdgeVertical] = "tp",
+            [TiltMoveAxis.EdgeHorizontal] = "rt",
+            [TiltMoveAxis.Backfocus] = "bf",
+        };
+
+        // Opposite mnemonic per axis (used for negative steps under EatSignEncoding.OppositeMnemonic).
+        // Backfocus has NO opposite mnemonic on the real device -- see the explicit guard in Format below;
+        // this table intentionally omits a Backfocus entry so any accidental lookup fails loudly rather than
+        // silently returning a wrong string.
+        private static readonly IReadOnlyDictionary<TiltMoveAxis, string> OppositeMnemonics = new Dictionary<TiltMoveAxis, string> {
+            [TiltMoveAxis.DiagonalA] = "bl",
+            [TiltMoveAxis.DiagonalB] = "br",
+            [TiltMoveAxis.EdgeVertical] = "bt",
+            [TiltMoveAxis.EdgeHorizontal] = "lt",
+        };
+
+        /// <summary>
+        /// The sign-encoding convention this formatter assumes until the live hardware capture (plan task
+        /// T15) confirms or corrects it. LIVE-CAPTURE: this is the seam T15 flips if the device turns out to
+        /// require the opposite-mnemonic convention instead.
+        /// </summary>
+        public const EatSignEncoding DefaultSignEncoding = EatSignEncoding.SignedArgument;
+
+        /// <summary>The position-query command. Deliberately no zero (<c>zr</c>) command -- zeroing positions is the vendor app's job, never the plugin's.</summary>
+        public static string PositionQuery() => "cp";
+
+        /// <summary>
+        /// Formats <paramref name="move"/>'s axis and step count into an ASG EAT wire command string.
+        /// See <see cref="Format(TiltMoveAxis, int, EatSignEncoding)"/> for the full formatting rules.
+        /// </summary>
+        public static string Format(TiltAdapterMove move, EatSignEncoding encoding = DefaultSignEncoding) {
+            if (move == null) {
+                throw new ArgumentNullException(nameof(move));
+            }
+            return Format(move.Axis, move.Steps, encoding);
+        }
+
+        /// <summary>
+        /// Formats an axis + signed step count into an ASG EAT wire command string (<c>&lt;mnemonic&gt;,&lt;value&gt;</c>).
+        ///
+        /// Under <see cref="EatSignEncoding.SignedArgument"/>: always the axis's positive mnemonic, with the
+        /// sign carried on the numeric value (e.g. DiagonalA,-5 -&gt; "tr,-5").
+        ///
+        /// Under <see cref="EatSignEncoding.OppositeMnemonic"/>: positive steps use the positive mnemonic
+        /// with the magnitude (e.g. DiagonalA,+5 -&gt; "tr,5"); negative steps use the OPPOSITE mnemonic
+        /// with the magnitude (e.g. DiagonalA,-5 -&gt; "bl,5").
+        ///
+        /// Backfocus has no opposite mnemonic on the real device, so a negative Backfocus move ALWAYS uses a
+        /// signed argument on the "bf" mnemonic, regardless of <paramref name="encoding"/> -- this is the one
+        /// sign unknown that is truly blocking (see plan task T15 item 3), asserted here so a future
+        /// encoding flip cannot silently break it.
+        ///
+        /// <paramref name="steps"/> == 0 is not a move the planner is ever expected to emit (it never emits
+        /// zero-magnitude moves); this formatter treats it as a caller error and throws
+        /// <see cref="ArgumentException"/> rather than silently emitting an ambiguous "no-op" command.
+        /// </summary>
+        public static string Format(TiltMoveAxis axis, int steps, EatSignEncoding encoding = DefaultSignEncoding) {
+            if (steps == 0) {
+                throw new ArgumentException("Cannot format a zero-magnitude move; the planner must never emit one.", nameof(steps));
+            }
+            if (!PositiveMnemonics.TryGetValue(axis, out var positiveMnemonic)) {
+                throw new ArgumentOutOfRangeException(nameof(axis), axis, "Unknown tilt move axis.");
+            }
+
+            // Backfocus has no opposite mnemonic on the real device: a negative backfocus move must ALWAYS be
+            // formatted as a signed argument on "bf", regardless of the requested encoding. This is the one
+            // blocking sign unknown -- do not let a future encoding change silently break it.
+            if (axis == TiltMoveAxis.Backfocus) {
+                return FormattableString.Invariant($"{positiveMnemonic},{steps}");
+            }
+
+            switch (encoding) {
+                case EatSignEncoding.SignedArgument:
+                    return FormattableString.Invariant($"{positiveMnemonic},{steps}");
+
+                case EatSignEncoding.OppositeMnemonic:
+                    if (steps > 0) {
+                        return FormattableString.Invariant($"{positiveMnemonic},{steps}");
+                    }
+                    if (!OppositeMnemonics.TryGetValue(axis, out var oppositeMnemonic)) {
+                        throw new ArgumentOutOfRangeException(nameof(axis), axis, "Axis has no opposite mnemonic.");
+                    }
+                    return FormattableString.Invariant($"{oppositeMnemonic},{-steps}");
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(encoding), encoding, "Unknown sign encoding.");
+            }
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatResponses.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatResponses.cs
@@ -1,0 +1,100 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Utility.SerialCommunication;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
+
+    /// <summary>
+    /// Pure parsing of an <see cref="EatRawExchange"/> into interpreted results -- no I/O (see
+    /// <c>EatSerialTransport.cs</c> for the actual serial send/receive). THE SEAM FILE (together with
+    /// <c>EatSerialTransport.cs</c>) that contains every assumption about the ASG EAT's response wire
+    /// format, each marked <c>// LIVE-CAPTURE:</c> for the plan's T15 hardware session. Every method here
+    /// is deliberately TOLERANT: pre-T15, real hardware responses are guaranteed to sometimes fail to parse
+    /// (the exact format is unknown), and callers (plan task T7's <c>EatTiltMotionController</c>) are
+    /// designed to treat that as "unknown", not as a crash.
+    /// </summary>
+    public static class EatResponses {
+
+        // LIVE-CAPTURE: the real ack format (success string, error string(s)) and WHEN it arrives (on
+        // command receipt vs on move completion) are unknown until T15's live transcript capture. Until
+        // then this recognizes no specific text at all -- it only distinguishes "the exchange did not time
+        // out" (tolerant success) from "it did" (failure). Structured as its own method (rather than being
+        // inlined at call sites) so T15 can add real ack/error-string recognition without changing this
+        // method's signature or any caller.
+        /// <summary>
+        /// Tolerant interpretation of a move command's response: true unless <paramref name="exchange"/>
+        /// timed out. Does NOT yet recognize any specific ack or error text -- see the LIVE-CAPTURE note
+        /// above.
+        /// </summary>
+        public static bool ParseMoveAck(EatRawExchange exchange) {
+            if (exchange == null) {
+                throw new ArgumentNullException(nameof(exchange));
+            }
+            return !exchange.TimedOut;
+        }
+
+        // LIVE-CAPTURE: assumed `cp` reply layout. The real EAT wire format -- delimiter(s), whether the
+        // four values are absolute counters or relative deltas, whether they arrive on one line or split
+        // across several, and even whether they're in TR/TL/BR/BL order at all -- is unconfirmed until
+        // T15's live transcript capture. The assumption implemented here: the first four integers found (in
+        // textual order, scanning the raw lines top to bottom) are taken directly as DEVICE motor order
+        // 1..4 = TR, TL, BR, BL (see TiltDevicePositions' own doc comment). Any non-digit character is
+        // treated as a delimiter, so this tolerates commas, spaces, or a mix, across one or many lines.
+        private static readonly Regex IntegerToken = new Regex(@"-?\d+", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Tolerant extraction of the four per-motor position counters from a <c>cp</c> response. Throws
+        /// <see cref="InvalidDeviceResponseException"/> (with the raw lines included in the message, for
+        /// diagnosability) if fewer than four integers can be found -- expected to happen routinely on real
+        /// hardware before T15 confirms the real format; callers treat that as "positions unknown", not a
+        /// crash.
+        /// </summary>
+        public static TiltDevicePositions ParseCpPositions(EatRawExchange exchange) {
+            if (exchange == null) {
+                throw new ArgumentNullException(nameof(exchange));
+            }
+
+            var values = new List<int>();
+            foreach (var line in exchange.Lines) {
+                if (line == null) {
+                    continue;
+                }
+                foreach (Match match in IntegerToken.Matches(line)) {
+                    if (values.Count >= 4) {
+                        break;
+                    }
+                    if (int.TryParse(match.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)) {
+                        values.Add(value);
+                    }
+                }
+                if (values.Count >= 4) {
+                    break;
+                }
+            }
+
+            if (values.Count != 4) {
+                var rawLines = string.Join(" | ", exchange.Lines);
+                throw new InvalidDeviceResponseException(
+                    $"Could not parse four EAT position integers from a 'cp' response (found {values.Count}). " +
+                    $"Command: '{exchange.Command}'. Raw lines: [{rawLines}]");
+            }
+
+            return new TiltDevicePositions(values, known: true);
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatResponses.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatResponses.cs
@@ -30,16 +30,18 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
     /// </summary>
     public static class EatResponses {
 
-        // LIVE-CAPTURE: the real ack format (success string, error string(s)) and WHEN it arrives (on
-        // command receipt vs on move completion) are unknown until T15's live transcript capture. Until
-        // then this recognizes no specific text at all -- it only distinguishes "the exchange did not time
-        // out" (tolerant success) from "it did" (failure). Structured as its own method (rather than being
-        // inlined at call sites) so T15 can add real ack/error-string recognition without changing this
-        // method's signature or any caller.
+        // Move-ack policy, confirmed against ASG EAT firmware 7.1.0 (see docs/asg-eat-serial-protocol-design.md):
+        // a successful move ends with a "***finished movement***" sentinel line, and EatSerialTransport's read
+        // loop returns as soon as it sees that sentinel (TimedOut=false). A move that never completes leaves the
+        // read loop to exhaust its timeout budget (TimedOut=true). So "did not time out" IS the ack signal here --
+        // the sentinel recognition has already happened one layer down, in the transport. SimulatedEatTransport
+        // likewise returns a non-timed-out exchange for a successful move. NOTE: an explicit device-side ERROR
+        // response format was not captured (see the doc's open items), so a rejected move that still returns a
+        // terminal sentinel is not yet distinguished; tighten here if such a response is ever captured.
         /// <summary>
-        /// Tolerant interpretation of a move command's response: true unless <paramref name="exchange"/>
-        /// timed out. Does NOT yet recognize any specific ack or error text -- see the LIVE-CAPTURE note
-        /// above.
+        /// Interpretation of a move command's response: success unless <paramref name="exchange"/> timed out.
+        /// The completion decision (reading through to "***finished movement***") lives in the transport's read
+        /// loop; this only maps that outcome to success/failure.
         /// </summary>
         public static bool ParseMoveAck(EatRawExchange exchange) {
             if (exchange == null) {
@@ -48,25 +50,34 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
             return !exchange.TimedOut;
         }
 
-        // LIVE-CAPTURE: assumed `cp` reply layout. The real EAT wire format -- delimiter(s), whether the
-        // four values are absolute counters or relative deltas, whether they arrive on one line or split
-        // across several, and even whether they're in TR/TL/BR/BL order at all -- is unconfirmed until
-        // T15's live transcript capture. The assumption implemented here: the first four integers found (in
-        // textual order, scanning the raw lines top to bottom) are taken directly as DEVICE motor order
-        // 1..4 = TR, TL, BR, BL (see TiltDevicePositions' own doc comment). Any non-digit character is
-        // treated as a delimiter, so this tolerates commas, spaces, or a mix, across one or many lines.
+        // `cp` reply layout, confirmed against ASG EAT firmware 7.1.0 (see docs/asg-eat-serial-protocol-design.md):
+        // the four positions are bare integer lines wrapped between "***Get Current Positions***" and
+        // "***End Current Positions***" marker lines, in WIRE order [TL, TR, BL, BR] (raster order), amid a stream
+        // of {UI|SET|...} GUI-driver lines that must be ignored. They are absolute EEPROM-persisted counters.
+        // SimulatedEatTransport and the pre-capture unit fixtures instead emit a plain integer list with no
+        // markers, already in device order [TR, TL, BR, BL]; those take the fallback path below (first four
+        // integers found, any non-digit char a delimiter -- tolerant of commas/spaces across one or many lines).
         private static readonly Regex IntegerToken = new Regex(@"-?\d+", RegexOptions.Compiled);
 
+        // Substring markers (matched with Contains, so the surrounding '***' and CR/LF framing are irrelevant).
+        private const string PositionBlockStartMarker = "Get Current Positions";
+        private const string PositionBlockEndMarker = "End Current Positions";
+
         /// <summary>
-        /// Tolerant extraction of the four per-motor position counters from a <c>cp</c> response. Throws
-        /// <see cref="InvalidDeviceResponseException"/> (with the raw lines included in the message, for
-        /// diagnosability) if fewer than four integers can be found -- expected to happen routinely on real
-        /// hardware before T15 confirms the real format; callers treat that as "positions unknown", not a
-        /// crash.
+        /// Extracts the four per-motor position counters from a <c>cp</c> response, in
+        /// <see cref="TiltDevicePositions"/> device motor order (TR, TL, BR, BL). Prefers the real device's
+        /// marked block (reordering its wire order [TL, TR, BL, BR] into device order); falls back to "the first
+        /// four integers found" for the simulator and pre-capture fixtures. Throws
+        /// <see cref="InvalidDeviceResponseException"/> (with the raw lines in the message) if neither yields
+        /// four integers; callers treat that as "positions unknown", not a crash.
         /// </summary>
         public static TiltDevicePositions ParseCpPositions(EatRawExchange exchange) {
             if (exchange == null) {
                 throw new ArgumentNullException(nameof(exchange));
+            }
+
+            if (TryParseMarkedPositionBlock(exchange, out var fromBlock)) {
+                return fromBlock;
             }
 
             var values = new List<int>();
@@ -95,6 +106,55 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
             }
 
             return new TiltDevicePositions(values, known: true);
+        }
+
+        /// <summary>
+        /// Parses the real ASG EAT's marked position block if present. Returns false (so the caller falls back to
+        /// the first-four-integers path) when there is no "***Get Current Positions***" marker at all. Throws
+        /// <see cref="InvalidDeviceResponseException"/> if the marker IS present but does not enclose exactly four
+        /// integers -- a genuinely malformed real-device response, not a "different format" case. The block's wire
+        /// order is [TL, TR, BL, BR]; it is reordered here into device motor order [TR, TL, BR, BL] to match
+        /// <see cref="TiltDevicePositions"/>.
+        /// </summary>
+        private static bool TryParseMarkedPositionBlock(EatRawExchange exchange, out TiltDevicePositions positions) {
+            positions = null;
+
+            int startIndex = -1;
+            for (int i = 0; i < exchange.Lines.Count; ++i) {
+                if (exchange.Lines[i] != null && exchange.Lines[i].Contains(PositionBlockStartMarker)) {
+                    startIndex = i;
+                    break;
+                }
+            }
+            if (startIndex < 0) {
+                return false;
+            }
+
+            var wire = new List<int>(4);
+            for (int i = startIndex + 1; i < exchange.Lines.Count && wire.Count < 4; ++i) {
+                var line = exchange.Lines[i];
+                if (line == null) {
+                    continue;
+                }
+                if (line.Contains(PositionBlockEndMarker)) {
+                    break;
+                }
+                if (int.TryParse(line.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)) {
+                    wire.Add(value);
+                }
+            }
+
+            if (wire.Count != 4) {
+                var rawLines = string.Join(" | ", exchange.Lines);
+                throw new InvalidDeviceResponseException(
+                    $"'cp' response had a '{PositionBlockStartMarker}' marker but did not enclose four integers (found {wire.Count}). " +
+                    $"Command: '{exchange.Command}'. Raw lines: [{rawLines}]");
+            }
+
+            // Wire order [TL, TR, BL, BR] -> device motor order [TR, TL, BR, BL].
+            var deviceOrder = new[] { wire[1], wire[0], wire[3], wire[2] };
+            positions = new TiltDevicePositions(deviceOrder, known: true);
+            return true;
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatSerialTransport.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatSerialTransport.cs
@@ -118,30 +118,37 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
 
         private const int DataBits = 8;
 
-        // LIVE-CAPTURE: outgoing-command line terminator, and (via the `newLine` parameter passed to
-        // GetSerialPort) the delimiter ReadLine() uses to frame INCOMING lines. The real EAT firmware's
-        // framing (\r vs \r\n vs \n) is unconfirmed until T15's live transcript capture. \r\n is the most
-        // common default for line-oriented serial devices and is used as the initial assumption.
+        // Outgoing-command line terminator, and (via the `newLine` parameter passed to GetSerialPort) the
+        // delimiter ReadLine() uses to frame INCOMING lines. Confirmed CRLF against ASG EAT firmware 7.1.0
+        // (Arduino Serial.println framing) -- see docs/asg-eat-serial-protocol-design.md.
         internal const string LineTerminator = "\r\n";
 
-        // LIVE-CAPTURE: whether the EAT needs DTR asserted to enumerate/stay open (common for Arduino-class
-        // USB-CDC devices), and whether asserting it triggers a reset-on-open + boot banner (also common on
-        // those boards -- this is exactly why OpenAsync drains for PostOpenSettleDuration below before the
-        // first real command). Defaulted to true as the more conservative assumption (a device that doesn't
-        // need DTR is normally unaffected by it being asserted; a device that DOES need it and doesn't get it
-        // may simply fail to respond at all). Confirm/flip in T15.
+        // Confirmed against ASG EAT firmware 7.1.0 (an Arduino Uno): asserting DTR on open triggers the classic
+        // Arduino auto-reset, so the MCU reboots and, after a ~1.5 s bootloader delay, emits a boot banner that
+        // ends in an "FW:<version>" line. DrainBootBannerAsync below waits that banner out before the first real
+        // command. See docs/asg-eat-serial-protocol-design.md.
         internal const bool DefaultDtrEnable = true;
 
-        // LIVE-CAPTURE: how long to drain and discard input immediately after Open(), to absorb a possible
-        // boot banner from an Arduino-class MCU resetting on port-open. The real settle time (if any banner
-        // exists at all) is unconfirmed until T15; this is a conservative but short guess.
-        internal static readonly TimeSpan PostOpenSettleDuration = TimeSpan.FromMilliseconds(500);
+        // Maximum time to drain the reset-on-open boot banner before giving up and proceeding. Confirmed against
+        // firmware 7.1.0: the MCU resets on open, is silent for ~1.5 s, then streams a banner ending ~2.5 s after
+        // open with an "FW:<version>" line. DrainBootBannerAsync stops as soon as it sees that marker (or the
+        // device goes quiet after the banner); this is only the safety cap.
+        internal static readonly TimeSpan PostOpenSettleTimeout = TimeSpan.FromSeconds(5);
 
-        // LIVE-CAPTURE: the "quiet window" -- both the per-poll ReadLine() timeout (passed as `readTimeout`
-        // to GetSerialPort) and the gap-since-last-line the read loop treats as "response complete" once at
-        // least one line has arrived. The real inter-line timing of a multi-line EAT response (if any) is
-        // unconfirmed until T15; also unconfirmed: whether the device echoes the command it received (an
-        // echo would show up as an ordinary line here -- EatResponses may need to learn to skip it in T15).
+        // The banner's final line (e.g. "FW:7.1.0"); its arrival means the sketch is running and ready.
+        internal const string BootBannerEndMarker = "FW:";
+
+        // Terminal sentinels the device prints at the end of a response (confirmed, firmware 7.1.0): a move ends
+        // with "***finished movement***", a query ('cp') with "***Action Processed***". The read loop returns as
+        // soon as it sees either, rather than relying on the quiet-window heuristic -- robust even if the device
+        // pauses mid-response (e.g. a slow multi-second move whose heartbeat gaps could otherwise look "quiet").
+        internal const string MoveCompleteSentinel = "***finished movement***";
+        internal const string QueryCompleteSentinel = "***Action Processed***";
+
+        // The "quiet window" -- the per-poll ReadLine() timeout (passed as `readTimeout` to GetSerialPort) and
+        // the gap-since-last-line the read loop treats as "response complete" once at least one line has arrived
+        // AND no terminal sentinel appeared (the fallback completion path). The device does NOT echo the command
+        // it received (confirmed 7.1.0), so no echo-skipping is needed.
         internal static readonly TimeSpan QuietWindow = TimeSpan.FromMilliseconds(200);
 
         // NOT a wire-format unknown -- derived directly from the plan's device facts (moves take 5-10 s).
@@ -182,16 +189,17 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
                     "The EAT transport is already open; call Close() before opening a new connection.");
             }
 
-            // EXACT port config per the plan's "Device facts" section: 9600 baud, no parity, 8 data bits,
-            // 1 stop bit, XON/XOFF flow control. DtrEnable/newLine/timeouts are the LIVE-CAPTURE-marked
-            // fields above.
+            // Port config confirmed against ASG EAT firmware 7.1.0: 9600 baud, no parity, 8 data bits, 1 stop
+            // bit, and NO flow control. The device is an Arduino Uno sketch with no software flow control, so
+            // Handshake.None is correct -- Handshake.XOnXOff would let the PC driver inject XON/XOFF (0x11/0x13)
+            // bytes into the sketch's command input. See docs/asg-eat-serial-protocol-design.md.
             var port = serialPortProvider.GetSerialPort(
                 portName,
                 BaudRate,
                 Parity.None,
                 DataBits,
                 StopBits.One,
-                Handshake.XOnXOff,
+                Handshake.None,
                 DefaultDtrEnable,
                 LineTerminator,
                 (int)QuietWindow.TotalMilliseconds,
@@ -209,9 +217,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
                 port.Open();
                 serialPort = port;
 
-                // Reset-on-open assumption (LIVE-CAPTURE, see PostOpenSettleDuration): drain and discard
-                // whatever arrives in the settle window before the first real command, in case opening the
-                // port reset an Arduino-class MCU and it's still emitting a boot banner.
+                // Reset-on-open (confirmed): opening asserts DTR, which resets the Arduino; drain and discard
+                // its boot banner (ending in "FW:<version>") before the first real command so the banner can't
+                // corrupt the first response.
                 await DrainBootBannerAsync(port, ct).ConfigureAwait(false);
             } catch {
                 // Half-open on failure: if ANY step above throws (DtrEnable set, Open, the boot-banner
@@ -307,19 +315,33 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
         }
 
         /// <summary>
-        /// Drains and discards input for <see cref="PostOpenSettleDuration"/> right after <see cref="OpenAsync"/>
-        /// opens the port. See the class remarks and the DefaultDtrEnable/PostOpenSettleDuration LIVE-CAPTURE
-        /// notes for why this exists (a possible boot banner from a reset-on-open MCU).
+        /// Drains and discards the reset-on-open boot banner right after <see cref="OpenAsync"/> opens the port
+        /// (see the class remarks). Returns as soon as the banner's terminating "FW:&lt;version&gt;" line is seen,
+        /// or once the device goes quiet after having emitted banner data, or after
+        /// <see cref="PostOpenSettleTimeout"/> as a safety cap. The Arduino is silent for ~1.5 s after the reset
+        /// before the banner streams, so an early quiet poll (before ANY data) must NOT end the drain -- only a
+        /// quiet poll AFTER data has arrived.
         /// </summary>
         private async Task DrainBootBannerAsync(ISerialPort port, CancellationToken ct) {
-            var deadline = DateTime.UtcNow + PostOpenSettleDuration;
+            var deadline = DateTime.UtcNow + PostOpenSettleTimeout;
+            var receivedAny = false;
             while (DateTime.UtcNow < deadline) {
                 ct.ThrowIfCancellationRequested();
                 try {
                     var line = await ReadLineOrThrowIfClosedAsync(port, ct).ConfigureAwait(false);
-                    Logger.Info($"EAT RX (post-open settle, discarded): {line}");
+                    Logger.Info($"EAT RX (post-open banner, discarded): {line}");
+                    receivedAny = true;
+                    if (line != null && line.Contains(BootBannerEndMarker)) {
+                        // Banner's final line ("FW:<version>") -- the sketch is up and idle; safe to send commands.
+                        return;
+                    }
                 } catch (TimeoutException) {
-                    // No data within this poll; keep polling until the settle window elapses.
+                    // The MCU is silent for ~1.5 s after the reset before the banner starts, so a quiet poll
+                    // before any data just means "still booting" -- keep waiting. A quiet poll AFTER the banner
+                    // has streamed means it is complete.
+                    if (receivedAny) {
+                        return;
+                    }
                 }
             }
         }
@@ -342,12 +364,17 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
                     var line = await ReadLineOrThrowIfClosedAsync(port, ct).ConfigureAwait(false);
                     Logger.Info($"EAT RX: {line}");
                     lines.Add(line);
+                    if (IsTerminalResponseLine(line)) {
+                        // The device signalled end-of-response -- return immediately instead of waiting out a
+                        // quiet window. Robust even if a slow move's "***moving***" heartbeats pause longer than
+                        // QuietWindow before the terminating sentinel arrives.
+                        return (lines, false);
+                    }
                 } catch (TimeoutException) {
                     if (lines.Count > 0) {
-                        // At least one line arrived and the device has now gone quiet for a full window --
-                        // treat the response as complete rather than waiting out the rest of the timeout
-                        // budget. LIVE-CAPTURE: assumes the device never pauses mid-response longer than
-                        // QuietWindow; unconfirmed until T15.
+                        // FALLBACK completion path: at least one line arrived, no terminal sentinel appeared, and
+                        // the device has now gone quiet for a full window. The normal path is the sentinel check
+                        // above; this only fires for a response that ends without a recognized sentinel.
                         return (lines, false);
                     }
                     // Nothing received yet -- a still-executing multi-second move with no output so far is
@@ -355,6 +382,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
                 }
             }
         }
+
+        /// <summary>True if <paramref name="line"/> is one of the device's end-of-response sentinels (see <see cref="MoveCompleteSentinel"/> / <see cref="QueryCompleteSentinel"/>).</summary>
+        private static bool IsTerminalResponseLine(string line) =>
+            line != null && (line.Contains(MoveCompleteSentinel) || line.Contains(QueryCompleteSentinel));
 
         /// <summary>
         /// Wraps the underlying (synchronous, blocking) <see cref="ISerialPort.ReadLine"/> in a background

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatSerialTransport.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatSerialTransport.cs
@@ -1,0 +1,382 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Utility;
+using NINA.Core.Utility.SerialCommunication;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO.Ports;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
+
+    /// <summary>
+    /// Immutable, raw, un-interpreted result of one request/response exchange with the ASG EAT over
+    /// <see cref="IEatTransport"/>. This is deliberately a dumb bag of bytes-as-lines: it carries exactly
+    /// what came back over the wire and nothing more. Interpreting <see cref="Lines"/> (ack recognition,
+    /// <c>cp</c> position extraction, etc.) is <c>EatResponses</c>'s job, not this type's -- keeping the two
+    /// concerns separate is what lets <c>EatResponses</c> be re-tuned in plan task T15 without touching the
+    /// transport.
+    /// </summary>
+    public sealed class EatRawExchange {
+
+        public EatRawExchange(string command, IReadOnlyList<string> lines, bool timedOut) {
+            Command = command ?? throw new ArgumentNullException(nameof(command));
+            Lines = new ReadOnlyCollection<string>((lines ?? Array.Empty<string>()).ToArray());
+            TimedOut = timedOut;
+        }
+
+        /// <summary>The exact command string that was sent (without the line terminator).</summary>
+        public string Command { get; }
+
+        /// <summary>
+        /// Raw response lines, verbatim, in the order received. Populated even when <see cref="TimedOut"/>
+        /// is true (whatever arrived before the overall timeout elapsed is still useful for diagnosing a
+        /// live capture transcript).
+        /// </summary>
+        public IReadOnlyList<string> Lines { get; }
+
+        /// <summary>
+        /// True if the overall exchange timeout elapsed before the response was judged complete (see
+        /// <see cref="IEatTransport.SendAsync"/>'s quiet-period/timeout race). False means the read loop
+        /// settled on a quiet period after receiving at least one line -- NOT that the response was
+        /// necessarily well-formed or successful; that judgment belongs to <c>EatResponses</c>.
+        /// </summary>
+        public bool TimedOut { get; }
+    }
+
+    /// <summary>
+    /// Transport abstraction for talking to a connected ASG EAT over serial. Deliberately narrow -- three
+    /// members plus a connectedness flag -- so <c>EatTiltMotionController</c> (plan task T7) can be built
+    /// and tested against a fake without any real I/O. The production implementation is
+    /// <see cref="EatSerialTransport"/>.
+    /// </summary>
+    public interface IEatTransport {
+
+        /// <summary>True after a successful <see cref="OpenAsync"/> until <see cref="Close"/>.</summary>
+        bool IsOpen { get; }
+
+        /// <summary>Opens the serial connection to the device on <paramref name="portName"/> (e.g. "COM3").</summary>
+        Task OpenAsync(string portName, CancellationToken ct);
+
+        /// <summary>Closes the connection. Idempotent -- safe to call when already closed or never opened.</summary>
+        void Close();
+
+        /// <summary>
+        /// Sends <paramref name="command"/> (without a line terminator -- the transport appends one) and
+        /// collects the response. See <see cref="EatSerialTransport"/>'s class remarks for the read-loop
+        /// contract. Never throws for a plain read timeout (returns <see cref="EatRawExchange.TimedOut"/>
+        /// = true instead); a closed port propagates <see cref="SerialPortClosedException"/>.
+        /// </summary>
+        Task<EatRawExchange> SendAsync(string command, TimeSpan timeout, CancellationToken ct);
+    }
+
+    /// <summary>
+    /// Custom serial transport for the ASG EAT -- THE SEAM FILE (together with <c>EatResponses.cs</c>) that
+    /// contains every assumption about the device's response wire format, each marked
+    /// <c>// LIVE-CAPTURE:</c> for the plan's T15 hardware session. Everything outside these two files must
+    /// be contract-tested against this transport's documented behavior and must not need to change once
+    /// T15 resolves the unknowns.
+    ///
+    /// Deliberately does NOT subclass <c>SerialSdk</c>: that base class does one fixed-timeout
+    /// <c>ReadLine</c> (500 ms default, 2 retries) per command and silently swallows write timeouts --
+    /// unusable for the EAT's 5-10 s moves under XON/XOFF flow control, where a write can legitimately
+    /// block for a long time and a write timeout must be a hard, visible failure. See the design doc's
+    /// "Key reuse" note.
+    ///
+    /// Read-loop design: after writing the command (+ line terminator), lines are collected by repeatedly
+    /// calling the underlying port's blocking <c>ReadLine()</c> (each call bounded by the port's configured
+    /// read timeout -- reused here as the "quiet window" -- see <see cref="QuietWindow"/>). Two races decide
+    /// when the exchange ends:
+    ///   1. QUIET PERIOD: once at least one line has been received, a subsequent poll that produces nothing
+    ///      within <see cref="QuietWindow"/> is treated as "the device has gone quiet, the response is
+    ///      complete" -- the exchange returns immediately with <c>TimedOut = false</c>, without waiting out
+    ///      the full budget. This lets fast commands (e.g. <c>cp</c>) return promptly.
+    ///   2. OVERALL TIMEOUT: before any line has arrived, a quiet poll does NOT end the exchange -- a move
+    ///      that produces no output at all for several seconds is normal, not an error, so the loop keeps
+    ///      polling until the caller's <c>timeout</c> budget (move commands pass >= 15 s, per plan task T7)
+    ///      is exhausted. Only then does the exchange end with <c>TimedOut = true</c>.
+    /// This is a design decision made under an unknown protocol, not a confirmed device behavior --
+    /// see the LIVE-CAPTURE markers below.
+    /// </summary>
+    public sealed class EatSerialTransport : IEatTransport, IDisposable {
+
+        /// <summary>ASG EAT serial parameters (plan's "Device facts" section) -- NOT a LIVE-CAPTURE unknown.</summary>
+        private const int BaudRate = 9600;
+
+        private const int DataBits = 8;
+
+        // LIVE-CAPTURE: outgoing-command line terminator, and (via the `newLine` parameter passed to
+        // GetSerialPort) the delimiter ReadLine() uses to frame INCOMING lines. The real EAT firmware's
+        // framing (\r vs \r\n vs \n) is unconfirmed until T15's live transcript capture. \r\n is the most
+        // common default for line-oriented serial devices and is used as the initial assumption.
+        internal const string LineTerminator = "\r\n";
+
+        // LIVE-CAPTURE: whether the EAT needs DTR asserted to enumerate/stay open (common for Arduino-class
+        // USB-CDC devices), and whether asserting it triggers a reset-on-open + boot banner (also common on
+        // those boards -- this is exactly why OpenAsync drains for PostOpenSettleDuration below before the
+        // first real command). Defaulted to true as the more conservative assumption (a device that doesn't
+        // need DTR is normally unaffected by it being asserted; a device that DOES need it and doesn't get it
+        // may simply fail to respond at all). Confirm/flip in T15.
+        internal const bool DefaultDtrEnable = true;
+
+        // LIVE-CAPTURE: how long to drain and discard input immediately after Open(), to absorb a possible
+        // boot banner from an Arduino-class MCU resetting on port-open. The real settle time (if any banner
+        // exists at all) is unconfirmed until T15; this is a conservative but short guess.
+        internal static readonly TimeSpan PostOpenSettleDuration = TimeSpan.FromMilliseconds(500);
+
+        // LIVE-CAPTURE: the "quiet window" -- both the per-poll ReadLine() timeout (passed as `readTimeout`
+        // to GetSerialPort) and the gap-since-last-line the read loop treats as "response complete" once at
+        // least one line has arrived. The real inter-line timing of a multi-line EAT response (if any) is
+        // unconfirmed until T15; also unconfirmed: whether the device echoes the command it received (an
+        // echo would show up as an ordinary line here -- EatResponses may need to learn to skip it in T15).
+        internal static readonly TimeSpan QuietWindow = TimeSpan.FromMilliseconds(200);
+
+        // NOT a wire-format unknown -- derived directly from the plan's device facts (moves take 5-10 s).
+        // Sized well beyond the longest legitimate move, with slack for XON/XOFF backpressure, so a
+        // legitimate slow move can never trip a write timeout. A write timeout is therefore a HARD failure
+        // (see WriteCommand) -- it means the link is genuinely stuck, not just busy with a move.
+        internal static readonly TimeSpan WriteTimeout = TimeSpan.FromSeconds(20);
+
+        private readonly ISerialPortProvider serialPortProvider;
+        private readonly SemaphoreSlim sendGate = new SemaphoreSlim(1, 1);
+        private ISerialPort serialPort;
+
+        /// <summary>Production constructor: uses the real NINA <see cref="SerialPortProvider"/>.</summary>
+        public EatSerialTransport() : this(new SerialPortProvider()) {
+        }
+
+        /// <summary>Test/DI constructor: accepts a substitute provider (and, transitively, a substitute port).</summary>
+        public EatSerialTransport(ISerialPortProvider serialPortProvider) {
+            this.serialPortProvider = serialPortProvider ?? throw new ArgumentNullException(nameof(serialPortProvider));
+        }
+
+        public bool IsOpen => serialPort != null;
+
+        /// <summary>
+        /// Opens the connection. Double-open guard (documented choice): if the transport is already open,
+        /// this THROWS <see cref="InvalidOperationException"/> rather than silently tearing down and
+        /// replacing the existing port -- a caller that wants to reconnect must <see cref="Close"/> first.
+        /// This keeps "open while open" an explicit caller error instead of a silent port leak.
+        /// </summary>
+        public async Task OpenAsync(string portName, CancellationToken ct) {
+            if (string.IsNullOrWhiteSpace(portName)) {
+                throw new ArgumentException("Port name must not be null or empty.", nameof(portName));
+            }
+            ct.ThrowIfCancellationRequested();
+
+            if (serialPort != null) {
+                throw new InvalidOperationException(
+                    "The EAT transport is already open; call Close() before opening a new connection.");
+            }
+
+            // EXACT port config per the plan's "Device facts" section: 9600 baud, no parity, 8 data bits,
+            // 1 stop bit, XON/XOFF flow control. DtrEnable/newLine/timeouts are the LIVE-CAPTURE-marked
+            // fields above.
+            var port = serialPortProvider.GetSerialPort(
+                portName,
+                BaudRate,
+                Parity.None,
+                DataBits,
+                StopBits.One,
+                Handshake.XOnXOff,
+                DefaultDtrEnable,
+                LineTerminator,
+                (int)QuietWindow.TotalMilliseconds,
+                (int)WriteTimeout.TotalMilliseconds);
+
+            if (port == null) {
+                throw new InvalidOperationException($"Serial port provider returned no port for '{portName}'.");
+            }
+
+            try {
+                // Set DtrEnable explicitly (in addition to passing it into GetSerialPort above) so the intent
+                // is unambiguous and independently observable/testable, regardless of what a given provider
+                // implementation does with the constructor-style parameter.
+                port.DtrEnable = DefaultDtrEnable;
+                port.Open();
+                serialPort = port;
+
+                // Reset-on-open assumption (LIVE-CAPTURE, see PostOpenSettleDuration): drain and discard
+                // whatever arrives in the settle window before the first real command, in case opening the
+                // port reset an Arduino-class MCU and it's still emitting a boot banner.
+                await DrainBootBannerAsync(port, ct).ConfigureAwait(false);
+            } catch {
+                // Half-open on failure: if ANY step above throws (DtrEnable set, Open, the boot-banner
+                // drain/settle), the port must never be left open with IsOpen == true (mirrors NINA's
+                // SerialSdk, which nulls its port on failure). Best-effort close the local port regardless of
+                // how far it got, then rethrow the original exception unmodified.
+                serialPort = null;
+                CloseQuietly(port);
+                throw;
+            }
+        }
+
+        public void Close() {
+            var port = serialPort;
+            serialPort = null;
+            if (port == null) {
+                return;
+            }
+            CloseQuietly(port);
+        }
+
+        /// <summary>Best-effort <see cref="ISerialPort.Close"/> that never throws -- shared by <see cref="Close"/> and <see cref="OpenAsync"/>'s failure path.</summary>
+        private static void CloseQuietly(ISerialPort port) {
+            try {
+                port.Close();
+            } catch (Exception ex) {
+                // Best-effort: the port is considered closed regardless (the serialPort field is already
+                // nulled by the caller).
+                Logger.Error("EAT transport: error while closing the serial port (ignored).", ex);
+            }
+        }
+
+        /// <summary>Disposes the internal send-serialization semaphore. Does NOT close the port -- call <see cref="Close"/> for that.</summary>
+        public void Dispose() {
+            sendGate.Dispose();
+        }
+
+        public async Task<EatRawExchange> SendAsync(string command, TimeSpan timeout, CancellationToken ct) {
+            if (string.IsNullOrEmpty(command)) {
+                throw new ArgumentException("Command must not be null or empty.", nameof(command));
+            }
+
+            // Only one command in flight at a time -- acquired for the whole write+read so a caller can
+            // never observe an interleaved response.
+            await sendGate.WaitAsync(ct).ConfigureAwait(false);
+            try {
+                // Snapshot the field into a LOCAL once, up front, and use only the local for the rest of this
+                // exchange. A concurrent Close() (e.g. from another thread while this write/read is still in
+                // flight) nulls the FIELD, but never this local -- so the underlying ISerialPort calls below
+                // still run against a live reference and fail (if at all) with the underlying port's own
+                // "closed" InvalidOperationException -- translated below to SerialPortClosedException -- never
+                // a NullReferenceException.
+                var port = serialPort;
+                if (port == null) {
+                    throw new InvalidOperationException("The EAT transport is not open; call OpenAsync first.");
+                }
+
+                await WriteCommandAsync(port, command, ct).ConfigureAwait(false);
+                var (lines, timedOut) = await ReadResponseAsync(port, timeout, ct).ConfigureAwait(false);
+                return new EatRawExchange(command, lines, timedOut);
+            } finally {
+                sendGate.Release();
+            }
+        }
+
+        /// <summary>
+        /// Writes <paramref name="command"/> (+ line terminator) to <paramref name="port"/>. Runs the
+        /// underlying (synchronous, blocking) <see cref="ISerialPort.Write"/> on a background task -- for
+        /// symmetry with the already-offloaded read, and because a blocking inline write could otherwise
+        /// freeze the caller (e.g. the UI thread) for up to <see cref="WriteTimeout"/> under an XON/XOFF
+        /// stall, which is exactly the backpressure scenario this transport exists to handle correctly.
+        /// </summary>
+        private async Task WriteCommandAsync(ISerialPort port, string command, CancellationToken ct) {
+            // Transcript logging (REQUIRED -- this raw TX/RX log is what T15 uses to resolve every
+            // LIVE-CAPTURE unknown against a real device).
+            Logger.Info($"EAT TX: {command}");
+
+            var wireCommand = command + LineTerminator;
+            try {
+                await Task.Run(() => port.Write(wireCommand), ct).ConfigureAwait(false);
+            } catch (InvalidOperationException ex) {
+                // The underlying SerialPort throws InvalidOperationException when the port is not open (e.g.
+                // unplugged mid-session) -- surface it as the NINA-idiomatic SerialPortClosedException
+                // instead of swallowing it (mirrors SerialSdk's own translation).
+                throw new SerialPortClosedException(
+                    $"Serial port '{port.PortName ?? "unknown"}' was closed while sending '{command}'.", ex);
+            }
+            // TimeoutException is intentionally NOT caught here. WriteTimeout is sized well beyond the
+            // longest legitimate move (see WriteTimeout above), so tripping it means the link is genuinely
+            // stuck, not just busy -- a HARD failure. NINA's own SerialSdk swallows write timeouts and
+            // presses on to read anyway; we deliberately do not, and let the exception propagate so the
+            // caller knows the device state may be dirty.
+        }
+
+        /// <summary>
+        /// Drains and discards input for <see cref="PostOpenSettleDuration"/> right after <see cref="OpenAsync"/>
+        /// opens the port. See the class remarks and the DefaultDtrEnable/PostOpenSettleDuration LIVE-CAPTURE
+        /// notes for why this exists (a possible boot banner from a reset-on-open MCU).
+        /// </summary>
+        private async Task DrainBootBannerAsync(ISerialPort port, CancellationToken ct) {
+            var deadline = DateTime.UtcNow + PostOpenSettleDuration;
+            while (DateTime.UtcNow < deadline) {
+                ct.ThrowIfCancellationRequested();
+                try {
+                    var line = await ReadLineOrThrowIfClosedAsync(port, ct).ConfigureAwait(false);
+                    Logger.Info($"EAT RX (post-open settle, discarded): {line}");
+                } catch (TimeoutException) {
+                    // No data within this poll; keep polling until the settle window elapses.
+                }
+            }
+        }
+
+        /// <summary>See the class remarks for the full quiet-period/overall-timeout read-loop contract.</summary>
+        private async Task<(List<string> Lines, bool TimedOut)> ReadResponseAsync(ISerialPort port, TimeSpan timeout, CancellationToken ct) {
+            var lines = new List<string>();
+            var deadline = DateTime.UtcNow + timeout;
+            while (true) {
+                ct.ThrowIfCancellationRequested();
+                if (DateTime.UtcNow >= deadline) {
+                    // Overall budget exhausted. LIVE-CAPTURE: a silent-but-successful move (no terminating
+                    // response at all) is indistinguishable, on the wire, from one that genuinely failed --
+                    // this transport cannot tell them apart. EatResponses.ParseMoveAck's tolerant policy is
+                    // the seam T15 tightens once the real ack behavior is known.
+                    return (lines, true);
+                }
+
+                try {
+                    var line = await ReadLineOrThrowIfClosedAsync(port, ct).ConfigureAwait(false);
+                    Logger.Info($"EAT RX: {line}");
+                    lines.Add(line);
+                } catch (TimeoutException) {
+                    if (lines.Count > 0) {
+                        // At least one line arrived and the device has now gone quiet for a full window --
+                        // treat the response as complete rather than waiting out the rest of the timeout
+                        // budget. LIVE-CAPTURE: assumes the device never pauses mid-response longer than
+                        // QuietWindow; unconfirmed until T15.
+                        return (lines, false);
+                    }
+                    // Nothing received yet -- a still-executing multi-second move with no output so far is
+                    // expected, not an error. Keep polling until the overall timeout elapses.
+                }
+            }
+        }
+
+        /// <summary>
+        /// Wraps the underlying (synchronous, blocking) <see cref="ISerialPort.ReadLine"/> in a background
+        /// task so callers can await it, translating a closed-port <see cref="InvalidOperationException"/>
+        /// into <see cref="SerialPortClosedException"/> (propagated, never swallowed). A plain read timeout
+        /// (<see cref="TimeoutException"/>) is left for the caller to interpret -- it is NOT necessarily an
+        /// error (see ReadResponseAsync). Note: because the underlying <c>SerialPort.ReadLine()</c> call
+        /// itself has no cancellation support, <paramref name="ct"/> is only observed between poll attempts,
+        /// not while a single ReadLine() call is blocked inside the port's own read timeout window -- the
+        /// same limitation NINA's own SerialSdk has. <paramref name="port"/> is always the LOCAL snapshot
+        /// taken by the caller (see <see cref="SendAsync"/>/<see cref="OpenAsync"/>), never a fresh read of
+        /// the <c>serialPort</c> field -- so a concurrent <see cref="Close"/> (which nulls the field) cannot
+        /// turn this into a <see cref="NullReferenceException"/>; the underlying port object itself simply
+        /// throws its own closed-port exception, translated below.
+        /// </summary>
+        private async Task<string> ReadLineOrThrowIfClosedAsync(ISerialPort port, CancellationToken ct) {
+            try {
+                return await Task.Run(() => port.ReadLine(), ct).ConfigureAwait(false);
+            } catch (InvalidOperationException ex) {
+                throw new SerialPortClosedException(
+                    $"Serial port '{port.PortName ?? "unknown"}' was closed while reading.", ex);
+            }
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatTiltMotionController.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatTiltMotionController.cs
@@ -1,0 +1,541 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Utility;
+using NINA.Core.Utility.SerialCommunication;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
+
+    /// <summary>
+    /// Thrown by <see cref="EatTiltMotionController"/> BEFORE any device I/O when a requested move (or,
+    /// for <see cref="EatTiltMotionController.OrderForMinimalPeakExcursion"/>, every possible ordering of
+    /// a small multi-move plan) would violate a configured soft limit -- <c>TiltDeviceMaxStepsPerCommand</c>
+    /// (a single command's magnitude) or <c>TiltDeviceMaxExcursionSteps</c> (a motor's resulting absolute,
+    /// or when positions are unknown this session, best-estimate position). This is the last line of
+    /// software defense against an EEPROM-persisted, physically-damaging motor move: every check this
+    /// exception guards runs strictly before <see cref="EatCommands.Format(TiltAdapterMove, EatSignEncoding)"/>
+    /// is even called, let alone anything reaches <see cref="IEatTransport.SendAsync"/>.
+    /// </summary>
+    [Serializable]
+    public sealed class TiltDeviceLimitException : Exception {
+
+        public TiltDeviceLimitException() {
+        }
+
+        public TiltDeviceLimitException(string message) : base(message) {
+        }
+
+        public TiltDeviceLimitException(string message, Exception innerException) : base(message, innerException) {
+        }
+    }
+
+    /// <summary>
+    /// Thrown by <see cref="EatTiltMotionController.ExecuteMoveAsync"/> when a move WAS sent (it passed
+    /// every pre-send limit check) but the device did not acknowledge success -- see
+    /// <see cref="EatResponses.ParseMoveAck"/>. Deliberately a DIFFERENT exception type from
+    /// <see cref="TiltDeviceLimitException"/>: a limit violation means nothing was ever sent (device state
+    /// is untouched), while this means a command WAS sent and its outcome is ambiguous (state may be
+    /// dirty -- see <c>EatSerialTransport</c>'s remarks on this exact ambiguity) -- callers (the wizard's
+    /// failure-recovery path, the inspector's applied-move journal) need to tell the two apart to decide
+    /// whether an inverse/recovery move is even meaningful.
+    /// </summary>
+    [Serializable]
+    public sealed class TiltDeviceCommandFailedException : Exception {
+
+        public TiltDeviceCommandFailedException() {
+        }
+
+        public TiltDeviceCommandFailedException(string message) : base(message) {
+        }
+
+        public TiltDeviceCommandFailedException(string message, Exception innerException) : base(message, innerException) {
+        }
+    }
+
+    /// <summary>
+    /// <see cref="ITiltMotionController"/> driver for the ASG EAT (plan task T7). Owns the safety-critical
+    /// soft-limit enforcement (every check happens BEFORE any command reaches the transport), the per-motor
+    /// shadow position tracking that makes excursion enforcement possible, and move sequencing.
+    ///
+    /// <para><b>Wizard-index -&gt; device-motor permutation (CRITICAL).</b> <see cref="TiltAdapterMove.PerCornerSteps"/>
+    /// is in WIZARD screw-index order (wizard1..4 at [0..3]). Every shadow update and excursion check in
+    /// this class needs DEVICE motor order (motor1..4 = TR, TL, BR, BL at [0..3] -- see
+    /// <see cref="TiltDevicePositions"/>). The connected convention is wizard1=TR, wizard2=TL, wizard3=BL,
+    /// wizard4=BR, so the device-motor vector is a PERMUTATION, not a straight copy, of the wizard vector:
+    /// motor1(TR)&lt;-wizard1, motor2(TL)&lt;-wizard2, motor3(BR)&lt;-wizard4, motor4(BL)&lt;-wizard3. See
+    /// <see cref="PermuteWizardToDeviceMotorOrder"/> -- every wizard-order-to-device-order conversion in
+    /// this file MUST go through it. (The per-command step CAP is unaffected -- it's a max over motors
+    /// either way -- but shadow tracking and 'cp' reconciliation are NOT permutation-invariant.)</para>
+    ///
+    /// <para><b>Shadow position tracking.</b> <see cref="ITiltAdapterOptions.TiltDeviceShadowPositions"/>
+    /// persists a per-motor cumulative step counter (DEVICE motor order) plus a validity flag across app
+    /// restarts -- see <see cref="SerializeShadowPositions"/> for the exact format. The validity flag
+    /// (exposed as <see cref="AbsolutePositionsKnown"/>) is TRUE only once a 'cp' response has actually
+    /// parsed (at connect or during a later poll); it is FALSE from a fresh install, or whenever the most
+    /// recent <see cref="ConnectAsync"/> could not confirm positions (GUARANTEED pre-T15, since the 'cp'
+    /// response format is unknown until the live hardware capture). Per the design doc's explicit
+    /// instruction, the plugin NEVER zeroes the shadow itself: on an unparseable 'cp' at connect, the
+    /// numeric counters are left exactly as loaded (from persisted state, or the zero-initialized default
+    /// if never seeded) -- only the confidence flag changes. This means excursion enforcement while
+    /// <see cref="AbsolutePositionsKnown"/> is false is enforced against the best available estimate (a
+    /// possibly-stale persisted value, or a from-this-session-only delta counter if nothing was ever
+    /// confirmed) rather than a verified absolute position -- a real but bounded and clearly-flagged risk,
+    /// backstopped by the always-enforced per-command cap and the approval dialog's unknown-position
+    /// warning (T13). A successfully-parsed 'cp' (at connect OR at any later poll) always overwrites the
+    /// shadow with ground truth and marks it valid -- this is also how a vendor-app zero (or any other
+    /// out-of-band device touch) gets picked up, since the plugin never sends its own zero command.</para>
+    ///
+    /// <para><b>Cancellation.</b> The ASG EAT has no abort command (plan's "Device facts"): once a move is
+    /// sent, it WILL run for 5-10 s on real hardware no matter what the caller's token does afterward.
+    /// <see cref="ExecuteMoveAsync"/> therefore only honors <c>ct</c> at ONE boundary -- the very start of
+    /// the call, before any validation or I/O -- and then always runs the actual send/settle to completion
+    /// using <see cref="CancellationToken.None"/> internally. A caller executing a multi-move plan
+    /// sequentially (one <see cref="ExecuteMoveAsync"/> call per move) gets the documented "current move
+    /// completes, then stops before the next" semantics for free: cancelling mid-move has no effect on the
+    /// in-flight call, but the NEXT call's entry check throws immediately without sending anything.</para>
+    /// </summary>
+    public sealed class EatTiltMotionController : BaseINPC, ITiltMotionController {
+
+        // Device motor order labels (index 0..3) -- for diagnostic/error text only, NEVER for a command
+        // formatting or permutation decision (see PermuteWizardToDeviceMotorOrder for that).
+        private static readonly string[] DeviceMotorLabels = { "TR", "TL", "BR", "BL" };
+
+        // Move commands take 5-10 s (plan's Device facts) -- comfortably beyond the plan-mandated >= 15 s
+        // floor so a legitimate slow move never trips the overall exchange budget.
+        internal static readonly TimeSpan MoveTimeout = TimeSpan.FromSeconds(20);
+
+        // 'cp' is a position query, not a multi-second move -- a much shorter overall exchange budget is
+        // appropriate here. Tunable (see plan T15 item 7), not a wire-format LIVE-CAPTURE unknown.
+        internal static readonly TimeSpan QueryTimeout = TimeSpan.FromSeconds(5);
+
+        private readonly IEatTransport transport;
+        private readonly ITiltAdapterOptions options;
+
+        // Per-motor cumulative step counters, DEVICE motor order (TR, TL, BR, BL at [0..3]) -- see the
+        // class remarks' "Shadow position tracking" section for the full seeding/reconciliation policy.
+        // NOT internally locked: the read-validate-send-update sequence in ExecuteMoveAsync (and the
+        // shadow mutations it makes) relies on T9's exclusive-operation token (TiltDeviceConnectionService's
+        // TryBeginOperation lease / hardwareLock) for mutual exclusion between concurrent callers, rather
+        // than a lock of its own here.
+        private readonly int[] shadowPositions = new int[4];
+        private bool shadowValid;
+        private bool connected;
+
+        /// <summary>Test seam: injects the transport so tests substitute <see cref="IEatTransport"/> instead of real serial I/O.</summary>
+        internal EatTiltMotionController(IEatTransport transport, ITiltAdapterOptions options) {
+            this.transport = transport ?? throw new ArgumentNullException(nameof(transport));
+            this.options = options ?? throw new ArgumentNullException(nameof(options));
+            LoadPersistedShadow();
+        }
+
+        /// <summary>Production constructor: uses the real <see cref="EatSerialTransport"/>. Matches the <c>TiltMotionControllerRegistry</c> factory signature.</summary>
+        public EatTiltMotionController(ITiltAdapterOptions options) : this(new EatSerialTransport(), options) {
+        }
+
+        public bool Connected {
+            get => connected;
+            private set {
+                if (connected == value) {
+                    return;
+                }
+                connected = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public TiltDeviceCapabilities Capabilities { get; } = new TiltDeviceCapabilities(
+            TiltDeviceTopology.FourCornerCoupled,
+            new[] { TiltMoveAxis.DiagonalA, TiltMoveAxis.DiagonalB, TiltMoveAxis.EdgeVertical, TiltMoveAxis.EdgeHorizontal, TiltMoveAxis.Backfocus },
+            supportsPerScrewIndependent: false);
+
+        /// <summary>
+        /// True once this controller's per-motor absolute step counters are trusted (seeded/reconciled from
+        /// a successfully-parsed 'cp' response, at connect or any later poll). False means excursion
+        /// enforcement is running against a best-estimate rather than a verified absolute position -- see
+        /// the class remarks' "Shadow position tracking" section. Callers (the T13 approval dialog, wizard
+        /// status text) should surface this as a degraded-enforcement warning.
+        /// </summary>
+        public bool AbsolutePositionsKnown => shadowValid;
+
+        public async Task ConnectAsync(string portName, CancellationToken ct) {
+            if (string.IsNullOrWhiteSpace(portName)) {
+                throw new ArgumentException("Port name must not be null or empty.", nameof(portName));
+            }
+
+            await transport.OpenAsync(portName, ct).ConfigureAwait(false);
+
+            // The 'cp' query is the ONLY source of truth this class trusts for confirming the device's
+            // current per-motor positions. A transport-level failure here (closed port, cancellation) is a
+            // real failure and must abort the connect; only an UNPARSEABLE response (ParseCpPositions
+            // throwing InvalidDeviceResponseException -- GUARANTEED pre-T15, since the wire format is
+            // unknown until the live hardware capture) is tolerated.
+            var exchange = await transport.SendAsync(EatCommands.PositionQuery(), QueryTimeout, ct).ConfigureAwait(false);
+            try {
+                var positions = EatResponses.ParseCpPositions(exchange);
+                ApplyKnownPositions(positions);
+            } catch (InvalidDeviceResponseException ex) {
+                Logger.Warning($"EAT connect: 'cp' response did not parse; positions unknown for this session (excursion enforcement degraded). {ex.Message}");
+                // Per the class remarks: NEVER zero the shadow -- leave the counters exactly as loaded by
+                // LoadPersistedShadow (or their zero-initialized default if never seeded); only the
+                // confidence flag changes. Do NOT fail the connect just because 'cp' didn't parse.
+                SetShadowValid(false);
+            }
+
+            Connected = true;
+        }
+
+        public Task DisconnectAsync(CancellationToken ct) {
+            transport.Close();
+            Connected = false;
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Validates and executes a single move against the connected EAT. See the class remarks'
+        /// "Cancellation" section for the single (entry-only) cancellation boundary.
+        ///
+        /// <para><b>Exception taxonomy for callers (T14/wizard failure-recovery).</b> Every pre-send limit
+        /// check throwing <see cref="TiltDeviceLimitException"/> means NOTHING was sent -- device state is
+        /// untouched and the shadow is unchanged. Once <see cref="IEatTransport.SendAsync"/> has actually
+        /// been called, two different outcomes both mean "a command may have physically executed and the
+        /// shadow was NOT advanced -- treat this as a potential state-dirty condition and consider a
+        /// revert/resync":
+        /// <list type="bullet">
+        /// <item><description><see cref="TiltDeviceCommandFailedException"/> -- covers both a write timeout
+        /// (a <see cref="TimeoutException"/> from <see cref="IEatTransport.SendAsync"/>, which
+        /// <c>EatSerialTransport</c> deliberately does not swallow -- see its <c>WriteCommand</c> remarks --
+        /// and which is wrapped here as this exception's <see cref="Exception.InnerException"/>) and a move
+        /// that sent cleanly but did not acknowledge success (<see cref="EatResponses.ParseMoveAck"/>
+        /// returned false).</description></item>
+        /// <item><description>A propagated <see cref="SerialPortClosedException"/> (e.g. the device was
+        /// unplugged mid-move) -- deliberately NOT wrapped/reclassified here, so T9's port-unplug handling
+        /// can still catch it by its own type, but it carries exactly the same "state may be dirty"
+        /// implication as <see cref="TiltDeviceCommandFailedException"/> above.</description></item>
+        /// </list>
+        /// </para>
+        /// </summary>
+        public async Task ExecuteMoveAsync(TiltAdapterMove move, IProgress<string> progress, CancellationToken ct) {
+            if (move == null) {
+                throw new ArgumentNullException(nameof(move));
+            }
+
+            // BETWEEN-COMMANDS cancellation boundary (see class remarks' "Cancellation" section): checked
+            // here, before ANY work for this move begins, and nowhere else in this method. The ASG EAT has
+            // no abort command, so once we pass this line the move always runs to completion regardless of
+            // what happens to ct afterward -- a caller executing a sequence of moves relies on the NEXT
+            // call hitting this same check to stop the sequence, not on this call being interrupted.
+            ct.ThrowIfCancellationRequested();
+
+            if (!Connected) {
+                throw new InvalidOperationException("EatTiltMotionController is not connected; call ConnectAsync first.");
+            }
+
+            // 1) Per-command cap -- BEFORE any device I/O.
+            int maxStepsPerCommand = options.TiltDeviceMaxStepsPerCommand;
+            int magnitude = Math.Abs(move.Steps);
+            if (magnitude > maxStepsPerCommand) {
+                throw new TiltDeviceLimitException(
+                    $"Move '{move.Description}' ({move.Axis}, {FormatSigned(move.Steps)} steps) exceeds the configured max steps per command ({maxStepsPerCommand}). Nothing was sent.");
+            }
+
+            // 2) Excursion -- BEFORE any device I/O. Predicted = current shadow (already reflecting every
+            // prior successfully-executed move) + this move's effect, permuted from WIZARD screw-index
+            // order into DEVICE motor order. Because the shadow is updated after every successful move
+            // (step 3 below), a caller executing a multi-move plan sequentially via repeated
+            // ExecuteMoveAsync calls gets INTERMEDIATE-state validation for free -- there is no separate
+            // plan-level excursion check beyond this per-call one.
+            var deviceDelta = PermuteWizardToDeviceMotorOrder(move.PerCornerSteps);
+            int maxExcursion = options.TiltDeviceMaxExcursionSteps;
+            var predicted = new int[4];
+            for (int i = 0; i < 4; ++i) {
+                predicted[i] = shadowPositions[i] + RoundToInt(deviceDelta[i]);
+                if (Math.Abs(predicted[i]) > maxExcursion) {
+                    string degradedNote = shadowValid ? string.Empty :
+                        " Absolute positions are unknown this session (excursion is enforced against the last known/persisted estimate, which may be stale) -- see AbsolutePositionsKnown.";
+                    throw new TiltDeviceLimitException(
+                        $"Move '{move.Description}' would move motor {i + 1} ({DeviceMotorLabels[i]}) to {predicted[i]} steps, exceeding the configured max excursion ({maxExcursion}).{degradedNote} Nothing was sent.");
+                }
+            }
+
+            // 3) Only now: format + send. No abort capability on the device -- CancellationToken.None is
+            // passed to the transport deliberately (see the cancellation remarks above): once we commit to
+            // sending, the exchange always runs to completion so the shadow bookkeeping below stays
+            // consistent with whatever actually happened on the device.
+            string wire = EatCommands.Format(move);
+            progress?.Report($"Sending {wire} ({move.Description})");
+
+            EatRawExchange exchange;
+            try {
+                exchange = await transport.SendAsync(wire, MoveTimeout, CancellationToken.None).ConfigureAwait(false);
+            } catch (TimeoutException ex) {
+                // A write timeout (EatSerialTransport.WriteCommand deliberately does NOT swallow this --
+                // WriteTimeout is sized well beyond any legitimate move, so tripping it means the link is
+                // genuinely stuck) means the command may have been partially or fully transmitted before the
+                // link died -- classify it exactly like an ack failure/timeout below: state is ambiguous, and
+                // the shadow must NOT be advanced. Deliberately does NOT catch SerialPortClosedException --
+                // see this method's XML doc for why that propagates unmodified instead.
+                throw new TiltDeviceCommandFailedException(
+                    $"EAT command '{wire}' ({move.Description}) failed to send (write timeout). Device state is ambiguous; positions were NOT advanced -- treat as a potential state-dirty condition.",
+                    ex);
+            }
+            if (!EatResponses.ParseMoveAck(exchange)) {
+                throw new TiltDeviceCommandFailedException(
+                    $"EAT command '{wire}' ({move.Description}) did not acknowledge success within {MoveTimeout.TotalSeconds:0}s. Device state is ambiguous; positions were NOT advanced -- treat as a potential state-dirty condition.");
+            }
+
+            // Success: advance + persist shadow ONLY here -- the throw above (ack failure/timeout) never
+            // reaches this line, so a failed/timed-out move never advances the shadow.
+            ApplyMoveDeltaToShadow(deviceDelta);
+            progress?.Report($"{wire} acknowledged");
+
+            double settleSeconds = options.TiltDeviceSettleSeconds;
+            if (settleSeconds > 0) {
+                // Settle is a fixed post-move safety wait, not a device abort point -- CancellationToken.None
+                // again, for the same "no abort, don't desync bookkeeping" reason as the send above.
+                progress?.Report($"Settling {settleSeconds:0.#}s");
+                await Task.Delay(TimeSpan.FromSeconds(settleSeconds), CancellationToken.None).ConfigureAwait(false);
+            }
+            progress?.Report($"{wire} complete");
+        }
+
+        public async Task<TiltDevicePositions> QueryPositionsAsync(CancellationToken ct) {
+            if (!Connected) {
+                throw new InvalidOperationException("EatTiltMotionController is not connected; call ConnectAsync first.");
+            }
+
+            var exchange = await transport.SendAsync(EatCommands.PositionQuery(), QueryTimeout, ct).ConfigureAwait(false);
+            TiltDevicePositions positions;
+            try {
+                positions = EatResponses.ParseCpPositions(exchange);
+            } catch (InvalidDeviceResponseException ex) {
+                // GUARANTEED pre-T15 -- tolerant no-op: leave the shadow (and its confidence flag) exactly
+                // as-is. A single failed poll must not retroactively invalidate an already-trusted shadow;
+                // "reconcile once the format is known" (design doc) means "reconcile when it parses",
+                // nothing more.
+                Logger.Warning($"EAT 'cp' poll did not parse; positions unknown for this poll. {ex.Message}");
+                return TiltDevicePositions.Unknown;
+            }
+
+            ApplyKnownPositions(positions);
+            return positions;
+        }
+
+        /// <summary>
+        /// Orders <paramref name="moves"/> (a small plan -- the design doc's minimal-move decomposition
+        /// caps a plan at 3 moves before cap-splitting) to minimize the PEAK per-motor excursion across
+        /// every intermediate state, starting from the CURRENT shadow. Pure/side-effect-free: does not
+        /// touch the shadow and sends nothing -- callers (T14) call this once to decide send order, then
+        /// invoke <see cref="ExecuteMoveAsync"/> for each move in the returned order (whose own per-move
+        /// validation remains the defensive, authoritative check; this method only picks the least-risky
+        /// order). Throws <see cref="TiltDeviceLimitException"/> if any move exceeds the per-command cap
+        /// (no ordering can fix that) or if even the best ordering's peak excursion exceeds the configured
+        /// max. Evaluates every permutation (at most 3! = 6 for the plans this feature ever produces) --
+        /// deliberately not intended to scale beyond a handful of moves.
+        /// </summary>
+        public IReadOnlyList<TiltAdapterMove> OrderForMinimalPeakExcursion(IReadOnlyList<TiltAdapterMove> moves) {
+            if (moves == null) {
+                throw new ArgumentNullException(nameof(moves));
+            }
+            if (moves.Count == 0) {
+                return Array.Empty<TiltAdapterMove>();
+            }
+
+            int maxStepsPerCommand = options.TiltDeviceMaxStepsPerCommand;
+            foreach (var move in moves) {
+                if (Math.Abs(move.Steps) > maxStepsPerCommand) {
+                    throw new TiltDeviceLimitException(
+                        $"Move '{move.Description}' ({move.Axis}, {FormatSigned(move.Steps)} steps) exceeds the configured max steps per command ({maxStepsPerCommand}); no ordering can fix this. Nothing was sent.");
+                }
+            }
+
+            int maxExcursion = options.TiltDeviceMaxExcursionSteps;
+            IReadOnlyList<TiltAdapterMove> bestOrder = null;
+            int bestPeak = int.MaxValue;
+            foreach (var candidate in GeneratePermutations(moves)) {
+                int peak = PeakExcursion(candidate);
+                if (peak < bestPeak) {
+                    bestPeak = peak;
+                    bestOrder = candidate;
+                }
+            }
+
+            if (bestOrder == null || bestPeak > maxExcursion) {
+                string degradedNote = shadowValid ? string.Empty :
+                    " Absolute positions are unknown this session (excursion is enforced against the last known/persisted estimate, which may be stale) -- see AbsolutePositionsKnown.";
+                throw new TiltDeviceLimitException(
+                    $"No ordering of the given {moves.Count} move(s) keeps every intermediate/final per-motor position within the configured max excursion ({maxExcursion} steps); the best achievable peak is {bestPeak} steps.{degradedNote} Nothing was sent.");
+            }
+
+            return bestOrder;
+        }
+
+        private int PeakExcursion(IReadOnlyList<TiltAdapterMove> order) {
+            var running = (int[])shadowPositions.Clone();
+            int peak = 0;
+            for (int i = 0; i < 4; ++i) {
+                peak = Math.Max(peak, Math.Abs(running[i]));
+            }
+            foreach (var move in order) {
+                var delta = PermuteWizardToDeviceMotorOrder(move.PerCornerSteps);
+                for (int i = 0; i < 4; ++i) {
+                    running[i] += RoundToInt(delta[i]);
+                    peak = Math.Max(peak, Math.Abs(running[i]));
+                }
+            }
+            return peak;
+        }
+
+        // Simple recursive permutation generator -- fine for the <= 3-move plans this feature ever
+        // produces (see TiltMovePlanner's "never exceeds three" guarantee); factorial blowup is a non-issue
+        // at n<=3 (at most 6 candidates).
+        private static IEnumerable<IReadOnlyList<TiltAdapterMove>> GeneratePermutations(IReadOnlyList<TiltAdapterMove> moves) {
+            if (moves.Count <= 1) {
+                yield return moves;
+                yield break;
+            }
+            for (int i = 0; i < moves.Count; ++i) {
+                var rest = new List<TiltAdapterMove>(moves);
+                var chosen = rest[i];
+                rest.RemoveAt(i);
+                foreach (var subPermutation in GeneratePermutations(rest)) {
+                    var result = new List<TiltAdapterMove>(moves.Count) { chosen };
+                    result.AddRange(subPermutation);
+                    yield return result;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Permutes a WIZARD-screw-index-ordered per-corner vector (wizard screws 1..4 at [0..3], as
+        /// produced by <see cref="TiltAdapterMove.PerCornerSteps"/>) into DEVICE motor order (TR, TL, BR,
+        /// BL at [0..3]). THE correctness anchor for every shadow-tracking and 'cp'-reconciliation
+        /// calculation in this class -- see the class remarks' "Wizard-index -&gt; device-motor
+        /// permutation" section for the full derivation:
+        /// <c>deviceMotorVec = [ wizardVec[0], wizardVec[1], wizardVec[3], wizardVec[2] ]</c> -- motor1
+        /// (TR) &lt;- wizard1, motor2 (TL) &lt;- wizard2, motor3 (BR) &lt;- wizard4, motor4 (BL) &lt;-
+        /// wizard3. Note this is NOT the identity permutation: wizard3 and wizard4 swap positions relative
+        /// to a naive "wizard order == device order" copy.
+        /// </summary>
+        internal static double[] PermuteWizardToDeviceMotorOrder(IReadOnlyList<double> wizardPerCornerSteps) {
+            if (wizardPerCornerSteps == null || wizardPerCornerSteps.Count != 4) {
+                throw new ArgumentException("Wizard per-corner vector must contain exactly 4 elements (wizard screw indices 1..4).", nameof(wizardPerCornerSteps));
+            }
+            return new[] {
+                wizardPerCornerSteps[0], // motor1 TR <- wizard1
+                wizardPerCornerSteps[1], // motor2 TL <- wizard2
+                wizardPerCornerSteps[3], // motor3 BR <- wizard4
+                wizardPerCornerSteps[2], // motor4 BL <- wizard3
+            };
+        }
+
+        /// <summary>
+        /// Serializes the shadow position state into the format persisted in
+        /// <see cref="ITiltAdapterOptions.TiltDeviceShadowPositions"/>:
+        /// <c>&lt;0|1&gt;;&lt;TR&gt;;&lt;TL&gt;;&lt;BR&gt;;&lt;BL&gt;</c> -- a leading validity flag ('1' =
+        /// <paramref name="valid"/>, the per-motor counters are trusted absolute positions; '0' = not yet
+        /// confirmed by a successfully-parsed 'cp' response) followed by the four DEVICE-motor-order (TR,
+        /// TL, BR, BL) counters, all semicolon-separated. Example: <c>1;10;-5;0;20</c>.
+        /// </summary>
+        internal static string SerializeShadowPositions(bool valid, IReadOnlyList<int> perMotorSteps) {
+            if (perMotorSteps == null || perMotorSteps.Count != 4) {
+                throw new ArgumentException("Per-motor step array must contain exactly 4 elements (DEVICE motor order TR, TL, BR, BL).", nameof(perMotorSteps));
+            }
+            return string.Join(";",
+                valid ? "1" : "0",
+                perMotorSteps[0].ToString(CultureInfo.InvariantCulture),
+                perMotorSteps[1].ToString(CultureInfo.InvariantCulture),
+                perMotorSteps[2].ToString(CultureInfo.InvariantCulture),
+                perMotorSteps[3].ToString(CultureInfo.InvariantCulture));
+        }
+
+        /// <summary>
+        /// Tolerant inverse of <see cref="SerializeShadowPositions"/>. Returns false (rather than throwing)
+        /// for null/empty/malformed input -- e.g. the very first run ever, before anything has been
+        /// persisted -- so callers treat that exactly like "never seeded" instead of crashing.
+        /// </summary>
+        internal static bool TryParseShadowPositions(string serialized, out bool valid, out int[] perMotorSteps) {
+            valid = false;
+            perMotorSteps = new int[4];
+            if (string.IsNullOrWhiteSpace(serialized)) {
+                return false;
+            }
+
+            var parts = serialized.Split(';');
+            if (parts.Length != 5) {
+                return false;
+            }
+            if (parts[0] != "0" && parts[0] != "1") {
+                return false;
+            }
+
+            var steps = new int[4];
+            for (int i = 0; i < 4; ++i) {
+                if (!int.TryParse(parts[i + 1], NumberStyles.Integer, CultureInfo.InvariantCulture, out steps[i])) {
+                    return false;
+                }
+            }
+
+            valid = parts[0] == "1";
+            perMotorSteps = steps;
+            return true;
+        }
+
+        private void LoadPersistedShadow() {
+            if (TryParseShadowPositions(options.TiltDeviceShadowPositions, out var valid, out var steps)) {
+                Array.Copy(steps, shadowPositions, 4);
+                shadowValid = valid;
+            }
+            // Else: unparseable/empty (e.g. the very first run ever) -- leave shadowPositions at its
+            // zero-initialized default and shadowValid false (never seeded). This is NOT the same as
+            // "zeroing" the shadow (which the plugin never does) -- it's simply the natural default for
+            // state that has never existed.
+        }
+
+        private void ApplyKnownPositions(TiltDevicePositions positions) {
+            var steps = positions.PerMotorSteps;
+            for (int i = 0; i < 4; ++i) {
+                shadowPositions[i] = i < steps.Count ? steps[i] : 0;
+            }
+            SetShadowValid(true);
+            PersistShadow();
+        }
+
+        private void ApplyMoveDeltaToShadow(IReadOnlyList<double> deviceDelta) {
+            for (int i = 0; i < 4; ++i) {
+                shadowPositions[i] += RoundToInt(deviceDelta[i]);
+            }
+            PersistShadow();
+        }
+
+        private void SetShadowValid(bool value) {
+            if (shadowValid == value) {
+                return;
+            }
+            shadowValid = value;
+            RaisePropertyChanged(nameof(AbsolutePositionsKnown));
+        }
+
+        private void PersistShadow() {
+            options.TiltDeviceShadowPositions = SerializeShadowPositions(shadowValid, shadowPositions);
+        }
+
+        private static int RoundToInt(double value) => (int)Math.Round(value, MidpointRounding.AwayFromZero);
+
+        private static string FormatSigned(int steps) => steps.ToString("+0;-0;0", CultureInfo.InvariantCulture);
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatWizardMapping.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatWizardMapping.cs
@@ -1,0 +1,133 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
+
+    /// <summary>
+    /// Maps the Tilt Adapter Calibration Wizard's <see cref="WizardStep"/> sequence onto device moves, and
+    /// defines the wizard-screw &lt;-&gt; device-corner correspondence that a device-linked calibration
+    /// establishes.
+    ///
+    /// CRITICAL: the wizard's per-step instruction text (<c>TiltAdapterWizardVM.StepInstructionsText</c>)
+    /// says "motor 1", "motor 3", etc. -- these are WIZARD-SCREW indices (the user's own labeled screws
+    /// 1..4), NOT device motor numbers. Connecting the device during calibration DEFINES the
+    /// correspondence: wizard-screw 1 == TR, wizard-screw 2 == TL, wizard-screw 3 == BL, wizard-screw 4 ==
+    /// BR -- the wizard's opposite pairs (1,3),(2,4) line up with the device's opposite pairs (TR,BL) and
+    /// (TL,BR). Every mapping below is expressed purely in <see cref="TiltMoveAxis"/>/
+    /// <see cref="TiltAdapterMove"/> terms (wizard-index per-corner space, per <c>TiltAdapterMove</c>'s
+    /// (s1,s2,s3,s4) unit-effect table); translating an axis to its ASG EAT wire mnemonic (e.g.
+    /// DiagonalA -&gt; "tr") is <c>EatCommands</c>'s job, not this file's -- keep those concerns separate.
+    /// </summary>
+    public static class EatWizardMapping {
+
+        /// <summary>
+        /// The device corner label for a wizard screw index (1-based): 1-&gt;TR, 2-&gt;TL, 3-&gt;BL,
+        /// 4-&gt;BR, per the device-linked-calibration correspondence documented on this class. Used to
+        /// label the live per-screw positions display while connected.
+        /// </summary>
+        public static string CornerLabelForWizardScrew(int wizardScrew) {
+            switch (wizardScrew) {
+                case 1: return "TR";
+                case 2: return "TL";
+                case 3: return "BL";
+                case 4: return "BR";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(wizardScrew), wizardScrew, "Wizard screw index must be 1-4.");
+            }
+        }
+
+        /// <summary>
+        /// The device move that realizes a calibration wizard step's instruction, or null for
+        /// <see cref="WizardStep.Baseline"/> (a measurement-only step -- no move). <paramref
+        /// name="appliedSteps"/> is N, the already-rounded integer step count (the wizard's persisted
+        /// per-calibration-step applied amount for a stepper device).
+        ///
+        /// Each case is annotated with the exact <c>StepInstructionsText</c> wording (four-screw,
+        /// isStepper) it realizes. The six executed moves (AllInward, ReBaseline1, Screw1, ReBaseline2,
+        /// Screw2, Complete) sum to (0,0,0,0) per corner -- the device returns to baseline at Complete; see
+        /// EatWizardMappingTests for the full-sequence regression that pins this.
+        /// </summary>
+        public static TiltAdapterMove MoveForStep(WizardStep step, int appliedSteps) {
+            switch (step) {
+                case WizardStep.Baseline:
+                    // "Ensure all screws are at their starting position, then click Run Measurement." --
+                    // measurement only, no move.
+                    return null;
+
+                case WizardStep.AllInward:
+                    // "Apply +N steps to EVERY motor, then click Run Measurement." -> all four wizard
+                    // screws +N -> (+N,+N,+N,+N) = Backfocus(+N).
+                    return new TiltAdapterMove(
+                        TiltMoveAxis.Backfocus, appliedSteps, TiltMoveGroup.Backfocus,
+                        $"Wizard All Inward: {FormatSigned(appliedSteps)} backfocus");
+
+                case WizardStep.ReBaseline1:
+                    // "Apply -N steps to every motor, returning to the baseline position, then click Run
+                    // Measurement." -> undoes AllInward -> (-N,-N,-N,-N) = Backfocus(-N).
+                    return new TiltAdapterMove(
+                        TiltMoveAxis.Backfocus, -appliedSteps, TiltMoveGroup.Backfocus,
+                        $"Wizard Re-Baseline 1: {FormatSigned(-appliedSteps)} backfocus");
+
+                case WizardStep.Screw1:
+                    // "Apply +N steps to motor 1 and -N steps to motor 3, then click Run Measurement." ->
+                    // wizard-screw1 +N, wizard-screw3 -N -> (+N,0,-N,0) = DiagonalA(+N).
+                    return new TiltAdapterMove(
+                        TiltMoveAxis.DiagonalA, appliedSteps, TiltMoveGroup.Tilt,
+                        $"Wizard Screw 1: {FormatSigned(appliedSteps)} diagonal-A");
+
+                case WizardStep.ReBaseline2:
+                    // "Apply -N steps to motor 1 and +N steps to motor 3, returning to the baseline
+                    // position, then click Run Measurement." -> undoes Screw1 -> (-N,0,+N,0) =
+                    // DiagonalA(-N).
+                    return new TiltAdapterMove(
+                        TiltMoveAxis.DiagonalA, -appliedSteps, TiltMoveGroup.Tilt,
+                        $"Wizard Re-Baseline 2: {FormatSigned(-appliedSteps)} diagonal-A");
+
+                case WizardStep.Screw2:
+                    // "Apply +N steps to motor 2 and -N steps to motor 4, then click Run Measurement." ->
+                    // wizard-screw2 +N, wizard-screw4 -N -> (0,+N,0,-N) = DiagonalB(+N).
+                    return new TiltAdapterMove(
+                        TiltMoveAxis.DiagonalB, appliedSteps, TiltMoveGroup.Tilt,
+                        $"Wizard Screw 2: {FormatSigned(appliedSteps)} diagonal-B");
+
+                case WizardStep.Complete:
+                    // "Return all motors to their original position." -- the restore move after Screw2 ->
+                    // undoes Screw2 -> (0,-N,0,+N) = DiagonalB(-N). Confirmed by the full-sequence trace:
+                    // this is exactly what returns the device to baseline (0,0,0,0) after the 6-step run.
+                    return new TiltAdapterMove(
+                        TiltMoveAxis.DiagonalB, -appliedSteps, TiltMoveGroup.Tilt,
+                        $"Wizard Complete: {FormatSigned(-appliedSteps)} diagonal-B (restore)");
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(step), step, "Unknown wizard step.");
+            }
+        }
+
+        /// <summary>
+        /// The inverse of <paramref name="move"/>: same axis and group, negated
+        /// <see cref="TiltAdapterMove.Steps"/>. Used for failure-recovery -- if a wizard-driven move fails
+        /// or is cancelled mid-flight, sending the inverse move returns the device to where it was before.
+        /// Null-safe: null in, null out.
+        /// </summary>
+        public static TiltAdapterMove InverseMove(TiltAdapterMove move) {
+            if (move == null) {
+                return null;
+            }
+            return new TiltAdapterMove(move.Axis, -move.Steps, move.Group, $"Inverse of: {move.Description}");
+        }
+
+        private static string FormatSigned(int steps) => steps >= 0 ? $"+{steps}" : steps.ToString();
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentChoice.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentChoice.cs
@@ -1,0 +1,60 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt {
+
+    /// <summary>
+    /// The immutable outcome of the tilt-device adjustment approval dialog. Not a simple enum because an
+    /// approval must carry WHAT was approved: the group toggles the user left enabled and the exact
+    /// <see cref="TiltAdapterMovePlan"/> that was on screen when Proceed was clicked — the executor must
+    /// send precisely those moves, never a replanned variant the user did not see. Cancel (or closing the
+    /// window) resolves to <see cref="Cancelled"/> with <see cref="Proceed"/> = false and no plan.
+    /// </summary>
+    public sealed class TiltDeviceAdjustmentChoice {
+
+        /// <summary>The shared cancel/dismiss result: no moves were approved; nothing may be sent.</summary>
+        public static readonly TiltDeviceAdjustmentChoice Cancelled =
+            new TiltDeviceAdjustmentChoice(proceed: false, applyTilt: false, applyBackfocus: false, finalPlan: null);
+
+        /// <summary>An approval carrying the toggles and the exact plan the user reviewed.</summary>
+        public static TiltDeviceAdjustmentChoice Proceeded(bool applyTilt, bool applyBackfocus, TiltAdapterMovePlan finalPlan) {
+            if (finalPlan == null) {
+                throw new ArgumentNullException(nameof(finalPlan), "An approved choice must carry the reviewed plan.");
+            }
+            return new TiltDeviceAdjustmentChoice(proceed: true, applyTilt: applyTilt, applyBackfocus: applyBackfocus, finalPlan: finalPlan);
+        }
+
+        private TiltDeviceAdjustmentChoice(bool proceed, bool applyTilt, bool applyBackfocus, TiltAdapterMovePlan finalPlan) {
+            Proceed = proceed;
+            ApplyTilt = applyTilt;
+            ApplyBackfocus = applyBackfocus;
+            FinalPlan = finalPlan;
+        }
+
+        /// <summary>True only when the user explicitly clicked Proceed; false for Cancel or window close.</summary>
+        public bool Proceed { get; }
+
+        /// <summary>State of the Tilt group checkbox at the moment of approval.</summary>
+        public bool ApplyTilt { get; }
+
+        /// <summary>State of the Backfocus group checkbox at the moment of approval.</summary>
+        public bool ApplyBackfocus { get; }
+
+        /// <summary>
+        /// The exact plan displayed when Proceed was clicked (the last replanner result). Null when
+        /// <see cref="Proceed"/> is false.
+        /// </summary>
+        public TiltAdapterMovePlan FinalPlan { get; }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPrompt.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPrompt.cs
@@ -38,17 +38,19 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt {
         /// </param>
         /// <param name="pitchMismatchWarning">Optional saved-vs-measured step-size mismatch advisory (null/empty ⇒ hidden).</param>
         /// <param name="positionsUnknown">True when device positions are unknown, degrading excursion enforcement.</param>
+        /// <param name="unitMicrons">Microns represented by one motor step, used to express the twist warning in µm.</param>
         public static async Task<TiltDeviceAdjustmentChoice> ShowAsync(
             IWindowServiceFactory windowServiceFactory,
             Func<bool, bool, TiltDevicePlanPreview> replanner,
             bool screwInwardCurvatureSignIsMeasured,
             string pitchMismatchWarning,
-            bool positionsUnknown) {
+            bool positionsUnknown,
+            double unitMicrons) {
             if (windowServiceFactory == null) {
                 throw new ArgumentNullException(nameof(windowServiceFactory));
             }
 
-            var vm = new TiltDeviceAdjustmentPromptVM(replanner, screwInwardCurvatureSignIsMeasured, pitchMismatchWarning, positionsUnknown);
+            var vm = new TiltDeviceAdjustmentPromptVM(replanner, screwInwardCurvatureSignIsMeasured, pitchMismatchWarning, positionsUnknown, unitMicrons);
             var windowService = windowServiceFactory.Create();
 
             // A button (or the X) raises RequestClose; close the host window, which fires OnClosed below.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPrompt.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPrompt.cs
@@ -1,0 +1,76 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Utility.WindowService;
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt {
+
+    /// <summary>Shows the tilt-device adjustment approval prompt modally and awaits the user's choice.</summary>
+    public static class TiltDeviceAdjustmentPrompt {
+
+        /// <summary>
+        /// Builds the prompt VM, shows it via NINA's <see cref="IWindowService"/> (which marshals window creation onto
+        /// the application dispatcher internally), and returns the user's choice. Safe to call from a background
+        /// thread: the awaited <see cref="TiltDeviceAdjustmentPromptVM.Choice"/> completes when the user clicks a
+        /// button or closes the window, and continuations run off the captured context. Cancel/close resolves to
+        /// <see cref="TiltDeviceAdjustmentChoice.Cancelled"/> — no moves may be sent in that case.
+        /// </summary>
+        /// <param name="windowServiceFactory">NINA window service factory used to host the modal.</param>
+        /// <param name="replanner">
+        /// Recomputes the plan (and the controller's limit check) for a given (includeTilt, includeBackfocus) toggle
+        /// state. Invoked once with (true, true) for the initial preview and again on every checkbox toggle.
+        /// </param>
+        /// <param name="screwInwardCurvatureSignIsMeasured">
+        /// False when the wizard never measured the backfocus direction — shows the "(assumed direction)" warning
+        /// whenever the current plan contains a backfocus move.
+        /// </param>
+        /// <param name="pitchMismatchWarning">Optional saved-vs-measured step-size mismatch advisory (null/empty ⇒ hidden).</param>
+        /// <param name="positionsUnknown">True when device positions are unknown, degrading excursion enforcement.</param>
+        public static async Task<TiltDeviceAdjustmentChoice> ShowAsync(
+            IWindowServiceFactory windowServiceFactory,
+            Func<bool, bool, TiltDevicePlanPreview> replanner,
+            bool screwInwardCurvatureSignIsMeasured,
+            string pitchMismatchWarning,
+            bool positionsUnknown) {
+            if (windowServiceFactory == null) {
+                throw new ArgumentNullException(nameof(windowServiceFactory));
+            }
+
+            var vm = new TiltDeviceAdjustmentPromptVM(replanner, screwInwardCurvatureSignIsMeasured, pitchMismatchWarning, positionsUnknown);
+            var windowService = windowServiceFactory.Create();
+
+            // A button (or the X) raises RequestClose; close the host window, which fires OnClosed below.
+            void onRequestClose(object s, EventArgs e) {
+                _ = windowService.Close();
+            }
+
+            EventHandler onClosed = null;
+            onClosed = (s, e) => {
+                windowService.OnClosed -= onClosed;
+                vm.RequestClose -= onRequestClose;
+                // Dispose resolves the choice to Cancel if no button set it (window closed via the X). No-op otherwise.
+                vm.Dispose();
+            };
+            windowService.OnClosed += onClosed;
+            vm.RequestClose += onRequestClose;
+
+            // Fire-and-forget (same as the other plugin dialogs); the result flows back through the VM's TCS, which we
+            // await below. The dialog Task itself is not awaited (it completes only when the window closes).
+            _ = windowService.ShowDialog(vm, "Tilt Adapter Adjustment", ResizeMode.NoResize, WindowStyle.SingleBorderWindow);
+
+            return await vm.Choice;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptControl.xaml
@@ -116,10 +116,13 @@
             Margin="0,4,0,0"
             Foreground="{StaticResource FgDim}"
             TextWrapping="Wrap"
-            Text="The commands below physically move the tilt adapter's motors, and the device stores every move in EEPROM. There is no automatic undo — verify each signed command before proceeding." />
+            Text="The moves below physically turn the tilt adapter's motor screws, and the device stores every move in EEPROM. There is no automatic undo — check which screws move, and how far, before proceeding." />
 
         <!--  Group toggles. Toggling either recomputes the plan below, so what is displayed is always
-              exactly what will be sent.  -->
+              exactly what will be sent. The captions are SIBLING TextBlocks, not CheckBox.Content: NINA's
+              themed CheckBox template does not render Content, so a caption placed inside the CheckBox is
+              invisible (the toggles then look unlabeled). Keeping the text as a sibling renders it in every
+              theme; AutomationProperties.Name carries the label to screen readers.  -->
         <StackPanel Grid.Row="2" Margin="0,12,0,0" Orientation="Horizontal">
             <TextBlock
                 Margin="0,0,10,0"
@@ -129,30 +132,38 @@
             <CheckBox
                 VerticalAlignment="Center"
                 VerticalContentAlignment="Center"
-                IsChecked="{Binding ApplyTilt}">
-                <TextBlock Foreground="{StaticResource Fg}" Text="Tilt correction" />
-            </CheckBox>
+                AutomationProperties.Name="Tilt correction"
+                IsChecked="{Binding ApplyTilt}" />
+            <TextBlock
+                Margin="6,0,0,0"
+                VerticalAlignment="Center"
+                Foreground="{StaticResource Fg}"
+                Text="Tilt correction" />
             <CheckBox
                 Margin="18,0,0,0"
                 VerticalAlignment="Center"
                 VerticalContentAlignment="Center"
-                IsChecked="{Binding ApplyBackfocus}">
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock Foreground="{StaticResource Fg}" Text="Backfocus correction" />
-                    <!--  Anchors the assumed-direction caveat to the group it applies to; the full
-                          explanation is in the warnings below.  -->
-                    <TextBlock
-                        Margin="6,0,0,0"
-                        Foreground="{StaticResource WarnFg}"
-                        Text="⚠ (assumed direction)"
-                        Visibility="{Binding AssumedDirectionWarningVisible, Converter={StaticResource BoolToVis}}" />
-                </StackPanel>
-            </CheckBox>
+                AutomationProperties.Name="Backfocus correction"
+                IsChecked="{Binding ApplyBackfocus}" />
+            <TextBlock
+                Margin="6,0,0,0"
+                VerticalAlignment="Center"
+                Foreground="{StaticResource Fg}"
+                Text="Backfocus correction" />
+            <!--  Anchors the assumed-direction caveat to the group it applies to; the full
+                  explanation is in the warnings below.  -->
+            <TextBlock
+                Margin="6,0,0,0"
+                VerticalAlignment="Center"
+                Foreground="{StaticResource WarnFg}"
+                Text="⚠ (assumed direction)"
+                Visibility="{Binding AssumedDirectionWarningVisible, Converter={StaticResource BoolToVis}}" />
         </StackPanel>
 
-        <!--  Move list: the signed wire command is the most prominent element of each row.  -->
+        <!--  Move list: each row reads semantically (which screws move, by how many signed steps). The raw
+              wire command is demoted to a small dim chip on the right for auditability, not the row anchor.  -->
         <StackPanel Grid.Row="3">
-            <TextBlock Style="{StaticResource SectionHeader}" Text="COMMANDS TO SEND" />
+            <TextBlock Style="{StaticResource SectionHeader}" Text="MOVES TO SEND" />
             <Border
                 Background="{StaticResource PanelBg}"
                 BorderBrush="{StaticResource PanelBorder}"
@@ -163,54 +174,62 @@
                     <ItemsControl ItemsSource="{Binding Moves}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <Grid Margin="0,3">
+                                <Grid Margin="0,4">
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="110" />
+                                        <ColumnDefinition Width="82" />
                                         <ColumnDefinition Width="*" />
                                         <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
+                                    <!--  Move-kind badge: Corner / Side / Backfocus.  -->
                                     <Border
                                         Grid.Column="0"
+                                        VerticalAlignment="Center"
                                         Background="{StaticResource CommandBg}"
                                         BorderBrush="{StaticResource PanelBorder}"
                                         BorderThickness="1"
                                         CornerRadius="3"
-                                        Padding="8,3">
+                                        Padding="6,3">
                                         <TextBlock
                                             HorizontalAlignment="Center"
-                                            FontFamily="Consolas"
-                                            FontSize="16"
-                                            FontWeight="Bold"
-                                            Foreground="{StaticResource CommandFg}"
-                                            Text="{Binding WireCommand}" />
+                                            FontSize="12"
+                                            FontWeight="SemiBold"
+                                            Foreground="{StaticResource Fg}"
+                                            Text="{Binding MoveKindLabel}" />
                                     </Border>
+                                    <!--  Primary line: which screws move, and by how many signed steps.  -->
                                     <TextBlock
                                         Grid.Column="1"
                                         Margin="10,0"
                                         VerticalAlignment="Center"
+                                        FontSize="13"
                                         Foreground="{StaticResource Fg}"
-                                        Text="{Binding Description}"
+                                        Text="{Binding SemanticText}"
                                         TextWrapping="Wrap" />
-                                    <Border
+                                    <!--  Demoted raw wire command (auditability), tooltip explains it.  -->
+                                    <TextBlock
                                         Grid.Column="2"
                                         VerticalAlignment="Center"
-                                        BorderBrush="{StaticResource PanelBorder}"
-                                        BorderThickness="1"
-                                        CornerRadius="8"
-                                        Padding="8,1">
-                                        <TextBlock
-                                            FontSize="11"
-                                            Foreground="{StaticResource FgDim}"
-                                            Text="{Binding GroupLabel}" />
-                                    </Border>
+                                        FontFamily="Consolas"
+                                        FontSize="11"
+                                        Foreground="{StaticResource FgDim}"
+                                        Text="{Binding WireCommand}"
+                                        ToolTip="The exact command string sent to the device." />
                                 </Grid>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                     <TextBlock
                         Foreground="{StaticResource FgDim}"
-                        Text="No commands will be sent."
+                        Text="No moves will be sent."
                         Visibility="{Binding HasNoMoves, Converter={StaticResource BoolToVis}}" />
+                    <!--  Legend: explains the signed-step direction without asserting a rig-dependent up/down.  -->
+                    <TextBlock
+                        Margin="0,8,0,0"
+                        FontSize="11"
+                        Foreground="{StaticResource FgDim}"
+                        TextWrapping="Wrap"
+                        Text="+ = the wizard's positive step direction (clockwise / tighten); − = the opposite. Screw numbers match the Tilt Adapter Wizard."
+                        Visibility="{Binding HasMoves, Converter={StaticResource BoolToVis}}" />
                 </StackPanel>
             </Border>
         </StackPanel>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptControl.xaml
@@ -128,7 +128,7 @@
                 Margin="0,0,10,0"
                 VerticalAlignment="Center"
                 Foreground="{StaticResource FgDim}"
-                Text="Apply:" />
+                Text="Apply" />
             <CheckBox
                 VerticalAlignment="Center"
                 VerticalContentAlignment="Center"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptControl.xaml
@@ -1,0 +1,316 @@
+<UserControl
+    x:Class="NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt.TiltDeviceAdjustmentPromptControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Background="#FF1E2125">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis" />
+
+        <!--  Self-contained palette so the dialog reads clearly regardless of the active NINA theme
+              (same approach as ReplaySettingsPromptControl).  -->
+        <SolidColorBrush x:Key="Fg" Color="White" />
+        <SolidColorBrush x:Key="FgDim" Color="#FFB8BEC6" />
+        <SolidColorBrush x:Key="PanelBg" Color="#FF262B31" />
+        <SolidColorBrush x:Key="PanelBorder" Color="#FF3E4650" />
+        <SolidColorBrush x:Key="CommandBg" Color="#FF10151B" />
+        <SolidColorBrush x:Key="CommandFg" Color="#FFFFD37E" />
+        <SolidColorBrush x:Key="WarnFg" Color="#FFE8C170" />
+        <SolidColorBrush x:Key="WarnBorder" Color="#FF8A6D2F" />
+        <SolidColorBrush x:Key="WarnBg" Color="#FF2E2A1D" />
+        <SolidColorBrush x:Key="DangerFg" Color="#FFF2938C" />
+        <SolidColorBrush x:Key="DangerBorder" Color="#FFA85049" />
+        <SolidColorBrush x:Key="DangerBg" Color="#FF33211F" />
+
+        <Style x:Key="SectionHeader" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Foreground" Value="{StaticResource FgDim}" />
+            <Setter Property="Margin" Value="0,12,0,4" />
+        </Style>
+
+        <!--  Advisory (amber) warning panel: user should read it, but may still proceed.  -->
+        <Style x:Key="WarningPanel" TargetType="Border">
+            <Setter Property="Margin" Value="0,6,0,0" />
+            <Setter Property="Padding" Value="10,8" />
+            <Setter Property="CornerRadius" Value="3" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Background" Value="{StaticResource WarnBg}" />
+            <Setter Property="BorderBrush" Value="{StaticResource WarnBorder}" />
+        </Style>
+
+        <!--  Blocking (red) warning panel: Proceed is disabled while this is visible.  -->
+        <Style x:Key="DangerPanel" TargetType="Border" BasedOn="{StaticResource WarningPanel}">
+            <Setter Property="Background" Value="{StaticResource DangerBg}" />
+            <Setter Property="BorderBrush" Value="{StaticResource DangerBorder}" />
+        </Style>
+
+        <Style x:Key="WarningText" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{StaticResource WarnFg}" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+        </Style>
+
+        <Style x:Key="DangerText" TargetType="TextBlock" BasedOn="{StaticResource WarningText}">
+            <Setter Property="Foreground" Value="{StaticResource DangerFg}" />
+        </Style>
+
+        <!--  Primary action: visually distinct so the point of no return is unmistakable, and clearly
+              grayed out when disabled (both groups off, or a hard travel limit is violated).  -->
+        <Style x:Key="ProceedButton" TargetType="Button">
+            <Setter Property="MinWidth" Value="110" />
+            <Setter Property="Padding" Value="14,6" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border
+                            x:Name="Bg"
+                            Background="#FF2E6DA4"
+                            BorderBrush="#FF3E86C4"
+                            BorderThickness="1"
+                            CornerRadius="4"
+                            Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bg" Property="Background" Value="#FF3A7DB8" />
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="Bg" Property="Background" Value="#FF285E8E" />
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="Bg" Property="Background" Value="#FF2A2F36" />
+                                <Setter TargetName="Bg" Property="BorderBrush" Value="#FF3E4650" />
+                                <Setter Property="Foreground" Value="#FF6E7681" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
+
+    <Grid Width="560" Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock
+            Grid.Row="0"
+            FontSize="16"
+            FontWeight="Bold"
+            Foreground="{StaticResource Fg}"
+            Text="Review motor commands" />
+
+        <!--  The cautionary framing: physical, EEPROM-persisted, no automatic undo.  -->
+        <TextBlock
+            Grid.Row="1"
+            Margin="0,4,0,0"
+            Foreground="{StaticResource FgDim}"
+            TextWrapping="Wrap"
+            Text="The commands below physically move the tilt adapter's motors, and the device stores every move in EEPROM. There is no automatic undo — verify each signed command before proceeding." />
+
+        <!--  Group toggles. Toggling either recomputes the plan below, so what is displayed is always
+              exactly what will be sent.  -->
+        <StackPanel Grid.Row="2" Margin="0,12,0,0" Orientation="Horizontal">
+            <TextBlock
+                Margin="0,0,10,0"
+                VerticalAlignment="Center"
+                Foreground="{StaticResource FgDim}"
+                Text="Apply:" />
+            <CheckBox
+                VerticalAlignment="Center"
+                VerticalContentAlignment="Center"
+                IsChecked="{Binding ApplyTilt}">
+                <TextBlock Foreground="{StaticResource Fg}" Text="Tilt correction" />
+            </CheckBox>
+            <CheckBox
+                Margin="18,0,0,0"
+                VerticalAlignment="Center"
+                VerticalContentAlignment="Center"
+                IsChecked="{Binding ApplyBackfocus}">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Foreground="{StaticResource Fg}" Text="Backfocus correction" />
+                    <!--  Anchors the assumed-direction caveat to the group it applies to; the full
+                          explanation is in the warnings below.  -->
+                    <TextBlock
+                        Margin="6,0,0,0"
+                        Foreground="{StaticResource WarnFg}"
+                        Text="⚠ (assumed direction)"
+                        Visibility="{Binding AssumedDirectionWarningVisible, Converter={StaticResource BoolToVis}}" />
+                </StackPanel>
+            </CheckBox>
+        </StackPanel>
+
+        <!--  Move list: the signed wire command is the most prominent element of each row.  -->
+        <StackPanel Grid.Row="3">
+            <TextBlock Style="{StaticResource SectionHeader}" Text="COMMANDS TO SEND" />
+            <Border
+                Background="{StaticResource PanelBg}"
+                BorderBrush="{StaticResource PanelBorder}"
+                BorderThickness="1"
+                CornerRadius="3"
+                Padding="10,8">
+                <StackPanel>
+                    <ItemsControl ItemsSource="{Binding Moves}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Grid Margin="0,3">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="110" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <Border
+                                        Grid.Column="0"
+                                        Background="{StaticResource CommandBg}"
+                                        BorderBrush="{StaticResource PanelBorder}"
+                                        BorderThickness="1"
+                                        CornerRadius="3"
+                                        Padding="8,3">
+                                        <TextBlock
+                                            HorizontalAlignment="Center"
+                                            FontFamily="Consolas"
+                                            FontSize="16"
+                                            FontWeight="Bold"
+                                            Foreground="{StaticResource CommandFg}"
+                                            Text="{Binding WireCommand}" />
+                                    </Border>
+                                    <TextBlock
+                                        Grid.Column="1"
+                                        Margin="10,0"
+                                        VerticalAlignment="Center"
+                                        Foreground="{StaticResource Fg}"
+                                        Text="{Binding Description}"
+                                        TextWrapping="Wrap" />
+                                    <Border
+                                        Grid.Column="2"
+                                        VerticalAlignment="Center"
+                                        BorderBrush="{StaticResource PanelBorder}"
+                                        BorderThickness="1"
+                                        CornerRadius="8"
+                                        Padding="8,1">
+                                        <TextBlock
+                                            FontSize="11"
+                                            Foreground="{StaticResource FgDim}"
+                                            Text="{Binding GroupLabel}" />
+                                    </Border>
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                    <TextBlock
+                        Foreground="{StaticResource FgDim}"
+                        Text="No commands will be sent."
+                        Visibility="{Binding HasNoMoves, Converter={StaticResource BoolToVis}}" />
+                </StackPanel>
+            </Border>
+        </StackPanel>
+
+        <!--  Per-corner residual after the commands above.  -->
+        <StackPanel Grid.Row="4">
+            <TextBlock Style="{StaticResource SectionHeader}" Text="RESIDUAL AFTER THESE COMMANDS" />
+            <Border
+                Background="{StaticResource PanelBg}"
+                BorderBrush="{StaticResource PanelBorder}"
+                BorderThickness="1"
+                CornerRadius="3"
+                Padding="10,8">
+                <StackPanel>
+                    <ItemsControl ItemsSource="{Binding CornerResiduals}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <UniformGrid Columns="4" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="0,2" HorizontalAlignment="Center">
+                                    <TextBlock
+                                        HorizontalAlignment="Center"
+                                        FontSize="11"
+                                        Foreground="{StaticResource FgDim}"
+                                        Text="{Binding Label}" />
+                                    <TextBlock
+                                        HorizontalAlignment="Center"
+                                        FontFamily="Consolas"
+                                        Foreground="{StaticResource Fg}"
+                                        Text="{Binding ValueText}" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                    <TextBlock
+                        Margin="0,6,0,0"
+                        FontSize="11"
+                        Foreground="{StaticResource FgDim}"
+                        TextWrapping="Wrap"
+                        Text="Error left at each screw after the commands above (step rounding plus anything the device cannot reach)." />
+                </StackPanel>
+            </Border>
+        </StackPanel>
+
+        <!--  Warnings: red = blocking, amber = read before proceeding.  -->
+        <StackPanel Grid.Row="5">
+            <Border Style="{StaticResource DangerPanel}" Visibility="{Binding HardLimitWarningVisible, Converter={StaticResource BoolToVis}}">
+                <StackPanel>
+                    <TextBlock
+                        FontWeight="Bold"
+                        Style="{StaticResource DangerText}"
+                        Text="⚠ Travel limit violated — Proceed is disabled" />
+                    <TextBlock
+                        Margin="0,3,0,0"
+                        Style="{StaticResource DangerText}"
+                        Text="{Binding LimitWarningText}" />
+                </StackPanel>
+            </Border>
+            <Border Style="{StaticResource WarningPanel}" Visibility="{Binding SoftLimitWarningVisible, Converter={StaticResource BoolToVis}}">
+                <TextBlock Style="{StaticResource WarningText}" Text="{Binding LimitWarningText}" />
+            </Border>
+            <Border Style="{StaticResource WarningPanel}" Visibility="{Binding PositionsUnknownWarningVisible, Converter={StaticResource BoolToVis}}">
+                <TextBlock Style="{StaticResource WarningText}" Text="{Binding PositionsUnknownWarningText}" />
+            </Border>
+            <Border Style="{StaticResource WarningPanel}" Visibility="{Binding AssumedDirectionWarningVisible, Converter={StaticResource BoolToVis}}">
+                <TextBlock Style="{StaticResource WarningText}" Text="{Binding AssumedDirectionWarningText}" />
+            </Border>
+            <Border Style="{StaticResource WarningPanel}" Visibility="{Binding TwistWarningVisible, Converter={StaticResource BoolToVis}}">
+                <TextBlock Style="{StaticResource WarningText}" Text="{Binding TwistWarningText}" />
+            </Border>
+            <Border Style="{StaticResource WarningPanel}" Visibility="{Binding PitchMismatchWarningVisible, Converter={StaticResource BoolToVis}}">
+                <TextBlock Style="{StaticResource WarningText}" Text="{Binding PitchMismatchWarning}" />
+            </Border>
+        </StackPanel>
+
+        <!--  Footer: scale of the action (count + duration) sits beside the buttons so it is part of the
+              user's final glance before clicking Proceed.  -->
+        <Grid Grid.Row="6" Margin="0,14,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TextBlock VerticalAlignment="Center" Foreground="{StaticResource FgDim}">
+                <Run Text="{Binding MoveCountText, Mode=OneWay}" />
+                <Run Text=" · estimated " />
+                <Run FontWeight="SemiBold" Foreground="{StaticResource Fg}" Text="{Binding EstimatedDurationText, Mode=OneWay}" />
+            </TextBlock>
+            <StackPanel Grid.Column="1" Orientation="Horizontal">
+                <Button MinWidth="90" Command="{Binding CancelCommand}">
+                    <TextBlock Margin="12,6" Text="Cancel" />
+                </Button>
+                <Button
+                    Margin="8,0,0,0"
+                    Command="{Binding ProceedCommand}"
+                    Content="Proceed"
+                    Style="{StaticResource ProceedButton}" />
+            </StackPanel>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptControl.xaml
@@ -196,15 +196,22 @@
                                             Foreground="{StaticResource Fg}"
                                             Text="{Binding MoveKindLabel}" />
                                     </Border>
-                                    <!--  Primary line: which screws move, and by how many signed steps.  -->
-                                    <TextBlock
-                                        Grid.Column="1"
-                                        Margin="10,0"
-                                        VerticalAlignment="Center"
-                                        FontSize="13"
-                                        Foreground="{StaticResource Fg}"
-                                        Text="{Binding SemanticText}"
-                                        TextWrapping="Wrap" />
+                                    <!--  Primary line: which screws move, and by how many signed steps. The
+                                          inline amber tag anchors the "assumed direction" warning to the exact
+                                          (backfocus) row it applies to.  -->
+                                    <StackPanel Grid.Column="1" Margin="10,0" VerticalAlignment="Center">
+                                        <TextBlock
+                                            FontSize="13"
+                                            Foreground="{StaticResource Fg}"
+                                            Text="{Binding SemanticText}"
+                                            TextWrapping="Wrap" />
+                                        <TextBlock
+                                            Margin="0,1,0,0"
+                                            FontSize="11"
+                                            Foreground="{StaticResource WarnFg}"
+                                            Text="⚠ direction assumed"
+                                            Visibility="{Binding AssumedDirection, Converter={StaticResource BoolToVis}}" />
+                                    </StackPanel>
                                     <!--  Demoted raw wire command (auditability), tooltip explains it.  -->
                                     <TextBlock
                                         Grid.Column="2"
@@ -244,35 +251,45 @@
                 CornerRadius="3"
                 Padding="10,8">
                 <StackPanel>
-                    <ItemsControl ItemsSource="{Binding CornerResiduals}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <UniformGrid Columns="4" />
-                            </ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <StackPanel Margin="0,2" HorizontalAlignment="Center">
-                                    <TextBlock
-                                        HorizontalAlignment="Center"
-                                        FontSize="11"
-                                        Foreground="{StaticResource FgDim}"
-                                        Text="{Binding Label}" />
-                                    <TextBlock
-                                        HorizontalAlignment="Center"
-                                        FontFamily="Consolas"
-                                        Foreground="{StaticResource Fg}"
-                                        Text="{Binding ValueText}" />
-                                </StackPanel>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
+                    <!--  2×2 spatial layout matching the sensor corners (TL | TR over BL | BR) so the residuals
+                          read like the corner map, not a linear 1-2-3-4 list. CornerResiduals stays in wizard
+                          screw order (1..4); the indexed bindings place each screw at its physical corner.  -->
+                    <Grid HorizontalAlignment="Left">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <!--  TL = wizard screw 2  -->
+                        <StackPanel Grid.Row="0" Grid.Column="0" Margin="0,0,20,6" HorizontalAlignment="Center">
+                            <TextBlock HorizontalAlignment="Center" FontSize="11" Foreground="{StaticResource FgDim}" Text="{Binding CornerResiduals[1].Label}" />
+                            <TextBlock HorizontalAlignment="Center" FontFamily="Consolas" Foreground="{StaticResource Fg}" Text="{Binding CornerResiduals[1].ValueText}" />
+                        </StackPanel>
+                        <!--  TR = wizard screw 1  -->
+                        <StackPanel Grid.Row="0" Grid.Column="1" Margin="0,0,0,6" HorizontalAlignment="Center">
+                            <TextBlock HorizontalAlignment="Center" FontSize="11" Foreground="{StaticResource FgDim}" Text="{Binding CornerResiduals[0].Label}" />
+                            <TextBlock HorizontalAlignment="Center" FontFamily="Consolas" Foreground="{StaticResource Fg}" Text="{Binding CornerResiduals[0].ValueText}" />
+                        </StackPanel>
+                        <!--  BL = wizard screw 3  -->
+                        <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,20,0" HorizontalAlignment="Center">
+                            <TextBlock HorizontalAlignment="Center" FontSize="11" Foreground="{StaticResource FgDim}" Text="{Binding CornerResiduals[2].Label}" />
+                            <TextBlock HorizontalAlignment="Center" FontFamily="Consolas" Foreground="{StaticResource Fg}" Text="{Binding CornerResiduals[2].ValueText}" />
+                        </StackPanel>
+                        <!--  BR = wizard screw 4  -->
+                        <StackPanel Grid.Row="1" Grid.Column="1" HorizontalAlignment="Center">
+                            <TextBlock HorizontalAlignment="Center" FontSize="11" Foreground="{StaticResource FgDim}" Text="{Binding CornerResiduals[3].Label}" />
+                            <TextBlock HorizontalAlignment="Center" FontFamily="Consolas" Foreground="{StaticResource Fg}" Text="{Binding CornerResiduals[3].ValueText}" />
+                        </StackPanel>
+                    </Grid>
                     <TextBlock
-                        Margin="0,6,0,0"
+                        Margin="0,8,0,0"
                         FontSize="11"
                         Foreground="{StaticResource FgDim}"
                         TextWrapping="Wrap"
-                        Text="Error left at each screw after the commands above (step rounding plus anything the device cannot reach)." />
+                        Text="Error left at each screw after the moves above (step rounding plus anything the device cannot reach). Positive = the screw ends slightly past its target; negative = slightly short. Under ~1 µm is within a single motor step." />
                 </StackPanel>
             </Border>
         </StackPanel>
@@ -291,20 +308,37 @@
                         Text="{Binding LimitWarningText}" />
                 </StackPanel>
             </Border>
+            <!--  Every advisory carries a short bold title + body (matching the danger panel), and the stack is
+                  ordered by severity: limit → assumed-direction → positions-unknown → twist → pitch-mismatch.  -->
             <Border Style="{StaticResource WarningPanel}" Visibility="{Binding SoftLimitWarningVisible, Converter={StaticResource BoolToVis}}">
-                <TextBlock Style="{StaticResource WarningText}" Text="{Binding LimitWarningText}" />
-            </Border>
-            <Border Style="{StaticResource WarningPanel}" Visibility="{Binding PositionsUnknownWarningVisible, Converter={StaticResource BoolToVis}}">
-                <TextBlock Style="{StaticResource WarningText}" Text="{Binding PositionsUnknownWarningText}" />
+                <StackPanel>
+                    <TextBlock FontWeight="Bold" Style="{StaticResource WarningText}" Text="Approaching travel limit" />
+                    <TextBlock Margin="0,3,0,0" Style="{StaticResource WarningText}" Text="{Binding LimitWarningText}" />
+                </StackPanel>
             </Border>
             <Border Style="{StaticResource WarningPanel}" Visibility="{Binding AssumedDirectionWarningVisible, Converter={StaticResource BoolToVis}}">
-                <TextBlock Style="{StaticResource WarningText}" Text="{Binding AssumedDirectionWarningText}" />
+                <StackPanel>
+                    <TextBlock FontWeight="Bold" Style="{StaticResource WarningText}" Text="Backfocus direction is assumed" />
+                    <TextBlock Margin="0,3,0,0" Style="{StaticResource WarningText}" Text="{Binding AssumedDirectionWarningText}" />
+                </StackPanel>
+            </Border>
+            <Border Style="{StaticResource WarningPanel}" Visibility="{Binding PositionsUnknownWarningVisible, Converter={StaticResource BoolToVis}}">
+                <StackPanel>
+                    <TextBlock FontWeight="Bold" Style="{StaticResource WarningText}" Text="Motor positions unknown" />
+                    <TextBlock Margin="0,3,0,0" Style="{StaticResource WarningText}" Text="{Binding PositionsUnknownWarningText}" />
+                </StackPanel>
             </Border>
             <Border Style="{StaticResource WarningPanel}" Visibility="{Binding TwistWarningVisible, Converter={StaticResource BoolToVis}}">
-                <TextBlock Style="{StaticResource WarningText}" Text="{Binding TwistWarningText}" />
+                <StackPanel>
+                    <TextBlock FontWeight="Bold" Style="{StaticResource WarningText}" Text="Twist cannot be corrected" />
+                    <TextBlock Margin="0,3,0,0" Style="{StaticResource WarningText}" Text="{Binding TwistWarningText}" />
+                </StackPanel>
             </Border>
             <Border Style="{StaticResource WarningPanel}" Visibility="{Binding PitchMismatchWarningVisible, Converter={StaticResource BoolToVis}}">
-                <TextBlock Style="{StaticResource WarningText}" Text="{Binding PitchMismatchWarning}" />
+                <StackPanel>
+                    <TextBlock FontWeight="Bold" Style="{StaticResource WarningText}" Text="Screw pitch mismatch" />
+                    <TextBlock Margin="0,3,0,0" Style="{StaticResource WarningText}" Text="{Binding PitchMismatchWarning}" />
+                </StackPanel>
             </Border>
         </StackPanel>
 
@@ -315,19 +349,27 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-            <TextBlock VerticalAlignment="Center" Foreground="{StaticResource FgDim}">
-                <Run Text="{Binding MoveCountText, Mode=OneWay}" />
-                <Run Text=" · estimated " />
-                <Run FontWeight="SemiBold" Foreground="{StaticResource Fg}" Text="{Binding EstimatedDurationText, Mode=OneWay}" />
-            </TextBlock>
-            <StackPanel Grid.Column="1" Orientation="Horizontal">
+            <StackPanel VerticalAlignment="Center">
+                <TextBlock Foreground="{StaticResource FgDim}">
+                    <Run Text="{Binding MoveCountText, Mode=OneWay}" />
+                    <Run Text=" · estimated " />
+                    <Run FontWeight="SemiBold" Foreground="{StaticResource Fg}" Text="{Binding EstimatedDurationText, Mode=OneWay}" />
+                </TextBlock>
+                <!--  Why Proceed is disabled, for the one case without a red panel (both groups off).  -->
+                <TextBlock
+                    Margin="0,2,0,0"
+                    Foreground="{StaticResource WarnFg}"
+                    Text="{Binding ProceedDisabledReason}"
+                    Visibility="{Binding ProceedDisabledReasonVisible, Converter={StaticResource BoolToVis}}" />
+            </StackPanel>
+            <StackPanel Grid.Column="1" VerticalAlignment="Center" Orientation="Horizontal">
                 <Button MinWidth="90" Command="{Binding CancelCommand}">
                     <TextBlock Margin="12,6" Text="Cancel" />
                 </Button>
                 <Button
                     Margin="8,0,0,0"
                     Command="{Binding ProceedCommand}"
-                    Content="Proceed"
+                    Content="{Binding ProceedButtonText}"
                     Style="{StaticResource ProceedButton}" />
             </StackPanel>
         </Grid>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptControl.xaml.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptControl.xaml.cs
@@ -1,0 +1,24 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System.Windows.Controls;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt {
+
+    /// <summary>Interaction logic for TiltDeviceAdjustmentPromptControl.xaml — the motorized tilt-adapter move approval dialog content.</summary>
+    public partial class TiltDeviceAdjustmentPromptControl : UserControl {
+
+        public TiltDeviceAdjustmentPromptControl() {
+            InitializeComponent();
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptVM.cs
@@ -1,0 +1,305 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Utility;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using RelayCommand = CommunityToolkit.Mvvm.Input.RelayCommand;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt {
+
+    /// <summary>
+    /// The immutable result of one replanner invocation: the recomputed plan plus the controller's limit
+    /// check against it. <see cref="HardLimitViolated"/> blocks Proceed; <see cref="LimitWarning"/> is the
+    /// user-facing explanation (which may also be a non-blocking advisory when the hard flag is false).
+    /// </summary>
+    public sealed class TiltDevicePlanPreview {
+
+        public TiltDevicePlanPreview(TiltAdapterMovePlan plan, bool hardLimitViolated, string limitWarning) {
+            Plan = plan ?? throw new ArgumentNullException(nameof(plan));
+            HardLimitViolated = hardLimitViolated;
+            LimitWarning = limitWarning ?? string.Empty;
+        }
+
+        /// <summary>The recomputed move plan for the current Tilt/Backfocus toggles.</summary>
+        public TiltAdapterMovePlan Plan { get; }
+
+        /// <summary>True when executing <see cref="Plan"/> would violate a device travel limit; blocks Proceed.</summary>
+        public bool HardLimitViolated { get; }
+
+        /// <summary>User-facing limit text (blocking when <see cref="HardLimitViolated"/>, advisory otherwise). Never null.</summary>
+        public string LimitWarning { get; }
+    }
+
+    /// <summary>
+    /// One row of the approval dialog's move list. <see cref="WireCommand"/> is the exact signed string
+    /// sent to the device (e.g. <c>tr,150</c>) — the safety-critical element the dialog displays verbatim.
+    /// </summary>
+    public sealed class TiltDeviceAdjustmentMoveRow {
+
+        public TiltDeviceAdjustmentMoveRow(string wireCommand, string description, TiltMoveGroup group) {
+            WireCommand = wireCommand ?? string.Empty;
+            Description = description ?? string.Empty;
+            Group = group;
+        }
+
+        /// <summary>The exact wire command string, e.g. <c>tr,150</c> or <c>bf,-20</c>.</summary>
+        public string WireCommand { get; }
+
+        /// <summary>Human-readable description of the move.</summary>
+        public string Description { get; }
+
+        public TiltMoveGroup Group { get; }
+
+        /// <summary>Display label for the group badge.</summary>
+        public string GroupLabel => Group == TiltMoveGroup.Backfocus ? "Backfocus" : "Tilt";
+    }
+
+    /// <summary>One labeled per-corner residual cell (wizard screw indices 1..4).</summary>
+    public sealed class TiltDeviceCornerResidualRow {
+
+        public TiltDeviceCornerResidualRow(string label, string valueText) {
+            Label = label ?? string.Empty;
+            ValueText = valueText ?? string.Empty;
+        }
+
+        public string Label { get; }
+
+        public string ValueText { get; }
+    }
+
+    /// <summary>
+    /// View model for the modal approval dialog shown before motorized tilt-adapter moves are executed.
+    /// The moves are physical and EEPROM-persisted, so the dialog's job is to make the exact signed wire
+    /// commands, the residual they leave behind, and every applicable warning unmistakable before the user
+    /// clicks Proceed. Toggling the Tilt/Backfocus group checkboxes re-invokes the injected replanner so
+    /// the displayed plan is ALWAYS the plan that would execute. Mirrors the
+    /// <c>ReplaySettingsPromptVM</c> TaskCompletionSource + RequestClose modal pattern.
+    /// </summary>
+    public sealed class TiltDeviceAdjustmentPromptVM : BaseINPC, IDisposable {
+        private readonly TaskCompletionSource<TiltDeviceAdjustmentChoice> tcs =
+            new TaskCompletionSource<TiltDeviceAdjustmentChoice>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private readonly Func<bool, bool, TiltDevicePlanPreview> replanner;
+        private readonly bool screwInwardCurvatureSignIsMeasured;
+        private readonly bool positionsUnknown;
+        private readonly RelayCommand proceedCommand;
+
+        private bool applyTilt = true;
+        private bool applyBackfocus = true;
+
+        public event EventHandler RequestClose;
+
+        public TiltDeviceAdjustmentPromptVM(
+            Func<bool, bool, TiltDevicePlanPreview> replanner,
+            bool screwInwardCurvatureSignIsMeasured,
+            string pitchMismatchWarning,
+            bool positionsUnknown) {
+            this.replanner = replanner ?? throw new ArgumentNullException(nameof(replanner));
+            this.screwInwardCurvatureSignIsMeasured = screwInwardCurvatureSignIsMeasured;
+            this.positionsUnknown = positionsUnknown;
+            PitchMismatchWarning = pitchMismatchWarning ?? string.Empty;
+
+            proceedCommand = new RelayCommand(Proceed, CanProceed);
+            CancelCommand = new RelayCommand(Cancel);
+
+            Replan();
+        }
+
+        /// <summary>Completes when the user clicks Proceed or Cancel (or closes the window ⇒ Cancel).</summary>
+        public Task<TiltDeviceAdjustmentChoice> Choice => tcs.Task;
+
+        public ICommand ProceedCommand => proceedCommand;
+
+        public ICommand CancelCommand { get; }
+
+        /// <summary>Tilt group toggle; changing it re-invokes the replanner and refreshes the whole preview.</summary>
+        public bool ApplyTilt {
+            get => applyTilt;
+            set {
+                if (applyTilt != value) {
+                    applyTilt = value;
+                    RaisePropertyChanged();
+                    Replan();
+                }
+            }
+        }
+
+        /// <summary>Backfocus group toggle; changing it re-invokes the replanner and refreshes the whole preview.</summary>
+        public bool ApplyBackfocus {
+            get => applyBackfocus;
+            set {
+                if (applyBackfocus != value) {
+                    applyBackfocus = value;
+                    RaisePropertyChanged();
+                    Replan();
+                }
+            }
+        }
+
+        /// <summary>The latest replanner result — the plan that will execute if the user proceeds now.</summary>
+        public TiltDevicePlanPreview Preview { get; private set; }
+
+        /// <summary>Display rows for <see cref="TiltAdapterMovePlan.Moves"/> (wire command + description + group).</summary>
+        public IReadOnlyList<TiltDeviceAdjustmentMoveRow> Moves { get; private set; }
+
+        public bool HasMoves => Moves.Count > 0;
+
+        public bool HasNoMoves => Moves.Count == 0;
+
+        /// <summary>"No commands" / "1 command" / "N commands" for the footer summary.</summary>
+        public string MoveCountText =>
+            Moves.Count == 0 ? "No commands"
+            : Moves.Count == 1 ? "1 command"
+            : string.Format(CultureInfo.InvariantCulture, "{0} commands", Moves.Count);
+
+        /// <summary>Labeled per-corner residual cells (Screw 1..4, µm).</summary>
+        public IReadOnlyList<TiltDeviceCornerResidualRow> CornerResiduals { get; private set; }
+
+        /// <summary>Human-friendly execution time estimate, e.g. "~30 s".</summary>
+        public string EstimatedDurationText => FormatDuration(Preview.Plan.EstimatedSeconds);
+
+        public bool HardLimitViolated => Preview.HardLimitViolated;
+
+        /// <summary>Blocking limit warning (red, disables Proceed).</summary>
+        public bool HardLimitWarningVisible => Preview.HardLimitViolated;
+
+        /// <summary>Advisory limit warning: text present but the hard flag is off (does not disable Proceed).</summary>
+        public bool SoftLimitWarningVisible => !Preview.HardLimitViolated && !string.IsNullOrWhiteSpace(Preview.LimitWarning);
+
+        public string LimitWarningText {
+            get {
+                if (!string.IsNullOrWhiteSpace(Preview.LimitWarning)) {
+                    return Preview.LimitWarning;
+                }
+                return Preview.HardLimitViolated ? "The planned moves would exceed a device travel limit." : string.Empty;
+            }
+        }
+
+        /// <summary>Visible when the plan carries a twist component of at least one whole step.</summary>
+        public bool TwistWarningVisible => Math.Abs(Preview.Plan.TwistResidualSteps) >= 1.0;
+
+        public string TwistWarningText => string.Format(
+            CultureInfo.InvariantCulture,
+            "This measurement includes a twist component of {0:+0.0;-0.0} steps that NO rigid-plane tilt adapter can correct. " +
+            "It is not part of any command below and will remain as residual tilt after the moves.",
+            Preview.Plan.TwistResidualSteps);
+
+        /// <summary>
+        /// Visible when the backfocus direction has never been measured by the wizard AND the current plan
+        /// contains a backfocus move — the one case where a command could physically go the wrong way.
+        /// </summary>
+        public bool AssumedDirectionWarningVisible =>
+            !screwInwardCurvatureSignIsMeasured && Preview.Plan.Moves.Any(m => m.Group == TiltMoveGroup.Backfocus);
+
+        public string AssumedDirectionWarningText =>
+            "The backfocus direction is assumed, not measured: the Tilt Adapter Wizard has never measured this adapter's " +
+            "screw inward-curvature direction. If the assumption is wrong, the backfocus command will move the wrong way. " +
+            "Re-run the wizard with curvature measurement enabled, or uncheck Backfocus.";
+
+        /// <summary>Pitch-mismatch advisory passed in by the caller (empty ⇒ hidden).</summary>
+        public string PitchMismatchWarning { get; }
+
+        public bool PitchMismatchWarningVisible => !string.IsNullOrWhiteSpace(PitchMismatchWarning);
+
+        /// <summary>Visible when the device's current motor positions are unknown (excursion enforcement degraded).</summary>
+        public bool PositionsUnknownWarningVisible => positionsUnknown;
+
+        public string PositionsUnknownWarningText =>
+            "The device's current motor positions are unknown, so soft travel-limit (max excursion) enforcement is degraded — " +
+            "the adapter could be driven farther from center than the configured limits allow. Verify positions in the vendor " +
+            "app before approving large moves.";
+
+        private void Replan() {
+            var preview = replanner(applyTilt, applyBackfocus)
+                ?? throw new InvalidOperationException("The tilt-device replanner returned a null preview.");
+            Preview = preview;
+            Moves = preview.Plan.Moves
+                .Select(m => new TiltDeviceAdjustmentMoveRow(EatCommands.Format(m), m.Description, m.Group))
+                .ToArray();
+            CornerResiduals = BuildCornerResiduals(preview.Plan.ResidualMicronsPerCorner);
+
+            RaisePropertyChanged(nameof(Preview));
+            RaisePropertyChanged(nameof(Moves));
+            RaisePropertyChanged(nameof(HasMoves));
+            RaisePropertyChanged(nameof(HasNoMoves));
+            RaisePropertyChanged(nameof(MoveCountText));
+            RaisePropertyChanged(nameof(CornerResiduals));
+            RaisePropertyChanged(nameof(EstimatedDurationText));
+            RaisePropertyChanged(nameof(HardLimitViolated));
+            RaisePropertyChanged(nameof(HardLimitWarningVisible));
+            RaisePropertyChanged(nameof(SoftLimitWarningVisible));
+            RaisePropertyChanged(nameof(LimitWarningText));
+            RaisePropertyChanged(nameof(TwistWarningVisible));
+            RaisePropertyChanged(nameof(TwistWarningText));
+            RaisePropertyChanged(nameof(AssumedDirectionWarningVisible));
+            proceedCommand.NotifyCanExecuteChanged();
+        }
+
+        private bool CanProceed() {
+            // Both groups off ⇒ nothing to approve; hard limit ⇒ physically unsafe. Cancel is always available.
+            return Preview != null && (applyTilt || applyBackfocus) && !Preview.HardLimitViolated;
+        }
+
+        private void Proceed() {
+            tcs.TrySetResult(TiltDeviceAdjustmentChoice.Proceeded(applyTilt, applyBackfocus, Preview.Plan));
+            RequestClose?.Invoke(this, EventArgs.Empty);
+        }
+
+        private void Cancel() {
+            tcs.TrySetResult(TiltDeviceAdjustmentChoice.Cancelled);
+            RequestClose?.Invoke(this, EventArgs.Empty);
+        }
+
+        private static IReadOnlyList<TiltDeviceCornerResidualRow> BuildCornerResiduals(IReadOnlyList<double> residualMicrons) {
+            var rows = new TiltDeviceCornerResidualRow[residualMicrons.Count];
+            for (int i = 0; i < residualMicrons.Count; ++i) {
+                rows[i] = new TiltDeviceCornerResidualRow(
+                    string.Format(CultureInfo.InvariantCulture, "Screw {0}", i + 1),
+                    FormatResidualMicrons(residualMicrons[i]));
+            }
+            return rows;
+        }
+
+        /// <summary>Signed one-decimal residual, e.g. "+0.9 µm" / "-1.2 µm" / "0.0 µm".</summary>
+        internal static string FormatResidualMicrons(double microns) {
+            return string.Format(CultureInfo.InvariantCulture, "{0:+0.0;-0.0;0.0} µm", microns);
+        }
+
+        /// <summary>Human-friendly duration: "0 s", "~30 s", "~1 min", "~1 min 35 s". Rounds up (never under-promises).</summary>
+        internal static string FormatDuration(double estimatedSeconds) {
+            if (!(estimatedSeconds > 0)) {
+                return "0 s";
+            }
+            int total = (int)Math.Ceiling(estimatedSeconds);
+            if (total < 60) {
+                return string.Format(CultureInfo.InvariantCulture, "~{0} s", total);
+            }
+            int minutes = total / 60;
+            int seconds = total % 60;
+            return seconds == 0
+                ? string.Format(CultureInfo.InvariantCulture, "~{0} min", minutes)
+                : string.Format(CultureInfo.InvariantCulture, "~{0} min {1} s", minutes, seconds);
+        }
+
+        public void Dispose() {
+            // Window dismissed without an explicit pick (e.g. the X button) ⇒ treat as Cancel. TrySetResult is a
+            // no-op if a button already set the result.
+            tcs.TrySetResult(TiltDeviceAdjustmentChoice.Cancelled);
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptVM.cs
@@ -117,6 +117,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt {
         private readonly Func<bool, bool, TiltDevicePlanPreview> replanner;
         private readonly bool screwInwardCurvatureSignIsMeasured;
         private readonly bool positionsUnknown;
+        private readonly double unitMicrons;
         private readonly RelayCommand proceedCommand;
 
         private bool applyTilt = true;
@@ -128,10 +129,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt {
             Func<bool, bool, TiltDevicePlanPreview> replanner,
             bool screwInwardCurvatureSignIsMeasured,
             string pitchMismatchWarning,
-            bool positionsUnknown) {
+            bool positionsUnknown,
+            double unitMicrons = 0.0) {
             this.replanner = replanner ?? throw new ArgumentNullException(nameof(replanner));
             this.screwInwardCurvatureSignIsMeasured = screwInwardCurvatureSignIsMeasured;
             this.positionsUnknown = positionsUnknown;
+            this.unitMicrons = unitMicrons;
             PitchMismatchWarning = pitchMismatchWarning ?? string.Empty;
 
             proceedCommand = new RelayCommand(Proceed, CanProceed);
@@ -237,11 +240,20 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt {
         /// <summary>Visible when the plan carries a twist component of at least one whole step.</summary>
         public bool TwistWarningVisible => Math.Abs(Preview.Plan.TwistResidualSteps) >= 1.0;
 
-        public string TwistWarningText => string.Format(
-            CultureInfo.InvariantCulture,
-            "This measurement includes a twist component of {0:+0.0;-0.0} steps that no rigid-plane tilt adapter can correct " +
-            "(the sensor is warped, not merely tilted). It is not part of any move below and remains as residual tilt afterwards.",
-            Preview.Plan.TwistResidualSteps);
+        public string TwistWarningText {
+            get {
+                double steps = Preview.Plan.TwistResidualSteps;
+                // Translate to µm when the step size is known, so the twist is on the same scale as the residual
+                // table above (which is in µm) instead of a bare step count the user must interpret.
+                string microns = unitMicrons > 0
+                    ? string.Format(CultureInfo.InvariantCulture, " (about {0:0.0} µm across the sensor)", Math.Abs(steps * unitMicrons))
+                    : string.Empty;
+                return string.Format(CultureInfo.InvariantCulture,
+                    "This measurement includes a twist component of {0:+0.0;-0.0} steps{1} that no rigid-plane tilt adapter can correct " +
+                    "(the sensor is warped, not merely tilted). It is not part of any move below and remains as residual tilt afterwards.",
+                    steps, microns);
+            }
+        }
 
         /// <summary>
         /// Visible when the backfocus direction has never been measured by the wizard AND the current plan
@@ -347,8 +359,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt {
 
             if (move.Axis == TiltMoveAxis.Backfocus) {
                 string signed = move.Steps.ToString("+0;-0;0", CultureInfo.InvariantCulture);
-                return string.Format(CultureInfo.InvariantCulture,
-                    "All four screws {0} steps together — changes backfocus (sensor spacing), not tilt.", signed);
+                return string.Format(CultureInfo.InvariantCulture, "All four screws {0} steps together", signed);
             }
 
             var perCorner = move.PerCornerSteps;
@@ -366,8 +377,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt {
                 }
             }
 
-            string kind = (move.Axis == TiltMoveAxis.DiagonalA || move.Axis == TiltMoveAxis.DiagonalB)
-                ? "Corner move" : "Side move";
+            // The move kind ("Corner"/"Side") is already shown in the row's badge, so it is not repeated here.
             var parts = new List<string>(2);
             if (positives.Count > 0) {
                 parts.Add(string.Format(CultureInfo.InvariantCulture, "{0} +{1}", FormatScrews(positives), magnitude));
@@ -375,7 +385,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt {
             if (negatives.Count > 0) {
                 parts.Add(string.Format(CultureInfo.InvariantCulture, "{0} -{1}", FormatScrews(negatives), magnitude));
             }
-            return string.Format(CultureInfo.InvariantCulture, "{0} — {1} steps", kind, string.Join(", ", parts));
+            return string.Format(CultureInfo.InvariantCulture, "{0} steps", string.Join(", ", parts));
         }
 
         /// <summary>"Screw 1" / "Screws 1 &amp; 2" / "Screws 1, 2 &amp; 3" for a list of wizard screw numbers.</summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptVM.cs
@@ -53,13 +53,20 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt {
     /// </summary>
     public sealed class TiltDeviceAdjustmentMoveRow {
 
-        public TiltDeviceAdjustmentMoveRow(string wireCommand, string semanticText, string moveKindLabel, string description, TiltMoveGroup group) {
+        public TiltDeviceAdjustmentMoveRow(string wireCommand, string semanticText, string moveKindLabel, string description, TiltMoveGroup group, bool assumedDirection = false) {
             WireCommand = wireCommand ?? string.Empty;
             SemanticText = semanticText ?? string.Empty;
             MoveKindLabel = moveKindLabel ?? string.Empty;
             Description = description ?? string.Empty;
             Group = group;
+            AssumedDirection = assumedDirection;
         }
+
+        /// <summary>
+        /// True when this row's move could physically go the wrong way because the backfocus direction was
+        /// never measured — the anchor for the "(assumed direction)" warning, shown inline on the row.
+        /// </summary>
+        public bool AssumedDirection { get; }
 
         /// <summary>The exact wire command string, e.g. <c>tr,150</c> or <c>bf,-20</c>.</summary>
         public string WireCommand { get; }
@@ -174,11 +181,35 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt {
 
         public bool HasNoMoves => Moves.Count == 0;
 
-        /// <summary>"No commands" / "1 command" / "N commands" for the footer summary.</summary>
+        /// <summary>"No moves" / "1 move" / "N moves" for the footer summary.</summary>
         public string MoveCountText =>
-            Moves.Count == 0 ? "No commands"
-            : Moves.Count == 1 ? "1 command"
-            : string.Format(CultureInfo.InvariantCulture, "{0} commands", Moves.Count);
+            Moves.Count == 0 ? "No moves"
+            : Moves.Count == 1 ? "1 move"
+            : string.Format(CultureInfo.InvariantCulture, "{0} moves", Moves.Count);
+
+        /// <summary>Dynamic Proceed-button label: "Send N moves" when there is something to send, else "Proceed".</summary>
+        public string ProceedButtonText =>
+            Moves.Count == 0 ? "Proceed"
+            : Moves.Count == 1 ? "Send 1 move"
+            : string.Format(CultureInfo.InvariantCulture, "Send {0} moves", Moves.Count);
+
+        /// <summary>
+        /// Explains why Proceed is disabled, for the case not already covered by a red panel (both groups off).
+        /// Empty when Proceed is enabled, or when the hard-limit panel is already carrying the explanation.
+        /// </summary>
+        public string ProceedDisabledReason {
+            get {
+                if (Preview != null && Preview.HardLimitViolated) {
+                    return string.Empty; // the blocking red panel already explains this.
+                }
+                if (!applyTilt && !applyBackfocus) {
+                    return "Select at least one correction to apply.";
+                }
+                return string.Empty;
+            }
+        }
+
+        public bool ProceedDisabledReasonVisible => !string.IsNullOrEmpty(ProceedDisabledReason);
 
         /// <summary>Labeled per-corner residual cells (Screw 1..4, µm).</summary>
         public IReadOnlyList<TiltDeviceCornerResidualRow> CornerResiduals { get; private set; }
@@ -208,8 +239,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt {
 
         public string TwistWarningText => string.Format(
             CultureInfo.InvariantCulture,
-            "This measurement includes a twist component of {0:+0.0;-0.0} steps that NO rigid-plane tilt adapter can correct. " +
-            "It is not part of any command below and will remain as residual tilt after the moves.",
+            "This measurement includes a twist component of {0:+0.0;-0.0} steps that no rigid-plane tilt adapter can correct " +
+            "(the sensor is warped, not merely tilted). It is not part of any move below and remains as residual tilt afterwards.",
             Preview.Plan.TwistResidualSteps);
 
         /// <summary>
@@ -243,7 +274,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt {
             Preview = preview;
             Moves = preview.Plan.Moves
                 .Select(m => new TiltDeviceAdjustmentMoveRow(
-                    EatCommands.Format(m), BuildSemanticText(m), BuildMoveKindLabel(m.Axis), m.Description, m.Group))
+                    EatCommands.Format(m), BuildSemanticText(m), BuildMoveKindLabel(m.Axis), m.Description, m.Group,
+                    assumedDirection: !screwInwardCurvatureSignIsMeasured && m.Group == TiltMoveGroup.Backfocus))
                 .ToArray();
             CornerResiduals = BuildCornerResiduals(preview.Plan.ResidualMicronsPerCorner);
 
@@ -252,6 +284,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt {
             RaisePropertyChanged(nameof(HasMoves));
             RaisePropertyChanged(nameof(HasNoMoves));
             RaisePropertyChanged(nameof(MoveCountText));
+            RaisePropertyChanged(nameof(ProceedButtonText));
+            RaisePropertyChanged(nameof(ProceedDisabledReason));
+            RaisePropertyChanged(nameof(ProceedDisabledReasonVisible));
             RaisePropertyChanged(nameof(CornerResiduals));
             RaisePropertyChanged(nameof(EstimatedDurationText));
             RaisePropertyChanged(nameof(HardLimitViolated));
@@ -355,12 +390,18 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt {
             return string.Format(CultureInfo.InvariantCulture, "Screws {0} & {1}", head, screws[screws.Count - 1]);
         }
 
+        // Wizard screw index (1..4) → physical corner, per the device-connected calibration convention the
+        // wizard's motor-position grid also uses (screw 1 = TR, 2 = TL, 3 = BL, 4 = BR). This dialog only ever
+        // runs against a connected device, so the mapping is fixed.
+        private static readonly string[] ScrewCornerLabels = { "TR", "TL", "BL", "BR" };
+
         private static IReadOnlyList<TiltDeviceCornerResidualRow> BuildCornerResiduals(IReadOnlyList<double> residualMicrons) {
             var rows = new TiltDeviceCornerResidualRow[residualMicrons.Count];
             for (int i = 0; i < residualMicrons.Count; ++i) {
-                rows[i] = new TiltDeviceCornerResidualRow(
-                    string.Format(CultureInfo.InvariantCulture, "Screw {0}", i + 1),
-                    FormatResidualMicrons(residualMicrons[i]));
+                string label = i < ScrewCornerLabels.Length
+                    ? string.Format(CultureInfo.InvariantCulture, "Screw {0} ({1})", i + 1, ScrewCornerLabels[i])
+                    : string.Format(CultureInfo.InvariantCulture, "Screw {0}", i + 1);
+                rows[i] = new TiltDeviceCornerResidualRow(label, FormatResidualMicrons(residualMicrons[i]));
             }
             return rows;
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptVM.cs
@@ -46,13 +46,17 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt {
     }
 
     /// <summary>
-    /// One row of the approval dialog's move list. <see cref="WireCommand"/> is the exact signed string
-    /// sent to the device (e.g. <c>tr,150</c>) — the safety-critical element the dialog displays verbatim.
+    /// One row of the approval dialog's move list. <see cref="SemanticText"/> is the human-meaningful
+    /// primary line (which numbered screws move, and by how many signed steps); <see cref="MoveKindLabel"/>
+    /// tags the move as Corner / Side / Backfocus. <see cref="WireCommand"/> is the exact string sent to the
+    /// device (e.g. <c>tr,150</c>), demoted to a small auditability chip rather than the row's anchor.
     /// </summary>
     public sealed class TiltDeviceAdjustmentMoveRow {
 
-        public TiltDeviceAdjustmentMoveRow(string wireCommand, string description, TiltMoveGroup group) {
+        public TiltDeviceAdjustmentMoveRow(string wireCommand, string semanticText, string moveKindLabel, string description, TiltMoveGroup group) {
             WireCommand = wireCommand ?? string.Empty;
+            SemanticText = semanticText ?? string.Empty;
+            MoveKindLabel = moveKindLabel ?? string.Empty;
             Description = description ?? string.Empty;
             Group = group;
         }
@@ -60,7 +64,16 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt {
         /// <summary>The exact wire command string, e.g. <c>tr,150</c> or <c>bf,-20</c>.</summary>
         public string WireCommand { get; }
 
-        /// <summary>Human-readable description of the move.</summary>
+        /// <summary>
+        /// Human-readable, screw-oriented description of the move (e.g. "Corner move — Screw 1 +142, Screw 3
+        /// −142 steps"). The primary text shown for each row.
+        /// </summary>
+        public string SemanticText { get; }
+
+        /// <summary>Short kind tag for the row badge: "Corner", "Side", or "Backfocus".</summary>
+        public string MoveKindLabel { get; }
+
+        /// <summary>The planner's internal axis description (kept for status text / diagnostics).</summary>
         public string Description { get; }
 
         public TiltMoveGroup Group { get; }
@@ -229,7 +242,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt {
                 ?? throw new InvalidOperationException("The tilt-device replanner returned a null preview.");
             Preview = preview;
             Moves = preview.Plan.Moves
-                .Select(m => new TiltDeviceAdjustmentMoveRow(EatCommands.Format(m), m.Description, m.Group))
+                .Select(m => new TiltDeviceAdjustmentMoveRow(
+                    EatCommands.Format(m), BuildSemanticText(m), BuildMoveKindLabel(m.Axis), m.Description, m.Group))
                 .ToArray();
             CornerResiduals = BuildCornerResiduals(preview.Plan.ResidualMicronsPerCorner);
 
@@ -263,6 +277,82 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt {
         private void Cancel() {
             tcs.TrySetResult(TiltDeviceAdjustmentChoice.Cancelled);
             RequestClose?.Invoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>Short kind tag for the row badge, derived from the move's axis.</summary>
+        internal static string BuildMoveKindLabel(TiltMoveAxis axis) {
+            switch (axis) {
+                case TiltMoveAxis.DiagonalA:
+                case TiltMoveAxis.DiagonalB:
+                    return "Corner";
+
+                case TiltMoveAxis.EdgeVertical:
+                case TiltMoveAxis.EdgeHorizontal:
+                    return "Side";
+
+                case TiltMoveAxis.Backfocus:
+                    return "Backfocus";
+
+                default:
+                    return "Move";
+            }
+        }
+
+        /// <summary>
+        /// Builds the human-readable, screw-oriented description of a move from its per-corner step effect
+        /// (wizard screw indices 1..4). Deliberately uses SIGNED STEPS (+ = the wizard's positive/clockwise
+        /// step direction, − = the opposite) rather than a physical "up/down": whether a positive step raises
+        /// or lowers a corner is rig-dependent (the ScrewInwardCurvatureSign the assumed-direction warning is
+        /// about), so asserting up/down here could be wrong. The one-line legend in the dialog explains the sign.
+        /// </summary>
+        internal static string BuildSemanticText(TiltAdapterMove move) {
+            if (move == null) {
+                return string.Empty;
+            }
+
+            if (move.Axis == TiltMoveAxis.Backfocus) {
+                string signed = move.Steps.ToString("+0;-0;0", CultureInfo.InvariantCulture);
+                return string.Format(CultureInfo.InvariantCulture,
+                    "All four screws {0} steps together — changes backfocus (sensor spacing), not tilt.", signed);
+            }
+
+            var perCorner = move.PerCornerSteps;
+            var positives = new List<int>();
+            var negatives = new List<int>();
+            int magnitude = 0;
+            for (int i = 0; i < perCorner.Count; ++i) {
+                int s = (int)Math.Round(perCorner[i], MidpointRounding.AwayFromZero);
+                if (s > 0) {
+                    positives.Add(i + 1);
+                    magnitude = Math.Abs(s);
+                } else if (s < 0) {
+                    negatives.Add(i + 1);
+                    magnitude = Math.Abs(s);
+                }
+            }
+
+            string kind = (move.Axis == TiltMoveAxis.DiagonalA || move.Axis == TiltMoveAxis.DiagonalB)
+                ? "Corner move" : "Side move";
+            var parts = new List<string>(2);
+            if (positives.Count > 0) {
+                parts.Add(string.Format(CultureInfo.InvariantCulture, "{0} +{1}", FormatScrews(positives), magnitude));
+            }
+            if (negatives.Count > 0) {
+                parts.Add(string.Format(CultureInfo.InvariantCulture, "{0} -{1}", FormatScrews(negatives), magnitude));
+            }
+            return string.Format(CultureInfo.InvariantCulture, "{0} — {1} steps", kind, string.Join(", ", parts));
+        }
+
+        /// <summary>"Screw 1" / "Screws 1 &amp; 2" / "Screws 1, 2 &amp; 3" for a list of wizard screw numbers.</summary>
+        private static string FormatScrews(IReadOnlyList<int> screws) {
+            if (screws.Count == 0) {
+                return string.Empty;
+            }
+            if (screws.Count == 1) {
+                return string.Format(CultureInfo.InvariantCulture, "Screw {0}", screws[0]);
+            }
+            var head = string.Join(", ", screws.Take(screws.Count - 1));
+            return string.Format(CultureInfo.InvariantCulture, "Screws {0} & {1}", head, screws[screws.Count - 1]);
         }
 
         private static IReadOnlyList<TiltDeviceCornerResidualRow> BuildCornerResiduals(IReadOnlyList<double> residualMicrons) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/SimulatedTiltPort.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/SimulatedTiltPort.cs
@@ -1,0 +1,32 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices {
+
+    /// <summary>
+    /// The synthetic "port" name that stands in for a serial COM port when connecting to the SIMULATED tilt
+    /// adapter (the camera simulator) instead of real hardware. It is offered as an entry in the wizard's
+    /// COM-port dropdown; <see cref="TiltDeviceConnectionService.ConnectAsync"/> routes it to the simulated
+    /// controller factory rather than the serial registry. Kept in one place so the dropdown, the routing, and
+    /// the plugin's factory wiring all agree on the exact string.
+    /// </summary>
+    public static class SimulatedTiltPort {
+
+        /// <summary>The port-dropdown entry that selects the simulated tilt adapter.</summary>
+        public const string PortName = "Simulator";
+
+        /// <summary>True iff <paramref name="portName"/> is the simulated-adapter sentinel (exact, case-sensitive).</summary>
+        public static bool IsSimulator(string portName) => string.Equals(portName, PortName, StringComparison.Ordinal);
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/TiltAdapterMove.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/TiltAdapterMove.cs
@@ -1,0 +1,115 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices {
+
+    /// <summary>
+    /// The five independent single-command move axes a 4-corner coupled tilt device (e.g. the ASG EAT)
+    /// can execute. Each axis corresponds to one of the orthogonal generators in the minimal-move
+    /// decomposition (see the design doc's "Core algorithm" section): DiagonalA/DiagonalB are the two
+    /// corner-pair generators (D1, D2), EdgeVertical/EdgeHorizontal are their sum/difference (E+, E-),
+    /// and Backfocus is the uniform generator (BF).
+    /// </summary>
+    public enum TiltMoveAxis {
+        DiagonalA,
+        DiagonalB,
+        EdgeVertical,
+        EdgeHorizontal,
+        Backfocus
+    }
+
+    /// <summary>
+    /// Which approval-dialog checkbox group a move belongs to (user decision #2: Tilt / Backfocus are
+    /// independently toggleable). Backfocus is exactly the <see cref="TiltMoveAxis.Backfocus"/> axis;
+    /// every other axis is Tilt.
+    /// </summary>
+    public enum TiltMoveGroup {
+        Tilt,
+        Backfocus
+    }
+
+    /// <summary>
+    /// A single, immutable, ready-to-send device move along one <see cref="TiltMoveAxis"/>. The
+    /// per-corner effect (in wizard screw indices 1..4, at array positions [0..3]) is computed from the
+    /// fixed unit effect-vector table in <see cref="UnitEffect"/> — it is impossible to construct a
+    /// <see cref="TiltAdapterMove"/> whose <see cref="PerCornerSteps"/> disagrees with its
+    /// <see cref="Axis"/>/<see cref="Steps"/>. Mirrors the constructor-assigned, get-only immutability
+    /// style of <c>TiltAdapterDevicePreset</c>.
+    /// </summary>
+    public sealed class TiltAdapterMove {
+
+        // Unit effect vectors in (s1, s2, s3, s4) wizard-screw-index space — THE correctness anchor for
+        // every device move this feature ever sends. Do not edit without re-verifying against the design
+        // doc's generator table; a sign error here is an EEPROM-persisted wrong-way motor move.
+        //   DiagonalA      : (+1,  0, -1,  0)
+        //   DiagonalB      : ( 0, +1,  0, -1)
+        //   EdgeVertical   : (+1, +1, -1, -1)
+        //   EdgeHorizontal : (+1, -1, -1, +1)
+        //   Backfocus      : (+1, +1, +1, +1)
+        // Wrapped via Array.AsReadOnly (not copied) so every call to UnitEffect returns a view over the
+        // same immutable table; ReadOnlyCollection<T> throws on any mutating IList<T> member, so external
+        // code cannot corrupt the table even by downcasting the returned IReadOnlyList<double>.
+        private static readonly IReadOnlyDictionary<TiltMoveAxis, ReadOnlyCollection<double>> UnitEffectVectors =
+            new Dictionary<TiltMoveAxis, ReadOnlyCollection<double>> {
+                [TiltMoveAxis.DiagonalA] = Array.AsReadOnly(new double[] { 1, 0, -1, 0 }),
+                [TiltMoveAxis.DiagonalB] = Array.AsReadOnly(new double[] { 0, 1, 0, -1 }),
+                [TiltMoveAxis.EdgeVertical] = Array.AsReadOnly(new double[] { 1, 1, -1, -1 }),
+                [TiltMoveAxis.EdgeHorizontal] = Array.AsReadOnly(new double[] { 1, -1, -1, 1 }),
+                [TiltMoveAxis.Backfocus] = Array.AsReadOnly(new double[] { 1, 1, 1, 1 }),
+            };
+
+        /// <summary>
+        /// The unit per-corner effect vector for one step of the given axis, in wizard screw indices
+        /// 1..4 at array positions [0..3]. See the class-level table for the exact values.
+        /// </summary>
+        public static IReadOnlyList<double> UnitEffect(TiltMoveAxis axis) {
+            if (!UnitEffectVectors.TryGetValue(axis, out var vector)) {
+                throw new ArgumentOutOfRangeException(nameof(axis), axis, "Unknown tilt move axis.");
+            }
+            return vector;
+        }
+
+        public TiltAdapterMove(TiltMoveAxis axis, int steps, TiltMoveGroup group, string description) {
+            Axis = axis;
+            Steps = steps;
+            Group = group;
+            Description = description ?? string.Empty;
+
+            var effect = UnitEffect(axis);
+            var perCornerSteps = new double[effect.Count];
+            for (int i = 0; i < effect.Count; ++i) {
+                perCornerSteps[i] = effect[i] * steps;
+            }
+            PerCornerSteps = Array.AsReadOnly(perCornerSteps);
+        }
+
+        public TiltMoveAxis Axis { get; }
+
+        /// <summary>Signed magnitude of the move along <see cref="Axis"/> (e.g. the "N" in <c>tr,N</c>).</summary>
+        public int Steps { get; }
+
+        public TiltMoveGroup Group { get; }
+
+        /// <summary>Human-readable description of the move, for the approval dialog / status text.</summary>
+        public string Description { get; }
+
+        /// <summary>
+        /// Per-corner signed step effect of this move, wizard screw indices 1..4 at [0..3]. Always equal
+        /// to <c>UnitEffect(Axis)[i] * Steps</c> — computed once in the constructor, never settable.
+        /// </summary>
+        public IReadOnlyList<double> PerCornerSteps { get; }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/TiltAdapterMovePlan.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/TiltAdapterMovePlan.cs
@@ -1,0 +1,57 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices {
+
+    /// <summary>
+    /// The immutable result of a minimal-move decomposition: the moves to send, the per-corner residual
+    /// (in microns) they leave behind, the unreachable twist component (reported, never planned — see
+    /// the design doc's "Core algorithm" section), and an estimated execution time. Pure storage: the
+    /// decomposition math itself lives in the planner (a later task). Mirrors the constructor-assigned,
+    /// get-only immutability style of <c>TiltAdapterDevicePreset</c>; incoming collections are
+    /// defensively copied so the plan can't be mutated out from under an in-flight approval dialog or
+    /// executor after construction.
+    /// </summary>
+    public sealed class TiltAdapterMovePlan {
+
+        public TiltAdapterMovePlan(
+            IReadOnlyList<TiltAdapterMove> moves,
+            IReadOnlyList<double> residualMicronsPerCorner,
+            double twistResidualSteps,
+            double estimatedSeconds) {
+            Moves = new ReadOnlyCollection<TiltAdapterMove>((moves ?? Array.Empty<TiltAdapterMove>()).ToArray());
+            ResidualMicronsPerCorner = new ReadOnlyCollection<double>((residualMicronsPerCorner ?? Array.Empty<double>()).ToArray());
+            TwistResidualSteps = twistResidualSteps;
+            EstimatedSeconds = estimatedSeconds;
+        }
+
+        /// <summary>The ordered, minimal set of device moves to send (≤ 3 before per-move cap splitting).</summary>
+        public IReadOnlyList<TiltAdapterMove> Moves { get; }
+
+        /// <summary>
+        /// Per-corner residual in microns after the planned moves are applied (applied − target) · 1.8,
+        /// wizard screw indices 1..4 at [0..3].
+        /// </summary>
+        public IReadOnlyList<double> ResidualMicronsPerCorner { get; }
+
+        /// <summary>The twist component (unreachable by any rigid-plane device); reported, never planned.</summary>
+        public double TwistResidualSteps { get; }
+
+        /// <summary>Estimated wall-clock execution time for <see cref="Moves"/>, in seconds.</summary>
+        public double EstimatedSeconds { get; }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/TiltDeviceConnectionService.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/TiltDeviceConnectionService.cs
@@ -99,6 +99,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices {
         private readonly IProfileService profileService;
         private readonly ITiltAdapterOptions options;
         private readonly Func<string, ITiltAdapterOptions, ITiltMotionController> controllerFactory;
+        // Builds the controller used when the caller selects the SimulatedTiltPort sentinel instead of a real COM
+        // port (the plugin wires this to an EatTiltMotionController over a SimulatedEatTransport). Null when no
+        // simulator is available (e.g. a headless/test host that never wires one) -- the sentinel then simply
+        // falls through to the serial registry, so this stays inert for every existing caller.
+        private readonly Func<ITiltMotionController> simulatedControllerFactory;
         private readonly ITiltDeviceTimeSource timeSource;
 
         // Guards every actual device touch (connect/disconnect/poll) AND is held for the entire lifetime of
@@ -139,19 +144,22 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices {
 
         private IReadOnlyList<int> currentPositions = Array.Empty<int>();
 
-        public TiltDeviceConnectionService(IProfileService profileService, ITiltAdapterOptions options)
-            : this(profileService, options, TiltMotionControllerRegistry.Create, new SystemTiltDeviceTimeSource(PollInterval)) {
+        public TiltDeviceConnectionService(IProfileService profileService, ITiltAdapterOptions options,
+                Func<ITiltMotionController> simulatedControllerFactory = null)
+            : this(profileService, options, TiltMotionControllerRegistry.Create, new SystemTiltDeviceTimeSource(PollInterval), simulatedControllerFactory) {
         }
 
-        /// <summary>Test seam: injects the controller factory (so tests substitute an <see cref="ITiltMotionController"/> instead of the real, not-yet-implemented EAT factory) and the time source (so tests drive virtual time deterministically).</summary>
+        /// <summary>Test seam: injects the controller factory (so tests substitute an <see cref="ITiltMotionController"/> instead of the real, not-yet-implemented EAT factory) and the time source (so tests drive virtual time deterministically). The optional <paramref name="simulatedControllerFactory"/> is the branch taken when the caller selects the <see cref="SimulatedTiltPort"/> sentinel.</summary>
         internal TiltDeviceConnectionService(
             IProfileService profileService,
             ITiltAdapterOptions options,
             Func<string, ITiltAdapterOptions, ITiltMotionController> controllerFactory,
-            ITiltDeviceTimeSource timeSource) {
+            ITiltDeviceTimeSource timeSource,
+            Func<ITiltMotionController> simulatedControllerFactory = null) {
             this.profileService = profileService ?? throw new ArgumentNullException(nameof(profileService));
             this.options = options ?? throw new ArgumentNullException(nameof(options));
             this.controllerFactory = controllerFactory ?? throw new ArgumentNullException(nameof(controllerFactory));
+            this.simulatedControllerFactory = simulatedControllerFactory; // nullable: sentinel routing is inert when unset
             this.timeSource = timeSource ?? throw new ArgumentNullException(nameof(timeSource));
 
             LastActivityUtc = this.timeSource.UtcNow;
@@ -212,7 +220,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices {
                     await DisconnectCoreAsync().ConfigureAwait(false);
                 }
 
-                var controller = controllerFactory(presetName, options)
+                // The SimulatedTiltPort sentinel routes to the simulated controller (camera simulator) instead of
+                // the serial registry; every real COM port goes through the registry unchanged. If no simulator
+                // factory was wired (e.g. a headless host), the sentinel falls through to the registry.
+                var useSimulator = SimulatedTiltPort.IsSimulator(portName) && simulatedControllerFactory != null;
+                var controller = (useSimulator ? simulatedControllerFactory() : controllerFactory(presetName, options))
                     ?? throw new InvalidOperationException($"Controller factory returned null for preset \"{presetName}\".");
                 try {
                     await controller.ConnectAsync(portName, ct).ConfigureAwait(false);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/TiltDeviceConnectionService.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/TiltDeviceConnectionService.cs
@@ -1,0 +1,464 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Utility;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Profile.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices {
+
+    /// <summary>
+    /// Minimal injectable time abstraction for <see cref="TiltDeviceConnectionService"/>'s position-polling
+    /// and 30-minute idle-disconnect timers. The service never reads <see cref="DateTime.Now"/> or starts a
+    /// real <see cref="System.Threading.Timer"/> directly — it only ever reacts to <see cref="Tick"/> and
+    /// compares wall-clock deltas against <see cref="UtcNow"/>. That makes cadence a property of the time
+    /// source, not the service: production uses <see cref="SystemTiltDeviceTimeSource"/> (a real timer
+    /// firing every <see cref="TiltDeviceConnectionService.PollInterval"/>), while tests substitute a fake
+    /// with a settable clock that fires <see cref="Tick"/> synchronously on demand — so advancing virtual
+    /// time by 5 seconds or 30 minutes deterministically drives a poll or the idle prompt without a single
+    /// real-time wait.
+    /// </summary>
+    public interface ITiltDeviceTimeSource : IDisposable {
+
+        /// <summary>Current time. Compared against stored timestamps (last poll, last user activity) — never assumed to advance by any particular amount between two reads.</summary>
+        DateTimeOffset UtcNow { get; }
+
+        /// <summary>Fires whenever the service should re-evaluate whether a poll or the idle prompt is due.</summary>
+        event EventHandler Tick;
+    }
+
+    /// <summary>
+    /// Production <see cref="ITiltDeviceTimeSource"/>: the real UTC clock plus a real
+    /// <see cref="System.Threading.Timer"/> ticking once per <paramref name="period"/>. Because
+    /// <see cref="TiltDeviceConnectionService"/> computes due-ness from wall-clock deltas rather than tick
+    /// counts, the exact period only bounds latency (how stale a displayed position or the idle prompt can
+    /// be) — it is not itself the unit callers reason about.
+    /// </summary>
+    internal sealed class SystemTiltDeviceTimeSource : ITiltDeviceTimeSource {
+        private readonly Timer timer;
+
+        public SystemTiltDeviceTimeSource(TimeSpan period) {
+            timer = new Timer(_ => Tick?.Invoke(this, EventArgs.Empty), null, period, period);
+        }
+
+        public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
+
+        public event EventHandler Tick;
+
+        public void Dispose() => timer.Dispose();
+    }
+
+    /// <summary>
+    /// Shared singleton (wired as <c>HocusFocusPlugin.TiltDeviceConnectionService</c>) owning the single
+    /// live connection to a motorized tilt-adapter device (e.g. the ASG EAT). Coordinates every consumer
+    /// that needs hardware access — the wizard's hands-off calibration (T11) and the inspector's Automatic
+    /// Adjustment (T14) — so they can never command the device at the same time, and owns the "is anyone
+    /// home" position-polling and 30-minute idle-disconnect prompt described in the design doc's user
+    /// decisions #6 and #7.
+    ///
+    /// <para><b>Concurrency model.</b> A single <see cref="SemaphoreSlim"/> (<c>hardwareLock</c>) guards
+    /// every actual touch of the device: <see cref="ConnectAsync"/>, <see cref="DisconnectAsync"/>, and the
+    /// timer-driven position poll all hold it for the duration of their device call. An exclusive
+    /// <see cref="TryBeginOperation"/> lease (see below) also claims this same lock for its entire
+    /// lifetime — that is what makes it a real cross-command lease rather than a per-command semaphore:
+    /// while a wizard calibration or an inspector adjustment plan holds the lease, every other hardware
+    /// touch (poll ticks, a stray Connect/Disconnect, a forced profile-change disconnect) is blocked out
+    /// until the lease is disposed. Poll ticks use a non-blocking <c>Wait(0)</c> and simply skip the tick if
+    /// the lock is busy (never queue up behind a move); Connect/Disconnect/the profile-change forced
+    /// disconnect use an async <c>WaitAsync</c> so they patiently wait their turn without blocking a
+    /// thread.</para>
+    ///
+    /// <para><b>Connect-while-connected.</b> <see cref="ConnectAsync"/> always tears down any existing
+    /// controller/session first (disconnect-then-reconnect), then connects fresh under the newly requested
+    /// preset/port. This lets "Connect" double as "reconnect" (e.g. the user picked a different COM port or
+    /// device preset) without requiring a separate Disconnect click first, and it is always safe: the old
+    /// controller is cleanly disconnected before the new one is ever touched.</para>
+    /// </summary>
+    public class TiltDeviceConnectionService : BaseINPC {
+
+        /// <summary>Position-poll cadence (design doc user decision #6: "refreshed by polling cp" at a constant cadence).</summary>
+        public static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(5);
+
+        /// <summary>Idle-prompt threshold (design doc user decision #7).</summary>
+        public static readonly TimeSpan IdleTimeout = TimeSpan.FromMinutes(30);
+
+        private readonly IProfileService profileService;
+        private readonly ITiltAdapterOptions options;
+        private readonly Func<string, ITiltAdapterOptions, ITiltMotionController> controllerFactory;
+        private readonly ITiltDeviceTimeSource timeSource;
+
+        // Guards every actual device touch (connect/disconnect/poll) AND is held for the entire lifetime of
+        // an active TryBeginOperation lease — see the class doc's "Concurrency model" section.
+        private readonly SemaphoreSlim hardwareLock = new SemaphoreSlim(1, 1);
+
+        // Guards the isOperationActive flag itself (TryBeginOperation/EndOperation are called from whatever
+        // thread the caller is on — typically the UI thread — and must never race each other).
+        private readonly object operationGate = new object();
+        private bool isOperationActive;
+
+        // lastActivityUtc/lastPollUtc are written on caller threads (Connect/TryBeginOperation/EndOperation,
+        // typically the UI thread) and read on the timer thread (TimeSource_Tick) without any lock guarding
+        // BOTH sides -- a plain DateTimeOffset field is > 8 bytes (a DateTime plus an offset), so a torn
+        // cross-thread read is possible. Stored as UTC ticks (a single 64-bit value) and accessed exclusively
+        // through the LastActivityUtc/LastPollUtc properties below via Interlocked, which guarantees an
+        // atomic, non-torn 64-bit read/write on every platform (unlike a plain `long` field access, which is
+        // only guaranteed atomic on 64-bit runtimes).
+        private long lastActivityUtcTicks;
+        private long lastPollUtcTicks = DateTimeOffset.MinValue.UtcTicks;
+
+        // Guards against the idle-prompt TOCTOU double-fire: the underlying System.Threading.Timer does NOT
+        // serialize its callback (TimeSource_Tick can be re-entered on a different pool thread if a previous
+        // tick's callback -- including this field's own check-and-set -- hasn't returned yet). 0 = not
+        // outstanding, 1 = outstanding. Always mutated via Interlocked so the check-and-set in CheckIdle is
+        // atomic; see CheckIdle for the full race this defends against.
+        private int idlePromptOutstandingFlag;
+
+        private DateTimeOffset LastActivityUtc {
+            get => new DateTimeOffset(Interlocked.Read(ref lastActivityUtcTicks), TimeSpan.Zero);
+            set => Interlocked.Exchange(ref lastActivityUtcTicks, value.UtcTicks);
+        }
+
+        private DateTimeOffset LastPollUtc {
+            get => new DateTimeOffset(Interlocked.Read(ref lastPollUtcTicks), TimeSpan.Zero);
+            set => Interlocked.Exchange(ref lastPollUtcTicks, value.UtcTicks);
+        }
+
+        private IReadOnlyList<int> currentPositions = Array.Empty<int>();
+
+        public TiltDeviceConnectionService(IProfileService profileService, ITiltAdapterOptions options)
+            : this(profileService, options, TiltMotionControllerRegistry.Create, new SystemTiltDeviceTimeSource(PollInterval)) {
+        }
+
+        /// <summary>Test seam: injects the controller factory (so tests substitute an <see cref="ITiltMotionController"/> instead of the real, not-yet-implemented EAT factory) and the time source (so tests drive virtual time deterministically).</summary>
+        internal TiltDeviceConnectionService(
+            IProfileService profileService,
+            ITiltAdapterOptions options,
+            Func<string, ITiltAdapterOptions, ITiltMotionController> controllerFactory,
+            ITiltDeviceTimeSource timeSource) {
+            this.profileService = profileService ?? throw new ArgumentNullException(nameof(profileService));
+            this.options = options ?? throw new ArgumentNullException(nameof(options));
+            this.controllerFactory = controllerFactory ?? throw new ArgumentNullException(nameof(controllerFactory));
+            this.timeSource = timeSource ?? throw new ArgumentNullException(nameof(timeSource));
+
+            LastActivityUtc = this.timeSource.UtcNow;
+            this.profileService.ProfileChanged += ProfileService_ProfileChanged;
+            this.timeSource.Tick += TimeSource_Tick;
+        }
+
+        public ITiltMotionController Controller { get; private set; }
+
+        public bool Connected { get; private set; }
+
+        /// <summary>True while an exclusive operation lease (see <see cref="TryBeginOperation"/>) is held.</summary>
+        public bool IsOperationActive => isOperationActive;
+
+        /// <summary>The <c>name</c> passed to the currently-active <see cref="TryBeginOperation"/> call, or null when no operation is active. For UI status text.</summary>
+        public string CurrentOperationName { get; private set; }
+
+        /// <summary>Per-motor positions from the most recent successful poll, in DEVICE motor order (see <see cref="TiltDevicePositions"/>). Empty/stale whenever <see cref="PositionsKnown"/> is false.</summary>
+        public IReadOnlyList<int> CurrentPositions => currentPositions;
+
+        /// <summary>False when the last poll failed, threw, or reported <see cref="TiltDevicePositions.Known"/> == false — the UI should show "unknown" rather than trusting <see cref="CurrentPositions"/>.</summary>
+        public bool PositionsKnown { get; private set; }
+
+        /// <summary>
+        /// Raised once, after 30 minutes with no user-initiated activity while connected (design doc user
+        /// decision #7). Suppressed from firing again until <see cref="ConfirmIdleDisconnectAsync"/> or
+        /// <see cref="KeepConnectedResetIdle"/> resolves the outstanding prompt.
+        /// </summary>
+        public event EventHandler IdlePromptRequested;
+
+        /// <summary>
+        /// Test-observability hook: the <see cref="Task"/> started by the most recent
+        /// <see cref="IProfileService.ProfileChanged"/>-triggered forced disconnect. Production code never
+        /// awaits this (NINA's <c>ProfileChanged</c> is a synchronous <see cref="EventHandler"/>, so the
+        /// forced disconnect is necessarily fire-and-forget there) — it exists purely so tests can await
+        /// deterministic completion of the forced disconnect instead of racing a background continuation.
+        /// </summary>
+        internal Task LastForcedDisconnectTask { get; private set; }
+
+        /// <summary>
+        /// Connects to the given device preset over the given serial port. If already connected, the
+        /// existing controller is disconnected first (see the class doc's "Connect-while-connected"
+        /// section) — this method always leaves the service connected to exactly the requested
+        /// preset/port on success, and disconnected on failure. Waits for any active
+        /// <see cref="TryBeginOperation"/> lease to be released before proceeding.
+        /// </summary>
+        public async Task ConnectAsync(string presetName, string portName, CancellationToken ct) {
+            if (string.IsNullOrEmpty(presetName)) {
+                throw new ArgumentException("Device preset name must not be empty.", nameof(presetName));
+            }
+            if (string.IsNullOrEmpty(portName)) {
+                throw new ArgumentException("Port name must not be empty.", nameof(portName));
+            }
+
+            await hardwareLock.WaitAsync(ct).ConfigureAwait(false);
+            try {
+                if (Connected) {
+                    await DisconnectCoreAsync().ConfigureAwait(false);
+                }
+
+                var controller = controllerFactory(presetName, options)
+                    ?? throw new InvalidOperationException($"Controller factory returned null for preset \"{presetName}\".");
+                try {
+                    await controller.ConnectAsync(portName, ct).ConfigureAwait(false);
+                } catch {
+                    // Controller leak / port-in-use lockout guard: the controller's own ConnectAsync may have
+                    // already opened the underlying port before failing on a later step (e.g. a 'cp'
+                    // handshake) -- best-effort disconnect it so the COM port isn't left open behind us, or
+                    // the NEXT connect attempt fails with "port in use". Secondary disconnect errors are
+                    // swallowed; the original connect failure is what the caller needs to see.
+                    try {
+                        await controller.DisconnectAsync(CancellationToken.None).ConfigureAwait(false);
+                    } catch (Exception disconnectEx) {
+                        Logger.Error(disconnectEx, "Error disconnecting tilt device controller after a failed connect attempt (ignored).");
+                    }
+                    throw;
+                }
+
+                Controller = controller;
+                // Record activity BEFORE flipping Connected -- both still inside hardwareLock. A timer tick
+                // racing this method must never be able to observe Connected == true together with a stale
+                // (possibly > 30-min-old) LastActivityUtc, which would fire the idle prompt immediately after
+                // a fresh connect.
+                RecordUserActivity();
+                SetConnected(true);
+                SetPositionsUnknown(); // Nothing polled yet under the new connection; the next timer tick populates it.
+                RaisePropertyChanged(nameof(Controller));
+            } finally {
+                hardwareLock.Release();
+            }
+        }
+
+        /// <summary>Disconnects (no-op if not already connected). Waits for any active <see cref="TryBeginOperation"/> lease, in-flight poll, or in-flight Connect to finish first — never yanks the port mid-command.</summary>
+        public async Task DisconnectAsync() {
+            await hardwareLock.WaitAsync().ConfigureAwait(false);
+            try {
+                await DisconnectCoreAsync().ConfigureAwait(false);
+            } finally {
+                hardwareLock.Release();
+            }
+        }
+
+        // Assumes hardwareLock is already held by the caller. Never throws for a well-behaved controller;
+        // if the controller's own DisconnectAsync throws (e.g. SerialPortClosedException from an unplugged
+        // device), the connection state is still cleared — a failed disconnect must not leave the service
+        // reporting a connection that's actually gone.
+        private async Task DisconnectCoreAsync() {
+            var controller = Controller;
+            if (controller == null) {
+                SetConnected(false);
+                return;
+            }
+            try {
+                await controller.DisconnectAsync(CancellationToken.None).ConfigureAwait(false);
+            } catch (Exception ex) {
+                Logger.Error(ex, "Error disconnecting tilt device controller; clearing connection state regardless.");
+            } finally {
+                Controller = null;
+                SetConnected(false);
+                SetPositionsUnknown();
+                LastPollUtc = DateTimeOffset.MinValue; // next connect polls promptly rather than waiting out a stale interval
+                Interlocked.Exchange(ref idlePromptOutstandingFlag, 0);
+                RaisePropertyChanged(nameof(Controller));
+            }
+        }
+
+        /// <summary>
+        /// Exclusive lease for a whole multi-command plan (a wizard calibration run or an inspector
+        /// Automatic Adjustment plan): while held, position polling is paused and any Connect/Disconnect
+        /// call (including a profile-change forced disconnect) blocks until the lease is disposed. Returns
+        /// null if another lease is already active OR a Connect/Disconnect/poll is currently in flight
+        /// (both cases mean "device busy" to the caller — this method never blocks waiting for either).
+        /// Disposing the returned token ends the lease, records user activity (resets the idle timer), and
+        /// resumes position polling.
+        /// </summary>
+        public IDisposable TryBeginOperation(string name) {
+            lock (operationGate) {
+                if (isOperationActive) {
+                    return null;
+                }
+                if (!hardwareLock.Wait(0)) {
+                    return null;
+                }
+                isOperationActive = true;
+            }
+
+            CurrentOperationName = name;
+            RaisePropertyChanged(nameof(IsOperationActive));
+            RaisePropertyChanged(nameof(CurrentOperationName));
+            RecordUserActivity();
+            return new OperationToken(this);
+        }
+
+        private void EndOperation() {
+            hardwareLock.Release();
+            lock (operationGate) {
+                isOperationActive = false;
+            }
+            CurrentOperationName = null;
+            RaisePropertyChanged(nameof(IsOperationActive));
+            RaisePropertyChanged(nameof(CurrentOperationName));
+            RecordUserActivity();
+            // No explicit "resume" call needed: the next timer tick sees Connected && !IsOperationActive
+            // and polls again on its own (see TryPollTick).
+        }
+
+        /// <summary>The "Yes" path for the idle-disconnect modal (T10): disconnects the device.</summary>
+        public Task ConfirmIdleDisconnectAsync() {
+            Interlocked.Exchange(ref idlePromptOutstandingFlag, 0);
+            return DisconnectAsync();
+        }
+
+        /// <summary>The "No" path for the idle-disconnect modal (T10): resets the idle timer and re-arms the prompt for the next 30-minute window. Does not touch the connection.</summary>
+        public void KeepConnectedResetIdle() {
+            Interlocked.Exchange(ref idlePromptOutstandingFlag, 0);
+            RecordUserActivity();
+        }
+
+        // User-initiated activity only (Connect, TryBeginOperation, and lease disposal, i.e. a completed
+        // move/plan/calibration step) — deliberately NOT called from the poll path, per the design doc:
+        // "Polling does NOT count as activity."
+        private void RecordUserActivity() {
+            LastActivityUtc = timeSource.UtcNow;
+        }
+
+        private void TimeSource_Tick(object sender, EventArgs e) {
+            var now = timeSource.UtcNow;
+            CheckIdle(now);
+            TryPollTick(now);
+        }
+
+        private void CheckIdle(DateTimeOffset now) {
+            if (!Connected || isOperationActive) {
+                // Suppressed while an operation lease is held: T11's hands-off calibration run can hold the
+                // lease past the 30-minute idle window. TryBeginOperation/EndOperation already record
+                // activity on begin/end, so the idle clock naturally resumes once the lease is released.
+                return;
+            }
+            if (now - LastActivityUtc < IdleTimeout) {
+                return;
+            }
+            // Atomic check-and-set (TOCTOU fix): the underlying System.Threading.Timer does not serialize its
+            // callback, so TimeSource_Tick (and therefore this method) can be re-entered concurrently on
+            // another pool thread if a previous tick's callback hasn't returned yet. Interlocked.CompareExchange
+            // ensures only ONE concurrent caller ever transitions the flag from "not outstanding" (0) to
+            // "outstanding" (1) and actually raises the event -- design doc user decision #7 requires the
+            // prompt fire EXACTLY once per idle window.
+            if (Interlocked.CompareExchange(ref idlePromptOutstandingFlag, 1, 0) != 0) {
+                return; // Already outstanding (or another concurrent tick just claimed it).
+            }
+            IdlePromptRequested?.Invoke(this, EventArgs.Empty);
+        }
+
+        private void TryPollTick(DateTimeOffset now) {
+            if (!Connected || isOperationActive) {
+                return; // Paused while an operation lease is held; resumes automatically once it's released.
+            }
+            if (now - LastPollUtc < PollInterval) {
+                return;
+            }
+            if (!hardwareLock.Wait(0)) {
+                return; // Connect/Disconnect/an operation just claimed the lock; try again next tick.
+            }
+            LastPollUtc = now;
+            var controllerSnapshot = Controller;
+            _ = RunPollAsync(controllerSnapshot);
+        }
+
+        private async Task RunPollAsync(ITiltMotionController controllerSnapshot) {
+            try {
+                if (controllerSnapshot == null) {
+                    SetPositionsUnknown();
+                    return;
+                }
+                TiltDevicePositions positions;
+                try {
+                    positions = await controllerSnapshot.QueryPositionsAsync(CancellationToken.None).ConfigureAwait(false);
+                } catch (Exception ex) {
+                    // Expected pre-T15 (the cp response format is unparseable): swallow and surface as "unknown" rather than crashing the poll loop.
+                    Logger.Error(ex, "Tilt device position poll failed; showing positions as unknown.");
+                    SetPositionsUnknown();
+                    return;
+                }
+                ApplyPositions(positions);
+            } finally {
+                hardwareLock.Release();
+            }
+        }
+
+        private void ApplyPositions(TiltDevicePositions positions) {
+            if (positions == null || !positions.Known) {
+                SetPositionsUnknown();
+                return;
+            }
+            currentPositions = new ReadOnlyCollection<int>(new List<int>(positions.PerMotorSteps));
+            PositionsKnown = true;
+            RaisePropertyChanged(nameof(CurrentPositions));
+            RaisePropertyChanged(nameof(PositionsKnown));
+        }
+
+        private void SetConnected(bool value) {
+            if (Connected == value) {
+                return;
+            }
+            Connected = value;
+            RaisePropertyChanged(nameof(Connected));
+        }
+
+        private void SetPositionsUnknown() {
+            if (!PositionsKnown && currentPositions.Count == 0) {
+                return;
+            }
+            currentPositions = Array.Empty<int>();
+            PositionsKnown = false;
+            RaisePropertyChanged(nameof(CurrentPositions));
+            RaisePropertyChanged(nameof(PositionsKnown));
+        }
+
+        private void ProfileService_ProfileChanged(object sender, EventArgs e) {
+            // NINA's ProfileChanged is a synchronous EventHandler; the forced disconnect must wait
+            // (possibly for a long-running operation lease) so it cannot run inline here. Stored for test
+            // observability — see LastForcedDisconnectTask's doc comment.
+            LastForcedDisconnectTask = ForceDisconnectForProfileChangeAsync();
+        }
+
+        private async Task ForceDisconnectForProfileChangeAsync() {
+            try {
+                // DisconnectAsync awaits hardwareLock, which is held for the entire duration of an active
+                // TryBeginOperation lease (and of any in-flight Connect/poll) — so this naturally waits for
+                // the in-flight command/operation to finish before yanking the port, per the design doc.
+                await DisconnectAsync().ConfigureAwait(false);
+            } catch (Exception ex) {
+                Logger.Error(ex, "Error force-disconnecting tilt device on profile change.");
+            }
+        }
+
+        private sealed class OperationToken : IDisposable {
+            private TiltDeviceConnectionService owner;
+
+            public OperationToken(TiltDeviceConnectionService owner) {
+                this.owner = owner;
+            }
+
+            public void Dispose() {
+                var o = Interlocked.Exchange(ref owner, null);
+                o?.EndOperation();
+            }
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/TiltDeviceConnectionService.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/TiltDeviceConnectionService.cs
@@ -307,13 +307,20 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices {
 
         private void EndOperation() {
             hardwareLock.Release();
+            // Record activity BEFORE clearing isOperationActive (mirrors the ConnectAsync ordering fix,
+            // which records activity before flipping Connected) -- a timer tick racing this method must
+            // never be able to observe isOperationActive == false together with a stale (possibly held past
+            // the 30-minute idle window, e.g. a long calibration run) LastActivityUtc, which would fire a
+            // spurious idle-disconnect prompt right as the operation ends. While isOperationActive is still
+            // true, CheckIdle returns early regardless of LastActivityUtc, so by the time the flag actually
+            // flips false below, activity is already fresh.
+            RecordUserActivity();
             lock (operationGate) {
                 isOperationActive = false;
             }
             CurrentOperationName = null;
             RaisePropertyChanged(nameof(IsOperationActive));
             RaisePropertyChanged(nameof(CurrentOperationName));
-            RecordUserActivity();
             // No explicit "resume" call needed: the next timer tick sees Connected && !IsOperationActive
             // and polls again on its own (see TryPollTick).
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/TiltMotionControllerRegistry.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/TiltMotionControllerRegistry.cs
@@ -1,0 +1,70 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices {
+
+    /// <summary>
+    /// Maps a <c>TiltAdapterDevicePreset.Name</c> to a factory that builds the
+    /// <see cref="ITiltMotionController"/> driving that device. This is the single place that decides
+    /// which presets are "motorized" (i.e. can be connected to and automated) versus manual/screw presets,
+    /// which have no entry here. To add a new motorized device: append one preset name → factory entry —
+    /// no other code in this file changes (mirrors the "append one entry" pattern of
+    /// <c>TiltAdapterDevicePreset.All</c>).
+    /// </summary>
+    public static class TiltMotionControllerRegistry {
+
+        // Exact preset Name strings from TiltAdapterDevicePreset.cs — kept as named constants here (rather
+        // than referenced live) so this file's entries are the single, grep-able source of "which presets
+        // are motorized"; TiltMotionControllerRegistryTests guards these against drift by iterating
+        // TiltAdapterDevicePreset.All and asserting every StepperMotors preset has an entry here.
+        private const string AsgEat90mmName = "ASG Electronic EAT - 90mm";
+        private const string AsgEatZwo461Name = "ASG Electronic EAT - ZWO 461";
+
+        // T7 replaces these placeholder factories with the real EatTiltMotionController factory.
+        private static ITiltMotionController ThrowNotYetWired(ITiltAdapterOptions options) =>
+            throw new NotImplementedException("EAT motion controller factory is wired in T7");
+
+        private static readonly IReadOnlyDictionary<string, Func<ITiltAdapterOptions, ITiltMotionController>> Factories =
+            new Dictionary<string, Func<ITiltAdapterOptions, ITiltMotionController>> {
+                [AsgEat90mmName] = ThrowNotYetWired,
+                [AsgEatZwo461Name] = ThrowNotYetWired,
+            };
+
+        /// <summary>True iff a motion controller factory is registered for the given device preset name.</summary>
+        public static bool IsMotorized(string presetName) =>
+            presetName != null && Factories.ContainsKey(presetName);
+
+        /// <summary>
+        /// Builds a new <see cref="ITiltMotionController"/> for the given device preset name. The returned
+        /// controller is not yet connected — call <see cref="ITiltMotionController.ConnectAsync"/> to open
+        /// the transport. <paramref name="options"/> is passed through so the driver can read its limit
+        /// configuration (max steps per command, max excursion, settle seconds); the connection port is
+        /// supplied separately to <see cref="ITiltMotionController.ConnectAsync"/>.
+        /// </summary>
+        public static ITiltMotionController Create(string presetName, ITiltAdapterOptions options) {
+            if (presetName == null || !Factories.TryGetValue(presetName, out var factory)) {
+                throw new ArgumentException($"No motion controller is registered for tilt-adapter device preset \"{presetName}\".", nameof(presetName));
+            }
+            return factory(options);
+        }
+
+        /// <summary>The device preset names this registry has a motion controller factory for.</summary>
+        public static IReadOnlyCollection<string> MotorizedPresetNames { get; } =
+            new ReadOnlyCollection<string>(Factories.Keys.ToArray());
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/TiltMotionControllerRegistry.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/TiltMotionControllerRegistry.cs
@@ -11,6 +11,7 @@
 #endregion "copyright"
 
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -35,14 +36,16 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices {
         private const string AsgEat90mmName = "ASG Electronic EAT - 90mm";
         private const string AsgEatZwo461Name = "ASG Electronic EAT - ZWO 461";
 
-        // T7 replaces these placeholder factories with the real EatTiltMotionController factory.
-        private static ITiltMotionController ThrowNotYetWired(ITiltAdapterOptions options) =>
-            throw new NotImplementedException("EAT motion controller factory is wired in T7");
+        // Both current EAT presets share a single, identical driver (EatTiltMotionController) -- the two
+        // presets differ only in screw radius/geometry (TiltAdapterDevicePreset.cs), not in serial protocol
+        // or command vocabulary, so one factory suffices for both entries (T7).
+        private static ITiltMotionController CreateEatController(ITiltAdapterOptions options) =>
+            new EatTiltMotionController(options);
 
         private static readonly IReadOnlyDictionary<string, Func<ITiltAdapterOptions, ITiltMotionController>> Factories =
             new Dictionary<string, Func<ITiltAdapterOptions, ITiltMotionController>> {
-                [AsgEat90mmName] = ThrowNotYetWired,
-                [AsgEatZwo461Name] = ThrowNotYetWired,
+                [AsgEat90mmName] = CreateEatController,
+                [AsgEatZwo461Name] = CreateEatController,
             };
 
         /// <summary>True iff a motion controller factory is registered for the given device preset name.</summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/TiltMovePlanner.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/TiltMovePlanner.cs
@@ -1,0 +1,293 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices {
+
+    /// <summary>
+    /// Topology-specific minimal-move planner. A 4-corner coupled device (like the ASG EAT) can only
+    /// reach a 3-D subspace of the 4-D per-screw target space in one move per generator; a future
+    /// 3-corner independent device would implement this interface with a trivially different planner
+    /// (one move per screw). See the design doc's "Core algorithm" section.
+    /// </summary>
+    public interface ITiltMovePlanner {
+
+        /// <summary>
+        /// Decomposes a per-screw signed step target vector (wizard indices 1..4, real-valued) into a
+        /// minimal set of device moves, honoring the Tilt/Backfocus group toggles and an optional
+        /// per-command step cap.
+        /// </summary>
+        /// <param name="sPerScrew">Per-screw signed step targets, wizard indices 1..4 at [0..3].</param>
+        /// <param name="includeTilt">When false, no DiagonalA/DiagonalB/EdgeVertical/EdgeHorizontal move is emitted.</param>
+        /// <param name="includeBackfocus">When false, no Backfocus move is emitted.</param>
+        /// <param name="unitMicrons">Microns represented by one step, for the residual report.</param>
+        /// <param name="maxStepsPerCommand">
+        /// Largest |Steps| a single emitted move may carry; larger moves are split into same-axis moves
+        /// whose signed magnitudes sum to the original. Default (<see cref="int.MaxValue"/>) never splits.
+        /// </param>
+        /// <param name="perMoveSeconds">Seconds attributed to each emitted move for the time estimate.</param>
+        TiltAdapterMovePlan Plan(
+            IReadOnlyList<double> sPerScrew,
+            bool includeTilt,
+            bool includeBackfocus,
+            double unitMicrons,
+            int maxStepsPerCommand = int.MaxValue,
+            double perMoveSeconds = 10);
+    }
+
+    /// <summary>
+    /// Pure, static core of the minimal-move decomposition described in the design doc's "Core
+    /// algorithm — minimal-move decomposition (4-corner coupled)" section. Everything here is a pure
+    /// function of its inputs — no device I/O, no NINA services — so it is directly unit-testable and
+    /// safe to call from a background thread.
+    ///
+    /// Orthogonal decomposition of the target vector s = (s1, s2, s3, s4) (wizard screw indices 1..4):
+    ///   a = (s1 − s3) / 2   → DiagonalA (D1) component
+    ///   b = (s2 − s4) / 2   → DiagonalB (D2) component
+    ///   f = (s1 + s2 + s3 + s4) / 4   → Backfocus (BF) component (the mean)
+    ///   t = (s1 − s2 + s3 − s4) / 4   → TWIST — physically unreachable by any rigid-plane device;
+    ///                                    reported, NEVER planned.
+    /// a, b, f, t are an orthogonal basis of R^4: s1 = a+f+t, s2 = b+f−t, s3 = −a+f+t, s4 = −b+f−t.
+    ///
+    /// The group split happens in COMMAND space: Backfocus = the BF projection f of the raw target s;
+    /// Tilt = the D1/D2 projections a, b of the raw target s. Because subtracting the mean f does not
+    /// change a or b, any off-center-curvature linear leakage in s automatically stays in the tilt
+    /// group without any explicit "subtract f first" step — do not refactor this into physical-origin
+    /// space, that would silently drop the leakage term.
+    /// </summary>
+    public static class TiltMovePlanner {
+
+        /// <summary>
+        /// Computes the exact orthogonal decomposition of a 4-corner target vector. See the class
+        /// remarks for the formulas; this is real-valued and un-rounded — <see cref="Plan"/> rounds
+        /// a, b, f independently after calling this.
+        /// </summary>
+        internal static (double a, double b, double f, double t) Decompose(IReadOnlyList<double> s) {
+            ValidateFourCorners(s, nameof(s));
+
+            double a = (s[0] - s[2]) / 2.0;
+            double b = (s[1] - s[3]) / 2.0;
+            double f = (s[0] + s[1] + s[2] + s[3]) / 4.0;
+            double t = (s[0] - s[1] + s[2] - s[3]) / 4.0;
+            return (a, b, f, t);
+        }
+
+        /// <summary>
+        /// Rounds a real-valued component to the nearest integer step, ties away from zero (matches
+        /// the signed-step rounding convention used elsewhere in this feature, e.g. TiltScrewGuidanceRow).
+        /// </summary>
+        internal static int RoundToStep(double value) {
+            return (int)Math.Round(value, MidpointRounding.AwayFromZero);
+        }
+
+        /// <summary>
+        /// Builds the minimal tilt-group move list (before cap-splitting) from independently-rounded
+        /// diagonal components ra, rb. Never forces a common magnitude to save a move: an edge move is
+        /// only emitted when ra and rb are ALREADY equal (or negatives of each other); otherwise up to
+        /// two diagonal moves are emitted, one per nonzero component.
+        /// </summary>
+        internal static IReadOnlyList<TiltAdapterMove> BuildTiltMoves(int ra, int rb) {
+            if (ra == 0 && rb == 0) {
+                return Array.Empty<TiltAdapterMove>();
+            }
+
+            if (ra == rb) {
+                // ra == rb and not both zero (handled above), so this magnitude is nonzero.
+                return new[] { NewMove(TiltMoveAxis.EdgeVertical, ra, TiltMoveGroup.Tilt) };
+            }
+
+            if (ra == -rb) {
+                // ra == -rb and not both zero (handled above), so this magnitude is nonzero.
+                return new[] { NewMove(TiltMoveAxis.EdgeHorizontal, ra, TiltMoveGroup.Tilt) };
+            }
+
+            var moves = new List<TiltAdapterMove>(2);
+            if (ra != 0) {
+                moves.Add(NewMove(TiltMoveAxis.DiagonalA, ra, TiltMoveGroup.Tilt));
+            }
+            if (rb != 0) {
+                moves.Add(NewMove(TiltMoveAxis.DiagonalB, rb, TiltMoveGroup.Tilt));
+            }
+            return moves;
+        }
+
+        /// <summary>Builds the single backfocus move for a rounded component rf, or null if rf == 0.</summary>
+        internal static TiltAdapterMove BuildBackfocusMove(int rf) {
+            if (rf == 0) {
+                return null;
+            }
+            return NewMove(TiltMoveAxis.Backfocus, rf, TiltMoveGroup.Backfocus);
+        }
+
+        /// <summary>
+        /// Splits a signed step magnitude into chunks of at most <paramref name="maxStepsPerCommand"/>,
+        /// same sign, summing back to <paramref name="steps"/>. Returns a single-element sequence
+        /// (unsplit) when already within the cap. Because the axes this feeds are orthogonal, the total
+        /// move count Σ ceil(|mᵢ|/cap) produced by splitting each move independently is provably minimal
+        /// under the cap.
+        /// </summary>
+        internal static IReadOnlyList<int> SplitStepsForCap(int steps, int maxStepsPerCommand) {
+            if (maxStepsPerCommand < 1) {
+                throw new ArgumentOutOfRangeException(nameof(maxStepsPerCommand), maxStepsPerCommand, "maxStepsPerCommand must be at least 1.");
+            }
+
+            int absSteps = Math.Abs(steps);
+            if (absSteps <= maxStepsPerCommand) {
+                return new[] { steps };
+            }
+
+            int sign = Math.Sign(steps);
+            var chunks = new List<int>();
+            int remaining = absSteps;
+            while (remaining > 0) {
+                int chunk = Math.Min(maxStepsPerCommand, remaining);
+                chunks.Add(sign * chunk);
+                remaining -= chunk;
+            }
+            return chunks;
+        }
+
+        /// <summary>
+        /// Applies <see cref="SplitStepsForCap"/> to every move in <paramref name="moves"/> whose
+        /// |Steps| exceeds the cap, preserving axis and group and replacing the single move with the
+        /// split sequence in place. Moves already within the cap pass through unchanged.
+        /// </summary>
+        internal static IReadOnlyList<TiltAdapterMove> ApplyCap(IReadOnlyList<TiltAdapterMove> moves, int maxStepsPerCommand) {
+            if (moves == null || moves.Count == 0) {
+                return Array.Empty<TiltAdapterMove>();
+            }
+
+            var result = new List<TiltAdapterMove>(moves.Count);
+            foreach (var move in moves) {
+                if (Math.Abs(move.Steps) <= maxStepsPerCommand) {
+                    result.Add(move);
+                    continue;
+                }
+
+                var parts = SplitStepsForCap(move.Steps, maxStepsPerCommand);
+                for (int i = 0; i < parts.Count; ++i) {
+                    string description = string.Format(
+                        CultureInfo.InvariantCulture, "{0} (part {1} of {2})", DescribeMove(move.Axis, parts[i]), i + 1, parts.Count);
+                    result.Add(new TiltAdapterMove(move.Axis, parts[i], move.Group, description));
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Decomposes <paramref name="sPerScrew"/> into a minimal set of device moves per the design
+        /// doc's "Core algorithm" section, applying the Tilt/Backfocus group toggles and the optional
+        /// per-command step cap, and reports the per-corner residual (which inherently includes both
+        /// rounding error and the unreachable twist, since twist is never applied) plus the raw twist.
+        /// </summary>
+        public static TiltAdapterMovePlan Plan(
+            IReadOnlyList<double> sPerScrew,
+            bool includeTilt,
+            bool includeBackfocus,
+            double unitMicrons,
+            int maxStepsPerCommand = int.MaxValue,
+            double perMoveSeconds = 10) {
+            ValidateFourCorners(sPerScrew, nameof(sPerScrew));
+            if (maxStepsPerCommand < 1) {
+                throw new ArgumentOutOfRangeException(nameof(maxStepsPerCommand), maxStepsPerCommand, "maxStepsPerCommand must be at least 1.");
+            }
+
+            var (a, b, f, t) = Decompose(sPerScrew);
+            int ra = RoundToStep(a);
+            int rb = RoundToStep(b);
+            int rf = RoundToStep(f);
+
+            var moves = new List<TiltAdapterMove>();
+            if (includeTilt) {
+                moves.AddRange(BuildTiltMoves(ra, rb));
+            }
+            if (includeBackfocus) {
+                var bfMove = BuildBackfocusMove(rf);
+                if (bfMove != null) {
+                    moves.Add(bfMove);
+                }
+            }
+
+            var cappedMoves = ApplyCap(moves, maxStepsPerCommand);
+
+            var applied = new double[4];
+            foreach (var move in cappedMoves) {
+                for (int i = 0; i < 4; ++i) {
+                    applied[i] += move.PerCornerSteps[i];
+                }
+            }
+
+            var residual = new double[4];
+            for (int i = 0; i < 4; ++i) {
+                residual[i] = (applied[i] - sPerScrew[i]) * unitMicrons;
+            }
+
+            double estimatedSeconds = cappedMoves.Count * perMoveSeconds;
+
+            return new TiltAdapterMovePlan(cappedMoves, residual, t, estimatedSeconds);
+        }
+
+        private static TiltAdapterMove NewMove(TiltMoveAxis axis, int steps, TiltMoveGroup group) {
+            return new TiltAdapterMove(axis, steps, group, DescribeMove(axis, steps));
+        }
+
+        private static string DescribeMove(TiltMoveAxis axis, int steps) {
+            string signed = steps.ToString("+0;-0;0", CultureInfo.InvariantCulture);
+            switch (axis) {
+                case TiltMoveAxis.DiagonalA:
+                    return $"Diagonal A: {signed} steps";
+
+                case TiltMoveAxis.DiagonalB:
+                    return $"Diagonal B: {signed} steps";
+
+                case TiltMoveAxis.EdgeVertical:
+                    return $"Edge vertical: {signed} steps";
+
+                case TiltMoveAxis.EdgeHorizontal:
+                    return $"Edge horizontal: {signed} steps";
+
+                case TiltMoveAxis.Backfocus:
+                    return $"Backfocus: {signed} steps";
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(axis), axis, "Unknown tilt move axis.");
+            }
+        }
+
+        private static void ValidateFourCorners(IReadOnlyList<double> s, string paramName) {
+            if (s == null || s.Count != 4) {
+                throw new ArgumentException("Per-screw target vector must contain exactly 4 elements (wizard screw indices 1..4).", paramName);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Thin <see cref="ITiltMovePlanner"/> adapter over <see cref="TiltMovePlanner"/> for the 4-corner
+    /// coupled topology (e.g. the ASG EAT) — the instance callers and the registry (T5) resolve. A
+    /// future <c>ThreeCornerIndependentPlanner</c> is a sibling of this class, not a modification to it.
+    /// </summary>
+    public sealed class FourCornerCoupledPlanner : ITiltMovePlanner {
+
+        public TiltAdapterMovePlan Plan(
+            IReadOnlyList<double> sPerScrew,
+            bool includeTilt,
+            bool includeBackfocus,
+            double unitMicrons,
+            int maxStepsPerCommand = int.MaxValue,
+            double perMoveSeconds = 10) {
+            return TiltMovePlanner.Plan(sPerScrew, includeTilt, includeBackfocus, unitMicrons, maxStepsPerCommand, perMoveSeconds);
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -242,7 +242,7 @@
                             Fill="{StaticResource PrimaryBrush}"
                             Stretch="Uniform" />
                     </StackPanel>
-                    <TextBlock VerticalAlignment="Center" Text="Screws + steps">
+                    <TextBlock VerticalAlignment="Center" Foreground="{StaticResource PrimaryBrush}" Text="Screws + steps">
                         <TextBlock.Style>
                             <Style TargetType="TextBlock">
                                 <Setter Property="Visibility" Value="Collapsed" />
@@ -657,7 +657,7 @@
                                     Stretch="Uniform" />
                                 <TextBlock VerticalAlignment="Center" Text="moves adapter" />
                             </StackPanel>
-                            <TextBlock VerticalAlignment="Center" Text="+ steps move adapter">
+                            <TextBlock VerticalAlignment="Center" Foreground="{StaticResource PrimaryBrush}" Text="+ steps move adapter">
                                 <TextBlock.Style>
                                     <Style TargetType="TextBlock">
                                         <Setter Property="Visibility" Value="Collapsed" />
@@ -787,7 +787,7 @@
                         </Button>
                     </Grid>
 
-                    <TextBlock Margin="0,10,0,0" Text="No calibration saved.">
+                    <TextBlock Margin="0,10,0,0" Foreground="{StaticResource PrimaryBrush}" Text="No calibration saved.">
                         <TextBlock.Style>
                             <Style TargetType="TextBlock">
                                 <Setter Property="Visibility" Value="Visible" />
@@ -817,6 +817,7 @@
                             Margin="0,10,0,0"
                             FontStyle="Italic"
                             Opacity="0.7"
+                            Foreground="{StaticResource PrimaryBrush}"
                             Text="Manually entered calibration (not measured by the wizard)."
                             TextWrapping="Wrap">
                             <TextBlock.Style>
@@ -1080,6 +1081,7 @@
                     <!--  Post-measurement status (shown when not measuring)  -->
                     <TextBlock
                         Margin="0,4,0,0"
+                        Foreground="{StaticResource PrimaryBrush}"
                         Text="{Binding StatusText}"
                         TextWrapping="Wrap">
                         <TextBlock.Style>
@@ -1500,6 +1502,7 @@
                         Margin="0,10,0,0"
                         FontStyle="Italic"
                         Opacity="0.7"
+                        Foreground="{StaticResource PrimaryBrush}"
                         Text="Set a screw radius (and thread pitch / step size) in Settings to measure adapter hardware."
                         TextWrapping="Wrap">
                         <TextBlock.Style>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -13,6 +13,79 @@
     </ResourceDictionary.MergedDictionaries>
 
     <!--
+        Live per-corner motor positions + Δ-since-run-start, shared by Panel A (connection pane), Panel B
+        (running steps) and Panel C (complete) so the display is visible DURING a device-driven run — Panel A
+        collapses while running, exactly when the positions update per move and the deltas matter most. The
+        self-gate (Visibility on IsTiltDeviceConnected) keeps it inert when no device is connected, so every
+        host can drop it in unconditionally. 2×2 layout matches the physical adapter corners; device motor
+        numbering per the vendor: TR=1, TL=2, BR=3, BL=4; wizard screw numbering per the device-connected
+        calibration convention: screw 1 ≡ TR, 2 ≡ TL, 3 ≡ BL, 4 ≡ BR. Counters read "unknown" until a
+        position query succeeds.
+    -->
+    <DataTemplate x:Key="HF_TiltDevicePositionsGrid">
+        <StackPanel
+            ToolTip="Current per-motor position counters, polled from the device (Δ is the change since this calibration run started). Corners use the device's own motor numbering (TR=1, TL=2, BR=3, BL=4); wizard screw numbers follow the device-connected calibration convention (screw 1 = TR, 2 = TL, 3 = BL, 4 = BR). Zero the counters in the vendor app if needed — the plugin never zeroes them.">
+            <StackPanel.Style>
+                <Style TargetType="StackPanel">
+                    <Setter Property="Visibility" Value="Collapsed" />
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsTiltDeviceConnected}" Value="True">
+                            <Setter Property="Visibility" Value="Visible" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </StackPanel.Style>
+            <TextBlock Margin="0,0,0,2" FontWeight="Bold" Text="Motor positions (steps)" />
+            <Grid HorizontalAlignment="Left" MinWidth="280">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <!--  Top-left corner: device motor 2, wizard screw 2  -->
+                <Border Grid.Row="0" Grid.Column="0" Margin="0,0,2,2" Padding="6,4"
+                    BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="3">
+                    <StackPanel>
+                        <TextBlock FontWeight="Bold" Text="TL · Motor 2" />
+                        <TextBlock FontSize="10" Opacity="0.7" Text="Wizard screw 2" />
+                        <TextBlock Margin="0,2,0,0" Text="{Binding ScrewPositionTopLeftDisplay}" />
+                    </StackPanel>
+                </Border>
+                <!--  Top-right corner: device motor 1, wizard screw 1  -->
+                <Border Grid.Row="0" Grid.Column="1" Margin="2,0,0,2" Padding="6,4"
+                    BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="3">
+                    <StackPanel>
+                        <TextBlock FontWeight="Bold" Text="TR · Motor 1" />
+                        <TextBlock FontSize="10" Opacity="0.7" Text="Wizard screw 1" />
+                        <TextBlock Margin="0,2,0,0" Text="{Binding ScrewPositionTopRightDisplay}" />
+                    </StackPanel>
+                </Border>
+                <!--  Bottom-left corner: device motor 4, wizard screw 3  -->
+                <Border Grid.Row="1" Grid.Column="0" Margin="0,2,2,0" Padding="6,4"
+                    BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="3">
+                    <StackPanel>
+                        <TextBlock FontWeight="Bold" Text="BL · Motor 4" />
+                        <TextBlock FontSize="10" Opacity="0.7" Text="Wizard screw 3" />
+                        <TextBlock Margin="0,2,0,0" Text="{Binding ScrewPositionBottomLeftDisplay}" />
+                    </StackPanel>
+                </Border>
+                <!--  Bottom-right corner: device motor 3, wizard screw 4  -->
+                <Border Grid.Row="1" Grid.Column="1" Margin="2,2,0,0" Padding="6,4"
+                    BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="3">
+                    <StackPanel>
+                        <TextBlock FontWeight="Bold" Text="BR · Motor 3" />
+                        <TextBlock FontSize="10" Opacity="0.7" Text="Wizard screw 4" />
+                        <TextBlock Margin="0,2,0,0" Text="{Binding ScrewPositionBottomRightDisplay}" />
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </StackPanel>
+    </DataTemplate>
+
+    <!--
         Sensor frame outline (10px thick border, EvenOdd) plus three diamond-shaped screw
         indicators at the 0° / 120° / 240° positions of a standard 3-screw tilt adapter.
     -->
@@ -334,72 +407,12 @@
                                     Text="{Binding TiltDeviceStatusText}" />
                             </StackPanel>
 
-                            <!--  Live per-corner motor positions (shown while connected; refreshed by the
-                                  connection service's position polling). 2×2 layout matches the physical
-                                  adapter corners. Device motor numbering per the vendor: TR=1, TL=2, BR=3,
-                                  BL=4. Wizard screw numbering per the device-connected calibration
-                                  convention: screw 1 ≡ TR, 2 ≡ TL, 3 ≡ BL, 4 ≡ BR. Counters read "unknown"
-                                  until a position query succeeds.  -->
-                            <StackPanel Margin="0,8,0,0"
-                                ToolTip="Current per-motor position counters, polled from the device. Corners use the device's own motor numbering (TR=1, TL=2, BR=3, BL=4); wizard screw numbers follow the device-connected calibration convention (screw 1 = TR, 2 = TL, 3 = BL, 4 = BR). Zero the counters in the vendor app if needed — the plugin never zeroes them.">
-                                <StackPanel.Style>
-                                    <Style TargetType="StackPanel">
-                                        <Setter Property="Visibility" Value="Collapsed" />
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding IsTiltDeviceConnected}" Value="True">
-                                                <Setter Property="Visibility" Value="Visible" />
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </StackPanel.Style>
-                                <TextBlock Margin="0,0,0,2" FontWeight="Bold" Text="Motor positions (steps)" />
-                                <Grid HorizontalAlignment="Left" MinWidth="280">
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto" />
-                                        <RowDefinition Height="Auto" />
-                                    </Grid.RowDefinitions>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="*" />
-                                    </Grid.ColumnDefinitions>
-                                    <!--  Top-left corner: device motor 2, wizard screw 2  -->
-                                    <Border Grid.Row="0" Grid.Column="0" Margin="0,0,2,2" Padding="6,4"
-                                        BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="3">
-                                        <StackPanel>
-                                            <TextBlock FontWeight="Bold" Text="TL · Motor 2" />
-                                            <TextBlock FontSize="10" Opacity="0.7" Text="Wizard screw 2" />
-                                            <TextBlock Margin="0,2,0,0" Text="{Binding ScrewPositionTopLeftDisplay}" />
-                                        </StackPanel>
-                                    </Border>
-                                    <!--  Top-right corner: device motor 1, wizard screw 1  -->
-                                    <Border Grid.Row="0" Grid.Column="1" Margin="2,0,0,2" Padding="6,4"
-                                        BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="3">
-                                        <StackPanel>
-                                            <TextBlock FontWeight="Bold" Text="TR · Motor 1" />
-                                            <TextBlock FontSize="10" Opacity="0.7" Text="Wizard screw 1" />
-                                            <TextBlock Margin="0,2,0,0" Text="{Binding ScrewPositionTopRightDisplay}" />
-                                        </StackPanel>
-                                    </Border>
-                                    <!--  Bottom-left corner: device motor 4, wizard screw 3  -->
-                                    <Border Grid.Row="1" Grid.Column="0" Margin="0,2,2,0" Padding="6,4"
-                                        BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="3">
-                                        <StackPanel>
-                                            <TextBlock FontWeight="Bold" Text="BL · Motor 4" />
-                                            <TextBlock FontSize="10" Opacity="0.7" Text="Wizard screw 3" />
-                                            <TextBlock Margin="0,2,0,0" Text="{Binding ScrewPositionBottomLeftDisplay}" />
-                                        </StackPanel>
-                                    </Border>
-                                    <!--  Bottom-right corner: device motor 3, wizard screw 4  -->
-                                    <Border Grid.Row="1" Grid.Column="1" Margin="2,2,0,0" Padding="6,4"
-                                        BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="3">
-                                        <StackPanel>
-                                            <TextBlock FontWeight="Bold" Text="BR · Motor 3" />
-                                            <TextBlock FontSize="10" Opacity="0.7" Text="Wizard screw 4" />
-                                            <TextBlock Margin="0,2,0,0" Text="{Binding ScrewPositionBottomRightDisplay}" />
-                                        </StackPanel>
-                                    </Border>
-                                </Grid>
-                            </StackPanel>
+                            <!--  Live per-corner motor positions + Δ (shared template; also rendered in the
+                                  running and complete panels). Self-gates on IsTiltDeviceConnected.  -->
+                            <ContentControl
+                                Margin="0,8,0,0"
+                                Content="{Binding}"
+                                ContentTemplate="{StaticResource HF_TiltDevicePositionsGrid}" />
 
                             <!--  Persisted per-profile device safety limits (project invariant: every
                                   persisted option gets a UI control — these three were deferred here
@@ -942,6 +955,17 @@
                         </Style>
                     </StackPanel.Style>
 
+                    <!--  Step progress + short title above the instruction paragraph (a: "Step N of M",
+                          b: a scannable header). Both are always populated on an active measurement step.  -->
+                    <TextBlock
+                        FontSize="11"
+                        Opacity="0.7"
+                        Text="{Binding StepProgressDisplay}" />
+                    <TextBlock
+                        Margin="0,1,0,6"
+                        FontWeight="Bold"
+                        Text="{Binding StepTitle}" />
+
                     <TextBlock
                         Margin="0,0,0,10"
                         Text="{Binding StepInstructions}"
@@ -1006,6 +1030,13 @@
                                 Text="Auto Run All" />
                         </Button>
                     </StackPanel>
+
+                    <!--  Live motor positions + Δ during the run (d). Panel A's copy is collapsed while
+                          running, so the display is repeated here where it updates per move.  -->
+                    <ContentControl
+                        Margin="0,4,0,4"
+                        Content="{Binding}"
+                        ContentTemplate="{StaticResource HF_TiltDevicePositionsGrid}" />
 
                     <!--  Device connection warning: shown when Run Measurement is visible but devices are not connected  -->
                     <TextBlock
@@ -1306,6 +1337,13 @@
                         Margin="0,0,0,5"
                         Text="{Binding StepInstructions}"
                         TextWrapping="Wrap" />
+
+                    <!--  Final motor positions + Δ: the most valuable moment for this display — confirm the
+                          restore-to-baseline move brought every Δ back to 0.  -->
+                    <ContentControl
+                        Margin="0,4,0,4"
+                        Content="{Binding}"
+                        ContentTemplate="{StaticResource HF_TiltDevicePositionsGrid}" />
 
                     <Border
                         Margin="0,5"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -82,6 +82,15 @@
                     </StackPanel>
                 </Border>
             </Grid>
+            <!--  Mapping made visible (not tooltip-only) so a user watching the physical adapter can tell
+                  which corner should be moving.  -->
+            <TextBlock
+                Margin="0,3,0,0"
+                FontSize="10"
+                FontStyle="Italic"
+                Opacity="0.7"
+                TextWrapping="Wrap"
+                Text="Screw 1 = TR, 2 = TL, 3 = BL, 4 = BR (matches the wizard). Δ is the change since this run started." />
         </StackPanel>
     </DataTemplate>
 
@@ -989,25 +998,13 @@
                                 </Style.Triggers>
                             </Style>
                         </StackPanel.Style>
+                        <!--  Auto Run All (T11): the primary path for a connected motorized adapter, so it is
+                              placed first and bold. It drives every remaining step (device move + measurement +
+                              advance) automatically through Complete, including the final restore-to-baseline
+                              move. Collapsed unless a motorized device is connected — so the manual button order
+                              (Run Measurement, Use Saved AF) is unchanged when it is hidden.  -->
                         <Button
                             Margin="0,0,6,0"
-                            Command="{Binding RunMeasurementCommand}">
-                            <TextBlock
-                                Margin="10,5,10,5"
-                                Foreground="{StaticResource ButtonForegroundBrush}"
-                                Text="Run Measurement" />
-                        </Button>
-                        <Button Command="{Binding UseSavedAFCommand}">
-                            <TextBlock
-                                Margin="10,5,10,5"
-                                Foreground="{StaticResource ButtonForegroundBrush}"
-                                Text="Use Saved AF" />
-                        </Button>
-                        <!--  Auto Run All (T11): only offered when a motorized device is connected — drives
-                              every remaining step (device move + measurement + advance) automatically through
-                              Complete, including the final restore-to-baseline move.  -->
-                        <Button
-                            Margin="6,0,0,0"
                             Command="{Binding AutoRunAllCommand}"
                             ToolTip="Drive every remaining calibration step automatically: the wizard sends each step's device move, runs the measurement, and advances — through Complete's restore-to-baseline move — without further clicks.">
                             <Button.Style>
@@ -1026,10 +1023,59 @@
                             </Button.Style>
                             <TextBlock
                                 Margin="10,5,10,5"
+                                FontWeight="Bold"
                                 Foreground="{StaticResource ButtonForegroundBrush}"
                                 Text="Auto Run All" />
                         </Button>
+                        <!--  Single-step: relabeled "Run This Step" when a motorized device is connected, to
+                              distinguish it from Auto Run All's whole-run automation.  -->
+                        <Button
+                            Margin="0,0,6,0"
+                            Command="{Binding RunMeasurementCommand}">
+                            <TextBlock Margin="10,5,10,5" Foreground="{StaticResource ButtonForegroundBrush}">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Text" Value="Run Measurement" />
+                                        <Style.Triggers>
+                                            <MultiDataTrigger>
+                                                <MultiDataTrigger.Conditions>
+                                                    <Condition Binding="{Binding IsMotorizedDevice}" Value="True" />
+                                                    <Condition Binding="{Binding IsTiltDeviceConnected}" Value="True" />
+                                                </MultiDataTrigger.Conditions>
+                                                <Setter Property="Text" Value="Run This Step" />
+                                            </MultiDataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+                        </Button>
+                        <Button Command="{Binding UseSavedAFCommand}">
+                            <TextBlock
+                                Margin="10,5,10,5"
+                                Foreground="{StaticResource ButtonForegroundBrush}"
+                                Text="Use Saved AF" />
+                        </Button>
                     </StackPanel>
+
+                    <!--  Connection status carried into the running view (B.10): a mid-run disconnect otherwise
+                          only surfaces when the next move fails. Shown while connected (with the positions).  -->
+                    <TextBlock
+                        Margin="0,4,0,0"
+                        FontStyle="Italic"
+                        Opacity="0.8"
+                        Text="{Binding TiltDeviceStatusText}"
+                        TextWrapping="Wrap">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsTiltDeviceConnected}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
 
                     <!--  Live motor positions + Δ during the run (d). Panel A's copy is collapsed while
                           running, so the display is repeated here where it updates per move.  -->
@@ -1081,10 +1127,29 @@
                         <Button
                             HorizontalAlignment="Left"
                             Command="{Binding CancelCommand}">
-                            <TextBlock
-                                Margin="10,5,10,5"
-                                Foreground="{StaticResource ButtonForegroundBrush}"
-                                Text="Cancel" />
+                            <!--  During Auto Run All, retitle + explain that cancelling is safe: it finishes the
+                                  in-flight move/measurement (no device abort command) then auto-returns to start.  -->
+                            <Button.Style>
+                                <Style BasedOn="{StaticResource {x:Type Button}}" TargetType="Button">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsAutoRunningAll}" Value="True">
+                                            <Setter Property="ToolTip" Value="Finishes the current move and measurement (the device has no abort command), then automatically returns every motor to its starting position." />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Button.Style>
+                            <TextBlock Margin="10,5,10,5" Foreground="{StaticResource ButtonForegroundBrush}">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Text" Value="Cancel" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsAutoRunningAll}" Value="True">
+                                                <Setter Property="Text" Value="Cancel Run" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
                         </Button>
                     </StackPanel>
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -291,6 +291,174 @@
                         <ComboBox MinWidth="120" ItemsSource="{Binding DeviceNames}" SelectedItem="{Binding SelectedDevice}" />
                     </UniformGrid>
 
+                    <!--  Motorized device connection (visible only for presets with a registered motion
+                          controller, i.e. the ASG EAT presets — collapsed for Manual/screw presets):
+                          COM port + Connect/Disconnect, live per-corner motor position counters, and the
+                          persisted device safety limits. Deliberately NO zero-positions control — zeroing
+                          the counters is the vendor app's job.  -->
+                    <GroupBox Margin="0,8,0,2" Header="Motorized Device Connection">
+                        <GroupBox.Style>
+                            <Style TargetType="GroupBox">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsMotorizedDevice}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </GroupBox.Style>
+                        <StackPanel Margin="5">
+
+                            <!--  COM port + rescan  -->
+                            <UniformGrid Margin="0,2" VerticalAlignment="Center" Columns="2">
+                                <TextBlock VerticalAlignment="Center" Text="Serial port"
+                                    ToolTip="COM port the device is attached to. Saved per profile. Use the ⟳ button to re-scan after plugging the device in." />
+                                <DockPanel>
+                                    <Button DockPanel.Dock="Right" Margin="6,0,0,0" Command="{Binding RefreshPortsCommand}"
+                                        ToolTip="Re-scan the available COM ports.">
+                                        <TextBlock Margin="8,3,8,3" Foreground="{StaticResource ButtonForegroundBrush}" Text="⟳" />
+                                    </Button>
+                                    <ComboBox MinWidth="90" ItemsSource="{Binding AvailablePortNames}" SelectedItem="{Binding SelectedPortName}" />
+                                </DockPanel>
+                            </UniformGrid>
+
+                            <!--  Connect / Disconnect + status line  -->
+                            <StackPanel Margin="0,6,0,0" Orientation="Horizontal">
+                                <Button Command="{Binding ConnectDeviceCommand}">
+                                    <TextBlock Margin="10,5,10,5" Foreground="{StaticResource ButtonForegroundBrush}" Text="Connect" />
+                                </Button>
+                                <Button Margin="6,0,0,0" Command="{Binding DisconnectDeviceCommand}">
+                                    <TextBlock Margin="10,5,10,5" Foreground="{StaticResource ButtonForegroundBrush}" Text="Disconnect" />
+                                </Button>
+                                <TextBlock Margin="10,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Opacity="0.8"
+                                    Text="{Binding TiltDeviceStatusText}" />
+                            </StackPanel>
+
+                            <!--  Live per-corner motor positions (shown while connected; refreshed by the
+                                  connection service's position polling). 2×2 layout matches the physical
+                                  adapter corners. Device motor numbering per the vendor: TR=1, TL=2, BR=3,
+                                  BL=4. Wizard screw numbering per the device-connected calibration
+                                  convention: screw 1 ≡ TR, 2 ≡ TL, 3 ≡ BL, 4 ≡ BR. Counters read "unknown"
+                                  until a position query succeeds.  -->
+                            <StackPanel Margin="0,8,0,0"
+                                ToolTip="Current per-motor position counters, polled from the device. Corners use the device's own motor numbering (TR=1, TL=2, BR=3, BL=4); wizard screw numbers follow the device-connected calibration convention (screw 1 = TR, 2 = TL, 3 = BL, 4 = BR). Zero the counters in the vendor app if needed — the plugin never zeroes them.">
+                                <StackPanel.Style>
+                                    <Style TargetType="StackPanel">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsTiltDeviceConnected}" Value="True">
+                                                <Setter Property="Visibility" Value="Visible" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </StackPanel.Style>
+                                <TextBlock Margin="0,0,0,2" FontWeight="Bold" Text="Motor positions (steps)" />
+                                <Grid HorizontalAlignment="Left" MinWidth="280">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <!--  Top-left corner: device motor 2, wizard screw 2  -->
+                                    <Border Grid.Row="0" Grid.Column="0" Margin="0,0,2,2" Padding="6,4"
+                                        BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="3">
+                                        <StackPanel>
+                                            <TextBlock FontWeight="Bold" Text="TL · Motor 2" />
+                                            <TextBlock FontSize="10" Opacity="0.7" Text="Wizard screw 2" />
+                                            <TextBlock Margin="0,2,0,0" Text="{Binding ScrewPositionTopLeftDisplay}" />
+                                        </StackPanel>
+                                    </Border>
+                                    <!--  Top-right corner: device motor 1, wizard screw 1  -->
+                                    <Border Grid.Row="0" Grid.Column="1" Margin="2,0,0,2" Padding="6,4"
+                                        BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="3">
+                                        <StackPanel>
+                                            <TextBlock FontWeight="Bold" Text="TR · Motor 1" />
+                                            <TextBlock FontSize="10" Opacity="0.7" Text="Wizard screw 1" />
+                                            <TextBlock Margin="0,2,0,0" Text="{Binding ScrewPositionTopRightDisplay}" />
+                                        </StackPanel>
+                                    </Border>
+                                    <!--  Bottom-left corner: device motor 4, wizard screw 3  -->
+                                    <Border Grid.Row="1" Grid.Column="0" Margin="0,2,2,0" Padding="6,4"
+                                        BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="3">
+                                        <StackPanel>
+                                            <TextBlock FontWeight="Bold" Text="BL · Motor 4" />
+                                            <TextBlock FontSize="10" Opacity="0.7" Text="Wizard screw 3" />
+                                            <TextBlock Margin="0,2,0,0" Text="{Binding ScrewPositionBottomLeftDisplay}" />
+                                        </StackPanel>
+                                    </Border>
+                                    <!--  Bottom-right corner: device motor 3, wizard screw 4  -->
+                                    <Border Grid.Row="1" Grid.Column="1" Margin="2,2,0,0" Padding="6,4"
+                                        BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="3">
+                                        <StackPanel>
+                                            <TextBlock FontWeight="Bold" Text="BR · Motor 3" />
+                                            <TextBlock FontSize="10" Opacity="0.7" Text="Wizard screw 4" />
+                                            <TextBlock Margin="0,2,0,0" Text="{Binding ScrewPositionBottomRightDisplay}" />
+                                        </StackPanel>
+                                    </Border>
+                                </Grid>
+                            </StackPanel>
+
+                            <!--  Persisted per-profile device safety limits (project invariant: every
+                                  persisted option gets a UI control — these three were deferred here
+                                  from the options task; the serial port option is the ComboBox above).  -->
+                            <TextBlock Margin="0,8,0,2" FontWeight="Bold" Text="Safety Limits" />
+                            <UniformGrid Margin="0,2" VerticalAlignment="Center" Columns="2">
+                                <TextBlock VerticalAlignment="Center" Text="Max steps per command"
+                                    ToolTip="Safety cap on the magnitude of a single commanded move, in device steps. Larger planned moves are split or refused." />
+                                <TextBox MinWidth="60">
+                                    <TextBox.Text>
+                                        <Binding Path="TiltAdapterOptions.TiltDeviceMaxStepsPerCommand" UpdateSourceTrigger="LostFocus">
+                                            <Binding.ValidationRules>
+                                                <rules:IntRangeRule>
+                                                    <rules:IntRangeRule.ValidRange>
+                                                        <rules:IntRangeChecker Maximum="100000" Minimum="1" />
+                                                    </rules:IntRangeRule.ValidRange>
+                                                </rules:IntRangeRule>
+                                            </Binding.ValidationRules>
+                                        </Binding>
+                                    </TextBox.Text>
+                                </TextBox>
+                            </UniformGrid>
+                            <UniformGrid Margin="0,2" VerticalAlignment="Center" Columns="2">
+                                <TextBlock VerticalAlignment="Center" Text="Max excursion (steps)"
+                                    ToolTip="Safety cap on the total cumulative travel (in device steps) a motor may move from its tracked home position before automation refuses to move it further." />
+                                <TextBox MinWidth="60">
+                                    <TextBox.Text>
+                                        <Binding Path="TiltAdapterOptions.TiltDeviceMaxExcursionSteps" UpdateSourceTrigger="LostFocus">
+                                            <Binding.ValidationRules>
+                                                <rules:IntRangeRule>
+                                                    <rules:IntRangeRule.ValidRange>
+                                                        <rules:IntRangeChecker Maximum="1000000" Minimum="1" />
+                                                    </rules:IntRangeRule.ValidRange>
+                                                </rules:IntRangeRule>
+                                            </Binding.ValidationRules>
+                                        </Binding>
+                                    </TextBox.Text>
+                                </TextBox>
+                            </UniformGrid>
+                            <UniformGrid Margin="0,2" VerticalAlignment="Center" Columns="2">
+                                <TextBlock VerticalAlignment="Center" Text="Settle time (s)"
+                                    ToolTip="Seconds to wait after each commanded move before treating the device as settled (before polling positions or sending the next command)." />
+                                <TextBox MinWidth="60">
+                                    <TextBox.Text>
+                                        <Binding Path="TiltAdapterOptions.TiltDeviceSettleSeconds" UpdateSourceTrigger="LostFocus">
+                                            <Binding.ValidationRules>
+                                                <rules:DoubleRangeRule>
+                                                    <rules:DoubleRangeRule.ValidRange>
+                                                        <rules:DoubleRangeChecker Maximum="600" Minimum="0" />
+                                                    </rules:DoubleRangeRule.ValidRange>
+                                                </rules:DoubleRangeRule>
+                                            </Binding.ValidationRules>
+                                        </Binding>
+                                    </TextBox.Text>
+                                </TextBox>
+                            </UniformGrid>
+                        </StackPanel>
+                    </GroupBox>
+
                     <!--  Adapter hardware: drives precise screw-turn amounts in the Aberration Inspector.
                           Disabled when a non-Manual device preset is selected.  -->
                     <UniformGrid Margin="0,5" VerticalAlignment="Center" Columns="2">
@@ -810,6 +978,32 @@
                                 Foreground="{StaticResource ButtonForegroundBrush}"
                                 Text="Use Saved AF" />
                         </Button>
+                        <!--  Auto Run All (T11): only offered when a motorized device is connected — drives
+                              every remaining step (device move + measurement + advance) automatically through
+                              Complete, including the final restore-to-baseline move.  -->
+                        <Button
+                            Margin="6,0,0,0"
+                            Command="{Binding AutoRunAllCommand}"
+                            ToolTip="Drive every remaining calibration step automatically: the wizard sends each step's device move, runs the measurement, and advances — through Complete's restore-to-baseline move — without further clicks.">
+                            <Button.Style>
+                                <Style TargetType="Button">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <MultiDataTrigger>
+                                            <MultiDataTrigger.Conditions>
+                                                <Condition Binding="{Binding IsMotorizedDevice}" Value="True" />
+                                                <Condition Binding="{Binding IsTiltDeviceConnected}" Value="True" />
+                                            </MultiDataTrigger.Conditions>
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </MultiDataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Button.Style>
+                            <TextBlock
+                                Margin="10,5,10,5"
+                                Foreground="{StaticResource ButtonForegroundBrush}"
+                                Text="Auto Run All" />
+                        </Button>
                     </StackPanel>
 
                     <!--  Device connection warning: shown when Run Measurement is visible but devices are not connected  -->
@@ -959,6 +1153,30 @@
                         </ContentControl.Style>
                     </ContentControl>
 
+                    <!--  Device-link dropped mid-run (a "Use Saved AF" step skipped a device move during what
+                          started as a device-driven run) — survives the advance to Complete (below), so it is
+                          rendered there too.  -->
+                    <Border
+                        Margin="0,6,0,0"
+                        Padding="5"
+                        BorderBrush="{StaticResource NotificationErrorBrush}"
+                        BorderThickness="1">
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasDeviceLinkDroppedWarning}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <TextBlock
+                            Foreground="{StaticResource NotificationErrorBrush}"
+                            Text="{Binding DeviceLinkDroppedWarningText}"
+                            TextWrapping="Wrap" />
+                    </Border>
+
                     <!--  Consistency warning (shown when tilt measurements across runs diverge)  -->
                     <Border
                         Margin="0,6,0,0"
@@ -1103,6 +1321,29 @@
                             </Style>
                         </Border.Style>
                         <TextBlock Text="{Binding WarningText}" TextWrapping="Wrap" />
+                    </Border>
+
+                    <!--  Device-link dropped mid-run: it survives the advance to Complete (the step panel that
+                          raised it is already hidden), so it must render here too  -->
+                    <Border
+                        Margin="0,5"
+                        Padding="5"
+                        BorderBrush="{StaticResource NotificationErrorBrush}"
+                        BorderThickness="1">
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasDeviceLinkDroppedWarning}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <TextBlock
+                            Foreground="{StaticResource NotificationErrorBrush}"
+                            Text="{Binding DeviceLinkDroppedWarningText}"
+                            TextWrapping="Wrap" />
                     </Border>
 
                     <!--  Consistency warning raised by the final step's repeats: it survives the advance to

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterDevicePreset.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterDevicePreset.cs
@@ -27,7 +27,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         private TiltAdapterDevicePreset(
             string name, bool isManual, int screwCount, TiltAdjustmentType adjustmentType,
-            double threadPitchMicrons, double stepperStepSizeMicrons, double screwRadiusMillimeters) {
+            double threadPitchMicrons, double stepperStepSizeMicrons, double screwRadiusMillimeters,
+            double defaultCalibrationAmount) {
             Name = name;
             IsManual = isManual;
             ScrewCount = screwCount;
@@ -35,6 +36,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             ThreadPitchMicrons = threadPitchMicrons;
             StepperStepSizeMicrons = stepperStepSizeMicrons;
             ScrewRadiusMillimeters = screwRadiusMillimeters;
+            DefaultCalibrationAmount = defaultCalibrationAmount;
         }
 
         public string Name { get; }
@@ -45,53 +47,70 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public double StepperStepSizeMicrons { get; }
         public double ScrewRadiusMillimeters { get; }
 
+        // Amount (full turns for screw adapters, steps for stepper adapters) the wizard pre-fills as
+        // the per-screw calibration applied amount when this preset is selected. Screw adapters default
+        // to 1 full turn; the ASG Electronic EAT stepper adapters default to 150 steps.
+        public double DefaultCalibrationAmount { get; }
+
         public static readonly TiltAdapterDevicePreset Manual = new TiltAdapterDevicePreset(
             ManualName, isManual: true, screwCount: 3, adjustmentType: TiltAdjustmentType.Screws,
-            threadPitchMicrons: -1, stepperStepSizeMicrons: -1, screwRadiusMillimeters: -1);
+            threadPitchMicrons: -1, stepperStepSizeMicrons: -1, screwRadiusMillimeters: -1,
+            defaultCalibrationAmount: 1.0);
 
         public static readonly IReadOnlyList<TiltAdapterDevicePreset> All = new[] {
             Manual,
             new TiltAdapterDevicePreset(
                 "Neumann CTU XT48", isManual: false, screwCount: 3, adjustmentType: TiltAdjustmentType.Screws,
-                threadPitchMicrons: 400, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 44),
+                threadPitchMicrons: 400, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 44,
+                defaultCalibrationAmount: 1.0),
 
             // ASG 78mm series
             new TiltAdapterDevicePreset(
                 "ASG Photon Cage - 78mm", isManual: false, screwCount: 4, adjustmentType: TiltAdjustmentType.Screws,
-                threadPitchMicrons: 212, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 44),  // 120 TPI (~212 µm/turn)
+                threadPitchMicrons: 212, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 44,
+                defaultCalibrationAmount: 1.0),  // 120 TPI (~212 µm/turn)
 
             // ASG 90mm series
             new TiltAdapterDevicePreset(
                 "ASG Photon Cage - 90mm", isManual: false, screwCount: 4, adjustmentType: TiltAdjustmentType.Screws,
-                threadPitchMicrons: 212, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 50),  // 120 TPI (~212 µm/turn)
+                threadPitchMicrons: 212, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 50,
+                defaultCalibrationAmount: 1.0),  // 120 TPI (~212 µm/turn)
             new TiltAdapterDevicePreset(
                 "ASG Electronic EAT - 90mm", isManual: false, screwCount: 4, adjustmentType: TiltAdjustmentType.StepperMotors,
-                threadPitchMicrons: -1, stepperStepSizeMicrons: 1.8, screwRadiusMillimeters: 55),
+                threadPitchMicrons: -1, stepperStepSizeMicrons: 1.8, screwRadiusMillimeters: 55,
+                defaultCalibrationAmount: 150),
 
             // ASG ZWO 461 series
             new TiltAdapterDevicePreset(
                 "ASG Photon Cage - ZWO 461", isManual: false, screwCount: 4, adjustmentType: TiltAdjustmentType.Screws,
-                threadPitchMicrons: 212, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 54),  // 120 TPI (~212 µm/turn)
+                threadPitchMicrons: 212, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 54,
+                defaultCalibrationAmount: 1.0),  // 120 TPI (~212 µm/turn)
             new TiltAdapterDevicePreset(
                 "ASG Electronic EAT - ZWO 461", isManual: false, screwCount: 4, adjustmentType: TiltAdjustmentType.StepperMotors,
-                threadPitchMicrons: -1, stepperStepSizeMicrons: 1.8, screwRadiusMillimeters: 62.75),
+                threadPitchMicrons: -1, stepperStepSizeMicrons: 1.8, screwRadiusMillimeters: 62.75,
+                defaultCalibrationAmount: 150),
 
             // OGMA series
             new TiltAdapterDevicePreset(
                 "OGMA Z'Tilter - 3-point configuration", isManual: false, screwCount: 3, adjustmentType: TiltAdjustmentType.Screws,
-                threadPitchMicrons: 450, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 48.9),
+                threadPitchMicrons: 450, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 48.9,
+                defaultCalibrationAmount: 1.0),
             new TiltAdapterDevicePreset(
                 "OGMA Z'Tilter - 4-point configuration", isManual: false, screwCount: 4, adjustmentType: TiltAdjustmentType.Screws,
-                threadPitchMicrons: 450, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 48.9),
+                threadPitchMicrons: 450, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 48.9,
+                defaultCalibrationAmount: 1.0),
             new TiltAdapterDevicePreset(
                 "OGMA O'Tilter", isManual: false, screwCount: 3, adjustmentType: TiltAdjustmentType.Screws,
-                threadPitchMicrons: 450, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 43.25),
+                threadPitchMicrons: 450, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 43.25,
+                defaultCalibrationAmount: 1.0),
             new TiltAdapterDevicePreset(
                 "OGMA +Tilter / OAG Pro - 3-point configuration", isManual: false, screwCount: 3, adjustmentType: TiltAdjustmentType.Screws,
-                threadPitchMicrons: 450, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 40),
+                threadPitchMicrons: 450, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 40,
+                defaultCalibrationAmount: 1.0),
             new TiltAdapterDevicePreset(
                 "OGMA +Tilter / OAG Pro - 4-point configuration", isManual: false, screwCount: 4, adjustmentType: TiltAdjustmentType.Screws,
-                threadPitchMicrons: 450, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 40),
+                threadPitchMicrons: 450, stepperStepSizeMicrons: -1, screwRadiusMillimeters: 40,
+                defaultCalibrationAmount: 1.0),
         };
 
         public static TiltAdapterDevicePreset ByName(string name) =>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
@@ -67,6 +67,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             lastMeasuredStepperStepSizeMicrons = optionsAccessor.GetValueDouble(nameof(LastMeasuredStepperStepSizeMicrons), -1.0);
             deviceName = optionsAccessor.GetValueString(nameof(DeviceName), TiltAdapterDevicePreset.ManualName);
             saveAFRunsPath = optionsAccessor.GetValueString(nameof(SaveAFRunsPath), string.Empty);
+            tiltDeviceSerialPortName = optionsAccessor.GetValueString(nameof(TiltDeviceSerialPortName), string.Empty);
+            tiltDeviceMaxStepsPerCommand = optionsAccessor.GetValueInt32(nameof(TiltDeviceMaxStepsPerCommand), 200);
+            tiltDeviceMaxExcursionSteps = optionsAccessor.GetValueInt32(nameof(TiltDeviceMaxExcursionSteps), 500);
+            tiltDeviceSettleSeconds = optionsAccessor.GetValueDouble(nameof(TiltDeviceSettleSeconds), 3.0);
+            deviceLinkedCalibrationDeviceName = optionsAccessor.GetValueString(nameof(DeviceLinkedCalibrationDeviceName), string.Empty);
+            tiltDeviceShadowPositions = optionsAccessor.GetValueString(nameof(TiltDeviceShadowPositions), string.Empty);
+            calibrationAppliedAmount = optionsAccessor.GetValueDouble(nameof(CalibrationAppliedAmount), -1.0);
         }
 
         private int screwCount;
@@ -338,6 +345,97 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 if (saveAFRunsPath != newValue) {
                     saveAFRunsPath = newValue;
                     optionsAccessor.SetValueString(nameof(SaveAFRunsPath), saveAFRunsPath);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private string tiltDeviceSerialPortName;
+
+        public string TiltDeviceSerialPortName {
+            get => tiltDeviceSerialPortName;
+            set {
+                if (tiltDeviceSerialPortName != value) {
+                    tiltDeviceSerialPortName = value;
+                    optionsAccessor.SetValueString(nameof(TiltDeviceSerialPortName), tiltDeviceSerialPortName);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private int tiltDeviceMaxStepsPerCommand;
+
+        public int TiltDeviceMaxStepsPerCommand {
+            get => tiltDeviceMaxStepsPerCommand;
+            set {
+                if (tiltDeviceMaxStepsPerCommand != value) {
+                    tiltDeviceMaxStepsPerCommand = value;
+                    optionsAccessor.SetValueInt32(nameof(TiltDeviceMaxStepsPerCommand), tiltDeviceMaxStepsPerCommand);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private int tiltDeviceMaxExcursionSteps;
+
+        public int TiltDeviceMaxExcursionSteps {
+            get => tiltDeviceMaxExcursionSteps;
+            set {
+                if (tiltDeviceMaxExcursionSteps != value) {
+                    tiltDeviceMaxExcursionSteps = value;
+                    optionsAccessor.SetValueInt32(nameof(TiltDeviceMaxExcursionSteps), tiltDeviceMaxExcursionSteps);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private double tiltDeviceSettleSeconds;
+
+        public double TiltDeviceSettleSeconds {
+            get => tiltDeviceSettleSeconds;
+            set {
+                if (tiltDeviceSettleSeconds != value) {
+                    tiltDeviceSettleSeconds = value;
+                    optionsAccessor.SetValueDouble(nameof(TiltDeviceSettleSeconds), tiltDeviceSettleSeconds);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private string deviceLinkedCalibrationDeviceName;
+
+        public string DeviceLinkedCalibrationDeviceName {
+            get => deviceLinkedCalibrationDeviceName;
+            set {
+                if (deviceLinkedCalibrationDeviceName != value) {
+                    deviceLinkedCalibrationDeviceName = value;
+                    optionsAccessor.SetValueString(nameof(DeviceLinkedCalibrationDeviceName), deviceLinkedCalibrationDeviceName);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private string tiltDeviceShadowPositions;
+
+        public string TiltDeviceShadowPositions {
+            get => tiltDeviceShadowPositions;
+            set {
+                if (tiltDeviceShadowPositions != value) {
+                    tiltDeviceShadowPositions = value;
+                    optionsAccessor.SetValueString(nameof(TiltDeviceShadowPositions), tiltDeviceShadowPositions);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private double calibrationAppliedAmount;
+
+        public double CalibrationAppliedAmount {
+            get => calibrationAppliedAmount;
+            set {
+                if (calibrationAppliedAmount != value) {
+                    calibrationAppliedAmount = value;
+                    optionsAccessor.SetValueDouble(nameof(CalibrationAppliedAmount), calibrationAppliedAmount);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
@@ -72,6 +72,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             tiltDeviceMaxExcursionSteps = optionsAccessor.GetValueInt32(nameof(TiltDeviceMaxExcursionSteps), 500);
             tiltDeviceSettleSeconds = optionsAccessor.GetValueDouble(nameof(TiltDeviceSettleSeconds), 3.0);
             deviceLinkedCalibrationDeviceName = optionsAccessor.GetValueString(nameof(DeviceLinkedCalibrationDeviceName), string.Empty);
+            calibrationIsReliable = optionsAccessor.GetValueBoolean(nameof(CalibrationIsReliable), false);
             tiltDeviceShadowPositions = optionsAccessor.GetValueString(nameof(TiltDeviceShadowPositions), string.Empty);
             calibrationAppliedAmount = optionsAccessor.GetValueDouble(nameof(CalibrationAppliedAmount), -1.0);
         }
@@ -410,6 +411,19 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 if (deviceLinkedCalibrationDeviceName != value) {
                     deviceLinkedCalibrationDeviceName = value;
                     optionsAccessor.SetValueString(nameof(DeviceLinkedCalibrationDeviceName), deviceLinkedCalibrationDeviceName);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool calibrationIsReliable;
+
+        public bool CalibrationIsReliable {
+            get => calibrationIsReliable;
+            set {
+                if (calibrationIsReliable != value) {
+                    calibrationIsReliable = value;
+                    optionsAccessor.SetValueBoolean(nameof(CalibrationIsReliable), calibrationIsReliable);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
@@ -69,7 +69,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             saveAFRunsPath = optionsAccessor.GetValueString(nameof(SaveAFRunsPath), string.Empty);
             tiltDeviceSerialPortName = optionsAccessor.GetValueString(nameof(TiltDeviceSerialPortName), string.Empty);
             tiltDeviceMaxStepsPerCommand = optionsAccessor.GetValueInt32(nameof(TiltDeviceMaxStepsPerCommand), 200);
-            tiltDeviceMaxExcursionSteps = optionsAccessor.GetValueInt32(nameof(TiltDeviceMaxExcursionSteps), 500);
+            // The real ASG EAT's absolute step counters rest at ~600 (EEPROM-persisted, not zeroed by the
+            // plugin), and the excursion check is |absolute position| <= max -- so the cap must comfortably
+            // exceed the resting counter plus the working travel, or the first move is rejected. See
+            // docs/asg-eat-serial-protocol-design.md.
+            tiltDeviceMaxExcursionSteps = optionsAccessor.GetValueInt32(nameof(TiltDeviceMaxExcursionSteps), 2000);
             tiltDeviceSettleSeconds = optionsAccessor.GetValueDouble(nameof(TiltDeviceSettleSeconds), 3.0);
             deviceLinkedCalibrationDeviceName = optionsAccessor.GetValueString(nameof(DeviceLinkedCalibrationDeviceName), string.Empty);
             calibrationIsReliable = optionsAccessor.GetValueBoolean(nameof(CalibrationIsReliable), false);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -24,6 +24,7 @@ using NINA.Equipment.Interfaces.ViewModel;
 using NINA.Equipment.Model;
 using NINA.Joko.Plugins.HocusFocus.AutoFocus;
 using NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay;
+using NINA.Joko.Plugins.HocusFocus.CameraSimulator;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.StarDetection;
 using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
@@ -89,6 +90,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // message box (ShowIdleDisconnectPromptAsync); tests inject a fake returning true/false and assert
         // the right TiltDeviceConnectionService method is called.
         private readonly Func<Task<bool>> confirmIdleDisconnectAsync;
+        // The simulator config the "Simulator" port checks against the selected EAT preset. Null-tolerant: a
+        // device-less test rig may not wire it, in which case the Simulator-port config check is skipped.
+        private readonly ICameraSimulatorOptions cameraSimulatorOptions;
+        // The "change the simulator config to match?" confirmation, injectable for tests (mirrors
+        // confirmIdleDisconnectAsync). Production default shows the NINA Yes/No message box (default No).
+        private readonly Func<string, string, Task<bool>> confirmSimConfigChangeAsync;
         private IReadOnlyList<string> availablePortNames;
         private string connectedPortName;
 
@@ -240,7 +247,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             InspectorVM inspector)
             : this(profileService, applicationStatusMediator, cameraMediator, focuserMediator, inspector,
                    HocusFocusPlugin.ApplicationDispatcher, HocusFocusPlugin.TiltAdapterOptions,
-                   HocusFocusPlugin.TiltDeviceConnectionService) { }
+                   HocusFocusPlugin.TiltDeviceConnectionService,
+                   cameraSimulatorOptions: HocusFocusPlugin.CameraSimulatorOptions) { }
 
         public TiltAdapterWizardVM(
             IProfileService profileService,
@@ -252,7 +260,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             ITiltAdapterOptions tiltAdapterOptions,
             TiltDeviceConnectionService tiltDeviceConnectionService = null,
             ISerialPortProvider serialPortProvider = null,
-            Func<Task<bool>> confirmIdleDisconnectAsync = null)
+            Func<Task<bool>> confirmIdleDisconnectAsync = null,
+            ICameraSimulatorOptions cameraSimulatorOptions = null,
+            Func<string, string, Task<bool>> confirmSimConfigChangeAsync = null)
             : base(profileService) {
             this.inspector = inspector;
             this.tiltAdapterOptions = tiltAdapterOptions;
@@ -260,6 +270,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             this.tiltDeviceConnectionService = tiltDeviceConnectionService;
             this.serialPortProvider = serialPortProvider; // null => created lazily on first enumeration
             this.confirmIdleDisconnectAsync = confirmIdleDisconnectAsync ?? ShowIdleDisconnectPromptAsync;
+            this.cameraSimulatorOptions = cameraSimulatorOptions;
+            this.confirmSimConfigChangeAsync = confirmSimConfigChangeAsync ?? ShowSimConfigChangePromptAsync;
             this.progress = ProgressFactory.Create(applicationStatusMediator, "Tilt Adapter Wizard");
             this.moveProgress = new Progress<string>(text => this.progress.Report(new ApplicationStatus { Status = $"Tilt Adapter Wizard: {text}" }));
 
@@ -1269,14 +1281,18 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         }
 
         private IReadOnlyList<string> EnumeratePortNames() {
+            // The simulated adapter is always offered first (and even if port enumeration fails), so a user with
+            // no hardware can still connect it. It's only ever visible when an EAT preset is selected -- the whole
+            // connection pane is gated on IsMotorizedDevice -- which is exactly when connecting the sim EAT applies.
+            var result = new List<string> { SimulatedTiltPort.PortName };
             try {
                 // Created here (not in the ctor): SerialPortProvider's constructor runs a WMI scan.
                 serialPortProvider ??= new SerialPortProvider();
-                return serialPortProvider.GetPortNames(deviceQuery: null, addDivider: false, addGenericPorts: true);
+                result.AddRange(serialPortProvider.GetPortNames(deviceQuery: null, addDivider: false, addGenericPorts: true));
             } catch (Exception ex) {
                 Logger.Error(ex, "Failed to enumerate serial ports for the tilt device connection");
-                return Array.Empty<string>();
             }
+            return result;
         }
 
         private void RefreshPorts() {
@@ -1293,6 +1309,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             var svc = tiltDeviceConnectionService;
             var port = SelectedPortName;
             if (svc == null || string.IsNullOrEmpty(port)) return;
+
+            // Connecting the SIMULATOR port has extra preconditions (active sim camera, matching sim config,
+            // aberrations on); if any is unmet and the user declines to fix it, abort before touching the service.
+            if (SimulatedTiltPort.IsSimulator(port) && !await PrepareSimulatorConnectionAsync()) {
+                return;
+            }
+
             try {
                 await svc.ConnectAsync(tiltAdapterOptions.DeviceName, port, CancellationToken.None);
                 connectedPortName = port;
@@ -1407,6 +1430,81 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 "Tilt Adapter Device Idle",
                 System.Windows.MessageBoxButton.YesNo,
                 System.Windows.MessageBoxResult.No);
+            return Task.FromResult(result == System.Windows.MessageBoxResult.Yes);
+        }
+
+        // Pre-connect checks for the "Simulator" port. Returns false to ABORT the connect. The simulated adapter
+        // only affects the HocusFocus camera simulator's images, its geometry must match the selected EAT preset
+        // for the calibration loop to converge, and aberration rendering must be on or the loop is inert.
+        private async Task<bool> PrepareSimulatorConnectionAsync() {
+            // 1) Block unless the HocusFocus camera simulator is the active, connected camera.
+            var camInfo = CameraInfo;
+            if (camInfo == null || !camInfo.Connected ||
+                !string.Equals(camInfo.DeviceId, HocusFocusSimulatorCamera.DeviceId, StringComparison.Ordinal)) {
+                Notification.ShowError(
+                    "Connect the HocusFocus camera simulator before connecting the simulated tilt adapter — " +
+                    "the simulated adapter only changes the HocusFocus simulator's images.");
+                return false;
+            }
+
+            // No simulator options wired (device-less test rig): nothing to check or fix, allow the connect.
+            if (cameraSimulatorOptions == null) {
+                return true;
+            }
+
+            // 2) The simulator's tilt-adapter geometry must match the selected EAT preset or the loop can't
+            //    converge. If it differs, offer to change the simulator config to match; if declined, don't connect.
+            var preset = TiltAdapterDevicePreset.ByName(tiltAdapterOptions.DeviceName);
+            if (SimConfigDiffersFromPreset(preset)) {
+                var apply = await confirmSimConfigChangeAsync(
+                    "The camera simulator's tilt-adapter configuration (screw count, motor/screw type, step size, " +
+                    "screw radius) differs from the selected EAT preset, so the automated calibration loop can't " +
+                    "converge. Change the simulator configuration to match and connect?",
+                    "Simulated Tilt Adapter Configuration");
+                if (!apply) {
+                    return false;
+                }
+                // Mirror ApplyDevice's preset -> options copy, into the Sim* fields. Screw angles and adapter
+                // direction are deliberately NOT synced: the device-linked calibration measures them, and forcing
+                // them would both be discarded and remove the coverage the simulator exists to provide.
+                cameraSimulatorOptions.SimScrewCount = preset.ScrewCount;
+                cameraSimulatorOptions.SimAdjustmentType = preset.AdjustmentType;
+                cameraSimulatorOptions.SimStepperStepSizeMicrons = preset.StepperStepSizeMicrons;
+                cameraSimulatorOptions.SimScrewRadiusMillimeters = preset.ScrewRadiusMillimeters;
+            }
+
+            // 3) Aberration rendering must be on or every simulated exposure is flat and the loop measures nothing.
+            if (!cameraSimulatorOptions.EnableAberrations) {
+                cameraSimulatorOptions.EnableAberrations = true;
+                Notification.ShowInformation(
+                    "Enabled camera-simulator aberrations so the tilt calibration loop can measure changes.");
+            }
+
+            return true;
+        }
+
+        // Compares only the four hardware fields the user cares about (screw count, motor/screw type, step size,
+        // screw radius) between the simulator config and the selected EAT preset.
+        private bool SimConfigDiffersFromPreset(TiltAdapterDevicePreset preset) =>
+            cameraSimulatorOptions.SimScrewCount != preset.ScrewCount ||
+            cameraSimulatorOptions.SimAdjustmentType != preset.AdjustmentType ||
+            !HardwareValuesMatch(cameraSimulatorOptions.SimStepperStepSizeMicrons, preset.StepperStepSizeMicrons) ||
+            !HardwareValuesMatch(cameraSimulatorOptions.SimScrewRadiusMillimeters, preset.ScrewRadiusMillimeters);
+
+        // Tolerant compare for the hardware doubles (step size, radius): a benign rounding difference must not force
+        // the prompt. After a "Yes" the fields are set from the preset verbatim, so a later connect matches exactly.
+        private static bool HardwareValuesMatch(double a, double b) {
+            if (a <= 0 || b <= 0) {
+                return a <= 0 && b <= 0;
+            }
+            return Math.Abs(a - b) / b <= 0.001;
+        }
+
+        // Production "change the simulator config?" prompt: NINA's Yes/No message box, default No (a dismissed
+        // dialog must never silently rewrite the simulator's configuration).
+        private static Task<bool> ShowSimConfigChangePromptAsync(string message, string title) {
+            var result = MyMessageBox.Show(
+                message, title, System.Windows.MessageBoxButton.YesNo, System.Windows.MessageBoxResult.No);
             return Task.FromResult(result == System.Windows.MessageBoxResult.Yes);
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -525,6 +525,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 RaisePropertyChanged(nameof(IsComplete));
                 RaisePropertyChanged(nameof(IsOnMeasurementStep));
                 RaisePropertyChanged(nameof(StepInstructions));
+                RaisePropertyChanged(nameof(StepProgressDisplay));
+                RaisePropertyChanged(nameof(StepTitle));
                 RaisePropertyChanged(nameof(IsCurrentStepAtBaseline));
                 RaisePropertyChanged(nameof(BaselineRecoveryInstructions));
                 NotifyCommandsCanExecuteChanged();
@@ -535,6 +537,52 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         // Steps that end with running the aberration inspector (measurement auto-advances)
         public bool IsOnMeasurementStep => activeMeasurementSteps.Contains(currentStep);
+
+        // "Step N of M" over the active measurement-step set (4- or 6-step, captured at run start). Empty on
+        // the terminal Complete panel, which shows its own "Calibration Complete!" header instead.
+        public string StepProgressDisplay {
+            get {
+                if (currentStep == WizardStep.Complete) {
+                    return string.Empty;
+                }
+                int idx = Array.IndexOf(activeMeasurementSteps, currentStep);
+                if (idx < 0) {
+                    return string.Empty;
+                }
+                return string.Format(CultureInfo.InvariantCulture, "Step {0} of {1}", idx + 1, activeMeasurementSteps.Length);
+            }
+        }
+
+        // Short, scannable title shown above the longer StepInstructions paragraph so the user can tell where
+        // they are without re-reading the instructions.
+        public string StepTitle => StepTitleText(currentStep);
+
+        internal static string StepTitleText(WizardStep step) {
+            switch (step) {
+                case WizardStep.Baseline: return "Baseline Measurement";
+                case WizardStep.AllInward: return "All Screws Inward";
+                case WizardStep.ReBaseline1: return "Return to Baseline";
+                case WizardStep.Screw1: return "Move Screw 1";
+                case WizardStep.ReBaseline2: return "Return to Baseline";
+                case WizardStep.Screw2: return "Move Screw 2";
+                case WizardStep.Complete: return "Calibration Complete";
+                default: return string.Empty;
+            }
+        }
+
+        // T11: true while Auto Run All is driving the calibration hands-off. Exposed (INPC) so the step copy
+        // can drop its "click Run Measurement" imperatives — those buttons are hidden during an automated run.
+        public bool IsAutoRunningAll {
+            get => isAutoRunningAll;
+            private set {
+                if (isAutoRunningAll != value) {
+                    isAutoRunningAll = value;
+                    RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(StepInstructions));
+                    RaisePropertyChanged(nameof(StepTitle));
+                }
+            }
+        }
 
         public bool IsCalibrationValid =>
             tiltAdapterOptions.IsCalibrated &&
@@ -783,19 +831,29 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // IsTiltDeviceConnected is false whenever the service is null or not connected).
         public string StepInstructions =>
             (IsTiltDeviceConnected && IsMotorizedDevice)
-                ? DeviceStepInstructionsText(currentStep, (int)Math.Round(CalibrationAppliedAmount))
+                ? DeviceStepInstructionsText(currentStep, (int)Math.Round(CalibrationAppliedAmount), IsAutoRunningAll)
                 : StepInstructionsText(currentStep, tiltAdapterOptions.ScrewCount, IsStepperAdjustment, CalibrationAppliedAmount);
 
         // Automated-status wording for a connected, device-driven run: describes what the wizard will send
         // (Move.Description) rather than what the user must do by hand. Baseline has no move (measurement
-        // only); every other step maps 1:1 via EatWizardMapping.MoveForStep.
-        internal static string DeviceStepInstructionsText(WizardStep step, int appliedSteps) {
+        // only); every other step maps 1:1 via EatWizardMapping.MoveForStep. When <paramref name="autoRunning"/>
+        // (Auto Run All is active) the "click Run Measurement" imperatives are dropped — those buttons are
+        // hidden during an automated run, so telling the user to click them reads as a stalled manual run.
+        internal static string DeviceStepInstructionsText(WizardStep step, int appliedSteps, bool autoRunning) {
             if (step == WizardStep.Baseline) {
-                return "Connected: the wizard will drive the tilt adapter through each calibration step automatically. " +
-                    "Ensure the device is at its starting position (as zeroed in the vendor app), then click Run Measurement " +
-                    "or Auto Run All to begin.";
+                return autoRunning
+                    ? "Running automatically — the wizard is driving the tilt adapter through the calibration. " +
+                        "No action needed; it will apply each move, measure, and advance on its own."
+                    : "Connected: the wizard will drive the tilt adapter through each calibration step automatically. " +
+                        "Ensure the device is at its starting position (as zeroed in the vendor app), then click Run Measurement " +
+                        "or Auto Run All to begin.";
             }
             var move = EatWizardMapping.MoveForStep(step, appliedSteps);
+            if (autoRunning) {
+                return move == null
+                    ? "Running automatically — measuring…"
+                    : $"Running automatically — {move.Description}. The wizard applies this move, measures, and advances without further input.";
+            }
             return move == null
                 ? "Click Run Measurement to continue."
                 : $"Automated: {move.Description}. Click Run Measurement (or Auto Run All) to apply this move and measure.";
@@ -1762,7 +1820,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 return;
             }
 
-            isAutoRunningAll = true;
+            IsAutoRunningAll = true;
             NotifyCommandsCanExecuteChanged();
 
             measureCts?.Dispose();
@@ -1799,7 +1857,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 StatusText = "Auto Run All cancelled; device returned to its original position.";
             } finally {
                 IsMeasuring = false;
-                isAutoRunningAll = false;
+                IsAutoRunningAll = false;
                 NotifyCommandsCanExecuteChanged();
             }
         }
@@ -2354,7 +2412,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             IsWizardRunning = false;
             IsMeasuring = false;
             isReplaying = false;
-            isAutoRunningAll = false;
+            IsAutoRunningAll = false;
             // Abandoning a device-driven run releases the exclusive lease so other automation (a future run,
             // the inspector's Automatic Adjustment) isn't blocked. Deliberately does NOT attempt to drive the
             // device back to baseline — an abandoned run's physical recovery is left to the user (mirrors the
@@ -2763,6 +2821,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             bool replayHasCurvatureSteps = byStep.ContainsKey(WizardStep.AllInward.ToString());
             var replaySteps = GetMeasurementSteps(replayHasCurvatureSteps);
             activeMeasurementSteps = replaySteps;
+            RaisePropertyChanged(nameof(StepProgressDisplay)); // step count (4 vs 6) may differ from the prior run
             foreach (var step in replaySteps) {
                 if (!byStep.ContainsKey(step.ToString())) {
                     Notification.ShowError($"metadata.json has no saved folder for step '{step}'. Cannot replay.");

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -97,6 +97,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // confirmIdleDisconnectAsync). Production default shows the NINA Yes/No message box (default No).
         private readonly Func<string, string, Task<bool>> confirmSimConfigChangeAsync;
         private IReadOnlyList<string> availablePortNames;
+        // Live per-motor device positions for the connection pane (device order TR/TL/BR/BL). During a device-
+        // driven run the service's cp poll is paused (the run holds the operation lease), so these are refreshed
+        // per move from the controller; when idle they mirror the service's polled CurrentPositions.
+        private IReadOnlyList<int> deviceDisplayPositions;
+        // Per-motor positions captured at the start of the current calibration run, for the "Δ since start" display.
+        private int[] calibrationBaselinePositions;
         private string connectedPortName;
 
         // Fix 3: ConnectTiltDeviceAsync defaults MeasureCurvatureDuringCalibration ON, but only once per VM
@@ -1217,7 +1223,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         public bool IsTiltDeviceConnected => tiltDeviceConnectionService?.Connected ?? false;
 
-        public bool TiltDevicePositionsKnown => tiltDeviceConnectionService?.PositionsKnown ?? false;
+        public bool TiltDevicePositionsKnown => (deviceDisplayPositions != null && deviceDisplayPositions.Count >= 4)
+            || (tiltDeviceConnectionService?.PositionsKnown ?? false);
 
         public string TiltDeviceStatusText {
             get {
@@ -1273,11 +1280,54 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public string ScrewPositionBottomLeftDisplay => TiltDevicePositionDisplay(3);
 
         private string TiltDevicePositionDisplay(int deviceMotorIndex) {
-            var svc = tiltDeviceConnectionService;
-            if (svc == null || !svc.PositionsKnown) return "unknown";
-            var positions = svc.CurrentPositions;
+            // Prefer the wizard's per-move snapshot (kept fresh during a run, when the service poll is paused);
+            // fall back to the service's polled positions when idle.
+            IReadOnlyList<int> positions = deviceDisplayPositions;
+            if (positions == null || positions.Count <= deviceMotorIndex) {
+                var svc = tiltDeviceConnectionService;
+                positions = (svc != null && svc.PositionsKnown) ? svc.CurrentPositions : null;
+            }
             if (positions == null || positions.Count <= deviceMotorIndex) return "unknown";
-            return positions[deviceMotorIndex].ToString(CultureInfo.InvariantCulture);
+
+            var pos = positions[deviceMotorIndex];
+            var text = pos.ToString(CultureInfo.InvariantCulture);
+            // Delta from the position captured when this calibration run started.
+            if (calibrationBaselinePositions != null && calibrationBaselinePositions.Length > deviceMotorIndex) {
+                var delta = pos - calibrationBaselinePositions[deviceMotorIndex];
+                text += $"  (Δ {delta.ToString("+0;-0;0", CultureInfo.InvariantCulture)})";
+            }
+            return text;
+        }
+
+        private void RaiseScrewPositionDisplays() {
+            RaisePropertyChanged(nameof(TiltDevicePositionsKnown));
+            RaisePropertyChanged(nameof(ScrewPositionTopRightDisplay));
+            RaisePropertyChanged(nameof(ScrewPositionTopLeftDisplay));
+            RaisePropertyChanged(nameof(ScrewPositionBottomRightDisplay));
+            RaisePropertyChanged(nameof(ScrewPositionBottomLeftDisplay));
+        }
+
+        // Refresh the wizard's live device-position snapshot straight from the controller. Used during a run,
+        // when the connection service's cp poll is paused (the run holds the operation lease). Optionally
+        // (re)captures the "delta since start" baseline. Best-effort: a failed/unknown read leaves the last
+        // snapshot in place so the display simply keeps showing the previous value.
+        private async Task RefreshRunDevicePositionsAsync(ITiltMotionController controller, bool captureBaseline) {
+            if (controller == null) {
+                return;
+            }
+            try {
+                var positions = await controller.QueryPositionsAsync(CancellationToken.None).ConfigureAwait(true);
+                if (positions == null || !positions.Known) {
+                    return;
+                }
+                deviceDisplayPositions = positions.PerMotorSteps.ToArray();
+                if (captureBaseline || calibrationBaselinePositions == null) {
+                    calibrationBaselinePositions = deviceDisplayPositions.ToArray();
+                }
+                RaiseScrewPositionDisplays();
+            } catch (Exception ex) {
+                Logger.Warning($"Failed to read tilt device positions for the wizard display: {ex.Message}");
+            }
         }
 
         private IReadOnlyList<string> EnumeratePortNames() {
@@ -1366,6 +1416,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     // has a stale value to leak into TiltDeviceStatusText.
                     if (!IsTiltDeviceConnected) {
                         connectedPortName = string.Empty;
+                        // A disconnect invalidates the live positions and the delta baseline.
+                        deviceDisplayPositions = null;
+                        calibrationBaselinePositions = null;
+                        RaiseScrewPositionDisplays();
                     }
                     RaisePropertyChanged(nameof(IsTiltDeviceConnected));
                     RaisePropertyChanged(nameof(TiltDeviceStatusText));
@@ -1374,11 +1428,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 }
                 if (e.PropertyName == nameof(TiltDeviceConnectionService.CurrentPositions) ||
                     e.PropertyName == nameof(TiltDeviceConnectionService.PositionsKnown)) {
-                    RaisePropertyChanged(nameof(TiltDevicePositionsKnown));
-                    RaisePropertyChanged(nameof(ScrewPositionTopRightDisplay));
-                    RaisePropertyChanged(nameof(ScrewPositionTopLeftDisplay));
-                    RaisePropertyChanged(nameof(ScrewPositionBottomRightDisplay));
-                    RaisePropertyChanged(nameof(ScrewPositionBottomLeftDisplay));
+                    // Idle poll update (paused during a run — then per-move RefreshRunDevicePositionsAsync drives this).
+                    var svc = tiltDeviceConnectionService;
+                    if (svc != null && svc.PositionsKnown && svc.CurrentPositions?.Count >= 4) {
+                        deviceDisplayPositions = svc.CurrentPositions.ToArray();
+                    }
+                    RaiseScrewPositionDisplays();
                 }
                 if (e.PropertyName == nameof(TiltDeviceConnectionService.IsOperationActive) ||
                     e.PropertyName == nameof(TiltDeviceConnectionService.CurrentOperationName)) {
@@ -1549,10 +1604,16 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
 
             try {
+                if (calibrationBaselinePositions == null) {
+                    // Capture the "delta since start" baseline before this run's first move.
+                    await RefreshRunDevicePositionsAsync(controller, captureBaseline: true).ConfigureAwait(true);
+                }
                 progress.Report(new ApplicationStatus { Status = $"Tilt Adapter Wizard: {move.Description}" });
                 StatusText = move.Description;
                 await controller.ExecuteMoveAsync(move, moveProgress, ct).ConfigureAwait(true);
                 appliedDeviceMovesThisRun.Add(move);
+                // Refresh the live position display + delta after the move (the poll is paused during the run).
+                await RefreshRunDevicePositionsAsync(controller, captureBaseline: false).ConfigureAwait(true);
                 return true;
             } catch (Exception ex) {
                 Logger.Error(ex, $"Tilt adapter device move failed for wizard step {step}.");
@@ -1564,6 +1625,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 MeasurementFailureText = BuildDeviceMoveFailureText(move, ex, deviceMayHaveMoved);
                 HasMeasurementFailureChoice = true;
                 return false;
+            } finally {
+                // Clear the transient bottom-left status. moveProgress leaves the last move step (e.g.
+                // "bf,150 complete") showing, which otherwise lingers in NINA's status bar after the command
+                // finishes; the next step (or its AutoFocus run) reports its own status afresh.
+                progress.Report(new ApplicationStatus { Status = string.Empty });
             }
         }
 
@@ -1603,20 +1669,25 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             if (controller == null || moves.Length == 0) {
                 return;
             }
-            for (int i = moves.Length - 1; i >= 0; i--) {
-                var inverse = EatWizardMapping.InverseMove(moves[i]);
-                if (inverse == null) {
-                    continue;
+            try {
+                for (int i = moves.Length - 1; i >= 0; i--) {
+                    var inverse = EatWizardMapping.InverseMove(moves[i]);
+                    if (inverse == null) {
+                        continue;
+                    }
+                    try {
+                        progress.Report(new ApplicationStatus { Status = $"Tilt Adapter Wizard: recovering — {inverse.Description}" });
+                        await controller.ExecuteMoveAsync(inverse, moveProgress, CancellationToken.None).ConfigureAwait(true);
+                    } catch (Exception ex) {
+                        Logger.Error(ex, "Failed to fully recover tilt adapter device position after an automated-run cancellation/failure.");
+                        MeasurementFailureText = $"Recovery failed while returning the device to its original position: {ex.Message}. Verify screw/motor positions before continuing.";
+                        HasMeasurementFailureChoice = true;
+                        return;
+                    }
                 }
-                try {
-                    progress.Report(new ApplicationStatus { Status = $"Tilt Adapter Wizard: recovering — {inverse.Description}" });
-                    await controller.ExecuteMoveAsync(inverse, moveProgress, CancellationToken.None).ConfigureAwait(true);
-                } catch (Exception ex) {
-                    Logger.Error(ex, "Failed to fully recover tilt adapter device position after an automated-run cancellation/failure.");
-                    MeasurementFailureText = $"Recovery failed while returning the device to its original position: {ex.Message}. Verify screw/motor positions before continuing.";
-                    HasMeasurementFailureChoice = true;
-                    return;
-                }
+            } finally {
+                // Clear the transient "recovering — …" bottom-left status so it doesn't linger after recovery.
+                progress.Report(new ApplicationStatus { Status = string.Empty });
             }
         }
 
@@ -1781,6 +1852,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             currentRunIsDeviceDriven = deviceDriven;
             deviceMoveAppliedForStep = null;
             appliedDeviceMovesThisRun.Clear();
+            // Re-capture the position-delta baseline for this run on the first device move below (the cp poll is
+            // paused for the whole run, so live positions come from the controller per move).
+            calibrationBaselinePositions = null;
 
             StatusText = string.Empty;
             ClearMeasurementFailureChoice();

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -111,7 +111,6 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
         }
 
-        private double calibrationAppliedAmount = 1.0;
         private double measuredHardwareMicrons = double.NaN;
         private TiltCalibrationConfidence lastConfidence;
         private double pitchUncertaintyMicrons = double.NaN;
@@ -320,6 +319,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 RaisePropertyChanged(nameof(AdjustmentType));
                 RaisePropertyChanged(nameof(IsStepperAdjustment));
                 RaisePropertyChanged(nameof(CalibrationAmountLabel));
+                // CalibrationAppliedAmount is now a wrapper over the persisted option (per-profile), so a
+                // profile swap can genuinely change its resolved value — re-raise it here for the same reason
+                // as the other wrapper properties above.
+                RaisePropertyChanged(nameof(CalibrationAppliedAmount));
                 // CalibrationAppliedAmountDisplay (turns/steps units) is intentionally not re-raised in this
                 // list: RaiseHardwareSummaryChanged() below already raises it on every ProfileChanged.
                 RaisePropertyChanged(nameof(ThreadPitchMicronsValue));
@@ -559,7 +562,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         // Per-step guidance for returning to baseline before retrying, shown in the failure panel.
         public string BaselineRecoveryInstructions =>
-            BaselineRecoveryText(currentStep, tiltAdapterOptions.ScrewCount, IsStepperAdjustment, calibrationAppliedAmount);
+            BaselineRecoveryText(currentStep, tiltAdapterOptions.ScrewCount, IsStepperAdjustment, CalibrationAppliedAmount);
 
         public bool HasRebaselineDriftWarning {
             get => hasRebaselineDriftWarning;
@@ -627,7 +630,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         }
 
         public string StepInstructions =>
-            StepInstructionsText(currentStep, tiltAdapterOptions.ScrewCount, IsStepperAdjustment, calibrationAppliedAmount);
+            StepInstructionsText(currentStep, tiltAdapterOptions.ScrewCount, IsStepperAdjustment, CalibrationAppliedAmount);
 
         // Formats the calibration move amount: "1 full turn" / "1.5 turns" for screws, whole "+N"
         // magnitude for steppers (sign is added by the caller's wording).
@@ -749,13 +752,18 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public ICommand ApplyManualCalibrationCommand { get; }
         public ICommand ClearCalibrationCommand { get; }
 
-        // Known amount the user moves each screw during the per-screw calibration steps (full turns
-        // for screws, steps for steppers). Defaults to 1.0 to match the "1 full turn" instructions.
+        // Amount the user moves each screw during the per-screw calibration steps (full turns for
+        // screws, steps for steppers). Persisted per profile via tiltAdapterOptions; -1 (unset) resolves
+        // to the selected device preset's default (TiltAdapterDevicePreset.DefaultCalibrationAmount) so
+        // it still matches the "1 full turn" / "150 steps" instructions before the user ever edits it.
         public double CalibrationAppliedAmount {
-            get => calibrationAppliedAmount;
+            get {
+                var raw = tiltAdapterOptions.CalibrationAppliedAmount;
+                return raw >= 0 ? raw : TiltAdapterDevicePreset.ByName(tiltAdapterOptions.DeviceName).DefaultCalibrationAmount;
+            }
             set {
-                if (calibrationAppliedAmount != value) {
-                    calibrationAppliedAmount = value;
+                if (value != tiltAdapterOptions.CalibrationAppliedAmount) {
+                    tiltAdapterOptions.CalibrationAppliedAmount = value;
                     RaisePropertyChanged();
                     RaisePropertyChanged(nameof(CalibrationAppliedAmountDisplay));
                     // The prompts embed the applied amount, so editing it must refresh them.
@@ -962,7 +970,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public string CalibrationPixelSizeDisplay => calibrationPixelSizeMicrons > 0 ? $"{calibrationPixelSizeMicrons:0.##} µm" : "—";
         public string CalibrationFocuserStepDisplay => calibrationFocuserStepMicrons > 0 ? $"{calibrationFocuserStepMicrons:0.###} µm" : "—";
         public string CalibrationScrewRadiusDisplay => calibrationScrewRadiusMm > 0 ? $"{calibrationScrewRadiusMm:0.##} mm" : "not set";
-        public string CalibrationAppliedAmountDisplay => IsStepperAdjustment ? $"{calibrationAppliedAmount:0.##} steps" : $"{calibrationAppliedAmount:0.##} turns";
+        public string CalibrationAppliedAmountDisplay => IsStepperAdjustment ? $"{CalibrationAppliedAmount:0.##} steps" : $"{CalibrationAppliedAmount:0.##} turns";
 
         public bool HasConfidenceInfo => lastConfidence != null;
 
@@ -1107,7 +1115,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 ScrewRadiusMillimeters = tiltAdapterOptions.ScrewRadiusMillimeters,
                 PixelSizeMicrons = profileService.ActiveProfile.CameraSettings.PixelSize,
                 FocuserStepSizeMicrons = EffectiveFocuserStepMicrons(),
-                CalibrationAppliedAmount = calibrationAppliedAmount,
+                CalibrationAppliedAmount = CalibrationAppliedAmount,
                 MeasurementAverageCount = Math.Max(1, tiltAdapterOptions.MeasurementAverageCount),
                 OptimizedStarDetectionSettings = CaptureDetectionSettings(),
                 MeasurementContext = CaptureMeasurementContext(
@@ -1455,7 +1463,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     tiltAdapterOptions.ScrewRadiusMillimeters,
                     profileService.ActiveProfile.CameraSettings.PixelSize,
                     EffectiveFocuserStepMicrons(),
-                    calibrationAppliedAmount,
+                    CalibrationAppliedAmount,
                     IsStepperAdjustment);
                 RebuildDiagram();
                 FinalizeMetadata();
@@ -1500,6 +1508,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         private void ApplyDevice(string name) {
             var preset = TiltAdapterDevicePreset.ByName(name);
+            // Captured BEFORE the DeviceName assignment below so the CalibrationAppliedAmount reset (further
+            // down) can tell a genuine user-driven device change apart from ApplyDevice's other call site --
+            // the constructor's re-lock-on-load path, which re-asserts the ALREADY-persisted device on every
+            // app start. Without this guard the ctor call would unconditionally overwrite a persisted, possibly
+            // user-edited CalibrationAppliedAmount with the preset default on every launch (this VM is a
+            // [PartCreationPolicy(CreationPolicy.Shared)] singleton, so the ctor runs exactly once per app run).
+            var previousName = tiltAdapterOptions.DeviceName;
             tiltAdapterOptions.DeviceName = preset.Name;
             if (!preset.IsManual) {
                 tiltAdapterOptions.ScrewCount = preset.ScrewCount;
@@ -1507,6 +1522,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 tiltAdapterOptions.ThreadPitchMicrons = preset.ThreadPitchMicrons;
                 tiltAdapterOptions.StepperStepSizeMicrons = preset.StepperStepSizeMicrons;
                 tiltAdapterOptions.ScrewRadiusMillimeters = preset.ScrewRadiusMillimeters;
+            }
+            // Reset the applied amount to the newly selected preset's default (still user-editable
+            // afterward) ONLY when the device actually changed. Applies to Manual too, so switching back to
+            // Manual resets to 1 full turn rather than leaving a leftover stepper value (e.g. 150) on screen --
+            // but re-asserting the SAME already-persisted device (the ctor path) must never clobber a value the
+            // user already customized for that device.
+            if (!string.Equals(preset.Name, previousName, System.StringComparison.Ordinal)) {
+                tiltAdapterOptions.CalibrationAppliedAmount = preset.DefaultCalibrationAmount;
             }
             RaisePropertyChanged(nameof(SelectedDevice));
             RaisePropertyChanged(nameof(IsManualDevice));
@@ -1516,6 +1539,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             RaisePropertyChanged(nameof(ScrewRadiusMillimetersValue));
             RaisePropertyChanged(nameof(IsStepperAdjustment));
             RaisePropertyChanged(nameof(CalibrationAmountLabel));
+            RaisePropertyChanged(nameof(CalibrationAppliedAmount));
             RaisePropertyChanged(nameof(CalibrationAppliedAmountDisplay));
         }
 
@@ -1753,7 +1777,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     radiusMm ?? tiltAdapterOptions.ScrewRadiusMillimeters,
                     pixelSizeMicrons ?? profileService.ActiveProfile.CameraSettings.PixelSize,
                     focuserStepMicrons ?? EffectiveFocuserStepMicrons(),
-                    calibrationAppliedAmount,
+                    CalibrationAppliedAmount,
                     IsStepperAdjustment);
             } finally {
                 calibrationTiltPlaneOverrideForTest = null;
@@ -1930,7 +1954,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 }
 
                 if (mode.UseMetadataGeometry) {
-                    calibrationAppliedAmount = metadata.CalibrationAppliedAmount;
+                    // Written directly (not via the CalibrationAppliedAmount property setter) so the two
+                    // dependent properties below are ALWAYS re-raised, even if the replayed value happens
+                    // to match what's already persisted (the property setter's no-op guard would otherwise
+                    // skip the raise, leaving a stale value on screen if the user has a pending edit).
+                    tiltAdapterOptions.CalibrationAppliedAmount = metadata.CalibrationAppliedAmount;
                     RaisePropertyChanged(nameof(CalibrationAppliedAmount));
                     RaisePropertyChanged(nameof(CalibrationAppliedAmountDisplay));
                     RunCalibrationMath(
@@ -1947,7 +1975,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                         tiltAdapterOptions.ScrewRadiusMillimeters,
                         profileService.ActiveProfile.CameraSettings.PixelSize,
                         EffectiveFocuserStepMicrons(),
-                        calibrationAppliedAmount,
+                        CalibrationAppliedAmount,
                         IsStepperAdjustment);
                 }
                 RebuildDiagram();

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -1442,6 +1442,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     hasDefaultedMeasureCurvatureOnConnect = true;
                     if (!tiltAdapterOptions.MeasureCurvatureDuringCalibration && !userExplicitlyDisabledMeasureCurvatureThisSession) {
                         tiltAdapterOptions.MeasureCurvatureDuringCalibration = true;
+                        // Surface the silent 4→6-step change so the extra "all screws" steps aren't confusing.
+                        Notification.ShowInformation("Enabled direction measurement (6-step calibration) for the connected device — " +
+                            "recommended for hands-off runs. You can turn it off under the measurement settings.");
                     }
                 }
                 RaisePropertyChanged(nameof(TiltDeviceStatusText));
@@ -1816,7 +1819,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     return; // StartAsync already surfaced why (validation failure or device busy).
                 }
             } else if (!currentRunIsDeviceDriven) {
-                Notification.ShowWarning("Restart the wizard (Abort Wizard, then Start) while the tilt adapter device is connected to use Auto Run All.");
+                Notification.ShowWarning("Restart the wizard (Abort Wizard, then Calibrate) while the tilt adapter device is connected to use Auto Run All.");
                 return;
             }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -14,6 +14,7 @@ using CommunityToolkit.Mvvm.Input;
 using NINA.Core.Model;
 using NINA.Core.Utility;
 using NINA.Core.Utility.Notification;
+using NINA.Core.Utility.SerialCommunication;
 using NINA.Core.Utility.WindowService;
 using NINA.Equipment.Equipment;
 using NINA.Equipment.Equipment.MyCamera;
@@ -26,6 +27,8 @@ using NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.StarDetection;
 using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
 using NINA.Profile.Interfaces;
 using NINA.WPF.Base.Interfaces.Mediator;
 using NINA.WPF.Base.ViewModel;
@@ -34,12 +37,14 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel.Composition;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Logger = NINA.Core.Utility.Logger;
+using MyMessageBox = NINA.Core.MyMessageBox.MyMessageBox;
 using RelayCommand = CommunityToolkit.Mvvm.Input.RelayCommand;
 
 namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
@@ -73,6 +78,28 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         private readonly IWindowServiceFactory windowServiceFactory = new WindowServiceFactory();
         private readonly IProgress<ApplicationStatus> progress;
 
+        // Shared motorized-device connection singleton (HocusFocusPlugin.TiltDeviceConnectionService in
+        // production, injected in tests; null-tolerant so device-less test rigs stay valid — the pane's
+        // commands/properties then degrade to "not connected"/disabled).
+        private readonly TiltDeviceConnectionService tiltDeviceConnectionService;
+        // Lazily created: SerialPortProvider's own constructor runs a WMI scan, so the real provider is only
+        // built on first port enumeration (when the pane is actually shown), never during VM construction.
+        private ISerialPortProvider serialPortProvider;
+        // The idle-disconnect confirmation, injectable for tests. Production default shows the NINA
+        // message box (ShowIdleDisconnectPromptAsync); tests inject a fake returning true/false and assert
+        // the right TiltDeviceConnectionService method is called.
+        private readonly Func<Task<bool>> confirmIdleDisconnectAsync;
+        private IReadOnlyList<string> availablePortNames;
+        private string connectedPortName;
+
+        // Fix 3: ConnectTiltDeviceAsync defaults MeasureCurvatureDuringCalibration ON, but only once per VM
+        // lifetime (this is a [PartCreationPolicy(CreationPolicy.Shared)] singleton, so "lifetime" == "session")
+        // and never once the user has explicitly turned it off — otherwise a disconnect -> reconnect cycle
+        // would silently re-force a deliberately disabled option back on. See the options PropertyChanged
+        // handler (ctor) and ConnectTiltDeviceAsync below.
+        private bool hasDefaultedMeasureCurvatureOnConnect;
+        private bool userExplicitlyDisabledMeasureCurvatureThisSession;
+
         private CameraInfo cameraInfo = DeviceInfo.CreateDefaultInstance<CameraInfo>();
         private FocuserInfo focuserInfo = DeviceInfo.CreateDefaultInstance<FocuserInfo>();
 
@@ -91,6 +118,42 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         private string confidenceWarningText = string.Empty;
         private bool hasMeasurementFailureChoice = false;
         private string measurementFailureText = string.Empty;
+        private bool hasDeviceLinkDroppedWarning = false;
+        private string deviceLinkDroppedWarningText = string.Empty;
+
+        // ---- T11: hands-off device-driven calibration state ------------------------------------------------
+        // Captured at StartAsync (and, when it bootstraps a not-yet-running wizard, AutoRunAllAsync) time:
+        // true when the run began connected to a motorized device, so every step's move is sent by the wizard
+        // itself instead of instructing the user. Read at NextStep's Complete transition to decide whether the
+        // device-linked calibration marker (ITiltAdapterOptions.DeviceLinkedCalibrationDeviceName) is set or
+        // cleared -- see RunCalibrationMath.
+        private bool currentRunIsDeviceDriven;
+        // The exclusive T9 operation lease held for the WHOLE duration of a device-driven run: StartAsync
+        // acquires it (refusing to start if the device is busy elsewhere); it is released once the run reaches
+        // Complete (right after the restore move is attempted, successful or not) or the run is abandoned via
+        // Restart. Null for a disconnected/manual run.
+        private IDisposable tiltDeviceOperationToken;
+        // Guards against re-sending a step's device move on a measurement retry: set to the step whose move
+        // has already been applied to the (real) device. A retry after a measurement-only failure (the move
+        // itself succeeded; AutoFocus/sensor-modeling failed) must not re-apply the same move a second time.
+        private WizardStep? deviceMoveAppliedForStep;
+        // Every device move successfully applied during the current device-driven run, in send order -- used
+        // to walk backwards (inverse, reverse order) to return the device to baseline on an Auto Run All
+        // cancellation or a hard failure partway through the sequence.
+        private readonly List<TiltAdapterMove> appliedDeviceMovesThisRun = new List<TiltAdapterMove>();
+        // AutoRunAllCommand re-entrancy guard.
+        private bool isAutoRunningAll;
+        // IProgress<string> adapter over the ApplicationStatus progress reporter, mirroring
+        // InspectorVM.RunAutomaticAdjustmentAsync's moveProgress -- the same status-bar wording convention for
+        // the other automated tilt-device consumer (T14).
+        private readonly IProgress<string> moveProgress;
+        // Test seam: when set, MeasureStep uses this instead of invoking the live inspector for a step's
+        // measurement. The delegate is responsible for seeding stepReadings for the step (via
+        // SeedStepReading) and returns whether the "measurement" succeeded. Lets Auto Run All's full-sequence
+        // orchestration (device move -> measurement -> NextStep, repeated to Complete) be exercised without a
+        // live inspector analysis, mirroring how RunCalibrationForTest bypasses RunCalibrationMath's live
+        // sensor-model input. Always null in production.
+        internal Func<WizardStep, CancellationToken, Task<bool>> MeasurementStepOverrideForTest { get; set; }
 
         // One (A, B, mean) tilt-plane reading plus the per-step field-curvature characterization, keyed by step.
         private readonly Dictionary<WizardStep, StepReading> stepReadings = new Dictionary<WizardStep, StepReading>();
@@ -176,7 +239,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             IFocuserMediator focuserMediator,
             InspectorVM inspector)
             : this(profileService, applicationStatusMediator, cameraMediator, focuserMediator, inspector,
-                   HocusFocusPlugin.ApplicationDispatcher, HocusFocusPlugin.TiltAdapterOptions) { }
+                   HocusFocusPlugin.ApplicationDispatcher, HocusFocusPlugin.TiltAdapterOptions,
+                   HocusFocusPlugin.TiltDeviceConnectionService) { }
 
         public TiltAdapterWizardVM(
             IProfileService profileService,
@@ -185,12 +249,19 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             IFocuserMediator focuserMediator,
             InspectorVM inspector,
             IApplicationDispatcher applicationDispatcher,
-            ITiltAdapterOptions tiltAdapterOptions)
+            ITiltAdapterOptions tiltAdapterOptions,
+            TiltDeviceConnectionService tiltDeviceConnectionService = null,
+            ISerialPortProvider serialPortProvider = null,
+            Func<Task<bool>> confirmIdleDisconnectAsync = null)
             : base(profileService) {
             this.inspector = inspector;
             this.tiltAdapterOptions = tiltAdapterOptions;
             this.applicationDispatcher = applicationDispatcher;
+            this.tiltDeviceConnectionService = tiltDeviceConnectionService;
+            this.serialPortProvider = serialPortProvider; // null => created lazily on first enumeration
+            this.confirmIdleDisconnectAsync = confirmIdleDisconnectAsync ?? ShowIdleDisconnectPromptAsync;
             this.progress = ProgressFactory.Create(applicationStatusMediator, "Tilt Adapter Wizard");
+            this.moveProgress = new Progress<string>(text => this.progress.Report(new ApplicationStatus { Status = $"Tilt Adapter Wizard: {text}" }));
 
             this.Title = "Tilt Adapter Wizard";
 
@@ -215,6 +286,20 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             RetryMeasurementCommand = new AsyncRelayCommand(RunMeasurementAsync, () => HasMeasurementFailureChoice && IsOnMeasurementStep && !IsMeasuring && AreDevicesConnected);
             ApplyManualCalibrationCommand = new RelayCommand(ApplyManualCalibration);
             ClearCalibrationCommand = new RelayCommand(ClearCalibration);
+            RefreshPortsCommand = new RelayCommand(RefreshPorts);
+            ConnectDeviceCommand = new AsyncRelayCommand(ConnectTiltDeviceAsync, () =>
+                IsMotorizedDevice && this.tiltDeviceConnectionService != null && !IsTiltDeviceConnected && !string.IsNullOrEmpty(SelectedPortName));
+            DisconnectDeviceCommand = new AsyncRelayCommand(DisconnectTiltDeviceAsync, () => IsTiltDeviceConnected);
+            AutoRunAllCommand = new AsyncRelayCommand(AutoRunAllAsync, () =>
+                IsMotorizedDevice && this.tiltDeviceConnectionService != null && IsTiltDeviceConnected &&
+                !isAutoRunningAll && !IsMeasuring && HasValidDeviceAppliedAmount());
+
+            // This VM is a Shared MEF singleton, so these ctor-time subscriptions intentionally live for the
+            // whole app run (like every other subscription in this ctor).
+            if (this.tiltDeviceConnectionService != null) {
+                this.tiltDeviceConnectionService.PropertyChanged += TiltDeviceConnectionService_PropertyChanged;
+                this.tiltDeviceConnectionService.IdlePromptRequested += TiltDeviceConnectionService_IdlePromptRequested;
+            }
 
             tiltAdapterOptions.PropertyChanged += (s, e) => OnUIThread(() => {
                 if (e.PropertyName == nameof(ITiltAdapterOptions.ScrewInwardCurvatureSign)) {
@@ -233,6 +318,15 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 }
                 if (e.PropertyName == nameof(ITiltAdapterOptions.MeasureCurvatureDuringCalibration)) {
                     RaisePropertyChanged(nameof(CurvatureSignProvenance));
+                    // Fix 3: the only two writers of this option are the checkbox (XAML binds it directly to
+                    // TiltAdapterOptions.MeasureCurvatureDuringCalibration, a user action) and
+                    // ConnectTiltDeviceAsync's own first-connect default (which only ever sets it to TRUE, never
+                    // false — see below). So a change to FALSE observed here can only be the user explicitly
+                    // unchecking it; remember that for the rest of this VM's lifetime so a later reconnect never
+                    // silently re-forces it back on.
+                    if (!tiltAdapterOptions.MeasureCurvatureDuringCalibration) {
+                        userExplicitlyDisabledMeasureCurvatureThisSession = true;
+                    }
                 }
                 if (e.PropertyName == nameof(ITiltAdapterOptions.CalibrationIsManual)) {
                     RaisePropertyChanged(nameof(IsCalibrationValid));
@@ -249,6 +343,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 if (e.PropertyName == nameof(ITiltAdapterOptions.DeviceName)) {
                     RaisePropertyChanged(nameof(SelectedDevice));
                     RaisePropertyChanged(nameof(IsManualDevice));
+                    RaisePropertyChanged(nameof(IsMotorizedDevice));
+                    NotifyCommandsCanExecuteChangedCore(); // ConnectDeviceCommand gates on IsMotorizedDevice
+                }
+                if (e.PropertyName == nameof(ITiltAdapterOptions.TiltDeviceSerialPortName)) {
+                    RaisePropertyChanged(nameof(SelectedPortName));
+                    NotifyCommandsCanExecuteChangedCore(); // ConnectDeviceCommand gates on a selected port
                 }
                 if (e.PropertyName == nameof(ITiltAdapterOptions.SaveAFRunsPath)) {
                     RaisePropertyChanged(nameof(SaveAFRunsPath));
@@ -300,6 +400,15 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 RaisePropertyChanged(nameof(FocuserStepSizeMicronsValue));
                 RaisePropertyChanged(nameof(SelectedDevice));
                 RaisePropertyChanged(nameof(IsManualDevice));
+                // TiltAdapterOptions' ProfileChanged reload raises one broadcast PropertyChanged (null name)
+                // that the per-name filters above never match, so the device-connection wrappers must be
+                // re-raised here like every other wrapper property (see the comment below). The connection
+                // service force-disconnects on profile change on its own; its Connected INPC refreshes the
+                // connected-state wrappers separately.
+                RaisePropertyChanged(nameof(IsMotorizedDevice));
+                RaisePropertyChanged(nameof(SelectedPortName));
+                RaisePropertyChanged(nameof(TiltDeviceStatusText));
+                NotifyCommandsCanExecuteChangedCore();
                 RaisePropertyChanged(nameof(SaveAFRunsPath));
                 RaisePropertyChanged(nameof(WizardSweepSummary));
                 // TiltAdapterOptions reloads its values from the new profile in its own ProfileChanged handler
@@ -598,6 +707,27 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
         }
 
+        // Fix 2 / [CRITICAL GATE]: set the moment a "Use Saved AF" measurement occurs mid-run during what
+        // started as a device-driven calibration (see MeasureStep) — the run has silently dropped out of
+        // device-driven mode, so DeviceLinkedCalibrationDeviceName will NOT be set at Complete and no further
+        // device moves will be sent. Survives the step advance to Complete (like HasMeasurementConsistencyWarning),
+        // so it is rendered on both the step panel and the Complete panel.
+        public bool HasDeviceLinkDroppedWarning {
+            get => hasDeviceLinkDroppedWarning;
+            private set {
+                hasDeviceLinkDroppedWarning = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public string DeviceLinkDroppedWarningText {
+            get => deviceLinkDroppedWarningText;
+            private set {
+                deviceLinkDroppedWarningText = value;
+                RaisePropertyChanged();
+            }
+        }
+
         // Transient per-run toggle: save each calibration step's AutoFocus sweep so the run can be replayed.
         // Always starts OFF and must be explicitly enabled before each run (not persisted). The folder is
         // persisted (SaveAFRunsPath) so the location is reused.
@@ -629,8 +759,29 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
         }
 
+        // T11 item 6: when a motorized device is connected, the wizard drives the moves itself, so the
+        // instruction becomes automated status (what the wizard is about to send) instead of the manual
+        // "turn screw" wording. Disconnected: EXACTLY the prior expression, unchanged (mandatory regression —
+        // IsTiltDeviceConnected is false whenever the service is null or not connected).
         public string StepInstructions =>
-            StepInstructionsText(currentStep, tiltAdapterOptions.ScrewCount, IsStepperAdjustment, CalibrationAppliedAmount);
+            (IsTiltDeviceConnected && IsMotorizedDevice)
+                ? DeviceStepInstructionsText(currentStep, (int)Math.Round(CalibrationAppliedAmount))
+                : StepInstructionsText(currentStep, tiltAdapterOptions.ScrewCount, IsStepperAdjustment, CalibrationAppliedAmount);
+
+        // Automated-status wording for a connected, device-driven run: describes what the wizard will send
+        // (Move.Description) rather than what the user must do by hand. Baseline has no move (measurement
+        // only); every other step maps 1:1 via EatWizardMapping.MoveForStep.
+        internal static string DeviceStepInstructionsText(WizardStep step, int appliedSteps) {
+            if (step == WizardStep.Baseline) {
+                return "Connected: the wizard will drive the tilt adapter through each calibration step automatically. " +
+                    "Ensure the device is at its starting position (as zeroed in the vendor app), then click Run Measurement " +
+                    "or Auto Run All to begin.";
+            }
+            var move = EatWizardMapping.MoveForStep(step, appliedSteps);
+            return move == null
+                ? "Click Run Measurement to continue."
+                : $"Automated: {move.Description}. Click Run Measurement (or Auto Run All) to apply this move and measure.";
+        }
 
         // Formats the calibration move amount: "1 full turn" / "1.5 turns" for screws, whole "+N"
         // magnitude for steppers (sign is added by the caller's wording).
@@ -751,6 +902,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public ICommand RetryMeasurementCommand { get; }
         public ICommand ApplyManualCalibrationCommand { get; }
         public ICommand ClearCalibrationCommand { get; }
+        public ICommand RefreshPortsCommand { get; }
+        public ICommand ConnectDeviceCommand { get; }
+        public ICommand DisconnectDeviceCommand { get; }
+        public ICommand AutoRunAllCommand { get; }
 
         // Amount the user moves each screw during the per-screw calibration steps (full turns for
         // screws, steps for steppers). Persisted per profile via tiltAdapterOptions; -1 (unset) resolves
@@ -862,6 +1017,15 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             tiltAdapterOptions.IsCalibrated = true;
             tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured = false;
             tiltAdapterOptions.CalibrationIsManual = true;
+            // [CRITICAL GATE] A manual entry's screw numbering/orientation is not guaranteed to match how the
+            // device's motors are wired — clear any device-linked marker so automation (the wizard's
+            // hands-off calibration and the inspector's Automatic Adjustment, T14) stays blocked until a
+            // fresh connected, device-driven calibration re-establishes the correspondence.
+            tiltAdapterOptions.DeviceLinkedCalibrationDeviceName = string.Empty;
+            // [CRITICAL GATE] A manual entry has no confidence computation to reuse (there are no per-step
+            // tilt vectors — the user typed a single angle) — conservative default: not automation-trusted
+            // until a fresh calibration run demonstrably passes its own confidence check.
+            tiltAdapterOptions.CalibrationIsReliable = false;
             // A manual entry supersedes whatever wizard run last measured the hardware — reset to the
             // unset sentinel (-1, what the options initialize to; PitchMismatchExceeds ignores <= 0) so
             // the inspector's pitch-mismatch warning can't compare the new adapter's configured pitch
@@ -1030,6 +1194,449 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         public bool IsManualDevice => TiltAdapterDevicePreset.ByName(tiltAdapterOptions.DeviceName).IsManual;
 
+        // ---- Motorized device connection (T10) --------------------------------------------------------------
+        // Everything below drives the "Motorized Device Connection" GroupBox in Panel A. The pane is only
+        // visible when the selected preset has a registered motion controller (the ASG EAT presets); all
+        // device access flows through the shared TiltDeviceConnectionService singleton. Deliberately NO
+        // zero-positions command anywhere — zeroing the counters is the vendor app's job (user decision #5).
+
+        /// <summary>True when the selected device preset has a registered motion controller (can be connected and automated).</summary>
+        public bool IsMotorizedDevice => TiltMotionControllerRegistry.IsMotorized(tiltAdapterOptions.DeviceName);
+
+        public bool IsTiltDeviceConnected => tiltDeviceConnectionService?.Connected ?? false;
+
+        public bool TiltDevicePositionsKnown => tiltDeviceConnectionService?.PositionsKnown ?? false;
+
+        public string TiltDeviceStatusText {
+            get {
+                var svc = tiltDeviceConnectionService;
+                if (svc == null || !svc.Connected) return "Not connected";
+                string port = string.IsNullOrEmpty(connectedPortName) ? string.Empty : $" on {connectedPortName}";
+                // Surfaces the exclusive-operation name so T11's hands-off calibration (and the inspector's
+                // plan execution) get a live status line for free.
+                return svc.IsOperationActive && !string.IsNullOrEmpty(svc.CurrentOperationName)
+                    ? $"Connected{port} — {svc.CurrentOperationName}"
+                    : $"Connected{port}";
+            }
+        }
+
+        /// <summary>COM ports available for the device connection. Enumerated lazily on first access (the provider's WMI scan only runs when the pane is shown); RefreshPortsCommand re-enumerates.</summary>
+        public IReadOnlyList<string> AvailablePortNames {
+            get {
+                if (availablePortNames == null) {
+                    availablePortNames = EnumeratePortNames();
+                }
+                return availablePortNames;
+            }
+        }
+
+        /// <summary>The selected COM port, persisted per profile (ITiltAdapterOptions.TiltDeviceSerialPortName).</summary>
+        public string SelectedPortName {
+            get => tiltAdapterOptions.TiltDeviceSerialPortName;
+            set {
+                // Fix 4: WPF's Selector coerces ComboBox.SelectedItem — and pushes the coercion back through
+                // this two-way binding — to null/empty whenever the bound value isn't present in the CURRENT
+                // AvailablePortNames (e.g. the persisted port's device is unplugged when the pane loads, or
+                // simply hasn't been enumerated yet). There is no "no selection" item in this ComboBox, so a
+                // null/empty incoming value can only ever be that coercion, never a genuine user choice —
+                // ignore it rather than wiping a remembered, non-empty persisted port.
+                if (string.IsNullOrEmpty(value)) {
+                    return;
+                }
+                if (tiltAdapterOptions.TiltDeviceSerialPortName != value) {
+                    tiltAdapterOptions.TiltDeviceSerialPortName = value;
+                    RaisePropertyChanged();
+                    NotifyCommandsCanExecuteChanged(); // ConnectDeviceCommand gates on a selected port
+                }
+            }
+        }
+
+        // Per-corner position counters in the 2x2 spatial layout of the physical adapter. The service's
+        // CurrentPositions list is in DEVICE motor order: [0]=TR (motor 1), [1]=TL (motor 2), [2]=BR (motor 3),
+        // [3]=BL (motor 4). "unknown" whenever PositionsKnown is false (e.g. the cp response is not parseable
+        // yet) or the index is missing.
+        public string ScrewPositionTopRightDisplay => TiltDevicePositionDisplay(0);
+        public string ScrewPositionTopLeftDisplay => TiltDevicePositionDisplay(1);
+        public string ScrewPositionBottomRightDisplay => TiltDevicePositionDisplay(2);
+        public string ScrewPositionBottomLeftDisplay => TiltDevicePositionDisplay(3);
+
+        private string TiltDevicePositionDisplay(int deviceMotorIndex) {
+            var svc = tiltDeviceConnectionService;
+            if (svc == null || !svc.PositionsKnown) return "unknown";
+            var positions = svc.CurrentPositions;
+            if (positions == null || positions.Count <= deviceMotorIndex) return "unknown";
+            return positions[deviceMotorIndex].ToString(CultureInfo.InvariantCulture);
+        }
+
+        private IReadOnlyList<string> EnumeratePortNames() {
+            try {
+                // Created here (not in the ctor): SerialPortProvider's constructor runs a WMI scan.
+                serialPortProvider ??= new SerialPortProvider();
+                return serialPortProvider.GetPortNames(deviceQuery: null, addDivider: false, addGenericPorts: true);
+            } catch (Exception ex) {
+                Logger.Error(ex, "Failed to enumerate serial ports for the tilt device connection");
+                return Array.Empty<string>();
+            }
+        }
+
+        private void RefreshPorts() {
+            availablePortNames = EnumeratePortNames();
+            RaisePropertyChanged(nameof(AvailablePortNames));
+            // Fix 4: a persisted port not previously enumerated (its device was unplugged) survives in the
+            // options (SelectedPortName's setter guard above never wipes it) but the ComboBox may still be
+            // showing no selection from that earlier mismatch — re-raise so it retries to visually select the
+            // persisted port now that a refresh may have brought it back into AvailablePortNames.
+            RaisePropertyChanged(nameof(SelectedPortName));
+        }
+
+        private async Task ConnectTiltDeviceAsync() {
+            var svc = tiltDeviceConnectionService;
+            var port = SelectedPortName;
+            if (svc == null || string.IsNullOrEmpty(port)) return;
+            try {
+                await svc.ConnectAsync(tiltAdapterOptions.DeviceName, port, CancellationToken.None);
+                connectedPortName = port;
+                // The SelectedPortName setter already persisted the port; re-assert here so a port that
+                // actually connected is always the one saved, whatever path selected it.
+                tiltAdapterOptions.TiltDeviceSerialPortName = port;
+                // T11 item 4: default the 6-step (curvature-measuring) flow ON the moment a device connects,
+                // so a hands-off calibration measures sigma via the real `bf` command by default (the exact
+                // command automation later replays) instead of relying on the assumed/manual direction.
+                // Fix 3: this is a DEFAULT applied at most ONCE per VM lifetime (this VM is a
+                // [PartCreationPolicy(CreationPolicy.Shared)] singleton, so "lifetime" == this session), and
+                // never when the user has explicitly disabled it (before OR after a prior connect) — without
+                // both guards, a disconnect -> reconnect cycle would silently re-force a deliberately disabled
+                // option back on every time (the original bug: this ran on EVERY connect).
+                if (!hasDefaultedMeasureCurvatureOnConnect) {
+                    hasDefaultedMeasureCurvatureOnConnect = true;
+                    if (!tiltAdapterOptions.MeasureCurvatureDuringCalibration && !userExplicitlyDisabledMeasureCurvatureThisSession) {
+                        tiltAdapterOptions.MeasureCurvatureDuringCalibration = true;
+                    }
+                }
+                RaisePropertyChanged(nameof(TiltDeviceStatusText));
+                RaisePropertyChanged(nameof(StepInstructions));
+            } catch (Exception ex) {
+                Logger.Error(ex, $"Failed to connect to the tilt adapter device on {port}");
+                Notification.ShowError($"Failed to connect to the tilt adapter device on {port}: {ex.Message}");
+            }
+        }
+
+        private async Task DisconnectTiltDeviceAsync() {
+            var svc = tiltDeviceConnectionService;
+            if (svc == null) return;
+            try {
+                await svc.DisconnectAsync();
+            } catch (Exception ex) {
+                Logger.Error(ex, "Failed to disconnect the tilt adapter device");
+                Notification.ShowError($"Failed to disconnect the tilt adapter device: {ex.Message}");
+            }
+        }
+
+        private void TiltDeviceConnectionService_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e) {
+            // The service raises INPC from its polling/idle timer threads; marshal without blocking them
+            // (same rationale as the device-info broadcasts, see PostToUIThread).
+            PostToUIThread(() => {
+                if (e.PropertyName == nameof(TiltDeviceConnectionService.Connected)) {
+                    // Fix 4: clear the remembered connected-port display field on EVERY disconnect (user-
+                    // initiated, an idle-timeout forced disconnect, or a connection loss) -- not just the
+                    // explicit Disconnect button -- so a later reconnect (possibly to a different port) never
+                    // has a stale value to leak into TiltDeviceStatusText.
+                    if (!IsTiltDeviceConnected) {
+                        connectedPortName = string.Empty;
+                    }
+                    RaisePropertyChanged(nameof(IsTiltDeviceConnected));
+                    RaisePropertyChanged(nameof(TiltDeviceStatusText));
+                    RaisePropertyChanged(nameof(StepInstructions));
+                    NotifyCommandsCanExecuteChangedCore();
+                }
+                if (e.PropertyName == nameof(TiltDeviceConnectionService.CurrentPositions) ||
+                    e.PropertyName == nameof(TiltDeviceConnectionService.PositionsKnown)) {
+                    RaisePropertyChanged(nameof(TiltDevicePositionsKnown));
+                    RaisePropertyChanged(nameof(ScrewPositionTopRightDisplay));
+                    RaisePropertyChanged(nameof(ScrewPositionTopLeftDisplay));
+                    RaisePropertyChanged(nameof(ScrewPositionBottomRightDisplay));
+                    RaisePropertyChanged(nameof(ScrewPositionBottomLeftDisplay));
+                }
+                if (e.PropertyName == nameof(TiltDeviceConnectionService.IsOperationActive) ||
+                    e.PropertyName == nameof(TiltDeviceConnectionService.CurrentOperationName)) {
+                    RaisePropertyChanged(nameof(TiltDeviceStatusText));
+                }
+            });
+        }
+
+        // Test-observability hook for the fire-and-forget idle-prompt handling (mirrors the service's
+        // LastForcedDisconnectTask): tests await it for deterministic completion.
+        internal Task LastIdlePromptTask { get; private set; }
+
+        private void TiltDeviceConnectionService_IdlePromptRequested(object sender, EventArgs e) {
+            // Fires on the service's timer thread; the modal must be shown from the UI thread. Post (never
+            // block the timer thread) and let the async handler route the answer back to the service.
+            PostToUIThread(() => LastIdlePromptTask = HandleIdlePromptRequestedAsync());
+        }
+
+        private async Task HandleIdlePromptRequestedAsync() {
+            var svc = tiltDeviceConnectionService;
+            if (svc == null) return;
+            bool disconnect;
+            try {
+                disconnect = await confirmIdleDisconnectAsync();
+            } catch (Exception ex) {
+                // Treat a failed prompt as "keep connected" but still resolve it, so the service re-arms
+                // rather than suppressing every future idle prompt behind a permanently-outstanding one.
+                Logger.Error(ex, "Tilt device idle-disconnect prompt failed; keeping the device connected");
+                svc.KeepConnectedResetIdle();
+                return;
+            }
+            try {
+                if (disconnect) {
+                    await svc.ConfirmIdleDisconnectAsync();
+                } else {
+                    svc.KeepConnectedResetIdle();
+                }
+            } catch (Exception ex) {
+                Logger.Error(ex, "Tilt device idle disconnect failed");
+            }
+        }
+
+        // Production idle prompt: NINA's message box (it marshals onto the application dispatcher itself,
+        // and the caller is already posted to the UI thread). Default answer is No — never disconnect the
+        // hardware because a dialog was dismissed.
+        private Task<bool> ShowIdleDisconnectPromptAsync() {
+            var result = MyMessageBox.Show(
+                "The tilt adapter device has been connected but idle for 30 minutes. Disconnect it?",
+                "Tilt Adapter Device Idle",
+                System.Windows.MessageBoxButton.YesNo,
+                System.Windows.MessageBoxResult.No);
+            return Task.FromResult(result == System.Windows.MessageBoxResult.Yes);
+        }
+
+        // ---- End motorized device connection ----------------------------------------------------------------
+
+        // ---- T11: hands-off device-driven calibration --------------------------------------------------------
+
+        /// <summary>
+        /// Sends the device move that realizes <paramref name="step"/>'s instruction (see
+        /// <see cref="EatWizardMapping.MoveForStep"/>) and awaits its completion. No-op (returns true
+        /// immediately) for <see cref="WizardStep.Baseline"/>, which is measurement-only — no move. On
+        /// failure or cancellation, surfaces the error through the existing measurement-failure panel
+        /// (<see cref="HasMeasurementFailureChoice"/> / <see cref="MeasurementFailureText"/>) and returns
+        /// false; callers must not proceed to a measurement for this step when this returns false.
+        ///
+        /// Recovery (sending <see cref="EatWizardMapping.InverseMove"/>) is attempted only when the device
+        /// may actually have moved: per <c>EatTiltMotionController.ExecuteMoveAsync</c>'s documented
+        /// exception taxonomy, a <c>TiltDeviceLimitException</c> or an <see cref="OperationCanceledException"/>
+        /// both mean NOTHING was sent (every soft-limit check and the single cancellation boundary run
+        /// strictly before any device I/O) — inverting in that case would send a spurious, physically real
+        /// move for a step that never happened. Any other exception (a command-failed/ambiguous-ack timeout,
+        /// or the serial port closing) means a command WAS sent and its outcome is ambiguous ("state-dirty"),
+        /// so a best-effort inverse is worth attempting. This mirrors the same taxonomy
+        /// InspectorVM's Automatic Adjustment (T14) journal-revert path already relies on.
+        /// </summary>
+        internal async Task<bool> ExecuteDeviceMoveForCurrentStepAsync(WizardStep step, CancellationToken ct) {
+            if (step == WizardStep.Baseline) {
+                return true;
+            }
+            var controller = tiltDeviceConnectionService?.Controller;
+            if (controller == null) {
+                StatusText = string.Empty;
+                MeasurementFailureText = "The tilt adapter device is not connected. Reconnect it before continuing this automated calibration.";
+                HasMeasurementFailureChoice = true;
+                return false;
+            }
+
+            int appliedSteps = (int)Math.Round(CalibrationAppliedAmount);
+            var move = EatWizardMapping.MoveForStep(step, appliedSteps);
+            if (move == null) {
+                return true; // Unreachable for a non-Baseline step today, but guard defensively.
+            }
+
+            try {
+                progress.Report(new ApplicationStatus { Status = $"Tilt Adapter Wizard: {move.Description}" });
+                StatusText = move.Description;
+                await controller.ExecuteMoveAsync(move, moveProgress, ct).ConfigureAwait(true);
+                appliedDeviceMovesThisRun.Add(move);
+                return true;
+            } catch (Exception ex) {
+                Logger.Error(ex, $"Tilt adapter device move failed for wizard step {step}.");
+                bool deviceMayHaveMoved = !(ex is TiltDeviceLimitException) && !(ex is OperationCanceledException);
+                if (deviceMayHaveMoved) {
+                    await TryRecoverFailedMoveAsync(controller, move).ConfigureAwait(true);
+                }
+                StatusText = string.Empty;
+                MeasurementFailureText = BuildDeviceMoveFailureText(move, ex, deviceMayHaveMoved);
+                HasMeasurementFailureChoice = true;
+                return false;
+            }
+        }
+
+        // Best-effort single-move recovery after a move that may have reached the device: sends the inverse
+        // of the move that just failed so the device returns to its position before this step. Always uses
+        // CancellationToken.None — a recovery attempt must never itself be skipped due to cancellation.
+        private async Task TryRecoverFailedMoveAsync(ITiltMotionController controller, TiltAdapterMove move) {
+            var inverse = EatWizardMapping.InverseMove(move);
+            if (inverse == null) {
+                return;
+            }
+            try {
+                await controller.ExecuteMoveAsync(inverse, moveProgress, CancellationToken.None).ConfigureAwait(true);
+            } catch (Exception ex) {
+                Logger.Error(ex, "Failed to recover tilt adapter device position after a failed move; the device may not be at its expected position.");
+            }
+        }
+
+        private static string BuildDeviceMoveFailureText(TiltAdapterMove move, Exception ex, bool recoveryAttempted) {
+            string reason = ex is OperationCanceledException ? "was cancelled before it was sent"
+                : ex is TiltDeviceLimitException ? $"was refused: {ex.Message}"
+                : $"failed: {ex.Message}";
+            string recovery = recoveryAttempted
+                ? " The device was sent the inverse move to return it to its position before this step; verify positions before continuing."
+                : " Nothing was sent to the device for this step.";
+            return $"Automated device move ({move.Description}) {reason}.{recovery}";
+        }
+
+        // Auto Run All cancellation/failure recovery: walks every device move successfully applied during the
+        // current run, in reverse, sending each one's inverse — returning the device to baseline. Best-effort;
+        // stops and surfaces a warning if a recovery move itself fails (device position becomes uncertain).
+        private async Task RecoverAppliedMovesAsync() {
+            var controller = tiltDeviceConnectionService?.Controller;
+            var moves = appliedDeviceMovesThisRun.ToArray();
+            appliedDeviceMovesThisRun.Clear();
+            deviceMoveAppliedForStep = null;
+            if (controller == null || moves.Length == 0) {
+                return;
+            }
+            for (int i = moves.Length - 1; i >= 0; i--) {
+                var inverse = EatWizardMapping.InverseMove(moves[i]);
+                if (inverse == null) {
+                    continue;
+                }
+                try {
+                    progress.Report(new ApplicationStatus { Status = $"Tilt Adapter Wizard: recovering — {inverse.Description}" });
+                    await controller.ExecuteMoveAsync(inverse, moveProgress, CancellationToken.None).ConfigureAwait(true);
+                } catch (Exception ex) {
+                    Logger.Error(ex, "Failed to fully recover tilt adapter device position after an automated-run cancellation/failure.");
+                    MeasurementFailureText = $"Recovery failed while returning the device to its original position: {ex.Message}. Verify screw/motor positions before continuing.";
+                    HasMeasurementFailureChoice = true;
+                    return;
+                }
+            }
+        }
+
+        private void ReleaseTiltDeviceOperationToken() {
+            var t = tiltDeviceOperationToken;
+            tiltDeviceOperationToken = null;
+            t?.Dispose();
+        }
+
+        // Whether the currently configured CalibrationAppliedAmount is safe to send to a connected motorized
+        // device: positive, and within both the per-command and cumulative-excursion safety caps (T8
+        // options). Used for AutoRunAllCommand's canExecute (fast/sync, no side effects).
+        private bool HasValidDeviceAppliedAmount() => TryValidateDeviceAppliedAmount(out _);
+
+        // Same check as HasValidDeviceAppliedAmount, with a human-readable reason for Notification.ShowError
+        // — called before StartAsync/AutoRunAllAsync actually proceeds with a device-driven run (T11 item 4).
+        private bool TryValidateDeviceAppliedAmount(out string error) {
+            int appliedSteps = (int)Math.Round(CalibrationAppliedAmount);
+            if (appliedSteps <= 0) {
+                error = "The applied amount per calibration step must be greater than zero to run a hands-off calibration.";
+                return false;
+            }
+            int maxSteps = tiltAdapterOptions.TiltDeviceMaxStepsPerCommand;
+            if (maxSteps > 0 && appliedSteps > maxSteps) {
+                error = $"The applied amount ({appliedSteps} steps) exceeds the configured maximum steps per command ({maxSteps}). Reduce the applied amount or increase the limit before running a hands-off calibration.";
+                return false;
+            }
+            int maxExcursion = tiltAdapterOptions.TiltDeviceMaxExcursionSteps;
+            if (maxExcursion > 0 && appliedSteps > maxExcursion) {
+                error = $"The applied amount ({appliedSteps} steps) exceeds the configured maximum excursion ({maxExcursion} steps). Reduce the applied amount or increase the limit before running a hands-off calibration.";
+                return false;
+            }
+            error = null;
+            return true;
+        }
+
+        /// <summary>
+        /// Drives every remaining calibration step from <see cref="CurrentStep"/> through
+        /// <see cref="WizardStep.Complete"/> automatically: device move, live measurement, advance — repeated
+        /// without further clicks — finishing with Complete's restore move (returns the device to baseline;
+        /// handled by <see cref="MeasureStep"/>, which this reuses for every step so the manual "Run
+        /// Measurement" flow and this loop share one code path). If the wizard is not yet running, starts it
+        /// first (mirrors clicking Start, including the applied-amount validation and exclusive
+        /// operation-token acquisition in <see cref="StartAsync"/>).
+        ///
+        /// Cancelling (the existing <see cref="CancelCommand"/> / measureCts) lets the CURRENT move/measurement
+        /// finish — the device has no abort command — then recovers toward baseline by sending the inverse of
+        /// every move applied so far, in reverse order (<see cref="RecoverAppliedMovesAsync"/>), and stops. A
+        /// hard failure partway through (a move or a measurement failing) is recovered the same way, UNLESS
+        /// the failure was Complete's own restore move — by then the calibration has already succeeded (and
+        /// the device-linked marker is already set), and ExecuteDeviceMoveForCurrentStepAsync already
+        /// attempted its own single-move recovery; layering a second whole-run rollback on top of that would
+        /// risk compounding an already-ambiguous device state.
+        /// </summary>
+        private async Task AutoRunAllAsync() {
+            if (!IsMotorizedDevice || !IsTiltDeviceConnected) {
+                Notification.ShowWarning("Connect the tilt adapter device before running the automated calibration.");
+                return;
+            }
+            if (!TryValidateDeviceAppliedAmount(out var validationError)) {
+                Notification.ShowError(validationError);
+                return;
+            }
+
+            if (!IsWizardRunning) {
+                await StartAsync();
+                if (!IsWizardRunning) {
+                    return; // StartAsync already surfaced why (validation failure or device busy).
+                }
+            } else if (!currentRunIsDeviceDriven) {
+                Notification.ShowWarning("Restart the wizard (Abort Wizard, then Start) while the tilt adapter device is connected to use Auto Run All.");
+                return;
+            }
+
+            isAutoRunningAll = true;
+            NotifyCommandsCanExecuteChanged();
+
+            measureCts?.Dispose();
+            measureCts = new CancellationTokenSource();
+            var token = measureCts.Token;
+            IsMeasuring = true;
+            try {
+                while (CurrentStep != WizardStep.Complete) {
+                    if (token.IsCancellationRequested) {
+                        await RecoverAppliedMovesAsync();
+                        ReleaseTiltDeviceOperationToken();
+                        StatusText = "Auto Run All cancelled; device returned to its original position.";
+                        return;
+                    }
+                    var stepBefore = CurrentStep;
+                    await MeasureStep(stepBefore, token, fromSaved: false);
+                    if (HasMeasurementFailureChoice) {
+                        if (CurrentStep != WizardStep.Complete) {
+                            // A move or measurement failed before the run finished — undo everything applied so far.
+                            await RecoverAppliedMovesAsync();
+                        }
+                        ReleaseTiltDeviceOperationToken();
+                        return;
+                    }
+                    if (CurrentStep == stepBefore) {
+                        // Defensive: NextStep() did not advance (unreachable when HasMeasurementFailureChoice
+                        // is false); never spin forever.
+                        break;
+                    }
+                }
+            } catch (OperationCanceledException) {
+                await RecoverAppliedMovesAsync();
+                ReleaseTiltDeviceOperationToken();
+                StatusText = "Auto Run All cancelled; device returned to its original position.";
+            } finally {
+                IsMeasuring = false;
+                isAutoRunningAll = false;
+                NotifyCommandsCanExecuteChanged();
+            }
+        }
+
+        // ---- End T11: hands-off device-driven calibration ------------------------------------------------
+
         // Inputs that feed the screw-turn calculation, wired to their source of truth: pixel size to
         // the active NINA camera profile, focuser step size to the Inspector's MicronsPerFocuserStep.
         public double PixelSizeMicronsValue {
@@ -1056,6 +1663,27 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         }
 
         private Task StartAsync() {
+            // T11 item 4/5: a connected, motorized run drives its own moves and must hold the exclusive T9
+            // operation lease for the whole run — acquire (or refuse) it BEFORE touching any other state, so
+            // a validation/busy failure leaves everything exactly as it was (no partial reset).
+            bool deviceDriven = IsTiltDeviceConnected && IsMotorizedDevice;
+            if (deviceDriven) {
+                if (!TryValidateDeviceAppliedAmount(out var validationError)) {
+                    Notification.ShowError(validationError);
+                    return Task.CompletedTask;
+                }
+                var opToken = tiltDeviceConnectionService.TryBeginOperation("Tilt Adapter Wizard Calibration");
+                if (opToken == null) {
+                    Notification.ShowError("The tilt adapter device is busy with another operation.");
+                    return Task.CompletedTask;
+                }
+                ReleaseTiltDeviceOperationToken(); // defensive; should already be null at this point
+                tiltDeviceOperationToken = opToken;
+            }
+            currentRunIsDeviceDriven = deviceDriven;
+            deviceMoveAppliedForStep = null;
+            appliedDeviceMovesThisRun.Clear();
+
             StatusText = string.Empty;
             ClearMeasurementFailureChoice();
             stepReadings.Clear();
@@ -1067,6 +1695,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             ConfidenceWarningText = string.Empty;
             HasWarning = false;
             WarningText = string.Empty;
+            HasDeviceLinkDroppedWarning = false;
+            DeviceLinkDroppedWarningText = string.Empty;
             ClearSummaryRows();
             runRootFolder = null;
             metadataPath = null;
@@ -1221,8 +1851,51 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             if (step == WizardStep.Baseline) {
                 ClearSummaryRows();
             }
-            var reading = await RunAveragedMeasurement(token, step, StepDescription(step), fromSaved);
-            if (reading == null) {
+
+            // Fix 2 / [CRITICAL GATE]: a "Use Saved AF" measurement (fromSaved) never drives the device — if
+            // this happens during a run that started device-driven, THIS step's real move (which the
+            // wizard-screw <-> device-corner correspondence depends on having actually happened) was skipped,
+            // so the run is no longer purely device-driven. Err safe the instant it happens: drop out of
+            // device-driven mode so (a) RunCalibrationMath — which reads currentRunIsDeviceDriven fresh at
+            // Complete — CLEARS DeviceLinkedCalibrationDeviceName instead of wrongly setting it, and (b) no
+            // further device moves — including Complete's restore move, which would otherwise "restore" a
+            // forward move that, for this step, never actually happened — are sent for the rest of this run.
+            // Release the exclusive operation lease too: this run will never touch the device again, so
+            // holding it would needlessly block other automation (a future run, the inspector's Automatic
+            // Adjustment) until Restart.
+            if (fromSaved && currentRunIsDeviceDriven) {
+                currentRunIsDeviceDriven = false;
+                ReleaseTiltDeviceOperationToken();
+                HasDeviceLinkDroppedWarning = true;
+                DeviceLinkDroppedWarningText =
+                    $"This run is no longer device-linked: \"Use Saved AF\" skipped the device move for step '{step}'. " +
+                    "The remaining steps will not move the device, and this calibration will not be marked as device-linked when it completes.";
+            }
+
+            // T11: a connected, motorized run drives this step's move itself, BEFORE the measurement. Never
+            // for a "Use Saved AF" re-analysis (fromSaved) — that re-analyzes already-captured frames; the
+            // physical device must not be moved again for it. deviceMoveAppliedForStep guards a measurement
+            // RETRY (the move already succeeded; only AutoFocus/sensor-modeling failed) from re-sending the
+            // same move a second time.
+            if (currentRunIsDeviceDriven && !fromSaved && deviceMoveAppliedForStep != step) {
+                bool moved = await ExecuteDeviceMoveForCurrentStepAsync(step, token);
+                if (!moved) {
+                    StatusText = string.Empty;
+                    return; // Failure text/HasMeasurementFailureChoice already set by ExecuteDeviceMoveForCurrentStepAsync.
+                }
+                deviceMoveAppliedForStep = step;
+            }
+
+            bool ok;
+            StepReading? reading;
+            if (MeasurementStepOverrideForTest != null) {
+                ok = await MeasurementStepOverrideForTest(step, token);
+                reading = ok ? Reading(step) : (StepReading?)null;
+            } else {
+                reading = await RunAveragedMeasurement(token, step, StepDescription(step), fromSaved);
+                ok = reading != null;
+            }
+            if (!ok || reading == null) {
                 // Show the inline failure panel (below) instead of the bare "Measurement failed." status — that left the
                 // screw-adjustment instruction on screen (reads as "re-adjust the screw") and duplicated the panel text
                 // right above the panel. Clear StatusText so the visible post-measurement status line doesn't leak the
@@ -1236,6 +1909,20 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             stepReadings[step] = reading.Value;
             RecordStepIntoMetadata(step, reading.Value);
             NextStep();
+
+            // T11: Complete's restore move (EatWizardMapping.MoveForStep(Complete, N) = DiagonalB(-N)) returns
+            // the device to baseline — sent automatically for ANY device-driven run, whether stepped manually
+            // (repeated "Run Measurement" clicks) or via AutoRunAllAsync's loop (which just calls this method
+            // repeatedly). The operation lease is released here, AFTER the restore move is attempted, so it
+            // still protects that final move — NOT in NextStep(), which runs synchronously and cannot await it.
+            if (CurrentStep == WizardStep.Complete && currentRunIsDeviceDriven) {
+                bool restored = await ExecuteDeviceMoveForCurrentStepAsync(WizardStep.Complete, CancellationToken.None);
+                ReleaseTiltDeviceOperationToken();
+                if (!restored) {
+                    return; // Failure text/HasMeasurementFailureChoice already set; calibration itself already succeeded.
+                }
+                StatusText = "Automated calibration complete; device returned to its original position.";
+            }
         }
 
         // Description shown on each summary row, reflecting the single move performed for the step.
@@ -1262,6 +1949,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // hardware-recovery path is exercisable without running the paraboloid fit. Always null in production, so
         // CalibrationTiltPlane below is byte-for-byte the live inspector chain.
         private TiltPlaneModel calibrationTiltPlaneOverrideForTest;
+
+        // Test seam: same override as above, settable directly (not just via RunCalibrationForTest's local
+        // try/finally) so ReplayAsync's per-step loop — which reads CalibrationTiltPlane directly, without a
+        // live inspector analysis — can be exercised under test too. Always null in production.
+        internal TiltPlaneModel CalibrationTiltPlaneOverrideForTest {
+            get => calibrationTiltPlaneOverrideForTest;
+            set => calibrationTiltPlaneOverrideForTest = value;
+        }
 
         // The wizard calibrates from the per-star sensor-curve model's tilt (the paraboloid Gx/Gy, expressed as a
         // TiltPlaneModel by SensorModelAberrationResult.CreateTiltPlaneModel) — NEVER the 4-corner region plane. The
@@ -1464,9 +2159,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     profileService.ActiveProfile.CameraSettings.PixelSize,
                     EffectiveFocuserStepMicrons(),
                     CalibrationAppliedAmount,
-                    IsStepperAdjustment);
+                    IsStepperAdjustment,
+                    deviceDriven: currentRunIsDeviceDriven);
                 RebuildDiagram();
                 FinalizeMetadata();
+                // NOTE: the device operation token (if any) is released by MeasureStep's caller AFTER the
+                // Complete restore move is attempted -- NOT here -- so the lease still protects that final
+                // move (NextStep runs synchronously and cannot await it).
             }
 
             // The measurement-consistency warning is intentionally NOT cleared here: it is set at the end of a
@@ -1483,6 +2182,16 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             IsWizardRunning = false;
             IsMeasuring = false;
             isReplaying = false;
+            isAutoRunningAll = false;
+            // Abandoning a device-driven run releases the exclusive lease so other automation (a future run,
+            // the inspector's Automatic Adjustment) isn't blocked. Deliberately does NOT attempt to drive the
+            // device back to baseline — an abandoned run's physical recovery is left to the user (mirrors the
+            // existing disconnected-run philosophy of BaselineRecoveryInstructions); only a controlled
+            // Auto Run All cancellation/failure attempts an automatic device recovery (RecoverAppliedMovesAsync).
+            ReleaseTiltDeviceOperationToken();
+            currentRunIsDeviceDriven = false;
+            deviceMoveAppliedForStep = null;
+            appliedDeviceMovesThisRun.Clear();
             SaveAFRuns = false; // saving must be re-enabled explicitly for each run
             stepReadings.Clear();
             measuredHardwareMicrons = double.NaN;
@@ -1501,6 +2210,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             RebaselineDriftWarningText = string.Empty;
             HasWarning = false;
             WarningText = string.Empty;
+            HasDeviceLinkDroppedWarning = false;
+            DeviceLinkDroppedWarningText = string.Empty;
             StatusText = string.Empty;
             ClearMeasurementFailureChoice();
             CurrentStep = WizardStep.Baseline;
@@ -1533,6 +2244,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
             RaisePropertyChanged(nameof(SelectedDevice));
             RaisePropertyChanged(nameof(IsManualDevice));
+            RaisePropertyChanged(nameof(IsMotorizedDevice));
             RaisePropertyChanged(nameof(AdjustmentType));
             RaisePropertyChanged(nameof(ThreadPitchMicronsValue));
             RaisePropertyChanged(nameof(StepperStepSizeMicronsValue));
@@ -1541,6 +2253,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             RaisePropertyChanged(nameof(CalibrationAmountLabel));
             RaisePropertyChanged(nameof(CalibrationAppliedAmount));
             RaisePropertyChanged(nameof(CalibrationAppliedAmountDisplay));
+            RaisePropertyChanged(nameof(StepInstructions));
+            // ApplyDevice only runs on the UI thread (SelectedDevice setter) or during construction, so the
+            // commands are notified without marshaling (a Dispatch here would break the "device broadcasts
+            // never block on the UI thread" accounting the F15 tests pin).
+            NotifyCommandsCanExecuteChangedCore(); // ConnectDeviceCommand gates on IsMotorizedDevice
         }
 
         private void UseMeasuredHardware() {
@@ -1566,8 +2283,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         // Runs the full calibration math from the six step readings and writes the results to the options. Shared
         // by a live run (geometry from the current options/profile) and a replay (geometry from the metadata).
+        // deviceDriven: true only for a completed CONNECTED, device-driven (hands-off) run — the wizard sent
+        // every step's move itself, so the wizard-screw <-> device-corner correspondence (EatWizardMapping) is
+        // known to be correct. False for a disconnected/manual-clicking run, a replay, or the RunCalibrationForTest
+        // seed path (its default) — see the [CRITICAL GATE] note on ITiltAdapterOptions.DeviceLinkedCalibrationDeviceName.
         private void RunCalibrationMath(int screwCount, double radiusMm, double pixelSize, double fStep,
-            double appliedAmount, bool isStepper) {
+            double appliedAmount, bool isStepper, bool deviceDriven) {
             bool measuredCurvature = stepReadings.ContainsKey(WizardStep.AllInward);
             var a = Reading(WizardStep.Baseline);
             var b = Reading(WizardStep.AllInward);
@@ -1598,6 +2319,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             tiltAdapterOptions.CalibratedScrewCount = screwCount;
             tiltAdapterOptions.IsCalibrated = true;
             tiltAdapterOptions.CalibrationIsManual = false;
+            // [CRITICAL GATE] Set ONLY on a successful, connected, device-driven run's completion; cleared for
+            // every other completion (disconnected live run, replay). A stale marker would let automation
+            // (T14's Automatic Adjustment / a future wizard auto-apply) apply corrections against a
+            // wizard-screw <-> device-corner correspondence that was never actually established by this
+            // calibration — err toward clearing whenever the run wasn't a fresh connected hands-off run.
+            tiltAdapterOptions.DeviceLinkedCalibrationDeviceName = deviceDriven ? tiltAdapterOptions.DeviceName : string.Empty;
 
             lastRawAngleDiff = rawDiff;
             lastMoveMagnitudeRatio = TiltCalibrationCalculator.MoveMagnitudeRatio(d1A, d1B, d2A, d2B);
@@ -1658,6 +2385,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 FallbackCurvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign
             });
             EvaluateCalibrationConfidence(lastConfidence);
+            // [CRITICAL GATE] Persist the confidence result as the automation-trust marker — the second half
+            // of the automation gate alongside DeviceLinkedCalibrationDeviceName above. Unlike that marker,
+            // this one is NOT conditioned on deviceDriven: a disconnected/manual-clicking live run and a
+            // replay both recompute this exact confidence from their own step readings, so their reliability
+            // is just as real (and just as gating) as a device-driven run's. Reused, never invented: this is
+            // the same lastConfidence.IsReliable the wizard already surfaces as the (previously non-blocking)
+            // HasConfidenceWarning banner above.
+            tiltAdapterOptions.CalibrationIsReliable = lastConfidence?.IsReliable ?? false;
             RaiseHardwareSummaryChanged();
         }
 
@@ -1769,7 +2504,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // branch can run under test.
         internal void RunCalibrationForTest(
             double? radiusMm = null, double? pixelSizeMicrons = null, double? focuserStepMicrons = null,
-            TiltPlaneModel tiltPlaneOverride = null) {
+            TiltPlaneModel tiltPlaneOverride = null, bool deviceDriven = false) {
             calibrationTiltPlaneOverrideForTest = tiltPlaneOverride;
             try {
                 RunCalibrationMath(
@@ -1778,7 +2513,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     pixelSizeMicrons ?? profileService.ActiveProfile.CameraSettings.PixelSize,
                     focuserStepMicrons ?? EffectiveFocuserStepMicrons(),
                     CalibrationAppliedAmount,
-                    IsStepperAdjustment);
+                    IsStepperAdjustment,
+                    deviceDriven);
             } finally {
                 calibrationTiltPlaneOverrideForTest = null;
             }
@@ -1794,16 +2530,39 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         //   (profile untouched) + the run's stored geometry — reproduces the original calibration exactly.
         // - Update profile to capture-time: persist the run's star-detection settings to the live profile, then replay
         //   against it + the run's stored geometry.
+        // Test seam: when set, ReplayAsync uses this instead of opening a real (modal, WinForms)
+        // FolderBrowserDialog. Called with the current SaveAFRunsPath (the dialog's initial selection in
+        // production); returns the folder to replay, or null/empty to simulate the dialog being cancelled.
+        // Always null in production.
+        internal Func<string, string> SelectReplayFolderForTest { get; set; }
+
+        // Test seam: when set, ReplayAsync uses this instead of showing the real (WPF-window) shared
+        // replay-settings modal (ReplaySettingsPrompt.ShowAsync). Always null in production.
+        internal Func<AutoFocusReplayMetadata, Task<ReplaySettingsChoice>> SelectReplaySettingsForTest { get; set; }
+
+        // Test seam: mirrors MeasurementStepOverrideForTest for the live wizard flow — when set, ReplayAsync
+        // uses this instead of invoking the live inspector's AnalyzeAutoFocusFromSavedPath for each step (the
+        // reading itself still comes from CalibrationTiltPlane, i.e. CalibrationTiltPlaneOverrideForTest
+        // above). Always null in production.
+        internal Func<WizardStep, CancellationToken, Task<bool>> ReplayStepOverrideForTest { get; set; }
+
         private async Task ReplayAsync() {
             string folder;
-            using (var dialog = new System.Windows.Forms.FolderBrowserDialog()) {
-                if (!string.IsNullOrEmpty(SaveAFRunsPath)) {
-                    dialog.SelectedPath = SaveAFRunsPath;
-                }
-                if (dialog.ShowDialog() != System.Windows.Forms.DialogResult.OK) {
+            if (SelectReplayFolderForTest != null) {
+                folder = SelectReplayFolderForTest(SaveAFRunsPath);
+                if (string.IsNullOrEmpty(folder)) {
                     return;
                 }
-                folder = dialog.SelectedPath;
+            } else {
+                using (var dialog = new System.Windows.Forms.FolderBrowserDialog()) {
+                    if (!string.IsNullOrEmpty(SaveAFRunsPath)) {
+                        dialog.SelectedPath = SaveAFRunsPath;
+                    }
+                    if (dialog.ShowDialog() != System.Windows.Forms.DialogResult.OK) {
+                        return;
+                    }
+                    folder = dialog.SelectedPath;
+                }
             }
 
             var metadataFile = Path.Combine(folder, "metadata.json");
@@ -1843,7 +2602,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // representative per-step AutoFocus replay snapshot). Cancelling / closing the modal aborts.
             var representativeStepFolder = byStep[replaySteps.First().ToString()];
             AutoFocusReplayMetadata.TryLoad(representativeStepFolder, out var replayMetadata, out _);
-            var choice = await ReplaySettingsPrompt.ShowAsync(windowServiceFactory, replayMetadata, ReplaySettingsPromptTexts.TiltCalibration);
+            var choice = SelectReplaySettingsForTest != null
+                ? await SelectReplaySettingsForTest(replayMetadata)
+                : await ReplaySettingsPrompt.ShowAsync(windowServiceFactory, replayMetadata, ReplaySettingsPromptTexts.TiltCalibration);
             if (choice == ReplaySettingsChoice.Cancel) {
                 return;
             }
@@ -1916,13 +2677,17 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                         ? BuildTiltReplayDetectionOverride(byStep[step.ToString()], metadata)
                         : null;
                     bool ok;
-                    // Force the per-star sensor-curve model so replay derives tilt from the paraboloid, like a live run.
-                    var prevForce = inspector.ForceSensorCurveModelGeneration;
-                    inspector.ForceSensorCurveModelGeneration = true;
-                    try {
-                        ok = await inspector.AnalyzeAutoFocusFromSavedPath(byStep[step.ToString()], token, detectionOverride);
-                    } finally {
-                        inspector.ForceSensorCurveModelGeneration = prevForce;
+                    if (ReplayStepOverrideForTest != null) {
+                        ok = await ReplayStepOverrideForTest(step, token);
+                    } else {
+                        // Force the per-star sensor-curve model so replay derives tilt from the paraboloid, like a live run.
+                        var prevForce = inspector.ForceSensorCurveModelGeneration;
+                        inspector.ForceSensorCurveModelGeneration = true;
+                        try {
+                            ok = await inspector.AnalyzeAutoFocusFromSavedPath(byStep[step.ToString()], token, detectionOverride);
+                        } finally {
+                            inspector.ForceSensorCurveModelGeneration = prevForce;
+                        }
                     }
                     if (!ok) {
                         StatusText = $"Replay failed at {step}.";
@@ -1961,22 +2726,29 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     tiltAdapterOptions.CalibrationAppliedAmount = metadata.CalibrationAppliedAmount;
                     RaisePropertyChanged(nameof(CalibrationAppliedAmount));
                     RaisePropertyChanged(nameof(CalibrationAppliedAmountDisplay));
+                    // [CRITICAL GATE] deviceDriven: false — a replay never sends live device moves (it
+                    // re-analyzes already-captured frames), so it can never re-establish the wizard-screw <->
+                    // device-corner correspondence, regardless of whether a device happens to be connected
+                    // right now. Always clears any prior device-linked marker.
                     RunCalibrationMath(
                         metadata.NumberOfScrews,
                         metadata.ScrewRadiusMillimeters,
                         metadata.PixelSizeMicrons,
                         metadata.FocuserStepSizeMicrons,
                         metadata.CalibrationAppliedAmount,
-                        metadata.IsStepperAdjustment);
+                        metadata.IsStepperAdjustment,
+                        deviceDriven: false);
                 } else {
                     // Use the current profile / tilt-adapter settings, exactly as a live calibration would.
+                    // [CRITICAL GATE] deviceDriven: false for the same reason as the branch above.
                     RunCalibrationMath(
                         tiltAdapterOptions.ScrewCount,
                         tiltAdapterOptions.ScrewRadiusMillimeters,
                         profileService.ActiveProfile.CameraSettings.PixelSize,
                         EffectiveFocuserStepMicrons(),
                         CalibrationAppliedAmount,
-                        IsStepperAdjustment);
+                        IsStepperAdjustment,
+                        deviceDriven: false);
                 }
                 RebuildDiagram();
                 // Update-profile choice: the replay succeeded, so now persist the run's capture-time star-detection
@@ -2186,6 +2958,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             ((RelayCommand)UseMeasuredHardwareCommand).NotifyCanExecuteChanged();
             ((AsyncRelayCommand)ReplayCommand).NotifyCanExecuteChanged();
             ((AsyncRelayCommand)RetryMeasurementCommand).NotifyCanExecuteChanged();
+            ((AsyncRelayCommand)ConnectDeviceCommand).NotifyCanExecuteChanged();
+            ((AsyncRelayCommand)DisconnectDeviceCommand).NotifyCanExecuteChanged();
+            ((AsyncRelayCommand)AutoRunAllCommand).NotifyCanExecuteChanged();
         }
 
         private static double NormalizeAngle(double deg) => ((deg % 360) + 360) % 360;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltScrewTargets.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltScrewTargets.cs
@@ -1,0 +1,88 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System.Collections.Generic;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
+
+    /// <summary>
+    /// Per-screw signed adjustment in unit-counts: "steps" for stepper motors, "turns" for screw
+    /// adapters. Mirrors <see cref="ScrewAxialCorrection"/> (axial best-focus microns) but already
+    /// divided by the adapter's unit size and signed for the curvature/backfocus direction, i.e.
+    /// the exact numbers the Aberration Inspector's numeric guidance table displays and the move
+    /// planner (T14) consumes.
+    /// </summary>
+    public readonly struct ScrewTarget {
+        public ScrewTarget(double tiltMicrons, double backfocusMicrons, double tiltSteps, double backfocusSteps, double totalSteps) {
+            TiltMicrons = tiltMicrons;
+            BackfocusMicrons = backfocusMicrons;
+            TiltSteps = tiltSteps;
+            BackfocusSteps = backfocusSteps;
+            TotalSteps = totalSteps;
+        }
+
+        /// <summary>Raw tilt correction in axial best-focus microns (unsigned by curvature sign).</summary>
+        public double TiltMicrons { get; }
+
+        /// <summary>Raw backfocus/curvature correction in axial best-focus microns (unsigned by curvature sign).</summary>
+        public double BackfocusMicrons { get; }
+
+        /// <summary>Tilt component, in unit-counts. No curvature-sign factor — the tilt direction is
+        /// already encoded by the stored response-convention screw angle.</summary>
+        public double TiltSteps { get; }
+
+        /// <summary>Backfocus component, in unit-counts, WITH the resolved curvature sign applied.</summary>
+        public double BackfocusSteps { get; }
+
+        /// <summary>Signed total adjustment, in unit-counts: TiltSteps + BackfocusSteps. CW/+ positive
+        /// (matches <see cref="TiltScrewGeometry.SignedTotalAdjustment"/> and the wizard's "+" prompts).</summary>
+        public double TotalSteps { get; }
+    }
+
+    /// <summary>
+    /// Shared per-screw target computation, pure and static, sitting on top of the existing
+    /// <see cref="TiltScrewGeometry"/> primitives. Single source of truth for the numeric values
+    /// the Aberration Inspector's guidance table displays (<c>InspectorVM.FillNumericGuidance</c>)
+    /// and the future motorized-adapter move planner (T14) consumes directly from
+    /// <c>SensorModel.DisplayedSensorModel</c> + <c>ITiltAdapterOptions</c> — deliberately independent
+    /// of both.
+    /// </summary>
+    public static class TiltScrewTargets {
+
+        /// <summary>
+        /// Per-screw signed targets from a fitted paraboloid model and adapter geometry. Per screw i:
+        ///   corr         = TiltScrewGeometry.ScrewCorrectionMicrons(gx, gy, kx, ky, x0, y0, angles[i], radiusMicrons)
+        ///   TiltSteps     = corr.TiltMicrons / unitMicrons
+        ///   BackfocusSteps = resolvedSign * corr.BackfocusMicrons / unitMicrons
+        ///   TotalSteps    = TiltScrewGeometry.SignedTotalAdjustment(corr.TiltMicrons, corr.BackfocusMicrons, unitMicrons, resolvedSign)
+        /// where resolvedSign is curvatureSign, defaulted to TiltScrewGeometry.DefaultScrewInwardCurvatureSign
+        /// when curvatureSign == 0 (mirrors InspectorVM.FillNumericGuidance's defensive resolve). The
+        /// curvature sign multiplies the BACKFOCUS component ONLY; the tilt component's direction is
+        /// already baked into the stored response-convention screw angle.
+        /// </summary>
+        public static IReadOnlyList<ScrewTarget> ComputePerScrewTargets(
+            double gx, double gy, double kx, double ky, double x0, double y0,
+            IReadOnlyList<double> anglesDegrees, double radiusMicrons, double unitMicrons, int curvatureSign) {
+            int resolvedSign = curvatureSign == 0 ? TiltScrewGeometry.DefaultScrewInwardCurvatureSign : curvatureSign;
+
+            var results = new ScrewTarget[anglesDegrees.Count];
+            for (int i = 0; i < anglesDegrees.Count; i++) {
+                var corr = TiltScrewGeometry.ScrewCorrectionMicrons(gx, gy, kx, ky, x0, y0, anglesDegrees[i], radiusMicrons);
+                double tiltSteps = corr.TiltMicrons / unitMicrons;
+                double backfocusSteps = resolvedSign * corr.BackfocusMicrons / unitMicrons;
+                double totalSteps = TiltScrewGeometry.SignedTotalAdjustment(corr.TiltMicrons, corr.BackfocusMicrons, unitMicrons, resolvedSign);
+                results[i] = new ScrewTarget(corr.TiltMicrons, corr.BackfocusMicrons, tiltSteps, backfocusSteps, totalSteps);
+            }
+            return results;
+        }
+    }
+}

--- a/docs/asg-eat-serial-protocol-design.md
+++ b/docs/asg-eat-serial-protocol-design.md
@@ -1,0 +1,263 @@
+# ASG EAT Serial Protocol — Live Hardware Capture (T15)
+
+**Status:** Captured from real hardware. Resolves the `// LIVE-CAPTURE:` unknowns in
+`EatSerialTransport.cs` and `EatResponses.cs`.
+
+**Capture context**
+- **Date:** 2026-07-17
+- **Device:** ASG Electronic EAT, enumerated by Windows as **"Arduino Uno (COM7)"** (ATmega328P + ATmega16U2 USB-serial bridge).
+- **Firmware version:** **7.1.0** (device reports `FW:7.1.0` at the end of its boot banner).
+- **Method:** direct `System.IO.Ports.SerialPort` session (PowerShell) using our production serial parameters, but logging **raw bytes** (hex + ASCII) instead of `ReadLine()`, so exact framing, banners, and chunk boundaries are visible. Commands were sent one at a time; each response captured in full. No move exceeded 5 steps; every move was reversed, leaving all four motors back at their starting value of **600** with EEPROM re-saved.
+
+> This device is fundamentally a **companion-GUI driver**: alongside its machine-readable answers it emits a stream of `{UI|SET|<widget>.<property>=<value>}` lines meant to drive a desktop app. Our parser must **ignore** those and key off the device's delimited data blocks and sentinels.
+
+---
+
+## 1. Serial parameters (confirmed)
+
+| Parameter | Value | vs. our code |
+|---|---|---|
+| Baud | **9600** | ✅ `EatSerialTransport.BaudRate` correct |
+| Data bits | **8** | ✅ correct |
+| Parity | **None** | ✅ correct |
+| Stop bits | **1** | ✅ correct |
+| Handshake | **None** | ⚠️ **code uses `Handshake.XOnXOff` — change to `None`** (see §7.2) |
+| DTR | **asserted** (required; also triggers reset-on-open) | ✅ `DefaultDtrEnable = true` correct |
+| RTS | not required (left deasserted) | — |
+| Line terminator (TX & RX) | **`\r\n` (CRLF, `0D 0A`)** | ✅ `LineTerminator = "\r\n"` correct |
+| Command echo | **none** (device does not echo the raw command line) | ✅ no echo-skipping needed |
+
+---
+
+## 2. Connection sequence & boot banner
+
+Opening the port **resets the MCU** (classic Arduino DTR auto-reset). Observed timeline:
+
+```
+T+0.00 s   port opened (DtrEnable=true)
+T+~1.5 s   first bytes arrive  ← bootloader delay; nothing before this
+T+~1.5–2.5 s   boot banner streams (see below)
+T+~2.5 s   banner ends with the FW version line
+```
+
+**⚠️ Our `PostOpenSettleDuration = 500 ms` is too short** — the device doesn't even *start* emitting until ~1.5 s after open, and the banner runs to ~2.5 s. Sending `cp` at 500 ms would hit the bootloader. See §7.1.
+
+**Boot banner (decoded, `\r\n` shown as line breaks):**
+
+```
+<LF>Initialize Setup
+{UI|SET|ready_light.On=True}
+{UI|SET|ready_light.IndicatorColor=green}
+{UI|SET|TR_input.Text=0}      {UI|SET|TL_input.Text=0}
+{UI|SET|BR_input.Text=0}      {UI|SET|BL_input.Text=0}
+{UI|SET|TP_input.Text=0}      {UI|SET|RT_input.Text=0}
+{UI|SET|LT_input.Text=0}      {UI|SET|BF_input.Text=0}
+{UI|SET|TR_curr_position.Text=600}   {UI|SET|TL_curr_position.Text=600}
+{UI|SET|BR_curr_position.Text=600}   {UI|SET|BL_curr_position.Text=600}
+{UI|SET|TL_input_setting.Text=600}   {UI|SET|TR_input_setting.Text=600}
+{UI|SET|BL_input_setting.Text=600}   {UI|SET|BR_input_setting.Text=600}
+{UI|SET|set_speed_input.Text=50}
+{UI|SET|set_max_speed_input.Text=50}
+{UI|SET|set_accel_input.Text=300}
+{UI|SET|orientationSelection.Value=1}
+{UI|SET|orientation_img_1.Visible=True}
+{UI|SET|orientation_img_2.Visible=False}
+{UI|SET|orientation_img_3.Visible=False}
+{UI|SET|orientation_img_4.Visible=False}
+FW:7.1.0
+```
+
+**Interpretable connection signals:**
+- **`FW:7.1.0`** — firmware version; the last banner line. A good "boot complete / device is an EAT" fingerprint and a robust end-of-banner marker to wait for instead of a fixed drain time.
+- **`Initialize Setup`** — first banner line (start-of-boot marker).
+- **`ready_light.IndicatorColor=green`** + **`ready_light.On=True`** — device-ready indicator.
+- The banner also reveals the full command vocabulary (`*_input` widgets: `TR TL BR BL TP RT LT BF`), current motor positions, and motion parameters (`speed=50`, `max_speed=50`, `accel=300`, `orientation=1`).
+
+Recommended connect handshake: open → **read/discard until a line matching `^FW:` is seen (or ~3 s timeout)** → then send `cp`.
+
+---
+
+## 3. Response framing & the `{UI|SET|...}` noise
+
+- Every line is terminated with **CRLF**.
+- Interleaved throughout every response are `{UI|SET|<widget>.<property>=<value>}` lines that drive the vendor GUI. **These are noise for us and must be ignored.**
+- The device's actual machine-readable output is delimited by `***...***` marker lines and (for the position list) bare integer lines.
+- **A single logical token can be split across serial reads.** Parse on **reassembled complete lines** (which `ReadLine()` gives us), never on raw read-chunk boundaries. (During capture, `***finished movement***` arrived split across two reads; our production `ReadLine()` approach is immune, but this confirms the requirement.)
+
+---
+
+## 4. Command reference
+
+### 4.1 `cp` — query current positions (read-only)
+
+**Request:** `cp\r\n`
+
+**Response (decoded; `{UI|SET|...}` lines omitted):**
+```
+{UI|SET|ready_light.IndicatorColor=Red}      ← busy
+… full {UI|SET|...} state dump …
+***Get Current Positions***
+600
+600
+600
+600
+***End Current Positions***
+{UI|SET|ready_light.IndicatorColor=green}    ← ready
+***Action Processed***                        ← QUERY completion sentinel
+```
+
+- The four positions are **bare integer lines between `***Get Current Positions***` and `***End Current Positions***`**.
+- **Completion sentinel for a query is `***Action Processed***`** (distinct from a move — see §5).
+- Positions are **absolute counters** (persisted in EEPROM), not deltas.
+- Duration ≈ 0.9 s (dominated by transmitting the ~1 KB `{UI|SET|...}` dump at 9600 baud).
+
+### 4.2 Move commands — `<mnemonic>,<value>`
+
+**Request:** e.g. `tr,5\r\n`, `tr,-5\r\n`, `bf,-5\r\n`
+
+**Response structure (decoded; `{UI|SET|...}` omitted):**
+```
+{UI|SET|ready_light.IndicatorColor=Red}      ← busy
+start_cmd: tr                                 ← echoes the mnemonic
+tilt_value: 5.00                              ← echoes the argument (as a float)
+moving TR + 5.00                              ← per-motor motion report (one line per moved motor)
+moving BL - -5.00
+***moving***                                  ← motion heartbeat (repeats during motion)
+***moving***  …
+{UI|SET|*_input.Text=0}                        ← UI resets input fields
+***Get Current Positions***
+600
+605
+595
+600
+***End Current Positions***
+***Save EEPROM***                             ← ⚠ positions persisted to EEPROM (no undo)
+… {UI|SET|...curr_position...} dump …
+{UI|SET|ready_light.IndicatorColor=green}    ← ready
+***finished movement***                       ← MOVE completion sentinel
+```
+
+- **Argument is parsed as a float** and echoed as `tilt_value: N.NN`.
+- **`start_cmd:` / `tilt_value:`** provide a free confirmation that the device parsed our command as intended (useful as a validation hook).
+- **`moving <MOTOR> <sign> <value>`** lines are the authoritative per-motor report of what physically moved. Backfocus reports as a single `moving Backfocus  + <value>` line (all four motors, one line).
+- Every move ends with **`***Save EEPROM***`** then **`***finished movement***`**. The EEPROM save confirms our whole no-undo safety model.
+- A response also embeds a fresh `***Get Current Positions***` block, so a move doubles as a position read (no separate `cp` needed after a move).
+
+### 4.3 Mnemonic → motor mapping
+
+Wizard/optics screw labels: **TR, TL, BL, BR**. Motor moves observed:
+
+| Mnemonic | Confirmed? | Motor effect (for `+N`) | Our model | Match |
+|---|---|---|---|---|
+| `tr` | ✅ **confirmed** | TR **+N**, BL **−N** | DiagonalA | ✅ |
+| `tl` | ✅ **confirmed** | TL **+N**, BR **−N** | DiagonalB | ✅ |
+| `bf` | ✅ **confirmed** | all four **+N** | Backfocus | ✅ |
+| `bl` | ⛔ not exercised | expected TR −N, BL +N (opposite of `tr`) | DiagonalA (opp.) | inferred |
+| `br` | ⛔ not exercised | expected TL −N, BR +N (opposite of `tl`) | DiagonalB (opp.) | inferred |
+| `tp` | ⛔ not exercised | expected TR+, TL+, BL−, BR− (top edge) | EdgeVertical | inferred |
+| `bt` | ⛔ not exercised | expected opposite of `tp` | EdgeVertical (opp.) | inferred |
+| `rt` | ⛔ not exercised | expected TR+, BR+, TL−, BL− (right edge) | EdgeHorizontal | inferred |
+| `lt` | ⛔ not exercised | expected opposite of `rt` | EdgeHorizontal (opp.) | inferred |
+
+The three exercised commands (`tr`, `tl`, `bf`) all matched our per-corner model exactly. The remaining mnemonics follow the identical `<mnemonic>,<value>` grammar; their exact per-motor directions were **not** exercised on hardware and should be confirmed opportunistically.
+
+### 4.4 Sign encoding — **`SignedArgument` confirmed**
+
+- `tr,-5` → `tilt_value: -5.00`, `moving TR + -5.00` / `moving BL - 5.00`. The device parses a **negative signed argument** directly.
+- `bf,-5` → `tilt_value: -5.00`, all four motors −5. **Negative backfocus works via a signed argument** on `bf` (no opposite mnemonic).
+- ✅ `EatCommands.DefaultSignEncoding = SignedArgument` is correct; the `Backfocus`-always-signed special case is correct. The `OppositeMnemonic` path is **not** needed for this firmware.
+
+---
+
+## 5. Completion sentinels (critical for the read loop)
+
+| Command type | Terminal sentinel |
+|---|---|
+| Query (`cp`) | `***Action Processed***` |
+| Move (`tr`, `tl`, `bf`, …) | `***finished movement***` |
+
+The read loop should **terminate an exchange when it sees the matching sentinel** (accept either, to be robust), instead of relying on the 200 ms quiet-window heuristic. `ready_light.IndicatorColor` transitions **Red → green** also bracket the busy period and can drive a live busy indicator.
+
+---
+
+## 6. Position block ordering — **⚠️ differs from our code**
+
+The bare-integer block in `***Get Current Positions***` is emitted in **raster order `[TL, TR, BL, BR]`**:
+
+| Block index | 0 | 1 | 2 | 3 |
+|---|---|---|---|---|
+| **Actual device** | **TL** | **TR** | **BL** | **BR** |
+| Our `TiltDevicePositions` assumption | TR | TL | BR | BL |
+
+Empirical proof:
+- `tr,+5` (TR→605, BL→595): block = `[600, 605, 595, 600]` ⇒ index 1 = TR, index 2 = BL.
+- `tl,+5` (TL→605, BR→595): block = `[605, 600, 600, 595]` ⇒ index 0 = TL, index 3 = BR.
+
+This is a **pairwise swap** (0↔1 and 2↔3) versus the assumed `[TR, TL, BR, BL]`. Shipping as-is would map every motor's counter to the wrong corner and corrupt shadow tracking / excursion enforcement.
+
+> **Quirk:** the *labeled* `{UI|SET|<corner>_curr_position.Text=N}` fields are emitted in a **different** order (`TR, TL, BR, BL`) than the bare block (`TL, TR, BL, BR`). The most robust parser reads the **labeled** `*_curr_position` fields **by corner name** (order-independent); the bare block is the fallback, parsed with the confirmed order `[TL, TR, BL, BR]`.
+
+---
+
+## 7. Required changes to our assumptions (T15 resolution)
+
+### 7.1 `EatSerialTransport` — settle / boot handling
+- **`PostOpenSettleDuration`**: 500 ms → **wait for the boot banner to finish**, i.e. read/discard until a line matching `^FW:` (with a ~3 s cap), because the MCU resets on open and is silent for ~1.5 s. A blind 500 ms drain sends `cp` into the bootloader.
+
+### 7.2 `EatSerialTransport` — handshake
+- **`Handshake.XOnXOff` → `Handshake.None`.** The Uno sketch has no software flow control; with `XOnXOff` the PC driver can inject `0x11`/`0x13` bytes into the sketch's input. `None` captured a ~1 KB burst cleanly with no loss at 9600 baud. Keep the write timeout generous regardless.
+
+### 7.3 `EatResponses.ParseCpPositions` — parsing
+- **Replace the "first four integers found" heuristic.** With the `{UI|SET|...}` dump present, the first integers encountered are GUI-widget values, not positions. Parse **either**:
+  1. the four bare integers **between `***Get Current Positions***` and `***End Current Positions***`**, mapped as `[TL, TR, BL, BR]`, **or** (preferred, order-independent)
+  2. the `{UI|SET|<corner>_curr_position.Text=N}` lines **by corner label**.
+- **Fix the block/motor order** to `[TL, TR, BL, BR]` (see §6) wherever `TiltDevicePositions` order is assumed.
+
+### 7.4 `EatResponses.ParseMoveAck` — ack
+- **Recognize `***finished movement***`** as the move-success sentinel (and `***Action Processed***` for queries), instead of "did not time out." Optionally validate `start_cmd:` / `tilt_value:` echo against what we sent.
+- The read loop can end each exchange **on the sentinel line**, which is faster and more reliable than the quiet-window race.
+
+### 7.5 Confirmed-correct (no change)
+- Serial params 9600/N/8/1, `DtrEnable=true`, CRLF framing.
+- `SignedArgument` sign encoding, including negative `bf` via signed argument.
+- Absolute EEPROM-persisted position counters; `***Save EEPROM***` after every move (validates the no-undo safety model).
+- `MoveTimeout = 20 s` is very safe: a 5-step move completed in **~1.4 s**; the "5–10 s" figure applies only to large moves.
+
+---
+
+## 8. Coverage / open items
+
+Exercised on hardware: connect+banner, `cp` (×2), `tr,5`, `tr,-5`, `tl,5`, `tl,-5`, `bf,5`, `bf,-5`. Not yet exercised (follow up opportunistically, ≤10-step reversible moves):
+- `tp`, `rt` and the opposite mnemonics `bl`, `br`, `bt`, `lt` — grammar is identical; only the exact per-motor directions are unconfirmed.
+- Device behavior on an **unrecognized/malformed** command (does it emit an error line or `***Action Processed***` with no effect?).
+- Behavior at/near travel limits (our soft limits should prevent reaching them; device-side clamping unknown).
+- Large-move timing (to sanity-check the 5–10 s figure and the 20 s timeout margin).
+
+---
+
+## Appendix A — Raw evidence excerpts
+
+`tr,5` (raw ASCII, `<CR><LF>` = CRLF):
+```
+start_cmd: tr<CR><LF>tilt_value: 5.00<CR><LF>moving TR + 5.00<CR><LF>moving BL - -5.00<CR><LF>
+***Get Current Positions***<CR><LF>600<CR><LF>605<CR><LF>595<CR><LF>600<CR><LF>***End Current Positions***<CR><LF>
+***Save EEPROM***<CR><LF> … ***finished movement***<CR><LF>
+```
+
+`tl,5`:
+```
+start_cmd: tl<CR><LF>tilt_value: 5.00<CR><LF>moving TL + 5.00<CR><LF>moving BR - 5.00<CR><LF>
+***Get Current Positions***<CR><LF>605<CR><LF>600<CR><LF>600<CR><LF>595<CR><LF>***End Current Positions***<CR><LF>
+```
+
+`bf,5`:
+```
+start_cmd: bf<CR><LF>tilt_value: 5.00<CR><LF>moving Backfocus  + 5.00<CR><LF>
+***Get Current Positions***<CR><LF>605<CR><LF>605<CR><LF>605<CR><LF>605<CR><LF>***End Current Positions***<CR><LF>
+```
+
+`cp` (query terminator differs):
+```
+***Get Current Positions***<CR><LF>600<CR><LF>600<CR><LF>600<CR><LF>600<CR><LF>***End Current Positions***<CR><LF>
+{UI|SET|ready_light.IndicatorColor=green}<CR><LF>***Action Processed***<CR><LF>
+```

--- a/docs/motorized-tilt-adapter-eat-design.md
+++ b/docs/motorized-tilt-adapter-eat-design.md
@@ -1,0 +1,171 @@
+# Motorized Tilt Adapter Automation (ASG EAT) — Design
+
+> Implementation plan: `plans/motorized-tilt-adapter-eat-plan.md`.
+
+## Context
+
+HocusFocus's Aberration Inspector already computes precise per-screw tilt + backfocus corrections
+(signed stepper steps for the ASG EAT presets in `TiltAdapterDevicePreset.cs`), but the user must
+apply them by hand in ASG's app. The ASG EAT is a 4-corner motorized tilt adapter controllable over
+serial. This feature closes the loop: connect to the EAT from the Tilt Adapter Calibration pane,
+compute a **minimal move sequence** from the fitted sensor model, get user approval, execute, and
+offer to re-run the inspector to confirm. The calibration wizard also drives its own measurement
+moves when connected (hands-off calibration). Design is extensible to other 4-corner coupled
+devices and future 3-corner independent devices.
+
+## Device facts (ASG EAT)
+
+- Serial: **9600 baud, 8 data bits, 1 stop bit, no parity, XON/XOFF** flow control.
+- Spec: `C:\Users\ghili\Downloads\ASG EAT Serial Commands.pdf` (commands only). **Response protocol
+  unknown** — captured live in T15. Moves take **5–10 s**; every move/config persists to EEPROM.
+  There is **no abort command** → cancellation is between-commands only.
+- Commands (`<mnemonic>,<value>`): diagonal `tr/tl/br/bl,N` (corner +N, opposite −N, 2 motors);
+  edge `tp/bt/lt/rt,N` (edge pair +N, opposite pair −N, 4 motors); backfocus `bf,N` (all 4 +N);
+  `zr` (zero position counters, no motion), `cp` (query positions), `cA/cB/cC,x` (speed/max/accel,
+  defaults 100/100/300), `or,1-4` (display-only graphic — cosmetic, NEVER rotation compensation),
+  `ep`/`up` (EEPROM read/update). v1 deliberately does not expose `cA/cB/cC`, `or`, `ep`, `up`,
+  **or `zr`** — zeroing positions is the user's job in the vendor app; the plugin never zeroes.
+- Device corner labels: **TR=motor1, TL=motor2, BR=motor3, BL=motor4** (opposite pairs (1,4),(2,3)).
+- Step size 1.8 µm/step, screw radius 55 / 62.75 mm (already in the two EAT presets,
+  `TiltAdapterDevicePreset.cs:67-77`).
+
+## User decisions already made (do not relitigate)
+
+1. The wizard's calibration moves are automated too when the device is connected.
+2. Approval dialog groups moves as **Tilt** and **Backfocus** with a checkbox per group.
+3. Safety = soft position limits + configurable max-excursion and max-steps-per-command.
+4. Manual connect button; device + COM port persisted per profile; **no auto-connect**.
+5. **No zero-positions capability** in the plugin — the user zeroes in the vendor app.
+6. **Per-screw current positions displayed while connected**, refreshed by polling `cp`.
+7. After **30 minutes idle** while connected, a **modal dialog** asks whether to disconnect.
+8. The wizard gets a **movement-amount-per-calibration-step setting**: screw adapters default to
+   **1 rotation**, ASG EAT presets default to **150 steps**.
+9. **One adjustment per measurement (hard invariant):** live automated adjustment never executes
+   more than one approved plan before requiring user input again, and a **fresh sensor-model run
+   is required to confirm the improvement** before any further automatic adjustment is possible.
+   No auto-looping; the same measurement can never be applied twice.
+
+## Core algorithm — minimal-move decomposition (4-corner coupled)
+
+Work in **wizard screw indices** (consecutive around the image; opposite pairs (1,3),(2,4) —
+`TiltCalibrationCalculator.ComputeScrewAngles`, TiltCalibrationCalculator.cs:209-230).
+Per-screw signed step targets come from `TiltScrewGeometry.ScrewCorrectionMicrons` +
+`SignedTotalAdjustment` semantics (`InspectorVM.FillNumericGuidance`, InspectorVM.cs:2006-2072):
+`s_i = (tilt_i + σ·backfocus_i) / unitMicrons`, real-valued (σ = resolved
+`ScrewInwardCurvatureSign`; **σ multiplies backfocus only** — tilt direction is already encoded in
+the stored response-convention angles).
+
+Device generators in `(s1,s2,s3,s4)` space (with the T4 mapping wizard1=TR, wizard2=TL,
+wizard3=BL, wizard4=BR):
+
+| Generator | Per-corner effect | EAT command |
+|---|---|---|
+| D1·x | (+x, 0, −x, 0) | `tr,x` |
+| D2·y | (0, +y, 0, −y) | `tl,y` |
+| E⁺·m = (D1+D2)·m | (+m, +m, −m, −m) | `tp,m` |
+| E⁻·m = (D1−D2)·m | (+m, −m, −m, +m) | `rt,m` |
+| BF·k | (+k, +k, +k, +k) | `bf,k` |
+
+D1, D2, BF are mutually orthogonal spanning a 3-D subspace of R⁴. Exact least-squares projection:
+`a = (s1−s3)/2` (D1), `b = (s2−s4)/2` (D2), `f = (s1+s2+s3+s4)/4` (BF), twist residual
+`t = (s1−s2+s3−s4)/4` — unreachable by ANY rigid-plane device. Report `t`, never plan it. (Note:
+`t` is exactly 0 for a square-clocked EAT with the axis-aligned paraboloid model; it becomes
+nonzero only when the adapter is clocked off 45° — don't treat the reporting path as dead code.)
+
+**Group split is defined in COMMAND space, not by physical origin** (critical: off-center curvature
+X0,Y0≠0 leaks a *linear* term into the D1/D2 components — a split by physical origin would drop it):
+- **Backfocus group** = BF projection `f = mean(s)` → one `bf` move.
+- **Tilt group** = D1/D2 projections of `(s − f)` → diagonal/edge moves.
+Groups stay orthogonal so the dialog checkboxes are independent and nothing is dropped.
+
+**Minimal command count (≤ 3):** round `a`, `b`, `f` independently to integers (bounds per-corner
+residual at 1.0 step = 1.8 µm — do not add a fancier optimizer).
+- Tilt: 0 moves if `ra==rb==0`; **1 edge move** iff `ra == ±rb ≠ 0` (all four sign combos map to
+  tp/bt/rt/lt with positive N); **1 diagonal** if exactly one nonzero; else **2 diagonals**.
+  Never force a common magnitude to save a move (a=3.4, b=2.4 via `tp,3` is worse than 2 diagonals).
+- Backfocus: +1 move if `rf≠0`.
+- Per-move cap splitting (if |magnitude| > cap) happens AFTER minimal decomposition; the axes are
+  orthogonal so Σ ceil(|mᵢ|/cap) is provably minimal under the cap.
+- Report per-corner residual µm = (applied − target)·1.8 in the approval dialog.
+
+**3-corner extensibility:** planner per topology behind one interface — `FourCornerCoupledPlanner`
+(above) vs future `ThreeCornerIndependentPlanner` (one move per screw; requires per-screw
+independent capability which the EAT driver declares it lacks).
+
+## Mapping contract + device-linked calibration gate
+
+The wizard requires opposite pairs at indices (1,3)/(2,4); EAT labels have opposite pairs
+(1,4)/(2,3). **Resolution:** when calibrating with the device connected, the wizard *defines*
+wizard-screw1 ≡ TR (`tr`), wizard-screw2 ≡ TL (`tl`) ⇒ wizard-screw3 ≡ BL, wizard-screw4 ≡ BR.
+Every wizard step then maps 1:1 to a command (Screw1 step "+N motor1/−N motor3" = `tr,N`;
+Screw2 = `tl,N`; AllInward = `bf,N`; ReBaseline1 = `bf,−N`; ReBaseline2 = `tr,−N`;
+**Complete's "return to original position" = `tl,−N`**). `ComputeScrewAngles` supports both
+windings (clockwise = rawDiff<180, TiltCalibrationCalculator.cs:215), so TR→TL adjacency fits
+regardless of image mirroring. Sign convention becomes self-consistent: calibration measures the
+response of the device's actual `+` direction because the wizard itself sent the commands.
+
+**[CRITICAL GATE]** Automation must be blocked unless the stored calibration is device-linked.
+`IsCalibrated` is set by ANY completed run (manual, manual-entry `ApplyManualCalibration`, replay)
+— a pre-existing manual EAT calibration where "screw 1" was, say, BR would make automation apply
+corrections rotated 90°/180°, worsening tilt unattended. Persist a **`DeviceLinkedCalibration`**
+marker (device preset name, set ONLY when a connected hands-off calibration completes; cleared by
+manual entry, replay-driven `RunCalibrationMath`, and disconnected runs). Gate the inspector's
+"Automatic Adjustment" button AND wizard auto-apply on it; remediation text: "Re-run calibration
+with the device connected." Also gate on calibration quality: `RunCalibrationMath` sets
+`IsCalibrated=true` even when quality validation fails — persist/reuse the confidence result and
+hard-block automation on unreliable calibrations.
+
+## Architecture (component map)
+
+```
+Interfaces/
+  ITiltMotionController.cs        device abstraction (topology, capabilities, moves, positions)
+TiltAdapterDevices/
+  TiltAdapterMove.cs              move axes/groups + per-corner effect vectors
+  TiltAdapterMovePlan.cs          moves + residuals + twist + time estimate
+  TiltMovePlanner.cs              pure static decomposition (core math)
+  TiltMotionControllerRegistry.cs preset-name → driver factory ("append one entry" pattern)
+  TiltDeviceConnectionService.cs  shared connection singleton (HocusFocusPlugin static):
+                                  cp position polling + 30-min idle prompt + operation token
+  Prompt/                         approval dialog (4-file ReplaySettingsPrompt pattern)
+  AsgEat/
+    EatCommands.cs                wire formatting + EatSignEncoding strategy   [sign seam]
+    EatSerialTransport.cs         custom read loop, transcript logging        [SEAM FILE]
+    EatResponses.cs               tolerant parsers (ack, cp)                  [SEAM FILE]
+    EatWizardMapping.cs           wizard-index/step ↔ device move
+    EatTiltMotionController.cs    limits, shadow positions, execution
+TiltAdapterWizard/
+  TiltScrewTargets.cs (new)       shared pure per-screw target computation
+  TiltAdapterOptions.cs (+ Interfaces/ITiltAdapterOptions.cs)  new persisted options
+  TiltAdapterWizardVM.cs          connection UI + hands-off calibration
+  DataTemplates.xaml              connection section + option controls
+AutoFocus/
+  InspectorVM.cs                  Automatic Adjustment command; guidance uses shared helper
+  DataTemplates.xaml              button in Tilt Adapter Guidance expander (:2809+)
+```
+
+Key reuse: NINA.Core `ISerialPort`/`SerialPortProvider` (WMI port enumeration,
+`Handshake.XOnXoff` supported), `SerialPortClosedException`, `InvalidDeviceResponseException` —
+already resolved transitively (System.IO.Ports 8.0.0 + System.Management 8.0.0 via
+Microsoft.Windows.Compatibility; **no new package refs**). Do **NOT** subclass `SerialSdk`: it does
+one `ReadLine` (500 ms default, 2 retries) per command and swallows write timeouts — unusable for
+5–10 s moves under XON/XOFF (verified in NINA source). Custom transport is a decision, not an option.
+Modal dialog pattern: `AutoFocus/Replay/ReplaySettingsPrompt.ShowAsync` (IWindowServiceFactory +
+TaskCompletionSource). Re-run inspector: `InspectorVM.AnalyzeAutoFocus(token, captureCameraBlock,
+saveOverride)` (InspectorVM.cs:251; the wizard already calls it at TiltAdapterWizardVM.cs:1266).
+
+## Risks / future work
+
+- **Response protocol unknown** — contained to 2 seam files + 2 sign constants; everything else
+  is contract-tested and must not change in T15.
+- **σ / direction errors** are the highest-consequence failure (EEPROM-persisted wrong-way moves);
+  mitigations: 6-step default when connected, device-linked gate, per-mnemonic live cross-check,
+  approval dialog with signed moves, post-adjustment worsening check + revert journal.
+- Camera/adapter rotation after calibration invalidates angles (no cheap detection) — documented;
+  worsening check is the backstop. `or` is cosmetic only.
+- Future: `ThreeCornerIndependentPlanner` (interface in place), other 4-corner devices (registry
+  "append one entry" + driver), sequence-item automation, manual-manual EAT users declaring a
+  corner mapping without recalibrating (deliberately out of v1 — recalibration is the safe path).
+- v1 leaves `cA/cB/cC`, `or`, `ep`, `up` unexposed.
+- Manual (documentation/docs) updates for the new UI belong in a follow-up PR per documentation
+  conventions (`.claude/docs/documentation-style.md`).

--- a/docs/tilt-adapter-ui-review-design.md
+++ b/docs/tilt-adapter-ui-review-design.md
@@ -140,6 +140,17 @@ Both the four explicit requests and every additional Fable suggestion have been 
   (direction-measurement default notification), B.8 (visible screw↔corner mapping), B.9 (verb alignment →
   "Calibrate"), B.10 (connection status in the running panel). — commit `da9d65a`.
 
-**Deferred (deliberately not done):** the twist warning's steps→µm translation (A.5) — it would require plumbing
-`unitMicrons` through the prompt VM ctor and the InspectorVM adjustment seam/tests; the wording was improved but
-kept in steps. Pull this in if wanted.
+**Twist warning steps→µm (A.5):** now implemented — `unitMicrons` is plumbed through
+`TiltDeviceAdjustmentPrompt.ShowAsync` → the prompt VM ctor → the InspectorVM adjustment seam, so the twist
+warning reads "…N steps (about X µm across the sensor)…".
+
+## Follow-up feedback (beyond the Fable review)
+
+A later round of direct feedback, also implemented on this branch:
+- Current stepper positions now shown in the inspector's **Tilt Adapter Guidance** section when a motorized
+  adapter is connected (2×2 corner grid, no Δ — the inspector has no calibration-run baseline).
+- "Review motor commands": "Apply:" → "Apply"; move rows drop the redundant "Corner move"/"Side move" prefix
+  (the badge already says it); the backfocus row is trimmed to "All four screws +N steps together".
+- The Focus Chart now shows the **5-curve (Center + 4 corners) view live during a sweep** even when the sensor
+  model is enabled — via a chart-only `ShowSingleAfCurve` gate (`ShowSensorModel.Tag AND NOT IsAnalysisRunning`)
+  that leaves every other sensor-model gate untouched.

--- a/docs/tilt-adapter-ui-review-design.md
+++ b/docs/tilt-adapter-ui-review-design.md
@@ -1,0 +1,136 @@
+# Motorized Tilt-Adapter UI Review — Update Guidance
+
+Design review of two UI surfaces of the motorized tilt-adapter (ASG EAT) feature, produced with Fable
+(`claude-fable-5`) reviewing the actual XAML/VM, then consolidated here. Scope: the **"Review motor
+commands" adjustment dialog** and the **Tilt Adapter Calibration Wizard UX** (especially when a motorized
+adapter is connected).
+
+Priority key: **[H]** high (includes the four explicitly-requested changes), **[M]** medium, **[L]** low.
+
+---
+
+## A. "Review motor commands" adjustment dialog
+Files: `TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptControl.xaml`,
+`TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptVM.cs`.
+
+**Overall:** The safety skeleton is solid (the displayed plan always equals what executes; hard limits block
+Proceed; warnings are tiered). But the information hierarchy is inverted for a non-expert: each row leads with
+the raw wire command (`tr,142`) in large bold monospace, while the human-meaningful fact — *which numbered
+screws move, and which way* — is absent (the `Description` is axis jargon, "Diagonal A: +142 steps"). The
+per-screw signed steps the UI needs are already on `TiltAdapterMove.PerCornerSteps`.
+
+1. **[H] Move-row semantics (user request #1).** Replace the prominent wire command with a semantic move line
+   built from `PerCornerSteps`:
+   - Corner axes (DiagonalA/B): `Corner move — Screw 1 up 142 steps, Screw 3 down 142 steps`.
+   - Edge axes (EdgeVertical/Horizontal): `Side move — Screws 1 & 2 up 20 steps, Screws 3 & 4 down 20 steps`.
+   - Backfocus: `Backfocus — all four screws move together (+N steps; changes sensor spacing, not tilt)`.
+   - Demote the wire command to a small dim monospace chip on the right (`sent as tr,142`) for auditability —
+     keep it, don't lead with it. Add a `Corner` / `Side` / `Backfocus` kind tag where the wide command box was.
+   - **Direction wording caveat:** use "up/down" only after confirming the positive-step physical convention
+     (see §C); if the convention is not pinned, say "driven +N / −N steps" with a one-line legend.
+
+2. **[H] Apply toggle labels (user request #2).** The captions are supplied as `CheckBox.Content`, which
+   NINA's themed CheckBox template frequently does **not** render — so the user sees two bare toggles beside
+   "Apply:". Fix: make each caption a **sibling `TextBlock`**, not `CheckBox.Content`, so it renders regardless
+   of theme; move the `⚠ (assumed direction)` badge out to sit after the Backfocus caption; add
+   `AutomationProperties.Name` on each CheckBox for screen readers.
+
+3. **[M] Corner context on screw references.** Append the corner to every "Screw N": `Screw 1 (TR)`,
+   `Screw 3 (BL)`. Optionally lay the residual cells out as a 2×2 spatial grid (TL|TR / BL|BR) matching the
+   sensor. **Verify the 1..4 ↔ corner mapping** against `.claude/docs/tilt-domain.md` first — it may be
+   rig-dependent (response-convention angles); if so, keep plain "Screw N" plus a legend.
+
+4. **[M] Intro copy.** Drop leftover jargon ("verify each signed command"). Reword to plain physical language:
+   "…turn the tilt adapter's motor screws, and the device remembers every move (stored in EEPROM). There is no
+   automatic undo — check which screws move, and in which direction, before proceeding."
+
+5. **[M] Warning-panel titles.** Give every warning the danger panel's title+body structure: "Approaching
+   travel limit", "Motor positions unknown", "Backfocus direction is assumed", "Twist cannot be corrected",
+   "Screw pitch mismatch". In the twist body, lowercase "no" and translate steps→µm (same scale as the residual
+   table). Order the stack by severity.
+
+6. **[M] Proceed disabled-state / label.** When both toggles are off, `CanProceed` is false but nothing near the
+   button says why. Add a dim reason (or a `ToolTipService.ShowOnDisabled` tooltip): "Select at least one
+   correction to apply." Optionally make the label dynamic ("Send 3 moves").
+
+7. **[M] Residual interpretation.** Add one line to the residual caption explaining sign/scale ("Positive = that
+   corner remains slightly high after the moves. Values under ~1 µm are within one motor step."). Verify sign
+   against the planner (residual = applied − target).
+
+8. **[M] Assumed-direction row anchor.** When the assumed-direction warning is active it applies to exactly the
+   Backfocus row — add a small inline `⚠ direction assumed` tag on that row so the warning has an anchor.
+
+9. **[L] Group badge / footer wording.** Once rows are semantic the Tilt/Backfocus pill is largely redundant
+   (drop it for Backfocus rows or replace with a subheader); rename "commands" → "moves" in the footer to match.
+
+---
+
+## B. Tilt Adapter Calibration Wizard UX
+Files: `TiltAdapterWizard/DataTemplates.xaml`, `TiltAdapterWizard/TiltAdapterWizardVM.cs`.
+
+**Overall:** The flow model is solid (explicit step enum, 4/6-step variants, device-driven vs manual, careful
+failure/recovery). But the **running-wizard surface (Panel B)** under-communicates: a single instruction
+paragraph with no step number, no title, and — during a run — no visibility of the motor positions the VM
+carefully refreshes per move (they live only in Panel A's connection GroupBox, which is collapsed while running).
+In Auto Run All mode the copy still tells the user to click buttons that are hidden. All four requested gaps are
+confirmed.
+
+1. **[H] Step number + total (request a).** Add `StepProgressDisplay` = `"Step {i+1} of {N}"` over the active
+   step set (N is 4 or 6 depending on `MeasureCurvatureDuringCalibration`); render dim at the top of Panel B.
+   Optionally append the variant: "Step 3 of 6 (direction measurement included)".
+
+2. **[H] Per-step header (request b).** Add a short `StepTitle` above the instruction paragraph: Baseline →
+   "Baseline Measurement", AllInward → "All Screws Inward", ReBaseline → "Return to Baseline", Screw1/2 →
+   "Move Screw 1/2", Complete → "Calibration Complete". Render bold, mirroring Panel C's existing bold header.
+
+3. **[H] Auto-Run-All copy (request c).** `DeviceStepInstructionsText` always ends "Click Run Measurement (or
+   Auto Run All)…", but during `AutoRunAllAsync` those buttons are hidden. Expose `IsAutoRunningAll` (INPC) and,
+   when true, return automated-status wording with no imperative ("Running automatically — taking the baseline
+   measurement." / "…the wizard will apply this move, measure, and advance without further input."). Keep the
+   "Click…" wording only for connected-but-manually-stepped mode. Consider a persistent "Auto Run All in
+   progress — Cancel returns the device to its starting position." banner.
+
+4. **[H] Motor positions + deltas visible during the run (request d).** The 2×2 position/Δ grid exists but only
+   in Panel A, which is collapsed while running — i.e. hidden exactly when `RefreshRunDevicePositionsAsync` is
+   updating it and the deltas matter. Extract it into a shared keyed `DataTemplate` and render it in **Panel B**
+   (gated on `IsTiltDeviceConnected`) and **Panel C** (so the user can verify the restore-to-baseline brought
+   every Δ back to 0 — the single most valuable moment for this display). Style Δ separately (accent when ≠0,
+   dim when 0) rather than appending it into the same text run.
+
+5. **[M] Auto Run All prominence.** For a connected motorized adapter, Auto Run All is the intended primary
+   path but is the third, identically-styled button. When `IsMotorizedDevice && IsTiltDeviceConnected`, make it
+   visually primary (accent) and reorder/retitle the others ("Run This Step" / "Use Saved AF").
+
+6. **[M] Cancel reassurance during Auto Run All.** Retitle Cancel → "Cancel Run" with a tooltip explaining it
+   finishes the in-flight move/measurement (no device abort command), then auto-returns every motor to its start.
+
+7. **[M] Surface the auto-enabled direction measurement.** `ConnectTiltDeviceAsync` silently turns on
+   `MeasureCurvatureDuringCalibration` (4→6 steps). Notify or note it so the extra "all screws" steps aren't
+   confusing (the step counter also mitigates this).
+
+8. **[M] Screw↔corner mapping in visible text.** The mapping is tooltip-only; repeat it once as visible small
+   italic, and/or highlight the moving corner cards during a device move.
+
+9. **[L] Verb consistency.** Align copy verbs with on-screen labels ("Calibrate"/"Abort Wizard"/"Done") — some
+   strings say "Start".
+
+10. **[L] Progress inside Auto Run All / Panel B device status.** Prefix `StatusText` with step context ("Step
+    3 of 6 — Run 1/2…") and carry the small `TiltDeviceStatusText` line into Panel B alongside the positions.
+
+---
+
+## C. Positive-step direction convention (blocker for "up/down" wording)
+Both the move-row semantics (§A.1) and any "up/down" copy depend on what a **positive step** does physically
+(raise/lower a corner, or drive it in/out). This must be confirmed against the wizard's existing terminology
+before hardcoding "up"/"down" — otherwise fall back to "+N / −N steps" with a legend. (Being fetched from the
+wizard XAML/VM + `TiltScrewTargets.cs`.)
+
+---
+
+## Implementation scope
+
+**Implementing now (the four explicit requests):** A.1 (semantic move rows), A.2 (toggle labels), B.1 (step
+number), B.2 (step header), B.3 (Auto-Run-All copy), B.4 (positions+deltas in the running view).
+
+**Offered as follow-ups (Fable's additional suggestions):** A.3–A.9 and B.5–B.10 above. These are real
+improvements but beyond the explicit asks; pull any into scope on request.

--- a/docs/tilt-adapter-ui-review-design.md
+++ b/docs/tilt-adapter-ui-review-design.md
@@ -127,10 +127,19 @@ wizard XAML/VM + `TiltScrewTargets.cs`.)
 
 ---
 
-## Implementation scope
+## Implementation scope — all implemented
 
-**Implementing now (the four explicit requests):** A.1 (semantic move rows), A.2 (toggle labels), B.1 (step
-number), B.2 (step header), B.3 (Auto-Run-All copy), B.4 (positions+deltas in the running view).
+Both the four explicit requests and every additional Fable suggestion have been implemented (branch
+`ghilios/motorized-tilt-adapter`, PR #140):
 
-**Offered as follow-ups (Fable's additional suggestions):** A.3–A.9 and B.5–B.10 above. These are real
-improvements but beyond the explicit asks; pull any into scope on request.
+- **Explicit requests:** A.1 (semantic move rows), A.2 (toggle labels), B.1 (step number), B.2 (step header),
+  B.3 (Auto-Run-All copy), B.4 (positions+deltas in the running/complete panels). — commit `31ea5c4`.
+- **Additional suggestions:** A.3 (corner labels + 2×2 residual grid), A.5 (titled/ordered warning panels), A.6
+  (dynamic Proceed label + disabled reason), A.7 (residual interpretation), A.8 (inline assumed-direction tag),
+  A.9 ("moves" wording); B.5 (Auto-Run-All primary/first + "Run This Step"), B.6 (Cancel Run + tooltip), B.7
+  (direction-measurement default notification), B.8 (visible screw↔corner mapping), B.9 (verb alignment →
+  "Calibrate"), B.10 (connection status in the running panel). — commit `da9d65a`.
+
+**Deferred (deliberately not done):** the twist warning's steps→µm translation (A.5) — it would require plumbing
+`unitMicrons` through the prompt VM ctor and the InspectorVM adjustment seam/tests; the wording was improved but
+kept in steps. Pull this in if wanted.

--- a/plans/motorized-tilt-adapter-eat-plan.md
+++ b/plans/motorized-tilt-adapter-eat-plan.md
@@ -1,0 +1,435 @@
+# Motorized Tilt Adapter Automation (ASG EAT) — Implementation Plan
+
+## Context
+
+HocusFocus's Aberration Inspector already computes precise per-screw tilt + backfocus corrections
+(signed stepper steps for the ASG EAT presets in `TiltAdapterDevicePreset.cs`), but the user must
+apply them by hand in ASG's app. The ASG EAT is a 4-corner motorized tilt adapter controllable over
+serial. This feature closes the loop: connect to the EAT from the Tilt Adapter Calibration pane,
+compute a **minimal move sequence** from the fitted sensor model, get user approval, execute, and
+offer to re-run the inspector to confirm. The calibration wizard also drives its own measurement
+moves when connected (hands-off calibration). Design is extensible to other 4-corner coupled
+devices and future 3-corner independent devices.
+
+**Execution notes for coordinating lower-powered models:**
+- `/clear` before executing (project rule). Tasks are small, **test-first**, independently verifiable.
+- Run `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo` after every change
+  (Windows dotnet.exe via WSL interop; timeout 600000). Never skip/ignore failing tests.
+- Every new `.cs` file gets the MPL copyright header (copy from `TiltScrewGeometry.cs:1-13`).
+- Parallelizable groups are marked; sequential spine is T1→T5→T6→T7→T11 and T2/T12/T13→T14.
+- Work on branch `ghilios/motorized-tilt-adapter`; never push to `develop` directly.
+
+## Device facts (ASG EAT)
+
+- Serial: **9600 baud, 8 data bits, 1 stop bit, no parity, XON/XOFF** flow control.
+- Spec: `C:\Users\ghili\Downloads\ASG EAT Serial Commands.pdf` (commands only). **Response protocol
+  unknown** — captured live in T15. Moves take **5–10 s**; every move/config persists to EEPROM.
+  There is **no abort command** → cancellation is between-commands only.
+- Commands (`<mnemonic>,<value>`): diagonal `tr/tl/br/bl,N` (corner +N, opposite −N, 2 motors);
+  edge `tp/bt/lt/rt,N` (edge pair +N, opposite pair −N, 4 motors); backfocus `bf,N` (all 4 +N);
+  `zr` (zero position counters, no motion), `cp` (query positions), `cA/cB/cC,x` (speed/max/accel,
+  defaults 100/100/300), `or,1-4` (display-only graphic — cosmetic, NEVER rotation compensation),
+  `ep`/`up` (EEPROM read/update). v1 deliberately does not expose `cA/cB/cC`, `or`, `ep`, `up`,
+  **or `zr`** — zeroing positions is the user's job in the vendor app; the plugin never zeroes.
+- Device corner labels: **TR=motor1, TL=motor2, BR=motor3, BL=motor4** (opposite pairs (1,4),(2,3)).
+- Step size 1.8 µm/step, screw radius 55 / 62.75 mm (already in the two EAT presets,
+  `TiltAdapterDevicePreset.cs:67-77`).
+
+## User decisions already made (do not relitigate)
+
+1. The wizard's calibration moves are automated too when the device is connected.
+2. Approval dialog groups moves as **Tilt** and **Backfocus** with a checkbox per group.
+3. Safety = soft position limits + configurable max-excursion and max-steps-per-command.
+4. Manual connect button; device + COM port persisted per profile; **no auto-connect**.
+5. **No zero-positions capability** in the plugin — the user zeroes in the vendor app.
+6. **Per-screw current positions displayed while connected**, refreshed by polling `cp`.
+7. After **30 minutes idle** while connected, a **modal dialog** asks whether to disconnect.
+8. The wizard gets a **movement-amount-per-calibration-step setting**: screw adapters default to
+   **1 rotation**, ASG EAT presets default to **150 steps**.
+9. **One adjustment per measurement (hard invariant):** live automated adjustment never executes
+   more than one approved plan before requiring user input again, and a **fresh sensor-model run
+   is required to confirm the improvement** before any further automatic adjustment is possible.
+   No auto-looping; the same measurement can never be applied twice.
+
+## Core algorithm — minimal-move decomposition (4-corner coupled)
+
+Work in **wizard screw indices** (consecutive around the image; opposite pairs (1,3),(2,4) —
+`TiltCalibrationCalculator.ComputeScrewAngles`, TiltCalibrationCalculator.cs:209-230).
+Per-screw signed step targets come from `TiltScrewGeometry.ScrewCorrectionMicrons` +
+`SignedTotalAdjustment` semantics (`InspectorVM.FillNumericGuidance`, InspectorVM.cs:2006-2072):
+`s_i = (tilt_i + σ·backfocus_i) / unitMicrons`, real-valued (σ = resolved
+`ScrewInwardCurvatureSign`; **σ multiplies backfocus only** — tilt direction is already encoded in
+the stored response-convention angles).
+
+Device generators in `(s1,s2,s3,s4)` space (with the T4 mapping wizard1=TR, wizard2=TL,
+wizard3=BL, wizard4=BR):
+
+| Generator | Per-corner effect | EAT command |
+|---|---|---|
+| D1·x | (+x, 0, −x, 0) | `tr,x` |
+| D2·y | (0, +y, 0, −y) | `tl,y` |
+| E⁺·m = (D1+D2)·m | (+m, +m, −m, −m) | `tp,m` |
+| E⁻·m = (D1−D2)·m | (+m, −m, −m, +m) | `rt,m` |
+| BF·k | (+k, +k, +k, +k) | `bf,k` |
+
+D1, D2, BF are mutually orthogonal spanning a 3-D subspace of R⁴. Exact least-squares projection:
+`a = (s1−s3)/2` (D1), `b = (s2−s4)/2` (D2), `f = (s1+s2+s3+s4)/4` (BF), twist residual
+`t = (s1−s2+s3−s4)/4` — unreachable by ANY rigid-plane device. Report `t`, never plan it. (Note:
+`t` is exactly 0 for a square-clocked EAT with the axis-aligned paraboloid model; it becomes
+nonzero only when the adapter is clocked off 45° — don't treat the reporting path as dead code.)
+
+**Group split is defined in COMMAND space, not by physical origin** (critical: off-center curvature
+X0,Y0≠0 leaks a *linear* term into the D1/D2 components — a split by physical origin would drop it):
+- **Backfocus group** = BF projection `f = mean(s)` → one `bf` move.
+- **Tilt group** = D1/D2 projections of `(s − f)` → diagonal/edge moves.
+Groups stay orthogonal so the dialog checkboxes are independent and nothing is dropped.
+
+**Minimal command count (≤ 3):** round `a`, `b`, `f` independently to integers (bounds per-corner
+residual at 1.0 step = 1.8 µm — do not add a fancier optimizer).
+- Tilt: 0 moves if `ra==rb==0`; **1 edge move** iff `ra == ±rb ≠ 0` (all four sign combos map to
+  tp/bt/rt/lt with positive N); **1 diagonal** if exactly one nonzero; else **2 diagonals**.
+  Never force a common magnitude to save a move (a=3.4, b=2.4 via `tp,3` is worse than 2 diagonals).
+- Backfocus: +1 move if `rf≠0`.
+- Per-move cap splitting (if |magnitude| > cap) happens AFTER minimal decomposition; the axes are
+  orthogonal so Σ ceil(|mᵢ|/cap) is provably minimal under the cap.
+- Report per-corner residual µm = (applied − target)·1.8 in the approval dialog.
+
+**3-corner extensibility:** planner per topology behind one interface — `FourCornerCoupledPlanner`
+(above) vs future `ThreeCornerIndependentPlanner` (one move per screw; requires per-screw
+independent capability which the EAT driver declares it lacks).
+
+## Mapping contract + device-linked calibration gate
+
+The wizard requires opposite pairs at indices (1,3)/(2,4); EAT labels have opposite pairs
+(1,4)/(2,3). **Resolution:** when calibrating with the device connected, the wizard *defines*
+wizard-screw1 ≡ TR (`tr`), wizard-screw2 ≡ TL (`tl`) ⇒ wizard-screw3 ≡ BL, wizard-screw4 ≡ BR.
+Every wizard step then maps 1:1 to a command (Screw1 step "+N motor1/−N motor3" = `tr,N`;
+Screw2 = `tl,N`; AllInward = `bf,N`; ReBaseline1 = `bf,−N`; ReBaseline2 = `tr,−N`;
+**Complete's "return to original position" = `tl,−N`**). `ComputeScrewAngles` supports both
+windings (clockwise = rawDiff<180, TiltCalibrationCalculator.cs:215), so TR→TL adjacency fits
+regardless of image mirroring. Sign convention becomes self-consistent: calibration measures the
+response of the device's actual `+` direction because the wizard itself sent the commands.
+
+**[CRITICAL GATE]** Automation must be blocked unless the stored calibration is device-linked.
+`IsCalibrated` is set by ANY completed run (manual, manual-entry `ApplyManualCalibration`, replay)
+— a pre-existing manual EAT calibration where "screw 1" was, say, BR would make automation apply
+corrections rotated 90°/180°, worsening tilt unattended. Persist a **`DeviceLinkedCalibration`**
+marker (device preset name, set ONLY when a connected hands-off calibration completes; cleared by
+manual entry, replay-driven `RunCalibrationMath`, and disconnected runs). Gate the inspector's
+"Automatic Adjustment" button AND wizard auto-apply on it; remediation text: "Re-run calibration
+with the device connected." Also gate on calibration quality: `RunCalibrationMath` sets
+`IsCalibrated=true` even when quality validation fails — persist/reuse the confidence result and
+hard-block automation on unreliable calibrations.
+
+## Architecture (component map)
+
+```
+Interfaces/
+  ITiltMotionController.cs        device abstraction (topology, capabilities, moves, positions)
+TiltAdapterDevices/
+  TiltAdapterMove.cs              move axes/groups + per-corner effect vectors
+  TiltAdapterMovePlan.cs          moves + residuals + twist + time estimate
+  TiltMovePlanner.cs              pure static decomposition (core math)
+  TiltMotionControllerRegistry.cs preset-name → driver factory ("append one entry" pattern)
+  TiltDeviceConnectionService.cs  shared connection singleton (HocusFocusPlugin static):
+                                  cp position polling + 30-min idle prompt + operation token
+  Prompt/                         approval dialog (4-file ReplaySettingsPrompt pattern)
+  AsgEat/
+    EatCommands.cs                wire formatting + EatSignEncoding strategy   [sign seam]
+    EatSerialTransport.cs         custom read loop, transcript logging        [SEAM FILE]
+    EatResponses.cs               tolerant parsers (ack, cp)                  [SEAM FILE]
+    EatWizardMapping.cs           wizard-index/step ↔ device move
+    EatTiltMotionController.cs    limits, shadow positions, execution
+TiltAdapterWizard/
+  TiltScrewTargets.cs (new)       shared pure per-screw target computation
+  TiltAdapterOptions.cs (+ Interfaces/ITiltAdapterOptions.cs)  new persisted options
+  TiltAdapterWizardVM.cs          connection UI + hands-off calibration
+  DataTemplates.xaml              connection section + option controls
+AutoFocus/
+  InspectorVM.cs                  Automatic Adjustment command; guidance uses shared helper
+  DataTemplates.xaml              button in Tilt Adapter Guidance expander (:2809+)
+```
+
+Key reuse: NINA.Core `ISerialPort`/`SerialPortProvider` (WMI port enumeration,
+`Handshake.XOnXoff` supported), `SerialPortClosedException`, `InvalidDeviceResponseException` —
+already resolved transitively (System.IO.Ports 8.0.0 + System.Management 8.0.0 via
+Microsoft.Windows.Compatibility; **no new package refs**). Do **NOT** subclass `SerialSdk`: it does
+one `ReadLine` (500 ms default, 2 retries) per command and swallows write timeouts — unusable for
+5–10 s moves under XON/XOFF (verified in NINA source). Custom transport is a decision, not an option.
+Modal dialog pattern: `AutoFocus/Replay/ReplaySettingsPrompt.ShowAsync` (IWindowServiceFactory +
+TaskCompletionSource). Re-run inspector: `InspectorVM.AnalyzeAutoFocus(token, captureCameraBlock,
+saveOverride)` (InspectorVM.cs:251; the wizard already calls it at TiltAdapterWizardVM.cs:1266).
+
+## Implementation tasks
+
+### T0 — Materialize spec + plan into the repo — DONE (planning session)
+`docs/motorized-tilt-adapter-eat-design.md` and this file already exist (written at plan
+approval, uncommitted). The executor's first commit on `ghilios/motorized-tilt-adapter`
+should include both.
+
+### T1 — Domain types (pure; no deps)
+**Create** `TiltAdapterDevices/TiltAdapterMove.cs`, `TiltAdapterDevices/TiltAdapterMovePlan.cs`.
+`enum TiltMoveAxis { DiagonalA, DiagonalB, EdgeVertical, EdgeHorizontal, Backfocus }`,
+`enum TiltMoveGroup { Tilt, Backfocus }`, immutable `TiltAdapterMove { Axis, Steps (signed int),
+Group, Description, double[] PerCornerSteps }` (wizard indices 1..4 at [0..3]),
+`TiltAdapterMovePlan { Moves, ResidualMicronsPerCorner, TwistResidualSteps, EstimatedSeconds }`.
+Mirror immutability of `TiltAdapterDevicePreset.cs:25-46`.
+**Tests first** (`Tests/TiltAdapterDevices/TiltAdapterMoveTests.cs`): per-axis `PerCornerSteps`
+match the generator table exactly.
+
+### T2 — TiltMovePlanner (core math) [after T1; parallel with T3/T4/T8/T12]
+**Create** `TiltAdapterDevices/TiltMovePlanner.cs` (pure static; `ITiltMovePlanner` interface for
+the future 3-corner impl). `Plan(double[] sPerScrew, bool includeTilt, bool includeBackfocus,
+double unitMicrons, double perMoveSeconds=10)` + `internal static Decompose(s) → (a,b,f,t)`.
+Implements the command-space group split, minimal-move rules, independent rounding, cap-splitting
+hook, residuals, twist. **Tests first** (`TiltMovePlannerTests.cs`): decomposition recovery
+(pure-tilt antisymmetric → a,b only; uniform → f only), single-edge merge for `ra==±rb` (e.g.
+a=4.6,b=5.4 → one `tp,5`), general → 2 diagonals, ≤3 moves total, sub-step targets → no moves,
+off-center-curvature leakage lands in tilt group (regression for the command-space split),
+residual math, twist reported-not-planned, group toggles, property-style random-input check
+(applied == rounded projection).
+
+### T3 — EAT command formatting [after T1; parallel]
+**Create** `TiltAdapterDevices/AsgEat/EatCommands.cs`. `enum EatSignEncoding { SignedArgument,
+OppositeMnemonic }` + `const Default… = SignedArgument // LIVE-CAPTURE`. Axis→mnemonic:
+DiagonalA→`tr`, DiagonalB→`tl`, EdgeVertical→`tp`/`bt`, EdgeHorizontal→`rt`/`lt`, Backfocus→`bf`.
+Opposite pairs tr↔bl, tl↔br, tp↔bt, rt↔lt; **`bf` has no opposite mnemonic → negative bf MUST use
+signed argument** (assert; this is the one blocking sign unknown). Formatter for `cp` (no `zr` — zeroing is deliberately unsupported).
+**Tests first**: exact wire strings for the whole vocabulary under both encodings.
+
+### T4 — Wizard-step ↔ device-move mapping [after T1; parallel]
+**Create** `TiltAdapterDevices/AsgEat/EatWizardMapping.cs`.
+`CornerLabelForWizardScrew(i)` → 1→TR, 2→TL, 3→BL, 4→BR. `MoveForStep(WizardStep, appliedSteps)`:
+Screw1→DiagonalA(+N), Screw2→DiagonalB(+N), AllInward→Backfocus(+N), ReBaseline1→Backfocus(−N),
+ReBaseline2→DiagonalA(−N), **Complete→DiagonalB(−N)** (the restore move), Baseline→null.
+**Tests first**: each step's `PerCornerSteps` matches the manual instruction wording from
+`StepInstructionsText` (TiltAdapterWizardVM.cs:639-691); inverses verified.
+
+### T5 — ITiltMotionController + registry [after T1]
+**Create** `Interfaces/ITiltMotionController.cs` (`Connected` INPC, `TiltDeviceCapabilities
+{ Topology, SupportedAxes }`, `ConnectAsync/DisconnectAsync`, `ExecuteMoveAsync(move, progress, ct)`,
+`QueryPositionsAsync` — **no zero-positions member**), `TiltAdapterDevices/TiltMotionControllerRegistry.cs`
+keyed by `TiltAdapterDevicePreset.Name` (entries for both EAT presets; factory wired in T7).
+**Tests first**: `IsMotorized` true for EAT presets / false otherwise; invariant guard
+`AdjustmentType==StepperMotors ⇒ registry entry exists` over `TiltAdapterDevicePreset.All`.
+
+### T6 — EAT transport + responses (THE SEAM FILES) [after T3, T5]
+**Create** `AsgEat/EatSerialTransport.cs` (+ `IEatTransport`) and `AsgEat/EatResponses.cs`. ALL
+response-format knowledge lives in these two files; every unknown marked `// LIVE-CAPTURE:`.
+Transport: `SerialPortProvider.GetSerialPort(port, 9600, Parity.None, 8, StopBits.One,
+Handshake.XOnXoff, …)`; own `SemaphoreSlim(1,1)`; `SendAsync(command, timeout, ct) →
+EatRawExchange { Command, Lines, TimedOut }` — read lines until quiet-period or timeout; move
+commands use ≥15 s timeout; **WriteTimeout > max move duration; write timeout = hard failure
+(state-dirty)**; decide `DtrEnable` explicitly (CDC devices often need it; port-open may reset an
+Arduino-class MCU and emit a boot banner — settle before first command); log every line
+`Logger.Info("EAT TX: …" / "EAT RX: …")` (raw). Responses: `ParseMoveAck` (tolerant default:
+success if !TimedOut), `ParseCpPositions` (TryParse-based; throws `InvalidDeviceResponseException`
+with raw lines in the message). **Tests first** (NSubstitute `ISerialPort` fakes): port config
+exact-args, line collection, timeout → TimedOut not throw, port-closed → throw, parser contracts.
+Tests pin the seam CONTRACT, not the unknown wire format.
+
+### T7 — EatTiltMotionController [after T4, T5, T6]
+**Create** `AsgEat/EatTiltMotionController.cs`; wire registry factory. Ctor
+`(IEatTransport, ITiltAdapterOptions)` + default ctor. Behavior:
+- `ConnectAsync`: open → `cp` → cache per-motor positions; if unparseable (guaranteed pre-T15):
+  positions unknown → excursion enforcement unavailable, surfaced as a UI warning flag.
+- **Shadow position tracking**: persisted per-profile per-motor cumulative counters (options, T8),
+  seeded from the first successful `cp` parse after connect; updated on every successful command;
+  reconciled against each `cp` poll once the format is known. (No plugin-side zeroing — if the user
+  zeroes in the vendor app, the next `cp` reconciliation picks it up.)
+- `ExecuteMoveAsync`: validate |steps| ≤ MaxStepsPerCommand and predicted per-motor positions
+  (wizard→device order via `EatWizardMapping`) ≤ MaxExcursion **including intermediate states**
+  (order a multi-move plan to minimize peak excursion — with ≤3 orthogonal moves just evaluate all
+  orderings); throw `TiltDeviceLimitException` BEFORE sending; format via `EatCommands`; send;
+  update cached+shadow positions; settle `TiltDeviceSettleSeconds`; progress "Move 1 of 3: …".
+- Policy when absolute position unknown: per-command cap always enforced; session-cumulative
+  excursion from connect enforced as fallback; warning shown in the approval dialog.
+- Capabilities: FourCornerCoupled; declares NO per-screw independent axis.
+**Tests first** (NSubstitute `IEatTransport`): cp on connect, formatted sends, cap violation →
+no send, excursion violation (incl. intermediate) → no send, position updates on success only,
+cancellation semantics (between-commands; current move completes).
+
+### T8 — New persisted options [independent; parallel from start]
+**Modify** `TiltAdapterOptions.cs` + `Interfaces/ITiltAdapterOptions.cs` (mirror the
+`ScrewInwardCurvatureSign` pattern: field + `InitializeOptions` load + persisting setter + INPC):
+`TiltDeviceSerialPortName` (""), `TiltDeviceMaxStepsPerCommand` (200 — tune in T15),
+`TiltDeviceMaxExcursionSteps` (500 — tune in T15), `TiltDeviceSettleSeconds` (3),
+`DeviceLinkedCalibrationDeviceName` ("" = not linked; the CRITICAL gate),
+`TiltDeviceShadowPositions` (string, serialized per-motor counters + validity flag), and
+**`CalibrationAppliedAmount` (double, persisted; −1 = unset → resolve to the preset default)** —
+this replaces the current session-only VM field (TiltAdapterWizardVM.cs:752-764). Also add a
+**`DefaultCalibrationAmount` field to `TiltAdapterDevicePreset`**: 1.0 (turns) for Manual and all
+screw presets, **150 (steps) for both EAT presets**; `ApplyDevice` (VM:1462) writes the preset
+default into the option on preset change (still user-editable afterward via the existing
+applied-amount input, which re-binds to the persisted option — the option's required UI control).
+**Tests first**: round-trips, defaults, INPC — mirror existing `TiltAdapterOptionsTests`; preset
+defaults (`EatPresets_DefaultCalibrationAmount_Is150`, screw presets 1.0); `ApplyDevice` writes
+the default. UI controls land in T10 (mandatory, project invariant).
+
+### T9 — Shared connection service singleton [after T5, T8]
+**Create** `TiltAdapterDevices/TiltDeviceConnectionService.cs` (`BaseINPC`): `Controller`,
+`Connected`, `ConnectAsync(presetName, port, ct)` via registry, `DisconnectAsync`,
+**exclusive-operation token** `TryBeginOperation(name) → IDisposable` + `IsOperationActive`
+(wizard calibration and inspector plan execution are mutually exclusive; a per-command semaphore
+is not enough), **force-disconnect on `IProfileService.ProfileChanged`** (waits for the in-flight
+command). Also owns:
+- **Position polling**: while connected, poll `cp` on a timer (constant, ~5 s) and expose
+  `int[] CurrentPositions` (+ `PositionsKnown`) via INPC for the UI; **pause polling while an
+  operation token is held** (moves/calibration) and resume after; pre-T15 (cp unparseable) surface
+  `PositionsKnown=false` so the UI shows "unknown". Polling does NOT count as activity.
+- **Idle tracking**: record last *user-initiated* activity (connect, any executed move/plan/
+  calibration step — polling excluded). After **30 min idle**, raise an `IdlePromptRequested`
+  event; the wizard VM (T10) shows a modal "Device idle for 30 minutes — disconnect?" via its
+  `windowServiceFactory` (marshaled through `applicationDispatcher`). Yes → `DisconnectAsync`;
+  No → reset the idle timer. Suppress re-prompting while a prompt is open.
+Wire as `HocusFocusPlugin.TiltDeviceConnectionService` static (mirror HocusFocusPlugin.cs:109-110,
+:252). **Tests first**: connect/disconnect state + INPC, connect-while-connected, operation-token
+exclusivity, profile-change disconnect, polling pauses during operations and resumes, poll updates
+`CurrentPositions`, idle timer fires `IdlePromptRequested` after 30 min without user activity (use
+an injectable clock/timer for tests), polling does not reset the idle timer, "No" resets it.
+
+### T10 — Wizard pane connection UI + option controls [after T8, T9]
+**Modify** `TiltAdapterWizardVM.cs`: `IsMotorizedDevice` (registry lookup on DeviceName; raise
+from `ApplyDevice` like `IsManualDevice` at :984), `AvailablePortNames`
+(`SerialPortProvider.GetPortNames()`), `RefreshPortsCommand`, `ConnectDeviceCommand` /
+`DisconnectDeviceCommand` (AsyncRelayCommand; canExecute motorized + port selected), status text,
+service injected via dual-ctor. Subscribe to the service's `IdlePromptRequested` and show the
+modal disconnect prompt (windowServiceFactory, ReplaySettingsPrompt pattern; result routed back
+to the service). **No zero-positions command anywhere** (vendor app's job).
+**Modify** `TiltAdapterWizard/DataTemplates.xaml`: "Motorized Device Connection" GroupBox in Panel
+A after the preset ComboBox (:288-315), Visibility on `IsMotorizedDevice`: COM-port ComboBox +
+refresh + Connect/Disconnect + status + a **live per-screw positions display** (4 corners labeled
+TR/TL/BR/BL with wizard screw numbers, bound to the service's polled `CurrentPositions`; shows
+"unknown" when `PositionsKnown=false`); numeric controls for the T8 limit/settle options (reuse
+existing `ValidationRules/`). **Tests first**: VM-level gating, command canExecute, connect
+persists port, idle prompt Yes → service disconnect / No → timer reset. Verify: suite + full
+solution build.
+
+### T11 — Hands-off wizard calibration [after T4, T7, T9, T10]
+**Modify** `TiltAdapterWizardVM.cs` (+ Panel B XAML :768+):
+- `internal async Task<bool> ExecuteDeviceMoveForCurrentStepAsync(ct)`: no-op for
+  Baseline; otherwise `EatWizardMapping.MoveForStep` → `Controller.ExecuteMoveAsync`; on
+  failure/cancel execute the inverse move (recovery table = T4 inverses; wire into the existing
+  failure-retry path at :1185-1187) and surface the error.
+- In the measurement flow (`RunMeasurementAsync` :1136 / `MeasureStep` :1173): when connected +
+  motorized, execute the device move BEFORE the inspector measurement; hold the T9 operation token
+  for the whole run.
+- `AutoRunAllCommand`: loop move→measure→`NextStep` to Complete (including Complete's restore
+  move `tl,−N`), honoring progress + cancellation (cancel finishes the current move, then recovers
+  toward baseline).
+- **When connected: default `MeasureCurvatureDuringCalibration` ON** (6-step flow measures σ via
+  the real `bf` command — the exact command automation later replays). If the user disables it,
+  backfocus moves later carry an "(assumed direction)" warning.
+- **Applied amount**: use the persisted `CalibrationAppliedAmount` setting (T8; EAT preset default
+  150 steps = 270 µm — the old 1.0 default would be 1.8 µm, noise-dominated against
+  `MinReliableSignalToNoise=2.0`); validate against `TiltDeviceMaxStepsPerCommand` and soft limits
+  before `StartAsync` proceeds.
+- On successful completion of a connected run: write `DeviceLinkedCalibrationDeviceName`; clear it
+  in `ApplyManualCalibration`, replay-driven `RunCalibrationMath`, and disconnected runs.
+- Instruction text: automated status ("Applying tr,+50 …") from `Move.Description` when connected;
+  manual text otherwise.
+**Tests first** (NSubstitute controller via service test ctor): per-step commands, baseline no-op,
+failure → inverse recovery, AutoRunAll walks 4-step and 6-step sequences incl. Complete restore,
+cancel → recovery, disconnected regression (behaves exactly as before), device-linked marker
+set/cleared correctly, applied-amount defaulting.
+
+### T12 — Shared per-screw target computation [independent; parallel from start]
+**Create** `TiltAdapterWizard/TiltScrewTargets.cs` (pure static, beside `TiltScrewGeometry`):
+`ComputePerScrewTargets(gx, gy, kx, ky, x0, y0, angles[], radiusMicrons, unitMicrons, σ) →
+double[] sPerScrew` (and tilt/backfocus micron components for display). **Modify**
+`InspectorVM.FillNumericGuidance` (:2006) to format its display strings FROM this helper
+(behavior unchanged); the planner (T14) consumes the same helper directly from
+`SensorModel.DisplayedSensorModel` — single source of truth, no widening of the display VM.
+**Tests first**: helper outputs formatted with `TiltAdapterGuidanceVM.FormatAmount` equal the
+previously displayed strings (regression lock); σ applies to backfocus only; positive = wizard "+".
+
+### T13 — Approval dialog [after T1; parallel with T6–T12]
+**Create** `TiltAdapterDevices/Prompt/` — 4-file `ReplaySettingsPrompt` pattern
+(`ReplaySettingsPrompt.cs:29-57`): `TiltDeviceAdjustmentPromptVM` (+Control.xaml, +static
+`ShowAsync`, +`TiltDeviceAdjustmentChoice { Proceed, ApplyTilt, ApplyBackfocus, FinalPlan }`).
+Contents: move list (wire command + human description + group), **Tilt / Backfocus checkboxes**
+(re-plan on toggle via injected replanner `Func<bool,bool,TiltAdapterMovePlan>`), per-corner
+residual µm, twist warning when |t| ≥ 1 step, "(assumed direction)" warning on backfocus when
+`!ScrewInwardCurvatureSignIsMeasured`, pitch-mismatch warning (reuse the
+`PitchMismatchExceeds` text from InspectorVM.cs:2065-2071), limit warnings / unknown-position
+warning, estimated duration; Proceed disabled when both groups off or a hard limit is violated.
+**Tests first**: toggle → replan, both-off → disabled, limit warning → disabled, choice carries plan.
+
+### T14 — Inspector "Automatic Adjustment" end-to-end [after T2, T9, T12, T13]
+**Modify** `AutoFocus/InspectorVM.cs`: `AutomaticAdjustmentCommand` (AsyncRelayCommand; canExecute:
+service `Connected` **&& `DeviceLinkedCalibrationDeviceName` matches the connected preset** &&
+numeric guidance available && `!IsWizardRunning` via operation token && calibration quality OK
+**&& the current sensor model is newer than the last executed adjustment** — a
+measurement-generation counter incremented on each completed inspector analysis and stamped onto
+any executed plan enforces the one-adjustment-per-measurement invariant: after a plan executes,
+the command stays disabled ("Run the Aberration Inspector to confirm before adjusting again")
+until a fresh sensor-model run completes; the same measurement can never drive two plans;
+re-raise on service INPC). Flow: `TiltScrewTargets` from `DisplayedSensorModel` →
+`TiltMovePlanner.Plan` → `TiltDeviceAdjustmentPrompt.ShowAsync` → hold operation token → execute
+`FinalPlan.Moves` sequentially with progress (`applicationStatusMediator`) and an **applied-move
+journal** → on failure/cancel: stop, offer one-click revert (inverse mnemonics, reverse order; if
+revert fails → mark positions dirty, force resync on next connect) → completion prompt "Re-run
+Aberration Inspector to confirm?" → yes → `await AnalyzeAutoFocus(token, true)`. After the re-run,
+compare before/after tilt magnitude and **warn loudly + offer revert if tilt worsened** (catches
+stale calibration / rotated camera). Extract `internal static` helpers for plan building.
+**Modify** `AutoFocus/DataTemplates.xaml`: button in the "Tilt Adapter Guidance" Expander (:2809+)
+near the numeric grid (:2967+); Visibility on service Connected, IsEnabled via canExecute; when
+connected but not device-linked, show the remediation hint instead.
+**Tests first**: targets-from-model (not strings), canExecute gates (disconnected / not linked /
+wizard running), dialog cancel → no moves, approved moves in order, mid-plan failure → journal +
+revert offer, re-run invoked on accept, **stale-measurement lockout** (after execution canExecute
+is false until a new analysis completes; a second execution off the same measurement is
+impossible; dialog-cancel does NOT consume the measurement).
+
+### T15 — Live protocol capture session (hardware; LAST; touches ONLY seam files)
+Resolve every `// LIVE-CAPTURE:` marker against the real EAT (transcript logging from T6 gives the
+raw data). **Files:** `EatResponses.cs`, `EatSerialTransport.cs` (+ possibly flip
+`EatCommands.DefaultSignEncoding`, + sign constants in `EatWizardMapping` if the device `+` is
+inverted — convention constants, not protocol code). Checklist:
+1. Framing: line terminator (\r vs \r\n vs \n), lines per command, boot banner on port open,
+   DTR requirement, reset-on-open behavior.
+2. Ack: format, error strings, and WHEN it arrives (command receipt vs move completion) → pick
+   completion strategy: ack-is-completion / poll `cp` (does the device answer `cp` mid-move or
+   does XOFF block it?) / fixed settle fallback.
+3. Negative values: is `tr,-10` accepted? (Only truly blocking for `bf` — no opposite mnemonic.)
+4. `cp` format: motor order (TR/TL/BR/BL?), absolute vs relative, units; reconcile shadow
+   counters; confirm the ~5 s polling cadence is safe (no firmware confusion, no XOFF stalls) and
+   that positions reflect vendor-app zeroing done outside the plugin.
+5. Semantics: `tr,10` relative move vs absolute target; EEPROM position after power-loss mid-move
+   (kill power mid-move; does cp reflect pre- or post-move?).
+6. Directions: per-mnemonic cross-check with `cp` before/after `tr/tl/tp/rt/bf` — verify `bf,+N`
+   moves TR the same physical direction as `tr,+N`; verify device `+` matches the wizard "+"
+   convention (one manual measurement); store per-mnemonic sign factors in the driver if needed.
+7. Travel limits → tune `MaxStepsPerCommand` / `MaxExcursionSteps` / `SettleSeconds` defaults (T8).
+8. Update `EatResponsesTests` fixtures with REAL captured lines; suite green.
+Then: full hands-off wizard calibration + Automatic Adjustment + re-run confirm on hardware.
+
+## Verification
+
+1. After every task: `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo` green.
+2. Full build (`dotnet build … -c Debug`) — the csproj PostBuild deploys the plugin into NINA's
+   plugin folder automatically (including on test runs).
+3. Pre-hardware smoke (NINA, no device): EAT preset selected → connection section appears; Manual
+   preset → hidden; disconnected wizard + inspector behave exactly as before (regression).
+4. Hardware (T15): capture transcript → parser fixtures updated → hands-off 6-step calibration →
+   inspector run → Automatic Adjustment (verify move list matches guidance table signs, residuals
+   sane) → approve → re-run → tilt/backfocus reduced; confirm the button stays disabled after
+   execution until the confirming re-run completes (one adjustment per measurement); test
+   cancel-mid-plan revert; test soft-limit refusal; test port-unplug mid-session
+   (SerialPortClosedException → clean disconnect + notify).
+
+## Risks / future work
+
+- **Response protocol unknown** — contained to 2 seam files + 2 sign constants; everything else
+  is contract-tested and must not change in T15.
+- **σ / direction errors** are the highest-consequence failure (EEPROM-persisted wrong-way moves);
+  mitigations: 6-step default when connected, device-linked gate, per-mnemonic live cross-check,
+  approval dialog with signed moves, post-adjustment worsening check + revert journal.
+- Camera/adapter rotation after calibration invalidates angles (no cheap detection) — documented;
+  worsening check is the backstop. `or` is cosmetic only.
+- Future: `ThreeCornerIndependentPlanner` (interface in place), other 4-corner devices (registry
+  "append one entry" + driver), sequence-item automation, manual-manual EAT users declaring a
+  corner mapping without recalibrating (deliberately out of v1 — recalibration is the safe path).
+- v1 leaves `cA/cB/cC`, `or`, `ep`, `up` unexposed.
+- Manual (documentation/docs) updates for the new UI belong in a follow-up PR per documentation
+  conventions (`.claude/docs/documentation-style.md`).

--- a/plans/simulated-eat-tilt-adapter-plan.md
+++ b/plans/simulated-eat-tilt-adapter-plan.md
@@ -1,0 +1,129 @@
+# Simulated ASG EAT Tilt Adapter — Connect & Calibrate Without Hardware — Plan
+
+> Per project convention (CLAUDE.md), before execution this plan should be saved as
+> `plans/simulated-eat-tilt-adapter-plan.md`. Design rationale (convergence proof, seam choice) can be
+> distilled into `docs/simulated-eat-tilt-adapter-design.md` if a separate spec is wanted.
+
+## Context
+
+The motorized tilt-adapter (ASG EAT) automation (PR #140, branch `ghilios/motorized-tilt-adapter`, tasks
+T0–T14 done) closes the loop: connect to the EAT over serial, run a hands-off calibration, compute a minimal
+move plan from the fitted sensor model, and apply it — but the whole feature is currently **blocked on T15
+live-hardware serial capture** and cannot be exercised end-to-end without the physical device.
+
+Separately, the plugin already ships a **camera simulator** (`HocusFocusSimulatorCamera`) and a **virtual tilt
+adapter** (`CameraSimulator/TiltAdapter/SimulatedTiltAdapter`) whose whole purpose is to close the calibration
+loop in software: inject a tilt → the inspector says how far to turn each screw → apply it → the injected tilt
+converges to flat. Today that virtual adapter is driven only by manual button clicks on a dockable panel.
+
+**This change makes the virtual tilt adapter connectable as if it were a real EAT over serial**, so a user can
+run the *entire* automated calibration + inspector "Automatic Adjustment" loop against the camera simulator with
+**no hardware connected**. Concretely: a `"Simulator"` entry appears in the Tilt Adapter Wizard's COM-port
+dropdown; selecting it and connecting routes the (unchanged) EAT motion controller onto a simulated transport
+that drives the virtual adapter. On connect, if the simulator's tilt config doesn't match the selected EAT
+preset, the user is asked whether to auto-fix it; if they decline, connect aborts.
+
+This also delivers a durable pre-hardware **testbed** for the T15 automation logic (planner, limits, shadow
+tracking, one-adjustment-per-measurement gate) — all of which the transport-level seam exercises unchanged.
+
+## Approach (validated by two independent design reviews)
+
+Insert the simulator at the **transport seam** (`IEatTransport`), keeping `EatTiltMotionController`,
+`EatCommands`, `EatResponses`, `TiltMovePlanner`, `EatWizardMapping`, and the wizard/inspector automation
+**completely unchanged**. When the wizard connects with the `"Simulator"` port sentinel, the connection service
+builds `new EatTiltMotionController(new SimulatedEatTransport(actuator), options)` instead of the serial-backed
+controller. The simulated transport answers `cp` with per-motor counters and turns each move command into a
+change in the camera simulator's injected aberration, so the next simulated exposure reflects it.
+
+### Why the closed loop converges (the correctness core)
+
+The wizard's **device-linked calibration measures** the sim's response: `RunCalibrationMath` overwrites the
+stored screw angles (`ComputeScrewAngles`) and — on the 6-step run — the curvature sign (`ComputeCurvatureSign`)
+with measured values, while the **hardware fields stay locked to the preset** (`ApplyDevice` sets
+`ScrewCount/AdjustmentType/StepperStepSizeMicrons/ScrewRadiusMillimeters`). Guidance then consumes preset-locked
+hardware + measured angles/sign. Because `SimulatedTiltAdapter.ApplyMoves` is the exact inverse of
+`TiltScrewGeometry.TiltCorrectionMicrons` under one shared plane model, the loop is the identity **iff the four
+hardware fields match a priori** — angles and sign self-correct via calibration. Load-bearing details:
+
+- **Radius must match** (it is not merely conservative): the backfocus target scales as R² while the sim's
+  backfocus response scales as 1/R²; a step-size adjustment cannot absorb both the R¹ tilt term and the R²
+  backfocus term. So a radius mismatch diverges backfocus.
+- **The 6-step curvature run must actually execute** for the sign to self-correct; otherwise backfocus can
+  diverge. The connect flow already defaults `MeasureCurvatureDuringCalibration = true` on connect
+  (`TiltAdapterWizardVM.cs:1302-1315`) — keep it.
+- **Device-linked gate ordering:** Automatic Adjustment is blocked until a *connected* calibration completes
+  (`DeviceLinkedCalibrationDeviceName`), which is exactly what forces the angle/sign measurement to happen first.
+  Since the simulated controller is a real `EatTiltMotionController` under the EAT preset, a completed simulated
+  hands-off calibration sets this marker and unlocks Automatic Adjustment — no special-casing needed.
+- **Index mapping:** feed each move's **wizard-order** `PerCornerSteps` (× step size) directly to
+  `ApplyMoves` (sim screw `i` ≡ wizard screw `i+1`). Do **not** apply `PermuteWizardToDeviceMotorOrder` on the
+  optics path — that would turn a pure tilt into a twist and break recovery. Track the `cp`/shadow counters
+  **separately in device order** (TR,TL,BR,BL) via `PermuteWizardToDeviceMotorOrder`, matching real hardware.
+- **Do NOT sync angles/sign** in the config-match fix — only the four hardware fields. Syncing angles/sign would
+  be immediately discarded by calibration and would remove the exact coverage the simulator exists to provide.
+
+### Operational preconditions (per user decisions)
+
+- **Block connect until the HocusFocus camera simulator is the active camera.** The calibration exposures only
+  respond to the virtual adapter when `HocusFocusSimulatorCamera` is the connected camera. Gate on
+  `cameraMediator.GetInfo().Connected && DeviceId == "HocusFocus_SimulatorCamera"`.
+- **Auto-enable aberration rendering + notify.** `ICameraSimulatorOptions.EnableAberrations` defaults **off** and
+  gates rendering (`HocusFocusSimulatorCamera` renders a flat field when off), making the loop inert. On connect
+  to the simulator, if it's off, enable it and show a status notification.
+
+## Components
+
+### New files
+
+| File | Responsibility |
+|---|---|
+| `TiltAdapterDevices/SimulatedTiltPort.cs` | Sentinel constant: `const string PortName = "Simulator"` + `IsSimulator(string)`. Shared by the connection service (routing), wizard VM (dropdown + gate), and plugin (factory). |
+| `CameraSimulator/TiltAdapter/ISimulatedTiltActuator.cs` | Seam the transport drives: `void ApplyWizardScrewSteps(double[] wizardOrderSteps)` (optics) and `int[] GetPerMotorPositions()` (device-order counters for `cp`). Unit-testable. |
+| `CameraSimulator/TiltAdapter/SimulatedTiltActuator.cs` | Impl over `ICameraSimulatorOptions` + `IApplicationDispatcher`. Builds a `SimulatedTiltAdapter` from `Sim*` options (mirror `RebuildAdapter`), feeds **wizard-order** steps to `ApplyMoves`, folds the result via `SimulatedTiltInjection.Fold` (marshalled onto the dispatcher so the shared `CameraSimulatorOptions` writes land on the UI thread and the dockable updates live), and accumulates **device-order** `cp` counters via `PermuteWizardToDeviceMotorOrder`. Catches the collinear-geometry guard like the VM does. |
+| `CameraSimulator/TiltAdapter/SimulatedTiltInjection.cs` | Behavior-preserving extraction of the sign-critical fold from `SimulatedTiltAdapterVM.ApplyDelta` (`:705-746`): `static bool Fold(ICameraSimulatorOptions, AberrationDelta, int pistonDirectionSign)`. Shared by the VM (delegates to it) and the actuator so the two halves of the loop cannot drift. |
+| `CameraSimulator/TiltAdapter/SimulatedEatTransport.cs` | `IEatTransport` impl. `SendAsync("cp")` → canonical `"p0,p1,p2,p3"` device-order line (parses via `EatResponses.ParseCpPositions`). `SendAsync(moveWire)` → `EatCommands.TryParse` → `TiltAdapterMove.PerCornerSteps` (wizard order) → `actuator.ApplyWizardScrewSteps(steps × unit)` → ack (`TimedOut=false` → `ParseMoveAck` true). Ctor takes `ISimulatedTiltActuator` (test seam). Unparseable command → throw (only `cp`/`Format` output is ever sent). |
+
+### Edits to existing files
+
+- **`TiltAdapterDevices/AsgEat/EatCommands.cs`** — add `public static bool TryParse(string wire, out TiltMoveAxis axis, out int steps, EatSignEncoding encoding = DefaultSignEncoding)`, the exact inverse of `Format`, using the same mnemonic tables. `bf` and `SignedArgument` decode the signed value; `OppositeMnemonic` decodes negatives from the opposite mnemonic. Round-trip-tested against `Format`.
+- **`TiltAdapterDevices/TiltDeviceConnectionService.cs`** — additive nullable `Func<ITiltMotionController> simulatedControllerFactory` on the public ctor (`:142`, only the plugin calls it) and the internal ctor (`:147`, all four test sites pass 4 positional args → unaffected). In `ConnectAsync` (`:215`), route: `SimulatedTiltPort.IsSimulator(portName) && simulatedControllerFactory != null ? simulatedControllerFactory() : controllerFactory(presetName, options)`. `controller.ConnectAsync(portName)` is unchanged (the sim transport ignores the port string). **Registry stays pure.**
+- **`HocusFocusPlugin.cs`** (`:125-127`) — pass the sim factory when constructing `TiltDeviceConnectionService`. A lazily-created shared `SimulatedTiltActuator(CameraSimulatorOptions, ApplicationDispatcher)` (captured in the closure) keeps counters + injected aberration coherent across reconnects; the closure runs only at Connect time, by when both singletons exist.
+- **`TiltAdapterWizard/TiltAdapterWizardVM.cs`**
+  - Inject `ICameraSimulatorOptions` (via `HocusFocusPlugin.CameraSimulatorOptions` in the `[ImportingConstructor]`; optional test-seam param in the full ctor, mirroring `confirmIdleDisconnectAsync`). Add an injectable `Func<string,string,Task<bool>> confirmSimConfigChangeAsync` seam defaulting to a `MyMessageBox.Show(..., YesNo, No)` wrapper.
+  - `EnumeratePortNames()` (`:1271`) — prepend `SimulatedTiltPort.PortName`. The sentinel is non-empty (survives the `SelectedPortName` null/empty guard) and enables `ConnectDeviceCommand`. The whole GroupBox is gated on `IsMotorizedDevice`, so it only appears under an EAT preset — correct scoping for free.
+  - `ConnectTiltDeviceAsync()` (`:1292`) — before `svc.ConnectAsync`, when `SimulatedTiltPort.IsSimulator(port)`:
+    1. **Block-until-active gate:** if `cameraMediator.GetInfo()` is not Connected or `DeviceId != "HocusFocus_SimulatorCamera"`, `Notification.ShowError(...)` and return (do not connect).
+    2. **Config-match:** compare `Sim{ScrewCount,AdjustmentType,StepperStepSizeMicrons,ScrewRadiusMillimeters}` vs `TiltAdapterDevicePreset.ByName(DeviceName)`. If differ → `confirmSimConfigChangeAsync(...)`; **No → return** (don't connect); **Yes →** write the four preset fields into the `Sim*` setters (mirror `ApplyDevice` `:2231-2235`).
+    3. **Auto-enable aberrations:** if `!cameraSimulatorOptions.EnableAberrations`, set it true and `Notification.ShowInformation("Enabled simulator aberrations for calibration.")`.
+- **`CameraSimulator/TiltAdapter/SimulatedTiltAdapterVM.cs`** — `ApplyDelta` (`:705`) becomes a one-line delegate to `SimulatedTiltInjection.Fold`. Behavior-preserving; the pinned sign tests keep passing.
+- **`CameraSimulator/HocusFocusSimulatorCamera.cs`** — add `public const string DeviceId = "HocusFocus_SimulatorCamera";` and make `Id => DeviceId`, so the wizard gate references the constant, not a magic string.
+
+## Task sequence (test-first; run the suite after each)
+
+1. **T1 — `EatCommands.TryParse`** + `EatCommandsTests`: round-trips `Format` for the whole vocabulary under both sign encodings; `"cp"` and malformed strings return false; negative `bf` under both encodings.
+2. **T2 — Extract `SimulatedTiltInjection.Fold`** from `ApplyDelta`; VM delegates. Existing `SimulatedTiltAdapterVMTests` sign/clamp tests are the regression lock (must stay green unchanged).
+3. **T3 — `ISimulatedTiltActuator` + `SimulatedTiltActuator`** + tests: counters start at 0 and advance in device order; wizard-order feed to `ApplyMoves`; diagonal pair → tilt-only, backfocus (all four) → backfocus-only; apply-then-inverse returns to baseline; fold marshalled through a recording dispatcher; collinear geometry still tracks counters and acks.
+4. **T4 — `SimulatedEatTransport`** + tests (substitute `ISimulatedTiltActuator`): `cp` line parses via `EatResponses.ParseCpPositions`; `"tr,5"`/`"tl,5"`/`"bf,150"` reach the actuator with correct wizard-order effects; move acks; unparseable throws. Plus an **integration test** through the real unchanged `EatTiltMotionController` (connect seeds shadow from `cp`; a move advances counters + folds aberration; `QueryPositionsAsync` returns them).
+5. **T5 — `SimulatedTiltPort` + connection-service routing** + tests: sentinel port uses the sim factory (registry not invoked); non-sentinel uses the registry; null sim factory is inert (existing tests unaffected).
+6. **T6 — Plugin wiring** (`HocusFocusPlugin`): construct the service with the sim factory; add the camera `DeviceId` const.
+7. **T7 — Wizard VM** + tests: dropdown contains the sentinel first; sentinel enables Connect; block-until-active refuses when the HF sim camera isn't active; config-match Yes writes the four `Sim*` fields then connects; No does not connect and writes nothing; matching config connects without prompt; aberrations auto-enabled on connect; a real COM port never prompts/gates. Update the one existing test that asserts exact `AvailablePortNames` contents (`AvailablePortNames_EnumeratesLazily...`) to include the sentinel.
+8. **T8 — End-to-end verification** (below).
+
+## Verification
+
+1. **Unit suite green after every task:** `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo` (Windows `dotnet.exe` via WSL interop; timeout 600000). Never skip/ignore failing tests.
+2. **Full build** deploys the plugin into NINA's plugin folder (PostBuild xcopy).
+3. **Manual end-to-end in NINA, no hardware:**
+   - Connect the **HocusFocus camera simulator** + a simulator focuser. Inject a tilt via the Simulator Tilt Adapter panel.
+   - In the Tilt Adapter Wizard, select an **EAT preset** (e.g. "ASG Electronic EAT - 90mm") → the connection section appears with **"Simulator"** in the port dropdown.
+   - Connect with a real COM port first → **no** config prompt/gate (regression). Switch to "Simulator": if the HF sim camera isn't active, connect is **refused**; with it active and a mismatched sim config, the **Yes/No popup** appears; **No** → not connected; **Yes** → the four sim fields update and it connects; aberrations auto-enable with a notification.
+   - Run the **hands-off 6-step calibration** through the simulated EAT → completes and sets the device-linked marker; the live per-corner positions update from `cp`.
+   - Run the **Aberration Inspector**, then **Automatic Adjustment** → approve the plan → moves apply to the sim → re-run confirms the injected tilt/backfocus **reduced**. Confirms the full loop with no hardware.
+   - Regression: Manual/screw presets show no "Simulator" entry and behave exactly as before.
+
+## Risks
+
+- **Sign/convergence** is the highest-consequence area; mitigated by extracting (not duplicating) the fold, the wizard-order-feed invariant, the radius-must-match gate, and defaulting the 6-step curvature run on connect. The integration test through the real controller is the backstop.
+- **Sim config drift after the config-fix** (user edits `Sim*` between connect and calibrate) — out of scope; the coherence badge already flags mismatches, and a fresh connect re-checks.
+- **`AvailablePortNames` test** is the only existing test that must change; all ctor changes are additive/optional so other test sites stay green.
+- This feature does not touch the T15 seam files and does not depend on the real wire format (the sim defines a clean, self-consistent `cp`/ack format the tolerant parsers already accept).


### PR DESCRIPTION
Closes the loop on tilt/backfocus correction: connect to the ASG EAT motorized tilt adapter over serial from the Tilt Adapter Calibration pane, run a hands-off calibration, and let the Aberration Inspector compute + apply a **minimal move sequence** with explicit user approval and a re-run confirmation. Implements `plans/motorized-tilt-adapter-eat-plan.md` (design in `docs/motorized-tilt-adapter-eat-design.md`).

## What's here (T1–T14; T15 is the hardware step, see below)
- **Core math** — orthogonal minimal-move decomposition (diagonal/edge/backfocus generators; ≤3 moves; twist reported, never planned), command-space Tilt/Backfocus split, per-command cap-splitting, per-corner residuals.
- **Device layer** — ASG EAT command formatting (with a sign-encoding seam), a custom XON/XOFF serial transport + tolerant parsers (**all unknown wire-format details isolated behind `// LIVE-CAPTURE:` markers for T15**), and a controller that enforces per-command cap + per-motor excursion (incl. intermediate states) **before** any EEPROM-persisting send, with shadow-position tracking and `cp` reconciliation.
- **Connection service** — shared singleton: manual connect (no auto-connect), per-profile COM port, `cp` position polling, exclusive-operation lease, 30-min idle-disconnect prompt, profile-change disconnect.
- **Wizard** — hands-off calibration drives the device's own measurement moves and, on a genuine connected run, marks the calibration device-linked.
- **Inspector** — "Automatic Adjustment": plan → approval dialog (signed wire commands front-and-center, Tilt/Backfocus toggles re-plan live) → execute with an applied-move journal → reverse-order revert on failure → optional re-run + tilt-worsening backstop.

## Safety gate
Automated moves require **all** of: connected, calibration **device-linked** (performed with *this* device), calibration **reliable** (SNR ≥ 2.0), valid guidance, no wizard operation in flight, and a **fresh** sensor-model run since the last adjustment (one adjustment per measurement; a cancel or an approved empty plan never consumes the measurement). State-ambiguous send failures are surfaced rather than reported as "nothing sent."

## Testing
Full suite **2180 passed / 0 failed**. Each task was implemented test-first and independently reviewed; the composed critical gate has a dedicated test lock. No hardware was involved.

## Remaining: T15 (hardware)
The live serial-protocol capture on a real EAT (line terminator, ack/`cp` framing, DTR/boot-banner, negative-value encoding, per-mnemonic direction cross-check, limit tuning) is deliberately **not** in this PR. It's contained to the two seam files + two sign constants (`// LIVE-CAPTURE:` markers) and the contract tests pin everything else so nothing outside the seams should change. Manual (documentation/docs) updates for the new UI belong in a follow-up per project conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013emnWAzJBXXqWZqqRx76QC