### PR TITLE
fix(tilt): show physical image angles in the wizard + camera-simulator tilt adapter

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/SimulatedTiltAdapterVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/SimulatedTiltAdapterVMTests.cs
@@ -839,6 +839,94 @@ public class SimulatedTiltAdapterVMTests {
         });
     }
 
+    // ---- Image-space (physical) angle display on −1 rigs -----------------------------------------------
+    //
+    // SimScrew{N}AngleDegrees are RESPONSE-convention (SimulatedTiltAdapter's contract), 180° from the
+    // physical image position on "CW moves adapter toward the objective" (−1) rigs. The Screw 1 input,
+    // the derived-angle readouts, and the diagram are all image-space, so they must convert — otherwise a
+    // screw physically at the top is drawn/reported at the bottom on −1 rigs. Mirrors the wizard fix
+    // (docs/tilt-wizard-diagram-orientation-design.md); SimScrew stays response-convention internally so
+    // the physics / coherence badge / copy-to-adapter are untouched.
+
+    [Test]
+    public void Screw1AngleInput_NegativeSign_RoundTripsPhysicalToResponseConvention() {
+        var options = Configured(screwCount: 3, curvatureSign: -1);
+        var vm = new SimulatedTiltAdapterVM(options, realAdapterOptions: null);
+
+        vm.Screw1AngleDegrees = 0.0; // physical: screw 1 at the top of the image
+
+        Assert.Multiple(() => {
+            Assert.That(options.SimScrew1AngleDegrees, Is.EqualTo(180.0).Within(1e-9), "stored in the response convention");
+            Assert.That(vm.Screw1AngleDegrees, Is.EqualTo(0.0).Within(1e-9), "reads back the physical angle");
+        });
+    }
+
+    [Test]
+    public void Screw1AngleInput_PositiveSign_IsIdentity() {
+        var options = Configured(screwCount: 3, curvatureSign: 1);
+        var vm = new SimulatedTiltAdapterVM(options, realAdapterOptions: null);
+
+        vm.Screw1AngleDegrees = 30.0;
+
+        Assert.Multiple(() => {
+            Assert.That(options.SimScrew1AngleDegrees, Is.EqualTo(30.0).Within(1e-9));
+            Assert.That(vm.Screw1AngleDegrees, Is.EqualTo(30.0).Within(1e-9));
+        });
+    }
+
+    [Test]
+    public void DerivedAngleDisplays_NegativeSign_ShowPhysicalImageAngles() {
+        // Stored 0/120/240 (response) → physical 180/300/60 on a −1 rig.
+        var options = Configured(screwCount: 3, curvatureSign: -1);
+        var vm = new SimulatedTiltAdapterVM(options, realAdapterOptions: null);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.Screw2AngleDisplay, Is.EqualTo("300.0°"));
+            Assert.That(vm.Screw3AngleDisplay, Is.EqualTo("60.0°"));
+        });
+    }
+
+    [Test]
+    public void DerivedAngleDisplays_PositiveSign_Unchanged() {
+        var options = Configured(screwCount: 3, curvatureSign: 1);
+        var vm = new SimulatedTiltAdapterVM(options, realAdapterOptions: null);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.Screw2AngleDisplay, Is.EqualTo("120.0°"));
+            Assert.That(vm.Screw3AngleDisplay, Is.EqualTo("240.0°"));
+        });
+    }
+
+    [Test]
+    public void Diagram_NegativeSign_DrawsStoredResponseAngleAtItsPhysicalPosition() {
+        // Stored screw 1 = 0° (response) is physically at 180° on a −1 rig → must draw at the BOTTOM
+        // (cy = 100 − 75·cos180 = 175 → Y = 163), not the top.
+        var options = Configured(screwCount: 3, curvatureSign: -1);
+        var vm = new SimulatedTiltAdapterVM(options, realAdapterOptions: null);
+
+        var screw1 = vm.ScrewDiagramItems.Single(i => i.Number == 1);
+        Assert.Multiple(() => {
+            Assert.That(screw1.AngleDegrees, Is.EqualTo(180.0).Within(1e-9), "physical angle");
+            Assert.That(screw1.Y, Is.EqualTo(163.0).Within(0.5), "canvas-bottom");
+        });
+    }
+
+    [Test]
+    public void AngleDisplaysAndDiagram_AdapterDirectionChange_FlipToTheOppositeSide() {
+        // Built +1: stored 0/120/240 == physical; screw 1 at the top.
+        var options = Configured(screwCount: 3, curvatureSign: 1);
+        var vm = new SimulatedTiltAdapterVM(options, realAdapterOptions: null);
+        Assert.That(vm.ScrewDiagramItems.Single(i => i.Number == 1).Y, Is.EqualTo(13.0).Within(0.5));
+        Assert.That(vm.Screw2AngleDisplay, Is.EqualTo("120.0°"));
+
+        options.SimScrewInwardCurvatureSign = -1; // reinterpret 180° away
+
+        Assert.Multiple(() => {
+            Assert.That(vm.ScrewDiagramItems.Single(i => i.Number == 1).Y, Is.EqualTo(163.0).Within(0.5), "screw 1 flips to the bottom");
+            Assert.That(vm.Screw2AngleDisplay, Is.EqualTo("300.0°"), "readouts flip too");
+        });
+    }
+
     // ---- Profile switches ---------------------------------------------------------------------------
 
     [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -766,6 +766,102 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             });
         }
 
+        // ---- Screw-angle display shows the PHYSICAL image position (readout + wizard diagram) --------------
+        //
+        // The persisted Screw{N}AngleDegrees are RESPONSE-convention angles (physical + 180° on
+        // "CW moves adapter toward the objective" / −1 rigs). Both the calibration readout and the
+        // wizard diagram are labelled image-space ("0° points up; image as shown in NINA"), and must
+        // therefore display the PHYSICAL angle — matching the Manual Calibration Entry field — not the
+        // raw stored value. Regression guard for docs/tilt-wizard-diagram-orientation-design.md.
+
+        private static (TiltAdapterWizardVM vm, ITiltAdapterOptions options) BuildCalibrated(
+            int sign, double s1, double s2, double s3, double s4 = double.NaN, int screwCount = 3) {
+            var (vm, options, _, _) = Build(screwCount: screwCount, configureOptions: o => {
+                o.IsCalibrated.Returns(true);
+                o.CalibratedScrewCount.Returns(screwCount);
+                o.ScrewInwardCurvatureSign.Returns(sign);
+                o.Screw1AngleDegrees.Returns(s1);
+                o.Screw2AngleDegrees.Returns(s2);
+                o.Screw3AngleDegrees.Returns(s3);
+                o.Screw4AngleDegrees.Returns(s4);
+            });
+            return (vm, options);
+        }
+
+        [Test]
+        public void RebuildDiagram_NegativeSign_PlacesPhysicalTopScrewAtCanvasTop() {
+            // −1 rig: screw 1 is physically at the TOP (physical 0°), stored as 0+180 = 180°. The
+            // diagram must draw it at canvas-top (cy = 100 − 75·cos0 = 25 → Y = 25 − 12 = 13), NOT at
+            // the bottom (the raw-stored 180° would give cy = 175). Screws 2/3 are physically 120/240.
+            var (vm, _) = BuildCalibrated(sign: -1, s1: 180, s2: 300, s3: 60);
+
+            var screw1 = vm.ScrewDiagramItems.Single(i => i.Number == 1);
+            Assert.Multiple(() => {
+                Assert.That(screw1.AngleDegrees, Is.EqualTo(0.0).Within(1e-9), "physical angle");
+                Assert.That(screw1.Y, Is.EqualTo(13.0).Within(0.5), "canvas-top, not bottom");
+                Assert.That(screw1.X, Is.EqualTo(88.0).Within(0.5), "horizontally centred");
+            });
+        }
+
+        [Test]
+        public void RebuildDiagram_PositiveSign_PlacesScrewsAtStoredAngles() {
+            // +1 rig: stored == physical, so the diagram is unchanged. Screw 1 stored 90° → right edge
+            // (cx = 175, cy = 100 → X = 163, Y = 88). Guards against a double 180° offset.
+            var (vm, _) = BuildCalibrated(sign: 1, s1: 90, s2: 210, s3: 330);
+
+            var screw1 = vm.ScrewDiagramItems.Single(i => i.Number == 1);
+            Assert.Multiple(() => {
+                Assert.That(screw1.AngleDegrees, Is.EqualTo(90.0).Within(1e-9));
+                Assert.That(screw1.X, Is.EqualTo(163.0).Within(0.5));
+                Assert.That(screw1.Y, Is.EqualTo(88.0).Within(0.5));
+            });
+        }
+
+        [Test]
+        public void PhysicalScrewAngles_NegativeSign_ConvertStoredResponseAnglesToPhysical() {
+            // Readout binds these; on a −1 rig they must be the stored angle − 180° (self-inverse).
+            var (vm, _) = BuildCalibrated(sign: -1, s1: 180, s2: 300, s3: 60);
+
+            Assert.Multiple(() => {
+                Assert.That(vm.PhysicalScrew1AngleDegrees, Is.EqualTo(0.0).Within(1e-9));
+                Assert.That(vm.PhysicalScrew2AngleDegrees, Is.EqualTo(120.0).Within(1e-9));
+                Assert.That(vm.PhysicalScrew3AngleDegrees, Is.EqualTo(240.0).Within(1e-9));
+            });
+        }
+
+        [Test]
+        public void PhysicalScrewAngles_PositiveSign_EqualStoredAngles() {
+            var (vm, _) = BuildCalibrated(sign: 1, s1: 90, s2: 210, s3: 330);
+
+            Assert.Multiple(() => {
+                Assert.That(vm.PhysicalScrew1AngleDegrees, Is.EqualTo(90.0).Within(1e-9));
+                Assert.That(vm.PhysicalScrew2AngleDegrees, Is.EqualTo(210.0).Within(1e-9));
+                Assert.That(vm.PhysicalScrew3AngleDegrees, Is.EqualTo(330.0).Within(1e-9));
+            });
+        }
+
+        [Test]
+        public void ScrewInwardCurvatureSignChange_RefreshesPhysicalAnglesAndDiagram() {
+            // Changing the adapter-direction setting flips the physical interpretation by 180°, so both
+            // the readout properties and the diagram must refresh when ScrewInwardCurvatureSign changes.
+            var (vm, options) = BuildCalibrated(sign: 1, s1: 0, s2: 120, s3: 240);
+            // Built on +1: screw 1 (stored 0° = physical top) starts at canvas-top.
+            Assert.That(vm.ScrewDiagramItems.Single(i => i.Number == 1).Y, Is.EqualTo(13.0).Within(0.5));
+
+            var raised = new System.Collections.Generic.List<string>();
+            vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+            options.ScrewInwardCurvatureSign.Returns(-1);
+            options.PropertyChanged += Raise.Event<System.ComponentModel.PropertyChangedEventHandler>(
+                options, new System.ComponentModel.PropertyChangedEventArgs(nameof(ITiltAdapterOptions.ScrewInwardCurvatureSign)));
+
+            Assert.Multiple(() => {
+                Assert.That(raised, Does.Contain(nameof(TiltAdapterWizardVM.PhysicalScrew1AngleDegrees)));
+                Assert.That(raised, Does.Contain(nameof(TiltAdapterWizardVM.PhysicalScrew2AngleDegrees)));
+                // Now interpreted as a −1 rig: physical = 0 + 180 = 180° → screw 1 moves to the bottom.
+                Assert.That(vm.ScrewDiagramItems.Single(i => i.Number == 1).Y, Is.EqualTo(163.0).Within(0.5));
+            });
+        }
+
         [Test]
         public void StepDescription_UsesRotationGlyphs() {
             // Summary-row glyphs must match the guidance legend (⟳ = clockwise / + steps,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltAdapterVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltAdapterVM.cs
@@ -458,12 +458,26 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
             }
         }
 
-        /// <summary>Screws 2..N are derived from Screw 1 + the numbering direction — rendered dimmed, never edited.</summary>
-        public string Screw2AngleDisplay => FormatAngle(options.SimScrew2AngleDegrees);
+        /// <summary>
+        /// Screw 1's PHYSICAL image angle (0° = straight up, increasing clockwise) — what the user enters and
+        /// what the "Screw 1 angle" box shows. The stored <c>SimScrew1AngleDegrees</c> is response-convention
+        /// (see <see cref="SimulatedTiltAdapter"/>), 180° from the physical position on "CW moves adapter toward
+        /// the objective" (−1) rigs; the self-inverse <see cref="TiltScrewGeometry.PhysicalToStoredAngle"/>
+        /// converts both ways. Writing SimScrew1AngleDegrees re-derives screws 2..N and rebuilds the panel via
+        /// <see cref="OnOptionsChanged"/>, which re-raises this property (through RebuildAll).
+        /// </summary>
+        public double Screw1AngleDegrees {
+            get => ToPhysicalAngle(options.SimScrew1AngleDegrees);
+            set => options.SimScrew1AngleDegrees = ToPhysicalAngle(value);
+        }
 
-        public string Screw3AngleDisplay => FormatAngle(options.SimScrew3AngleDegrees);
+        /// <summary>Screws 2..N are derived from Screw 1 + the numbering direction — rendered dimmed, never edited.
+        /// Shown as PHYSICAL image angles, like Screw 1 and the diagram.</summary>
+        public string Screw2AngleDisplay => FormatAngle(ToPhysicalAngle(options.SimScrew2AngleDegrees));
 
-        public string Screw4AngleDisplay => FormatAngle(options.SimScrew4AngleDegrees);
+        public string Screw3AngleDisplay => FormatAngle(ToPhysicalAngle(options.SimScrew3AngleDegrees));
+
+        public string Screw4AngleDisplay => FormatAngle(ToPhysicalAngle(options.SimScrew4AngleDegrees));
 
         public IReadOnlyList<int> ScrewCountOptions { get; } = new[] { 3, 4 };
 
@@ -505,6 +519,12 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
         private int ResolvedCurvatureSign => options.SimScrewInwardCurvatureSign == 0
             ? TiltScrewGeometry.DefaultScrewInwardCurvatureSign
             : Math.Sign(options.SimScrewInwardCurvatureSign);
+
+        /// <summary>Converts a stored response-convention screw angle to its physical image angle (self-inverse;
+        /// identical on +1 rigs, 180° apart on −1). Every image-space display (Screw 1 input, derived readouts,
+        /// the diagram, the row labels) goes through this; the physics keeps consuming the raw stored angle.</summary>
+        private double ToPhysicalAngle(double storedAngle) =>
+            TiltScrewGeometry.PhysicalToStoredAngle(storedAngle, ResolvedCurvatureSign);
 
         public ObservableCollection<TiltScrewDiagramItem> ScrewDiagramItems { get; }
         public ObservableCollection<TiltScrewConnectionLine> ScrewConnectionLines { get; }
@@ -1041,7 +1061,9 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
         private void RebuildRows() {
             Rows.Clear();
             var n = ScrewCount;
-            var angles = SimAngles();
+            // Row labels name the screw's image-space angle / side, so show the PHYSICAL angle (the turn
+            // buttons and coupling text are angle-independent and unaffected).
+            var angles = SimAngles().Select(ToPhysicalAngle).ToArray();
 
             if (n == 3) {
                 for (var i = 0; i < 3; i++) {
@@ -1131,7 +1153,9 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
             ScrewConnectionLines.Clear();
 
             var n = ScrewCount;
-            var angles = SimAngles();
+            // The diagram depicts image space ("0° points up; image as shown in NINA"), so plot the PHYSICAL
+            // position — 180° from the stored response angle on −1 rigs, identical on +1.
+            var angles = SimAngles().Select(ToPhysicalAngle).ToArray();
             if (angles.Take(n).Any(a => !double.IsFinite(a))) return;
 
             var centers = new (double cx, double cy)[n];

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml
@@ -154,7 +154,7 @@
 
                 <TextBlock Grid.Row="7" Grid.Column="0" VerticalAlignment="Center" Text="Screw 1 angle" ToolTip="{StaticResource HFSim_ScrewAngle_Tooltip}" />
                 <ninactrl:UnitTextBox Grid.Row="7" Grid.Column="1" MinWidth="80" Margin="5,2,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="{StaticResource HFSim_ScrewAngle_Tooltip}" Unit="°">
-                    <Binding Path="Options.SimScrew1AngleDegrees" UpdateSourceTrigger="LostFocus">
+                    <Binding Path="Screw1AngleDegrees" UpdateSourceTrigger="LostFocus">
                         <Binding.ValidationRules>
                             <rules:FloatRangeRule>
                                 <rules:FloatRangeRule.ValidRange>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -270,15 +270,15 @@
         <StackPanel>
             <UniformGrid Margin="0,2" VerticalAlignment="Center" Columns="2">
                 <TextBlock HorizontalAlignment="Center" Text="Screw 1" />
-                <TextBlock HorizontalAlignment="Center" Text="{Binding TiltAdapterOptions.Screw1AngleDegrees, StringFormat={}{0:F1}°}" />
+                <TextBlock HorizontalAlignment="Center" Text="{Binding PhysicalScrew1AngleDegrees, StringFormat={}{0:F1}°}" />
             </UniformGrid>
             <UniformGrid Margin="0,2" VerticalAlignment="Center" Columns="2">
                 <TextBlock HorizontalAlignment="Center" Text="Screw 2" />
-                <TextBlock HorizontalAlignment="Center" Text="{Binding TiltAdapterOptions.Screw2AngleDegrees, StringFormat={}{0:F1}°}" />
+                <TextBlock HorizontalAlignment="Center" Text="{Binding PhysicalScrew2AngleDegrees, StringFormat={}{0:F1}°}" />
             </UniformGrid>
             <UniformGrid Margin="0,2" VerticalAlignment="Center" Columns="2">
                 <TextBlock HorizontalAlignment="Center" Text="Screw 3" />
-                <TextBlock HorizontalAlignment="Center" Text="{Binding TiltAdapterOptions.Screw3AngleDegrees, StringFormat={}{0:F1}°}" />
+                <TextBlock HorizontalAlignment="Center" Text="{Binding PhysicalScrew3AngleDegrees, StringFormat={}{0:F1}°}" />
             </UniformGrid>
             <!--  Screw 4 row — collapses when ScrewCount == 3  -->
             <UniformGrid Margin="0,2" VerticalAlignment="Center" Columns="2">
@@ -293,7 +293,7 @@
                     </Style>
                 </UniformGrid.Style>
                 <TextBlock HorizontalAlignment="Center" Text="Screw 4" />
-                <TextBlock HorizontalAlignment="Center" Text="{Binding TiltAdapterOptions.Screw4AngleDegrees, StringFormat={}{0:F1}°}" />
+                <TextBlock HorizontalAlignment="Center" Text="{Binding PhysicalScrew4AngleDegrees, StringFormat={}{0:F1}°}" />
             </UniformGrid>
             <!--  Curvature row — the arrow shows how the curvature effect responds to clockwise screw turns  -->
             <UniformGrid

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -338,6 +338,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     RaisePropertyChanged(nameof(CurvatureSignDescription));
                     RaisePropertyChanged(nameof(CwMovesAdapterTowardObjective));
                     RaisePropertyChanged(nameof(CurvatureSignProvenance));
+                    // The readout + diagram show physical image angles, which are stored ± 180° keyed on
+                    // this sign — refresh both (RebuildDiagram also re-raises the PhysicalScrew* props).
+                    RebuildDiagram();
                 }
                 if (e.PropertyName == nameof(ITiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured)) {
                     RaisePropertyChanged(nameof(CurvatureSignDescription));
@@ -520,6 +523,20 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public ObservableCollection<TiltScrewDiagramItem> ScrewDiagramItems { get; }
         public ObservableCollection<TiltScrewConnectionLine> ScrewConnectionLines { get; }
         public ObservableCollection<TiltMeasurementSummaryRow> StepMeasurementSummary { get; }
+
+        // The calibration readout and the wizard diagram both display the PHYSICAL image position of
+        // each screw (0° = straight up, increasing clockwise) — matching the "Manual Calibration Entry"
+        // field and the diagram's "image as shown in NINA" caption. The persisted Screw{N}AngleDegrees
+        // are RESPONSE-convention angles (the direction a CW turn drives the tilt gradient), which sit
+        // 180° from the physical position on "CW moves adapter toward the objective" (−1) rigs and
+        // coincide with it on the default +1 rig. TiltScrewGeometry.PhysicalToStoredAngle is
+        // self-inverse, so the same call converts stored→physical with the adapter-direction sign in
+        // effect. RebuildDiagram() re-raises these (and the sign-change handler calls it) so the
+        // readout tracks both a re-calibration and a direction change.
+        public double PhysicalScrew1AngleDegrees => TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw1AngleDegrees, tiltAdapterOptions.ScrewInwardCurvatureSign);
+        public double PhysicalScrew2AngleDegrees => TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw2AngleDegrees, tiltAdapterOptions.ScrewInwardCurvatureSign);
+        public double PhysicalScrew3AngleDegrees => TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw3AngleDegrees, tiltAdapterOptions.ScrewInwardCurvatureSign);
+        public double PhysicalScrew4AngleDegrees => TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw4AngleDegrees, tiltAdapterOptions.ScrewInwardCurvatureSign);
 
         public bool IsWizardRunning {
             get => isWizardRunning;
@@ -3232,17 +3249,29 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         }
 
         private void RebuildDiagram() {
+            // RebuildDiagram is the single choke point reached on every calibration, direction, and
+            // profile change — refresh the readout's physical-angle properties here too (before the
+            // early-return guard, so a Clear also updates them).
+            RaisePropertyChanged(nameof(PhysicalScrew1AngleDegrees));
+            RaisePropertyChanged(nameof(PhysicalScrew2AngleDegrees));
+            RaisePropertyChanged(nameof(PhysicalScrew3AngleDegrees));
+            RaisePropertyChanged(nameof(PhysicalScrew4AngleDegrees));
+
             ScrewDiagramItems.Clear();
             ScrewConnectionLines.Clear();
 
             int n = tiltAdapterOptions.ScrewCount;
             if (n < 3 || !IsCalibrationValid) return;
 
+            // Stored angles are RESPONSE-convention; the diagram depicts image space ("0° points up;
+            // image as shown in NINA"), so plot the PHYSICAL position — 180° from stored on −1 rigs,
+            // identical on +1. Self-inverse PhysicalToStoredAngle converts stored→physical.
+            int sign = tiltAdapterOptions.ScrewInwardCurvatureSign;
             var angles = new[] {
-                tiltAdapterOptions.Screw1AngleDegrees,
-                tiltAdapterOptions.Screw2AngleDegrees,
-                tiltAdapterOptions.Screw3AngleDegrees,
-                n == 4 ? tiltAdapterOptions.Screw4AngleDegrees : double.NaN
+                TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw1AngleDegrees, sign),
+                TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw2AngleDegrees, sign),
+                TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw3AngleDegrees, sign),
+                n == 4 ? TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw4AngleDegrees, sign) : double.NaN
             };
 
             var centers = new (double cx, double cy)[n];

--- a/docs/tilt-wizard-diagram-orientation-design.md
+++ b/docs/tilt-wizard-diagram-orientation-design.md
@@ -3,7 +3,11 @@
 **Status:** Fixed (2026-07-22). The durable fix below is implemented — `RebuildDiagram` and the
 info-panel readout both convert to physical via `PhysicalToStoredAngle`, and the diagram/readout now
 refresh on an adapter-direction change. Covered by `TiltAdapterWizardVMTests`
-(`RebuildDiagram_NegativeSign_PlacesPhysicalTopScrewAtCanvasTop` et al.).
+(`RebuildDiagram_NegativeSign_PlacesPhysicalTopScrewAtCanvasTop` et al.). The camera-simulator virtual
+tilt adapter (`SimulatedTiltAdapterVM`) shared the same latent bug — its `SimScrew{N}AngleDegrees` are
+response-convention too — and was fixed the same way: the Screw 1 input, derived-angle readouts, diagram,
+and row labels convert to physical (`ToPhysicalAngle`), while `SimScrew` stays response-convention so the
+physics/coherence/copy paths are untouched. Covered by `SimulatedTiltAdapterVMTests`.
 **Date:** 2026-07-04 (investigation); 2026-07-22 (fix)
 **Trigger:** User reports, refined across two messages:
 1. "The orientation in the tilt adapter calibration wizard is vertically flipped — 0° comes out of the bottom of the image instead of the top."

--- a/docs/tilt-wizard-diagram-orientation-design.md
+++ b/docs/tilt-wizard-diagram-orientation-design.md
@@ -1,7 +1,10 @@
 # Tilt Adapter Wizard — screw-angle ↔ tilt-effect orientation
 
-**Status:** Investigation complete (root cause found, verified). Fix not yet applied.
-**Date:** 2026-07-04
+**Status:** Fixed (2026-07-22). The durable fix below is implemented — `RebuildDiagram` and the
+info-panel readout both convert to physical via `PhysicalToStoredAngle`, and the diagram/readout now
+refresh on an adapter-direction change. Covered by `TiltAdapterWizardVMTests`
+(`RebuildDiagram_NegativeSign_PlacesPhysicalTopScrewAtCanvasTop` et al.).
+**Date:** 2026-07-04 (investigation); 2026-07-22 (fix)
 **Trigger:** User reports, refined across two messages:
 1. "The orientation in the tilt adapter calibration wizard is vertically flipped — 0° comes out of the bottom of the image instead of the top."
 2. (with screenshot) "The user believes when they turn **Screw #2** it actually moves the **top** instead of the bottom."


### PR DESCRIPTION
## Problem

Screw-angle displays in the tilt-adapter UI showed the raw persisted `Screw{N}AngleDegrees`. Those are **response-convention** angles (the direction a CW turn drives the tilt gradient), which are **180° from the physical image position on "CW moves adapter toward the objective" (−1) rigs** and identical on the default +1 rig. Every surface is labelled image-space ("0° points up; image as shown in NINA"), so on −1 rigs a screw physically at the **top** was drawn/reported at the **bottom**.

Root-cause analysis: `docs/tilt-wizard-diagram-orientation-design.md`.

This PR fixes it in **both** places that display screw angles.

## 1. Tilt Adapter Wizard (`fix(tilt-wizard)`)

The wizard's **diagram** and **readout** displayed raw stored angles, while the **Manual Entry** field was already physical — so on −1 rigs the diagram/readout disagreed with the entry field and drew the top screw at the bottom.

- New `PhysicalScrew{1..4}AngleDegrees` VM properties; the readout binds these.
- `RebuildDiagram` plots the physical angle and re-raises the readout properties.
- An adapter-direction change now calls `RebuildDiagram`, so diagram + readout refresh **live**.

| −1 rig, physical top screw | Readout | Diagram |
|---|---|---|
| before | `180.0°` (stored) | **bottom** |
| after | `0.0°` (physical) | **top** |

## 2. Camera-simulator virtual tilt adapter (`fix(camera-sim)`)

Same latent bug, *hidden*: the simulator's Screw 1 **input**, the derived-angle **readouts**, and the **diagram** were **all** raw response, so they agreed with each other but sat 180° from the true physical position on −1 rigs — and the physics acted on the opposite side from where the diagram drew.

- New `Screw1AngleDegrees` wrapper (physical ⇄ response, self-inverse); the input binds it.
- `Screw2/3/4AngleDisplay`, the diagram, and the row labels / side names convert via a `ToPhysicalAngle` helper.
- Direction changes already trigger `RebuildAll`, so everything refreshes live.

## Invariant preserved (both)

`Screw*`/`SimScrew*` stay **response-convention internally** — the guidance/backfocus math, the simulator physics (`SimulatedTiltAdapter`), the coherence badge, and copy-from/to-adapter are all untouched. Only image-space **display + input** convert.

## Tests

TDD, all watched fail first, then pass:
- `TiltAdapterWizardVMTests` — 5 new (`RebuildDiagram_NegativeSign_PlacesPhysicalTopScrewAtCanvasTop`, …).
- `SimulatedTiltAdapterVMTests` — 6 new (`Diagram_NegativeSign_DrawsStoredResponseAngleAtItsPhysicalPosition`, …).

**Full suite: 2899 passed, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2Tk9ujPg45PkaJRQBsVzU
