### PR TITLE
docs: camera simulator pages, narrowband live-sweep Quick Start step, manual-wide review fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,7 @@
 *.py    text eol=lf
 *.yml   text eol=lf
 *.yaml  text eol=lf
+
+# Workflow scripts must stay LF in the working tree: the Claude Code Workflow tool
+# rejects scripts containing CR as "control characters" in the approval dialog.
+.claude/workflows/*.js text eol=lf

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -19,7 +19,7 @@ the field.
 
 ## Key features
 
-- **[Improved star detection](overview/star-detection.md)** — accurate, gradient-aware HFR measurement
+- **[Improved star detection](overview/star-detection.md)** — gradient-aware HFR measurement
   plus optional Gaussian and Moffat 4.0 PSF fitting for eccentricity and FWHM, with simple defaults and an
   advanced mode for fine tuning.
 - **[Customizable star annotation](overview/star-annotation.md)** — configurable colors and fonts, with
@@ -29,18 +29,21 @@ the field.
 - **[Tilt / aberration inspector](overview/tilt-aberration-inspector.md)** — generates a sensor tilt and
   curvature model, measuring backfocus error even in the presence of tilt, plus FWHM contour maps and
   eccentricity vector fields.
+- **[Camera simulator](overview/camera-simulator.md)** — a synthetic camera that renders physically
+  realistic star fields from an ASTAP star database, with defocus, donuts, and injectable sensor tilt,
+  so autofocus and tilt correction can be tested and rehearsed in the daytime.
 
 !!! note "Mix and match"
     You can use the new star detector or the new annotator independently; keep whichever you like.
     To enable the autofocus and aberration-inspector features, Hocus Focus must be selected for both
-    Autofocus and Star Detector.
+    Auto Focus and Star Detector.
 
 ## Installation
 
 Hocus Focus is published through NINA's in-app plugin manager: open **Plugins → Available**, find
 **Hocus Focus**, and install it. To turn on its features afterward, go to
 **Options → Imaging → Image Options** and select **Hocus Focus** in the **Star Detector**, **Star Annotator**,
-and **Autofocus** dropdowns.
+and **Auto Focus** dropdowns.
 
 ![Selecting Hocus Focus as the Star Detector in Options, Imaging, Image Options](assets/screenshots/image-options-dropdown.png){ width=488 }
 

--- a/documentation/docs/optimization/index.md
+++ b/documentation/docs/optimization/index.md
@@ -14,7 +14,7 @@ settings by the *quality of the focus curve they produce* (not by any single han
 optimizes the whole detection pipeline against the outcome you actually care about.
 
 The wizard launches from the top of the Star Detection options page. Its optimized settings are
-stored **separately** from your presets and are activated by a single Simple-Mode toggle ("Use
+stored **separately** from your presets and are activated by a single Simple-mode toggle ("Use
 Optimized Settings") that only appears once a run has succeeded. Nothing is overwritten until you
 confirm, and the toggle is fully reversible.
 
@@ -26,7 +26,7 @@ reproducible and the optimizer can be exercised without launching NINA.
 
 ![The optimization wizard start page with the saved-run source picker, mode, and objective toggles](../assets/screenshots/optimizer-wizard-start.png){ width=620 }
 
-*The wizard's start page: choose a saved auto-focus run and the optimization objectives.*
+*The wizard's start page: choose a saved autofocus run and the optimization objectives.*
 
 The high-level loop has three steps:
 
@@ -47,7 +47,7 @@ The high-level loop has three steps:
 
 ![The optimization wizard summary with the focus curve, focus precision, stars per frame, and recommended step size](../assets/screenshots/optimizer-wizard-summary.png){ width=620 }
 
-*The summary shows the resulting focus curve, focus precision, and a recommended auto-focus step size.*
+*The summary shows the resulting focus curve, focus precision, and a recommended autofocus step size.*
 
 Optionally, you can label a handful of hard frames (missed stars, false positives) to add a
 **recall/precision** term to the score (recall = the fraction of real stars recovered; precision = the
@@ -104,11 +104,12 @@ A live run goes like this:
     The optimizer needs stars all the way out to the defocused ends of the sweep, so pick an exposure
     long enough to keep them visible there. Narrowband filters often need a longer exposure to start.
     Once a live run succeeds, shorten the exposure and run it again to find how far you can push it (see
-    the [Quick Start](../quick-start.md) narrowband tip).
+    the [Quick Start](../quick-start.md) narrowband section).
 
-On the summary, a live run adds one option beside the recommended step size: **Apply this exposure time
-to my profile when I click Accept**. Turn it on to adopt the sweep exposure as your auto-focus exposure
-time, so you focus with the exposure you optimized against.
+On the summary, a live run adds an **Exposure** row beside the recommended step size, and the **Apply
+these auto-focus settings to my profile when I click Accept** checkbox covers it: turn it on to adopt
+the sweep exposure as your auto-focus exposure time, so you focus with the exposure you optimized
+against.
 
 ## How a candidate is scored
 
@@ -154,7 +155,7 @@ This section documents every moving part of the optimizer:
 !!! tip "When the wizard helps most"
 
     Run it when you have switched cameras, scopes, or filters; when autofocus has felt unreliable; or
-    when you have never tuned star detection beyond the Simple-Mode presets. The wizard optimizes
+    when you have never tuned star detection beyond the Simple-mode presets. The wizard optimizes
     against one saved run at a time, which keeps its recommendation interpretable, so the more
     representative that run is of how you actually autofocus (same camera, scope, filter, and
     exposure), the better the result. If you have several saved runs, pick the cleanest, most typical

--- a/documentation/docs/optimization/labels-recall-precision.md
+++ b/documentation/docs/optimization/labels-recall-precision.md
@@ -21,12 +21,13 @@ categories:
 
 | Category | What it marks | Drives |
 |---|---|---|
-| **Missed** | A real star with no detection marker — a false negative | Recall |
+| **Missed** | A real star with no detection marker (a false negative) | Recall |
 | **Wrongly-rejected** | A star the detector found but a gate rejected, which you want kept | Recall |
 | **Should-reject** | An accepted detection you judge spurious — a false positive | Precision |
 
-You create these in the labeling tool: drag a box over a real star the detector missed, click a rejected
-candidate you think should have been kept, or click an accepted candidate that should have been thrown out.
+You create these in the review view (**"Review frames"** on the wizard summary): drag a box over a real star
+the detector missed, click a rejected candidate you think should have been kept, or click an accepted
+candidate that should have been thrown out.
 
 ## Scoring by box containment
 
@@ -59,10 +60,11 @@ Labeling turns the optimizer into a guided tool: you optimize, look at what it g
 and re-optimize so the new term pushes the search toward your judgment.
 
 1. **Optimize** once with no labels to get a baseline detection setting.
-2. **Review** the frames: drag boxes on missed stars, click false positives (*should-reject*), click
+2. **Review frames**: drag boxes on missed stars, click false positives (*should-reject*), click
    wrongly-rejected candidates you want back.
-3. **Re-optimize with labels.** The recall/precision term is now active, so moves that recover your missed
-   stars and suppress your false positives score higher.
+3. **Optimize with feedback.** Press **"Optimize with feedback"** (on the Review page, or from the prompt on
+   the summary) to re-run the search with your labels. The recall/precision term is now active, so moves that
+   recover your missed stars and suppress your false positives score higher.
 
 !!! tip "When labels are worth the effort"
     Reach for labels when the proxy terms have plateaued but you can still *see* problems: faint companions

--- a/documentation/docs/optimization/objective-function.md
+++ b/documentation/docs/optimization/objective-function.md
@@ -49,8 +49,8 @@ multiplicative penalties default to exactly 1.0 (no effect) and only bite in spe
 their own sections below.
 
 !!! note "The aberration-inspection objective reweights these"
-    The weights above are the default, autofocus-tuned objective. When you select **"Optimize for
-    aberration inspection"** on the wizard's start page, the optimizer swaps in a star-count-favoring
+    The weights above are the default, autofocus-tuned objective. When you select **Optimize for
+    aberration inspection** on the wizard's start page, the optimizer swaps in a star-count-favoring
     objective (`ObjectiveConstants.ForAberrationInspection`) that recovers far more stars across the
     frame (what a [tilt / curvature model](../overview/tilt-aberration-inspector.md) needs), while a
     fit guard tied to your current settings' \(\sigma_{\text{focus}}\) keeps the focus curve usable.
@@ -189,7 +189,7 @@ a sub-score.
 The sub-scores above are combined by a weighted **average**. The defocus-precision term is different: it
 is a **multiplicative** penalty in \([0.5, 1.0]\) applied after the weighted sum. It guards the optional
 defocus-aware gates (which relax distortion/centering to recover bloated donut stars) from being abused to
-flood near-focus frames with junk.
+flood near-focus frames with junk, so the optimizer can safely explore turning them on.
 
 \[
 J_{\text{run}} \;\leftarrow\; J_{\text{run}} \times S_{\text{defocus-precision}}, \qquad
@@ -226,10 +226,6 @@ Two properties make this safe:
 *The penalty stays at 1.0 until the near-focus relaxed fraction exceeds the 0.20 threshold, then decays at
 strength 0.5 down to a floor of 0.5.*
 
-!!! warning "The defocus-aware gates are opt-in"
-    This penalty exists so the optimizer can safely explore turning the gates on (recovering bloated
-    donuts on the extremes) without learning to manufacture spurious near-focus stars.
-
 ## \(S_{\text{hfr-outlier}}\) — the bright-blob penalty
 
 A bright star whose core saturates measures a half-flux radius that reads too large, because its peak clips flat. If
@@ -246,7 +242,7 @@ The accepted-star HFRs from the near-focus frames are pooled, and a star counts 
 HFR clears **both** bars: at least \(4\times\) the robust scatter (median absolute deviation) above the median,
 **and** at least \(1.5\times\) the median. The first bar handles loose frames; the second guards the case where every
 star is nearly identical, so the scatter collapses toward zero. The penalty is then a function of the outlier
-**fraction** \(f\) — outliers over accepted stars in the near-focus pool:
+**fraction** \(f\) (outliers over accepted stars in the near-focus pool):
 
 \[
 S_{\text{hfr-outlier}} = \operatorname{clip}_{[0.5,\,1]}\!\bigl(\,1 - \text{Strength}\cdot\max(0,\; f - \text{Threshold})\,\bigr),

--- a/documentation/docs/optimization/search-variables.md
+++ b/documentation/docs/optimization/search-variables.md
@@ -36,7 +36,7 @@ Most axes are a one-to-one alias for a single `StarDetectorParams` field. Two ar
 
 ### `DefocusAwareGates` (Boolean)
 
-A single on/off switch that flips **both** defocus-aware gate relaxations together (`DefocusAwareDistortion` and `DefocusAwareCentering`) in lockstep. When enabled, these gates relax the distortion and centering checks for large candidates (large size is used as a defocus proxy), recovering bloated and donut-shaped defocused stars that the strict gates would reject (see [defocused stars](../settings/acceptance-gates.md)).
+A single on/off switch that flips **both** defocus-aware gate relaxations together (`DefocusAwareDistortion` and `DefocusAwareCentering`) in lockstep. When enabled, these gates relax the distortion and centering checks for large candidates (large size is used as a defocus proxy), recovering bloated and donut-shaped defocused stars that the strict gates would reject (see [Defocus-Aware Gates](../settings/acceptance-gates.md#defocus-aware-gates)).
 
 The variable reads the distortion flag as its value and writes the same value to both flags. Both flags are OFF in the default seed parameters, so the baseline is unchanged, and the search may flip the pair on if it helps the curve.
 
@@ -67,7 +67,7 @@ Detection is internally split into a cacheable **EARLY context** (image preparat
 - **LATE axes** are everything else: `Sensitivity`, `StarClippingMultiplier`, `PeakResponse`, `MaxDistortion`, `MinHFR`, `StarCenterTolerance`, `MinimumStarBoundingBoxSize`, and, when donut recovery is enabled, the synthetic `DefocusAwareGates`. A move on a LATE axis is a **per-frame cache hit**: it reuses the already-built early context and only re-runs the cheap gate/measure stage.
 
 !!! tip "Why this is ~10–13× faster"
-    The staged compass search refines all the cheap LATE axes first (with the EARLY params pinned, so every probe is a cache hit), then runs one bounded EARLY stage, and only revisits EARLY if it keeps improving. This drastically cuts the number of full re-detects versus probing every axis on every sweep, without changing which points are reachable, only the order they're visited. See [the search algorithm](search-algorithm.md).
+    The staged compass search refines all the cheap LATE axes first (with the EARLY params pinned, so every probe is a cache hit), then runs one bounded EARLY stage, and only revisits EARLY if it keeps improving. This cuts the number of full re-detects versus probing every axis on every sweep, without changing which points are reachable, only the order they're visited. See [the search algorithm](search-algorithm.md).
 
 ![Staged compass/pattern search trajectory on a 2D objective surface](../assets/figures/compass-search.png){ width=620 }
 

--- a/documentation/docs/optimization/step-size.md
+++ b/documentation/docs/optimization/step-size.md
@@ -48,9 +48,9 @@ that many points on each side of the estimated minimum lands neatly inside the f
     new number when the curve genuinely supports one.
 
 !!! tip "How to use the recommendation"
-    Treat it as a starting point for the autofocus **Step Size** on the same rig and filter. Because the band
-    width depends on focal ratio, pixel scale, and the focuser's steps-per-unit-travel, the right step differs
-    between setups, which is exactly why deriving it from a measured curve beats a fixed guess. The step size
-    also feeds back into the objective: \(S_{\text{focus}}\) normalizes focus uncertainty by the step size, so
-    a well-chosen step makes the optimization's focus score meaningful (see
-    [The objective function](objective-function.md) and [AF-curve fitting](af-curve-fitting.md)).
+    Treat it as a starting point for your profile's **Auto Focus Step Size** on the same rig and filter.
+    Because the band width depends on focal ratio, pixel scale, and the focuser's steps-per-unit-travel,
+    the right step differs between setups, which is exactly why deriving it from a measured curve beats a
+    fixed guess. The step size also feeds back into the objective: \(S_{\text{focus}}\) normalizes focus
+    uncertainty by the step size, so a well-chosen step makes the optimization's focus score meaningful
+    (see [The objective function](objective-function.md) and [AF-curve fitting](af-curve-fitting.md)).

--- a/documentation/docs/overview/autofocus.md
+++ b/documentation/docs/overview/autofocus.md
@@ -34,7 +34,7 @@ A focus sweep produces a set of (focuser position, HFR) points that form a V: sh
 
 **Finalization.** Once the sweep is complete:
 
-1. In **Hybrid** mode all four concrete hyperbolic models are refit on the final points (each rejecting its own outliers), and the model with the smallest expected best-focus uncertainty is chosen.
+1. In **Hybrid** mode all four concrete hyperbolic models are refit on the final points (with consensus outlier rejection: only points that every solved model flags are removed), and the model with the smallest expected best-focus uncertainty is chosen.
 2. A leave-one-out stability pass refits with each point omitted in turn, reporting the spread of predicted best-focus positions.
 3. The final focus position is read from the chosen model: the hyperbolic/parabolic minimum, the trendline intersection, or (for the blended trend models) the average of the two.
 4. The fit is checked against the active rejection gate (\(R^2\) or reduced \(\chi^2\)) and confirmed to lie inside the measured sweep, an optional *Focuser Offset* is applied, and the focuser moves there.

--- a/documentation/docs/overview/camera-simulator-rendering.md
+++ b/documentation/docs/overview/camera-simulator-rendering.md
@@ -1,0 +1,221 @@
+# Camera Simulator Rendering Model
+
+The [Camera Simulator](camera-simulator.md) page covers setting the simulator up and what to use it
+for. This page is the supplement: how a frame is actually generated, stage by stage, and the
+physical model behind each stage. Nothing here is needed to use the simulator; it is for
+understanding why the frames behave like a real camera's.
+
+Every exposure runs the same pipeline. The simulator queries the ASTAP catalog for stars in the
+field of view, projects each star onto the sensor, computes its local defocus from the focuser
+position and the aberration surface, renders a point-spread function of the right size, converts
+the star's magnitude into photoelectrons, and stamps the result into an electron accumulator. A
+uniform sky and dark-current background is added, and the accumulated electrons are then developed
+into a 16-bit frame by applying photon noise, read noise, gain, and the bias pedestal, pixel by
+pixel.
+
+## From catalog to pixel positions
+
+Stars are read from the ASTAP star database for a region covering the sensor's diagonal field of
+view plus a 5% margin, down to the configured **Limiting Magnitude**. The database stores stars
+sorted bright to faint, so the read stops early once the limit is reached. Coordinates are
+Gaia-derived and treated as J2000; the mount's reported pointing is transformed to J2000 before
+projection when needed.
+
+Each star is projected with a gnomonic (TAN) tangent-plane projection, the standard projection for
+a flat sensor behind an optic. The plate scale comes from the effective focal length and the
+sensor's pixel size. Frame rotation is applied in the tangent plane: with a rotator connected the
+frame renders at the rotator's mechanical angle plus the **Field Rotation** offset, otherwise at
+**Field Rotation** directly. Stars slightly outside the frame are kept when their PSF could spill
+onto the sensor, so a half-donut at the edge of a defocused frame looks the way it should.
+
+## From magnitude to electrons
+
+The heart of the simulator is a radiometric exposure calculator. A star of magnitude \(m\)
+delivers
+
+\[
+N_\star = F_0 \cdot 10^{-0.4\,m} \cdot A \cdot \Delta\lambda \cdot QE(\lambda_c) \cdot T \cdot t
+\]
+
+photoelectrons over its whole PSF, where:
+
+- \(F_0 = 1.00\times10^{4}\) photons s⁻¹ cm⁻² nm⁻¹ is the zero-magnitude flux density,
+  V-referenced (Bessell 1998).
+- \(A = \tfrac{\pi}{4} D^2 (1 - \varepsilon^2)\) is the unobstructed collecting area in cm², from
+  the aperture \(D\) and the central-obstruction fraction \(\varepsilon\).
+- \(\Delta\lambda\) is the selected filter's bandwidth and \(\lambda_c\) its central wavelength.
+- \(QE(\lambda_c)\) is the sensor's quantum efficiency, sampled from a piecewise-linear QE curve at
+  the filter's central wavelength.
+- \(T\) is the **Optical Throughput** setting and \(t\) the exposure time.
+
+This is a deliberate gray-star approximation: every star uses its catalog magnitude with a single
+V-referenced zero point, with no per-star color term and no atmospheric extinction. What the model
+does capture is the part that matters for focus work: how star signal scales with aperture,
+exposure time, filter bandwidth, and sensor QE.
+
+The narrowband behavior falls straight out of the \(\Delta\lambda\) factor. A luminance filter
+passes a 320 nm band; an Hα 3 nm filter passes about 1% of that, so the same star delivers about a
+hundred times fewer electrons. That is why the simulator reproduces narrowband autofocus problems
+(too few stars, noisy HFR) without any special-casing.
+
+### Filters
+
+| Filter | Central wavelength (nm) | Bandwidth (nm) |
+|---|---|---|
+| L | 540.0 | 320 |
+| R | 635.0 | 100 |
+| G | 530.0 | 100 |
+| B | 465.0 | 100 |
+| Hα 5nm / 3nm | 656.3 | 5 / 3 |
+| OIII 5nm / 3nm | 500.7 | 5 / 3 |
+| SII 5nm / 3nm | 672.4 | 5 / 3 |
+
+The filter's central wavelength is also the wavelength used by the diffraction and defocus model
+below, so switching from OIII to SII subtly changes the diffraction-limited PSF, as it should.
+
+### Sensors
+
+The four sensor models carry datasheet-derived parameters. All share a Sony
+back-illuminated QE curve anchored to a published IMX455 measurement (about 80% peak QE, falling
+toward the red: roughly 0.75 at 530 nm, 0.50 at Hα, 0.46 at SII).
+
+| Model | Resolution | Pixel (µm) | Bit depth | Full well (e⁻) | Read noise (e⁻, low → high conversion gain) |
+|---|---|---|---|---|---|
+| IMX455 | 9576 × 6388 | 3.76 | 16 | 50000 | 3.5 → 1.5 |
+| IMX571 | 6248 × 4176 | 3.76 | 16 | 50000 | 2.8 → 1.5 |
+| IMX533 | 3008 × 3008 | 3.76 | 14 | 50000 | 3.8 → 1.5 |
+| IMX294 | 4144 × 2822 | 4.63 | 14 | 66000 | 7.0 → 1.3 |
+
+### Sky and dark current
+
+The sky background applies the same radiometric formula to the **Sky Brightness** surface
+brightness \(\mu\) (mag/arcsec²), multiplied by the solid angle one pixel subtends:
+
+\[
+N_{\text{sky}} = F_0 \cdot 10^{-0.4\,\mu} \cdot A \cdot \Delta\lambda \cdot QE(\lambda_c) \cdot T
+\cdot t \cdot \Omega_{\text{px}} ,
+\]
+
+with \(\Omega_{\text{px}}\) the pixel area in arcsec². Because the sky is broadband too, a 3 nm
+filter suppresses it by the same factor it suppresses stars, which is exactly why long narrowband
+subs tolerate bright sky.
+
+Dark current follows the usual doubling law: the sensor's datasheet dark current at its reference
+temperature, doubled for every 6.5 °C above it (and halved below), times the exposure time. The
+**Sensor Temperature** setting feeds this directly.
+
+## The point-spread function
+
+The PSF is a defocused annulus convolved with a Gaussian blur. In focus, the annulus collapses and
+the profile reduces to a pure Gaussian whose width combines seeing and diffraction:
+
+\[
+\sigma_{\min} = \sqrt{\sigma_{\text{seeing}}^2 + \sigma_{\text{diff}}^2} .
+\]
+
+The seeing term converts the **Seeing** FWHM from arcseconds to pixels through the plate scale.
+The diffraction term uses the FWHM of an annular-aperture Airy core,
+
+\[
+\text{FWHM}_{\text{diff}} = \left(1.0290 - 0.5673\,\varepsilon^2 + 0.3919\,\varepsilon^4\right)
+\frac{\lambda\,N}{p} \ \text{px},
+\]
+
+for wavelength \(\lambda\), focal ratio \(N\), pixel size \(p\), and obstruction
+\(\varepsilon\). The minimum HFR follows as \(\text{HFR}_{\min} = \sqrt{\pi/2}\,\sigma_{\min}
+\approx 1.2533\,\sigma_{\min}\).
+
+Kernels are generated numerically from the analytic radial profile, rasterized at 4× oversampling
+into sixteen sub-pixel phase variants, and normalized so each integrates to exactly one. Stamping a
+star picks the phase kernel nearest its fractional pixel position, so sub-pixel centroids survive
+into the rendered frame. Diffraction rings are not modeled; the analytic profile is HFR-exact,
+which is what star detection and focus measurement respond to.
+
+## Defocus and donuts
+
+Defocus is driven by the focuser. With a step size of \(k\) µm of focus travel per step (the
+shared **Focuser Step Size** setting), the sensor sits
+
+\[
+\Delta = k \,(\text{steps} - x_0)
+\]
+
+microns from perfect focus, where \(x_0\) is **Optimal Focuser Position**. Geometric optics turns
+that defocus into an annulus: outer radius \(r_{\text{out}} = |\Delta| / 2N\) at the focal plane,
+inner radius \(\varepsilon \cdot r_{\text{out}}\). With a central obstruction enabled the
+defocused star is a donut with a dark hole; without one it is a filled disk.
+
+The resulting HFR-versus-position curve is
+
+\[
+\text{HFR}(\text{steps}) = \sqrt{\text{HFR}_{\min}^2 + \bigl(\kappa\,(\text{steps} -
+x_0)\bigr)^2},
+\qquad
+\kappa = \frac{k\,(1 + \varepsilon + \varepsilon^2)}{3\,N\,p\,(1 + \varepsilon)} ,
+\]
+
+which is the same hyperbolic family the [autofocus curve fit](hyperbola-fitting.md) assumes. This
+is by construction, not coincidence: the PSF kernels are sized from this model, so the V-curve that
+autofocus measures against the simulator agrees with the V-curve the model predicts.
+
+To keep rendering fast, defocus is quantized so that the donut's outer radius changes by at most a
+quarter pixel per level, and one PSF kernel is built and cached per level per exposure. A smooth
+tilt across the sensor therefore collapses onto a small set of kernels instead of one per star.
+
+## Tilt and field curvature
+
+With **Enable Aberrations** on, best focus is no longer one focuser position for the whole sensor.
+The simulator models the best-focus surface as a tilted paraboloid over sensor coordinates, the
+exact surface family the Aberration Inspector's
+[sensor model](sensor-model.md) fits: a tilt plane (gradients \(G_x, G_y\)), an isotropic curvature
+term \(K\), and an optical-axis offset. Each star's local defocus is the gap between the focuser's
+current focus plane and this surface at the star's position, fed into the defocus model above. The
+aberrations are purely local defocus: stars blur and donut asymmetrically across the field, but no
+coma or astigmatism stretching is modeled.
+
+The options map onto the surface in the inspector's own reporting convention, so injection and
+measurement are two sides of one identity:
+
+- **Tilt Angle** is the tilt azimuth, \(\operatorname{atan2}(G_y, G_x)\).
+- **Tilt Amount** is the inspector's *Tilt Effect*: the worst-case center-to-corner focus swing
+  caused by the tilt plane, in microns.
+- **Backfocus Error** is the inspector's *Curvature Effect*: the corner-versus-center offset caused
+  by the curvature term, in microns.
+
+Inject 30 µm of tilt at 45° and a Detailed Analysis measures 30 µm at 45°, up to the noise of the
+measurement itself. One deliberate subtlety: with a rotator connected the star field rotates, but
+the tilt stays fixed to the sensor, because on a real camera the tilted sensor rotates along with
+the rotator.
+
+## Noise and readout
+
+The stamped stars plus sky and dark current give each pixel an expected electron count \(\lambda\).
+Development converts that to ADU with the full noise chain, per pixel:
+
+1. **Shot noise**: a Poisson draw with mean \(\lambda\) (an exact Poisson sampler below 40
+   electrons, a Gaussian approximation above, where the distributions agree to within a percent).
+2. **Full-well clamp**: electrons saturate at the sensor's full-well capacity.
+3. **Read noise**: a Gaussian draw whose width follows the sensor's gain-dependent read-noise
+   curve, including the step down at the dual-conversion-gain threshold (gain 100 on the IMX
+   sensors here, 120 on the IMX294).
+4. **Digitization**: electrons divide by the e⁻/ADU gain, the **Bias Pedestal** is added, and the
+   result clamps to the sensor's bit depth. The gain law is ZWO-style, 0.1 dB per gain unit:
+   \(g_{e^-/\text{ADU}} = (\text{full well} / 2^{\text{bits}}) \cdot 10^{-\text{gain}/200}\).
+
+The result is a mono 16-bit frame with the statistics a calibrated eye expects: background
+standard deviation set by sky shot noise and read noise, faint stars emerging from the noise floor
+as exposure grows, bright stars saturating and flattening.
+
+## Determinism
+
+Every frame is reproducible. The per-exposure noise seed mixes the **Noise Seed** option with the
+focuser position and an exposure counter that resets when the camera connects, so repeated
+exposures at one position differ (as on a real camera) while a fixed sequence of exposures after
+connecting replays identically. Development is partitioned into 64 fixed stripes, each with its own
+seeded generator, so the output is bit-identical regardless of how many CPU cores render it.
+
+Rendering starts when the exposure starts and is collected at download, mirroring a real camera's
+exposure-then-download rhythm; its parallel loops share the plugin's CPU governor so a render
+cannot starve star detection running concurrently during an autofocus. If the catalog is missing
+or the field is empty, the simulator still delivers a starless frame of sky, dark current, and
+noise rather than failing the exposure.

--- a/documentation/docs/overview/camera-simulator.md
+++ b/documentation/docs/overview/camera-simulator.md
@@ -1,0 +1,145 @@
+# Camera Simulator
+
+Hocus Focus includes a full camera simulator: a synthetic imaging camera that renders physically
+realistic star fields for wherever the connected mount points. Select it in place of a real camera
+and everything downstream runs unmodified, as it would under a real sky: star detection, autofocus,
+the [Aberration Inspector](tilt-aberration-inspector.md), and the
+[Tilt Adapter Wizard](tilt-adapter-wizard.md). The difference is that you choose the sky brightness,
+the seeing, the filter, the focus error, and even the sensor tilt. That makes it a daytime test
+bench: watch a complete autofocus V-curve, stress the detector with defocused donut stars, or
+rehearse an entire tilt calibration without opening the roof.
+
+The stars are real. The simulator reads an ASTAP star database, projects the catalog stars for the
+mount's current pointing onto the sensor at your rig's pixel scale, and renders each one through a
+physical exposure model: aperture, filter bandpass, sensor quantum efficiency, sky glow, seeing,
+photon noise, and read noise. Defocused stars grow into donuts, a tilted sensor blurs one corner
+before the other, and the HFR curve autofocus measures is the same hyperbola it fits on a real rig.
+The full model is documented in the
+[Camera Simulator Rendering Model](camera-simulator-rendering.md).
+
+## Install ASTAP and a star database
+
+The simulator's only external dependency is an ASTAP star database. If you already use ASTAP for
+plate solving and installed a star database with it, there is nothing more to do: the simulator
+looks in ASTAP's default installation folder, `C:\Program Files\astap`.
+
+Otherwise, install both:
+
+1. **[ASTAP](https://www.hnsky.org/astap.htm)**: the installer is linked at the top of the ASTAP
+   home page.
+2. **A star database**: from the
+   [ASTAP star database downloads](https://sourceforge.net/projects/astap-program/files/star_databases/).
+   **D50** (the general-purpose database ASTAP recommends for most users) is a good choice; **D80**
+   is denser and gives the simulator more faint stars to draw. The wide-field **W08** database is
+   too shallow for typical imaging fields of view.
+
+Any ASTAP star database works. The simulator auto-detects whatever database is in the folder, in
+both the current 1476-cell format (`.1476` cell files) and the older 290-cell format (`.290`), and
+prefers the finer 1476-cell partitioning when both are present. If ASTAP is installed somewhere
+else, point **ASTAP Catalog Path** on the plugin's **Camera Sim** options tab at the database
+folder. The path is re-read for every exposure, so a change takes effect on the next frame without
+reconnecting the camera.
+
+If the database is missing, exposures fail with an error naming the folder it searched, and the
+Camera Sim tab's path field is where to fix it.
+
+## Connect it
+
+The simulator appears in NINA's normal equipment chooser:
+
+1. Connect a **focuser** and a **mount** first. NINA's built-in simulator focuser and simulator
+   telescope are fine. The camera reads the focuser position to compute defocus and the mount
+   pointing to select catalog stars, so an exposure without them fails with an error saying which
+   device is missing.
+2. In **Equipment → Camera**, select **Hocus Focus Simulator** (listed under **Hocus Focus**) and
+   connect.
+3. Optionally connect a **rotator**: the frame then renders at the rotator's mechanical angle, with
+   the **Field Rotation** setting acting as an offset. Without a rotator, **Field Rotation** sets
+   the frame rotation directly.
+
+The camera is monochrome, 1×1 binning only, with a gain slider and no cooler control (its
+**Temperature** readout reports the configured sensor temperature). There is no live view.
+
+## Configure the rig
+
+Click the gear icon next to the camera in **Equipment → Camera** to open the **Hocus Focus
+Simulator Setup** dialog. This is the physical rig, set once:
+
+| Setting | Default | What it does |
+|---|---|---|
+| **Sensor Model** | IMX455 (ASI6200MM / QHY600M) | Chooses the sensor: IMX455, IMX571 (ASI2600MM / QHY268M), IMX533 (ASI533MM), or IMX294 (ASI294MM). Each brings its real resolution, pixel size, bit depth, full-well capacity, read-noise curve, and dark current. Change it while disconnected: NINA latches resolution and pixel size when the camera connects. |
+| **Aperture** (mm) | blank | Leave blank to infer from your NINA telescope settings; the greyed hint shows the value in effect. |
+| **Focal Length** (mm) | blank | Leave blank to take the focal length from **Options → Equipment → Telescope**. A fresh profile falls back to 980 mm at f/7. |
+| **Central Obstruction** | on | Whether the optic has a central obstruction. This is what puts the hole in defocused donut stars. |
+| **Obstruction Fraction** | 0.3 | Obstruction diameter as a fraction of the aperture. Typical Newtonian/SCT values are 0.3–0.5. |
+| **Optical Throughput** | 0.85 | Light loss through the optical train. |
+
+Everything else lives on the plugin's **Camera Sim** options tab (NINA's options → **Plugins** →
+**Hocus Focus**) and is meant to change per session. Every value there is read when an exposure
+starts, so edits apply to the next frame.
+
+| Setting | Default | What it does |
+|---|---|---|
+| **Optimal Focuser Position** | 5000 steps | The focuser position at which stars are sharpest. Move the focuser away from it and stars defocus. |
+| **Focuser Step Size** | unset | Microns of defocus per focuser step. This is the same setting as the Aberration Inspector's **Focuser Step Size**; editing either changes both. Blank renders at 2 µm/step. |
+| **Gain** | 100 | Camera gain, on a ZWO-style scale. Affects e⁻/ADU and read noise, including the high-conversion-gain step. |
+| **Bias Pedestal** | 500 ADU | Offset added to every pixel. |
+| **Sensor Temperature** | −10 °C | Sets dark current, which doubles every 6.5 °C. |
+| **Filter** | L (Luminance) | L, R, G, B, or narrowband: Hα, OIII, SII in 5 nm and 3 nm bandwidths. Narrowband filters pass proportionally less light, so faint-star autofocus problems reproduce faithfully. |
+| **Sky Brightness** | 20.5 mag/arcsec² | Sky background level. Around 21–22 is a dark site, 18–19 heavy light pollution. |
+| **Seeing** | 2.5 arcsec | Atmospheric seeing, as a FWHM. |
+| **ASTAP Catalog Path** | `C:\Program Files\astap` | Folder containing the ASTAP star database. |
+| **Limiting Magnitude** | 16 | Faintest catalog stars rendered. |
+| **Field Rotation** | 0° | Frame rotation; an offset to the rotator's mechanical angle when one is connected. |
+| **Noise Seed** | 42 | Base seed for the noise. A fixed sequence of exposures taken after connecting replays identically; repeated exposures at one position still differ, as on a real camera. |
+
+The tab also shows the rig values (aperture, focal length, obstruction) read-only, so you can
+confirm what the next exposure will use without opening the setup dialog.
+
+## Autofocus against the simulator
+
+With the pieces connected, run an autofocus exactly as in the
+[Quick Start](../quick-start.md): the sweep produces defocused donuts at the wings, a V-shaped HFR
+curve, and a fitted minimum at **Optimal Focuser Position**. Because the simulator's
+HFR-versus-focuser-position curve is the same hyperbola the [autofocus model](hyperbola-fitting.md)
+fits, it is a clean environment for practicing step-size tuning, trying the
+[Optimization Wizard](../optimization/index.md), or reproducing a detection problem with known
+ground truth. Nothing needs to be dark, tracked, or in focus first.
+
+## Rehearse a tilt calibration in the daytime
+
+The simulator can inject a known sensor tilt and expose a **simulated tilt adapter** whose screws
+you turn with buttons. The Aberration Inspector measures the injected tilt exactly, so the whole
+correction loop (measure, turn the screw the guidance names, measure again) can be walked through
+at your desk before you ever touch the real adapter.
+
+1. On the **Camera Sim** tab, turn on **Enable Aberrations** and inject a tilt: set **Tilt Angle**
+   (the direction, as an azimuth in the inspector's convention), **Tilt Amount** (the
+   center-to-corner focus swing in microns; 20–50 µm is a clearly visible tilt), and optionally a
+   **Backfocus Error**.
+2. Under **Tilt Adapter**, configure the simulated adapter's geometry: screw count, thread pitch,
+   screw radius, and screw 1 angle. If you have already set up a real adapter in the
+   [Tilt Adapter Wizard](tilt-adapter-wizard.md), press **Copy from adapter settings** so the
+   simulated adapter matches it; a badge shows whether the two agree. Then turn on **Show tilt
+   adapter panel in Imaging** (the panel appears after a NINA restart the first time).
+3. Connect the simulator focuser, telescope, and the **Hocus Focus Simulator** camera. Hocus Focus
+   must be selected for both **Star Detector** and **Auto Focus** under
+   **Options → Imaging → Image Options**.
+4. In the Imaging tab, run the Aberration Inspector's **Detailed Analysis**. It reports the tilt
+   you injected, along with per-screw guidance such as `0.75 ⟳` for each screw.
+5. Open the **Simulator Tilt Adapter** panel next to the inspector. For each screw the guidance
+   names, set **Amount per click** to the printed magnitude and click that screw's ⟳ or ⟲ button.
+   The panel shows the resulting plane and the net position of every screw.
+6. Re-run **Detailed Analysis** and repeat. Applied correctly, the guidance converges: the panel
+   reads **✓ ≈ flat** and the inspector's tilt drops within tolerance.
+
+This is the same loop you run on the real rig at night, with the same guidance text and the same
+conventions, so mistakes are free and the workflow is familiar before real screws are involved.
+The panel can also stand in for real screws when the Tilt Adapter Wizard prompts for calibration
+turns, though the inspector guidance loop above is the flow the simulator is built around.
+
+!!! note "Match the simulated adapter to the real settings"
+    The inspector computes its guidance from the *real* tilt-adapter settings, while the simulated
+    adapter obeys its own geometry. If the two differ, the guidance will not converge in the
+    simulator. The panel's badge (**matches adapter ✓** / **⚠ differs from adapter settings**)
+    makes the mismatch visible, and **Copy from adapter settings** resolves it in one click.

--- a/documentation/docs/overview/hyperbola-fitting.md
+++ b/documentation/docs/overview/hyperbola-fitting.md
@@ -1,4 +1,4 @@
-# Hyperbolic Focus-Curve Fitting
+# Hyperbolic Curve Fitting
 
 A focus sweep produces a set of `(focuser position, HFR)` points that trace a V: HFR is large when the
 star is defocused and drops to a minimum at best focus. Hocus Focus fits a hyperbola to that V, reads

--- a/documentation/docs/overview/index.md
+++ b/documentation/docs/overview/index.md
@@ -1,18 +1,18 @@
 # Overview & Features
 
-Hocus Focus is a plugin for [NINA](https://nighttime-imaging.eu/) that provides improved star detection, star annotation, autofocus, and tilt correction. It replaces or augments NINA's built-in star handling and auto-focus routines with a more accurate star detector, a fully customizable annotator, a concurrent auto-focus engine, and an aberration inspector that measures backfocus and sensor-tilt errors.
+Hocus Focus is a plugin for [NINA](https://nighttime-imaging.eu/) that provides improved star detection, star annotation, autofocus, and tilt correction. It replaces or augments NINA's built-in star handling and autofocus routines with a more accurate star detector, a fully customizable annotator, a concurrent autofocus engine, and an aberration inspector that measures backfocus and sensor-tilt errors.
 
-The plugin is deliberately modular: the star detector, the annotator, and the auto-focus engine can each be enabled independently, so keep whichever pieces you like and leave the rest on NINA's defaults. The features are wired in under **Options → Imaging → Image Options**, where installing the plugin adds **Star Detector**, **Star Annotator**, and **Autofocus** dropdowns; select **Hocus Focus** in each to turn that feature on.
+The plugin is deliberately modular: the star detector, the annotator, and the autofocus engine can each be enabled independently, so keep whichever pieces you like and leave the rest on NINA's defaults. The features are wired in under **Options → Imaging → Image Options**, where installing the plugin adds **Star Detector**, **Star Annotator**, and **Auto Focus** dropdowns; select **Hocus Focus** in each to turn that feature on.
 
 !!! note "Requirements"
 
-    Hocus Focus targets NINA 3.2.0.2001 or newer (the plugin's declared `MinimumApplicationVersion`). The Aberration Inspector in particular requires that **Hocus Focus is selected for both Autofocus and Star Detector**.
+    Hocus Focus targets NINA 3.2.0.2001 or newer (the plugin's declared `MinimumApplicationVersion`). The Aberration Inspector in particular requires that **Hocus Focus is selected for both Auto Focus and Star Detector**.
 
 ## The four feature areas
 
 ### Star Detection
 
-The improved star detector measures each star's HFR empirically from a robust, gradient-aware background fit, so HFR does not depend on PSF modeling. On top of that it can fit a point-spread function (PSF) to each star (both a Gaussian and a Moffat 4 model are supported) to report per-star **eccentricity and FWHM**. A star whose PSF fit fails the goodness-of-fit gate keeps its empirical HFR and reports no FWHM or eccentricity. When parameters are set well, the result is a lower HFR standard deviation across a frame, because cleaner detection and measurement reduce scatter. See [Star Detection](star-detection.md) for the full detection pipeline.
+The improved star detector measures each star's HFR empirically from a robust, gradient-aware background fit, so HFR does not depend on PSF modeling. On top of that it can fit a point-spread function (PSF) to each star (Gaussian and Moffat profiles are supported, with Moffat 4.0 the default) to report per-star **eccentricity and FWHM**. A star whose PSF fit fails the goodness-of-fit gate keeps its empirical HFR and reports no FWHM or eccentricity. When parameters are set well, the result is a lower HFR standard deviation across a frame, because cleaner detection and measurement reduce scatter. See [Star Detection](star-detection.md) for the full detection pipeline.
 
 ### Star Annotation
 
@@ -20,14 +20,22 @@ The annotator controls how detected stars are drawn on top of an image. It offer
 
 ### Autofocus
 
-The Hocus Focus auto-focus engine analyzes each exposure while the next focus point is being exposed, which can make it faster than NINA's built-in auto focuser. It can save AF runs (the images and the annotated star detection) so a run can be replayed later with different settings. The concurrent design is especially valuable with the Hocus Focus star detector, which is more resource-intensive than the built-in one. See [Autofocus](autofocus.md).
+The Hocus Focus autofocus engine analyzes each exposure while the next focus point is being exposed, which can make it faster than NINA's built-in autofocus engine. It can save AF runs (the images and the annotated star detection) so a run can be replayed later with different settings. The concurrent design is especially valuable with the Hocus Focus star detector, which is more resource-intensive than the built-in one. See [Autofocus](autofocus.md).
 
 ### Tilt & Aberration Inspector
 
-The inspector estimates **backfocus and tilt errors** by running an auto-focus and computing AF curves for the center and corner regions of the sensor, split into a 3×3 grid. The result is a full sensor tilt and curvature model, which lets it measure backfocus error even when tilt is present. For single exposures it also generates FWHM contour maps and eccentricity vector fields for a quick visual read, offers a 3D visualization of sensor tilt, and can replay saved AF runs. See [Tilt & Aberration Inspector](tilt-aberration-inspector.md), [Sensor Model Fitting](sensor-model.md) for how the tilt and curvature model is fit, and the [Tilt Adapter Wizard](tilt-adapter-wizard.md) for turning a measured tilt into concrete screw adjustments.
+The inspector estimates **backfocus and tilt errors** by running an autofocus and computing AF curves for the center and corner regions of the sensor, split into a 3×3 grid. The result is a full sensor tilt and curvature model, which lets it measure backfocus error even when tilt is present. For single exposures it also generates FWHM contour maps and eccentricity vector fields for a quick visual read, offers a 3D visualization of sensor tilt, and can replay saved AF runs. See [Tilt & Aberration Inspector](tilt-aberration-inspector.md), [Sensor Model Fitting](sensor-model.md) for how the tilt and curvature model is fit, and the [Tilt Adapter Wizard](tilt-adapter-wizard.md) for turning a measured tilt into concrete screw adjustments.
 
 ![Sensor tilt and curvature best-focus offset map](../assets/figures/tilt-heatmap.png){ width=620 }
 *The Aberration Inspector models how best-focus position varies across the sensor, separating uniform backfocus error from tilt and field curvature.*
+
+## The camera simulator
+
+Alongside the four feature areas, the plugin ships a **camera simulator**: a synthetic camera that
+renders physically realistic star fields from an ASTAP star database, complete with defocus, donut
+stars, and injectable sensor tilt. Connect it in place of a real camera to exercise everything above
+in the daytime, from a first autofocus run to a full tilt-calibration rehearsal. See
+[Camera Simulator](camera-simulator.md).
 
 ## Simple vs Advanced configuration
 
@@ -43,6 +51,6 @@ Start at the Simple level: the defaults are a reasonable starting point, and hig
 
 !!! tip "When to go beyond Simple"
 
-    If detection already finds plenty of clean stars and your auto-focus curves are tight, the defaults are doing their job; leave them alone. Advanced tuning and the Optimization Wizard pay off when a particular setup (unusual pixel scale, heavy nebulosity, persistent false detections, or bloated defocused stars) is tripping up the defaults.
+    If detection already finds plenty of clean stars and your autofocus curves are tight, the defaults are doing their job; leave them alone. Advanced tuning and the Optimization Wizard pay off when a particular setup (unusual pixel scale, heavy nebulosity, persistent false detections, or bloated defocused stars) is tripping up the defaults.
 
 For the full per-setting reference, see [Settings](../settings/index.md). To have those settings tuned automatically against your saved runs, see the [Optimization Wizard](../optimization/index.md).

--- a/documentation/docs/overview/sensor-model.md
+++ b/documentation/docs/overview/sensor-model.md
@@ -20,11 +20,12 @@ is the focuser position (in microns) at which that point of the sensor reaches b
 
 The inspector fits the focus surface at two levels of detail.
 
-- The **4-corners model** is the simpler of the two, always computed. It measures best focus at the
-  center and the four corners, then reads tilt from how the corners differ and backfocus from how the
-  corners sit relative to the center. It is cheap and needs only those five focus curves, but it cannot
-  tell field curvature apart from backfocus, and it says nothing about sensor centering.
-- The **sensor surface model** (the **Sensor Curve Model** option) is the rigorous model. It fits a
+- The **4-corners model** (the [tilt plane](tilt-aberration-inspector.md#the-tilt-plane) on the
+  inspector page) is the simpler of the two, always computed. It measures best focus at the center
+  and the four corners, then reads tilt from how the corners differ and backfocus from how the
+  corners sit relative to the center. It is cheap and needs only those five focus curves, but it
+  cannot tell field curvature apart from backfocus, and it says nothing about sensor centering.
+- The **sensor surface model** (the **Sensor Curve Model Enabled** option) is the rigorous model. It fits a
   focus curve for *every* matched star across the frame, then fits a tilted paraboloid through all of
   those best-focus positions. That extra data lets it separate tilt, field curvature, and centering,
   and put an uncertainty on each result. It is also more demanding: it needs many well-fit stars, so it

--- a/documentation/docs/overview/star-annotation.md
+++ b/documentation/docs/overview/star-annotation.md
@@ -13,7 +13,7 @@ The annotator converts the displayed image to an 8-bit grayscale canvas, draws e
 
 If **Show Annotations** is off, the annotator returns the image untouched, and nothing else in this page applies until you turn it back on.
 
-Auto Focus works a little differently: it measures each frame with its own detection pass, and **Annotate During Auto Focus** overlays that same detection — the very stars that produced the HFR point — onto each frame as the sweep runs. It is on by default; turn it off to watch the sweep on unmarked frames.
+Auto Focus works a little differently: it measures each frame with its own detection pass, and **Annotate During Auto Focus** overlays that same detection (the very stars that produced the HFR point) onto each frame as the sweep runs. It is on by default; turn it off to watch the sweep on unmarked frames.
 
 By default the annotator draws *every* detected star. If you turn **Show All Stars** off, it keeps only the **Maximum Stars** brightest stars (sorted by average brightness) and labels those. The rejection boxes described later are drawn from the detector's metrics independently of this limit, so they always appear in full when their toggle is on.
 
@@ -114,14 +114,10 @@ The mask pixels are blended onto the image in **Structure Map Color** (*"The col
 
 ## Practical recipes
 
-!!! example "Tuning detection quality"
-    Cap labels (**Show All Stars** off, **Maximum Stars** ≈ 50), then enable the rejection toggles one or two at a time with distinct colors. Walk the gates until the accepted set looks right for your focal ratio and seeing.
+**Tuning detection quality.** Cap labels (**Show All Stars** off, **Maximum Stars** ≈ 50), then enable the rejection toggles one or two at a time with distinct colors. Walk the gates until the accepted set looks right for your focal ratio and seeing.
 
-!!! example "Checking focus quality across the field"
-    Set **Show Property** to FWHM or Eccentricity (PSF modeling required) and watch for consistent, low values near best focus. The star-center reticule makes off-center or trailed stars at the defocus extremes easy to spot.
+**Checking focus quality across the field.** Set **Show Property** to FWHM or Eccentricity (PSF modeling required) and watch for consistent, low values near best focus. The star-center reticule makes off-center or trailed stars at the defocus extremes easy to spot.
 
-!!! example "Mapping the PSF across the sensor"
-    Combine **Star Bounds Type = PSF** with the Eccentricity or PSF Rotation label to overlay the actual fitted ellipse shape and orientation everywhere in the frame. Systematic stretch toward the corners points to tilt, coma, or curvature, the kind of thing the Tilt & Aberration Inspector quantifies.
+**Mapping the PSF across the sensor.** Combine **Star Bounds Type = PSF** with the Eccentricity or PSF Rotation label to overlay the actual fitted ellipse shape and orientation everywhere in the frame. Systematic stretch toward the corners points to tilt, coma, or curvature, the kind of thing the Tilt & Aberration Inspector quantifies.
 
-!!! example "Understanding contamination in nebulosity"
-    Turn on **Show Contaminated** while imaging over bright nebulosity. Because flagged stars draw whether or not they were rejected, you can immediately see which measurements a gradient or close neighbor may be biasing.
+**Understanding contamination in nebulosity.** Turn on **Show Contaminated** while imaging over bright nebulosity. Because flagged stars draw whether or not they were rejected, you can immediately see which measurements a gradient or close neighbor may be biasing.

--- a/documentation/docs/overview/star-detection.md
+++ b/documentation/docs/overview/star-detection.md
@@ -58,7 +58,7 @@ An optional Gaussian blur (radius configurable) suppresses pixel-to-pixel noise 
 the floor and the structure step is cleaner. It can be applied to the image actually measured, to the
 structure-detection copy only, or to neither. Blurring trades a little positional precision for sensitivity,
 so it helps most on noisy, short, or high-gain subs and can hurt on already-clean, well-sampled frames. See
-[Pre-processing](../settings/preprocessing.md).
+[Preprocessing](../settings/preprocessing.md).
 
 ### 4. Wavelet structure detection (remove large-scale structures)
 
@@ -90,7 +90,7 @@ T = \text{median} + k_\sigma \cdot \sigma_{\text{noise}}
 Raising \( k_\sigma \) demands a stronger signal to count as a star (fewer, more reliable detections);
 lowering it admits fainter structure (more stars, more risk of noise). By default this threshold is computed
 *per region* rather than once for the whole frame (locally adaptive binarization), so the same multiplier stays
-fair across a vignetted or gradient-heavy frame. See [Pre-processing](../settings/preprocessing.md), and
+fair across a vignetted or gradient-heavy frame. See [Preprocessing](../settings/preprocessing.md), and
 [Adaptive Binarization](../settings/adaptive-binarization.md) for why the default multiplier is 2.
 
 ### 6. Optional dilation
@@ -129,7 +129,7 @@ For each candidate the detector measures, in order:
 does not require fitting a model.*
 
 The pixel sampling step controls the HFR grid: a finer step samples undersampled stars more faithfully at
-some cost in speed. See [Pre-processing](../settings/preprocessing.md) and
+some cost in speed. See [Preprocessing](../settings/preprocessing.md) and
 [PSF Modeling](../settings/psf-modeling.md) for the optional model fit (step 10).
 
 ### 9. Acceptance gates

--- a/documentation/docs/overview/tilt-aberration-inspector.md
+++ b/documentation/docs/overview/tilt-aberration-inspector.md
@@ -115,6 +115,10 @@ counter-clockwise (loosen); stepper adapters show signed steps (`+35 steps`) mat
 prompts. A legend at the top of the section defines both conventions and is marked "(assumed)" until
 the adapter direction has been measured in the wizard.
 
+The whole correction loop can be rehearsed in the daytime against the
+[Camera Simulator](camera-simulator.md#rehearse-a-tilt-calibration-in-the-daytime), which injects a
+known tilt and provides on-screen buttons standing in for the adapter's screws.
+
 ## Inspector options
 
 These settings live in the inspector panel (not the main Options page). Defaults and ranges are taken

--- a/documentation/docs/overview/tilt-adapter-wizard.md
+++ b/documentation/docs/overview/tilt-adapter-wizard.md
@@ -4,7 +4,9 @@ A measured tilt plane tells you which corners need to move and by how much, but 
 the sensor along that screw's own axis. To convert the [Tilt & Aberration
 Inspector](tilt-aberration-inspector.md) measurement into a concrete instruction (*"turn this screw
 clockwise ¼ turn"*), the wizard must know where each screw sits relative to the sensor and how far a
-turn moves it. That mapping is established once by the **Tilt Adapter Wizard**.
+turn moves it. That mapping is established once by the **Tilt Adapter Wizard**. (To practice the
+measure-and-correct loop before working on real hardware, see the
+[Camera Simulator](camera-simulator.md#rehearse-a-tilt-calibration-in-the-daytime).)
 
 ![The Tilt Adapter Guidance table giving the direction and number of turns for each screw](../assets/screenshots/inspector-tilt-guidance.png){ width=620 }
 
@@ -49,9 +51,9 @@ every step ends with a measurement. From the change in the tilt vector \((\Delta
 computes each screw's angle.
 
 The four-step run does not measure which way a clockwise turn moves the adapter. That direction
-comes from the adapter direction setting in the wizard's **Measurement** section, labeled **Turning
-screws clockwise moves the adapter** (or **Applying + steps moves the adapter** for steppers):
-either **Toward the camera — outward** (the default) or **Toward the objective — inward**. Until it
+comes from the adapter direction setting in the wizard's **Measurement** section, labeled **Screw ⟳
+moves adapter** (or **+ steps move adapter** for steppers):
+either **Toward the camera** (outward, the default) or **Toward the objective** (inward). Until it
 is measured, guidance marks the direction "(assumed)". To measure it, turn on **Measure direction**:
 this adds two steps (an all-screws-clockwise move plus a return to baseline) that determine the sign
 of the effect (`ScrewInwardCurvatureSign`) from the curvature change, and the saved calibration then
@@ -113,7 +115,7 @@ adapter direction setting, so guidance stays marked "(assumed)" until a **Measur
 verifies it. The entered angle is interpreted with the adapter direction setting in effect when you
 click **Apply**; if you change that setting later, click **Apply** again. If guidance moves the
 tilt the wrong way after a manual entry, the numbering direction is flipped: switch it and Apply
-again. A wrong adapter direction setting inverts guidance the same way — correct that setting and
+again. A wrong adapter direction setting inverts guidance the same way; correct that setting and
 click **Apply** again.
 
 ## Hardware model and device presets

--- a/documentation/docs/quick-start.md
+++ b/documentation/docs/quick-start.md
@@ -31,7 +31,7 @@ Turn on the parts you want. Go to **Options → Imaging → Image Options** and,
 
 - **Star Detector** — the improved detector (see [Star Detection](overview/star-detection.md)).
 - **Star Annotator** — the customizable overlay (see [Star Annotation](overview/star-annotation.md)).
-- **Autofocus** — the concurrent autofocus engine (see [Autofocus](overview/autofocus.md)).
+- **Auto Focus** — the concurrent autofocus engine (see [Autofocus](overview/autofocus.md)).
 
 ![The Image Options dropdowns set to Hocus Focus for Star Detector, Star Annotator, and Autofocus](assets/screenshots/image-options-all.png){ width=510 }
 
@@ -39,7 +39,7 @@ Turn on the parts you want. Go to **Options → Imaging → Image Options** and,
 
 !!! note "Some features need both"
     The autofocus engine and the Aberration Inspector require Hocus Focus to be selected for both
-    **Autofocus** and **Star Detector**. You can otherwise mix and match, for example keeping only the detector.
+    **Auto Focus** and **Star Detector**. You can otherwise mix and match, for example keeping only the detector.
 
 ## 3. Get a first autofocus working
 
@@ -72,8 +72,8 @@ this stage.*
 If the curve looks flat, the step size is too small. If stars vanish at the ends of the sweep, the step
 size is too large; reduce it, or set **Focus Range** to **Wide Range** so heavily defocused donut stars
 are still detected. If few stars are found even near focus, increase the exposure time. Narrowband
-filters in particular can need much longer autofocus exposures at first; the tip in step 6 shows how to
-work back down.
+filters in particular can need much longer autofocus exposures at first; step 7 shows how to bootstrap
+them and work the exposure back down.
 
 → Full detail: [Autofocus](overview/autofocus.md).
 
@@ -122,19 +122,40 @@ computationally expensive and can take a while on a slow imaging computer.
     computer, **Import** the exported `.json` file, review exactly what will change, and apply. See
     [exporting and importing settings](settings/index.md#exporting-and-importing-star-detection-settings).
 
-!!! tip "Narrowband filters: bootstrap with a live sweep, then shorten"
-    Through a narrowband filter, so few stars appear that autofocus often won't converge, so you never get
-    a working run to save and replay. Use the wizard's **Live Auto-Focus** source instead: reach
-    rough focus manually, and it captures a fixed focus sweep and tunes detection against it without
-    needing a working autofocus first. Set the exposure long enough that stars stay visible out at the
-    wings of the sweep, so the optimizer has data across the whole curve. Once a run succeeds, shorten the
-    exposure and run the sweep again to find how far you can push it; a well-tuned detector handles much
-    fainter stars than the defaults. Finish with the exposure and settings you will actually autofocus
-    with; the summary can write the sweep exposure into your profile for you.
-
 → Full detail: [Star Detection Optimization](optimization/index.md).
 
-## 7. If you run into trouble
+## 7. Narrowband filters: tune with a live sweep
+
+Skip this step unless you autofocus through narrowband filters. Through Hα, OIII, or SII, so few
+stars appear that autofocus often will not converge at all, which leaves you with no saved run for
+the wizard to replay. The wizard's **Live Auto-Focus** source breaks that deadlock: instead of
+replaying a run, it captures one, without needing a working autofocus first.
+
+Reach focus manually before starting (a Bahtinov mask or a careful manual pass is fine); the sweep
+is centered on the current focuser position, so it has to begin near focus. Then, in the wizard:
+
+1. Choose **Live Auto-Focus** as the **Source**, and set the **Exposure**. Start with an exposure
+   time you know shows stars through this filter, even if it is far longer than you would ever
+   autofocus with. The sweep needs stars visible out at its defocused ends, and a too-short
+   exposure just produces empty frames that nothing can be tuned against.
+2. Choose the folder to **Save captured frames to** and press **Start**. The wizard sweeps the
+   focuser across a fixed range (built from your profile's auto-focus step size and offset steps),
+   saves an image at every point whether or not any stars are detected, returns the focuser to
+   where it started, and then searches for the detection settings that build the cleanest focus
+   curve from those frames.
+3. Once a run succeeds, run it again with a shorter exposure, and keep shortening until the result
+   degrades. This finds how far you can push this filter: a well-tuned detector handles much
+   fainter stars than the defaults, and narrowband autofocus exposures often end up several times
+   shorter than the safe starting value.
+4. Finish with the exposure you will actually autofocus with. On the summary, turn on **Apply
+   these auto-focus settings to my profile when I click Accept**: along with the recommended step
+   size, it writes the sweep's exposure into your profile as the auto-focus exposure time, so you
+   focus with the exposure you optimized against.
+
+→ Full detail: the live-run walkthrough in
+[Star Detection Optimization](optimization/index.md#saved-and-live-sources).
+
+## 8. If you run into trouble
 
 Saved runs replay deterministically, so sharing one lets the plugin author reproduce exactly what your
 rig did, frame by frame. If autofocus misbehaves or a result looks wrong:
@@ -161,6 +182,10 @@ With autofocus working and tuned, the same detector and saved-run machinery feed
 - **If you have a tilt adapter, calibrate it.** The **Tilt Adapter Wizard** learns where each screw sits
   relative to your sensor and how far a turn moves it, turning tilt measurements into concrete
   screw-turn guidance. → [Tilt Adapter Wizard](overview/tilt-adapter-wizard.md)
+- **Practice in the daytime.** The **Camera Simulator** renders realistic star fields from an ASTAP
+  star database, complete with defocus, donuts, and injectable sensor tilt, so you can test autofocus
+  settings or rehearse a full tilt calibration with no sky at all.
+  → [Camera Simulator](overview/camera-simulator.md)
 - **Customize the annotation overlay**: colors, fonts, and what gets drawn over accepted and rejected
   stars. → [Star Annotation](overview/star-annotation.md)
 - **Go deeper on the settings.** Every detection knob, and everything the optimizer searches over, is

--- a/documentation/docs/settings/acceptance-gates.md
+++ b/documentation/docs/settings/acceptance-gates.md
@@ -23,7 +23,7 @@ This page documents the gates exposed as **Advanced** star-detection options. Th
 !!! note
     These settings live under **Advanced** star detection. In **Simple** mode they are derived for you from the noise level, pixel scale, and focus-range presets, and the values below are what those presets resolve to. If you have run the [Optimization Wizard](../optimization/index.md), a curated subset of these gates is what it tunes.
 
-## Summary
+## Settings at a glance
 
 | Setting | Default | Range | Effect |
 |---|---|---|---|
@@ -47,13 +47,13 @@ Rejects candidates whose signal does not rise far enough above the local backgro
 
 > Given a star with a normalized brightness measure of **s**, a local background of **b**, and a background noise level of **n**, star sensitivity is measured as the ratio of the star brightness above the background relative to the background noise **(s-b)/n**. The noise level **n** is measured on the image actually used for star measurement, so this value is an honest multiple of the real noise and means the same thing regardless of noise-reduction settings. The default of 2 works well; if you find a large number of rejections due to low sensitivity, smaller values increase sensitivity
 
-A candidate is accepted only when its normalized brightness divided by the measurement-image noise σ exceeds this threshold, so the gate is a signal-to-noise floor:
+A candidate is accepted only when its brightness above background divided by the measurement-image noise \(n\) exceeds this threshold, so the gate is a signal-to-noise floor:
 
 \[
 \frac{s - b}{n} > \text{BrightnessSensitivity}
 \]
 
-**Smaller values are more sensitive** (they admit fainter stars); larger values are stricter. Because σ is measured on the image actually sampled for star measurement, the same threshold keeps its meaning whether or not noise reduction is enabled.
+**Smaller values are more sensitive** (they admit fainter stars); larger values are stricter. Because \(n\) is measured on the image actually sampled for star measurement, the same threshold keeps its meaning whether or not noise reduction is enabled.
 
 **Default:** 2.0. **Range:** ≥ 0 (must be non-negative)
 

--- a/documentation/docs/settings/adaptive-binarization.md
+++ b/documentation/docs/settings/adaptive-binarization.md
@@ -2,8 +2,8 @@
 
 Candidate formation begins by binarizing the structure map at a noise floor: a pixel must rise a set number of
 noise sigmas above the background to survive as part of a star candidate. That floor is the single biggest lever
-on [recall](precision-recall.md), because a star that never clears it never becomes a candidate. This page tells
-how the floor's default was lowered, and then made to vary across the frame.
+on [recall](precision-recall.md), because a star that never clears it never becomes a candidate. This page
+explains how the floor's default was lowered, and then made to vary across the frame.
 
 ## The settings
 
@@ -38,7 +38,7 @@ help recall in isolation.*
 
 A lower floor admits fainter stars, and fainter stars can carry noisier HFR, so the next question was whether
 this hurts the focus curve. It does not. The per-region HFR-versus-focuser curve was rebuilt at each multiplier
-and parabola-fit for best-focus position and goodness of fit:
+(NC) and parabola-fit for best-focus position and goodness of fit:
 
 | Region | NC = 4 (legacy) | NC = 2 (default) |
 |---|---|---|
@@ -53,8 +53,8 @@ stars but with slightly more corner scatter, so the setpoint landed at **2.0**.
 
 Why 2 and not 1.5? Three checks ran independently and agreed across a 17-run bank of saved focus runs:
 
-- Recall @ SNR≥12 rose bank-wide as the multiplier fell, with the median going from 0.797 at NC=4 to 0.870 at
-  NC=2.
+- Recall @ SNR≥12 rose bank-wide as the multiplier fell, with the median going from 0.797 at NC = 4 to 0.870 at
+  NC = 2.
 - On the run with the most complete golden (so its precision is trustworthy), dropping to 2 roughly doubled
   recall (0.189 → 0.459) for a negligible precision cost (0.849 → 0.811).
 - The per-run optimizer, which minimizes focus scatter and is therefore immune to the precision-measurement
@@ -65,7 +65,7 @@ So the default changed from **4 to 2**.
 
 ## A single global floor is the wrong shape
 
-A single global multiplier still leaves recall on the table. Recall was still climbing at NC=2 on the cleanest
+A single global multiplier still leaves recall on the table. Recall was still climbing at NC = 2 on the cleanest
 frames, yet a lower global value floods the noisy corners with false candidates. The reason is that the floor is
 one scalar applied to a frame that is not uniform. Vignetting, sky gradients, amp glow, and field-edge falloff
 make the local background and local noise vary by two to four times across a single frame. A global floor is
@@ -88,12 +88,12 @@ blocks by default) and upsampled to the full frame. The multiplier stays at 2, b
 where the background is clean, recovering faint stars, and high where it is noisy, rejecting noise. This is the
 same local-statistics approach the reference detector uses to define the recall target in the first place.
 
-Tested OFF against ON at NC=2 across the 17-run bank, the surface improves recall and precision *together*,
+Tested OFF against ON at NC = 2 across the 17-run bank, the surface improves recall and precision *together*,
 which no single global value can do:
 
 ![Adaptive binarization OFF versus ON: recall, precision, and focus scatter all improve](../assets/figures/nc-adaptive-ab.png){ width=700 }
 
-*OFF versus ON at NC=2. Bank-median recall @ SNR≥12 and precision both rise, and the autofocus fit tightens. On
+*OFF versus ON at NC = 2. Bank-median recall @ SNR≥12 and precision both rise, and the autofocus fit tightens. On
 the run with the most complete golden, recall jumps from 0.459 to 0.862 and the focus scatter is more than
 halved.*
 
@@ -104,9 +104,9 @@ default**. The multiplier stays at 2; the surface is what makes that 2 fair ever
 
 Two independent switches turn the change off:
 
-- **`LocallyAdaptiveBinarization = false`** reverts the floor's *shape* to the legacy single global scalar. With
-  it off, candidate formation is bit-for-bit identical to the pre-change detector.
-- **`NoiseClippingMultiplier = 4.0`** reverts the floor's *level* to the legacy default.
+- Turning **Locally Adaptive Binarization** off reverts the floor's *shape* to the legacy single global scalar.
+  With it off, candidate formation is bit-for-bit identical to the pre-change detector.
+- Setting **Noise Clipping Multiplier** back to **4.0** reverts the floor's *level* to the legacy default.
 
 Setting both restores the full legacy behavior. The only reason to do that is to reproduce or compare against the
 old detector. The validated defaults (NC = 2, adaptive on) beat the legacy settings on every rollout criterion

--- a/documentation/docs/settings/advanced-debug.md
+++ b/documentation/docs/settings/advanced-debug.md
@@ -87,7 +87,7 @@ default), so the applied radius is 4/6. None stays 0 because filtering is off.
 The *sensitivity scale* compensates for how the noise σ is measured per preset, so that the same effective
 threshold is preserved across presets. It feeds into the derived **Brightness Sensitivity** described below.
 At **None** there is no blur and noise reduction is fully disabled; at **High**, noise reduction is also
-applied to the measurement image, not just the structure map.
+applied to the measurement image, not just the structure-detection image.
 
 !!! tip "When this helps"
 
@@ -205,9 +205,10 @@ or each star's own measured HFR.
 
 !!! tip "When this helps"
 
-    Leave on **Median** for almost all cases; it is robust without tuning. Use **Mean + Outlier Detection**
-    only if you specifically want a mean-based aggregate with an explicit, MAD-based outlier cut (e.g. when
-    comparing against tooling that reports a mean). On sparse fields the mean can be noisier than the median.
+    Leave on **Median** for almost all cases; it needs no tuning and a few bad stars do not move it. Use
+    **Mean + Outlier Detection** only if you specifically want a mean-based aggregate with an explicit,
+    MAD-based outlier cut (e.g. when comparing against tooling that reports a mean). On sparse fields the
+    mean can be noisier than the median.
 
 ## Use AutoFocus Crop
 

--- a/documentation/docs/settings/contamination.md
+++ b/documentation/docs/settings/contamination.md
@@ -19,7 +19,7 @@ test fires and whether a flagged star is thrown out or merely marked.
 | Reject Contaminated Stars | On | On / Off | On removes flagged stars from the result; Off keeps them and only marks them. |
 
 These are Advanced-mode options. In Simple mode the preset derivation never overrides them,
-so they keep whatever value you (or a reset) last set, i.e. the defaults above.
+so they keep whatever value you (or a reset) last set (for most users, the defaults above).
 
 ## How the gradient-robust test works
 
@@ -104,7 +104,7 @@ Decides whether a flagged star is removed from the result or kept and only marke
 
 **Default:** On &nbsp;•&nbsp; **Range:** On / Off
 
-When **on**, a flagged star is dropped via the `Contaminated` rejection gate and never enters
+When **on**, a flagged star is dropped via the **Contaminated** rejection gate and never enters
 the HFR/PSF aggregation. When **off**, the same star stays in the detected set carrying its
 "contamination suspected" marker, useful for inspection and for the labeling/diagnostic
 tools, which keep flagged stars so they can be analyzed.

--- a/documentation/docs/settings/index.md
+++ b/documentation/docs/settings/index.md
@@ -64,7 +64,7 @@ When **Use Optimized Settings** is on and a wizard result exists, Simple mode fi
 
 ### Exporting and importing star-detection settings
 
-Star-detection settings can move between machines. Two buttons at the bottom of the Star Detection options pane, **Export** and **Import**, write and read a single `.json` file (named `HocusFocusStarDetection_<timestamp>.json`). This is how you tune on one computer and image on another: run the [Optimization Wizard](../optimization/index.md) on a fast desktop, **Export**, then **Import** on the imaging computer.
+Star-detection settings can move between machines. Two buttons at the bottom of the **Star Detector** tab, **Export** and **Import**, write and read a single `.json` file (named `HocusFocusStarDetection_<timestamp>.json`). This is how you tune on one computer and image on another: run the [Optimization Wizard](../optimization/index.md) on a fast desktop, **Export**, then **Import** on the imaging computer.
 
 Only **star-detection** settings are written, not autofocus, inspector, or tilt settings. The wizard's optimized-settings snapshot is included too, so the imported profile can turn it on with **Use Optimized Settings**. A few values are deliberately left out because they belong to one computer: the intermediate-image path, the **Save Intermediate** flag, **Debug Mode**, and **PSF Parallel Size**. Those keep their local values on import.
 
@@ -145,11 +145,11 @@ Internally the detector splits into an **EARLY** phase (`BuildDetectionContext`)
 - **EARLY** parameters affect the prepared image, the candidate region set, and the noise estimates. Changing one forces a **full re-detect**. These are the hotpixel knobs (`HotpixelFiltering`, `HotpixelThresholdingEnabled`, `HotpixelThreshold`), noise reduction (`StarMeasurementNoiseReductionEnabled`, `NoiseReductionRadius`, `NoiseClippingMultiplier`, `LocallyAdaptiveBinarization`, `AdaptiveNoiseBlockSize`), the structure-map knobs (`StructureLayers`, `DefocusAwareStructure`, `StructureLayerBoost`, `StructureDilationSize`, `StructureDilationCount`), `SaturationThreshold`, and the detection `Region`.
 - **LATE** parameters only re-gate or re-measure the candidates that already exist (sensitivity, distortion, centering, min-HFR, PSF settings, the defocus-aware *gate* relaxations, contamination). They are cheap to change.
 
-You don't normally need to think about this when using NINA, since it changes whichever parameters you change. The distinction matters because the [Optimization Wizard](../optimization/index.md) and the headless tooling exploit it: an expensive early context is cached and reused across many late-only candidate moves, which is what makes the optimizer fast. The safe failure mode of the cache is always a redundant recompute, never stale reuse.
+You don't normally need to think about this when using NINA, where every detection runs the full pipeline anyway. The distinction matters because the [Optimization Wizard](../optimization/index.md) and the headless tooling exploit it: an expensive early context is cached and reused across many late-only candidate moves, which is what makes the optimizer fast. The safe failure mode of the cache is always a redundant recompute, never stale reuse.
 
 !!! note "Profile-scoped and auto-saved"
 
-    All star-detection settings are stored per NINA profile. Switching profiles re-derives Simple-mode settings from that profile's presets. There is also a **Reset Defaults** action that restores every parameter to its shipped value (Simple mode, Typical presets, PSF modeling on with Moffat 4.0, and so on) and clears any optimized snapshot.
+    All star-detection settings are stored per NINA profile, and changes are written to the active profile as you make them — there is no separate save step. Switching profiles re-derives Simple-mode settings from that profile's presets. There is also a **Reset Defaults** action that restores every parameter to its shipped value (Simple mode, Typical presets, PSF modeling on with Moffat 4.0, and so on) and clears any optimized snapshot.
 
 ## Reference sub-pages
 

--- a/documentation/docs/settings/preprocessing.md
+++ b/documentation/docs/settings/preprocessing.md
@@ -6,7 +6,7 @@ Before Hocus Focus can find and measure stars, it has to decide what is *signal*
 2. **Thresholding** — how far above the noise floor a pixel must sit to count as a star candidate (`NoiseClippingMultiplier`, applied as a per-region surface when `LocallyAdaptiveBinarization` is on) or to be included in a star's flux/HFR measurement (`StarClippingMultiplier`).
 3. **Sub-pixel sampling** — how finely star centers and HFR are sampled between whole pixels (`PixelSampleSize`).
 
-A key idea runs through all of these: Hocus Focus keeps **two images**. A *structure-detection image* is used to find where the candidate stars are, and a *measurement image* is used to measure each star's centroid, flux, HFR, and PSF. By default the noise reduction is applied **only** to the structure-detection image, so candidate-finding is robust to noise while the measurements stay on the sharp, unblurred pixels.
+A key idea runs through all of these: Hocus Focus keeps **two images**. A *structure-detection image* is used to find where the candidate stars are, and a *measurement image* is used to measure each star's centroid, flux, HFR, and PSF. By default the noise reduction is applied **only** to the structure-detection image, so candidate-finding tolerates noise while the measurements stay on the sharp, unblurred pixels.
 
 ![The preprocessing and noise settings highlighted in the advanced Star Detector list](../assets/screenshots/advanced-preprocessing.png){ width=375 }
 
@@ -55,7 +55,7 @@ The radius is a *half-size*: the convolution kernel spans roughly twice the radi
 
 This is the switch that controls Hocus Focus's two-image design. With it **off** (default), candidate *finding* runs on the blurred structure-detection image, but every measurement (centroid, flux, HFR, PSF) is taken from the sharp, unblurred image, so the blur cannot bias the numbers. With it **on**, the same blurred pixels feed both stages.
 
-Turning it on changes what the noise σ is measured against. Hocus Focus tracks two noise estimates: a structure σ (on the noise-reduced structure source, used only by the binarize threshold) and a measurement σ (on the image actually sampled). The brightness and star clipping multipliers are honest multiples of that **measurement** σ, so they keep their meaning regardless of this switch.
+Turning it on changes what the noise σ is measured against. Hocus Focus tracks two noise estimates: a structure σ (on the noise-reduced structure source, used only by the binarization threshold) and a measurement σ (on the image actually sampled). The brightness and star clipping multipliers are honest multiples of that **measurement** σ, so they keep their meaning regardless of this switch.
 
 !!! tip "When this helps"
     Enable it only for **very noisy** data where the unblurred pixels are too noisy to measure HFR reliably. The High noise preset turns it on for you and also raises the radius. It can hurt in normal conditions: blurring the measurement pixels inflates measured HFR and softens the PSF, biasing the autofocus curve. Leave it off unless you have a specific noise problem.

--- a/documentation/docs/settings/psf-modeling.md
+++ b/documentation/docs/settings/psf-modeling.md
@@ -6,7 +6,7 @@ After a star is detected and its HFR measured, Hocus Focus can fit an analytic *
 
 *The PSF modeling block: model type, resolution, parallel batch size, and fit threshold.*
 
-These settings live under the **Advanced** star-detection options. They do not affect star *acceptance* (which stars pass the [acceptance gates](acceptance-gates.md)). They only shape the per-star *shape measurement* that PSF fitting produces.
+These settings live under the **Advanced** star-detection options. They do not affect star *acceptance* (which stars pass the [acceptance gates](acceptance-gates.md)). They only affect the per-star *shape measurement* that PSF fitting produces.
 
 ## What PSF modeling does
 
@@ -97,7 +97,7 @@ After a star is fit, its coefficient of determination \( R^2 \) is compared agai
     Keep **0.9** for clean, well-fit metrics. **Lower** it (e.g. toward 0.8) if too many real stars are getting no FWHM because their fits fall just short, common for noisy frames or unusual profiles. **Raise** it toward 1.0 to admit only near-perfect fits when you want the cleanest possible shape statistics and can afford fewer measured stars.
 
 !!! warning
-    Setting the threshold to 0 is not allowed (the valid range is open at zero). A very low threshold lets poorly-fit stars through with unreliable FWHM/eccentricity; a very high threshold can leave most stars with no shape metrics at all.
+    A very low threshold lets poorly-fit stars through with unreliable FWHM/eccentricity; a very high one can leave most stars with no shape metrics at all.
 
 ## PSF Pixel Integration
 

--- a/documentation/docs/settings/structure-detection.md
+++ b/documentation/docs/settings/structure-detection.md
@@ -23,7 +23,7 @@ The detector removes large-scale structure with an **à-trous (dyadic) B3-spline
 | Setting | Default | Range | Effect |
 |---|---|---|---|
 | Structure Layers | 4 | integer > 0 | Wavelet layers kept; structures larger than ~\(2^{\text{layers}}\) px are removed as background. More layers keep larger (e.g. defocused) stars. |
-| Defocus-Aware Structure | Off | On / Off | When on, removes background more coarsely so heavily-defocused donut stars survive and form candidates. Off ⇒ detection unchanged. |
+| Defocus-Aware Structure | Off | On / Off | When on, removes background more coarsely so heavily defocused donut stars survive and form candidates. Off ⇒ detection unchanged. |
 | Structure Layer Boost | 0 | 0–6 | Extra wavelet layers added *only* while Defocus-Aware Structure is on. Higher ⇒ coarser removal ⇒ bigger donuts survive. |
 | Structure Dilation Size | 3 | 3–30 px | Diameter of the morphological filter that grows candidate blobs in the structure map. |
 | Structure Dilation Iterations | 0 | ≥ 0 | How many times the dilation is applied. 0 disables dilation. |
@@ -58,7 +58,7 @@ When this is **off**, the effective layer count is exactly `StructureLayers`, so
 *A heavily defocused star becomes a large hollow donut, exactly the structure that aggressive background removal can erase before it is ever evaluated.*
 
 !!! tip "When to adjust"
-    **Enable it** only when collecting autofocus frames far from focus *and* you observe donut stars missing entirely (no candidate at all), not merely rejected by a gate. Pair it with a **Structure Layer Boost above 0**. On its own, with boost at 0, it changes nothing. If the donuts are present but rejected with a reason (TooDistorted / NotCentered), the fix is the **Defocus-Aware Gates** on the [Acceptance Gates](acceptance-gates.md) page, not this; if the donuts fragment into small arcs (rejected as **Too Small**), reach for the [Recover Out-of-Focus Donut Stars](acceptance-gates.md#recover-out-of-focus-donut-stars) group, which reconnects the ring. **Leave it off** for normal near-focus imaging; it adds nothing there and only widens what counts as a star.
+    **Enable it** only when collecting autofocus frames far from focus *and* you observe donut stars missing entirely (no candidate at all), not merely rejected by a gate. Pair it with a **Structure Layer Boost above 0**. On its own, with boost at 0, it changes nothing. If the donuts are present but rejected with a reason (**Too Distorted** / **Not Centered**), the fix is the **Defocus-Aware Gates** on the [Acceptance Gates](acceptance-gates.md) page, not this; if the donuts fragment into small arcs (rejected as **Too Small**), reach for the [Recover Out-of-Focus Donut Stars](acceptance-gates.md#recover-out-of-focus-donut-stars) group, which reconnects the ring. **Leave it off** for normal near-focus imaging; it adds nothing there and only widens what counts as a star.
 
 ## Structure Layer Boost
 
@@ -100,4 +100,4 @@ At the default of 0 the dilation step is skipped entirely, so **Structure Dilati
     **Raise it to 1+** when bounding boxes are too tight around stars at high focal length and a single dilation pass is not enough. **Leave it at 0** for typical sampling; most rigs never need dilation. It can hurt the same way as Structure Dilation Size, only faster: extra iterations compound the blob growth, so in dense star fields neighbors merge and small structures balloon.
 
 !!! warning
-    Structure Layers, Defocus-Aware Structure, and Structure Layer Boost are **early-stage** parameters: they change which candidates are formed in the first place. Structure Dilation Size and Iterations also reshape candidate geometry. Change these only when stars are missing or boxed wrong at the *structure* level. If a star is being **rejected with a reason** (too distorted, low sensitivity, too flat, not centered), the fix belongs on the [Acceptance Gates](acceptance-gates.md) page instead.
+    Structure Layers, Defocus-Aware Structure, and Structure Layer Boost are **early-stage** parameters: they change which candidates are formed in the first place, and the two dilation settings reshape candidate geometry. If a star is instead rejected with a reason (**Too Distorted**, **Low Sensitivity**, **Too Flat**, **Not Centered**), the fix belongs on the [Acceptance Gates](acceptance-gates.md) page.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,8 @@ nav:
       - Tilt & Aberration Inspector: overview/tilt-aberration-inspector.md
       - Tilt Adapter Wizard: overview/tilt-adapter-wizard.md
       - Sensor Model Fitting: overview/sensor-model.md
+      - Camera Simulator: overview/camera-simulator.md
+      - Camera Simulator Rendering Model: overview/camera-simulator-rendering.md
   - Star Detection Settings:
       - settings/index.md
       - Precision & Recall: settings/precision-recall.md


### PR DESCRIPTION
## Summary

- **New [Camera Simulator](documentation/docs/overview/camera-simulator.md) page**: what the simulator is, installing ASTAP + a star database (links, default `C:\Program Files\astap` path, `.1476`/`.290` auto-detection), connecting it (focuser + mount required), the rig setup dialog and Camera Sim settings reference, autofocus testing, and a step-by-step **daytime tilt-calibration rehearsal** using the injected aberrations and the Simulator Tilt Adapter panel.
- **New [Camera Simulator Rendering Model](documentation/docs/overview/camera-simulator-rendering.md) supplement**: the frame-generation algorithms with the actual formulas — catalog query and TAN projection, magnitude-to-electrons radiometry (sensor QE curve, filter bandpasses, sky brightness, dark current), the annulus⊛Gaussian PSF, defocus/donut geometry and its by-construction agreement with the autofocus hyperbola, the tilted-paraboloid aberration surface, the shot/read/gain noise chain, and determinism.
- **Quick Start**: the narrowband tip is promoted to a full step — Live Auto-Focus source with a settable exposure, captures the whole sweep regardless of detection, requires manual focus first; start with a known-good exposure and iterate shorter, then write the result back to the profile from the summary.
- **Manual-wide cleanup** from an adversarial doc review (48 verified findings applied): exact in-app labels (**Auto Focus** dropdown, **Optimize with feedback**, **Screw ⟳ moves adapter**, **Sensor Curve Model Enabled**), terminology/spelling drift, and redundant admonitions.
- `.gitattributes`: force LF for `.claude/workflows/*.js` so saved workflows stay invokable under `core.autocrlf=true`.

## Test plan

- [x] `mkdocs build --strict` passes (all internal links resolve)
- [x] Every documented setting/label verified against the source (four-agent code research pass; review findings independently verified before applying)
- [x] No plugin code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013emnWAzJBXXqWZqqRx76QC