### PR TITLE
Stop a flat optimizer axis riding to its bound; source harness settings from files

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Harness/HarnessSettingsStoreTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Harness/HarnessSettingsStoreTests.cs
@@ -1,0 +1,129 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Image.ImageData;
+using NUnit.Framework;
+using System.Collections.Generic;
+using TestApp;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Harness;
+
+/// <summary>
+/// The harness settings store. These cover the two properties the store exists to guarantee — that a run's
+/// settings come from a file rather than mutable profile state, and that PixelScale comes from the DATA rather
+/// than from whichever rig the local profile happens to describe.
+/// </summary>
+[TestFixture]
+public class HarnessSettingsStoreTests {
+
+    private static HarnessSettingsStore.FileOptionsAccessor Accessor(params (string Key, string Value)[] pairs) {
+        var bag = new Dictionary<string, string>();
+        foreach (var (k, v) in pairs) {
+            bag[k] = v;
+        }
+        return new HarnessSettingsStore.FileOptionsAccessor(bag);
+    }
+
+    // ---- The accessor -------------------------------------------------------------------------------------
+
+    [Test]
+    public void Accessor_ReadsTypedValuesBackFromTheFileBag() {
+        var a = Accessor(("BrightnessSensitivity", "33.3333"), ("StructureLayers", "5"),
+                         ("DefocusAwareDonutDetection", "True"), ("MeasurementAverage", "Median"));
+        Assert.Multiple(() => {
+            Assert.That(a.GetValueDouble("BrightnessSensitivity", 10.0), Is.EqualTo(33.3333).Within(1e-9));
+            Assert.That(a.GetValueInt32("StructureLayers", 4), Is.EqualTo(5));
+            Assert.That(a.GetValueBoolean("DefocusAwareDonutDetection", false), Is.True);
+        });
+    }
+
+    [Test]
+    public void Accessor_FallsBackToTheDefault_ForAMissingOrUnparseableKey() {
+        // A harness must never throw on a key it does not care about, and a corrupt value must not be silently
+        // read as some other number — both degrade to the caller's stated default.
+        var a = Accessor(("BrightnessSensitivity", "not-a-number"));
+        Assert.Multiple(() => {
+            Assert.That(a.GetValueDouble("BrightnessSensitivity", 10.0), Is.EqualTo(10.0));
+            Assert.That(a.GetValueDouble("NeverWritten", 7.5), Is.EqualTo(7.5));
+        });
+    }
+
+    [Test]
+    public void Accessor_WritesStayInTheBag_AndSuppressWritesBlocksThem() {
+        // Writes must never reach the user's profile as a side effect of a harness run.
+        var bag = new Dictionary<string, string>();
+        var a = new HarnessSettingsStore.FileOptionsAccessor(bag);
+        a.SetValueDouble("BrightnessSensitivity", 12.5);
+        Assert.That(bag["BrightnessSensitivity"], Is.EqualTo("12.5"));
+
+        a.SuppressWrites = true;
+        a.SetValueDouble("BrightnessSensitivity", 99.0);
+        Assert.That(bag["BrightnessSensitivity"], Is.EqualTo("12.5"), "SuppressWrites must block the write");
+    }
+
+    [Test]
+    public void Accessor_UsesInvariantCulture() {
+        // A machine with a comma decimal separator must not read 33.3333 as 333333.
+        var a = Accessor(("BrightnessSensitivity", "33.3333"));
+        Assert.That(a.GetValueDouble("BrightnessSensitivity", 0.0), Is.EqualTo(33.3333).Within(1e-9));
+    }
+
+    // ---- PixelScale from the frame, not the profile -------------------------------------------------------
+
+    private static ImageMetaData Meta(double pixelSize, double focalLength, int binX = 1) {
+        var m = new ImageMetaData();
+        m.Camera.PixelSize = pixelSize;
+        m.Camera.BinX = binX;
+        m.Telescope.FocalLength = focalLength;
+        return m;
+    }
+
+    [Test]
+    public void PixelScale_ComesFromTheFrameHeader_NotTheSettingsFile() {
+        // The measured 3800mm case: the frame says 3.76um / 3800mm = 0.204 arcsec/px, while the local profile
+        // described a 703mm rig at 1.10. Using the profile value under-reported the scale by 5x on this run, and
+        // across the bank the true scales span 0.74-5.97 arcsec/px.
+        var settings = new HarnessSettingsStore.Resolved { PixelSizeMicrons = 3.76, FocalLengthMm = 703.0, Path = "f.json" };
+        var scale = HarnessSettingsStore.PixelScaleForFrame(Meta(3.76, 3800.0), settings, out var source);
+        Assert.Multiple(() => {
+            Assert.That(scale, Is.EqualTo(0.2041).Within(0.001));
+            Assert.That(source, Is.EqualTo("frame header"));
+        });
+    }
+
+    [Test]
+    public void PixelScale_ScalesWithBinning() {
+        var scale = HarnessSettingsStore.PixelScaleForFrame(Meta(3.76, 3800.0, binX: 2), null, out _);
+        Assert.That(scale, Is.EqualTo(0.4082).Within(0.001));
+    }
+
+    [Test]
+    public void PixelScale_FallsBackToTheSettingsFile_WhenTheHeaderHasNone() {
+        var settings = new HarnessSettingsStore.Resolved { PixelSizeMicrons = 3.76, FocalLengthMm = 585.0, Path = "f.json" };
+        var scale = HarnessSettingsStore.PixelScaleForFrame(Meta(double.NaN, double.NaN), settings, out var source);
+        Assert.Multiple(() => {
+            Assert.That(scale, Is.EqualTo(1.3257).Within(0.001));
+            Assert.That(source, Does.Contain("settings file"));
+        });
+    }
+
+    [Test]
+    public void PixelScale_IsNaN_WhenNeitherSourceHasIt_RatherThanFabricated() {
+        // A frame with no scale information must not be handed an invented one: NaN is what the previous
+        // profile path produced too, and PixelScale-dependent gates already handle it.
+        var scale = HarnessSettingsStore.PixelScaleForFrame(Meta(double.NaN, double.NaN), null, out var source);
+        Assert.Multiple(() => {
+            Assert.That(double.IsNaN(scale), Is.True);
+            Assert.That(source, Does.Contain("unavailable"));
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj
@@ -25,6 +25,7 @@
     <Compile Include="..\TestApp\GoldenStarSet.cs" Link="Golden\GoldenStarSet.cs" />
     <Compile Include="..\TestApp\GoldenGeometry.cs" Link="Golden\GoldenGeometry.cs" />
     <Compile Include="..\TestApp\BankVerification.cs" Link="Bank\BankVerification.cs" />
+    <Compile Include="..\TestApp\HarnessSettingsStore.cs" Link="Harness\HarnessSettingsStore.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerTests.cs
@@ -418,6 +418,121 @@ public class StarDetectionOptimizerTests {
         });
     }
 
+    // ---- Inert-axis (free-rider) landscape -------------------------------------------------------------
+    // Reproduces a real 3800mm run: J depends ONLY on StarClippingMultiplier; Sensitivity is provably inert
+    // (a gate sweep over 0..15 produced bit-identical star counts and HFRs on every frame, because the
+    // sensitivity gate rejected 0 of ~1300 candidates). Phase A grids Sensitivity x StarClip with Sensitivity
+    // as the OUTER loop and level 0 = v.Lower, so the winning StarClip is first found in the Sensitivity=0
+    // row and drags Sensitivity to its lower bound; later rows tie exactly and are refused by the strict `>`.
+    // The delivered Sensitivity=0 then reads to the user as "gate at the bottom of its range".
+    // StarClip's optimum sits exactly ON a Phase-A grid level (levels over [0.25, 10] at 4 levels are
+    // 0.25 / 3.5 / 6.75 / 10), and InertSeed starts far from it, so the coarse grid genuinely improves via
+    // StarClip -- which is the precondition for Sensitivity to ride along as a free rider.
+    private const double InertOptStarClip = 3.5;
+
+    private static StarDetectorParams InertSeed() => new StarDetectorParams {
+        Sensitivity = 2.0,
+        StarClippingMultiplier = 0.5,
+    };
+
+    private static Func<StarDetectorParams, CancellationToken, Task<IReadOnlyList<RunEvaluationMetrics>>> InertSensitivityEvaluator() {
+        return (p, token) => {
+            var dClip = (p.StarClippingMultiplier - InertOptStarClip) / 4.5;   // Sensitivity deliberately unread
+            var stepSize = 100.0;
+            IReadOnlyList<RunEvaluationMetrics> runs = new[] {
+                new RunEvaluationMetrics {
+                    SigmaFocus = stepSize * (0.02 + Math.Abs(dClip)),
+                    LooStdError = double.NaN,
+                    StepSize = stepSize,
+                    RSquared = 0.99,
+                    ReducedChiSquared = 1.0,
+                    FrameStarCounts = Enumerable.Repeat(50, 10).ToList()
+                }
+            };
+            return Task.FromResult(runs);
+        };
+    }
+
+    [Test]
+    public async Task Optimize_LeavesAnInertAxisAtItsSeedValue_RatherThanItsLowerBound() {
+        var optimizer = new StarDetectionOptimizer();
+        var seed = InertSeed();   // Sensitivity = 2.0
+        var variables = OptimizerVariable.CreateCuratedSet();
+
+        var result = await optimizer.OptimizeAsync(
+            seed, variables, InertSensitivityEvaluator(), DefaultSettings(), null, CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(result.BestParams.Sensitivity, Is.EqualTo(seed.Sensitivity).Within(1e-9),
+                "Sensitivity cannot change J at all here, so the search must not report having changed it");
+            Assert.That(result.ChangedVariables.Any(v => v.Name == nameof(StarDetectorParams.Sensitivity)), Is.False,
+                "an inert axis must not appear in ChangedVariables");
+            Assert.That(result.BestJ, Is.GreaterThanOrEqualTo(result.SeedJ),
+                "reverting inert axes must never cost J");
+        });
+    }
+
+    [Test]
+    public async Task Optimize_PullsAnAxisBackToTheNearestEqualJPoint_WhenTheSeedIsOutsideThePlateau() {
+        // The real 3800mm case, and the one a revert-all-the-way-to-seed rule cannot fix. Sensitivity is inert
+        // across a PLATEAU of [0, 15] but genuinely (slightly) worse above it, while the seed sits at 33.3 —
+        // outside the plateau. Reverting fully to 33.3 correctly costs J and is refused, which would strand the
+        // axis at 0 and keep raising the false "gate is at the bottom of its range" banner. The search must
+        // instead pull back to the point NEAREST the seed that costs nothing, landing inside the plateau but
+        // well clear of the floor.
+        const double plateauTop = 15.0;
+        Func<StarDetectorParams, CancellationToken, Task<IReadOnlyList<RunEvaluationMetrics>>> plateau = (p, token) => {
+            var dClip = (p.StarClippingMultiplier - InertOptStarClip) / 4.5;
+            // Flat in Sensitivity up to plateauTop, then a gentle real penalty above it.
+            var sensPenalty = p.Sensitivity <= plateauTop ? 0.0 : (p.Sensitivity - plateauTop) / 100.0;
+            var stepSize = 100.0;
+            IReadOnlyList<RunEvaluationMetrics> runs = new[] {
+                new RunEvaluationMetrics {
+                    SigmaFocus = stepSize * (0.02 + Math.Abs(dClip) + sensPenalty),
+                    LooStdError = double.NaN,
+                    StepSize = stepSize,
+                    RSquared = 0.99,
+                    ReducedChiSquared = 1.0,
+                    FrameStarCounts = Enumerable.Repeat(50, 10).ToList()
+                }
+            };
+            return Task.FromResult(runs);
+        };
+
+        var seed = new StarDetectorParams { Sensitivity = 33.3333, StarClippingMultiplier = 0.5 };
+        var variables = OptimizerVariable.CreateCuratedSet();
+        var result = await new StarDetectionOptimizer().OptimizeAsync(
+            seed, variables, plateau, DefaultSettings(), null, CancellationToken.None);
+
+        Assert.Multiple(() => {
+            // Asserted against the search-floor BAND rather than a bit-exact 0: a genuinely-floored search
+            // lands on 0.125/0.25/0.5 as often as on 0 (Sensitivity's step halves to InitialStep x
+            // StepFloorFraction), so `== 0` would miss most real cases. Consumers that warn about a floored
+            // gate use the same one-full-step band.
+            const double sensitivityFloorBand = 1.0;
+            Assert.That(result.BestParams.Sensitivity, Is.GreaterThan(sensitivityFloorBand),
+                "an axis with a wide equal-J plateau must not be left sitting at its floor");
+            Assert.That(result.BestParams.Sensitivity, Is.LessThanOrEqualTo(plateauTop + 1e-9),
+                "must stay inside the plateau — pulling past it would cost real J");
+            Assert.That(result.BestJ, Is.GreaterThanOrEqualTo(result.SeedJ),
+                "the pull-back must never regress J");
+        });
+    }
+
+    [Test]
+    public async Task Optimize_KeepsAnAxisThatActuallyEarnedItsChange() {
+        // The guard must not undo real improvements: StarClip genuinely drives J in this landscape.
+        var optimizer = new StarDetectionOptimizer();
+        var seed = InertSeed();   // StarClippingMultiplier = 0.5, optimum 3.5
+        var variables = OptimizerVariable.CreateCuratedSet();
+
+        var result = await optimizer.OptimizeAsync(
+            seed, variables, InertSensitivityEvaluator(), DefaultSettings(), null, CancellationToken.None);
+
+        Assert.That(result.BestParams.StarClippingMultiplier, Is.Not.EqualTo(seed.StarClippingMultiplier).Within(1e-9),
+            "the axis that actually moves J must still be optimized");
+    }
+
     /// <summary>
     /// A synchronous <see cref="IProgress{T}"/> test double: <see cref="Report"/> appends directly to a list
     /// on the calling thread, so reports are captured deterministically (unlike <see cref="Progress{T}"/>,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizer.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizer.cs
@@ -128,6 +128,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // Phase B — compass/pattern search.
             (bestTheta, bestJ) = await ctx.PatternSearch(bestTheta, bestJ, seedJ).ConfigureAwait(false);
 
+            // Phase C — revert every axis that did not earn its change (see RevertNeutralAxes).
+            (bestTheta, bestJ) = await ctx.RevertNeutralAxes(theta0, bestTheta, bestJ, seedJ).ConfigureAwait(false);
+
             // Materialize the winning params.
             var bestParams = ctx.Materialize(bestTheta);
 
@@ -156,6 +159,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         private sealed class SearchContext {
             // Fixed compass directions tried for every variable each sweep: + then −, deterministic order.
             private static readonly double[] Directions = { +1.0, -1.0 };
+
+            /// <summary>Phase-C pull-back fractions along incumbent → seed, MOST SEED-WARD FIRST so the first
+            /// accepted one is the nearest-to-seed neutral point. Four coarse steps rather than a bisection: the
+            /// question is "is this axis inert over a wide region", which does not need sub-step resolution, and a
+            /// fixed ladder keeps the phase deterministic and its cost bounded at ≤4 evals per changed axis.</summary>
+            private static readonly double[] PullBackFractions = { 1.0, 0.75, 0.5, 0.25 };
 
             private readonly StarDetectionOptimizer owner;
             private readonly StarDetectorParams seed;
@@ -316,6 +325,77 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     }
                 }
                 Report("CoarseGrid", bestTheta, bestJ, seedJ);
+                return (bestTheta, bestJ);
+            }
+
+            /// <summary>
+            /// Phase C. For every axis the search moved, try putting it BACK to its seed value and keep the
+            /// revert when doing so costs no J. Deterministic order (variable order), one pass, at most one
+            /// evaluation per changed axis — and most are memo hits, since the seed value on that axis was
+            /// usually visited during the search.
+            ///
+            /// <para><b>Why this is needed.</b> An axis that cannot move J at all is a FREE RIDER: Phase A grids
+            /// Sensitivity × StarClippingMultiplier with Sensitivity as the OUTER loop and level 0 = <c>Lower</c>,
+            /// so the winning StarClip is first discovered in the <c>Sensitivity = Lower</c> row and drags
+            /// Sensitivity to its lower bound. Later rows re-test the same StarClip at higher Sensitivity, score
+            /// EXACTLY the same, and are refused by the strict <c>j &gt; bestJ</c> — so nothing can ever undo it.
+            /// Phase B cannot undo it either: <see cref="CompassStage"/> moves one axis at a time and also demands
+            /// strict improvement, so a flat axis is frozen wherever Phase A left it.</para>
+            ///
+            /// <para>Measured on a real 3800 mm run: sweeping the Sensitivity gate over 0–15 produced BIT-IDENTICAL
+            /// star counts and median HFRs on all 11 frames (the gate rejected 0 of ~1300 candidates), yet the
+            /// optimizer reported <c>Sensitivity: 33.3→0</c>. That spurious floor is user-visible — it raises the
+            /// "star acceptance gate is at the bottom of its range" banner and drives
+            /// <see cref="ExposureRecommender"/> to answer a question about exposure that the run never posed.</para>
+            ///
+            /// <para><b>Exact ties only.</b> The comparison is <c>j &gt;= bestJ</c> with no tolerance: a genuinely
+            /// inert axis produces a bit-identical J (identical detector inputs ⇒ identical metrics), so no epsilon
+            /// is required to catch it, and introducing one would let this phase trade away real, if small,
+            /// improvements. This can never regress the result — a revert is kept only when J does not drop, and
+            /// <see cref="OptimizationResult.BestJ"/> is updated to the (equal-or-better) reverted value.</para>
+            ///
+            /// <para>Axes are pulled back INDEPENDENTLY and greedily, each against the current incumbent, so a
+            /// pull-back that is only neutral BECAUSE an earlier axis already moved is still caught; conversely two
+            /// axes that are individually neutral but jointly matter cannot both move, because the second is
+            /// evaluated against the first's already-updated incumbent.</para>
+            ///
+            /// <para><b>Graded, not all-or-nothing.</b> Reverting only to the seed exactly is not enough: the flat
+            /// region is a PLATEAU, and the seed can sit outside it. On the measured run the plateau was
+            /// Sensitivity ∈ [0, 15] while the seed was 33.3 — a full revert genuinely costs J and is correctly
+            /// refused, which would strand the axis at 0 and keep raising the false floor banner. So each axis is
+            /// tried at a few fixed fractions along the path from the incumbent BACK toward the seed, most
+            /// seed-ward first, and the first that costs no J wins: the axis ends at the point nearest its seed
+            /// that the data cannot distinguish from the search's answer.</para>
+            /// </summary>
+            public async Task<(double[] theta, double j)> RevertNeutralAxes(double[] theta0, double[] bestTheta, double bestJ, double seedJ) {
+                var moved = false;
+                for (var i = 0; i < variables.Count; i++) {
+                    if (bestTheta[i] == theta0[i]) {
+                        continue; // never moved
+                    }
+                    foreach (var t in PullBackFractions) {
+                        if (BudgetExhausted) {
+                            break;
+                        }
+                        // t = 1 is the seed itself; smaller t stays nearer the search's answer.
+                        var value = variables[i].Quantize(bestTheta[i] + t * (theta0[i] - bestTheta[i]));
+                        if (value == bestTheta[i]) {
+                            continue; // quantized back onto the incumbent: nothing to test
+                        }
+                        var candidate = (double[])bestTheta.Clone();
+                        candidate[i] = value;
+                        var j = await EvalJ(candidate).ConfigureAwait(false);
+                        if (j >= bestJ) {
+                            bestTheta = candidate;
+                            bestJ = j;
+                            moved = true;
+                            break; // most seed-ward neutral point for this axis; go to the next axis
+                        }
+                    }
+                }
+                if (moved) {
+                    Report("RevertNeutral", bestTheta, bestJ, seedJ);
+                }
                 return (bestTheta, bestJ);
             }
 

--- a/Joko.NINA.Plugins/TestApp/AfFitDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/AfFitDiagnosticRunner.cs
@@ -123,8 +123,11 @@ namespace TestApp {
             var paramsFrom = DiagnosticUtil.GetArg(args, "--params-from");
             var (baseParams, paramsSource) = LoadOriginalDetectorParams(afRun, paramsFrom);
             if (baseParams == null) {
-                var guid = PluginOptionsAccessor.GetAssemblyGuid(typeof(StarDetectionOptions));
-                var accessor = new PluginOptionsAccessor(profileService, guid.Value);
+                // Detector settings come from the harness's LOCAL settings file, not the NINA profile: a
+                // profile-sourced value is mutable machine state nothing records, and the ACTIVE profile can
+                // even be a different telescope between runs. See HarnessSettingsStore.
+                var harnessSettings = HarnessSettingsStore.Resolve(args, profileService, profileService.ActiveProfile);
+                var accessor = harnessSettings.Accessor;
                 var options = new StarDetectionOptions(profileService, accessor);
                 baseParams = HocusFocusStarDetection.BuildStarDetectorParams(options);
                 paramsSource = "current profile (no saved detection JSON found in run)";

--- a/Joko.NINA.Plugins/TestApp/BankDonutMetaRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/BankDonutMetaRunner.cs
@@ -78,7 +78,11 @@ namespace TestApp {
             if (profileService.ActiveProfile == null) {
                 throw new InvalidOperationException("No active NINA profile could be loaded. Pass --profile-id.");
             }
-            var starDetectionOptions = new StarDetectionOptions(profileService);
+            // Detector settings come from the harness's LOCAL settings file, not the NINA profile: a
+            // profile-sourced value is mutable machine state nothing records, and the ACTIVE profile can
+            // even be a different telescope between runs. See HarnessSettingsStore.
+            var harnessSettings = HarnessSettingsStore.Resolve(args, profileService, profileService.ActiveProfile);
+            var starDetectionOptions = new StarDetectionOptions(profileService, harnessSettings.Accessor);
 
             // Donut detection ON so the extreme frames' bloated/donut stars are actually measured.
             var detectorParams = HocusFocusStarDetection.BuildDefaultStarDetectorParams();

--- a/Joko.NINA.Plugins/TestApp/BankVerifyRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/BankVerifyRunner.cs
@@ -143,10 +143,12 @@ namespace TestApp {
             profileService.TryLoad(profileId ?? string.Empty);
             var activeProfile = profileService.ActiveProfile
                 ?? throw new InvalidOperationException("No active NINA profile could be loaded. Pass --profile-id.");
-            var starDetectionOptions = new StarDetectionOptions(profileService);
-            var pluginGuid = PluginOptionsAccessor.GetAssemblyGuid(typeof(StarDetectionOptions))
-                ?? throw new InvalidOperationException("Could not resolve the HocusFocus plugin assembly GUID");
-            var accessor = new PluginOptionsAccessor(profileService, pluginGuid);
+            // Detector settings come from the harness's LOCAL settings file, not the NINA profile: a
+            // profile-sourced value is mutable machine state nothing records, and the ACTIVE profile can
+            // even be a different telescope between runs. See HarnessSettingsStore.
+            var harnessSettings = HarnessSettingsStore.Resolve(args, profileService, activeProfile);
+            var starDetectionOptions = new StarDetectionOptions(profileService, harnessSettings.Accessor);
+            var accessor = harnessSettings.Accessor;
             var inspectorOptions = new InspectorOptions(profileService);
             var autoFocusOptions = new AutoFocusOptions(profileService);
             const int binning = 1;

--- a/Joko.NINA.Plugins/TestApp/ContaminationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/ContaminationDiagnosticRunner.cs
@@ -104,11 +104,11 @@ namespace TestApp {
             Console.WriteLine($"Profile: {activeProfile.Name} ({activeProfile.Id})");
             Logger.Info($"Loaded profile {activeProfile.Name} ({activeProfile.Id})");
 
-            var guid = PluginOptionsAccessor.GetAssemblyGuid(typeof(StarDetectionOptions));
-            if (guid == null) {
-                throw new InvalidOperationException("Could not resolve the HocusFocus plugin assembly GUID");
-            }
-            var accessor = new PluginOptionsAccessor(profileService, guid.Value);
+            // Detector settings come from the harness's LOCAL settings file, not the NINA profile: a
+            // profile-sourced value is mutable machine state nothing records, and the ACTIVE profile can
+            // even be a different telescope between runs. See HarnessSettingsStore.
+            var harnessSettings = HarnessSettingsStore.Resolve(args, profileService, activeProfile);
+            var accessor = harnessSettings.Accessor;
             var options = new StarDetectionOptions(profileService, accessor);
             LogResolvedOptions(options);
 

--- a/Joko.NINA.Plugins/TestApp/DiagnoseLabelsRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/DiagnoseLabelsRunner.cs
@@ -137,11 +137,11 @@ namespace TestApp {
             }
             Line($"Profile: {activeProfile.Name} ({activeProfile.Id})");
 
-            var guid = PluginOptionsAccessor.GetAssemblyGuid(typeof(StarDetectionOptions));
-            if (guid == null) {
-                throw new InvalidOperationException("Could not resolve the HocusFocus plugin assembly GUID");
-            }
-            var accessor = new PluginOptionsAccessor(profileService, guid.Value);
+            // Detector settings come from the harness's LOCAL settings file, not the NINA profile: a
+            // profile-sourced value is mutable machine state nothing records, and the ACTIVE profile can
+            // even be a different telescope between runs. See HarnessSettingsStore.
+            var harnessSettings = HarnessSettingsStore.Resolve(args, profileService, activeProfile);
+            var accessor = harnessSettings.Accessor;
             var starDetectionOptions = new StarDetectionOptions(profileService, accessor);
 
             var discovered = DiscoverRuns(runsDir);

--- a/Joko.NINA.Plugins/TestApp/FocusSweepDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/FocusSweepDiagnosticRunner.cs
@@ -128,8 +128,11 @@ namespace TestApp {
                     throw new InvalidOperationException("No active NINA profile. Pass --profile-id, run NINA once, or use --default-params.");
                 }
                 Console.WriteLine($"Profile: {profileService.ActiveProfile.Name} ({profileService.ActiveProfile.Id})");
-                var guid = PluginOptionsAccessor.GetAssemblyGuid(typeof(StarDetectionOptions));
-                var accessor = new PluginOptionsAccessor(profileService, guid.Value);
+                // Detector settings come from the harness's LOCAL settings file, not the NINA profile: a
+                // profile-sourced value is mutable machine state nothing records, and the ACTIVE profile can
+                // even be a different telescope between runs. See HarnessSettingsStore.
+                var harnessSettings = HarnessSettingsStore.Resolve(args, profileService, profileService.ActiveProfile);
+                var accessor = harnessSettings.Accessor;
                 var options = new StarDetectionOptions(profileService, accessor);
                 // F11 step 6: optionally apply a NoiseLevel preset's exact params (for the None/High recalibration
                 // measurement) by switching the in-memory options to simple mode at the requested preset with the

--- a/Joko.NINA.Plugins/TestApp/GoldenEvalRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/GoldenEvalRunner.cs
@@ -110,8 +110,11 @@ namespace TestApp {
             if (activeProfile == null) {
                 throw new InvalidOperationException("No active NINA profile could be loaded. Pass --profile-id, or run NINA once to create a profile.");
             }
-            var guid = PluginOptionsAccessor.GetAssemblyGuid(typeof(StarDetectionOptions));
-            var accessor = new PluginOptionsAccessor(profileService, guid.Value);
+            // Detector settings come from the harness's LOCAL settings file, not the NINA profile: a
+            // profile-sourced value is mutable machine state nothing records, and the ACTIVE profile can
+            // even be a different telescope between runs. See HarnessSettingsStore.
+            var harnessSettings = HarnessSettingsStore.Resolve(args, profileService, activeProfile);
+            var accessor = harnessSettings.Accessor;
             var options = new StarDetectionOptions(profileService, accessor);
 
             Directory.CreateDirectory(outDir);

--- a/Joko.NINA.Plugins/TestApp/HarnessSettingsStore.cs
+++ b/Joko.NINA.Plugins/TestApp/HarnessSettingsStore.cs
@@ -1,0 +1,492 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using Newtonsoft.Json;
+using NINA.Plugin.Interfaces;
+using NINA.Profile;
+using NINA.Profile.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace TestApp {
+
+    /// <summary>
+    /// The headless harness's own settings store: a LOCAL JSON FILE, not the NINA profile.
+    ///
+    /// <para><b>Why this exists.</b> Every runner used to build its detector settings from the active NINA
+    /// profile via <c>PluginOptionsAccessor</c>. That made a harness invocation depend on mutable, machine-local
+    /// state nothing recorded — and it is not even stable within one session: two <c>optimize</c> runs launched
+    /// seconds apart over the SAME saved run were seeded at Sensitivity 33.3333 and 15.6667 respectively, which
+    /// silently invalidated a before/after comparison. A settings file makes a run reproducible, diffable, and
+    /// safe to run concurrently.</para>
+    ///
+    /// <para><b>Bootstrap.</b> When no settings file exists, the profile's current values are exported to one
+    /// ONCE and that file is used from then on. This keeps existing invocations working while making the values
+    /// they depend on explicit and version-controllable — after the first run the profile is never read for
+    /// settings again, so later profile edits cannot silently change harness results.</para>
+    ///
+    /// <para>The profile is still loaded, because NINA's image loaders need one to read XISF/FITS. It is no
+    /// longer the source of DETECTOR SETTINGS or of the pixel-scale inputs.</para>
+    /// </summary>
+    internal static class HarnessSettingsStore {
+
+        /// <summary>Default file name, resolved next to the TestApp executable so it travels with the harness.</summary>
+        public const string DefaultFileName = "harness_settings.json";
+
+        /// <summary>Serialized form: the raw plugin option key/value bag plus the pixel-scale inputs.</summary>
+        internal sealed class HarnessSettingsFile {
+            public int SchemaVersion { get; set; } = 1;
+
+            /// <summary>Provenance only — which profile the values were first exported from, and when.</summary>
+            public string ExportedFromProfile { get; set; }
+
+            public DateTime ExportedAtUtc { get; set; }
+
+            /// <summary>Pixel size in microns; feeds <c>PixelScale</c>. Previously <c>CameraSettings.PixelSize</c>.</summary>
+            public double PixelSizeMicrons { get; set; }
+
+            /// <summary>Focal length in mm; feeds <c>PixelScale</c>. Previously <c>TelescopeSettings.FocalLength</c>.</summary>
+            public double FocalLengthMm { get; set; }
+
+            /// <summary>Every plugin option key the detector reads, stored as strings exactly as the profile
+            /// stores them, so this file is a faithful snapshot rather than a curated subset that could drift
+            /// from whatever <c>StarDetectionOptions</c> happens to read next release.</summary>
+            public Dictionary<string, string> Options { get; set; } = new Dictionary<string, string>(StringComparer.Ordinal);
+
+            /// <summary>How a per-dataset file's derived values were arrived at, so the file explains itself.</summary>
+            public string DerivedNotes { get; set; }
+        }
+
+        /// <summary>
+        /// An <see cref="IPluginOptionsAccessor"/> backed by an in-memory bag loaded from the settings file.
+        /// Writes stay in memory (and are persisted only when the caller asks), so a harness run can never
+        /// mutate the user's profile as a side effect — something the profile-backed accessor could do.
+        /// </summary>
+        internal sealed class FileOptionsAccessor : IPluginOptionsAccessor {
+            private readonly Dictionary<string, string> values;
+
+            public FileOptionsAccessor(Dictionary<string, string> values) {
+                this.values = values ?? new Dictionary<string, string>(StringComparer.Ordinal);
+            }
+
+            public bool SuppressWrites { get; set; }
+
+            /// <summary>A copy of the underlying bag, for seeding a per-dataset file from a shared base.</summary>
+            public Dictionary<string, string> Snapshot() => new Dictionary<string, string>(values, StringComparer.Ordinal);
+
+            private T Get<T>(string key, T defaultValue, Func<string, T> parse) {
+                if (key == null || !values.TryGetValue(key, out var raw) || string.IsNullOrEmpty(raw)) {
+                    return defaultValue;
+                }
+                try {
+                    return parse(raw);
+                } catch {
+                    return defaultValue;
+                }
+            }
+
+            private void Set(string key, string raw) {
+                if (SuppressWrites || key == null) {
+                    return;
+                }
+                values[key] = raw;
+            }
+
+            public bool GetValueBoolean(string key, bool defaultValue) => Get(key, defaultValue, bool.Parse);
+
+            public double GetValueDouble(string key, double defaultValue) =>
+                Get(key, defaultValue, s => double.Parse(s, System.Globalization.CultureInfo.InvariantCulture));
+
+            public float GetValueSingle(string key, float defaultValue) =>
+                Get(key, defaultValue, s => float.Parse(s, System.Globalization.CultureInfo.InvariantCulture));
+
+            public int GetValueInt32(string key, int defaultValue) =>
+                Get(key, defaultValue, s => int.Parse(s, System.Globalization.CultureInfo.InvariantCulture));
+
+            public int GetValueInt(string key, int defaultValue) => GetValueInt32(key, defaultValue);
+
+            public string GetValueString(string key, string defaultValue) => Get(key, defaultValue, s => s);
+
+            public DateTime GetValueDateTime(string key, DateTime defaultValue) =>
+                Get(key, defaultValue, s => DateTime.Parse(s, System.Globalization.CultureInfo.InvariantCulture));
+
+            public Guid GetValueGuid(string key, Guid defaultValue) => Get(key, defaultValue, Guid.Parse);
+
+            public T GetValueEnum<T>(string key, T defaultValue) where T : struct, Enum =>
+                Get(key, defaultValue, s => (T)Enum.Parse(typeof(T), s, ignoreCase: true));
+
+            public void SetValueBoolean(string key, bool value) => Set(key, value.ToString());
+
+            public void SetValueDouble(string key, double value) =>
+                Set(key, value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+            public void SetValueSingle(string key, float value) =>
+                Set(key, value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+            public void SetValueInt32(string key, int value) =>
+                Set(key, value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+            public void SetValueInt(string key, int value) => SetValueInt32(key, value);
+
+            public void SetValueString(string key, string value) => Set(key, value);
+
+            public void SetValueDateTime(string key, DateTime value) =>
+                Set(key, value.ToString("o", System.Globalization.CultureInfo.InvariantCulture));
+
+            public void SetValueGuid(string key, Guid value) => Set(key, value.ToString());
+
+            public void SetValueEnum<T>(string key, T value) where T : struct, Enum => Set(key, value.ToString());
+
+            public void RemoveValue(string key) {
+                if (!SuppressWrites && key != null) {
+                    values.Remove(key);
+                }
+            }
+
+            // The remaining IPluginOptionsAccessor surface. The detector reads none of these, but the interface
+            // requires them and a harness must never throw on a key it simply does not care about — so they round
+            // trip through the same string bag as everything else rather than being NotImplementedException stubs.
+            private static readonly System.Globalization.CultureInfo Inv = System.Globalization.CultureInfo.InvariantCulture;
+
+            public byte GetValueByte(string key, byte defaultValue) => Get(key, defaultValue, s => byte.Parse(s, Inv));
+
+            public void SetValueByte(string key, byte value) => Set(key, value.ToString(Inv));
+
+            public sbyte GetValueSByte(string key, sbyte defaultValue) => Get(key, defaultValue, s => sbyte.Parse(s, Inv));
+
+            public void SetValueSByte(string key, sbyte value) => Set(key, value.ToString(Inv));
+
+            public char GetValueChar(string key, char defaultValue) => Get(key, defaultValue, char.Parse);
+
+            public void SetValueChar(string key, char value) => Set(key, value.ToString());
+
+            public decimal GetValueDecimal(string key, decimal defaultValue) => Get(key, defaultValue, s => decimal.Parse(s, Inv));
+
+            public void SetValueDecimal(string key, decimal value) => Set(key, value.ToString(Inv));
+
+            public System.Windows.Media.Color GetValueColor(string key, System.Windows.Media.Color defaultValue) =>
+                Get(key, defaultValue, s => (System.Windows.Media.Color)System.Windows.Media.ColorConverter.ConvertFromString(s));
+
+            public void SetValueColor(string key, System.Windows.Media.Color value) => Set(key, value.ToString());
+
+            public uint GetValueUInt32(string key, uint defaultValue) => Get(key, defaultValue, s => uint.Parse(s, Inv));
+
+            public void SetValueUInt32(string key, uint value) => Set(key, value.ToString(Inv));
+
+            public short GetValueInt16(string key, short defaultValue) => Get(key, defaultValue, s => short.Parse(s, Inv));
+
+            public void SetValueInt16(string key, short value) => Set(key, value.ToString(Inv));
+
+            public ushort GetValueUInt16(string key, ushort defaultValue) => Get(key, defaultValue, s => ushort.Parse(s, Inv));
+
+            public void SetValueUInt16(string key, ushort value) => Set(key, value.ToString(Inv));
+
+            public long GetValueInt64(string key, long defaultValue) => Get(key, defaultValue, s => long.Parse(s, Inv));
+
+            public void SetValueInt64(string key, long value) => Set(key, value.ToString(Inv));
+
+            public ulong GetValueUInt64(string key, ulong defaultValue) => Get(key, defaultValue, s => ulong.Parse(s, Inv));
+
+            public void SetValueUInt64(string key, ulong value) => Set(key, value.ToString(Inv));
+        }
+
+        /// <summary>The resolved settings for a harness run.</summary>
+        internal sealed class Resolved {
+            public IPluginOptionsAccessor Accessor { get; set; }
+            public double PixelSizeMicrons { get; set; }
+            public double FocalLengthMm { get; set; }
+            public string Path { get; set; }
+            public bool WasBootstrapped { get; set; }
+        }
+
+        /// <summary>
+        /// PixelScale (arcsec/binned-pixel) for a frame, taken FROM THE FRAME'S OWN HEADER wherever possible.
+        ///
+        /// <para><b>Why not the profile.</b> The AF bank is other people's data. Their pixel size and focal
+        /// length are recorded in their frames (FITS <c>XPIXSZ</c>/<c>FOCALLEN</c>, and the XISF equivalents,
+        /// both of which NINA's loaders populate onto <c>MetaData</c>); the local profile describes a completely
+        /// different rig. Measured across the bank the true scales span <b>0.74 to 5.97 arcsec/px</b> — timmer at
+        /// 130 mm against toml999 at 1060 mm — while a profile-sourced value applied ONE number to all of them,
+        /// so every PixelScale-dependent gate was evaluated at the wrong scale on nearly every run.</para>
+        ///
+        /// <para>Falls back to the settings file only when a frame carries no usable header, and returns NaN when
+        /// neither has one — the same NaN the profile path produced, so a frame with no scale information is not
+        /// silently given a fabricated one. <paramref name="source"/> reports which of the three applied, so a
+        /// runner can say so rather than leaving the provenance implicit.</para>
+        /// </summary>
+        public static double PixelScaleForFrame(NINA.Image.ImageData.ImageMetaData meta, Resolved settings, out string source) {
+            var metaPixelSize = meta?.Camera?.PixelSize ?? double.NaN;
+            var metaFocalLength = meta?.Telescope?.FocalLength ?? double.NaN;
+            var binX = meta?.Camera?.BinX ?? 1;
+            var binning = Math.Max(double.IsNaN(binX) ? 1 : binX, 1);
+
+            if (metaPixelSize > 0.0 && metaFocalLength > 0.0) {
+                source = "frame header";
+                return NINA.Joko.Plugins.HocusFocus.Utility.MathUtility.ArcsecPerPixel(metaPixelSize, metaFocalLength) * binning;
+            }
+            if (settings != null && settings.PixelSizeMicrons > 0.0 && settings.FocalLengthMm > 0.0) {
+                source = $"settings file ({settings.Path}) — frame header carried no pixel size / focal length";
+                return NINA.Joko.Plugins.HocusFocus.Utility.MathUtility.ArcsecPerPixel(
+                    settings.PixelSizeMicrons, settings.FocalLengthMm) * binning;
+            }
+            source = "unavailable (neither the frame header nor the settings file has pixel size + focal length)";
+            return double.NaN;
+        }
+
+        /// <summary>
+        /// Per-dataset settings, written beside the run as <see cref="DefaultFileName"/>.
+        ///
+        /// <para><b>Why per dataset.</b> The bank is other people's data and a single shared bundle cannot
+        /// describe it: pixel scale alone spans <b>0.66–5.97 arcsec/px</b> (FlyData at 2350 mm against timmer at
+        /// 130 mm), and the detection-binning factor that puts a run inside the detector's calibrated 2–4 px HFR
+        /// band is a property of that run's optics and seeing, not of whoever ran the harness. Deriving both from
+        /// the dataset — and RECORDING the result next to it — makes a run reproducible and lets a human correct
+        /// a bad derivation by editing one file rather than by changing global state.</para>
+        ///
+        /// <para>An existing per-run file is used AS-IS and never re-derived: once a human has looked at a
+        /// dataset and set its values, a later harness run must not silently overwrite that judgement.</para>
+        /// </summary>
+        /// <param name="runDir">Folder holding the run's frames; the settings file is written here.</param>
+        /// <param name="baseSettings">Shared base — everything not derived per run comes from this.</param>
+        /// <param name="firstFrameMeta">First frame's metadata, for the pixel-scale inputs.</param>
+        /// <param name="inFocusHfrPixels">The run's fitted in-focus HFR, for the binning derivation. NaN ⇒ the
+        /// base setting's binning is kept, since a binning guess with no HFR behind it is not a derivation.</param>
+        public static Resolved ResolveForRun(
+            string runDir, Resolved baseSettings, NINA.Image.ImageData.ImageMetaData firstFrameMeta, double inFocusHfrPixels) {
+            var path = Path.Combine(runDir, DefaultFileName);
+            if (File.Exists(path)) {
+                var existing = JsonConvert.DeserializeObject<HarnessSettingsFile>(File.ReadAllText(path))
+                    ?? new HarnessSettingsFile();
+                Console.WriteLine($"  settings: {path} (existing, not re-derived)");
+                return new Resolved {
+                    Accessor = new FileOptionsAccessor(existing.Options),
+                    PixelSizeMicrons = existing.PixelSizeMicrons,
+                    FocalLengthMm = existing.FocalLengthMm,
+                    Path = path,
+                    WasBootstrapped = false
+                };
+            }
+
+            // Start from the shared base so only the genuinely per-dataset knobs differ from it.
+            var options = new Dictionary<string, string>(
+                (baseSettings?.Accessor as FileOptionsAccessor)?.Snapshot() ?? new Dictionary<string, string>(),
+                StringComparer.Ordinal);
+            var file = new HarnessSettingsFile {
+                ExportedFromProfile = $"derived from dataset ({Path.GetFileName(Path.GetDirectoryName(runDir)) ?? runDir})",
+                ExportedAtUtc = DateTime.UtcNow,
+                PixelSizeMicrons = firstFrameMeta?.Camera?.PixelSize ?? (baseSettings?.PixelSizeMicrons ?? 0.0),
+                FocalLengthMm = firstFrameMeta?.Telescope?.FocalLength ?? (baseSettings?.FocalLengthMm ?? 0.0),
+                Options = options
+            };
+
+            var notes = new List<string>();
+            if (double.IsFinite(inFocusHfrPixels) && inFocusHfrPixels > 0.0) {
+                var factor = NINA.Joko.Plugins.HocusFocus.Utility.DetectionBinningResolver.RecommendFromHfr(inFocusHfrPixels);
+                var setting = NINA.Joko.Plugins.HocusFocus.Utility.DetectionBinningResolver.ToSetting(factor);
+                options["DetectionBinning"] = setting.ToString();
+                notes.Add($"DetectionBinning={setting} from in-focus HFR {inFocusHfrPixels:0.00}px " +
+                    $"(target {NINA.Joko.Plugins.HocusFocus.Utility.DetectionBinningResolver.TargetHfrPixels:0.0}px)");
+            } else {
+                notes.Add("DetectionBinning kept from base (no fitted in-focus HFR for this dataset)");
+            }
+            notes.Add(file.PixelSizeMicrons > 0 && file.FocalLengthMm > 0
+                ? $"PixelScale inputs {file.PixelSizeMicrons:0.00}um / {file.FocalLengthMm:0.#}mm from the frame header"
+                : "PixelScale inputs unavailable from the frame header; base values kept");
+            file.DerivedNotes = string.Join("; ", notes);
+
+            File.WriteAllText(path, JsonConvert.SerializeObject(file, Formatting.Indented));
+            Console.WriteLine($"  settings: derived {path} — {file.DerivedNotes}");
+            return new Resolved {
+                Accessor = new FileOptionsAccessor(file.Options),
+                PixelSizeMicrons = file.PixelSizeMicrons,
+                FocalLengthMm = file.FocalLengthMm,
+                Path = path,
+                WasBootstrapped = true
+            };
+        }
+
+        /// <summary>
+        /// The fitted in-focus HFR (px) from a run's <c>autofocus_report_Region0.json</c>, or NaN. This is the
+        /// SAME quantity DetectionBinningResolver expects: the AF curve's minimum, in the pixel space the run was
+        /// actually detected in.
+        /// </summary>
+        public static double ReadInFocusHfr(string runFolder) {
+            var path = Path.Combine(runFolder ?? string.Empty, "autofocus_report_Region0.json");
+            if (!File.Exists(path)) {
+                return double.NaN;
+            }
+            try {
+                var o = JsonConvert.DeserializeObject<Newtonsoft.Json.Linq.JObject>(File.ReadAllText(path));
+                var v = o?["CalculatedFocusPoint"]?["Value"];
+                return v == null ? double.NaN : (double)v;
+            } catch {
+                return double.NaN;
+            }
+        }
+
+        /// <summary>Default settings path: next to the TestApp executable.</summary>
+        public static string DefaultPath() =>
+            Path.Combine(AppContext.BaseDirectory ?? Directory.GetCurrentDirectory(), DefaultFileName);
+
+        /// <summary>
+        /// Resolves the harness settings for this run. Order: <c>--settings &lt;path&gt;</c>, else the default
+        /// path, else bootstrap one from <paramref name="activeProfile"/> and use that. Prints which file was
+        /// used, so a run's provenance is visible in its own log rather than implied.
+        /// </summary>
+        public static Resolved Resolve(string[] args, IProfileService profileService, IProfile activeProfile) =>
+            ResolveAt(SettingsPathArg(args), profileService, activeProfile);
+
+        /// <summary>The <c>--settings</c> value, read inline rather than through the harness's CLI helper so this
+        /// store stays dependency-free and unit-testable on its own.</summary>
+        private static string SettingsPathArg(string[] args) {
+            for (var i = 0; args != null && i < args.Length - 1; i++) {
+                if (string.Equals(args[i], "--settings", StringComparison.OrdinalIgnoreCase)) {
+                    return args[i + 1];
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// <see cref="Resolve"/> with the path already extracted — the arg-free core, so the store carries no
+        /// dependency on the harness's CLI helpers and can be unit tested on its own.
+        /// </summary>
+        public static Resolved ResolveAt(string explicitPath, IProfileService profileService, IProfile activeProfile) {
+            var path = string.IsNullOrWhiteSpace(explicitPath) ? DefaultPath() : explicitPath;
+
+            if (File.Exists(path)) {
+                var loaded = JsonConvert.DeserializeObject<HarnessSettingsFile>(File.ReadAllText(path))
+                    ?? new HarnessSettingsFile();
+                Console.WriteLine($"Settings: {path} (exported {loaded.ExportedAtUtc:u} from profile '{loaded.ExportedFromProfile}')");
+                return new Resolved {
+                    Accessor = new FileOptionsAccessor(loaded.Options),
+                    PixelSizeMicrons = loaded.PixelSizeMicrons,
+                    FocalLengthMm = loaded.FocalLengthMm,
+                    Path = path,
+                    WasBootstrapped = false
+                };
+            }
+
+            if (!string.IsNullOrWhiteSpace(explicitPath)) {
+                throw new FileNotFoundException($"Harness settings file not found: {path}", path);
+            }
+
+            var file = ExportFromProfile(profileService, activeProfile);
+            File.WriteAllText(path, JsonConvert.SerializeObject(file, Formatting.Indented));
+            Console.WriteLine($"Settings: bootstrapped {path} from profile '{activeProfile?.Name}'. " +
+                "Later runs read this file; the profile is not consulted for settings again.");
+            return new Resolved {
+                Accessor = new FileOptionsAccessor(file.Options),
+                PixelSizeMicrons = file.PixelSizeMicrons,
+                FocalLengthMm = file.FocalLengthMm,
+                Path = path,
+                WasBootstrapped = true
+            };
+        }
+
+        /// <summary>
+        /// Snapshots the profile's plugin options + pixel-scale inputs. Reads through the REAL accessor so the
+        /// exported values are exactly what the profile-backed path would have produced — the bootstrap must be
+        /// behaviour-preserving, or the first run after this change would silently differ from the last one
+        /// before it.
+        /// </summary>
+        internal static HarnessSettingsFile ExportFromProfile(IProfileService profileService, IProfile activeProfile) {
+            var file = new HarnessSettingsFile {
+                ExportedFromProfile = activeProfile?.Name,
+                ExportedAtUtc = DateTime.UtcNow,
+                PixelSizeMicrons = activeProfile?.CameraSettings?.PixelSize ?? 0.0,
+                FocalLengthMm = activeProfile?.TelescopeSettings?.FocalLength ?? 0.0
+            };
+
+            var guid = PluginOptionsAccessor.GetAssemblyGuid(
+                typeof(NINA.Joko.Plugins.HocusFocus.StarDetection.StarDetectionOptions));
+            if (guid == null) {
+                return file;
+            }
+
+            // Copy through StarDetectionOptions' OWN PROPERTY SURFACE rather than reading raw keys. The profile
+            // stores plugin options as typed values with no "list my keys" API, so a raw read has to guess both
+            // the key list and each key's type -- and a miss is silent: the loaded options fall back to the
+            // option's DEFAULT, which looks like a perfectly valid run. Assigning property-by-property makes the
+            // options class itself emit the right keys with the right types, so the snapshot cannot drift from
+            // what the class actually reads, and a newly added option is captured with no change here.
+            var fromProfile = new NINA.Joko.Plugins.HocusFocus.StarDetection.StarDetectionOptions(
+                profileService, new PluginOptionsAccessor(profileService, guid.Value));
+            var toFile = new NINA.Joko.Plugins.HocusFocus.StarDetection.StarDetectionOptions(
+                profileService, new FileOptionsAccessor(file.Options));
+
+            foreach (var prop in typeof(NINA.Joko.Plugins.HocusFocus.StarDetection.StarDetectionOptions).GetProperties()) {
+                if (!prop.CanRead || !prop.CanWrite || prop.GetIndexParameters().Length > 0) {
+                    continue;
+                }
+                try {
+                    var value = prop.GetValue(fromProfile);
+                    // Write a DIFFERENT value first so the option's change-detecting setter actually fires.
+                    // Without this the snapshot is SPARSE: a value equal to the shipped default never reaches the
+                    // file, and the file then inherits whatever the default IS AT LOAD TIME. That is
+                    // behaviour-preserving today and quietly wrong the day a default changes — precisely the
+                    // silent drift a settings file exists to prevent. Density costs one extra write per property.
+                    var poison = Poison(value, prop.PropertyType);
+                    if (poison != null) {
+                        prop.SetValue(toFile, poison);
+                    }
+                    prop.SetValue(toFile, value);
+                } catch {
+                    // A property that refuses a round trip (computed, validated, or profile-coupled) is not a
+                    // detector knob we can carry; skip it rather than abort the whole export.
+                }
+            }
+            return file;
+        }
+
+        /// <summary>
+        /// A value of <paramref name="type"/> guaranteed to differ from <paramref name="value"/>, used only to
+        /// trip a change-detecting setter. Null when no such value can be produced, in which case the property is
+        /// written once and may stay absent from the file (see <see cref="ExportFromProfile"/>).
+        /// </summary>
+        private static object Poison(object value, Type type) {
+            var t = Nullable.GetUnderlyingType(type) ?? type;
+            if (t == typeof(bool)) {
+                return !(bool)(value ?? false);
+            }
+            if (t == typeof(string)) {
+                return (value as string) == "~" ? "~~" : "~";
+            }
+            if (t.IsEnum) {
+                foreach (var candidate in Enum.GetValues(t)) {
+                    if (!Equals(candidate, value)) {
+                        return candidate;
+                    }
+                }
+                return null;
+            }
+            if (t == typeof(double) || t == typeof(float) || t == typeof(decimal)
+                || t == typeof(int) || t == typeof(long) || t == typeof(short)
+                || t == typeof(byte) || t == typeof(sbyte)
+                || t == typeof(uint) || t == typeof(ulong) || t == typeof(ushort)) {
+                try {
+                    // +1 in the property's own type. Doubles that are NaN compare unequal to everything, so any
+                    // finite value already differs; 0 is a safe, in-range choice for every numeric knob here.
+                    var current = Convert.ToDouble(value ?? 0);
+                    return Convert.ChangeType(double.IsNaN(current) ? 0.0 : current + 1.0, t);
+                } catch {
+                    return null;
+                }
+            }
+            if (t == typeof(DateTime)) {
+                return ((DateTime)(value ?? DateTime.UnixEpoch)).AddDays(1);
+            }
+            return null;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/TestApp/InspectAlignRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/InspectAlignRunner.cs
@@ -94,7 +94,11 @@ namespace TestApp {
                 ?? throw new InvalidOperationException("No active NINA profile could be loaded. Pass --profile-id.");
             Console.WriteLine($"Profile: {activeProfile.Name} ({activeProfile.Id})");
 
-            var starDetectionOptions = new StarDetectionOptions(profileService);
+            // Detector settings come from the harness's LOCAL settings file, not the NINA profile: a
+            // profile-sourced value is mutable machine state nothing records, and the ACTIVE profile can
+            // even be a different telescope between runs. See HarnessSettingsStore.
+            var harnessSettings = HarnessSettingsStore.Resolve(args, profileService, activeProfile);
+            var starDetectionOptions = new StarDetectionOptions(profileService, harnessSettings.Accessor);
             var inspectorOptions = new InspectorOptions(profileService);
             var autoFocusOptions = new AutoFocusOptions(profileService);
 

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -170,11 +170,11 @@ namespace TestApp {
             Console.WriteLine($"Profile: {activeProfile.Name} ({activeProfile.Id})");
             Logger.Info($"Loaded profile {activeProfile.Name} ({activeProfile.Id})");
 
-            var guid = PluginOptionsAccessor.GetAssemblyGuid(typeof(StarDetectionOptions));
-            if (guid == null) {
-                throw new InvalidOperationException("Could not resolve the HocusFocus plugin assembly GUID");
-            }
-            var accessor = new PluginOptionsAccessor(profileService, guid.Value);
+            // Detector settings come from the harness's LOCAL settings file, never the NINA profile: a
+            // profile-sourced seed is mutable machine state nothing records, and TryLoad("") picks whichever
+            // profile is ACTIVE -- two runs of the same data minutes apart were seeded from different telescopes.
+            var harnessSettings = HarnessSettingsStore.Resolve(args, profileService, activeProfile);
+            var accessor = harnessSettings.Accessor;
             var starDetectionOptions = new StarDetectionOptions(profileService, accessor);
             var afOptions = new AutoFocusOptions(profileService);
 
@@ -183,12 +183,12 @@ namespace TestApp {
             // (image.RawImageData.MetaData.Camera.BinX, which defaults to 1 when unset); the harness loads raw
             // float Mats with no NINA metadata, so binning = 1 is used (the same value an unbinned/unset frame
             // yields in production). PixelScale only feeds PixelScale-dependent detection gates, not the curve fit.
+            // PixelScale is resolved PER RUN from each run's own frame headers (see PrepareRunAsync). The bank is
+            // other people's data -- true scales span 0.277-5.966 arcsec/px -- so one harness-wide value taken from
+            // the local profile was wrong for nearly every run. This is only the fallback for callers that never
+            // load a frame; every detecting path overwrites it from the frame header.
             const int binning = 1;
-            var pixelScale = MathUtility.ArcsecPerPixel(activeProfile.CameraSettings.PixelSize, activeProfile.TelescopeSettings.FocalLength) * binning;
-            if (double.IsNaN(pixelScale)) {
-                Console.WriteLine("WARNING: PixelScale is NaN (pixel size / focal length not set in the profile). Detection will still run; PixelScale-dependent gates use NaN.");
-                Logger.Warning("PixelScale is NaN; pixel size / focal length not set in the profile");
-            }
+            var pixelScale = MathUtility.ArcsecPerPixel(harnessSettings.PixelSizeMicrons, harnessSettings.FocalLengthMm) * binning;
 
             // Mirror the wizard's seed/baseline split (optimizer default seed + current-settings baseline):
             //  - Seed = fully-DEFAULT params (BuildDefaultStarDetectorParams) — the bundle the optimizer STARTS from,
@@ -282,6 +282,7 @@ namespace TestApp {
                 perFilterStore: new StubPerFilterStarDetectionStore(accessor));
             var ctx = new RunDetectionContext {
                 ProfileService = profileService,
+                HarnessSettings = harnessSettings,
                 AfOptions = afOptions,
                 AlglibAPI = alglibAPI,
                 Detector = detector,
@@ -329,6 +330,7 @@ namespace TestApp {
             public double LowSigmaOutlierRejection;
             public StarDetectorParams Seed;       // optimizer start = fully-default params (wizard's LoadedRun.Seed)
             public StarDetectorParams Baseline;    // current settings = displayed "before" (wizard's LoadedRun.Baseline)
+            public HarnessSettingsStore.Resolved HarnessSettings;  // local settings file; fallback for PixelScale
             public IReadOnlyList<OptimizerVariable> Variables;
             public int? MaxEvals;
             public string LabelsDir;
@@ -390,7 +392,20 @@ namespace TestApp {
                 var subDir = Path.Combine(outDir, OptimizationRunDiscovery.SanitizeForFileName(d.RunId));
                 var loadedRuns = new List<LoadedHarnessRun>(1);
                 try {
-                    loadedRuns.Add(await PrepareRunAsync(ctx, d, labelsByRun).ConfigureAwait(false));
+                    var loaded = await PrepareRunAsync(ctx, d, labelsByRun).ConfigureAwait(false);
+                    loadedRuns.Add(loaded);
+                    // PixelScale from THIS run's frames. Per-run mode optimizes each run independently, so each
+                    // carries the scale its data actually has. Joint mode cannot express this (one bundle, many scales).
+                    if (double.IsFinite(loaded.PixelScale)) {
+                        ctx.Seed.PixelScale = loaded.PixelScale;
+                        ctx.Baseline.PixelScale = loaded.PixelScale;
+                    }
+                    Console.WriteLine($"  {d.RunId}: PixelScale {F(ctx.Seed.PixelScale)} arcsec/px ({loaded.PixelScaleSource})");
+                    // Per-dataset settings, derived from THIS run and recorded beside it.
+                    var runFolder = Path.GetDirectoryName(d.Frames.First().Path);
+                    HarnessSettingsStore.ResolveForRun(
+                        runFolder, ctx.HarnessSettings, loaded.FirstFrameMeta,
+                        HarnessSettingsStore.ReadInFocusHfr(runFolder));
                     Directory.CreateDirectory(subDir);
                     var outcome = await OptimizeRunSetAsync(ctx, runsDir, subDir, loadedRuns).ConfigureAwait(false);
                     if (!outcome.HardFloorPassed) {
@@ -431,13 +446,21 @@ namespace TestApp {
             RunDetectionContext ctx, OptimizationRunDiscovery.DiscoveredRun d,
             Dictionary<string, IReadOnlyList<FrameLabels>> labelsByRun) {
             var frames = new List<RunFrame>(d.Frames.Count);
-            foreach (var frame in d.Frames) {
+            var runPixelScale = double.NaN;
+            var pixelScaleSource = "unset";
+            NINA.Image.ImageData.ImageMetaData firstFrameMeta = null;
+            for (var i = 0; i < d.Frames.Count; i++) {
+                var frame = d.Frames[i];
                 // The IRenderedImage the LIVE app detects on (see DiagnosticUtil.LoadRenderedImage). Detection reads
                 // it without mutating it — Detect/BuildDetectionContext build their own source Mat per call — so one
                 // load per frame serves every candidate evaluation. NOTHING is CFA-filtered here: the filter and the
                 // debayer belong inside Detect, at each candidate's own HotpixelThreshold/HotpixelThresholdingEnabled,
                 // which is what keeps those two searched axes meaningful.
                 var rendered = await DiagnosticUtil.LoadRenderedImage(frame.Path, ctx.ProfileService).ConfigureAwait(false);
+                if (i == 0) {
+                    firstFrameMeta = rendered.RawImageData?.MetaData;
+                    runPixelScale = HarnessSettingsStore.PixelScaleForFrame(firstFrameMeta, ctx.HarnessSettings, out pixelScaleSource);
+                }
                 frames.Add(new RunFrame {
                     FrameId = frame.Path,
                     FocuserPosition = frame.FocuserPosition,
@@ -469,7 +492,8 @@ namespace TestApp {
             var labels = labelsByRun.TryGetValue(d.RunId, out var ls) ? ls : null;
             var data = new RunEvaluationData(d.RunId, frames, splitDetector, ctx.AlglibAPI, fitConfig, labels);
             Console.WriteLine($"  {d.RunId}: inferred step size {stepSize}" + (labels != null ? $", {labels.Count} labeled position(s)" : ", unlabeled"));
-            return new LoadedHarnessRun { Discovered = d, Data = data, StepSize = stepSize, Frames = frames };
+            return new LoadedHarnessRun { Discovered = d, Data = data, StepSize = stepSize, Frames = frames,
+                PixelScale = runPixelScale, PixelScaleSource = pixelScaleSource, FirstFrameMeta = firstFrameMeta };
         }
 
         /// <summary>
@@ -802,6 +826,11 @@ namespace TestApp {
             public RunEvaluationData Data;
             public int StepSize;
             public List<RunFrame> Frames; // the loaded-once frame images, retained for release
+            // PixelScale (arcsec/binned-px) from this run's OWN first frame header, and that frame's metadata for
+            // the per-dataset settings derivation. NaN when neither frame nor settings file supplies one.
+            public double PixelScale = double.NaN;
+            public string PixelScaleSource = "unset";
+            public NINA.Image.ImageData.ImageMetaData FirstFrameMeta;
         }
 
         /// <summary>

--- a/Joko.NINA.Plugins/TestApp/RecommendRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/RecommendRunner.cs
@@ -116,11 +116,11 @@ namespace TestApp {
             }
             Line($"Profile: {activeProfile.Name} ({activeProfile.Id})");
 
-            var guid = PluginOptionsAccessor.GetAssemblyGuid(typeof(StarDetectionOptions));
-            if (guid == null) {
-                throw new InvalidOperationException("Could not resolve the HocusFocus plugin assembly GUID");
-            }
-            var accessor = new PluginOptionsAccessor(profileService, guid.Value);
+            // Detector settings come from the harness's LOCAL settings file, not the NINA profile: a
+            // profile-sourced value is mutable machine state nothing records, and the ACTIVE profile can
+            // even be a different telescope between runs. See HarnessSettingsStore.
+            var harnessSettings = HarnessSettingsStore.Resolve(args, profileService, activeProfile);
+            var accessor = harnessSettings.Accessor;
             var starDetectionOptions = new StarDetectionOptions(profileService, accessor);
 
             var discovery = OptimizationRunDiscovery.Discover(runsDir);

--- a/Joko.NINA.Plugins/TestApp/StarReview/StarReviewRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/StarReview/StarReviewRunner.cs
@@ -117,11 +117,11 @@ namespace TestApp.StarReview {
             }
             Console.WriteLine($"Profile: {activeProfile.Name} ({activeProfile.Id})");
 
-            var guid = PluginOptionsAccessor.GetAssemblyGuid(typeof(StarDetectionOptions));
-            if (guid == null) {
-                throw new InvalidOperationException("Could not resolve the HocusFocus plugin assembly GUID");
-            }
-            var accessor = new PluginOptionsAccessor(profileService, guid.Value);
+            // Detector settings come from the harness's LOCAL settings file, not the NINA profile: a
+            // profile-sourced value is mutable machine state nothing records, and the ACTIVE profile can
+            // even be a different telescope between runs. See HarnessSettingsStore.
+            var harnessSettings = HarnessSettingsStore.Resolve(args, profileService, activeProfile);
+            var accessor = harnessSettings.Accessor;
             var starDetectionOptions = new StarDetectionOptions(profileService, accessor);
 
             var discovered = DiscoverRuns(runsDir);

--- a/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
@@ -169,9 +169,11 @@ namespace TestApp {
                 ?? throw new InvalidOperationException("No active NINA profile could be loaded. Pass --profile-id, or run NINA at least once.");
             Console.WriteLine($"Profile: {activeProfile.Name} ({activeProfile.Id})");
 
-            var guid = PluginOptionsAccessor.GetAssemblyGuid(typeof(StarDetectionOptions))
-                ?? throw new InvalidOperationException("Could not resolve the HocusFocus plugin assembly GUID");
-            var accessor = new PluginOptionsAccessor(profileService, guid);
+            // Detector settings come from the harness's LOCAL settings file, not the NINA profile: a
+            // profile-sourced value is mutable machine state nothing records, and the ACTIVE profile can
+            // even be a different telescope between runs. See HarnessSettingsStore.
+            var harnessSettings = HarnessSettingsStore.Resolve(args, profileService, activeProfile);
+            var accessor = harnessSettings.Accessor;
             var starDetectionOptions = new StarDetectionOptions(profileService, accessor);
             var afOptions = new AutoFocusOptions(profileService);
             var inspectorOptions = new InspectorOptions(profileService);


### PR DESCRIPTION
Split out of #159 so it can be reviewed independently of the exposure-recommendation feature. Two defects found while investigating a false *"star acceptance gate is at the bottom of its range"* warning on a 3800 mm rig.

## Optimizer free rider

Phase A grids Sensitivity × StarClippingMultiplier with **Sensitivity as the outer loop** and level 0 = `Lower`. The winning StarClip is therefore first found in the `Sensitivity = 0` row and drags Sensitivity to its bound; later rows re-test the same StarClip at higher Sensitivity, score *identically*, and are refused by the strict `j > bestJ`. Phase B can't undo it either — `CompassStage` also demands strict improvement — so a flat axis freezes wherever Phase A left it.

Measured on the reported run: sweeping the gate 0→15 produced **bit-identical star counts and median HFRs on all 11 frames** (0 of ~1300 candidates rejected for low sensitivity), yet the optimizer reported `Sensitivity: 33.3 → 0`.

New **Phase C** pulls each changed axis back toward its seed at fractions 1.0 / 0.75 / 0.5 / 0.25, taking the first that costs no J. Graded rather than all-or-nothing because the flat region is a *plateau the seed can sit outside*: on that run the plateau was [0, 15] against a seed of 33.3, so a full revert genuinely costs J, is correctly refused, and would strand the axis at 0. Exact-tie comparison, so it can never regress J.

## Harness settings from files

Detector settings came from the active NINA profile — mutable machine state nothing records. Worse: `TryLoad("")` picks whichever profile is *active*, and two `optimize` runs over the same saved run minutes apart were seeded at Sensitivity **33.3333** and **15.6667**, from different telescopes. That silently invalidated a before/after comparison.

All 12 runners now read a local JSON settings file behind an `IPluginOptionsAccessor`, bootstrapped once from the profile. The export forces each change-detecting setter to fire so the snapshot is **dense** (44 keys, not the 10 that happened to differ from defaults) — a sparse file would inherit whatever a default *is at load time*, which is the drift a settings file exists to prevent.

## PixelScale per dataset

Taken from each frame's own header, with each run getting a settings file derived from its own data (binning from its fitted in-focus HFR via `DetectionBinningResolver`). The bank is other people's data — true scales span **0.277–5.966 arcsec/px (21.5×)** — so one profile-sourced value was wrong for nearly every run.

## Bank-wide validation

Ran the full A/B optimizer prepass across all 19 datasets on both builds, differing only by Phase C. **1 of 38 landings changed:**

| `bobp_m101` config A | before | after |
|---|---|---|
| Sensitivity | **0.0** | **7.5** |
| `SensitivityIsAtFloor` | true | **false** |
| σ_focus | 0.0998 | **0.0771** (23% tighter) |
| BestJ | 0.9980293 | **0.9981132** |

The other 37 are byte-identical, so the fix is inert on the bank except where the defect actually occurred — and where it occurred it removed a spurious floor *and* improved focus precision.

3,088 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7R7TUBTvPt5R44CWhu2HT