### PR TITLE
feat(tilt-guidance): add Minutes display unit for screw-turn guidance

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/TiltAdapterGuidanceVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/TiltAdapterGuidanceVMTests.cs
@@ -37,9 +37,26 @@ public class TiltAdapterGuidanceVMTests {
     }
 
     [Test]
+    public void FormatAmount_ScrewsMinutes_ScalesSixtyMinutesPerTurnWithGlyph() {
+        Assert.Multiple(() => {
+            // 60 minutes = 1 full turn (clock-face convention, not arcminutes).
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(1.0, steps: false, TiltGuidanceAngleUnit.Minutes), Is.EqualTo("60.0 min ⟳"));
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(-0.5, steps: false, TiltGuidanceAngleUnit.Minutes), Is.EqualTo("30.0 min ⟲"));
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(0.25, steps: false, TiltGuidanceAngleUnit.Minutes), Is.EqualTo("15.0 min ⟳"));
+            // One decimal place: 0.125 turn = 7.5 min.
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(0.125, steps: false, TiltGuidanceAngleUnit.Minutes), Is.EqualTo("7.5 min ⟳"));
+            // Same physical noise floor as turns/degrees: |turns| < 0.005 renders as the dash.
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(0.004, steps: false, TiltGuidanceAngleUnit.Minutes), Is.EqualTo("—"));
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(-0.004, steps: false, TiltGuidanceAngleUnit.Minutes), Is.EqualTo("—"));
+            // At the floor, 0.005 turn = 0.3 min stays visible rather than rounding down to 0.
+            Assert.That(TiltAdapterGuidanceVM.FormatAmount(0.005, steps: false, TiltGuidanceAngleUnit.Minutes), Is.EqualTo("0.3 min ⟳"));
+        });
+    }
+
+    [Test]
     public void FormatAmount_Steppers_IgnoreUnitAndShowSignedSteps() {
-        // The unit selector never applies to steppers; assert both units render identical whole steps.
-        foreach (var unit in new[] { TiltGuidanceAngleUnit.Turns, TiltGuidanceAngleUnit.Degrees }) {
+        // The unit selector never applies to steppers; assert every unit renders identical whole steps.
+        foreach (var unit in new[] { TiltGuidanceAngleUnit.Turns, TiltGuidanceAngleUnit.Degrees, TiltGuidanceAngleUnit.Minutes }) {
             Assert.Multiple(() => {
                 Assert.That(TiltAdapterGuidanceVM.FormatAmount(35.2, steps: true, unit), Is.EqualTo("+35 steps"));
                 Assert.That(TiltAdapterGuidanceVM.FormatAmount(-35.2, steps: true, unit), Is.EqualTo("−35 steps"));
@@ -58,6 +75,8 @@ public class TiltAdapterGuidanceVMTests {
                 Is.EqualTo("⬆ = adapter moves toward the objective · ⟳ = clockwise (tighten) · amounts in turns"));
             Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: false, signIsMeasured: true, TiltGuidanceAngleUnit.Degrees),
                 Is.EqualTo("⬆ = adapter moves toward the objective · ⟳ = clockwise (tighten) · amounts in degrees"));
+            Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: false, signIsMeasured: true, TiltGuidanceAngleUnit.Minutes),
+                Is.EqualTo("⬆ = adapter moves toward the objective · ⟳ = clockwise (tighten) · amounts in minutes"));
             Assert.That(TiltAdapterGuidanceVM.BuildDirectionLegend(steps: false, signIsMeasured: false, TiltGuidanceAngleUnit.Degrees),
                 Is.EqualTo("⬆ = adapter moves toward the objective · ⟳ = clockwise (tighten) · amounts in degrees (assumed — set or measure in the Tilt Adapter Wizard)"));
             // Steppers ignore the unit word entirely.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs
@@ -186,15 +186,16 @@ public class TiltAdapterOptionsTests {
         Assert.That(options.AngleDisplayUnit, Is.EqualTo(TiltGuidanceAngleUnit.Turns));
     }
 
-    [Test]
-    public void AngleDisplayUnit_PersistsAndRoundTrips() {
+    [TestCase(TiltGuidanceAngleUnit.Degrees)]
+    [TestCase(TiltGuidanceAngleUnit.Minutes)]
+    public void AngleDisplayUnit_PersistsAndRoundTrips(TiltGuidanceAngleUnit unit) {
         var (options, store, _) = Build();
-        options.AngleDisplayUnit = TiltGuidanceAngleUnit.Degrees;
+        options.AngleDisplayUnit = unit;
         Assert.Multiple(() => {
             Assert.That(store.GetValueEnum(nameof(TiltAdapterOptions.AngleDisplayUnit), TiltGuidanceAngleUnit.Turns),
-                Is.EqualTo(TiltGuidanceAngleUnit.Degrees));
+                Is.EqualTo(unit));
             var reloaded = new TiltAdapterOptions(Substitute.For<IProfileService>(), store);
-            Assert.That(reloaded.AngleDisplayUnit, Is.EqualTo(TiltGuidanceAngleUnit.Degrees));
+            Assert.That(reloaded.AngleDisplayUnit, Is.EqualTo(unit));
         });
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -3021,7 +3021,7 @@
                                     Visibility="{Binding TiltGuidance.HasFourScrewBackfocus, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                             </Grid>
 
-                            <!--  Turns/Degrees display selector — screw adapters only (steppers always show whole steps)  -->
+                            <!--  Turns/Degrees/Minutes display selector — screw adapters only (steppers always show whole steps)  -->
                             <StackPanel
                                 Margin="5,8,5,0"
                                 Orientation="Horizontal"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltScrewGuidanceRow.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltScrewGuidanceRow.cs
@@ -42,7 +42,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         public bool HasNumericGuidance { get; set; }
         public bool UnitsAreSteps { get; set; }
 
-        // The Turns/Degrees dropdown is meaningful only for screw adapters with numeric guidance;
+        // The Turns/Degrees/Minutes dropdown is meaningful only for screw adapters with numeric guidance;
         // steppers always show whole steps. Single derived bool so the XAML uses one plain Visibility
         // binding (mirrors HasFourScrewBackfocus).
         public bool ShowAngleUnitSelector => HasNumericGuidance && !UnitsAreSteps;
@@ -80,7 +80,11 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         /// "(assumed)" flags a direction setting never verified by a wizard measurement.
         /// </summary>
         public static string BuildDirectionLegend(bool steps, bool signIsMeasured, TiltGuidanceAngleUnit angleUnit) {
-            string unitWord = angleUnit == TiltGuidanceAngleUnit.Degrees ? "degrees" : "turns";
+            string unitWord = angleUnit switch {
+                TiltGuidanceAngleUnit.Degrees => "degrees",
+                TiltGuidanceAngleUnit.Minutes => "minutes",
+                _ => "turns"
+            };
             string body = steps
                 ? "⬆ = adapter moves toward the objective · steps are signed as in the wizard prompts"
                 : $"⬆ = adapter moves toward the objective · ⟳ = clockwise (tighten) · amounts in {unitWord}";
@@ -90,11 +94,11 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
         /// <summary>
         /// Format a signed per-screw adjustment. Positive = clockwise / the wizard-prompt "+" step
-        /// direction. Screws render the magnitude with a rotation glyph — either turns ("1.25 ⟳",
-        /// 2 decimals) or whole degrees ("45° ⟳", 1 turn = 360°) per <paramref name="angleUnit"/>;
-        /// steppers render signed whole steps ("+35 steps") and ignore the unit. Values below the
-        /// 0.005-turn noise floor render as an em dash with no direction mark (so the smallest shown
-        /// degree value is ~2°).
+        /// direction. Screws render the magnitude with a rotation glyph — turns ("1.25 ⟳", 2 decimals),
+        /// whole degrees ("45° ⟳", 1 turn = 360°), or minutes ("15.0 min ⟳", 60 minutes = 1 turn,
+        /// 1 decimal) per <paramref name="angleUnit"/>; steppers render signed whole steps ("+35 steps")
+        /// and ignore the unit. Values below the 0.005-turn noise floor render as an em dash with no
+        /// direction mark (so the smallest shown value is ~2° / 0.3 min).
         /// </summary>
         public static string FormatAmount(double signedAmount, bool steps, TiltGuidanceAngleUnit angleUnit) {
             if (steps) {
@@ -107,6 +111,13 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             if (angleUnit == TiltGuidanceAngleUnit.Degrees) {
                 long degrees = (long)Math.Round(Math.Abs(signedAmount) * 360.0, MidpointRounding.AwayFromZero);
                 return $"{degrees}° {glyph}";
+            }
+            if (angleUnit == TiltGuidanceAngleUnit.Minutes) {
+                // 60 minutes = one full turn (clock-face convention, NOT arcminutes). One decimal
+                // preserves turns' physical resolution (0.1 min = 0.6° = 0.00167 turn) and keeps
+                // values just above the 0.005-turn floor visible (0.005 turn = 0.3 min) rather than
+                // rounding them down to a misleading 0.
+                return $"{Math.Abs(signedAmount) * 60.0:0.0} min {glyph}";
             }
             return $"{Math.Abs(signedAmount):0.00} {glyph}";
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltAdapterOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltAdapterOptions.cs
@@ -27,7 +27,10 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         Turns = 0,
 
         [Description("Degrees")]
-        Degrees = 1
+        Degrees = 1,
+
+        [Description("Minutes")]
+        Minutes = 2
     }
 
     public interface ITiltAdapterOptions : INotifyPropertyChanged {
@@ -60,7 +63,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         TiltAdjustmentType AdjustmentType { get; set; }      // screws vs stepper motors
 
         // Display unit for the Tilt Adapter Guidance numeric amounts on screw adapters:
-        // Turns (default) or Degrees (1 turn = 360°). Ignored for stepper adapters (always whole steps).
+        // Turns (default), Degrees (1 turn = 360°), or Minutes (1 turn = 60 min). Ignored for
+        // stepper adapters (always whole steps).
         TiltGuidanceAngleUnit AngleDisplayUnit { get; set; }
 
         double ThreadPitchMicrons { get; set; }              // axial microns per full screw turn


### PR DESCRIPTION
## Summary

Adds **Minutes** as a third display unit for the Aberration Inspector's tilt-adapter screw-turn guidance, alongside the existing **Turns** and **Degrees**. In this unit **60 minutes = one full turn** (clock-face convention — *not* arcminutes).

## Changes

- **`ITiltAdapterOptions.cs`** — added `Minutes = 2` (`[Description("Minutes")]`) to `TiltGuidanceAngleUnit`. The guidance dropdown builds its items from `EnumBindingSource`, so it picks up the new value with **no XAML binding change**.
- **`TiltScrewGuidanceRow.cs`** — `FormatAmount` renders minutes as `turns × 60` to one decimal (e.g. `15.0 min ⟳`); `BuildDirectionLegend` reports "amounts in minutes".
- **`DataTemplates.xaml`** — comment-only tweak.

## Design notes

- **One decimal, not whole minutes:** whole-minute rounding would collapse values just above the 0.005-turn noise floor (0.005 turn = 0.3 min) down to a misleading `0`. One decimal keeps them visible, mirroring the degrees mode's ~2° floor.
- **Spelled `min` suffix, not `′`:** in an astro context the prime symbol reads as arcminutes (a full turn is 21600 of those, not 60), so the unit is spelled out to avoid confusion.

## Tests

Added coverage for minutes formatting, the legend word, the stepper unit-ignoring path, and the Minutes-option persistence round-trip. Full suite: **2852 passed** (the lone failure was a pre-existing thread-scheduling flake in `EatSerialTransportTests`, which passes on isolated re-run and is unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2Tk9ujPg45PkaJRQBsVzU