### PR TITLE
Non-negative motor travel for the motorized tilt adapter

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/SimulatedEatTransportTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/SimulatedEatTransportTests.cs
@@ -146,14 +146,22 @@ public class SimulatedEatTransportTests {
         Assert.That(controller.AbsolutePositionsKnown, Is.True, "the simulated cp reply always parses, so positions are known");
 
         var tiltBefore = simOptions.TiltAmountMicrons;
+
+        // The simulated actuator starts every motor at 0, and travel below 0 is refused, so a differential
+        // tilt move needs headroom underneath first -- exactly the lift the planner adds automatically on the
+        // real device. Doing it explicitly here keeps this test about the transport/actuator round trip.
+        await controller.ExecuteMoveAsync(
+            new TiltAdapterMove(TiltMoveAxis.Backfocus, 50, TiltMoveGroup.Backfocus, "bf,50"), null, CancellationToken.None);
+
         var move = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 50, TiltMoveGroup.Tilt, "tr,50");
         await controller.ExecuteMoveAsync(move, null, CancellationToken.None);
 
         var positions = await controller.QueryPositionsAsync(CancellationToken.None);
 
         Assert.Multiple(() => {
-            // DiagonalA +50 -> device order [50, 0, 0, -50] (TR, TL, BR, BL).
-            Assert.That(positions.PerMotorSteps, Is.EqualTo(new[] { 50, 0, 0, -50 }));
+            // Backfocus +50 -> [50, 50, 50, 50]; DiagonalA +50 then adds [+50, 0, 0, -50] in device order
+            // (TR, TL, BR, BL), landing on [100, 50, 50, 0] with nothing below zero.
+            Assert.That(positions.PerMotorSteps, Is.EqualTo(new[] { 100, 50, 50, 0 }));
             Assert.That(simOptions.TiltAmountMicrons, Is.Not.EqualTo(tiltBefore), "the move must fold into the simulator's injected tilt");
         });
     }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatTiltMotionControllerTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatTiltMotionControllerTests.cs
@@ -268,16 +268,19 @@ public class EatTiltMotionControllerTests {
         // moveA alone is within the excursion cap; moveA THEN moveB would push a shared motor beyond it.
         // moveB's own validation (using the shadow AFTER moveA already succeeded) must catch this.
         var transport = NewTransport();
-        WithCpResponse(transport, 0, 0, 0, 0);
-        var options = NewOptions(maxStepsPerCommand: 200, maxExcursionSteps: 50);
+        // Baseline 50 with a ceiling of 100: moveA fits under both bounds, and the pair breaches the ceiling.
+        // (A zero baseline cannot express this any more -- moveA's own -40 corner would be refused by the floor
+        // before the intermediate-state ceiling check this test is about ever came into play.)
+        WithCpResponse(transport, 50, 50, 50, 50);
+        var options = NewOptions(maxStepsPerCommand: 200, maxExcursionSteps: 100);
         var controller = new EatTiltMotionController(transport, options);
         await controller.ConnectAsync("COM5", CancellationToken.None);
 
-        var moveA = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 40, TiltMoveGroup.Tilt, "A"); // TR=+40, BL=-40 (within 50)
+        var moveA = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 40, TiltMoveGroup.Tilt, "A"); // TR=90, BL=10 (inside [0,100])
         await controller.ExecuteMoveAsync(moveA, null, CancellationToken.None);
         transport.ClearReceivedCalls();
 
-        var moveB = new TiltAdapterMove(TiltMoveAxis.Backfocus, 20, TiltMoveGroup.Backfocus, "B"); // would push TR to 60, BL to -20
+        var moveB = new TiltAdapterMove(TiltMoveAxis.Backfocus, 20, TiltMoveGroup.Backfocus, "B"); // would push TR to 110 (> 100)
 
         Assert.ThrowsAsync<TiltDeviceLimitException>(async () => await controller.ExecuteMoveAsync(moveB, null, CancellationToken.None));
         await transport.DidNotReceive().SendAsync(Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
@@ -412,7 +415,9 @@ public class EatTiltMotionControllerTests {
     [Test]
     public async Task ExecuteMoveAsync_DiagonalAMove_UpdatesShadowAtTRAndBL_NotTLOrBR() {
         var transport = NewTransport();
-        WithCpResponse(transport, 0, 0, 0, 0);
+        // Nonzero baseline: a diagonal move is differential (one corner up, the opposite down), and travel
+        // below 0 is refused, so this permutation check needs headroom underneath to exercise the move at all.
+        WithCpResponse(transport, 100, 100, 100, 100);
         var options = NewOptions();
         var controller = new EatTiltMotionController(transport, options);
         await controller.ConnectAsync("COM5", CancellationToken.None);
@@ -424,14 +429,15 @@ public class EatTiltMotionControllerTests {
         var move = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 45, TiltMoveGroup.Tilt, "diagonal A");
         await controller.ExecuteMoveAsync(move, null, CancellationToken.None);
 
-        var expected = EatTiltMotionController.SerializeShadowPositions(true, new[] { 45, 0, 0, -45 });
+        var expected = EatTiltMotionController.SerializeShadowPositions(true, new[] { 145, 100, 100, 55 });
         Assert.That(options.TiltDeviceShadowPositions, Is.EqualTo(expected));
     }
 
     [Test]
     public async Task ExecuteMoveAsync_DiagonalBMove_UpdatesShadowAtTLAndBR_NotTROrBL() {
         var transport = NewTransport();
-        WithCpResponse(transport, 0, 0, 0, 0);
+        // Nonzero baseline for the same reason as the DiagonalA case above.
+        WithCpResponse(transport, 100, 100, 100, 100);
         var options = NewOptions();
         var controller = new EatTiltMotionController(transport, options);
         await controller.ConnectAsync("COM5", CancellationToken.None);
@@ -441,7 +447,7 @@ public class EatTiltMotionControllerTests {
         var move = new TiltAdapterMove(TiltMoveAxis.DiagonalB, 30, TiltMoveGroup.Tilt, "diagonal B");
         await controller.ExecuteMoveAsync(move, null, CancellationToken.None);
 
-        var expected = EatTiltMotionController.SerializeShadowPositions(true, new[] { 0, 30, -30, 0 });
+        var expected = EatTiltMotionController.SerializeShadowPositions(true, new[] { 100, 130, 70, 100 });
         Assert.That(options.TiltDeviceShadowPositions, Is.EqualTo(expected));
     }
 
@@ -575,13 +581,15 @@ public class EatTiltMotionControllerTests {
     [Test]
     public async Task OrderForMinimalPeakExcursion_PicksOrderingWithSmallestPeak() {
         var transport = NewTransport();
-        WithCpResponse(transport, 0, 0, 0, 0);
-        var options = NewOptions(maxStepsPerCommand: 100, maxExcursionSteps: 50);
+        // Baseline 60 keeps BOTH orderings clear of the floor (A-first dips to 5, B-first to 15), so the
+        // choice below is driven purely by peak excursion -- what this test is about -- with no bias in play.
+        WithCpResponse(transport, 60, 60, 60, 60);
+        var options = NewOptions(maxStepsPerCommand: 100, maxExcursionSteps: 110);
         var controller = new EatTiltMotionController(transport, options);
         await controller.ConnectAsync("COM5", CancellationToken.None);
 
-        // moveA alone spikes TR to 55 (> 50). moveB alone is small. Applying B THEN A never spikes past 45;
-        // applying A THEN B spikes to 55 first. The final combined state (45) is identical either way.
+        // moveA alone spikes TR to 115 (> 110). moveB alone is small. Applying B THEN A never spikes past 105;
+        // applying A THEN B spikes to 115 first. The final combined state (105) is identical either way.
         var moveA = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 55, TiltMoveGroup.Tilt, "A");
         var moveB = new TiltAdapterMove(TiltMoveAxis.DiagonalA, -10, TiltMoveGroup.Tilt, "B");
 
@@ -618,6 +626,115 @@ public class EatTiltMotionControllerTests {
         var move = new TiltAdapterMove(TiltMoveAxis.Backfocus, 51, TiltMoveGroup.Backfocus, "too big");
 
         Assert.Throws<TiltDeviceLimitException>(() => controller.OrderForMinimalPeakExcursion(new[] { move }));
+    }
+
+    // --- Travel window [0, maxExcursion]: the floor and the automatic upward bias --------------------------
+
+    [Test]
+    public async Task ExecuteMoveAsync_WouldDriveMotorBelowZero_ThrowsBeforeSending_ShadowUnchanged() {
+        var transport = NewTransport();
+        WithCpResponse(transport, 30, 30, 30, 30);
+        var options = NewOptions(maxStepsPerCommand: 200, maxExcursionSteps: 1000);
+        var controller = new EatTiltMotionController(transport, options);
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+        var shadowBefore = options.TiltDeviceShadowPositions;
+        transport.ClearReceivedCalls();
+
+        // Well inside the ceiling, but BL would land at -10. The floor, not the cap, must stop this.
+        var move = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 40, TiltMoveGroup.Tilt, "drives BL negative");
+
+        var ex = Assert.ThrowsAsync<TiltDeviceLimitException>(
+            async () => await controller.ExecuteMoveAsync(move, null, CancellationToken.None));
+        Assert.That(ex.Message, Does.Contain("below 0"));
+        await transport.DidNotReceive().SendAsync(Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+        Assert.That(options.TiltDeviceShadowPositions, Is.EqualTo(shadowBefore));
+    }
+
+    [Test]
+    public async Task ExecuteMoveAsync_LandsExactlyAtZero_IsAllowed() {
+        var transport = NewTransport();
+        WithCpResponse(transport, 40, 40, 40, 40);
+        var controller = new EatTiltMotionController(transport, NewOptions(maxStepsPerCommand: 200, maxExcursionSteps: 1000));
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+
+        // BL lands on exactly 0 -- the floor is inclusive, so this is legal.
+        var move = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 40, TiltMoveGroup.Tilt, "BL to exactly zero");
+
+        Assert.DoesNotThrowAsync(async () => await controller.ExecuteMoveAsync(move, null, CancellationToken.None));
+    }
+
+    [Test]
+    public async Task OrderForMinimalPeakExcursion_PlanWouldGoBelowZero_PrependsExactBackfocusBias() {
+        var transport = NewTransport();
+        WithCpResponse(transport, 0, 0, 0, 0);
+        var options = NewOptions(maxStepsPerCommand: 200, maxExcursionSteps: 1000);
+        var controller = new EatTiltMotionController(transport, options);
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+
+        // From zeroed counters a diagonal correction drives BL to -25, so the sequence must be lifted by
+        // exactly 25 -- no more (bias is a real backfocus change, so overshooting it is a defect, not slack).
+        var move = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 25, TiltMoveGroup.Tilt, "tilt");
+
+        var order = controller.OrderForMinimalPeakExcursion(new[] { move });
+
+        Assert.That(order, Has.Count.EqualTo(2));
+        Assert.That(order[0].Axis, Is.EqualTo(TiltMoveAxis.Backfocus));
+        Assert.That(order[0].Steps, Is.EqualTo(25));
+        Assert.That(order[0].Description, Does.Contain("bias"));
+        Assert.That(order[1], Is.SameAs(move));
+
+        // The whole returned sequence must actually execute -- the bias is only correct if it makes the
+        // controller's own per-move floor check pass for every move that follows it.
+        foreach (var m in order) {
+            await controller.ExecuteMoveAsync(m, null, CancellationToken.None);
+        }
+    }
+
+    [Test]
+    public async Task OrderForMinimalPeakExcursion_PlanStaysAboveZero_AddsNoBias() {
+        var transport = NewTransport();
+        WithCpResponse(transport, 500, 500, 500, 500);
+        var controller = new EatTiltMotionController(transport, NewOptions(maxStepsPerCommand: 200, maxExcursionSteps: 1000));
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+
+        var move = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 25, TiltMoveGroup.Tilt, "tilt");
+
+        var order = controller.OrderForMinimalPeakExcursion(new[] { move });
+
+        Assert.That(order, Is.EqualTo(new[] { move }), "ample headroom below zero means no bias is warranted");
+    }
+
+    [Test]
+    public async Task OrderForMinimalPeakExcursion_BiasExceedsPerCommandCap_IsSplit() {
+        var transport = NewTransport();
+        WithCpResponse(transport, 0, 0, 0, 0);
+        var controller = new EatTiltMotionController(transport, NewOptions(maxStepsPerCommand: 60, maxExcursionSteps: 1000));
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+
+        // Needs a 50-step lift... but the move itself is 50, and the cap is 60, so the bias fits in one part.
+        // Use a larger correction to force the bias itself past the cap: BL would reach -150.
+        var move = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 60, TiltMoveGroup.Tilt, "tilt");
+        var order = controller.OrderForMinimalPeakExcursion(new[] { move });
+
+        var biasMoves = order.Take(order.Count - 1).ToArray();
+        Assert.That(biasMoves.Sum(m => m.Steps), Is.EqualTo(60), "the split parts must sum to the exact lift needed");
+        Assert.That(biasMoves.All(m => Math.Abs(m.Steps) <= 60), Is.True, "no bias part may exceed the per-command cap");
+        Assert.That(order[order.Count - 1], Is.SameAs(move));
+    }
+
+    [Test]
+    public async Task OrderForMinimalPeakExcursion_BiasWouldBreachCeiling_Throws() {
+        var transport = NewTransport();
+        WithCpResponse(transport, 0, 0, 0, 0);
+        var controller = new EatTiltMotionController(transport, NewOptions(maxStepsPerCommand: 200, maxExcursionSteps: 60));
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+
+        // The correction alone fits under 60, and the 50-step lift alone fits too -- but lifted, the high
+        // corner reaches 100. The ceiling has to be checked AFTER the bias is added, not before.
+        var move = new TiltAdapterMove(TiltMoveAxis.DiagonalA, 50, TiltMoveGroup.Tilt, "tilt");
+
+        var ex = Assert.Throws<TiltDeviceLimitException>(() => controller.OrderForMinimalPeakExcursion(new[] { move }));
+        Assert.That(ex.Message, Does.Contain("bias"));
     }
 
     [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -2415,7 +2415,34 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             var plan = TiltMovePlanner.Plan(sPerScrew, includeTilt, includeBackfocus, unitMicrons, maxStepsPerCommand);
             try {
                 var ordered = controller.OrderForMinimalPeakExcursion(plan.Moves);
-                var orderedPlan = new TiltAdapterMovePlan(ordered, plan.ResidualMicronsPerCorner, plan.TwistResidualSteps, plan.EstimatedSeconds);
+                // The controller may PREPEND a backfocus bias so a differential tilt correction never drives a
+                // motor below 0. That bias is a genuine piston -- it shifts backfocus -- so the residual has to
+                // be recomputed from what will actually be sent. Carrying the unbiased plan's residual here
+                // would silently under-report the very backfocus error the bias introduces.
+                var applied = new double[4];
+                foreach (var move in ordered) {
+                    for (int i = 0; i < 4; ++i) {
+                        applied[i] += move.PerCornerSteps[i];
+                    }
+                }
+                var residual = new double[4];
+                for (int i = 0; i < 4; ++i) {
+                    residual[i] = (applied[i] - sPerScrew[i]) * unitMicrons;
+                }
+
+                // The bias is the uniform surplus the controller added on top of what was planned; it lands
+                // equally on all four corners (it is a piston), so the smallest per-corner surplus is it.
+                var planned = new double[4];
+                foreach (var move in plan.Moves) {
+                    for (int i = 0; i < 4; ++i) {
+                        planned[i] += move.PerCornerSteps[i];
+                    }
+                }
+                int biasSteps = (int)Math.Round(Enumerable.Range(0, 4).Min(i => applied[i] - planned[i]));
+                // A prepended bias also adds real execution time; scale the estimate by the per-move rate the
+                // planner used rather than carrying a move count that no longer matches.
+                double perMoveSeconds = plan.Moves.Count > 0 ? plan.EstimatedSeconds / plan.Moves.Count : 0.0;
+                var orderedPlan = new TiltAdapterMovePlan(ordered, residual, plan.TwistResidualSteps, ordered.Count * perMoveSeconds, Math.Max(0, biasSteps));
                 return new TiltDevicePlanPreview(orderedPlan, hardLimitViolated: false, limitWarning: string.Empty);
             } catch (TiltDeviceLimitException ex) {
                 return new TiltDevicePlanPreview(plan, hardLimitViolated: true, limitWarning: ex.Message);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatTiltMotionController.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatTiltMotionController.cs
@@ -253,20 +253,29 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
                     $"Move '{move.Description}' ({move.Axis}, {FormatSigned(move.Steps)} steps) exceeds the configured max steps per command ({maxStepsPerCommand}). Nothing was sent.");
             }
 
-            // 2) Excursion -- BEFORE any device I/O. Predicted = current shadow (already reflecting every
+            // 2) Travel window -- BEFORE any device I/O. Predicted = current shadow (already reflecting every
             // prior successfully-executed move) + this move's effect, permuted from WIZARD screw-index
             // order into DEVICE motor order. Because the shadow is updated after every successful move
             // (step 3 below), a caller executing a multi-move plan sequentially via repeated
             // ExecuteMoveAsync calls gets INTERMEDIATE-state validation for free -- there is no separate
-            // plan-level excursion check beyond this per-call one.
+            // plan-level check beyond this per-call one.
+            //
+            // The window is [0, maxExcursion] -- NOT symmetric. Travel below zero is disallowed outright,
+            // so a plan whose tilt component would carry a motor negative must be biased upward first;
+            // OrderForMinimalPeakExcursion prepends exactly that bias. This check is the backstop, so it
+            // stays strict even for callers that bypass the planner.
             var deviceDelta = PermuteWizardToDeviceMotorOrder(move.PerCornerSteps);
             int maxExcursion = options.TiltDeviceMaxExcursionSteps;
             var predicted = new int[4];
             for (int i = 0; i < 4; ++i) {
                 predicted[i] = shadowPositions[i] + RoundToInt(deviceDelta[i]);
-                if (Math.Abs(predicted[i]) > maxExcursion) {
-                    string degradedNote = shadowValid ? string.Empty :
-                        " Absolute positions are unknown this session (excursion is enforced against the last known/persisted estimate, which may be stale) -- see AbsolutePositionsKnown.";
+                string degradedNote = shadowValid ? string.Empty :
+                    " Absolute positions are unknown this session (the travel window is enforced against the last known/persisted estimate, which may be stale) -- see AbsolutePositionsKnown.";
+                if (predicted[i] < 0) {
+                    throw new TiltDeviceLimitException(
+                        $"Move '{move.Description}' would move motor {i + 1} ({DeviceMotorLabels[i]}) to {predicted[i]} steps; travel below 0 is not allowed. Raise the motors away from zero (a positive backfocus move, or re-zero the counters in the vendor app) before applying a correction that drives this corner down.{degradedNote} Nothing was sent.");
+                }
+                if (predicted[i] > maxExcursion) {
                     throw new TiltDeviceLimitException(
                         $"Move '{move.Description}' would move motor {i + 1} ({DeviceMotorLabels[i]}) to {predicted[i]} steps, exceeding the configured max excursion ({maxExcursion}).{degradedNote} Nothing was sent.");
                 }
@@ -364,40 +373,79 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
             }
 
             int maxExcursion = options.TiltDeviceMaxExcursionSteps;
+
+            // Pick the ordering needing the SMALLEST upward bias first, and only then the smallest peak.
+            // Bias is a piston move -- it shifts backfocus for real -- so spending it is worse than
+            // running closer to the ceiling, and the cheapest ordering is the one that dips least.
             IReadOnlyList<TiltAdapterMove> bestOrder = null;
+            int bestBias = int.MaxValue;
             int bestPeak = int.MaxValue;
             foreach (var candidate in GeneratePermutations(moves)) {
-                int peak = PeakExcursion(candidate);
-                if (peak < bestPeak) {
+                var (peak, trough) = RangeOf(candidate);
+                int bias = Math.Max(0, -trough);
+                if (bias < bestBias || (bias == bestBias && peak < bestPeak)) {
+                    bestBias = bias;
                     bestPeak = peak;
                     bestOrder = candidate;
                 }
             }
 
-            if (bestOrder == null || bestPeak > maxExcursion) {
-                string degradedNote = shadowValid ? string.Empty :
-                    " Absolute positions are unknown this session (excursion is enforced against the last known/persisted estimate, which may be stale) -- see AbsolutePositionsKnown.";
+            string degradedNote = shadowValid ? string.Empty :
+                " Absolute positions are unknown this session (the travel window is enforced against the last known/persisted estimate, which may be stale) -- see AbsolutePositionsKnown.";
+
+            // The bias lifts every motor, so it raises the ceiling pressure by exactly its own size --
+            // check the ceiling AFTER adding it, never before.
+            if (bestOrder == null || bestPeak + bestBias > maxExcursion) {
                 throw new TiltDeviceLimitException(
-                    $"No ordering of the given {moves.Count} move(s) keeps every intermediate/final per-motor position within the configured max excursion ({maxExcursion} steps); the best achievable peak is {bestPeak} steps.{degradedNote} Nothing was sent.");
+                    $"No ordering of the given {moves.Count} move(s) keeps every intermediate/final per-motor position within the travel window [0, {maxExcursion}] steps; the best achievable ordering peaks at {bestPeak + bestBias} steps (including the {bestBias}-step bias needed to keep every motor at or above 0).{degradedNote} Nothing was sent.");
+            }
+
+            if (bestBias > 0) {
+                // Tilt moves are differential (one corner up, the opposite corner down), so a correction
+                // applied near zero would drive a motor negative. Lift all four first by the exact shortfall.
+                // Split to respect the per-command cap; the bias parts run before every planned move.
+                var withBias = new List<TiltAdapterMove>(bestOrder.Count + 1);
+                var parts = TiltMovePlanner.SplitStepsForCap(bestBias, maxStepsPerCommand);
+                for (int i = 0; i < parts.Count; ++i) {
+                    string partNote = parts.Count > 1
+                        ? $" (part {i + 1} of {parts.Count})"
+                        : string.Empty;
+                    withBias.Add(new TiltAdapterMove(
+                        TiltMoveAxis.Backfocus, parts[i], TiltMoveGroup.Backfocus,
+                        $"Backfocus bias: {FormatSigned(parts[i])} steps{partNote} — raises all four motors so the correction below stays at or above 0"));
+                }
+                withBias.AddRange(bestOrder);
+                Logger.Info($"Tilt plan needs a {bestBias}-step upward bias to keep every motor at or above 0; prepended {parts.Count} backfocus move(s).");
+                return withBias;
             }
 
             return bestOrder;
         }
 
-        private int PeakExcursion(IReadOnlyList<TiltAdapterMove> order) {
+        /// <summary>
+        /// Highest and lowest per-motor position reached anywhere in <paramref name="order"/>, counting the
+        /// starting state and every intermediate state. Signed, not absolute: the travel window is
+        /// [0, maxExcursion], so the trough is what decides whether an upward bias is needed and the peak is
+        /// what decides whether the ceiling is breached. Collapsing these into one |value| would hide a dip
+        /// below zero behind a comfortable-looking magnitude.
+        /// </summary>
+        private (int peak, int trough) RangeOf(IReadOnlyList<TiltAdapterMove> order) {
             var running = (int[])shadowPositions.Clone();
-            int peak = 0;
+            int peak = int.MinValue;
+            int trough = int.MaxValue;
             for (int i = 0; i < 4; ++i) {
-                peak = Math.Max(peak, Math.Abs(running[i]));
+                peak = Math.Max(peak, running[i]);
+                trough = Math.Min(trough, running[i]);
             }
             foreach (var move in order) {
                 var delta = PermuteWizardToDeviceMotorOrder(move.PerCornerSteps);
                 for (int i = 0; i < 4; ++i) {
                     running[i] += RoundToInt(delta[i]);
-                    peak = Math.Max(peak, Math.Abs(running[i]));
+                    peak = Math.Max(peak, running[i]);
+                    trough = Math.Min(trough, running[i]);
                 }
             }
-            return peak;
+            return (peak, trough);
         }
 
         // Simple recursive permutation generator -- fine for the <= 3-move plans this feature ever

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptControl.xaml
@@ -340,6 +340,12 @@
                     <TextBlock Margin="0,3,0,0" Style="{StaticResource WarningText}" Text="{Binding PitchMismatchWarning}" />
                 </StackPanel>
             </Border>
+            <Border Style="{StaticResource WarningPanel}" Visibility="{Binding BiasWarningVisible, Converter={StaticResource BoolToVis}}">
+                <StackPanel>
+                    <TextBlock FontWeight="Bold" Style="{StaticResource WarningText}" Text="Backfocus bias added" />
+                    <TextBlock Margin="0,3,0,0" Style="{StaticResource WarningText}" Text="{Binding BiasWarningText}" TextWrapping="Wrap" />
+                </StackPanel>
+            </Border>
         </StackPanel>
 
         <!--  Footer: scale of the action (count + duration) sits beside the buttons so it is part of the

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptVM.cs
@@ -267,6 +267,28 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt {
             "screw inward-curvature direction. If the assumption is wrong, the backfocus command will move the wrong way. " +
             "Re-run the wizard with curvature measurement enabled, or uncheck Backfocus.";
 
+        /// <summary>
+        /// Visible when the plan had to be lifted to keep every motor at or above 0. This is not a
+        /// formatting detail: the bias is a piston that moves backfocus for real, so the user has to see it
+        /// before approving, not discover it afterwards in the residual table.
+        /// </summary>
+        public bool BiasWarningVisible => Preview.Plan.BiasSteps > 0;
+
+        public string BiasWarningText {
+            get {
+                int steps = Preview.Plan.BiasSteps;
+                string microns = unitMicrons > 0
+                    ? string.Format(CultureInfo.InvariantCulture, " ({0:0.0} µm)", steps * unitMicrons)
+                    : string.Empty;
+                return string.Format(CultureInfo.InvariantCulture,
+                    "A backfocus bias of +{0} steps{1} was added ahead of the correction. Travel below 0 is not allowed, and a tilt " +
+                    "correction moves one corner down, so the motors must be lifted first to make room. This moves all four screws " +
+                    "together, so it changes backfocus by that amount — it is included in the residual below. To avoid the bias, " +
+                    "raise the motors further from zero (or re-zero the counters in the vendor app) before adjusting.",
+                    steps, microns);
+            }
+        }
+
         /// <summary>Pitch-mismatch advisory passed in by the caller (empty ⇒ hidden).</summary>
         public string PitchMismatchWarning { get; }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/TiltAdapterMovePlan.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/TiltAdapterMovePlan.cs
@@ -32,11 +32,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices {
             IReadOnlyList<TiltAdapterMove> moves,
             IReadOnlyList<double> residualMicronsPerCorner,
             double twistResidualSteps,
-            double estimatedSeconds) {
+            double estimatedSeconds,
+            int biasSteps = 0) {
             Moves = new ReadOnlyCollection<TiltAdapterMove>((moves ?? Array.Empty<TiltAdapterMove>()).ToArray());
             ResidualMicronsPerCorner = new ReadOnlyCollection<double>((residualMicronsPerCorner ?? Array.Empty<double>()).ToArray());
             TwistResidualSteps = twistResidualSteps;
             EstimatedSeconds = estimatedSeconds;
+            BiasSteps = biasSteps;
         }
 
         /// <summary>The ordered, minimal set of device moves to send (≤ 3 before per-move cap splitting).</summary>
@@ -53,5 +55,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices {
 
         /// <summary>Estimated wall-clock execution time for <see cref="Moves"/>, in seconds.</summary>
         public double EstimatedSeconds { get; }
+
+        /// <summary>
+        /// Steps of upward backfocus bias prepended to <see cref="Moves"/> so no motor is driven below 0
+        /// (0 ⇒ none was needed). A tilt correction is differential — one corner up, the opposite corner
+        /// down — so near zero it has to be lifted to fit in the [0, max excursion] travel window. This is
+        /// a genuine piston: it shifts backfocus by <c>BiasSteps</c> × step size, which is why it is
+        /// reported separately and included in <see cref="ResidualMicronsPerCorner"/> rather than hidden.
+        /// </summary>
+        public int BiasSteps { get; }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -456,7 +456,7 @@
                             </UniformGrid>
                             <UniformGrid Margin="0,2" VerticalAlignment="Center" Columns="2">
                                 <TextBlock VerticalAlignment="Center" Text="Max excursion (steps)"
-                                    ToolTip="Safety cap on how far from zero a motor's absolute position counter may go, in device steps. The counters are stored in the adapter and carry over between sessions, so this bounds the magnitude in either direction (a cap of 2000 allows -2000 to +2000). Automation refuses a move that would carry any motor past the cap." />
+                                    ToolTip="Upper bound of the travel window, in device steps. Automation keeps every motor within [0, this value] and refuses any move that would leave it — travel below 0 is never allowed. The counters are stored in the adapter and carry over between sessions, so the cap must exceed wherever the motors already sit plus the travel you intend to use. Because a tilt correction drives one corner down, a correction near 0 is automatically preceded by a backfocus move that lifts all four motors enough to fit." />
                                 <TextBox MinWidth="60">
                                     <TextBox.Text>
                                         <Binding Path="TiltAdapterOptions.TiltDeviceMaxExcursionSteps" UpdateSourceTrigger="LostFocus">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -456,7 +456,7 @@
                             </UniformGrid>
                             <UniformGrid Margin="0,2" VerticalAlignment="Center" Columns="2">
                                 <TextBlock VerticalAlignment="Center" Text="Max excursion (steps)"
-                                    ToolTip="Safety cap on the total cumulative travel (in device steps) a motor may move from its tracked home position before automation refuses to move it further." />
+                                    ToolTip="Safety cap on how far from zero a motor's absolute position counter may go, in device steps. The counters are stored in the adapter and carry over between sessions, so this bounds the magnitude in either direction (a cap of 2000 allows -2000 to +2000). Automation refuses a move that would carry any motor past the cap." />
                                 <TextBox MinWidth="60">
                                     <TextBox.Text>
                                         <Binding Path="TiltAdapterOptions.TiltDeviceMaxExcursionSteps" UpdateSourceTrigger="LostFocus">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
@@ -69,10 +69,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             saveAFRunsPath = optionsAccessor.GetValueString(nameof(SaveAFRunsPath), string.Empty);
             tiltDeviceSerialPortName = optionsAccessor.GetValueString(nameof(TiltDeviceSerialPortName), string.Empty);
             tiltDeviceMaxStepsPerCommand = optionsAccessor.GetValueInt32(nameof(TiltDeviceMaxStepsPerCommand), 200);
-            // The real ASG EAT's absolute step counters rest at ~600 (EEPROM-persisted, not zeroed by the
-            // plugin), and the excursion check is |absolute position| <= max -- so the cap must comfortably
-            // exceed the resting counter plus the working travel, or the first move is rejected. See
-            // docs/asg-eat-serial-protocol-design.md.
+            // The EAT's step counters are absolute and EEPROM-persisted (never zeroed by the plugin), so they
+            // carry over between sessions and can sit anywhere -- positive or negative -- depending on prior
+            // adjustments. The excursion check is |absolute position| <= max, so the cap must comfortably
+            // exceed wherever the motors already are plus the working travel, or the first move is rejected.
+            // See docs/asg-eat-serial-protocol-design.md.
             tiltDeviceMaxExcursionSteps = optionsAccessor.GetValueInt32(nameof(TiltDeviceMaxExcursionSteps), 2000);
             tiltDeviceSettleSeconds = optionsAccessor.GetValueDouble(nameof(TiltDeviceSettleSeconds), 3.0);
             deviceLinkedCalibrationDeviceName = optionsAccessor.GetValueString(nameof(DeviceLinkedCalibrationDeviceName), string.Empty);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
@@ -70,10 +70,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             tiltDeviceSerialPortName = optionsAccessor.GetValueString(nameof(TiltDeviceSerialPortName), string.Empty);
             tiltDeviceMaxStepsPerCommand = optionsAccessor.GetValueInt32(nameof(TiltDeviceMaxStepsPerCommand), 200);
             // The EAT's step counters are absolute and EEPROM-persisted (never zeroed by the plugin), so they
-            // carry over between sessions and can sit anywhere -- positive or negative -- depending on prior
-            // adjustments. The excursion check is |absolute position| <= max, so the cap must comfortably
-            // exceed wherever the motors already are plus the working travel, or the first move is rejected.
-            // See docs/asg-eat-serial-protocol-design.md.
+            // carry over between sessions and sit wherever prior adjustments left them. Automation confines
+            // them to [0, max]: travel below 0 is disallowed outright, so this is the UPPER bound only and
+            // must comfortably exceed wherever the motors already are plus the working travel. Since a tilt
+            // correction is differential, one near zero gets an automatic upward backfocus bias first, which
+            // consumes headroom under this cap. See docs/asg-eat-serial-protocol-design.md.
             tiltDeviceMaxExcursionSteps = optionsAccessor.GetValueInt32(nameof(TiltDeviceMaxExcursionSteps), 2000);
             tiltDeviceSettleSeconds = optionsAccessor.GetValueDouble(nameof(TiltDeviceSettleSeconds), 3.0);
             deviceLinkedCalibrationDeviceName = optionsAccessor.GetValueString(nameof(DeviceLinkedCalibrationDeviceName), string.Empty);

--- a/documentation/docs/overview/motorized-tilt-adapter.md
+++ b/documentation/docs/overview/motorized-tilt-adapter.md
@@ -41,9 +41,11 @@ first successful position query, and during a calibration run each one also show
 since the run started.
 
 The counters are **absolute** and stored in the adapter's EEPROM: they survive power cycles and do
-not reset between sessions, so they carry whatever position your earlier adjustments left them at,
-and they may be positive or negative. The plugin never zeroes them; if you want the counters
-re-zeroed, do it in the vendor's app.
+not reset between sessions, so they carry whatever position your earlier adjustments left them at.
+The plugin never zeroes them; if you want the counters re-zeroed, do it in the vendor's app.
+
+Automation keeps every motor inside a travel window of **0 to Max excursion**. Travel below 0 is
+never sent, so the useful working room is whatever sits between your current counters and the cap.
 
 ## Hands-off calibration
 
@@ -95,8 +97,9 @@ The dialog shows:
   most about one step (1.8 µm) of error per corner.
 - Warnings when something needs attention: the adapter direction is still assumed rather than
   measured, the saved step size disagrees with the wizard's last measured value, the measured tilt
-  contains a twist component that no rigid adapter can remove, or a move would violate a travel
-  limit (which disables sending).
+  contains a twist component that no rigid adapter can remove, a [backfocus bias](#why-corrections-near-zero-add-a-backfocus-move)
+  had to be added to keep the motors at or above 0, or a move would violate a travel limit (which
+  disables sending).
 - The move count and an estimated duration. Each move takes roughly five to ten seconds.
 
 **Cancel** sends nothing. The confirm button, labeled **Send 2 moves** (or however many are
@@ -120,16 +123,31 @@ bound what automation may send:
 | Setting | Default | What it does |
 |---|---|---|
 | **Max steps per command** | 200 | Cap on the magnitude of a single commanded move. Larger planned moves are split or refused. |
-| **Max excursion (steps)** | 2000 | Cap on the absolute position counter any motor may reach. A move that would carry a motor past it is refused before anything is sent. |
+| **Max excursion (steps)** | 2000 | Upper bound of the travel window. Every motor is kept between 0 and this value; a move that would carry one outside it is refused before anything is sent. |
 | **Settle time (s)** | 3 | Seconds to wait after each commanded move before polling positions or sending the next command. |
 
 The excursion limit is compared against the adapter's absolute, EEPROM-persisted counters, not
-against how far the current session has moved. It bounds the *magnitude* of a counter, so it applies
-the same way in both directions: with the default of 2000, a motor may sit anywhere from -2000 to
-+2000. Because those counters carry over between sessions and can sit well away from zero, the cap
-has to exceed wherever your motors currently are plus the travel you intend to use — a limit set
-tighter than a motor's current position refuses the very first move, however small that move is. A
-refused move names the motor and the position it would have reached, and nothing is sent.
+against how far the current session has moved. It is the **upper** bound of a travel window whose
+lower bound is fixed at 0: with the default of 2000, every motor is kept between 0 and 2000.
+Because the counters carry over between sessions, the cap has to exceed wherever your motors
+currently sit plus the travel you intend to use — a limit set tighter than a motor's current
+position refuses the very first move, however small that move is. A refused move names the motor and
+the position it would have reached, and nothing is sent.
+
+### Why corrections near zero add a backfocus move
+
+A tilt correction is **differential**: it drives one corner up and the opposite corner down by the
+same amount. With the motors at or near 0 there is nothing below to give, so the correction cannot
+be applied as-is.
+
+Rather than refuse it, the plugin lifts the whole adapter first: it prepends a **backfocus bias**, a
+move that raises all four motors by the smallest amount that keeps the correction inside the window.
+The approval dialog shows the bias as its own move and warns that it is present.
+
+The bias is not free. Moving all four screws together *is* a backfocus change, so it shifts your
+backfocus by the bias amount, and that shift is included in the residuals the dialog reports. To
+avoid it, give the motors room to work before adjusting — raise them away from zero in the vendor's
+app, or apply a positive backfocus move of your own — so corrections have travel underneath them.
 
 ## The Simulator port
 
@@ -174,8 +192,14 @@ completes.
 **A move was refused by a limit.** The error says which limit. For **Max steps per command**, either
 reduce the amount being sent (for calibration, **Steps applied per screw**) or raise the limit. For
 **Max excursion (steps)**, remember the check is against the absolute counters: a motor already
-sitting near the cap in either direction has no headroom left, so either raise the cap or re-zero
-the counters in the vendor's app.
+sitting near the cap has no headroom left, so either raise the cap or re-zero the counters in the
+vendor's app.
+
+**A move was refused for going below 0.** Travel below zero is never sent. During a calibration run
+(which sends its moves directly rather than through the planner) this means the motors are sitting
+too close to zero for a differential move of that size — raise them first, in the vendor's app or
+with a positive backfocus move, then re-run. If a motor is *already* at a negative counter from
+earlier work outside the plugin, no move will be accepted until you re-zero it in the vendor's app.
 
 **The Simulator port refuses to connect.** Connect the **Hocus Focus Simulator** camera first, and
 answer Yes when asked to change the simulator's tilt configuration to match the preset (or align the

--- a/documentation/docs/overview/motorized-tilt-adapter.md
+++ b/documentation/docs/overview/motorized-tilt-adapter.md
@@ -41,8 +41,9 @@ first successful position query, and during a calibration run each one also show
 since the run started.
 
 The counters are **absolute** and stored in the adapter's EEPROM: they survive power cycles and do
-not reset to zero between sessions (an EAT as shipped rests near 600 on every motor). The plugin
-never zeroes them; if you want the counters re-zeroed, do it in the vendor's app.
+not reset between sessions, so they carry whatever position your earlier adjustments left them at,
+and they may be positive or negative. The plugin never zeroes them; if you want the counters
+re-zeroed, do it in the vendor's app.
 
 ## Hands-off calibration
 
@@ -123,11 +124,12 @@ bound what automation may send:
 | **Settle time (s)** | 3 | Seconds to wait after each commanded move before polling positions or sending the next command. |
 
 The excursion limit is compared against the adapter's absolute, EEPROM-persisted counters, not
-against how far the current session has moved. Since those counters rest a few hundred steps from
-zero (near 600 per motor as shipped), the cap must exceed the resting value plus your working
-travel; that is why the default is 2000 rather than something small, and why lowering it near or
-below the resting counter value would refuse the very first move. A refused move names the motor
-and the position it would have reached, and nothing is sent.
+against how far the current session has moved. It bounds the *magnitude* of a counter, so it applies
+the same way in both directions: with the default of 2000, a motor may sit anywhere from -2000 to
++2000. Because those counters carry over between sessions and can sit well away from zero, the cap
+has to exceed wherever your motors currently are plus the travel you intend to use — a limit set
+tighter than a motor's current position refuses the very first move, however small that move is. A
+refused move names the motor and the position it would have reached, and nothing is sent.
 
 ## The Simulator port
 
@@ -171,9 +173,9 @@ completes.
 
 **A move was refused by a limit.** The error says which limit. For **Max steps per command**, either
 reduce the amount being sent (for calibration, **Steps applied per screw**) or raise the limit. For
-**Max excursion (steps)**, remember the check is against the absolute counters: an adapter whose
-counters already rest near the cap has no headroom, so either raise the cap or re-zero the counters
-in the vendor's app.
+**Max excursion (steps)**, remember the check is against the absolute counters: a motor already
+sitting near the cap in either direction has no headroom left, so either raise the cap or re-zero
+the counters in the vendor's app.
 
 **The Simulator port refuses to connect.** Connect the **Hocus Focus Simulator** camera first, and
 answer Yes when asked to change the simulator's tilt configuration to match the preset (or align the

--- a/plans/tilt-nonnegative-travel-plan.md
+++ b/plans/tilt-nonnegative-travel-plan.md
@@ -1,0 +1,69 @@
+# Non-Negative Motor Travel for the Motorized Tilt Adapter — Plan
+
+## Context
+
+The EAT's step counters are absolute and EEPROM-persisted. Today the only bound is
+`|position| <= TiltDeviceMaxExcursionSteps`, so automation may drive a motor to a negative counter.
+Per user decision, **travel below 0 is not allowed**: the valid range becomes `[0, maxExcursion]`.
+
+The consequence that shapes this plan: **tilt moves are differential**. A diagonal move drives one
+corner `+N` and the opposite corner `−N`, so from counters at 0 *every* tilt correction would violate
+a hard floor. Rather than making a zeroed adapter incapable of tilt correction, the planner
+**automatically prepends a positive backfocus (piston) bias** large enough that the whole sequence
+stays at or above 0.
+
+The bias is a real optical change — all four screws move together, which shifts backfocus — so it
+must be disclosed in the approval dialog and counted in the residual, never hidden.
+
+## Design
+
+### Enforcement (`EatTiltMotionController`)
+
+- `ExecuteMoveAsync`: reject a move whose predicted position for any motor is `< 0`, with a distinct
+  message from the over-cap case. Still strictly before anything is sent; shadow untouched.
+- `PeakExcursion` becomes `RangeOf(order)` returning `(peak, trough)` — the max and min running
+  position across the starting state and every intermediate state.
+
+### Auto-bias (`OrderForMinimalPeakExcursion`)
+
+The method keeps its name and signature (no interface churn, and `BuildPlanPreview` already treats
+its output as the WYSIWYG execution order, so a prepended bias surfaces in the dialog for free). Its
+contract widens: *return the exact sequence to execute*, which may begin with a bias move.
+
+For each candidate ordering: simulate to get `(peak, trough)`; required bias `B = max(0, -trough)`.
+Choose the ordering minimizing `B` first, then `peak` — least backfocus disturbance wins. If `B > 0`,
+prepend `Backfocus +B`, split by `maxStepsPerCommand` when needed. Reject when `peak + B >
+maxExcursion`, naming which bound failed.
+
+### Honest reporting (`InspectorVM.BuildPlanPreview`)
+
+Recompute the residual from the **ordered** move list rather than carrying the unbiased plan's
+residual, so the uniform `+B` shows up as backfocus error instead of being silently dropped. Detect
+the bias by comparing summed per-corner steps of the ordered list against the planned list.
+
+### Disclosure
+
+- Bias move `Description` states what it is and why.
+- Approval dialog gains a warning when a bias is present, giving its backfocus effect in microns.
+- Tooltips + manual describe the `[0, maxExcursion]` range and the auto-bias.
+
+## Tasks (test-first; full suite after each)
+
+1. `RangeOf` + the `< 0` rejection in `ExecuteMoveAsync`; tests for below-zero refusal, exactly-zero
+   allowed, shadow unchanged, nothing sent.
+2. Auto-bias in `OrderForMinimalPeakExcursion`; tests for bias sizing, minimal-bias ordering choice,
+   bias splitting under the per-command cap, and infeasible-because-of-the-ceiling.
+3. `BuildPlanPreview` residual recomputation; test that a biased plan reports the backfocus residual.
+4. Dialog warning; test the warning appears only with a bias.
+5. Update existing tests that assume negative travel is legal (they start from `[0,0,0,0]` and expect
+   differential moves to succeed) — rebaseline them onto positive starting counters.
+6. Tooltips (`Max excursion`) + `documentation/docs/overview/motorized-tilt-adapter.md`.
+
+## Risks
+
+- **Existing tests encode the old rule** (e.g. `EatTiltMotionControllerTests.cs:276`). Each one must
+  be re-read and rebaselined deliberately, not mechanically flipped — a test that was asserting
+  "negative allowed" is now asserting the opposite behavior and needs a real starting position.
+- **A device already at a negative counter** cannot be recovered by the plugin under a hard floor;
+  document the vendor-app re-zero path.
+- Bias sizing interacts with both bounds; the ceiling check must run *after* the bias is added.


### PR DESCRIPTION
Two related changes to how the motorized tilt adapter's travel limits work. Started as a docs correction to #148 and grew a behavior change on top.

## 1. Travel below 0 is no longer allowed (`a8a72d2`)

The travel window becomes **`[0, TiltDeviceMaxExcursionSteps]`** instead of `|position| <= max`.

### The wrinkle: tilt moves are differential

A diagonal move drives one corner `+N` and the opposite corner `−N`. A hard floor alone would make *every* tilt correction impossible from counters at or near zero — a freshly zeroed adapter could do no tilt work at all.

So instead of refusing them, the controller **prepends a backfocus bias**: the smallest uniform lift that keeps the whole sequence inside the window. Orderings are chosen by **smallest required bias first**, peak excursion second — a bias is a real piston, so spending one is worse than running nearer the ceiling. The ceiling is checked *after* the bias is added, and the bias splits to respect the per-command cap.

### The bias is disclosed, not hidden

Moving all four screws together *is* a backfocus change, so it shifts backfocus by its own size. That is surfaced three ways:

- `BuildPlanPreview` recomputes the residual from the sequence that will **actually be sent**, so the induced backfocus error shows up in the residual table instead of being dropped along with the unbiased plan's numbers.
- `TiltAdapterMovePlan.BiasSteps` carries it explicitly, and the approval dialog gains a **"Backfocus bias added"** warning giving the shift in microns and how to avoid it.
- The bias move carries its own description, so it reads as a distinct step in the move list rather than as part of the correction.

`ExecuteMoveAsync` keeps a strict floor check as the backstop for callers that bypass the planner — the wizard's calibration sends moves directly — naming the motor and how to make room.

### Test rebaselining

Five existing tests encoded the old symmetric rule by starting at `[0,0,0,0]` and expecting differential moves to succeed. Each was rebaselined onto a positive starting position that **preserves what it was actually testing** (permutation correctness, intermediate-state enforcement, peak-excursion ordering) rather than flipped to expect a refusal. Six new tests cover the floor, exact bias sizing, no-bias-when-unneeded, bias splitting, and the post-bias ceiling check.

## 2. The docs correction that started this (`90ceb5e`)

The manual claimed an EAT "as shipped" rests near 600 on every motor. That was never a property of the hardware — it was where one device's counters sat during the protocol capture. Also rewrites the **Max excursion** tooltip, which described a cumulative-travel-from-home budget the plugin has never implemented.

The `600`s in `docs/asg-eat-serial-protocol-design.md` stay: they record what one device reported during the capture, which is accurate as evidence.

> Note: `a8a72d2` supersedes this commit's "negative counters are permitted" wording, since negatives are now disallowed outright.

## Verification

- Full unit suite: **2712 passed, 0 failed** (2706 + 6 new)
- Strict MkDocs build passes with no warnings
- The floor logic is verified against `EatTiltMotionController.cs` behavior by test, but **not yet exercised on the physical device** — the hardware integration test is `[Explicit]` and was not re-run for this change

Plan: `plans/tilt-nonnegative-travel-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWCmsi3cY3jfuLiyPjVrvK