### PR TITLE
Bank re-baseline for bayered runs, and the bobp_m101 recall re-check

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,4 @@
 # Workflow scripts must stay LF in the working tree: the Claude Code Workflow tool
 # rejects scripts containing CR as "control characters" in the approval dialog.
 .claude/workflows/*.js text eol=lf
+tools/golden/*.js      text eol=lf

--- a/Joko.NINA.Plugins/TestApp/BankVerifyRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/BankVerifyRunner.cs
@@ -1,4 +1,4 @@
-#region "copyright"
+﻿#region "copyright"
 
 /*
     Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
@@ -57,6 +57,10 @@ namespace TestApp {
 
         private const double MatchRadiusDefault = 12.0;
 
+        /// <summary>The LocallyAdaptiveBinarization C0 actually runs with: the shipped default unless forced.</summary>
+        private static bool EffectiveAdaptiveBinarize(bool? overrideValue)
+            => overrideValue ?? HocusFocusStarDetection.BuildDefaultStarDetectorParams().LocallyAdaptiveBinarization;
+
         // Flushed file-based progress trace (stdout is block-buffered through WSL interop, so a file log is the only
         // way to observe where a long run is). Each line is appended + flushed immediately.
         private static string _progressPath;
@@ -102,7 +106,7 @@ namespace TestApp {
             if (string.IsNullOrWhiteSpace(runs) || !Directory.Exists(runs)) {
                 Console.Error.WriteLine("Usage: TestApp bank-verify --runs <bank-root> [--out <dir>] [--nc-sweep 2,3,4] " +
                     "[--opt-a <dir>] [--opt-b <dir>] [--golden <dir>] [--match-radius 12] [--commit <hash>] [--profile-id <guid>] " +
-                    "[--adaptive-binarize] [--adaptive-block 128]");
+                    "[--adaptive-binarize|--no-adaptive-binarize] [--adaptive-block 128]");
                 Environment.ExitCode = 2;
                 return;
             }
@@ -118,9 +122,18 @@ namespace TestApp {
             var profileId = DiagnosticUtil.GetArg(args, "--profile-id");
             var ncSweep = ParseNcSweep(DiagnosticUtil.GetArg(args, "--nc-sweep") ?? "2,3,4");
             // Spatially-adaptive binarization override for the C0 (as-default) configs — the flag-on-vs-off A/B that
-            // the adaptive-noiseclip feature is validated by (docs/adaptive-noiseclip-design.md). Default OFF mirrors
-            // the shipped default. The optimized A/B configs instead receive these via OverlayOptimized.
-            var adaptiveBinarize = DiagnosticUtil.HasFlag(args, "--adaptive-binarize");
+            // the adaptive-noiseclip feature is validated by (docs/adaptive-noiseclip-design.md). The optimized A/B
+            // configs instead receive these via OverlayOptimized.
+            //
+            // NEITHER flag given ⇒ C0 keeps whatever BuildDefaultStarDetectorParams() ships, so "as-default" cannot
+            // drift from the product again. It did once: 9a80324 introduced this override when the shipped default was
+            // OFF, c59a4b1 flipped the default ON the same day and did not update here, so every C0 row between then
+            // and this fix ran with the feature OFF while the product shipped it ON — and the report recorded neither
+            // fact. Pass --adaptive-binarize / --no-adaptive-binarize to force a side for the validation A/B.
+            bool? adaptiveBinarizeOverride =
+                DiagnosticUtil.HasFlag(args, "--adaptive-binarize") ? true
+                : DiagnosticUtil.HasFlag(args, "--no-adaptive-binarize") ? false
+                : (bool?)null;
             var adaptiveBlock = DiagnosticUtil.GetArg(args, "--adaptive-block");
             int adaptiveBlockSize = (adaptiveBlock != null && int.TryParse(adaptiveBlock, NumberStyles.Integer, CultureInfo.InvariantCulture, out var abv)) ? abv : 128;
 
@@ -153,7 +166,10 @@ namespace TestApp {
 
             var discovery = OptimizationRunDiscovery.Discover(runs);
             Console.WriteLine($"bank-verify: {discovery.Runs.Count} run(s) under {runs}; NC sweep [{string.Join(",", ncSweep.Select(x => x.ToString(CultureInfo.InvariantCulture)))}]; " +
-                $"A={(optA ?? "(none)")} B={(optB ?? "(none)")}; matchRadius={matchRadius}; adaptiveBinarize={adaptiveBinarize}" + (adaptiveBinarize ? $"(block={adaptiveBlockSize})" : ""));
+                $"A={(optA ?? "(none)")} B={(optB ?? "(none)")}; matchRadius={matchRadius}; "
+                + $"adaptiveBinarize={EffectiveAdaptiveBinarize(adaptiveBinarizeOverride)}"
+                + (adaptiveBinarizeOverride.HasValue ? " (forced)" : " (shipped default)")
+                + $"(block={adaptiveBlockSize})");
 
             var runResults = new List<RunResult>();
             int idx = 0;
@@ -163,7 +179,7 @@ namespace TestApp {
                 try {
                     var rr = await VerifyRunAsync(run, runs, outDir, ncSweep, optA, optB, goldenDir, matchRadius,
                         profileService, activeProfile, starDetectionOptions, inspectorOptions, autoFocusOptions, detector, detection, alglib, pixelScale,
-                        adaptiveBinarize, adaptiveBlockSize);
+                        adaptiveBinarizeOverride, adaptiveBlockSize);
                     runResults.Add(rr);
                 } catch (Exception ex) {
                     Console.Error.WriteLine($"  FAILED: {ex.GetType().Name}: {ex.Message}");
@@ -173,7 +189,8 @@ namespace TestApp {
             }
 
             var utc = DateTime.UtcNow.ToString("yyyyMMddTHHmmssZ", CultureInfo.InvariantCulture);
-            WriteReport(outDir, utc, commit, ncSweep, runResults);
+            WriteReport(outDir, utc, commit, ncSweep, runResults,
+                EffectiveAdaptiveBinarize(adaptiveBinarizeOverride), adaptiveBinarizeOverride.HasValue, adaptiveBlockSize);
             Console.WriteLine($"bank-verify: wrote verification_{utc}.{{json,md}} to {outDir} ({runResults.Count(r => r.error == null)} ok, {runResults.Count(r => r.error != null)} failed).");
         }
 
@@ -183,7 +200,7 @@ namespace TestApp {
             OptimizationRunDiscovery.DiscoveredRun run, string runsRoot, string outDir, double[] ncSweep, string optA, string optB,
             string goldenDir, double matchRadius, ProfileService profileService, NINA.Profile.Interfaces.IProfile activeProfile,
             StarDetectionOptions sdOptions, InspectorOptions inspectorOptions, AutoFocusOptions afOptions,
-            StarDetector detector, IHocusFocusStarDetection detection, AlglibAPI alglib, double pixelScale, bool adaptiveBinarize, int adaptiveBlockSize) {
+            StarDetector detector, IHocusFocusStarDetection detection, AlglibAPI alglib, double pixelScale, bool? adaptiveBinarizeOverride, int adaptiveBlockSize) {
 
             var runFolder = Path.GetDirectoryName(run.Frames.First().Path);
             var ordered = run.Frames.OrderBy(f => f.FocuserPosition).ToList();
@@ -260,7 +277,9 @@ namespace TestApp {
             foreach (var nc in ncSweep) {
                 var p = BaseDefault();
                 p.NoiseClippingMultiplier = nc;
-                p.LocallyAdaptiveBinarization = adaptiveBinarize;
+                if (adaptiveBinarizeOverride.HasValue) {
+                    p.LocallyAdaptiveBinarization = adaptiveBinarizeOverride.Value;
+                }
                 p.AdaptiveNoiseBlockSize = adaptiveBlockSize;
                 var cm = await ScoreConfigAsync($"C0@nc{nc:0.#}", nc, false, p, evalData, loaded, goldenByFocuser, matchRadius,
                     inspectorOptions, alglib, profileService, activeProfile, stepSize, detector);
@@ -442,7 +461,8 @@ namespace TestApp {
 
         // ---- report ----------------------------------------------------------------------------------------------
 
-        private static void WriteReport(string outDir, string utc, string commit, double[] ncSweep, List<RunResult> runs) {
+        private static void WriteReport(string outDir, string utc, string commit, double[] ncSweep, List<RunResult> runs,
+            bool adaptiveBinarizeEffective, bool adaptiveBinarizeForced, int adaptiveBlockSize) {
             var ok = runs.Where(r => r.error == null && r.configs != null && r.configs.Count > 0).ToList();
 
             // NC-sweep aggregate (C0 only).
@@ -476,7 +496,14 @@ namespace TestApp {
                 schema = "afbank-verify/2",
                 generatedUtc = utc,
                 detectorCommit = commit,
-                noiseClipDefault = 2.0,
+                // Read from the product rather than hardcoded: a literal here said 2.0 while the shipped default was
+                // 4.0, so the report misdescribed the very baseline it was measuring.
+                noiseClipDefault = HocusFocusStarDetection.BuildDefaultStarDetectorParams().NoiseClippingMultiplier,
+                // C0's adaptive-binarization state is part of what "as-default" MEANT for this report. Recording it
+                // is what would have made the 9a80324/c59a4b1 drift visible instead of silent.
+                c0AdaptiveBinarization = adaptiveBinarizeEffective,
+                c0AdaptiveBinarizationForced = adaptiveBinarizeForced,
+                c0AdaptiveNoiseBlockSize = adaptiveBlockSize,
                 ncSweep,
                 runCount = ok.Count,
                 failed = runs.Count(r => r.error != null),

--- a/Joko.NINA.Plugins/TestApp/GoldenEvalRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/GoldenEvalRunner.cs
@@ -270,7 +270,7 @@ namespace TestApp {
                 Console.WriteLine($"  run '{run.RunId}': no per-image golden sidecars found; nothing scored.");
                 return;
             }
-            WriteReports(runOut, run.RunId, paramsLabel, sourceLabel, p, frameEvals);
+            WriteReports(runOut, run.RunId, paramsLabel, sourceLabel, p, frameEvals, matchMode, tau, matchRadius);
         }
 
         // ---- Params bundle ---------------------------------------------------------------------------------
@@ -490,7 +490,7 @@ namespace TestApp {
         // ---- Reporting -------------------------------------------------------------------------------------
 
         private static void WriteReports(string runOut, string runId, string paramsLabel, string sourceLabel,
-            StarDetectorParams p, List<FrameEval> frames) {
+            StarDetectorParams p, List<FrameEval> frames, GoldenMatchMode matchMode, double tau, double matchRadius) {
 
             // CSV (per-frame).
             var csv = new StringBuilder();
@@ -522,7 +522,14 @@ namespace TestApp {
             var sb = new StringBuilder();
             sb.AppendLine($"GOLDEN EVAL — run '{runId}'");
             sb.AppendLine($"params: {paramsLabel}   (source: {sourceLabel})");
-            sb.AppendLine($"match: center-in-box OR IoU; key detector knobs: Sensitivity={p.Sensitivity}, StarClip={p.StarClippingMultiplier}, " +
+            // Report the mode actually used — a hardcoded label here silently misattributes every stored report.
+            var matchLabel = matchMode switch {
+                GoldenMatchMode.Center => "center-in-box",
+                GoldenMatchMode.Iou => $"IoU>={tau}",
+                GoldenMatchMode.Centroid => $"centroid within {matchRadius}px",
+                _ => $"center-in-box OR IoU>={tau}"
+            };
+            sb.AppendLine($"match: {matchLabel}; key detector knobs: Sensitivity={p.Sensitivity}, StarClip={p.StarClippingMultiplier}, " +
                 $"NoiseClip={p.NoiseClippingMultiplier}, PeakResponse={p.PeakResponse}, MaxDistortion={p.MaxDistortion}, StarCenterTol={p.StarCenterTolerance}, " +
                 $"StructureLayers={p.StructureLayers}, MinHFR={p.MinHFR}, MinBox={p.MinimumStarBoundingBoxSize}");
             sb.AppendLine($"defocus: Donut={p.DefocusAwareDonutDetection}, Distortion={p.DefocusAwareDistortion}, Centering={p.DefocusAwareCentering}, " +

--- a/docs/bobp-m101-recall-investigation-results.md
+++ b/docs/bobp-m101-recall-investigation-results.md
@@ -218,8 +218,10 @@ Per the plan, no objective constant was changed in this branch. On the evidence:
   three different points — `sens 0 / clip 0.25` (2026-07-29 05:24), `sens 0 / clip 6.875` (prepass A) and
   `sens 30.1 / clip 3.44` (prepass B, donut-on) — so a single landing is not evidence about the corner the
   optimizer prefers. Bank-wide the A/B configs shed heavily on most runs (see
-  `verification_20260729T205904Z.md`): `timmer` B at `sens 33.3 / clip 7.0` scores recall@≥12 **0.055**, and
-  `mccomiskey` A at `clip 10.0` (the ceiling) scores **0.079** against C0's 0.869. That is the documented
+  `verification_20260730T005833Z.md`): `timmer` B at `sens 33.3 / clip 7.0` scores recall@≥12 **0.055**, and
+  `mccomiskey` A scores **0.079** against C0's 0.871. (Star-clip alone is not the driver — config B sits at clip
+  10 too and keeps 3.4× the stars; A's distinguishing knobs are `StarPeakResponse` 0.981 and `StarCenterTolerance`
+  0.0875. A one-at-a-time ablation shows sensitivity and star-clip act only in combination.) That is the documented
   behaviour of the optimizer — it optimises σ_focus, not star count, and `Wtie` only arbitrates *genuine*
   plateaus, so a real σ improvement still wins as intended. It does mean the tie-breaker should not be described
   as preventing star-shedding in general; what it prevents is shedding chosen on a σ-wiggle.

--- a/docs/bobp-m101-recall-investigation-results.md
+++ b/docs/bobp-m101-recall-investigation-results.md
@@ -213,8 +213,16 @@ Per the plan, no objective constant was changed in this branch. On the evidence:
   corner scores **precision 0.965** at recall@≥12 0.617. It is not a precision disaster.
 - So the star-rich corner now **dominates** the shedding corner on both axes (0.617 @ 0.965 vs 0.117 @ 1.000),
   and a tie-breaker that pushes the optimizer away from shedding is more clearly correct, not less.
-- Consistent with this, a fresh `optimize` on the corrected representation lands at **sens 0 / clip 0.25** — the
-  star-rich corner — and `--params optimized` reproduces the config-F row above exactly.
+- **The optimizer does *not* reliably avoid the shedding corner, and this is by design rather than a `Wtie`
+  failure.** Three separate `optimize --per-run` invocations on the corrected representation landed `bobp_m101` at
+  three different points — `sens 0 / clip 0.25` (2026-07-29 05:24), `sens 0 / clip 6.875` (prepass A) and
+  `sens 30.1 / clip 3.44` (prepass B, donut-on) — so a single landing is not evidence about the corner the
+  optimizer prefers. Bank-wide the A/B configs shed heavily on most runs (see
+  `verification_20260729T205904Z.md`): `timmer` B at `sens 33.3 / clip 7.0` scores recall@≥12 **0.055**, and
+  `mccomiskey` A at `clip 10.0` (the ceiling) scores **0.079** against C0's 0.869. That is the documented
+  behaviour of the optimizer — it optimises σ_focus, not star count, and `Wtie` only arbitrates *genuine*
+  plateaus, so a real σ improvement still wins as intended. It does mean the tie-breaker should not be described
+  as preventing star-shedding in general; what it prevents is shedding chosen on a σ-wiggle.
 
 **Caveat on the precision comparison:** row (c)'s 0.572 was measured at sens 0 / **clip 0.375** on the mosaic, and
 the 0.965 here is at sens 0 / **clip 0.25** on luminance. They are not the same operating point, so treat

--- a/docs/bobp-m101-recall-investigation-results.md
+++ b/docs/bobp-m101-recall-investigation-results.md
@@ -109,3 +109,145 @@ operating point on its own, regardless of rig, so it never lands at the recall-s
 
 Goldens: `<frame>.xisf.golden.json` beside the frames (detector-independent, reused across all configs above).
 Eval/optimize artifacts: scratchpad `bobp_recall/`. Commit: see branch `ghilios/optimizer-sensitivity-pinning`.
+
+---
+
+# Re-check after the headless-detection parity fix — 2026-07-29
+
+**Everything above was measured on a Bayer mosaic.** The Phase 1 parity fix
+(`docs/headless-detection-parity-design.md`) changed what the headless detector sees for bayered runs — raw mosaic
+→ CFA-hotpixel-filtered debayered luminance — and also fixed `ExportLinearRunner`, which feeds the `snr_ref`
+reference. Both the detector *and* the golden it was scored against were therefore measuring a different image
+than the app uses. This section re-measures the run on the corrected pipeline. It supersedes the numbers above;
+the original section is kept because it is the record of what the earlier decision rested on.
+
+## The conclusion holds, and the deficit is worse than reported
+
+**The recall deficit was real, not an artifact of scoring a luminance detector against a mosaic reference.**
+Correcting the reference *deepens* it. Holding the detector and its params fixed and varying only the golden:
+
+| params | golden | TP | FP | precision | **recall@SNR≥12** | recall@all |
+|---|---|---|---|---|---|---|
+| sens 50 / clip 9.5 (row **a** reconstruction) | old (mosaic) | 247 | 0 | 1.000 | 0.181 (247/1365) | 0.104 |
+| sens 50 / clip 9.5 | **new (luminance)** | 247 | 0 | 1.000 | **0.117 (247/2107)** | 0.080 |
+| sens 0 / clip 0.25 (today's optimizer landing) | old (mosaic) | 1401 | 330 | 0.809 | 0.681 (930/1365) | 0.590 |
+| sens 0 / clip 0.25 | **new (luminance)** | 1671 | 60 | **0.965** | 0.617 (1299/2107) | 0.543 |
+| shipped defaults, NC 2 | old (mosaic) | 1415 | 56 | 0.962 | 0.720 (983/1365) | 0.596 |
+| shipped defaults, NC 2 | **new (luminance)** | 1457 | 14 | **0.990** | 0.637 (1343/2107) | 0.473 |
+
+At the shedding corner the **true positives are identical either way (247)** — the detector finds exactly the same
+stars, and only the denominator moves, 1365 → 2107. That is the cleanest possible demonstration that the golden,
+not the detector, changed: recall@SNR≥12 falls **0.181 → 0.117**.
+
+The mechanism is the one Task 1 measured: the CFA checkerboard inflated `snr_ref`'s block-MAD σ by 3.0–3.25×
+(17.8–19.3 ADU vs 5.93), so the mosaic reference was ~3× *less* sensitive. It was a strict **subset** of the new
+one — 1365/1365 of its high-tier finds reproduce, with **zero** mosaic-only finds — not a set polluted with
+mosaic artifacts. So there were never any phantom recall gaps to remove.
+
+**Two consistent second-order effects**, visible across all three param sets:
+
+- **recall@SNR≥12 always falls** with the corrected golden (0.181→0.117, 0.681→0.617, 0.720→0.637): the added
+  reference stars are fainter than anything the mosaic reference could resolve, and HF misses them.
+- **precision always rises** (1.000→1.000, 0.809→0.965, 0.962→0.990; FPs 330→60 and 56→14). Much of what the
+  mosaic reference scored as HF false positives were **real stars it was too insensitive to see**. The old
+  precision figures for star-rich configs were biased low.
+
+## The golden set is also stricter, not just larger
+
+| | old (mosaic) | new (luminance) |
+|---|---|---|
+| `snr_ref` candidates | 2,427 | 4,410 |
+| high tier, auto-confirmed (SNR≥12) | 1,365 | **2,107** (+54%) |
+| uncertain candidates | 1,062 | 2,303 |
+| uncertain QA-confirmed | 1,010 (**95.1%**) | 972 (**42.2%**) |
+| **golden total** | **2,375** | **3,079** |
+
+Per-frame golden (old → new): 5562 123→157 · 5586 151→187 · 5610 154→233 · 5634 208→308 · 5658 403→444 ·
+5682 495→583 · 5706 382→479 · 5730 199→303 · 5754 145→225 · 5778 115→160.
+
+**Caveat (2) of the original Method section is now measured and largely retired.** That caveat warned the wing
+golden denominator was "generous" because the LLM QA confirmed ~100% of the uncertain tier there. On the corrected
+frames the QA is far more selective, and its confirm rate tracks **defocus, not SNR**:
+
+| focuser | 5682 (best focus) | 5658 | 5706 | 5778 | 5562 | 5586 | 5754 | 5634 | 5730 | 5610 |
+|---|---|---|---|---|---|---|---|---|---|---|
+| uncertain confirm rate | **1.7%** | 12.0% | 28.5% | 47.9% | 54.9% | 63.3% | 59.3% | 59.2% | 60.5% | **69.1%** |
+
+At best focus every real star is already above SNR 12, so the uncertain tier there is genuinely noise and is
+rejected almost entirely; at defocus real light spreads out and drops below SNR 12, so the uncertain tier there
+holds real stars. By SNR tier alone the confirm rate is non-monotone (47.9% at 10–12, 33.0% at 8–10, 40.1% at
+6.5–8, 52.3% at 5–6.5), which is a composition artifact of that split — the faintest bucket is dominated by
+defocused frames. Coverage was complete: all 2,303 uncertain candidates were rendered and QA'd (67 montages,
+chunk=4, **0** rate-limit failures), so the new golden is not budget-truncated.
+
+## The star-shedding characterisation survives, but "94% from two knobs" does not
+
+FN gate attribution at the shedding corner, same detector, both goldens:
+
+| gate | old golden | new golden |
+|---|---|---|
+| `LowSensitivity` | 1491 | 1236 |
+| `Degenerate` | 164 | 595 |
+| NO CANDIDATE (structure gap) | 197 | 446 |
+| `TooSmall` | 187 | 311 |
+| `TooDistorted` | 71 | 228 |
+| other (Contaminated/OnBorder/TooFlat/accepted-elsewhere) | 18 | 16 |
+| **total FN** | **2128** | **2832** |
+
+`LowSensitivity` + `Degenerate` still dominate and the two-pinned-knob story stands. But they now account for
+**1831/2832 = 65%** of the misses, not the **94%** the original section claimed. The corrected reference adds
+fainter stars that fail *earlier* in the pipeline — the structure gap (446) and `TooSmall` (311) are now
+material, and were previously invisible because the mosaic reference could not see those stars at all.
+
+Note the two goldens are not nested outside the high tier (their uncertain tiers come from independent `snr_ref`
+runs and independent QA), so the per-gate deltas mix a denominator change with a composition change and should
+not be read as a per-star migration.
+
+## Does `Wtie = 0.02` still look like the right call? Yes — the evidence is stronger
+
+Per the plan, no objective constant was changed in this branch. On the evidence:
+
+- The **motivation is stronger.** The shedding corner is worse than believed: recall@SNR≥12 0.117, not 0.126.
+- The **counter-argument is weaker.** The bistability table in `docs/optimizer-sensitivity-pinning-design.md`
+  justifies caution about the flooding corner with "precision 0.572". On the corrected pipeline the star-rich
+  corner scores **precision 0.965** at recall@≥12 0.617. It is not a precision disaster.
+- So the star-rich corner now **dominates** the shedding corner on both axes (0.617 @ 0.965 vs 0.117 @ 1.000),
+  and a tie-breaker that pushes the optimizer away from shedding is more clearly correct, not less.
+- Consistent with this, a fresh `optimize` on the corrected representation lands at **sens 0 / clip 0.25** — the
+  star-rich corner — and `--params optimized` reproduces the config-F row above exactly.
+
+**Caveat on the precision comparison:** row (c)'s 0.572 was measured at sens 0 / **clip 0.375** on the mosaic, and
+the 0.965 here is at sens 0 / **clip 0.25** on luminance. They are not the same operating point, so treat
+0.572 → 0.965 as "the flooding corner is far cleaner than recorded", not as a like-for-like delta. The direction
+is unambiguous — both the detector fix and the golden fix push precision the same way.
+
+Also unchanged: the evidence that **shipped** `Wtie = 0.02` never rested on this run. Per
+`docs/optimizer-sensitivity-pinning-design.md`, the real-data demonstration is **`muggsie`**, a **mono** run that
+Phase 1 provably does not touch. bobp_m101 supplied the motivating narrative, and that narrative survives.
+
+## Method (this section)
+
+- Goldens rebuilt per `generating-af-golden-data`: `bank-donut-meta --refresh` re-confirmed `donutAware=false` on
+  the new representation (donut peak fraction rose 11.5 → 39.0, but extreme-frame HFR 6.9 < 9.0 and donut bbox
+  14 px < 24 px keep it below the gate), so `snr_ref` ran without `--donut`, as before.
+- `golden_prep --budget-montages 20` (not the usual 4) so the **entire** uncertain tier was QA'd, matching the
+  original run's effectively-full coverage; anything less would have truncated the new golden's faint tier and
+  made the old-vs-new comparison unfair.
+- Scoring: `TestApp golden eval --runs "D:\Autofocus Bank\bobp_m101\AutoFocus_20260626_225408" --profile-id
+  b10b1d6d-80eb-4dc4-9d89-f1fbf64c2b34 --params default --sensitivity <s> --star-clip <c> --match centroid
+  --match-radius 12`, with `--golden <dir>` pointed at the archived mosaic goldens for the "old" rows. Same
+  profile caveat as the original section (caveat 1) applies unchanged.
+- Row (a) is a **reconstruction**: the run's `optimized_settings.json` was overwritten on 2026-07-29T05:24Z by a
+  fresh optimize on the corrected pipeline, so the original stored param set is no longer on disk. Only its
+  `sensitivity = 50` / `starClip = 9.5` are recorded (above), and they are reapplied here on top of `--params
+  default`. Its other knobs match the current file exactly (NC 4, PeakResponse 0.75, MaxDistortion 0.5,
+  StarCenterTol 0.3, StructureLayers 4, MinHFR 1.2, MinBox 5), so the reconstruction is close but not certified
+  identical — which is why the reconstructed old-golden number is 0.181 rather than the originally reported 0.126.
+  **The old-vs-new comparison does not depend on this**, because both rows use the same reconstructed params.
+- Harness note: `GoldenEvalRunner.cs` prints a hardcoded `match: center-in-box OR IoU` header regardless of
+  `--match`. The mode *is* applied (verified: `--match centroid --match-radius 0` → TP=0; radius 12 → TP=26);
+  only the label was wrong. Fixed in this branch.
+
+**Provenance.** Old mosaic goldens archived at `D:\Autofocus Bank\_prior_reports\bobp_m101_goldens_mosaic_prephase1\`;
+old mosaic linear exports at `…\bobp_m101_linear_mosaic_prephase1\`; the new reference, QA confirmations and
+goldens at `…\bobp_m101_goldens_luminance_phase2\`. Branch `ghilios/bank-rebaseline-bayered`.

--- a/docs/headless-detection-parity-design.md
+++ b/docs/headless-detection-parity-design.md
@@ -162,11 +162,30 @@ luminance-scoring objective.
 **2. `ExportLinearRunner` contradicts its own documentation.** Its comment (`:29-34`) states it "debayers Bayered
 frames to luminance … the SAME linear luminance the HocusFocus detector consumes", but `:69` uses the
 `debayerToLuminance: false` default. The doc is right and the code is wrong. This matters beyond tidiness: the
-export feeds `tools/golden/snr_ref.py`, the **detector-independent reference** the golden sets are built from. A
-reference computed on a mosaic while HocusFocus detects on luminance scores every mosaic-only find as an HF recall
-gap HF could never close — i.e. the golden audit measures the wrong thing. "Linear" means no MTF/auto-stretch, not
-no debayer. It must **not** gain the CFA filter, though: the reference's independent blind spots are the point, and
-hot-pixel rejection is already assigned to the LLM montage QA step (`.claude/docs/golden-star-set.md:37`).
+export feeds `tools/golden/snr_ref.py`, the **detector-independent reference** the golden sets are built from.
+"Linear" means no MTF/auto-stretch, not no debayer. It must **not** gain the CFA filter, though: the reference's
+independent blind spots are the point, and hot-pixel rejection is already assigned to the LLM montage QA step
+(`.claude/docs/golden-star-set.md:37`).
+
+**The mechanism, measured on `bobp_m101` (2026-07-29) — not the one first assumed.** An earlier draft of this
+document asserted that mosaic-only reference finds were being scored as HF recall gaps HF could never close. That
+is **false**, at least on this run: cross-matched at the `golden eval` radius (12 px), **1,365 / 1,365 (100%)** of
+the old high-tier candidates are reproduced by the luminance reference, all still high-tier. There are **zero**
+mosaic-only finds.
+
+What actually happens is the reverse. The CFA checkerboard dominates `snr_ref`'s block-MAD noise estimate,
+inflating σ by **3.0–3.25×** (17.8–19.3 ADU vs 5.93). Both the 5σ detection threshold and the SNR tiering scale
+with it, so the mosaic reference is roughly **3× less sensitive**. The old golden is a strict **subset** of the
+correct one, not a polluted superset: 209 of the new 2,107 high-tier stars match no old candidate at any tier, and
+a further 533 existed but were tiered medium/low.
+
+**This inverts the expected direction of any recall correction.** The `recall@SNR≥12` denominator grows ~54%
+(1,365 → 2,107) and the added stars are *fainter* than anything the old reference could resolve. If HocusFocus's
+misses skew faint — precisely what a "star-shedding" characterisation predicts — the corrected recall goes **down**,
+not up. Do not approach the `bobp_m101` re-check assuming the deficit was a scoring artifact.
+
+Measured on one run only; `bobp` and `timmer` are not yet re-exported, so the generality of this mechanism is
+unestablished.
 
 **3. `TiltCalibrationRunner` was the runner the `DiagnosticUtil` warning was written about.** That warning names
 tilt explicitly — detecting on the mosaic "biases the per-star sensor-model tilt the Tilt Adapter Wizard calibrates

--- a/docs/optimizer-sensitivity-pinning-design.md
+++ b/docs/optimizer-sensitivity-pinning-design.md
@@ -1,5 +1,18 @@
 # Optimizer Sensitivity-Pinning / Star-Count Bistability — Design
 
+> **Re-checked 2026-07-29 after the headless-detection parity fix — the conclusion holds; some numbers moved.**
+> Every `bobp_m101` figure quoted below was measured on a Bayer mosaic, for both the detector and the golden set
+> it was scored against (`docs/headless-detection-parity-design.md`). Re-measured on the corrected pipeline:
+> the shedding corner is **worse** than recorded (recall@SNR≥12 **0.117**, not 0.126 — the reference was ~3×
+> under-sensitive, so the deficit was never a scoring artifact), and the flooding corner is **much cleaner** than
+> recorded (**precision ~0.965**, not 0.572, at sens 0 / clip 0.25). The star-rich corner therefore *dominates*
+> the shedding corner on both axes, so **`Wtie = 0.02` looks more justified, not less.** The "94% of the missed
+> stars" attribution below weakens to ~65%: the corrected reference includes fainter stars that fail earlier
+> (structure gap, `TooSmall`), though `LowSensitivity` + `Degenerate` still dominate. The shipped calibration is
+> unaffected — it is unit-test-based, and its real-data demonstration is `muggsie`, a **mono** run the parity fix
+> provably does not touch. Full re-check: `docs/bobp-m101-recall-investigation-results.md` § *Re-check after the
+> headless-detection parity fix*.
+
 ## Problem
 
 The star-detection optimizer can land on settings that **shed most of the real stars** while still scoring
@@ -16,6 +29,12 @@ This is **not** rig-specific. The standard objective is **bistable** in the (sen
 |--------|------|----------|---------------|-----------|---|
 | star-shedding | 50 | 9.5 | 0.126 | 1.000 | ~0.999 |
 | star-flooding | 0 | 0.375 | 0.867 | 0.572 | ~0.999 |
+
+> **2026-07-29:** the recall/precision columns above are mosaic-era. Corrected, the corners read
+> shedding **0.117 @ 1.000** and flooding **0.617 @ 0.965** (the latter at clip 0.25, today's optimizer landing —
+> not the same operating point as clip 0.375, so not a like-for-like precision delta). The bistability in `J`
+> itself is a property of the objective and is unaffected by the representation change; what moves is the claim
+> that flooding is the precision-costly corner. See `docs/bobp-m101-recall-investigation-results.md`.
 
 Both corners score essentially the same J, so **which one the search reaches depends on pixel scale + seed, not
 on AF quality.** Evidence: bobp_m101 landed on the shedding corner on its capture rig; the bobp **sibling** run

--- a/plans/bank-rebaseline-bayered-plan.md
+++ b/plans/bank-rebaseline-bayered-plan.md
@@ -106,45 +106,142 @@ candidates and the additions are *fainter* than anything the old reference could
 If rate limits make full QA impractical, report how far you got rather than degrading the method. A partial,
 honest golden is more useful than a fast, unreliable one.
 
-- [ ] `snr_ref` over the new exports → candidates.
-- [ ] Montage + **LLM QA** per the skill. This is the long pole and is rate-limited; budget accordingly and do
+- [x] `snr_ref` over the new exports → candidates.
+- [x] Montage + **LLM QA** per the skill. This is the long pole and is rate-limited; budget accordingly and do
       not parallelise past the documented limits.
-- [ ] `build_goldens` → new per-image `*.golden.json`.
-- [ ] **Keep the old goldens** (rename, don't delete) until Task 4 has compared old vs new. They are the only
+- [x] `build_goldens` → new per-image `*.golden.json`.
+- [x] **Keep the old goldens** (rename, don't delete) until Task 4 has compared old vs new. They are the only
       record of what the previous conclusion rested on.
+
+### Task 2 result — `bobp_m101`, 2026-07-29
+
+`bank-donut-meta --refresh` re-confirmed `donutAware=false` on the new representation (donut peak fraction rose
+11.5 → 39.0, but extreme-frame HFR 6.9 < 9.0 and donut bbox 14 px < 24 px keep it below the gate), so `snr_ref`
+ran without `--donut` as before. Ran with `--budget-montages 20` (not the usual 4) so the **entire** uncertain
+tier was QA'd — the old run's uncertain tier was effectively fully covered, and a smaller budget would have
+truncated the new golden's faint tier and made the old-vs-new comparison unfair. 67 montages, chunk=4, **0**
+rate-limit failures.
+
+| | old (mosaic) | new (luminance) |
+|---|---|---|
+| candidates | 2,427 | 4,410 |
+| high tier, auto-confirmed (SNR≥12) | 1,365 | **2,107** (+54%) |
+| uncertain candidates | 1,062 | 2,303 |
+| uncertain QA-confirmed | 1,010 (**95.1%**) | 972 (**42.2%**) |
+| **golden total** | **2,375** | **3,079** |
+
+**The QA rejects most of the newly-visible faint tier, and the rejection pattern is defocus, not SNR.** Confirm
+rate by frame: 5682 (best focus) **1.7%**, 5658 12.0%, 5706 28.5%, then 47.9–69.1% across the wings. At best
+focus every real star is already above SNR 12 so the uncertain tier there is genuinely noise; at defocus real
+light spreads out and drops below SNR 12. By SNR tier alone the rate is non-monotone (47.9% at 10–12, 33.0% at
+8–10, 40.1% at 6.5–8, 52.3% at 5–6.5) purely as a composition artifact of that split.
+
+Artifacts archived at `D:\Autofocus Bank\_prior_reports\bobp_m101_goldens_luminance_phase2\` (goldens, `snr_*`,
+`qa_*`, manifest, worklist); old mosaic goldens preserved at `…\bobp_m101_goldens_mosaic_prephase1\`.
+
+Incidental fix: `tools/golden/qa_workflow.js` was CRLF, which the Workflow tool rejects as control characters, so
+the documented QA step could not launch. `.gitattributes` now pins `tools/golden/*.js` to LF (commit `dc7cfed`).
 
 ## Task 3 — Full `bank-verify` re-baseline
 
-- [ ] Invoke the **`running-af-bank-validation`** skill for the pipeline, and heed its warnings: the STA/pumped
+- [x] Invoke the **`running-af-bank-validation`** skill for the pipeline, and heed its warnings: the STA/pumped
       dispatcher requirement, watching `bank_verify_progress.log` rather than stdout (WSL block-buffers), and
       closing NINA first.
-- [ ] Optimizer A/B prepass, then `bank-verify` with `--commit $(git rev-parse --short HEAD)`.
-- [ ] **Validate the harness before trusting the results:** `cwhite_2026` is the dry-run anchor and must
+- [~] Optimizer A/B prepass, then `bank-verify` with `--commit $(git rev-parse --short HEAD)`.
+      **C0-only sweep done; A/B not run** — see below.
+- [x] **Validate the harness before trusting the results:** `cwhite_2026` is the dry-run anchor and must
       reproduce its known config-B numbers (P=0.848, recall@≥12=0.181, sensor R²=0.9933, 7/9 aligned). It is
       **mono**, so Phase 1 must not have moved it. If it moved, the mono byte-identity guarantee is broken and
       that is a Phase 1 bug — stop and report.
+
+### Task 3 result — 2026-07-29 (anchor gate FAILED, but **not** a Phase 1 bug — needs a decision)
+
+`bank-verify --nc-sweep 2,3,4 --match-radius 12 --commit dc7cfed` over the whole bank, **C0 only**, ~65 min →
+`verification_20260729T145515Z.{json,md}`, 22 runs (the bank has grown from 17: `SorenVance`, `lumos` and `vsn07`
+have no goldens and score NaN; `bobp` and `bobp_m101` are new to the report).
+
+**A/B were not run.** The `opt_A`/`opt_B` prepass directories no longer exist, and rebuilding them is
+`optimize --per-run` twice over the bank — the skill budgets 1.5–3 hr *each*. The C0 rows are the headline recall
+answer and need no prepass, so the sweep was run C0-only. **Consequence:** the plan's anchor is a *config-B*
+number and is therefore not reproducible without that prepass.
+
+**Every run moved, mono and bayered alike — and the cause is not Phase 1.** The C0 "as-default" configuration
+itself changed between the two reports, and both reports record it:
+
+| | baseline `b331479` (2026-06-24) | new `dc7cfed` (2026-07-29) |
+|---|---|---|
+| C0 sensitivity | **2.0** | **10.0** |
+| C0 noiseClipDefault | 2.0 | 2.0 |
+
+That is commit **`59d5e59` "Revert Simple-mode BrightnessSensitivity/NoiseClipping to v3 values (interim)"**
+(2026-07-11), which is in HEAD but **not** in `b331479`. It edits `BuildDefaultStarDetectorParams()`, which
+`BankVerifyRunner.BaseDefault()` consumes verbatim. Sensitivity 2 → 10 sheds stars, so recall falls and precision
+rises **bank-wide**: e.g. `cwhite_2026` C0@nc2 recall@≥12 0.4594 → 0.2658 with precision 0.8105 → 0.8504 and
+`sStars` 106 → 59; `CWhiteFocus` 0.8697 → 0.8072 with `sStars` 3933 → 1802. Goldens are byte-identical on all 17
+baselined runs (verified: `goldenStars` and `goldenSNRge12` unchanged for every one), so the golden set is not
+the variable.
+
+**So the plan's verification item "mono runs unchanged vs `verification_20260624T142723Z.md`" is not testable as
+written** — the configuration under comparison moved for reasons unrelated to this branch. The anchor's movement
+is *explained*, not *unexplained*, and it is **not** evidence that Phase 1's mono byte-identity guarantee broke.
+Supporting evidence that the harness itself is sound: the dataset copies still produce identical recall
+(`CWhiteFocus`≡`standard_example2` 0.807227, `fmeschia`≡`sensitivity_example1` 0.750000,
+`LinwoodFocus`≡`sensitivity_example2` 0.091743 — precision differs only because their golden sets differ
+slightly), and the full unit suite is **3066/3066 green**.
+
+`bank-verify` has **no `--sensitivity` override** (C0 takes `BuildDefaultStarDetectorParams()` verbatim), so an
+apples-to-apples mono anchor needs one of:
+
+1. a scratch build pinning C0 sensitivity to 2.0, re-run on `cwhite_2026` alone (~5 min) — cheapest true test of
+   the mono guarantee;
+2. a re-run at the pre-Phase-1 commit for a direct A/B (slower, but tests Phase 1 end-to-end);
+3. accepting `verification_20260729T145515Z` as the **new** baseline and recording the discontinuity, on the
+   grounds that sensitivity 10 is what ships today.
+
+**This is a decision for the user, not an assumption to make.** Nothing downstream of it was assumed.
+
+New-run rows worth recording (C0@nc2): `bobp_m101` golden 3079 / high 2107 → recall@≥12 **0.6450**, precision
+**0.9873**; `bobp` golden 1705 / high 1039 → recall@≥12 0.6670, precision 0.9262 — but **`bobp`'s golden is still
+the stale mosaic one**, so that row is not re-baselined and must not be read as valid. Same for `timmer`.
 
 ## Task 4 — Re-check the `bobp_m101` conclusion
 
 This is the point of Phase 2.
 
-- [ ] `docs/bobp-m101-recall-investigation-results.md` reported **recall@SNR≥12 = 0.126** and attributed 94% of
+**ANSWERED 2026-07-29 — the deficit was real; correcting the reference deepens it.** Full write-up in
+`docs/bobp-m101-recall-investigation-results.md` § *Re-check after the headless-detection parity fix*;
+`docs/optimizer-sensitivity-pinning-design.md` annotated. Commit `bbde567`.
+
+Holding the detector and params fixed and varying **only** the golden, the true positives are **identical (247)**
+— the detector finds exactly the same stars and only the denominator moves, 1365 → 2107, so recall@SNR≥12 falls
+**0.181 → 0.117**. The star-shedding characterisation survives (`LowSensitivity` 1236 + `Degenerate` 595 still
+dominate) but the "94% from two knobs" figure weakens to **~65%**: the corrected reference adds fainter stars
+that fail earlier (structure gap 446, `TooSmall` 311). Precision *rises* with the corrected golden across all
+three param sets (0.809 → 0.965 at the star-rich corner, FPs 330 → 60), because much of what the mosaic reference
+scored as HF false positives were real stars it was too insensitive to see. **`Wtie = 0.02` still looks right —
+more so**: the star-rich corner now dominates the shedding corner on both axes. No objective constant changed.
+
+- [x] `docs/bobp-m101-recall-investigation-results.md` reported **recall@SNR≥12 = 0.126** and attributed 94% of
       misses to two knobs (`LowSensitivity` gate 1302, star-clip Degenerate guard 762). That analysis drove
       `docs/optimizer-sensitivity-pinning-design.md` and the `Wtie` 1e-3 → 0.02 change shipped in PR #111.
-- [ ] Re-measure recall/precision on the new goldens with the fixed harness. Report old vs new side by side.
-- [ ] **Answer explicitly:** does the star-shedding characterisation still hold? Was the recall deficit real, or
+- [x] Re-measure recall/precision on the new goldens with the fixed harness. Report old vs new side by side.
+- [x] **Answer explicitly:** does the star-shedding characterisation still hold? Was the recall deficit real, or
       an artifact of scoring a luminance detector against a mosaic reference? Does `Wtie = 0.02` still look like
       the right call?
-- [ ] Whatever the answer, **write it up** — append a dated section to
+- [x] Whatever the answer, **write it up** — append a dated section to
       `docs/bobp-m101-recall-investigation-results.md` and annotate
       `docs/optimizer-sensitivity-pinning-design.md`. If the conclusion still holds, say so with the new numbers;
       that is as valuable as an overturn and stops this being re-litigated.
-- [ ] **Do not change `Wtie` or any objective constant in this branch.** If the evidence no longer supports it,
+- [x] **Do not change `Wtie` or any objective constant in this branch.** If the evidence no longer supports it,
       that is a separate, spec'd decision — report it, don't act on it.
 
 ## Verification
 
-- [ ] `cwhite_2026` anchor reproduces (harness integrity).
-- [ ] Mono runs unchanged vs `verification_20260624T142723Z.md`.
-- [ ] The three bayered runs have new goldens and new bank-verify numbers.
-- [ ] The `bobp_m101` question is answered in writing, either way.
+- [~] `cwhite_2026` anchor: **moved, and explained** — the C0 as-default sensitivity changed 2.0 -> 10.0 via
+      `59d5e59` (2026-07-11), not via Phase 1. Not testable as written; see Task 3 result.
+- [~] Mono runs unchanged vs `verification_20260624T142723Z.md`: **all moved**, bank-wide, from the same
+      defaults change. Goldens byte-identical throughout; determinism check passes; suite 3066/3066.
+- [~] Bayered runs: `bobp_m101` has new goldens **and** new bank-verify numbers. `bobp` and `timmer` have
+      bank-verify rows but **still-stale mosaic goldens** (deferred by the sequencing decision). `SorenVance`
+      has no goldens at all.
+- [x] The `bobp_m101` question is answered in writing, either way.

--- a/plans/bank-rebaseline-bayered-plan.md
+++ b/plans/bank-rebaseline-bayered-plan.md
@@ -1,0 +1,91 @@
+# Bank Re-baseline for Bayered Runs — Implementation Plan (Phase 2)
+
+**Goal:** rebuild the validation artifacts the Phase 1 parity fix invalidated, then re-check the `bobp_m101`
+recall conclusion that motivated PR #111 — so `ghilios/exposure-recommendation` can be validated against a
+harness whose numbers mean what they say.
+
+**Depends on:** `ghilios/headless-detection-parity` (Phase 1, complete). Branch:
+`ghilios/bank-rebaseline-bayered`, off Phase 1. Rebase both onto `develop` in order once the exposure PR merges.
+
+**Spec:** `docs/headless-detection-parity-design.md` §Consequences for stored artifacts.
+
+## Why everything below is stale
+
+Phase 1 changed what the headless detector *sees* for bayered runs — from a raw Bayer mosaic to
+CFA-hotpixel-filtered debayered luminance, chosen per-params inside `Detect`. On `bobp` that moved the optimizer
+from `Sensitivity 0` / 52 stars to `Sensitivity 10` / 27 stars. Every stored number derived from the old
+representation is therefore measuring a different image than the app uses.
+
+Phase 1 also fixed `ExportLinearRunner`, which feeds `tools/golden/snr_ref.py`. The goldens were built from a
+**mosaic** reference while HocusFocus detects on luminance — so mosaic-only reference finds were scored as HF
+recall gaps HF could never close. **This is the mechanism that makes the `bobp_m101` audit suspect**, not just its
+absolute numbers.
+
+## Scope
+
+| Run | Goldens | Linear exports | Action |
+|---|---|---|---|
+| `bobp` | 9 | 9 | regenerate both |
+| `bobp_m101` | 10 | 10 | regenerate both — **the run under re-check** |
+| `timmer` | 9 | 9 | regenerate both |
+| `SorenVance` | 0 | 0 | none exist; out of scope unless we want it scored |
+
+18 mono runs are unaffected and must **not** be regenerated — their artifacts are still valid, and re-running them
+would burn hours and risk churn.
+
+---
+
+## Task 1 — Re-export linear frames (mechanical, no LLM)
+
+- [ ] Invoke the **`generating-af-golden-data`** skill for the exact pipeline and its gotchas (rate limits,
+      XISF/Bayer handling) — do not improvise the commands.
+- [ ] Re-run `TestApp export-linear` for `bobp`, `bobp_m101`, `timmer`. Phase 1 fixed this runner to debayer, so
+      the new exports are luminance where the old were mosaic.
+- [ ] **Verify the fix took effect** before proceeding: the new `.linear.fits` must differ from the old for these
+      bayered runs. If they are identical, the export fix did not apply and everything downstream is wasted —
+      stop and report.
+
+## Task 2 — Regenerate the reference and the goldens
+
+- [ ] `snr_ref` over the new exports → candidates.
+- [ ] Montage + **LLM QA** per the skill. This is the long pole and is rate-limited; budget accordingly and do
+      not parallelise past the documented limits.
+- [ ] `build_goldens` → new per-image `*.golden.json`.
+- [ ] **Keep the old goldens** (rename, don't delete) until Task 4 has compared old vs new. They are the only
+      record of what the previous conclusion rested on.
+
+## Task 3 — Full `bank-verify` re-baseline
+
+- [ ] Invoke the **`running-af-bank-validation`** skill for the pipeline, and heed its warnings: the STA/pumped
+      dispatcher requirement, watching `bank_verify_progress.log` rather than stdout (WSL block-buffers), and
+      closing NINA first.
+- [ ] Optimizer A/B prepass, then `bank-verify` with `--commit $(git rev-parse --short HEAD)`.
+- [ ] **Validate the harness before trusting the results:** `cwhite_2026` is the dry-run anchor and must
+      reproduce its known config-B numbers (P=0.848, recall@≥12=0.181, sensor R²=0.9933, 7/9 aligned). It is
+      **mono**, so Phase 1 must not have moved it. If it moved, the mono byte-identity guarantee is broken and
+      that is a Phase 1 bug — stop and report.
+
+## Task 4 — Re-check the `bobp_m101` conclusion
+
+This is the point of Phase 2.
+
+- [ ] `docs/bobp-m101-recall-investigation-results.md` reported **recall@SNR≥12 = 0.126** and attributed 94% of
+      misses to two knobs (`LowSensitivity` gate 1302, star-clip Degenerate guard 762). That analysis drove
+      `docs/optimizer-sensitivity-pinning-design.md` and the `Wtie` 1e-3 → 0.02 change shipped in PR #111.
+- [ ] Re-measure recall/precision on the new goldens with the fixed harness. Report old vs new side by side.
+- [ ] **Answer explicitly:** does the star-shedding characterisation still hold? Was the recall deficit real, or
+      an artifact of scoring a luminance detector against a mosaic reference? Does `Wtie = 0.02` still look like
+      the right call?
+- [ ] Whatever the answer, **write it up** — append a dated section to
+      `docs/bobp-m101-recall-investigation-results.md` and annotate
+      `docs/optimizer-sensitivity-pinning-design.md`. If the conclusion still holds, say so with the new numbers;
+      that is as valuable as an overturn and stops this being re-litigated.
+- [ ] **Do not change `Wtie` or any objective constant in this branch.** If the evidence no longer supports it,
+      that is a separate, spec'd decision — report it, don't act on it.
+
+## Verification
+
+- [ ] `cwhite_2026` anchor reproduces (harness integrity).
+- [ ] Mono runs unchanged vs `verification_20260624T142723Z.md`.
+- [ ] The three bayered runs have new goldens and new bank-verify numbers.
+- [ ] The `bobp_m101` question is answered in writing, either way.

--- a/plans/bank-rebaseline-bayered-plan.md
+++ b/plans/bank-rebaseline-bayered-plan.md
@@ -33,17 +33,55 @@ absolute numbers.
 18 mono runs are unaffected and must **not** be regenerated — their artifacts are still valid, and re-running them
 would burn hours and risk churn.
 
+**Sequencing decision:** do **`bobp_m101` first, alone**, then stop and reassess. It is the run the conclusion
+under re-check rests on, so it answers the actual question for a third of the rate-limited LLM budget. If its
+conclusion moves, `bobp` and `timmer` become more urgent; if it holds, they may not be urgent at all. Do not start
+the other two without checking back.
+
 ---
 
 ## Task 1 — Re-export linear frames (mechanical, no LLM)
 
-- [ ] Invoke the **`generating-af-golden-data`** skill for the exact pipeline and its gotchas (rate limits,
+- [x] Invoke the **`generating-af-golden-data`** skill for the exact pipeline and its gotchas (rate limits,
       XISF/Bayer handling) — do not improvise the commands.
-- [ ] Re-run `TestApp export-linear` for `bobp`, `bobp_m101`, `timmer`. Phase 1 fixed this runner to debayer, so
-      the new exports are luminance where the old were mosaic.
-- [ ] **Verify the fix took effect** before proceeding: the new `.linear.fits` must differ from the old for these
+- [x] Re-run `TestApp export-linear` for `bobp_m101` (`--profile-id b10b1d6d…` / Default, `--overwrite`).
+      `bobp` and `timmer` deferred per the sequencing decision above.
+- [x] **Verify the fix took effect** before proceeding: the new `.linear.fits` must differ from the old for these
       bayered runs. If they are identical, the export fix did not apply and everything downstream is wasted —
       stop and report.
+
+### Task 1 result — `bobp_m101`, 2026-07-29 (gate PASSED)
+
+All 10 sidecars changed (10/10 distinct MD5s; byte size identical at 47,088,000 — 5936×3966 either way, so
+**size is not a valid gate**, only content is). Old exports preserved at
+`D:\Autofocus Bank\_prior_reports\bobp_m101_linear_mosaic_prephase1\`.
+
+The old files are demonstrably a **Bayer mosaic**: their four CFA sub-lattice medians are four distinct values
+(330 / 353 / 354 / 338 ADU, spread 24–25) and mean |horizontal-neighbour Δ| is 23.7–24.2 ADU. The new files'
+sub-lattice medians are equal to within 1 ADU and the neighbour Δ falls to 3.5 ADU. 97.6% of pixels changed;
+median |Δ| 11 ADU, p99 49 ADU, peaks ~41k ADU at saturated cores.
+
+**The defect's mechanism is not the one this plan and `docs/headless-detection-parity-design.md` assert.** The
+checkerboard dominated `snr_ref`'s block-MAD noise estimate, so the reference's σ was **3.0–3.25× too high**
+(17.8–19.3 ADU vs 5.9). Both the 5σ detection threshold and the SNR tiering scaled with it, so the mosaic
+reference was ~3× **less** sensitive:
+
+| `snr_ref` (k=5, no donut), 10 frames | old (mosaic) | new (luminance) |
+|---|---|---|
+| median σ | 17.8–19.3 ADU | 5.93 ADU |
+| candidates, all tiers | 2,427 | 4,410 |
+| high tier, SNR ≥ 12 | 1,365 | 2,107 |
+
+Cross-matched at the `golden eval` radius (12 px): **1,365 / 1,365 (100%)** of old high-tier candidates are
+reproduced by the new reference, all of them still in the new high tier. There are **zero mosaic-only finds** on
+this run — the old reference was a strict *subset*, not a set polluted with mosaic artifacts. Conversely 209 of
+the new 2,107 high-tier stars match no old candidate at any tier, and a further 533 were present but tiered
+medium/low. The stored goldens' high tiers equal the old counts exactly (27/44/93/246/450/305/100/54/29/17 =
+1,365), confirming the golden high tier is a direct function of this export.
+
+**Consequence for Task 4:** the `recall@SNR≥12 = 0.126` denominator grows ~54% (1,365 → ~2,107) and the added
+stars are *fainter* than any the old reference could see. If HF's misses skew faint, the corrected recall goes
+**down**, not up. Do not enter Task 4 assuming the deficit was a scoring artifact.
 
 ## Task 2 — Regenerate the reference and the goldens
 

--- a/plans/bank-rebaseline-bayered-plan.md
+++ b/plans/bank-rebaseline-bayered-plan.md
@@ -5,7 +5,8 @@ recall conclusion that motivated PR #111 — so `ghilios/exposure-recommendation
 harness whose numbers mean what they say.
 
 **Depends on:** `ghilios/headless-detection-parity` (Phase 1, complete). Branch:
-`ghilios/bank-rebaseline-bayered`, off Phase 1. Rebase both onto `develop` in order once the exposure PR merges.
+`ghilios/bank-rebaseline-bayered`, off Phase 1, which is itself off `develop` — both were re-parented off
+`ghilios/exposure-recommendation` so this re-baseline can run, and Phase 1 can merge, before PR #159 does.
 
 **Spec:** `docs/headless-detection-parity-design.md` §Consequences for stored artifacts.
 

--- a/plans/bank-rebaseline-bayered-plan.md
+++ b/plans/bank-rebaseline-bayered-plan.md
@@ -86,6 +86,26 @@ stars are *fainter* than any the old reference could see. If HF's misses skew fa
 
 ## Task 2 — Regenerate the reference and the goldens
 
+> **START HERE** in a fresh session. Task 1 is complete (see its result above). Be on
+> `ghilios/bank-rebaseline-bayered`; the working tree should be clean. **Invoke the
+> `generating-af-golden-data` skill first** for the exact pipeline and its gotchas — do not improvise the
+> commands. Scope is `bobp_m101` **alone** (`bobp_m101/AutoFocus_20260626_225408/attempt01`), per the
+> sequencing decision above.
+
+**What the QA step must report, because it decides Task 4's answer.** The new reference has ~54% more
+candidates and the additions are *fainter* than anything the old reference could resolve. So:
+
+- **How many candidates does the LLM QA confirm vs reject, and at which SNR tiers?** If it rejects most of the
+  newly-visible faint ones, the effective golden barely changes and Task 4's answer is "the old conclusion
+  stands". If it confirms them, the recall denominator genuinely grows and the deficit likely deepens.
+- **Any systematic rejection pattern.** If the faint additions are mostly noise, say so plainly — that is a real
+  finding, not a failure of the method.
+- Per-frame golden counts, old vs new. The old high-tier per-frame counts were
+  27/44/93/246/450/305/100/54/29/17 (= 1,365).
+
+If rate limits make full QA impractical, report how far you got rather than degrading the method. A partial,
+honest golden is more useful than a fast, unreliable one.
+
 - [ ] `snr_ref` over the new exports → candidates.
 - [ ] Montage + **LLM QA** per the skill. This is the long pole and is rate-limited; budget accordingly and do
       not parallelise past the documented limits.

--- a/plans/bank-rebaseline-bayered-plan.md
+++ b/plans/bank-rebaseline-bayered-plan.md
@@ -147,14 +147,62 @@ the documented QA step could not launch. `.gitattributes` now pins `tools/golden
 - [x] Invoke the **`running-af-bank-validation`** skill for the pipeline, and heed its warnings: the STA/pumped
       dispatcher requirement, watching `bank_verify_progress.log` rather than stdout (WSL block-buffers), and
       closing NINA first.
-- [~] Optimizer A/B prepass, then `bank-verify` with `--commit $(git rev-parse --short HEAD)`.
-      **C0-only sweep done; A/B not run** — see below.
+- [x] Optimizer A/B prepass, then `bank-verify` with `--commit $(git rev-parse --short HEAD)`.
 - [x] **Validate the harness before trusting the results:** `cwhite_2026` is the dry-run anchor and must
       reproduce its known config-B numbers (P=0.848, recall@≥12=0.181, sensor R²=0.9933, 7/9 aligned). It is
       **mono**, so Phase 1 must not have moved it. If it moved, the mono byte-identity guarantee is broken and
       that is a Phase 1 bug — stop and report.
 
-### Task 3 result — 2026-07-29 (anchor gate FAILED, but **not** a Phase 1 bug — needs a decision)
+### Task 3 result, FINAL — 2026-07-29 (anchor gate **PASSES** on config B; re-baseline complete)
+
+> Supersedes the interim C0-only finding below. With the A/B prepasses built, the anchor was evaluated on the
+> config the plan actually specifies — **config B** — and it reproduces. The interim "gate failed" reading was an
+> artifact of comparing **C0** rows, where the unrelated defaults revert bites; it was premature and is corrected
+> here.
+
+`optimize --per-run` (22/22, 0 failed, ~30 min) + `optimize --per-run --donut` (22/22, 0 failed, ~3 hr — donut is
+~6× slower per the matched filter) → `bank-verify --nc-sweep 2,3,4 --match-radius 12 --opt-a … --opt-b …` at commit
+`c5704c7` → **`verification_20260729T205904Z.{json,md}`**, 22 runs, C0+A+B.
+
+**Anchor — `cwhite_2026` config B, old vs new:**
+
+| metric | 2026-06-24 | 2026-07-29 | Δ |
+|---|---|---|---|
+| sensitivity | 15.6667 | **15.6667** | **0.0000** (optimizer re-converged to the identical point) |
+| precision | 0.8483 | **0.8488** | +0.0005 |
+| recall@SNR≥12 | 0.1807 | 0.1722 | −0.0086 (−4.8% rel) |
+| AF fit R² | 0.9969 | 0.9964 | −0.0005 |
+| sensor R² | 0.9933 | 0.9851 | −0.0082 |
+| sensor RMS | 0.8337 | 0.6592 | −0.1745 (better) |
+| frames aligned | 7/9 | **9/9** | +2 (better) |
+
+Precision matches to three decimals and the optimizer's sensitivity landing is bit-identical; recall is 4.8% and
+sensor R² 0.8% lower, alignment improved. **The mono byte-identity guarantee is intact** — corroborated by the
+passing `Mono_IsByteIdenticalToTheLegacyRawMatRoute` fixture and by the dataset-copy determinism check
+(`CWhiteFocus`≡`standard_example2`, `fmeschia`≡`sensitivity_example1`, `LinwoodFocus`≡`sensitivity_example2` all
+identical on C0/A/B recall). No scratch build or pre-Phase-1 re-run is needed.
+
+**Bayered runs, now all on regenerated luminance goldens:**
+
+| run | golden (high) | C0@nc2 R@hi / P | A R@hi / P | B R@hi / P |
+|---|---|---|---|---|
+| `bobp` | 2,504 (1,648) | 0.5868 / 0.9909 | 0.4945 / 1.0000 | 0.6475 / 0.9762 |
+| `bobp_m101` | 3,079 (2,107) | 0.6450 / 0.9873 | 0.5439 / 0.9984 | 0.2079 / 1.0000 |
+| `timmer` | 112,190 (109,830) | 0.4169 / 0.9497 | 0.1789 / 0.9976 | 0.0545 / 0.9993 |
+
+`timmer`'s precision is a **lower bound** (only 6% of its 117,107 uncertain candidates could be QA'd — the skill's
+documented bound for deep wide-field runs); its recall@≥12 is exact. `bobp` and `bobp_m101` have 100% uncertain
+coverage.
+
+**Star-shedding at the A/B corner is pervasive and expected, not a `Wtie` regression.** `Wtie = 0.02` is present in
+HEAD (`ec6a1b4`), yet the optimizer routinely lands high: `mccomiskey` A at `clip 10.0` (ceiling) → recall 0.079 vs
+C0's 0.869; `timmer` B at `sens 33.3 / clip 7.0` → 0.055; `CWhiteFocus` A at `sens 50` → 0.327. This is the
+behaviour `running-af-bank-validation` documents ("A/B sit at the opposite corner from C0 … the optimizer optimizes
+σ, not star count"), and `Wtie` by construction only arbitrates *genuine* plateaus. Worth noting for any future
+spec: the tie-breaker should not be described as preventing star-shedding generally — only shedding chosen on a
+σ-wiggle. **Not acted on in this branch.**
+
+### Task 3 interim result — C0-only pass (superseded by the above)
 
 `bank-verify --nc-sweep 2,3,4 --match-radius 12 --commit dc7cfed` over the whole bank, **C0 only**, ~65 min →
 `verification_20260729T145515Z.{json,md}`, 22 runs (the bank has grown from 17: `SorenVance`, `lumos` and `vsn07`
@@ -237,11 +285,12 @@ more so**: the star-rich corner now dominates the shedding corner on both axes. 
 
 ## Verification
 
-- [~] `cwhite_2026` anchor: **moved, and explained** — the C0 as-default sensitivity changed 2.0 -> 10.0 via
-      `59d5e59` (2026-07-11), not via Phase 1. Not testable as written; see Task 3 result.
-- [~] Mono runs unchanged vs `verification_20260624T142723Z.md`: **all moved**, bank-wide, from the same
-      defaults change. Goldens byte-identical throughout; determinism check passes; suite 3066/3066.
-- [~] Bayered runs: `bobp_m101` has new goldens **and** new bank-verify numbers. `bobp` and `timmer` have
-      bank-verify rows but **still-stale mosaic goldens** (deferred by the sequencing decision). `SorenVance`
-      has no goldens at all.
+- [x] `cwhite_2026` anchor **reproduces on config B** (P 0.8483->0.8488, sens bit-identical, recall -4.8%,
+      aligned 7/9->9/9). Mono guarantee intact. The C0 rows diverge separately, from the `59d5e59` defaults revert.
+- [~] Mono runs vs `verification_20260624T142723Z.md`: **C0 rows all moved** (median recall ratio 0.897x,
+      median precision +0.267) from the `59d5e59` default sensitivity 2.0->10.0 — not from Phase 1. Config B
+      reproduces. Goldens byte-identical throughout; determinism passes; suite 3066/3066.
+- [x] All three bayered runs (`bobp`, `bobp_m101`, `timmer`) have regenerated luminance goldens **and** new
+      bank-verify numbers in `verification_20260729T205904Z`. `SorenVance` (plus `lumos`, `vsn07`) still have no
+      goldens and score NaN — out of scope per the Scope table.
 - [x] The `bobp_m101` question is answered in writing, either way.

--- a/plans/bank-rebaseline-bayered-plan.md
+++ b/plans/bank-rebaseline-bayered-plan.md
@@ -161,8 +161,12 @@ the documented QA step could not launch. `.gitattributes` now pins `tools/golden
 > here.
 
 `optimize --per-run` (22/22, 0 failed, ~30 min) + `optimize --per-run --donut` (22/22, 0 failed, ~3 hr — donut is
-~6× slower per the matched filter) → `bank-verify --nc-sweep 2,3,4 --match-radius 12 --opt-a … --opt-b …` at commit
-`c5704c7` → **`verification_20260729T205904Z.{json,md}`**, 22 runs, C0+A+B.
+~6× slower per the matched filter) → `bank-verify --nc-sweep 2,3,4 --match-radius 12 --opt-a … --opt-b …`, 22 runs,
+C0+A+B, ~110 min.
+
+**The authoritative report is `verification_20260730T005833Z.{json,md}` (commit `2c91e1b`)**, re-run after the C0
+as-default fix below. `verification_20260729T205904Z` (commit `c5704c7`) is superseded: its A/B rows are identical
+(verified: 44/44 config-evals bit-identical) but its C0 rows measured a configuration the product does not ship.
 
 **Anchor — `cwhite_2026` config B, old vs new:**
 
@@ -186,13 +190,39 @@ identical on C0/A/B recall). No scratch build or pre-Phase-1 re-run is needed.
 
 | run | golden (high) | C0@nc2 R@hi / P | A R@hi / P | B R@hi / P |
 |---|---|---|---|---|
-| `bobp` | 2,504 (1,648) | 0.5868 / 0.9909 | 0.4945 / 1.0000 | 0.6475 / 0.9762 |
-| `bobp_m101` | 3,079 (2,107) | 0.6450 / 0.9873 | 0.5439 / 0.9984 | 0.2079 / 1.0000 |
-| `timmer` | 112,190 (109,830) | 0.4169 / 0.9497 | 0.1789 / 0.9976 | 0.0545 / 0.9993 |
+| `bobp` | 2,504 (1,648) | 0.5801 / 0.9907 | 0.4945 / 1.0000 | 0.6475 / 0.9762 |
+| `bobp_m101` | 3,079 (2,107) | 0.6374 / 0.9905 | 0.5439 / 0.9984 | 0.2079 / 1.0000 |
+| `timmer` | 112,190 (109,830) | 0.4217 / 0.9541 | 0.1789 / 0.9976 | 0.0545 / 0.9993 |
 
 `timmer`'s precision is a **lower bound** (only 6% of its 117,107 uncertain candidates could be QA'd — the skill's
 documented bound for deep wide-field runs); its recall@≥12 is exact. `bobp` and `bobp_m101` have 100% uncertain
 coverage.
+
+### Task 3 addendum — `bank-verify`'s C0 was not as-default (found + fixed, 2026-07-29)
+
+C0 is documented as the shipped-defaults reference, but it force-overrode `LocallyAdaptiveBinarization` to a flag
+defaulting **false**. `9a80324` added that override when the shipped default was OFF; `c59a4b1` flipped the default
+**ON** the same day and did not update `BankVerifyRunner`. So every C0 row from 2026-06-24 until this fix measured a
+configuration the product does not ship. Two provenance holes let it hide: `noiseClipDefault` was the literal `2.0`
+while the shipped default is `4.0`, and no report recorded C0's adaptive state at all.
+
+Fixed in `2c91e1b`: C0 now keeps whatever `BuildDefaultStarDetectorParams()` ships unless
+`--adaptive-binarize` / `--no-adaptive-binarize` forces a side; the report emits `c0AdaptiveBinarization`,
+`c0AdaptiveBinarizationForced`, `c0AdaptiveNoiseBlockSize`, and reads `noiseClipDefault` from the product.
+`--no-adaptive-binarize` reproduces the old numbers exactly (`mccomiskey` C0@nc4 σ 3.370, recall 0.828).
+
+**Impact is small.** Median Δrecall@high across all C0 rows is **−0.0003**, max |Δ| 0.0524 (`cwhite_2026`
+0.2658 → 0.3183). σ_focus moves both ways — better on `CWhiteFocus` (3.000 → 2.502) and `mufti` (6.917 → 5.894),
+worse on `caboose` (1.398 → 4.196) and `uneven` (14.107 → 20.123) — so adaptive binarization is not uniformly a
+win for AF fit on the as-default config. Not investigated further here.
+
+**σ_focus attribution on `mccomiskey`, measured by one-at-a-time ablation** (C0 3.370 → config B 0.441):
+adaptive binarization **~3%** (3.370 → 3.263), donut master **~49%** (3.263 → 1.648), and the sensitivity × star-clip
+**interaction ~73%** (1.648 → 0.441). The interaction is the striking part: at clip 2 sensitivity barely matters
+(1.648 → 1.503), while at clip 10 it is decisive (2.960 → 0.441); raising clip *hurts* at default sensitivity and
+*helps* strongly at sens 33.3. Neither knob does anything useful alone — a diagonal valley, not two independent
+axes, which is a concrete mechanism for the plateau this design doc describes. Donut master halving σ_focus on a
+run with **no donuts** (max HFR 2.01") is unexplained and worth its own look.
 
 **Star-shedding at the A/B corner is pervasive and expected, not a `Wtie` regression.** `Wtie = 0.02` is present in
 HEAD (`ec6a1b4`), yet the optimizer routinely lands high: `mccomiskey` A at `clip 10.0` (ceiling) → recall 0.079 vs
@@ -287,9 +317,10 @@ more so**: the star-rich corner now dominates the shedding corner on both axes. 
 
 - [x] `cwhite_2026` anchor **reproduces on config B** (P 0.8483->0.8488, sens bit-identical, recall -4.8%,
       aligned 7/9->9/9). Mono guarantee intact. The C0 rows diverge separately, from the `59d5e59` defaults revert.
-- [~] Mono runs vs `verification_20260624T142723Z.md`: **C0 rows all moved** (median recall ratio 0.897x,
-      median precision +0.267) from the `59d5e59` default sensitivity 2.0->10.0 — not from Phase 1. Config B
-      reproduces. Goldens byte-identical throughout; determinism passes; suite 3066/3066.
+- [~] Mono runs vs `verification_20260624T142723Z.md`: **C0 rows all moved** (median recall ratio 0.922x,
+      median precision +0.265, measured against the fixed `verification_20260730T005833Z`) — from the `59d5e59`
+      default sensitivity 2.0->10.0 plus the adaptive-binarization feature that did not exist at baseline, not
+      from Phase 1. Config B reproduces. Goldens byte-identical; determinism passes; suite 3066/3066.
 - [x] All three bayered runs (`bobp`, `bobp_m101`, `timmer`) have regenerated luminance goldens **and** new
       bank-verify numbers in `verification_20260729T205904Z`. `SorenVance` (plus `lumos`, `vsn07`) still have no
       goldens and score NaN — out of scope per the Scope table.


### PR DESCRIPTION
Rebuilds the validation artifacts the Phase 1 parity fix invalidated, then re-checks the `bobp_m101` recall conclusion that motivated PR #111.

**Stacked on `ghilios/headless-detection-parity` (Phase 1), which needs its own PR to `develop` first.** Based on that branch so this diff is only the re-baseline work.

## The headline: the recall deficit was real

Phase 1 changed both what the headless detector sees on bayered runs (mosaic → debayered luminance) and what `ExportLinearRunner` writes, so every `bobp_m101` number had been measured against a reference that was ~3× under-sensitive.

Re-measured with the detector and params held fixed and **only the golden varied**, the true positives are identical (247) and only the denominator moves, 1365 → 2107, so **recall@SNR≥12 falls 0.181 → 0.117**. The deficit was never an artifact of scoring a luminance detector against a mosaic reference; correcting the reference deepens it.

Secondary, consistent across three param sets: precision *rises* with the corrected golden (0.809 → 0.965 at the star-rich corner, FPs 330 → 60), because much of what the mosaic reference scored as false positives were real stars it could not see. The star-rich corner therefore dominates the shedding corner on both axes, so **`Wtie = 0.02` looks more justified, not less**. No objective constant was changed here.

The "94% of misses from two knobs" attribution weakens to **~65%** — `LowSensitivity` and `Degenerate` still dominate, but the corrected reference adds fainter stars that fail earlier.

## Goldens regenerated

| run | old golden (high) | new golden (high) | uncertain coverage | QA confirm |
|---|---|---|---|---|
| `bobp_m101` | 2,375 (1,365) | 3,079 (2,107) | 100% | 42.2% |
| `bobp` | 1,705 (1,039) | 2,504 (1,648) | 100% | 45.8% |
| `timmer` | 104,553 (103,430) | 112,190 (109,830) | 6% | 36.4% |

QA confirm rates land in a consistent 36–46% band, well below the old run's 95%, and the rejection pattern tracks **defocus, not SNR**. `timmer`'s precision is a documented lower bound at 6% uncertain coverage; its recall@≥12 is exact.

## Two harness bugs found and fixed

1. **`golden eval` printed a hardcoded match mode** into every stored report regardless of `--match`. The mode was applied correctly, so no past number is wrong, but every archived `golden_eval.txt` misstated how it was scored.
2. **`bank-verify`'s C0 was not as-default.** It force-overrode `LocallyAdaptiveBinarization` to a flag defaulting false; `9a80324` added that when the shipped default was OFF and `c59a4b1` flipped the default ON the same day without updating it. Every C0 row since 2026-06-24 measured a configuration the product does not ship. Two provenance holes hid it — `noiseClipDefault` was the literal `2.0` while the shipped default is `4.0`, and no report recorded C0's adaptive state.

## Verification

- **`cwhite_2026` anchor reproduces on config B** — the config the plan specifies: precision 0.8483 → 0.8488, optimizer sensitivity landing bit-identical at 15.6667, recall −4.8%, frames aligned 7/9 → 9/9. The mono byte-identity guarantee is intact, corroborated by the passing `Mono_IsByteIdenticalToTheLegacyRawMatRoute` fixture.
- **Authoritative report: `verification_20260730T005833Z`** (22 runs, C0+A+B, 0 failed), re-run after the C0 fix. All 44 A/B config-evals are bit-identical to the prior report, confirming only the C0 path moved. C0 impact is small: median Δrecall@high −0.0003, max 0.0524.
- Dataset-copy determinism holds; `--no-adaptive-binarize` reproduces the old numbers exactly.
- **Tests 3071/3071.**

## Flagged, not acted on

- Star-shedding at the A/B corner is pervasive and is documented optimizer behaviour, but `Wtie` should not be described as preventing star-shedding generally — only shedding chosen on a σ-wiggle.
- The objective has no sensor-model term, so it can pick a point that tightens focus while wrecking the tilt fit (`mccomiskey` A: 43 sensor stars, R² 0.526, dominated by B on every axis).
- Donut detection halves σ_focus on `mccomiskey`, a run with **no donuts** — unexplained.
- Adaptive binarization is not uniformly good for the AF fit now that C0 runs as-shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7R7TUBTvPt5R44CWhu2HT