### PR TITLE
feat(autofocus): robustness when starting far from focus

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusEngineSweepBatteryTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusEngineSweepBatteryTests.cs
@@ -113,7 +113,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
                 //   (2) reversal trace  -> the focuser was actually driven
                 Assert.That(harness.Focuser.MoveHistory, Is.Not.Empty, "the focuser must have been driven through the sweep");
                 //   (3) window-excluded vs rejected partition. The sweep reaches ~40 steps out, well beyond the
-                //       ±(offsetSteps+1)*stepSize window, so Behavior A must have excluded those far points...
+                //       ±(offsetSteps+0.5)*stepSize window, so Behavior A must have excluded those far points...
                 Assert.That(region.WindowExcludedPoints, Is.Not.Null.And.Not.Empty,
                     "far points outside the symmetric window must be surfaced as window-excluded (Behavior A ran)");
                 //       ...and window-exclusion is disjoint from Grubbs rejection by construction.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusEngineSweepBatteryTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusEngineSweepBatteryTests.cs
@@ -1,0 +1,793 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Enum;
+using NINA.Core.Interfaces;
+using NINA.Equipment.Equipment.MyCamera;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Image.ImageAnalysis;
+using NINA.Image.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus.Harness;
+using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NINA.Profile.Interfaces;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
+
+    /// <summary>
+    /// Tier-A deterministic AutoFocus sweep battery. Unlike <c>AutoFocusEngineTests</c> (which only drives the engine to
+    /// failure through all-mocked equipment) and the VM tests (which stub <c>engine.Run</c> wholesale), this fixture
+    /// drives a full, SUCCESSFUL <see cref="AutoFocusEngine.Run"/> in-process: a state-backed focuser that actually
+    /// moves (<see cref="MovingFocuserMediator"/>), an imaging mediator that stamps each frame with its capture-time
+    /// position (<see cref="StampedImagingMediator"/> + <see cref="SweepFrameLedger"/>), and scripted detection
+    /// (<see cref="ScriptedStarDetection"/>) that turns a <see cref="DegradationScenario"/> into HFR/σ/star-count per
+    /// frame — no pixels rendered, fully deterministic.
+    ///
+    /// This file ships the harness INFRA plus the full deterministic scenario battery (C0/C1, A1–A3, B1–B3, F1/F2,
+    /// AB1), built on <see cref="BuildHarness"/> and the three observables it exposes: the final position, the focuser
+    /// <see cref="MovingFocuserMediator.MoveHistory"/>, and the window-excluded-vs-rejected partition on the region
+    /// result. Every scenario below was hand-traced against NINA core's <c>TrendlineFitting</c> semantics (minimum =
+    /// min(Y+ErrorY) over the X-ordered valid points; a point joins the left/right trend only when it lies on that
+    /// side of the minimum AND <c>Y &gt; Minimum.Y + 0.1</c>), so the expected MoveHistory shapes in the comments are
+    /// exact, not aspirational. Two engine facts the assertions deliberately accommodate:
+    /// <list type="bullet">
+    ///   <item>Zero-HFR (starless) points flow into <c>lastValidFocusPoints</c>, so far failure points legitimately
+    ///   appear in <c>WindowExcludedPoints</c> with <c>Measure == 0</c>. Disjointness from <c>RejectedPoints</c> still
+    ///   holds because each refit rebuilds RejectedPoints from the kept subset only.</item>
+    ///   <item>The Grubbs test can numerically flag a point even on exact-hyperbola data (near-zero residual σ), so
+    ///   "RejectedPoints is empty" is only asserted where <c>MaxOutlierRejections = 0</c> pins it.</item>
+    /// </list>
+    /// </summary>
+    [TestFixture]
+    public class AutoFocusEngineSweepBatteryTests {
+
+        // Shared geometry for the battery scenarios (C1 keeps its own local constants + the default DefocusModel
+        // baseline to prove the harness works with the simulator's real optics; everything below uses the steeper
+        // analytic hyperbola from SteepScenario so the trend-walk is exactly hand-traceable).
+        private const int Focus = 10000;
+        private const int StepSize = 5;
+        private const int OffsetSteps = 5;
+
+        [SetUp]
+        public void ResetStaticGuardBefore() {
+            // AutoFocusInProgress is a process-wide static; reset it so each test starts from a known state regardless of
+            // execution order (mirrors AutoFocusEngineTests).
+            AutoFocusEngine.ResetAutoFocusInProgressForTests();
+        }
+
+        [TearDown]
+        public void ResetStaticGuardAfter() {
+            AutoFocusEngine.ResetAutoFocusInProgressForTests();
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        // C1 — Start FAR, clean symmetric curve. Proves the harness drives a full successful sweep end-to-end.
+        // ------------------------------------------------------------------------------------------------------------
+        [Test]
+        public async Task C1_StartFarFromFocus_CleanCurve_BootstrapsAndConvergesNearFocus() {
+            const int focus = 10000;
+            const int stepSize = 5;
+            const int offsetSteps = 5;
+
+            var scenario = DegradationScenario.CleanSymmetric(focus, stepSize);
+            var options = DefaultSweepOptions(scenario, offsetSteps);
+            // C1 tests the base bootstrap (+ the always-on symmetric window). Behavior B's reversal is exercised by the
+            // cutoff scenarios; a clean far start must simply march to focus, so keep the directional cap OFF here.
+            options.MaxBlindStepsPerDirection = 0;
+
+            // Start 40 steps ABOVE focus (the seeds sit on the high side, so the walk naturally descends toward focus).
+            var startPosition = focus + 40 * stepSize;
+            var harness = BuildHarness(scenario, options, startPosition, focuserMin: focus - 5000, focuserMax: focus + 5000);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+            var result = await harness.Engine.Run(options, imagingFilter: null, token: cts.Token, progress: null);
+
+            Assert.That(result, Is.Not.Null, "Run() must produce a result");
+            Assert.Multiple(() => {
+                Assert.That(result.Succeeded, Is.True, "a clean far-from-focus sweep must succeed");
+                Assert.That(result.RegionResults, Has.Length.EqualTo(1), "region==null path yields a single full-frame region");
+
+                var region = result.RegionResults[0];
+                Assert.That(region.EstimatedFinalFocuserPosition, Is.EqualTo(focus).Within(2.0 * stepSize),
+                    "the fitted vertex must land within a couple steps of true focus");
+
+                // The three observables the rest of the battery asserts on — exercised here to prove they are populated:
+                //   (1) final position  -> region.EstimatedFinalFocuserPosition (checked above)
+                //   (2) reversal trace  -> the focuser was actually driven
+                Assert.That(harness.Focuser.MoveHistory, Is.Not.Empty, "the focuser must have been driven through the sweep");
+                //   (3) window-excluded vs rejected partition. The sweep reaches ~40 steps out, well beyond the
+                //       ±(offsetSteps+1)*stepSize window, so Behavior A must have excluded those far points...
+                Assert.That(region.WindowExcludedPoints, Is.Not.Null.And.Not.Empty,
+                    "far points outside the symmetric window must be surfaced as window-excluded (Behavior A ran)");
+                //       ...and window-exclusion is disjoint from Grubbs rejection by construction.
+                var excludedPositions = region.WindowExcludedPoints.Select(p => p.FocuserPosition).ToHashSet();
+                var rejectedPositions = (region.RejectedPoints ?? Array.Empty<AutoFocusRegionPoint>()).Select(p => p.FocuserPosition);
+                Assert.That(rejectedPositions.Any(excludedPositions.Contains), Is.False,
+                    "a point is never both window-excluded and Grubbs-rejected");
+            });
+
+            // The focuser was ultimately commanded to (approximately) the calculated focus point.
+            Assert.That(harness.Focuser.Position, Is.EqualTo(focus).Within(2.0 * stepSize),
+                "the focuser ends at the calculated focus point");
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        // C0 — Inert control. A well-centered clean sweep must be byte-identical whether the knobs are on-but-inert
+        // (window enabled + cap 8, neither ever triggered) or hard-off (window disabled + cap 0). MoveHistory equality
+        // is the strongest cheap byte-identity proxy: identical sampling, identical final-validation move.
+        // ------------------------------------------------------------------------------------------------------------
+        [Test]
+        public async Task C0_WellCentered_KnobsOnButInert_ByteIdenticalToKnobsOff() {
+            // Expected walk (both runs): seeds +5s..+1s, L1 at focus, L2 at -1s (first left-trend point -> break),
+            // queue-left -2s..-5s, final-validation move to 10000. Nothing is far, nothing fails, no cap pressure.
+            var onScenario = SteepScenario();
+            var onOptions = DefaultSweepOptions(onScenario, OffsetSteps);
+            onOptions.SymmetricFocusWindowEnabled = true;
+            onOptions.MaxBlindStepsPerDirection = 8;
+            var onHarness = BuildHarness(onScenario, onOptions, Focus, Focus - 5000, Focus + 5000);
+            var onResult = await RunSweep(onHarness, onOptions);
+
+            var offScenario = SteepScenario();
+            var offOptions = DefaultSweepOptions(offScenario, OffsetSteps);
+            offOptions.SymmetricFocusWindowEnabled = false;
+            offOptions.MaxBlindStepsPerDirection = 0;
+            var offHarness = BuildHarness(offScenario, offOptions, Focus, Focus - 5000, Focus + 5000);
+            var offResult = await RunSweep(offHarness, offOptions);
+
+            Assert.Multiple(() => {
+                Assert.That(onResult.Succeeded, Is.True, "on-but-inert run succeeds");
+                Assert.That(offResult.Succeeded, Is.True, "knobs-off run succeeds");
+                Assert.That(onHarness.Focuser.MoveHistory.ToArray(), Is.EqualTo(offHarness.Focuser.MoveHistory.ToArray()).AsCollection,
+                    "identical focuser trajectories - the knobs must not perturb sampling or the final move");
+                Assert.That(onResult.RegionResults[0].EstimatedFinalFocuserPosition,
+                    Is.EqualTo(offResult.RegionResults[0].EstimatedFinalFocuserPosition),
+                    "identical (bit-for-bit) fitted vertex - the window pass on an all-in-window curve is a pure no-op");
+                Assert.That(onResult.RegionResults[0].WindowExcludedPoints, Is.Empty, "nothing excluded when on-but-inert");
+                Assert.That(offResult.RegionResults[0].WindowExcludedPoints, Is.Empty, "nothing excluded when disabled");
+            });
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        // A1 — Lopsided valid far points. Start 20 steps above focus with clean detection: the descent samples a heavy
+        // right arm (+25s..-5s => 31 valid points). Behavior A must surface everything outside vertex ± 6 steps as
+        // WindowExcluded (never Rejected) and the windowed refit must land on true focus. The flag-off control proves
+        // the exclusion comes from Behavior A alone and that sampling is untouched (identical MoveHistory).
+        // ------------------------------------------------------------------------------------------------------------
+        [Test]
+        public async Task A1_LopsidedFarStart_FarPointsWindowExcluded_NotRejected_FitUsesWindowOnly() {
+            var start = Focus + 20 * StepSize; // 10100
+
+            var scenario = SteepScenario();
+            var options = DefaultSweepOptions(scenario, OffsetSteps);
+            options.MaxBlindStepsPerDirection = 0; // isolate Behavior A
+            var harness = BuildHarness(scenario, options, start, Focus - 5000, Focus + 5000);
+            var result = await RunSweep(harness, options);
+
+            var region = result.RegionResults[0];
+            var excluded = PositionsOf(region.WindowExcludedPoints);
+            var rejected = PositionsOf(region.RejectedPoints);
+            // Every sampled valid point from +7 steps outward is unambiguously outside vertex ± 6*stepSize (the ± 6s
+            // boundary points sit exactly ON the strict boundary, so they are deliberately left out of the assertion).
+            var farPositions = PositionRange(Focus + 7 * StepSize, Focus + 25 * StepSize);
+
+            Assert.Multiple(() => {
+                Assert.That(result.Succeeded, Is.True, "a lopsided clean sweep succeeds");
+                Assert.That(region.EstimatedFinalFocuserPosition, Is.EqualTo(Focus).Within(StepSize),
+                    "the windowed refit lands on true focus");
+                Assert.That(excluded, Is.SupersetOf(farPositions), "every far valid point is window-excluded");
+                Assert.That(excluded.Where(p => Math.Abs(p - Focus) <= 5 * StepSize), Is.Empty,
+                    "no core point (within +/-5 steps of focus) is ever window-excluded");
+                Assert.That(farPositions.Intersect(rejected), Is.Empty,
+                    "far points are categorized as window-excluded, never as Grubbs-rejected");
+                Assert.That(excluded.Intersect(rejected), Is.Empty, "window-excluded and rejected stay disjoint");
+            });
+
+            // Flag-off control: identical sampling (windowing is finalize-only), no exclusions, same vertex.
+            var controlScenario = SteepScenario();
+            var controlOptions = DefaultSweepOptions(controlScenario, OffsetSteps);
+            controlOptions.MaxBlindStepsPerDirection = 0;
+            controlOptions.SymmetricFocusWindowEnabled = false;
+            var controlHarness = BuildHarness(controlScenario, controlOptions, start, Focus - 5000, Focus + 5000);
+            var controlResult = await RunSweep(controlHarness, controlOptions);
+
+            Assert.Multiple(() => {
+                Assert.That(controlResult.Succeeded, Is.True, "control run succeeds");
+                Assert.That(controlResult.RegionResults[0].WindowExcludedPoints, Is.Empty,
+                    "with the internal flag off, nothing is window-excluded");
+                Assert.That(controlHarness.Focuser.MoveHistory.ToArray(), Is.EqualTo(harness.Focuser.MoveHistory.ToArray()).AsCollection,
+                    "windowing is finalize-only: the sampled trajectory is identical with the flag on or off");
+                Assert.That(controlResult.RegionResults[0].EstimatedFinalFocuserPosition, Is.EqualTo(Focus).Within(StepSize),
+                    "on exact-hyperbola data the unwindowed fit finds the same vertex (the pure-data control)");
+            });
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        // A2 — All points in-window. A well-centered sweep samples -5s..+5s only; every point is strictly inside
+        // vertex ± 6 steps, so WindowExcludedPoints must be EMPTY and the fit unaffected.
+        // ------------------------------------------------------------------------------------------------------------
+        [Test]
+        public async Task A2_AllPointsInWindow_WindowExcludedEmpty() {
+            var scenario = SteepScenario();
+            var options = DefaultSweepOptions(scenario, OffsetSteps);
+            options.MaxBlindStepsPerDirection = 0;
+            var harness = BuildHarness(scenario, options, Focus, Focus - 5000, Focus + 5000);
+            var result = await RunSweep(harness, options);
+
+            var region = result.RegionResults[0];
+            Assert.Multiple(() => {
+                Assert.That(result.Succeeded, Is.True);
+                Assert.That(region.WindowExcludedPoints, Is.Empty, "an all-in-window sweep excludes nothing");
+                Assert.That(region.EstimatedFinalFocuserPosition, Is.EqualTo(Focus).Within(1.0),
+                    "noise-free exact-hyperbola data recovers the vertex almost exactly");
+                Assert.That(harness.Focuser.MoveHistory.Min(), Is.EqualTo(Focus - 5 * StepSize), "walk floor is -5 steps");
+                Assert.That(harness.Focuser.MoveHistory.Max(), Is.EqualTo(Focus + 5 * StepSize), "walk ceiling is +5 steps");
+            });
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        // A3 — Start INSIDE a far low-HFR spurious plateau (the detector "sees" false stars in noise at and beyond the
+        // start). Expected engine behavior, hand-traced:
+        //   * initial HFR = 1.1 (spurious, nonzero => the initial gate passes);
+        //   * seeds -13s/-12s are spurious, -11s..-9s are true; the flat plateau can never produce a left-trend point
+        //     (all within TrendlineFitting's fixed 0.1 threshold of the minimum), so the walk marches LEFT deeper into
+        //     the plateau until the directional cap (8 step-outs) fires -> Behavior B's step-out reversal;
+        //   * the forced-right walk then descends the true curve through focus and terminates normally;
+        //   * finalization: with Grubbs disabled (MaxOutlierRejections=0) the WINDOW alone must exclude the whole
+        //     spurious cluster and the refit must land on true focus - the "false minimum does not hijack the center"
+        //     guarantee (window centered on the fitted vertex, not the lowest raw point: the plateau IS the lowest band).
+        // NOTE (engine contract, discovered by tracing): without Behavior B this walk never terminates - a flat low
+        // plateau at the advancing edge can never yield the trend point the stop condition needs. A3 therefore runs
+        // with the cap ON; Behavior A alone cannot rescue a walk that never completes.
+        // FalseSigma is 0.4 (vs SigmaBase 0.1) so the weighted provisional fit is anchored by the true V; the false
+        // plateau still wins every "lowest raw point" comparison (1.1 vs everything except the 1.0 vertex).
+        // ------------------------------------------------------------------------------------------------------------
+        [Test]
+        public async Task A3_StartInsideFarSpuriousPlateau_WindowExcludesFalseMinimum_FinalIsTrueFocus() {
+            var start = Focus - 14 * StepSize; // 9930, inside the plateau (onset 12 steps, left side)
+            var scenario = SteepScenario(s => {
+                s.Spurious = new SpuriousSpec(OnsetSteps: 12, Side: FocusSide.Left, FalseHfr: 1.1, FalseStarCount: 10, FalseSigma: 0.4);
+            });
+            var options = DefaultSweepOptions(scenario, OffsetSteps);
+            options.MaxBlindStepsPerDirection = 8;   // required for termination (see note above)
+            options.MaxOutlierRejections = 0;        // isolate Behavior A: no Grubbs help against the false cluster
+            var harness = BuildHarness(scenario, options, start, Focus - 5000, Focus + 5000);
+            var result = await RunSweep(harness, options);
+
+            var region = result.RegionResults[0];
+            var excluded = PositionsOf(region.WindowExcludedPoints);
+            var history = harness.Focuser.MoveHistory.ToList();
+            // Sampled spurious plateau points: seeds -13s/-12s plus the 8 capped left step-outs (-14s..-21s).
+            var spuriousPositions = PositionRange(Focus - 21 * StepSize, Focus - 12 * StepSize);
+
+            Assert.Multiple(() => {
+                Assert.That(result.Succeeded, Is.True, "the run recovers despite starting inside the false plateau");
+                Assert.That(region.EstimatedFinalFocuserPosition, Is.EqualTo(Focus).Within(StepSize),
+                    "the final vertex is TRUE focus, not the (lower-HFR) spurious plateau");
+                Assert.That(excluded, Is.SupersetOf(spuriousPositions),
+                    "every sampled spurious point is excluded by the symmetric window");
+                Assert.That(excluded.Where(p => Math.Abs(p - Focus) <= 3 * StepSize), Is.Empty,
+                    "the true core of the curve is never excluded");
+                Assert.That(PositionsOf(region.RejectedPoints), Is.Empty,
+                    "MaxOutlierRejections=0 and no starless points: the window alone did all the excluding");
+
+                // Behavior B's step-out reversal is what terminated the plateau march: exactly 8 capped left
+                // step-outs (floor = start + step - 8*step), then a return to the start, then the rightward rescue.
+                Assert.That(history.Min(), Is.EqualTo(start - 7 * StepSize), "left march stopped at exactly the cap");
+                var reversalIndex = history.LastIndexOf(start);
+                Assert.That(reversalIndex, Is.GreaterThan(history.IndexOf(history.Min())),
+                    "the return-to-start (reversal) comes after the capped plateau march");
+                Assert.That(history.Max(), Is.EqualTo(Focus + 5 * StepSize), "the rescue walk tops out at the +5s queue fill");
+            });
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        // B1 — One-direction cutoff: the seed arm (always placed on the high side) is entirely starless because the
+        // right side cuts off at exactly the start distance. All 5 seeds fail => the failure budget trips on the very
+        // first walk iteration => Behavior B returns to the start and forces the LEFT direction, which descends
+        // through true focus and converges. The cap-off control proves the reversal is what rescued the run: without
+        // it the same geometry throws TooManyFailedMeasurements and the sweep fails without ever exploring below the
+        // start.
+        // Expected MoveHistory (capped run): [+5s..+1s seeds] [start = reversal return] [start = L1] [descend ... -1s]
+        // [queue-left -2s..-5s] [final-validation ~focus].
+        // ------------------------------------------------------------------------------------------------------------
+        [Test]
+        public async Task B1_SeedsStarless_ReversalRescuesLeftward_ControlWithoutCapFails() {
+            var start = Focus + 10 * StepSize; // 10050; right side starless beyond exactly 10 steps
+            var scenario = SteepScenario(s => s.RightCutoffSteps = 10);
+            var options = DefaultSweepOptions(scenario, OffsetSteps);
+            options.MaxBlindStepsPerDirection = 8;
+            var harness = BuildHarness(scenario, options, start, Focus - 5000, Focus + 5000);
+            var result = await RunSweep(harness, options);
+
+            var region = result.RegionResults[0];
+            var history = harness.Focuser.MoveHistory.ToList();
+            var excluded = PositionsOf(region.WindowExcludedPoints);
+
+            Assert.Multiple(() => {
+                Assert.That(result.Succeeded, Is.True, "the reversal rescues a start whose entire seed arm is starless");
+                Assert.That(region.EstimatedFinalFocuserPosition, Is.EqualTo(Focus).Within(StepSize));
+
+                // The dead (starless) direction was abandoned, not extended: nothing beyond the seed ceiling.
+                Assert.That(history.Max(), Is.EqualTo(start + OffsetSteps * StepSize),
+                    "the capped direction is never probed beyond the seeds");
+                // Seeds first, then the reversal's return-to-start move.
+                Assert.That(history.Take(OffsetSteps), Is.EqualTo(new[] { start + 5 * StepSize, start + 4 * StepSize, start + 3 * StepSize, start + 2 * StepSize, start + StepSize }).AsCollection,
+                    "the five seed moves descend from start+5s to start+1s");
+                Assert.That(history[OffsetSteps], Is.EqualTo(start), "the sixth move is the reversal's return to the start");
+                Assert.That(history.Min(), Is.EqualTo(Focus - 5 * StepSize), "the rescue walk fills the left arm to -5 steps");
+
+                // Partition: far valid points (+7s..+10s) window-excluded; the starless seed positions also land in
+                // WindowExcluded (with Measure 0) because zero-HFR points remain in the fit-input list. Disjointness holds.
+                Assert.That(excluded, Is.SupersetOf(PositionRange(Focus + 7 * StepSize, Focus + 10 * StepSize)));
+                Assert.That(excluded.Intersect(PositionsOf(region.RejectedPoints)), Is.Empty);
+            });
+
+            // Control: same geometry, cap disabled => TooManyFailedMeasurements aborts the sweep; the engine never
+            // explores below the start (min move = the failure restore to the start position itself).
+            var controlScenario = SteepScenario(s => s.RightCutoffSteps = 10);
+            var controlOptions = DefaultSweepOptions(controlScenario, OffsetSteps);
+            controlOptions.MaxBlindStepsPerDirection = 0;
+            var controlHarness = BuildHarness(controlScenario, controlOptions, start, Focus - 5000, Focus + 5000);
+            var controlResult = await RunSweep(controlHarness, controlOptions);
+
+            Assert.Multiple(() => {
+                Assert.That(controlResult, Is.Not.Null, "the control fails gracefully, not catastrophically");
+                Assert.That(controlResult.Succeeded, Is.False, "without the cap the starless seed arm kills the sweep");
+                Assert.That(controlHarness.Focuser.MoveHistory.Min(), Is.GreaterThanOrEqualTo(start),
+                    "without the reversal the engine never explores the good (left) side");
+            });
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        // B2 — Bootstrap cap respected. Start far above focus with clean stars: the descent can't form a bracket
+        // within the cap (every new point is a fresh minimum), so the STEP-OUT cap fires after exactly 8 left
+        // step-outs — well clear of a focuser travel limit placed 12 steps below the start. The reversal then probes
+        // right into a starless cutoff, exhausts the failure budget, and the run fails GRACEFULLY (both directions
+        // exhausted => TooManyFailedMeasurements, caught) instead of crashing into the "Focuser reached its limit"
+        // exception. The cap-off control shows the hazard is real: the unbounded descent marches into the travel
+        // limit (requested target below the focuser minimum).
+        // ------------------------------------------------------------------------------------------------------------
+        [Test]
+        public async Task B2_CapBoundsExcursion_NoFocuserLimitThrow_ControlMarchesIntoLimit() {
+            var start = Focus + 40 * StepSize;       // 10200
+            var focuserMin = start - 12 * StepSize;  // 10140 — the travel hazard the cap must keep clear of
+            var focuserMax = Focus + 100 * StepSize;
+
+            var scenario = SteepScenario(s => s.RightCutoffSteps = 45); // starless beyond +45 steps (seed top is +45s, valid)
+            var options = DefaultSweepOptions(scenario, OffsetSteps);
+            options.MaxBlindStepsPerDirection = 8;
+            var harness = BuildHarness(scenario, options, start, focuserMin, focuserMax);
+            var result = await RunSweep(harness, options);
+
+            var history = harness.Focuser.MoveHistory.ToList();
+            var seedFloor = start + StepSize; // 10205, the lowest seed position
+            Assert.Multiple(() => {
+                Assert.That(result, Is.Not.Null, "both-directions-exhausted is a graceful failure, not a crash");
+                Assert.That(result.Succeeded, Is.False, "this geometry is genuinely unfocusable (focus lies beyond the cap)");
+                Assert.That(history.Min(), Is.EqualTo(start + StepSize - 8 * StepSize),
+                    "the descent stopped at exactly the effective cap (8 step-outs beyond the seed floor)");
+                Assert.That(history.Where(p => p < seedFloor).Distinct().Count(), Is.EqualTo(8),
+                    "distinct walked positions in the capped direction == the cap");
+                Assert.That(history.Min(), Is.GreaterThan(focuserMin),
+                    "the capped walk never approaches the focuser travel limit");
+                Assert.That(history.Max(), Is.EqualTo(Focus + 50 * StepSize),
+                    "the post-reversal probe is bounded by the failure budget (cutoff + offsetSteps failures)");
+                Assert.That(history.Last(), Is.EqualTo(start), "the focuser is restored to the start after the failure");
+            });
+
+            // Control: cap disabled => the descent marches into the travel limit (a requested move below the focuser
+            // minimum trips the engine's limit guard). Still handled: a failed result, not an unhandled throw.
+            var controlScenario = SteepScenario(s => s.RightCutoffSteps = 45);
+            var controlOptions = DefaultSweepOptions(controlScenario, OffsetSteps);
+            controlOptions.MaxBlindStepsPerDirection = 0;
+            var controlHarness = BuildHarness(controlScenario, controlOptions, start, focuserMin, focuserMax);
+            var controlResult = await RunSweep(controlHarness, controlOptions);
+
+            Assert.Multiple(() => {
+                Assert.That(controlResult, Is.Not.Null);
+                Assert.That(controlResult.Succeeded, Is.False);
+                Assert.That(controlHarness.Focuser.MoveHistory.Min(), Is.LessThan(focuserMin),
+                    "without the cap the walk requests a move beyond the focuser travel limit — the hazard B removes");
+            });
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        // B3 — Mirror of B1: the LEFT side is starless just below the start, so the natural left walk piles up 5
+        // failures => failure-budget reversal => the forced RIGHT walk completes the bracket and the sweep converges.
+        // Expected MoveHistory: [seeds +3s..-1s] [L1 -2s] [L2..L6 -3s..-7s all starless] [reversal return to start]
+        // [R +4s,+5s => break] [queue-left -8s..-10s (starless fill; failedLeft widens the target)] [final ~focus].
+        // Note the queue-left dip AFTER the reversal — the engine deliberately back-fills the left arm target; the
+        // reversal evidence is the post-return exploration of NEW HIGHS beyond the seed ceiling.
+        // ------------------------------------------------------------------------------------------------------------
+        [Test]
+        public async Task B3_LeftSideStarless_ReversalRescuesRightward_ControlWithoutCapFails() {
+            var start = Focus - 2 * StepSize; // 9990; left side starless beyond exactly 2 steps
+            var scenario = SteepScenario(s => s.LeftCutoffSteps = 2);
+            var options = DefaultSweepOptions(scenario, OffsetSteps);
+            options.MaxBlindStepsPerDirection = 8;
+            var harness = BuildHarness(scenario, options, start, Focus - 5000, Focus + 5000);
+            var result = await RunSweep(harness, options);
+
+            var region = result.RegionResults[0];
+            var history = harness.Focuser.MoveHistory.ToList();
+            var seedCeiling = Focus + 3 * StepSize; // 10015, highest seed position
+
+            Assert.Multiple(() => {
+                Assert.That(result.Succeeded, Is.True, "the reversal rescues a start pinned against a left cutoff");
+                Assert.That(region.EstimatedFinalFocuserPosition, Is.EqualTo(Focus).Within(StepSize));
+
+                // The failing left excursion reached -7s before the failure budget tripped.
+                Assert.That(history, Does.Contain(Focus - 7 * StepSize), "the left walk probed into the starless zone");
+                var reversalIndex = history.LastIndexOf(start);
+                Assert.That(reversalIndex, Is.GreaterThan(history.IndexOf(Focus - 7 * StepSize)),
+                    "the return-to-start comes after the failed left excursion");
+                Assert.That(history.Skip(reversalIndex + 1).Any(p => p > seedCeiling), Is.True,
+                    "after the reversal the OTHER direction is explored beyond the seed ceiling (+4s/+5s)");
+
+                // Every real (nonzero-HFR) point sits inside the window here; only far starless fill points are
+                // window-excluded (they carry Measure == 0).
+                Assert.That(region.WindowExcludedPoints.Where(p => p.Measurement.Measure > 0.0), Is.Empty,
+                    "no valid star point is window-excluded in this mildly lopsided sweep");
+                Assert.That(PositionsOf(region.WindowExcludedPoints).Intersect(PositionsOf(region.RejectedPoints)), Is.Empty);
+            });
+
+            // Control: cap off => the 5 left failures throw and the sweep dies without ever exploring right of the seeds.
+            var controlScenario = SteepScenario(s => s.LeftCutoffSteps = 2);
+            var controlOptions = DefaultSweepOptions(controlScenario, OffsetSteps);
+            controlOptions.MaxBlindStepsPerDirection = 0;
+            var controlHarness = BuildHarness(controlScenario, controlOptions, start, Focus - 5000, Focus + 5000);
+            var controlResult = await RunSweep(controlHarness, controlOptions);
+
+            Assert.Multiple(() => {
+                Assert.That(controlResult.Succeeded, Is.False, "without the cap the left-cutoff geometry kills the sweep");
+                Assert.That(controlHarness.Focuser.MoveHistory.Max(), Is.EqualTo(seedCeiling),
+                    "without the reversal the engine never explores beyond the seed ceiling");
+            });
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        // F1 — Truly starless everywhere. Engine contract (observed, not the naive expectation): the initial-HFR gate
+        // is RACY by design — OnNextAttempt() clears AnalysisTasks after the initial capture was queued, so
+        // StartBlindFocusPoints' InitialHFR==0 check may or may not see the completed measurement. The run therefore
+        // fails through one of two graceful paths: (a) InitialHFRFailedException before any seed move, or (b) the
+        // seed/walk failure budget (with the cap on: seeds fail -> one reversal -> the other arm fails ->
+        // TooManyFailedMeasurements). Both paths share the guarantees asserted here: a failed (non-null) result, no
+        // fitted vertex, a BOUNDED excursion, the focuser restored, and the process-wide guard released.
+        // ------------------------------------------------------------------------------------------------------------
+        [Test]
+        public async Task F1_StarlessEverywhere_FailsGracefully_BoundedExcursion_GuardReleased() {
+            var start = Focus + 40 * StepSize;
+            var scenario = SteepScenario(s => {
+                s.LeftCutoffSteps = 0;  // starless at any distance from focus on the left...
+                s.RightCutoffSteps = 0; // ...and on the right => starless everywhere the sweep can look
+            });
+            var options = DefaultSweepOptions(scenario, OffsetSteps);
+            options.MaxBlindStepsPerDirection = 8;
+            var harness = BuildHarness(scenario, options, start, Focus - 5000, Focus + 5000);
+            var result = await RunSweep(harness, options);
+
+            Assert.That(result, Is.Not.Null, "a starless field fails gracefully, it does not crash Run()");
+            var region = result.RegionResults[0];
+            var history = harness.Focuser.MoveHistory.ToList();
+            Assert.Multiple(() => {
+                Assert.That(result.Succeeded, Is.False);
+                Assert.That(double.IsNaN(region.EstimatedFinalFocuserPosition), Is.True, "no vertex was ever fitted");
+                Assert.That(region.WindowExcludedPoints, Is.Empty, "finalization was never reached");
+                Assert.That(region.RejectedPoints, Is.Empty, "no fit ever ran (never 3 valid points)");
+                // Path (a): only the restore move. Path (b): seeds (up to +6 steps), one reversal, and a left arm
+                // bounded by the fresh failure budget (offsetSteps zero-HFR points past the start). Never a runaway.
+                Assert.That(history.Max(), Is.LessThanOrEqualTo(start + (OffsetSteps + 1) * StepSize),
+                    "no probing beyond the seed arm");
+                Assert.That(history.Min(), Is.GreaterThanOrEqualTo(start - (OffsetSteps + 3) * StepSize),
+                    "the starless walk is bounded by the failure budget - no runaway toward a focuser limit");
+                Assert.That(history.Last(), Is.EqualTo(start), "the focuser is restored to the start");
+                Assert.That(harness.Focuser.Position, Is.EqualTo(start), "the focuser ends where it began");
+            });
+
+            // Guard-release proof: an immediate second run must be admitted (a leaked in-progress guard returns null).
+            var secondHarness = BuildHarness(scenario, options, start, Focus - 5000, Focus + 5000);
+            var secondResult = await RunSweep(secondHarness, options);
+            Assert.That(secondResult, Is.Not.Null, "the in-progress guard was released by the failed run");
+            Assert.That(secondResult.Succeeded, Is.False);
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        // F2a — Starless only far, stars near, cap comfortably larger than the start distance. The descent tolerates
+        // the 3 starless outer seeds, reaches focus well inside the cap, and converges with no reversal — the far
+        // starless zones are only ever touched by the seed arm.
+        // ------------------------------------------------------------------------------------------------------------
+        [Test]
+        public async Task F2a_StarlessOnlyFar_AmpleCap_ConvergesWithoutReversal() {
+            var start = Focus + 10 * StepSize; // 10050, inside the starred band (stars within +/-12 steps of focus)
+            var scenario = SteepScenario(s => {
+                s.LeftCutoffSteps = 12;
+                s.RightCutoffSteps = 12;
+            });
+            var options = DefaultSweepOptions(scenario, OffsetSteps);
+            options.MaxBlindStepsPerDirection = 20; // ample: the descent needs ~12 steps to reach and cross focus
+            var harness = BuildHarness(scenario, options, start, Focus - 5000, Focus + 5000);
+            var result = await RunSweep(harness, options);
+
+            var region = result.RegionResults[0];
+            var excluded = PositionsOf(region.WindowExcludedPoints);
+            Assert.Multiple(() => {
+                Assert.That(result.Succeeded, Is.True, "3 starless outer seeds do not sink a sweep that can reach focus");
+                Assert.That(region.EstimatedFinalFocuserPosition, Is.EqualTo(Focus).Within(StepSize));
+                Assert.That(harness.Focuser.MoveHistory.Max(), Is.EqualTo(start + OffsetSteps * StepSize),
+                    "the far starless side is only ever probed by the seeds — no reversal, no far excursion");
+                Assert.That(harness.Focuser.MoveHistory.Min(), Is.EqualTo(Focus - 5 * StepSize));
+                Assert.That(excluded, Is.SupersetOf(PositionRange(Focus + 7 * StepSize, Focus + 12 * StepSize)),
+                    "the far valid arm (+7s..+12s) is window-excluded from the final fit");
+                Assert.That(excluded.Intersect(PositionsOf(region.RejectedPoints)), Is.Empty);
+            });
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        // F2b — Same geometry, cap TIGHTER than the start-to-focus distance. Engine contract (hand-traced, and worth
+        // documenting): the descent caps out at 8 step-outs BEFORE reaching focus (no bracket has formed), reverses
+        // into the far starless side, exhausts the fresh failure budget, and fails gracefully. A cap smaller than the
+        // plausible start error converts a recoverable far start into a clean failure — this is the real, asserted
+        // behavior, deliberately distinct from F2a.
+        // ------------------------------------------------------------------------------------------------------------
+        [Test]
+        public async Task F2b_StarlessOnlyFar_TightCap_CapsOutBeforeFocus_FailsGracefully() {
+            var start = Focus + 10 * StepSize;
+            var scenario = SteepScenario(s => {
+                s.LeftCutoffSteps = 12;
+                s.RightCutoffSteps = 12;
+            });
+            var options = DefaultSweepOptions(scenario, OffsetSteps);
+            options.MaxBlindStepsPerDirection = 8; // tighter than the ~12 steps the descent needs
+            var harness = BuildHarness(scenario, options, start, Focus - 5000, Focus + 5000);
+            var result = await RunSweep(harness, options);
+
+            var history = harness.Focuser.MoveHistory.ToList();
+            Assert.Multiple(() => {
+                Assert.That(result, Is.Not.Null, "graceful failure, not a crash");
+                Assert.That(result.Succeeded, Is.False,
+                    "a cap tighter than the start-to-focus distance reverses prematurely and the run fails cleanly");
+                Assert.That(history.Min(), Is.EqualTo(start + StepSize - 8 * StepSize),
+                    "the descent stopped at exactly the cap (+3 steps from focus — before bracketing)");
+                Assert.That(history.Max(), Is.EqualTo(Focus + 20 * StepSize),
+                    "the post-reversal probe is bounded by the fresh failure budget beyond the +12-step cutoff");
+                Assert.That(history.Last(), Is.EqualTo(start), "the focuser is restored to the start");
+            });
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        // AB1 — Combined worst case: a far low-HFR spurious plateau (+12s..+16s at HFR 1.1, star-count 10) capped by a
+        // starless cutoff beyond +16s, start on the clean side at +10s, production-like options (Grubbs enabled,
+        // cap 8). Hand-traced composition:
+        //   * the spurious seed cluster fakes a minimum whose left trend fills from TRUE points => the walk turns
+        //     right INTO the plateau, hits the cutoff, piles up 5 failures => Behavior B reverses (failure budget);
+        //   * the forced-left walk descends through true focus and terminates normally;
+        //   * finalization: the false cluster (the lowest raw band on the curve!) is neutralized — window exclusion
+        //     (plus at most MaxOutlierRejections Grubbs picks on the provisional passes, which each refit re-derives)
+        //     leaves a clean core fit whose vertex is TRUE focus.
+        // The spurious cluster reports an inflated σ (0.4 vs the baseline 0.1) — the realistic signature of stars
+        // imagined in noise. The equal-σ variant of the same geometry is AB2 below: there the engine's real behavior
+        // is a fail-SAFE (the poisoned fit fails validation), never a wrong focus position.
+        // ------------------------------------------------------------------------------------------------------------
+        [Test]
+        public async Task AB1_FarFalseMinimumPlusCutoff_ReversalAndWindowRecoverTrueFocus() {
+            var start = Focus + 10 * StepSize; // 10050
+            var scenario = SteepScenario(s => {
+                s.Spurious = new SpuriousSpec(OnsetSteps: 12, Side: FocusSide.Right, FalseHfr: 1.1, FalseStarCount: 10, FalseSigma: 0.4);
+                s.RightCutoffSteps = 16;
+            });
+            var options = DefaultSweepOptions(scenario, OffsetSteps);
+            options.MaxBlindStepsPerDirection = 8;
+            var harness = BuildHarness(scenario, options, start, Focus - 5000, Focus + 5000);
+            var result = await RunSweep(harness, options);
+
+            var region = result.RegionResults[0];
+            var excluded = PositionsOf(region.WindowExcludedPoints);
+            var rejected = PositionsOf(region.RejectedPoints);
+            var history = harness.Focuser.MoveHistory.ToList();
+            // Sampled spurious plateau: seeds +12s..+15s plus the one right step-out to +16s.
+            var spuriousPositions = PositionRange(Focus + 12 * StepSize, Focus + 16 * StepSize);
+
+            Assert.Multiple(() => {
+                Assert.That(result.Succeeded, Is.True, "the combined worst case still converges");
+                Assert.That(region.EstimatedFinalFocuserPosition, Is.EqualTo(Focus).Within(StepSize),
+                    "the final vertex is TRUE focus — the low-HFR false cluster does not capture the fit");
+
+                // Every sampled spurious point was kept OUT of the final fit, and the two exclusion categories
+                // remain disjoint (window-excluded points are never re-labeled as rejected, or vice versa).
+                Assert.That(spuriousPositions.Except(excluded.Union(rejected)), Is.Empty,
+                    "every spurious point is neutralized via window-exclusion (or a Grubbs pick on a provisional pass)");
+                Assert.That(excluded.Intersect(rejected), Is.Empty);
+                Assert.That(excluded.Where(p => Math.Abs(p - Focus) <= 3 * StepSize), Is.Empty,
+                    "the true core is never excluded");
+
+                // Behavior B's failure-budget reversal: the rightward probe dies at the cutoff (+17s..+21s all
+                // starless), the engine returns to the start, and the rescue happens leftward through focus.
+                Assert.That(history.Max(), Is.EqualTo(Focus + 21 * StepSize),
+                    "the rightward march is bounded by the failure budget beyond the cutoff");
+                var reversalIndex = history.LastIndexOf(start);
+                Assert.That(reversalIndex, Is.GreaterThan(history.IndexOf(history.Max())),
+                    "the return-to-start comes after the failed rightward march");
+                Assert.That(history.Min(), Is.EqualTo(Focus - 5 * StepSize), "the rescue fills the left arm to -5 steps");
+            });
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        // AB2 — AB1's geometry with an EQUAL-σ false plateau (σ 0.1, indistinguishable from real measurements). This
+        // is beyond what the finalization window can repair: the weighted hyperbolic fit itself is captured/broken by
+        // the plateau (alglib fails to produce a usable model around it), so finalization cannot fit a vertex and the
+        // run FAILS — the engine's real, asserted contract here is fail-SAFE: it never reports a focus position from
+        // the poisoned curve, and it restores the focuser. (Discovered while tuning: with equal σ the provisional fit
+        // is dragged toward the plateau, the windowed refit around that hijacked center has no left arm, and the
+        // hyperbolic solve fails => FitQuality failure. A wrong ANSWER never escapes.)
+        // ------------------------------------------------------------------------------------------------------------
+        [Test]
+        public async Task AB2_EqualSigmaFalsePlateau_FailsSafe_NeverReportsFalseFocus() {
+            var start = Focus + 10 * StepSize;
+            var scenario = SteepScenario(s => {
+                s.Spurious = new SpuriousSpec(OnsetSteps: 12, Side: FocusSide.Right, FalseHfr: 1.1, FalseStarCount: 10, FalseSigma: 0.1);
+                s.RightCutoffSteps = 16;
+            });
+            var options = DefaultSweepOptions(scenario, OffsetSteps);
+            options.MaxBlindStepsPerDirection = 8;
+            var harness = BuildHarness(scenario, options, start, Focus - 5000, Focus + 5000);
+            var result = await RunSweep(harness, options);
+
+            Assert.Multiple(() => {
+                Assert.That(result.Succeeded, Is.False,
+                    "an equal-σ false plateau breaks the fit and the run fails validation — fail-safe, not fail-wrong");
+                Assert.That(double.IsNaN(result.RegionResults[0].EstimatedFinalFocuserPosition), Is.True,
+                    "no vertex is ever reported from the poisoned curve");
+                Assert.That(harness.Focuser.Position, Is.EqualTo(start),
+                    "the focuser is restored to the start — it never settles in the false-minimum band");
+            });
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+        // Reusable harness construction — the battery builds every scenario on top of these helpers.
+        // ------------------------------------------------------------------------------------------------------------
+
+        /// <summary>
+        /// A steep analytic hyperbola baseline: HFR(pos) = sqrt(1 + (0.12·(pos − focus))²), i.e. a 1.0 px floor rising
+        /// 0.6 px per 5-unit step. Chosen so EVERY point one or more steps off the vertex clears NINA core
+        /// <c>TrendlineFitting</c>'s fixed <c>Minimum.Y + 0.1</c> trend threshold (HFR at ±1 step = 1.166 vs threshold
+        /// 1.1) — with the simulator's default optics the near-focus CFZ is flat, trend membership goes fuzzy, and the
+        /// walk over-samples unpredictably. With this curve (and zero noise) every scenario's walk, and therefore its
+        /// MoveHistory, is exactly derivable by hand. It is still a pure hyperbola, so a noise-free HYPERBOLIC fit
+        /// recovers the vertex exactly.
+        /// </summary>
+        private static DegradationScenario SteepScenario(Action<DegradationScenario> configure = null) {
+            var scenario = new DegradationScenario(Focus, StepSize) {
+                BaselineHfr = pos => Math.Sqrt(1.0 + Math.Pow(0.12 * (pos - Focus), 2.0))
+            };
+            configure?.Invoke(scenario);
+            return scenario;
+        }
+
+        private static async Task<AutoFocusResult> RunSweep(SweepHarness harness, AutoFocusEngineOptions options) {
+            using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+            var result = await harness.Engine.Run(options, imagingFilter: null, token: cts.Token, progress: null);
+            Assert.That(result, Is.Not.Null, "Run() must always produce a result (a null means the in-progress guard rejected the run)");
+            return result;
+        }
+
+        private static int[] PositionsOf(AutoFocusRegionPoint[] points) {
+            return (points ?? Array.Empty<AutoFocusRegionPoint>()).Select(p => p.FocuserPosition).OrderBy(p => p).ToArray();
+        }
+
+        /// <summary>Every focuser grid position from <paramref name="lowInclusive"/> to <paramref name="highInclusive"/> in <see cref="StepSize"/> increments.</summary>
+        private static int[] PositionRange(int lowInclusive, int highInclusive) {
+            return Enumerable.Range(0, (highInclusive - lowInclusive) / StepSize + 1).Select(i => lowInclusive + i * StepSize).ToArray();
+        }
+
+        internal sealed class SweepHarness {
+            public AutoFocusEngine Engine { get; init; }
+            public MovingFocuserMediator Focuser { get; init; }
+            public ScriptedStarDetection Detection { get; init; }
+            public SweepFrameLedger Ledger { get; init; }
+            public DegradationScenario Scenario { get; init; }
+        }
+
+        /// <summary>
+        /// A fully-specified <see cref="AutoFocusEngineOptions"/> tuned for deterministic in-process sweeps:
+        /// single-threaded (MaxConcurrent=1), one frame per point, STARHFR + HYPERBOLIC, no saving, a generous timeout,
+        /// HFR-improvement validation on, and the always-on symmetric window enabled. Behavior B (the directional cap)
+        /// is left OFF by default; scenarios that exercise the reversal set <see cref="AutoFocusEngineOptions.MaxBlindStepsPerDirection"/>.
+        /// </summary>
+        internal static AutoFocusEngineOptions DefaultSweepOptions(DegradationScenario scenario, int offsetSteps) {
+            return new AutoFocusEngineOptions {
+                DebayerImage = false,
+                NumberOfAFStars = 0,
+                TotalNumberOfAttempts = 1,
+                ValidateHfrImprovement = true,
+                AutoFocusMethod = AFMethodEnum.STARHFR,
+                AutoFocusCurveFitting = AFCurveFittingEnum.HYPERBOLIC,
+                AutoFocusInitialOffsetSteps = offsetSteps,
+                AutoFocusStepSize = scenario.StepSize,
+                FramesPerPoint = 1,
+                MaxConcurrent = 1,
+                Save = false,
+                SavePath = null,
+                AutoFocusTimeout = TimeSpan.FromMinutes(5),
+                HFRImprovementThreshold = 0.1,
+                FocuserOffset = 0,
+                MaxBlindStepsPerDirection = 0,
+                MaxOutlierRejections = 3,
+                OutlierRejectionConfidence = 0.95,
+                WeightedHyperbolicFitEnabled = true,
+                HyperbolicFitModel = HyperbolicFitModel.Symmetric,
+                FitRejectionCriterion = FitRejectionCriterion.RSquared,
+                ReducedChiSquaredRejectionThreshold = 0.0,
+                SymmetricFocusWindowEnabled = true
+            };
+        }
+
+        /// <summary>
+        /// Wires an <see cref="AutoFocusEngine"/> for a deterministic sweep: a <see cref="MovingFocuserMediator"/> at
+        /// <paramref name="startPosition"/> clamped to <c>[<paramref name="focuserMin"/>, <paramref name="focuserMax"/>]</c>,
+        /// a <see cref="StampedImagingMediator"/> + <see cref="SweepFrameLedger"/> feeding a
+        /// <see cref="ScriptedStarDetection"/> for <paramref name="scenario"/>, and a profile whose focuser settings match
+        /// <paramref name="options"/> (STARHFR + HYPERBOLIC — both the DTO and the profile must agree, since finalization
+        /// reads the profile). Everything else is a bare NSubstitute.
+        /// </summary>
+        internal static SweepHarness BuildHarness(DegradationScenario scenario, AutoFocusEngineOptions options, int startPosition, int focuserMin, int focuserMax) {
+            var focuser = new MovingFocuserMediator(startPosition, focuserMin, focuserMax);
+            var ledger = new SweepFrameLedger();
+            var imaging = new StampedImagingMediator(focuser, ledger);
+            var detection = new ScriptedStarDetection(ledger, scenario);
+
+            var starDetectionSelector = Substitute.For<IPluggableBehaviorSelector<IStarDetection>>();
+            starDetectionSelector.GetBehavior().Returns(detection);
+            starDetectionSelector.SelectedBehavior.Returns(detection);
+
+            // The engine reads cameraMediator.GetInfo() in IsSubSampleEnabled/GetSubSampleRectangle; a bare substitute
+            // returns null there. A connected camera that CANNOT sub-sample keeps the full-frame region==null path.
+            var cameraMediator = Substitute.For<ICameraMediator>();
+            cameraMediator.GetInfo().Returns(new CameraInfo { Connected = true, CanSubSample = false });
+
+            var profileService = Substitute.For<IProfileService>();
+            // Finalization (ValidateCalculatedFocusPosition) reads the fitting/method off the PROFILE, so it must agree
+            // with the DTO. R²/χ² thresholds default to 0 ⇒ no fit-quality rejection of a clean fit.
+            profileService.ActiveProfile.FocuserSettings.AutoFocusMethod.Returns(options.AutoFocusMethod);
+            profileService.ActiveProfile.FocuserSettings.AutoFocusCurveFitting.Returns(options.AutoFocusCurveFitting);
+
+            var engine = new AutoFocusEngine(
+                profileService: profileService,
+                cameraMediator: cameraMediator,
+                filterWheelMediator: Substitute.For<IFilterWheelMediator>(),
+                focuserMediator: focuser,
+                guiderMediator: Substitute.For<IGuiderMediator>(),
+                imagingMediator: imaging,
+                imageDataFactory: Substitute.For<IImageDataFactory>(),
+                starDetectionSelector: starDetectionSelector,
+                starAnnotatorSelector: Substitute.For<IPluggableBehaviorSelector<IStarAnnotator>>(),
+                autoFocusOptions: Substitute.For<IAutoFocusOptions>(),
+                starAnnotatorOptions: Substitute.For<IStarAnnotatorOptions>(),
+                alglibAPI: new AlglibAPI());
+
+            return new SweepHarness {
+                Engine = engine,
+                Focuser = focuser,
+                Detection = detection,
+                Ledger = ledger,
+                Scenario = scenario
+            };
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusEngineSweepBatteryTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusEngineSweepBatteryTests.cs
@@ -356,21 +356,20 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
         }
 
         // ------------------------------------------------------------------------------------------------------------
-        // B2 — Bootstrap cap respected. Start far above focus with clean stars: the descent can't form a bracket
-        // within the cap (every new point is a fresh minimum), so the STEP-OUT cap fires after exactly 8 left
-        // step-outs — well clear of a focuser travel limit placed 12 steps below the start. The reversal then probes
-        // right into a starless cutoff, exhausts the failure budget, and the run fails GRACEFULLY (both directions
-        // exhausted => TooManyFailedMeasurements, caught) instead of crashing into the "Focuser reached its limit"
-        // exception. The cap-off control shows the hazard is real: the unbounded descent marches into the travel
-        // limit (requested target below the focuser minimum).
+        // B2 — Focus lies BEYOND the focuser travel limit (focus 10000, limit at 10140). A PRODUCTIVE descent (the
+        // lowest measured HFR keeps improving as the walk nears focus) is NOT counted against the directional cap, so
+        // the walk is not reversed mid-descent — it uses the full available travel trying to reach focus and stops at
+        // the HARDWARE travel limit, failing GRACEFULLY there (a handled "focuser reached its limit", not a crash).
+        // The cap bounds NON-productive excursions (wrong-way / starless — see B1/B3); a genuinely unreachable focus is
+        // bounded by the travel limit, not by an arbitrary step cap.
         // ------------------------------------------------------------------------------------------------------------
         [Test]
-        public async Task B2_CapBoundsExcursion_NoFocuserLimitThrow_ControlMarchesIntoLimit() {
+        public async Task B2_ProductiveDescentBoundedByTravelLimit_NotByCap_FailsGracefully() {
             var start = Focus + 40 * StepSize;       // 10200
-            var focuserMin = start - 12 * StepSize;  // 10140 — the travel hazard the cap must keep clear of
+            var focuserMin = start - 12 * StepSize;  // 10140 — focus (10000) sits below this, i.e. unreachable
             var focuserMax = Focus + 100 * StepSize;
 
-            var scenario = SteepScenario(s => s.RightCutoffSteps = 45); // starless beyond +45 steps (seed top is +45s, valid)
+            var scenario = SteepScenario(s => s.RightCutoffSteps = 45);
             var options = DefaultSweepOptions(scenario, OffsetSteps);
             options.MaxBlindStepsPerDirection = 8;
             var harness = BuildHarness(scenario, options, start, focuserMin, focuserMax);
@@ -379,32 +378,16 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
             var history = harness.Focuser.MoveHistory.ToList();
             var seedFloor = start + StepSize; // 10205, the lowest seed position
             Assert.Multiple(() => {
-                Assert.That(result, Is.Not.Null, "both-directions-exhausted is a graceful failure, not a crash");
-                Assert.That(result.Succeeded, Is.False, "this geometry is genuinely unfocusable (focus lies beyond the cap)");
-                Assert.That(history.Min(), Is.EqualTo(start + StepSize - 8 * StepSize),
-                    "the descent stopped at exactly the effective cap (8 step-outs beyond the seed floor)");
-                Assert.That(history.Where(p => p < seedFloor).Distinct().Count(), Is.EqualTo(8),
-                    "distinct walked positions in the capped direction == the cap");
-                Assert.That(history.Min(), Is.GreaterThan(focuserMin),
-                    "the capped walk never approaches the focuser travel limit");
-                Assert.That(history.Max(), Is.EqualTo(Focus + 50 * StepSize),
-                    "the post-reversal probe is bounded by the failure budget (cutoff + offsetSteps failures)");
-                Assert.That(history.Last(), Is.EqualTo(start), "the focuser is restored to the start after the failure");
-            });
-
-            // Control: cap disabled => the descent marches into the travel limit (a requested move below the focuser
-            // minimum trips the engine's limit guard). Still handled: a failed result, not an unhandled throw.
-            var controlScenario = SteepScenario(s => s.RightCutoffSteps = 45);
-            var controlOptions = DefaultSweepOptions(controlScenario, OffsetSteps);
-            controlOptions.MaxBlindStepsPerDirection = 0;
-            var controlHarness = BuildHarness(controlScenario, controlOptions, start, focuserMin, focuserMax);
-            var controlResult = await RunSweep(controlHarness, controlOptions);
-
-            Assert.Multiple(() => {
-                Assert.That(controlResult, Is.Not.Null);
-                Assert.That(controlResult.Succeeded, Is.False);
-                Assert.That(controlHarness.Focuser.MoveHistory.Min(), Is.LessThan(focuserMin),
-                    "without the cap the walk requests a move beyond the focuser travel limit — the hazard B removes");
+                Assert.That(result, Is.Not.Null, "reaching the travel limit is a graceful failure, not a crash");
+                Assert.That(result.Succeeded, Is.False, "focus is beyond the focuser travel limit — genuinely unreachable");
+                // The productive descent is NOT cut off at the cap (8 step-outs): it walks well past that, down to the
+                // travel limit, ultimately requesting a position at/below focuserMin (which trips the engine's limit guard).
+                Assert.That(history.Where(p => p < seedFloor).Distinct().Count(), Is.GreaterThan(8),
+                    "a productive descent is bounded by the travel limit, not the step cap");
+                Assert.That(history.Min(), Is.LessThanOrEqualTo(focuserMin),
+                    "the descent reaches the focuser travel limit (the real bound)");
+                Assert.That(history.Max(), Is.EqualTo(start + OffsetSteps * StepSize),
+                    "no reversal excursion above the seed ceiling — a productive descent never reverses");
             });
         }
 
@@ -540,34 +523,32 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
         }
 
         // ------------------------------------------------------------------------------------------------------------
-        // F2b — Same geometry, cap TIGHTER than the start-to-focus distance. Engine contract (hand-traced, and worth
-        // documenting): the descent caps out at 8 step-outs BEFORE reaching focus (no bracket has formed), reverses
-        // into the far starless side, exhausts the fresh failure budget, and fails gracefully. A cap smaller than the
-        // plausible start error converts a recoverable far start into a clean failure — this is the real, asserted
-        // behavior, deliberately distinct from F2a.
+        // F2b — Same geometry as F2a but with a MODEST cap (8) SMALLER than the start-to-focus distance. This is the
+        // regression guard for the reported bug: a productive descent (the lowest measured HFR keeps improving as the
+        // walk nears focus) must NOT be counted against the directional cap, so a far-but-recoverable start is not
+        // abandoned just because it needs more than `cap` steps to reach focus. The walk reaches focus and converges,
+        // exactly like F2a — the cap only bounds NON-productive excursions (see the B-scenarios).
         // ------------------------------------------------------------------------------------------------------------
         [Test]
-        public async Task F2b_StarlessOnlyFar_TightCap_CapsOutBeforeFocus_FailsGracefully() {
+        public async Task F2b_StarlessOnlyFar_ModestCap_ProductiveDescentNotCapped_Converges() {
             var start = Focus + 10 * StepSize;
             var scenario = SteepScenario(s => {
                 s.LeftCutoffSteps = 12;
                 s.RightCutoffSteps = 12;
             });
             var options = DefaultSweepOptions(scenario, OffsetSteps);
-            options.MaxBlindStepsPerDirection = 8; // tighter than the ~12 steps the descent needs
+            options.MaxBlindStepsPerDirection = 8; // smaller than the ~10 steps to focus — but a productive descent isn't capped
             var harness = BuildHarness(scenario, options, start, Focus - 5000, Focus + 5000);
             var result = await RunSweep(harness, options);
 
             var history = harness.Focuser.MoveHistory.ToList();
             Assert.Multiple(() => {
-                Assert.That(result, Is.Not.Null, "graceful failure, not a crash");
-                Assert.That(result.Succeeded, Is.False,
-                    "a cap tighter than the start-to-focus distance reverses prematurely and the run fails cleanly");
-                Assert.That(history.Min(), Is.EqualTo(start + StepSize - 8 * StepSize),
-                    "the descent stopped at exactly the cap (+3 steps from focus — before bracketing)");
-                Assert.That(history.Max(), Is.EqualTo(Focus + 20 * StepSize),
-                    "the post-reversal probe is bounded by the fresh failure budget beyond the +12-step cutoff");
-                Assert.That(history.Last(), Is.EqualTo(start), "the focuser is restored to the start");
+                Assert.That(result.Succeeded, Is.True,
+                    "a productive descent toward a reachable focus is not cut off by a modest cap");
+                Assert.That(result.RegionResults[0].EstimatedFinalFocuserPosition, Is.EqualTo(Focus).Within(StepSize));
+                Assert.That(history.Max(), Is.EqualTo(start + OffsetSteps * StepSize),
+                    "no reversal: the far starless side is only ever probed by the seeds");
+                Assert.That(history.Min(), Is.EqualTo(Focus - 5 * StepSize), "the descent reaches and brackets focus");
             });
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusEngineTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusEngineTests.cs
@@ -516,22 +516,22 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
 
         [Test]
         public void IsWithinFocusWindow_StrictBoundaries_SymmetricMembership() {
-            // Half-width = (offsetSteps + 1) * stepSize = 6 * 5 = 30, so the window is the OPEN interval (9970, 10030).
+            // Half-width = (offsetSteps + 0.5) * stepSize = 5.5 * 5 = 27.5, so the window is the OPEN interval (9972.5, 10027.5).
             const double min = 10000;
             Assert.Multiple(() => {
                 Assert.That(AutoFocusEngine.IsWithinFocusWindow(min, min, 5, 5), Is.True, "the center is inside");
-                Assert.That(AutoFocusEngine.IsWithinFocusWindow(min - 29, min, 5, 5), Is.True, "just inside the low edge");
-                Assert.That(AutoFocusEngine.IsWithinFocusWindow(min + 29, min, 5, 5), Is.True, "just inside the high edge");
-                Assert.That(AutoFocusEngine.IsWithinFocusWindow(min - 30, min, 5, 5), Is.False, "exactly on the low edge is excluded (strict)");
-                Assert.That(AutoFocusEngine.IsWithinFocusWindow(min + 30, min, 5, 5), Is.False, "exactly on the high edge is excluded (strict)");
-                Assert.That(AutoFocusEngine.IsWithinFocusWindow(min - 31, min, 5, 5), Is.False, "outside the low edge");
-                Assert.That(AutoFocusEngine.IsWithinFocusWindow(min + 31, min, 5, 5), Is.False, "outside the high edge");
+                Assert.That(AutoFocusEngine.IsWithinFocusWindow(min - 27, min, 5, 5), Is.True, "just inside the low edge");
+                Assert.That(AutoFocusEngine.IsWithinFocusWindow(min + 27, min, 5, 5), Is.True, "just inside the high edge");
+                Assert.That(AutoFocusEngine.IsWithinFocusWindow(min - 27.5, min, 5, 5), Is.False, "exactly on the low edge is excluded (strict)");
+                Assert.That(AutoFocusEngine.IsWithinFocusWindow(min + 27.5, min, 5, 5), Is.False, "exactly on the high edge is excluded (strict)");
+                Assert.That(AutoFocusEngine.IsWithinFocusWindow(min - 28, min, 5, 5), Is.False, "outside the low edge");
+                Assert.That(AutoFocusEngine.IsWithinFocusWindow(min + 28, min, 5, 5), Is.False, "outside the high edge");
             });
         }
 
         [Test]
         public void PartitionByFocusWindow_LopsidedSplit_ExcludesFarPoints_IncludingSpuriousLowHfr() {
-            // Window (9970, 10030) around the FITTED VERTEX (10000). Points cluster far to the right, plus a
+            // Window (9972.5, 10027.5) around the FITTED VERTEX (10000). Points cluster far to the right, plus a
             // spurious LOW-HFR point far to the left that a lowest-raw-point center would have chased. Because the
             // center is the vertex (not the lowest point), the spurious point simply lands outside the window and is
             // excluded rather than defining the minimum.
@@ -569,7 +569,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
             // window (leaving the full fit intact) whenever fewer than 3 valid points would remain. Here only two
             // points fall inside the window, which the caller detects via included.Count(Y>0) and declines to apply.
             var points = new List<ScatterErrorPoint> {
-                SE(9995, 2.0), SE(10005, 2.1),                 // the only two inside (9970, 10030)
+                SE(9995, 2.0), SE(10005, 2.1),                 // the only two inside (9972.5, 10027.5)
                 SE(10050, 5.0), SE(10080, 7.0), SE(10110, 9.0) // three far right
             };
             var (included, excluded) = AutoFocusEngine.PartitionByFocusWindow(points, 10000, 5, 5);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusEngineTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusEngineTests.cs
@@ -15,9 +15,11 @@ using NINA.Profile.Interfaces;
 using NINA.WPF.Base.ViewModel.AutoFocus;
 using NSubstitute;
 using NUnit.Framework;
+using OxyPlot.Series;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
@@ -503,6 +505,101 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
                     AutoFocusEngine.AutoFocusFailureMode.HfrRegression, calculatedPoint: 54073, currentSweepCenter: 54073, calculatedPointRetryUsed: false), Is.False);
                 Assert.That(AutoFocusEngine.ShouldRetryFromCalculatedPoint(
                     AutoFocusEngine.AutoFocusFailureMode.FinalPointOutOfBounds, calculatedPoint: -1, currentSweepCenter: 54073, calculatedPointRetryUsed: false), Is.False);
+            });
+        }
+
+        // --- Behavior A: symmetric-window helpers (final-fit exclusion) ---
+        // The window/refit loop (ApplyFinalSymmetricWindow) needs a full region-state harness, but its geometry is
+        // factored into these pure static helpers, unit-tested directly the same way ComputeSweepPositions is.
+
+        private static ScatterErrorPoint SE(double x, double y) => new ScatterErrorPoint(x, y, 0, 0.1);
+
+        [Test]
+        public void IsWithinFocusWindow_StrictBoundaries_SymmetricMembership() {
+            // Half-width = (offsetSteps + 1) * stepSize = 6 * 5 = 30, so the window is the OPEN interval (9970, 10030).
+            const double min = 10000;
+            Assert.Multiple(() => {
+                Assert.That(AutoFocusEngine.IsWithinFocusWindow(min, min, 5, 5), Is.True, "the center is inside");
+                Assert.That(AutoFocusEngine.IsWithinFocusWindow(min - 29, min, 5, 5), Is.True, "just inside the low edge");
+                Assert.That(AutoFocusEngine.IsWithinFocusWindow(min + 29, min, 5, 5), Is.True, "just inside the high edge");
+                Assert.That(AutoFocusEngine.IsWithinFocusWindow(min - 30, min, 5, 5), Is.False, "exactly on the low edge is excluded (strict)");
+                Assert.That(AutoFocusEngine.IsWithinFocusWindow(min + 30, min, 5, 5), Is.False, "exactly on the high edge is excluded (strict)");
+                Assert.That(AutoFocusEngine.IsWithinFocusWindow(min - 31, min, 5, 5), Is.False, "outside the low edge");
+                Assert.That(AutoFocusEngine.IsWithinFocusWindow(min + 31, min, 5, 5), Is.False, "outside the high edge");
+            });
+        }
+
+        [Test]
+        public void PartitionByFocusWindow_LopsidedSplit_ExcludesFarPoints_IncludingSpuriousLowHfr() {
+            // Window (9970, 10030) around the FITTED VERTEX (10000). Points cluster far to the right, plus a
+            // spurious LOW-HFR point far to the left that a lowest-raw-point center would have chased. Because the
+            // center is the vertex (not the lowest point), the spurious point simply lands outside the window and is
+            // excluded rather than defining the minimum.
+            var points = new List<ScatterErrorPoint> {
+                SE(9500, 1.2),    // spurious low-HFR far left -> excluded
+                SE(9980, 3.0),
+                SE(10000, 2.0),
+                SE(10020, 3.1),
+                SE(10060, 6.0),   // far right -> excluded
+                SE(10090, 8.0),   // far right -> excluded
+            };
+            var (included, excluded) = AutoFocusEngine.PartitionByFocusWindow(points, minimumX: 10000, offsetSteps: 5, stepSize: 5);
+            Assert.Multiple(() => {
+                Assert.That(included.Select(p => p.X), Is.EquivalentTo(new[] { 9980.0, 10000.0, 10020.0 }));
+                Assert.That(excluded.Select(p => p.X), Is.EquivalentTo(new[] { 9500.0, 10060.0, 10090.0 }));
+            });
+        }
+
+        [Test]
+        public void PartitionByFocusWindow_AllWithinWindow_ExcludesNothing() {
+            // No point falls outside the window, so the partition is a no-op and the caller keeps the full fit.
+            var points = new List<ScatterErrorPoint> {
+                SE(9980, 3.0), SE(9990, 2.5), SE(10000, 2.0), SE(10010, 2.6), SE(10020, 3.2)
+            };
+            var (included, excluded) = AutoFocusEngine.PartitionByFocusWindow(points, 10000, 5, 5);
+            Assert.Multiple(() => {
+                Assert.That(included, Has.Count.EqualTo(5));
+                Assert.That(excluded, Is.Empty);
+            });
+        }
+
+        [Test]
+        public void PartitionByFocusWindow_WouldKeepFewerThanThree_IsDetectableSoCallerHoldsTheFloor() {
+            // The window helper only splits; the >=3-kept floor lives in ApplyFinalSymmetricWindow, which refuses to
+            // window (leaving the full fit intact) whenever fewer than 3 valid points would remain. Here only two
+            // points fall inside the window, which the caller detects via included.Count(Y>0) and declines to apply.
+            var points = new List<ScatterErrorPoint> {
+                SE(9995, 2.0), SE(10005, 2.1),                 // the only two inside (9970, 10030)
+                SE(10050, 5.0), SE(10080, 7.0), SE(10110, 9.0) // three far right
+            };
+            var (included, excluded) = AutoFocusEngine.PartitionByFocusWindow(points, 10000, 5, 5);
+            Assert.Multiple(() => {
+                Assert.That(included.Count(p => p.Y > 0.0), Is.EqualTo(2), "fewer than 3 kept -> caller must NOT window");
+                Assert.That(excluded, Has.Count.EqualTo(3));
+            });
+        }
+
+        // --- Behavior B: directional reversal decision ---
+        // The full walk needs the sweep harness, but the reverse-or-not decision is a pure helper, tested directly.
+
+        [TestCase(8, 8, false, false, true, TestName = "ShouldReverseDirection_AtCapWithoutBracket_Reverses")]
+        [TestCase(7, 8, false, false, false, TestName = "ShouldReverseDirection_BelowCap_DoesNotReverse")]
+        [TestCase(9, 8, true, false, false, TestName = "ShouldReverseDirection_WithTwoSidedBracket_DoesNotReverse")]
+        [TestCase(20, 8, false, true, false, TestName = "ShouldReverseDirection_AlreadyReversed_LatchesAgainstOscillation")]
+        public void ShouldReverseDirection_TruthTable(int stepOutsThisDir, int effectiveCap, bool bracketFormed, bool hasReversed, bool expected) {
+            Assert.That(AutoFocusEngine.ShouldReverseDirection(stepOutsThisDir, effectiveCap, bracketFormed, hasReversed), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void ShouldReverseDirection_DisabledSemantics_NeverReversesBelowTheEffectiveFloorCap() {
+            // When Behavior B is disabled (configured cap 0) the walk gates the helper away entirely, but even the
+            // effective floor cap (Math.Max(0, offsetSteps + 1)) is a valid, non-tightening bound: a walk that never
+            // reaches that many step-outs in a direction cannot reverse.
+            var effectiveCap = Math.Max(0, 5 + 1);
+            Assert.Multiple(() => {
+                Assert.That(AutoFocusEngine.ShouldReverseDirection(0, effectiveCap, bracketFormed: false, hasReversed: false), Is.False);
+                Assert.That(AutoFocusEngine.ShouldReverseDirection(effectiveCap - 1, effectiveCap, bracketFormed: false, hasReversed: false), Is.False);
+                Assert.That(AutoFocusEngine.ShouldReverseDirection(effectiveCap, effectiveCap, bracketFormed: false, hasReversed: false), Is.True);
             });
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/Harness/DegradationScenario.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/Harness/DegradationScenario.cs
@@ -159,7 +159,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus.Harness {
         }
 
         // A DefocusModel hyperbola centered on best focus: HFR(pos) = √(HfrMin² + (κ·(pos − focus))²). Optics chosen to
-        // give a well-conditioned V (HfrMin ≈ 0.9 px, a clear rise over the ±(offsetSteps+1)·stepSize window). Because
+        // give a well-conditioned V (HfrMin ≈ 0.9 px, a clear rise over the ±(offsetSteps+0.5)·stepSize window). Because
         // this IS a pure hyperbola, the HYPERBOLIC fit recovers the vertex exactly from noise-free samples.
         private static Func<int, double> DefaultBaselineHfr(int focusPosition) {
             var model = new DefocusModel(

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/Harness/DegradationScenario.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/Harness/DegradationScenario.cs
@@ -1,0 +1,177 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using MathNet.Numerics.Distributions;
+using NINA.Joko.Plugins.HocusFocus.CameraSimulator.Rendering;
+using System;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus.Harness {
+
+    /// <summary>Which side of best focus a knob applies to. "Left" is the low-position side, "Right" the high side.</summary>
+    internal enum FocusSide {
+        Left,
+        Right
+    }
+
+    /// <summary>
+    /// Injects a spurious LOW-HFR "false minimum" far from focus — the case where the detector imagines a small cluster
+    /// of stars in background noise, producing a dip in the HFR curve that a lowest-raw-point center would chase.
+    /// Behavior A defends against exactly this by centering the window on the fitted vertex, not the lowest sample.
+    /// </summary>
+    /// <param name="OnsetSteps">|pos − focus| ≥ OnsetSteps·stepSize on <paramref name="Side"/> triggers the false minimum.</param>
+    /// <param name="Side">Which side the false minimum sits on.</param>
+    /// <param name="FalseHfr">The spuriously LOW reported HFR (typically ≈ HfrFloor × 1.1 — near the true minimum).</param>
+    /// <param name="FalseStarCount">Stars the false detection reports (≥ 2, so it survives the ≥2-usable-stars floor and forms a real fit point).</param>
+    /// <param name="FalseSigma">HFR σ reported with the false cluster.</param>
+    internal sealed record SpuriousSpec(
+        int OnsetSteps,
+        FocusSide Side,
+        double FalseHfr,
+        int FalseStarCount,
+        double FalseSigma);
+
+    /// <summary>
+    /// A fully deterministic, seeded description of what the (scripted) star detector "sees" at any focuser position
+    /// during a driven AutoFocus sweep. <see cref="Evaluate(int)"/> maps a position to <c>(hfr, sigma, starCount)</c>
+    /// from the distance to focus, with three composable degradation knobs the battery sweeps over:
+    /// <list type="bullet">
+    ///   <item><b>Cutoff</b> — <see cref="LeftCutoffSteps"/> / <see cref="RightCutoffSteps"/>: beyond that many steps on a
+    ///   side the field goes starless (<c>hfr = 0</c>, the engine's failure signal).</item>
+    ///   <item><b>Spurious</b> — <see cref="Spurious"/>: a false low-HFR minimum far out on one side.</item>
+    ///   <item><b>Asymmetry</b> — any left/right imbalance in the cutoff/spurious knobs (a lopsided run).</item>
+    /// </list>
+    /// Precedence at a position: cutoff (hard starless at the extreme) → spurious (false minimum in the near-far band) →
+    /// baseline V-curve. All randomness is seeded per position (a fresh RNG keyed on <see cref="Seed"/> + position), so
+    /// the same position always yields the same values regardless of the order detections complete — essential because
+    /// detection runs on pooled tasks.
+    /// </summary>
+    internal sealed class DegradationScenario {
+
+        public DegradationScenario(int focusPosition, int stepSize) {
+            if (stepSize <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(stepSize), stepSize, "stepSize must be positive");
+            }
+            FocusPosition = focusPosition;
+            StepSize = stepSize;
+            BaselineHfr = DefaultBaselineHfr(focusPosition);
+        }
+
+        /// <summary>True best-focus position (the V-curve vertex).</summary>
+        public int FocusPosition { get; }
+
+        /// <summary>Focuser step size, used to convert the step-based knobs to position offsets.</summary>
+        public int StepSize { get; }
+
+        /// <summary>
+        /// Baseline HFR as a function of focuser position. Defaults to a <see cref="DefocusModel"/> hyperbola centered on
+        /// <see cref="FocusPosition"/> (the same model the camera simulator uses — the single source of truth), but is
+        /// settable so a scenario can substitute any curve.
+        /// </summary>
+        public Func<int, double> BaselineHfr { get; set; }
+
+        /// <summary>Beyond this many steps LEFT of focus, detection returns 0 stars. Null ⇒ never cuts off on the left.</summary>
+        public int? LeftCutoffSteps { get; set; }
+
+        /// <summary>Beyond this many steps RIGHT of focus, detection returns 0 stars. Null ⇒ never cuts off on the right.</summary>
+        public int? RightCutoffSteps { get; set; }
+
+        /// <summary>Optional spurious low-HFR false-minimum injector. Null ⇒ no false minimum.</summary>
+        public SpuriousSpec Spurious { get; set; }
+
+        /// <summary>Stars reported at best focus, before any distance falloff.</summary>
+        public int BaselineStarCount { get; set; } = 60;
+
+        /// <summary>Floor on the baseline star count (never falls below this while stars are still detected).</summary>
+        public int MinStarCount { get; set; } = 5;
+
+        /// <summary>Stars lost per step of |defocus| (0 ⇒ constant star count everywhere in-band).</summary>
+        public double StarCountFalloffPerStep { get; set; } = 0.0;
+
+        /// <summary>Baseline HFR σ reported for a normal detection.</summary>
+        public double SigmaBase { get; set; } = 0.1;
+
+        /// <summary>Extra HFR σ added per step of |defocus| (0 ⇒ uniform σ).</summary>
+        public double SigmaInflationPerStep { get; set; } = 0.0;
+
+        /// <summary>Std-dev of seeded Gaussian noise added to the baseline (and spurious) HFR. 0 ⇒ noise-free.</summary>
+        public double NoiseSigma { get; set; } = 0.0;
+
+        /// <summary>Master seed for the per-position noise RNG.</summary>
+        public int Seed { get; set; } = 1;
+
+        /// <summary>The baseline HFR at best focus (the V-curve floor). Handy for sizing <see cref="SpuriousSpec.FalseHfr"/>.</summary>
+        public double HfrFloor => BaselineHfr(FocusPosition);
+
+        /// <summary>
+        /// Deterministically maps a focuser position to the detector's <c>(hfr, sigma, starCount)</c>. A zero-star result
+        /// always carries <c>hfr = 0</c> and a finite σ (the "found no usable stars" signal, distinct from an analysis
+        /// error's NaN σ). See the precedence note on the class.
+        /// </summary>
+        public (double hfr, double sigma, int starCount) Evaluate(int position) {
+            var delta = position - FocusPosition;
+            var absDelta = Math.Abs(delta);
+            var absSteps = absDelta / (double)StepSize;
+            var side = delta < 0 ? FocusSide.Left : FocusSide.Right;
+
+            // 1) Cutoff: hard starless at the far extreme. hfr = 0, σ = 0 (finite) ⇒ engine reads "no usable stars".
+            var cutoffSteps = side == FocusSide.Left ? LeftCutoffSteps : RightCutoffSteps;
+            if (cutoffSteps.HasValue && absDelta > cutoffSteps.Value * StepSize) {
+                return (0.0, 0.0, 0);
+            }
+
+            // 2) Spurious: a false low-HFR minimum in the near-far band on its side.
+            if (Spurious != null && side == Spurious.Side && absDelta >= Spurious.OnsetSteps * StepSize) {
+                var falseHfr = Math.Max(1e-3, Spurious.FalseHfr + Noise(position));
+                return (falseHfr, Spurious.FalseSigma, Spurious.FalseStarCount);
+            }
+
+            // 3) Baseline V-curve. Clamp to a small positive floor so a normal detection never reads as a failure (0).
+            var hfr = Math.Max(1e-3, BaselineHfr(position) + Noise(position));
+            var starCount = (int)Math.Round(Math.Max(MinStarCount, BaselineStarCount - StarCountFalloffPerStep * absSteps));
+            var sigma = SigmaBase + SigmaInflationPerStep * absSteps;
+            return (hfr, sigma, starCount);
+        }
+
+        /// <summary>
+        /// A clean, symmetric baseline V-curve with every degradation knob off — no cutoffs, no spurious minimum, no
+        /// falloff/inflation, no noise. Used by the C1 smoke test to prove the harness drives a full successful sweep.
+        /// </summary>
+        public static DegradationScenario CleanSymmetric(int focusPosition, int stepSize) {
+            return new DegradationScenario(focusPosition, stepSize);
+        }
+
+        private double Noise(int position) {
+            if (NoiseSigma <= 0.0) {
+                return 0.0;
+            }
+            // Fresh RNG per position ⇒ the noise at a position is independent of the order detections complete.
+            var rng = new Random(unchecked(Seed * 397 ^ position));
+            return new Normal(0.0, NoiseSigma, rng).Sample();
+        }
+
+        // A DefocusModel hyperbola centered on best focus: HFR(pos) = √(HfrMin² + (κ·(pos − focus))²). Optics chosen to
+        // give a well-conditioned V (HfrMin ≈ 0.9 px, a clear rise over the ±(offsetSteps+1)·stepSize window). Because
+        // this IS a pure hyperbola, the HYPERBOLIC fit recovers the vertex exactly from noise-free samples.
+        private static Func<int, double> DefaultBaselineHfr(int focusPosition) {
+            var model = new DefocusModel(
+                apertureMillimeters: 100.0,
+                focalLengthMillimeters: 550.0,
+                centralObstructionFraction: 0.0,
+                pixelSizeMicrons: 3.76,
+                seeingArcsec: 2.0,
+                wavelengthNm: 550.0,
+                focuserStepSizeMicrons: 5.0,
+                optimalFocuserPosition: focusPosition);
+            return position => model.HfrAtFocuserPosition(position);
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/Harness/ScriptedStarDetection.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/Harness/ScriptedStarDetection.cs
@@ -1,0 +1,104 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Model;
+using NINA.Image.ImageAnalysis;
+using NINA.Image.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Media;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus.Harness {
+
+    /// <summary>
+    /// A fully-scripted <see cref="IHocusFocusStarDetection"/> for the deterministic AutoFocus sweep harness. It never
+    /// looks at pixels: it reads the CAPTURE-time focuser position for the frame out of the <see cref="SweepFrameLedger"/>
+    /// (never the focuser's live position — see the ledger) and asks a <see cref="DegradationScenario"/> for the
+    /// <c>(hfr, sigma, starCount)</c> that position should yield, then packs that into a <see cref="StarDetectionResult"/>.
+    /// A zero-star result carries <c>AverageHFR = 0</c>, which is precisely the engine's "found no usable stars" failure
+    /// signal. Only the full-frame <see cref="IStarDetection.Detect(IRenderedImage, PixelFormat, StarDetectionParams, IProgress{ApplicationStatus}, CancellationToken)"/>
+    /// overloads are wired (the engine's <c>region == null</c> path); every region/PSF/context member throws, so a wiring
+    /// mistake surfaces loudly instead of silently returning garbage.
+    /// </summary>
+    internal sealed class ScriptedStarDetection : IHocusFocusStarDetection {
+        private readonly SweepFrameLedger ledger;
+        private readonly DegradationScenario scenario;
+
+        public ScriptedStarDetection(SweepFrameLedger ledger, DegradationScenario scenario) {
+            this.ledger = ledger ?? throw new ArgumentNullException(nameof(ledger));
+            this.scenario = scenario ?? throw new ArgumentNullException(nameof(scenario));
+        }
+
+        public string Name => "Scripted (test)";
+
+        public string ContentId => "Scripted_Test_StarDetection";
+
+        public Task<StarDetectionResult> Detect(IRenderedImage image, PixelFormat pf, StarDetectionParams p, IProgress<ApplicationStatus> progress, CancellationToken token) {
+            token.ThrowIfCancellationRequested();
+            return Task.FromResult(EvaluateFrame(image));
+        }
+
+        // The AF engine routes here only when ModelPSF is set (the "Review Frames" path); detection HFR is identical, so
+        // reuse the same scripted evaluation rather than throwing — keeps the harness robust if a scenario sets ModelPSF.
+        public Task<StarDetectionResult> Detect(IRenderedImage image, PixelFormat pf, StarDetectionParams p, IProgress<ApplicationStatus> progress, CancellationToken token, bool modelPSFForAutoFocus) {
+            token.ThrowIfCancellationRequested();
+            return Task.FromResult(EvaluateFrame(image));
+        }
+
+        private StarDetectionResult EvaluateFrame(IRenderedImage image) {
+            var position = ledger.PositionFor(image);
+            var (hfr, sigma, starCount) = scenario.Evaluate(position);
+
+            var starList = new List<DetectedStar>(Math.Max(0, starCount));
+            for (var i = 0; i < starCount; i++) {
+                starList.Add(new DetectedStar { HFR = hfr });
+            }
+
+            // AverageHFR/HFRStdDev must be set explicitly: StarDetectionResult defaults them to NaN, but the engine reads
+            // Measure = AverageHFR and treats 0 as "no stars". starCount == 0 ⇒ hfr == 0 (the scenario guarantees this).
+            return new StarDetectionResult {
+                AverageHFR = hfr,
+                HFRStdDev = sigma,
+                DetectedStars = starCount,
+                StarList = starList,
+                Params = null
+            };
+        }
+
+        // ---- Unreached on the region==null Run() path (region/PSF/context/optimizer surfaces). --------------------
+
+        public IStarDetectionOptions StarDetectionOptions => null;
+
+        public IStarDetectionAnalysis CreateAnalysis() => throw new NotSupportedException();
+
+        public void UpdateAnalysis(IStarDetectionAnalysis analysis, StarDetectionParams p, StarDetectionResult result) => throw new NotSupportedException();
+
+        public HocusFocusDetectionParams ToHocusFocusParams(StarDetectionParams p) => throw new NotSupportedException();
+
+        public StarDetectorParams GetStarDetectorParams(IRenderedImage image, StarDetectionRegion starDetectionRegion, bool isAutoFocus) => throw new NotSupportedException();
+
+        public StarDetectorParams GetStarDetectorParams(IRenderedImage image, StarDetectionRegion starDetectionRegion, bool isAutoFocus, IStarDetectionOptions optionsOverride) => throw new NotSupportedException();
+
+        public StarDetectorParams GetDefaultStarDetectorParams(IRenderedImage image, StarDetectionRegion starDetectionRegion, bool isAutoFocus) => throw new NotSupportedException();
+
+        public Task<StarDetectionResult> Detect(IRenderedImage image, HocusFocusDetectionParams hocusFocusParams, StarDetectorParams detectorParams, IProgress<ApplicationStatus> progress, CancellationToken token) => throw new NotSupportedException();
+
+        public Task<HocusFocusDetectionContext> BuildDetectionContext(IRenderedImage image, HocusFocusDetectionParams hocusFocusParams, StarDetectorParams detectorParams, IProgress<ApplicationStatus> progress, CancellationToken token) => throw new NotSupportedException();
+
+        public StarDetectionResult GateAndMeasure(HocusFocusDetectionContext context, StarDetectorParams detectorParams, CancellationToken token) => throw new NotSupportedException();
+
+        public string ComputeEarlyCacheKey(StarDetectorParams detectorParams) => throw new NotSupportedException();
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/Harness/StampedImagingMediator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/Harness/StampedImagingMediator.cs
@@ -1,0 +1,128 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Model;
+using NINA.Core.Utility;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Equipment.Interfaces.ViewModel;
+using NINA.Equipment.Model;
+using NINA.Image.ImageData;
+using NINA.Image.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NSubstitute;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Media.Imaging;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus.Harness {
+
+    /// <summary>
+    /// A deterministic <see cref="IImagingMediator"/> for the AutoFocus sweep harness. It never renders pixels: on
+    /// <see cref="CaptureImage"/> it snapshots the focuser's position NOW and threads that position through the
+    /// exposure → image-data → rendered-frame chain, so <see cref="SweepFrameLedger"/> can bind the finished frame to
+    /// the position it was captured at (see the ledger for why "current" position is wrong). The image objects are
+    /// NSubstitute stand-ins carrying only what the engine's <c>region == null</c> path reads: small
+    /// <see cref="ImageProperties"/> (64×64, 16-bit, non-bayered) and a null <see cref="IRenderedImage.OriginalImage"/>
+    /// so the live-annotation path early-returns.
+    /// </summary>
+    internal sealed class StampedImagingMediator : IImagingMediator {
+        private readonly MovingFocuserMediator focuser;
+        private readonly SweepFrameLedger ledger;
+        private readonly int width;
+        private readonly int height;
+        private readonly int bitDepth;
+        private readonly bool isBayered;
+
+        // Carries the capture-time position from CaptureImage forward to PrepareImage: the position is stamped onto the
+        // IImageData the exposure yields, then read back when that image data is prepared. Reference-keyed so it is
+        // collected with the frames.
+        private sealed class PositionBox {
+            public int Position;
+        }
+
+        private readonly ConditionalWeakTable<IImageData, PositionBox> positionsByImageData = new ConditionalWeakTable<IImageData, PositionBox>();
+
+        public StampedImagingMediator(MovingFocuserMediator focuser, SweepFrameLedger ledger, int width = 64, int height = 64, int bitDepth = 16, bool isBayered = false) {
+            this.focuser = focuser ?? throw new ArgumentNullException(nameof(focuser));
+            this.ledger = ledger ?? throw new ArgumentNullException(nameof(ledger));
+            this.width = width;
+            this.height = height;
+            this.bitDepth = bitDepth;
+            this.isBayered = isBayered;
+        }
+
+        public Task<IExposureData> CaptureImage(CaptureSequence sequence, CancellationToken token, IProgress<ApplicationStatus> progress, string targetName = "") {
+            token.ThrowIfCancellationRequested();
+
+            // Snapshot the focuser position at CAPTURE time. Everything downstream reads this stamped value, never the
+            // live position, so a since-moved focuser cannot mis-attribute this frame's HFR.
+            var capturedPosition = focuser.Position;
+
+            var imageData = MakeImageData();
+            positionsByImageData.AddOrUpdate(imageData, new PositionBox { Position = capturedPosition });
+
+            var exposureData = Substitute.For<IExposureData>();
+            exposureData.ToImageData(Arg.Any<IProgress<ApplicationStatus>>(), Arg.Any<CancellationToken>())
+                .Returns(_ => Task.FromResult(imageData));
+            return Task.FromResult(exposureData);
+        }
+
+        public Task<IRenderedImage> PrepareImage(IImageData imageData, PrepareImageParameters parameters, CancellationToken token) {
+            token.ThrowIfCancellationRequested();
+
+            var capturedPosition = positionsByImageData.TryGetValue(imageData, out var box)
+                ? box.Position
+                : focuser.Position; // Only reached if an unstamped IImageData is prepared; keeps behavior defined.
+
+            var rendered = Substitute.For<IRenderedImage>();
+            rendered.RawImageData.Returns(imageData);
+            rendered.OriginalImage.Returns((BitmapSource)null); // annotation path early-returns on a null OriginalImage
+            rendered.Image.Returns((BitmapSource)null);
+
+            ledger.Associate(rendered, capturedPosition);
+            return Task.FromResult(rendered);
+        }
+
+        private IImageData MakeImageData() {
+            var imageData = Substitute.For<IImageData>();
+            imageData.Properties.Returns(new ImageProperties(width, height, bitDepth, isBayered, gain: 0, offset: 0));
+            return imageData;
+        }
+
+        // ---- Unreached on the region==null Run() path. -----------------------------------------------------------
+
+        public Task<IRenderedImage> CaptureAndPrepareImage(CaptureSequence sequence, PrepareImageParameters parameters, CancellationToken token, IProgress<ApplicationStatus> progress)
+            => throw new NotSupportedException();
+
+        public Task<IRenderedImage> PrepareImage(IExposureData imageData, PrepareImageParameters parameters, CancellationToken token)
+            => throw new NotSupportedException();
+
+        public Task<bool> StartLiveView(CaptureSequence sequence, CancellationToken ct) => throw new NotSupportedException();
+
+        public void DestroyImage() { }
+
+        public void SetImage(BitmapSource img) { }
+
+        public int GetImageRotation() => 0;
+
+        public void SetImageRotation(int rotation) { }
+
+        public void SetSubSambleRectangle(ObservableRectangle observableRectangle) { }
+
+        public void RegisterHandler(IImagingVM handler) { }
+
+        public event EventHandler<ImagePreparedEventArgs> ImagePrepared { add { } remove { } }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/Harness/SweepFrameLedger.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/Harness/SweepFrameLedger.cs
@@ -1,0 +1,57 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Image.Interfaces;
+using System;
+using System.Runtime.CompilerServices;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus.Harness {
+
+    /// <summary>
+    /// Maps each rendered/prepared frame to the focuser position it was CAPTURED at. This is what kills the
+    /// capture/detect concurrency race in the deterministic harness: capture happens on the walk thread and stamps the
+    /// current position, but detection runs later on a pooled task by which time the focuser may already have moved on
+    /// to the next point. Scripted detection therefore reads the FRAME's stamped position from this ledger, never the
+    /// focuser's live "current" position. Keyed by reference identity (a <see cref="ConditionalWeakTable{TKey, TValue}"/>)
+    /// so entries are collected with their frames and no test needs to clear it.
+    /// </summary>
+    internal sealed class SweepFrameLedger {
+
+        // ConditionalWeakTable requires a reference-type value; box the int so it can be stored (and updated on the rare
+        // re-association of the same frame instance).
+        private sealed class PositionBox {
+            public int Position;
+        }
+
+        private readonly ConditionalWeakTable<IRenderedImage, PositionBox> positionsByFrame = new ConditionalWeakTable<IRenderedImage, PositionBox>();
+
+        /// <summary>Binds <paramref name="image"/> to the focuser <paramref name="position"/> in effect at capture time.</summary>
+        public void Associate(IRenderedImage image, int position) {
+            if (image == null) {
+                throw new ArgumentNullException(nameof(image));
+            }
+            positionsByFrame.AddOrUpdate(image, new PositionBox { Position = position });
+        }
+
+        /// <summary>
+        /// Returns the focuser position <paramref name="image"/> was captured at. Throws if the frame was never
+        /// associated — an unassociated frame reaching detection means the harness wiring is broken, and silently
+        /// falling back to a "current" position would reintroduce the very race this ledger exists to remove.
+        /// </summary>
+        public int PositionFor(IRenderedImage image) {
+            if (image != null && positionsByFrame.TryGetValue(image, out var box)) {
+                return box.Position;
+            }
+            throw new InvalidOperationException("No focuser position is associated with this frame. The StampedImagingMediator must Associate every prepared frame before detection reads it.");
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/HocusFocusVMBehavioralTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/HocusFocusVMBehavioralTests.cs
@@ -5,6 +5,7 @@ using NINA.Joko.Plugins.HocusFocus.AutoFocus;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.Tests.Synthetic;
 using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NINA.WPF.Base.ViewModel.AutoFocus;
 using NSubstitute;
 using NUnit.Framework;
 using OxyPlot;
@@ -12,6 +13,7 @@ using OxyPlot.Series;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -41,6 +43,56 @@ public class HocusFocusVMBehavioralTests {
             Assert.That(vm.LastReport, Is.Null);
             Assert.That(vm.LoadSavedAutoFocusRunCommand, Is.Not.Null);
             Assert.That(vm.CancelLoadSavedAutoFocusRunCommand, Is.Not.Null);
+        });
+    }
+
+    // Regression: window-excluded points (Behavior A) must render ONLY as hollow rings. They are added to the filled
+    // marker series (PlotCoreFocusPoints) and connecting line (PlotFocusPoints) live, then moved to the hollow overlay
+    // at finalization. If they were left in the filled series, the filled marker would draw over the ring and the
+    // excluded point would look identical to an included one (the bug this guards). FocusPoints (report/fit) stays full.
+    [Test]
+    public void ApplyWindowExclusionToDisplay_MovesExcludedToHollowOverlay_KeepsFocusPointsFull() {
+        var vm = new MediatorBundle().BuildHocusFocusVM();
+        var positions = new[] { 100, 200, 300, 400, 500 };
+        foreach (var x in positions) {
+            var p = new ScatterErrorPoint(x, 3.0, 0, 0.1);
+            vm.FocusPoints.Add(p);
+            vm.PlotCoreFocusPoints.Add(p);
+            vm.PlotFocusPoints.Add(new DataPoint(x, 3.0));
+        }
+
+        // Finalization excludes the two far points (100 and 500) from the fit window.
+        var excluded = new List<AutoFocusRegionPoint> {
+            new AutoFocusRegionPoint { FocuserPosition = 100, Measurement = new MeasureAndError { Measure = 8.0, Stdev = 0.5 } },
+            new AutoFocusRegionPoint { FocuserPosition = 500, Measurement = new MeasureAndError { Measure = 8.2, Stdev = 0.5 } },
+        };
+        vm.ApplyWindowExclusionToDisplay(excluded);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.PlotCoreFocusPoints.Select(p => (int)Math.Round(p.X)), Is.EquivalentTo(new[] { 200, 300, 400 }));
+            Assert.That(vm.PlotFocusPoints.Select(p => (int)Math.Round(p.X)), Is.EquivalentTo(new[] { 200, 300, 400 }));
+            Assert.That(vm.PlotWindowExcludedFocusPoints.Select(p => (int)Math.Round(p.X)), Is.EquivalentTo(new[] { 100, 500 }));
+            Assert.That(vm.HasWindowExcludedFocusPoints, Is.True);
+            // Full measured set is untouched, so the saved report and fit still see every point.
+            Assert.That(vm.FocusPoints.Select(p => (int)Math.Round(p.X)), Is.EquivalentTo(positions));
+        });
+    }
+
+    [Test]
+    public void ApplyWindowExclusionToDisplay_NoExclusions_LeavesFilledSeriesIntact() {
+        var vm = new MediatorBundle().BuildHocusFocusVM();
+        foreach (var x in new[] { 200, 300, 400 }) {
+            var p = new ScatterErrorPoint(x, 3.0, 0, 0.1);
+            vm.PlotCoreFocusPoints.Add(p);
+            vm.FocusPoints.Add(p);
+        }
+
+        vm.ApplyWindowExclusionToDisplay(System.Array.Empty<AutoFocusRegionPoint>());
+
+        Assert.Multiple(() => {
+            Assert.That(vm.PlotCoreFocusPoints, Has.Count.EqualTo(3));
+            Assert.That(vm.PlotWindowExcludedFocusPoints, Is.Empty);
+            Assert.That(vm.HasWindowExcludedFocusPoints, Is.False);
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/Replay/AutoFocusReplayOptionsMapperTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/Replay/AutoFocusReplayOptionsMapperTests.cs
@@ -26,7 +26,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus.Replay {
             WeightedHyperbolicFitEnabled = true,
             HyperbolicFitModel = HyperbolicFitModel.SmoothBlend,
             FitRejectionCriterion = FitRejectionCriterion.ReducedChiSquared,
-            ReducedChiSquaredRejectionThreshold = 3.3
+            ReducedChiSquaredRejectionThreshold = 3.3,
+            MaxBlindStepsPerDirection = 6,
+            SymmetricFocusWindowEnabled = false
         };
 
         private static AutoFocusReplayMetadata SampleMetadata() => new AutoFocusReplayMetadata() {
@@ -83,7 +85,10 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus.Replay {
                 WeightedHyperbolicFitEnabled = true,
                 HyperbolicFitModel = HyperbolicFitModel.UnevenBlend,
                 FitRejectionCriterion = FitRejectionCriterion.ReducedChiSquared,
-                ReducedChiSquaredRejectionThreshold = 2.7
+                ReducedChiSquaredRejectionThreshold = 2.7,
+                MaxBlindStepsPerDirection = 6,
+                // Non-default (the DTO defaults this true) so a broken Apply/Capture that drops it fails the round-trip.
+                SymmetricFocusWindowEnabled = false
             };
             var snapshot = AutoFocusReplayOptionsMapper.Capture(source);
             var target = new AutoFocusEngineOptions();
@@ -106,6 +111,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus.Replay {
                 Assert.That(target.HyperbolicFitModel, Is.EqualTo(HyperbolicFitModel.UnevenBlend));
                 Assert.That(target.FitRejectionCriterion, Is.EqualTo(FitRejectionCriterion.ReducedChiSquared));
                 Assert.That(target.ReducedChiSquaredRejectionThreshold, Is.EqualTo(2.7));
+                Assert.That(target.MaxBlindStepsPerDirection, Is.EqualTo(6));
+                Assert.That(target.SymmetricFocusWindowEnabled, Is.EqualTo(false));
             });
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/CameraSimulatorAfDegradationCapstoneTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/CameraSimulatorAfDegradationCapstoneTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NINA.Joko.Plugins.HocusFocus.CameraSimulator;
+using NINA.Joko.Plugins.HocusFocus.CameraSimulator.Rendering;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.CameraSimulator {
+
+    /// <summary>
+    /// Tier-B realism capstones for the far-from-focus AutoFocus robustness battery
+    /// (<c>AutoFocusEngineSweepBatteryTests</c>). The deterministic Tier-A battery scripts its detector; these tests
+    /// anchor Tier A's degradation assumptions to real physics: full frames rendered by the real
+    /// <see cref="StarFieldCompositor"/> and read by the real <see cref="StarDetector"/>, with degradation induced
+    /// only via PHYSICAL levers (star magnitude, sky brightness, exposure, defocus distance).
+    /// <list type="bullet">
+    ///   <item><b>R1</b> — a field that detects cleanly at focus goes (near-)starless far from focus: the premise of
+    ///   the F1/F2/B-series cutoff scenarios.</item>
+    ///   <item><b>R2</b> — on a low-SNR frame far from focus, whatever the detector reports is a small population of
+    ///   LOW-HFR blobs, never real high-HFR donuts: the premise of the A3/AB1 false-minimum scenarios (spurious far
+    ///   detections mimic good focus because noise blobs are compact).</item>
+    /// </list>
+    /// Renders are seeded (<c>NoiseSeed</c>), so the detection outcomes asserted here are deterministic.
+    /// </summary>
+    [TestFixture]
+    [Category("SlowIntegration")]
+    public class CameraSimulatorAfDegradationCapstoneTests {
+
+        // Star field shared by both capstones: 8 faint stars spread across the frame, clear of the borders.
+        // Bright enough to be unambiguous at focus with the default scene sky/exposure, faint enough that their
+        // far-defocus donuts (flux spread over hundreds of pixels) sink below the noise. (Tuned empirically: at
+        // mag ~13 the +120-step donuts were STILL cleanly detected — the real detector is remarkably donut-tolerant —
+        // hence the fainter field and deeper defocus here.)
+        private static readonly (double px, double py, double mag)[] Placements = {
+            (500, 500, 14.6), (1500, 520, 14.8), (2500, 500, 15.0),
+            (520, 1500, 14.7), (2500, 1500, 15.2),
+            (500, 2500, 15.4), (1500, 2500, 14.9), (2500, 2500, 15.1),
+        };
+
+        private const int FarOffsetSteps = 240; // 1200 µm of defocus — far beyond any sane AF window
+
+        /// <summary>
+        /// R1 — faint field far from focus ⇒ the real detector goes (near-)starless. Confirms the regime Tier A's
+        /// cutoff knob scripts as "(0, 0, 0) beyond N steps": detection does not degrade gracefully far out, it
+        /// collapses, which is exactly what F1/F2 and the B-series reversal scenarios assume.
+        /// </summary>
+        [Test]
+        public async Task R1_FaintField_DetectsAtFocus_GoesStarlessFarFromFocus() {
+            var projection = SyntheticCameraTestScene.Projection();
+            var stars = Placements.Select(s => SyntheticCameraTestScene.StarAtPixel(projection, s.px, s.py, s.mag)).ToList();
+            var reader = new FakeCatalogReader(stars);
+
+            // Near-focus frame: every star should be an easy detection.
+            var nearRequest = SyntheticCameraTestScene.Request(SyntheticCameraTestScene.OptimalFocuserPosition);
+            var nearDetected = await Detect(reader, nearRequest);
+            var nearMatched = CountMatched(nearDetected);
+
+            // Far frame: the same field, 120 steps out. The defocus model predicts a huge donut; the per-pixel
+            // signal collapses by the donut's area ratio and the detector should find essentially nothing.
+            var farRequest = SyntheticCameraTestScene.Request(SyntheticCameraTestScene.OptimalFocuserPosition + FarOffsetSteps);
+            var expectedDonutHfr = ExpectedHfr(farRequest, FarOffsetSteps);
+            var farDetected = await Detect(reader, farRequest);
+            var farMatched = CountMatched(farDetected);
+
+            TestContext.WriteLine($"near: detected={nearDetected.Count} matched={nearMatched}/{Placements.Length}");
+            TestContext.WriteLine($"far (+{FarOffsetSteps} steps, expected donut HFR {expectedDonutHfr:F1}px): detected={farDetected.Count} matched={farMatched}");
+
+            Assert.Multiple(() => {
+                Assert.That(nearMatched, Is.GreaterThanOrEqualTo(6),
+                    "the field must be genuinely detectable at focus — otherwise 'goes starless far out' proves nothing");
+                Assert.That(farMatched, Is.LessThanOrEqualTo(1),
+                    "far from focus the real stars vanish (their donuts sink below the noise)");
+                Assert.That(farDetected.Count, Is.LessThanOrEqualTo(3),
+                    "the far frame is (near-)starless overall — the F1/F2 cutoff regime is physically real");
+            });
+        }
+
+        /// <summary>
+        /// R2 — low-SNR frame far from focus ⇒ any detections the real detector does report are FEW and LOW-HFR
+        /// (compact noise blobs), never the real ~13 px donuts. This is precisely the A3/AB1 premise: far-from-focus
+        /// spurious detections carry deceptively LOW HFR, so they can fake a focus minimum — and nothing detected far
+        /// out ever reports the true (high) defocus HFR.
+        /// </summary>
+        [Test]
+        public async Task R2_LowSnrFarFromFocus_AnyDetectionsAreFewAndLowHfr() {
+            var projection = SyntheticCameraTestScene.Projection();
+            var stars = Placements.Select(s => SyntheticCameraTestScene.StarAtPixel(projection, s.px, s.py, s.mag)).ToList();
+            var reader = new FakeCatalogReader(stars);
+
+            // Harsher physics than R1: bright sky + short exposure — the classic low-SNR AF frame.
+            const double harshSkyMagPerArcsec2 = 17.5;
+            const double harshExposureSeconds = 0.6;
+
+            var farRequest = SyntheticCameraTestScene.Request(
+                SyntheticCameraTestScene.OptimalFocuserPosition + FarOffsetSteps,
+                exposureSeconds: harshExposureSeconds) with {
+                SkyBrightnessMagPerArcsec2 = harshSkyMagPerArcsec2
+            };
+            var expectedDonutHfr = ExpectedHfr(farRequest, FarOffsetSteps);
+
+            var farDetected = await Detect(reader, farRequest);
+            var farMatched = CountMatched(farDetected);
+            var hfrs = farDetected.Select(d => d.HFR).OrderByDescending(h => h).ToList();
+
+            TestContext.WriteLine($"far low-SNR (+{FarOffsetSteps} steps, sky {harshSkyMagPerArcsec2}, {harshExposureSeconds}s): " +
+                $"detected={farDetected.Count} matched={farMatched} expectedDonutHFR={expectedDonutHfr:F1}px " +
+                $"HFRs=[{string.Join(", ", hfrs.Select(h => h.ToString("F2")))}]");
+
+            Assert.Multiple(() => {
+                // A small spurious population is tolerated (that is the point); a large one would mean the detector
+                // hallucinates whole star fields, which Tier A does not model.
+                Assert.That(farDetected.Count, Is.LessThanOrEqualTo(12),
+                    "far-out low-SNR frames yield at most a small population of detections");
+                Assert.That(farMatched, Is.LessThanOrEqualTo(1), "none of the real stars' donuts survive the noise");
+                // The A3/AB1 premise: anything reported far out is a compact (low-HFR) blob, nothing resembling the
+                // true defocus donut. A detection at ~the donut HFR would be a REAL measurement, not a spurious one.
+                Assert.That(farDetected.Where(d => d.HFR >= 0.5 * expectedDonutHfr), Is.Empty,
+                    "no far-out detection reports anywhere near the true defocus HFR — spurious detections are low-HFR");
+            });
+        }
+
+        // ------------------------------------------------------------------------------------------------------------
+
+        private static async Task<List<Star>> Detect(FakeCatalogReader reader, RenderRequest request) {
+            var sensor = SyntheticCameraTestScene.SensorDef;
+            var pixels = new StarFieldCompositor(reader).Render(request, CancellationToken.None);
+            using var mat = CvImageUtility.ToOpenCVMat(pixels, sensor.BitDepth, sensor.Width, sensor.Height);
+            var result = await new StarDetector(new AlglibAPI()).Detect(mat, new StarDetectorParams(), null, CancellationToken.None);
+            return result.DetectedStars ?? new List<Star>();
+        }
+
+        /// <summary>Injected stars recovered within 6 px of their projected pixel (the capstone matching convention).</summary>
+        private static int CountMatched(List<Star> detected) {
+            var matched = 0;
+            foreach (var (px, py, _) in Placements) {
+                var hit = detected.Any(d => Math.Sqrt((d.Center.X - px) * (d.Center.X - px) + (d.Center.Y - py) * (d.Center.Y - py)) < 6.0);
+                if (hit) {
+                    ++matched;
+                }
+            }
+            return matched;
+        }
+
+        private static double ExpectedHfr(RenderRequest request, int focuserOffsetSteps) {
+            var model = DefocusModel.FromRequest(request, SyntheticCameraTestScene.SensorDef, SyntheticCameraTestScene.FilterDef);
+            return model.HfrAtDefocusMicrons(focuserOffsetSteps * SyntheticCameraTestScene.FocuserStepSizeMicrons);
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
@@ -53,6 +53,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
         public bool KeepFramesForReview { get; set; }
         public string LastSelectedLoadPath { get; set; }
         public int FocuserOffset { get; set; }
+        public int MaxBlindStepsPerDirection { get; set; }
         public int MaxOutlierRejections { get; set; }
         public double OutlierRejectionConfidence { get; set; } = 0.95;
         public bool WeightedHyperbolicFitEnabled { get; set; }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TestDoubles/MediatorBundle.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TestDoubles/MediatorBundle.cs
@@ -26,7 +26,10 @@ internal sealed class MediatorBundle {
     public IApplicationStatusMediator ApplicationStatusMediator { get; } = Substitute.For<IApplicationStatusMediator>();
     public IImagingMediator ImagingMediator { get; } = Substitute.For<IImagingMediator>();
     public ICameraMediator CameraMediator { get; } = Substitute.For<ICameraMediator>();
-    public IFocuserMediator FocuserMediator { get; } = Substitute.For<IFocuserMediator>();
+    public IFocuserMediator FocuserMediator { get; private set; } = Substitute.For<IFocuserMediator>();
+
+    // Set by WithMovingFocuser: the concrete state-backed focuser (exposes Position + MoveHistory for assertions).
+    public MovingFocuserMediator MovingFocuser { get; private set; }
     public IFilterWheelMediator FilterWheelMediator { get; } = Substitute.For<IFilterWheelMediator>();
     public ITelescopeMediator TelescopeMediator { get; } = Substitute.For<ITelescopeMediator>();
     public IGuiderMediator GuiderMediator { get; } = Substitute.For<IGuiderMediator>();
@@ -52,6 +55,15 @@ internal sealed class MediatorBundle {
 
     public MediatorBundle WithFocuserConnected(bool connected = true, int position = 0) {
         FocuserMediator.GetInfo().Returns(new FocuserInfo { Connected = connected, Position = position });
+        return this;
+    }
+
+    // Swaps the substitute focuser for a concrete state-backed one that actually moves (clamping to [min, max]) and
+    // records every requested target in MoveHistory — the seam the deterministic AutoFocus sweep harness drives and
+    // the trace Behavior B's reversal is asserted against.
+    public MediatorBundle WithMovingFocuser(int start, int min = int.MinValue / 2, int max = int.MaxValue / 2) {
+        MovingFocuser = new MovingFocuserMediator(start, min, max);
+        FocuserMediator = MovingFocuser;
         return this;
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TestDoubles/MovingFocuserMediator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TestDoubles/MovingFocuserMediator.cs
@@ -1,0 +1,129 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Equipment.Equipment.MyFocuser;
+using NINA.Equipment.Interfaces;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Equipment.Interfaces.ViewModel;
+using OxyPlot;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles {
+
+    /// <summary>
+    /// A concrete, state-backed <see cref="IFocuserMediator"/> for the deterministic AutoFocus sweep harness. Unlike a
+    /// bare NSubstitute focuser, this actually MOVES: <see cref="MoveFocuser(int, CancellationToken)"/> clamps the
+    /// requested target to <c>[Min, Max]</c>, updates <see cref="Position"/>, and returns the (clamped) landing
+    /// position — so the engine's "Focuser reached its limit" guard (which compares the returned position against the
+    /// requested one) fires exactly when the travel range is exceeded. Every REQUESTED target (pre-clamp) is appended to
+    /// <see cref="MoveHistory"/>, which is how Behavior B's reversal is asserted: a cap-out shows up as a return toward
+    /// the start followed by moves in the opposite direction. Only the three members the engine actually calls —
+    /// <see cref="GetInfo"/>, <see cref="MoveFocuser(int, CancellationToken)"/>, and <see cref="ToggleTempComp(bool)"/> —
+    /// carry real behavior; the rest of the interface throws or no-ops.
+    /// </summary>
+    internal sealed class MovingFocuserMediator : IFocuserMediator {
+        private readonly List<int> moveHistory = new List<int>();
+
+        public MovingFocuserMediator(int start, int min = int.MinValue / 2, int max = int.MaxValue / 2) {
+            if (min > max) {
+                throw new ArgumentException($"min ({min}) must be <= max ({max})");
+            }
+            this.Min = min;
+            this.Max = max;
+            this.Position = Math.Min(max, Math.Max(min, start));
+        }
+
+        /// <summary>Current focuser position (already clamped into <c>[Min, Max]</c>).</summary>
+        public int Position { get; private set; }
+
+        /// <summary>Lower travel limit. A move below it clamps here, which trips the engine's limit guard.</summary>
+        public int Min { get; }
+
+        /// <summary>Upper travel limit. A move above it clamps here, which trips the engine's limit guard.</summary>
+        public int Max { get; }
+
+        /// <summary>Temperature reported by <see cref="GetInfo"/> (deterministic, never read for anything else here).</summary>
+        public double Temperature { get; set; } = 20.0;
+
+        /// <summary>
+        /// Every REQUESTED move target, in call order (pre-clamp). Behavior B's one-shot reversal is asserted against
+        /// this: the sweep caps out going one way, returns toward the start (initialFocusPosition), then explores the
+        /// other direction.
+        /// </summary>
+        public IReadOnlyList<int> MoveHistory => moveHistory;
+
+        public FocuserInfo GetInfo() => new FocuserInfo {
+            Connected = true,
+            Position = Position,
+            Temperature = Temperature,
+            IsMoving = false,
+            TempComp = false,
+            TempCompAvailable = false
+        };
+
+        public Task<int> MoveFocuser(int position, CancellationToken ct) {
+            ct.ThrowIfCancellationRequested();
+            moveHistory.Add(position);
+            Position = Math.Min(Max, Math.Max(Min, position));
+            return Task.FromResult(Position);
+        }
+
+        // ToggleTempComp is gated behind TempCompAvailable (false here), so the engine never calls it — but keep it a
+        // safe no-op rather than a throw in case a future caller does.
+        public void ToggleTempComp(bool tempComp) { }
+
+        // ---- Unreached on the region==null Run() path: fail loudly if the harness ever grows to touch them. --------
+
+        public Task<int> MoveFocuserRelative(int position, CancellationToken ct) => throw new NotSupportedException();
+
+        public Task<int> MoveFocuserByTemperatureRelative(double temperature, double slope, CancellationToken ct) => throw new NotSupportedException();
+
+        public void BroadcastSuccessfulAutoFocusRun(AutoFocusInfo info) { }
+
+        public void BroadcastNewAutoFocusPoint(DataPoint dataPoint) { }
+
+        public void BroadcastUserFocused(FocuserInfo info) { }
+
+        public void BroadcastAutoFocusRunStarting() { }
+
+        public void RegisterHandler(IFocuserVM handler) { }
+
+        public void RegisterConsumer(IFocuserConsumer consumer) { }
+
+        public void RemoveConsumer(IFocuserConsumer consumer) { }
+
+        public Task<IList<string>> Rescan() => throw new NotSupportedException();
+
+        public Task<bool> Connect() => throw new NotSupportedException();
+
+        public Task Disconnect() => throw new NotSupportedException();
+
+        public void Broadcast(FocuserInfo deviceInfo) { }
+
+        public string Action(string actionName, string actionParameters) => throw new NotSupportedException();
+
+        public string SendCommandString(string command, bool raw = true) => throw new NotSupportedException();
+
+        public bool SendCommandBool(string command, bool raw = true) => throw new NotSupportedException();
+
+        public void SendCommandBlind(string command, bool raw = true) => throw new NotSupportedException();
+
+        public IDevice GetDevice() => throw new NotSupportedException();
+
+        public event Func<object, EventArgs, Task> Connected { add { } remove { } }
+
+        public event Func<object, EventArgs, Task> Disconnected { add { } remove { } }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
@@ -269,7 +269,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
             /// <summary>
             /// Behavior A (symmetric-window exclusion at finalization only). Excludes fit-input points that fall
-            /// outside the window <c>minimum ± (offsetSteps+1)*stepSize</c>, then refits on the kept subset, so a
+            /// outside the window <c>minimum ± (offsetSteps+0.5)*stepSize</c>, then refits on the kept subset, so a
             /// lopsided or far-from-focus sweep does not bias the final fit. The window is centered on the FITTED
             /// VERTEX (<see cref="DetermineFinalFocusPoint"/> — a post-Grubbs, weighted least-squares estimate), NOT
             /// the lowest raw point, so a single spurious low-HFR far point cannot drag the center out to itself.
@@ -2064,10 +2064,10 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
         // Behavior A pure helpers for the final-fit symmetric window. Kept static and side-effect-free (mirroring
         // ComputeSweepPositions) so the window membership and partition logic can be unit-tested without a full sweep
-        // harness. STRICT bounds per spec: a point exactly on minimum ± (offsetSteps+1)*stepSize is treated as outside.
+        // harness. STRICT bounds per spec: a point exactly on minimum ± (offsetSteps+0.5)*stepSize is treated as outside.
         internal static bool IsWithinFocusWindow(double position, double minimumX, int offsetSteps, int stepSize) {
-            return position > minimumX - (offsetSteps + 1) * stepSize
-                && position < minimumX + (offsetSteps + 1) * stepSize;
+            return position > minimumX - (offsetSteps + 0.5) * stepSize
+                && position < minimumX + (offsetSteps + 0.5) * stepSize;
         }
 
         internal static (List<ScatterErrorPoint> included, List<ScatterErrorPoint> excluded) PartitionByFocusWindow(

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
@@ -1428,6 +1428,12 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             // fresh TooManyFailedMeasurements budget rather than immediately re-tripping on the pre-reversal failures.
             // Stays 0 when Behavior B is disabled, so the throw condition is byte-identical to `failureCount >= offsetSteps`.
             var failureBaseline = 0;
+            // Lowest trend-minimum HFR seen so far. Behavior B treats a walk that keeps LOWERING this (i.e. descending
+            // toward focus) as productive and resets its step-out budget, so a far start that legitimately needs many
+            // steps to reach focus is not reversed mid-descent. Only genuine non-progress — a wrong-way HFR rise or
+            // persistent detection failure, where the minimum stops improving — accumulates toward the cap. See the
+            // reset inside the walk loop.
+            double bestMinimumHfr = double.PositiveInfinity;
 
             // The single reversal action shared by both cap-out triggers (the failure-count throw site and the
             // directional step cap): latch hasReversed, force the opposite direction with a fresh step-out budget,
@@ -1517,6 +1523,22 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 // reversal can fire, so the branch taken (and everything inside it) is byte-identical to the original.
                 var stepLeft = leftTrendCount < offsetSteps;
                 if (behaviorBEnabled) {
+                    // A step that lowered the lowest MEASURED HFR means this direction is productively descending toward
+                    // focus — even before a two-sided bracket forms. We read the lowest measured point directly, NOT
+                    // trendlineFit.Minimum: that is the left/right trend INTERSECTION, which is null during a one-sided
+                    // descent (exactly the phase this guard exists for). Reset the step-out budget on every such
+                    // improvement so a far start is not reversed mid-descent; only genuine non-progress (a wrong-way HFR
+                    // rise or persistent detection failure, where the lowest HFR stops improving) accumulates toward the cap.
+                    var currentMinHfr = focusPoints.Values
+                        .Where(m => m.Measure > 0.0)
+                        .Select(m => m.Measure)
+                        .DefaultIfEmpty(double.PositiveInfinity)
+                        .Min();
+                    if (currentMinHfr < bestMinimumHfr - 1e-6) {
+                        bestMinimumHfr = currentMinHfr;
+                        leftStepOuts = 0;
+                        rightStepOuts = 0;
+                    }
                     if (forcedDirection.HasValue) {
                         stepLeft = forcedDirection.Value == WalkDirection.Left;
                     }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusEngine.cs
@@ -98,6 +98,11 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
             public ImmutableList<ScatterErrorPoint> RejectedPoints { get; private set; }
 
+            // Points excluded from the final fit because they fall outside the symmetric focus window (Behavior A).
+            // A sibling of RejectedPoints (Grubbs outliers), never reclassified as rejected. Empty until Behavior A
+            // populates it.
+            public ImmutableList<ScatterErrorPoint> WindowExcludedPoints { get; private set; }
+
             public static CurveFittingResult Calculate(
                 AutoFocusState state,
                 AFMethodEnum method,
@@ -163,7 +168,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     if (rejectedPoint == null || outlierRejectedPoints >= maxOutlierRejectedPoints) {
                         return new CurveFittingResult() {
                             Fittings = fittings,
-                            RejectedPoints = ImmutableList.CreateRange(rejectedPoints)
+                            RejectedPoints = ImmutableList.CreateRange(rejectedPoints),
+                            WindowExcludedPoints = ImmutableList<ScatterErrorPoint>.Empty
                         };
                     }
 
@@ -203,11 +209,16 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             public AutoFocusFitting Fittings { get; private set; } = new AutoFocusFitting();
             public Dictionary<int, MeasureAndError> RejectedPoints { get; private set; } = new Dictionary<int, MeasureAndError>();
 
+            // Points excluded from the final fit by the symmetric focus window (Behavior A), a sibling of
+            // RejectedPoints (Grubbs outliers). Stays empty until Behavior A fills it.
+            public Dictionary<int, MeasureAndError> WindowExcludedPoints { get; private set; } = new Dictionary<int, MeasureAndError>();
+
             public void ResetMeasurements() {
                 lock (SubMeasurementsLock) {
                     this.MeasurementsByFocuserPoint.Clear();
                     this.SubMeasurementsByFocuserPoints.Clear();
                     this.RejectedPoints.Clear();
+                    this.WindowExcludedPoints.Clear();
                     this.FinalHFRSubMeasurements.Clear();
                     this.FinalHFR = null;
                     this.Fittings.Reset();
@@ -254,6 +265,60 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
             public void CalculateFinalFocusPoint() {
                 this.FinalFocusPoint = DetermineFinalFocusPoint();
+            }
+
+            /// <summary>
+            /// Behavior A (symmetric-window exclusion at finalization only). Excludes fit-input points that fall
+            /// outside the window <c>minimum ± (offsetSteps+1)*stepSize</c>, then refits on the kept subset, so a
+            /// lopsided or far-from-focus sweep does not bias the final fit. The window is centered on the FITTED
+            /// VERTEX (<see cref="DetermineFinalFocusPoint"/> — a post-Grubbs, weighted least-squares estimate), NOT
+            /// the lowest raw point, so a single spurious low-HFR far point cannot drag the center out to itself.
+            /// Bounded fit→window→refit fixed point: point removal is monotonic, so it terminates in at most
+            /// <c>offsetSteps+1</c> passes (usually 1). The kept set is never allowed below 3 valid (Y &gt; 0) points,
+            /// the floor under which <see cref="CurveFittingResult.Calculate"/> returns null. Dropped points are
+            /// recorded in <see cref="WindowExcludedPoints"/>, a sibling of the Grubbs <see cref="RejectedPoints"/>
+            /// and disjoint from it by construction (windowing runs before the fit; Grubbs runs inside the fit of the
+            /// kept subset). Refitting goes through <see cref="UpdateCurveFittings"/>, which only swaps
+            /// <c>lastValidFocusPoints</c> and the derived fittings — <see cref="MeasurementsByFocuserPoint"/> (the raw
+            /// measurements for reports/charts) is never touched. Returns true when any point was excluded. No-op
+            /// (returns false, byte-identical) when the internal <c>SymmetricFocusWindowEnabled</c> flag is off.
+            /// </summary>
+            public bool ApplyFinalSymmetricWindow(int offsetSteps, int stepSize) {
+                if (!State.Options.SymmetricFocusWindowEnabled) {
+                    return false;
+                }
+                if (lastValidFocusPoints == null) {
+                    return false;
+                }
+
+                var anyExcluded = false;
+                var maxPasses = offsetSteps + 1;
+                for (var pass = 0; pass < maxPasses; pass++) {
+                    var center = DetermineFinalFocusPoint()?.X;
+                    if (!center.HasValue) {
+                        break;
+                    }
+
+                    var (included, excluded) = PartitionByFocusWindow(lastValidFocusPoints, center.Value, offsetSteps, stepSize);
+                    if (excluded.Count == 0) {
+                        break;
+                    }
+
+                    // Never drop below the 3-valid-point floor the fit requires; if we would, keep the current fit as-is.
+                    if (included.Count(p => p.Y > 0.0) < 3) {
+                        break;
+                    }
+
+                    UpdateCurveFittings(included);
+                    lock (SubMeasurementsLock) {
+                        foreach (var ep in excluded) {
+                            var focuserPosition = (int)Math.Round(ep.X);
+                            this.WindowExcludedPoints[focuserPosition] = new MeasureAndError() { Measure = ep.Y, Stdev = ep.ErrorY };
+                        }
+                    }
+                    anyExcluded = true;
+                }
+                return anyExcluded;
             }
 
             /// <summary>
@@ -478,6 +543,28 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             }
             // Guard a no-op / runaway re-sweep: require a valid point that differs from the center we just swept.
             return calculatedPoint >= 0 && calculatedPoint != currentSweepCenter;
+        }
+
+        // Which way the blind sweep is stepping. Only meaningful when Behavior B (the directional bootstrap cap) is
+        // enabled; the initial seed points sit on the high side, so the pre-walk direction is treated as Right.
+        private enum WalkDirection {
+            Left,
+            Right
+        }
+
+        private static WalkDirection OppositeDirection(WalkDirection direction) {
+            return direction == WalkDirection.Left ? WalkDirection.Right : WalkDirection.Left;
+        }
+
+        // Behavior B decision (directional bootstrap cap + one-shot reversal). Pure so it is unit-testable without a
+        // full sweep harness. Reverse only when the direction we are ABOUT to step has already reached the effective
+        // cap, we have not yet formed a two-sided interior bracket, and we have not already reversed once (latch → at
+        // most one reversal per sweep, so no oscillation).
+        internal static bool ShouldReverseDirection(int stepOutsThisDir, int effectiveCap, bool bracketFormed, bool hasReversed) {
+            if (hasReversed || bracketFormed) {
+                return false;
+            }
+            return stepOutsThisDir >= effectiveCap;
         }
 
         // Builds the diagnostic explaining WHY the HFR-improvement validation rejected a region. The generic
@@ -1322,6 +1409,43 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             Logger.Info("Waiting on initial focuser move analyses");
             await Task.WhenAll(autoFocusState.AnalysisTasks);
 
+            // Behavior B (directional bootstrap cap + one-shot reversal). When the configured cap is 0 the behavior
+            // is DISABLED and the walk below is byte-identical to the original: no counter influences a decision and
+            // the TooManyFailedMeasurements throw reverts to `failureCount >= offsetSteps`. effectiveCap can never be
+            // tighter than a valid two-sided bracket needs (offsetSteps + 1). All of this is pure local state read
+            // only under the same SubMeasurementsLock trend snapshot the walk already relies on, so the reversal
+            // decision depends only on counts/trend state, not measurement completion order (replay determinism).
+            var configuredCap = autoFocusState.Options.MaxBlindStepsPerDirection;
+            var behaviorBEnabled = configuredCap > 0;
+            var effectiveCap = Math.Max(configuredCap, offsetSteps + 1);
+            var leftStepOuts = 0;
+            var rightStepOuts = 0;
+            var hasReversed = false;
+            WalkDirection? forcedDirection = null;
+            // The seed points sit on the high (right) side, so failures before the first walk step are attributed to Right.
+            var lastStepDirection = WalkDirection.Right;
+            // Failures accumulated BEFORE the (single) reversal are baselined out so the reversed direction gets a
+            // fresh TooManyFailedMeasurements budget rather than immediately re-tripping on the pre-reversal failures.
+            // Stays 0 when Behavior B is disabled, so the throw condition is byte-identical to `failureCount >= offsetSteps`.
+            var failureBaseline = 0;
+
+            // The single reversal action shared by both cap-out triggers (the failure-count throw site and the
+            // directional step cap): latch hasReversed, force the opposite direction with a fresh step-out budget,
+            // baseline out the pre-reversal failures, and physically return toward the start before exploring the
+            // other side. Only ever called when Behavior B is enabled and !hasReversed, so it fires at most once.
+            async Task ReverseWalkAsync(WalkDirection newForcedDirection, int currentFailureCount) {
+                hasReversed = true;
+                forcedDirection = newForcedDirection;
+                if (newForcedDirection == WalkDirection.Left) {
+                    leftStepOuts = 0;
+                } else {
+                    rightStepOuts = 0;
+                }
+                failureBaseline = currentFailureCount;
+                Logger.Info($"Blind AutoFocus could not bracket focus within {effectiveCap} steps going {OppositeDirection(newForcedDirection)}; returning to {initialFocusPosition} and forcing the {newForcedDirection} direction");
+                await focuserMediator.MoveFocuser(initialFocusPosition, token);
+            }
+
             while (true) {
                 token.ThrowIfCancellationRequested();
 
@@ -1334,8 +1458,16 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
                 var currentPosition = focuserMediator.GetInfo().Position;
                 var failureCount = focusPoints.Count(fp => fp.Value.Measure == 0.0);
-                if (failureCount >= offsetSteps) {
-                    throw new TooManyFailedMeasurementsException(failureCount);
+                if (failureCount - failureBaseline >= offsetSteps) {
+                    if (behaviorBEnabled && !hasReversed) {
+                        // Behavior B: the direction we've been walking piled up too many failed detections without
+                        // bracketing focus. Rather than failing the whole sweep, return to the start and try the
+                        // other direction once (reversal-aware throw). Only once BOTH directions are exhausted
+                        // (hasReversed, i.e. offsetSteps NEW failures after the reversal) do we actually throw.
+                        await ReverseWalkAsync(OppositeDirection(lastStepDirection), failureCount);
+                    } else {
+                        throw new TooManyFailedMeasurementsException(failureCount);
+                    }
                 }
 
                 // When we've reached a limit on either end of the potential minimum based on trends, then we can queue up the remaining points
@@ -1380,7 +1512,25 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     break;
                 }
 
-                if (leftTrendCount < offsetSteps) {
+                // Behavior B: choose the step direction, honoring a forced direction set by a prior reversal. When
+                // the behavior is disabled, stepLeft is exactly the original `leftTrendCount < offsetSteps` and no
+                // reversal can fire, so the branch taken (and everything inside it) is byte-identical to the original.
+                var stepLeft = leftTrendCount < offsetSteps;
+                if (behaviorBEnabled) {
+                    if (forcedDirection.HasValue) {
+                        stepLeft = forcedDirection.Value == WalkDirection.Left;
+                    }
+                    var bracketFormed = leftTrendCount > 0 && rightTrendCount > 0;
+                    var stepOutsThisDir = stepLeft ? leftStepOuts : rightStepOuts;
+                    if (ShouldReverseDirection(stepOutsThisDir, effectiveCap, bracketFormed, hasReversed)) {
+                        await ReverseWalkAsync(stepLeft ? WalkDirection.Right : WalkDirection.Left, failureCount);
+                        stepLeft = forcedDirection.Value == WalkDirection.Left;
+                    }
+                }
+
+                if (stepLeft) {
+                    ++leftStepOuts;
+                    lastStepDirection = WalkDirection.Left;
                     var previousTarget = leftMostPosition;
                     leftMostPosition -= stepSize;
                     var actualFocuserPosition = await focuserMediator.MoveFocuser(leftMostPosition, token);
@@ -1395,6 +1545,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     Logger.Info("Waiting on next left movement analysis");
                     await Task.WhenAll(autoFocusState.AnalysisTasks);
                 } else { // if (rightTrendCount < offsetSteps) {
+                    ++rightStepOuts;
+                    lastStepDirection = WalkDirection.Right;
                     var previousTarget = rightMostPosition;
                     rightMostPosition += stepSize;
                     var actualFocuserPosition = await focuserMediator.MoveFocuser(rightMostPosition, token);
@@ -1714,9 +1866,14 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                         }
                     }
 
+                    // Out-of-bounds gate keeps using the FULL measured range so windowing can only reduce a
+                    // FinalPointOutOfBounds, never narrow the range and mask an extrapolating fit.
                     var min = autoFocusRegionState.MeasurementsByFocuserPoint.Min(x => x.Key);
                     var max = autoFocusRegionState.MeasurementsByFocuserPoint.Max(x => x.Key);
 
+                    // Behavior A: exclude far points outside the symmetric window (per region, around its own vertex)
+                    // and refit BEFORE model selection, so a lopsided/far-from-focus sweep does not bias the final fit.
+                    autoFocusRegionState.ApplyFinalSymmetricWindow(autoFocusState.Options.AutoFocusInitialOffsetSteps, autoFocusState.Options.AutoFocusStepSize);
                     autoFocusRegionState.SelectBestHyperbolicModel();
                     autoFocusRegionState.CalculateFinalFocusPoint();
                     autoFocusRegionState.ComputeLeaveOneOutStability();
@@ -1905,6 +2062,28 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             return positions;
         }
 
+        // Behavior A pure helpers for the final-fit symmetric window. Kept static and side-effect-free (mirroring
+        // ComputeSweepPositions) so the window membership and partition logic can be unit-tested without a full sweep
+        // harness. STRICT bounds per spec: a point exactly on minimum ± (offsetSteps+1)*stepSize is treated as outside.
+        internal static bool IsWithinFocusWindow(double position, double minimumX, int offsetSteps, int stepSize) {
+            return position > minimumX - (offsetSteps + 1) * stepSize
+                && position < minimumX + (offsetSteps + 1) * stepSize;
+        }
+
+        internal static (List<ScatterErrorPoint> included, List<ScatterErrorPoint> excluded) PartitionByFocusWindow(
+            IReadOnlyList<ScatterErrorPoint> points, double minimumX, int offsetSteps, int stepSize) {
+            var included = new List<ScatterErrorPoint>();
+            var excluded = new List<ScatterErrorPoint>();
+            foreach (var point in points) {
+                if (IsWithinFocusWindow(point.X, minimumX, offsetSteps, stepSize)) {
+                    included.Add(point);
+                } else {
+                    excluded.Add(point);
+                }
+            }
+            return (included, excluded);
+        }
+
         private async Task<AutoFocusResult> RunImpl(AutoFocusEngineOptions options, FilterInfo imagingFilter, List<StarDetectionRegion> regions, CancellationToken token, IProgress<ApplicationStatus> progress) {
             if (!TryClaimAutoFocusInProgress()) {
                 Notification.ShowError("Another AutoFocus is already in progress");
@@ -1993,7 +2172,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                         EstimatedFinalFocuserPosition = rs.FinalFocusPoint?.X ?? double.NaN,
                         EstimatedFinalHFR = rs.FinalFocusPoint?.Y ?? double.NaN,
                         Fittings = rs.Fittings,
-                        RejectedPoints = rs.RejectedPoints.Select(p => new AutoFocusRegionPoint() { FocuserPosition = p.Key, Measurement = p.Value }).ToArray()
+                        RejectedPoints = rs.RejectedPoints.Select(p => new AutoFocusRegionPoint() { FocuserPosition = p.Key, Measurement = p.Value }).ToArray(),
+                        WindowExcludedPoints = rs.WindowExcludedPoints.Select(p => new AutoFocusRegionPoint() { FocuserPosition = p.Key, Measurement = p.Value }).ToArray()
                     }).OrderBy(r => r.RegionIndex).ToArray(),
                     SaveFolder = autoFocusState.SaveFolder
                 };
@@ -2480,6 +2660,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
                 await Task.WhenAll(focuserPositionTasks);
                 foreach (var regionState in state.FocusRegionStates) {
+                    // Behavior A: window each region around its own fitted vertex and refit before model selection.
+                    regionState.ApplyFinalSymmetricWindow(state.Options.AutoFocusInitialOffsetSteps, state.Options.AutoFocusStepSize);
                     regionState.SelectBestHyperbolicModel();
                     regionState.CalculateFinalFocusPoint();
                     // Mirror the live Run path: compute best-focus stability so a replayed/loaded run shows LOO in
@@ -2499,7 +2681,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                         EstimatedFinalFocuserPosition = rs.FinalFocusPoint?.X ?? double.NaN,
                         EstimatedFinalHFR = rs.FinalFocusPoint?.Y ?? double.NaN,
                         Fittings = rs.Fittings,
-                        RejectedPoints = rs.RejectedPoints.Select(p => new AutoFocusRegionPoint() { FocuserPosition = p.Key, Measurement = p.Value }).ToArray()
+                        RejectedPoints = rs.RejectedPoints.Select(p => new AutoFocusRegionPoint() { FocuserPosition = p.Key, Measurement = p.Value }).ToArray(),
+                        WindowExcludedPoints = rs.WindowExcludedPoints.Select(p => new AutoFocusRegionPoint() { FocuserPosition = p.Key, Measurement = p.Value }).ToArray()
                     }).OrderBy(r => r.RegionIndex).ToArray(),
                     SaveFolder = state.SaveFolder
                 };
@@ -2551,7 +2734,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 FocuserPosition = imageState.FocuserPosition,
                 Measurement = measurement,
                 Fittings = regionState.Fittings.Clone(),
-                RejectedPoints = regionState.RejectedPoints.Select(p => new AutoFocusRegionPoint() { FocuserPosition = p.Key, Measurement = p.Value }).ToArray()
+                RejectedPoints = regionState.RejectedPoints.Select(p => new AutoFocusRegionPoint() { FocuserPosition = p.Key, Measurement = p.Value }).ToArray(),
+                WindowExcludedPoints = regionState.WindowExcludedPoints.Select(p => new AutoFocusRegionPoint() { FocuserPosition = p.Key, Measurement = p.Value }).ToArray()
             });
         }
 
@@ -2699,7 +2883,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     EstimatedFinalFocuserPosition = s.FinalFocusPoint?.X ?? double.NaN,
                     FinalFocuserPosition = (int)Math.Round(s.FinalFocusPoint?.X ?? -1),
                     Fittings = s.Fittings,
-                    RejectedPoints = s.RejectedPoints.Select(p => new AutoFocusRegionPoint() { FocuserPosition = p.Key, Measurement = p.Value }).ToArray()
+                    RejectedPoints = s.RejectedPoints.Select(p => new AutoFocusRegionPoint() { FocuserPosition = p.Key, Measurement = p.Value }).ToArray(),
+                    WindowExcludedPoints = s.WindowExcludedPoints.Select(p => new AutoFocusRegionPoint() { FocuserPosition = p.Key, Measurement = p.Value }).ToArray()
                 }).ToImmutableList();
             Completed?.Invoke(this, new AutoFocusCompletedEventArgs() {
                 Iteration = iteration,
@@ -2769,12 +2954,16 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 AutoFocusInitialOffsetSteps = profileService.ActiveProfile.FocuserSettings.AutoFocusInitialOffsetSteps,
                 AutoFocusStepSize = ((savedAttempt?.StepSize != null) && (savedAttempt?.StepSize > 0)) ? savedAttempt.StepSize.Value : profileService.ActiveProfile.FocuserSettings.AutoFocusStepSize,
                 FocuserOffset = autoFocusOptions.FocuserOffset,
+                MaxBlindStepsPerDirection = autoFocusOptions.MaxBlindStepsPerDirection,
                 MaxOutlierRejections = autoFocusOptions.MaxOutlierRejections,
                 OutlierRejectionConfidence = autoFocusOptions.OutlierRejectionConfidence,
                 WeightedHyperbolicFitEnabled = autoFocusOptions.WeightedHyperbolicFitEnabled,
                 HyperbolicFitModel = autoFocusOptions.HyperbolicFitModel,
                 FitRejectionCriterion = autoFocusOptions.FitRejectionCriterion,
                 ReducedChiSquaredRejectionThreshold = autoFocusOptions.ReducedChiSquaredRejectionThreshold,
+                // Always-on internal behavior (Behavior A). Hard-wired true; the DTO flag is a test seam only, with
+                // no persisted option or UI. Nothing consumes it yet at this checkpoint.
+                SymmetricFocusWindowEnabled = true,
             };
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/AutoFocusOptions.cs
@@ -58,6 +58,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             keepFramesForReview = optionsAccessor.GetValueBoolean(nameof(KeepFramesForReview), false);
             lastSelectedLoadPath = optionsAccessor.GetValueString("LastSelectedLoadPath", "");
             focuserOffset = optionsAccessor.GetValueInt32("FocuserOffset", 0);
+            maxBlindStepsPerDirection = optionsAccessor.GetValueInt32(nameof(MaxBlindStepsPerDirection), 8);
             maxOutlierRejections = optionsAccessor.GetValueInt32(nameof(MaxOutlierRejections), 1);
             outlierRejectionConfidence = optionsAccessor.GetValueDouble(nameof(OutlierRejectionConfidence), 0.90);
             weightedHyperbolicFitEnabled = optionsAccessor.GetValueBoolean(nameof(WeightedHyperbolicFitEnabled), true);
@@ -76,6 +77,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             KeepFramesForReview = false;
             LastSelectedLoadPath = "";
             FocuserOffset = 0;
+            MaxBlindStepsPerDirection = 8;
             MaxOutlierRejections = 1;
             OutlierRejectionConfidence = 0.90;
             WeightedHyperbolicFitEnabled = true;
@@ -204,6 +206,23 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 if (focuserOffset != value) {
                     focuserOffset = value;
                     optionsAccessor.SetValueInt32("FocuserOffset", focuserOffset);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private int maxBlindStepsPerDirection;
+
+        public int MaxBlindStepsPerDirection {
+            get => maxBlindStepsPerDirection;
+            set {
+                if (maxBlindStepsPerDirection != value) {
+                    if (value < 0) {
+                        throw new ArgumentException("MaxBlindStepsPerDirection must be non-negative", nameof(MaxBlindStepsPerDirection));
+                    }
+
+                    maxBlindStepsPerDirection = value;
+                    optionsAccessor.SetValueInt32(nameof(MaxBlindStepsPerDirection), maxBlindStepsPerDirection);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -124,7 +124,19 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
-            <oxy:Plot
+            <DockPanel Grid.Row="0">
+                <!--  Legend for the hollow window-excluded markers, shown only once the symmetric focus window (Behavior A)
+                      actually excludes a point. ○ = a far-from-focus point dropped from the fit — deliberately NOT the app's
+                      red-cross "rejected point" language, since these points are present and valid, just outside the window.  -->
+                <TextBlock
+                    DockPanel.Dock="Bottom"
+                    Margin="6,2,0,0"
+                    HorizontalAlignment="Left"
+                    FontSize="10"
+                    Foreground="{StaticResource SecondaryBrush}"
+                    Text="&#x25CB; excluded — outside focus window"
+                    Visibility="{Binding HasWindowExcludedFocusPoints, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                <oxy:Plot
                 Background="{StaticResource BackgroundBrush}"
                 PlotAreaBackground="{StaticResource BackgroundBrush}"
                 PlotAreaBorderColor="{Binding Path=Color, Source={StaticResource BorderBrush}}"
@@ -160,6 +172,24 @@
                         TicklineColor="{Binding Path=Color, Source={StaticResource SecondaryBrush}}" />
                 </oxy:Plot.Axes>
                 <oxy:Plot.Series>
+                    <!--  Window-excluded overlay (Behavior A): sweep points outside the symmetric focus window, rendered as
+                          hollow rings (transparent fill + faint primary stroke) with a dimmed HFR error bar, so they read as
+                          "present but excluded from the fit" WITHOUT the red-cross "rejected point" language used below.
+                          Declared BEFORE the filled FocusPoints series so it draws underneath. Empty (nothing drawn) for a
+                          well-centered run, so this is inert at the baseline. Mirrors the optimizer's recovery overlay.  -->
+                    <oxy:ScatterErrorSeries
+                        DataFieldX="FocusPosition"
+                        DataFieldY="HFR"
+                        ErrorBarColor="{Binding Path=Color, Source={StaticResource NotificationErrorBrush}, Converter={StaticResource SetAlphaToColorConverter}, ConverterParameter=100}"
+                        ErrorBarStopWidth="2"
+                        ErrorBarStrokeThickness="1"
+                        ItemsSource="{Binding PlotWindowExcludedFocusPoints}"
+                        MarkerFill="Transparent"
+                        MarkerSize="5"
+                        MarkerStroke="{Binding Path=Color, Source={StaticResource PrimaryBrush}, Converter={StaticResource SetAlphaToColorConverter}, ConverterParameter=150}"
+                        MarkerStrokeThickness="1.5"
+                        MarkerType="Circle"
+                        TrackerFormatString="Focuser: {2:0}, HFR: {4:0.000} (excluded)" />
                     <oxy:ScatterErrorSeries
                         DataFieldX="FocusPosition"
                         DataFieldY="HFR"
@@ -371,7 +401,8 @@
                         </oxy:PointAnnotation.Stroke>
                     </oxy:PointAnnotation>
                 </oxy:Plot.Annotations>
-            </oxy:Plot>
+                </oxy:Plot>
+            </DockPanel>
             <StackPanel Grid.Row="1" Orientation="Vertical">
                 <Border
                     Margin="0,5,0,0"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -196,7 +196,7 @@
                         ErrorBarColor="{Binding Path=Color, Source={StaticResource NotificationErrorBrush}}"
                         ErrorBarStopWidth="2"
                         ErrorBarStrokeThickness="2"
-                        ItemsSource="{Binding FocusPoints}"
+                        ItemsSource="{Binding PlotCoreFocusPoints}"
                         MarkerFill="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
                         MarkerType="Circle" />
                     <oxy:LineSeries

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/HocusFocusVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/HocusFocusVM.cs
@@ -63,6 +63,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         private AsyncObservableCollection<DataPoint> plotFocusPointsObservable;
         private AsyncObservableCollection<ScatterPoint> plotRejectedFocusPointsObservable;
         private AsyncObservableCollection<ScatterErrorPoint> plotWindowExcludedFocusPointsObservable;
+        private AsyncObservableCollection<ScatterErrorPoint> plotCoreFocusPointsObservable;
         private QuadraticFitting quadraticFitting;
         private TrendlineFitting trendLineFitting;
         private TimeSpan autoFocusDuration;
@@ -133,6 +134,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             PlotFocusPoints = new AsyncObservableCollection<DataPoint>();
             PlotRejectedFocusPoints = new AsyncObservableCollection<ScatterPoint>();
             PlotWindowExcludedFocusPoints = new AsyncObservableCollection<ScatterErrorPoint>();
+            PlotCoreFocusPoints = new AsyncObservableCollection<ScatterErrorPoint>();
             ClearCharts();
 
             this.progress = ProgressFactory.Create(applicationStatusMediator, "Hocus Focus");
@@ -246,6 +248,23 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             }
             set {
                 focusPointsObservable = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// The filled AF-curve markers actually drawn on the chart: the measured points MINUS the window-excluded
+        /// ones (Behavior A). The chart's filled ScatterErrorSeries binds here, while <see cref="FocusPoints"/> stays
+        /// the full measured set used by the saved report and the fit. Keeping them separate is what lets the hollow
+        /// "excluded" overlay read as hollow: a window-excluded point left in the filled series would be drawn over
+        /// its ring and look identical to an included point. Mirrors the optimizer chart's CorePoints/RecoveryPoints split.
+        /// </summary>
+        public AsyncObservableCollection<ScatterErrorPoint> PlotCoreFocusPoints {
+            get {
+                return plotCoreFocusPointsObservable;
+            }
+            set {
+                plotCoreFocusPointsObservable = value;
                 RaisePropertyChanged();
             }
         }
@@ -386,6 +405,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             PlotFocusPoints.Clear();
             PlotRejectedFocusPoints.Clear();
             PlotWindowExcludedFocusPoints.Clear();
+            PlotCoreFocusPoints.Clear();
             RaisePropertyChanged(nameof(HasWindowExcludedFocusPoints));
             TrendlineFitting = null;
             QuadraticFitting = null;
@@ -740,6 +760,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             PlotFinalFocusPointWithError.Clear();
             PlotFocusPoints.Clear();
             PlotRejectedFocusPoints.Clear();
+            PlotCoreFocusPoints.Clear();
+            PlotWindowExcludedFocusPoints.Clear();
+            RaisePropertyChanged(nameof(HasWindowExcludedFocusPoints));
         }
 
         private void AutoFocusEngine_CompletedNoReport(object sender, AutoFocusFinishedEventArgsBase e) {
@@ -782,19 +805,39 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 }
             }
 
-            // Symmetric-window exclusions (Behavior A) are only produced by the finalized region fit, so the real set
-            // arrives here (empty on the live per-point events). Mirror the rejected-overlay re-sync as a sibling
-            // collection, built like the main FocusPoints series so the hollow-ring overlay carries the same HFR error bar.
-            PlotWindowExcludedFocusPoints.Clear();
-            if (firstRegion.WindowExcludedPoints != null) {
-                foreach (var wp in firstRegion.WindowExcludedPoints) {
-                    PlotWindowExcludedFocusPoints.Add(new ScatterErrorPoint(wp.FocuserPosition, wp.Measurement.Measure, 0, AutoFocusEngine.SafeDisplayError(wp.Measurement.Stdev)));
-                }
-            }
-            RaisePropertyChanged(nameof(HasWindowExcludedFocusPoints));
+            // Symmetric-window exclusions (Behavior A) are produced only by the finalized region fit, so the real set
+            // arrives here (empty on the live per-point events). Move them into the hollow-ring overlay and out of the
+            // filled/line display series (see ApplyWindowExclusionToDisplay); FocusPoints is left intact.
+            ApplyWindowExclusionToDisplay(firstRegion.WindowExcludedPoints);
 
             RefreshFinalFocusPointError();
             AutoFocusDuration = e.Duration;
+        }
+
+        /// <summary>
+        /// Reconciles the chart's display series with the finalized window-excluded set (Behavior A): fills the hollow
+        /// "excluded" overlay and removes those focuser positions from the filled-marker (<see cref="PlotCoreFocusPoints"/>)
+        /// and connecting-line (<see cref="PlotFocusPoints"/>) series, so each excluded point renders ONLY as a hollow
+        /// ring. Without the removal the filled marker is drawn over the ring and an excluded point looks identical to an
+        /// included one. <see cref="FocusPoints"/> — the full measured set feeding the report and fit — is left intact.
+        /// internal so the partition is unit-testable without driving a full engine run.
+        /// </summary>
+        internal void ApplyWindowExclusionToDisplay(IReadOnlyList<AutoFocusRegionPoint> windowExcludedPoints) {
+            PlotWindowExcludedFocusPoints.Clear();
+            if (windowExcludedPoints != null && windowExcludedPoints.Count > 0) {
+                var excludedPositions = new HashSet<int>();
+                foreach (var wp in windowExcludedPoints) {
+                    excludedPositions.Add(wp.FocuserPosition);
+                    PlotWindowExcludedFocusPoints.Add(new ScatterErrorPoint(wp.FocuserPosition, wp.Measurement.Measure, 0, AutoFocusEngine.SafeDisplayError(wp.Measurement.Stdev)));
+                }
+                foreach (var core in PlotCoreFocusPoints.Where(p => excludedPositions.Contains((int)Math.Round(p.X))).ToList()) {
+                    PlotCoreFocusPoints.Remove(core);
+                }
+                foreach (var line in PlotFocusPoints.Where(p => excludedPositions.Contains((int)Math.Round(p.X))).ToList()) {
+                    PlotFocusPoints.Remove(line);
+                }
+            }
+            RaisePropertyChanged(nameof(HasWindowExcludedFocusPoints));
         }
 
         private void AutoFocusEngine_MeasurementPointCompleted(object sender, AutoFocusMeasurementPointCompletedEventArgs e) {
@@ -802,7 +845,12 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 return;
             }
 
-            FocusPoints.AddSorted(new ScatterErrorPoint(e.FocuserPosition, e.Measurement.Measure, 0, AutoFocusEngine.SafeDisplayError(e.Measurement.Stdev)), focusPointComparer);
+            var focusPoint = new ScatterErrorPoint(e.FocuserPosition, e.Measurement.Measure, 0, AutoFocusEngine.SafeDisplayError(e.Measurement.Stdev));
+            FocusPoints.AddSorted(focusPoint, focusPointComparer);
+            // Mirror into the filled DISPLAY series. Window exclusions are known only at finalization, so during the
+            // live sweep the two are identical; AutoFocusEngine_CompletedNoReport prunes the excluded points from the
+            // core/line series (not from FocusPoints) so they end up rendered only as hollow rings.
+            PlotCoreFocusPoints.AddSorted(focusPoint, focusPointComparer);
             var dataPoint = new DataPoint(e.FocuserPosition, e.Measurement.Measure);
             PlotFocusPoints.AddSorted(dataPoint, plotPointComparer);
             this.focuserMediator.BroadcastNewAutoFocusPoint(dataPoint);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/HocusFocusVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/HocusFocusVM.cs
@@ -62,6 +62,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         private ReportAutoFocusPoint lastAutoFocusPoint;
         private AsyncObservableCollection<DataPoint> plotFocusPointsObservable;
         private AsyncObservableCollection<ScatterPoint> plotRejectedFocusPointsObservable;
+        private AsyncObservableCollection<ScatterErrorPoint> plotWindowExcludedFocusPointsObservable;
         private QuadraticFitting quadraticFitting;
         private TrendlineFitting trendLineFitting;
         private TimeSpan autoFocusDuration;
@@ -131,6 +132,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             PlotFinalFocusPointWithError = new AsyncObservableCollection<ScatterErrorPoint>();
             PlotFocusPoints = new AsyncObservableCollection<DataPoint>();
             PlotRejectedFocusPoints = new AsyncObservableCollection<ScatterPoint>();
+            PlotWindowExcludedFocusPoints = new AsyncObservableCollection<ScatterErrorPoint>();
             ClearCharts();
 
             this.progress = ProgressFactory.Create(applicationStatusMediator, "Hocus Focus");
@@ -326,6 +328,26 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             }
         }
 
+        /// <summary>
+        /// Sweep points excluded from the final fit by the symmetric focus window (Behavior A) — points that lie outside
+        /// minimum ± (offsetSteps+1)*stepSize. Rendered on the results chart as hollow rings, deliberately distinct from
+        /// the red-cross <see cref="PlotRejectedFocusPoints"/> (Grubbs outliers): these points are present and valid, just
+        /// too far from focus to inform the fit. Uses ScatterErrorPoint (not ScatterPoint) so the dimmed HFR error bar
+        /// renders like the main <see cref="FocusPoints"/> series. Empty when nothing is excluded (well-centered runs).
+        /// </summary>
+        public AsyncObservableCollection<ScatterErrorPoint> PlotWindowExcludedFocusPoints {
+            get {
+                return plotWindowExcludedFocusPointsObservable;
+            }
+            set {
+                plotWindowExcludedFocusPointsObservable = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        /// <summary>Gates the "○ excluded — outside focus window" chart legend; true only once the window excludes a point.</summary>
+        public bool HasWindowExcludedFocusPoints => PlotWindowExcludedFocusPoints?.Count > 0;
+
         public QuadraticFitting QuadraticFitting {
             get => quadraticFitting;
             set {
@@ -363,6 +385,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             PlotFinalFocusPointWithError.Clear();
             PlotFocusPoints.Clear();
             PlotRejectedFocusPoints.Clear();
+            PlotWindowExcludedFocusPoints.Clear();
+            RaisePropertyChanged(nameof(HasWindowExcludedFocusPoints));
             TrendlineFitting = null;
             QuadraticFitting = null;
             HyperbolicFitting = null;
@@ -758,6 +782,17 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 }
             }
 
+            // Symmetric-window exclusions (Behavior A) are only produced by the finalized region fit, so the real set
+            // arrives here (empty on the live per-point events). Mirror the rejected-overlay re-sync as a sibling
+            // collection, built like the main FocusPoints series so the hollow-ring overlay carries the same HFR error bar.
+            PlotWindowExcludedFocusPoints.Clear();
+            if (firstRegion.WindowExcludedPoints != null) {
+                foreach (var wp in firstRegion.WindowExcludedPoints) {
+                    PlotWindowExcludedFocusPoints.Add(new ScatterErrorPoint(wp.FocuserPosition, wp.Measurement.Measure, 0, AutoFocusEngine.SafeDisplayError(wp.Measurement.Stdev)));
+                }
+            }
+            RaisePropertyChanged(nameof(HasWindowExcludedFocusPoints));
+
             RefreshFinalFocusPointError();
             AutoFocusDuration = e.Duration;
         }
@@ -776,6 +811,15 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             foreach (var rp in e.RejectedPoints) {
                 PlotRejectedFocusPoints.Add(new ScatterPoint(rp.FocuserPosition, rp.Measurement.Measure));
             }
+
+            // Window exclusions are decided only at finalization, so e.WindowExcludedPoints is empty on the live events;
+            // clear-and-refill keeps the sibling overlay consistent with the rejected overlay (the real set lands via
+            // AutoFocusEngine_CompletedNoReport). Built like FocusPoints so the hollow-ring overlay keeps its HFR error bar.
+            PlotWindowExcludedFocusPoints.Clear();
+            foreach (var wp in e.WindowExcludedPoints) {
+                PlotWindowExcludedFocusPoints.Add(new ScatterErrorPoint(wp.FocuserPosition, wp.Measurement.Measure, 0, AutoFocusEngine.SafeDisplayError(wp.Measurement.Stdev)));
+            }
+            RaisePropertyChanged(nameof(HasWindowExcludedFocusPoints));
 
             this.TrendlineFitting = e.Fittings.TrendlineFitting;
             this.GaussianFitting = e.Fittings.GaussianFitting;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/AutoFocusReplayMetadata.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/AutoFocusReplayMetadata.cs
@@ -162,6 +162,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay {
         public HyperbolicFitModel HyperbolicFitModel { get; set; }
         public FitRejectionCriterion FitRejectionCriterion { get; set; }
         public double ReducedChiSquaredRejectionThreshold { get; set; }
+        public int MaxBlindStepsPerDirection { get; set; }
+        public bool SymmetricFocusWindowEnabled { get; set; }
     }
 
     /// <summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/AutoFocusReplayOptionsMapper.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/AutoFocusReplayOptionsMapper.cs
@@ -69,6 +69,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay {
             options.HyperbolicFitModel = snapshot.HyperbolicFitModel;
             options.FitRejectionCriterion = snapshot.FitRejectionCriterion;
             options.ReducedChiSquaredRejectionThreshold = snapshot.ReducedChiSquaredRejectionThreshold;
+            options.MaxBlindStepsPerDirection = snapshot.MaxBlindStepsPerDirection;
+            options.SymmetricFocusWindowEnabled = snapshot.SymmetricFocusWindowEnabled;
         }
 
         /// <summary>Captures the fit/method fields of an engine options bundle into a serializable snapshot.</summary>
@@ -92,7 +94,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus.Replay {
                 WeightedHyperbolicFitEnabled = options.WeightedHyperbolicFitEnabled,
                 HyperbolicFitModel = options.HyperbolicFitModel,
                 FitRejectionCriterion = options.FitRejectionCriterion,
-                ReducedChiSquaredRejectionThreshold = options.ReducedChiSquaredRejectionThreshold
+                ReducedChiSquaredRejectionThreshold = options.ReducedChiSquaredRejectionThreshold,
+                MaxBlindStepsPerDirection = options.MaxBlindStepsPerDirection,
+                SymmetricFocusWindowEnabled = options.SymmetricFocusWindowEnabled
             };
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IAutoFocusEngine.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IAutoFocusEngine.cs
@@ -80,6 +80,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         public TimeSpan AutoFocusTimeout { get; set; }
         public double HFRImprovementThreshold { get; set; }
         public int FocuserOffset { get; set; }
+        public int MaxBlindStepsPerDirection { get; set; }
         public int MaxOutlierRejections { get; set; }
         public double OutlierRejectionConfidence { get; set; }
         public bool WeightedHyperbolicFitEnabled { get; set; }
@@ -120,6 +121,12 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         // .StarDetectionOptions. Null = use the detector's current options (live capture and "use current settings"
         // replay). Transient/per-call; never persisted.
         public IStarDetectionOptions StarDetectionOptionsOverride { get; set; } = null;
+
+        // Internal-only test seam / safety valve for the always-on symmetric-window exclusion at the final fit
+        // (points outside minimum ± (offsetSteps+1)*stepSize are excluded from the fit but still surfaced). Hard-
+        // wired true in GetOptions; NOT a persisted IAutoFocusOptions property and NOT exposed in the UI. Tests
+        // construct options with it false to assert the byte-identical no-window control.
+        public bool SymmetricFocusWindowEnabled { get; set; } = true;
     }
 
     public interface IAutoFocusEngine {
@@ -234,6 +241,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         public double EstimatedFinalFocuserPosition { get; set; }
         public double EstimatedFinalHFR { get; set; }
         public AutoFocusRegionPoint[] RejectedPoints { get; set; }
+        public AutoFocusRegionPoint[] WindowExcludedPoints { get; set; }
     }
 
     public class AutoFocusResult {
@@ -264,6 +272,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         public MeasureAndError Measurement { get; set; }
         public AutoFocusFitting Fittings { get; set; }
         public AutoFocusRegionPoint[] RejectedPoints { get; set; }
+        public AutoFocusRegionPoint[] WindowExcludedPoints { get; set; }
     }
 
     public class AutoFocusSubMeasurementPointCompletedEventArgs : EventArgs {
@@ -283,6 +292,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         public int FinalFocuserPosition { get; set; }
         public AutoFocusFitting Fittings { get; set; }
         public AutoFocusRegionPoint[] RejectedPoints { get; set; }
+        public AutoFocusRegionPoint[] WindowExcludedPoints { get; set; }
     }
 
     public class AutoFocusFinishedEventArgsBase : EventArgs {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IAutoFocusOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IAutoFocusOptions.cs
@@ -22,6 +22,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         bool KeepFramesForReview { get; set; }
         string LastSelectedLoadPath { get; set; }
         int FocuserOffset { get; set; }
+        int MaxBlindStepsPerDirection { get; set; }
         int MaxOutlierRejections { get; set; }
         double OutlierRejectionConfidence { get; set; }
         bool WeightedHyperbolicFitEnabled { get; set; }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
@@ -525,6 +525,7 @@
     <TextBlock x:Key="RotatedHyperbolicFit_Tooltip" Text="Allows hyperbolic fitting to rotate. This can be useful if your focus curve is asymmetrical." />
     <TextBlock x:Key="MeasurementAverage_Tooltip" Text="Controls how the average star measurement across the frame is calculated. Median is robust to outliers, and is the default." />
     <TextBlock x:Key="MaxAutoFocusOutlierRejections_Tooltip" Text="Controls the maximum number of points that can be rejected as outliers during Auto Focus curve fitting." />
+    <TextBlock x:Key="MaxBlindStepsPerDirection_Tooltip" Text="Maximum number of blind AutoFocus steps attempted in each direction before reversing to try the other side. Set to 0 to disable the cap." />
     <TextBlock x:Key="AutoFocusOutlierRejectionConfidence_Tooltip" Text="Confidence level for a two-tailed Grubbs statistical test of outliers to use during Auto Focus curve fitting. 0.90 is a reasonable default." />
     <DataTemplate x:Key="HocusFocus_AutoFocus_Options">
         <Grid Margin="5" VerticalAlignment="Top">
@@ -577,6 +578,7 @@
                 <RowDefinition />
                 <RowDefinition Style="{StaticResource ShowOnReducedChiSquaredCriterion}" />
                 <RowDefinition Style="{StaticResource ShowOnRSquaredCriterion}" />
+                <RowDefinition />
             </Grid.RowDefinitions>
             <TextBlock
                 Grid.Row="0"
@@ -915,6 +917,28 @@
                                 <rules:DoubleRangeChecker Maximum="1.0" Minimum="0" />
                             </rules:DoubleRangeRule.ValidRange>
                         </rules:DoubleRangeRule>
+                    </Binding.ValidationRules>
+                </Binding>
+            </ninactrl:UnitTextBox>
+
+            <TextBlock
+                Grid.Row="16"
+                Grid.Column="0"
+                VerticalAlignment="Center"
+                Text="Max Blind Steps Per Direction"
+                ToolTip="{StaticResource MaxBlindStepsPerDirection_Tooltip}" />
+            <ninactrl:UnitTextBox
+                Grid.Row="16"
+                Grid.Column="1"
+                MinWidth="80"
+                Margin="5,5,0,0"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                ToolTip="{StaticResource MaxBlindStepsPerDirection_Tooltip}"
+                Unit="steps">
+                <Binding Path="AutoFocusOptions.MaxBlindStepsPerDirection" UpdateSourceTrigger="LostFocus">
+                    <Binding.ValidationRules>
+                        <rules:GreaterZeroRule />
                     </Binding.ValidationRules>
                 </Binding>
             </ninactrl:UnitTextBox>

--- a/plans/af-far-from-focus-robustness-plan.md
+++ b/plans/af-far-from-focus-robustness-plan.md
@@ -1,0 +1,286 @@
+# Plan: Autofocus robustness when starting far from focus
+
+## Context
+
+HocusFocus's blind autofocus (`AutoFocusEngine.StartBlindFocusPoints`) seeds points on the high side of
+the start, then adaptively walks left/right by trendline counts until it brackets a minimum. When a run
+**starts far from focus** two things go wrong today:
+
+1. **Lopsided curves.** If detection still works far out, the completed sweep ends up with many more points
+   on one side of the minimum than the other, biasing the final fit.
+2. **Failure to bootstrap.** The initial outward points can be too far off to establish a curve — and when
+   detection degrades (no stars far from focus, or *spurious low-HFR "stars" imagined in background noise*
+   creating a false minimum), the walk either throws `TooManyFailedMeasurementsException` or locks onto
+   garbage. The only current mitigation is a coarse once-per-run re-center (`ShouldRetryFromCalculatedPoint`)
+   after a whole failed sweep.
+
+This change adds two engine behaviors + matching visualization + a simulator test battery, so autofocus
+converges to a reliable, balanced curve from a poor start. Behavior parity when disabled/inert is a hard
+invariant (mirrors the focus-recovery feature).
+
+**Scope decisions (confirmed with user):**
+- Only the **directional cap** is a user-facing option. The **symmetric window** is always-on internal
+  behavior (inert for balanced runs), with an internal-only engine flag as a test seam / safety valve — no
+  persisted option, no UI.
+- Test battery uses **both tiers**: a fast deterministic scripted-degradation battery driving the full
+  engine end-to-end, plus 2–3 realistic simulator-camera render capstones that confirm the real detector
+  actually produces the degraded regimes.
+
+---
+
+## Behavior A — Symmetric-window exclusion at the final fit (always-on internal)
+
+**Goal:** the final fit only includes points within `minimum ± (offsetSteps+1)*stepSize`; points outside
+that window are excluded from the fit but still surfaced for display.
+
+**Where:** apply at **finalization only**, never in the hot live `CurveFittingResult.Calculate` (the live
+trendline drives the walk's stop condition; clipping it would change sampling). Add a region method invoked
+in both finalization loops before `SelectBestHyperbolicModel()`:
+- `ValidateCalculatedFocusPosition` finalize site (`AutoFocusEngine.cs` ~:1720)
+- `RerunImpl` finalize site (~:2483)
+
+**Method (new, on `AutoFocusRegionState`):** `bool ApplyFinalSymmetricWindow(int offsetSteps, int stepSize)`
+— a bounded **fit → window → refit** fixed point:
+1. Provisional center = `DetermineFinalFocusPoint()?.X` (the fitted vertex: hyperbolic/quadratic minimum or
+   trend/curve average per configured method). **Center on the fitted vertex, NOT the lowest raw point** —
+   the vertex is a post-Grubbs, weighted least-squares estimate, so a single spurious low-HFR far point can't
+   define the center the way `TrendlineFitting.Minimum` (literally the lowest sample) would. This is the key
+   guard against consideration #3's false minimum.
+2. Partition points by the window; if none fall outside → return (no-op, byte-identical). If keeping ≥3
+   points, drop the outside points, `UpdateCurveFittings(kept)`, repeat.
+3. Monotonic point-removal ⇒ terminates in ≤ `offsetSteps+1` passes (usually 1). Never let kept < 3 (the
+   `Calculate` `<3 ⇒ null` floor). Order-independent (fit already canonicalizes point order).
+
+**Pure, unit-testable helpers** (mirror the `ComputeSweepPositions` static-helper pattern):
+```csharp
+internal static bool IsWithinFocusWindow(double position, double minimumX, int offsetSteps, int stepSize)
+    => position > minimumX - (offsetSteps + 1) * stepSize
+    && position < minimumX + (offsetSteps + 1) * stepSize;   // strict, per spec
+
+internal static (List<ScatterErrorPoint> included, List<ScatterErrorPoint> excluded)
+    PartitionByFocusWindow(IReadOnlyList<ScatterErrorPoint> points, double minimumX, int offsetSteps, int stepSize);
+```
+
+**Distinct category — window-excluded ≠ Grubbs-rejected.** Window-exclusion runs *before* the fit; Grubbs
+runs *inside* the fit of the windowed subset, so the two sets are disjoint. Surface excluded points on the
+same channels `RejectedPoints` uses, as a **sibling** (never reclassified as rejected):
+- `AutoFocusRegionState.WindowExcludedPoints : Dictionary<int,MeasureAndError>` (beside `RejectedPoints` ~:204;
+  clear in `ResetMeasurements`).
+- `CurveFittingResult.WindowExcludedPoints : ImmutableList<ScatterErrorPoint>` (beside `RejectedPoints` ~:99).
+- `AutoFocusRegionResult.WindowExcludedPoints`, `AutoFocusRegionHFR.WindowExcludedPoints`,
+  `AutoFocusMeasurementPointCompletedEventArgs.WindowExcludedPoints` (`AutoFocusRegionPoint[]`, in
+  `IAutoFocusEngine.cs` ~:230/:277/:266) — populated alongside the existing `RejectedPoints` `.Select(...)`
+  at ~:1996/:2502/:2554/:2702 (empty on the live per-point events; real set on completed/final).
+
+**Multi-region:** the window pass runs **per region** around each region's own vertex (correct for tilt
+runs where regions focus at different positions). Out-of-bounds gate keeps using the full point range, so
+windowing can only *reduce* `FinalPointOutOfBounds`, never mask an extrapolating fit.
+
+**Internal enable flag (test seam, not user-facing):** add `bool SymmetricFocusWindowEnabled` to
+`AutoFocusEngineOptions` (DTO) **only**, default `true`, wired to `true` in `GetOptions` (not read from any
+persisted `IAutoFocusOptions` property, no UI). Tests construct options with it `false` to assert the C0
+byte-identical control. `ApplyFinalSymmetricWindow` early-returns when false.
+
+---
+
+## Behavior B — Directional bootstrap cap + reversal (user-facing cap)
+
+**Goal:** cap points attempted in each direction; if one direction can't bootstrap a bracket within the cap,
+return toward the start and try the other direction once. Combined with A → a balanced final curve.
+
+**Where:** inside the `StartBlindFocusPoints` walk loop (`AutoFocusEngine.cs` ~:1325).
+
+**Mechanics:**
+- Track `leftStepOuts` / `rightStepOuts` (incremented on the step-LEFT ~:1383 and step-RIGHT ~:1397 branches;
+  failed detections on an arm count as step-outs too).
+- A direction "failed to bootstrap" when its counter reaches the **effective cap** without an interior
+  two-sided bracket (`leftTrendCount>0 && rightTrendCount>0`, which the break conditions at :1345/:1363
+  already require).
+- Add `bool hasReversed = false` + `WalkDirection? forcedDirection = null`. On first cap-out (and
+  `!hasReversed`): set `hasReversed`, `MoveFocuser(initialFocusPosition)` (return toward start), force the
+  opposite direction, reset that arm's counter for a fresh budget, log the reversal. At most **one** reversal
+  per sweep (latch → no oscillation).
+- Make the `TooManyFailedMeasurementsException` throw (~:1336) **reversal-aware**: when B is enabled and
+  `!hasReversed`, reverse instead of throwing; only throw once both directions are exhausted (or B disabled).
+
+**Effective cap:** `Math.Max(configured, offsetSteps + 1)` — a positive value can never be tighter than a
+valid bracket needs.
+
+**Composition (three tiers, cheapest first):** reversal lives *inside* the first sweep attempt (before the
+throw and before the coarse retry). If both directions cap out → throw → the existing once-per-run
+`ShouldRetryFromCalculatedPoint` re-center (~:470/:1508) remains as the coarser outer tier, unchanged. The
+`maxIterations` backstop (~:1469) still bounds everything.
+
+**Pure helper (unit-testable):**
+`internal static bool ShouldReverseDirection(int stepOutsThisDir, int effectiveCap, bool bracketFormed, bool hasReversed)`.
+
+**Replay determinism:** counters/decision are read under `SubMeasurementsLock` after
+`await Task.WhenAll(AnalysisTasks)` — the same order-independent trend snapshot the walk already relies on.
+
+---
+
+## Options & configuration
+
+| Symbol | Kind | Default | Sites |
+|---|---|---|---|
+| `MaxBlindStepsPerDirection` | **user option** (int, "steps", 0=disabled, validate ≥0) | 8 | `IAutoFocusOptions.cs` + `AutoFocusOptions.cs` (field + `InitializeOptions` + `ResetDefaults` + property with `SetValueInteger`) + `AutoFocusEngineOptions` (`IAutoFocusEngine.cs`) + `GetOptions` (~:2755) + **UI control** in `Resources/OptionsDataTemplates.xaml` |
+| `SymmetricFocusWindowEnabled` | **internal engine flag** (test seam) | true | `AutoFocusEngineOptions` DTO only; hard-wired `true` in `GetOptions`; NO persisted property, NO UI |
+
+- Window half-width reuses existing profile `AutoFocusInitialOffsetSteps` / `AutoFocusStepSize` — **no new
+  numeric option**.
+- **UI control** for `MaxBlindStepsPerDirection`: append a `RowDefinition` + `ninactrl:UnitTextBox Unit="steps"`
+  in `OptionsDataTemplates.xaml` (copy the "Max Outlier Rejections" `UnitTextBox` ~:766-780, swap
+  `GreaterZeroRule` for a zero-allowing non-negative rule) + a `*_Tooltip` `TextBlock` resource. Satisfies the
+  "every persisted option needs a UI control" invariant.
+
+**Backward-compat invariant:** `MaxBlindStepsPerDirection = 0` ⇒ no counters/reversal, throw reverts to the
+original `if (failureCount >= offsetSteps) throw;`. `SymmetricFocusWindowEnabled = false` ⇒ `ApplyFinalSymmetricWindow`
+early-returns. Both defaults on + a well-centered run ⇒ still a no-op (window includes all points, no cap hit,
+new DTO arrays empty).
+
+---
+
+## Chart visualization — window-excluded points as hollow rings
+
+Reuse the recovery-overlay idiom Fable built for the optimizer (partition into a **separate ItemsSource +
+separate overlay series**, no per-point boolean) — deliberately *not* the red-cross "rejected" language.
+Reference: `StarDetection/Optimization/DataTemplates.xaml:44-51,90-100`.
+
+Target is **Chart A**, the live/main AF results chart:
+- **`AutoFocus/HocusFocusVM.cs`:** add `PlotWindowExcludedFocusPoints : AsyncObservableCollection<ScatterErrorPoint>`
+  (mirror `PlotRejectedFocusPoints` decl ~:319 / init ~:133 / clear in `ClearCharts()` ~:365) + gating bool
+  `HasWindowExcludedFocusPoints`. Populate in both `MeasurementPointCompleted` (~:775-778) and the final
+  re-sync `CompletedNoReport` (~:754-759), from the new `WindowExcludedPoints` DTO members. Use
+  `ScatterErrorPoint` (not `ScatterPoint`) so the dimmed error bar renders.
+- **`AutoFocus/DataTemplates.xaml`:** add an `oxy:ScatterErrorSeries` overlay in `<oxy:Plot.Series>` (~:162),
+  declared *before* the filled `FocusPoints` series so it draws underneath. Style = hollow ring:
+  `MarkerFill="Transparent"`, `MarkerStroke={PrimaryBrush via SetAlphaToColorConverter, param 150}`,
+  `MarkerType="Circle"`, `MarkerSize="5"`, dimmed error bar (`NotificationErrorBrush` alpha 100). Leave the
+  red-cross `PlotRejectedFocusPoints` series (~:177-182) untouched. Add a legend `TextBlock`
+  "○ excluded — outside focus window" gated on `HasWindowExcludedFocusPoints` via
+  `BooleanToVisibilityCollapsedConverter`. Both converters are NINA-core StaticResources already in scope.
+
+Byte-identical when the window excludes nothing (empty collection ⇒ overlay draws nothing, legend collapses).
+
+---
+
+## Test battery — two tiers (deterministic + realistic)
+
+Closes a known gap: nothing today drives a **successful** full `AutoFocusEngine.Run()` in-process (VM tests
+stub `engine.Run` wholesale; `AutoFocusEngineTests` only drive it to failure). The `Run()` default path uses
+full-frame `IStarDetection.Detect(...)` and reads only `AverageHFR`/`HFRStdDev`/`DetectedStars` — pixels are
+never touched on that path, which makes scripted detection viable.
+
+### Tier A — deterministic scripted battery (the workhorse)
+New test doubles (under `Tests/TestDoubles/` and `Tests/AutoFocus/Harness/`):
+- **`MovingFocuserMediator`** — state-backed `IFocuserMediator` that actually moves, clamps to `[Min,Max]`,
+  and records `MoveHistory` (asserts B's reversal). Add `MediatorBundle.WithMovingFocuser(start,min,max)`.
+- **`SweepFrameLedger` + `StampedImagingMediator`** — bind each captured frame to the focuser position **at
+  capture time** (via `ConditionalWeakTable<IRenderedImage,int>`), so detection reads the frame's position,
+  not a since-moved one (kills the concurrency race). `CaptureImage`/`ToImageData`/`PrepareImage` return
+  small substitutes with `Properties` set (64×64, 16-bit, non-bayered) and `OriginalImage=null` (annotation
+  early-returns).
+- **`ScriptedStarDetection : IHocusFocusStarDetection`** — `Detect(image,...)` looks up `pos =
+  ledger.PositionFor(image)`, returns `scenario.Evaluate(pos)` as `AverageHFR`/`HFRStdDev`/`DetectedStars`
+  (zero-star ⇒ `AverageHFR=0`, the engine's failure signal). Injected via
+  `IPluggableBehaviorSelector<IStarDetection>` (already an engine ctor arg).
+- **`DegradationScenario` / `SpuriousSpec`** (seeded records) — deterministic `Evaluate(pos)` returning
+  `(hfr, sigma, starCount)` from `|pos−focus|`: baseline HFR from `DefocusModel.HfrAtFocuserPosition`
+  (single source of truth), left/right detection cutoffs (zero beyond), a **spurious low-HFR injector**
+  (false minimum), star-count drop, σ inflation, asymmetry. Reuse `SyntheticFocusCurveSamples`' seeded-noise
+  convention.
+
+Engine constructed via the `AutoFocusEngineTests.Build(...)` shape with `MaxConcurrent=1`, `FramesPerPoint=1`,
+`STARHFR`/`HYPERBOLIC`, `Save=false`; `[SetUp]/[TearDown]` resets the process-wide in-progress guard.
+
+**Scenario battery** (Tier A unless marked): `focus=10000`, `stepSize=5`, `offsetSteps=5`, start far unless noted.
+| # | Scenario | Asserts | A/B |
+|---|---|---|---|
+| C0 | Control, knobs off, well-behaved | byte-identical result (window-excluded set empty; same focus) | — |
+| C1 | Start far, clean curve | bootstraps, final within tol (smoke test — write first) | — |
+| A1 | Lopsided valid far points | far points → **WindowExcluded** not `RejectedPoints`; fit uses window only | A |
+| A2 | All points in-window | WindowExcluded empty; identical to no-window | A |
+| A3 | Asymmetric spurious low-HFR far side | does NOT lock onto false min; final ≈ true focus; spurious → excluded | A |
+| B1 | One-direction cutoff | `MoveHistory` shows cap hit → return to start → other direction; final within tol | B |
+| B2 | Bootstrap cap respected | distinct positions ≤ cap bound; no "focuser limit" throw | B |
+| B3 | Reversal → success other direction (mirror of B1) | direction symmetry | B |
+| F1 | Truly starless everywhere | `Succeeded=false` gracefully, guard released, no crash | safety |
+| F2 | Starless only far, stars near | B reversal still finds focus, else graceful fail | B |
+| AB1 | Combined worst case (far false-min + cutoff on right, clean left) | B reverses, A excludes false cluster, final ≈ true focus | A+B |
+| R1 | **Tier B**: real render, faint field → starless far out | real `StarDetector` ~0 stars far out (confirms F1) | realism |
+| R2 | **Tier B**: real render, low SNR → spurious low-HFR far out | real detector yields ≤N spurious low-HFR far out (confirms A3/AB1) | realism |
+
+### Tier B — realism capstones (2–3, `[Category("SlowIntegration")]`)
+Reuse `SyntheticCameraTestScene` + `StarFieldCompositor` + `FakeCatalogReader` + the real `StarDetector`
+(the `CameraSimulatorCapstoneTests` pattern). Induce degradation via **physical levers** (faint
+`LimitingMagnitude`/`Magnitude` → starless; high `SkyBrightnessMagPerArcsec2`/short `ExposureSeconds` → low-SNR
+spurious), optionally a thin `DegradingStarDetectionDecorator` wrapping the real detector when a precise
+spurious count is needed. Purpose: anchor Tier A's synthetic assumptions to real render+detect physics.
+
+### Fable handoff
+Build the **infra** now (mechanical/deterministic): the four doubles, the `DegradationScenario`/`SpuriousSpec`
+records, and the C1 smoke test proving `Run()` completes in-process. **Hand to a Fable-model subagent** the
+exhaustive scenario enumeration + expected-outcome tuning — exact cutoff steps, the `SpuriousSpec` HFR/onset
+that reliably create a false minimum the pre-change engine would lock onto, tolerance bands, and the precise
+`MoveHistory` (B) / partition-membership (A) assertions. Clean handoff: infra exposes three deterministic
+knobs (cutoff, spurious, asymmetry) and three observables (final position, `MoveHistory`, WindowExcluded-vs-
+Rejected partition); Fable sweeps the knob space to earn "high confidence."
+
+---
+
+## Files to modify
+
+**Production:**
+- `AutoFocus/AutoFocusEngine.cs` — Behavior A (`ApplyFinalSymmetricWindow` + `IsWithinFocusWindow`/
+  `PartitionByFocusWindow`, called at both finalize sites), Behavior B (counters + reversal +
+  `ShouldReverseDirection` in `StartBlindFocusPoints`, reversal-aware throw), `WindowExcludedPoints` on
+  `AutoFocusRegionState`/`CurveFittingResult`, `GetOptions` wiring.
+- `Interfaces/IAutoFocusEngine.cs` — `WindowExcludedPoints` on `AutoFocusRegionResult`,
+  `AutoFocusRegionHFR`, `AutoFocusMeasurementPointCompletedEventArgs`; `MaxBlindStepsPerDirection` +
+  `SymmetricFocusWindowEnabled` on `AutoFocusEngineOptions`.
+- `Interfaces/IAutoFocusOptions.cs` + `AutoFocus/AutoFocusOptions.cs` — `MaxBlindStepsPerDirection` (user
+  option, 5-site pattern).
+- `Resources/OptionsDataTemplates.xaml` — `MaxBlindStepsPerDirection` UnitTextBox + tooltip (invariant).
+- `AutoFocus/HocusFocusVM.cs` — `PlotWindowExcludedFocusPoints` + `HasWindowExcludedFocusPoints` (decl/init/
+  clear/populate).
+- `AutoFocus/DataTemplates.xaml` — hollow-ring `ScatterErrorSeries` overlay + legend caption.
+
+**Tests:**
+- `Tests/TestDoubles/MovingFocuserMediator.cs`, `MediatorBundle.cs` (`WithMovingFocuser`).
+- `Tests/AutoFocus/Harness/` — `SweepFrameLedger.cs`, `StampedImagingMediator.cs`, `ScriptedStarDetection.cs`,
+  `DegradationScenario.cs`.
+- `Tests/AutoFocus/AutoFocusEngineSweepBatteryTests.cs` (Tier A) + new pure-helper tests in
+  `AutoFocusEngineTests.cs`.
+- `Tests/CameraSimulator/` — 2–3 realism capstones next to `CameraSimulatorCapstoneTests.cs`.
+
+---
+
+## Verification
+
+1. **Unit/battery suite** (Windows `dotnet.exe test` via WSL interop — no dotnet in WSL; `wslpath -w` the sln,
+   timeout 600000; note the flaky `SendAsync_WritesOnABackgroundThread` EAT test is unrelated):
+   `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`. Run at milestones + a final gate.
+   All Tier-A scenarios green; Tier-B capstones green (may gate behind `SlowIntegration`).
+2. **Pure-helper tests**: `IsWithinFocusWindow`, `PartitionByFocusWindow` (lopsided, false-low-star-doesn't-
+   shift-center, no-op-when-centered, ≥3 floor), `ShouldReverseDirection`.
+3. **Replay regression** (`running-af-bank-validation` skill): replay a saved lopsided/far-from-focus AF-bank
+   run with `MaxBlindStepsPerDirection` on vs `0` and `SymmetricFocusWindowEnabled` on vs off — confirm the
+   off/inert path is byte-identical and the on path yields a centered curve with balanced arm counts.
+4. **In-app NINA validation** (Windows MCP, the "Default" profile's HocusFocus Simulator camera which renders
+   focus-dependent frames): set the focuser far from the simulator's `OptimalFocuserPosition`, run autofocus,
+   confirm — (a) the sweep reverses when it starts on the wrong/degraded side (log + focuser trajectory),
+   (b) the final curve is balanced and converges near optimal, (c) the results chart renders window-excluded
+   points as hollow rings with the "○ excluded — outside focus window" caption, distinct from red-cross
+   rejects. Full-res capture on this rig needs `PrintWindow(PW_RENDERFULLCONTENT=2)`.
+
+## Sequencing
+
+1. Options plumbing (`MaxBlindStepsPerDirection` user option + UI; internal `SymmetricFocusWindowEnabled`) —
+   no behavior change; verify round-trip.
+2. `WindowExcludedPoints` DTO/state category (empty for now).
+3. Behavior A (`ApplyFinalSymmetricWindow` + helpers) + pure-helper tests.
+4. Behavior B (reversal + cap + helper) + pure-helper tests.
+5. Chart overlay (VM + XAML).
+6. Test harness infra + C1 smoke test.
+7. Fable subagent: enumerate + tune the full battery (Tier A) and the realism capstones (Tier B).
+8. Replay + in-app validation.

--- a/plans/af-far-from-focus-robustness-plan.md
+++ b/plans/af-far-from-focus-robustness-plan.md
@@ -30,7 +30,7 @@ invariant (mirrors the focus-recovery feature).
 
 ## Behavior A — Symmetric-window exclusion at the final fit (always-on internal)
 
-**Goal:** the final fit only includes points within `minimum ± (offsetSteps+1)*stepSize`; points outside
+**Goal:** the final fit only includes points within `minimum ± (offsetSteps+0.5)*stepSize`; points outside
 that window are excluded from the fit but still surfaced for display.
 
 **Where:** apply at **finalization only**, never in the hot live `CurveFittingResult.Calculate` (the live
@@ -54,8 +54,8 @@ in both finalization loops before `SelectBestHyperbolicModel()`:
 **Pure, unit-testable helpers** (mirror the `ComputeSweepPositions` static-helper pattern):
 ```csharp
 internal static bool IsWithinFocusWindow(double position, double minimumX, int offsetSteps, int stepSize)
-    => position > minimumX - (offsetSteps + 1) * stepSize
-    && position < minimumX + (offsetSteps + 1) * stepSize;   // strict, per spec
+    => position > minimumX - (offsetSteps + 0.5) * stepSize
+    && position < minimumX + (offsetSteps + 0.5) * stepSize;   // strict, per spec
 
 internal static (List<ScatterErrorPoint> included, List<ScatterErrorPoint> excluded)
     PartitionByFocusWindow(IReadOnlyList<ScatterErrorPoint> points, double minimumX, int offsetSteps, int stepSize);


### PR DESCRIPTION
## What & why

Blind autofocus can start far from focus (a screw adjustment, a filter change) and then either collect a **lopsided curve** (more points on one side of the minimum, biasing the fit) or **fail to bootstrap** when detection degrades far out — no stars detected, or spurious low-HFR "stars" imagined in background noise creating a false minimum. This adds two engine behaviors so autofocus converges to a reliable, balanced curve from a poor start.

Design: `plans/af-far-from-focus-robustness-plan.md`.

## Behavior A — symmetric-window fit exclusion (always-on)

At finalization, sweep points outside `minimum ± (offsetSteps+0.5)*stepSize` are excluded from the fit via a bounded fit→window→refit, **centered on the fitted vertex** (not the lowest raw point) so a spurious low-HFR far point can't hijack the window center. The half-width keeps exactly `offsetSteps` points per side and drops the next position out. Excluded points become a new `WindowExcludedPoints` category — **distinct from Grubbs outlier rejects** — and render on the AF results chart as hollow "○ excluded — outside focus window" rings (reusing the optimizer's recovery-overlay idiom, not the red-cross "rejected" language). Refit reuses the existing `UpdateCurveFittings` overlay, so raw `MeasurementsByFocuserPoint` stays intact for reports/charts. Inert on a well-centered run (the window includes every point → byte-identical).

## Behavior B — directional bootstrap cap + one-shot reversal

New user option **`MaxBlindStepsPerDirection`** (default **8**, `0` = disabled), surfaced in the AF options UI. When a sweep direction **makes no progress** — the lowest measured HFR stops improving — for the capped number of steps without forming a bracket, the walk returns toward the start and forces the opposite direction **once** (latched, no oscillation), composing below the existing once-per-run re-center retry. A **productive descent (HFR still improving toward focus) is never counted against the cap**, so a far-but-recoverable start rides the descent all the way in; only wrong-way / starless excursions trip the reversal. `cap = 0` restores the original walk and throw byte-for-byte.

## Chart

Window-excluded points are partitioned into a dedicated `PlotCoreFocusPoints` (filled) vs the hollow overlay, so an excluded point renders **only** as a hollow ring (a point left in the filled series would be drawn over its ring and look identical to an included one). `FocusPoints` stays the full set for the report and fit.

## Tests

- **New end-to-end harness** (`Tests/AutoFocus/Harness/` + `MovingFocuserMediator`) that drives a *successful* `AutoFocusEngine.Run()` fully in-process — closing a long-standing gap (previously only pure helpers were unit-tested and VM tests stubbed `engine.Run` wholesale).
- **Scripted degradation battery** (`AutoFocusEngineSweepBatteryTests`): C0/C1, A1–A3, B1–B3, F1, F2a/b, AB1/AB2 — injecting zero-detection and spurious low-HFR-false-minimum regimes as a deterministic function of distance from focus, asserting final position, the reversal via `MoveHistory`, and the `WindowExcluded` vs `Rejected` partition. **F2b** is the regression guard that a modest cap does **not** abandon a productive far descent; **B2** confirms a focus beyond the focuser travel limit is bounded by that hardware limit and fails gracefully.
- **2 real-render capstones** (`CameraSimulatorAfDegradationCapstoneTests`, `[Category("SlowIntegration")]`) confirming the real detector actually produces those regimes.
- Pure-helper unit tests (`IsWithinFocusWindow` / `PartitionByFocusWindow` / `ShouldReverseDirection`) and a `HocusFocusVM` chart-partition regression test.

**Full suite: 2925 passed, 0 failed.**

## Live validation (NINA simulator camera)

**Behavior B confirmed end-to-end**: starting far above optimal, the reversal fired with the exact log line — `Blind AutoFocus could not bracket focus within 8 steps going Right; returning to … and forcing the Left direction` — and the run converged near optimal (R² = 1.00). The new option renders in the AF settings. A subsequent live run surfaced two follow-up fixes now included here: the hollow-ring overdraw (excluded points were drawn filled) and the Behavior-B cap prematurely reversing a productive descent (the cap now counts only non-progress).

## Commits

- feat: far-from-focus robustness (behaviors A+B, harness, battery)
- fix: render window-excluded points as hollow rings, not filled (partition the filled series)
- refactor: tighten symmetric focus window to `(offsetSteps+0.5)*stepSize`
- fix: don't reverse a productive descent — the directional cap counts non-progress only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2Tk9ujPg45PkaJRQBsVzU
