### PR TITLE
feat(tilt): simulator tilt-angle display, single-screw entry, wizard calibration clear

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/SimulatedTiltAdapterVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/SimulatedTiltAdapterVMTests.cs
@@ -530,7 +530,9 @@ public class SimulatedTiltAdapterVMTests {
             Assert.That(vm.TiltAmountMicrons, Is.EqualTo(12.4));
             Assert.That(vm.TiltAngleDegrees, Is.EqualTo(214.0));
             Assert.That(vm.BackfocusErrorMicrons, Is.EqualTo(-5.0));
-            Assert.That(vm.TiltDisplay, Is.EqualTo("12.4 µm @ 214°"));
+            // The state strip now shows the tilt as the sensor-plane angle θ (not µm), at the injected azimuth.
+            Assert.That(vm.TiltAngleThetaDegrees, Is.GreaterThan(0.0), "a non-zero injected swing yields a positive tilt angle");
+            Assert.That(vm.TiltDisplay, Is.EqualTo($"{vm.TiltAngleThetaDegrees.ToString("0.000", System.Globalization.CultureInfo.CurrentCulture)}° @ 214°"));
             Assert.That(vm.BackfocusDisplay, Is.EqualTo("−5.0 µm"));
         });
     }
@@ -628,18 +630,39 @@ public class SimulatedTiltAdapterVMTests {
     }
 
     [Test]
-    public void AutoFillEvenly_WritesAValidGeometryInOneClick([Values(3, 4)] int screwCount) {
+    public void ScrewAngles_DeriveEvenlyFromScrew1Clockwise([Values(3, 4)] int screwCount) {
         var options = Configured(screwCount);
-        options.SimScrew1AngleDegrees = double.NaN;
         var vm = new SimulatedTiltAdapterVM(options, realAdapterOptions: null);
-        Assert.That(vm.IsAdapterConfigured, Is.False, "guard: a NaN angle must gate the panel");
 
-        vm.AutoFillAnglesCommand.Execute(null);
+        options.SimScrewNumberingClockwise = true;
+        options.SimScrew1AngleDegrees = 0.0;
+
+        var step = 360.0 / screwCount;
+        Assert.Multiple(() => {
+            Assert.That(vm.IsAdapterConfigured, Is.True);
+            Assert.That(options.SimScrew2AngleDegrees, Is.EqualTo(step).Within(1e-9));
+            Assert.That(options.SimScrew3AngleDegrees, Is.EqualTo(2 * step).Within(1e-9));
+            if (screwCount == 4) {
+                Assert.That(options.SimScrew4AngleDegrees, Is.EqualTo(3 * step).Within(1e-9));
+            } else {
+                Assert.That(double.IsNaN(options.SimScrew4AngleDegrees), Is.True);
+            }
+        });
+    }
+
+    [Test]
+    public void ScrewNumbering_CounterClockwise_ReversesTheDerivedAngles() {
+        var options = Configured(screwCount: 3);
+        var vm = new SimulatedTiltAdapterVM(options, realAdapterOptions: null);
+
+        options.SimScrew1AngleDegrees = 0.0;
+        options.SimScrewNumberingClockwise = false;
 
         Assert.Multiple(() => {
             Assert.That(vm.IsAdapterConfigured, Is.True);
-            Assert.That(options.SimScrew1AngleDegrees, Is.EqualTo(screwCount == 3 ? 0.0 : 45.0));
-            Assert.That(options.SimScrew2AngleDegrees, Is.EqualTo(screwCount == 3 ? 120.0 : 135.0));
+            // Counter-clockwise: screw i advances -i·(360/N) from screw 1, normalized to [0, 360).
+            Assert.That(options.SimScrew2AngleDegrees, Is.EqualTo(240.0).Within(1e-9));
+            Assert.That(options.SimScrew3AngleDegrees, Is.EqualTo(120.0).Within(1e-9));
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/CameraSimulatorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/CameraSimulatorOptions.cs
@@ -257,6 +257,7 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator {
             // Heal a stored screw count outside 3|4 (a hand-edited or legacy profile). SimulatedTiltAdapter rejects
             // anything else, so an unhealed value would surface as a panel-construction crash rather than a 3.
             simScrewCount = optionsAccessor.GetValueInt32(nameof(SimScrewCount), 3) == 4 ? 4 : 3;
+            simScrewNumberingClockwise = optionsAccessor.GetValueBoolean(nameof(SimScrewNumberingClockwise), true);
             simScrew1AngleDegrees = optionsAccessor.GetValueDouble(nameof(SimScrew1AngleDegrees), 0.0);
             simScrew2AngleDegrees = optionsAccessor.GetValueDouble(nameof(SimScrew2AngleDegrees), 120.0);
             simScrew3AngleDegrees = optionsAccessor.GetValueDouble(nameof(SimScrew3AngleDegrees), 240.0);
@@ -300,6 +301,7 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator {
             OpticalAxisOffsetXMicrons = 0.0;
             OpticalAxisOffsetYMicrons = 0.0;
             SimScrewCount = 3;
+            SimScrewNumberingClockwise = true;
             SimScrew1AngleDegrees = 0.0;
             SimScrew2AngleDegrees = 120.0;
             SimScrew3AngleDegrees = 240.0;
@@ -703,6 +705,19 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator {
                 if (simScrewCount != clamped) {
                     simScrewCount = clamped;
                     optionsAccessor.SetValueInt32(nameof(SimScrewCount), simScrewCount);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool simScrewNumberingClockwise;
+
+        public bool SimScrewNumberingClockwise {
+            get => simScrewNumberingClockwise;
+            set {
+                if (simScrewNumberingClockwise != value) {
+                    simScrewNumberingClockwise = value;
+                    optionsAccessor.SetValueBoolean(nameof(SimScrewNumberingClockwise), simScrewNumberingClockwise);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltAdapterVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltAdapterVM.cs
@@ -155,7 +155,6 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
             RezeroCommand = new RelayCommand(Rezero);
             ZeroAberrationsCommand = new RelayCommand(ZeroAberrations);
             EnableAberrationsCommand = new RelayCommand(() => options.EnableAberrations = true);
-            AutoFillAnglesCommand = new RelayCommand(AutoFillAngles);
             CopyFromAdapterCommand = new RelayCommand(CopyFromAdapter, () => CanCopyAdapterSettings);
             CopyToAdapterCommand = new RelayCommand(() => IsCopyToAdapterPending = true, () => CanCopyAdapterSettings);
             ConfirmCopyToAdapterCommand = new RelayCommand(ConfirmCopyToAdapter);
@@ -178,7 +177,6 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
         public ICommand RezeroCommand { get; }
         public ICommand ZeroAberrationsCommand { get; }
         public ICommand EnableAberrationsCommand { get; }
-        public ICommand AutoFillAnglesCommand { get; }
         public ICommand CopyFromAdapterCommand { get; }
         public ICommand CopyToAdapterCommand { get; }
         public ICommand ConfirmCopyToAdapterCommand { get; }
@@ -298,8 +296,57 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
         public string FlatText => IsFlat ? "✓ ≈ flat" : string.Empty;
 
         public string TiltDisplay =>
-            $"{options.TiltAmountMicrons.ToString("0.0", CultureInfo.CurrentCulture)} µm @ " +
+            $"{TiltAngleThetaDegrees.ToString("0.000", CultureInfo.CurrentCulture)}° @ " +
             $"{TiltCalibrationCalculator.NormalizeAngle(options.TiltAngleDegrees).ToString("0", CultureInfo.CurrentCulture)}°";
+
+        /// <summary>
+        /// The sensor-plane tilt angle θ (degrees), the quantity the Aberration Inspector reports: θ = atan(|g|),
+        /// where the gradient magnitude |g| = <see cref="ICameraSimulatorOptions.TiltAmountMicrons"/> / den and
+        /// den = |cosφ|·halfW + |sinφ|·halfH is the same azimuth-dependent span AberrationSurface uses. Shown instead
+        /// of the raw µm swing so injection and recovery speak the same units.
+        /// </summary>
+        public double TiltAngleThetaDegrees {
+            get {
+                var den = TiltDen(options.TiltAngleDegrees);
+                var g = den > 0 ? options.TiltAmountMicrons / den : 0.0;
+                return Math.Atan(g) * 180.0 / Math.PI;
+            }
+        }
+
+        /// <summary>
+        /// Two-way injection of the tilt as an angle. Get is <see cref="TiltAngleThetaDegrees"/>; set converts back to
+        /// the persisted µm swing at the current azimuth (TiltAmount = tan θ · den). θ is a magnitude — direction is
+        /// the azimuth — so a negative entry is treated as 0.
+        /// </summary>
+        public double InjectedTiltAngleDegrees {
+            get => TiltAngleThetaDegrees;
+            set => SetTiltFromAngle(Math.Max(0.0, value), options.TiltAngleDegrees);
+        }
+
+        /// <summary>
+        /// Two-way injection of the tilt azimuth. Setting it preserves the current tilt angle θ (rotating the tilt
+        /// direction should not change how steep the plane is), so the persisted µm swing is recomputed for the new
+        /// azimuth's span.
+        /// </summary>
+        public double InjectedTiltAzimuthDegrees {
+            get => options.TiltAngleDegrees;
+            set {
+                var theta = TiltAngleThetaDegrees;
+                options.TiltAngleDegrees = value;
+                SetTiltFromAngle(theta, value);
+            }
+        }
+
+        private void SetTiltFromAngle(double thetaDegrees, double azimuthDegrees) {
+            var amount = Math.Tan(thetaDegrees * Math.PI / 180.0) * TiltDen(azimuthDegrees);
+            options.TiltAmountMicrons = Math.Clamp(amount, 0.0, AberrationBoundMicrons);
+        }
+
+        private double TiltDen(double azimuthDegrees) {
+            var (halfW, halfH) = SensorHalfDimensionsMicrons();
+            var phi = azimuthDegrees * Math.PI / 180.0;
+            return Math.Abs(Math.Cos(phi)) * halfW + Math.Abs(Math.Sin(phi)) * halfH;
+        }
 
         public string BackfocusDisplay => FormatSignedMicrons(options.BackfocusErrorMicrons);
 
@@ -376,8 +423,9 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
 
         public bool HasConfigurationBanner => !IsAdapterConfigured;
 
-        /// <summary>True when the banner's one-click fix (Auto-fill evenly) is the right offer.</summary>
-        public bool CanAutoFillFromBanner => !IsAdapterConfigured && UnitMicrons > 0 && options.SimScrewRadiusMillimeters > 0;
+        /// <summary>Auto-fill was removed: screws 2..N are derived from Screw 1 + the numbering direction, so there is
+        /// never an "invalid angles" state to one-click-fix. Kept as a stable false binding for the banner template.</summary>
+        public bool CanAutoFillFromBanner => false;
 
         public bool ShowAberrationsDisabledBanner => !options.EnableAberrations;
 
@@ -406,7 +454,9 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
             }
         }
 
-        /// <summary>Screws 3 and 4 are derived (+180°) on a coupled 4-screw adapter — rendered dimmed, never edited.</summary>
+        /// <summary>Screws 2..N are derived from Screw 1 + the numbering direction — rendered dimmed, never edited.</summary>
+        public string Screw2AngleDisplay => FormatAngle(options.SimScrew2AngleDegrees);
+
         public string Screw3AngleDisplay => FormatAngle(options.SimScrew3AngleDegrees);
 
         public string Screw4AngleDisplay => FormatAngle(options.SimScrew4AngleDegrees);
@@ -431,6 +481,21 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
         public string SelectedAdapterDirection {
             get => CwMovesAdapterTowardObjective ? TowardObjective : TowardCamera;
             set => CwMovesAdapterTowardObjective = string.Equals(value, TowardObjective, StringComparison.Ordinal);
+        }
+
+        private const string NumberingClockwise = "Clockwise";
+        private const string NumberingCounterClockwise = "Counter-clockwise";
+
+        public IReadOnlyList<string> ScrewNumberingOptions { get; } = new[] { NumberingClockwise, NumberingCounterClockwise };
+
+        /// <summary>
+        /// Bound by the "Screw numbering" ComboBox: the direction the screw numbers advance around the image. Only
+        /// Screw 1 is entered; screws 2..N follow evenly in this direction. Image-space, because a diagonal/flip in
+        /// the optical train can reverse the apparent handedness (see docs/tilt-domain.md).
+        /// </summary>
+        public string SelectedScrewNumbering {
+            get => options.SimScrewNumberingClockwise ? NumberingClockwise : NumberingCounterClockwise;
+            set => options.SimScrewNumberingClockwise = string.Equals(value, NumberingClockwise, StringComparison.Ordinal);
         }
 
         private int ResolvedCurvatureSign => options.SimScrewInwardCurvatureSign == 0
@@ -800,26 +865,6 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
             options.BackfocusErrorMicrons = 0.0;
         }
 
-        private void AutoFillAngles() {
-            derivingAngles = true;
-            try {
-                if (ScrewCount == 3) {
-                    options.SimScrew1AngleDegrees = 0.0;
-                    options.SimScrew2AngleDegrees = 120.0;
-                    options.SimScrew3AngleDegrees = 240.0;
-                    options.SimScrew4AngleDegrees = double.NaN;
-                } else {
-                    options.SimScrew1AngleDegrees = 45.0;
-                    options.SimScrew2AngleDegrees = 135.0;
-                    options.SimScrew3AngleDegrees = 225.0;
-                    options.SimScrew4AngleDegrees = 315.0;
-                }
-            } finally {
-                derivingAngles = false;
-            }
-            RebuildAll();
-        }
-
         // ---- Copy from / to the real adapter ---------------------------------------------------------
 
         private void CopyFromAdapter() {
@@ -828,9 +873,9 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
             try {
                 options.SimScrewCount = realAdapter.ScrewCount == 4 ? 4 : 3;
                 options.SimScrew1AngleDegrees = realAdapter.Screw1AngleDegrees;
-                options.SimScrew2AngleDegrees = realAdapter.Screw2AngleDegrees;
-                options.SimScrew3AngleDegrees = realAdapter.Screw3AngleDegrees;
-                options.SimScrew4AngleDegrees = options.SimScrewCount == 4 ? realAdapter.Screw4AngleDegrees : double.NaN;
+                options.SimScrewNumberingClockwise = InferNumberingClockwise(realAdapter);
+                // Only Screw 1 + the numbering direction are authoritative now; place screws 2..N evenly from them.
+                DeriveScrewAnglesCore();
                 options.SimScrewInwardCurvatureSign = ResolveSign(realAdapter.ScrewInwardCurvatureSign);
                 options.SimAdjustmentType = realAdapter.AdjustmentType;
                 if (realAdapter.ThreadPitchMicrons > 0) options.SimThreadPitchMicrons = realAdapter.ThreadPitchMicrons;
@@ -891,16 +936,13 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
 
             switch (e.PropertyName) {
                 case nameof(ICameraSimulatorOptions.SimScrewCount):
-                    DeriveOppositeAngles();
-                    RebuildAll();
-                    break;
-
                 case nameof(ICameraSimulatorOptions.SimScrew1AngleDegrees):
-                case nameof(ICameraSimulatorOptions.SimScrew2AngleDegrees):
-                    DeriveOppositeAngles();
+                case nameof(ICameraSimulatorOptions.SimScrewNumberingClockwise):
+                    DeriveScrewAngles();
                     RebuildAll();
                     break;
 
+                case nameof(ICameraSimulatorOptions.SimScrew2AngleDegrees):
                 case nameof(ICameraSimulatorOptions.SimScrew3AngleDegrees):
                 case nameof(ICameraSimulatorOptions.SimScrew4AngleDegrees):
                 case nameof(ICameraSimulatorOptions.SimScrewInwardCurvatureSign):
@@ -935,27 +977,39 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
         private void OnRealAdapterChanged(object sender, PropertyChangedEventArgs e) => RaiseCoherenceChanged();
 
         /// <summary>
-        /// Opposite screws on a coupled 4-screw adapter are 180° apart by construction, so screws 3 and 4 are
-        /// derived rather than entered — that kills an entire class of configuration typos.
+        /// Only Screw 1 is entered; screws 2..N are placed evenly around the sensor (360/N apart), advancing in the
+        /// numbering direction the user picked. This yields a valid, coherent configuration from a single input and
+        /// still satisfies the coupled-4-screw invariant (screw i and i+2 land 180° apart by construction).
         /// </summary>
-        private void DeriveOppositeAngles() {
+        private void DeriveScrewAngles() {
             if (derivingAngles) return;
             derivingAngles = true;
             try {
-                if (ScrewCount == 4) {
-                    options.SimScrew3AngleDegrees = Opposite(options.SimScrew1AngleDegrees);
-                    options.SimScrew4AngleDegrees = Opposite(options.SimScrew2AngleDegrees);
-                } else {
-                    // Mirrors the existing convention: a 3-screw rig's 4th angle is NaN, never a stale value.
-                    options.SimScrew4AngleDegrees = double.NaN;
-                }
+                DeriveScrewAnglesCore();
             } finally {
                 derivingAngles = false;
             }
         }
 
-        private static double Opposite(double angle) =>
-            double.IsNaN(angle) ? double.NaN : TiltCalibrationCalculator.NormalizeAngle(angle + 180.0);
+        /// <summary>The derivation itself, callable from inside an existing <see cref="derivingAngles"/> guard (e.g. Copy from adapter).</summary>
+        private void DeriveScrewAnglesCore() {
+            var n = ScrewCount;
+            var sign = options.SimScrewNumberingClockwise ? 1.0 : -1.0;
+            var step = 360.0 / n;
+            var s1 = options.SimScrew1AngleDegrees;
+            options.SimScrew2AngleDegrees = EvenlySpaced(s1, sign, step, 1);
+            options.SimScrew3AngleDegrees = EvenlySpaced(s1, sign, step, 2);
+            options.SimScrew4AngleDegrees = n == 4 ? EvenlySpaced(s1, sign, step, 3) : double.NaN;
+        }
+
+        private static double EvenlySpaced(double screw1, double sign, double step, int index) =>
+            double.IsNaN(screw1) ? double.NaN : TiltCalibrationCalculator.NormalizeAngle(screw1 + sign * index * step);
+
+        /// <summary>Infers the numbering direction from the real adapter's screw 1→2 step (defaults to clockwise).</summary>
+        private static bool InferNumberingClockwise(ITiltAdapterOptions adapter) {
+            var delta = TiltCalibrationCalculator.NormalizeAngle(adapter.Screw2AngleDegrees - adapter.Screw1AngleDegrees);
+            return double.IsNaN(delta) || delta <= 180.0;
+        }
 
         private double[] SimAngles() => new[] {
             options.SimScrew1AngleDegrees, options.SimScrew2AngleDegrees,
@@ -988,6 +1042,9 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
         private void AfterStateChanged() {
             RaisePropertyChanged(nameof(TiltAmountMicrons));
             RaisePropertyChanged(nameof(TiltAngleDegrees));
+            RaisePropertyChanged(nameof(TiltAngleThetaDegrees));
+            RaisePropertyChanged(nameof(InjectedTiltAngleDegrees));
+            RaisePropertyChanged(nameof(InjectedTiltAzimuthDegrees));
             RaisePropertyChanged(nameof(BackfocusErrorMicrons));
             RaisePropertyChanged(nameof(TiltDisplay));
             RaisePropertyChanged(nameof(BackfocusDisplay));

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml
@@ -25,7 +25,7 @@
     <TextBlock x:Key="HFSim_ScrewAngle_Tooltip" Text="Position angle of the screw in the image: 0° = straight up (12 o'clock), increasing clockwise. Image space — mirrors or diagonals in the optical train can flip these relative to the physical adapter." />
     <TextBlock x:Key="HFSim_DerivedAngle_Tooltip" Text="Derived, not entered: opposite screws on a coupled 4-screw adapter are 180° apart by construction, so this angle follows its partner automatically." />
     <TextBlock x:Key="HFSim_Direction_Tooltip" Text="Which way a clockwise (tightening) turn drives the adapter plate on this rig. This is the same setting the Tilt Adapter Wizard calls the adapter direction, and it decides whether ⟳ raises or lowers the simulated backfocus." />
-    <TextBlock x:Key="HFSim_AutoFill_Tooltip" Text="Writes 0/120/240° (3 screws) or 45/135/225/315° (4 screws). For a simulated rig the exact angles rarely matter; this gets a valid configuration in one click." />
+    <TextBlock x:Key="HFSim_Numbering_Tooltip" Text="The direction the screw numbers advance around the image (clockwise or counter-clockwise from Screw 1). Only Screw 1's angle is entered; screws 2…N are placed evenly (360°/N apart) in this direction. Pick the direction that matches how the screws appear in your image — a diagonal or flip can reverse the apparent handedness." />
 
     <!--
         The adapter's geometry, factored out of the panel so the plugin's Camera Simulator options page can host
@@ -50,6 +50,7 @@
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
+                    <RowDefinition />
                     <RowDefinition />
                     <RowDefinition />
                     <RowDefinition />
@@ -146,8 +147,13 @@
                 <TextBlock Grid.Row="5" Grid.Column="0" VerticalAlignment="Center" ToolTip="{StaticResource HFSim_Direction_Tooltip}" controls:IconizedText.Text="⟳ tighten moves adapter toward" />
                 <ComboBox Grid.Row="5" Grid.Column="1" MinWidth="80" Margin="5,2,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" ItemsSource="{Binding AdapterDirectionOptions}" SelectedItem="{Binding SelectedAdapterDirection}" ToolTip="{StaticResource HFSim_Direction_Tooltip}" />
 
-                <TextBlock Grid.Row="6" Grid.Column="0" VerticalAlignment="Center" Text="Screw 1 angle" ToolTip="{StaticResource HFSim_ScrewAngle_Tooltip}" />
-                <ninactrl:UnitTextBox Grid.Row="6" Grid.Column="1" MinWidth="80" Margin="5,2,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="{StaticResource HFSim_ScrewAngle_Tooltip}" Unit="°">
+                <!--  Only Screw 1 is entered; the numbering direction places screws 2..N evenly. Image-space, because
+                      a diagonal or flip in the optical train can reverse the apparent handedness (docs/tilt-domain.md).  -->
+                <TextBlock Grid.Row="6" Grid.Column="0" VerticalAlignment="Center" Text="Screw numbering" ToolTip="{StaticResource HFSim_Numbering_Tooltip}" />
+                <ComboBox Grid.Row="6" Grid.Column="1" MinWidth="80" Margin="5,2,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" ItemsSource="{Binding ScrewNumberingOptions}" SelectedItem="{Binding SelectedScrewNumbering}" ToolTip="{StaticResource HFSim_Numbering_Tooltip}" />
+
+                <TextBlock Grid.Row="7" Grid.Column="0" VerticalAlignment="Center" Text="Screw 1 angle" ToolTip="{StaticResource HFSim_ScrewAngle_Tooltip}" />
+                <ninactrl:UnitTextBox Grid.Row="7" Grid.Column="1" MinWidth="80" Margin="5,2,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="{StaticResource HFSim_ScrewAngle_Tooltip}" Unit="°">
                     <Binding Path="Options.SimScrew1AngleDegrees" UpdateSourceTrigger="LostFocus">
                         <Binding.ValidationRules>
                             <rules:FloatRangeRule>
@@ -159,79 +165,17 @@
                     </Binding>
                 </ninactrl:UnitTextBox>
 
-                <TextBlock Grid.Row="7" Grid.Column="0" VerticalAlignment="Center" Text="Screw 2 angle" ToolTip="{StaticResource HFSim_ScrewAngle_Tooltip}" />
-                <ninactrl:UnitTextBox Grid.Row="7" Grid.Column="1" MinWidth="80" Margin="5,2,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="{StaticResource HFSim_ScrewAngle_Tooltip}" Unit="°">
-                    <Binding Path="Options.SimScrew2AngleDegrees" UpdateSourceTrigger="LostFocus">
-                        <Binding.ValidationRules>
-                            <rules:FloatRangeRule>
-                                <rules:FloatRangeRule.ValidRange>
-                                    <rules:FloatRangeChecker Maximum="360" Minimum="0" />
-                                </rules:FloatRangeRule.ValidRange>
-                            </rules:FloatRangeRule>
-                        </Binding.ValidationRules>
-                    </Binding>
-                </ninactrl:UnitTextBox>
+                <!--  Screws 2..N are derived from Screw 1 + the numbering direction — rendered dimmed, never edited.
+                      That kills an entire class of configuration typos and keeps the coupled-4-screw invariant.  -->
+                <TextBlock Grid.Row="8" Grid.Column="0" VerticalAlignment="Center" Text="Screw 2 angle" ToolTip="{StaticResource HFSim_DerivedAngle_Tooltip}" />
+                <TextBlock Grid.Row="8" Grid.Column="1" Margin="5,2,0,0" VerticalAlignment="Center" Opacity="0.55" Text="{Binding Screw2AngleDisplay}" ToolTip="{StaticResource HFSim_DerivedAngle_Tooltip}" />
 
-                <!--  3 screws: screw 3 is entered. 4 screws: screws 3 and 4 render dimmed as derived
-                      (+180°) values — opposite screws on a coupled adapter are 180° apart by construction,
-                      and deriving them kills an entire class of configuration typos.  -->
-                <TextBlock Grid.Row="8" Grid.Column="0" VerticalAlignment="Center" Text="Screw 3 angle" ToolTip="{StaticResource HFSim_ScrewAngle_Tooltip}" />
-                <ninactrl:UnitTextBox
-                    Grid.Row="8"
-                    Grid.Column="1"
-                    MinWidth="80"
-                    Margin="5,2,0,0"
-                    HorizontalAlignment="Left"
-                    VerticalAlignment="Center"
-                    ToolTip="{StaticResource HFSim_ScrewAngle_Tooltip}"
-                    Unit="°"
-                    Visibility="{Binding IsThreeScrew, Converter={StaticResource HFSim_BooleanToVisibilityConverter}}">
-                    <Binding Path="Options.SimScrew3AngleDegrees" UpdateSourceTrigger="LostFocus">
-                        <Binding.ValidationRules>
-                            <rules:FloatRangeRule>
-                                <rules:FloatRangeRule.ValidRange>
-                                    <rules:FloatRangeChecker Maximum="360" Minimum="0" />
-                                </rules:FloatRangeRule.ValidRange>
-                            </rules:FloatRangeRule>
-                        </Binding.ValidationRules>
-                    </Binding>
-                </ninactrl:UnitTextBox>
-                <TextBlock
-                    Grid.Row="8"
-                    Grid.Column="1"
-                    Margin="5,2,0,0"
-                    VerticalAlignment="Center"
-                    Opacity="0.55"
-                    Text="{Binding Screw3AngleDisplay}"
-                    ToolTip="{StaticResource HFSim_DerivedAngle_Tooltip}"
-                    Visibility="{Binding IsFourScrew, Converter={StaticResource HFSim_BooleanToVisibilityConverter}}" />
+                <TextBlock Grid.Row="9" Grid.Column="0" VerticalAlignment="Center" Text="Screw 3 angle" ToolTip="{StaticResource HFSim_DerivedAngle_Tooltip}" />
+                <TextBlock Grid.Row="9" Grid.Column="1" Margin="5,2,0,0" VerticalAlignment="Center" Opacity="0.55" Text="{Binding Screw3AngleDisplay}" ToolTip="{StaticResource HFSim_DerivedAngle_Tooltip}" />
 
-                <TextBlock
-                    Grid.Row="9"
-                    Grid.Column="0"
-                    VerticalAlignment="Center"
-                    Text="Screw 4 angle"
-                    ToolTip="{StaticResource HFSim_DerivedAngle_Tooltip}"
-                    Visibility="{Binding IsFourScrew, Converter={StaticResource HFSim_BooleanToVisibilityConverter}}" />
-                <TextBlock
-                    Grid.Row="9"
-                    Grid.Column="1"
-                    Margin="5,2,0,0"
-                    VerticalAlignment="Center"
-                    Opacity="0.55"
-                    Text="{Binding Screw4AngleDisplay}"
-                    ToolTip="{StaticResource HFSim_DerivedAngle_Tooltip}"
-                    Visibility="{Binding IsFourScrew, Converter={StaticResource HFSim_BooleanToVisibilityConverter}}" />
+                <TextBlock Grid.Row="10" Grid.Column="0" VerticalAlignment="Center" Text="Screw 4 angle" ToolTip="{StaticResource HFSim_DerivedAngle_Tooltip}" Visibility="{Binding IsFourScrew, Converter={StaticResource HFSim_BooleanToVisibilityConverter}}" />
+                <TextBlock Grid.Row="10" Grid.Column="1" Margin="5,2,0,0" VerticalAlignment="Center" Opacity="0.55" Text="{Binding Screw4AngleDisplay}" ToolTip="{StaticResource HFSim_DerivedAngle_Tooltip}" Visibility="{Binding IsFourScrew, Converter={StaticResource HFSim_BooleanToVisibilityConverter}}" />
             </Grid>
-
-            <Button
-                Margin="0,6,0,0"
-                HorizontalAlignment="Left"
-                Command="{Binding AutoFillAnglesCommand}"
-                Style="{StaticResource StandardButton}"
-                ToolTip="{StaticResource HFSim_AutoFill_Tooltip}">
-                <TextBlock Margin="6,2" Text="Auto-fill evenly" />
-            </Button>
 
             <!--  The wizard's diagram, reused unchanged: it already solves the mirroring-education problem
                   (0° chevron, "top of image" caption, clockwise cue). It lives here and not in Operate
@@ -331,15 +275,6 @@
                         Foreground="{StaticResource NotificationWarningTextBrush}"
                         Text="{Binding ConfigurationBannerText}"
                         TextWrapping="Wrap" />
-                    <Button
-                        Margin="8,0,0,0"
-                        VerticalAlignment="Center"
-                        Command="{Binding AutoFillAnglesCommand}"
-                        Style="{StaticResource StandardButton}"
-                        ToolTip="{StaticResource HFSim_AutoFill_Tooltip}"
-                        Visibility="{Binding CanAutoFillFromBanner, Converter={StaticResource HFSim_BooleanToVisibilityConverter}}">
-                        <TextBlock Margin="6,1" Text="Auto-fill evenly" />
-                    </Button>
                 </WrapPanel>
             </Border>
 
@@ -578,9 +513,9 @@
                             <RowDefinition />
                         </Grid.RowDefinitions>
 
-                        <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Text="Tilt Azimuth" ToolTip="Azimuth φ of the sensor tilt (degrees, inspector convention: 0° = up, increasing clockwise)." />
-                        <ninactrl:UnitTextBox Grid.Row="0" Grid.Column="1" MinWidth="80" Margin="5,2,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="Azimuth φ of the sensor tilt (degrees, inspector convention: 0° = up, increasing clockwise)." Unit="°">
-                            <Binding Path="Options.TiltAngleDegrees" UpdateSourceTrigger="LostFocus">
+                        <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Text="Tilt Azimuth" ToolTip="Azimuth φ of the sensor tilt (degrees, inspector convention: 0° = up, increasing clockwise). Rotating it preserves the tilt angle θ." />
+                        <ninactrl:UnitTextBox Grid.Row="0" Grid.Column="1" MinWidth="80" Margin="5,2,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="Azimuth φ of the sensor tilt (degrees, inspector convention: 0° = up, increasing clockwise). Rotating it preserves the tilt angle θ." Unit="°">
+                            <Binding Path="InjectedTiltAzimuthDegrees" StringFormat="{}{0:0.0}" UpdateSourceTrigger="LostFocus">
                                 <Binding.ValidationRules>
                                     <rules:FloatRangeRule>
                                         <rules:FloatRangeRule.ValidRange>
@@ -591,13 +526,13 @@
                             </Binding>
                         </ninactrl:UnitTextBox>
 
-                        <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Text="Tilt Amount" ToolTip="Center-to-corner focus swing (µm) produced by sensor tilt. A non-negative magnitude — the direction is the azimuth." />
-                        <ninactrl:UnitTextBox Grid.Row="1" Grid.Column="1" MinWidth="80" Margin="5,2,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="Center-to-corner focus swing (µm) produced by sensor tilt. A non-negative magnitude — the direction is the azimuth." Unit="µm">
-                            <Binding Path="Options.TiltAmountMicrons" UpdateSourceTrigger="LostFocus">
+                        <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Text="Tilt Angle" ToolTip="Sensor-plane tilt angle θ (degrees) — the same quantity the Aberration Inspector reports. A non-negative magnitude; direction is the azimuth. Stored as the underlying center-to-corner µm swing at the current azimuth." />
+                        <ninactrl:UnitTextBox Grid.Row="1" Grid.Column="1" MinWidth="80" Margin="5,2,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="Sensor-plane tilt angle θ (degrees) — the same quantity the Aberration Inspector reports. A non-negative magnitude; direction is the azimuth. Stored as the underlying center-to-corner µm swing at the current azimuth." Unit="°">
+                            <Binding Path="InjectedTiltAngleDegrees" StringFormat="{}{0:0.000}" UpdateSourceTrigger="LostFocus">
                                 <Binding.ValidationRules>
                                     <rules:FloatRangeRule>
                                         <rules:FloatRangeRule.ValidRange>
-                                            <rules:FloatRangeChecker Maximum="10000" Minimum="0" />
+                                            <rules:FloatRangeChecker Maximum="45" Minimum="0" />
                                         </rules:FloatRangeRule.ValidRange>
                                     </rules:FloatRangeRule>
                                 </Binding.ValidationRules>
@@ -606,7 +541,7 @@
 
                         <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Text="Backfocus Error" ToolTip="Corner-versus-center curvature offset (µm) from a backfocus error." />
                         <ninactrl:UnitTextBox Grid.Row="2" Grid.Column="1" MinWidth="80" Margin="5,2,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="Corner-versus-center curvature offset (µm) from a backfocus error." Unit="µm">
-                            <Binding Path="Options.BackfocusErrorMicrons" UpdateSourceTrigger="LostFocus">
+                            <Binding Path="Options.BackfocusErrorMicrons" StringFormat="{}{0:0.0}" UpdateSourceTrigger="LostFocus">
                                 <Binding.ValidationRules>
                                     <rules:FloatRangeRule>
                                         <rules:FloatRangeRule.ValidRange>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ICameraSimulatorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ICameraSimulatorOptions.cs
@@ -153,10 +153,11 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         // guides from the REAL calibration, so the two must be comparable but must never implicitly overwrite
         // each other. The panel surfaces a coherence badge + explicit copy commands instead.
         int SimScrewCount { get; set; }                      // 3 or 4
-        double SimScrew1AngleDegrees { get; set; }           // clockwise from top, image space
-        double SimScrew2AngleDegrees { get; set; }
-        double SimScrew3AngleDegrees { get; set; }
-        double SimScrew4AngleDegrees { get; set; }           // double.NaN when 3-screw
+        bool SimScrewNumberingClockwise { get; set; }        // true: screws numbered increasing clockwise in image space
+        double SimScrew1AngleDegrees { get; set; }           // clockwise from top, image space; the only entered screw
+        double SimScrew2AngleDegrees { get; set; }           // derived: Screw1 ± i·(360/N) per SimScrewNumberingClockwise
+        double SimScrew3AngleDegrees { get; set; }           // derived
+        double SimScrew4AngleDegrees { get; set; }           // derived; double.NaN when 3-screw
         int SimScrewInwardCurvatureSign { get; set; }        // +1 / -1
         TiltAdjustmentType SimAdjustmentType { get; set; }
         double SimThreadPitchMicrons { get; set; }           // axial µm per full turn

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -679,6 +679,14 @@
                                 ContentTemplate="{StaticResource HF_TiltScrewDiagram}"
                                 Content="{Binding}" />
                         </Grid>
+
+                        <Button
+                            Margin="0,10,0,0"
+                            HorizontalAlignment="Left"
+                            Command="{Binding ClearCalibrationCommand}"
+                            ToolTip="Clears the saved calibration (screw angles and the calibrated/manual flags), returning this pane to &quot;No calibration saved.&quot; The device selection and its configured hardware/direction are kept — re-run the wizard or use Manual Calibration Entry to set a new one.">
+                            <TextBlock Margin="6,2" Text="Clear Calibration" />
+                        </Button>
                     </StackPanel>
 
                     <!--  Manual calibration entry: writes the same persisted state a wizard run

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -215,6 +215,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             ReplayCommand = new AsyncRelayCommand(ReplayAsync, () => !IsWizardRunning && !IsMeasuring);
             RetryMeasurementCommand = new AsyncRelayCommand(RunMeasurementAsync, () => HasMeasurementFailureChoice && IsOnMeasurementStep && !IsMeasuring && AreDevicesConnected);
             ApplyManualCalibrationCommand = new RelayCommand(ApplyManualCalibration);
+            ClearCalibrationCommand = new RelayCommand(ClearCalibration);
 
             tiltAdapterOptions.PropertyChanged += (s, e) => OnUIThread(() => {
                 if (e.PropertyName == nameof(ITiltAdapterOptions.ScrewInwardCurvatureSign)) {
@@ -746,6 +747,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public ICommand ReplayCommand { get; }
         public ICommand RetryMeasurementCommand { get; }
         public ICommand ApplyManualCalibrationCommand { get; }
+        public ICommand ClearCalibrationCommand { get; }
 
         // Known amount the user moves each screw during the per-screw calibration steps (full turns
         // for screws, steps for steppers). Defaults to 1.0 to match the "1 full turn" instructions.
@@ -861,6 +863,43 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // Clear stale wizard-run display state (measured-hardware panel, per-run warnings, summary
             // rows — the same state Restart clears) that would otherwise describe the previous run next
             // to a manually entered calibration.
+            measuredHardwareMicrons = double.NaN;
+            lastConfidence = null;
+            pitchUncertaintyMicrons = double.NaN;
+            lastRawAngleDiff = double.NaN;
+            lastMoveMagnitudeRatio = double.NaN;
+            HasWarning = false;
+            WarningText = string.Empty;
+            HasMeasurementConsistencyWarning = false;
+            MeasurementConsistencyWarningText = string.Empty;
+            HasRebaselineDriftWarning = false;
+            RebaselineDriftWarningText = string.Empty;
+            HasConfidenceWarning = false;
+            ConfidenceWarningText = string.Empty;
+            ClearSummaryRows();
+            RaiseHardwareSummaryChanged();
+            RebuildDiagram();
+        }
+
+        /// <summary>
+        /// Clears the saved calibration RESULTS — screw angles, the calibrated/manual flags, the calibrated screw
+        /// count, the measured-curvature-sign flag, and the measured-hardware sentinels — leaving the device
+        /// selection and its configured hardware/direction intact. Reverses <see cref="ApplyManualCalibration"/>'s
+        /// field writes and runs the same display-state cleanup, so the pane returns to the "No calibration saved"
+        /// state without a wizard run.
+        /// </summary>
+        private void ClearCalibration() {
+            tiltAdapterOptions.Screw1AngleDegrees = double.NaN;
+            tiltAdapterOptions.Screw2AngleDegrees = double.NaN;
+            tiltAdapterOptions.Screw3AngleDegrees = double.NaN;
+            tiltAdapterOptions.Screw4AngleDegrees = double.NaN;
+            tiltAdapterOptions.CalibratedScrewCount = 0;
+            tiltAdapterOptions.IsCalibrated = false;
+            tiltAdapterOptions.CalibrationIsManual = false;
+            tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured = false;
+            tiltAdapterOptions.LastMeasuredThreadPitchMicrons = -1;
+            tiltAdapterOptions.LastMeasuredStepperStepSizeMicrons = -1;
+
             measuredHardwareMicrons = double.NaN;
             lastConfidence = null;
             pitchUncertaintyMicrons = double.NaN;


### PR DESCRIPTION
Simulator Tilt Adapter + Tilt Adapter Wizard UX feedback.

## Changes
1. **1-decimal injected aberration** — the Simulator's Tilt Azimuth and Backfocus input boxes round to 1 decimal instead of showing raw float precision.
2. **Tilt shown as an angle** — the tilt magnitude is now the sensor-plane tilt angle θ (degrees, `F3` — the same quantity the Aberration Inspector's `TiltAngleDisplay` reports) instead of a µm swing, in **both** the state-strip readout and the injected-aberration input. `θ = atan(TiltAmountMicrons / den)`, `den = |cosφ|·halfW + |sinφ|·halfH`; editing the azimuth preserves θ (rotating the tilt direction doesn't change how steep the plane is).
3. **Single-screw entry** — the Simulator's screw configuration now takes only Screw 1's angle plus a new **Screw numbering** dropdown (clockwise / counter-clockwise, persisted via `SimScrewNumberingClockwise`). Screws 2…N are derived evenly (`Screw1 ± i·360/N`) and shown dimmed. "Auto-fill evenly" is removed; copy-from-adapter infers the numbering direction from the real adapter's screw 1→2 step.
4. **Clear Calibration** — the Tilt Adapter Wizard's saved-calibration pane gains a "Clear Calibration" button that resets the calibration results (screw angles, calibrated/manual flags, calibrated screw count, measured-sign flag, measured-hardware sentinels) while keeping the device selection and its configured hardware.

## Not included
The adapter-coherence badge's angle tolerance is intentionally left at **2°**. The spurious "differs from adapter settings" report after a calibration is coming from elsewhere and is being tracked separately with a concrete reproduction.

## Verification
- Build: 0 errors. `dotnet test`: **2136 passed, 0 failed** (branch built off `develop`).
- New tests cover the evenly-spaced derivation (CW and CCW) and the θ state-strip display.
- XAML-heavy (two panels); best confirmed by eye in NINA across the two tilt views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)