### PR TITLE
feat(focus-recovery): Live-mode focus recovery for the Star Detection Optimizer wizard

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationObjectiveTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationObjectiveTests.cs
@@ -570,6 +570,261 @@ public class OptimizationObjectiveTests {
             "the shipped tie-breaker keeps the star-rich corner on the plateau");
     }
 
+    // ---- Focus recovery: exempt tagged recovery frames from the star-count gates ----
+
+    // A run with explicit per-frame counts and a parallel FrameIsRecovery tag list (null => baseline / no recovery).
+    // All other sub-scores are held healthy so the star-count gates are the only thing under test.
+    private static RunEvaluationMetrics RecoveryRun(int[] counts, bool[] isRecovery, double sigmaFocus = 0.05) =>
+        new RunEvaluationMetrics {
+            SigmaFocus = sigmaFocus,
+            LooStdError = double.NaN,
+            StepSize = 1.0,
+            RSquared = 0.99,
+            ReducedChiSquared = 1.0,
+            FrameStarCounts = counts,
+            FrameIsRecovery = isRecovery
+        };
+
+    [Test]
+    public void JRun_HardFloorExemption_TaggedRecoveryFramesDoNotZeroJ() {
+        var c = C; // NHard=3, MaxFramesBelowHardFloor=0
+        // Two starved wing frames (0 and 1 stars) + 7 healthy frames. This is the core failure the feature fixes:
+        // recovery frames routinely detect < NHard stars, and the hard floor would force J = 0 for every candidate.
+        var counts = new[] { 0, 1, 40, 40, 40, 40, 40, 40, 40 };
+
+        // Untagged (baseline): the starved frames must STILL hard-fail (proves the null path keeps gating).
+        var untagged = RecoveryRun(counts, isRecovery: null);
+        Assert.That(OptimizationObjective.JRun(untagged, c), Is.EqualTo(0.0),
+            "with FrameIsRecovery null the starved frames must still force the hard floor => J == 0");
+
+        // Same counts, but the two starved frames are tagged recovery => exempt from the hard floor.
+        var tagged = RecoveryRun(counts,
+            isRecovery: new[] { true, true, false, false, false, false, false, false, false });
+        Assert.That(OptimizationObjective.JRun(tagged, c), Is.GreaterThan(0.0),
+            "starved frames tagged as recovery are exempt from the hard floor => J > 0");
+    }
+
+    [Test]
+    public void JRun_HardFloorExemption_NonRecoveryStarvedFrameStillHardFails() {
+        var c = C;
+        // Frame index 2 is starved (2 < 3) but NOT tagged recovery => it must still hard-fail even though the
+        // outer wings are tagged. Exemption applies ONLY to tagged frames.
+        var counts = new[] { 0, 1, 2, 40, 40, 40, 40, 40, 40 };
+        var tagged = RecoveryRun(counts,
+            isRecovery: new[] { true, true, false, false, false, false, false, false, false });
+        Assert.That(OptimizationObjective.JRun(tagged, c), Is.EqualTo(0.0),
+            "a starved NON-recovery frame is not exempt => the run still hard-fails");
+    }
+
+    [Test]
+    public void JRun_SStars_IgnoresTaggedRecoveryFrames() {
+        var c = C;
+        // Healthy counts chosen so S_stars is BELOW 1.0 (min-term 1, median-term 0.5) and therefore sensitive to
+        // any starved frame that leaks into nMin/nMedian.
+        var healthy = Enumerable.Repeat(10, 7).ToArray();
+
+        // Baseline: only the 7 healthy frames, no recovery tagging.
+        var noRecovery = RecoveryRun(healthy, isRecovery: null, sigmaFocus: 0.2);
+
+        // Same 7 healthy frames PLUS two starved (count 2) frames tagged as recovery. If those leaked into S_stars,
+        // nMin would collapse to 2 and J would drop; the exemption must make J equal to the run without them.
+        var withRecovery = RecoveryRun(
+            new[] { 2, 2 }.Concat(healthy).ToArray(),
+            isRecovery: new[] { true, true }.Concat(Enumerable.Repeat(false, 7)).ToArray(),
+            sigmaFocus: 0.2);
+
+        Assert.That(OptimizationObjective.JRun(withRecovery, c),
+            Is.EqualTo(OptimizationObjective.JRun(noRecovery, c)).Within(1e-12),
+            "starved recovery frames must not drag nMin/nMedian => J matches the run without them");
+    }
+
+    [Test]
+    public void TieBreakerScore_IgnoresTaggedRecoveryFrames() {
+        var c = C;
+        // Baseline plateau: 9 frames @ 100 stars, no recovery.
+        var baseline = PlateauRun(100);
+
+        // Same 9 healthy frames @ 100 plus two recovery frames whose counts (0 and 5000) would swing the mean
+        // dramatically if counted. Tagged recovery => excluded from the tie-breaker mean.
+        var withRecovery = new RunEvaluationMetrics {
+            SigmaFocus = 1e-6, LooStdError = double.NaN, StepSize = 100.0, RSquared = 1.0, ReducedChiSquared = 1.0,
+            FrameStarCounts = new[] { 0, 5000 }.Concat(Enumerable.Repeat(100, 9)).ToArray(),
+            FrameIsRecovery = new[] { true, true }.Concat(Enumerable.Repeat(false, 9)).ToArray()
+        };
+
+        Assert.That(OptimizationObjective.TieBreakerScore(withRecovery, c),
+            Is.EqualTo(OptimizationObjective.TieBreakerScore(baseline, c)).Within(1e-12),
+            "recovery frames (even wild outlier counts) must not move the tie-breaker mean");
+    }
+
+    [Test]
+    [TestCase(0.05, 40)]
+    [TestCase(0.18, 25)]
+    [TestCase(0.30, 10)]
+    [TestCase(0.50, 8)]
+    public void JRun_BitIdentical_WhenFrameIsRecoveryNull(double sigmaFocus, int starsPerFrame) {
+        // Regression net for THE OVERRIDING INVARIANT: when FrameIsRecovery is null (every legacy caller / Replay /
+        // production autofocus), the recovery code path must be provably inert — JRun must equal the pre-feature
+        // weighted-sum formula. Wtie = 0 isolates the primary objective (LegacyJRun models only the weighted sum).
+        var c = new ObjectiveConstants { Wtie = 0.0 };
+        var m = GoodRun(sigmaFocus: sigmaFocus, frameCount: 10, starsPerFrame: starsPerFrame);
+        Assert.That(m.FrameIsRecovery, Is.Null, "baseline: recovery tagging absent");
+        Assert.Multiple(() => {
+            Assert.That(OptimizationObjective.JRun(m, c), Is.EqualTo(LegacyJRun(m, c, null, null)),
+                "recovery code path must be inert when FrameIsRecovery is null (unlabeled)");
+            Assert.That(OptimizationObjective.JRun(m, c, recall: 0.8, precision: 0.7),
+                Is.EqualTo(LegacyJRun(m, c, 0.8, 0.7)),
+                "recovery code path must be inert when FrameIsRecovery is null (labeled)");
+        });
+    }
+
+    // A run with per-frame positions/counts/relaxed and an optional recovery tag list, for SDefocusPrecision tests.
+    // bestFocus = NaN forces the run-level FALLBACK path; a finite bestFocus uses the near-focus PRIMARY path.
+    private static RunEvaluationMetrics PrecisionRun(
+            int[] positions, int[] counts, int[] relaxed, bool[] isRecovery,
+            int stepSize = 100, double bestFocus = 5000, double sigmaFocus = 0.05) =>
+        new RunEvaluationMetrics {
+            SigmaFocus = sigmaFocus,
+            LooStdError = double.NaN,
+            StepSize = stepSize,
+            RSquared = 0.99,
+            ReducedChiSquared = 1.0,
+            FrameStarCounts = counts,
+            FrameFocuserPositions = positions,
+            FrameRelaxationAdmittedCounts = relaxed,
+            BestFocusPosition = bestFocus,
+            FrameIsRecovery = isRecovery
+        };
+
+    [Test]
+    public void SDefocusPrecision_PrimaryWindow_ExemptsRecoveryFrameInsideWindow() {
+        var c = C; // near-focus window = 1.5 * 100 = 150 around bestFocus 5000
+        // Genuine near-focus frames carry a real relaxed fraction (30/120 = 0.25 => penalty 0.975).
+        var positions = new[] { 4900, 5000, 5100 };
+        var counts = new[] { 40, 40, 40 };
+        var relaxed = new[] { 10, 10, 10 };
+        var basePenalty = OptimizationObjective.SDefocusPrecision(
+            PrecisionRun(positions, counts, relaxed, isRecovery: null), c);
+
+        // A recovery frame lands INSIDE the window (position 5000, the poor-start scenario) with heavy relaxation.
+        var posRec = new[] { 4900, 5000, 5100, 5000 };
+        var countsRec = new[] { 40, 40, 40, 40 };
+        var relaxedRec = new[] { 10, 10, 10, 40 };
+        var withTagged = OptimizationObjective.SDefocusPrecision(
+            PrecisionRun(posRec, countsRec, relaxedRec, new[] { false, false, false, true }), c);
+        var withUntagged = OptimizationObjective.SDefocusPrecision(
+            PrecisionRun(posRec, countsRec, relaxedRec, isRecovery: null), c);
+
+        Assert.Multiple(() => {
+            Assert.That(withTagged, Is.EqualTo(basePenalty).Within(1e-12),
+                "a recovery frame inside the near-focus window must not create/inflate the precision penalty");
+            Assert.That(withUntagged, Is.LessThan(basePenalty),
+                "the SAME frame untagged DOES inflate the penalty — proving the recovery exemption is what suppresses it");
+        });
+    }
+
+    [Test]
+    public void SDefocusPrecision_Fallback_ExemptsRecoveryFrame() {
+        var c = C; // bestFocus = NaN => run-level fallback
+        var positions = new[] { 4900, 5000, 5100 };
+        var basePenalty = OptimizationObjective.SDefocusPrecision(
+            PrecisionRun(positions, new[] { 40, 40, 40 }, new[] { 20, 20, 20 }, isRecovery: null, bestFocus: double.NaN), c);
+
+        var posRec = new[] { 4900, 5000, 5100, 4600 };
+        var countsRec = new[] { 40, 40, 40, 40 };
+        var relaxedRec = new[] { 20, 20, 20, 40 };
+        var withTagged = OptimizationObjective.SDefocusPrecision(
+            PrecisionRun(posRec, countsRec, relaxedRec, new[] { false, false, false, true }, bestFocus: double.NaN), c);
+        var withUntagged = OptimizationObjective.SDefocusPrecision(
+            PrecisionRun(posRec, countsRec, relaxedRec, isRecovery: null, bestFocus: double.NaN), c);
+
+        Assert.Multiple(() => {
+            Assert.That(withTagged, Is.EqualTo(basePenalty).Within(1e-12),
+                "fallback penalty must be unchanged by a tagged recovery frame (numerator AND denominator both skip it)");
+            Assert.That(withTagged, Is.GreaterThanOrEqualTo(c.DefocusPrecisionMinFactor),
+                "the recovery-exempt fraction stays consistent (never > 1) => penalty stays within [MinFactor, 1]");
+            Assert.That(withUntagged, Is.LessThan(basePenalty),
+                "the same frame untagged DOES lower the fallback penalty");
+        });
+    }
+
+    // A fallback-path HFR run (positions null / bestFocus NaN => pool every eligible frame) with a recovery tag list.
+    private static RunEvaluationMetrics HfrFallbackRun(IReadOnlyList<double>[] frameHfrs, bool[] isRecovery) =>
+        new RunEvaluationMetrics {
+            SigmaFocus = 0.05,
+            LooStdError = double.NaN,
+            StepSize = 100,
+            RSquared = 0.99,
+            ReducedChiSquared = 1.0,
+            FrameStarCounts = frameHfrs.Select(f => f.Count).ToArray(),
+            FrameStarHFRs = frameHfrs,
+            FrameIsRecovery = isRecovery
+        };
+
+    [Test]
+    public void SHfrOutlier_Fallback_ExemptsRecoveryFrame() {
+        var c = C;
+        var baseFrames = new IReadOnlyList<double>[] { NormalsPlusBlob(9), NormalsPlusBlob(9), NormalsPlusBlob(9) };
+        var basePenalty = OptimizationObjective.SHfrOutlier(HfrFallbackRun(baseFrames, isRecovery: null), c);
+
+        var recoveryFrame = (IReadOnlyList<double>)Normals(10, hfr: 6.0); // an all-bloated recovery frame
+        var withFrames = new[] { baseFrames[0], baseFrames[1], baseFrames[2], recoveryFrame };
+        var withTagged = OptimizationObjective.SHfrOutlier(HfrFallbackRun(withFrames, new[] { false, false, false, true }), c);
+        var withUntagged = OptimizationObjective.SHfrOutlier(HfrFallbackRun(withFrames, isRecovery: null), c);
+
+        Assert.Multiple(() => {
+            Assert.That(withTagged, Is.EqualTo(basePenalty).Within(1e-12),
+                "a tagged recovery frame must not change the pooled outlier fraction");
+            Assert.That(withUntagged, Is.Not.EqualTo(basePenalty).Within(1e-12),
+                "the same frame untagged DOES change the pooled HFR sample");
+        });
+    }
+
+    // A fallback-path coverage run (positions null / bestFocus NaN => average every finite frame) with a recovery tag list.
+    private static RunEvaluationMetrics CoverageFallbackRun(double[] occupancy, bool[] isRecovery) =>
+        new RunEvaluationMetrics {
+            SigmaFocus = 0.05,
+            LooStdError = double.NaN,
+            StepSize = 100,
+            RSquared = 0.99,
+            ReducedChiSquared = 1.0,
+            FrameStarCounts = Enumerable.Repeat(40, occupancy.Length).ToArray(),
+            FrameRegionOccupancy = occupancy,
+            FrameIsRecovery = isRecovery
+        };
+
+    [Test]
+    public void SCoverage_Fallback_ExemptsRecoveryFrame() {
+        var c = C;
+        var baseCov = OptimizationObjective.SCoverage(CoverageFallbackRun(new[] { 0.2, 0.4, 0.6 }, isRecovery: null), c);
+        var withTagged = OptimizationObjective.SCoverage(
+            CoverageFallbackRun(new[] { 0.2, 0.4, 0.6, 1.0 }, new[] { false, false, false, true }), c);
+        var withUntagged = OptimizationObjective.SCoverage(
+            CoverageFallbackRun(new[] { 0.2, 0.4, 0.6, 1.0 }, isRecovery: null), c);
+        Assert.Multiple(() => {
+            Assert.That(withTagged, Is.EqualTo(baseCov).Within(1e-12),
+                "a tagged recovery frame with skewed occupancy must not move the coverage mean");
+            Assert.That(withUntagged, Is.GreaterThan(baseCov),
+                "the same frame untagged DOES move the coverage mean");
+        });
+    }
+
+    [Test]
+    public void JRun_AllFramesRecovery_DoesNotThrow() {
+        var c = C;
+        // Degenerate (can't happen in practice — the evaluator always leaves >= 3 non-recovery frames): EVERY frame is
+        // tagged recovery and below the hard floor. JRun (via SStars) and TieBreakerScore both route the counts through
+        // the internal NonRecoveryStarCounts, whose empty filtered sequence must fall back to the original counts so
+        // Min/Median/Average never throw; the hard floor must also treat every frame as exempt (no divide-by-empty).
+        var m = RecoveryRun(new[] { 0, 1, 2, 0 }, isRecovery: new[] { true, true, true, true });
+        double j = double.NaN;
+        Assert.Multiple(() => {
+            Assert.That(() => j = OptimizationObjective.JRun(m, c), Throws.Nothing);
+            Assert.That(() => OptimizationObjective.TieBreakerScore(m, c), Throws.Nothing);
+        });
+        Assert.That(j, Is.InRange(0.0, 1.0), "JRun still returns a valid score with every frame exempt");
+    }
+
     // ---- JTotal ----
 
     [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationDataTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/RunEvaluationDataTests.cs
@@ -431,6 +431,266 @@ public class RunEvaluationDataTests {
         });
     }
 
+    // ── Focus recovery ────────────────────────────────────────────────────────────────────────────────────────
+
+    private static RunFitConfig UnweightedFitConfig() => new RunFitConfig {
+        StepSize = 100,
+        UseWeights = false,
+        MaxOutlierRejections = 0,
+        RejectionConfidence = 0.0,
+        PreferredModel = null
+    };
+
+    private static List<RunFrame> FramesAt(IEnumerable<int> positions) =>
+        positions.Select(pos => new RunFrame { FrameId = $"pos_{pos}", FocuserPosition = pos, Image = pos }).ToList();
+
+    // Detection delegate returning a clean hyperbola HFR with a per-position stdev (so a test can make a chosen
+    // position zero-scatter), a fixed star count, and no centers.
+    private static Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> HyperbolaDetectWithStdev(
+        Func<int, double> stdevFor, int starCount = 50) {
+        return (image, p, token) => {
+            var pos = (int)image;
+            return Task.FromResult(new FrameDetectionResult {
+                AverageHFR = Hfr(pos),
+                HFRStdDev = stdevFor(pos),
+                StarCount = starCount,
+                StarCenters = Array.Empty<(double X, double Y)>()
+            });
+        };
+    }
+
+    private static double ErrorYAt(RunEvaluationResult r, int x) =>
+        r.Points.First(pt => Math.Abs(pt.X - x) < 0.5).ErrorY;
+
+    // A GENTLE symmetric hyperbola about a chosen center (HFR ~2 at focus, ~6 at ±400 for the default sweep). Used by
+    // the down-weighting test to place the recovery-position HFRs on a DIFFERENT (false) center than the interior.
+    private static double GentleHfr(int pos, int center) {
+        const double a = 2.0, b = 70.0;
+        var dx = (pos - center) / b;
+        return Math.Sqrt(a * a + dx * dx);
+    }
+
+    [Test]
+    public async Task EvaluateAndFitAsync_RecoverySteps_MarksOutermostNPerSideAsRecovery() {
+        // 9 distinct positions (p0-400..p0+400), N=2 => the 2 smallest AND 2 largest positions are recovery; the
+        // interior 5 are not. Recovery is defined by distinct position.
+        var data = new RunEvaluationData("recovery", NineFrames(), HyperbolaDetect(), NewAlglib(), DefaultFitConfig()) {
+            RecoveryStepsPerSide = 2
+        };
+        var result = await data.EvaluateAndFitAsync(new StarDetectorParams(), CancellationToken.None);
+        var flags = result.Metrics.FrameIsRecovery;
+        var positions = result.Metrics.FrameFocuserPositions;
+
+        Assert.That(flags, Is.Not.Null, "N>0 with enough positions => a recovery flag list");
+        Assert.That(flags.Count, Is.EqualTo(9));
+        var recovery = new HashSet<int> { HyperbolaP0 - 400, HyperbolaP0 - 300, HyperbolaP0 + 300, HyperbolaP0 + 400 };
+        Assert.Multiple(() => {
+            for (var i = 0; i < flags.Count; i++) {
+                Assert.That(flags[i], Is.EqualTo(recovery.Contains(positions[i])),
+                    $"frame at position {positions[i]} recovery flag");
+            }
+            Assert.That(flags.Count(f => f), Is.EqualTo(4), "exactly 2-per-side extreme positions are recovery");
+        });
+    }
+
+    [Test]
+    public async Task EvaluateAndFitAsync_RecoverySteps_InflatesRecoveryErrorY_IncludingZeroScatterPosition() {
+        // Interior (non-recovery) positions carry per-frame stdev 0.05; the smallest recovery position (p0-400) is a
+        // SINGLE frame with per-frame HFRStdDev 0. AverageMeasurement pools that lone frame with no VALID variance
+        // contribution (validVarianceCount == 0 since HFRStdDev is not > 0), so its pooled Stdev is NaN, which
+        // SafeDisplayError maps to display error 0. refErr = median(non-recovery display errors) = 0.05, so even the
+        // zero-scatter recovery position is down-weighted: ErrorY = inflation * max(0, refErr) = inflation * refErr.
+        var zeroScatterPos = HyperbolaP0 - 400;
+        var detect = HyperbolaDetectWithStdev(pos => pos == zeroScatterPos ? 0.0 : 0.05);
+        var data = new RunEvaluationData("recovery-inflate", NineFrames(), detect, NewAlglib(), DefaultFitConfig()) {
+            RecoveryStepsPerSide = 2
+        };
+        var result = await data.EvaluateAndFitAsync(new StarDetectorParams(), CancellationToken.None);
+
+        const double refErr = 0.05;      // median of the interior positions' display errors
+        const double interiorErrorY = 0.05;
+        var recoveryPositions = new[] { HyperbolaP0 - 400, HyperbolaP0 - 300, HyperbolaP0 + 300, HyperbolaP0 + 400 };
+        var interiorPositions = new[] { HyperbolaP0 - 200, HyperbolaP0 - 100, HyperbolaP0, HyperbolaP0 + 100, HyperbolaP0 + 200 };
+
+        Assert.Multiple(() => {
+            Assert.That(result.Points.Count, Is.EqualTo(9), "weighted fit keeps recovery points (down-weighted)");
+            foreach (var pos in interiorPositions) {
+                Assert.That(ErrorYAt(result, pos), Is.EqualTo(interiorErrorY).Within(1e-9),
+                    "non-recovery point ErrorY is unchanged from the baseline scatter");
+            }
+            foreach (var pos in recoveryPositions) {
+                Assert.That(ErrorYAt(result, pos), Is.EqualTo(RunEvaluationData.RecoveryErrorInflation * refErr).Within(1e-9),
+                    $"recovery point at {pos} is down-weighted (ErrorY = inflation * max(ownStdev, refErr))");
+                Assert.That(ErrorYAt(result, pos), Is.GreaterThan(interiorErrorY), "recovery ErrorY exceeds the reference");
+            }
+            // The zero-scatter recovery position is STILL down-weighted (0 * inflation would be inert => must use refErr).
+            Assert.That(ErrorYAt(result, zeroScatterPos), Is.EqualTo(RunEvaluationData.RecoveryErrorInflation * refErr).Within(1e-9));
+            Assert.That(ErrorYAt(result, zeroScatterPos), Is.GreaterThan(0.0), "zero-scatter recovery point is not weightless");
+        });
+    }
+
+    [Test]
+    public async Task EvaluateAndFitAsync_TooFewPositions_CollapsesToNoRecovery() {
+        // 4 distinct positions with a large N: perSide = min(N, (4-3)/2) = 0 => no recovery (>=3 anchors preserved).
+        var frames = FramesAt(new[] { HyperbolaP0 - 300, HyperbolaP0 - 100, HyperbolaP0 + 100, HyperbolaP0 + 300 });
+        var data = new RunEvaluationData("too-few", frames, HyperbolaDetect(), NewAlglib(), DefaultFitConfig()) {
+            RecoveryStepsPerSide = 5
+        };
+        var result = await data.EvaluateAndFitAsync(new StarDetectorParams(), CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(result.Metrics.FrameIsRecovery, Is.Null, "cap collapses perSide to 0 => no recovery");
+            Assert.That(result.NonRecoveryPooledPointCount, Is.EqualTo(result.PooledPointCount),
+                "no recovery => non-recovery count equals the pooled count");
+            Assert.That(result.PooledPointCount, Is.EqualTo(4), "all 4 positions still feed the fit");
+        });
+    }
+
+    [Test]
+    public async Task EvaluateAndFitAsync_CapLimitsPerSideToPositiveValue() {
+        // 6 distinct positions with a large N: perSide = min(5, (6-3)/2) = min(5, 1) = 1 => exactly the outermost ONE
+        // position per side is recovery (2 recovery positions), leaving 4 interior anchors. Exercises the cap between
+        // its collapse-to-0 boundary and the requested N.
+        var positions = new[] { HyperbolaP0 - 250, HyperbolaP0 - 150, HyperbolaP0 - 50, HyperbolaP0 + 50, HyperbolaP0 + 150, HyperbolaP0 + 250 };
+        var data = new RunEvaluationData("cap", FramesAt(positions), HyperbolaDetect(), NewAlglib(), DefaultFitConfig()) {
+            RecoveryStepsPerSide = 5
+        };
+        var result = await data.EvaluateAndFitAsync(new StarDetectorParams(), CancellationToken.None);
+        var flags = result.Metrics.FrameIsRecovery;
+        var framePositions = result.Metrics.FrameFocuserPositions;
+
+        var recovery = new HashSet<int> { HyperbolaP0 - 250, HyperbolaP0 + 250 }; // only the outermost 1 per side
+        Assert.Multiple(() => {
+            Assert.That(flags, Is.Not.Null);
+            Assert.That(flags.Count, Is.EqualTo(6));
+            for (var i = 0; i < flags.Count; i++) {
+                Assert.That(flags[i], Is.EqualTo(recovery.Contains(framePositions[i])),
+                    $"frame at position {framePositions[i]} recovery flag");
+            }
+            Assert.That(flags.Count(f => f), Is.EqualTo(2), "perSide capped to 1 => exactly 2 recovery positions");
+            Assert.That(result.PooledPointCount, Is.EqualTo(6), "weighted fit keeps all positions (recovery down-weighted)");
+            Assert.That(result.NonRecoveryPooledPointCount, Is.EqualTo(4), "4 interior anchors are non-recovery");
+        });
+    }
+
+    [Test]
+    public async Task EvaluateAndFitAsync_DownWeightingKeepsMinimumNearTruth_DespiteCorruptedWings() {
+        // The feature's raison d'être: the interior positions lie on a hyperbola centered at the TRUE minimum
+        // (HyperbolaP0), but the outermost (recovery) positions are CORRUPTED onto a hyperbola with a false center —
+        // off-curve points that, at full weight, drag the fitted minimum away from truth. With recovery ON the
+        // corrupted wings are down-weighted 10×, so the clean interior anchors keep the minimum near truth; with
+        // recovery OFF (same corrupted points, full weight) the minimum is dragged noticeably away.
+        const int falseCenter = HyperbolaP0 + 600;
+        var recovery = new HashSet<int> { HyperbolaP0 - 400, HyperbolaP0 - 300, HyperbolaP0 + 300, HyperbolaP0 + 400 };
+        Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> detect = (image, p, token) => {
+            var pos = (int)image;
+            var hfr = recovery.Contains(pos) ? GentleHfr(pos, falseCenter) : GentleHfr(pos, HyperbolaP0);
+            return Task.FromResult(new FrameDetectionResult {
+                AverageHFR = hfr,
+                HFRStdDev = 0.05,
+                StarCount = 50,
+                StarCenters = Array.Empty<(double X, double Y)>()
+            });
+        };
+
+        var runOn = new RunEvaluationData("down-on", NineFrames(), detect, NewAlglib(), DefaultFitConfig()) {
+            RecoveryStepsPerSide = 2
+        };
+        var runOff = new RunEvaluationData("down-off", NineFrames(), detect, NewAlglib(), DefaultFitConfig()) {
+            RecoveryStepsPerSide = 0
+        };
+        var onResult = await runOn.EvaluateAndFitAsync(new StarDetectorParams(), CancellationToken.None);
+        var offResult = await runOff.EvaluateAndFitAsync(new StarDetectorParams(), CancellationToken.None);
+
+        var onBest = onResult.Metrics.BestFocusPosition;
+        var offBest = offResult.Metrics.BestFocusPosition;
+        Assert.Multiple(() => {
+            Assert.That(double.IsFinite(onBest), Is.True, "recovery-ON fit must produce a finite minimum");
+            Assert.That(double.IsFinite(offBest), Is.True, "recovery-OFF fit must produce a finite minimum");
+            // Recovery ON keeps the minimum near the true center despite the corrupted wings.
+            Assert.That(Math.Abs(onBest - HyperbolaP0), Is.LessThan(100.0),
+                "down-weighted wings must not drag the minimum far from truth");
+            // Recovery OFF drags the minimum noticeably away from truth (direction depends on the corruption geometry).
+            Assert.That(Math.Abs(offBest - HyperbolaP0), Is.GreaterThan(100.0),
+                "full-weight corrupted wings drag the minimum away from truth");
+            Assert.That(Math.Abs(onBest - HyperbolaP0), Is.LessThan(Math.Abs(offBest - HyperbolaP0)),
+                "recovery keeps the minimum strictly closer to truth than the full-weight fit");
+        });
+    }
+
+    [Test]
+    public async Task EvaluateAndFitAsync_DuplicateFramesAtRecoveryPosition_AllFlagged() {
+        // Two frames at the smallest position (a recovery position) => BOTH frames are flagged (recovery is by
+        // distinct position). 10 frames, 9 distinct positions.
+        var frames = NineFrames();
+        frames.Add(new RunFrame { FrameId = "pos_dup", FocuserPosition = HyperbolaP0 - 400, Image = HyperbolaP0 - 400 });
+        var data = new RunEvaluationData("dup", frames, HyperbolaDetect(), NewAlglib(), DefaultFitConfig()) {
+            RecoveryStepsPerSide = 2
+        };
+        var result = await data.EvaluateAndFitAsync(new StarDetectorParams(), CancellationToken.None);
+        var flags = result.Metrics.FrameIsRecovery;
+        var positions = result.Metrics.FrameFocuserPositions;
+
+        Assert.Multiple(() => {
+            Assert.That(flags, Is.Not.Null);
+            Assert.That(flags.Count, Is.EqualTo(10), "per-frame flags include the duplicate frame");
+            var atSmallest = Enumerable.Range(0, flags.Count).Where(i => positions[i] == HyperbolaP0 - 400).ToList();
+            Assert.That(atSmallest.Count, Is.EqualTo(2), "two frames sit at the smallest position");
+            Assert.That(atSmallest.All(i => flags[i]), Is.True, "all frames at a recovery position are flagged");
+        });
+    }
+
+    [Test]
+    public async Task EvaluateAndFitAsync_UnweightedFit_ExcludesRecoveryFromPoints_ButKeepsFlags() {
+        // With UseWeights=false the fitter ignores ErrorY, so inflation cannot down-weight — recovery positions are
+        // EXCLUDED from the fit points entirely. They still populate the per-frame FrameIsRecovery flags, and
+        // NonRecoveryPooledPointCount stays consistent with the excluded set.
+        var data = new RunEvaluationData("unweighted", NineFrames(), HyperbolaDetect(), NewAlglib(), UnweightedFitConfig()) {
+            RecoveryStepsPerSide = 2
+        };
+        var result = await data.EvaluateAndFitAsync(new StarDetectorParams(), CancellationToken.None);
+
+        var recovery = new HashSet<int> { HyperbolaP0 - 400, HyperbolaP0 - 300, HyperbolaP0 + 300, HyperbolaP0 + 400 };
+        Assert.Multiple(() => {
+            Assert.That(result.PooledPointCount, Is.EqualTo(5), "the 4 recovery positions are excluded from the fit");
+            Assert.That(result.NonRecoveryPooledPointCount, Is.EqualTo(5), "all fitted points are non-recovery");
+            Assert.That(result.Points.Any(pt => recovery.Contains((int)Math.Round(pt.X))), Is.False,
+                "no recovery position appears in the fit points");
+            // Metrics still tag every frame (only the FIT omits the recovery positions).
+            Assert.That(result.Metrics.FrameIsRecovery, Is.Not.Null);
+            Assert.That(result.Metrics.FrameIsRecovery.Count(f => f), Is.EqualTo(4));
+        });
+    }
+
+    [Test]
+    public async Task EvaluateAndFitAsync_RecoveryOff_IsByteIdenticalBaseline() {
+        // Regression guard: RecoveryStepsPerSide == 0 (default) => FrameIsRecovery null, NonRecoveryPooledPointCount ==
+        // PooledPointCount, and the interior (non-recovery) points' ErrorY are IDENTICAL to a run with N=2 (the
+        // recovery feature only perturbs the extremes; it never touches the baseline points).
+        var detect = HyperbolaDetectWithStdev(_ => 0.05);
+        var baseline = new RunEvaluationData("baseline", NineFrames(), detect, NewAlglib(), DefaultFitConfig());
+        var withRecovery = new RunEvaluationData("with-recovery", NineFrames(), detect, NewAlglib(), DefaultFitConfig()) {
+            RecoveryStepsPerSide = 2
+        };
+        var baseResult = await baseline.EvaluateAndFitAsync(new StarDetectorParams(), CancellationToken.None);
+        var recResult = await withRecovery.EvaluateAndFitAsync(new StarDetectorParams(), CancellationToken.None);
+
+        var interiorPositions = new[] { HyperbolaP0 - 200, HyperbolaP0 - 100, HyperbolaP0, HyperbolaP0 + 100, HyperbolaP0 + 200 };
+        Assert.Multiple(() => {
+            Assert.That(baseResult.Metrics.FrameIsRecovery, Is.Null, "feature off => FrameIsRecovery is null (not an all-false list)");
+            Assert.That(baseResult.NonRecoveryPooledPointCount, Is.EqualTo(baseResult.PooledPointCount),
+                "feature off => non-recovery count equals the pooled count");
+            Assert.That(baseResult.Points.Count, Is.EqualTo(9));
+            Assert.That(baseResult.Points.All(pt => Math.Abs(pt.ErrorY - 0.05) < 1e-9), Is.True,
+                "baseline points carry the raw display scatter");
+            // The interior points are byte-identical between the baseline and the recovery run.
+            foreach (var pos in interiorPositions) {
+                Assert.That(ErrorYAt(recResult, pos), Is.EqualTo(ErrorYAt(baseResult, pos)).Within(1e-12),
+                    "recovery must not perturb the interior (non-recovery) fit points");
+            }
+        });
+    }
+
     // Synchronous IProgress so reports are captured on the calling thread (no SynchronizationContext marshaling).
     private sealed class ImmediateProgress<T> : IProgress<T> {
         private readonly Action<T> onReport;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -1420,6 +1420,169 @@ public class StarDetectionOptimizerWizardVMTests {
         Assert.That(vm.IsLive, Is.True, "Live mode shows the confirmation panel");
     }
 
+    // ---- Focus recovery (Task C): session-only knob, widened Live sweep, run tagging --------------------
+
+    [Test]
+    public void FocusRecoverySteps_DefaultsToOne_AndClampsNegativeToZero() {
+        var vm = NewVM(LoaderReturning(GoodRun()));
+        Assert.That(vm.FocusRecoverySteps, Is.EqualTo(1), "focus recovery defaults to 1");
+        vm.FocusRecoverySteps = -3;
+        Assert.That(vm.FocusRecoverySteps, Is.EqualTo(0), "a negative value clamps to 0");
+        vm.FocusRecoverySteps = 4;
+        Assert.That(vm.FocusRecoverySteps, Is.EqualTo(4), "a positive value is kept");
+    }
+
+    [Test]
+    public void FocusRecoverySteps_Live_WidensSweepReadouts_Replay_LeavesThemUnchanged() {
+        var profileService = Substitute.For<IProfileService>();
+        var focuserSettings = Substitute.For<IFocuserSettings>();
+        focuserSettings.AutoFocusInitialOffsetSteps.Returns(4);
+        focuserSettings.AutoFocusNumberOfFramesPerPoint.Returns(1);
+        profileService.ActiveProfile.FocuserSettings.Returns(focuserSettings);
+        var vm = NewVM(LoaderReturning(GoodRun()), profileService: profileService);
+
+        // Live mode: recovery widens the effective sweep readouts, and editing it raises change notifications.
+        vm.SourceMode = SourceMode.Live;
+        Assert.That(vm.SweepEffectiveOffsetSteps, Is.EqualTo(4 + 1), "the default recovery=1 already widens the Live sweep");
+
+        var raised = new List<string>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+        vm.FocusRecoverySteps = 3;
+
+        Assert.Multiple(() => {
+            Assert.That(vm.SweepEffectiveOffsetSteps, Is.EqualTo(4 + 3), "profile offset (4) + recovery (3)");
+            Assert.That(vm.SweepPointCount, Is.EqualTo(2 * (4 + 3) + 1), "point count follows the widened offset");
+            Assert.That(vm.SweepEstimatedFrames, Is.EqualTo((2 * (4 + 3) + 1) * 1), "estimated frames follow the widened point count");
+            Assert.That(raised, Does.Contain(nameof(vm.FocusRecoverySteps)));
+            Assert.That(raised, Does.Contain(nameof(vm.SweepEffectiveOffsetSteps)));
+            Assert.That(raised, Does.Contain(nameof(vm.SweepPointCount)));
+            Assert.That(raised, Does.Contain(nameof(vm.SweepEstimatedFrames)));
+        });
+
+        // Replay mode: the SAME edit leaves the readouts unchanged (recovery adds 0 off the Live path).
+        vm.SourceMode = SourceMode.Replay;
+        var effBefore = vm.SweepEffectiveOffsetSteps;
+        var pointsBefore = vm.SweepPointCount;
+        var framesBefore = vm.SweepEstimatedFrames;
+        vm.FocusRecoverySteps = 6;
+        Assert.Multiple(() => {
+            Assert.That(vm.SweepEffectiveOffsetSteps, Is.EqualTo(4), "Replay ignores recovery: effective offset == profile offset");
+            Assert.That(vm.SweepEffectiveOffsetSteps, Is.EqualTo(effBefore));
+            Assert.That(vm.SweepPointCount, Is.EqualTo(pointsBefore), "Replay point count is unchanged by recovery");
+            Assert.That(vm.SweepEstimatedFrames, Is.EqualTo(framesBefore), "Replay estimated frames are unchanged by recovery");
+        });
+    }
+
+    [Test]
+    public async Task Start_LiveSweep_PassesWidenedOffsetToEngine() {
+        const int P = 3;   // profile offset the engine's GetOptions reports
+        const int N = 2;   // recovery steps per side
+        var baseTimeout = TimeSpan.FromSeconds(300);
+        AutoFocusEngineOptions captured = null;
+        var engine = Substitute.For<IAutoFocusEngine>();
+        engine.GetOptions().Returns(_ => new AutoFocusEngineOptions {
+            AutoFocusInitialOffsetSteps = P,
+            AutoFocusStepSize = DefaultStepSize,
+            AutoFocusTimeout = baseTimeout
+        });
+        engine.CaptureFixedSweepAsync(default, default, default, default).ReturnsForAnyArgs(ci => {
+            captured = ci.ArgAt<AutoFocusEngineOptions>(0);
+            return Task.FromResult(new AutoFocusResult { Succeeded = true, SaveFolder = @"C:\live\attempt" });
+        });
+        var vm = NewVM(LoaderReturning(GoodRun()), isCameraConnected: () => true, isFocuserConnected: () => true, autoFocusEngine: engine);
+        vm.SourceMode = SourceMode.Live;
+        vm.OptimizeMode = WizardOptimizeMode.UseCurrentSettings;
+        vm.SaveFolderPath = @"C:\live";
+        vm.FocusRecoverySteps = N;
+
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.That(captured, Is.Not.Null, "the widened options were handed to the engine's fixed sweep");
+        var oldPoints = 2 * P + 1;
+        var newPoints = 2 * (P + N) + 1;
+        Assert.Multiple(() => {
+            Assert.That(vm.ErrorMessage, Is.Null.Or.Empty, "the widened Live run completes cleanly");
+            Assert.That(captured.AutoFocusInitialOffsetSteps, Is.EqualTo(P + N), "offset widened by N recovery steps");
+            Assert.That(captured.AutoFocusStepSize, Is.EqualTo(DefaultStepSize), "step size is untouched (recovery widens, not refines)");
+            Assert.That(captured.AutoFocusTimeout.Ticks,
+                Is.EqualTo((long)(baseTimeout.Ticks * (double)newPoints / oldPoints)),
+                "timeout scaled by the point-count ratio (2(P+N)+1)/(2P+1)");
+        });
+    }
+
+    [Test]
+    public void ApplyFocusRecovery_WidensOffsetAndScalesTimeout_NeverStepSize() {
+        var options = new AutoFocusEngineOptions {
+            AutoFocusInitialOffsetSteps = 5,
+            AutoFocusStepSize = 100,
+            AutoFocusTimeout = TimeSpan.FromSeconds(600)
+        };
+        StarDetectionOptimizerWizardVM.ApplyFocusRecovery(options, 2);
+        var oldPoints = 2 * 5 + 1;   // 11
+        var newPoints = 2 * 7 + 1;   // 15
+        Assert.Multiple(() => {
+            Assert.That(options.AutoFocusInitialOffsetSteps, Is.EqualTo(7), "offset bumped by N");
+            Assert.That(options.AutoFocusStepSize, Is.EqualTo(100), "step size never changes");
+            Assert.That(options.AutoFocusTimeout.Ticks,
+                Is.EqualTo((long)(TimeSpan.FromSeconds(600).Ticks * (double)newPoints / oldPoints)),
+                "timeout scaled by the point-count ratio");
+        });
+    }
+
+    [Test]
+    public void ApplyFocusRecovery_NonPositiveSteps_IsCompleteNoOp() {
+        foreach (var n in new[] { 0, -1, -5 }) {
+            var options = new AutoFocusEngineOptions {
+                AutoFocusInitialOffsetSteps = 5,
+                AutoFocusStepSize = 100,
+                AutoFocusTimeout = TimeSpan.FromSeconds(600)
+            };
+            StarDetectionOptimizerWizardVM.ApplyFocusRecovery(options, n);
+            Assert.Multiple(() => {
+                Assert.That(options.AutoFocusInitialOffsetSteps, Is.EqualTo(5), $"offset unchanged at N={n}");
+                Assert.That(options.AutoFocusStepSize, Is.EqualTo(100), $"step size unchanged at N={n}");
+                Assert.That(options.AutoFocusTimeout, Is.EqualTo(TimeSpan.FromSeconds(600)), $"timeout unchanged at N={n}");
+            });
+        }
+    }
+
+    [Test]
+    public async Task Start_Live_StampsRecoverySnapshotOntoLoadedRun() {
+        // The loaded run's RunEvaluationData must carry the snapshotted recovery steps so the evaluator tags the outer
+        // frames. The fake loader hands back the same LoadedRun instance we hold, and RecoveryStepsPerSide survives the
+        // post-run Dispose (it is a plain int), so we can read the stamp after Start completes.
+        var run = GoodRun();
+        var engine = LiveEngine(_ => new AutoFocusResult { Succeeded = true, SaveFolder = @"C:\live\attempt" });
+        var vm = NewVM(LoaderReturning(run), isCameraConnected: () => true, isFocuserConnected: () => true, autoFocusEngine: engine);
+        vm.SourceMode = SourceMode.Live;
+        vm.OptimizeMode = WizardOptimizeMode.UseCurrentSettings;
+        vm.SaveFolderPath = @"C:\live";
+        vm.FocusRecoverySteps = 2;
+
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.ErrorMessage, Is.Null.Or.Empty);
+            Assert.That(run.Data.RecoveryStepsPerSide, Is.EqualTo(2), "a Live start stamps the recovery snapshot onto the loaded run");
+        });
+    }
+
+    [Test]
+    public async Task Start_Replay_LeavesRecoverySnapshotAtZero() {
+        // Recovery must be inert for Replay: even with the box set, a Replay start stamps 0 so the run is untagged.
+        var run = GoodRun();
+        var vm = NewVM(LoaderReturning(run));
+        vm.FocusRecoverySteps = 5; // Replay must ignore this
+        vm.SourcePaths[0] = @"C:\run1";
+
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Summary));
+            Assert.That(run.Data.RecoveryStepsPerSide, Is.EqualTo(0), "a Replay start leaves recovery inert regardless of the box value");
+        });
+    }
+
     // ---- Per-filter star detection: target filter state + Start validation -----------------------------
 
     [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -174,6 +174,11 @@ public class StarDetectionOptimizerWizardVMTests {
         public int LabelOverloadCalls { get; private set; }
         public int NoLabelCalls { get; private set; }
 
+        // Every LoadedRun this fake manufactures, in creation order. The VM's load-and-stamp choke-point mutates the
+        // SAME RunEvaluationData instance AFTER the loader returns it, so RecoveryStepsPerSide read here (post-flow)
+        // reflects the stamp — letting a test assert reload paths preserve the recovery tag.
+        public List<LoadedRun> ProducedRuns { get; } = new List<LoadedRun>();
+
         public RecordingLoader(double optSensitivity = 10.0, int seedSensitivity = 2) {
             this.optSensitivity = optSensitivity;
             this.seedSensitivity = seedSensitivity;
@@ -185,11 +190,13 @@ public class StarDetectionOptimizerWizardVMTests {
 
         private LoadedRun Make(string folder, IReadOnlyList<FrameLabels> labels) {
             var data = new RunEvaluationData(RunIdFor(folder), NineFrames(), OptimizableDetect(optSensitivity), NewAlglib(), DefaultFitConfig(), labels);
-            return new LoadedRun {
+            var run = new LoadedRun {
                 Data = data,
                 Seed = new StarDetectorParams { Sensitivity = seedSensitivity, StarClippingMultiplier = 2.0 },
                 AfOptions = new AutoFocusEngineOptions { AutoFocusStepSize = DefaultStepSize, AutoFocusInitialOffsetSteps = 4 }
             };
+            ProducedRuns.Add(run);
+            return run;
         }
 
         public Task<LoadedRun> LoadSavedRunAsync(string attemptFolderPath, StarDetectionRegion region, CancellationToken token) =>
@@ -1580,6 +1587,89 @@ public class StarDetectionOptimizerWizardVMTests {
         Assert.Multiple(() => {
             Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Summary));
             Assert.That(run.Data.RecoveryStepsPerSide, Is.EqualTo(0), "a Replay start leaves recovery inert regardless of the box value");
+        });
+    }
+
+    // Reload-survival regression: the load-and-stamp choke-point must keep the recovery tag on EVERY reload path
+    // (re-optimize AND continue). A future change that drops the stamp from a reload path must fail these. The
+    // RecordingLoader manufactures a fresh run per load and records them, so we can inspect the runs the RELOAD
+    // produced (after the originating Start's runs) and assert their stamped RecoveryStepsPerSide.
+
+    [Test]
+    public async Task ReOptimize_Live_ReloadedRunKeepsRecoveryTag() {
+        var loader = new RecordingLoader();
+        var engine = LiveEngine(_ => new AutoFocusResult { Succeeded = true, SaveFolder = @"C:\live\attempt" });
+        var vm = NewVM(loader, isCameraConnected: () => true, isFocuserConnected: () => true, autoFocusEngine: engine,
+            frameReviewBuilder: new FakeReviewBuilder().Build);
+        vm.SourceMode = SourceMode.Live;
+        vm.SaveFolderPath = @"C:\live";
+        vm.FocusRecoverySteps = 2;
+
+        await vm.StartAsync(CancellationToken.None);
+        await vm.ReviewCommand.ExecuteAsync(null);
+        vm.ReviewVM.AddMissedBox(150.0, 175.0, 18.0, 18.0);
+        vm.BackToSummaryCommand.Execute(null);
+        Assert.That(vm.ReOptimizeCommand.CanExecute(null), Is.True, "precondition: labeled + idle => re-optimize enabled");
+
+        var producedBeforeReload = loader.ProducedRuns.Count;
+        await vm.ReOptimizeCommand.ExecuteAsync(null);
+
+        var reloaded = loader.ProducedRuns.Skip(producedBeforeReload).ToList();
+        Assert.Multiple(() => {
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Summary));
+            Assert.That(reloaded, Is.Not.Empty, "the re-optimize path re-loaded at least one run");
+            Assert.That(reloaded.All(r => r.Data.RecoveryStepsPerSide == 2), Is.True,
+                "the re-optimize reload preserved the recovery tag (snapshot N=2)");
+        });
+    }
+
+    [Test]
+    public async Task Continue_Live_ReloadedRunKeepsRecoveryTag() {
+        var loader = new RecordingLoader();
+        var engine = LiveEngine(_ => new AutoFocusResult { Succeeded = true, SaveFolder = @"C:\live\attempt" });
+        var vm = NewVM(loader, isCameraConnected: () => true, isFocuserConnected: () => true, autoFocusEngine: engine,
+            frameReviewBuilder: new FakeReviewBuilder().Build);
+        vm.SourceMode = SourceMode.Live;
+        vm.SaveFolderPath = @"C:\live";
+        vm.FocusRecoverySteps = 2;
+
+        await vm.StartAsync(CancellationToken.None);
+        Assert.That(vm.CanContinueOptimization, Is.True, "precondition: an optimize pass ran so continue is available");
+
+        var producedBeforeReload = loader.ProducedRuns.Count;
+        await vm.ContinueOptimizationCommand.ExecuteAsync(null);
+
+        var reloaded = loader.ProducedRuns.Skip(producedBeforeReload).ToList();
+        Assert.Multiple(() => {
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Summary));
+            Assert.That(reloaded, Is.Not.Empty, "the continue path re-loaded at least one run");
+            Assert.That(reloaded.All(r => r.Data.RecoveryStepsPerSide == 2), Is.True,
+                "the continue reload preserved the recovery tag (snapshot N=2)");
+        });
+    }
+
+    [Test]
+    public async Task ReOptimize_Replay_ReloadedRunStaysUntagged() {
+        // The mirror case: a Replay reload must stay inert (0) even with the recovery box set, because the snapshot
+        // was taken as 0 at a Replay Start — so the tag never leaks onto a replay's re-optimize pass.
+        var loader = new RecordingLoader();
+        var vm = NewVM(loader, frameReviewBuilder: new FakeReviewBuilder().Build);
+        vm.FocusRecoverySteps = 5; // Replay must ignore this
+        vm.SourcePaths[0] = @"C:\reopt-run";
+
+        await vm.StartAsync(CancellationToken.None);
+        await vm.ReviewCommand.ExecuteAsync(null);
+        vm.ReviewVM.AddMissedBox(150.0, 175.0, 18.0, 18.0);
+        vm.BackToSummaryCommand.Execute(null);
+
+        var producedBeforeReload = loader.ProducedRuns.Count;
+        await vm.ReOptimizeCommand.ExecuteAsync(null);
+
+        var reloaded = loader.ProducedRuns.Skip(producedBeforeReload).ToList();
+        Assert.Multiple(() => {
+            Assert.That(reloaded, Is.Not.Empty, "the re-optimize path re-loaded at least one run");
+            Assert.That(reloaded.All(r => r.Data.RecoveryStepsPerSide == 0), Is.True,
+                "a Replay reload stays untagged regardless of the box value");
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -23,6 +23,7 @@ using NINA.WPF.Base.ViewModel.AutoFocus;
 using NSubstitute;
 using NSubstitute.Core;
 using NUnit.Framework;
+using OxyPlot.Series;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -2651,6 +2652,88 @@ public class StarDetectionOptimizerWizardVMTests {
         // Toggling away from Feedback hides the comparison.
         vm.SelectedVariant = OptimizationVariant.Optimized;
         Assert.That(vm.HasStarCountChanges, Is.False, "the comparison only shows on the feedback variant");
+    }
+
+    // ---- Recovery-point partitioning (chart's hollow-marker overlay) -----------------------------------
+
+    private static ScatterErrorPoint Sep(double x, double y = 2.0) => new ScatterErrorPoint(x, y, 0, 0.1);
+
+    [Test]
+    public void PartitionRecoveryPoints_RecoveryOff_AllCore_NoRecovery() {
+        // FrameIsRecovery == null (the baseline / feature-off case) ⇒ every point is core, the overlay is empty.
+        var points = new List<ScatterErrorPoint> { Sep(100), Sep(200), Sep(300) };
+        var eval = new RunEvaluationResult {
+            Points = points,
+            Metrics = new RunEvaluationMetrics {
+                FrameIsRecovery = null,
+                FrameFocuserPositions = new[] { 100, 200, 300 }
+            }
+        };
+
+        var (core, recovery) = StarDetectionOptimizerWizardVM.PartitionRecoveryPoints(eval);
+
+        Assert.Multiple(() => {
+            Assert.That(recovery, Is.Empty, "no recovery data ⇒ empty overlay");
+            Assert.That(core.Select(p => p.X), Is.EquivalentTo(points.Select(p => p.X)), "all points are core");
+            Assert.That(core.Count, Is.EqualTo(points.Count));
+        });
+    }
+
+    [Test]
+    public void PartitionRecoveryPoints_SplitsByRecoveryPosition_PartitionIsExactAndDisjoint() {
+        // Positions 100 and 500 are the far-from-focus recovery extremes; 200/300/400 are core. Two frames share
+        // position 100 (both flagged) to prove distinct-position handling doesn't duplicate the single pooled point.
+        var points = new List<ScatterErrorPoint> { Sep(100), Sep(200), Sep(300), Sep(400), Sep(500) };
+        var eval = new RunEvaluationResult {
+            Points = points,
+            Metrics = new RunEvaluationMetrics {
+                FrameFocuserPositions = new[] { 100, 100, 200, 300, 400, 500 },
+                FrameIsRecovery = new[] { true, true, false, false, false, true }
+            }
+        };
+
+        var (core, recovery) = StarDetectionOptimizerWizardVM.PartitionRecoveryPoints(eval);
+
+        Assert.Multiple(() => {
+            Assert.That(recovery.Select(p => p.X), Is.EquivalentTo(new[] { 100.0, 500.0 }), "recovery positions ⇒ overlay");
+            Assert.That(core.Select(p => p.X), Is.EquivalentTo(new[] { 200.0, 300.0, 400.0 }), "the rest ⇒ main series");
+            // core ∪ recovery == points, with no duplication.
+            Assert.That(core.Count + recovery.Count, Is.EqualTo(points.Count));
+            Assert.That(core.Concat(recovery).Select(p => p.X), Is.EquivalentTo(points.Select(p => p.X)));
+        });
+    }
+
+    [Test]
+    public void PartitionRecoveryPoints_RecoveryPositionAbsentFromPoints_EmptyRecovery() {
+        // Un-weighted-fit case: a recovery position is flagged in the metrics but was EXCLUDED from eval.Points
+        // upstream. It therefore matches no point ⇒ the overlay is empty and every present point is core.
+        var points = new List<ScatterErrorPoint> { Sep(200), Sep(300), Sep(400) };
+        var eval = new RunEvaluationResult {
+            Points = points,
+            Metrics = new RunEvaluationMetrics {
+                FrameFocuserPositions = new[] { 100, 200, 300, 400, 500 },
+                FrameIsRecovery = new[] { true, false, false, false, true } // 100 & 500 flagged but not in Points
+            }
+        };
+
+        var (core, recovery) = StarDetectionOptimizerWizardVM.PartitionRecoveryPoints(eval);
+
+        Assert.Multiple(() => {
+            Assert.That(recovery, Is.Empty, "flagged recovery positions absent from Points ⇒ nothing to overlay");
+            Assert.That(core.Select(p => p.X), Is.EquivalentTo(points.Select(p => p.X)), "all present points are core");
+        });
+    }
+
+    [Test]
+    public void OptimizationCurve_HasRecoveryPoints_TrueOnlyWhenNonEmpty() {
+        var none = new OptimizationCurve { RecoveryPoints = null };
+        var empty = new OptimizationCurve { RecoveryPoints = System.Array.Empty<ScatterErrorPoint>() };
+        var some = new OptimizationCurve { RecoveryPoints = new[] { Sep(100) } };
+        Assert.Multiple(() => {
+            Assert.That(none.HasRecoveryPoints, Is.False, "null ⇒ no overlay/caption");
+            Assert.That(empty.HasRecoveryPoints, Is.False, "empty ⇒ no overlay/caption");
+            Assert.That(some.HasRecoveryPoints, Is.True, "non-empty ⇒ overlay/caption shown");
+        });
     }
 
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -37,7 +37,19 @@
           the fitted curve, and a PointAnnotation diamond at the curve minimum (best focus). The default tracker shows
           the per-point readout on hover/click.  -->
     <DataTemplate DataType="{x:Type local:OptimizationCurve}">
-        <oxy:Plot
+        <DockPanel>
+            <!--  Legend for the hollow recovery markers, shown only when the selected variant has recovery points.
+                  ○ = a far-from-focus recovery point (down-weighted in the fit) — deliberately NOT the app's red-cross
+                  "rejected point" language, since these points are present, just down-weighted.  -->
+            <TextBlock
+                DockPanel.Dock="Bottom"
+                Margin="6,2,0,0"
+                HorizontalAlignment="Left"
+                FontSize="10"
+                Foreground="{StaticResource SecondaryBrush}"
+                Text="&#x25CB; recovery point — down-weighted in fit"
+                Visibility="{Binding HasRecoveryPoints, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+            <oxy:Plot
             MinHeight="240"
             Background="{StaticResource BackgroundBrush}"
             PlotAreaBackground="{StaticResource BackgroundBrush}"
@@ -71,11 +83,26 @@
                     Title="Focuser position" />
             </oxy:Plot.Axes>
             <oxy:Plot.Series>
+                <!--  Recovery overlay: the far-from-focus, down-weighted points rendered as hollow rings (transparent
+                      fill + faint primary stroke) with a dimmed error bar, so they read as "present but down-weighted"
+                      WITHOUT the red-cross "rejected point" language. Declared BEFORE the main series so it draws
+                      underneath. Empty (nothing drawn) when recovery is off, so this is inert at the baseline.  -->
+                <oxy:ScatterErrorSeries
+                    ErrorBarColor="{Binding Path=Color, Source={StaticResource NotificationErrorBrush}, Converter={StaticResource SetAlphaToColorConverter}, ConverterParameter=100}"
+                    ErrorBarStopWidth="2"
+                    ErrorBarStrokeThickness="1"
+                    ItemsSource="{Binding RecoveryPoints}"
+                    MarkerFill="Transparent"
+                    MarkerSize="5"
+                    MarkerStroke="{Binding Path=Color, Source={StaticResource PrimaryBrush}, Converter={StaticResource SetAlphaToColorConverter}, ConverterParameter=150}"
+                    MarkerStrokeThickness="1.5"
+                    MarkerType="Circle"
+                    TrackerFormatString="Focuser: {2:0}, HFR: {4:0.000} (recovery)" />
                 <oxy:ScatterErrorSeries
                     ErrorBarColor="{Binding Path=Color, Source={StaticResource NotificationErrorBrush}}"
                     ErrorBarStopWidth="2"
                     ErrorBarStrokeThickness="2"
-                    ItemsSource="{Binding Points}"
+                    ItemsSource="{Binding CorePoints}"
                     MarkerFill="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
                     MarkerType="Circle"
                     TrackerFormatString="Focuser: {2:0}, HFR: {4:0.000}" />
@@ -91,7 +118,8 @@
                     X="{Binding Minimum.X}"
                     Y="{Binding Minimum.Y}" />
             </oxy:Plot.Annotations>
-        </oxy:Plot>
+            </oxy:Plot>
+        </DockPanel>
     </DataTemplate>
 
     <!--  Fitted focus graph for a registered star WITH an accepted fit (Review Frames hover): plain scatter (NO error

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -28,6 +28,7 @@
     <TextBlock x:Key="SDOpt_LiveExposure_Tooltip" Text="The exposure for every frame of the sweep, starting from your profile's auto-focus exposure. Make it long enough that stars stay visible out at the defocused ends of the sweep. Narrowband filters usually need a longer exposure to start. After a good result you can adopt this exposure into your profile from the summary." />
     <TextBlock x:Key="SDOpt_LiveSaveFolder_Tooltip" Text="The captured frames are saved here, in a timestamped AutoFocus_… subfolder, then loaded back like a saved run so the optimizer can search them. A folder is required before Start. Choosing one also saves it as your Hocus Focus auto-focus save path." />
     <TextBlock x:Key="SDOpt_TargetFilter_Tooltip" Text="Per-filter star detection is enabled, so this run tunes ONE filter's settings set. The baseline and 'current settings' come from this filter's set; a live sweep moves the wheel to this filter and exposes through it; and Accept writes the optimized result into this filter's set." />
+    <TextBlock x:Key="SDOpt_FocusRecovery_Tooltip" Text="Widens the live sweep by this many extra steps on EACH side, so the auto-focus curve can still bracket focus when you start well off focus. The extra far-from-focus frames are down-weighted in the fit and exempt from the star-count requirements, so they help find focus without skewing it. Set 0 to disable recovery." />
 
     <!--  Auto-focus curve chart for ONE settings variant. The Summary panel hosts this via a ContentControl bound to
           SelectedCurve, so toggling the variant rebuilds the plot from a fresh OptimizationCurve instance (a robust
@@ -425,6 +426,33 @@
                         <StackPanel Margin="0,8,0,0" Orientation="Horizontal">
                             <TextBlock Width="200" VerticalAlignment="Center" Text="Step size" />
                             <TextBlock VerticalAlignment="Center" Text="{Binding SweepStepSize}" />
+                        </StackPanel>
+                        <!--  Editable focus recovery: widen the sweep by N extra steps on each side so the curve can
+                              bracket focus even when starting well off focus. The resulting point count shows directly
+                              below (SweepPointCount already reflects the widened total). 0 disables recovery.  -->
+                        <StackPanel Margin="0,2" Orientation="Horizontal">
+                            <TextBlock
+                                Width="200"
+                                VerticalAlignment="Center"
+                                Text="Focus recovery (extra steps/side)"
+                                ToolTip="{StaticResource SDOpt_FocusRecovery_Tooltip}" />
+                            <TextBox
+                                MinWidth="80"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                ToolTip="{StaticResource SDOpt_FocusRecovery_Tooltip}">
+                                <TextBox.Text>
+                                    <Binding Path="FocusRecoverySteps" UpdateSourceTrigger="LostFocus">
+                                        <Binding.ValidationRules>
+                                            <rules:IntRangeRule>
+                                                <rules:IntRangeRule.ValidRange>
+                                                    <rules:IntRangeChecker Maximum="25" Minimum="0" />
+                                                </rules:IntRangeRule.ValidRange>
+                                            </rules:IntRangeRule>
+                                        </Binding.ValidationRules>
+                                    </Binding>
+                                </TextBox.Text>
+                            </TextBox>
                         </StackPanel>
                         <StackPanel Margin="0,2" Orientation="Horizontal">
                             <TextBlock Width="200" VerticalAlignment="Center" Text="Number of points" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationCurve.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationCurve.cs
@@ -40,7 +40,21 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
     /// </summary>
     public sealed class OptimizationCurve {
         public string Label { get; set; }
+
+        /// <summary>The FULL pooled scatter set (core ∪ recovery). Remains the set backing <see cref="Bounds"/> and
+        /// <see cref="HasFit"/>, so axis extents and fit-presence are unaffected by the core/recovery split. The chart
+        /// draws the split subsets (<see cref="CorePoints"/> + <see cref="RecoveryPoints"/>), not this list directly.</summary>
         public IReadOnlyList<ScatterErrorPoint> Points { get; set; }
+
+        /// <summary>The NON-recovery subset of <see cref="Points"/> — the near-focus points the MAIN scatter series draws.
+        /// <c>Points == CorePoints ∪ RecoveryPoints</c>. Equal in content to <see cref="Points"/> when recovery is off.</summary>
+        public IReadOnlyList<ScatterErrorPoint> CorePoints { get; set; }
+
+        /// <summary>The far-from-focus recovery subset of <see cref="Points"/> — down-weighted in the fit, drawn as the
+        /// hollow overlay series. Never null (callers set an empty list when there is no recovery). <c>Points ==
+        /// CorePoints ∪ RecoveryPoints</c>.</summary>
+        public IReadOnlyList<ScatterErrorPoint> RecoveryPoints { get; set; }
+
         public AlglibHyperbolicFitting Fit { get; set; }
 
         /// <summary>Accepted star count per frame for this variant's params (parallel to
@@ -68,6 +82,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
         /// <summary>True when there is a real fit and at least one scatter point to plot.</summary>
         public bool HasFit => Fit != null && Points != null && Points.Count > 0;
+
+        /// <summary>True when there is at least one far-from-focus recovery point to draw as the hollow overlay (and to
+        /// show the "recovery point" caption). False when recovery is off or every recovery position was excluded upstream.</summary>
+        public bool HasRecoveryPoints => RecoveryPoints != null && RecoveryPoints.Count > 0;
     }
 
     /// <summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationObjective.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationObjective.cs
@@ -307,9 +307,24 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             var effRecall = recall ?? m.Recall;
             var effPrecision = precision ?? m.Precision;
 
-            // Hard constraint: too many starved frames.
+            // Hard constraint: too many starved frames. Far-from-focus RECOVERY frames (m.FrameIsRecovery[i] == true)
+            // are EXEMPT — they routinely detect < NHard stars by design, so counting them would force J = 0 for every
+            // candidate and make the wizard unusable. When FrameIsRecovery is null (the baseline — every legacy caller /
+            // Replay / production autofocus) the recovery guard is never taken, so `below` reduces EXACTLY to
+            // FrameStarCounts.Count(n => n < c.NHard) and J stays byte-identical.
             if (m.FrameStarCounts != null) {
-                var below = m.FrameStarCounts.Count(n => n < c.NHard);
+                var counts = m.FrameStarCounts;
+                var isRecovery = m.FrameIsRecovery;
+                var below = 0;
+                for (var i = 0; i < counts.Count; i++) {
+                    if (counts[i] >= c.NHard) {
+                        continue;
+                    }
+                    if (IsRecoveryFrame(isRecovery, i)) {
+                        continue; // exempt tagged recovery frame from the hard floor
+                    }
+                    below++;
+                }
                 if (below > c.MaxFramesBelowHardFloor) {
                     return 0.0;
                 }
@@ -319,7 +334,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             if (double.IsNaN(sFocus)) {
                 return 0.0; // unusable focus σ => hard fail
             }
-            var sStars = SStars(m.FrameStarCounts, c);
+            // S_stars is computed over the NON-recovery frames only: nMin/nMedian must not be dragged down by the
+            // heavily-defocused recovery wings. NonRecoveryStarCounts returns the ORIGINAL list reference when
+            // FrameIsRecovery is null, so this is byte-identical at the baseline.
+            var sStars = SStars(NonRecoveryStarCounts(m), c);
             var sFit = SFit(m.RSquared, m.ReducedChiSquared, c);
 
             // Region-coverage reward: an ADDITIVE sub-score folded into the renormalized weighted sum. Active only
@@ -394,7 +412,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             if (m?.FrameStarCounts == null || m.FrameStarCounts.Count == 0) {
                 return 0.0;
             }
-            var nMean = m.FrameStarCounts.Average();
+            // The tie-breaker is active by default (Wtie > 0) and is NOT near-focus-windowed, so the far-out recovery
+            // wings WOULD bias this plateau-search mean. Take it over the NON-recovery frames only. NonRecoveryStarCounts
+            // returns the ORIGINAL list reference when FrameIsRecovery is null ⇒ this mean is byte-identical at the baseline.
+            var nMean = NonRecoveryStarCounts(m).Average();
             // Unsaturating total-star richness: mean/(mean+k), half-saturated at the S_stars target knee.
             var tStars = nMean / (nMean + c.NTarget);
 
@@ -431,6 +452,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// (total relaxed / total accepted), guarded by <see cref="ObjectiveConstants.MinFramesForPenalty"/> and
         /// <see cref="ObjectiveConstants.MinAcceptedForPenalty"/> so a thin run can't be spuriously penalized.</para>
         ///
+        /// <para>Recovery frames (<see cref="RunEvaluationMetrics.FrameIsRecovery"/>[i] == true) are EXEMPT on BOTH
+        /// paths — numerator, denominator, the zero-relaxation short-circuit, and the fallback frame-count gate all
+        /// skip them. A recovery frame is heavily defocused by design, so its by-design donut relaxation must never
+        /// drive a NEAR-FOCUS precision penalty even when a short/skewed sweep places a recovery position inside the
+        /// near-focus window. When <see cref="RunEvaluationMetrics.FrameIsRecovery"/> is null (the baseline) every skip
+        /// is inert, so J is byte-identical.</para>
+        ///
         /// <para>Penalty shape (both signals): <c>1 − Strength · max(0, relaxedFrac − Threshold)</c>, clamped to
         /// [<see cref="ObjectiveConstants.DefocusPrecisionMinFactor"/>, 1]. At or below the threshold the factor is
         /// exactly 1.0.</para>
@@ -446,10 +474,19 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             }
 
             // Cheap short-circuit: zero relaxation anywhere ⇒ exactly 1.0 (the gate-OFF baseline). This is the
-            // bit-identity guarantee: when every per-frame relaxed count is 0, J is returned unchanged.
+            // bit-identity guarantee: when every per-frame relaxed count is 0, J is returned unchanged. RECOVERY frames
+            // are skipped here so their by-design relaxation never counts toward the penalty (relaxation confined to
+            // recovery frames ⇒ no penalty). nonRecoveryRelaxedFrames counts the NON-recovery frames over the SAME list
+            // the fallback frame-count gate references, so null FrameIsRecovery ⇒ it equals relaxed.Count (byte-identical).
+            var isRecovery = m.FrameIsRecovery;
             long totalRelaxed = 0;
+            var nonRecoveryRelaxedFrames = 0;
             for (var i = 0; i < relaxed.Count; i++) {
+                if (IsRecoveryFrame(isRecovery, i)) {
+                    continue; // recovery relaxation is by-design donut recovery, never a precision defect
+                }
                 totalRelaxed += relaxed[i];
+                nonRecoveryRelaxedFrames++;
             }
             if (totalRelaxed == 0) {
                 return 1.0;
@@ -469,6 +506,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 long nearRelaxed = 0;
                 long nearAccepted = 0;
                 for (var i = 0; i < relaxed.Count; i++) {
+                    // A recovery frame inside the window (the poor-start scenario) is exempt: skipping it drops BOTH its
+                    // relaxed and accepted counts together, so nearFrac stays a pure NON-recovery signal.
+                    if (IsRecoveryFrame(isRecovery, i)) {
+                        continue;
+                    }
                     if (Math.Abs(positions[i] - m.BestFocusPosition) <= window) {
                         nearRelaxed += relaxed[i];
                         nearAccepted += counts[i];
@@ -484,13 +526,19 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             }
 
             // ── Fallback: run-level relaxed fraction (documented choice when no positions/fit minimum) ───────
+            // Denominator skips recovery frames to stay consistent with the recovery-exempt totalRelaxed numerator (so
+            // the fraction can never exceed 1 or spuriously penalize a recovery-heavy run). The frame-count gate uses
+            // nonRecoveryRelaxedFrames (not counts.Count, which can differ from relaxed.Count on the fallback path).
             long totalAccepted = 0;
             if (counts != null) {
                 for (var i = 0; i < counts.Count; i++) {
+                    if (IsRecoveryFrame(isRecovery, i)) {
+                        continue;
+                    }
                     totalAccepted += counts[i];
                 }
             }
-            if (relaxed.Count < c.MinFramesForPenalty || totalAccepted < c.MinAcceptedForPenalty || totalAccepted <= 0) {
+            if (nonRecoveryRelaxedFrames < c.MinFramesForPenalty || totalAccepted < c.MinAcceptedForPenalty || totalAccepted <= 0) {
                 return 1.0; // too thin to trust ⇒ no penalty
             }
             var frac = (double)totalRelaxed / totalAccepted;
@@ -561,8 +609,16 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // Pool the eligible frames' accepted-star HFRs into one robust sample (maximizes n for the median/MAD).
             var pooled = new List<double>();
             var eligibleFrames = 0;
+            var isRecovery = m.FrameIsRecovery;
             for (var i = 0; i < hfrs.Count; i++) {
                 if (canUseNearFocus && Math.Abs(positions[i] - m.BestFocusPosition) > window) {
+                    continue;
+                }
+                // Exempt tagged recovery frames from the pooled HFR sample on BOTH paths. On the near-focus (primary)
+                // path this matters only when a short/skewed sweep places a recovery position inside the window; it also
+                // protects the FALLBACK pool (taken when BestFocusPosition is NaN), which otherwise pools every frame.
+                // Null FrameIsRecovery ⇒ guard never fires ⇒ byte-identical baseline.
+                if (IsRecoveryFrame(isRecovery, i)) {
                     continue;
                 }
                 var fr = hfrs[i];
@@ -651,10 +707,18 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 IsFinite(m.BestFocusPosition) && m.StepSize > 0.0 && c.NearFocusWindowSteps > 0.0;
             var window = canUseNearFocus ? c.NearFocusWindowSteps * m.StepSize : 0.0;
 
+            var isRecovery = m.FrameIsRecovery;
             var sum = 0.0;
             var n = 0;
             for (var i = 0; i < occ.Count; i++) {
                 if (canUseNearFocus && Math.Abs(positions[i] - m.BestFocusPosition) > window) {
+                    continue;
+                }
+                // Exempt tagged recovery frames from the coverage mean on BOTH paths. On the near-focus (primary) path
+                // this matters only when a short/skewed sweep places a recovery position inside the window; it also
+                // protects the FALLBACK average (taken when BestFocusPosition is NaN), which otherwise averages every
+                // finite frame. Null FrameIsRecovery ⇒ guard never fires ⇒ byte-identical baseline.
+                if (IsRecoveryFrame(isRecovery, i)) {
                     continue;
                 }
                 if (!IsFinite(occ[i])) {
@@ -757,6 +821,40 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             }
             return false;
         }
+
+        /// <summary>
+        /// The per-frame accepted-star counts with far-from-focus RECOVERY frames removed (those tagged in
+        /// <see cref="RunEvaluationMetrics.FrameIsRecovery"/>). Recovery frames are the outer, heavily-defocused sweep
+        /// positions that detect few/no stars; they are down-weighted in the fit and must not bias the star-count
+        /// sub-scores or gates. When <see cref="RunEvaluationMetrics.FrameIsRecovery"/> is null (the baseline — every
+        /// legacy caller / Replay / production autofocus) this returns the ORIGINAL list reference unchanged, so all
+        /// downstream star-count math (Min/Median/Average) is byte-identical. If filtering would remove EVERY frame it
+        /// also falls back to the original list, so a caller using Min/Average never sees an empty sequence (in practice
+        /// this can't happen — the recovery tagging always leaves ≥ 3 non-recovery frames).
+        /// </summary>
+        private static IReadOnlyList<int> NonRecoveryStarCounts(RunEvaluationMetrics m) {
+            var counts = m.FrameStarCounts;
+            var isRecovery = m.FrameIsRecovery;
+            if (counts == null || isRecovery == null) {
+                return counts; // baseline: same reference => byte-identical downstream
+            }
+            var filtered = new List<int>(counts.Count);
+            for (var i = 0; i < counts.Count; i++) {
+                if (IsRecoveryFrame(isRecovery, i)) {
+                    continue; // exempt far-from-focus recovery frame
+                }
+                filtered.Add(counts[i]);
+            }
+            return filtered.Count == 0 ? counts : filtered; // never hand back an empty sequence
+        }
+
+        /// <summary>
+        /// True iff frame <paramref name="i"/> is tagged a far-from-focus RECOVERY frame. Bounds-checked so a caller can
+        /// pass a <paramref name="flags"/> list that is null (the baseline ⇒ always false ⇒ byte-identical) or, defensively,
+        /// shorter than the frame axis. The single guard used at every recovery-exemption site (hard floor, SDefocusPrecision,
+        /// SHfrOutlier, SCoverage) so the null/bounds semantics can't drift between them.
+        /// </summary>
+        private static bool IsRecoveryFrame(IReadOnlyList<bool> flags, int i) => flags != null && i < flags.Count && flags[i];
 
         private static bool IsFinite(double v) => !double.IsNaN(v) && !double.IsInfinity(v);
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationObjective.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizationObjective.cs
@@ -210,6 +210,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         // entirely (J bit-identical at the baseline).
         public IReadOnlyList<double> FrameRegionOccupancy { get; set; }
 
+        // Parallel to FrameStarCounts; true ⇒ this frame is a far-from-focus recovery frame
+        // (down-weighted in the fit, exempt from star-count gates). null ⇒ baseline (no recovery).
+        public IReadOnlyList<bool> FrameIsRecovery { get; set; }
+
         // Label scores for this run, supplied by the evaluator only when labels exist; null otherwise. The
         // optimizer passes these straight through to JRun, keeping itself label-agnostic.
         public double? Recall { get; set; }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationData.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/RunEvaluationData.cs
@@ -138,6 +138,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// <summary>Number of DISTINCT focuser positions that fed the fit (frames at the same position are pooled).</summary>
         public int PooledPointCount { get; set; }
 
+        /// <summary>Number of NON-recovery distinct positions actually added to the fit's <see cref="Points"/>. In the
+        /// weighted fit recovery positions ARE added (down-weighted), so this is less than <see cref="PooledPointCount"/>;
+        /// in the un-weighted fit recovery positions are excluded, so it equals <see cref="PooledPointCount"/>. When the
+        /// focus-recovery feature is off (no recovery positions) this equals <see cref="PooledPointCount"/> exactly.</summary>
+        public int NonRecoveryPooledPointCount { get; set; }
+
         /// <summary>The pooled (mean) HFR at each distinct focuser position; for assertions/diagnostics.</summary>
         public IReadOnlyDictionary<int, double> PooledHfrByPosition { get; set; }
 
@@ -200,6 +206,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         // A hyperbola has 4-5 parameters; fewer than this many distinct positions can never determine a fit.
         private const int MinPositionsForFit = 3;
 
+        // Focus-recovery down-weighting: the multiplier applied to a recovery sweep position's pooled scatter (its fit
+        // ErrorY) so its fit weight (1/ErrorY — see HyperbolicFittingAlglib) lands at ≈ 1/RecoveryErrorInflation of a
+        // typical near-focus point's. A far-from-focus "recovery" frame is noisy (few/no stars) and should only PIN the
+        // curve's wings, never STEER the minimum, so it is bracketed in at ~1/10 the weight. Single tuning knob.
+        // Internal (not private) so the test suite can assert the down-weighted ErrorY against the production symbol.
+        internal const double RecoveryErrorInflation = 10.0;
+
         // Region-coverage grid (structural, not a scoring weight): per-frame occupancy is computed over a
         // CoverageGridRows × CoverageGridCols equal tiling of the sensor, matching the inspector's region set. 3×3
         // is coarse enough that a thin-but-spread frame still registers full coverage, yet penalizes corner clusters.
@@ -224,6 +237,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         // the frame fan-out at that value; <= 0 means "use DefaultFrameParallelism". Not persisted; an in-memory knob
         // only (settable so tests can force cap=1 to prove the parallel path ≡ the sequential path).
         public int FrameParallelismOverride { get; set; } = 0;
+
+        // Focus-recovery knob (in-memory, not persisted; mirrors FrameParallelismOverride's style). Number of extra
+        // sweep steps per side captured for focus recovery: the outermost RecoveryStepsPerSide DISTINCT sweep positions
+        // per side are DOWN-WEIGHTED in the AF curve fit (their ErrorY inflated by RecoveryErrorInflation, or excluded
+        // outright when the fit is un-weighted) and TAGGED (FrameIsRecovery) so a later task's objective can exempt them
+        // from the star-count gates. Default 0 ⇒ feature off ⇒ byte-identical: no recovery set is computed, no ErrorY
+        // changes, no fit point is added/removed, and FrameIsRecovery on the metrics is null.
+        public int RecoveryStepsPerSide { get; set; } = 0;
 
         /// <summary>The effective frame-detection concurrency cap for this run: the override when set (> 0), else
         /// <see cref="DefaultFrameParallelism"/>. Always in [1, frameCount].</summary>
@@ -629,12 +650,75 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 measures.Add(new MeasureAndError { Measure = detection.AverageHFR, Stdev = detection.HFRStdDev });
             }
 
+            // Focus-recovery: identify the outermost RecoveryStepsPerSide DISTINCT sweep positions per side (the
+            // far-from-focus extremes). Null when the feature is off / too few positions / the cap collapses perSide to
+            // 0, in which case every downstream value is byte-identical to the baseline (see ComputeRecoveryPositions).
+            var recoveryPositions = ComputeRecoveryPositions(byPosition, RecoveryStepsPerSide);
+
+            // Per-frame recovery flags (PARALLEL to frameStarCounts / frameFocuserPositions). A frame is a recovery
+            // frame iff its DISTINCT focuser position is in the recovery set, so ALL frames sharing a recovery position
+            // are flagged. Left null (never an all-false list) when there is no recovery ⇒ baseline / FrameIsRecovery null.
+            List<bool> frameIsRecovery = null;
+            if (recoveryPositions != null) {
+                frameIsRecovery = new List<bool>(frameFocuserPositions.Count);
+                foreach (var pos in frameFocuserPositions) {
+                    frameIsRecovery.Add(recoveryPositions.Contains(pos));
+                }
+            }
+
             var points = new List<ScatterErrorPoint>(byPosition.Count);
             var pooledHfr = new Dictionary<int, double>(byPosition.Count);
-            foreach (var kvp in byPosition) {
-                var pooled = kvp.Value.AverageMeasurement();
-                pooledHfr[kvp.Key] = pooled.Measure;
-                points.Add(new ScatterErrorPoint(kvp.Key, pooled.Measure, 0, SafeDisplayError(pooled.Stdev)));
+            int nonRecoveryPooledPointCount;
+            if (recoveryPositions == null) {
+                // Baseline path — verbatim: pool every position and add exactly one fit point each (byte-identical).
+                foreach (var kvp in byPosition) {
+                    var pooled = kvp.Value.AverageMeasurement();
+                    pooledHfr[kvp.Key] = pooled.Measure;
+                    points.Add(new ScatterErrorPoint(kvp.Key, pooled.Measure, 0, SafeDisplayError(pooled.Stdev)));
+                }
+                nonRecoveryPooledPointCount = points.Count;
+            } else {
+                // Recovery path: pool each position ONCE (avoid re-pooling), collecting the non-recovery display errors
+                // so we can derive a positive reference scatter for the down-weighting.
+                var pooledByPosition = new List<(int Pos, double Measure, double DisplayError, bool IsRecovery)>(byPosition.Count);
+                var nonRecoveryErrors = new List<double>();
+                foreach (var kvp in byPosition) {
+                    var pooled = kvp.Value.AverageMeasurement();
+                    pooledHfr[kvp.Key] = pooled.Measure;
+                    var displayError = SafeDisplayError(pooled.Stdev);
+                    var isRecovery = recoveryPositions.Contains(kvp.Key);
+                    pooledByPosition.Add((kvp.Key, pooled.Measure, displayError, isRecovery));
+                    if (!isRecovery) {
+                        nonRecoveryErrors.Add(displayError);
+                    }
+                }
+
+                // Reference scatter: the median of the NON-recovery positions' display errors, floored strictly
+                // positive. This keeps the inflated recovery ErrorY positive even when a recovery position's own scatter
+                // is 0 (a single frame there ⇒ SafeDisplayError == 0, and 0 × inflation would be inert / weightless).
+                var medianError = 0.0;
+                if (nonRecoveryErrors.Count > 0) {
+                    (medianError, _) = nonRecoveryErrors.MedianMAD();
+                }
+                var refErr = Math.Max(medianError, 1e-6);
+
+                var addedNonRecovery = 0;
+                foreach (var pp in pooledByPosition) {
+                    if (pp.IsRecovery) {
+                        if (fitConfig.UseWeights) {
+                            // Down-weight: inflate ErrorY so the fit weight (1/ErrorY) is ≈ 1/RecoveryErrorInflation of a
+                            // typical point's. max(ownError, refErr) keeps it strictly positive and never below the ref.
+                            var inflatedError = RecoveryErrorInflation * Math.Max(pp.DisplayError, refErr);
+                            points.Add(new ScatterErrorPoint(pp.Pos, pp.Measure, 0, inflatedError));
+                        }
+                        // Un-weighted fit: ErrorY is ignored by the fitter, so inflation cannot down-weight — EXCLUDE the
+                        // recovery position from the fit input entirely (it still populates the per-frame metrics below).
+                    } else {
+                        points.Add(new ScatterErrorPoint(pp.Pos, pp.Measure, 0, pp.DisplayError));
+                        addedNonRecovery++;
+                    }
+                }
+                nonRecoveryPooledPointCount = addedNonRecovery;
             }
 
             // 3. Fit (or degrade gracefully when there are too few distinct positions).
@@ -649,6 +733,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 FrameFocuserPositions = frameFocuserPositions,
                 FrameStarHFRs = frameStarHfrs,
                 FrameRegionOccupancy = frameRegionOccupancy,
+                // null (never an all-false list) when the focus-recovery feature is off ⇒ baseline.
+                FrameIsRecovery = frameIsRecovery,
                 BestFocusPosition = double.NaN
             };
             AlglibHyperbolicFitting bestFit = null;
@@ -685,6 +771,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 Metrics = metrics,
                 BestFit = bestFit,
                 PooledPointCount = points.Count,
+                NonRecoveryPooledPointCount = nonRecoveryPooledPointCount,
                 PooledHfrByPosition = pooledHfr,
                 Points = points
             };
@@ -763,6 +850,32 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 }
                 return results;
             };
+        }
+
+        /// <summary>
+        /// The outermost <paramref name="recoverySteps"/> DISTINCT sweep positions per side (the far-from-focus
+        /// extremes), taken from the SORTED keys of <paramref name="byPosition"/> — the authoritative distinct
+        /// positions the fit pools on. <c>perSide</c> is capped at <c>(D − MinPositionsForFit) / 2</c> so the fit always
+        /// keeps ≥ <see cref="MinPositionsForFit"/> non-recovery anchor positions (2·perSide ≤ D − MinPositionsForFit).
+        /// Returns <b>null</b> (no recovery) when <paramref name="recoverySteps"/> ≤ 0, there are no positions, or the
+        /// cap collapses perSide to 0 — so the caller's downstream values stay byte-identical to the baseline.
+        /// </summary>
+        private static HashSet<int> ComputeRecoveryPositions(SortedDictionary<int, List<MeasureAndError>> byPosition, int recoverySteps) {
+            var d = byPosition.Count;
+            if (recoverySteps <= 0 || d <= 0) {
+                return null;
+            }
+            var perSide = Math.Min(recoverySteps, Math.Max(0, (d - MinPositionsForFit) / 2));
+            if (perSide <= 0) {
+                return null;
+            }
+            var sortedKeys = byPosition.Keys.ToList(); // ascending distinct sweep positions
+            var recoveryPositions = new HashSet<int>();
+            for (var k = 0; k < perSide; k++) {
+                recoveryPositions.Add(sortedKeys[k]);            // one of the perSide smallest positions
+                recoveryPositions.Add(sortedKeys[d - 1 - k]);    // one of the perSide largest positions
+            }
+            return recoveryPositions;
         }
 
         /// <summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -1973,10 +1973,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     SetProgress("Loading frames", 0, 0);
                     var loadProgress = new Progress<RunLoadProgress>(rp =>
                         SetProgress("Loading frames", rp.Current, rp.Total));
-                    var loaded = await loader.LoadSavedRunAsync(folder, region, null, loadProgress, ResolveBaselineOptionsOverride(), token).ConfigureAwait(true);
-                    // Stamp the recovery snapshot so the evaluator tags the outer sweep frames as recovery. 0 for
-                    // Replay/non-Live => RunEvaluationData is byte-identical to before (FrameIsRecovery stays null).
-                    loaded.Data.RecoveryStepsPerSide = capturedRecoveryStepsPerSide;
+                    // Load + stamp the recovery snapshot together through the single choke-point (see LoadRunStampedAsync).
+                    var loaded = await LoadRunStampedAsync(folder, null, loadProgress, token).ConfigureAwait(true);
                     runs.Add(loaded);
                     // Record the actual folder loaded (in load order) so the re-optimize path can re-read it from disk
                     // after the source Mats are disposed. Snapshotted in SnapshotReviewInputs on full success.
@@ -2003,6 +2001,23 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             foreach (var run in runs) {
                 run?.Data?.Dispose();
             }
+        }
+
+        /// <summary>The SINGLE load-and-stamp choke-point for every run this VM loads. Loads the run through the loader
+        /// exactly as the inline call sites did (same region/baseline-override; each caller still forwards its own
+        /// <paramref name="frameLabels"/> and <paramref name="progress"/>), then stamps the recovery snapshot onto the
+        /// loaded <see cref="RunEvaluationData"/> so the evaluator tags the outer sweep frames as recovery. Every reload
+        /// path (acquire, re-optimize, continue) routes through here, so a future reload site can't ship un-stamped and
+        /// silently drop the tag. Reads the <see cref="capturedRecoveryStepsPerSide"/> field on purpose: continue /
+        /// re-optimize intentionally reuse the originating Start's snapshot. 0 for Replay/non-Live => the stamp is inert
+        /// (RunEvaluationData is byte-identical to before, <see cref="RunEvaluationMetrics.FrameIsRecovery"/> stays null).</summary>
+        private async Task<LoadedRun> LoadRunStampedAsync(
+            string folder, IReadOnlyList<FrameLabels> frameLabels, IProgress<RunLoadProgress> progress, CancellationToken token) {
+            var loaded = await loader.LoadSavedRunAsync(folder, region, frameLabels, progress, ResolveBaselineOptionsOverride(), token).ConfigureAwait(true);
+            if (loaded?.Data != null) {
+                loaded.Data.RecoveryStepsPerSide = capturedRecoveryStepsPerSide;
+            }
+            return loaded;
         }
 
         /// <summary>
@@ -2731,10 +2746,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     var frameLabels = LabelConverter.ToFrameLabels(runLabels);
                     var loadProgress = new Progress<RunLoadProgress>(rp =>
                         SetProgress("Loading frames", rp.Current, rp.Total));
-                    var loaded = await loader.LoadSavedRunAsync(folder, region, frameLabels, loadProgress, ResolveBaselineOptionsOverride(), token).ConfigureAwait(true);
-                    // CRITICAL: stamp the SAME recovery snapshot the first pass used, or the feedback/second optimize
-                    // pass loses the tag and its runs hard-floor on star-count gates, making its J disagree with pass 1.
-                    loaded.Data.RecoveryStepsPerSide = capturedRecoveryStepsPerSide;
+                    // CRITICAL: load + stamp through the single choke-point (LoadRunStampedAsync) so the feedback/second
+                    // optimize pass reuses the SAME recovery snapshot the first pass used — otherwise it loses the tag and
+                    // its runs hard-floor on star-count gates, making its J disagree with pass 1.
+                    var loaded = await LoadRunStampedAsync(folder, frameLabels, loadProgress, token).ConfigureAwait(true);
                     reloaded.Add(loaded);
                 }
 
@@ -2861,11 +2876,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     var folder = reoptimizeRunFolders[i];
                     var loadProgress = new Progress<RunLoadProgress>(rp =>
                         SetProgress("Loading frames", rp.Current, rp.Total));
-                    // No labels for a plain continue (byte-identical to the no-label load).
-                    var loaded = await loader.LoadSavedRunAsync(folder, region, null, loadProgress, ResolveBaselineOptionsOverride(), token).ConfigureAwait(true);
-                    // Same rationale as the re-optimize loop: stamp the recovery snapshot so a continued round keeps the
-                    // recovery tag and its J stays comparable with the prior round. 0 for Replay/N=0 => inert.
-                    loaded.Data.RecoveryStepsPerSide = capturedRecoveryStepsPerSide;
+                    // No labels for a plain continue (byte-identical to the no-label load); load + stamp through the single
+                    // choke-point (LoadRunStampedAsync) so a continued round keeps the recovery tag and its J stays
+                    // comparable with the prior round. 0 for Replay/N=0 => inert.
+                    var loaded = await LoadRunStampedAsync(folder, null, loadProgress, token).ConfigureAwait(true);
                     reloaded.Add(loaded);
                 }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -620,6 +620,28 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             }
         }
 
+        private int focusRecoverySteps = 1;
+
+        /// <summary>Session-only "Focus recovery = N" knob (default 1, VM-only, resets each launch like
+        /// <see cref="StartFromCurrentSettings"/> since the VM is constructed fresh per wizard launch). Only meaningful
+        /// in Live mode: it widens the captured focuser sweep by N extra steps PER SIDE beyond the profile's
+        /// <see cref="SweepOffsetSteps"/> (see <see cref="SweepEffectiveOffsetSteps"/> / <see cref="ApplyFocusRecovery"/>),
+        /// and is snapshotted at Start onto every loaded run's <see cref="RunEvaluationData.RecoveryStepsPerSide"/> so the
+        /// evaluator TAGS those outer frames as recovery (down-weighted in the fit, exempt from star-count gates). Inert
+        /// for Replay and production autofocus: <see cref="SweepEffectiveOffsetSteps"/> adds 0 when not Live, the snapshot
+        /// is 0 unless the run is Live, and <see cref="ApplyFocusRecovery"/> is a no-op at N &lt;= 0.</summary>
+        public int FocusRecoverySteps {
+            get => focusRecoverySteps;
+            set {
+                var clamped = Math.Max(0, value);
+                if (focusRecoverySteps != clamped) {
+                    focusRecoverySteps = clamped;
+                    RaisePropertyChanged();
+                    RaiseSweepReadoutsChanged();
+                }
+            }
+        }
+
         /// <summary>Pass-through to the profile-saved <see cref="IStarDetectionOptions.DefocusAwareDonutDetection"/>
         /// master toggle, surfaced on the wizard start page. Default OFF. UNLIKE <see cref="StartFromCurrentSettings"/>
         /// (VM-only, resets each launch) this is a true profile option: the setter persists IMMEDIATELY on click
@@ -757,7 +779,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         // do not change during the wizard, so they need no change notifications beyond the initial bind.
         public int SweepStepSize => profileService.ActiveProfile.FocuserSettings.AutoFocusStepSize;
         public int SweepOffsetSteps => profileService.ActiveProfile.FocuserSettings.AutoFocusInitialOffsetSteps;
-        public int SweepPointCount => 2 * SweepOffsetSteps + 1;
+
+        /// <summary>The offset-steps-per-side the Live sweep will actually capture: the profile's
+        /// <see cref="SweepOffsetSteps"/> plus the session-only <see cref="FocusRecoverySteps"/> recovery steps. Adds 0
+        /// unless the source is Live, so the Replay readouts (and any production path) are byte-identical to before.</summary>
+        public int SweepEffectiveOffsetSteps => SweepOffsetSteps + (IsLive ? Math.Max(0, FocusRecoverySteps) : 0);
+
+        public int SweepPointCount => 2 * SweepEffectiveOffsetSteps + 1;
         public int SweepFramesPerPoint => profileService.ActiveProfile.FocuserSettings.AutoFocusNumberOfFramesPerPoint;
         public string SweepBinning {
             get {
@@ -820,6 +848,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
         private void RaiseSweepReadoutsChanged() {
             RaisePropertyChanged(nameof(SweepStepSize));
+            RaisePropertyChanged(nameof(SweepEffectiveOffsetSteps));
             RaisePropertyChanged(nameof(SweepPointCount));
             RaisePropertyChanged(nameof(SweepBinning));
             RaisePropertyChanged(nameof(SweepFilterName));
@@ -1448,6 +1477,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         // live capture happened (gates the exposure write-back offer). A fresh Replay run clears the flag.
         private double capturedLiveExposureSeconds;
         private bool lastRunWasLive;
+        // Snapshotted at Start (Live => Math.Max(0, FocusRecoverySteps), else 0) and stamped onto EVERY loaded run's
+        // RunEvaluationData.RecoveryStepsPerSide (acquire AND the re-optimize/feedback reload loop) so both optimize
+        // passes tag the same outer frames as recovery even if the UI box is later edited. 0 for Replay => inert.
+        private int capturedRecoveryStepsPerSide;
 
         private bool LastRunWasLive {
             get => lastRunWasLive;
@@ -1730,6 +1763,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // Whether this fresh run is a Live sweep decides whether the Summary offers the exposure write-back.
             // (Continue/Re-optimize don't reset it — they preserve the original run's nature.)
             LastRunWasLive = SourceMode == SourceMode.Live;
+            // Snapshot the recovery knob NOW so a later edit of the box can't desync the widened capture from the
+            // tagging, nor the first optimize pass from the re-optimize/feedback pass. Replay => 0 (recovery inert).
+            capturedRecoveryStepsPerSide = (SourceMode == SourceMode.Live) ? Math.Max(0, FocusRecoverySteps) : 0;
             ResetVariants();
             // Clear stale progress so a re-run after a cancel/complete doesn't briefly show the previous run's
             // evaluation count / phase / improvement before the first progress callback overwrites them.
@@ -1938,6 +1974,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     var loadProgress = new Progress<RunLoadProgress>(rp =>
                         SetProgress("Loading frames", rp.Current, rp.Total));
                     var loaded = await loader.LoadSavedRunAsync(folder, region, null, loadProgress, ResolveBaselineOptionsOverride(), token).ConfigureAwait(true);
+                    // Stamp the recovery snapshot so the evaluator tags the outer sweep frames as recovery. 0 for
+                    // Replay/non-Live => RunEvaluationData is byte-identical to before (FrameIsRecovery stays null).
+                    loaded.Data.RecoveryStepsPerSide = capturedRecoveryStepsPerSide;
                     runs.Add(loaded);
                     // Record the actual folder loaded (in load order) so the re-optimize path can re-read it from disk
                     // after the source Mats are disposed. Snapshotted in SnapshotReviewInputs on full success.
@@ -2005,6 +2044,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 options.UseExactImagingFilter = true;
             }
 
+            // Widen the captured sweep by the snapshotted recovery steps (never the live box) so the widened capture and
+            // the tagged evaluation use the identical N, and scale the per-run timeout so the longer sweep doesn't time
+            // out. No-op at N <= 0, keeping the Live path byte-identical when recovery is off.
+            ApplyFocusRecovery(options, capturedRecoveryStepsPerSide);
+
             // Route the sweep's progress: the engine's per-point reports (tagged with its source) carry the focuser
             // position + frame count and drive the frame bar; the camera's own reports carry the exposure countdown.
             var captureProgress = new Progress<ApplicationStatus>(HandleCaptureProgress);
@@ -2022,6 +2066,28 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 CaptureContextText = null;
                 CaptureExposureText = null;
                 ExposureProgressMax = 0;
+            }
+        }
+
+        /// <summary>Widens a Live sweep's per-run options for focus recovery: adds <paramref name="recoverySteps"/> extra
+        /// offset steps PER SIDE (widening the sweep RANGE, not refining it — <see cref="AutoFocusEngineOptions.AutoFocusStepSize"/>
+        /// is deliberately untouched) and scales ONLY the per-run <see cref="AutoFocusEngineOptions.AutoFocusTimeout"/>
+        /// override by the point-count ratio so the longer sweep (the fixed sweep enforces a hard timeout) doesn't time
+        /// out. Never touches the persisted profile offset or timeout seconds. A no-op at <paramref name="recoverySteps"/>
+        /// &lt;= 0 (or null options), so the Live path stays byte-identical when recovery is off. Internal + static so the
+        /// widening is directly unit-testable.</summary>
+        internal static void ApplyFocusRecovery(AutoFocusEngineOptions options, int recoverySteps) {
+            if (options == null || recoverySteps <= 0) {
+                return; // N<=0 keeps the Live path byte-identical
+            }
+            var oldOffset = options.AutoFocusInitialOffsetSteps;
+            var oldPoints = 2 * oldOffset + 1;
+            var newOffset = oldOffset + recoverySteps;
+            var newPoints = 2 * newOffset + 1;
+            options.AutoFocusInitialOffsetSteps = newOffset;             // widen range (do NOT touch AutoFocusStepSize — recovery widens, not refines)
+            if (oldPoints > 0 && newPoints > oldPoints) {                // scale ONLY the per-run timeout override (fixed sweep enforces AutoFocusTimeout)
+                var oldTicks = options.AutoFocusTimeout.Ticks;
+                options.AutoFocusTimeout = TimeSpan.FromTicks((long)(oldTicks * (double)newPoints / oldPoints));
             }
         }
 
@@ -2071,7 +2137,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             var results = await AnalyzeWithProgressAsync(runs, guardParams, token).ConfigureAwait(true);
             var anyUsable = false;
             foreach (var eval in results) {
-                if (double.IsFinite(eval.Metrics.SigmaFocus) && eval.PooledPointCount >= MinPositionsForFit) {
+                // Gate on the NON-recovery positions: with recovery frames the raw PooledPointCount is trivially >= 3, so
+                // a starless-near-focus run could pass on recovery positions alone. RecoveryStepsPerSide == 0 =>
+                // NonRecoveryPooledPointCount == PooledPointCount, so Replay/N=0 behavior is unchanged.
+                if (double.IsFinite(eval.Metrics.SigmaFocus) && eval.NonRecoveryPooledPointCount >= MinPositionsForFit) {
                     anyUsable = true;
                     break;
                 }
@@ -2663,6 +2732,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     var loadProgress = new Progress<RunLoadProgress>(rp =>
                         SetProgress("Loading frames", rp.Current, rp.Total));
                     var loaded = await loader.LoadSavedRunAsync(folder, region, frameLabels, loadProgress, ResolveBaselineOptionsOverride(), token).ConfigureAwait(true);
+                    // CRITICAL: stamp the SAME recovery snapshot the first pass used, or the feedback/second optimize
+                    // pass loses the tag and its runs hard-floor on star-count gates, making its J disagree with pass 1.
+                    loaded.Data.RecoveryStepsPerSide = capturedRecoveryStepsPerSide;
                     reloaded.Add(loaded);
                 }
 
@@ -2791,6 +2863,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                         SetProgress("Loading frames", rp.Current, rp.Total));
                     // No labels for a plain continue (byte-identical to the no-label load).
                     var loaded = await loader.LoadSavedRunAsync(folder, region, null, loadProgress, ResolveBaselineOptionsOverride(), token).ConfigureAwait(true);
+                    // Same rationale as the re-optimize loop: stamp the recovery snapshot so a continued round keeps the
+                    // recovery tag and its J stays comparable with the prior round. 0 for Replay/N=0 => inert.
+                    loaded.Data.RecoveryStepsPerSide = capturedRecoveryStepsPerSide;
                     reloaded.Add(loaded);
                 }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -25,6 +25,7 @@ using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review;
 using NINA.Joko.Plugins.HocusFocus.Utility;
 using NINA.Profile.Interfaces;
 using OpenCvSharp;
+using OxyPlot.Series;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -2301,6 +2302,39 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// settings (baseline) and best, averaged across runs), and the recommended step size from the representative (first) run's best
         /// fit, clamped to the focuser's max increment when known.
         /// </summary>
+        /// <summary>
+        /// Splits an evaluation's pooled scatter points into the NON-recovery (core) subset and the far-from-focus
+        /// RECOVERY subset, so the chart can draw the recovery points as a visually-distinct hollow overlay while the
+        /// main series draws only the core. A point is a recovery point iff its focuser position (X, rounded) is one of
+        /// the DISTINCT positions flagged as recovery in <see cref="RunEvaluationMetrics.FrameIsRecovery"/>.
+        ///
+        /// <para>When recovery is OFF (<c>FrameIsRecovery</c> null) — or no position is flagged, or the recovery
+        /// positions were excluded from <c>eval.Points</c> upstream (the un-weighted-fit case) — this returns
+        /// <c>(points, empty)</c>, so <c>CorePoints</c> is content-identical to <c>Points</c> and the overlay is empty:
+        /// rendering is byte-identical to before this feature. <c>core ∪ recovery == points</c> with no duplication.</para>
+        /// </summary>
+        internal static (IReadOnlyList<ScatterErrorPoint> core, IReadOnlyList<ScatterErrorPoint> recovery)
+            PartitionRecoveryPoints(RunEvaluationResult eval) {
+            var points = eval.Points;
+            var metrics = eval.Metrics;
+            if (points == null) return (System.Array.Empty<ScatterErrorPoint>(), System.Array.Empty<ScatterErrorPoint>());
+            if (metrics?.FrameIsRecovery == null || metrics.FrameFocuserPositions == null) {
+                return (points, System.Array.Empty<ScatterErrorPoint>());   // recovery off ⇒ all core, none recovery
+            }
+            var recoverySet = new HashSet<int>();
+            var flags = metrics.FrameIsRecovery;
+            var positions = metrics.FrameFocuserPositions;
+            var n = System.Math.Min(flags.Count, positions.Count);
+            for (var i = 0; i < n; i++) { if (flags[i]) recoverySet.Add(positions[i]); }
+            if (recoverySet.Count == 0) return (points, System.Array.Empty<ScatterErrorPoint>());
+            var core = new List<ScatterErrorPoint>();
+            var recovery = new List<ScatterErrorPoint>();
+            foreach (var p in points) {
+                if (recoverySet.Contains((int)System.Math.Round(p.X))) recovery.Add(p); else core.Add(p);
+            }
+            return (core, recovery);
+        }
+
         private async Task<(OptimizationSummary Summary, OptimizationCurve CurrentCurve, OptimizationCurve OptimizedCurve)>
             BuildSummaryAsync(IReadOnlyList<LoadedRun> runs, OptimizationResult res, CancellationToken token) {
             // The displayed "before" is the user's CURRENT settings (Baseline), NOT the optimizer's default seed.
@@ -2334,13 +2368,17 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 if (double.IsFinite(bestEval.Metrics.SigmaFocus)) { bestSigmaSum += bestEval.Metrics.SigmaFocus; bestSigmaCount++; }
                 if (i == 0) {
                     representativeBestFit = bestEval.BestFit;
+                    var (baselineCore, baselineRecovery) = PartitionRecoveryPoints(baselineEval);
+                    var (bestCore, bestRecovery) = PartitionRecoveryPoints(bestEval);
                     currentCurveLocal = new OptimizationCurve {
                         Label = "Current", Points = baselineEval.Points, Fit = baselineEval.BestFit,
+                        CorePoints = baselineCore, RecoveryPoints = baselineRecovery,
                         FrameStarCounts = baselineEval.Metrics.FrameStarCounts,
                         FrameFocuserPositions = baselineEval.Metrics.FrameFocuserPositions
                     };
                     optimizedCurveLocal = new OptimizationCurve {
                         Label = "Optimized", Points = bestEval.Points, Fit = bestEval.BestFit,
+                        CorePoints = bestCore, RecoveryPoints = bestRecovery,
                         FrameStarCounts = bestEval.Metrics.FrameStarCounts,
                         FrameFocuserPositions = bestEval.Metrics.FrameFocuserPositions
                     };

--- a/plans/focus-recovery-plan.md
+++ b/plans/focus-recovery-plan.md
@@ -1,0 +1,248 @@
+# Plan: "Focus recovery" for the Star Detection Optimizer wizard (Live mode)
+
+## Context
+
+The Star Detection Optimizer wizard's **Live** source mode captures a fixed, non-convergent
+focuser sweep centered on the user's current (rough-focus) position, then optimizes star-detection
+parameters against those frames. The sweep is strictly symmetric: `2·offsetSteps + 1` positions at
+`center ± i·stepSize` (`ComputeSweepPositions`, `AutoFocusEngine.cs:1893`), where `offsetSteps` comes
+from the profile's `AutoFocusInitialOffsetSteps`. This assumes the starting position is genuinely near
+focus. When it is **not** (the user is beyond the sweep's reach), the whole sweep can sit on one flank
+of the focus curve, never bracketing the minimum — so the AF curve fit fails and the optimizer has
+nothing usable to score.
+
+This change adds a **"Focus recovery"** knob to the wizard that widens the Live sweep by *N* extra
+steps per side, giving the fit measurements far enough out to bracket focus even from a poor start. The
+extra far-from-focus frames are noisy (few/no stars), so they are fed to the curve fit at **reduced
+weight** and are **exempt from the optimizer's star-count gates** — otherwise they would break the
+objective (see "Why the exemption is mandatory" below).
+
+**Confirmed scope decisions (from the user):**
+1. **Scope:** the detection-optimizer wizard's **Live mode only**. Production autofocus
+   (`StartBlindFocusPoints`) and Replay mode are untouched and stay byte-identical.
+2. **Extension:** `Focus recovery = N` adds **N steps per side** (symmetric): effective offset =
+   `profile offsetSteps + N`, sweep = `2·(offset+N)+1` positions.
+3. **Weighting:** **fit-only, down-weighted.** Recovery frames feed only the curve fit at reduced
+   weight and are exempt from the star-count hard floor & star-count sub-scores.
+4. **Persistence:** wizard **session-only** VM property, default 1 each launch (like
+   `StartFromCurrentSettings`). No persisted profile option → no `Resources/OptionsDataTemplates.xaml`
+   control needed.
+
+### Why the exemption is mandatory (not just a refinement)
+`OptimizationObjective.JRun` (`OptimizationObjective.cs:300`) has a **hard floor**:
+`MaxFramesBelowHardFloor = 0`, so **any** single frame with `< NHard (3)` accepted stars forces
+`J = 0`. Heavily-defocused recovery frames routinely detect `< 3` stars, so adding them without an
+exemption would zero out **every** candidate and make the wizard unusable. Consideration #2's
+down-weighting is therefore a correctness requirement of consideration #1, not an optional extra.
+
+---
+
+## Implementation
+
+Preserve the file's pervasive **bit-identical-baseline invariant** throughout: when `N == 0`
+(Replay / recovery off), every new list field must be **null** (not an all-false list) and every new
+branch must return the exact current behavior.
+
+### 1. Wizard VM option + readouts — `StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs`
+- Add a session-only VM property mirroring `StartFromCurrentSettings` (~line 607):
+  - `private int focusRecoverySteps = 1;` (field default = 1; the VM is constructed fresh each launch,
+    so no explicit reset is needed).
+  - `public int FocusRecoverySteps { get; set; }` — clamp to `Math.Max(0, value)`, raise
+    `RaisePropertyChanged()` **and** `RaiseSweepReadoutsChanged()` (the point count changes).
+- Effective-offset readouts (the Live readouts at ~758–819 read the profile):
+  - Add `public int SweepEffectiveOffsetSteps => SweepOffsetSteps + (IsLive ? Math.Max(0, FocusRecoverySteps) : 0);`
+  - Change `SweepPointCount` to `2 * SweepEffectiveOffsetSteps + 1` (so `SweepEstimatedFrames` /
+    `SweepEstimatedDurationText` widen automatically).
+  - Add `SweepEffectiveOffsetSteps` to `RaiseSweepReadoutsChanged()` (~821).
+- Recovery is inert for Replay (`SweepEffectiveOffsetSteps` adds 0 when `!IsLive`, and step 3 leaves
+  Replay's `RecoveryStepsPerSide == 0`).
+
+### 2. Widen the Live sweep — `RunLiveAttemptAsync` (~1977), same file
+- Add an **`internal static` helper** so the bump is unit-testable (the file already exposes
+  `HandleCaptureProgress` as `internal`, and the test assembly has `InternalsVisibleTo`):
+  `internal static void ApplyFocusRecovery(AutoFocusEngineOptions options, int recoverySteps)`.
+  - No-op when `recoverySteps <= 0` (keeps N=0 byte-identical).
+  - `options.AutoFocusInitialOffsetSteps += recoverySteps;` (do **not** touch `AutoFocusStepSize` —
+    recovery widens range, it does not refine spacing).
+  - **Scale the timeout** by the point-count ratio, because `CaptureFixedSweepImpl`
+    (`AutoFocusEngine.cs`) enforces `new CancellationTokenSource(options.AutoFocusTimeout)`:
+    `options.AutoFocusTimeout = TimeSpan.FromTicks((long)(oldTicks * (double)newPoints / oldPoints));`
+    Scale only the **per-run override**, never the persisted `AutoFocusTimeoutSeconds` (same discipline
+    as `InspectorVM.ApplySignalAmplification`, `InspectorVM.cs:1228`).
+- Call `ApplyFocusRecovery(options, FocusRecoverySteps);` right after the existing
+  `Save`/`SavePath`/`OverrideAutoFocusExposureTime` mutations, before `CaptureFixedSweepAsync` (~2014).
+
+### 3. Thread the recovery tag into the evaluator → metrics → objective
+- **`RunEvaluationData.cs`:** add `public int RecoveryStepsPerSide { get; set; } = 0;` (mirrors the
+  existing in-memory `FrameParallelismOverride` knob, ~226). Default 0 ⇒ Replay/harness byte-identical.
+- **Wizard, `StartAsync`:** snapshot the applied value alongside `LastRunWasLive` into a new field:
+  `capturedRecoveryStepsPerSide = (SourceMode == SourceMode.Live) ? Math.Max(0, FocusRecoverySteps) : 0;`
+  (snapshot, so a later edit of the box can't desync the two optimize passes).
+- **`AcquireAsync` (~1940)** and the **re-optimize/feedback reload loop (~2665)** — both create fresh
+  `LoadedRun`s via `loader.LoadSavedRunAsync(...)`. After each, set
+  `loaded.Data.RecoveryStepsPerSide = capturedRecoveryStepsPerSide;`.
+  **The reload site is critical** — miss it and the feedback pass loses the tag, so the run suddenly
+  hard-floors and its J disagrees with the first pass.
+- **Recovery-position identification** in `EvaluateAndFitAsync` (~623, over the existing ascending
+  `SortedDictionary<int,…> byPosition`): let `D = byPosition.Count`, `N = RecoveryStepsPerSide`.
+  - `N <= 0` or `D == 0` → no recovery; leave `FrameIsRecovery = null`; build `points` exactly as today.
+  - Else `perSide = Math.Min(N, Math.Max(0, (D - MinPositionsForFit) / 2));` (always leaves ≥3
+    non-recovery anchor positions). Mark the `perSide` smallest and `perSide` largest distinct
+    positions → `HashSet<int> recoveryPositions`. `perSide == 0` → treat as no recovery (null).
+  - This handles failed/missing frames (perSide shrinks), asymmetric loaded sets (extremes of the
+    sorted list), and `FramesPerPoint > 1` (recovery is per distinct position; all frames at that
+    position are flagged).
+  - Build `FrameIsRecovery` parallel to `FrameStarCounts` in the same 604–617 loop as
+    `recoveryPositions.Contains(frames[i].FocuserPosition)`; assign to metrics **only when**
+    `recoveryPositions.Count > 0` (else null).
+- **`OptimizationObjective.cs` `RunEvaluationMetrics` (~179):** add
+  `public IReadOnlyList<bool> FrameIsRecovery { get; set; }` (parallel to `FrameStarCounts`; documented
+  `null ⇒ baseline`, like the other nullable parallel lists).
+
+### 4. Down-weight recovery points in the fit — `RunEvaluationData.cs` pooled-point build (~632)
+Fit weight is `1 / max(|ErrorY|, 1e-6)` (`HyperbolicFittingAlglib.cs:33`), so inflating a recovery
+position's `ErrorY` down-weights it. Two traps the implementation **must** handle:
+- **`ErrorY == 0` far frames** (single-frame or degenerate scatter → `SafeDisplayError` yields 0): a
+  bare `× factor` is inert. Compute a positive reference scatter and floor against it:
+  `refErr = Math.Max(median(SafeDisplayError(stdev) over non-recovery positions), 1e-6);`
+  recovery `ErrorY = RecoveryErrorInflation * Math.Max(SafeDisplayError(pooled.Stdev), refErr);`
+  Ship a documented constant `RecoveryErrorInflation = 10.0` (recovery point ≈ 1/10 the weight of a
+  typical near-focus point — a bracketing point that pins the wings without steering the minimum), as a
+  single tuning knob. (Optional later refinement: distance-grade the factor by ring; ship the flat
+  factor first.)
+- **`UseWeights == false`** (`fitConfig.UseWeights`, from `WeightedHyperbolicFitEnabled`, default
+  **true**): the fit ignores `ErrorY` entirely, so inflation can't down-weight. In this mode, when
+  `recoveryPositions.Count > 0`, **exclude** recovery positions from the fit input `points` (they still
+  populate all per-frame metrics, so the objective exemption and capture accounting are unaffected;
+  only the fit omits them). `PooledPointCount` then counts fitted (non-recovery) positions.
+- Byte-identity: `RecoveryStepsPerSide == 0` ⇒ `recoveryPositions` empty ⇒ no inflation, no exclusion,
+  identical `points`/`ErrorY`/`FrameIsRecovery`.
+
+### 5. Objective exemptions — `OptimizationObjective.cs` `JRun` (`null ⇒ bit-identical` everywhere)
+- **Hard floor (~307):** count starved frames only among non-recovery frames —
+  `below = count of i where FrameStarCounts[i] < c.NHard AND !(FrameIsRecovery?[i] ?? false)`.
+  This is the core fix.
+- **`SStars` (~263):** compute `nMin`/`nMedian` over **non-recovery** frames only (filter the counts by
+  `FrameIsRecovery` before the call, or pass it in). `null ⇒` identical.
+- **`TieBreakerScore` (~389):** it uses `FrameStarCounts.Average()` over **all** frames and is active
+  by default (`Wtie = 0.02`) and is **not** near-focus-windowed — filter recovery frames out of that
+  mean, or recovery wings bias the plateau search. (Surfaced by the plan audit; easy to miss.)
+- **Near-focus penalties (`SDefocusPrecision`/`SHfrOutlier`/`SCoverage`):** no change on the primary
+  path — they already window to `1.5·step` of `BestFocusPosition`, which excludes the outer recovery
+  frames. *Optional low-risk hardening:* add `if (FrameIsRecovery?[i] ?? false) continue;` in their
+  fallback loops (taken only when `BestFocusPosition` is NaN) so even the fallback excludes recovery
+  frames.
+- Thread `FrameIsRecovery` from `EvaluateAndFitAsync`'s metrics assembly (~641) into the new field.
+
+### 6. Wizard UI — `StarDetection/Optimization/DataTemplates.xaml` (wizard XAML, **not** `OptionsDataTemplates.xaml`)
+- Inside the existing `IsLive`-gated `StackPanel` (~line 418), add a **"Focus recovery (extra steps per
+  side)"** integer input near the capture summary (just above the "Number of points" row). Use the
+  file's numeric idiom (`ninactrl:UnitTextBox`/`TextBox`, `UpdateSourceTrigger=LostFocus`) bound to
+  `FocusRecoverySteps` with a **≥ 0** validation rule (there's a `rules:GreaterThanZeroRule` precedent
+  at ~line 458; add/reuse a non-negative-int rule). Add a tooltip string alongside the other
+  `SDOpt_*_Tooltip` resources.
+- The "Number of points" row already binds `SweepPointCount` (now effective), so the widened count shows
+  automatically. Optionally add a small "(includes N recovery steps/side)" note bound to
+  `FocusRecoverySteps`/`SweepEffectiveOffsetSteps`.
+
+### 7. Seed-guard hardening (recommended) — `SeedFitIsUsableAsync` (~2058)
+The guard requires finite σ **and** `PooledPointCount >= 3`. With recovery frames the count is trivially
+≥ 3, so a starless-near-focus run could pass on recovery positions alone. Add
+`NonRecoveryPooledPointCount` to `RunEvaluationResult` (fitted non-recovery positions) and gate on that
+instead. `RecoveryStepsPerSide == 0` ⇒ `NonRecoveryPooledPointCount == PooledPointCount` (unchanged).
+
+### 8. Summary curve (optional, cosmetic) — `BuildSummaryAsync` (~2245)
+Recovery points appear on the plotted Current/Optimized curves (they're in `Points`). Functionally fine.
+Optionally add `IReadOnlyList<bool> FrameIsRecovery` to `OptimizationCurve` and render recovery scatter
+points hollow/greyed so the user reads them as down-weighted bracketing points. Not required for
+correctness. (`StepSizeRecommender.Recommend` reads the half-width off the **fitted model**, so
+down-weighted recovery points barely move the recommendation — no change needed there.)
+
+---
+
+## Files to modify
+- `StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs` — VM property + readouts,
+  `ApplyFocusRecovery` helper, `RunLiveAttemptAsync`, snapshot in `StartAsync`, tag in `AcquireAsync`
+  **and** the re-optimize reload loop, seed-guard gate.
+- `StarDetection/Optimization/RunEvaluationData.cs` — `RecoveryStepsPerSide`, recovery-position
+  identification, `ErrorY` inflation, unweighted-mode exclusion, `FrameIsRecovery` +
+  `NonRecoveryPooledPointCount` plumbing.
+- `StarDetection/Optimization/OptimizationObjective.cs` — `RunEvaluationMetrics.FrameIsRecovery`;
+  `JRun` hard-floor + `SStars` + `TieBreakerScore` exemptions.
+- `StarDetection/Optimization/DataTemplates.xaml` — Live-panel recovery control + effective-offset readout.
+
+**Reuse (don't reinvent):** `InspectorVM.ApplySignalAmplification` (option-mutation + timeout-scaling
+precedent), `RunEvaluationData.FrameParallelismOverride` (in-memory knob precedent), `SafeDisplayError`
+(`RunEvaluationData.cs:773`), and the existing `null ⇒ bit-identical` nullable-parallel-list pattern
+throughout `OptimizationObjective.cs`.
+
+---
+
+## Risks & edge cases
+- **`UseWeights == false`** makes `ErrorY` inflation inert → recovery positions must be **excluded** from
+  the fit in that mode (uncommon path; default is weighted).
+- **`ErrorY == 0` recovery points** → the reference-scatter floor (`refErr`) is what actually
+  down-weights them; a bare multiply does nothing. Subtlest correctness point.
+- **`TieBreakerScore` (Wtie = 0.02)** is an un-obvious `FrameStarCounts` consumer, not near-focus
+  windowed — must be filtered.
+- **Re-optimize reload** drops the tag unless `capturedRecoveryStepsPerSide` is re-applied — first vs
+  second pass J divergence / hard-floor.
+- **Timeout scaling** is required (fixed sweep enforces `AutoFocusTimeout`); scale only the per-run
+  override.
+- **True focus near a sweep extreme:** recovery is geometric (outermost N), so a genuinely near-focus
+  outer frame could be down-weighted/exempt. Conservative (never zeroes a good run) and consistent with
+  the confirmed geometric definition; the near-focus penalties still key off `BestFocusPosition`.
+- **`RecoveryErrorInflation` magnitude:** too low ⇒ wings bend the fit; too high ⇒ recovery points add
+  nothing. Ship ~10, cover with a fit-shape test, expose as one constant.
+
+---
+
+## Test plan (NUnit 4.4.0)
+**Wizard VM / helper** (`StarDetectionOptimizerWizardVMTests`, extends existing `CaptureFixedSweepAsync`
+stub + `HandleCaptureProgress` tests):
+- `FocusRecoverySteps` defaults to 1; negative clamps to 0.
+- Widens `SweepEffectiveOffsetSteps`/`SweepPointCount`/`SweepEstimatedFrames` and raises their
+  `PropertyChanged`; only affects readouts in Live mode.
+- `Start_LiveSweep_PassesWidenedOffsetToEngine` — capture the options passed to
+  `CaptureFixedSweepAsync`; assert `AutoFocusInitialOffsetSteps == profileOffset + N` and timeout grew
+  by the point ratio.
+- `ApplyFocusRecovery` direct tests: bumps offset by N; scales timeout by point ratio; zero/negative is
+  a no-op; does not change `AutoFocusStepSize`.
+
+**Evaluator** (`RunEvaluationDataTests`, synthetic frames + fake detector):
+- Marks outermost N-per-side as recovery; recovery positions get inflated `ErrorY` (incl. a zero-scatter
+  recovery point still down-weighted); too-few-positions leaves ≥3 anchors (null when perSide collapses
+  to 0); duplicate positions flag all frames there; unweighted fit excludes recovery from
+  `Points`/`PooledPointCount` but keeps `FrameIsRecovery`; `RecoveryStepsPerSide == 0` is byte-identical
+  (`FrameIsRecovery == null`).
+
+**Objective** (`OptimizationObjectiveTests`):
+- Recovery frames exempt from the hard floor (`J > 0` where it would be 0 without the tag); `SStars`
+  ignores recovery frames; `TieBreakerScore` ignores recovery frames; **`FrameIsRecovery == null` is
+  bit-identical** to the pre-feature `JRun` (the regression guard, parameterized).
+
+---
+
+## Verification (end-to-end)
+1. **Unit suite** — run at **milestones, not after every edit** (per the user's reduced-cadence
+   preference): once after the evaluator + objective changes (steps 3–5, the correctness core), and
+   once as a final gate before completion. Between those, rely on a compile/build to catch breakage.
+   `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`
+   (In this WSL environment use Windows `dotnet.exe` via interop with a `wslpath -w`'d solution path;
+   timeout ~600s. The csproj PostBuild also xcopies the plugin into NINA's plugin folder.)
+   All existing tests must stay green — the `FrameIsRecovery == null` / `RecoveryStepsPerSide == 0`
+   regression guards prove the baseline is untouched.
+2. **In-app (NINA + Windows MCP):** open the Star Detection Optimizer wizard → Live mode; confirm the
+   "Focus recovery" input shows and that "Number of points" / "Total frames" / "Estimated time" widen as
+   it changes. Run a Live sweep starting deliberately **off** focus with recovery = 1–2 and confirm the
+   sweep captures the wider range, the optimizer produces a usable curve+result (does **not** hard-fail
+   on the defocused wings), and the recommended step size is sane.
+3. **Regression:** run a **Replay** optimization and confirm identical behavior to before (recovery
+   inert), and a recovery=0 Live run to confirm the no-op path.
+
+---
+
+## Note on plan location
+Per the project's `CLAUDE.md`, implementation plans live in the repo's `plans/` folder with a
+`-plan.md` suffix. This file is the plan-mode working copy; on execution, save it to
+`plans/focus-recovery-plan.md` in the repo, and `/clear` context before implementing.


### PR DESCRIPTION
## Summary

Adds a **"Focus recovery"** knob to the Star Detection Optimizer wizard's **Live** source mode. When the user starts a Live sweep well off focus, the fixed symmetric sweep can sit entirely on one flank of the focus curve and never bracket the minimum, so the AF-curve fit fails and the optimizer has nothing usable to score. `Focus recovery = N` widens the Live sweep by **N extra steps per side** (effective offset = `profile offset + N`, `2·(offset+N)+1` positions) so the fit can bracket focus from a poor start.

The far-from-focus recovery frames are noisy (few/no stars), so they are:
- **fed to the curve fit at reduced weight** (inflated `ErrorY` ⇒ ~1/10 the fit weight; excluded entirely when the fit is un-weighted), and
- **exempt from the optimizer's star-count gates** — this is a correctness requirement, not a nicety: `JRun`'s hard floor (`MaxFramesBelowHardFloor = 0`) would otherwise let any `< 3`-star recovery frame zero out **every** candidate and make the wizard unusable.

**Scope:** wizard Live mode only. Replay mode and production autofocus (`StartBlindFocusPoints`) are byte-identical — the feature is inert whenever `RecoveryStepsPerSide == 0` (every new nullable parallel list stays `null`, no `ErrorY` changes, no fit point added/removed).

## What changed

- **`RunEvaluationData.cs`** — tag the outermost `N` distinct sweep positions/side (`FrameIsRecovery`), down-weight their pooled fit `ErrorY` with a zero-scatter `refErr` floor, exclude them from the fit in un-weighted mode, expose `NonRecoveryPooledPointCount`. `perSide = min(N, (D−3)/2)` always leaves ≥3 non-recovery anchors.
- **`OptimizationObjective.cs`** — exempt `FrameIsRecovery` frames from the hard floor, `SStars`, `TieBreakerScore`, **and** the near-focus penalties (`SDefocusPrecision`/`SHfrOutlier`/`SCoverage`) on both the near-focus and fallback paths, via a single `IsRecoveryFrame` helper.
- **`StarDetectionOptimizerWizardVM.cs`** — session-only `FocusRecoverySteps` knob (default 1), effective-offset readouts, `ApplyFocusRecovery` (widens the per-run capture + scales only the per-run `AutoFocusTimeout`, never the persisted seconds), a snapshot stamped onto every loaded run through one **load-and-stamp choke-point** (acquire / re-optimize / continue), and a seed-guard that gates on `NonRecoveryPooledPointCount`.
- **`DataTemplates.xaml`** — Live-panel integer control bound to `FocusRecoverySteps` with an `IntRangeRule` (0–25, allows "off"), plus a tooltip. The "Number of points" / "Total frames" / "Estimated time" readouts widen automatically.
- **Results-chart styling (`OptimizationCurve.cs` + `DataTemplates.xaml`)** — recovery scatter points render as **hollow rings** (transparent fill, faded theme-color stroke, faded error bars) on an overlay OxyPlot series, with a conditional caption `○ recovery point — down-weighted in fit`. This reads as "present but down-weighted," deliberately distinct from the app's red-cross "rejected point" language. Design + fidelity by Fable; byte-identical when recovery is off (the overlay is empty and the caption collapses).

## Test Plan

Automated (full suite **2888 passed, 0 failed**):
- [x] `RunEvaluationDataTests` — recovery tagging, `ErrorY` inflation incl. zero-scatter, `perSide` cap, un-weighted exclusion, end-to-end "down-weighting keeps the fitted minimum near truth despite corrupted wings", and an N=0 byte-identical regression guard.
- [x] `OptimizationObjectiveTests` — hard-floor / `SStars` / `TieBreakerScore` / near-focus-penalty exemptions (incl. the `SDefocusPrecision` primary-window leak), and a parameterized `FrameIsRecovery == null` bit-identical regression guard.
- [x] `StarDetectionOptimizerWizardVMTests` — clamp/defaults, Live-widens-vs-Replay-inert readouts, widened-offset + scaled-timeout passed to the engine, `ApplyFocusRecovery` direct tests, reload-survival tests for all reload sites, and the results-chart recovery-point partition (`PartitionRecoveryPoints`) + `HasRecoveryPoints`.

Manual (recommended before merge — requires NINA):
- [ ] Open the wizard → Live mode; confirm the "Focus recovery" input shows and "Number of points" / "Total frames" / "Estimated time" widen as it changes. Run a Live sweep deliberately started **off** focus with recovery = 1–2 and confirm the optimizer produces a usable curve + result (does not hard-fail on the defocused wings) and a sane recommended step size.
- [x] **Results chart, rendered check** — validated via a faithful headless OxyPlot render (same engine + exact `ScatterErrorSeries` styling, real NINA Light + Persian theme colors, stress-test scenario with a large recovery error bar). Fable's verdict: **ship as-is** — the hollow rings read as clearly lighter/subordinate to the solid points in both themes, and the faded error bar does not dominate the ring (the alpha-drop fallback was rejected). A full in-app run in a live NINA is still worthwhile for the end-to-end flow above.
- [ ] Regression: a **Replay** optimization behaves identically to before (recovery inert), and a recovery = 0 Live run confirms the no-op path.

## Notes

- Recovery defaults to **1** (ON) in Live per the plan's confirmed scope decision — conservative (down-weighted + exempt, never zeroes a good run); set 0 to disable.
- Built via sequential subagent tasks, each gated by spec + adversarial-correctness + code-quality review (which caught and fixed a real `SDefocusPrecision` near-focus-window leak the plan's premise missed, and folded three reload-stamp sites into one choke-point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2Tk9ujPg45PkaJRQBsVzU
