### PR TITLE
Synthetic AF bank wave 2: re-baseline at afbank-verify/5, refute F24, ship F27/F28/F30/F34

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Bank/ConvergenceBandTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Bank/ConvergenceBandTests.cs
@@ -1,0 +1,86 @@
+using NUnit.Framework;
+using TestApp.SynthBank;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Bank {
+
+    /// <summary>
+    /// The fourth harness-calibration bug found on the synthetic AF bank, and the third in this family:
+    /// <c>synth-validate</c> reported <c>converged: true</c> for a round that applied nothing, at ANY step,
+    /// because a degenerate fit makes <c>StepSizeRecommender</c> hold the current step — indistinguishable at the
+    /// call site from it agreeing. <c>D05_tec140_1000mm</c> S2 reported convergence at step 140 against a
+    /// behavioral step of 35, in the same JSON object as assertion A3 failing that number against [21, 56].
+    /// </summary>
+    [TestFixture]
+    public class ConvergenceBandTests {
+
+        private const double DefaultTolerance = 0.4;
+
+        [Test]
+        public void HalfWidth_IsTheFractionalTolerance_OnAnOrdinaryStep() {
+            Assert.That(ConvergenceBand.HalfWidth(35.0, DefaultTolerance), Is.EqualTo(14.0).Within(1e-12));
+        }
+
+        [Test]
+        public void HalfWidth_FloorsAtHalfAStep_SoTinyStepsStayExpressible() {
+            // Without the floor a behavioral step of 1 would demand |step - 1| <= 0.4, which the integer step
+            // grid cannot express as anything but exactness.
+            Assert.That(ConvergenceBand.HalfWidth(1.0, DefaultTolerance), Is.EqualTo(0.5).Within(1e-12));
+        }
+
+        [TestCase(double.NaN)]
+        [TestCase(double.PositiveInfinity)]
+        [TestCase(0.0)]
+        [TestCase(-35.0)]
+        public void HalfWidth_IsUndefined_WhenTheBehavioralStepNeverConverged(double stepBehavioral) {
+            Assert.That(ConvergenceBand.HalfWidth(stepBehavioral, DefaultTolerance), Is.NaN);
+        }
+
+        [Test]
+        public void Contains_RejectsTheD05Case_TheBugThisFixIsFor() {
+            // The measured failure, pinned: final step 140, behavioral 35. This used to be reported as
+            // convergence while A3 failed the identical number.
+            var band = ConvergenceBand.HalfWidth(35.0, DefaultTolerance);
+            Assert.That(ConvergenceBand.Contains(140, 35.0, band), Is.False,
+                "a step 4x the behavioral fixed point is not convergence, whatever the loop stopped for");
+        }
+
+        [Test]
+        public void Contains_AcceptsAStepInsideTheBand() {
+            var band = ConvergenceBand.HalfWidth(35.0, DefaultTolerance); // 14 => [21, 49]
+            Assert.Multiple(() => {
+                Assert.That(ConvergenceBand.Contains(35, 35.0, band), Is.True);
+                Assert.That(ConvergenceBand.Contains(21, 35.0, band), Is.True, "inclusive at the lower edge");
+                Assert.That(ConvergenceBand.Contains(49, 35.0, band), Is.True, "inclusive at the upper edge");
+                Assert.That(ConvergenceBand.Contains(20, 35.0, band), Is.False);
+                Assert.That(ConvergenceBand.Contains(50, 35.0, band), Is.False);
+            });
+        }
+
+        [Test]
+        public void Contains_IsFalse_WhenTheBandIsUndefined() {
+            // An unknown band is not a passing one. Contains is only ever asked in order to make a positive
+            // claim, so it must never answer yes without evidence.
+            Assert.Multiple(() => {
+                Assert.That(ConvergenceBand.Contains(35, double.NaN, double.NaN), Is.False);
+                Assert.That(ConvergenceBand.Contains(35, 35.0, double.NaN), Is.False);
+            });
+        }
+
+        [Test]
+        public void Band_IsAStrictSubsetOfAssertionA3sBand_SoTheTwoCannotContradict() {
+            // A3 asserts [0.6, 1.6] x step_behavioral. This band is [0.6, 1.4] x at the default tolerance —
+            // same lower edge, tighter upper edge. That containment is what guarantees a run reported as
+            // converged is never one A3 rejects, which is the contradiction D05 exhibited.
+            const double behavioral = 35.0;
+            var band = ConvergenceBand.HalfWidth(behavioral, DefaultTolerance);
+            var a3Lo = 0.6 * behavioral;
+            var a3Hi = 1.6 * behavioral;
+            for (var step = 1; step <= 200; step++) {
+                if (ConvergenceBand.Contains(step, behavioral, band)) {
+                    Assert.That(step, Is.InRange(a3Lo, a3Hi),
+                        $"step {step} is inside the convergence band but outside A3's terminal band");
+                }
+            }
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Golden/TruthProtectionTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Golden/TruthProtectionTests.cs
@@ -151,5 +151,138 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Golden {
                 Assert.That(rects[1].W, Is.EqualTo(7.0));
             });
         }
+
+        // ---- The symmetric protection predicate (afbank-verify/5) --------------------------------------------
+
+        [Test]
+        public void ExcludeProtected_UsesTheSamePredicateAsMatching_NotTheDetectionsBoundingBox() {
+            // THE reason /5 exists. GoldenMatch.Covers excludes on `centre-in-box OR IoU(box, det.bbox) > 0`, so
+            // a WIDE detection is protected by its own size: a 60 px donut bbox overlaps a protection box whose
+            // centre is 30+ px away, far outside the 12 px match radius. Measured on the saved wave-1 detection
+            // dumps that reads up to 0.011 high, always flattering. ExcludeProtected compares centroids only.
+            var truth = new List<SyntheticStarDisposition> { Disp(SyntheticTier.Omitted, 500, 500, hfr: 3.0) };
+            // A wide detection centred 35 px away — well outside the match radius, so NOT a protected detection,
+            // but its 60 px box still overlaps the 24 px protection box.
+            var det = new List<DetBox> { new DetBox(new RectD(505, 470, 60, 60), 535, 500) };
+            var fps = new List<int> { 0 };
+
+            var viaCovers = GoldenMatch.ExcludeUnresolved(
+                fps, det, TruthProtection.BuildExclusionRects(null, truth, 12.0));
+            var viaCentroid = TruthProtection.ExcludeProtected(
+                fps, det, TruthProtection.ProtectionCenters(truth), 12.0);
+
+            Assert.Multiple(() => {
+                Assert.That(viaCovers, Is.Empty, "precondition: the bbox-dilated predicate launders this one");
+                Assert.That(viaCentroid, Has.Count.EqualTo(1),
+                    "35 px from the nearest real star is outside the 12 px match radius, so it stays a false positive");
+            });
+        }
+
+        [Test]
+        public void ExcludeProtected_DropsADetectionInsideTheMatchRadius() {
+            var truth = new List<SyntheticStarDisposition> { Disp(SyntheticTier.Omitted, 500, 500) };
+            var det = new List<DetBox> { new DetBox(new RectD(503, 503, 8, 8), 507, 507) }; // ~9.9 px away
+            Assert.That(TruthProtection.ExcludeProtected(new List<int> { 0 }, det,
+                TruthProtection.ProtectionCenters(truth), 12.0), Is.Empty);
+        }
+
+        [Test]
+        public void ExcludeProtected_NoTruth_IsANoOp_SoTheRealBankIsUnaffected() {
+            var det = new List<DetBox> { new DetBox(new RectD(0, 0, 4, 4), 2, 2) };
+            Assert.Multiple(() => {
+                Assert.That(TruthProtection.ExcludeProtected(new List<int> { 0 }, det,
+                    TruthProtection.ProtectionCenters(null), 12.0), Has.Count.EqualTo(1));
+                Assert.That(TruthProtection.ProtectionCenters(null), Is.Empty);
+            });
+        }
+
+        // ---- The regression guard: a detection on a real star is never a false positive ----------------------
+
+        [Test]
+        public void CountWithinRadius_IsTheF31Signature_AndMustBeZeroUnderTheRepair() {
+            // Synthetic truth is COMPLETE by construction, so "is there a real star here?" has an exact answer.
+            // A scored false positive within the match radius of one is the F31 bug, whatever tier the golden
+            // policy assigned. This is the invariant bank-verify now reports as `truthViolations`.
+            var truth = new List<SyntheticStarDisposition> {
+                Disp(SyntheticTier.Omitted, 500, 500),
+                Disp(GoldenConfidence.High, 900, 900)
+            };
+            var det = new List<DetBox> {
+                new DetBox(new RectD(496, 496, 8, 8), 500, 500),   // on the omitted star — the F31 case
+                new DetBox(new RectD(2996, 2996, 8, 8), 3000, 3000) // on nothing — a genuine false positive
+            };
+            var golden = new List<RectD>();
+            var match = GoldenMatch.Match(golden, det, GoldenMatchMode.Centroid, 0.3, 12.0);
+            var all = TruthProtection.AllCenters(truth);
+
+            var unrepaired = TruthProtection.CountWithinRadius(match.FalsePositives, det, all, 12.0);
+            var repaired = TruthProtection.CountWithinRadius(
+                TruthProtection.ExcludeProtected(match.FalsePositives, det,
+                    TruthProtection.ProtectionCenters(truth), 12.0),
+                det, all, 12.0);
+
+            Assert.Multiple(() => {
+                Assert.That(unrepaired, Is.EqualTo(1), "the /3 metric charged this real star as junk");
+                Assert.That(repaired, Is.Zero, "under the repair, no scored false positive sits on a real star");
+            });
+        }
+
+        [Test]
+        public void AllCenters_CoversEveryTier_NotJustTheProtectedOnes() {
+            var truth = new List<SyntheticStarDisposition> {
+                Disp(SyntheticTier.Omitted, 1, 1),
+                Disp(SyntheticTier.MergedInto, 2, 2),
+                Disp(SyntheticTier.Unresolved, 3, 3),
+                Disp(GoldenConfidence.High, 4, 4)
+            };
+            Assert.Multiple(() => {
+                Assert.That(TruthProtection.AllCenters(truth), Has.Count.EqualTo(4));
+                Assert.That(TruthProtection.ProtectionCenters(truth), Has.Count.EqualTo(2));
+                Assert.That(TruthProtection.AllCenters(null), Is.Empty);
+            });
+        }
+
+        // ---- The null control -------------------------------------------------------------------------------
+
+        [Test]
+        public void ShiftForNullControl_MovesEveryDetectionOffItsStar_AndWrapsInsideTheFrame() {
+            // The null control answers "what does chance alone score?", which is the only way to tell a real
+            // 1.000 from a saturated metric. The first cut of the F31 repair read 1.000 on all 17 datasets
+            // BECAUSE protection was 2*HFR wide, and the precision column alone could not show that.
+            var det = new List<DetBox> {
+                new DetBox(new RectD(96, 96, 8, 8), 100, 100),
+                new DetBox(new RectD(3990, 2990, 8, 8), 3994, 2994)   // wraps on both axes
+            };
+            var shifted = TruthProtection.ShiftForNullControl(det, 4000, 3000);
+            Assert.Multiple(() => {
+                Assert.That(shifted, Has.Count.EqualTo(2));
+                Assert.That(shifted[0].Cx, Is.EqualTo(100 + TruthProtection.NullShiftX).Within(1e-9));
+                Assert.That(shifted[0].Cy, Is.EqualTo(100 + TruthProtection.NullShiftY).Within(1e-9));
+                Assert.That(shifted[1].Cx, Is.EqualTo((3994.0 + TruthProtection.NullShiftX) % 4000).Within(1e-9));
+                Assert.That(shifted[1].Cy, Is.EqualTo((2994.0 + TruthProtection.NullShiftY) % 3000).Within(1e-9));
+                Assert.That(shifted.All(s => s.Cx >= 0 && s.Cx < 4000 && s.Cy >= 0 && s.Cy < 3000),
+                    "every shifted detection stays inside the frame");
+                Assert.That(shifted[0].Box.W, Is.EqualTo(8.0), "size is preserved — only position moves");
+            });
+        }
+
+        [Test]
+        public void ShiftForNullControl_ShiftIsLargerThanAnyMatchRadiusInTheBank() {
+            // If the shift were comparable to the match radius the null would still see the real stars, and a
+            // saturated metric would pass the check it exists to fail.
+            Assert.Multiple(() => {
+                Assert.That(TruthProtection.NullShiftX, Is.GreaterThan(100));
+                Assert.That(TruthProtection.NullShiftY, Is.GreaterThan(100));
+            });
+        }
+
+        [Test]
+        public void ShiftForNullControl_DegenerateFrame_ReturnsEmpty_RatherThanDividingByZero() {
+            var det = new List<DetBox> { new DetBox(new RectD(0, 0, 4, 4), 2, 2) };
+            Assert.Multiple(() => {
+                Assert.That(TruthProtection.ShiftForNullControl(det, 0, 100), Is.Empty);
+                Assert.That(TruthProtection.ShiftForNullControl(null, 100, 100), Is.Empty);
+            });
+        }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj
@@ -30,6 +30,7 @@
     <!-- G5's golden policy (StarTruth to GoldenFrame): pure, no NINA/OpenCV coupling, so it links the same way. -->
     <Compile Include="..\TestApp\SynthBank\GoldenFromTruth.cs" Link="Golden\GoldenFromTruth.cs" />
     <Compile Include="..\TestApp\SynthBank\TruthProtection.cs" Link="Golden\TruthProtection.cs" />
+    <Compile Include="..\TestApp\SynthBank\ConvergenceBand.cs" Link="Bank\ConvergenceBand.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/ExposureRecommenderTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/ExposureRecommenderTests.cs
@@ -13,6 +13,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.StarDetection;
 using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
 using NUnit.Framework;
@@ -556,6 +557,112 @@ public class ExposureRecommenderTests {
             Assert.That(rec.ExposureIsNotTheLimit, Is.True);
             Assert.That(rec.IncreasesExposure, Is.False, "must not simultaneously claim the exposure is fine AND propose raising it");
             Assert.That(rec.RecommendedSeconds, Is.EqualTo(3.2).Within(1e-9), "returns current EXACTLY -- not a rounded-then-maxed approximation");
+        });
+    }
+
+    // ── F28: a zero rejection count means nothing when the gate could not reject ────────────────────────────
+
+    /// <summary>Params at shipped defaults except for the gate: PeakResponse 0.75, StarClip 2.0 ⇒ the gate is
+    /// provably inert at or below 1.5.</summary>
+    private static StarDetectorParams GateParams(double sensitivity, double peakResponse = 0.75, double starClip = 2.0) =>
+        new StarDetectorParams { Sensitivity = sensitivity, PeakResponse = peakResponse, StarClippingMultiplier = starClip };
+
+    [TestCase(0.0)]
+    [TestCase(1.0)]   // ExposureRecommender.SensitivityFloorThreshold — the whole population this advice is shown to
+    [TestCase(1.5)]   // the bound itself; the gate rejects on `<=`, so a candidate AT the bound still survives
+    public void Recommend_GateBelowItsOwnInertBound_IsStarCountLimited_NotExhausted(double sensitivity) {
+        // F28. Every candidate's gate statistic exceeds PeakResponse x EffectiveClipMultiplier = 1.5, so a gate
+        // at or below that rejects NOTHING no matter what the frames hold. Reading the resulting zero as
+        // "the field is exhausted" made StarFieldIsExhausted unconditional exactly where the advice is surfaced
+        // (HasLowStarSignal fires at Sensitivity <= 1.0), so StarCountIsTheLimit could never fire for the users
+        // it was written for.
+        var frame = Frame(20.0, 21.0, 22.0, 23.0, 24.0);
+        var metrics = BuildMetrics(new[] { frame, frame, frame }, gateRejectionsPerFrame: 0);
+
+        var rec = ExposureRecommender.Recommend(metrics, DefaultConstants(), currentExposureSeconds: 2.0, GateParams(sensitivity));
+
+        Assert.Multiple(() => {
+            Assert.That(rec.GateIsProvablyInert, Is.True);
+            Assert.That(rec.InertGateBound, Is.EqualTo(1.5).Within(1e-12));
+            Assert.That(rec.StarCountIsTheLimit, Is.True, "no evidence is not negative evidence — offer the probe");
+            Assert.That(rec.StarFieldIsExhausted, Is.False);
+        });
+    }
+
+    [Test]
+    public void Recommend_GateAboveItsInertBound_StillReadsZeroRejectionsAsExhausted() {
+        // The 2/7/14 s measurement must not be walked back. That rig's gate was live (it rejected 5 candidates at
+        // 2 s), so a zero there IS evidence, and the verdict is unchanged.
+        var frame = Frame(20.0, 21.0, 22.0, 23.0, 24.0);
+        var metrics = BuildMetrics(new[] { frame, frame, frame }, gateRejectionsPerFrame: 0);
+
+        var rec = ExposureRecommender.Recommend(metrics, DefaultConstants(), currentExposureSeconds: 14.0, GateParams(sensitivity: 10.0));
+
+        Assert.Multiple(() => {
+            Assert.That(rec.GateIsProvablyInert, Is.False);
+            Assert.That(rec.StarFieldIsExhausted, Is.True);
+            Assert.That(rec.StarCountIsTheLimit, Is.False);
+        });
+    }
+
+    [Test]
+    public void Recommend_InertBound_TracksTheSearchedAxes_NotAHardCodedConstant() {
+        // PeakResponse and StarClippingMultiplier are BOTH searched optimizer axes, and F23 wave 1 measured
+        // landings at StarClip 6.25 and 6.75. Hard-coding 1.5 would misjudge exactly those configurations.
+        var frame = Frame(20.0, 21.0, 22.0, 23.0, 24.0);
+        var metrics = BuildMetrics(new[] { frame, frame, frame }, gateRejectionsPerFrame: 0);
+
+        var rec = ExposureRecommender.Recommend(metrics, DefaultConstants(), currentExposureSeconds: 2.0,
+            GateParams(sensitivity: 6.0, peakResponse: 1.0, starClip: 6.25));
+
+        Assert.Multiple(() => {
+            Assert.That(rec.InertGateBound, Is.EqualTo(6.25).Within(1e-12));
+            Assert.That(rec.GateIsProvablyInert, Is.True, "a gate of 6.0 under a 6.25 bound is still inert");
+        });
+    }
+
+    [Test]
+    public void Recommend_AnObservedRejection_RefutesTheInertProof() {
+        // The proof says the gate cannot reject; an actual rejection says it did. Observation wins — that can only
+        // mean the params handed in do not describe the run that produced these metrics.
+        var frame = Frame(20.0, 21.0, 22.0, 23.0, 24.0);
+        var metrics = BuildMetrics(new[] { frame, frame, frame }, gateRejectionsPerFrame: 3);
+
+        var rec = ExposureRecommender.Recommend(metrics, DefaultConstants(), currentExposureSeconds: 2.0, GateParams(sensitivity: 0.0));
+
+        Assert.Multiple(() => {
+            Assert.That(rec.GateIsProvablyInert, Is.False);
+            Assert.That(rec.StarCountIsTheLimit, Is.True, "via the ordinary rejection evidence, not the inert path");
+        });
+    }
+
+    [Test]
+    public void Recommend_WithoutDetectorParams_IsIdenticalToThePreF28Behaviour() {
+        // Every existing caller and test passes no params. "Unknown" must never be read as "inert".
+        var frame = Frame(20.0, 21.0, 22.0, 23.0, 24.0);
+        var metrics = BuildMetrics(new[] { frame, frame, frame }, gateRejectionsPerFrame: 0);
+
+        var rec = ExposureRecommender.Recommend(metrics, DefaultConstants(), currentExposureSeconds: 14.0);
+
+        Assert.Multiple(() => {
+            Assert.That(rec.InertGateBound, Is.NaN);
+            Assert.That(rec.GateIsProvablyInert, Is.False);
+            Assert.That(rec.StarFieldIsExhausted, Is.True);
+        });
+    }
+
+    [Test]
+    public void InertSensitivityBound_UsesTheDonutCap_WhenTheMasterCanCap() {
+        // EffectiveClipMultiplier caps at 2.0 for extended candidates when the donut master is on, so the SMALLEST
+        // value it can return -- which is what a settings-level bound must use -- is the capped one.
+        var p = new StarDetectorParams {
+            PeakResponse = 0.75, StarClippingMultiplier = 8.0,
+            DefocusAwareDonutDetection = true, DefocusDistortionSizeReference = 30.0
+        };
+        Assert.Multiple(() => {
+            Assert.That(StarDetector.MinEffectiveClipMultiplier(p), Is.EqualTo(2.0).Within(1e-12));
+            Assert.That(StarDetector.InertSensitivityBound(p), Is.EqualTo(1.5).Within(1e-12));
+            Assert.That(StarDetector.InertSensitivityBound(null), Is.NaN);
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/OptimizedStarDetectionSettingsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/OptimizedStarDetectionSettingsTests.cs
@@ -34,9 +34,15 @@ public class OptimizedStarDetectionSettingsTests {
     }
 
     [Test]
-    public void DefaultSchemaVersion_IsTwo() {
-        // v2 added the defocus-aware axes (master + donut/spike knobs).
-        Assert.That(new OptimizedStarDetectionSettings().SchemaVersion, Is.EqualTo(2));
+    public void DefaultSchemaVersion_IsCurrent() {
+        // v2 added the defocus-aware axes (master + donut/spike knobs); v3 added the optional Provenance block
+        // (F30) and changed no knob semantics. Asserted against the constant as well as the literal, so the next
+        // bump does not silently pass while leaving the default behind.
+        Assert.Multiple(() => {
+            Assert.That(new OptimizedStarDetectionSettings().SchemaVersion,
+                Is.EqualTo(OptimizedStarDetectionSettings.CurrentSchemaVersion));
+            Assert.That(OptimizedStarDetectionSettings.CurrentSchemaVersion, Is.EqualTo(3));
+        });
     }
 
     [Test]
@@ -113,7 +119,7 @@ public class OptimizedStarDetectionSettingsTests {
             Assert.That(dto.FinalJ, Is.EqualTo(0.4));
             Assert.That(dto.RecommendedStepSize, Is.EqualTo(25));
             Assert.That(dto.RecommendedOffsetSteps, Is.EqualTo(6));
-            Assert.That(dto.SchemaVersion, Is.EqualTo(2));
+            Assert.That(dto.SchemaVersion, Is.EqualTo(OptimizedStarDetectionSettings.CurrentSchemaVersion));
             Assert.That(dto.CreatedAtUtc, Is.InRange(before, after));
             Assert.That(dto.CreatedAtUtc.Kind, Is.EqualTo(DateTimeKind.Utc));
         });
@@ -134,6 +140,90 @@ public class OptimizedStarDetectionSettingsTests {
             Assert.That(clone, Is.Not.SameAs(original));
             Assert.That(original.BrightnessSensitivity, Is.EqualTo(3.3));
             Assert.That(clone.BrightnessSensitivity, Is.EqualTo(99.0));
+        });
+    }
+
+    // ── F30: a landing must say which invocation produced it ────────────────────────────────────────────────
+
+    [Test]
+    public void FromParams_WithoutProvenance_OmitsTheBlockEntirely() {
+        // A snapshot written by the SHIPPING plugin has no argv and no harness settings file. It must stay
+        // byte-identical to before this field existed, and a reader must see "unattributable" rather than a
+        // fabricated producer.
+        var dto = OptimizedStarDetectionSettings.FromParams(new StarDetectorParams(), 1, 0.5, 0.9, 10, 4);
+        var json = JsonConvert.SerializeObject(dto);
+
+        Assert.Multiple(() => {
+            Assert.That(dto.Provenance, Is.Null);
+            Assert.That(json, Does.Not.Contain("Provenance"));
+        });
+    }
+
+    [Test]
+    public void FromParams_WithProvenance_RoundTripsTheInvocation() {
+        var prov = new OptimizerProvenance {
+            Producer = "TestApp optimize",
+            CommandLine = "optimize --per-run --runs D:\\SyntheticAutofocusBank --donut",
+            SettingsFingerprint = "a1b2c3d4e5f6",
+            ProducerVersion = "3.4.0.1"
+        };
+        var dto = OptimizedStarDetectionSettings.FromParams(new StarDetectorParams(), 17, 0.5, 0.9, 10, 4, prov);
+        var round = JsonConvert.DeserializeObject<OptimizedStarDetectionSettings>(JsonConvert.SerializeObject(dto));
+
+        Assert.Multiple(() => {
+            // THE point of F30: the two F23 arms differed only by a flag, and this is where that shows.
+            Assert.That(round.Provenance.CommandLine, Does.Contain("--donut"));
+            Assert.That(round.Provenance.Producer, Is.EqualTo("TestApp optimize"));
+            Assert.That(round.Provenance.SettingsFingerprint, Is.EqualTo("a1b2c3d4e5f6"));
+            Assert.That(round.SchemaVersion, Is.EqualTo(OptimizedStarDetectionSettings.CurrentSchemaVersion));
+        });
+    }
+
+    [Test]
+    public void FromParams_CopiesProvenance_SoTheProducerCannotMutateAStoredLanding() {
+        var prov = new OptimizerProvenance { CommandLine = "optimize --per-run" };
+        var dto = OptimizedStarDetectionSettings.FromParams(new StarDetectorParams(), 1, 0.0, 0.0, 1, 1, prov);
+        prov.CommandLine = "optimize --per-run --donut"; // the caller reuses one instance across the batch
+
+        Assert.That(dto.Provenance.CommandLine, Is.EqualTo("optimize --per-run"),
+            "a landing records the invocation as it was when written");
+    }
+
+    [Test]
+    public void Clone_DeepCopiesProvenance_NotJustTheReference() {
+        // MemberwiseClone is shallow: without an explicit copy every clone would ALIAS one provenance instance,
+        // and a mutation through any of them would rewrite the history of all the others.
+        var original = OptimizedStarDetectionSettings.FromParams(
+            new StarDetectorParams(), 1, 0.0, 0.0, 1, 1, new OptimizerProvenance { CommandLine = "original" });
+        var clone = original.Clone();
+        clone.Provenance.CommandLine = "mutated";
+
+        Assert.Multiple(() => {
+            Assert.That(clone.Provenance, Is.Not.SameAs(original.Provenance));
+            Assert.That(original.Provenance.CommandLine, Is.EqualTo("original"));
+        });
+    }
+
+    [Test]
+    public void ASchemaV2File_StillLoads_WithNoProvenance() {
+        // Forward/backward knob compatibility: v3 added only metadata, so every landing already on disk must
+        // still deserialize — reporting "no provenance" rather than failing or inventing one.
+        const string v2 = "{\"BrightnessSensitivity\":3.3,\"SchemaVersion\":2,\"RunCount\":4}";
+        var dto = JsonConvert.DeserializeObject<OptimizedStarDetectionSettings>(v2);
+
+        Assert.Multiple(() => {
+            Assert.That(dto.SchemaVersion, Is.EqualTo(2));
+            Assert.That(dto.BrightnessSensitivity, Is.EqualTo(3.3));
+            Assert.That(dto.Provenance, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Provenance_ToString_SkipsWhatIsUnset() {
+        Assert.Multiple(() => {
+            Assert.That(new OptimizerProvenance().ToString(), Is.EqualTo("(no provenance)"));
+            Assert.That(new OptimizerProvenance { Producer = "TestApp optimize", CommandLine = "--donut" }.ToString(),
+                Is.EqualTo("TestApp optimize | --donut"));
         });
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -1285,6 +1285,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 nameof(OptimizedStarDetectionSettings.RecommendedStepSize),
                 nameof(OptimizedStarDetectionSettings.RecommendedOffsetSteps),
                 nameof(OptimizedStarDetectionSettings.SchemaVersion),
+                // F30 provenance: records WHICH INVOCATION produced the landing. Metadata, not a knob — nothing
+                // applies it to StarDetectorParams, and the replay overlay must not try to.
+                nameof(OptimizedStarDetectionSettings.Provenance),
             };
             var curatedKnobs = typeof(OptimizedStarDetectionSettings)
                 .GetProperties(BindingFlags.Public | BindingFlags.Instance)

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
@@ -803,9 +803,10 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         /// so the fold is additive and does not double-count values already present on the main metrics.
         /// </summary>
         /// <summary>
-        /// Returns all seven <c>*Bounds</c> lists in a fixed, canonical order. Every method that needs to
-        /// iterate over all bounds lists (Merge, SortBounds, AddROIOffset) uses this helper so that adding an
-        /// eighth bounds list in the future requires only a single edit here.
+        /// Returns all NINE <c>*Bounds</c> lists in a fixed, canonical order. Every method that needs to iterate
+        /// over all bounds lists (Merge, SortBounds, AddROIOffset) uses this helper, so adding another one
+        /// requires a single edit here. (The count read "seven" long after TooElongatedBounds and
+        /// BloomSuppressedBounds joined the list — the helper is the source of truth, not the prose.)
         /// </summary>
         private List<List<Rect>> AllBoundsLists() => new List<List<Rect>> {
             TooDistortedBounds,
@@ -933,9 +934,22 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
     /// <summary>
     /// Per-rejected-candidate diagnostics, captured only when
     /// <see cref="StarDetectorParams.CollectRejectedCandidateDiagnostics"/> is enabled. One record is produced for
-    /// EVERY candidate a late gate rejects (unlike the metrics <c>*Bounds</c> lists, which only exist for seven of
-    /// the gates), so the label-driven recommender can attribute a labeled "wrongly-rejected" star to the exact
-    /// gate that killed it and invert that gate's threshold. <see cref="MeasuredValue"/> is the scalar the gate
+    /// EVERY candidate a late gate rejects — unlike the metrics <c>*Bounds</c> lists, which carry only geometry
+    /// (a rect, with no measured value and no threshold) and do not even span the gates: there are NINE of them
+    /// against <see cref="RejectionGate"/>'s TWELVE constants, they cover eight (TooSmall, OnBorder,
+    /// HFRAnalysisFailed and TooLowHFR have none), and the ninth, <c>SaturatedBounds</c>, corresponds to no gate
+    /// at all because saturated stars are kept and masked during the PSF fit rather than rejected. So the
+    /// label-driven recommender can
+    /// attribute a labeled "wrongly-rejected" star to the exact gate that killed it and invert that gate's
+    /// threshold.
+    ///
+    /// <para><b>Not reachable from the optimizer</b> (F30's sibling, F27). These records live on
+    /// <c>HocusFocusStarDetectorResult.RejectedCandidates</c>, and
+    /// <c>HocusFocusStarDetection.BuildStarDetectionResult</c> copies only <c>Metrics</c> forward — the type the
+    /// optimizer consumes has no member for them at all. Only the review/feedback path re-detects with the flag
+    /// on, outside the optimizer loop. Anything in the objective needing per-rejection detail has to plumb this
+    /// through first; the <c>*Bounds</c> rect lists ARE reachable at the same seam that reads
+    /// <c>LowSensitivity</c>/<c>TooFlat</c>, but they answer a strictly weaker question.</para> <see cref="MeasuredValue"/> is the scalar the gate
     /// compared against <see cref="ThresholdValue"/>; both are <see cref="double.NaN"/> for the non-scalar gates
     /// (OnBorder/Degenerate/HFRAnalysisFailed), which can only be flagged, not threshold-recovered.
     /// </summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/ExposureRecommender.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/ExposureRecommender.cs
@@ -12,6 +12,7 @@
 
 using System;
 using System.Collections.Generic;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.Utility;
 
 namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
@@ -170,6 +171,26 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// is the conservative direction, since it withholds an exposure recommendation rather than inventing one.
         /// </summary>
         public int GateRejectedCount { get; set; }
+
+        /// <summary>
+        /// <see cref="StarDetector.InertSensitivityBound"/> for the detector settings this recommendation was
+        /// computed from — the gate value at or below which the Sensitivity gate provably cannot reject anything.
+        /// <see cref="double.NaN"/> when <see cref="ExposureRecommender.Recommend"/> was called without detector
+        /// params, which is treated as "unknown", never as "inert".
+        /// </summary>
+        public double InertGateBound { get; set; } = double.NaN;
+
+        /// <summary>
+        /// True when the run's Sensitivity gate sat at or below <see cref="InertGateBound"/> AND
+        /// <see cref="GateRejectedCount"/> is 0 — the gate could not have rejected anything, so its zero rejection
+        /// count is empty by construction and is NOT evidence that the star field is exhausted (F28). Always false
+        /// when the bound is unknown.
+        ///
+        /// <para>The <c>GateRejectedCount == 0</c> conjunct is a consistency guard rather than part of the proof:
+        /// an observed rejection refutes the derivation and wins, which can only happen when the params handed to
+        /// <see cref="ExposureRecommender.Recommend"/> do not describe the run that produced the metrics.</para>
+        /// </summary>
+        public bool GateIsProvablyInert { get; set; }
 
         /// <summary>
         /// Candidates rejected as flat-topped across the whole run (recovery frames included). Heavily defocused
@@ -424,7 +445,16 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// recommend shortening a deliberately long exposure back down to the cap) — the branch is unconditional,
         /// not incidental to either scenario's arithmetic.</para>
         /// </summary>
-        public static ExposureRecommendation Recommend(RunEvaluationMetrics metrics, ObjectiveConstants c, double currentExposureSeconds) {
+        /// <param name="detectorParams">
+        /// The detector settings the scored run was evaluated WITH, used only to compute
+        /// <see cref="StarDetector.InertSensitivityBound"/> so a Sensitivity gate that provably cannot reject
+        /// anything is not mistaken for a field with nothing left (F28). MUST be the variant's own params — pair
+        /// optimized metrics with optimized params and baseline metrics with baseline params, the same way
+        /// <c>OptimizationSummary.VariantSensitivity</c>/<c>BaselineSensitivity</c> are paired. Null ⇒ the bound is
+        /// unknown, and every verdict is identical to the pre-F28 behaviour.
+        /// </param>
+        public static ExposureRecommendation Recommend(RunEvaluationMetrics metrics, ObjectiveConstants c, double currentExposureSeconds,
+                                                       StarDetectorParams detectorParams = null) {
             if (metrics?.FrameStarSnrs == null) {
                 return NoRecommendation(currentExposureSeconds, usableFrameCount: 0, shortFrameCount: 0);
             }
@@ -514,8 +544,32 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // times the exposure bought six stars across five frames. Without this test the probe recommended
             // another doubling every run, and the user climbed 2 s -> 14 s on its advice for nothing.
             var gateIsHoldingStarsBack = gateRejectedCount > 0;
-            var starCountIsTheLimit = signalIsSufficient && everyFrameShort && gateIsHoldingStarsBack;
-            var starFieldIsExhausted = signalIsSufficient && everyFrameShort && !gateIsHoldingStarsBack;
+
+            // ...but a count of zero only MEANS anything when the gate could have produced a non-zero one. The
+            // clip/normalize stage guarantees every candidate's gate statistic exceeds
+            // PeakResponse × EffectiveClipMultiplier (1.5 at shipped defaults), so a Sensitivity at or below that
+            // rejects NOTHING regardless of what the frames contain, and LowSensitivity is identically 0. That
+            // inert region strictly CONTAINS the band this advice is surfaced in — OptimizationSummary
+            // .HasLowStarSignal fires at Sensitivity <= 1.0 — so reading the empty counter as exhaustion made
+            // StarFieldIsExhausted unconditional and StarCountIsTheLimit unreachable for precisely the population
+            // the affordance was written for. That is F28.
+            //
+            // The bound is computed, never hard-coded: PeakResponse and StarClippingMultiplier are both searched
+            // axes, and the donut master caps the effective clip for extended candidates.
+            //
+            // This does NOT walk back the 2/7/14 s measurement above. That rig rejected 5 candidates at 2 s, so
+            // its gate was demonstrably live; it still lands on starFieldIsExhausted, unchanged. The two
+            // populations are disjoint by construction — an inert gate requires gateRejectedCount == 0.
+            var inertGateBound = StarDetector.InertSensitivityBound(detectorParams);
+            // Observation beats derivation: an actual rejection refutes the proof (which can only mean the params
+            // do not describe the run that produced these metrics), so it clears the flag rather than arguing with
+            // it. Unknown params leave the flag false, i.e. byte-identical to the pre-F28 behaviour.
+            var gateIsProvablyInert = !gateIsHoldingStarsBack && double.IsFinite(inertGateBound)
+                && detectorParams.Sensitivity <= inertGateBound;
+            // An absent measurement is not a negative one. An inert gate falls to the PROBE — which ships with its
+            // own stopping rule — rather than to a verdict of exhaustion nothing in the run supports.
+            var starCountIsTheLimit = signalIsSufficient && everyFrameShort && (gateIsHoldingStarsBack || gateIsProvablyInert);
+            var starFieldIsExhausted = signalIsSufficient && everyFrameShort && !gateIsHoldingStarsBack && !gateIsProvablyInert;
             var exposureIsNotTheLimit = signalIsSufficient && !everyFrameShort;
 
             // Sky-limited scaling answers the S/N question only. Under starCountIsTheLimit the ratio is <= 1, so it
@@ -565,7 +619,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 StarCountIsTheLimit = starCountIsTheLimit,
                 StarFieldIsExhausted = starFieldIsExhausted,
                 GateRejectedCount = gateRejectedCount,
-                FlatRejectedCount = flatRejectedCount
+                FlatRejectedCount = flatRejectedCount,
+                InertGateBound = inertGateBound,
+                GateIsProvablyInert = gateIsProvablyInert
             };
         }
 
@@ -584,7 +640,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 StarCountIsTheLimit = false,
                 StarFieldIsExhausted = false,
                 GateRejectedCount = 0,
-                FlatRejectedCount = 0
+                FlatRejectedCount = 0,
+                InertGateBound = double.NaN,
+                GateIsProvablyInert = false
             };
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
@@ -68,10 +68,44 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public double FinalJ { get; set; }
         public int RecommendedStepSize { get; set; }
         public int RecommendedOffsetSteps { get; set; }
-        public int SchemaVersion { get; set; } = 2;
+
+        /// <summary>
+        /// v1 = the original curated knob set. v2 added the defocus-aware axes. v3 added the optional
+        /// <see cref="Provenance"/> block (F30) and changed NO knob semantics, so a v3 file stays knob-compatible
+        /// with v2 in both directions — an older build ignores the unknown key, and a newer build reads a v1/v2
+        /// file with <see cref="Provenance"/> left null. Nothing branches on this number and nothing should start
+        /// REJECTING a higher one: the whole AF-bank toolchain reads this DTO, and a hard version gate would break
+        /// it on the next bump.
+        /// </summary>
+        public const int CurrentSchemaVersion = 3;
+
+        public int SchemaVersion { get; set; } = CurrentSchemaVersion;
+
+        /// <summary>
+        /// WHICH INVOCATION produced this landing — null when that is unknown, which covers every file written
+        /// before schema 3 and every snapshot that captures live settings rather than an optimizer result. Null
+        /// means <b>unattributable</b> and must never be read as "matches me".
+        ///
+        /// <para><b>Why this exists.</b> A landing recorded when it was written and how well it scored, and nothing
+        /// about what produced it. <c>optimize --per-run</c> writes each landing back into the RUN's own folder as
+        /// well as into <c>--out</c> (F15), so a bank folder accumulates whichever prepass went last and a reader
+        /// has to INFER the arm from a knob value. That inference holds only while exactly one knob varies between
+        /// arms. F23 wave 1 ran three arms differing by objective constants and search domain, the inference
+        /// silently broke, and the misattribution produced a wrong followup entry that was committed twice before
+        /// a control arm disproved it.</para>
+        ///
+        /// <para>Omitted from the JSON entirely when null, so a plugin-written snapshot is byte-identical to
+        /// before this field existed.</para>
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public OptimizerProvenance Provenance { get; set; }
 
         public OptimizedStarDetectionSettings Clone() {
-            return (OptimizedStarDetectionSettings)MemberwiseClone();
+            var copy = (OptimizedStarDetectionSettings)MemberwiseClone();
+            // MemberwiseClone is shallow, so without this every copy would ALIAS one provenance instance — and a
+            // mutation through any of them would rewrite the history of all the others.
+            copy.Provenance = Provenance?.Clone();
+            return copy;
         }
 
         /// <summary>
@@ -82,8 +116,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// headless harness (<c>OptimizationDiagnosticRunner</c>) call this so the two paths can never drift.
         /// <see cref="CreatedAtUtc"/> is stamped with <see cref="DateTime.UtcNow"/> at the call site.
         /// </summary>
+        /// <param name="provenance">Optional record of the invocation that produced this landing. Leave it null
+        /// for a snapshot that CAPTURES live settings rather than reporting an optimizer result — the tilt
+        /// wizard's <c>CaptureDetectionSettings</c> is exactly that, and stamping a producer on it would be a
+        /// lie.</param>
         public static OptimizedStarDetectionSettings FromParams(
-            StarDetectorParams p, int runCount, double baselineJ, double finalJ, int recommendedStepSize, int recommendedOffsetSteps) {
+            StarDetectorParams p, int runCount, double baselineJ, double finalJ, int recommendedStepSize, int recommendedOffsetSteps,
+            OptimizerProvenance provenance = null) {
             if (p == null) {
                 throw new ArgumentNullException(nameof(p));
             }
@@ -124,8 +163,51 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 BaselineJ = baselineJ,
                 FinalJ = finalJ,
                 RecommendedStepSize = recommendedStepSize,
-                RecommendedOffsetSteps = recommendedOffsetSteps
+                RecommendedOffsetSteps = recommendedOffsetSteps,
+                Provenance = provenance?.Clone()
             };
+        }
+    }
+
+    /// <summary>
+    /// Which invocation produced an <see cref="OptimizedStarDetectionSettings"/> landing, and under what
+    /// configuration (F30). Metadata only — nothing here is ever applied to
+    /// <see cref="StarDetectorParams"/>, and every overlay helper ignores it.
+    ///
+    /// <para>Every field is optional and the block is omitted from the JSON when null, so a snapshot written by
+    /// the SHIPPING plugin — which has no argv and no harness settings file — stays exactly as it was, and a file
+    /// written before this existed still loads, reporting "no provenance" rather than a fabricated one.</para>
+    /// </summary>
+    [JsonObject(MemberSerialization.OptOut, ItemNullValueHandling = NullValueHandling.Ignore)]
+    public sealed class OptimizerProvenance {
+
+        /// <summary>What wrote this, e.g. <c>"TestApp optimize"</c> or <c>"HocusFocus wizard"</c>. The coarse
+        /// discriminator: argv is meaningful only for the harness.</summary>
+        public string Producer { get; set; }
+
+        /// <summary>The effective command line, arguments joined by a single space. This is the field F30 is
+        /// about: two prepasses differing by one flag are otherwise indistinguishable once written.</summary>
+        public string CommandLine { get; set; }
+
+        /// <summary>Stable fingerprint of the settings the run was DRIVEN by. Hashes the semantic content rather
+        /// than the file's bytes, so re-exporting or re-indenting a settings file does not make a landing look
+        /// like it came from a different configuration.</summary>
+        public string SettingsFingerprint { get; set; }
+
+        /// <summary>Assembly informational version of whatever produced this, so a landing also identifies the
+        /// build it came from.</summary>
+        public string ProducerVersion { get; set; }
+
+        public OptimizerProvenance Clone() => (OptimizerProvenance)MemberwiseClone();
+
+        /// <summary>One-line summary for a log or a console line; skips whatever is unset.</summary>
+        public override string ToString() {
+            var parts = new System.Collections.Generic.List<string>();
+            if (!string.IsNullOrWhiteSpace(Producer)) { parts.Add(Producer); }
+            if (!string.IsNullOrWhiteSpace(ProducerVersion)) { parts.Add($"v{ProducerVersion}"); }
+            if (!string.IsNullOrWhiteSpace(CommandLine)) { parts.Add(CommandLine); }
+            if (!string.IsNullOrWhiteSpace(SettingsFingerprint)) { parts.Add($"settings#{SettingsFingerprint}"); }
+            return parts.Count > 0 ? string.Join(" | ", parts) : "(no provenance)";
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -3119,8 +3119,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     // pass. objectiveConstants (not a fresh ObjectiveConstants) so the recommendation inverts the
                     // SAME NTarget star-count knee the search just optimized against; the aberration-inspection
                     // profile moves that knee to 60.
-                    exposureAdvice = ExposureRecommender.Recommend(bestEval.Metrics, objectiveConstants, runExposureSeconds);
-                    baselineExposureAdvice = ExposureRecommender.Recommend(baselineEval.Metrics, objectiveConstants, runExposureSeconds);
+                    // Each variant gets ITS OWN params: the inert-gate bound is PeakResponse x the effective clip
+                    // multiplier and both are searched axes, so the optimized and current settings can have
+                    // different bounds on the same frames (F28). Same pairing rule as VariantSensitivity /
+                    // BaselineSensitivity.
+                    exposureAdvice = ExposureRecommender.Recommend(bestEval.Metrics, objectiveConstants, runExposureSeconds, res.BestParams);
+                    baselineExposureAdvice = ExposureRecommender.Recommend(baselineEval.Metrics, objectiveConstants, runExposureSeconds, baseline);
                     var (baselineCore, baselineRecovery) = PartitionRecoveryPoints(baselineEval);
                     var (bestCore, bestRecovery) = PartitionRecoveryPoints(bestEval);
                     currentCurveLocal = new OptimizationCurve {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarSignalCopy.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarSignalCopy.cs
@@ -304,6 +304,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // arguing for a SHORTER exposure directly beneath a row proposing a longer one.
             if (advice.StarCountIsTheLimit) {
                 var probe = $"S/N {advice.MeasuredSnr:0.#} already meets the S/N target of {ExposureRecommender.TargetSensitivity:0.#}, so there is no S/N shortfall to derive from. The frames are short of stars, not of signal: this is a {ExposureRecommender.StarCountProbeFactor:0}× probe, {advice.CurrentSeconds:0.##} s → {FormatExposureSeconds(advice.RawSeconds)} s per frame{DescribeSweepCost(advice.RawSeconds, summary.CurrentOffsetSteps)}. Whether more exposure finds more stars depends on the field, so check the star count afterwards.";
+                if (advice.GateIsProvablyInert) {
+                    // Say why the probe is being offered with no rejection evidence behind it. This belongs in the
+                    // derivation tooltip rather than the body: the body is capped at diagnosis plus one
+                    // instruction, and this is background on where the number came from.
+                    probe += $" No candidate was rejected for being too faint, but at a Brightness Sensitivity of {summary.VariantSensitivity:0.###} none could be: the detector's own clipping guarantees every candidate measures at least {advice.InertGateBound:0.##} S/N, so that count is empty by construction and is not evidence either way.";
+                }
                 if (advice.CapLimitsRecommendation) {
                     probe += advice.CappedByAbsoluteLimit
                         ? $" Capped at {advice.RecommendedSeconds:0.##} s: {ExposureRecommender.MaxRecommendedExposureSeconds:0} s per frame is the ceiling a sweep can sustain."

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
@@ -1490,6 +1490,43 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
         }
 
         /// <summary>
+        /// The SMALLEST value <see cref="EffectiveClipMultiplier"/> can return for <paramref name="p"/> across every
+        /// possible candidate size — the donut-capped value when the master can cap at all, else the multiplier
+        /// verbatim. Candidate-size-INDEPENDENT by construction, which is what makes
+        /// <see cref="InertSensitivityBound"/> a property of the SETTINGS rather than of one candidate. Keep in
+        /// lockstep with <see cref="EffectiveClipMultiplier"/>: same predicate, minus the size test.
+        /// </summary>
+        public static double MinEffectiveClipMultiplier(StarDetectorParams p) {
+            if (p.DefocusAwareDonutDetection && p.DefocusDistortionSizeReference > 0.0) {
+                return Math.Min(p.StarClippingMultiplier, DonutClipMultiplierCap);
+            }
+            return p.StarClippingMultiplier;
+        }
+
+        /// <summary>
+        /// Strict lower bound on the Sensitivity-gate statistic for every candidate that reaches the gate. A
+        /// <see cref="StarDetectorParams.Sensitivity"/> at or below this rejects <b>nothing</b>, so
+        /// <see cref="StarDetectorMetrics.LowSensitivity"/> is then identically 0 and its value carries no
+        /// information about the frame at all (followup F28). 0.75 × 2.0 = <b>1.5</b> at shipped defaults.
+        ///
+        /// <para><b>Derivation.</b> Every clip survivor satisfies <c>raw − background &gt; clipMargin =
+        /// EffectiveClipMultiplier · σ</c>, so <c>meanFlux</c> — the mean over exactly those survivors — exceeds it
+        /// too; <c>peak</c> is the max over the same set, so <c>peak ≥ meanFlux</c>; hence
+        /// <c>NormalizedBrightness = peak − (1 − PeakResponse)·meanFlux = (peak − meanFlux) + PeakResponse·meanFlux
+        /// ≥ PeakResponse·meanFlux</c>. Dividing by the same σ the gate divides by gives
+        /// <c>sensitivity &gt; PeakResponse × EffectiveClipMultiplier</c>. The donut branch takes
+        /// <c>max(perPixel, integrated)</c>, so it can only raise the statistic and the bound survives.</para>
+        ///
+        /// <para><b>Not a constant.</b> <see cref="StarDetectorParams.PeakResponse"/> and
+        /// <see cref="StarDetectorParams.StarClippingMultiplier"/> are both searched optimizer axes, so a caller
+        /// must compute this from the params the run was actually evaluated with. Hard-coding 1.5 would be wrong
+        /// for exactly the landings this matters on — F23 wave 1 measured configurations at StarClip 6.25 and
+        /// 6.75, where the bound is over 4×.</para>
+        /// </summary>
+        public static double InertSensitivityBound(StarDetectorParams p) =>
+            p == null ? double.NaN : p.PeakResponse * MinEffectiveClipMultiplier(p);
+
+        /// <summary>
         /// Companion to <see cref="ComputeEffectiveMaxDistortion"/> for the NotCentered gate. Computes the
         /// effective StarCenterTolerance the centering check uses for a candidate of bbox max-dimension
         /// <paramref name="candidateSize"/> (= max(bbox.Width, bbox.Height), the SAME defocus proxy the distortion

--- a/Joko.NINA.Plugins/TestApp/BankVerifyRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/BankVerifyRunner.cs
@@ -410,6 +410,8 @@ namespace TestApp {
 
             // Detect each frame once → golden P/R + sensor-model star lists.
             int tp = 0, fp = 0, fn = 0, matchedHigh = 0, totalHigh = 0, matchedAll = 0, totalAll = 0;
+            // /5 instrument self-checks — see the header comment on the schema field.
+            int detections = 0, truthViolations = 0, nullTp = 0, nullFp = 0;
             var sensorFrames = new List<SensorDetectedStars>();
             DrawingSize imageSize = DrawingSize.Empty;
             foreach (var (focuser, path, image) in loaded) {
@@ -424,15 +426,48 @@ namespace TestApp {
                     var det = stars.Select(s => new DetBox(RectD.FromRect(s.StarBoundingBox), s.Center.X, s.Center.Y)).ToList();
                     var goldenRects = gf.Stars.Select(b => new RectD(b.X, b.Y, b.W, b.H)).ToList();
                     var match = GoldenMatch.Match(goldenRects, det, GoldenMatchMode.Centroid, 0.3, matchRadius);
-                    // F31: subtract detections that land on a box the reference cannot judge — the golden's own
-                    // `unresolved`, PLUS the real-but-unboxed truth stars (`omitted` / `merged-into`) that the
+                    // F31: subtract detections that land on something the reference cannot judge — the golden's
+                    // own `unresolved`, PLUS the real-but-unboxed truth stars (`omitted` / `merged-into`) that the
                     // golden policy dropped. This runner previously did neither, so every detection of a
                     // sub-3.5-SNR real star was charged as a false positive; measured, 96% of the bank's reported
-                    // false positives were real stars. Empty for the real bank (no truth sidecar) => no-op.
-                    var exclusionRects = TruthProtection.BuildExclusionRects(
-                        gf.Unresolved, truthByFocuser.TryGetValue(focuser, out var td) ? td : null, matchRadius);
-                    var falsePositives = GoldenMatch.ExcludeUnresolved(match.FalsePositives, det, exclusionRects);
+                    // false positives were real stars. Both are no-ops on the real bank (no truth sidecar, and a
+                    // pre-v2 golden carries no `unresolved`).
+                    //
+                    // The two exclusions use DIFFERENT predicates, deliberately. The golden's `unresolved` boxes
+                    // keep `GoldenMatch.ExcludeUnresolved`'s `Covers` semantics because that is the real bank's
+                    // scoring path and moving it would break comparability with every published real-bank number.
+                    // The truth protection uses the CENTROID predicate instead — the same one matching uses — so
+                    // a detection is protected iff it would have been MATCHED had the star carried a golden box.
+                    // `Covers` dilates each rect by the DETECTION'S OWN bounding box, which on a wing donut
+                    // reaches far past the match radius; measured on the saved wave-1 dumps that read up to 0.011
+                    // high, always in the flattering direction.
+                    truthByFocuser.TryGetValue(focuser, out var td);
+                    var unresolvedRects = (gf.Unresolved ?? new List<GoldenStarBox>())
+                        .Select(b => new RectD(b.X, b.Y, b.W, b.H)).ToList();
+                    var falsePositives = TruthProtection.ExcludeProtected(
+                        GoldenMatch.ExcludeUnresolved(match.FalsePositives, det, unresolvedRects),
+                        det, TruthProtection.ProtectionCenters(td), matchRadius);
                     tp += match.Pairs.Count; fp += falsePositives.Count; fn += match.FalseNegatives.Count;
+                    detections += det.Count;
+
+                    // The F31 signature, counted rather than reasoned about: a scored false positive that sits on
+                    // a REAL rendered star. Complete by construction, so this has an exact answer and the answer
+                    // must be 0. It was 52/318 on D09 and 79/337 on D17 under the /3 metric.
+                    truthViolations += TruthProtection.CountWithinRadius(
+                        falsePositives, det, TruthProtection.AllCenters(td), matchRadius);
+
+                    // The NULL CONTROL. Same detections, translated with wraparound: whatever precision survives
+                    // is chance coincidence. A metric reading 1.000 with a null near 0 is measuring; one reading
+                    // 1.000 with a high null is saturated, which is how the first cut of the F31 repair failed.
+                    if (td != null) {
+                        var shifted = TruthProtection.ShiftForNullControl(det, props.Width, props.Height);
+                        var nullMatch = GoldenMatch.Match(goldenRects, shifted, GoldenMatchMode.Centroid, 0.3, matchRadius);
+                        var nullFalsePositives = TruthProtection.ExcludeProtected(
+                            GoldenMatch.ExcludeUnresolved(nullMatch.FalsePositives, shifted, unresolvedRects),
+                            shifted, TruthProtection.ProtectionCenters(td), matchRadius);
+                        nullTp += nullMatch.Pairs.Count;
+                        nullFp += nullFalsePositives.Count;
+                    }
                     var matchedGolden = new HashSet<int>(match.Pairs.Select(x => x.Golden));
                     for (int gi = 0; gi < gf.Stars.Count; gi++) {
                         var matched = matchedGolden.Contains(gi);
@@ -451,9 +486,24 @@ namespace TestApp {
             cm.precision = prAll.Precision;
             cm.recallAll = totalAll > 0 ? (double)matchedAll / totalAll : double.NaN;
             cm.recallHigh = totalHigh > 0 ? (double)matchedHigh / totalHigh : double.NaN;
+            cm.detections = detections;
+            cm.truthViolations = truthViolations;
+            // How much of the detection set the precision ratio actually saw. Protection removes a detection from
+            // BOTH sides rather than crediting it, so a low value does not bias precision — but it does mean the
+            // number rests on a smaller sample, and at Sensitivity 0 that reaches ~57% on D17. Reported so a reader
+            // can weigh a precision figure instead of assuming every detection was judged.
+            cm.scoredFraction = detections > 0 ? (double)(tp + fp) / detections : double.NaN;
+            cm.precisionNull = (nullTp + nullFp) > 0 ? (double)nullTp / (nullTp + nullFp) : double.NaN;
 
             // Sensor-model paraboloid fit (reuses SensorModel.RegisterStarsAndFit, like inspect-align).
-            Prog($"  [{label}] golden done (P={cm.precision:F3} R@hi={cm.recallHigh:F3}); sensor fit start");
+            Prog($"  [{label}] golden done (P={cm.precision:F3} null={cm.precisionNull:F3} viol={cm.truthViolations} R@hi={cm.recallHigh:F3}); sensor fit start");
+            if (cm.truthViolations > 0) {
+                // Loud on purpose. This is the exact shape of F31, and four harness-calibration bugs have now
+                // been found by someone happening to look rather than by anything failing.
+                Console.WriteLine($"    !! [{label}] {cm.truthViolations} scored false positive(s) sit on a REAL rendered star "
+                    + "— the precision metric is charging for correct detections again (F31). Precision from this run is not trustworthy.");
+                Logger.Warning($"bank-verify {label}: {cm.truthViolations} scored false positives land within the match radius of a truth star (F31 regression)");
+            }
             try {
                 var focuserSizeMicrons = inspectorOptions.MicronsPerFocuserStep > 0 ? inspectorOptions.MicronsPerFocuserStep : 1.0;
                 var pixelSize = activeProfile.CameraSettings.PixelSize > 0 ? activeProfile.CameraSettings.PixelSize : 3.76;
@@ -580,7 +630,16 @@ namespace TestApp {
                 // F31 bumps this to /4: false positives are no longer charged for detections of real stars the
                 // golden policy dropped, so precision from a /4 report is NOT comparable to a /3 one. Recall is
                 // unchanged by construction (the golden's `stars` list still defines what must be found).
-                schema = "afbank-verify/4",
+                // /5 makes the metric self-checking rather than merely repaired. Three additions:
+                //   - truth protection now uses the CENTROID predicate matching itself uses, instead of
+                //     GoldenMatch.Covers, which dilated every protection box by the detection's own bounding box
+                //     and read up to 0.011 high on donut frames;
+                //   - `precisionNull` reports what chance alone scores, so a 1.000 can be told from a saturated
+                //     metric without re-deriving anything (the first cut of the F31 repair was saturated);
+                //   - `truthViolations` counts scored false positives sitting on real rendered stars, which is
+                //     the F31 signature itself and must be 0.
+                // Precision from /5 is comparable to /4 to within the protection-predicate change above.
+                schema = "afbank-verify/5",
                 generatedUtc = utc,
                 detectorCommit = commit,
                 // The bank-wide --pixel-scale mode ("header" default, "profile" the pre-V-P1 escape hatch). The
@@ -652,14 +711,19 @@ namespace TestApp {
             sb.AppendLine();
             sb.AppendLine("## Per-run (config rows)");
             sb.AppendLine();
-            sb.AppendLine("| run | camera | golden (≥12) | donutAware | config | NC | recall@≥12 | recall@all | precision | AF σ | AF R² | sensor R² | RMS µm | sChi | tilt° | stars | aligned |");
-            sb.AppendLine("|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|");
+            sb.AppendLine("| run | camera | golden (≥12) | donutAware | config | NC | recall@≥12 | recall@all | precision | null | scored | viol | AF σ | AF R² | sensor R² | RMS µm | sChi | tilt° | stars | aligned |");
+            sb.AppendLine("|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|");
             foreach (var r in runs) {
-                if (r.error != null) { sb.AppendLine($"| {r.runId} | — | — | — | ERROR | | | | | | | | | | | | {r.error} |"); continue; }
+                if (r.error != null) { sb.AppendLine($"| {r.runId} | — | — | — | ERROR | | | | | | | | | | | | | | | {r.error} |"); continue; }
                 foreach (var c in r.configs) {
-                    sb.AppendLine($"| {r.runId} | {r.camera} | {r.goldenStars} ({r.goldenSNRge12}) | {r.donutAware} | {c.config} | {Fmt(c.nc)} | {Fmt(c.recallHigh)} | {Fmt(c.recallAll)} | {Fmt(c.precision)} | {Fmt(c.sigmaFocus)} | {Fmt(c.afR2)} | {Fmt(c.sR2)} | {Fmt(c.sRMS)} | {Fmt(c.sChi)} | {Fmt(c.sTheta)} | {c.sStars} | {c.framesAligned}/{r.framesTotal} |");
+                    sb.AppendLine($"| {r.runId} | {r.camera} | {r.goldenStars} ({r.goldenSNRge12}) | {r.donutAware} | {c.config} | {Fmt(c.nc)} | {Fmt(c.recallHigh)} | {Fmt(c.recallAll)} | {Fmt(c.precision)} | {Fmt(c.precisionNull)} | {Fmt(c.scoredFraction)} | {c.truthViolations} | {Fmt(c.sigmaFocus)} | {Fmt(c.afR2)} | {Fmt(c.sR2)} | {Fmt(c.sRMS)} | {Fmt(c.sChi)} | {Fmt(c.sTheta)} | {c.sStars} | {c.framesAligned}/{r.framesTotal} |");
                 }
             }
+            sb.AppendLine();
+            sb.AppendLine("**null** is the precision the same detections earn after being translated with wraparound — chance alone. "
+                + "It is the floor this metric can read; a precision of 1.000 means the detector found no false positives only when null is near 0. "
+                + "**scored** is the fraction of detections that entered the precision ratio at all (the rest sit on reference objects that cannot be judged). "
+                + "**viol** counts scored false positives sitting on a real rendered star and MUST be 0 — see F31.");
             File.WriteAllText(Path.Combine(outDir, $"verification_{utc}.md"), sb.ToString());
         }
 
@@ -707,6 +771,26 @@ namespace TestApp {
             public double sRMS { get; set; } = double.NaN;
             public double sChi { get; set; } = double.NaN;
             public double sTheta { get; set; } = double.NaN;
+            /// <summary>Accepted stars this config detected across the run's scored frames — the denominator
+            /// <see cref="scoredFraction"/> is a fraction of.</summary>
+            public int detections { get; set; }
+            /// <summary>Scored false positives that sit within the match radius of a REAL rendered truth star.
+            /// MUST be 0: synthetic truth is complete by construction, so a detection on a rendered star is
+            /// correct whatever tier the golden policy gave it. Non-zero means F31 has regressed and this run's
+            /// precision is not trustworthy. Always 0 on the real bank, which has no truth sidecar.</summary>
+            public int truthViolations { get; set; }
+            /// <summary>Fraction of <see cref="detections"/> that entered the precision ratio (the rest landed on
+            /// protected or unresolved reference objects and are unjudgeable). Not a bias — protection removes a
+            /// detection from both numerator and denominator — but precision rests on a smaller sample as this
+            /// falls, and at Sensitivity 0 it reaches ~0.57.</summary>
+            public double scoredFraction { get; set; } = double.NaN;
+            /// <summary>NULL CONTROL: precision after translating every detection with wraparound, destroying
+            /// correspondence with the frame while preserving count and clustering. This is the score chance
+            /// alone earns, and therefore the floor the metric cannot read below. A precision of 1.000 means
+            /// something only when this is near 0 — the first cut of the F31 repair read 1.000 everywhere
+            /// BECAUSE it was saturated, which the precision column alone cannot distinguish. NaN on the real
+            /// bank (no truth sidecar, so no synthetic null is defined).</summary>
+            public double precisionNull { get; set; } = double.NaN;
             public int framesAligned { get; set; }
         }
 

--- a/Joko.NINA.Plugins/TestApp/GoldenEvalRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/GoldenEvalRunner.cs
@@ -265,10 +265,18 @@ namespace TestApp {
                 // policy dropped (`omitted` / `merged-into`). Without the second group, every detection of a
                 // sub-3.5-SNR real star is charged as a false positive — 96% of the synthetic bank's reported
                 // false positives were real stars. No sidecar (the real bank) => identical to before.
-                var unresolvedRects = TruthProtection.BuildExclusionRects(
-                    gf.Unresolved, TruthProtection.LoadForImage(frame.Path), effectiveMatchRadius);
+                //
+                // The truth half uses the CENTROID predicate (the one matching itself uses) rather than
+                // GoldenMatch.Covers, which dilates each rect by the detection's own bounding box and so protects
+                // a wide donut detection far past the match radius. Kept identical to BankVerifyRunner so the two
+                // harnesses cannot disagree about what a false positive is.
+                var truthDispositions = TruthProtection.LoadForImage(frame.Path);
+                var unresolvedRects = (gf.Unresolved ?? new List<GoldenStarBox>())
+                    .Select(b => new RectD(b.X, b.Y, b.W, b.H)).ToList();
                 var match = GoldenMatch.Match(goldenRects, det, matchMode, tau, effectiveMatchRadius);
-                var falsePositives = GoldenMatch.ExcludeUnresolved(match.FalsePositives, det, unresolvedRects);
+                var falsePositives = TruthProtection.ExcludeProtected(
+                    GoldenMatch.ExcludeUnresolved(match.FalsePositives, det, unresolvedRects),
+                    det, TruthProtection.ProtectionCenters(truthDispositions), effectiveMatchRadius);
 
                 var fe = new FrameEval {
                     FocuserPosition = frame.FocuserPosition,

--- a/Joko.NINA.Plugins/TestApp/HarnessSettingsStore.cs
+++ b/Joko.NINA.Plugins/TestApp/HarnessSettingsStore.cs
@@ -17,6 +17,7 @@ using NINA.Profile.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace TestApp {
 
@@ -207,6 +208,48 @@ namespace TestApp {
             public double FocalLengthMm { get; set; }
             public string Path { get; set; }
             public bool WasBootstrapped { get; set; }
+        }
+
+        /// <summary>
+        /// Stable fingerprint of the settings a run was ACTUALLY driven by (F30): the resolved pixel-scale inputs
+        /// plus the settings file's own contents. Hashes the file's SEMANTIC content, not its bytes — a settings
+        /// file that is re-exported or re-indented must not make a landing look as though it came from a different
+        /// configuration.
+        ///
+        /// <para>Returns null when there is nothing to fingerprint, which reads as "unknown" downstream rather
+        /// than as a match. Never throws: a fingerprint is diagnostic metadata, and failing to compute one must
+        /// not abort an optimize run that is otherwise fine.</para>
+        /// </summary>
+        public static string Fingerprint(Resolved resolved) {
+            if (resolved == null) {
+                return null;
+            }
+            try {
+                var inv = System.Globalization.CultureInfo.InvariantCulture;
+                var sb = new System.Text.StringBuilder();
+                // '#'-prefixed so these can never collide with an option key of the same name.
+                sb.Append("#pixelSizeMicrons=").Append(resolved.PixelSizeMicrons.ToString("R", inv)).Append('\n');
+                sb.Append("#focalLengthMm=").Append(resolved.FocalLengthMm.ToString("R", inv)).Append('\n');
+                if (!string.IsNullOrEmpty(resolved.Path) && File.Exists(resolved.Path)) {
+                    // The file's parsed option bag, key-sorted, rather than its raw text: whitespace, key order and
+                    // the export-provenance fields (ExportedAtUtc / ExportedFromProfile / DerivedNotes) all move
+                    // without changing a single detection.
+                    var parsed = Newtonsoft.Json.Linq.JObject.Parse(File.ReadAllText(resolved.Path));
+                    var options = parsed["Options"] as Newtonsoft.Json.Linq.JObject;
+                    if (options != null) {
+                        foreach (var prop in options.Properties().OrderBy(x => x.Name, StringComparer.Ordinal)) {
+                            sb.Append(prop.Name).Append('=').Append(prop.Value?.ToString(Newtonsoft.Json.Formatting.None)).Append('\n');
+                        }
+                    }
+                }
+                using var sha = System.Security.Cryptography.SHA256.Create();
+                var hash = sha.ComputeHash(System.Text.Encoding.UTF8.GetBytes(sb.ToString()));
+                // 12 hex chars: enough to distinguish the handful of configurations a bank session uses, short
+                // enough to read in a console line.
+                return BitConverter.ToString(hash, 0, 6).Replace("-", string.Empty).ToLowerInvariant();
+            } catch (Exception) {
+                return null;
+            }
         }
 
         /// <summary>

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -827,7 +827,7 @@ namespace TestApp {
             var landedSensitivity = outcome.Result.BestParams.Sensitivity;
             var sensitivityAtFloor = ExposureRecommender.SensitivityIsAtFloor(landedSensitivity);
             var exposureRecommendation = sensitivityAtFloor
-                ? ExposureRecommender.Recommend(bestM, outcome.ObjectiveConstants, run.CapturedExposureSeconds)
+                ? ExposureRecommender.Recommend(bestM, outcome.ObjectiveConstants, run.CapturedExposureSeconds, outcome.Result.BestParams)
                 : null;
 
             return new AggregateRow {
@@ -1171,7 +1171,9 @@ namespace TestApp {
                 // this set, so its Sensitivity is the same landed value for each row; bestM/run.CapturedExposureSeconds
                 // are this run's own metrics/exposure, and c is the same ObjectiveConstants the runs were scored with.
                 var sensitivityIsAtFloor = ExposureRecommender.SensitivityIsAtFloor(result.BestParams.Sensitivity);
-                var exposureRec = sensitivityIsAtFloor ? ExposureRecommender.Recommend(bestM, c, run.CapturedExposureSeconds) : null;
+                var exposureRec = sensitivityIsAtFloor
+                    ? ExposureRecommender.Recommend(bestM, c, run.CapturedExposureSeconds, result.BestParams)
+                    : null;
                 AppendExposureRecommendationLines(sb, "    ", result.BestParams.Sensitivity, sensitivityIsAtFloor, exposureRec);
             }
             sb.AppendLine();

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -185,6 +185,18 @@ namespace TestApp {
             // profile-sourced seed is mutable machine state nothing records, and TryLoad("") picks whichever
             // profile is ACTIVE -- two runs of the same data minutes apart were seeded from different telescopes.
             var harnessSettings = HarnessSettingsStore.Resolve(args, profileService, activeProfile);
+            // F30: a landing must say which invocation produced it. Without this, `optimize --per-run` writing
+            // back into each run's own folder (F15) leaves a bank holding whichever prepass went last, and the
+            // only way to tell two arms apart is to INFER the arm from a knob — an inference that broke the moment
+            // F23 wave 1 ran three arms differing by more than one flag.
+            var provenance = new OptimizerProvenance {
+                Producer = "TestApp optimize",
+                CommandLine = string.Join(" ", args ?? Array.Empty<string>()),
+                SettingsFingerprint = HarnessSettingsStore.Fingerprint(harnessSettings),
+                ProducerVersion = (System.Reflection.CustomAttributeExtensions.GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>(
+                    System.Reflection.Assembly.GetEntryAssembly()))?.InformationalVersion
+            };
+            Console.WriteLine($"provenance: {provenance}");
             var accessor = harnessSettings.Accessor;
             var starDetectionOptions = new StarDetectionOptions(profileService, accessor);
             var afOptions = new AutoFocusOptions(profileService);
@@ -294,6 +306,7 @@ namespace TestApp {
             var ctx = new RunDetectionContext {
                 ProfileService = profileService,
                 HarnessSettings = harnessSettings,
+                Provenance = provenance,
                 AfOptions = afOptions,
                 AlglibAPI = alglibAPI,
                 Detector = detector,
@@ -352,6 +365,10 @@ namespace TestApp {
             public bool Inspection;     // --inspection: use the aberration-inspection objective
             public bool LegacyObjective; // --legacy-objective: zero the HFR-outlier penalty + coverage reward (A/B "before")
             public int ContinueRounds;  // --continue-rounds: extra chained passes after the first (0-2)
+
+            // F30: which invocation is producing these landings. Stamped onto every optimized_settings.json this
+            // run writes, so a bank folder full of prepasses from different arms stops being ambiguous.
+            public OptimizerProvenance Provenance;
 
             // F23 arm selectors; null ⇒ shipping default. See the flag comments in RunImpl.
             public double? SensitivityFloor;      // --sensitivity-floor: mechanism (b)
@@ -686,7 +703,7 @@ namespace TestApp {
             // so the headless and in-app handoffs can never drift. The source-folder copies each carry that run's OWN
             // recommended step (StepSizeRecommender, exactly as BuildAggregateRow computes it); the single --out copy
             // uses the representative (first) run's step in joint mode (see WriteOptimizedSettings).
-            WriteOptimizedSettings(targetDir, loadedRuns, perRunBest, result, baselineJ, focuserMaxStep);
+            WriteOptimizedSettings(targetDir, loadedRuns, perRunBest, result, baselineJ, focuserMaxStep, ctx.Provenance);
 
             await WriteAnnotatedFrames(targetDir, loadedRuns, result.BestParams, ctx.Detector,
                 ctx.MeasurementAverage, ctx.HighSigmaOutlierRejection, ctx.LowSigmaOutlierRejection, ctx.AnnotateAll).ConfigureAwait(false);
@@ -719,14 +736,14 @@ namespace TestApp {
         /// </summary>
         private static void WriteOptimizedSettings(
             string targetDir, List<LoadedHarnessRun> loadedRuns, List<RunEvaluationResult> perRunBest,
-            OptimizationResult result, double baselineJ, int? focuserMaxStep) {
+            OptimizationResult result, double baselineJ, int? focuserMaxStep, OptimizerProvenance provenance = null) {
             // Per-run source-folder copies: each run's frame directory gets the winner snapshot with its OWN step.
             for (int i = 0; i < loadedRuns.Count; i++) {
                 var run = loadedRuns[i];
                 try {
                     var rec = StepSizeRecommender.Recommend(perRunBest[i].BestFit, run.StepSize, focuserMaxStep);
                     var dto = OptimizedStarDetectionSettings.FromParams(
-                        result.BestParams, loadedRuns.Count, baselineJ, result.BestJ, rec.StepSize, rec.OffsetSteps);
+                        result.BestParams, loadedRuns.Count, baselineJ, result.BestJ, rec.StepSize, rec.OffsetSteps, provenance);
                     var json = JsonConvert.SerializeObject(dto);
 
                     // The run's source folder is the directory holding its frames (each run's frames live together).
@@ -753,7 +770,7 @@ namespace TestApp {
                 try {
                     var rec = StepSizeRecommender.Recommend(perRunBest[0].BestFit, representative.StepSize, focuserMaxStep);
                     var dto = OptimizedStarDetectionSettings.FromParams(
-                        result.BestParams, loadedRuns.Count, baselineJ, result.BestJ, rec.StepSize, rec.OffsetSteps);
+                        result.BestParams, loadedRuns.Count, baselineJ, result.BestJ, rec.StepSize, rec.OffsetSteps, provenance);
                     var json = JsonConvert.SerializeObject(dto);
                     var outPath = Path.Combine(targetDir, "optimized_settings.json");
                     File.WriteAllText(outPath, json);

--- a/Joko.NINA.Plugins/TestApp/SynthBank/ConvergenceBand.cs
+++ b/Joko.NINA.Plugins/TestApp/SynthBank/ConvergenceBand.cs
@@ -1,0 +1,67 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+
+namespace TestApp.SynthBank {
+
+    /// <summary>
+    /// The one definition of "this step counts as converged", shared by <c>SynthValidateRunner</c>'s two stop
+    /// branches so they cannot drift apart — which they had.
+    ///
+    /// <para><b>The bug this exists to prevent.</b> A round that applied nothing used to set
+    /// <c>stoppedReason = "converged (round applied nothing)"</c> unconditionally, and the terminal's
+    /// <c>Converged</c> flag was then derived by string-matching that reason for a "converged" prefix. But
+    /// <c>StepSizeRecommender.Degenerate</c> holds the CURRENT step whenever the fit is unusable — no
+    /// <c>Fitting</c>, a non-finite vertex, a non-positive minimum HFR, or the 3× band never crossed — so a
+    /// broken fit produces a no-op recommendation that is byte-identical to the recommender genuinely agreeing.
+    /// The loop read "nothing changed" as success. Measured on <c>D05_tec140_1000mm</c> S2: <c>converged: true</c>
+    /// at <c>finalStepSize</c> 140 against <c>stepBehavioral</c> 35, while assertion A3 scored that same number
+    /// against [21, 56] and FAILED it — the two verdicts contradicting each other inside one JSON object. The
+    /// effect is to inflate convergence counts on exactly the runs that are most broken.</para>
+    ///
+    /// <para><b>Why the tolerance band and not A3's.</b> A3 asserts <c>[0.6, 1.6] × step_behavioral</c>; this band
+    /// is <c>±max(0.5, tolerance · |step_behavioral|)</c>, i.e. <c>[0.6, 1.4] ×</c> at the default tolerance of
+    /// 0.4. It is a strict SUBSET sharing A3's lower bound, so a run this calls converged can never be one A3
+    /// rejects. Choosing the looser band would have re-opened the same contradiction from the other side.</para>
+    ///
+    /// <para>Pure, dependency-free and source-linked into the test project, because a predicate that decides
+    /// whether a harness is reporting success needs its own tests more than most code does. Three of the four
+    /// harness-calibration bugs found on this bank were in this family.</para>
+    /// </summary>
+    public static class ConvergenceBand {
+
+        /// <summary>
+        /// Half-width of the band a step must land inside to be called converged, or <see cref="double.NaN"/> when
+        /// <paramref name="stepBehavioral"/> never reached a finite positive fixed point and no band is definable.
+        ///
+        /// <para>The <c>0.5</c> floor keeps the band meaningful for very small behavioral steps, where a pure
+        /// fractional tolerance would demand exactness the integer step grid cannot express.</para>
+        /// </summary>
+        public static double HalfWidth(double stepBehavioral, double tolerance) {
+            if (!double.IsFinite(stepBehavioral) || stepBehavioral <= 0.0) {
+                return double.NaN;
+            }
+            return Math.Max(0.5, tolerance * Math.Abs(stepBehavioral));
+        }
+
+        /// <summary>
+        /// Whether <paramref name="step"/> is inside the band. <b>False when the band is undefined</b> — an
+        /// unknown band is not a passing one, and <see cref="Contains"/> is only ever asked in order to make a
+        /// positive claim. Callers that must still stop on an undefined band handle that case explicitly rather
+        /// than inheriting a permissive default from here.
+        /// </summary>
+        public static bool Contains(int step, double stepBehavioral, double halfWidth) =>
+            double.IsFinite(halfWidth) && double.IsFinite(stepBehavioral)
+                && Math.Abs(step - stepBehavioral) <= halfWidth;
+    }
+}

--- a/Joko.NINA.Plugins/TestApp/SynthBank/TruthProtection.cs
+++ b/Joko.NINA.Plugins/TestApp/SynthBank/TruthProtection.cs
@@ -156,6 +156,15 @@ namespace TestApp.SynthBank {
         /// Convenience for a scoring loop: the golden's own <c>unresolved</c> boxes plus the truth-derived
         /// protection boxes, as the rect list <see cref="GoldenMatch.ExcludeUnresolved"/> expects. Both inputs
         /// may be null.
+        ///
+        /// <para><b>Prefer <see cref="ExcludeProtected"/> for the truth half.</b> <see cref="GoldenMatch.ExcludeUnresolved"/>
+        /// applies <c>centre-in-box OR IoU(box, detection bbox) &gt; 0</c>, so the DETECTION'S OWN bounding box
+        /// dilates every rect — a wide donut detection is excluded well past the match radius, which is not what
+        /// "protection is exactly as generous as matching" says. Measured on the saved wave-1 detection dumps,
+        /// that reads up to 0.011 high (D09 s0: 1.0000 against 0.9909 symmetric; D17 s0: 0.9895 against 0.9793) —
+        /// small, but systematic and always flattering. This overload is kept for the golden's own
+        /// <c>unresolved</c> boxes, whose <c>Covers</c> semantics are the REAL bank's scoring path and must not
+        /// move.</para>
         /// </summary>
         public static List<RectD> BuildExclusionRects(
                 IReadOnlyList<GoldenStarBox> goldenUnresolved,
@@ -167,6 +176,116 @@ namespace TestApp.SynthBank {
             }
             rects.AddRange(BuildProtectionBoxes(dispositions, matchRadius).Select(b => new RectD(b.X, b.Y, b.W, b.H)));
             return rects;
+        }
+
+        /// <summary>Binned centres of the real-but-unboxed truth stars (<see cref="UnboxedRealTiers"/>) — the
+        /// population <see cref="ExcludeProtected"/> protects. Empty for a null/absent sidecar.</summary>
+        public static List<(double X, double Y)> ProtectionCenters(IReadOnlyList<SyntheticStarDisposition> dispositions) =>
+            Centers(dispositions, d => UnboxedRealTiers.Contains(d.Tier ?? string.Empty));
+
+        /// <summary>Binned centres of EVERY star in the sidecar, whatever tier the golden policy gave it. This is
+        /// the complete rendered population, so "is there a real star here?" has an exact answer — which is what
+        /// <see cref="CountWithinRadius"/> turns into the F31 regression guard.</summary>
+        public static List<(double X, double Y)> AllCenters(IReadOnlyList<SyntheticStarDisposition> dispositions) =>
+            Centers(dispositions, _ => true);
+
+        private static List<(double X, double Y)> Centers(
+                IReadOnlyList<SyntheticStarDisposition> dispositions, Func<SyntheticStarDisposition, bool> predicate) {
+            var pts = new List<(double X, double Y)>();
+            if (dispositions == null) {
+                return pts;
+            }
+            foreach (var d in dispositions) {
+                if (d == null || !predicate(d)) {
+                    continue;
+                }
+                if (!double.IsFinite(d.BinnedCenterX) || !double.IsFinite(d.BinnedCenterY)) {
+                    continue; // cannot protect what we cannot place
+                }
+                pts.Add((d.BinnedCenterX, d.BinnedCenterY));
+            }
+            return pts;
+        }
+
+        /// <summary>
+        /// Drops false positives whose CENTROID is within <paramref name="radius"/> of a protected truth star —
+        /// exactly the predicate <see cref="GoldenMatch.Match"/> uses in <see cref="GoldenMatchMode.Centroid"/>
+        /// mode, so a detection is excluded iff it would have been MATCHED had this star carried a golden box.
+        /// Anything wider invents true positives; anything narrower re-creates F31.
+        /// </summary>
+        public static List<int> ExcludeProtected(
+                IReadOnlyList<int> falsePositives, IReadOnlyList<DetBox> detected,
+                IReadOnlyList<(double X, double Y)> centers, double radius) {
+            if (falsePositives == null) {
+                return new List<int>();
+            }
+            if (centers == null || centers.Count == 0 || !(radius > 0.0)) {
+                return falsePositives.ToList();
+            }
+            return falsePositives.Where(di => !WithinRadius(detected[di], centers, radius)).ToList();
+        }
+
+        /// <summary>How many of <paramref name="indices"/> sit within <paramref name="radius"/> of one of
+        /// <paramref name="centers"/>. Used with <see cref="AllCenters"/> to count scored false positives that
+        /// are in fact real rendered stars — the F31 signature, which must be 0.</summary>
+        public static int CountWithinRadius(
+                IReadOnlyList<int> indices, IReadOnlyList<DetBox> detected,
+                IReadOnlyList<(double X, double Y)> centers, double radius) {
+            if (indices == null || centers == null || centers.Count == 0 || !(radius > 0.0)) {
+                return 0;
+            }
+            return indices.Count(di => WithinRadius(detected[di], centers, radius));
+        }
+
+        private static bool WithinRadius(DetBox det, IReadOnlyList<(double X, double Y)> centers, double radius) {
+            var r2 = radius * radius;
+            foreach (var (x, y) in centers) {
+                var dx = det.Cx - x;
+                var dy = det.Cy - y;
+                if (dx * dx + dy * dy <= r2) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// The NULL CONTROL: every detection translated by (<see cref="NullShiftX"/>, <see cref="NullShiftY"/>)
+        /// with wraparound. Detection count and spatial clustering survive; correspondence with the frame does
+        /// not. Re-scoring these against the same reference gives the precision a detector would earn by
+        /// CHANCE — the floor the metric can never read below, and therefore the only honest way to tell a real
+        /// 1.000 from a saturated one.
+        ///
+        /// <para>This exists because the F31 repair failed twice in opposite directions before it worked: first
+        /// biased (the golden omitted real stars), then saturated (protection sized by 2·HFR read 1.000 on all
+        /// 17 datasets and measured nothing). Both look like a clean result from the precision column alone. A
+        /// reported null makes the difference checkable instead of something a reader has to think to ask.</para>
+        /// </summary>
+        public static List<DetBox> ShiftForNullControl(IReadOnlyList<DetBox> detected, int frameWidth, int frameHeight) {
+            var shifted = new List<DetBox>();
+            if (detected == null || frameWidth <= 0 || frameHeight <= 0) {
+                return shifted;
+            }
+            foreach (var d in detected) {
+                var cx = Wrap(d.Cx + NullShiftX, frameWidth);
+                var cy = Wrap(d.Cy + NullShiftY, frameHeight);
+                var bx = Wrap(d.Box.X + NullShiftX, frameWidth);
+                var by = Wrap(d.Box.Y + NullShiftY, frameHeight);
+                shifted.Add(new DetBox(new RectD(bx, by, d.Box.W, d.Box.H), cx, cy));
+            }
+            return shifted;
+        }
+
+        /// <summary>Null-control translation, x (px). Far larger than any PSF or match radius in the bank, and
+        /// not a round number, so it cannot line up with a rendered grid.</summary>
+        public const int NullShiftX = 317;
+
+        /// <summary>Null-control translation, y (px) — see <see cref="NullShiftX"/>.</summary>
+        public const int NullShiftY = 211;
+
+        private static double Wrap(double v, int extent) {
+            var m = v % extent;
+            return m < 0 ? m + extent : m;
         }
     }
 }

--- a/Joko.NINA.Plugins/TestApp/SynthValidateRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/SynthValidateRunner.cs
@@ -443,6 +443,23 @@ namespace TestApp.SynthBank {
 
             var scenarioDir = Path.Combine(datasetOutDir, scenario.Id);
             string stoppedReason = null;
+            var converged = false;
+
+            // ONE definition of the tolerance band a convergence CLAIM is judged against, shared by both stop
+            // branches below. They used to disagree: a round that applied nothing declared convergence at ANY
+            // step, while assertion A3 scored that same step against a band and FAILED it — `D05_tec140_1000mm`
+            // S2 reported `converged: true` with `finalStepSize` 140 against `stepBehavioral` 35 and an A3 band
+            // of [21,56], in the same JSON object as the assertion rejecting it. That inflates convergence counts
+            // on precisely the runs that are most broken, and it is the fourth bug found in this family.
+            //
+            // The band is the loop's own (±max(0.5, tolerance·|step_behavioral|), i.e. [0.6,1.4]× at the default
+            // tolerance 0.4), which is a strict SUBSET of A3's [0.6,1.6]× and shares its lower bound — so a run
+            // this now calls converged cannot be one A3 fails. Gated only on `stepBehavioral` being a finite
+            // fixed point, exactly like A3, rather than on `isConvergenceScenario`: whether stopping EARLY is
+            // desirable depends on the scenario, but whether a stop deserves to be CALLED convergence does not.
+            var stepBand = ConvergenceBand.HalfWidth(stepBehavioral, expected.StepSizeTolerance);
+            var bandKnown = double.IsFinite(stepBand);
+            bool WithinStepBand(int step) => ConvergenceBand.Contains(step, stepBehavioral, stepBand);
 
             for (var roundIndex = 0; roundIndex < effectiveMaxRounds; roundIndex++) {
                 token.ThrowIfCancellationRequested();
@@ -465,7 +482,20 @@ namespace TestApp.SynthBank {
                     break;
                 }
                 if (!roundReport.Applied.AppliedAnything) {
-                    stoppedReason = "converged (round applied nothing)";
+                    // A no-op round always STOPS the loop — the recommender is not going to move on its own — but
+                    // it is only CONVERGENCE if it stopped somewhere the scenario would accept. A degenerate fit
+                    // produces a byte-identical no-op: `StepSizeRecommender.Degenerate` holds the current step
+                    // when there is no `Fitting`, when the vertex or minimum HFR is non-finite, or when the 3x
+                    // band is never crossed. So "nothing changed" is exactly as consistent with a broken fit as
+                    // with a converged one, and the step VALUE is the only thing that separates them.
+                    if (!bandKnown || WithinStepBand(state.StepSize)) {
+                        converged = true;
+                        stoppedReason = "converged (round applied nothing)";
+                    } else {
+                        stoppedReason = $"stalled (round applied nothing, but step {state.StepSize} is outside the "
+                            + $"{stepBand:0.###} tolerance band of step_behavioral {stepBehavioral:0.###}) — "
+                            + "a no-op recommendation from a degenerate fit, not convergence";
+                    }
                     break;
                 }
                 // Converged ALSO means "inside the tolerance band", not only "applied literally nothing". The
@@ -476,18 +506,19 @@ namespace TestApp.SynthBank {
                 // of 127 in ONE round from a 4x-too-coarse start of 508, then jittered 132/129/124, and was
                 // flagged "expected convergence within <= 2 round(s), used 4". Stopping at the band makes
                 // RoundsUsed mean "rounds to reach the target", which is what the scenario expectations are about.
-                if (isConvergenceScenario && double.IsFinite(stepBehavioral) && stepBehavioral > 0) {
-                    var band = Math.Max(0.5, expected.StepSizeTolerance * Math.Abs(stepBehavioral));
-                    if (Math.Abs(state.StepSize - stepBehavioral) <= band) {
-                        stoppedReason = $"converged (step {state.StepSize} within the {band:0.###} tolerance band of step_behavioral {stepBehavioral:0.###})";
-                        break;
-                    }
+                if (isConvergenceScenario && WithinStepBand(state.StepSize)) {
+                    converged = true;
+                    stoppedReason = $"converged (step {state.StepSize} within the {stepBand:0.###} tolerance band of step_behavioral {stepBehavioral:0.###})";
+                    break;
                 }
             }
 
-            var converged = stoppedReason != null && stoppedReason.StartsWith("converged", StringComparison.Ordinal);
+            // `converged` is now set explicitly at each stop site rather than derived by string-matching
+            // `stoppedReason` for a "converged" prefix, so the flag and the human-readable reason cannot drift
+            // apart — which is how a stall came to be labelled as convergence in the first place.
             var terminal = new ScenarioTerminal {
                 Converged = converged,
+                StepToleranceBand = stepBand,
                 RoundsUsed = report.Rounds.Count,
                 StoppedReason = stoppedReason ?? $"reached --max-rounds ({effectiveMaxRounds})",
                 StepTheory = stepTheory,
@@ -697,7 +728,9 @@ namespace TestApp.SynthBank {
             // Gated EXACTLY as OptimizationDiagnosticRunner.BuildAggregateRow gates it: only when the landed
             // Sensitivity is at the optimizer's search floor. Never computed ungated (design instruction).
             var sensitivityAtFloor = ExposureRecommender.SensitivityIsAtFloor(result.BestParams.Sensitivity);
-            var exposureRec = sensitivityAtFloor ? ExposureRecommender.Recommend(metrics, objectiveConstants, capturedExposureSeconds) : null;
+            var exposureRec = sensitivityAtFloor
+                ? ExposureRecommender.Recommend(metrics, objectiveConstants, capturedExposureSeconds, result.BestParams)
+                : null;
             round.ExposureRecommendation = new ExposureRecommendationSnapshot {
                 SensitivityAtFloor = sensitivityAtFloor,
                 Computed = sensitivityAtFloor,

--- a/Joko.NINA.Plugins/TestApp/SynthValidationReport.cs
+++ b/Joko.NINA.Plugins/TestApp/SynthValidationReport.cs
@@ -130,9 +130,20 @@ namespace TestApp.SynthBank {
     /// (cross-round) assertions A1-A3, the deltas versus the dataset's expected-optimal bootstrap, and the
     /// rolled-up flags/verdict.</summary>
     public sealed class ScenarioTerminal {
+        /// <summary>True only when the loop stopped at a step INSIDE <see cref="StepToleranceBand"/> of
+        /// <see cref="StepBehavioral"/>. A round that applies nothing stops the loop but does not by itself earn
+        /// this flag: a degenerate fit makes the recommender hold the current step, which is byte-identical to it
+        /// agreeing, so "nothing changed" alone used to report convergence at a step 4x too wide while assertion
+        /// A3 failed the same number in the same object.</summary>
         [JsonProperty("converged")] public bool Converged { get; set; }
         [JsonProperty("roundsUsed")] public int RoundsUsed { get; set; }
         [JsonProperty("stoppedReason")] public string StoppedReason { get; set; }
+
+        /// <summary>The half-width <see cref="Converged"/> was decided with, so the flag is checkable from the
+        /// report alone: <c>converged</c> implies <c>|finalStepSize − stepBehavioral| ≤ stepToleranceBand</c>.
+        /// NaN when <see cref="StepBehavioral"/> never reached a finite fixed point, in which case no band exists
+        /// and a no-op stop is the only convergence signal available.</summary>
+        [JsonProperty("stepToleranceBand")] public double StepToleranceBand { get; set; } = double.NaN;
 
         // step_behavioral vs step_theory (design A3's crux — see docs/followups.md F18).
         [JsonProperty("stepTheory")] public double StepTheory { get; set; } = double.NaN;

--- a/docs/f23-objective-precision-term-results.md
+++ b/docs/f23-objective-precision-term-results.md
@@ -1,9 +1,10 @@
 # F23 — giving the optimizer objective a false-positive cost
 
 Wave 1 of the AF-recommender hardening work. Plan:
-[`plans/af-recommender-hardening-plan.md`](../plans/af-recommender-hardening-plan.md) — which is the only surviving
-written form of it: the design spec these documents cite as `docs/af-recommender-hardening-design.md` was
-never committed, so every link to it dangles. See [F27](followups.md).
+[`plans/af-recommender-hardening-plan.md`](../plans/af-recommender-hardening-plan.md) — the design of record on
+`develop`: the spec these documents cite as `docs/af-recommender-hardening-design.md` was never merged (it lives
+on the unmerged branch `ghilios/af-recommender-hardening-design`, `8b7867c`), so every link to it dangles here.
+See [F27](followups.md).
 Baseline: [`docs/synthetic-af-bank-baseline.json`](synthetic-af-bank-baseline.json), transcribed from
 [`docs/synthetic-af-bank-baseline-results.md`](synthetic-af-bank-baseline-results.md).
 

--- a/docs/f23-objective-precision-term-results.md
+++ b/docs/f23-objective-precision-term-results.md
@@ -1,7 +1,9 @@
 # F23 — giving the optimizer objective a false-positive cost
 
-Wave 1 of [`docs/af-recommender-hardening-design.md`](af-recommender-hardening-design.md).
-Plan: [`plans/af-recommender-hardening-plan.md`](../plans/af-recommender-hardening-plan.md).
+Wave 1 of the AF-recommender hardening work. Plan:
+[`plans/af-recommender-hardening-plan.md`](../plans/af-recommender-hardening-plan.md) — which is the only surviving
+written form of it: the design spec these documents cite as `docs/af-recommender-hardening-design.md` was
+never committed, so every link to it dangles. See [F27](followups.md).
 Baseline: [`docs/synthetic-af-bank-baseline.json`](synthetic-af-bank-baseline.json), transcribed from
 [`docs/synthetic-af-bank-baseline-results.md`](synthetic-af-bank-baseline-results.md).
 

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -538,7 +538,7 @@ a dead band around the 4.5/7.5 px boundaries so a marginal rig does not flip bet
 under-reading pushes small-HFR rigs toward the `MinHFR` cliff.
 
 ### F27 — The optimizer cannot reach the rejected-candidate diagnostics an approved spec says it can
-**Status:** Open · found 2026-08-03 implementing [F23](#f23--the-optimizer-objective-has-no-precision-term-so-it-trades-precision-away-for-marginal-recall)
+**Status:** **Done** (2026-08-03, wave 2 — the spec was never committed; record corrected and the seam documented in code) · found 2026-08-03 implementing [F23](#f23--the-optimizer-objective-has-no-precision-term-so-it-trades-precision-away-for-marginal-recall)
 
 [`docs/af-recommender-hardening-design.md`](af-recommender-hardening-design.md) lists "the rejected-candidate
 diagnostics (`CollectRejectedCandidateDiagnostics`)" among the signals "already collected" and available to
@@ -558,13 +558,39 @@ choice of three proxy signals and in fact had one. The gap is cheap to close: th
 cache-key **denylist** (`IStarDetector.cs:523-542`), so enabling it inside the optimizer would invalidate no
 memo and no early-context key; the only cost is per-detection allocation in the hot loop.
 
-**Next step.** Either add `RejectedCandidates` to `HocusFocusStarDetectionResult` and summarise it into
-`FrameDetectionResult`, or correct the spec. Note the nine per-gate `*Bounds` rect lists **are** already on
-`Metrics` and reachable at the same one-line seam that reads `LowSensitivity`/`TooFlat`
-(`RunEvaluationLoader.cs:331-335`), so they are the cheaper signal if per-rejection geometry is wanted.
+**Resolved 2026-08-03 by correcting the record, not the code.** Every code claim above was re-verified line by
+line and holds at HEAD. Two things changed the resolution:
+
+1. **The spec was never merged.** `docs/af-recommender-hardening-design.md` is absent from `develop`; it exists
+   only on the unmerged branch `ghilios/af-recommender-hardening-design` (`8b7867c`). Three merged documents
+   linked to it, so every one of those links dangles for anyone not sitting on that branch. They now point at
+   [`plans/af-recommender-hardening-plan.md`](../plans/af-recommender-hardening-plan.md), the design of record on
+   `develop`. (Worth stating precisely: a first pass at this entry said the spec "was never committed and no
+   revision of it exists", which is wrong in the direction that would have justified rewriting it from
+   scratch.)
+2. **The plan already had it right.** Its "signals already available" table reads `CollectRejectedCandidateDiagnostics
+   records | no — RejectedCandidates never reaches HocusFocusStarDetectionResult`. So the false claim lived only
+   in the uncommitted spec, and the committed artifact contradicted it correctly the whole time. Wave 1 was
+   written from the version that was wrong.
+
+**Not plumbed, deliberately.** Adding `RejectedCandidates` to the optimizer's contract buys per-rejection detail
+nothing currently needs, at a per-detection allocation cost in the hot loop. The seam is instead **documented
+where someone would look for it** (`Interfaces/IStarDetector.cs`, on `RejectedCandidateRecord`), so the next
+person to assume the optimizer can see these records is told otherwise by the type itself rather than by a
+design document that may not survive. The `*Bounds` rect lists are noted there too, with the caveat the original
+entry left out: they carry geometry only — no measured value, no threshold — so they answer a strictly weaker
+question and are not a drop-in substitute.
+
+**Also fixed:** the `AllBoundsLists()` doc comment said "seven" and "an eighth in the future" while the helper
+returns **nine** — it had drifted when `TooElongatedBounds` and `BloomSuppressedBounds` were added. The
+`RejectedCandidateRecord` comment repeated the same stale count, and the true relationship is more lopsided than
+either number suggests: `RejectionGate` has **twelve** constants, the nine `*Bounds` lists cover **eight** of
+them (TooSmall, OnBorder, HFRAnalysisFailed and TooLowHFR have none), and the ninth — `SaturatedBounds` —
+corresponds to no gate at all, because saturated stars are KEPT and masked during the PSF fit rather than
+rejected. So "the `*Bounds` lists cover most gates" was making the gap look smaller than it is.
 
 ### F28 — `LowSensitivity` reads exactly zero precisely when the Sensitivity gate has collapsed
-**Status:** Open · found 2026-08-03 implementing [F23](#f23--the-optimizer-objective-has-no-precision-term-so-it-trades-precision-away-for-marginal-recall)
+**Status:** **Done** (2026-08-03, wave 2 — discriminator now gated on the gate being able to reject; user-visible) · found 2026-08-03 implementing [F23](#f23--the-optimizer-objective-has-no-precision-term-so-it-trades-precision-away-for-marginal-recall)
 
 The gate rejects on `sensitivity <= p.Sensitivity` (`StarDetector.cs:1763`), and every candidate's
 `sensitivity` is bounded below by `PeakResponse × EffectiveClipMultiplier` — 0.75 × 2.0 = **1.5** at shipped
@@ -590,13 +616,25 @@ recommender always concludes the field has nothing more to give.
 and valuable (2 s → 5 rejections, 14 s → zero; the comment at `ExposureRecommender.cs:511-514` records it).
 That rig was not at the search floor. The defect is the *interaction* with the floor, not the test.
 
-**Next step.** Make the discriminator conditional on the gate being able to reject at all — compare
-`p.Sensitivity` against `PeakResponse × EffectiveClipMultiplier` and report "the gate is inert, so its
-rejection count carries no information" rather than silently reading it as exhaustion. Never use this counter
-as a false-positive signal: the pathological landing produces its cleanest possible value.
+**Fixed 2026-08-03 (wave 2).** The discriminator is now conditional on the gate being able to reject at all.
+`StarDetector.InertSensitivityBound(p)` = `PeakResponse × MinEffectiveClipMultiplier(p)` is computed from the
+run's own params — never hard-coded, because both factors are searched axes and F23 wave 1 measured landings at
+`StarClip` 6.25 and 6.75 where the bound is over 4× the default. `ExposureRecommendation` gains
+`InertGateBound` and `GateIsProvablyInert`; an inert gate now falls to the **probe** (which ships with its own
+stopping rule) rather than to a verdict of exhaustion nothing in the run supports, and the derivation tooltip
+says why the rejection count carries no information.
+
+**This is user-visible**, and narrowly so: signal-sufficient runs where every frame is short of the star-count
+target AND the gate sat below its own inert bound move from "no exposure offered" to a 2× probe. The rig that
+motivated the zero-rejections test is untouched — it rejected 5 candidates at 2 s, so its gate was demonstrably
+live, and the two populations are disjoint by construction (`gateIsProvablyInert` requires
+`gateRejectedCount == 0`). An observed rejection refutes the derivation and wins.
+
+The entry's closing warning stands and is worth repeating: **never use this counter as a false-positive
+signal.** The pathological landing produces its cleanest possible value.
 
 ### F30 — A stored `optimized_settings.json` does not say which config produced it
-**Status:** Open · found 2026-08-03 pinning the [F23](#f23--the-optimizer-objective-has-no-precision-term-so-it-trades-precision-away-for-marginal-recall) baseline
+**Status:** **Done** (2026-08-03, wave 2 — provenance block added, schema 3) · found 2026-08-03 pinning the [F23](#f23--the-optimizer-objective-has-no-precision-term-so-it-trades-precision-away-for-marginal-recall) baseline
 
 **Retraction first.** This entry was originally filed as "the published V2 config-A landings do not
 reproduce". **That was wrong, and the error was mine, not the tool's.** Re-running `optimize --per-run` at
@@ -623,12 +661,21 @@ search domain).
 **Why it matters.** The misattribution cost real time and produced a wrong followup entry that was committed
 twice before the control arm disproved it. A one-line provenance field would have made it impossible.
 
-**Next step.** Add the effective `optimize` argv (and ideally a hash of the resolved `harness_settings.json`)
-to `OptimizedStarDetectionSettings`, so a landing is self-describing and a stale copy announces itself.
+**Fixed 2026-08-03 (wave 2).** `OptimizedStarDetectionSettings` gains an optional `Provenance` block
+(`Producer`, `CommandLine`, `SettingsFingerprint`, `ProducerVersion`) and the schema goes to **3**. The
+fingerprint hashes the harness settings' *semantic* content — the parsed option bag, key-sorted, plus the
+resolved pixel-scale inputs — not the file's bytes, so re-exporting or re-indenting a settings file does not make
+a landing look as though it came from a different configuration.
 
-**Next step.** Record the provenance in `optimized_settings.json`, which already carries `CreatedAtUtc`,
-`RunCount`, `BaselineJ` and `FinalJ`: add the full `optimize` argv and a hash of the effective
-`harness_settings.json`. Cheap, and it makes a landing self-describing.
+**Degrades in both directions.** The block is omitted from the JSON entirely when null, so a snapshot written by
+the shipping plugin is byte-identical to before; a v1/v2 file still loads with `Provenance` null, which reads as
+**unattributable** and must never be read as "matches me"; and the tilt wizard's `CaptureDetectionSettings` —
+which snapshots *live* settings rather than an optimizer result — deliberately keeps it null, because stamping a
+producer on it would be a lie. `Clone()` deep-copies it: `MemberwiseClone` is shallow, so without that every copy
+would alias one instance.
+
+The underlying overwrite ([F15](#f15--optimize---per-run-overwrites-each-runs-stored-settings)) is unchanged — a
+bank folder still accumulates whichever prepass went last. What changes is that the survivor now says so.
 
 ### F31 — Synthetic-bank precision is NOT exact: the golden omits real stars, and they score as false positives
 **Status:** Open · found 2026-08-03 verifying the [F23](#f23--the-optimizer-objective-has-no-precision-term-so-it-trades-precision-away-for-marginal-recall) wave-1 result · **INVALIDATES F23's evidence base**
@@ -798,6 +845,42 @@ Using the golden star bbox to detect donuts fails: `Panos` is a genuine donut ru
 frame measures a median bbox of only 12 px, because the SNR reference detects **fragments** of a thin ring rather
 than the ring. This is the documented under-counting of defocused donuts in `.claude/docs/golden-star-set.md`.
 Use the heuristic's own donut statistics, or render the pixels and classify them.
+
+### F34 — `synth-validate` scored a stalled run as converged, at a step 4× outside the band its own assertion failed it on
+**Status:** **Done** (2026-08-03, wave 2) · found 2026-08-03 re-measuring [F25](#f25--from-a-far-too-wide-sweep-the-step-recommender-widens-it-further-inflating-the-sweep-to-3x-its-correct-width)
+
+The fourth harness-calibration bug on this bank, and the third in the convergence-predicate family. The round
+loop set `stoppedReason = "converged (round applied nothing)"` unconditionally, and `ScenarioTerminal.Converged`
+was then derived by string-matching that reason for a `"converged"` prefix.
+
+**Evidence.** `D05_tec140_1000mm` S2:
+
+```
+converged: true
+stoppedReason: "converged (round applied nothing)"
+finalStepSize: 140     stepBehavioral: 35     deltaStepVsExpected: +105
+assertions: A3 verdict=FAIL  "final step 140 outside [21,56] = [0.6,1.6]x step_behavioral (35)"
+```
+
+Two verdicts contradicting each other inside one JSON object.
+
+**Mechanism.** `StepSizeRecommender.Degenerate` **holds the current step** whenever the fit is unusable — no
+`Fitting`, a non-finite vertex, a non-positive minimum HFR, or the 3× band never crossed. The driver applies a
+step only when it differs, so a degenerate fit produces `AppliedAnything == false` that is byte-identical to the
+recommender genuinely agreeing. The loop read "nothing changed" as success, which inflates convergence counts on
+exactly the runs that are most broken.
+
+**Fixed.** A no-op round still STOPS the loop — the recommender is not going to move on its own — but it counts
+as convergence only when the step is inside the tolerance band, and reports `stalled` otherwise. The band moved
+into `ConvergenceBand` so both stop branches share one definition, and it is a strict subset of A3's `[0.6,1.6]×`
+sharing its lower bound, so the two verdicts cannot contradict each other again. `Converged` is now set
+explicitly at each stop site instead of parsed out of prose, and `stepToleranceBand` is recorded on the terminal
+so the claim is checkable from the report alone.
+
+**Why it is worth a numbered entry.** Four calibration bugs have now been found on this harness — three in this
+family — every one by someone happening to look rather than by anything failing. A harness that reports its own
+success is load-bearing for every conclusion drawn from it; see also the `truthViolations` /
+`precisionNull` guards added to `bank-verify` for the same reason ([F31](#f31--synthetic-bank-precision-is-not-exact-the-golden-omits-real-stars-and-they-score-as-false-positives)).
 
 ---
 

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -431,6 +431,13 @@ This is a **cold-start plateau**, not a missing knob, and it is why the earlier 
 is defensible, only the silence is a problem") was too generous: the gate costs a whole class of rigs their
 autofocus, and the fix is within the existing search space.
 
+**It also reproduces on the REAL bank, twice (2026-08-03).** `BaselineJ` — the objective at shipped defaults — is
+exactly **0.0000** on `Panos` and `LinwoodFocus`, the only two runs in the 19-run bank where it is. Both are the
+same silent null result D01/D02 produce synthetically, on real frames from real rigs. They are also the only two
+runs whose recall@≥12 *improves* under the optimizer (+0.031 and +0.089), for the reason F32 gives: they are the
+only ones with any headroom to climb. So this is not a synthetic-bank artifact of the render, and the affected
+population is not hypothetical.
+
 **Next step.** Two parts, and the second is the substantive one.
 1. *Report it.* When a large fraction of accepted candidates are rejected by `MinHFR` specifically, say so and
    name the pixel-scale / focal-length combination. The counts are already collected
@@ -697,6 +704,78 @@ perfect.
    `synthetic-af-bank-baseline-results.md`, `docs/synthetic-af-bank-baseline.json`, F23, F24, and the
    `precisionMin` bands in `synthetic-af-bank-expectations.json`. Until then, treat synthetic precision as a
    lower bound and do not use it as an acceptance gate.
+
+### F32 — `J` is saturated near 1.0, so the optimizer trades enormous recall for numerically trivial gains
+**Status:** Open · found 2026-08-03 re-reading the wave-1 real-bank control arm
+
+The objective's landings are not close calls. Across the 17 scorable real-bank runs, `optimize --per-run` gives
+up a **median 0.243 of recall@SNR≥12** to gain a **median ΔJ of +0.0125** — and the worst cases are far starker
+than the median.
+
+**Evidence.** `bank-verify --runs "D:\\Autofocus Bank" --opt-a` (wave-1 control arm, `afbank-verify/3`, 19 runs,
+0 failed), against each run's own `BaselineJ`/`FinalJ` from its stored landing:
+
+| run | recall@≥12 C0 → A | Δrecall | ΔJ | landed Sensitivity |
+|---|---|---|---|---|
+| `toml999` | 0.819 → 0.357 | **−0.462** | **+0.0002** | 33.3 |
+| `muggsie` | 0.879 → 0.512 | −0.368 | +0.0039 | 17.2 |
+| `CWhiteFocus` | 0.810 → 0.327 | −0.483 | +0.0042 | 50.0 |
+| `uneven` | 0.931 → 0.319 | −0.613 | +0.0046 | 31.2 |
+| `bobp` | 0.580 → 0.495 | −0.086 | +0.0041 | 10.0 |
+
+`toml999` is the entry's clearest statement: **two ten-thousandths of `J` bought with 46 points of recall.** At
+`BaselineJ` values of 0.98–0.999 there is almost no headroom left, so every remaining move is a rounding error in
+the objective and a catastrophe in the star list. The search is behaving correctly; the scale it is climbing has
+run out.
+
+**Why it matters.** This is upstream of [F23](#f23--the-optimizer-objective-has-no-precision-term-so-it-trades-precision-away-for-marginal-recall)
+and of [F4](#f4--the-objective-has-no-sensor-model-term). A precision term, a sensor term, or any other new term
+added to a `J` that already sits at 0.998 will be competing for the same exhausted fourth decimal place. It also
+explains why F23's wave-1 mechanism (a) could produce real precision movement and still clear no acceptance gate:
+the term was fighting for headroom that does not exist. And it reframes the wizard's own presentation — a landing
+reported as an improvement over the current settings is, on most runs, an improvement too small to mean anything
+while the change in what gets detected is enormous.
+
+**Next step.** Before adding any further term to `J`, measure its dynamic range on both banks: the distribution of
+`FinalJ − BaselineJ` over the runs, and the recall/precision movement per unit `J`. If the trade rate is what
+these numbers say, the fix is to rescale or re-anchor the objective (or gate acceptance on the *magnitude* of the
+improvement) rather than to add a term. Cheap to check: the numbers above come from files already on disk.
+
+### F33 — The synthetic bank does not reproduce the real bank's optimizer failure mode
+**Status:** Open · found 2026-08-03 re-reading the wave-1 arms side by side
+
+On the synthetic bank the optimizer drives `BrightnessSensitivity` **down** to its 0.0 floor and detects *more*.
+On the real bank it drives Sensitivity **up**, often to the top of the range, and detects far *fewer*. Those are
+opposite behaviours, and the synthetic bank was built to study the first one.
+
+**Evidence.** Landed Sensitivity and detection counts, same wave-1 control arm, same binary:
+
+| bank | landings | detections C0 → A |
+|---|---|---|
+| synthetic (6 of 17 datasets) | Sensitivity **0.0** (D09, D10, D11, D12, D15, D17) | up |
+| real: `CWhiteFocus` | **50.0** | 1807 → **534** |
+| real: `standard_example1` | **34.3** | 602 → **177** |
+| real: `toml999` | **33.3** | 677 → **228** |
+| real: `uneven` | **31.2** | 406 → **133** |
+| real: `mccomiskey` | 0.0, but **StarClip 10.0** (the maximum) | 3606 → **43** |
+
+`mccomiskey` is the instructive one: Sensitivity reads 0.0, which looks like the synthetic pathology, but the
+effective gate is `PeakResponse × StarClip = 0.75 × 10 = 7.5` — the *same escape route* F23 wave 1 measured on
+D12 and D15, here operating as the shedding mechanism rather than the loosening one. Reading the Sensitivity axis
+alone misclassifies this run.
+
+**Why it matters.** [F23](#f23--the-optimizer-objective-has-no-precision-term-so-it-trades-precision-away-for-marginal-recall)'s
+framing — "the optimizer drives `BrightnessSensitivity` to its 0.0 floor" — is a **synthetic-bank-only**
+description. Any fix designed and accepted against the synthetic bank alone is being tuned on the opposite sign of
+the effect it needs to correct on real rigs, which is how wave 1's arm (a) came to be a wash on the real bank
+while showing real movement on the synthetic one. It also bounds the bank's claim: the synthetic bank measures
+precision exactly (that is real and now verified), but it does not currently exhibit
+[F4](#f4--the-objective-has-no-sensor-model-term)'s star-shedding at all.
+
+**Next step.** Two parts. (1) Report the *effective* gate `max(Sensitivity, PeakResponse × StarClip)` wherever a
+landing's Sensitivity is quoted, so a `mccomiskey`-shaped landing is not read as a floor landing. (2) Decide
+deliberately whether the bank should grow a dataset class that reproduces the shedding regime — and until it does,
+score every candidate objective change on **both** banks, never the synthetic one alone.
 
 ---
 

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -261,8 +261,8 @@ principle".
 consecutive rounds, stop deferring and let the step update proceed. Fixing F22 would also dissolve this, but the
 livelock is worth guarding against independently — any future oscillating recommendation would reproduce it.
 
-### F23 — The optimizer objective has no precision term, so it trades precision away for marginal recall
-**Status:** Open · found 2026-08-02, the first measurement of **exact** detector precision (synthetic AF bank)
+### F23 — ~~The optimizer objective has no precision term, so it trades precision away for marginal recall~~
+**Status:** **Won't fix as written** (2026-08-03, wave 2 — evidence base void; the real effect is ~1/5 the size and the axis is recall, see F32/F33) · found 2026-08-02
 
 The objective `J` rewards star count and fit quality. Nothing in it penalises a false positive — and
 nothing could have, because until this bank existed precision was only ever a *lower bound* on real data
@@ -324,20 +324,55 @@ section describes part of the problem, not all of it.
 `MarginalSnrStrength` therefore ships at **0** (inert; J bit-identical to before). The implementation is kept,
 tested and flag-selectable so the next attempt starts from a measured position.
 
-**Next step (revised).** The proxy must be computed on a statistic the search cannot lift — `peak/σ` with
-`PeakResponse` out of the expression — which needs new plumbing, since `Star` exposes only the gated
-`MeasuredSensitivity` today. Independently, find the second false-positive source that operates at healthy
-Sensitivity (D08, D16). Original framing below.
+> ## ⚠ THE EVIDENCE BASE ABOVE IS VOID (2026-08-03, wave 2 — re-measured at `afbank-verify/5`)
+>
+> Every precision figure in this entry came from a metric that charged a false positive for each real star the
+> golden policy had dropped ([F31](#f31--synthetic-bank-precision-is-not-exact-the-golden-omits-real-stars-and-they-score-as-false-positives)).
+> Re-measured on the same landings:
+>
+> | | as recorded above | re-measured at `/5` |
+> |---|---|---|
+> | C0@nc2 precision, worst of 17 | 0.942 | **1.000** |
+> | Config A precision, worst of 17 | 0.451 (D09) | **0.910** (D10) |
+> | Config A datasets below 0.90 | 6 | **0** |
+> | D09 "bought +0.034 recall for −0.542 precision" | — | +0.034 recall for **−0.042** precision |
+>
+> **The headline claim — "it gains a few points of recall and gives up half the precision" — is false.** The
+> detector's real false-positive rate on this bank is 0–9%, and the reading is a measurement rather than a
+> saturated metric: the null control (the same detections translated with wraparound) scores 0.000–0.169, and
+> `truthViolations` is 0 on all 51 config rows.
+>
+> **What survives.** The *direction* is real and lands on exactly the datasets named here — D10 0.910,
+> D09 0.958, D17 0.959, D15 0.968, every one a long-focal-length rig landing at Sensitivity 0. That is roughly
+> one fifth the size of the artifact that hid it. Far too small to justify an objective term; not zero either.
+> Both wave-1 mechanisms are correctly rejected, but for a reason the entry does not give: they were suppressing
+> **real detections**. On D09 the control arm found 510 stars at 97.8% true precision where the term-on arm
+> found 231.
+>
+> **And a term could not have helped anyway.** See [F32](#f32--j-is-saturated-near-10-so-the-optimizer-trades-enormous-recall-for-numerically-trivial-gains):
+> `J` already sits at 0.98–0.999 before the search starts, so any new term competes for an exhausted fourth
+> decimal place. That is the better explanation for why mechanism (a) produced real precision movement and still
+> cleared no gate.
+>
+> **Where the problem actually is.** [F33](#f33--the-synthetic-bank-does-not-reproduce-the-real-banks-optimizer-failure-mode):
+> on the REAL bank the optimizer drives Sensitivity *up* to 31–50 and sheds 45% of recall at the median, the
+> opposite sign of the synthetic behaviour this entry describes. Recall, not precision, is the axis with a
+> defect on it.
+
+**Next step (revised again).** Do not build a precision term. Read F32 and F33 first: the objective's scale is
+exhausted, and the failure mode this entry describes does not transfer to real rigs. The "second false-positive
+source at healthy Sensitivity" (D08 at 8 with 0.748, D16 at 2.5 with 0.744) also dissolves — both score **1.000**
+at `/5`. Earlier framings retained below as the record.
 
 **Next step (original).** Add a precision-like term to the objective. It cannot be true precision on real data
 (that is the whole problem), but two proxies are already available: the golden-independent
 false-positive *proxies* the detector already collects, and — for tuning and regression — this bank,
 where precision is exact. Any change wants scoring against **both** banks, since the synthetic one can
 now measure exactly the quantity the real one cannot. Related: [F4](#f4--the-objective-has-no-sensor-model-term)
-is the same shape of gap (a term the objective omits), and [F11](#f11--precision-is-a-lower-bound-on-runs-whose-faint-tier-was-budget-truncated--re-measured) is why this went unseen.
+is the same shape of gap (a term the objective omits), and [F11](#f11--precision-is-a-lower-bound-on-runs-whose-faint-tier-was-budget-truncated--re-run-these-with-more-montages) is why this went unseen.
 
-### F24 — Donut detection costs precision even where donuts exist, and badly where they do not
-**Status:** Open · found 2026-08-02 on the synthetic AF bank
+### F24 — ~~Donut detection costs precision even where donuts exist, and badly where they do not~~ → it costs RECALL where it is not needed
+**Status:** Open, **restated** (2026-08-03, wave 2 — the precision claim is refuted; a recall claim replaces it) · found 2026-08-02 on the synthetic AF bank
 
 Config B (donut-aware detection forced on) reduced precision on **every** dataset where it was
 measurable, including the datasets that genuinely have donuts, and most sharply on the ε=0 control that
@@ -364,9 +399,53 @@ still no product signal that recommends it ([F1](#f1--the-donut-heuristic-misses
 the heuristic missing *small* donuts). This says the cost of enabling it wrongly is high and concrete,
 which raises the stakes on getting that signal right.
 
-**Next step.** Score the nine donut-gated axes individually against this bank to find which of them
-carries the precision cost — the synthetic donuts are clean and high-SNR, so anything that loses
-precision here is losing it structurally rather than to noise.
+> ## ⚠ REFUTED AND RESTATED (2026-08-03, wave 2)
+>
+> **The precision claim above is an artifact of the pre-[F31](#f31--synthetic-bank-precision-is-not-exact-the-golden-omits-real-stars-and-they-score-as-false-positives)
+> metric and does not survive re-measurement.** This is the one wave-1 followup that was never re-measured,
+> because the config-B prepass output no longer existed; it has now been re-derived and scored at
+> `afbank-verify/5`.
+>
+> | dataset | ε | C0@nc2 | **B, as re-measured** | B, as this entry recorded it |
+> |---|---|---|---|---|
+> | **D13_apo200_1800mm** | **0** | 1.000 | **1.000** | 0.653 |
+> | D14_cdk14_2563mm_e47 | 0.47 | 1.000 | **0.997** | 0.671 |
+> | D12_c14_585_afbin2 | 0.34 | 1.000 | **0.997** | 0.506 |
+> | D09_c14_3800mm | 0.34 | 1.000 | **1.000** | 0.448 |
+>
+> **Config B's precision never falls below 0.991 on any of the 17 datasets**, and on the ε=0 control it is a
+> flat 1.000. There is no precision cost to find, so there is nothing for the "score the nine donut-gated axes"
+> next step to attribute.
+
+**What is actually true, measured at `/5`: donut detection costs RECALL where it is not needed, and buys a
+large σ_focus improvement almost everywhere.** Config B against C0@nc2:
+
+| dataset | ε | Δrecall@high | σ_focus C0 → B |
+|---|---|---|---|
+| D16_esprit550_ha3 | 0 | **−0.147** | 0.615 → 0.315 |
+| D04_esprit_550mm | 0 | **−0.113** | 0.232 → 0.059 |
+| D13_apo200_1800mm | 0 | −0.014 | **2.352 → 0.291** |
+| D03_redcat_250mm | 0 | **+0.138** | 1.183 → 0.341 |
+| D11_rc10_585_afbin2 | 0.47 | +0.030 | 0.101 → 0.444 |
+| D09_c14_3800mm | 0.34 | +0.078 | 1.141 → 0.644 |
+
+D13 is the sharpest reversal. This entry cited it as the case that proved donut detection fires on things that
+are not donuts and does damage; re-measured, D13 keeps 1.000 precision, gives up 0.014 recall, and its AF fit
+**improves eightfold** (σ_focus 2.352 → 0.291). That is [F5](#f5--donut-detection-halves-σ_focus-on-a-run-with-no-donuts)
+happening again, not a defect. `donutEffect` over the 17 A/B pairs is now `donutHelpedAF: 8`,
+`donutHurtSensor: 6` — still no clean win, but no longer the "costs precision everywhere" picture.
+
+**Why it matters, restated.** Donut detection remains a bootstrap input gating nine optimizer axes with no
+product signal recommending it ([F1](#f1--the-donut-heuristic-misses-small-donuts) is the heuristic missing
+*small* donuts). The stakes on getting that signal right are unchanged — but the cost of enabling it wrongly is
+**lost faint stars on a well-sampled refractor**, not admitted junk, and a fix aimed at the wrong one of those
+would have been wasted.
+
+**Next step.** Find what the recall loss on D16 and D04 is: both are unobstructed 550 mm refractors, so the
+donut-gated relaxations should be inert on them and are not. Score the nine gated axes against ΔRECALL on those
+two datasets. Note also that the two survivors of the original entry are untouched by all of this: C0 is *not*
+broken on the synthetic donut datasets (unlike the real bank's `Panos`/`mufti`/`LinwoodFocus`), and there is
+still no signal that recommends the master.
 
 ### F19 — The exposure recommendation is decided by the 20 brightest stars, so a rich field can never earn one
 **Status:** Open · found 2026-08-02 deriving expected-optimal exposures for the synthetic AF bank
@@ -440,13 +519,26 @@ population is not hypothetical.
 
 **Next step.** Two parts, and the second is the substantive one.
 1. *Report it.* When a large fraction of accepted candidates are rejected by `MinHFR` specifically, say so and
-   name the pixel-scale / focal-length combination. The counts are already collected
-   (`CollectRejectedCandidateDiagnostics`), so this is reporting, not new measurement.
+   name the pixel-scale / focal-length combination. The counts are already collected — but **not where the
+   optimizer can see them**: `CollectRejectedCandidateDiagnostics` records never reach the optimizer's
+   evaluation path ([F27](#f27--the-optimizer-cannot-reach-the-rejected-candidate-diagnostics-an-approved-spec-says-it-can)).
+   The nine per-gate `*Bounds` rect lists *are* reachable at the same seam that reads
+   `LowSensitivity`/`TooFlat`, and one of them is `TooLowHFR`… except it is not: `*Bounds` covers eight of
+   `RejectionGate`'s twelve constants and `TooLowHFR` is one of the four with none. So this is reporting **plus**
+   one new counter, not reporting alone.
 2. *Seed out of the plateau.* Before optimizing, if the median in-focus HFR is at or below `MinHFR`, seed
    `MinHFR` beneath it (the measured HFR is available from the same in-focus record
    `DetectionBinningResolver` already consumes) so the search starts somewhere with a gradient. Score any change
    on **D01–D03** of the synthetic bank, where the correct answer is known and current recall is 0.135 / 0.475 /
    0.400.
+
+   **The risk to design against.** A seeded `MinHFR` is a knob the search may not be able to climb back out of:
+   the objective is flat in its neighbourhood on exactly these rigs, which is why the search never moves it
+   today. Seed it to a value *measured* from the frames, not to a permissively low one, and re-check that a rig
+   which does NOT need the seed (D05, whose search finds 1.45 unaided) is left alone. Compounding factor from
+   [F22](#f22--detection-binning-is-a-hard-threshold-on-a-measurement-that-under-reads-so-boundary-rigs-get-the-wrong-factor):
+   the same measured-HFR under-read that flips the binning factor also pushes small-HFR rigs toward this cliff,
+   so a seed derived from the measured value inherits that bias.
 
 ### F21 — `StepSizeRecommender`'s half-width is not stable against noise, even on a perfect fit
 **Status:** Open · found 2026-08-02 running the synthetic bank's S0 control
@@ -678,7 +770,7 @@ The underlying overwrite ([F15](#f15--optimize---per-run-overwrites-each-runs-st
 bank folder still accumulates whichever prepass went last. What changes is that the survivor now says so.
 
 ### F31 — Synthetic-bank precision is NOT exact: the golden omits real stars, and they score as false positives
-**Status:** Open · found 2026-08-03 verifying the [F23](#f23--the-optimizer-objective-has-no-precision-term-so-it-trades-precision-away-for-marginal-recall) wave-1 result · **INVALIDATES F23's evidence base**
+**Status:** **Done** (2026-08-03, wave 2 — repaired, validated against a null control, and everything re-baselined at `afbank-verify/5`) · found 2026-08-03 verifying the F23 wave-1 result · **INVALIDATED F23's evidence base**
 
 `docs/synthetic-af-bank-baseline-results.md` headlines the synthetic bank with "Golden precision (D06,
 `golden eval`) **1.000** — 205 TP, **0 FP**. Exact, not a lower bound." That claim does not generalise. Measured
@@ -723,7 +815,7 @@ The control arm detects **510** stars on D09 at **97.8%** true precision where t
 100% — so both F23 wave-1 mechanisms were suppressing *real detections*, not junk.
 
 **Why it matters — this also inverts the bank's selling point.** Precision against the synthetic golden is a
-**lower bound**, for exactly the reason [F11](#f11--precision-is-a-lower-bound-on-runs-whose-faint-tier-was-budget-truncated--re-measured)
+**lower bound**, for exactly the reason [F11](#f11--precision-is-a-lower-bound-on-runs-whose-faint-tier-was-budget-truncated--re-run-these-with-more-montages)
 gives on the real bank: the reference is incomplete below the tier cut. The synthetic bank's claim to measure
 precision *exactly* is what justified building it, and as implemented it does not hold.
 
@@ -741,16 +833,49 @@ nothing. Protection is now the match radius exactly. Before trusting a re-baseli
 still SPREADS across datasets; all-1.000 means the metric is saturated again, not that the detector is
 perfect.
 
-**Next step.** Three separable pieces.
-1. **Score against truth, not the golden**, for synthetic runs — the truth sidecar is already written beside every
-   frame and is complete by construction. This is the correct fix and it makes the bank's original claim true.
-2. Failing that, make `bank-verify` honour the golden's `coverage` field (it currently ignores it,
-   `GoldenStarSet.cs:81-93`) and call `ExcludeUnresolved`, and emit `omitted` stars into `unresolved` so they are
-   at least excludable rather than invisible.
-3. **Regenerate every precision number that rests on this**: the V2 matrix in
-   `synthetic-af-bank-baseline-results.md`, `docs/synthetic-af-bank-baseline.json`, F23, F24, and the
-   `precisionMin` bands in `synthetic-af-bank-expectations.json`. Until then, treat synthetic precision as a
-   lower bound and do not use it as an acceptance gate.
+**Closed 2026-08-03 (wave 2), with the instrument validated before anything was baselined against it.**
+
+**The validation came first, and it was cheap.** `golden eval` writes `detected_f<focuser>.csv` per frame, so 30
+saved configurations (D09/D13/D17 at nine Sensitivity values, plus D10/D11/D12) could be re-scored **offline**
+under four policies with the detector never running again. Re-implementing `GoldenMatch` in Python reproduced
+the published C# `/3` numbers exactly — D09 s0 0.8037 vs 0.804, D17 s0 0.6974 vs 0.697, D13 s0 0.8504 vs 0.850 —
+which is what made its other columns believable. Minutes of work; it would have caught this before wave 1 began.
+
+What it showed:
+
+- **The metric is NOT saturated.** A null control (the same detections translated with wraparound — count and
+  clustering preserved, correspondence destroyed) scores **0.000–0.012**. The 2·HFR saturation this entry warns
+  about would have shown up as a high null. It does not.
+- **Three independent policies agree to within 0.006** at 0.98–1.00: the as-implemented `/4` metric, a variant
+  whose protection predicate is exactly the matching predicate, and direct truth scoring.
+- **The `/3` violation, counted:** detections charged as a false positive while sitting within the match radius
+  of a real rendered star number 52/318 on D09 s0, 79/337 on D17 s0, 139/1075 on D13 s0. Under `/4`, **0 on all
+  30 configurations**.
+- **A residual asymmetry in the `/4` repair, always flattering.** `GoldenMatch.Covers` excludes on
+  `centre-in-box OR IoU(box, det.bbox) > 0`, so the *detection's own bounding box* dilates every protection box
+  and a wide donut detection is protected well past the match radius — despite the class comment claiming
+  protection is "exactly as generous as matching". Measured: D09 s0 reads 1.0000 under the implemented predicate
+  against 0.9909 under the symmetric one. Small (≤0.011), systematic, one-directional.
+
+**Shipped as `afbank-verify/5`.** Truth protection now uses the centroid predicate matching itself uses (the
+golden's own `unresolved` boxes keep `Covers`, since that is the real bank's path and must not move), and every
+config row now reports `precisionNull`, `truthViolations` and `scoredFraction`. Next-step (1) — score directly
+against truth — was measured and found to agree with the repaired golden+protection scoring to within 0.006, so
+it was not worth a second scoring path; next-step (2) is moot.
+
+**Next-step (3) is done.** The V3 matrix in
+[`synthetic-af-bank-baseline-results.md`](synthetic-af-bank-baseline-results.md), a new measured
+[`synthetic-af-bank-baseline.json`](synthetic-af-bank-baseline.json), re-derived `precisionMin` bands in
+[`synthetic-af-bank-expectations.json`](synthetic-af-bank-expectations.json) (the old 0.95/0.98 were fitted to
+the broken metric and were *not* carried forward), and [F23](#f23--the-optimizer-objective-has-no-precision-term-so-it-trades-precision-away-for-marginal-recall)
+/ [F24](#f24--donut-detection-costs-precision-even-where-donuts-exist-and-badly-where-they-do-not--it-costs-recall-where-it-is-not-needed)
+both re-measured — F23 void as written, F24 refuted and restated as a recall finding.
+
+**The lesson, stated so it outlives the bug.** Reproducibility validated nothing here. Every check confirmed
+determinism, and a deterministic pipeline reproduces a systematic error perfectly; the bias lived in the
+reference all the checks shared. What caught it was scoring against an *independent* source. And a metric can
+fail in two directions — biased, then saturated — which is why `precisionNull` now ships alongside every
+precision figure rather than being something a reader has to think to ask for.
 
 ### F32 — `J` is saturated near 1.0, so the optimizer trades enormous recall for numerically trivial gains
 **Status:** Open · found 2026-08-03 re-reading the wave-1 real-bank control arm
@@ -847,7 +972,7 @@ than the ring. This is the documented under-counting of defocused donuts in `.cl
 Use the heuristic's own donut statistics, or render the pixels and classify them.
 
 ### F34 — `synth-validate` scored a stalled run as converged, at a step 4× outside the band its own assertion failed it on
-**Status:** **Done** (2026-08-03, wave 2) · found 2026-08-03 re-measuring [F25](#f25--from-a-far-too-wide-sweep-the-step-recommender-widens-it-further-inflating-the-sweep-to-3x-its-correct-width)
+**Status:** **Done** (2026-08-03, wave 2) · found 2026-08-03 re-measuring [F25](#f25--from-a-far-too-wide-sweep-the-step-recommender-widens-it-further-instead-of-recovering)
 
 The fourth harness-calibration bug on this bank, and the third in the convergence-predicate family. The round
 loop set `stoppedReason = "converged (round applied nothing)"` unconditionally, and `ScenarioTerminal.Converged`

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -532,6 +532,15 @@ population is not hypothetical.
    on **D01–D03** of the synthetic bank, where the correct answer is known and current recall is 0.135 / 0.475 /
    0.400.
 
+   **Measured 2026-08-03 — see [F35](#f35--minhfr-should-be-seeded-from-the-sweep-wings-and-neither-available-hfr-statistic-can-size-it), which changes this step in two ways.**
+   (a) The trigger as written is **circular** — D01's in-focus frame detects zero stars, so there is no median
+   in-focus HFR to read. It has to come from the sweep WINGS, which are richly populated (816–2002 stars/frame)
+   and already fit at R² = 0.911. (b) The success criterion here is wrong: lowering the gate moves D01's recall
+   only **0.135 → 0.165**, because `TooLowHFR` accounts for just 1877 of ~38500 missed stars while the structure
+   map never proposes 18801 of them. What it *does* do is put 5 stars back on the vertex frame at `MinHFR` 0.5,
+   which clears the `NHard` = 3 hard floor and is the entire reason `FinalJ` is 0. **Score this fix on "the hard
+   floor passes", not on recall** — and do not expect it to lift the W-class band.
+
    **The risk to design against.** A seeded `MinHFR` is a knob the search may not be able to climb back out of:
    the objective is flat in its neighbourhood on exactly these rigs, which is why the search never moves it
    today. Seed it to a value *measured* from the frames, not to a permissively low one, and re-check that a rig
@@ -948,6 +957,101 @@ precision exactly (that is real and now verified), but it does not currently exh
 landing's Sensitivity is quoted, so a `mccomiskey`-shaped landing is not read as a floor landing. (2) Decide
 deliberately whether the bank should grow a dataset class that reproduces the shedding regime — and until it does,
 score every candidate objective change on **both** banks, never the synthetic one alone.
+
+### F35 — `MinHFR` should be seeded from the sweep WINGS, and neither available HFR statistic can size it
+**Status:** Open · found 2026-08-03 answering "how far can `MinHFR` safely come down?" for
+[F20](#f20--below-minhfr-the-autofocus-objective-collapses-to-exactly-zero-with-no-diagnostic)
+
+[F20](#f20--below-minhfr-the-autofocus-objective-collapses-to-exactly-zero-with-no-diagnostic)'s proposed fix —
+"if the median in-focus HFR is at or below `MinHFR`, seed `MinHFR` beneath it" — **cannot be implemented as
+written, because it is circular.** On `D01_ultrawide_40mm` the in-focus frame detects **zero** stars at the
+default gate, so there is no median in-focus HFR to read. The measurement that would trigger the fix is the one
+the gate has destroyed.
+
+**The wings break the circularity, and cost nothing.** Far from focus the PSF is large, so those frames are
+unaffected by the gate and richly populated — D01's four outer frames carry **816–2002** accepted stars each at
+`MinHFR` 1.2. The hyperbola fit already succeeds on them (**R² = 0.911**), and `BestFit.Minimum.Y` is already
+computed and already read by the wizard as `baselineInFocusHfr`. So the trigger is available today with no new
+measurement: *fit the curve from whatever frames produce stars, and compare the predicted vertex against
+`MinHFR`.*
+
+**But the fit must TRIGGER the adjustment, not SIZE it — both available statistics are biased the same way.**
+
+| statistic | reads | truth | error |
+|---|---|---|---|
+| wing-only hyperbola vertex (frames with ≥100 stars) | **0.548 px** | 0.238 px | **2.3× high** |
+| median measured HFR of survivors at focuser 5991 | **1.33 px** | 0.606 px | **2.2× high** |
+| median measured HFR of survivors at focuser 6009 | **1.68 px** | 0.606 px | **2.8× high** |
+
+The second and third are **left-censored at `MinHFR` itself** — only stars measuring above the gate can be
+seen, so the surviving sample's median is bounded below by the very knob being tuned. This is structurally the
+same trap [F23](#f23--the-optimizer-objective-has-no-precision-term-so-it-trades-precision-away-for-marginal-recall)
+wave 1 hit, where the marginal-SNR statistic was left-censored at the Sensitivity gate. The first is a
+different mechanism (a hyperbola's vertex parameter is the one the wings constrain worst) with the same sign.
+
+**Both biases understate how far the gate must come down**, so a plausible rule like `MinHFR = 0.8 × predicted`
+gives 0.44 on D01 — which still gates its true 0.238 px vertex completely. The fix would have looked applied and
+changed nothing.
+
+**How low is safe: measured, and the answer is "as low as you like".**
+`golden eval --params default --min-hfr <M>`, exact precision against synthetic truth, 8 values from 1.2 to 0.1:
+
+| `MinHFR` | D01 recall@high | D01 FP | D02 recall@high | D02 FP | D01 vertex-frame stars |
+|---|---|---|---|---|---|
+| 1.2 (default) | 0.129 | **0** | 0.451 | **0** | **0** |
+| 0.9 | 0.152 | **0** | 0.507 | **0** | **0** |
+| 0.7 | 0.160 | **0** | 0.567 | **0** | 2 |
+| **0.5** | 0.164 | **0** | 0.588 | **0** | **5** |
+| 0.35 | 0.164 | **0** | 0.594 | **0** | 5 |
+| 0.25 | 0.165 | **0** | 0.595 | **0** | 5 |
+| 0.1 | 0.165 | **0** | — | — | 6 |
+
+**Zero false positives at every value on both datasets**, and the recall gain saturates by ~0.35. `MinHFR` is a
+second line of defence — hot-pixel filtering is separate and enabled by default — and on this bank it is not
+carrying any of the load. **0.25–0.35 captures all the available gain.**
+
+**The mechanism is the hard floor, not recall — and that reframes F20.** Lowering the gate moves D01's recall
+only 0.129 → 0.165. What it actually does is put stars back on the **vertex frame**: 0 → 2 at 0.7, and **0 → 5
+at 0.5**, which is the first value that clears the objective's `NHard` = 3 stars-per-frame requirement. That is
+the whole of `FinalJ = 0.00000`. So the fix is real and worth shipping, but its success criterion is *"the hard
+floor passes and the search gets a gradient"*, **not** *"recall recovers"*.
+
+**And `MinHFR` is only 5% of D01's recall problem.** False-negative attribution at the two extremes:
+
+| gate | at `MinHFR` 1.2 | at 0.1 |
+|---|---|---|
+| NO CANDIDATE (structure gap) | **18801** | **18800** |
+| TooSmall | 6398 | 6398 |
+| LowSensitivity | 6301 | 6301 |
+| TooDistorted | 2387 | 2387 |
+| NotCentered | 2228 | 2228 |
+| **TooLowHFR** | **1877** | **1** |
+
+`TooLowHFR` is 1877 of ~38500 missed golden stars. Removing it entirely leaves every other gate untouched.
+**The W class's recall is lost in candidate FORMATION** — the structure map never proposes 49% of them, and
+`MinimumStarBoundingBoxSize` (default 5 px) rejects another 17% as `TooSmall` — so anyone expecting the
+`MinHFR` fix to lift D01 toward the 0.90 W-class band will be disappointed, and the band stays missed for a
+reason this entry does not address.
+
+**Why it matters.** F20 is the strongest surviving finding on this bank and its fix was one circular statistic
+away from being unimplementable. The censoring point generalises past `MinHFR`: **any gate whose threshold is
+tuned from the surviving sample is tuning against a distribution it truncated.** That has now bitten twice
+(Sensitivity in F23, HFR here), which makes it a review question rather than a coincidence.
+
+**Next step.** Three pieces.
+1. Seed `MinHFR` when `BestFit.Minimum.Y` (from the wing-populated fit) sits at or below it — **trigger only**.
+2. Size the seed from **pixel scale and sampling**, not from either censored statistic. The measured floor is
+   0.25–0.35 px with no precision cost on this bank; validate on D01–D03 where the truth vertex is known
+   (0.238 / 0.280 / ~0.97 px). Note the gate is `star.HFR <= p.MinHFR`, inclusive, so the seed must be strictly
+   below the HFR to be kept.
+3. Widen the search where it matters: `OptimizerVariable`'s `MinHFR` axis is `Continuous(0.1, 5.0, step 0.25)`,
+   so from 1.2 the reachable grid is 0.95 → 0.70 → 0.45 → 0.20. Only 0.20 clears D01, it is four steps away with
+   `J` flat the whole way (F20's cold-start plateau), and a 0.25 step is far too coarse in a sub-pixel regime —
+   0.45 → 0.20 is a 2.25× jump. A seed makes the walk unnecessary; a finer low-end step makes it survivable.
+
+**The risk to design against, unchanged from F20:** the objective rewards star count, so nothing pulls a seeded
+`MinHFR` back up. It is a knob the search cannot climb out of, which is why the seed must come from geometry
+rather than from a measurement the gate itself shaped.
 
 ---
 

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -1002,6 +1002,20 @@ sharing its lower bound, so the two verdicts cannot contradict each other again.
 explicitly at each stop site instead of parsed out of prose, and `stepToleranceBand` is recorded on the terminal
 so the claim is checkable from the report alone.
 
+**Verified on the motivating case.** `synth-validate --datasets D05_tec140_1000mm --scenarios S2 --max-rounds 4`
+re-run after the fix:
+
+```
+converged:         false
+stoppedReason:     "stalled (round applied nothing, but step 140 is outside the 14 tolerance band of
+                    step_behavioral 35) — a no-op recommendation from a degenerate fit, not convergence"
+finalStepSize: 140    stepBehavioral: 35    stepToleranceBand: 14
+assertions:    A3 verdict=FAIL  "final step 140 outside [21,56] = [0.6,1.6]x step_behavioral (35)"
+```
+
+Same run, same step, same A3 failure — the report no longer contradicts itself, and the terminal now publishes
+the band its verdict was reached with.
+
 **Why it is worth a numbered entry.** Four calibration bugs have now been found on this harness — three in this
 family — every one by someone happening to look rather than by anything failing. A harness that reports its own
 success is load-bearing for every conclusion drawn from it; see also the `truthViolations` /

--- a/docs/synthetic-af-bank-baseline-results.md
+++ b/docs/synthetic-af-bank-baseline-results.md
@@ -105,73 +105,92 @@ recall@≥12=0.181, sensor R²=0.9933, 7/9 aligned. That is a **config-B** numbe
 donut forced on) from the June prepass and sits behind every merge into `develop` since, so it is not a
 valid guard for this change. The single-commit before/after above is the guard that isolates it.
 
-## V2 — the precision/recall baseline, and the biggest result in this document
+## V3 — the precision/recall baseline, re-measured after the metric was repaired
 
-`bank-verify --runs D:\SyntheticAutofocusBank --nc-sweep 2,3,4 --opt-a … --opt-b …`, schema
-`afbank-verify/3`, header pixel scale, 17 runs, 0 failed. C0 = stock defaults; A = `optimize --per-run`;
-B = the same with donut detection forced on. Cells are **recall@high / precision**.
+> **The V2 table that stood here is retired.** It was scored by a metric that charged a false positive for
+> every real star the golden policy had dropped ([F31](followups.md)), so **96% of the false positives it
+> reported were real rendered stars** and every precision figure in it was an artifact. It survives in
+> [`synthetic-af-bank-baseline.json`](synthetic-af-bank-baseline.json) — marked `SUPERSEDED`, with the
+> precision keys renamed `precision_VOID` so a tool reading them for a gate fails loudly — as the audit trail
+> of how a reproducible measurement can be reproducibly wrong.
 
-| dataset | C0@nc2 | A | B | afR² (C0) |
-|---|---|---|---|---|
-| D01_ultrawide_40mm | 0.135 / 0.963 | 0.129 / 0.970 | 0.115 / 0.967 | 0.9098 |
-| D02_rich_135mm | 0.475 / 0.991 | 0.451 / 0.991 | 0.442 / 0.990 | 0.9172 |
-| D03_redcat_250mm | 0.400 / 0.988 | 0.396 / 0.992 | 0.537 / 0.991 | 0.9512 |
-| D04_esprit_550mm | 0.810 / 0.979 | 0.855 / 0.977 | 0.697 / 0.977 | 0.9993 |
-| D05_tec140_1000mm | **0.982** / 0.986 | 0.989 / 0.966 | 0.978 / 0.992 | 0.9999 |
-| D06_sparse_1000mm | **0.982** / 0.978 | 0.964 / 0.984 | 0.988 / 0.977 | 0.9997 |
-| D07_rc10_2000mm | 0.965 / 0.953 | 0.973 / 0.941 | 0.944 / 0.859 | 1.0000 |
-| D08_c11_2800mm | **1.000** / 0.959 | 0.990 / **0.748** | 1.000 / 0.781 | 0.9996 |
-| D09_c14_3800mm | 0.922 / 0.993 | 0.956 / **0.451** | 1.000 / **0.448** | 0.9992 |
-| D10_rc16_3250mm_sparse | 0.983 / **1.000** | 0.931 / **0.547** | 0.966 / 0.661 | 0.9996 |
-| D11_rc10_585_afbin2 | 0.887 / 0.986 | 0.850 / **0.732** | 0.917 / 0.627 | 1.0000 |
-| D12_c14_585_afbin2 | 0.897 / 0.952 | 0.897 / **0.653** | 0.879 / **0.506** | 0.9994 |
-| D13_apo200_1800mm (ε=0 control) | **1.000** / 0.962 | 1.000 / 0.985 | 0.986 / **0.653** | 0.9992 |
-| D14_cdk14_2563mm_e47 | 0.979 / 0.965 | 0.990 / 0.948 | 0.984 / 0.671 | 0.9997 |
-| D15_cdk20_3454mm_e47 | 0.954 / 0.979 | 0.943 / **0.531** | 0.931 / 0.708 | 0.9992 |
-| D16_esprit550_ha3 | 0.886 / 0.985 | 0.908 / **0.744** | 0.739 / 0.983 | 0.9954 |
-| D17_cdk14_oiii5 | **1.000** / 0.942 | 1.000 / **0.465** | 1.000 / 0.567 | 0.9988 |
+`bank-verify --runs D:\SyntheticAutofocusBank --nc-sweep 2 --opt-a … --opt-b …`, schema **`afbank-verify/5`**,
+header pixel scale, 17 runs, 0 failed. C0 = stock defaults; A = `optimize --per-run`; B = the same with donut
+detection forced on. Cells are **recall@high / precision**.
 
-**Reading it — three things, in order of importance.**
+| dataset | C0@nc2 | A | B | null (C0) | afR² (C0) |
+|---|---|---|---|---|---|
+| D01_ultrawide_40mm | 0.135 / 1.000 | 0.129 / 1.000 | 0.115 / 1.000 | 0.169 | 0.9098 |
+| D02_rich_135mm | 0.475 / 1.000 | 0.451 / 1.000 | 0.442 / 1.000 | 0.067 | 0.9172 |
+| D03_redcat_250mm | 0.400 / 1.000 | 0.396 / 1.000 | **0.537** / 1.000 | 0.036 | 0.9512 |
+| D04_esprit_550mm | 0.810 / 1.000 | 0.855 / 1.000 | **0.697** / 1.000 | 0.113 | 0.9993 |
+| D05_tec140_1000mm | 0.982 / 1.000 | 0.989 / 1.000 | 0.978 / 1.000 | 0.013 | 0.9999 |
+| D06_sparse_1000mm | 0.982 / 1.000 | 0.964 / 1.000 | 0.988 / 1.000 | 0.000 | 0.9999 |
+| D07_rc10_2000mm | 0.965 / 1.000 | 0.973 / 1.000 | 0.944 / 0.999 | 0.029 | 1.0000 |
+| D08_c11_2800mm | 1.000 / 1.000 | 0.990 / 1.000 | 1.000 / 1.000 | 0.000 | 0.9996 |
+| D09_c14_3800mm | 0.922 / 1.000 | 0.956 / **0.958** | 1.000 / 1.000 | 0.000 | 0.9996 |
+| D10_rc16_3250mm_sparse | 0.983 / 1.000 | 0.931 / **0.910** | 0.966 / 0.991 | 0.000 | 0.9996 |
+| D11_rc10_585_afbin2 | 0.887 / 1.000 | 0.850 / 1.000 | 0.917 / 1.000 | 0.000 | 1.0000 |
+| D12_c14_585_afbin2 | 0.897 / 1.000 | 0.897 / 1.000 | 0.879 / 0.997 | 0.000 | 0.9994 |
+| D13_apo200_1800mm (ε=0 control) | 1.000 / 1.000 | 1.000 / 1.000 | 0.986 / **1.000** | 0.003 | 0.9992 |
+| D14_cdk14_2563mm_e47 | 0.979 / 1.000 | 0.990 / 1.000 | 0.984 / 0.997 | 0.002 | 1.0000 |
+| D15_cdk20_3454mm_e47 | 0.954 / 1.000 | 0.943 / **0.968** | 0.931 / 1.000 | 0.000 | 1.0000 |
+| D16_esprit550_ha3 | 0.886 / 1.000 | 0.908 / 1.000 | **0.739** / 1.000 | 0.000 | 0.9954 |
+| D17_cdk14_oiii5 | 1.000 / 1.000 | 1.000 / **0.959** | 1.000 / 1.000 | 0.006 | 0.9995 |
 
-**1. The optimizer trades precision away for marginal recall (F23).** C0's precision never falls below
-**0.942** on any dataset. Config A falls to 0.451. On D09 the optimizer bought +0.034 recall for −0.542
-precision; on D10, +0.000 recall (it lost 0.052) for −0.453 precision. The objective rewards star count
-and fit quality and has no false-positive term — and could not have had one, because on the real bank
-precision is only a lower bound (F11). This is the single result that most justifies the bank existing:
-it is invisible without exact truth, and it reframes every prior "A beat C0" conclusion.
+**null** is the precision the same detections earn after being translated with wraparound — chance alone, and
+therefore the floor this metric can read. It is reported because a precision column of 1.000 is exactly what a
+saturated metric produces, and this baseline exists to replace one that failed that way. `truthViolations` — a
+scored false positive sitting on a real rendered star, the F31 signature itself — is **0 on all 51 config
+rows**.
 
-**2. Recall tracks focal length exactly as physics predicts, then cliffs.** 0.135 → 0.475 → 0.400 →
-0.810 → **0.982** as the PSF grows past `MinHFR` and becomes well sampled. The design's M-class anchor
-("well-sampled ⇒ essentially everything", ≥0.97) is **validated** at 0.982/0.982/1.000. The W-class band
-(≥0.90) is **missed badly**, and for a reason worth stating: it was set assuming a gentle pixelization
-loss, but the real mechanism is the hard `MinHFR` cliff (F20) — D01 detects *zero* stars at focus while
-its goldens are fully populated. The band is left as written, with a note; it should be revisited when
-F20 is addressed, not widened to fit.
+### Reading it
 
-**3. Donut detection costs precision everywhere, including where donuts are absent (F24).** D13 is the
-1800 mm **unobstructed** control, present exactly so "donut" and "long focal length" cannot be
-confounded — config B takes its precision from 0.962 to **0.653**. Two design assumptions also fell:
-C0 is *not* broken on synthetic donut datasets (D08 and D17 reach recall 1.000 at precision 0.942–0.959),
-unlike the real bank's donut runs; and `donutEffect` across the 17 A/B pairs is `donutHelpedAF: 5`,
-`donutHurtSensor: 6` — no clear win either way.
+**1. The detector produces essentially no false positives on this bank, and that is now a measurement.**
+C0@nc2 is 1.000 on all 17 datasets against a null floor of 0.000–0.169, so the metric had ample room to read
+lower and did not. The detector's real false-positive rate here is **0–9%**, concentrated entirely in config A
+on four long-focal-length datasets.
 
-The NC sweep independently recommends **NC = 2** (recall@high 0.95, precision 0.98, still rising at the
-bottom of the swept range), which agrees with the real bank's conclusion in
-`af-bank-noiseclip-sweep-results.md` — a useful cross-check that the synthetic bank is not living in its
-own universe.
+**2. F23's direction survives; its magnitude does not.** Config A does cost precision, and on exactly the
+datasets F23 named — D10 0.910, D09 0.958, D17 0.959, D15 0.968, all long focal length, all landing at
+Sensitivity 0. But V2 reported that as 0.451–0.547. The effect is real and roughly **one-fifth** the size of
+the artifact that hid it, and C0's "never below 0.942" was really "never below 1.000". No objective term is
+justified by numbers this small; see [F32](followups.md) for why one could not have helped anyway.
+
+**3. F24 is refuted, and the real cost of donut detection is recall.** F24's headline was "donut detection
+costs precision even where donuts exist, and badly where they do not — D13 0.962 → 0.653". Re-measured,
+**D13 scores 1.000 under config B**, and B's precision never falls below 0.991 on any dataset. What B actually
+costs is *recall*, on the datasets that do not need it: D16 0.886 → **0.739**, D04 0.810 → **0.697**,
+D13 1.000 → 0.986. And it genuinely helps where the PSF is annular or undersampled: D03 0.400 → **0.537**,
+D11 0.887 → 0.917. That is a different finding with a different fix.
+
+**4. Recall still tracks focal length exactly as physics predicts, then cliffs.** 0.135 → 0.475 → 0.400 →
+0.810 → 0.982 as the PSF grows past `MinHFR` and becomes well sampled. Untouched by the metric repair — the
+golden's `stars` list defines what must be found and F31 does not change it. The W-class band is still missed
+badly, still for the `MinHFR` cliff ([F20](followups.md)), and D01 still detects *zero* stars at focus while
+its goldens are fully populated.
+
+**5. Watch the scored fraction on config A.** At a floored Sensitivity only 45–75% of detections enter the
+precision ratio at all (D09 0.471, D17 0.485, D12 0.508); the rest land on real stars the golden dropped and
+are unjudgeable. That is not a bias — protection removes a detection from both numerator and denominator, and
+the null shows chance protection is ~0 — but precision on those rows rests on a materially smaller sample than
+C0's, and a future comparison should say so rather than treating the two as equally well determined.
 
 ### Expectation-band scorecard
 
 | band | result |
 |---|---|
 | W class C0@nc2 recall@high ≥ 0.90 | **MISS** (0.135 / 0.475 / 0.400) — F20, band left unwidened |
-| W class C0@nc2 precision ≥ 0.95 | PASS (0.963 / 0.991 / 0.988) |
+| W class C0@nc2 precision ≥ 0.98 | PASS (1.000 / 1.000 / 1.000) |
 | M class C0@nc2 recall@high ≥ 0.97 | PARTIAL — D05/D06/D13 pass (0.982–1.000); D04 0.810 and D16 0.886 miss |
-| M class C0@nc2 precision ≥ 0.95 | PASS (0.962–0.986) |
+| M class C0@nc2 precision ≥ 0.98 | PASS (1.000 across the class) |
 | L classes on config B, recall ≥ 0.90 | mostly PASS (0.879–1.000; D12 0.879 marginal) |
-| L classes on config B, precision ≥ 0.90 | **MISS across the board** (0.448–0.859) — F23/F24 |
-| Config A precision ≥ 0.98, non-donut | PARTIAL — D02/D03 pass; D16 0.744 misses badly |
+| L classes on config B, precision ≥ 0.98 | PASS (0.991–1.000) — was a MISS across the board under the V2 metric |
+| Config A precision ≥ 0.95, non-donut | PASS (1.000 on every non-donut dataset) |
 | afR² floor 0.95 | PASS on 15/17; D01 0.910 and D02 0.917 miss (F20) |
+
+The bands themselves were re-derived for this baseline — the old 0.95/0.98 were fitted to the broken metric.
+See [`synthetic-af-bank-expectations.json`](synthetic-af-bank-expectations.json) for the reasoning behind each.
 
 ## V1 — the full S0–S6 convergence matrix
 

--- a/docs/synthetic-af-bank-baseline.json
+++ b/docs/synthetic-af-bank-baseline.json
@@ -1,109 +1,667 @@
 {
-  "schemaVersion": 1,
-  "status": "SUPERSEDED",
-  "schema": "afbank-verify/3",
-  "doNotUseAsRegressionGate": true,
-  "supersededBy": "F31 in docs/followups.md — re-baseline against afbank-verify/4 before using any precision number here",
-  "_WARNING": [
-    "EVERY PRECISION VALUE IN THIS FILE IS AN ARTIFACT. Do not gate on them, do not diff against them,",
-    "do not quote them. They are retained ONLY as the audit trail of what the pre-F31 metric reported.",
+  "schemaVersion": 2,
+  "status": "MEASURED",
+  "schema": "afbank-verify/5",
+  "supersedes": "the afbank-verify/3 baseline, retained in this file's git history and summarised under _supersededNote",
+  "_READ_THIS_FIRST": [
+    "Precision here is MEASURED, and the report carries its own evidence that it is:",
     "",
-    "WHY. bank-verify scored a detection as a false positive whenever it did not match a box in the",
-    "*.golden.json sidecar. GoldenFromTruth tiers truth stars by native PEAK-PIXEL SNR and drops anything",
-    "below 3.5 to Tier='omitted', which appears in NEITHER `stars` NOR `unresolved` — so nothing excluded",
-    "it, and bank-verify never called GoldenMatch.ExcludeUnresolved at all. Defocus destroys peak-pixel SNR",
-    "while leaving integrated flux intact, so the golden evaporates toward the sweep wings: D08_c11_2800mm",
-    "holds 81 golden stars at focus and 9 at the extreme frame, against 123-126 truth stars per frame.",
+    "  precisionNull   -- the precision the SAME detections earn after being translated with wraparound.",
+    "                     Chance alone. It is the floor the metric can read, and it is 0.000-0.169 here, so a",
+    "                     precision of 1.000 means the detector found no false positives rather than meaning",
+    "                     the metric cannot tell. The first cut of the F31 repair read 1.000 everywhere BECAUSE",
+    "                     it was saturated, and nothing in a precision column alone can distinguish the two.",
+    "  truthViolations -- scored false positives sitting on a REAL rendered star. This is the F31 bug's own",
+    "                     signature and it is 0 on all 51 config rows. Non-zero means the metric has regressed",
+    "                     and no precision number from that run is usable.",
+    "  scoredFraction  -- how much of the detection set entered the precision ratio. On config A at a floored",
+    "                     Sensitivity this falls to 0.45-0.75, so those rows rest on a smaller sample than C0's.",
+    "                     Not a bias (protection removes a detection from BOTH sides) but do not treat a config-A",
+    "                     precision as equally well determined as a C0 one.",
     "",
-    "MEASURED. Re-scored against each frame's own *.truth.json, 96% of the false positives this file records",
-    "are REAL RENDERED STARS — D09 control arm: 510 detections, 280 scored FP, 269 with a truth star within",
-    "the match radius, 11 genuinely spurious. With the metric repaired (afbank-verify/4) the same runs score",
-    "precision 1.000 on all 17 datasets, while recall is bit-identical to the values below.",
-    "",
-    "THE TRAP THIS FILE IS THE RECORD OF. These numbers REPRODUCE EXACTLY — a same-session control arm",
-    "re-derived config A from scratch and matched every published digit, and C0@nc2 matched too. That was",
-    "taken as evidence they were trustworthy. Reproducible is not the same as correct: a deterministic",
-    "pipeline reproduces a systematic error perfectly. Every check run against this file confirmed",
-    "determinism and none of them could have caught the bias, because the bias lives in the reference the",
-    "checks all share.",
-    "",
-    "WHAT IS STILL USABLE HERE: the recall columns (recall@high / the golden `stars` list defines what must",
-    "be found, and F31 does not change it) and afR2. Precision only is void."
+    "A /5 precision is NOT comparable to a /3 one (which charged real stars as false positives) and differs",
+    "slightly from a /4 one (whose protection predicate was dilated by the detection's own bounding box)."
   ],
-  "source": "docs/synthetic-af-bank-baseline-results.md",
-  "measuredUtc": "2026-08-02",
-  "detectorCommit": "unknown (pre-b3f7165; the V2 run predates the synth-validate eps fixes)",
-  "bankRoot": "D:\\SyntheticAutofocusBank",
+  "_supersededNote": [
+    "The previous baseline was scored by a metric under which 96% of reported false positives were real rendered",
+    "stars. Its headline -- 'C0 precision never below 0.942, config A reaches 0.451' -- is really 'C0 never below",
+    "1.000, config A reaches 0.910'. Those numbers REPRODUCED EXACTLY across a same-session control arm, which was",
+    "taken as evidence they were trustworthy. A deterministic pipeline reproduces a systematic error perfectly:",
+    "every check confirmed determinism and none could catch the bias, because the bias lived in the reference the",
+    "checks all shared. That is why this file now pins a null control rather than only a measurement."
+  ],
+  "source": "D:\\\\hf_w2\\\\verify_v5\\\\verification_20260803T213709Z.json",
+  "measuredUtc": "2026-08-03T21:37:09Z",
+  "detectorCommit": "51d8e7c",
+  "bankRoot": "D:\\\\SyntheticAutofocusBank",
   "pixelScaleMode": "header",
-  "_provenanceNotes": [
-    "Transcribed verbatim from the V2 table in docs/synthetic-af-bank-baseline-results.md (lines 115-134),",
-    "produced by: TestApp bank-verify --runs D:\\SyntheticAutofocusBank --nc-sweep 2,3,4 --opt-a <A>",
-    "--opt-b <B> --pixel-scale header   (17 runs, 0 failed, schema afbank-verify/3).",
-    "",
-    "recall@high on THIS bank is recall at golden peak SNR >= 20 (goldenHighSnr in",
-    "SynthBank/synthetic-bank-spec.json), NOT >= 12. The bank-verify markdown column header 'recall@SNR>=12'",
-    "and the JSON field 'goldenSNRge12' are misnomers on the synthetic bank.",
-    "",
-    "Per-dataset sigmaFocus was not published in the V2 table, so it is absent here.",
-    "afR2 is the C0 value only; per-config afR2 was not published.",
-    "",
-    "SEPARATE TRAP, unrelated to F31: the optimized_settings.json copies sitting in each dataset's attempt01/",
-    "folder are NOT config A. optimize --per-run overwrites them in place (F15), so they hold whichever prepass",
-    "ran last -- config B, identifiable only by DefocusAwareDonutDetection:true inside the file. Reading them",
-    "as config A shows 5 datasets at BrightnessSensitivity 0.0 instead of 6 and looks like a reproducibility",
-    "failure. It is not; it is a misattributed artifact. See F30."
+  "matchRadiusPx": 12,
+  "ncSweep": [
+    2
   ],
   "configs": {
     "C0@nc2": "shipped product defaults, NoiseClippingMultiplier = 2",
-    "A": "optimize --per-run landings (donut master NOT forced)",
-    "B": "optimize --per-run --donut landings (donut master forced on in bank-verify)"
+    "A": "optimize --per-run landings (donut master NOT forced). Prepass: the wave-1 control arm at develop f066c94, which re-derived config A from an unmodified HEAD and reproduced the published V2 landings exactly on all 17 datasets.",
+    "B": "optimize --per-run --donut landings, donut master forced on in bank-verify. Prepass re-derived 2026-08-03 (D:\\\\hf_w2\\\\B_A); the V2 config-B prepass output no longer existed, which is why F24 could not be re-measured in wave 1."
   },
-  "runs": {
-    "D01_ultrawide_40mm/attempt01":     { "C0@nc2": { "recallHigh": 0.135, "precision_VOID": 0.963, "afR2": 0.9098 }, "A": { "recallHigh": 0.129, "precision_VOID": 0.970 }, "B": { "recallHigh": 0.115, "precision_VOID": 0.967 } },
-    "D02_rich_135mm/attempt01":         { "C0@nc2": { "recallHigh": 0.475, "precision_VOID": 0.991, "afR2": 0.9172 }, "A": { "recallHigh": 0.451, "precision_VOID": 0.991 }, "B": { "recallHigh": 0.442, "precision_VOID": 0.990 } },
-    "D03_redcat_250mm/attempt01":       { "C0@nc2": { "recallHigh": 0.400, "precision_VOID": 0.988, "afR2": 0.9512 }, "A": { "recallHigh": 0.396, "precision_VOID": 0.992 }, "B": { "recallHigh": 0.537, "precision_VOID": 0.991 } },
-    "D04_esprit_550mm/attempt01":       { "C0@nc2": { "recallHigh": 0.810, "precision_VOID": 0.979, "afR2": 0.9993 }, "A": { "recallHigh": 0.855, "precision_VOID": 0.977 }, "B": { "recallHigh": 0.697, "precision_VOID": 0.977 } },
-    "D05_tec140_1000mm/attempt01":      { "C0@nc2": { "recallHigh": 0.982, "precision_VOID": 0.986, "afR2": 0.9999 }, "A": { "recallHigh": 0.989, "precision_VOID": 0.966 }, "B": { "recallHigh": 0.978, "precision_VOID": 0.992 } },
-    "D06_sparse_1000mm/attempt01":      { "C0@nc2": { "recallHigh": 0.982, "precision_VOID": 0.978, "afR2": 0.9997 }, "A": { "recallHigh": 0.964, "precision_VOID": 0.984 }, "B": { "recallHigh": 0.988, "precision_VOID": 0.977 } },
-    "D07_rc10_2000mm/attempt01":        { "C0@nc2": { "recallHigh": 0.965, "precision_VOID": 0.953, "afR2": 1.0000 }, "A": { "recallHigh": 0.973, "precision_VOID": 0.941 }, "B": { "recallHigh": 0.944, "precision_VOID": 0.859 } },
-    "D08_c11_2800mm/attempt01":         { "C0@nc2": { "recallHigh": 1.000, "precision_VOID": 0.959, "afR2": 0.9996 }, "A": { "recallHigh": 0.990, "precision_VOID": 0.748 }, "B": { "recallHigh": 1.000, "precision_VOID": 0.781 } },
-    "D09_c14_3800mm/attempt01":         { "C0@nc2": { "recallHigh": 0.922, "precision_VOID": 0.993, "afR2": 0.9992 }, "A": { "recallHigh": 0.956, "precision_VOID": 0.451 }, "B": { "recallHigh": 1.000, "precision_VOID": 0.448 } },
-    "D10_rc16_3250mm_sparse/attempt01": { "C0@nc2": { "recallHigh": 0.983, "precision_VOID": 1.000, "afR2": 0.9996 }, "A": { "recallHigh": 0.931, "precision_VOID": 0.547 }, "B": { "recallHigh": 0.966, "precision_VOID": 0.661 } },
-    "D11_rc10_585_afbin2/attempt01":    { "C0@nc2": { "recallHigh": 0.887, "precision_VOID": 0.986, "afR2": 1.0000 }, "A": { "recallHigh": 0.850, "precision_VOID": 0.732 }, "B": { "recallHigh": 0.917, "precision_VOID": 0.627 } },
-    "D12_c14_585_afbin2/attempt01":     { "C0@nc2": { "recallHigh": 0.897, "precision_VOID": 0.952, "afR2": 0.9994 }, "A": { "recallHigh": 0.897, "precision_VOID": 0.653 }, "B": { "recallHigh": 0.879, "precision_VOID": 0.506 } },
-    "D13_apo200_1800mm/attempt01":      { "C0@nc2": { "recallHigh": 1.000, "precision_VOID": 0.962, "afR2": 0.9992 }, "A": { "recallHigh": 1.000, "precision_VOID": 0.985 }, "B": { "recallHigh": 0.986, "precision_VOID": 0.653 } },
-    "D14_cdk14_2563mm_e47/attempt01":   { "C0@nc2": { "recallHigh": 0.979, "precision_VOID": 0.965, "afR2": 0.9997 }, "A": { "recallHigh": 0.990, "precision_VOID": 0.948 }, "B": { "recallHigh": 0.984, "precision_VOID": 0.671 } },
-    "D15_cdk20_3454mm_e47/attempt01":   { "C0@nc2": { "recallHigh": 0.954, "precision_VOID": 0.979, "afR2": 0.9992 }, "A": { "recallHigh": 0.943, "precision_VOID": 0.531 }, "B": { "recallHigh": 0.931, "precision_VOID": 0.708 } },
-    "D16_esprit550_ha3/attempt01":      { "C0@nc2": { "recallHigh": 0.886, "precision_VOID": 0.985, "afR2": 0.9954 }, "A": { "recallHigh": 0.908, "precision_VOID": 0.744 }, "B": { "recallHigh": 0.739, "precision_VOID": 0.983 } },
-    "D17_cdk14_oiii5/attempt01":        { "C0@nc2": { "recallHigh": 1.000, "precision_VOID": 0.942, "afR2": 0.9988 }, "A": { "recallHigh": 1.000, "precision_VOID": 0.465 }, "B": { "recallHigh": 1.000, "precision_VOID": 0.567 } }
-  },
-  "_precisionFieldRenamed": [
-    "The precision key is deliberately spelled 'precision_VOID' rather than 'precision'. Any tool that reads",
-    "this file for a precision gate will fail loudly on a missing key instead of silently comparing against a",
-    "number that means nothing. Recall and afR2 keep their normal names because they remain valid."
+  "_recallHighNote": [
+    "recall@high on THIS bank is recall at golden peak SNR >= 20 (goldenHighSnr in synthetic-bank-spec.json),",
+    "NOT >= 12. The bank-verify markdown column header 'recall@SNR>=12' and the JSON field 'goldenSNRge12' are",
+    "misnomers on the synthetic bank. Recall is UNCHANGED by the F31 repair -- the golden's `stars` list still",
+    "defines what must be found -- so these values are directly comparable to the superseded baseline's."
   ],
-  "landedConfigA": {
-    "_comment": [
-      "The config-A landed BrightnessSensitivity values, confirmed by a same-session control arm that",
-      "reproduced this table exactly. These ARE trustworthy — the search is reproducible; only the",
-      "precision metric it was judged by was not."
-    ],
-    "sensitivityAtFloor": [
-      "D09_c14_3800mm", "D17_cdk14_oiii5", "D15_cdk20_3454mm_e47",
-      "D10_rc16_3250mm_sparse", "D12_c14_585_afbin2", "D11_rc10_585_afbin2"
-    ],
-    "meanPrecisionAtFloor_VOID": 0.563,
-    "meanPrecisionAboveFloor_VOID": 0.931,
-    "_note": [
-      "The 0.563-vs-0.931 split was F23's central evidence — 'the optimizer drives Sensitivity to the floor",
-      "and precision collapses'. Under the repaired metric both groups score 1.000. The split measured how",
-      "many REAL faint stars a low Sensitivity finds, which the golden then charged as false positives."
-    ]
-  },
-  "headline_VOID": {
-    "_note": "Retained verbatim as the claim F31 refuted. All three numbers are artifacts.",
-    "c0PrecisionMin": 0.942,
-    "configAPrecisionMin": 0.451,
-    "configAPrecisionBelow0_90": 6
+  "runs": {
+    "D01_ultrawide_40mm/attempt01": {
+      "C0@nc2": {
+        "recallHigh": 0.135276,
+        "recallAll": 0.232624,
+        "precision": 1.0,
+        "precisionNull": 0.168575,
+        "scoredFraction": 0.963359,
+        "truthViolations": 0,
+        "sigmaFocus": 0.505508,
+        "afR2": 0.909831,
+        "sensitivity": 10.0
+      },
+      "A": {
+        "recallHigh": 0.128629,
+        "recallAll": 0.175955,
+        "precision": 1.0,
+        "precisionNull": 0.161822,
+        "scoredFraction": 0.9698,
+        "truthViolations": 0,
+        "sigmaFocus": 0.595807,
+        "afR2": 0.90373,
+        "sensitivity": 10.0
+      },
+      "B": {
+        "recallHigh": 0.115297,
+        "recallAll": 0.162481,
+        "precision": 1.0,
+        "precisionNull": 0.163331,
+        "scoredFraction": 0.966887,
+        "truthViolations": 0,
+        "sigmaFocus": 0.66243,
+        "afR2": 0.902995,
+        "sensitivity": 10.0
+      },
+      "protectedStars": 18529
+    },
+    "D02_rich_135mm/attempt01": {
+      "C0@nc2": {
+        "recallHigh": 0.474818,
+        "recallAll": 0.547842,
+        "precision": 1.0,
+        "precisionNull": 0.066969,
+        "scoredFraction": 0.990595,
+        "truthViolations": 0,
+        "sigmaFocus": 0.225832,
+        "afR2": 0.917157,
+        "sensitivity": 10.0
+      },
+      "A": {
+        "recallHigh": 0.451231,
+        "recallAll": 0.525045,
+        "precision": 1.0,
+        "precisionNull": 0.066582,
+        "scoredFraction": 0.99115,
+        "truthViolations": 0,
+        "sigmaFocus": 0.275573,
+        "afR2": 0.915478,
+        "sensitivity": 10.0
+      },
+      "B": {
+        "recallHigh": 0.441963,
+        "recallAll": 0.513165,
+        "precision": 1.0,
+        "precisionNull": 0.066931,
+        "scoredFraction": 0.990027,
+        "truthViolations": 0,
+        "sigmaFocus": 0.219518,
+        "afR2": 0.912306,
+        "sensitivity": 10.0
+      },
+      "protectedStars": 489
+    },
+    "D03_redcat_250mm/attempt01": {
+      "C0@nc2": {
+        "recallHigh": 0.399827,
+        "recallAll": 0.47381,
+        "precision": 1.0,
+        "precisionNull": 0.036262,
+        "scoredFraction": 0.988253,
+        "truthViolations": 0,
+        "sigmaFocus": 1.183134,
+        "afR2": 0.951239,
+        "sensitivity": 10.0
+      },
+      "A": {
+        "recallHigh": 0.395505,
+        "recallAll": 0.257674,
+        "precision": 1.0,
+        "precisionNull": 0.039109,
+        "scoredFraction": 0.99187,
+        "truthViolations": 0,
+        "sigmaFocus": 0.299409,
+        "afR2": 0.997201,
+        "sensitivity": 32.333333
+      },
+      "B": {
+        "recallHigh": 0.537497,
+        "recallAll": 0.387074,
+        "precision": 1.0,
+        "precisionNull": 0.03472,
+        "scoredFraction": 0.991345,
+        "truthViolations": 0,
+        "sigmaFocus": 0.341101,
+        "afR2": 0.998425,
+        "sensitivity": 17.666667
+      },
+      "protectedStars": 977
+    },
+    "D04_esprit_550mm/attempt01": {
+      "C0@nc2": {
+        "recallHigh": 0.810439,
+        "recallAll": 0.72289,
+        "precision": 1.0,
+        "precisionNull": 0.113059,
+        "scoredFraction": 0.978784,
+        "truthViolations": 0,
+        "sigmaFocus": 0.23216,
+        "afR2": 0.999315,
+        "sensitivity": 10.0
+      },
+      "A": {
+        "recallHigh": 0.854901,
+        "recallAll": 0.624621,
+        "precision": 1.0,
+        "precisionNull": 0.117596,
+        "scoredFraction": 0.977027,
+        "truthViolations": 0,
+        "sigmaFocus": 0.02135,
+        "afR2": 0.999992,
+        "sensitivity": 19.666667
+      },
+      "B": {
+        "recallHigh": 0.697318,
+        "recallAll": 0.377976,
+        "precision": 1.0,
+        "precisionNull": 0.116929,
+        "scoredFraction": 0.976986,
+        "truthViolations": 0,
+        "sigmaFocus": 0.058813,
+        "afR2": 0.999933,
+        "sensitivity": 17.666667
+      },
+      "protectedStars": 15015
+    },
+    "D05_tec140_1000mm/attempt01": {
+      "C0@nc2": {
+        "recallHigh": 0.982098,
+        "recallAll": 0.863577,
+        "precision": 1.0,
+        "precisionNull": 0.013473,
+        "scoredFraction": 0.985833,
+        "truthViolations": 0,
+        "sigmaFocus": 0.148086,
+        "afR2": 0.999947,
+        "sensitivity": 10.0
+      },
+      "A": {
+        "recallHigh": 0.989123,
+        "recallAll": 0.914085,
+        "precision": 1.0,
+        "precisionNull": 0.014035,
+        "scoredFraction": 0.96571,
+        "truthViolations": 0,
+        "sigmaFocus": 0.076883,
+        "afR2": 0.999986,
+        "sensitivity": 8.0
+      },
+      "B": {
+        "recallHigh": 0.977566,
+        "recallAll": 0.801961,
+        "precision": 1.0,
+        "precisionNull": 0.01342,
+        "scoredFraction": 0.992269,
+        "truthViolations": 0,
+        "sigmaFocus": 0.077864,
+        "afR2": 0.99999,
+        "sensitivity": 10.0
+      },
+      "protectedStars": 7893
+    },
+    "D06_sparse_1000mm/attempt01": {
+      "C0@nc2": {
+        "recallHigh": 0.982036,
+        "recallAll": 0.884831,
+        "precision": 1.0,
+        "precisionNull": 0.0,
+        "scoredFraction": 0.978261,
+        "truthViolations": 0,
+        "sigmaFocus": 0.267434,
+        "afR2": 0.999875,
+        "sensitivity": 10.0
+      },
+      "A": {
+        "recallHigh": 0.964072,
+        "recallAll": 0.853933,
+        "precision": 1.0,
+        "precisionNull": 0.0,
+        "scoredFraction": 0.983819,
+        "truthViolations": 0,
+        "sigmaFocus": 0.057878,
+        "afR2": 0.99999,
+        "sensitivity": 10.0
+      },
+      "B": {
+        "recallHigh": 0.988024,
+        "recallAll": 0.949438,
+        "precision": 1.0,
+        "precisionNull": 0.0,
+        "scoredFraction": 0.976879,
+        "truthViolations": 0,
+        "sigmaFocus": 0.117807,
+        "afR2": 0.999967,
+        "sensitivity": 8.125
+      },
+      "protectedStars": 189
+    },
+    "D07_rc10_2000mm/attempt01": {
+      "C0@nc2": {
+        "recallHigh": 0.964587,
+        "recallAll": 0.845683,
+        "precision": 1.0,
+        "precisionNull": 0.029412,
+        "scoredFraction": 0.952527,
+        "truthViolations": 0,
+        "sigmaFocus": 0.057244,
+        "afR2": 0.999998,
+        "sensitivity": 10.0
+      },
+      "A": {
+        "recallHigh": 0.973019,
+        "recallAll": 0.860639,
+        "precision": 1.0,
+        "precisionNull": 0.028616,
+        "scoredFraction": 0.941264,
+        "truthViolations": 0,
+        "sigmaFocus": 0.068228,
+        "afR2": 0.999994,
+        "sensitivity": 8.0
+      },
+      "B": {
+        "recallHigh": 0.944351,
+        "recallAll": 0.914344,
+        "precision": 0.998515,
+        "precisionNull": 0.023873,
+        "scoredFraction": 0.860703,
+        "truthViolations": 0,
+        "sigmaFocus": 0.185646,
+        "afR2": 0.999927,
+        "sensitivity": 7.0
+      },
+      "protectedStars": 1972
+    },
+    "D08_c11_2800mm/attempt01": {
+      "C0@nc2": {
+        "recallHigh": 1.0,
+        "recallAll": 0.88254,
+        "precision": 1.0,
+        "precisionNull": 0.0,
+        "scoredFraction": 0.958621,
+        "truthViolations": 0,
+        "sigmaFocus": 0.933847,
+        "afR2": 0.999614,
+        "sensitivity": 10.0
+      },
+      "A": {
+        "recallHigh": 0.990099,
+        "recallAll": 0.996825,
+        "precision": 1.0,
+        "precisionNull": 0.0,
+        "scoredFraction": 0.747619,
+        "truthViolations": 0,
+        "sigmaFocus": 0.354844,
+        "afR2": 0.999948,
+        "sensitivity": 8.0
+      },
+      "B": {
+        "recallHigh": 1.0,
+        "recallAll": 0.803175,
+        "precision": 1.0,
+        "precisionNull": 0.0,
+        "scoredFraction": 0.780864,
+        "truthViolations": 0,
+        "sigmaFocus": 0.202337,
+        "afR2": 0.99998,
+        "sensitivity": 12.0
+      },
+      "protectedStars": 735
+    },
+    "D09_c14_3800mm/attempt01": {
+      "C0@nc2": {
+        "recallHigh": 0.922222,
+        "recallAll": 0.628205,
+        "precision": 1.0,
+        "precisionNull": 0.0,
+        "scoredFraction": 0.993243,
+        "truthViolations": 0,
+        "sigmaFocus": 1.140838,
+        "afR2": 0.999608,
+        "sensitivity": 10.0
+      },
+      "A": {
+        "recallHigh": 0.955556,
+        "recallAll": 0.982906,
+        "precision": 0.958333,
+        "precisionNull": 0.0,
+        "scoredFraction": 0.470588,
+        "truthViolations": 0,
+        "sigmaFocus": 0.682799,
+        "afR2": 0.999896,
+        "sensitivity": 0.0
+      },
+      "B": {
+        "recallHigh": 1.0,
+        "recallAll": 0.982906,
+        "precision": 1.0,
+        "precisionNull": 0.0,
+        "scoredFraction": 0.448343,
+        "truthViolations": 0,
+        "sigmaFocus": 0.643927,
+        "afR2": 0.999861,
+        "sensitivity": 0.0
+      },
+      "protectedStars": 3929
+    },
+    "D10_rc16_3250mm_sparse/attempt01": {
+      "C0@nc2": {
+        "recallHigh": 0.982759,
+        "recallAll": 0.765217,
+        "precision": 1.0,
+        "precisionNull": 0.0,
+        "scoredFraction": 1.0,
+        "truthViolations": 0,
+        "sigmaFocus": 1.036151,
+        "afR2": 0.999624,
+        "sensitivity": 10.0
+      },
+      "A": {
+        "recallHigh": 0.931034,
+        "recallAll": 0.965217,
+        "precision": 0.909836,
+        "precisionNull": 0.0,
+        "scoredFraction": 0.600985,
+        "truthViolations": 0,
+        "sigmaFocus": 0.573749,
+        "afR2": 0.99989,
+        "sensitivity": 0.0
+      },
+      "B": {
+        "recallHigh": 0.965517,
+        "recallAll": 0.982609,
+        "precision": 0.991228,
+        "precisionNull": 0.0,
+        "scoredFraction": 0.666667,
+        "truthViolations": 0,
+        "sigmaFocus": 1.037879,
+        "afR2": 0.999786,
+        "sensitivity": 0.0
+      },
+      "protectedStars": 88
+    },
+    "D11_rc10_585_afbin2/attempt01": {
+      "C0@nc2": {
+        "recallHigh": 0.887218,
+        "recallAll": 0.642643,
+        "precision": 1.0,
+        "precisionNull": 0.0,
+        "scoredFraction": 0.986175,
+        "truthViolations": 0,
+        "sigmaFocus": 0.101177,
+        "afR2": 0.999983,
+        "sensitivity": 10.0
+      },
+      "A": {
+        "recallHigh": 0.849624,
+        "recallAll": 0.891892,
+        "precision": 1.0,
+        "precisionNull": 0.002463,
+        "scoredFraction": 0.731527,
+        "truthViolations": 0,
+        "sigmaFocus": 0.118674,
+        "afR2": 0.999985,
+        "sensitivity": 0.0
+      },
+      "B": {
+        "recallHigh": 0.917293,
+        "recallAll": 0.942943,
+        "precision": 1.0,
+        "precisionNull": 0.006012,
+        "scoredFraction": 0.626747,
+        "truthViolations": 0,
+        "sigmaFocus": 0.444079,
+        "afR2": 0.999506,
+        "sensitivity": 0.0
+      },
+      "protectedStars": 990
+    },
+    "D12_c14_585_afbin2/attempt01": {
+      "C0@nc2": {
+        "recallHigh": 0.897196,
+        "recallAll": 0.537994,
+        "precision": 1.0,
+        "precisionNull": 0.0,
+        "scoredFraction": 0.951613,
+        "truthViolations": 0,
+        "sigmaFocus": 1.330664,
+        "afR2": 0.999413,
+        "sensitivity": 10.0
+      },
+      "A": {
+        "recallHigh": 0.897196,
+        "recallAll": 0.942249,
+        "precision": 1.0,
+        "precisionNull": 0.0,
+        "scoredFraction": 0.652632,
+        "truthViolations": 0,
+        "sigmaFocus": 3.817582,
+        "afR2": 0.988039,
+        "sensitivity": 0.0
+      },
+      "B": {
+        "recallHigh": 0.878505,
+        "recallAll": 0.914894,
+        "precision": 0.996689,
+        "precisionNull": 0.001961,
+        "scoredFraction": 0.507563,
+        "truthViolations": 0,
+        "sigmaFocus": 0.530791,
+        "afR2": 0.999883,
+        "sensitivity": 0.0
+      },
+      "protectedStars": 4002
+    },
+    "D13_apo200_1800mm/attempt01": {
+      "C0@nc2": {
+        "recallHigh": 1.0,
+        "recallAll": 0.960759,
+        "precision": 1.0,
+        "precisionNull": 0.002538,
+        "scoredFraction": 0.961977,
+        "truthViolations": 0,
+        "sigmaFocus": 2.352441,
+        "afR2": 0.999224,
+        "sensitivity": 10.0
+      },
+      "A": {
+        "recallHigh": 1.0,
+        "recallAll": 0.756962,
+        "precision": 1.0,
+        "precisionNull": 0.001647,
+        "scoredFraction": 0.985173,
+        "truthViolations": 0,
+        "sigmaFocus": 1.16725,
+        "afR2": 0.999664,
+        "sensitivity": 12.0
+      },
+      "B": {
+        "recallHigh": 0.98556,
+        "recallAll": 0.983544,
+        "precision": 1.0,
+        "precisionNull": 0.001688,
+        "scoredFraction": 0.652941,
+        "truthViolations": 0,
+        "sigmaFocus": 0.29096,
+        "afR2": 0.999991,
+        "sensitivity": 2.5
+      },
+      "protectedStars": 663
+    },
+    "D14_cdk14_2563mm_e47/attempt01": {
+      "C0@nc2": {
+        "recallHigh": 0.979167,
+        "recallAll": 0.842941,
+        "precision": 1.0,
+        "precisionNull": 0.001918,
+        "scoredFraction": 0.964627,
+        "truthViolations": 0,
+        "sigmaFocus": 0.118606,
+        "afR2": 0.999986,
+        "sensitivity": 10.0
+      },
+      "A": {
+        "recallHigh": 0.989583,
+        "recallAll": 0.93985,
+        "precision": 1.0,
+        "precisionNull": 0.002534,
+        "scoredFraction": 0.947767,
+        "truthViolations": 0,
+        "sigmaFocus": 0.23783,
+        "afR2": 0.999937,
+        "sensitivity": 10.0
+      },
+      "B": {
+        "recallHigh": 0.984375,
+        "recallAll": 0.639933,
+        "precision": 0.997396,
+        "precisionNull": 0.0,
+        "scoredFraction": 0.673094,
+        "truthViolations": 0,
+        "sigmaFocus": 0.062882,
+        "afR2": 0.999995,
+        "sensitivity": 16.166667
+      },
+      "protectedStars": 4160
+    },
+    "D15_cdk20_3454mm_e47/attempt01": {
+      "C0@nc2": {
+        "recallHigh": 0.954023,
+        "recallAll": 0.724409,
+        "precision": 1.0,
+        "precisionNull": 0.0,
+        "scoredFraction": 0.978723,
+        "truthViolations": 0,
+        "sigmaFocus": 0.201654,
+        "afR2": 0.999958,
+        "sensitivity": 10.0
+      },
+      "A": {
+        "recallHigh": 0.942529,
+        "recallAll": 0.964567,
+        "precision": 0.968379,
+        "precisionNull": 0.0,
+        "scoredFraction": 0.548807,
+        "truthViolations": 0,
+        "sigmaFocus": 1.388652,
+        "afR2": 0.998025,
+        "sensitivity": 0.0
+      },
+      "B": {
+        "recallHigh": 0.931034,
+        "recallAll": 0.771654,
+        "precision": 1.0,
+        "precisionNull": 0.0,
+        "scoredFraction": 0.707581,
+        "truthViolations": 0,
+        "sigmaFocus": 0.197186,
+        "afR2": 0.999932,
+        "sensitivity": 10.0
+      },
+      "protectedStars": 722
+    },
+    "D16_esprit550_ha3/attempt01": {
+      "C0@nc2": {
+        "recallHigh": 0.88587,
+        "recallAll": 0.468215,
+        "precision": 1.0,
+        "precisionNull": 0.0,
+        "scoredFraction": 0.984576,
+        "truthViolations": 0,
+        "sigmaFocus": 0.615196,
+        "afR2": 0.995386,
+        "sensitivity": 10.0
+      },
+      "A": {
+        "recallHigh": 0.907609,
+        "recallAll": 0.546455,
+        "precision": 1.0,
+        "precisionNull": 0.0,
+        "scoredFraction": 0.74376,
+        "truthViolations": 0,
+        "sigmaFocus": 0.171172,
+        "afR2": 0.99934,
+        "sensitivity": 2.5
+      },
+      "B": {
+        "recallHigh": 0.73913,
+        "recallAll": 0.350856,
+        "precision": 1.0,
+        "precisionNull": 0.0,
+        "scoredFraction": 0.982877,
+        "truthViolations": 0,
+        "sigmaFocus": 0.314641,
+        "afR2": 0.998542,
+        "sensitivity": 10.0
+      },
+      "protectedStars": 13544
+    },
+    "D17_cdk14_oiii5/attempt01": {
+      "C0@nc2": {
+        "recallHigh": 1.0,
+        "recallAll": 0.860577,
+        "precision": 1.0,
+        "precisionNull": 0.005525,
+        "scoredFraction": 0.942105,
+        "truthViolations": 0,
+        "sigmaFocus": 0.54315,
+        "afR2": 0.999543,
+        "sensitivity": 10.0
+      },
+      "A": {
+        "recallHigh": 1.0,
+        "recallAll": 1.0,
+        "precision": 0.958525,
+        "precisionNull": 0.006993,
+        "scoredFraction": 0.485459,
+        "truthViolations": 0,
+        "sigmaFocus": 2.648151,
+        "afR2": 0.990752,
+        "sensitivity": 0.0
+      },
+      "B": {
+        "recallHigh": 1.0,
+        "recallAll": 0.990385,
+        "precision": 1.0,
+        "precisionNull": 0.008721,
+        "scoredFraction": 0.567493,
+        "truthViolations": 0,
+        "sigmaFocus": 0.146185,
+        "afR2": 0.99998,
+        "sensitivity": 0.0
+      },
+      "protectedStars": 7159
+    }
   }
 }

--- a/docs/synthetic-af-bank-expectations.json
+++ b/docs/synthetic-af-bank-expectations.json
@@ -1,15 +1,27 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
+  "scoredAgainstSchema": "afbank-verify/5",
   "_comment": [
-    "Expected precision/recall bands for the synthetic AF bank, checked in so a V2 bank-verify run can be",
-    "scored against a stated expectation instead of against whatever it happened to produce. A cell landing",
-    "outside its band is a FLAG that gets triaged into docs/followups.md -- it is NEVER fixed by widening the",
-    "band here. Widening a band is a deliberate, separately-justified edit.",
+    "Expected precision/recall bands for the synthetic AF bank, checked in so a bank-verify run can be scored",
+    "against a stated expectation instead of against whatever it happened to produce. A cell landing outside its",
+    "band is a FLAG that gets triaged into docs/followups.md -- it is NEVER fixed by widening the band here.",
+    "Widening a band is a deliberate, separately-justified edit.",
     "",
     "Why these numbers can be demanded at all: golden tier 'high' is peak SNR >= 20, which is 2x the detector's",
     "own default Sensitivity gate (~10). A star the detector misses at 2x its own threshold, on a clean synthetic",
-    "frame whose truth is exact, is a genuine recall defect rather than a borderline call. And because synthetic",
-    "truth is complete, precision here is an exact measurement, not the lower bound the real bank can only give."
+    "frame whose truth is exact, is a genuine recall defect rather than a borderline call.",
+    "",
+    "PRECISION BANDS WERE RE-DERIVED AT SCHEMA /5 (2026-08-03). The previous 0.95/0.98 were fitted to a metric",
+    "that charged a false positive for every real star the golden policy dropped (F31), under which 96% of",
+    "reported false positives were real rendered stars. They are NOT carried forward -- a band calibrated to a",
+    "broken instrument encodes the breakage. Measured at /5, C0@nc2 precision is 1.000 on all 17 datasets and",
+    "config B never falls below 0.991, so the bands below are set where a REGRESSION would show rather than where",
+    "the old artifact happened to sit.",
+    "",
+    "ALWAYS CHECK precisionNull AND truthViolations BEFORE SCORING A PRECISION BAND. truthViolations must be 0;",
+    "non-zero means the metric is charging real stars again and no precision figure from that run is usable.",
+    "precisionNull is what chance alone scores -- if it approaches the band, the metric is saturated and passing",
+    "the band means nothing. Both are emitted per config by bank-verify at /5."
   ],
 
   "classes": {
@@ -17,10 +29,11 @@
       "description": "Wide field, unobstructed, severely oversampled (HFR_min at or under the R2 pixelization floor). Judged on C0@nc2 -- these need no optimizer enrichment.",
       "config": "C0@nc2",
       "recallHighMin": 0.90,
-      "precisionMin": 0.95,
+      "precisionMin": 0.98,
+      "_precisionRationale": "Measured 1.000 on all three W datasets at /5. Set at 0.98 rather than 1.000 because this class carries the bank's highest chance-coincidence floor -- D01's precisionNull is 0.169, by far the largest, since a 19.4 arcsec/px field packs ~2000 protected truth stars per frame. A band at 1.000 would be scoring noise on the one class where the metric has least headroom.",
       "_recallRationale": "Lower than the M class on purpose: at 0.7px HFR_min the PSF is at the pixelization limit, where centroiding and the MinHFR floor legitimately cost recall.",
       "_measured2026_08_02": [
-        "MISSED, badly: D01 0.135, D02 0.475, D03 0.400 against the 0.90 floor. Precision was met (0.963/0.991/0.988).",
+        "MISSED, badly: D01 0.135, D02 0.475, D03 0.400 against the 0.90 floor. Precision was met (1.000 on all three at /5; the 0.963/0.991/0.988 first recorded here were artifacts of the pre-F31 metric).",
         "The band is NOT widened to fit. It is recorded as wrong for a specific, understood reason: it was set",
         "assuming a gentle pixelization loss, when the actual mechanism is the hard MinHFR = 1.2px gate (F20).",
         "D01's in-focus frames detect ZERO stars while their goldens are fully populated, so this is a cliff, not a slope.",
@@ -33,21 +46,24 @@
       "description": "Mid focal length, unobstructed, well sampled. The 'well-sampled implies ~everything' anchor.",
       "config": "C0@nc2",
       "recallHighMin": 0.97,
-      "precisionMin": 0.95,
+      "precisionMin": 0.99,
+      "_precisionRationale": "Measured 1.000 across the class at /5, against a null of 0.000-0.113. Well-sampled unobstructed frames are where the detector has the least excuse for a false positive, so this is the tightest precision band in the set.",
       "_recallRationale": "The strictest band in the set. If the detector cannot find 97% of stars at 2x its own gate on a clean, well-sampled synthetic frame, something is wrong that no amount of real-bank noise should have been hiding."
     },
     "L34": {
       "description": "Long focal length, 0.34 central obstruction (SCT class). Donut PSFs at the sweep extremes.",
       "config": "B",
       "recallHighMin": 0.90,
-      "precisionMin": 0.90,
+      "precisionMin": 0.98,
+      "_precisionRationale": "Measured 0.991-1.000 under config B at /5. The pre-F31 band of 0.90 was a MISS across the board (0.448-0.859) purely because of the metric defect; at /5 the whole class clears 0.98 comfortably, so that is where a real regression would show.",
       "_configRationale": "Judged on config B (donut detection forced on) because C0 is expected to be broken on donut datasets -- that breakage is recorded, not treated as a failure."
     },
     "L47": {
       "description": "Long focal length, 0.47 central obstruction (RC/CDK class). The deepest donuts in the bank.",
       "config": "B",
       "recallHighMin": 0.90,
-      "precisionMin": 0.90
+      "precisionMin": 0.98,
+      "_precisionRationale": "See L34. Measured 0.991-1.000 under config B at /5."
     }
   },
 
@@ -72,8 +88,24 @@
   },
 
   "globalBands": {
-    "configAPrecisionMinNonDonut": 0.98,
-    "_configAComment": "Config A is the optimizer's own landing with donut detection OFF. On a dataset with no donuts, the optimizer has every opportunity to tune precision, so 0.98 is the floor for it having done so. Donut datasets are exempt because A deliberately withholds the axis they need.",
+    "configAPrecisionMinNonDonut": 0.99,
+    "_configAComment": "Config A is the optimizer's own landing with donut detection OFF. On a dataset with no donuts the optimizer has every opportunity to tune precision, and at /5 it measures 1.000 on EVERY non-donut dataset, so 0.99 is the floor for it having done so.",
+    "configAPrecisionMinDonut": 0.90,
+    "_configADonutComment": [
+      "Config A on a DONUT dataset is the one place precision genuinely degrades: D10 0.910, D09 0.958, D17 0.959,",
+      "D15 0.968 -- the long-focal-length rigs that land at Sensitivity 0. This is F23's predicted effect, real but",
+      "roughly one fifth the size of the artifact that hid it (V2 reported these as 0.451-0.547). The band is set",
+      "just under the worst observed value: it is a REGRESSION guard, not an endorsement. Do not read a pass here as",
+      "'the objective has no precision problem' -- read F32 instead, which is why the problem is not fixable by",
+      "adding a term.",
+      "",
+      "Also check scoredFraction on these rows. It falls to 0.45-0.75 at a floored Sensitivity, so config-A",
+      "precision on a donut dataset rests on roughly half the sample C0's does."
+    ],
+    "precisionNullMax": 0.20,
+    "_precisionNullComment": "A run whose null control approaches its precision band is not measuring anything. Observed 0.000-0.169 (D01 is the maximum, being the densest field). If this rises materially, the protection geometry has been loosened and the precision bands above stop meaning what they say.",
+    "truthViolationsMax": 0,
+    "_truthViolationsComment": "A scored false positive sitting on a real rendered star is the F31 defect itself. Synthetic truth is complete by construction, so this has an exact answer and the answer is zero. ANY non-zero value voids every precision figure in that run -- it is not a tolerance.",
     "autofocusRSquaredMin": 0.95,
     "_afR2Comment": "Per-run autofocus fit R^2 on the synthetic hyperbola. The render matches DefocusModel by construction, so anything below 0.95 means the DETECTOR's HFR is not tracking the optical truth -- which is the interesting failure, not a fitting artifact.",
     "sensorModelRSquaredMin": 0.90,
@@ -81,7 +113,7 @@
   },
 
   "regressionRule": {
-    "_comment": "Applies when comparing two runs on the SAME schema (afbank-verify/3) and the same bank seeds. Any breach is a FLAG for triage, not an automatic failure -- read the per-run notes first.",
+    "_comment": "Applies when comparing two runs on the SAME schema (afbank-verify/5) and the same bank seeds. Any breach is a FLAG for triage, not an automatic failure -- read the per-run notes first. Comparing across schema versions is meaningless for precision: /3 charged real stars as false positives, and /4's protection predicate was dilated by the detection's own bounding box.",
     "recallHighDropMax": 0.02,
     "precisionDropMax": 0.02,
     "sigmaFocusWorseFractionMax": 0.20,

--- a/docs/synthetic-af-bank-followups-wave2-results.md
+++ b/docs/synthetic-af-bank-followups-wave2-results.md
@@ -191,6 +191,11 @@ still viable.
 | F34 — convergence requires the tolerance band | no (harness) |
 | F27 — stale gate counts corrected, the optimizer seam documented | no (docs) |
 
+**F34 verified on its motivating case.** `synth-validate --datasets D05_tec140_1000mm --scenarios S2` now
+reports `converged: false` with `stoppedReason: "stalled (round applied nothing, but step 140 is outside the 14
+tolerance band of step_behavioral 35)"`, and A3 still FAILs the same number. Same run, same step, same
+assertion — the report no longer contradicts itself.
+
 **F28 is the only behavioural change.** Signal-sufficient runs where every frame is short of the star-count
 target AND the gate sat below its own inert bound move from "no exposure offered" to a 2× probe. The rig that
 motivated the zero-rejections test is untouched — it rejected 5 candidates at 2 s, so its gate was demonstrably

--- a/docs/synthetic-af-bank-followups-wave2-results.md
+++ b/docs/synthetic-af-bank-followups-wave2-results.md
@@ -1,0 +1,211 @@
+# Synthetic AF bank — followups wave 2
+
+Plan: [`plans/synthetic-af-bank-followups-wave2-plan.md`](../plans/synthetic-af-bank-followups-wave2-plan.md).
+Wave 1: [`docs/f23-objective-precision-term-results.md`](f23-objective-precision-term-results.md).
+Baseline: [`docs/synthetic-af-bank-baseline-results.md`](synthetic-af-bank-baseline-results.md) §V3.
+
+*The question: [F31](followups.md) proved the metric wave 1 was scored against was broken. Re-measure everything
+that rested on it, close F24 (the one followup wave 1 never re-measured), and ship the findings that never
+depended on precision.*
+
+## Headline
+
+| what | result |
+|---|---|
+| Does the repaired metric measure anything? | **Yes** — null control 0.000–0.169, `truthViolations` 0 on all 51 rows |
+| F23 — "trades precision for marginal recall" | **Won't fix as written.** Real effect ~1/5 the reported size; C0's floor was 1.000, not 0.942 |
+| F24 — "donut detection costs precision" | **REFUTED.** D13 (ε=0 control) scores **1.000** under B, not 0.653. Restated as a *recall* finding |
+| F27 — rejected-candidate diagnostics | **Done** — the spec making the claim was never merged; record corrected, seam documented in code |
+| F28 — `LowSensitivity` reads 0 when the gate is inert | **Done** — user-visible; the exposure probe now reaches the population it was written for |
+| F30 — a landing does not say what produced it | **Done** — provenance block, schema 3 |
+| F34 — `synth-validate` scored a stall as convergence | **Done** — convergence now requires the tolerance band |
+| New: F32 | **`J` is saturated near 1.0.** `toml999` gives up 0.462 of recall@≥12 to gain **+0.0002** of `J` |
+| New: F33 | **The synthetic bank does not reproduce the real bank's failure mode** — opposite signs |
+
+## The gate: validate the instrument before spending hours against it
+
+Wave 1's most expensive lesson was that reproducibility validated nothing — every check confirmed determinism,
+and a deterministic pipeline reproduces a systematic error perfectly, because the bias lived in the reference
+all the checks shared. So wave 2 opened by checking the instrument against an independent source, and did it
+**without running the detector at all**.
+
+`golden eval` writes `detected_f<focuser>.csv` per frame. Thirty saved configurations were still on disk from
+wave 1 — D09/D13/D17 at nine Sensitivity values each, plus D10/D11/D12 — so every scoring policy could be
+applied to a bit-identical detection set offline. Minutes of work.
+
+**The offline scorer was validated first.** Re-implementing `GoldenMatch.Match` / `ExcludeUnresolved` in Python
+reproduces the published C# `/3` numbers exactly: D09 s0 **0.8037** vs 0.804, D17 s0 **0.6974** vs 0.697,
+D13 s0 **0.8504** vs 0.850, D12 s0 **0.8222** vs the 0.822 in that run's own `golden_eval.txt`. Only then were
+its other columns worth reading.
+
+| dataset | sens | dets | `/3` | `/4` impl | `/4` sym | truth | **null** | scored |
+|---|---|---|---|---|---|---|---|---|
+| D09_c14_3800mm | 0 | 318 | 0.8037 | 1.0000 | 0.9909 | 0.9937 | **0.0000** | 0.689 |
+| D13_apo200_1800mm | 0 | 1075 | 0.8504 | 1.0000 | 1.0000 | 1.0000 | **0.0028** | 0.735 |
+| D17_cdk14_oiii5 | 0 | 337 | 0.6974 | 0.9895 | 0.9793 | 0.9881 | **0.0093** | 0.573 |
+| D11_rc10_585_afbin2 | 0 | 415 | 0.9070 | 1.0000 | 1.0000 | 1.0000 | **0.0024** | 0.752 |
+| D12_c14_585_afbin2 | 0 | 493 | 0.8222 | 1.0000 | 1.0000 | 1.0000 | **0.0023** | 0.600 |
+
+**null** translates every detection by (+317, +211) with wraparound: count and clustering survive,
+correspondence with the frame does not, so whatever precision remains is chance. **truth** scores TP as "within
+the match radius of any rendered star". **scored** is the fraction of detections entering the ratio at all.
+
+Four findings, each of which changed what wave 2 did:
+
+**1. All-1.000 here is a measurement, not saturation — the stop condition passes.** The null reads 0.000–0.012.
+A detector placing detections at random scores essentially zero, so the metric's dynamic range is effectively
+the full interval. The 2·HFR saturation F31 warns about would have appeared here as a *high* null.
+
+**2. Three independent policies agree to within 0.006.** The real false-positive rate is **0–2%** on these
+configurations, confirming F31 from a second direction.
+
+**3. The `/3` violation, counted rather than argued.** Detections charged as a false positive while sitting on a
+real rendered star: **52/318** on D09 s0, **79/337** on D17 s0, **139/1075** on D13 s0, **64/493** on D12 s0.
+Under `/4`: **0 on all 30 configurations.** That count is now a shipped field.
+
+**4. A residual asymmetry in the F31 repair, always flattering.** `GoldenMatch.Covers` excludes on
+`centre-in-box OR IoU(box, det.bbox) > 0`, so the *detection's own bounding box* dilates every protection box —
+a wide donut detection is protected far past the match radius, despite the class comment claiming protection is
+"exactly as generous as matching". Measured at ≤0.011 and one-directional. Fixed in `/5`.
+
+## What `afbank-verify/5` adds
+
+Three things, so the next reader can check the instrument instead of trusting it:
+
+- **A symmetric protection predicate.** A detection is excluded iff its centroid is within the match radius of a
+  protected truth star — the same predicate matching uses. The golden's own `unresolved` boxes keep `Covers`,
+  because that is the real bank's scoring path and moving it would break comparability with every published
+  real-bank number.
+- **`precisionNull`** — what chance alone scores, per config. The floor the metric can read.
+- **`truthViolations`** — scored false positives sitting on a real rendered star. The F31 signature itself; it
+  must be 0, and a non-zero value prints loudly rather than producing a quietly wrong number.
+
+Plus `scoredFraction`, because at a floored Sensitivity only 45–75% of detections are judgeable and a precision
+figure there rests on a much smaller sample than C0's.
+
+Real-bank runs have no truth sidecar, so every new path is a no-op and real-bank numbers stay comparable.
+
+## The re-baseline
+
+Full V3 matrix in [`synthetic-af-bank-baseline-results.md`](synthetic-af-bank-baseline-results.md). The two
+results that move:
+
+**F23's direction survives, its magnitude does not.**
+
+| | as recorded | at `/5` |
+|---|---|---|
+| C0@nc2 precision, worst of 17 | 0.942 | **1.000** |
+| Config A precision, worst of 17 | 0.451 (D09) | **0.910** (D10) |
+| Config A datasets below 0.90 | 6 | **0** |
+
+Config A does cost precision, on exactly the datasets F23 named — D10 0.910, D09 0.958, D17 0.959, D15 0.968,
+every one a long-focal-length rig landing at Sensitivity 0. That is a real effect roughly **one fifth** the size
+of the artifact that hid it.
+
+**F24 is refuted.** Its headline was "donut detection costs precision even where donuts exist, and badly where
+they do not — D13 0.962 → 0.653" on the ε=0 control. Re-measured, **D13 scores 1.000 under config B**, and B's
+precision never falls below 0.991 on any dataset. What B actually costs is *recall*, and only where it is not
+needed:
+
+| dataset | ε | Δrecall@high | σ_focus C0 → B |
+|---|---|---|---|
+| D16_esprit550_ha3 | 0 | **−0.147** | 0.615 → 0.315 |
+| D04_esprit_550mm | 0 | **−0.113** | 0.232 → 0.059 |
+| D13_apo200_1800mm | 0 | −0.014 | **2.352 → 0.291** |
+| D03_redcat_250mm | 0 | **+0.138** | 1.183 → 0.341 |
+
+D13 is the sharpest reversal: the dataset cited as proof that donut detection does damage keeps 1.000 precision,
+gives up 0.014 recall, and improves its AF fit **eightfold**.
+
+**The bands were re-derived, not carried forward.** 0.95/0.98 were fitted to the broken metric, and a band
+calibrated to a broken instrument encodes the breakage. They now sit where a regression would show, plus two
+instrument gates: `precisionNullMax` 0.20 and `truthViolationsMax` 0 — the latter a *void* condition, not a
+tolerance.
+
+## The findings that never depended on precision
+
+These are the real remaining value, and F31 touches none of them.
+
+### F32 — `J` is saturated near 1.0
+
+Across the 17 scorable real-bank runs the optimizer gives up a **median 0.243 of recall@≥12** to gain a **median
+ΔJ of +0.0125**:
+
+| run | recall@≥12 C0 → A | Δrecall | ΔJ |
+|---|---|---|---|
+| `toml999` | 0.819 → 0.357 | **−0.462** | **+0.0002** |
+| `CWhiteFocus` | 0.810 → 0.327 | −0.483 | +0.0042 |
+| `uneven` | 0.931 → 0.319 | −0.613 | +0.0046 |
+| `muggsie` | 0.879 → 0.512 | −0.368 | +0.0039 |
+
+`toml999` states it best: **two ten-thousandths of `J` bought with 46 points of recall.** At `BaselineJ` values
+of 0.98–0.999 there is no headroom left, so every remaining move is a rounding error in the objective and a
+catastrophe in the star list.
+
+This is upstream of F23 and F4. **A precision term, a sensor term, or any other new term added to a `J` already
+sitting at 0.998 competes for an exhausted fourth decimal place** — which is the better explanation for why F23
+wave 1's mechanism (a) produced real precision movement and still cleared no gate.
+
+### F33 — the synthetic bank does not reproduce the real bank's failure mode
+
+| bank | landings | detections C0 → A |
+|---|---|---|
+| synthetic (6 of 17) | Sensitivity **0.0** | up |
+| real: `CWhiteFocus` | **50.0** | 1807 → **534** |
+| real: `standard_example1` | **34.3** | 602 → **177** |
+| real: `mccomiskey` | 0.0, but **StarClip 10.0** | 3606 → **43** |
+
+Opposite signs. F23's framing — "the optimizer drives `BrightnessSensitivity` to its 0.0 floor" — is a
+**synthetic-bank-only** description; on real rigs it drives Sensitivity *up* and sheds stars. `mccomiskey` is
+the instructive case: Sensitivity reads 0.0, which looks like the synthetic pathology, but the effective gate is
+`PeakResponse × StarClip = 7.5` — the same escape route F23 wave 1 measured on D12 and D15, operating here as
+the shedding mechanism.
+
+**Consequence:** no objective change may be accepted on the synthetic bank alone.
+
+### F20 reproduces on the real bank
+
+`BaselineJ` is exactly **0.0000** on `Panos` and `LinwoodFocus` — the only two runs of nineteen where it is, and
+the only two whose recall *improves* under the optimizer (+0.031, +0.089), for the reason F32 gives: they are
+the only ones with headroom to climb. So the cold-start plateau is not a synthetic artifact of the render, and
+the affected population is not hypothetical. The prepass reproduced it again under config B: D01 and D02 both
+report `currentJ=0 bestJ=0 hard-floor FAIL`.
+
+The risk on the proposed fix stands and is worth restating: seeding `MinHFR` beneath the measured in-focus HFR
+creates a knob the search has no gradient to climb back out of, so it should be seeded to a *measured* value,
+not a permissive one.
+
+### F22 is unaffected
+
+A binning/HFR result, not a precision one. Still confirmed, its "calibrate out the bias" fix still ruled out
+(the under-read tracks the Sensitivity landing rather than being a property of the measurement), hysteresis
+still viable.
+
+## What shipped
+
+| change | user-visible? |
+|---|---|
+| `afbank-verify/5` — symmetric protection, `precisionNull`, `truthViolations`, `scoredFraction` | no (harness) |
+| F28 — the exposure discriminator is conditional on the gate being able to reject | **yes** |
+| F30 — `Provenance` on `optimized_settings.json`, schema 3 | no (metadata) |
+| F34 — convergence requires the tolerance band | no (harness) |
+| F27 — stale gate counts corrected, the optimizer seam documented | no (docs) |
+
+**F28 is the only behavioural change.** Signal-sufficient runs where every frame is short of the star-count
+target AND the gate sat below its own inert bound move from "no exposure offered" to a 2× probe. The rig that
+motivated the zero-rejections test is untouched — it rejected 5 candidates at 2 s, so its gate was demonstrably
+live, and the two populations are disjoint by construction.
+
+## Reproduce
+
+```
+# config-B prepass (~55 min; config A reuses the wave-1 control arm)
+TestApp optimize --per-run --runs "D:\SyntheticAutofocusBank" --out <B> --max-evals 250 --donut
+
+# the V3 matrix, all three configs in one pass (~24 min)
+TestApp bank-verify --runs "D:\SyntheticAutofocusBank" --out <dir> --nc-sweep 2 \
+    --match-radius 12 --pixel-scale header --opt-a <A> --opt-b <B>
+```
+
+Check `truthViolations == 0` and `precisionNull` before reading any precision figure. Both are in the per-run
+JSON and in the markdown table.

--- a/plans/af-recommender-hardening-plan.md
+++ b/plans/af-recommender-hardening-plan.md
@@ -1,8 +1,9 @@
 # AF recommender hardening — implementation plan (wave 1: F23 only)
 
-Design spec: **never committed.** `docs/af-recommender-hardening-design.md` does not exist in the repository
-and no revision of it does, so this plan is the design of record. Its "Signals already available" table
-(below) is what actually held up under checking; the spec's version of that claim did not. See
+Design spec: **never merged.** `docs/af-recommender-hardening-design.md` exists only on the unmerged branch
+`ghilios/af-recommender-hardening-design` (`8b7867c`) and is absent from `develop`, so this plan is the design
+of record and every link to the spec dangles for anyone not on that branch. Its "Signals already available"
+table (below) is what actually held up under checking; the spec's version of that claim did not. See
 [F27](../docs/followups.md).
 Baseline measurements: [`docs/synthetic-af-bank-baseline-results.md`](../docs/synthetic-af-bank-baseline-results.md).
 Followups: [`docs/followups.md`](../docs/followups.md) — F23 is the only entry this plan touches.

--- a/plans/af-recommender-hardening-plan.md
+++ b/plans/af-recommender-hardening-plan.md
@@ -1,6 +1,9 @@
 # AF recommender hardening — implementation plan (wave 1: F23 only)
 
-Design spec: [`docs/af-recommender-hardening-design.md`](../docs/af-recommender-hardening-design.md).
+Design spec: **never committed.** `docs/af-recommender-hardening-design.md` does not exist in the repository
+and no revision of it does, so this plan is the design of record. Its "Signals already available" table
+(below) is what actually held up under checking; the spec's version of that claim did not. See
+[F27](../docs/followups.md).
 Baseline measurements: [`docs/synthetic-af-bank-baseline-results.md`](../docs/synthetic-af-bank-baseline-results.md).
 Followups: [`docs/followups.md`](../docs/followups.md) — F23 is the only entry this plan touches.
 

--- a/plans/synthetic-af-bank-followups-wave2-plan.md
+++ b/plans/synthetic-af-bank-followups-wave2-plan.md
@@ -1,0 +1,170 @@
+# Synthetic AF bank — followups wave 2
+
+Executes the remaining synthetic-bank followups after [F31](../docs/followups.md) invalidated the
+precision metric that wave 1 was scored against. Wave 1's results:
+[`docs/f23-objective-precision-term-results.md`](../docs/f23-objective-precision-term-results.md).
+
+**Branch:** `ghilios/synth-bank-followups-wave2` off `develop` (`f066c94`).
+
+## What this wave is for
+
+Wave 1 measured F23 against a metric that charged a false positive for every real star the golden
+policy had dropped. F31 repaired the metric (`afbank-verify/4`) and killed F23 as written. That
+leaves three separable jobs:
+
+1. **Re-baseline** everything that rested on the broken precision — but only after proving the
+   repaired metric measures something.
+2. **Re-measure F24**, the one wave-1 followup explicitly left unmeasured, which currently reads as
+   confirmed on evidence from the same broken metric.
+3. **Ship the findings that never depended on precision** (F20, the recall collapse, F22) and the
+   cheap independent fixes (F27, F28, F30, the convergence predicate).
+
+## Task 0 — validate the measuring instrument (GATE, done before anything else)
+
+The wave-1 lesson: *verify the instrument against an independent source before running a multi-hour
+experiment against it.* Wave 1's every reproducibility check passed while the reference they all
+shared was biased. So this wave starts by re-scoring **saved detection dumps** — `golden eval` writes
+`detected_f<focuser>.csv` per frame, so the detector never has to run again and every scoring policy
+sees a bit-identical detection set.
+
+30 saved configurations (D09/D13/D17 at nine Sensitivity values each, plus D10/D11/D12 at
+Sensitivity 0), scored under four policies plus a null control.
+
+**The offline scorer is validated first:** re-implementing `GoldenMatch.Match` /
+`GoldenMatch.ExcludeUnresolved` in Python reproduces the published C# `/3` numbers exactly — D09 s0
+0.8037 vs 0.804, D17 s0 0.6974 vs 0.697, D13 s0 0.8504 vs 0.850, D12 s0 0.8222 vs the 0.822 in that
+run's own `golden_eval.txt`. Only then are its other columns believable.
+
+### GATE result — the metric is NOT saturated; baselining may proceed
+
+| dataset | sens | dets | P `/3` | P `/4` impl | P `/4` sym | P truth | **null** | scored frac |
+|---|---|---|---|---|---|---|---|---|
+| D09_c14_3800mm | 0 | 318 | 0.8037 | 1.0000 | 0.9909 | 0.9937 | **0.0000** | 0.689 |
+| D09_c14_3800mm | 6 | 214 | 1.0000 | 1.0000 | 1.0000 | 1.0000 | **0.0000** | 0.963 |
+| D13_apo200_1800mm | 0 | 1075 | 0.8504 | 1.0000 | 1.0000 | 1.0000 | **0.0028** | 0.735 |
+| D17_cdk14_oiii5 | 0 | 337 | 0.6974 | 0.9895 | 0.9793 | 0.9881 | **0.0093** | 0.573 |
+| D11_rc10_585_afbin2 | 0 | 415 | 0.9070 | 1.0000 | 1.0000 | 1.0000 | **0.0024** | 0.752 |
+| D12_c14_585_afbin2 | 0 | 493 | 0.8222 | 1.0000 | 1.0000 | 1.0000 | **0.0023** | 0.600 |
+
+- **null** = the same detections translated by (+317, +211) px with wraparound. Count and spatial
+  clustering are preserved; correspondence with the frame is destroyed. Whatever precision survives
+  is chance coincidence, and it is the floor the metric can never read below.
+- **P truth** = TP iff the detection is within the match radius of *any* rendered truth star, the
+  policy F31's next-step (1) asks for.
+- **scored frac** = the fraction of detections that enter the precision ratio at all.
+
+Four findings, each of which changes what this wave does:
+
+**1. All-1.000 here is a measurement, not saturation.** The null control reads **0.000–0.012**. A
+detector placing its detections at random would score essentially zero, so the metric's dynamic range
+is effectively the full interval and a reading of 1.000 means the detector really did not produce
+false positives. The 2·HFR saturation F31 warns about would have shown up here as a *high* null; it
+does not. This is the specific check the stop condition asks for, and it passes.
+
+**2. Three independent policies agree to within 0.006.** The as-implemented `/4` metric, a `/4`
+variant whose protection predicate is exactly the matching predicate, and direct truth scoring all
+land at 0.98–1.00 on every configuration. The real false-positive rate is **0–2%**, confirming F31
+from a second direction.
+
+**3. The `/3` metric is confirmed broken, with the violation counted directly.** Detections charged
+as a false positive while sitting within the match radius of a real rendered star: **52/318** on D09
+s0, **79/337** on D17 s0, **139/1075** on D13 s0, **64/493** on D12 s0. Under `/4` that count is
+**0 on all 30 configurations**. This is the assertion Task 5 turns into a permanent guard.
+
+**4. A real residual asymmetry in the `/4` repair, always flattering.** `GoldenMatch.Covers` excludes
+on `centre-in-box OR IoU(box, det.bbox) > 0`, so the *detection's own bounding box* dilates every
+protection box — a wide donut detection is protected well past the match radius. The class comment
+claims protection is "exactly as generous as matching"; measured, it is not: D09 s0 reads 1.0000
+under the implemented predicate against 0.9909 under the symmetric one, D17 s0 0.9895 against 0.9793.
+Small (≤0.011) but systematic and one-directional. Fixed in Task 1.
+
+**Not a bias, but worth reporting: the denominator shrinks.** At Sensitivity 0 only 57–75% of
+detections enter the ratio; the rest land on protected stars and are unjudgeable. That is not
+laundering — the excluded fraction is enriched **2.5–53×** over the chance rate implied by the
+protected area, so those detections are overwhelmingly on real stars — but precision at low
+Sensitivity is measured over a materially smaller sample and the report should say so.
+
+## Task 1 — make the instrument self-reporting (`afbank-verify/5`)
+
+Three changes to `BankVerifyRunner` / `TruthProtection`, none of which touch the real bank (no truth
+sidecar ⇒ every path is a no-op and real-bank numbers stay comparable):
+
+1. **Symmetric protection predicate.** Exclude a false positive on a truth-protection box iff its
+   centroid is within `matchRadius` of the truth star — the same predicate matching uses. Leave
+   `GoldenMatch.ExcludeUnresolved`'s `Covers` semantics alone for the golden's own `unresolved`
+   boxes, which is the real-bank path and must not move.
+2. **Null-control precision, reported per config.** Re-score the same detections translated with
+   wraparound. Costs no extra detection pass. A future reader can tell saturation from a real 1.000
+   without re-deriving anything.
+3. **`truthViolations`, reported per config.** The count of scored false positives sitting within
+   `matchRadius` of any truth star. Must be 0. This is the F31 bug's signature, and it is now a
+   number in every report rather than something a person has to think to check.
+
+Also report `scoredFraction` (detections entering the ratio ÷ detections).
+
+## Task 2 — re-baseline
+
+Prepass provenance:
+
+- **Config A** reuses `D:\hf_w2\..\hf_f23\H_A` — the wave-1 control arm, which re-derived config A
+  from an unmodified HEAD and reproduced the published V2 landings exactly on all 17 datasets. Not
+  re-run; re-running a reproduced deterministic search buys nothing.
+- **Config B** is re-derived here (`optimize --per-run --donut`, `D:\hf_w2\B_A`). The V2 config-B
+  prepass output no longer exists and wave 1 never re-ran it, which is precisely why F24 could not be
+  re-measured.
+
+One `bank-verify --nc-sweep 2 --opt-a <A> --opt-b <B>` pass yields the whole matrix. Then:
+
+- rewrite the V2 matrix in `docs/synthetic-af-bank-baseline-results.md` as a V3 matrix at `/5`;
+- write a new measured `docs/synthetic-af-bank-baseline.json` (the old one stays as the audit trail
+  it was converted into);
+- **re-derive** the `precisionMin` bands in `docs/synthetic-af-bank-expectations.json` from the
+  measured distribution. 0.95/0.98 came from the broken metric and are not carried forward.
+
+## Task 3 — F24
+
+Score config B against config A and C0 on the same pass. F24's claim is "donut detection costs
+precision, 0.962 → 0.653 on the ε=0 control (D13)". Both of those numbers are `/3`. Close the entry
+or restate it on `/5` evidence, whichever the measurement supports.
+
+## Task 4 — the findings that never depended on precision
+
+Documentation only; no behavioural change proposed here.
+
+- **F20** — the objective is identically 0 below `MinHFR`, so D01/D02 land `FinalJ = 0.00000` and the
+  search has no gradient at all. Strongest surviving finding. Record the risk that seeding `MinHFR`
+  creates a knob the search cannot climb back out of.
+- **Recall, not precision, is the interesting axis.** On the real bank the optimizer's landings give
+  up 50–90% of recall@≥12 (`mccomiskey` 0.871 → 0.079). Untouched by F31 — the golden's `stars` list
+  still defines what must be found.
+- **F22** stays confirmed; its "calibrate out the bias" fix stays ruled out; hysteresis stays viable.
+
+## Task 5 — cheap independent fixes
+
+- **F27** — `RejectedCandidates` never reaches the optimizer's evaluation path. Close the gap or
+  correct the spec.
+- **F28** — the Sensitivity gate provably rejects nothing below `PeakResponse × StarClip`, so
+  `LowSensitivity` reads 0 exactly when the gate has collapsed, making `ExposureRecommender`'s
+  `StarCountIsTheLimit` branch unreachable for the users it was written for.
+- **F30** — a stored `optimized_settings.json` does not record which invocation produced it.
+- **Convergence predicate** — `synth-validate` scores `converged=true` ("round applied nothing") at a
+  step 4× outside the tolerance band, inflating convergence counts on the most degenerate runs.
+
+## Task 6 — the regression guard
+
+`truthViolations` (Task 1) is the runtime half. The unit half asserts the invariant directly: a
+detection within the match radius of a rendered truth star is never scored as a false positive,
+whatever tier the golden policy assigned it. Four harness-calibration bugs have now been found, three
+in the convergence-predicate family; this class needs to fail loudly rather than be noticed.
+
+## Order of execution
+
+The config-B prepass is the long pole (30–60 min) and depends on nothing, so it starts first and runs
+detached while Task 1 and Task 5 proceed. `bank-verify` (~19–25 min for three configs) needs both the
+prepass and the `/5` binary. Every run is launched detached with a progress file; the exe is
+file-locked while running, so rebuilds go to a separate `-o` directory.
+
+## Conventions
+
+Findings are **flagged in `docs/followups.md`**, not fixed inline. Never push `develop`. Full suite
+before the PR.


### PR DESCRIPTION
Executes the remaining synthetic-bank followups after [F31](../blob/ghilios/synth-bank-followups-wave2/docs/followups.md) invalidated the precision metric wave 1 was scored against.

Plan: `plans/synthetic-af-bank-followups-wave2-plan.md` · Results: `docs/synthetic-af-bank-followups-wave2-results.md`

## The gate came first, and it was cheap

Wave 1's expensive lesson was that **reproducibility validated nothing** — every check confirmed determinism, and a deterministic pipeline reproduces a systematic error perfectly, because the bias lived in the reference all the checks shared.

So this opened by checking the instrument against an independent source, **without running the detector at all**. `golden eval` writes `detected_f<focuser>.csv` per frame, so 30 saved configurations were re-scored offline under four policies plus a null control. The offline scorer was itself validated first, by reproducing the published C# numbers to four decimals (D09 s0 0.8037 vs 0.804, D17 s0 0.6974 vs 0.697, D13 s0 0.8504 vs 0.850). Minutes of work; it would have caught F31 before wave 1 started.

- **Not saturated** — the null control (detections translated with wraparound) scores **0.000–0.012**, so all-1.000 is a measurement, not a metric reporting itself. The stop condition passes.
- **Three independent policies agree to within 0.006** at 0.98–1.00.
- **The `/3` violation, counted:** 52/318 on D09, 79/337 on D17, 139/1075 on D13 charged as false positives while sitting on real rendered stars. **0 under `/4`.**
- **A residual asymmetry, always flattering:** `GoldenMatch.Covers` dilates every protection box by the *detection's own bounding box*, so a wide donut detection is protected past the match radius — despite the comment claiming protection is "exactly as generous as matching". ≤0.011, one-directional. Fixed.

## `afbank-verify/5` — the metric now carries its own evidence

`precisionNull` (what chance alone scores), `truthViolations` (scored FPs on real stars — the F31 signature, must be 0), `scoredFraction`, and a protection predicate symmetric with matching. Real-bank runs have no truth sidecar, so every new path is a no-op.

## Re-baseline (V3) — 17 runs, 0 failed, `truthViolations` 0 on all 51 config rows

**F24 is REFUTED.** It was the one wave-1 followup never re-measured, so it read as confirmed on evidence from the same broken metric that killed F23. Its headline case — D13, the ε=0 control that exists so "donut" and "long focal length" cannot be confounded — scores **1.000** under config B, not 0.653. B's precision never falls below 0.991 anywhere.

Restated on evidence: donut detection costs **recall** where it is not needed (D16 0.886 → 0.739, D04 0.810 → 0.697, both unobstructed 550mm refractors) and helps where the PSF is annular (D03 0.400 → 0.537). D13 keeps 1.000 precision, gives up 0.014 recall, and improves its AF fit **eightfold** (σ_focus 2.352 → 0.291).

**F23 → won't fix as written.** C0's "never below 0.942" was really **1.000**; config A's worst is **0.910**, not 0.451; **zero** datasets below 0.90 where six were. The direction survives on exactly the datasets it named, at ~1/5 the size of the artifact that hid it.

The `precisionMin` bands were **re-derived, not carried forward** — 0.95/0.98 were fitted to the broken metric, and a band calibrated to a broken instrument encodes the breakage.

## Two new findings, neither of which depended on precision

**F32 — `J` is saturated near 1.0.** Across 17 real-bank runs the optimizer gives up a median **0.243 of recall@≥12** to gain a median **ΔJ of +0.0125**. `toml999` gives up **0.462** for **+0.0002**. Any new term — precision, sensor model, anything — competes for an exhausted fourth decimal place.

**F33 — the synthetic bank does not reproduce the real bank's failure mode.** Synthetic: Sensitivity driven **down** to 0, more detections. Real: driven **up** to 31–50, 3–80× fewer (CWhiteFocus 1807 → 534, mccomiskey 3606 → 43). Opposite signs, so no objective change may be accepted on the synthetic bank alone.

Also: **F20 reproduces on the real bank** — `BaselineJ` is exactly 0.0000 on `Panos` and `LinwoodFocus`, the only two runs of nineteen where it is.

## Shipped

| | user-visible? |
|---|---|
| `afbank-verify/5` instrument | no |
| **F28** — the exposure discriminator is conditional on the gate being able to reject | **yes** |
| F30 — `Provenance` on `optimized_settings.json`, schema 3 | no |
| F34 — convergence requires the tolerance band | no |
| F27 — stale gate counts corrected, optimizer seam documented | no |

**F28 is the only behavioural change.** The Sensitivity gate provably rejects nothing below `PeakResponse × EffectiveClipMultiplier` (1.5 at defaults), and that inert region strictly *contains* the band this advice is surfaced in (`HasLowStarSignal` fires at Sensitivity ≤ 1.0) — so `StarCountIsTheLimit` was structurally unreachable for exactly the population it was written for, and those users were told "these frames contain every star the detector can find" from a counter incapable of being non-zero. The 2/7/14 s rig that motivated the zero-rejections test is untouched: it rejected 5 candidates at 2 s, so its gate was live, and the two populations are disjoint by construction.

**F34 verified on its motivating case:** D05 S2 now reports `converged: false` / `"stalled (round applied nothing, but step 140 is outside the 14 tolerance band of step_behavioral 35)"` with A3 still failing the same number — the report no longer contradicts itself.

## Tests

`3354 passed, 0 failed` (32 new). The reproducibility guard in `TiltAdapterWizardVMTests` did its job: it reflects over every read/write DTO property and failed until `Provenance` was declared metadata rather than a knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7R7TUBTvPt5R44CWhu2HT