### PR TITLE
Motorized tilt adapter: user manual + dark-theme text fix

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -2900,7 +2900,7 @@
                                 Margin="5"
                                 FontStyle="Italic">
                                 <TextBlock.Style>
-                                    <Style TargetType="TextBlock">
+                                    <Style BasedOn="{StaticResource StandardTextBlock}" TargetType="TextBlock">
                                         <Setter Property="Visibility" Value="Collapsed" />
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding TiltGuidance.HasTiltGuidance}" Value="False">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -13,6 +13,16 @@
     </ResourceDictionary.MergedDictionaries>
 
     <!--
+        THEME HAZARD — every local <TextBlock.Style> in this file must carry
+        BasedOn="{StaticResource StandardTextBlock}". NINA.WPF.Base ships a KEYLESS TextBlock style
+        (Resources/Styles/TextBlock.xaml, BasedOn StandardTextBlock => Foreground = PrimaryBrush) in
+        Application.Resources, and that implicit style applies only to elements with no explicit Style.
+        Setting <TextBlock.Style> — even one that just flips Visibility on a DataTrigger — replaces it
+        outright, so Foreground falls back to the WPF default of Black and the text renders black on the
+        dark theme background. BasedOn keeps the theme foreground while the trigger still applies.
+    -->
+
+    <!--
         Live per-corner motor positions + Δ-since-run-start, shared by Panel A (connection pane), Panel B
         (running steps) and Panel C (complete) so the display is visible DURING a device-driven run — Panel A
         collapses while running, exactly when the positions update per move and the deltas matter most. The
@@ -326,7 +336,7 @@
                     </StackPanel>
                     <TextBlock VerticalAlignment="Center" Foreground="{StaticResource PrimaryBrush}" Text="Screws + steps">
                         <TextBlock.Style>
-                            <Style TargetType="TextBlock">
+                            <Style BasedOn="{StaticResource StandardTextBlock}" TargetType="TextBlock">
                                 <Setter Property="Visibility" Value="Collapsed" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding IsStepperAdjustment}" Value="True">
@@ -681,7 +691,7 @@
                             </StackPanel>
                             <TextBlock VerticalAlignment="Center" Foreground="{StaticResource PrimaryBrush}" Text="+ steps move adapter">
                                 <TextBlock.Style>
-                                    <Style TargetType="TextBlock">
+                                    <Style BasedOn="{StaticResource StandardTextBlock}" TargetType="TextBlock">
                                         <Setter Property="Visibility" Value="Collapsed" />
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding IsStepperAdjustment}" Value="True">
@@ -811,7 +821,7 @@
 
                     <TextBlock Margin="0,10,0,0" Foreground="{StaticResource PrimaryBrush}" Text="No calibration saved.">
                         <TextBlock.Style>
-                            <Style TargetType="TextBlock">
+                            <Style BasedOn="{StaticResource StandardTextBlock}" TargetType="TextBlock">
                                 <Setter Property="Visibility" Value="Visible" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding IsCalibrationValid}" Value="True">
@@ -843,7 +853,7 @@
                             Text="Manually entered calibration (not measured by the wizard)."
                             TextWrapping="Wrap">
                             <TextBlock.Style>
-                                <Style TargetType="TextBlock">
+                                <Style BasedOn="{StaticResource StandardTextBlock}" TargetType="TextBlock">
                                     <Setter Property="Visibility" Value="Collapsed" />
                                     <Style.Triggers>
                                         <DataTrigger Binding="{Binding TiltAdapterOptions.CalibrationIsManual}" Value="True">
@@ -1034,7 +1044,7 @@
                             Command="{Binding RunMeasurementCommand}">
                             <TextBlock Margin="10,5,10,5" Foreground="{StaticResource ButtonForegroundBrush}">
                                 <TextBlock.Style>
-                                    <Style TargetType="TextBlock">
+                                    <Style BasedOn="{StaticResource StandardTextBlock}" TargetType="TextBlock">
                                         <Setter Property="Text" Value="Run Measurement" />
                                         <Style.Triggers>
                                             <MultiDataTrigger>
@@ -1066,7 +1076,7 @@
                         Text="{Binding TiltDeviceStatusText}"
                         TextWrapping="Wrap">
                         <TextBlock.Style>
-                            <Style TargetType="TextBlock">
+                            <Style BasedOn="{StaticResource StandardTextBlock}" TargetType="TextBlock">
                                 <Setter Property="Visibility" Value="Collapsed" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding IsTiltDeviceConnected}" Value="True">
@@ -1091,7 +1101,7 @@
                         Text="{Binding ConnectionWarningText}"
                         TextWrapping="Wrap">
                         <TextBlock.Style>
-                            <Style TargetType="TextBlock">
+                            <Style BasedOn="{StaticResource StandardTextBlock}" TargetType="TextBlock">
                                 <Setter Property="Visibility" Value="Collapsed" />
                                 <Style.Triggers>
                                     <MultiDataTrigger>
@@ -1140,7 +1150,7 @@
                             </Button.Style>
                             <TextBlock Margin="10,5,10,5" Foreground="{StaticResource ButtonForegroundBrush}">
                                 <TextBlock.Style>
-                                    <Style TargetType="TextBlock">
+                                    <Style BasedOn="{StaticResource StandardTextBlock}" TargetType="TextBlock">
                                         <Setter Property="Text" Value="Cancel" />
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding IsAutoRunningAll}" Value="True">
@@ -1181,7 +1191,7 @@
                         Text="{Binding StatusText}"
                         TextWrapping="Wrap">
                         <TextBlock.Style>
-                            <Style TargetType="TextBlock">
+                            <Style BasedOn="{StaticResource StandardTextBlock}" TargetType="TextBlock">
                                 <Setter Property="Visibility" Value="Visible" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding IsMeasuring}" Value="True">
@@ -1524,7 +1534,7 @@
                         Foreground="{StaticResource PrimaryBrush}"
                         Text="{Binding ConfidenceSummaryDisplay}">
                         <TextBlock.Style>
-                            <Style TargetType="TextBlock">
+                            <Style BasedOn="{StaticResource StandardTextBlock}" TargetType="TextBlock">
                                 <Setter Property="Visibility" Value="Collapsed" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding HasConfidenceInfo}" Value="True">
@@ -1609,7 +1619,7 @@
                         Text="Set a screw radius (and thread pitch / step size) in Settings to measure adapter hardware."
                         TextWrapping="Wrap">
                         <TextBlock.Style>
-                            <Style TargetType="TextBlock">
+                            <Style BasedOn="{StaticResource StandardTextBlock}" TargetType="TextBlock">
                                 <Setter Property="Visibility" Value="Collapsed" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding HasMeasuredHardware}" Value="False">

--- a/documentation/docs/overview/camera-simulator.md
+++ b/documentation/docs/overview/camera-simulator.md
@@ -138,6 +138,11 @@ conventions, so mistakes are free and the workflow is familiar before real screw
 The panel can also stand in for real screws when the Tilt Adapter Wizard prompts for calibration
 turns, though the inspector guidance loop above is the flow the simulator is built around.
 
+The simulated adapter can also stand in for a **motorized** adapter: select an ASG Electronic EAT
+preset in the wizard and connect to the **Simulator** port to run the hands-off calibration and the
+inspector's Automatic Adjustment against it. See the [Simulator
+port](motorized-tilt-adapter.md#the-simulator-port).
+
 !!! note "Match the simulated adapter to the real settings"
     The inspector computes its guidance from the *real* tilt-adapter settings, while the simulated
     adapter obeys its own geometry. If the two differ, the guidance will not converge in the

--- a/documentation/docs/overview/motorized-tilt-adapter.md
+++ b/documentation/docs/overview/motorized-tilt-adapter.md
@@ -1,0 +1,180 @@
+# Motorized Tilt Adapter
+
+For most tilt adapters, the correction loop ends with you and a hex key: the [Tilt & Aberration
+Inspector](tilt-aberration-inspector.md) measures the tilt, and the guidance table says which screw to
+turn by hand. A motorized adapter closes that loop in software. Select one of the **ASG Electronic
+EAT** presets in the [Tilt Adapter Wizard](tilt-adapter-wizard.md), connect the adapter over its
+serial port, and the wizard runs its calibration hands-off, sending the motor moves itself. Once a
+connected calibration completes, the inspector gains an **Automatic Adjustment** button that turns a
+measurement into motor commands, shows them to you for approval, and executes them. A built-in
+**Simulator** port drives the [Camera Simulator's](camera-simulator.md) virtual adapter the same way,
+so the entire workflow can be tried with no hardware attached.
+
+## Motorized device presets
+
+The **Device** list in the wizard includes two motorized presets, **ASG Electronic EAT - 90mm** and
+**ASG Electronic EAT - ZWO 461**. Selecting either one makes a **Motorized Device Connection**
+section appear below the preset. For the Manual entry and every screw preset the section stays
+hidden, and the wizard behaves exactly as described on the [Tilt Adapter
+Wizard](tilt-adapter-wizard.md) page.
+
+The EAT is a 4-screw adapter whose motors move in coupled groups: a corner command drives that
+corner's motor forward and the opposite corner's motor backward, and a backfocus command drives all
+four together. The plugin plans corrections in those native moves, so a full tilt-plus-backfocus
+correction takes at most three commands.
+
+## Connecting
+
+1. Plug the adapter in and pick its COM port under **Serial port** (the ⟳ button re-scans the list).
+   The port is saved per profile.
+2. Click **Connect**. Opening the port restarts the adapter's controller, so it takes a few seconds
+   to boot before it responds; the status line then reads *Connected on COM7* (or whichever port you
+   chose). There is no auto-connect: the plugin only opens the port when you click.
+3. Click **Disconnect** when you are done. If the connection sits unused for 30 minutes, a dialog
+   asks whether to disconnect it.
+
+While connected, a **Motor positions (steps)** grid shows each corner's current position counter,
+polled from the device. The corners are labeled with the device's own motor numbering (**TR ·
+Motor 1**, **TL · Motor 2**, **BR · Motor 3**, **BL · Motor 4**) and with the wizard screw number
+each corner maps to (screw 1 = TR, 2 = TL, 3 = BL, 4 = BR). The counters read "unknown" until the
+first successful position query, and during a calibration run each one also shows Δ, its change
+since the run started.
+
+The counters are **absolute** and stored in the adapter's EEPROM: they survive power cycles and do
+not reset to zero between sessions (an EAT as shipped rests near 600 on every motor). The plugin
+never zeroes them; if you want the counters re-zeroed, do it in the vendor's app.
+
+## Hands-off calibration
+
+With the device connected, the wizard performs its own calibration moves instead of prompting you to
+turn screws, and the step instructions describe what the wizard is about to send rather than what
+you must do.
+
+- **Steps applied per screw** defaults to 150 steps for the EAT presets (270 µm at 1.8 µm per step),
+  large enough that each calibration move stands well above measurement noise. The value must fit
+  within the [safety limits](#safety-limits) before a run will start.
+- The first time you connect in a session, the wizard turns on **Measure direction** (the six-step
+  calibration) and notifies you. Leaving it on is recommended: the adapter's direction is then
+  measured with the same backfocus command that Automatic Adjustment later sends. If you turn it
+  off, backfocus moves keep an "(assumed direction)" warning.
+- **Auto Run All** drives every remaining step without further clicks: the wizard sends the step's
+  move, runs the measurement, advances, and finishes with a restore move that returns every motor to
+  its starting position. To step through manually instead, use **Run This Step** (the **Run
+  Measurement** button is relabeled while a motorized device is connected), which sends one step's
+  move and measurement at a time.
+- Cancelling an automated run (**Cancel Run**) is safe but not instant: the device has no abort
+  command, so the in-flight move and measurement finish first, and the wizard then sends the inverse
+  of every move applied so far, returning the adapter to its starting position.
+
+Completing a calibration with the device connected also records that the calibration is **linked to
+that device**: because the wizard sent every move itself, the correspondence between wizard screws
+and physical corners is established by measurement rather than assumption. [Automatic
+Adjustment](#automatic-adjustment) requires this link. It is cleared by any calibration the wizard
+did not drive itself: a
+[Manual Calibration Entry](tilt-adapter-wizard.md#manual-calibration-entry), a
+[replayed](tilt-adapter-wizard.md#saving-and-replaying-a-calibration-run) calibration, a run
+performed without the device connected, or substituting **Use Saved AF** for a live measurement
+partway through a connected run.
+
+## Automatic Adjustment
+
+While the device is connected, the inspector's **Tilt Adapter Guidance** section shows the live
+motor positions and an **Automatic Adjustment** button beneath the numeric guidance table. Clicking
+it computes a move plan from the current measurement's fitted sensor model (the same numbers the
+guidance table displays) and opens a **Review motor commands** dialog. Nothing moves until you
+approve the plan there.
+
+The dialog shows:
+
+- **Apply** checkboxes for **Tilt correction** and **Backfocus correction**. Toggling either one
+  recomputes the plan, so the listed moves are always exactly what will be sent.
+- The moves to send, each described by which screws travel and by how many signed steps, with the
+  raw serial command alongside for auditing.
+- The residual left at each screw after the moves: plans are rounded to whole steps, which leaves at
+  most about one step (1.8 µm) of error per corner.
+- Warnings when something needs attention: the adapter direction is still assumed rather than
+  measured, the saved step size disagrees with the wizard's last measured value, the measured tilt
+  contains a twist component that no rigid adapter can remove, or a move would violate a travel
+  limit (which disables sending).
+- The move count and an estimated duration. Each move takes roughly five to ten seconds.
+
+**Cancel** sends nothing. The confirm button, labeled **Send 2 moves** (or however many are
+planned), executes the moves in order and then offers to re-run the Aberration Inspector to confirm
+the improvement. Every move is physical and is stored in the adapter's EEPROM, so review the list
+before sending; there is no automatic undo.
+
+!!! note "One adjustment per measurement"
+    After a plan executes, **Automatic Adjustment** stays disabled until a new Detailed Analysis
+    completes, so the same measurement can never be applied twice and every adjustment is confirmed
+    by a fresh measurement before the next one. If the confirming run shows the tilt got *worse*
+    (a sign of a stale calibration or a camera rotated since calibration), the plugin says so and
+    offers to revert, sending the inverse of each move in reverse order. A failure partway through
+    a plan brings the same revert offer.
+
+## Safety limits
+
+Three persisted settings in the **Motorized Device Connection** section, under **Safety Limits**,
+bound what automation may send:
+
+| Setting | Default | What it does |
+|---|---|---|
+| **Max steps per command** | 200 | Cap on the magnitude of a single commanded move. Larger planned moves are split or refused. |
+| **Max excursion (steps)** | 2000 | Cap on the absolute position counter any motor may reach. A move that would carry a motor past it is refused before anything is sent. |
+| **Settle time (s)** | 3 | Seconds to wait after each commanded move before polling positions or sending the next command. |
+
+The excursion limit is compared against the adapter's absolute, EEPROM-persisted counters, not
+against how far the current session has moved. Since those counters rest a few hundred steps from
+zero (near 600 per motor as shipped), the cap must exceed the resting value plus your working
+travel; that is why the default is 2000 rather than something small, and why lowering it near or
+below the resting counter value would refuse the very first move. A refused move names the motor
+and the position it would have reached, and nothing is sent.
+
+## The Simulator port
+
+When a motorized preset is selected, the **Serial port** list always offers **Simulator** as its
+first entry. Connecting to it drives the [Camera
+Simulator's](camera-simulator.md#rehearse-a-tilt-calibration-in-the-daytime) virtual tilt adapter
+instead of real hardware. Everything behaves as it does with the real device, and the injected tilt
+converges toward flat as corrections are applied, so you can walk through the whole motorized
+workflow at your desk before connecting a real adapter.
+
+Connecting to the Simulator port checks three preconditions:
+
+- The **Hocus Focus Simulator** must be the connected camera. Otherwise the connect is refused with
+  an error, since the simulated adapter only changes the simulator's images.
+- The simulator's tilt-adapter geometry (screw count, adjustment type, step size, screw radius) must
+  match the selected EAT preset, or the calibration loop cannot converge. If they differ, a dialog
+  offers to change the simulator's configuration to match; declining aborts the connect.
+- **Enable Aberrations** on the **Camera Sim** options tab is switched on automatically (with a
+  notification) if it was off, because the loop measures nothing on aberration-free frames.
+
+## Troubleshooting
+
+**Connect fails or the port is missing.** Click ⟳ to re-scan after plugging the device in, and make
+sure no other program (the vendor's app, a serial monitor) is holding the port. The adapter takes a
+few seconds to boot after the port opens, so a slow first response is normal.
+
+**Automatic Adjustment is not visible.** The button only appears while a device is connected.
+Connect it from the wizard's **Motorized Device Connection** section; the inspector uses the same
+connection.
+
+**Automatic Adjustment is disabled with "This calibration is not linked to the connected
+device."** Run a calibration with the device connected (Auto Run All is the easiest path). A
+calibration entered by hand or replayed from disk cannot prove which physical corner its screw 1
+refers to, and automation applying a rotated correction would make tilt worse
+unattended. The companion message, "This calibration is low-confidence", means the connected
+calibration ran but did not pass its own quality validation; re-run it under better conditions.
+
+**Automatic Adjustment is disabled right after an adjustment.** That is the
+one-adjustment-per-measurement rule. Run a new Detailed Analysis; the button re-enables when it
+completes.
+
+**A move was refused by a limit.** The error says which limit. For **Max steps per command**, either
+reduce the amount being sent (for calibration, **Steps applied per screw**) or raise the limit. For
+**Max excursion (steps)**, remember the check is against the absolute counters: an adapter whose
+counters already rest near the cap has no headroom, so either raise the cap or re-zero the counters
+in the vendor's app.
+
+**The Simulator port refuses to connect.** Connect the **Hocus Focus Simulator** camera first, and
+answer Yes when asked to change the simulator's tilt configuration to match the preset (or align the
+two yourself on the **Camera Sim** tab).

--- a/documentation/docs/overview/tilt-aberration-inspector.md
+++ b/documentation/docs/overview/tilt-aberration-inspector.md
@@ -115,6 +115,11 @@ counter-clockwise (loosen); stepper adapters show signed steps (`+35 steps`) mat
 prompts. A legend at the top of the section defines both conventions and is marked "(assumed)" until
 the adapter direction has been measured in the wizard.
 
+With a connected motorized adapter, the guidance section also shows the adapter's live motor
+positions and an **Automatic Adjustment** button: after you approve the planned motor moves in a
+review dialog, the inspector sends them to the adapter itself. See [Motorized Tilt
+Adapter](motorized-tilt-adapter.md#automatic-adjustment).
+
 The whole correction loop can be rehearsed in the daytime against the
 [Camera Simulator](camera-simulator.md#rehearse-a-tilt-calibration-in-the-daytime), which injects a
 known tilt and provides on-screen buttons standing in for the adapter's screws.

--- a/documentation/docs/overview/tilt-adapter-wizard.md
+++ b/documentation/docs/overview/tilt-adapter-wizard.md
@@ -48,7 +48,9 @@ The wizard establishes the screw-to-tilt mapping empirically. The default run is
 a known amount of motion, worded as clockwise/counter-clockwise (tighten/loosen) turns for screws
 (e.g., "Turn screw 1 CLOCKWISE exactly 1 full turn") and as signed +/− steps for stepper adapters;
 every step ends with a measurement. From the change in the tilt vector \((\Delta A, \Delta B)\) it
-computes each screw's angle.
+computes each screw's angle. With a connected [motorized
+adapter](motorized-tilt-adapter.md#hands-off-calibration), the wizard sends these moves itself
+instead of prompting for them.
 
 The four-step run does not measure which way a clockwise turn moves the adapter. That direction
 comes from the adapter direction setting in the wizard's **Measurement** section, labeled **Screw ⟳
@@ -151,7 +153,9 @@ built-in presets are:
 
 The ASG Photon Cage adjusters are 120 TPI, which is 211.7 µm per full turn (the manufacturer rounds
 this to ~212). For the motorized EAT units the Screw Radius column is the radius of the motors from
-the sensor center.
+the sensor center. The two **ASG Electronic EAT** presets are motorized: the wizard can connect to
+the adapter over a serial port, run the calibration hands-off, and let the inspector apply
+corrections automatically. See [Motorized Tilt Adapter](motorized-tilt-adapter.md).
 
 **Not in the list?** Pick the **"Manual"** entry. It leaves every hardware field editable, so you can
 enter your adapter's adjustment type, screw count, thread pitch (or stepper step size), and screw

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
       - Hyperbolic Curve Fitting: overview/hyperbola-fitting.md
       - Tilt & Aberration Inspector: overview/tilt-aberration-inspector.md
       - Tilt Adapter Wizard: overview/tilt-adapter-wizard.md
+      - Motorized Tilt Adapter: overview/motorized-tilt-adapter.md
       - Sensor Model Fitting: overview/sensor-model.md
       - Camera Simulator: overview/camera-simulator.md
       - Camera Simulator Rendering Model: overview/camera-simulator-rendering.md


### PR DESCRIPTION
Two follow-ups to the motorized tilt adapter feature merged in #140.

## 1. Dark-theme text fix (`e26b651`)

The wizard's "Connected on \<port\>" status line rendered **black on the dark theme background**.

NINA.WPF.Base ships a keyless `TextBlock` style (`Resources/Styles/TextBlock.xaml`, `BasedOn StandardTextBlock` → `Foreground = PrimaryBrush`) in `Application.Resources`. An implicit style applies only to elements with no explicit `Style`, so every local `<TextBlock.Style>` — including ones that do nothing but flip `Visibility` on a `DataTrigger` — replaced it and let `Foreground` fall back to WPF's default of Black.

Fixed by adding `BasedOn="{StaticResource StandardTextBlock}"` to all 11 local TextBlock styles in the wizard templates, plus the inspector's "Run a measurement to see guidance." placeholder, which had the same defect. Several of the 11 were latent (the TextBlock also set `Foreground` locally); fixing them all means the next visibility-only trigger added here can't regress. The hazard is documented at the top of the wizard dictionary.

## 2. User manual (`35257cf`)

New page `overview/motorized-tilt-adapter.md`, the deferred documentation follow-up. Covers the motorized presets, connecting, hands-off calibration and the device-linked requirement, Automatic Adjustment (plan review, one-adjustment-per-measurement, revert-on-worse), safety limits, the Simulator port, and troubleshooting.

Dedicated page rather than sections added to the existing tilt pages: the feature spans both the wizard and the inspector, and `tilt-adapter-wizard.md` is dense enough that a manual screw-adapter user needs to read straight through without stepping over motorized-only steps. Cross-linked from the wizard, inspector, and camera simulator pages.

Drafted with Fable; option defaults, preset names, and every quoted UI label were verified against the source.

### Note for review

The page documents **Max excursion** as a bound on the adapter's **absolute, EEPROM-persisted counters** — what `EatTiltMotionController` actually checks, and the only reading under which the 2000 default makes sense. The wizard tooltip still describes it as cumulative travel from a tracked home position. That wording is worth tightening in a separate code change.

## Verification

- Full unit suite: **2706 passed, 0 failed** (hardware test correctly skipped)
- Solution builds clean (pre-existing warnings only)
- Strict MkDocs build (the exact CI command) passes with no warnings
- The theme fix is XAML-only and unverified in a running NINA — worth a visual confirm that the status line now reads in the theme colour

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWCmsi3cY3jfuLiyPjVrvK