### PR TITLE
fix(tilt): replay step counter froze at "Step 1 of 6"; block resuming a rolled-back automated run

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -1863,6 +1863,107 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             });
         }
 
+        // Once an automated run takes its cancel/failure exit it is NOT resumable: RecoverAppliedMovesAsync has
+        // undone this run's device moves (so the readings already in stepReadings no longer describe where the
+        // device physically is) and the exclusive operation lease has been released. Re-entering AutoRunAllAsync
+        // skips StartAsync -- IsWizardRunning is still true -- so it would resume at the stale CurrentStep,
+        // re-send moves computed from a rolled-back position, and run unleased. Same for the failure panel's
+        // "Run AutoFocus again". Both must be disabled until the user starts a fresh run.
+        [Test]
+        public void AutoRunAll_AfterCancelAndRecovery_CannotBeResumed() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            StubSuccessfulMoves(controller);
+            Connect(vm);
+            options.MeasureCurvatureDuringCalibration.Returns(false);
+
+            vm.MeasurementStepOverrideForTest = (step, ct) => {
+                vm.SeedStepReading(step, 0.1, 0.0, 1000.0);
+                if (step == WizardStep.Screw1) {
+                    vm.CancelCommand.Execute(null);
+                }
+                return Task.FromResult(true);
+            };
+
+            ((AsyncRelayCommand)vm.AutoRunAllCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+
+            Assert.Multiple(() => {
+                // Precondition: this is exactly the state the existing cancel/recovery test leaves behind.
+                Assert.That(vm.IsComplete, Is.False);
+                Assert.That(vm.IsWizardRunning, Is.True, "the wizard panel stays up so the user can read what happened");
+                Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.ReBaseline2), "the stale step a resume would restart from");
+
+                Assert.That(vm.AutoRunAllCommand.CanExecute(null), Is.False,
+                    "resuming would re-send moves computed from a position the rollback already undid");
+                Assert.That(vm.RetryMeasurementCommand.CanExecute(null), Is.False,
+                    "re-measuring the stale step is invalid for the same reason");
+                Assert.That(vm.StatusText, Does.Contain("cannot be resumed"),
+                    "the user must be told to start over rather than left with two dead buttons");
+            });
+        }
+
+        [Test]
+        public void AutoRunAll_AfterMidRunFailureAndRecovery_CannotBeResumed() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            StubSuccessfulMoves(controller);
+            Connect(vm);
+            options.MeasureCurvatureDuringCalibration.Returns(false);
+            // RetryMeasurementCommand also gates on AreDevicesConnected, so connect the imaging devices --
+            // otherwise the retry assertion below would pass vacuously and prove nothing about the latch.
+            vm.UpdateDeviceInfo(new CameraInfo { Connected = true });
+            vm.UpdateDeviceInfo(new FocuserInfo { Connected = true });
+
+            // Screw1's measurement fails outright -- MeasureStep sets HasMeasurementFailureChoice, and
+            // AutoRunAllAsync rolls the run's applied moves back before returning.
+            vm.MeasurementStepOverrideForTest = (step, ct) => {
+                if (step == WizardStep.Screw1) {
+                    return Task.FromResult(false);
+                }
+                vm.SeedStepReading(step, 0.1, 0.0, 1000.0);
+                return Task.FromResult(true);
+            };
+
+            ((AsyncRelayCommand)vm.AutoRunAllCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+
+            Assert.Multiple(() => {
+                Assert.That(vm.HasMeasurementFailureChoice, Is.True, "precondition: the failure panel is showing");
+                Assert.That(vm.IsWizardRunning, Is.True, "the failure panel lives inside the run panel; it must stay visible");
+                Assert.That(vm.AutoRunAllCommand.CanExecute(null), Is.False);
+                Assert.That(vm.RetryMeasurementCommand.CanExecute(null), Is.False);
+                Assert.That(vm.MeasurementFailureText, Does.Contain("cannot be resumed"),
+                    "the failure panel must explain why its own retry button is dead");
+            });
+        }
+
+        // The latch is per-run: starting a fresh run must clear it, or the wizard would be permanently bricked
+        // for automated use after the first cancellation.
+        [Test]
+        public void AutoRunAll_AfterCancelAndRecovery_AFreshStartClearsTheLatch() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            StubSuccessfulMoves(controller);
+            Connect(vm);
+            options.MeasureCurvatureDuringCalibration.Returns(false);
+            vm.MeasurementStepOverrideForTest = (step, ct) => {
+                vm.SeedStepReading(step, 0.1, 0.0, 1000.0);
+                if (step == WizardStep.Screw1) {
+                    vm.CancelCommand.Execute(null);
+                }
+                return Task.FromResult(true);
+            };
+            ((AsyncRelayCommand)vm.AutoRunAllCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+            Assert.That(vm.AutoRunAllCommand.CanExecute(null), Is.False, "precondition: latched");
+
+            vm.RestartCommand.Execute(null);
+            vm.StartCommand.Execute(null);
+
+            Assert.Multiple(() => {
+                Assert.That(vm.AutoRunAllCommand.CanExecute(null), Is.True);
+                Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Baseline));
+            });
+        }
+
         [Test]
         public void Disconnected_FourStepFlow_NeverTouchesController_AndClearsDeviceLinkedMarker() {
             // BuildMotorized gives a motorized preset + a real controller mock, but the device is NEVER

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -655,6 +655,30 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             Assert.That(vm6.StepProgressDisplay, Is.EqualTo("Step 1 of 6"));
         }
 
+        // Companion to the replay counter test: the LIVE path's counter must advance too. The check above only
+        // ever asserted the Baseline value, so a regression in NextStep's advance (or in the array it indexes)
+        // would have gone unnoticed. Drives the step advance directly -- the live measurement itself needs a
+        // real inspector, but NextStep is the single point every live path funnels through to change the step.
+        [Test]
+        public void StepProgressDisplay_AdvancesThroughTheLiveRun() {
+            var (vm, _, _, _) = Build();
+            vm.StartCommand.Execute(null);
+
+            var progress = new List<string> { vm.StepProgressDisplay };
+            for (int i = 0; i < 3; i++) {
+                vm.NextStep();
+                progress.Add(vm.StepProgressDisplay);
+            }
+
+            Assert.Multiple(() => {
+                Assert.That(progress, Is.EqualTo(new[] { "Step 1 of 4", "Step 2 of 4", "Step 3 of 4", "Step 4 of 4" }));
+                // One more advance lands on Complete, whose panel carries its own header instead of a counter.
+                vm.NextStep();
+                Assert.That(vm.IsComplete, Is.True);
+                Assert.That(vm.StepProgressDisplay, Is.Empty);
+            });
+        }
+
         [Test]
         public void BuildSweepSummary_CountsSweepsAndImages() {
             // 4 steps × 2 averaged measurements = 8 sweeps; profile: 4 offset steps, 1 frame, amp 2 => 17 images/run.
@@ -2066,6 +2090,78 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         // headless. Proves ReplayAsync's own RunCalibrationMath call site (deviceDriven: false, always) actually clears a
         // PRE-EXISTING device-linked marker, not just that RunCalibrationMath does so in isolation (already covered by
         // RunCalibrationForTest_NotDeviceDriven_ClearsDeviceLinkedMarker above).
+        // A replay must drive CurrentStep exactly like a live run does, so the wizard header ("Step N of M", the
+        // step title, and the instruction paragraph -- all derived from currentStep and re-raised only by the
+        // CurrentStep setter) tracks the step actually being re-analyzed. Regression: the replay loop used to
+        // leave currentStep pinned at Baseline for the whole run, so every step read "Step 1 of 6" under a
+        // "Baseline Measurement" header telling the user to click a button that is collapsed during a replay.
+        [Test]
+        public void ReplayAsync_AdvancesStepHeaderThroughEveryReplayedStep() {
+            var (vm, _, _, _) = Build(screwCount: 3,
+                configureOptions: o => o.MeasureCurvatureDuringCalibration.Returns(true));
+
+            string runRoot = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "hf-tilt-replay-test-" + Guid.NewGuid().ToString("N"));
+            // The 6-step shape (curvature steps saved), which is where the reported "Step 1 of 6" was seen.
+            var stepFolders = new[] { "01_Baseline", "02_AllInward", "03_ReBaseline1", "04_Screw1", "05_ReBaseline2", "06_Screw2" };
+            var steps = new[] { WizardStep.Baseline, WizardStep.AllInward, WizardStep.ReBaseline1, WizardStep.Screw1, WizardStep.ReBaseline2, WizardStep.Screw2 };
+            System.IO.Directory.CreateDirectory(runRoot);
+            try {
+                foreach (var stepFolder in stepFolders) {
+                    System.IO.Directory.CreateDirectory(System.IO.Path.Combine(runRoot, stepFolder));
+                }
+                var metadata = new TiltCalibrationMetadata {
+                    NumberOfScrews = 3,
+                    PixelSizeMicrons = 3.76,
+                    FocuserStepSizeMicrons = 3.6,
+                    ScrewRadiusMillimeters = 44,
+                    CalibrationAppliedAmount = 1.0,
+                    RunStepMapping = steps.Select((s, i) => new TiltRunStepMapping { Step = s.ToString(), Folder = stepFolders[i] }).ToList()
+                };
+                System.IO.File.WriteAllText(System.IO.Path.Combine(runRoot, "metadata.json"), metadata.Serialize());
+
+                var tiltPlane = new TiltPlaneModel(new System.Drawing.Size(6248, 4176), fRatio: 7,
+                    a: 0.1, b: 0.05, c: 0, mean: 7000, focuserStepSizeMicrons: 3.6,
+                    centerPosition: 7000, topLeftPosition: 7000, topRightPosition: 7000,
+                    bottomLeftPosition: 7000, bottomRightPosition: 7000);
+                vm.CalibrationTiltPlaneOverrideForTest = tiltPlane;
+                vm.SelectReplayFolderForTest = _ => runRoot;
+                vm.SelectReplaySettingsForTest = _ => Task.FromResult(ReplaySettingsChoice.UseCurrentSettings);
+
+                // The per-step seam doubles as the observer: it runs while the VM is mid-step, so it sees exactly
+                // what the wizard panel would be showing at that moment.
+                var observed = new List<(WizardStep step, string progress, string title, string status, string instructions)>();
+                vm.ReplayStepOverrideForTest = (step, ct) => {
+                    observed.Add((step, vm.StepProgressDisplay, vm.StepTitle, vm.StatusText, vm.StepInstructions));
+                    return Task.FromResult(true);
+                };
+
+                ((AsyncRelayCommand)vm.ReplayCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+
+                Assert.Multiple(() => {
+                    Assert.That(vm.IsComplete, Is.True, "precondition: the replay actually ran to completion");
+                    Assert.That(observed.Select(o => o.step), Is.EqualTo(steps), "every saved step is replayed, in order");
+                    Assert.That(observed.Select(o => o.progress), Is.EqualTo(new[] {
+                        "Step 1 of 6", "Step 2 of 6", "Step 3 of 6", "Step 4 of 6", "Step 5 of 6", "Step 6 of 6" }));
+                    // The title must track the step too -- same root cause, separately visible to the user.
+                    Assert.That(observed.Select(o => o.title),
+                        Is.EqualTo(steps.Select(TiltAdapterWizardVM.StepTitleText)));
+                    // Status text uses the human step title, not the raw enum name.
+                    Assert.That(observed.Select(o => o.status),
+                        Is.EqualTo(steps.Select(s => $"Replaying {TiltAdapterWizardVM.StepTitleText(s)}...")));
+                    // A replay re-analyzes saved frames: the instruction paragraph must not tell the user to turn
+                    // screws or click a button that is collapsed for the whole replay.
+                    Assert.That(observed.Select(o => o.instructions),
+                        Is.EqualTo(steps.Select(TiltAdapterWizardVM.ReplayStepInstructionsText)));
+                    Assert.That(observed.Select(o => o.instructions),
+                        Has.None.Contains("Run Measurement").And.None.Contains("CLOCKWISE"));
+                    // The replay flag is transient: it must be cleared once the replay finishes.
+                    Assert.That(vm.IsReplaying, Is.False);
+                });
+            } finally {
+                System.IO.Directory.Delete(runRoot, recursive: true);
+            }
+        }
+
         [Test]
         public void ReplayAsync_ClearsAPreExistingDeviceLinkedMarker() {
             var (vm, options, _, _) = Build(screwCount: 3);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -1876,6 +1876,10 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             StubSuccessfulMoves(controller);
             Connect(vm);
             options.MeasureCurvatureDuringCalibration.Returns(false);
+            // Every command below also gates on AreDevicesConnected / IsOnMeasurementStep; connect the imaging
+            // devices so each assertion fails for the latch's absence rather than passing vacuously.
+            vm.UpdateDeviceInfo(new CameraInfo { Connected = true });
+            vm.UpdateDeviceInfo(new FocuserInfo { Connected = true });
 
             vm.MeasurementStepOverrideForTest = (step, ct) => {
                 vm.SeedStepReading(step, 0.1, 0.0, 1000.0);
@@ -1897,8 +1901,71 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                     "resuming would re-send moves computed from a position the rollback already undid");
                 Assert.That(vm.RetryMeasurementCommand.CanExecute(null), Is.False,
                     "re-measuring the stale step is invalid for the same reason");
+                // EVERY way back into the measurement loop must be closed, not just the two obvious buttons:
+                // these two live in the same Panel B row and call the same handlers.
+                Assert.That(vm.RunMeasurementCommand.CanExecute(null), Is.False,
+                    "\"Run This Step\" calls the same RunMeasurementAsync as the retry button");
+                Assert.That(vm.UseSavedAFCommand.CanExecute(null), Is.False,
+                    "\"Use Saved AF\" reaches the same Complete from the same stale readings");
                 Assert.That(vm.StatusText, Does.Contain("cannot be resumed"),
-                    "the user must be told to start over rather than left with two dead buttons");
+                    "the user must be told to start over rather than left with dead buttons");
+            });
+        }
+
+        // The latch must NOT fire when nothing was actually rolled back. A measurement that fails on Baseline
+        // has had no device move applied yet (Baseline has none), so RecoverAppliedMovesAsync undoes nothing and
+        // the run's readings still describe where the device physically is -- retrying is legitimate, and
+        // latching there would regress a working flow into "Abort Wizard and start over".
+        [Test]
+        public void AutoRunAll_BaselineMeasurementFailure_WithNoMovesApplied_StaysRetryable() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            StubSuccessfulMoves(controller);
+            Connect(vm);
+            options.MeasureCurvatureDuringCalibration.Returns(false);
+            vm.UpdateDeviceInfo(new CameraInfo { Connected = true });
+            vm.UpdateDeviceInfo(new FocuserInfo { Connected = true });
+
+            vm.MeasurementStepOverrideForTest = (step, ct) => Task.FromResult(false); // fails on Baseline
+
+            ((AsyncRelayCommand)vm.AutoRunAllCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+
+            Assert.Multiple(() => {
+                Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Baseline), "precondition: failed before advancing");
+                Assert.That(vm.HasMeasurementFailureChoice, Is.True, "precondition: the failure panel is showing");
+                controller.DidNotReceive().ExecuteMoveAsync(Arg.Any<TiltAdapterMove>(), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+                Assert.That(vm.RetryMeasurementCommand.CanExecute(null), Is.True,
+                    "nothing was rolled back, so re-running AutoFocus for Baseline is still valid");
+                Assert.That(vm.MeasurementFailureText, Does.Not.Contain("cannot be resumed"));
+            });
+        }
+
+        // Cancelling before any move has been applied must not claim the device was moved back -- nothing moved.
+        [Test]
+        public void AutoRunAll_CancelBeforeAnyMoveApplied_DoesNotClaimTheDeviceWasReturned() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            StubSuccessfulMoves(controller);
+            Connect(vm);
+            options.MeasureCurvatureDuringCalibration.Returns(false);
+
+            // Cancel during Baseline's measurement: Baseline applies no device move, so the loop notices the
+            // cancellation with appliedDeviceMovesThisRun still empty.
+            vm.MeasurementStepOverrideForTest = (step, ct) => {
+                vm.SeedStepReading(step, 0.1, 0.0, 1000.0);
+                if (step == WizardStep.Baseline) {
+                    vm.CancelCommand.Execute(null);
+                }
+                return Task.FromResult(true);
+            };
+
+            ((AsyncRelayCommand)vm.AutoRunAllCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+
+            Assert.Multiple(() => {
+                controller.DidNotReceive().ExecuteMoveAsync(Arg.Any<TiltAdapterMove>(), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+                Assert.That(vm.StatusText, Does.Contain("cancelled"));
+                Assert.That(vm.StatusText, Does.Not.Contain("returned to its original position"),
+                    "no move was ever sent, so there was nothing to return");
             });
         }
 
@@ -1955,11 +2022,20 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             ((AsyncRelayCommand)vm.AutoRunAllCommand).ExecuteAsync(null).GetAwaiter().GetResult();
             Assert.That(vm.AutoRunAllCommand.CanExecute(null), Is.False, "precondition: latched");
 
+            // StartAsync must clear the latch on its own. Restart also clears it, so going through Restart first
+            // would let this test pass even if StartAsync's clear were deleted -- assert after each separately.
             vm.RestartCommand.Execute(null);
+            Assert.That(vm.AutoRunAllCommand.CanExecute(null), Is.True, "Restart clears the latch");
+
+            // Re-latch, then prove StartAsync clears it without Restart's help. StartCommand requires the wizard
+            // to be idle, which Restart above already ensured; re-latching directly keeps the two clears independent.
+            vm.SetDeviceRunAbandonedForTest(true);
+            Assert.That(vm.AutoRunAllCommand.CanExecute(null), Is.False, "precondition: latched again");
+
             vm.StartCommand.Execute(null);
 
             Assert.Multiple(() => {
-                Assert.That(vm.AutoRunAllCommand.CanExecute(null), Is.True);
+                Assert.That(vm.AutoRunAllCommand.CanExecute(null), Is.True, "StartAsync clears the latch");
                 Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Baseline));
             });
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -1,4 +1,4 @@
-#region "copyright"
+﻿#region "copyright"
 
 /*
     Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
@@ -570,6 +570,20 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
         }
 
+        // True while ReplayAsync is re-analyzing a saved run. Exposed (INPC) for the same reason as
+        // IsAutoRunningAll below: the step copy must drop its "turn the screws / click Run Measurement"
+        // imperatives, since a replay touches no hardware and those buttons are collapsed for its duration.
+        public bool IsReplaying {
+            get => isReplaying;
+            private set {
+                if (isReplaying != value) {
+                    isReplaying = value;
+                    RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(StepInstructions));
+                }
+            }
+        }
+
         // T11: true while Auto Run All is driving the calibration hands-off. Exposed (INPC) so the step copy
         // can drop its "click Run Measurement" imperatives — those buttons are hidden during an automated run.
         public bool IsAutoRunningAll {
@@ -830,9 +844,18 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // "turn screw" wording. Disconnected: EXACTLY the prior expression, unchanged (mandatory regression —
         // IsTiltDeviceConnected is false whenever the service is null or not connected).
         public string StepInstructions =>
-            (IsTiltDeviceConnected && IsMotorizedDevice)
-                ? DeviceStepInstructionsText(currentStep, (int)Math.Round(CalibrationAppliedAmount), IsAutoRunningAll)
-                : StepInstructionsText(currentStep, tiltAdapterOptions.ScrewCount, IsStepperAdjustment, CalibrationAppliedAmount);
+            IsReplaying
+                ? ReplayStepInstructionsText(currentStep)
+                : (IsTiltDeviceConnected && IsMotorizedDevice)
+                    ? DeviceStepInstructionsText(currentStep, (int)Math.Round(CalibrationAppliedAmount), IsAutoRunningAll)
+                    : StepInstructionsText(currentStep, tiltAdapterOptions.ScrewCount, IsStepperAdjustment, CalibrationAppliedAmount);
+
+        // Replay wording: a replay re-analyzes already-captured frames, so every imperative in the live copy
+        // ("turn ALL screws CLOCKWISE", "click Run Measurement") is wrong — nothing is captured, no hardware
+        // moves, and the measurement buttons are collapsed by the IsMeasuring trigger for the whole replay.
+        internal static string ReplayStepInstructionsText(WizardStep step) =>
+            $"Replaying — re-analyzing the saved frames for {StepTitleText(step)}. No action needed: nothing is " +
+            "captured and the tilt adapter is not moved during a replay.";
 
         // Automated-status wording for a connected, device-driven run: describes what the wizard will send
         // (Move.Description) rather than what the user must do by hand. Baseline has no move (measurement
@@ -2414,7 +2437,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             measureCts?.Cancel();
             IsWizardRunning = false;
             IsMeasuring = false;
-            isReplaying = false;
+            IsReplaying = false;
             IsAutoRunningAll = false;
             // Abandoning a device-driven run releases the exclusive lease so other automation (a future run,
             // the inspector's Automatic Adjustment) isn't blocked. Deliberately does NOT attempt to drive the
@@ -2871,7 +2894,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             measureCts = new CancellationTokenSource();
             var token = measureCts.Token;
 
-            isReplaying = true;
+            IsReplaying = true;
             IsWizardRunning = true;
             IsMeasuring = true;
             stepReadings.Clear();
@@ -2903,7 +2926,15 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             try {
                 foreach (var step in replaySteps) {
                     token.ThrowIfCancellationRequested();
-                    StatusText = $"Replaying {step}...";
+                    // Mirror the live path's step advance (NextStep -> CurrentStep). The wizard header is entirely
+                    // derived from currentStep -- StepProgressDisplay ("Step N of M"), StepTitle and StepInstructions
+                    // are re-raised ONLY by this setter -- and Panel B is on screen for the whole replay, so without
+                    // this the header stays frozen on the pre-replay step (every step reading "Step 1 of 6" under a
+                    // "Baseline Measurement" heading). Assigned through the property, not the field, for that reason.
+                    // Safe mid-replay despite the setter's NotifyCommandsCanExecuteChanged: IsMeasuring is true for
+                    // the whole run, which is what actually gates every measurement command's canExecute.
+                    CurrentStep = step;
+                    StatusText = $"Replaying {StepTitleText(step)}...";
                     // Capture-time modes ("use captured in memory" and "update profile") replay each step with its own
                     // detached capture-time star-detection snapshot as an override, so the live profile is untouched
                     // during the replay. "Use current settings" passes null and uses the current profile.
@@ -2924,14 +2955,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                         }
                     }
                     if (!ok) {
-                        StatusText = $"Replay failed at {step}.";
-                        Notification.ShowError($"Replay failed at step '{step}'. The saved frames could not be analyzed.{profileNotChangedNote}");
+                        StatusText = $"Replay failed at {StepTitleText(step)}.";
+                        Notification.ShowError($"Replay failed at step '{StepTitleText(step)}'. The saved frames could not be analyzed.{profileNotChangedNote}");
                         return;
                     }
                     var m = CalibrationTiltPlane;
                     if (m == null) {
-                        StatusText = $"Replay produced no tilt model at {step}.";
-                        Notification.ShowError($"Replay produced no sensor-curve-model tilt at step '{step}'. The per-star paraboloid could not be fit.{profileNotChangedNote}");
+                        StatusText = $"Replay produced no tilt model at {StepTitleText(step)}.";
+                        Notification.ShowError($"Replay produced no sensor-curve-model tilt at step '{StepTitleText(step)}'. The per-star paraboloid could not be fit.{profileNotChangedNote}");
                         return;
                     }
                     var reading = new StepReading {
@@ -3002,7 +3033,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 // The live profile is only persisted on a successful "update profile to capture-time" replay (above), so
                 // a cancelled/failed replay leaves it untouched — nothing to restore. The in-memory per-step override
                 // never touches the profile either.
-                isReplaying = false;
+                IsReplaying = false;
                 IsMeasuring = false;
                 inspector.SensorModelFocuserSizeOverrideMicrons = prevFocuserOverride;
                 inspector.SensorModelFRatioOverride = prevFRatioOverride;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -303,8 +303,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             StepMeasurementSummary.CollectionChanged += OnSummaryCollectionChanged;
 
             StartCommand = new AsyncRelayCommand(StartAsync, () => !IsWizardRunning);
-            RunMeasurementCommand = new AsyncRelayCommand(RunMeasurementAsync, () => IsOnMeasurementStep && !IsMeasuring && AreDevicesConnected);
-            UseSavedAFCommand = new AsyncRelayCommand(RunSavedMeasurementAsync, () => IsOnMeasurementStep && !IsMeasuring);
+            // deviceRunAbandoned gates EVERY re-entry into the measurement loop, not just Auto Run All: these two
+            // buttons sit in the same Panel B row, stay visible in exactly the post-rollback state, and reach the
+            // same handlers (RunMeasurementCommand shares RunMeasurementAsync with RetryMeasurementCommand below).
+            // Leaving either open would let one click resume a run whose device moves had just been undone.
+            RunMeasurementCommand = new AsyncRelayCommand(RunMeasurementAsync, () => IsOnMeasurementStep && !IsMeasuring && AreDevicesConnected && !deviceRunAbandoned);
+            UseSavedAFCommand = new AsyncRelayCommand(RunSavedMeasurementAsync, () => IsOnMeasurementStep && !IsMeasuring && !deviceRunAbandoned);
             CancelCommand = new RelayCommand(CancelMeasurement, () => IsMeasuring);
             RestartCommand = new RelayCommand(Restart);
             UseMeasuredHardwareCommand = new RelayCommand(UseMeasuredHardware, () => HasMeasuredHardware);
@@ -1754,14 +1758,19 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // Auto Run All cancellation/failure recovery: walks every device move successfully applied during the
         // current run, in reverse, sending each one's inverse — returning the device to baseline. Best-effort;
         // stops and surfaces a warning if a recovery move itself fails (device position becomes uncertain).
-        private async Task RecoverAppliedMovesAsync() {
+        // Returns what actually happened, which the caller needs in order to decide whether the run is still
+        // resumable: anyRolledBack is true once at least one inverse move has been sent (the device no longer
+        // matches this run's readings), recoveryFailed is true if a recovery move threw (position uncertain).
+        // A run that had applied nothing yields (false, false) and is untouched.
+        private async Task<(bool anyRolledBack, bool recoveryFailed)> RecoverAppliedMovesAsync() {
             var controller = tiltDeviceConnectionService?.Controller;
             var moves = appliedDeviceMovesThisRun.ToArray();
             appliedDeviceMovesThisRun.Clear();
             deviceMoveAppliedForStep = null;
             if (controller == null || moves.Length == 0) {
-                return;
+                return (false, false);
             }
+            bool anyRolledBack = false;
             try {
                 for (int i = moves.Length - 1; i >= 0; i--) {
                     var inverse = EatWizardMapping.InverseMove(moves[i]);
@@ -1771,37 +1780,56 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     try {
                         progress.Report(new ApplicationStatus { Status = $"Tilt Adapter Wizard: recovering — {inverse.Description}" });
                         await controller.ExecuteMoveAsync(inverse, moveProgress, CancellationToken.None).ConfigureAwait(true);
+                        anyRolledBack = true;
                     } catch (Exception ex) {
                         Logger.Error(ex, "Failed to fully recover tilt adapter device position after an automated-run cancellation/failure.");
                         MeasurementFailureText = $"Recovery failed while returning the device to its original position: {ex.Message}. Verify screw/motor positions before continuing.";
                         HasMeasurementFailureChoice = true;
-                        return;
+                        return (anyRolledBack, true);
                     }
                 }
             } finally {
                 // Clear the transient "recovering — …" bottom-left status so it doesn't linger after recovery.
                 progress.Report(new ApplicationStatus { Status = string.Empty });
             }
+            return (anyRolledBack, false);
         }
 
         // The single cancel/failure exit for an automated run: roll this run's device moves back, release the
-        // exclusive lease, and latch the run as unresumable (see deviceRunAbandoned). Every caller previously
-        // did the first two by hand and none did the third, which left "Auto Run All" and the failure panel's
-        // "Run AutoFocus again" live on a run whose device state had just been undone underneath them.
-        private async Task AbandonDeviceRunAsync() {
-            await RecoverAppliedMovesAsync();
+        // exclusive lease, and — when the rollback actually changed the device — latch the run as unresumable
+        // (see deviceRunAbandoned). Every caller previously did the first two by hand and none did the third,
+        // which left the measurement buttons live on a run whose device state had been undone underneath them.
+        private async Task AbandonDeviceRunAsync(bool cancelled) {
+            var (anyRolledBack, recoveryFailed) = await RecoverAppliedMovesAsync();
             ReleaseTiltDeviceOperationToken();
+
+            if (cancelled) {
+                StatusText = anyRolledBack
+                    ? "Auto Run All cancelled; the tilt adapter was returned to its original position."
+                    : "Auto Run All cancelled.";
+            }
+
+            // Only a run whose moves were actually undone — or whose rollback failed, leaving the position
+            // uncertain — is unresumable: its stored readings no longer describe where the device is. A run
+            // that had applied nothing (e.g. an AutoFocus failure on Baseline, which has no move) is physically
+            // untouched, so leave it retryable exactly as it was before this latch existed.
+            if (!anyRolledBack && !recoveryFailed) {
+                return;
+            }
             deviceRunAbandoned = true;
+
+            string reason = recoveryFailed
+                ? "This calibration run cannot be resumed: the tilt adapter could not be fully returned to its original position."
+                : "This calibration run cannot be resumed because the tilt adapter was returned to its original position.";
+            string cannotResume = $"{reason} Click Abort Wizard, then Calibrate, to start a new run.";
             // Say so wherever the user is already looking: the failure panel when there is one (it owns the
             // retry button this just disabled), otherwise the status line used by the cancel path.
-            const string CannotResume = "This calibration run cannot be resumed because the tilt adapter was returned to its " +
-                "original position. Click Abort Wizard, then Calibrate, to start a new run.";
             if (HasMeasurementFailureChoice) {
                 MeasurementFailureText = string.IsNullOrEmpty(MeasurementFailureText)
-                    ? CannotResume
-                    : $"{MeasurementFailureText} {CannotResume}";
+                    ? cannotResume
+                    : $"{MeasurementFailureText} {cannotResume}";
             } else {
-                StatusText = string.IsNullOrEmpty(StatusText) ? CannotResume : $"{StatusText} {CannotResume}";
+                StatusText = string.IsNullOrEmpty(StatusText) ? cannotResume : $"{StatusText} {cannotResume}";
             }
         }
 
@@ -1886,8 +1914,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             try {
                 while (CurrentStep != WizardStep.Complete) {
                     if (token.IsCancellationRequested) {
-                        StatusText = "Auto Run All cancelled; device returned to its original position.";
-                        await AbandonDeviceRunAsync();
+                        await AbandonDeviceRunAsync(cancelled: true);
                         return;
                     }
                     var stepBefore = CurrentStep;
@@ -1895,8 +1922,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     if (HasMeasurementFailureChoice) {
                         if (CurrentStep != WizardStep.Complete) {
                             // A move or measurement failed before the run finished — undo everything applied so far,
-                            // which also latches the run as unresumable.
-                            await AbandonDeviceRunAsync();
+                            // which also latches the run as unresumable if that rollback moved the device.
+                            await AbandonDeviceRunAsync(cancelled: false);
                         } else {
                             // Only Complete's own restore move failed: the calibration itself already succeeded, so
                             // there is nothing to abandon (and MeasureStep already released the lease at Complete).
@@ -1911,8 +1938,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     }
                 }
             } catch (OperationCanceledException) {
-                StatusText = "Auto Run All cancelled; device returned to its original position.";
-                await AbandonDeviceRunAsync();
+                await AbandonDeviceRunAsync(cancelled: true);
             } finally {
                 IsMeasuring = false;
                 IsAutoRunningAll = false;
@@ -2788,6 +2814,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             stepReadings[step] = new StepReading { A = a, B = b, Mean = mean };
         }
 
+        // Test seam: set the abandoned-run latch directly, so a test can prove StartAsync clears it WITHOUT
+        // going through Restart first (Restart clears it too, which would otherwise mask a missing clear).
+        internal void SetDeviceRunAbandonedForTest(bool value) {
+            deviceRunAbandoned = value;
+            NotifyCommandsCanExecuteChanged();
+        }
+
         // Test seam: run the calibration math over the seeded step readings (mirrors NextStep -> Complete). The
         // optional overrides supply the sensor geometry a live run reads from the inspector/profile + the paraboloid
         // tilt-plane model (all of which the seed path bypasses), so RunCalibrationMath's hardware-recovery + pitch
@@ -2988,15 +3021,19 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                             inspector.ForceSensorCurveModelGeneration = prevForce;
                         }
                     }
+                    // Failure messages keep the raw WizardStep name: it matches the saved step folder on disk
+                    // (StepFolderName -> "03_ReBaseline1" / "05_ReBaseline2"), whereas StepTitleText maps BOTH
+                    // re-baseline steps to "Return to Baseline". The toast outlives the panel (a failed replay
+                    // collapses it), so it is the only thing telling the user which folder to look at.
                     if (!ok) {
-                        StatusText = $"Replay failed at {StepTitleText(step)}.";
-                        Notification.ShowError($"Replay failed at step '{StepTitleText(step)}'. The saved frames could not be analyzed.{profileNotChangedNote}");
+                        StatusText = $"Replay failed at {step}.";
+                        Notification.ShowError($"Replay failed at step '{step}'. The saved frames could not be analyzed.{profileNotChangedNote}");
                         return;
                     }
                     var m = CalibrationTiltPlane;
                     if (m == null) {
-                        StatusText = $"Replay produced no tilt model at {StepTitleText(step)}.";
-                        Notification.ShowError($"Replay produced no sensor-curve-model tilt at step '{StepTitleText(step)}'. The per-star paraboloid could not be fit.{profileNotChangedNote}");
+                        StatusText = $"Replay produced no tilt model at {step}.";
+                        Notification.ShowError($"Replay produced no sensor-curve-model tilt at step '{step}'. The per-star paraboloid could not be fit.{profileNotChangedNote}");
                         return;
                     }
                     var reading = new StepReading {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -156,6 +156,15 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         private readonly List<TiltAdapterMove> appliedDeviceMovesThisRun = new List<TiltAdapterMove>();
         // AutoRunAllCommand re-entrancy guard.
         private bool isAutoRunningAll;
+        // Latched when an automated run takes its cancel/failure exit. That exit rolls this run's device moves
+        // back (RecoverAppliedMovesAsync) and releases the exclusive operation lease, which together make the
+        // run unresumable: the readings already in stepReadings describe a device position that no longer
+        // exists, and re-entering AutoRunAllAsync skips StartAsync (IsWizardRunning is still true) so it would
+        // resume at the stale CurrentStep, unleased, sending moves computed from the rolled-back position.
+        // Gates AutoRunAllCommand and the failure panel's RetryMeasurementCommand; cleared by StartAsync and
+        // Restart. Deliberately does NOT tear the run panel down -- the failure text explaining what happened
+        // lives inside it.
+        private bool deviceRunAbandoned;
         // IProgress<string> adapter over the ApplicationStatus progress reporter, mirroring
         // InspectorVM.RunAutomaticAdjustmentAsync's moveProgress -- the same status-bar wording convention for
         // the other automated tilt-device consumer (T14).
@@ -301,7 +310,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             UseMeasuredHardwareCommand = new RelayCommand(UseMeasuredHardware, () => HasMeasuredHardware);
             BrowseSaveFolderCommand = new RelayCommand(BrowseSaveFolder);
             ReplayCommand = new AsyncRelayCommand(ReplayAsync, () => !IsWizardRunning && !IsMeasuring);
-            RetryMeasurementCommand = new AsyncRelayCommand(RunMeasurementAsync, () => HasMeasurementFailureChoice && IsOnMeasurementStep && !IsMeasuring && AreDevicesConnected);
+            RetryMeasurementCommand = new AsyncRelayCommand(RunMeasurementAsync, () => HasMeasurementFailureChoice && IsOnMeasurementStep && !IsMeasuring && AreDevicesConnected && !deviceRunAbandoned);
             ApplyManualCalibrationCommand = new RelayCommand(ApplyManualCalibration);
             ClearCalibrationCommand = new RelayCommand(ClearCalibration);
             RefreshPortsCommand = new RelayCommand(RefreshPorts);
@@ -310,7 +319,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             DisconnectDeviceCommand = new AsyncRelayCommand(DisconnectTiltDeviceAsync, () => IsTiltDeviceConnected);
             AutoRunAllCommand = new AsyncRelayCommand(AutoRunAllAsync, () =>
                 IsMotorizedDevice && this.tiltDeviceConnectionService != null && IsTiltDeviceConnected &&
-                !isAutoRunningAll && !IsMeasuring && HasValidDeviceAppliedAmount());
+                !isAutoRunningAll && !IsMeasuring && !deviceRunAbandoned && HasValidDeviceAppliedAmount());
 
             // This VM is a Shared MEF singleton, so these ctor-time subscriptions intentionally live for the
             // whole app run (like every other subscription in this ctor).
@@ -1775,6 +1784,27 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
         }
 
+        // The single cancel/failure exit for an automated run: roll this run's device moves back, release the
+        // exclusive lease, and latch the run as unresumable (see deviceRunAbandoned). Every caller previously
+        // did the first two by hand and none did the third, which left "Auto Run All" and the failure panel's
+        // "Run AutoFocus again" live on a run whose device state had just been undone underneath them.
+        private async Task AbandonDeviceRunAsync() {
+            await RecoverAppliedMovesAsync();
+            ReleaseTiltDeviceOperationToken();
+            deviceRunAbandoned = true;
+            // Say so wherever the user is already looking: the failure panel when there is one (it owns the
+            // retry button this just disabled), otherwise the status line used by the cancel path.
+            const string CannotResume = "This calibration run cannot be resumed because the tilt adapter was returned to its " +
+                "original position. Click Abort Wizard, then Calibrate, to start a new run.";
+            if (HasMeasurementFailureChoice) {
+                MeasurementFailureText = string.IsNullOrEmpty(MeasurementFailureText)
+                    ? CannotResume
+                    : $"{MeasurementFailureText} {CannotResume}";
+            } else {
+                StatusText = string.IsNullOrEmpty(StatusText) ? CannotResume : $"{StatusText} {CannotResume}";
+            }
+        }
+
         private void ReleaseTiltDeviceOperationToken() {
             var t = tiltDeviceOperationToken;
             tiltDeviceOperationToken = null;
@@ -1856,19 +1886,22 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             try {
                 while (CurrentStep != WizardStep.Complete) {
                     if (token.IsCancellationRequested) {
-                        await RecoverAppliedMovesAsync();
-                        ReleaseTiltDeviceOperationToken();
                         StatusText = "Auto Run All cancelled; device returned to its original position.";
+                        await AbandonDeviceRunAsync();
                         return;
                     }
                     var stepBefore = CurrentStep;
                     await MeasureStep(stepBefore, token, fromSaved: false);
                     if (HasMeasurementFailureChoice) {
                         if (CurrentStep != WizardStep.Complete) {
-                            // A move or measurement failed before the run finished — undo everything applied so far.
-                            await RecoverAppliedMovesAsync();
+                            // A move or measurement failed before the run finished — undo everything applied so far,
+                            // which also latches the run as unresumable.
+                            await AbandonDeviceRunAsync();
+                        } else {
+                            // Only Complete's own restore move failed: the calibration itself already succeeded, so
+                            // there is nothing to abandon (and MeasureStep already released the lease at Complete).
+                            ReleaseTiltDeviceOperationToken();
                         }
-                        ReleaseTiltDeviceOperationToken();
                         return;
                     }
                     if (CurrentStep == stepBefore) {
@@ -1878,9 +1911,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     }
                 }
             } catch (OperationCanceledException) {
-                await RecoverAppliedMovesAsync();
-                ReleaseTiltDeviceOperationToken();
                 StatusText = "Auto Run All cancelled; device returned to its original position.";
+                await AbandonDeviceRunAsync();
             } finally {
                 IsMeasuring = false;
                 IsAutoRunningAll = false;
@@ -1942,6 +1974,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
             StatusText = string.Empty;
             ClearMeasurementFailureChoice();
+            deviceRunAbandoned = false; // a fresh run starts from Baseline and re-acquires the exclusive lease
             stepReadings.Clear();
             HasMeasurementConsistencyWarning = false;
             MeasurementConsistencyWarningText = string.Empty;
@@ -2446,6 +2479,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // Auto Run All cancellation/failure attempts an automatic device recovery (RecoverAppliedMovesAsync).
             ReleaseTiltDeviceOperationToken();
             currentRunIsDeviceDriven = false;
+            deviceRunAbandoned = false;
             deviceMoveAppliedForStep = null;
             appliedDeviceMovesThisRun.Clear();
             SaveAFRuns = false; // saving must be re-enabled explicitly for each run


### PR DESCRIPTION
Two fixes in the tilt-adapter wizard. The first is the reported bug; the second was found while auditing the surrounding code and is the larger, riskier half.

## 1. Replay step header froze (`b228ef2`)

Replaying a saved calibration showed **"Step 1 of 6" on every step**.

`ReplayAsync`'s loop never assigned `CurrentStep` — the only write in the method was `CurrentStep = Complete`, *after* the loop. Every property the wizard header renders is derived from `currentStep` and re-raised only by that setter, and Panel B is on screen for the whole replay, so the header stayed pinned to the pre-replay step. The denominator was already correct (the loop preamble refreshes `activeMeasurementSteps`), so only the numerator was stuck.

The fix assigns `CurrentStep` at the top of the loop, mirroring the live path's `NextStep()`. Safe mid-replay: the setter's `NotifyCommandsCanExecuteChanged` cannot enable anything because `IsMeasuring` is true for the replay's duration, which is what every measurement command's `canExecute` actually gates on.

Two related bits of the same header came along:
- `isReplaying` was a **write-only field** (assigned in three places, read nowhere). Promoted to an INPC property feeding replay-specific instruction copy — the paragraph previously told the user to turn screws CLOCKWISE and click a button collapsed for the entire replay.
- The progress status line used the raw enum ("Replaying ReBaseline1…"); now uses `StepTitleText`.

**Live paths audited and unaffected.** Manual and Auto Run All both funnel through `NextStep()` → `CurrentStep`, and `StartAsync` reassigns `activeMeasurementSteps` before any run reads it, so replay's mutation of that shared field cannot leak into a live run.

## 2. Rolled-back automated run stayed resumable (`2fb24d8`, `dac0982`)

`AutoRunAllAsync`'s cancel and mid-run-failure exits call `RecoverAppliedMovesAsync` (inverting every move the run applied, returning the device to baseline) and release the exclusive lease — but left `IsWizardRunning` true, `currentRunIsDeviceDriven` true, `CurrentStep` mid-run and `stepReadings` populated, with no run-state gate on any command.

Clicking Auto Run All again skipped `StartAsync` (`IsWizardRunning` still true) and resumed at the stale step: re-sending moves computed from a position the rollback had already undone — resuming at `ReBaseline2` sends the inverse-of-`Screw1` move to a device already back at baseline, driving the screw *past* it — mixing post-rollback readings into `stepReadings` alongside pre-rollback ones, and running **without the device lease**, so the inspector's Automatic Adjustment could drive the same motors concurrently. The run then completes and persists a silently wrong calibration marked device-linked.

A `deviceRunAbandoned` latch now gates every re-entry into the measurement loop. The run panel deliberately stays up — the failure text explaining what happened lives inside it — so the buttons grey out and the copy says to Abort Wizard and start over. Cleared by `StartAsync` and `Restart`.

`dac0982` is a review follow-up correcting two mistakes in `2fb24d8`:
- It gated only `AutoRunAllCommand` and `RetryMeasurementCommand`. **`RunMeasurementCommand` binds to the same `RunMeasurementAsync` as the retry button**, and both it and `UseSavedAFCommand` sit in the same visible Panel B row — so the run was still resumable by one click while the new copy claimed it wasn't. All four are gated now.
- It latched even when *nothing* was rolled back. An AutoFocus failure on Baseline applies no device move, so the device is untouched and retry is legitimate; latching there regressed a working flow. `RecoverAppliedMovesAsync` now reports `(anyRolledBack, recoveryFailed)` and the latch fires only when the device actually changed or the rollback itself failed. The cancel status is composed from the same outcome, so it no longer claims the adapter was returned when no move was ever sent.

The Complete-restore-move failure keeps its existing behavior: the calibration has already succeeded there and nothing is rolled back, so the run is not latched.

## Testing

Full suite green: **2725 passed**.

Each fix was driven from a failing test — the replay test fails at index `[1]` with `"Step 1 of 6"`, exactly the user report. Also added a live-path counter test, since the existing one only ever asserted the Baseline value and would not have caught a regression in `NextStep`'s advance.

Two assertions were initially vacuous and were fixed: `RetryMeasurementCommand.CanExecute` passed for lack of a connected camera/focuser rather than because of the latch, and the fresh-start test went through `Restart` first, so it would have passed even if `StartAsync`'s clear were deleted.

## Reviewer note

Part 2 drives motors and is the riskier half. The tests cover the state machine but **not the device** — I'd want the cancel and mid-run-failure paths exercised on the real COM7 rig before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KeVJGpd11iZxrJtj9uywkB