### PR TITLE
Synthetic AF bank followups wave 3 — F35 MinHFR seeding, F24/F32/F33 measured, F36 audit

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/ExposureRecommenderTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/ExposureRecommenderTests.cs
@@ -666,6 +666,53 @@ public class ExposureRecommenderTests {
         });
     }
 
+    // ── F33: the EFFECTIVE gate, max(Sensitivity, InertSensitivityBound) ────────────────────────────────────
+
+    /// <summary>
+    /// The `mccomiskey` landing, verbatim from its own optimized_settings.json. This is the case F33 was filed
+    /// on: Sensitivity reads 0.0 — indistinguishable from the synthetic bank's floor-landing pathology — while
+    /// the structure/clip stage enforces 9.81 and detections collapse 3606 -> 43.
+    ///
+    /// <para>Note 9.81, not the 7.5 the register originally quoted: that figure used the DEFAULT PeakResponse of
+    /// 0.75, but this landing's own PeakResponse is 0.98. Both inputs are searched axes, so the gate must always
+    /// be computed from the landing's own params.</para>
+    /// </summary>
+    [Test]
+    public void EffectiveSensitivityGate_ExposesAFloorLandingThatIsNotAFloor() {
+        var mccomiskey = new StarDetectorParams {
+            Sensitivity = 0.0, PeakResponse = 0.98, StarClippingMultiplier = 10.0,
+            DefocusAwareDonutDetection = false
+        };
+        Assert.Multiple(() => {
+            Assert.That(ExposureRecommender.SensitivityIsAtFloor(mccomiskey.Sensitivity), Is.True,
+                "the raw axis reads as a floor landing — which is the misreading");
+            Assert.That(StarDetector.EffectiveSensitivityGate(mccomiskey), Is.EqualTo(9.8).Within(1e-9));
+        });
+    }
+
+    /// <summary>When Sensitivity is the binding constraint the effective gate IS Sensitivity — the common case.</summary>
+    [Test]
+    public void EffectiveSensitivityGate_IsTheRawAxis_WhenTheAxisBinds() {
+        var p = new StarDetectorParams { Sensitivity = 34.3, PeakResponse = 0.75, StarClippingMultiplier = 2.9 };
+        Assert.That(StarDetector.EffectiveSensitivityGate(p), Is.EqualTo(34.3).Within(1e-9));
+    }
+
+    /// <summary>
+    /// The donut cap flows through: with the master on, an extended candidate's clip is capped at 2.0, so the
+    /// bound — and therefore the effective gate — uses the capped value, matching InertSensitivityBound.
+    /// </summary>
+    [Test]
+    public void EffectiveSensitivityGate_HonoursTheDonutClipCap() {
+        var p = new StarDetectorParams {
+            Sensitivity = 0.0, PeakResponse = 0.75, StarClippingMultiplier = 8.0,
+            DefocusAwareDonutDetection = true, DefocusDistortionSizeReference = 30.0
+        };
+        Assert.Multiple(() => {
+            Assert.That(StarDetector.EffectiveSensitivityGate(p), Is.EqualTo(1.5).Within(1e-12));
+            Assert.That(StarDetector.EffectiveSensitivityGate(null), Is.NaN);
+        });
+    }
+
     // ── StarCountIsTheLimit: bright enough, but too few ─────────────────────────────────────────────────────
 
     [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/MinHfrSeedTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/MinHfrSeedTests.cs
@@ -1,0 +1,107 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System.Linq;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Optimization;
+
+/// <summary>
+/// F35 — the MinHFR seeding rule. The fitted vertex TRIGGERS the seed; it never SIZES it, because every HFR
+/// statistic available before the search is biased upward (the wing fit over-predicts the vertex 2.3x, and the
+/// surviving-star medians are left-censored at MinHFR itself). The size is a constant in binned detection
+/// pixels, justified by sampling and measured against synthetic truth.
+/// </summary>
+[TestFixture]
+public class MinHfrSeedTests {
+
+    private const double DefaultGate = 1.2;   // HocusFocusStarDetection.BuildDefaultStarDetectorParams
+
+    /// <summary>
+    /// D01_ultrawide_40mm. The wing-only hyperbola fit reads 0.548 px against a truth vertex of 0.238 — it is
+    /// 2.3x high and STILL sits below the 1.2 gate, which is exactly why the trigger works despite the bias.
+    /// </summary>
+    [Test]
+    public void Resolve_SeedsBeneathTheGate_WhenTheFittedVertexIsBelowIt() {
+        Assert.That(MinHfrSeed.Resolve(0.548, DefaultGate), Is.EqualTo(MinHfrSeed.SeedFloor));
+    }
+
+    /// <summary>
+    /// D05_tec140_1000mm — the control that makes a global rule defensible. Truth vertex 1.804 px, well clear of
+    /// the gate, recall flat at 0.985 across the whole MinHFR sweep. A rig that does not need the seed must not
+    /// receive it.
+    /// </summary>
+    [Test]
+    public void Resolve_LeavesAWellSampledRigAlone() {
+        Assert.That(MinHfrSeed.Resolve(1.804, DefaultGate), Is.Null);
+    }
+
+    /// <summary>
+    /// The gate is <c>star.HFR &lt;= p.MinHFR</c> (INCLUSIVE, StarDetector.cs:1873), so a vertex sitting exactly
+    /// AT the gate is already being rejected wholesale. That is the collapse F20 describes, not a boundary case
+    /// to leave alone.
+    /// </summary>
+    [Test]
+    public void Resolve_SeedsWhenTheVertexSitsExactlyOnTheInclusiveGate() {
+        Assert.That(MinHfrSeed.Resolve(DefaultGate, DefaultGate), Is.EqualTo(MinHfrSeed.SeedFloor));
+    }
+
+    /// <summary>
+    /// A run with no determinable fit yields NaN (RunEvaluationResult.BestFit is null =&gt; Minimum.Y is NaN).
+    /// Re-gating a detector off a statistic that does not exist is the circularity F35 was filed to remove.
+    /// </summary>
+    [Test]
+    public void Resolve_DoesNothingWithoutAUsableFit([Values(double.NaN, double.PositiveInfinity, double.NegativeInfinity)] double vertex) {
+        Assert.That(MinHfrSeed.Resolve(vertex, DefaultGate), Is.Null);
+    }
+
+    /// <summary>
+    /// The rule only ever LOWERS the gate. A user (or a prior landing) who already set MinHFR beneath the floor
+    /// must not have it raised — the objective rewards star count, so a raised gate is a knob the search has no
+    /// gradient to climb back down.
+    /// </summary>
+    [Test]
+    public void Resolve_NeverRaisesAGateThatIsAlreadyLower() {
+        Assert.That(MinHfrSeed.Resolve(0.05, 0.2), Is.Null);
+    }
+
+    /// <summary>Equal to the floor is not lower than the floor — no write, so the landing stays comparable.</summary>
+    [Test]
+    public void Resolve_DoesNothingWhenTheGateAlreadyEqualsTheFloor() {
+        Assert.That(MinHfrSeed.Resolve(0.1, MinHfrSeed.SeedFloor), Is.Null);
+    }
+
+    /// <summary>
+    /// The seed must survive <see cref="OptimizerVariable"/>'s bounds. A value below the axis Lower is silently
+    /// raised at theta0 (StarDetectionOptimizer.cs:115), which would apply the fix and change nothing — the exact
+    /// failure mode F35 warns about for the "0.8 x predicted" rule.
+    /// </summary>
+    [Test]
+    public void SeedFloor_IsReachableOnTheMinHfrAxis() {
+        var axis = OptimizerVariable.CreateCuratedSet().Single(v => v.Name == nameof(StarDetectorParams.MinHFR));
+        Assert.Multiple(() => {
+            Assert.That(MinHfrSeed.SeedFloor, Is.GreaterThanOrEqualTo(axis.Lower));
+            Assert.That(axis.Quantize(MinHfrSeed.SeedFloor), Is.EqualTo(MinHfrSeed.SeedFloor));
+        });
+    }
+
+    /// <summary>
+    /// The measured safe band is 0.25-0.35 px: FP = 0 in all 32 configurations of the D01/D02/D03/D05 sweep, and
+    /// the recall gain saturates by 0.5. Pinned so a later retune has to argue with the measurement.
+    /// </summary>
+    [Test]
+    public void SeedFloor_SitsInTheMeasuredSafeBand() {
+        Assert.That(MinHfrSeed.SeedFloor, Is.InRange(0.25, 0.35));
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerTests.cs
@@ -533,6 +533,60 @@ public class StarDetectionOptimizerTests {
             "the axis that actually moves J must still be optimized");
     }
 
+    // --- F35: MinHfrSeedFloor, applied at the engine seam ahead of theta0 -------------------------------------
+
+    /// <summary>
+    /// The seed must be stamped BEFORE theta0 is read, so the search genuinely starts from the lowered gate —
+    /// rather than merely being permitted to reach it, which on F20's cold-start plateau it never does.
+    /// </summary>
+    [Test]
+    public async Task MinHfrSeedFloor_LowersTheSeedGateBeforeTheFirstEvaluation() {
+        var seed = Seed();
+        seed.MinHFR = 1.2;
+        var settings = DefaultSettings();
+        settings.MinHfrSeedFloor = MinHfrSeed.SeedFloor;
+        var seenFirst = double.NaN;
+
+        await new StarDetectionOptimizer().OptimizeAsync(seed, OptimizerVariable.CreateCuratedSet(),
+            SyntheticEvaluator(p => { if (double.IsNaN(seenFirst)) { seenFirst = p.MinHFR; } }),
+            settings, null, CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(seenFirst, Is.EqualTo(MinHfrSeed.SeedFloor).Within(1e-9),
+                "the seed evaluation — the never-regress floor — must already see the seeded gate");
+            Assert.That(seed.MinHFR, Is.EqualTo(MinHfrSeed.SeedFloor).Within(1e-9));
+        });
+    }
+
+    /// <summary>Null (every caller that does not opt in, including synth-validate and tilt) must be bit-identical.</summary>
+    [Test]
+    public async Task MinHfrSeedFloor_Unset_LeavesTheSeedUntouched() {
+        var seed = Seed();
+        seed.MinHFR = 1.2;
+
+        await new StarDetectionOptimizer().OptimizeAsync(seed, OptimizerVariable.CreateCuratedSet(),
+            SyntheticEvaluator(), DefaultSettings(), null, CancellationToken.None);
+
+        Assert.That(seed.MinHFR, Is.EqualTo(1.2).Within(1e-9));
+    }
+
+    /// <summary>
+    /// Only ever lowers. The objective rewards star count, so nothing pulls a seeded MinHFR back up — raising a
+    /// gate a caller deliberately set lower would be a knob with no gradient to climb back down.
+    /// </summary>
+    [Test]
+    public async Task MinHfrSeedFloor_NeverRaisesAGateThatIsAlreadyLower() {
+        var seed = Seed();
+        seed.MinHFR = 0.15;
+        var settings = DefaultSettings();
+        settings.MinHfrSeedFloor = MinHfrSeed.SeedFloor;   // 0.30 > 0.15
+
+        await new StarDetectionOptimizer().OptimizeAsync(seed, OptimizerVariable.CreateCuratedSet(),
+            SyntheticEvaluator(), settings, null, CancellationToken.None);
+
+        Assert.That(seed.MinHFR, Is.EqualTo(0.15).Within(1e-9));
+    }
+
     /// <summary>
     /// A synchronous <see cref="IProgress{T}"/> test double: <see cref="Report"/> appends directly to a list
     /// on the calling thread, so reports are captured deterministically (unlike <see cref="Progress{T}"/>,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerTests.cs
@@ -554,8 +554,42 @@ public class StarDetectionOptimizerTests {
         Assert.Multiple(() => {
             Assert.That(seenFirst, Is.EqualTo(MinHfrSeed.SeedFloor).Within(1e-9),
                 "the seed evaluation — the never-regress floor — must already see the seeded gate");
-            Assert.That(seed.MinHFR, Is.EqualTo(MinHfrSeed.SeedFloor).Within(1e-9));
+            Assert.That(seed.MinHFR, Is.EqualTo(1.2).Within(1e-9),
+                "the CALLER'S seed must be left alone — see MinHfrSeedFloor_DoesNotLeakIntoALaterRun");
         });
+    }
+
+    /// <summary>
+    /// THE REGRESSION THIS EXISTS FOR. Callers reuse one <see cref="StarDetectorParams"/> across many runs:
+    /// TestApp <c>optimize --per-run</c> builds a single context outside its per-dataset loop, and the wizard
+    /// hands over a live reference to <c>runs[0].Seed</c>. An in-place write inside the engine therefore leaks
+    /// the first run's seeded gate into every later run — silently re-gating datasets whose own fit never
+    /// triggered, and making the result depend on dataset ORDER.
+    ///
+    /// <para>Measured before the fix: one firing on D01 dragged the entire 17-dataset synthetic bank to
+    /// MinHFR 0.3, including <c>D05_tec140_1000mm</c> — the control whose whole purpose is to be left alone —
+    /// while printing exactly one "seeding" line, because every subsequent run saw a seed that was already at
+    /// the floor and so never triggered.</para>
+    /// </summary>
+    [Test]
+    public async Task MinHfrSeedFloor_DoesNotLeakIntoALaterRun() {
+        var sharedSeed = Seed();
+        sharedSeed.MinHFR = 1.2;
+        var variables = OptimizerVariable.CreateCuratedSet();
+
+        // Run 1 opts in (its fit triggered).
+        var withFloor = DefaultSettings();
+        withFloor.MinHfrSeedFloor = MinHfrSeed.SeedFloor;
+        await new StarDetectionOptimizer().OptimizeAsync(sharedSeed, variables, SyntheticEvaluator(), withFloor, null, CancellationToken.None);
+
+        // Run 2 does NOT opt in (a well-sampled rig — D05's case). It must start from the ORIGINAL gate.
+        var seenSecond = double.NaN;
+        await new StarDetectionOptimizer().OptimizeAsync(sharedSeed, variables,
+            SyntheticEvaluator(p => { if (double.IsNaN(seenSecond)) { seenSecond = p.MinHFR; } }),
+            DefaultSettings(), null, CancellationToken.None);
+
+        Assert.That(seenSecond, Is.EqualTo(1.2).Within(1e-9),
+            "a run whose fit did not trigger the seed must not inherit the previous run's seeded gate");
     }
 
     /// <summary>Null (every caller that does not opt in, including synth-validate and tilt) must be bit-identical.</summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/MinHfrSeed.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/MinHfrSeed.cs
@@ -1,0 +1,94 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+
+namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
+
+    /// <summary>
+    /// F35 — seeds <see cref="StarDetectorParams.MinHFR"/> beneath the gate on rigs whose stars are smaller than
+    /// it, so the optimizer starts somewhere with a gradient instead of on a plateau where <c>J</c> is identically
+    /// zero (F20).
+    ///
+    /// <para><b>The fit TRIGGERS the seed; it never SIZES it.</b> That split is the whole finding. Every HFR
+    /// statistic available before the search reads high, and both do so in the direction that would make a
+    /// fit-derived seed useless:</para>
+    /// <list type="bullet">
+    /// <item>the wing-only hyperbola vertex over-predicts by <b>2.3x</b> on D01 (0.548 px read vs 0.238 px truth) —
+    /// a hyperbola's vertex is the parameter its wings constrain worst; and</item>
+    /// <item>the median measured HFR of surviving stars reads <b>2.2–2.8x</b> high because it is
+    /// <b>left-censored at <see cref="StarDetectorParams.MinHFR"/> itself</b> — only stars measuring above the
+    /// gate can be seen, so the sample's median is bounded below by the very knob being tuned. Structurally the
+    /// same trap as tuning Sensitivity from the marginal-SNR distribution it truncated (F23).</item>
+    /// </list>
+    /// <para>Both biases UNDERSTATE how far the gate must come down, so a plausible rule like
+    /// <c>0.8 x predicted</c> yields 0.44 on D01 and still gates its true 0.238 px vertex completely — the fix
+    /// would have looked applied and changed nothing.</para>
+    ///
+    /// <para><b>Why a constant is the geometric answer.</b> <see cref="StarDetectorParams.MinHFR"/> is already
+    /// dimensionally self-contained: from the software-binning stage onward the whole pipeline runs in binned
+    /// pixels, so every pixel-unit param "stays in the range it was calibrated for regardless of the rig"
+    /// (StarDetector.cs:483-486). There is no arcsec/px conversion to apply. What bounds the seed is sampling:
+    /// HFR cannot fall far below pixel quantization, because a star whose flux lands in essentially one pixel
+    /// still measures a few tenths of a pixel.</para>
+    ///
+    /// <para><b>The value is measured, not argued.</b> <c>golden eval --min-hfr</c> over 8 values from 1.2 to 0.1
+    /// on D01/D02/D03 plus the D05 control scores <b>zero false positives in all 32 configurations</b>, with the
+    /// recall gain saturating by 0.5. <c>D05_tec140_1000mm</c> (truth vertex 1.80 px) is <b>flat at 0.985 across
+    /// the entire range</b> — a rig that does not need the seed is provably unperturbed, which is what lets the
+    /// rule be evaluated without first detecting the wide-field case the gate has already hidden.</para>
+    ///
+    /// <para><b>The success criterion is the hard floor, not recall.</b> Lowering D01's gate moves recall only
+    /// 0.129 → 0.165 (<c>TooLowHFR</c> is 1877 of ~38500 missed stars; the structure map never proposes 18801 of
+    /// them). What it does is put <b>5 stars on the vertex frame</b>, clearing the objective's <c>NHard</c> = 3
+    /// per-frame requirement — which is the entire cause of <c>FinalJ = 0.00000</c>.</para>
+    /// </summary>
+    public static class MinHfrSeed {
+
+        /// <summary>
+        /// The seeded gate, in BINNED detection pixels. Mid-band of the measured-safe 0.25–0.35 px window, and
+        /// comfortably above <c>OptimizerVariable</c>'s <c>MinHFRLower</c> (0.1) so it is never silently raised
+        /// when the search reads it into theta0 (StarDetectionOptimizer.cs:115).
+        /// </summary>
+        public const double SeedFloor = 0.30;
+
+        /// <summary>
+        /// The MinHFR to seed the search with, or <c>null</c> to leave the seed untouched.
+        /// </summary>
+        /// <param name="fitVertexHfr">
+        /// <c>BestFit.Minimum.Y</c> from a hyperbola fit taken BEFORE the search — the wing frames are far from
+        /// focus, so their PSF is large and the gate does not touch them (D01's four outer frames carry 816–2002
+        /// accepted stars each at MinHFR 1.2, and the fit succeeds at R² = 0.911). Pass <see cref="double.NaN"/>
+        /// when no fit is available.
+        /// </param>
+        /// <param name="currentMinHfr">The gate the search would otherwise start from.</param>
+        /// <remarks>
+        /// The rule only ever LOWERS. The objective rewards star count, so nothing pulls a seeded MinHFR back up —
+        /// it is a knob the search cannot climb out of, which is why it comes from geometry rather than from a
+        /// measurement the gate itself shaped, and why it must never raise a gate a caller deliberately set lower.
+        /// </remarks>
+        public static double? Resolve(double fitVertexHfr, double currentMinHfr) {
+            if (!IsUsable(fitVertexHfr)) {
+                return null;                      // no fit => no trigger; never re-gate off a statistic that does not exist
+            }
+            if (fitVertexHfr > currentMinHfr) {
+                return null;                      // the rig's stars clear the gate; leave it alone (the D05 case)
+            }
+            if (!(SeedFloor < currentMinHfr)) {
+                return null;                      // already at or beneath the floor; only ever lower
+            }
+            return SeedFloor;
+        }
+
+        private static bool IsUsable(double v) => !double.IsNaN(v) && !double.IsInfinity(v);
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
@@ -70,6 +70,34 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public int RecommendedOffsetSteps { get; set; }
 
         /// <summary>
+        /// The gate this landing ACTUALLY enforces — <c>max(BrightnessSensitivity, StarPeakResponse ×
+        /// effective StarClippingMultiplier)</c> (followup F33). Derived, get-only: it adds no state, so it needs
+        /// no schema bump and is computed for every landing already on disk when one is read back.
+        ///
+        /// <para>Reported because <see cref="BrightnessSensitivity"/> alone misclassifies a whole shape of landing.
+        /// A run can record <c>0.0</c> here — which reads as "the optimizer drove the gate to its floor", the
+        /// synthetic bank's pathology — while the structure/clip stage enforces a gate many times the shipped
+        /// default. Read <see cref="EffectiveSensitivityGate"/> instead whenever the question is "how hard is this
+        /// landing culling stars".</para>
+        /// </summary>
+        [JsonProperty(Order = 100)]
+        public double EffectiveSensitivityGate => StarDetector.EffectiveSensitivityGate(GateParams());
+
+        /// <summary>
+        /// The minimal <see cref="StarDetectorParams"/> the gate algebra reads, rebuilt from this DTO. Deliberately
+        /// partial — it exists so <see cref="EffectiveSensitivityGate"/> routes through the SAME
+        /// <see cref="StarDetector"/> helpers the detector itself uses (the donut clip cap in particular), rather
+        /// than restating that algebra here where it could silently drift.
+        /// </summary>
+        private StarDetectorParams GateParams() => new StarDetectorParams {
+            Sensitivity = BrightnessSensitivity,
+            PeakResponse = StarPeakResponse,
+            StarClippingMultiplier = StarClippingMultiplier,
+            DefocusAwareDonutDetection = DefocusAwareDonutDetection,
+            DefocusDistortionSizeReference = DefocusDistortionSizeReference,
+        };
+
+        /// <summary>
         /// v1 = the original curated knob set. v2 added the defocus-aware axes. v3 added the optional
         /// <see cref="Provenance"/> block (F30) and changed NO knob semantics, so a v3 file stays knob-compatible
         /// with v2 in both directions — an older build ignores the unknown key, and a newer build reads a v1/v2

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizer.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizer.cs
@@ -130,7 +130,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // nothing pulls a seeded MinHFR back up, and raising a gate a caller deliberately set lower would be a
             // knob with no gradient to climb back down. See MinHfrSeed for why the value is a sampling constant
             // and not derived from any measured HFR.
+            //
+            // CLONE, DO NOT MUTATE THE CALLER'S SEED. Callers reuse one StarDetectorParams across many runs --
+            // TestApp `optimize --per-run` builds a single RunDetectionContext outside its per-dataset loop, and
+            // the wizard passes a live reference to runs[0].Seed. An in-place write here leaks the first run's
+            // seeded gate into every subsequent run, which silently re-gates datasets whose fit never triggered.
+            // Measured: it took the whole 17-dataset synthetic bank to MinHFR 0.3 off ONE firing on D01, including
+            // D05 -- the control whose entire job is to be left alone.
             if (settings.MinHfrSeedFloor is double minHfrFloor && minHfrFloor < seed.MinHFR) {
+                seed = seed.Clone();
                 seed.MinHFR = minHfrFloor;
             }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizer.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizer.cs
@@ -36,6 +36,24 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// Phase-B stops halving a Continuous variable's step once it drops below InitialStep × this fraction.
         /// </summary>
         public double StepFloorFraction { get; set; } = 0.125;
+
+        /// <summary>
+        /// F35 — when set, <see cref="StarDetectorParams.MinHFR"/> is lowered to this value on the seed before the
+        /// search reads θ0, so a rig whose stars are smaller than the shipped gate starts somewhere with a
+        /// gradient instead of on the plateau where <c>J</c> is identically zero (F20).
+        ///
+        /// <para><b>The caller decides, the engine applies.</b> The trigger is
+        /// <c>BestFit.Minimum.Y &lt;= MinHFR</c> from a fit taken BEFORE the search, and
+        /// <see cref="RunEvaluationMetrics"/> — all this engine sees of an evaluation — carries the vertex X only
+        /// (<c>BestFocusPosition</c>), never its Y. So the two callers that already hold a pre-search
+        /// <c>RunEvaluationResult</c> compute the rule via <see cref="MinHfrSeed.Resolve"/> and pass the answer
+        /// here; the clamp lives in one place, ahead of θ0, so the seeded value flows into the seed evaluation,
+        /// into the never-regress floor, and into <c>RevertNeutralAxes</c>' notion of the seed.</para>
+        ///
+        /// <para>Null (the default) leaves every caller bit-identical — which is deliberately the case for
+        /// <c>synth-validate</c> and <c>tilt</c>, neither of which fits a curve before optimizing.</para>
+        /// </summary>
+        public double? MinHfrSeedFloor { get; set; }
     }
 
     /// <summary>Progress payload emitted during <see cref="StarDetectionOptimizer.OptimizeAsync"/>.</summary>
@@ -106,6 +124,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 throw new ArgumentNullException(nameof(evaluator));
             }
             settings = settings ?? new OptimizerSettings();
+
+            // F35 — seed MinHFR beneath the gate BEFORE θ0 is read, so the search starts from the lowered value
+            // rather than merely being allowed to reach it. Only ever lowers: the objective rewards star count, so
+            // nothing pulls a seeded MinHFR back up, and raising a gate a caller deliberately set lower would be a
+            // knob with no gradient to climb back down. See MinHfrSeed for why the value is a sampling constant
+            // and not derived from any measured HFR.
+            if (settings.MinHfrSeedFloor is double minHfrFloor && minHfrFloor < seed.MinHFR) {
+                seed.MinHFR = minHfrFloor;
+            }
 
             var ctx = new SearchContext(this, seed, variables, evaluator, settings, progress, token);
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -537,6 +537,18 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         // the "before" the live readout counts from — so the σ pair shown mid-run matches the results page.
         private double currentBaselineSigma = double.NaN;
 
+        // F35 — the hyperbola vertex HFR (BestFit.Minimum.Y) from the MOST RECENT pre-search analyze pass, which
+        // is the statistic that triggers the MinHFR seed. Captured in AnalyzeWithProgressAsync because every path
+        // that reaches OptimizeAsync runs one first (the seed guard on Start; an explicit warm-up on each
+        // feedback/continue/re-optimize path), and because the fit is thrown away afterwards everywhere else.
+        //
+        // It must come from the WINGS, and it does: far from focus the PSF is large, so those frames are
+        // untouched by the gate and richly populated (D01's four outer frames carry 816-2002 accepted stars each
+        // at the default MinHFR, fitting at R2 = 0.911). The in-focus frames -- the ones F20's original wording
+        // wanted to measure -- are exactly the ones the gate has emptied, which is what made that trigger
+        // circular. NaN when no fit was determinable, which MinHfrSeed treats as "do nothing".
+        private double seedFitVertexHfr = double.NaN;
+
         /// <summary>
         /// MEF/T5 convenience constructor: wires the real collaborators from the plugin singletons + mediators.
         /// The wizard is not MEF-exported (it is created on demand by T5's launch command), so this just supplies
@@ -2920,6 +2932,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 var frameProgress = new Progress<RunLoadProgress>(rp => SetProgress(label, rp.Current, rp.Total));
                 results.Add(await run.Data.EvaluateAndFitAsync(paramsSelector(run), frameProgress, token).ConfigureAwait(true));
             }
+            // F35 — stash run 0's fitted vertex HFR for the MinHFR seeding rule. Run 0 is the representative run
+            // everywhere else in this VM (the plotted curve, the binning recommendation, the exposure advice), so
+            // the seed follows the same convention. Recomputed on every analyze pass, so a re-optimize after the
+            // user changes settings re-triggers off the fit those settings produce rather than a stale one.
+            seedFitVertexHfr = results.Count > 0 ? (results[0].BestFit?.Minimum.Y ?? double.NaN) : double.NaN;
             return results;
         }
 
@@ -2982,6 +2999,21 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // on), so it needs more iterations to converge: use the larger budget when enabled, else the standard
             // one. Re-applied each call so toggling the donut master between builds takes effect.
             optimizerSettings.MaxEvaluations = donutMaster ? DonutMaxEvaluations : standardMaxEvaluations;
+            // F35 — seed MinHFR beneath the gate when the pre-search fit says this rig's stars are smaller than it
+            // (F20's cold-start plateau: J is identically 0 across the neighbourhood, so no single-axis step
+            // improves anything and the search never lowers the gate on its own).
+            //
+            // FRESH passes only. Both non-fresh paths supply a seedOverride: "Continue optimizing" seeds from the
+            // prior round's best, and the feedback path seeds from GateRecommender's analytic recommendation --
+            // which owns MinHFR itself for RejectionGate.TooLowHFR. In both cases MinHFR is already the search's
+            // (or the recommender's) to set, and re-stamping the floor would silently undo an upward move that had
+            // been earned. A seed is a START condition, not a bound.
+            //
+            // Assigned unconditionally, including to null, for the same reason MaxEvaluations is re-applied above:
+            // optimizerSettings is a reused field and a value from a prior pass must never leak into this one.
+            optimizerSettings.MinHfrSeedFloor = seedOverride == null
+                ? MinHfrSeed.Resolve(seedFitVertexHfr, seed.MinHFR)
+                : null;
             var variables = variablesOverride ?? OptimizerVariable.CreateCuratedSet(seed);
             var evaluator = RunEvaluationData.CreateEvaluator(runs.Select(r => r.Data).ToList());
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
@@ -1527,6 +1527,26 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             p == null ? double.NaN : p.PeakResponse * MinEffectiveClipMultiplier(p);
 
         /// <summary>
+        /// The gate a set of detector settings ACTUALLY enforces:
+        /// <c>max(Sensitivity, InertSensitivityBound)</c>. Report this wherever a landing's
+        /// <see cref="StarDetectorParams.Sensitivity"/> is quoted (followup F33).
+        ///
+        /// <para><b>Why the raw axis misleads.</b> Sensitivity below
+        /// <see cref="InertSensitivityBound"/> rejects nothing, so the structure/clip stage — not the Sensitivity
+        /// knob — is what is culling stars. A landing can therefore read <c>Sensitivity 0.0</c>, which looks like
+        /// the synthetic bank's "the optimizer drove the gate to its floor" pathology, while enforcing a gate
+        /// several times the shipped default. The real-bank <c>mccomiskey</c> run is the case that motivated this:
+        /// Sensitivity 0.0 with PeakResponse 0.98 × StarClip 10.0 ⇒ an effective gate of <b>9.81</b>, and
+        /// detections collapsing 3606 → 43. Read as a floor landing it says the opposite of what it does.</para>
+        ///
+        /// <para>Two more landings in the same arm are misread the same way (<c>caboose</c> at 5.05 on the real
+        /// bank; D11 at 2.36 and D12 at 2.10 on the synthetic one), so this is a systematic reading error rather
+        /// than one odd run.</para>
+        /// </summary>
+        public static double EffectiveSensitivityGate(StarDetectorParams p) =>
+            p == null ? double.NaN : Math.Max(p.Sensitivity, InertSensitivityBound(p));
+
+        /// <summary>
         /// Companion to <see cref="ComputeEffectiveMaxDistortion"/> for the NotCentered gate. Computes the
         /// effective StarCenterTolerance the centering check uses for a candidate of bbox max-dimension
         /// <paramref name="candidateSize"/> (= max(bbox.Width, bbox.Height), the SAME defocus proxy the distortion

--- a/Joko.NINA.Plugins/TestApp/BankVerifyRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/BankVerifyRunner.cs
@@ -400,7 +400,13 @@ namespace TestApp {
             InspectorOptions inspectorOptions, AlglibAPI alglib, ProfileService profileService, NINA.Profile.Interfaces.IProfile activeProfile, int stepSize,
             StarDetector detector) {
 
-            var cm = new ConfigMetrics { config = label, nc = nc, donut = donut, sensitivity = p.Sensitivity };
+            // effectiveSensitivity is set HERE, from the same params the config is scored with, so C0/A/B all get it
+            // from one place (the A/B call sites re-stamp `sensitivity` afterwards; the effective gate must not
+            // acquire a second, drift-prone assignment).
+            var cm = new ConfigMetrics {
+                config = label, nc = nc, donut = donut, sensitivity = p.Sensitivity,
+                effectiveSensitivity = StarDetector.EffectiveSensitivityGate(p)
+            };
 
             // AF fit (reuses the optimizer's evaluation path → reproduces the dry-run σ_focus).
             Prog($"  [{label}] EvaluateAndFitAsync start (NC={nc}, donut={donut})");
@@ -759,6 +765,21 @@ namespace TestApp {
             public string config { get; set; }
             public double nc { get; set; }
             public double sensitivity { get; set; }
+
+            /// <summary>
+            /// F33 — <c>max(sensitivity, PeakResponse x effective StarClip)</c>: the gate this config actually
+            /// enforces. Read this, not <see cref="sensitivity"/>, when asking how hard a config is culling.
+            /// A config can record <c>sensitivity 0.0</c> — the synthetic bank's "drove the gate to its floor"
+            /// signature — while enforcing several times the shipped default; 2 of the 6 synthetic-bank
+            /// Sensitivity-0.0 landings (D11 at 2.36, D12 at 2.10) are exactly that, as is the real bank's
+            /// mccomiskey at 9.81.
+            ///
+            /// <para>ADDITIVE and derived, so the <c>afbank-verify</c> schema is deliberately NOT bumped: no
+            /// number changes and every prior report stays comparable. The /4 and /5 bumps were for changes that
+            /// made numbers non-comparable, which this is not.</para>
+            /// </summary>
+            public double effectiveSensitivity { get; set; } = double.NaN;
+
             public bool donut { get; set; }
             public double recallHigh { get; set; } = double.NaN;
             public double recallAll { get; set; } = double.NaN;

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -452,11 +452,14 @@ namespace TestApp {
                     aggregate.Add(row);
                     Console.WriteLine($"  -> {d.RunId}: currentJ={F(outcome.BaselineJ)} bestJ={F(outcome.Result.BestJ)} " +
                         $"hard-floor {(outcome.HardFloorPassed ? "PASS" : "FAIL")}; outputs in {subDir}");
+                    // F33: always quote the EFFECTIVE gate next to the raw axis. "sensitivity=0.0 (AT FLOOR)" is
+                    // exactly the line that made mccomiskey look like a floor landing when its real gate was 9.81.
+                    var gate = $"     sensitivity={F(row.BrightnessSensitivity)} (effective gate {F(row.EffectiveSensitivityGate)})";
                     Console.WriteLine(row.SensitivityIsAtFloor && row.ExposureRecommendation?.HasRecommendation == true
-                        ? $"     sensitivity={F(row.BrightnessSensitivity)} (AT FLOOR): exposure rec {F(row.ExposureRecommendation.CurrentSeconds)}s -> {F(row.ExposureRecommendation.RecommendedSeconds)}s"
+                        ? $"{gate} (AT FLOOR): exposure rec {F(row.ExposureRecommendation.CurrentSeconds)}s -> {F(row.ExposureRecommendation.RecommendedSeconds)}s"
                         : row.SensitivityIsAtFloor
-                            ? $"     sensitivity={F(row.BrightnessSensitivity)} (AT FLOOR): no exposure recommendation (insufficient data)"
-                            : $"     sensitivity={F(row.BrightnessSensitivity)} (not at floor)");
+                            ? $"{gate} (AT FLOOR): no exposure recommendation (insufficient data)"
+                            : $"{gate} (not at floor)");
                 } catch (Exception ex) {
                     anyFailure = true;
                     Console.Error.WriteLine($"  -> {d.RunId}: FAILED to optimize ({ex.Message}); continuing to next run");
@@ -636,8 +639,25 @@ namespace TestApp {
             var buildsBefore = dataList.Sum(d => d.ContextBuilds);
             var reusesBefore = dataList.Sum(d => d.ContextReuses);
 
+            // F35 — seed MinHFR beneath the gate when the pre-search fit says this rig's stars are smaller than it.
+            // perRunBaseline (built above, before the objective was even finalized) already holds the fits, so the
+            // trigger statistic costs nothing extra here. Run 0 is the representative run, matching the wizard.
+            // The seeded value is reported below so a landing never silently differs from its recorded seed.
+            settings.MinHfrSeedFloor = MinHfrSeed.Resolve(
+                perRunBaseline.Count > 0 ? (perRunBaseline[0].BestFit?.Minimum.Y ?? double.NaN) : double.NaN,
+                ctx.Seed.MinHFR);
+            if (settings.MinHfrSeedFloor is double seededMinHfr) {
+                Console.WriteLine($"  MinHFR seed (F35): fitted vertex HFR {F(perRunBaseline[0].BestFit?.Minimum.Y ?? double.NaN)} px "
+                    + $"is at or below the gate {F(ctx.Seed.MinHFR)}; seeding MinHFR -> {F(seededMinHfr)}");
+            }
+
             var sw = System.Diagnostics.Stopwatch.StartNew();
             var result = await optimizer.OptimizeAsync(ctx.Seed, variables, evaluator, settings, progress, CancellationToken.None).ConfigureAwait(false);
+
+            // The seed is a START condition, not a bound: once the first pass has run, MinHFR is the search's to
+            // move. Leaving the floor set would re-stamp it on every continue round and silently undo any upward
+            // move the search had earned.
+            settings.MinHfrSeedFloor = null;
 
             // --continue-rounds: chain additional passes, each re-seeded from the prior best with a FRESH curated set
             // (resets the pattern-search step scale, so it can make larger moves again — the point of "Continue").
@@ -818,6 +838,12 @@ namespace TestApp {
             public double BrightnessSensitivity = double.NaN;
             public bool SensitivityIsAtFloor;
             public ExposureRecommendation ExposureRecommendation;
+
+            // F33 — the gate this landing ACTUALLY enforces: max(Sensitivity, PeakResponse x effective StarClip).
+            // Reported alongside BrightnessSensitivity everywhere because the raw axis misclassifies a whole shape
+            // of landing: mccomiskey records Sensitivity 0.0 (which reads as "drove the gate to its floor") while
+            // enforcing 9.81 and shedding 3606 detections down to 43.
+            public double EffectiveSensitivityGate = double.NaN;
         }
 
         /// <summary>Builds an aggregate row from a per-run outcome (exactly one run in the set in --per-run mode).
@@ -862,7 +888,8 @@ namespace TestApp {
                     : string.Join("; ", changed.Select(t => $"{t.Name}: {F(t.Cur)}->{F(t.Best)}")),
                 BrightnessSensitivity = landedSensitivity,
                 SensitivityIsAtFloor = sensitivityAtFloor,
-                ExposureRecommendation = exposureRecommendation
+                ExposureRecommendation = exposureRecommendation,
+                EffectiveSensitivityGate = StarDetector.EffectiveSensitivityGate(outcome.Result.BestParams)
             };
         }
 
@@ -894,7 +921,7 @@ namespace TestApp {
                 sb.AppendLine($"  sigma_focus : {F(r.BaselineSigmaFocus)} -> {F(r.BestSigmaFocus)}  (current -> optimized)");
                 sb.AppendLine($"  rec. step   : {r.RecommendedStep}");
                 sb.AppendLine($"  changed     : {r.ChangedParams}");
-                AppendExposureRecommendationLines(sb, "  ", r.BrightnessSensitivity, r.SensitivityIsAtFloor, r.ExposureRecommendation);
+                AppendExposureRecommendationLines(sb, "  ", r.BrightnessSensitivity, r.EffectiveSensitivityGate, r.SensitivityIsAtFloor, r.ExposureRecommendation);
                 sb.AppendLine();
             }
 
@@ -908,8 +935,15 @@ namespace TestApp {
         /// or printed for a healthy run. When it fired but <see cref="ExposureRecommendation.HasRecommendation"/> is
         /// false (thin data or an unrecorded exposure), that is reported explicitly rather than silently omitted.
         /// </summary>
-        private static void AppendExposureRecommendationLines(StringBuilder sb, string indent, double brightnessSensitivity, bool sensitivityIsAtFloor, ExposureRecommendation rec) {
-            sb.AppendLine($"{indent}sensitivity : {F(brightnessSensitivity)}{(sensitivityIsAtFloor ? "  (AT SEARCH FLOOR -- frames may be signal-starved)" : "")}");
+        /// <param name="effectiveSensitivityGate">
+        /// F33 — <c>max(Sensitivity, PeakResponse x effective StarClip)</c>, the gate the settings actually enforce.
+        /// Printed on the same line as the raw axis because that line, alone, misclassifies a whole shape of
+        /// landing: "sensitivity : 0.0 (AT SEARCH FLOOR)" is what made mccomiskey read as a floor landing when it
+        /// was enforcing 9.81 and had shed 3606 detections down to 43.
+        /// </param>
+        private static void AppendExposureRecommendationLines(StringBuilder sb, string indent, double brightnessSensitivity, double effectiveSensitivityGate, bool sensitivityIsAtFloor, ExposureRecommendation rec) {
+            sb.AppendLine($"{indent}sensitivity : {F(brightnessSensitivity)} (effective gate {F(effectiveSensitivityGate)})"
+                + (sensitivityIsAtFloor ? "  (AT SEARCH FLOOR -- frames may be signal-starved)" : ""));
             if (!sensitivityIsAtFloor) {
                 sb.AppendLine($"{indent}exposure rec: n/a (Sensitivity is not at the search floor)");
                 return;
@@ -1191,7 +1225,8 @@ namespace TestApp {
                 var exposureRec = sensitivityIsAtFloor
                     ? ExposureRecommender.Recommend(bestM, c, run.CapturedExposureSeconds, result.BestParams)
                     : null;
-                AppendExposureRecommendationLines(sb, "    ", result.BestParams.Sensitivity, sensitivityIsAtFloor, exposureRec);
+                AppendExposureRecommendationLines(sb, "    ", result.BestParams.Sensitivity,
+                    StarDetector.EffectiveSensitivityGate(result.BestParams), sensitivityIsAtFloor, exposureRec);
             }
             sb.AppendLine();
 

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -447,6 +447,45 @@ two datasets. Note also that the two survivors of the original entry are untouch
 broken on the synthetic donut datasets (unlike the real bank's `Panos`/`mufti`/`LinwoodFocus`), and there is
 still no signal that recommends the master.
 
+**Answered 2026-08-03 (wave 3): it is not any of the nine axes — it is what the MASTER TOGGLE turns on by
+default.** Reading the two landings before running anything settled the framing: **the search moved none of the
+nine.** D16 landed every one at its default; D04 moved only `DefocusDistortionSizeReference` 30 → 28.75, and
+that one is provably inert (bit-identical recall). A per-axis ablation would have returned nine nulls.
+
+Arms hold every parameter at defaults and vary only master-gated mechanisms. `golden eval`, ~40 s each,
+precision **1.000** / FP **0** throughout:
+
+| arm | D16 recall@high | D04 recall@high |
+|---|---|---|
+| master OFF | **0.821** (151/184) | **0.762** (16853/22109) |
+| master ON | 0.793 | 0.723 |
+| + structure boost 0 | **0.821** (all recovered) | 0.732 (23%) |
+| + morph-close 1 | 0.799 (21%) | 0.758 (90%) |
+| **+ both** | **0.821 (151/184)** | **0.762 (16853/22109)** |
+
+Neutralizing both recovers the master-OFF recall **exactly — the same star counts, not merely the same ratio**,
+on both datasets. The two mechanisms are:
+
+1. **A silent +2 structure boost.** Master ON with `DefocusAwareStructure` OFF still applies
+   `DonutDefaultStructureLayerBoost = 2` (`StarDetector.cs:610-615`), taking `StructureLayers` 4 → 6. More
+   wavelet layers subtracted erases more small-star structure. Dominant on D16.
+2. **A 5 px morph-close.** `DonutMorphCloseSize` **defaults to 5 and is neutral at 1**, so the master runs a
+   morphological close that merges compact stars. Dominant on D04.
+
+**Caveat:** these arms run at default shared params (NC 4.0), so −0.028 / −0.039 is the master's own cost, not
+the −0.147 / −0.113 above (NC 2, against B's full landing). The master residue is a fifth to a third of it; the
+rest is B's different landing on the *shared* axes.
+
+**And the mechanism is [F32](#f32--j-is-saturated-near-10-so-the-optimizer-trades-enormous-recall-for-numerically-trivial-gains).**
+Both are reachable by the search — `DonutMorphCloseSize` is a curated axis and `StructureLayerBoost` becomes
+settable once `DefocusAwareStructure` flips on. The optimizer never neutralizes them because `J` does not pay
+for recall. **This is not a missing knob; it is a saturated objective, measured on two specific rigs.**
+
+**Remaining next step.** Consider defaulting the master's structure boost and morph-close to neutral on runs the
+donut heuristic did not flag, or making the objective pay for recall. Both are behaviour changes, so per
+[F33](#f33--the-synthetic-bank-does-not-reproduce-the-real-banks-optimizer-failure-mode) they must be scored on
+**both** banks. Reproduce: `D:\hf_w3\run_f24_arms.sh` and `run_f24_arms2.sh`.
+
 ### F19 — The exposure recommendation is decided by the 20 brightest stars, so a rich field can never earn one
 **Status:** Open · found 2026-08-02 deriving expected-optimal exposures for the synthetic AF bank
 
@@ -510,12 +549,32 @@ This is a **cold-start plateau**, not a missing knob, and it is why the earlier 
 is defensible, only the silence is a problem") was too generous: the gate costs a whole class of rigs their
 autofocus, and the fix is within the existing search space.
 
-**It also reproduces on the REAL bank, twice (2026-08-03).** `BaselineJ` — the objective at shipped defaults — is
-exactly **0.0000** on `Panos` and `LinwoodFocus`, the only two runs in the 19-run bank where it is. Both are the
-same silent null result D01/D02 produce synthetically, on real frames from real rigs. They are also the only two
-runs whose recall@≥12 *improves* under the optimizer (+0.031 and +0.089), for the reason F32 gives: they are the
-only ones with any headroom to climb. So this is not a synthetic-bank artifact of the render, and the affected
-population is not hypothetical.
+**It also reproduces on the REAL bank (2026-08-03).** `BaselineJ` — the objective at shipped defaults — is
+exactly **0.0000** on `Panos` and `LinwoodFocus`. Both are the same silent null result D01/D02 produce
+synthetically, on real frames from real rigs, and both are runs whose recall@≥12 *improves* under the optimizer
+(+0.031 and +0.089), for the reason F32 gives: they have headroom to climb. So this is not a synthetic-bank
+artifact of the render, and the affected population is not hypothetical.
+
+> **Corrected 2026-08-03 (wave 3), twice over.**
+>
+> **(a) "The only two runs of nineteen" is wrong — it is four.** `SorenVance` and `lumos` also carry
+> `BaselineJ` exactly 0.0000. They split, too: `SorenVance` climbs 0 → **0.9701** while `lumos` stays 0 → 0, so
+> the cold-start plateau is **sometimes** escapable — which the two-run framing hid.
+>
+> **(b) NONE of the four is the defect this entry describes, and that is the bigger correction.** The claim
+> above — that they are "the same silent null result D01/D02 produce synthetically" — was tested directly by the
+> [F35](#f35--minhfr-should-be-seeded-from-the-sweep-wings-and-neither-available-hfr-statistic-can-size-it)
+> seeding run over all 19 real runs. **The seed fired on zero of them**, because all four have a fit vertex
+> *above* the 1.2 gate, and all 19 landings came back bit-identical to the control. Their `J = 0` comes from
+> having almost no stars at all — `lumos` and `SorenVance` detect **zero** at C0, `Panos` 33 and `LinwoodFocus`
+> 13 across nine frames — not from stars being rejected for measuring too small.
+>
+> **Two different defects present identically** as `currentJ=0 bestJ=0 hard-floor FAIL`: the `MinHFR` gate
+> emptying the curve's core (synthetic D01/D02) and a frame with no detectable signal (real `lumos`/`SorenVance`).
+> Only the first is a detector-configuration problem. So this entry's strongest claim — that the affected
+> population is not hypothetical because it reproduces on real rigs — **is not supported**; what reproduces on
+> the real bank is the *symptom*, not the cause. The synthetic bank is currently the only place the real defect
+> is known to exist.
 
 **Next step.** Two parts, and the second is the substantive one.
 1. *Report it.* When a large fraction of accepted candidates are rejected by `MinHFR` specifically, say so and
@@ -922,6 +981,33 @@ while the change in what gets detected is enormous.
 these numbers say, the fix is to rescale or re-anchor the objective (or gate acceptance on the *magnitude* of the
 improvement) rather than to add a term. Cheap to check: the numbers above come from files already on disk.
 
+**Measured 2026-08-03 (wave 3).** Done, from files already on disk, over all three arms. `BaselineJ` and
+`FinalJ` come from each run's stored landing; recall from the `/5` synthetic verify and the `/3` real one —
+valid because `recallHigh` derives only from `match.Pairs` (`BankVerifyRunner.cs:488`) and the `/5` repair
+touched only the false-positive list, so the real bank's *precision* is void but its *recall* is not.
+
+| arm | median `BaselineJ` | median Δ`J` | median Δrecall@≥12 | **median trade rate** (Δrecall per unit Δ`J`) |
+|---|---|---|---|---|
+| synthetic A | 0.952 | +0.0101 | **0.000** | **0.00** |
+| synthetic B | 0.992 | +0.0021 | −0.014 | **−1.01** |
+| **real A** | 0.977 | +0.0126 | **−0.243** | **−17.32** |
+
+Three things follow, and the third is the one that changes the plan:
+
+1. **The headline number reproduces exactly.** Median Δrecall on the real bank is −0.243, as recorded above.
+2. **The worst case is far worse than "0.0002 for 46 points".** Expressed as a rate, `toml999` gives up **3018
+   points of recall per unit of `J`**; `uneven` −134, `CWhiteFocus` −116, `muggsie` −94. The fourth decimal is
+   not a rounding error, it is the entire remaining scale.
+3. **The two banks disagree in SIGN, not just in magnitude** — the synthetic bank's median trade rate is
+   **0.00**, i.e. config A costs the synthetic bank no recall at all while costing the real bank a quarter of
+   it. So the synthetic bank cannot measure this defect, and
+   [F33](#f33--the-synthetic-bank-does-not-reproduce-the-real-banks-optimizer-failure-mode)'s rule applies to
+   any proposed rescaling as much as to a new term. **A candidate objective change must move the real-bank
+   trade rate, and the synthetic bank cannot tell you whether it did.**
+
+Reproduce: `D:\hf_w3\f32_dynrange.py` (reads `hf_w2/verify_v5`, `hf_f23/verify_real_H`, and the `H_A` / `B_A`
+/ `H_real_A` landings; no detector run).
+
 ### F33 — The synthetic bank does not reproduce the real bank's optimizer failure mode
 **Status:** Open · found 2026-08-03 re-reading the wave-1 arms side by side
 
@@ -941,9 +1027,23 @@ opposite behaviours, and the synthetic bank was built to study the first one.
 | real: `mccomiskey` | 0.0, but **StarClip 10.0** (the maximum) | 3606 → **43** |
 
 `mccomiskey` is the instructive one: Sensitivity reads 0.0, which looks like the synthetic pathology, but the
-effective gate is `PeakResponse × StarClip = 0.75 × 10 = 7.5` — the *same escape route* F23 wave 1 measured on
-D12 and D15, here operating as the shedding mechanism rather than the loosening one. Reading the Sensitivity axis
-alone misclassifies this run.
+effective gate is `PeakResponse × StarClip` — the *same escape route* F23 wave 1 measured on D12 and D15, here
+operating as the shedding mechanism rather than the loosening one. Reading the Sensitivity axis alone
+misclassifies this run.
+
+> **Corrected 2026-08-03 (wave 3), and it is more general than one run.** The `0.75 × 10 = 7.5` above used the
+> *default* `PeakResponse`; this landing's own `StarPeakResponse` is **0.98**, so its effective gate is
+> **9.81**. Both inputs are searched axes, so the gate must always be computed from the landing's own params —
+> the same trap the entry warns about, one level down. And `mccomiskey` is not alone: **`caboose`** also lands
+> Sensitivity 0.0 with an effective gate of **5.05**, and on the synthetic bank **2 of the 6** "Sensitivity 0.0"
+> landings F23 cites are not floor landings either (**D11 → 2.36**, **D12 → 2.10**; D09/D10/D15/D17 are genuine,
+> all below the 1.5 inert bound). So this is a systematic reading error, not one odd run.
+>
+> **Shipped:** `StarDetector.EffectiveSensitivityGate(p)` = `max(Sensitivity, InertSensitivityBound(p))`,
+> reported alongside every quoted landing Sensitivity — `optimized_settings.json` (derived, get-only, no schema
+> bump), `optimize`'s console + `optimize_summary.txt` + `aggregate_summary.*`, and `bank-verify`'s per-config
+> `effectiveSensitivity`. The `afbank-verify` schema is deliberately **not** bumped: the field is additive and
+> derived, no number changes, and the /4 and /5 bumps were for changes that made numbers non-comparable.
 
 **Why it matters.** [F23](#f23--the-optimizer-objective-has-no-precision-term-so-it-trades-precision-away-for-marginal-recall)'s
 framing — "the optimizer drives `BrightnessSensitivity` to its 0.0 floor" — is a **synthetic-bank-only**
@@ -959,8 +1059,69 @@ deliberately whether the bank should grow a dataset class that reproduces the sh
 score every candidate objective change on **both** banks, never the synthetic one alone.
 
 ### F35 — `MinHFR` should be seeded from the sweep WINGS, and neither available HFR statistic can size it
-**Status:** Open · found 2026-08-03 answering "how far can `MinHFR` safely come down?" for
+**Status:** Done (wave 3) · found 2026-08-03 answering "how far can `MinHFR` safely come down?" for
 [F20](#f20--below-minhfr-the-autofocus-objective-collapses-to-exactly-zero-with-no-diagnostic)
+
+**Shipped 2026-08-03** — `MinHfrSeed.Resolve` + `OptimizerSettings.MinHfrSeedFloor`, applied at the engine seam
+ahead of θ0. Two of this entry's own premises were wrong and are corrected below.
+
+Synthetic bank, 17/17, `EXIT=0` where the wave-1 arm exited 3. The seed fires on exactly **three** datasets —
+D01 (fit vertex 0.762 px), D02 (0.749) and D03 (1.015), i.e. precisely the undersampled rigs this entry and F20
+name:
+
+| dataset | seed? | `MinHFR` new / control | `FinalJ` new / control |
+|---|---|---|---|
+| `D01_ultrawide_40mm` | **YES** | 0.100 / 1.200 | **0.99018 / 0.00000** |
+| `D02_rich_135mm` | **YES** | 0.550 / 1.200 | **0.99656 / 0.00000** |
+| `D03_redcat_250mm` | **YES** | 0.300 / 0.450 | 0.99549 / 0.99486 |
+| the other 14 | no | **identical** | **identical to 5 dp** |
+
+**D01 and D02 go from `FinalJ` exactly 0 to a real landing — the whole of F20's defect — and 14 of 17 landings
+are bit-identical to the control**, including D05 at 1.450. On every rig the change was not designed for it is a
+no-op, not a small perturbation. Zero datasets that did not trigger landed at the seed constant.
+
+**Real bank: 19/19 landings bit-identical to the control, seed fired on ZERO runs** (per F33's "both banks"
+rule). Exactly inert, not "within noise". It also disproves F20's claim that its real-bank runs are the same
+defect — see the correction in [F20](#f20--below-minhfr-the-autofocus-objective-collapses-to-exactly-zero-with-no-diagnostic).
+**The fix is real and measured, but its real-bank population on this bank is empty**, so the user-facing benefit
+is unproven on real frames until an undersampled short-focal-length rig enters the bank. Do not claim otherwise.
+
+Two things the run adds. **`BaselineJ = 0` is not by itself evidence of this defect**: D17 reads 0 like D01/D02,
+but its vertex is above the gate, the seed correctly declines, and its landing is unchanged — it was already
+escaping on its own. And **the censoring bias is visible but survivable**: D01's fit read 0.762 px against a
+0.238 truth vertex (3.2× high) and still cleared 1.2, which is exactly why a *trigger-only* use of the fit works
+where a *sizing* use cannot — `0.8 × predicted` would have given 0.61 and re-gated the rig completely.
+
+> **The validation run caught a bug in the fix, and the D05 control is what caught it.** The first bank pass
+> read 17/17 hard-floor PASS — and was wrong. D05 landed `MinHFR` **0.300** (the seed constant) despite a
+> 1.804 px truth vertex that must never trigger; 14 of 17 datasets landed at exactly 0.300 while the log printed
+> the seeding line exactly **once**. Cause: `OptimizeAsync` wrote `seed.MinHFR` **in place**, and callers reuse
+> one `StarDetectorParams` — TestApp builds its context once *outside* the per-dataset loop
+> (`OptimizationDiagnosticRunner.cs:306` vs `:426`), and the wizard passes a live reference to `runs[0].Seed`.
+> So D01's genuine firing permanently re-gated the other sixteen, each of which then saw a seed already at the
+> floor and correctly declined to trigger. **One real firing, sixteen silent ones, order-dependent results.**
+> Fixed by cloning the seed; the regression test was confirmed to FAIL without the fix. Note the first unit test
+> asserted `seed.MinHFR == SeedFloor` — it codified the bug and passed. **D05 exists purely to be boring, and a
+> boring reading was the only thing that separated a working fix from one that had re-gated the whole bank.**
+
+> **Correction 1 — the trigger statistic is not available where this entry says it is.** `BestFit.Minimum.Y` is
+> "already read by the wizard as `baselineInFocusHfr`" only **after** the search, in `BuildSummaryAsync`
+> (`StarDetectionOptimizerWizardVM.cs:3115`). The shared engine seam cannot see it at all:
+> `RunEvaluationMetrics` carries the vertex **X only** (`BestFocusPosition`, `RunEvaluationData.cs:817-818`) and
+> has no `Minimum.Y` field of any kind. Resolved by splitting the rule — the **caller** computes the trigger
+> (the wizard and TestApp `optimize` both already hold a pre-search `RunEvaluationResult`), the **engine**
+> applies the clamp. `synth-validate` and `tilt` fit no curve before optimizing, so they deliberately do not opt
+> in and stay bit-identical.
+>
+> **Correction 2 — step 3 rests on a grid that does not exist, so it is NOT a fix.** `Continuous` is not
+> quantized: `OptimizerVariable.Quantize` is *identity + clamp* for it (`:83-92`), and `InitialStep` is the
+> **initial pattern-search stride**, which Phase B halves on every non-improving sweep down to
+> `InitialStep × StepFloorFraction` = **0.03125**. So the axis already resolves to ~0.03 px — the "0.45 → 0.20
+> is a 2.25× jump" framing describes only the first descent stride. And on the motivating rigs it is moot in
+> both directions: `MinHFR` is absent from Phase A (`CoarseGrid` is `Sensitivity × StarClippingMultiplier` only,
+> `:299-303`), so it moves solely through strictly-improving Phase-B moves — which on D01/D02's flat `J` never
+> happen **at any stride**. Retuning `InitialStep` would perturb every rig that *does* have a gradient while
+> doing nothing for the ones this entry is about. **Not shipped, deliberately.**
 
 [F20](#f20--below-minhfr-the-autofocus-objective-collapses-to-exactly-zero-with-no-diagnostic)'s proposed fix —
 "if the median in-focus HFR is at or below `MinHFR`, seed `MinHFR` beneath it" — **cannot be implemented as
@@ -1066,6 +1227,48 @@ tuned from the surviving sample is tuning against a distribution it truncated.**
 **The risk to design against, unchanged from F20:** the objective rewards star count, so nothing pulls a seeded
 `MinHFR` back up. It is a knob the search cannot climb out of, which is why the seed must come from geometry
 rather than from a measurement the gate itself shaped.
+
+### F36 — Which pre-wave-2 entries actually rested on the broken precision metric: audited, and it is none of them
+**Status:** Done (wave 3) · raised 2026-08-03 as "F1–F8, F18, F21, F25, F26 have not been re-verified"
+
+After [F31](#f31--synthetic-bank-precision-is-not-exact-the-golden-omits-real-stars) voided every `/3` precision
+number and [F23](#f23--the-optimizer-objective-has-no-precision-term-so-it-trades-precision-away-for-marginal-recall)/[F24](#f24--donut-detection-costs-precision-even-where-donuts-exist-and-badly-where-it-does-not)
+were re-measured, the open question was whether the *other* entries measured on those same landings needed the
+same treatment. That was an inference from what changed, not a check. **It has now been checked, entry by entry.**
+
+**Result: no entry's conclusion depends on the repaired precision metric.** Every one of F1–F8, F18, F21, F25 and
+F26 rests on σ_focus, recall, R², or landed parameter values — and `recallHigh` derives only from `match.Pairs`
+(`BankVerifyRunner.cs:488`), which the `/5` repair never touched. One clause is the exception, below.
+
+| entry | rests on | verdict |
+|---|---|---|
+| F1, F2 | donut-flag thresholds (`frac`, HFR, bbox) | unaffected |
+| F3 | recall@≥12 on the real bank | unaffected — but see below |
+| F4 | σ_focus, `J`, sensor-model stars/R² | unaffected |
+| F5, F6, F18, F21, F25 | σ_focus, R², curve geometry | unaffected |
+| F7 | σ_focus, and recall "essentially unchanged" | unaffected |
+| F8 | landed Sensitivity/StarClip corners | unaffected — but see below |
+| F26 | binning/convergence, **plus one precision clause** | one clause unverified |
+
+**The one genuinely unverified clause.** F26 states that with the F23 marginal-SNR term enabled "D12 S6 converges
+… even though it **fails its own precision gates**." Those gates were the wave-1 `/3` ones, and F23's real
+precision effect turned out to be roughly one fifth of the artifact that hid it. The convergence result stands;
+the "fails its precision gates" half is not evidence until re-scored at `/5`.
+
+**Two entries are changed by [F33](#f33--the-synthetic-bank-does-not-reproduce-the-real-banks-optimizer-failure-mode)'s
+effective-gate correction instead — a different repair than the one being audited for.**
+
+- **F8** reads three landings as `sens 0 / clip 0.25`, `sens 0 / clip 6.875`, `sens 30.1 / clip 3.44` and calls
+  them non-reproducible. By **effective** gate they are further apart still — roughly **0.19**, **5.2** and
+  **30.1** — so the entry's conclusion is not merely intact but understated. Two landings that read as the same
+  "sens 0" corner are enforcing gates 27× apart.
+- **F3** cites `mccomiskey` A shedding to recall 0.079 as evidence `Wtie` does not prevent star-shedding. That
+  run's gate is now known to be **9.81**, not the floor its Sensitivity 0.0 suggests, which identifies the
+  shedding *mechanism* (the clip escape route) the entry left unnamed.
+
+**Why it matters.** The blanket assumption — "these were measured on suspect landings, so they are all suspect" —
+would have cost a full re-measurement pass and found nothing. The actual exposure was one clause in one entry.
+Recording the audit so it is not re-opened on the same inference next wave.
 
 ---
 

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -996,19 +996,33 @@ changed nothing.
 **How low is safe: measured, and the answer is "as low as you like".**
 `golden eval --params default --min-hfr <M>`, exact precision against synthetic truth, 8 values from 1.2 to 0.1:
 
-| `MinHFR` | D01 recall@high | D01 FP | D02 recall@high | D02 FP | D01 vertex-frame stars |
-|---|---|---|---|---|---|
-| 1.2 (default) | 0.129 | **0** | 0.451 | **0** | **0** |
-| 0.9 | 0.152 | **0** | 0.507 | **0** | **0** |
-| 0.7 | 0.160 | **0** | 0.567 | **0** | 2 |
-| **0.5** | 0.164 | **0** | 0.588 | **0** | **5** |
-| 0.35 | 0.164 | **0** | 0.594 | **0** | 5 |
-| 0.25 | 0.165 | **0** | 0.595 | **0** | 5 |
-| 0.1 | 0.165 | **0** | — | — | 6 |
+recall@high per dataset, **FP = 0 in all 32 configurations**:
 
-**Zero false positives at every value on both datasets**, and the recall gain saturates by ~0.35. `MinHFR` is a
-second line of defence — hot-pixel filtering is separate and enabled by default — and on this bank it is not
-carrying any of the load. **0.25–0.35 captures all the available gain.**
+| `MinHFR` | D01 (40 mm) | D02 (135 mm) | D03 (250 mm) | D05 control (1000 mm) | D01 vertex-frame stars |
+|---|---|---|---|---|---|
+| 1.2 (default) | 0.129 | 0.451 | 0.393 | 0.985 | **0** |
+| 0.9 | 0.152 | 0.507 | 0.535 | 0.985 | **0** |
+| 0.7 | 0.160 | 0.567 | 0.581 | 0.985 | 2 |
+| **0.5** | 0.164 | 0.588 | 0.585 | 0.985 | **5** |
+| 0.35 | 0.164 | 0.594 | 0.585 | 0.985 | 5 |
+| 0.25 | 0.165 | 0.595 | 0.585 | 0.985 | 5 |
+| 0.15 | 0.165 | 0.595 | 0.585 | 0.985 | 5 |
+| 0.1 | 0.165 | 0.595 | 0.585 | 0.985 | 6 |
+
+**Zero false positives at every value on every dataset**, and the recall gain saturates by 0.5 at the latest.
+`MinHFR` is a second line of defence — hot-pixel filtering is separate and enabled by default — and on this bank
+it is not carrying any of the load. **0.25–0.35 captures all the available gain on every class.**
+
+**`D05_tec140_1000mm` is the control that makes a GLOBAL seed defensible.** Its in-focus HFR is 1.77 px, well
+clear of every gate value tested, and its recall is **flat at 0.985 from 1.2 all the way to 0.1** — not one star
+gained or lost. A rig that does not need the seed is provably unperturbed by it, so the adjustment does not have
+to be conditioned on first detecting the wide-field case (which is the detection the gate has already
+prevented). Without this row the seeding rule would need a trigger it cannot evaluate.
+
+**The largest gain is D03, not D01.** `D03_redcat_250mm` moves **0.393 → 0.585 (+0.192)** against D01's +0.036.
+The fix helps *marginally* undersampled rigs most, not the extreme one — D01 is dominated by candidate-formation
+losses that this gate does not touch (see the attribution table below). Anyone scoping this work off D01 alone
+will both underestimate the benefit and misattribute where it lands.
 
 **The mechanism is the hard floor, not recall — and that reframes F20.** Lowering the gate moves D01's recall
 only 0.129 → 0.165. What it actually does is put stars back on the **vertex frame**: 0 → 2 at 0.7, and **0 → 5

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -514,7 +514,22 @@ is not, the candidate is a faint-end statistic (e.g. the SNR at the star count t
 than a fixed rank.
 
 ### F20 — Below `MinHFR` the autofocus objective collapses to exactly zero, with no diagnostic
-**Status:** Open · found 2026-08-02 running `optimize --per-run` over the synthetic AF bank
+**Status:** Open — **part 2 done, part 1 outstanding** · found 2026-08-02 running `optimize --per-run` over the
+synthetic AF bank
+
+> **Where this stands after wave 3.** The two halves of this entry's fix have diverged and the entry should not
+> be read as half-closed by accident:
+>
+> - **Part 2, "seed out of the plateau": DONE** via [F35](#f35--minhfr-should-be-seeded-from-the-sweep-wings-and-neither-available-hfr-statistic-can-size-it).
+>   D01 and D02 go from `FinalJ` exactly 0 to real landings; 14/17 synthetic and 19/19 real landings are
+>   bit-identical to the control.
+> - **Part 1, "report it": NOT DONE — and it is this entry's actual title.** Nothing user-facing still says
+>   "your stars are smaller than the minimum HFR". TestApp prints a seeding line; the **wizard says nothing**.
+>   The blocker named below is unchanged: `TooLowHFR` is one of the four `RejectionGate` constants with **no
+>   `*Bounds` rect list**, so it is not reachable at the seam that already reads `LowSensitivity`/`TooFlat`.
+>   This is still reporting **plus** one new counter.
+> - **The real-bank claim below is disproven** (see the correction under Evidence). What reproduces on real rigs
+>   is the *symptom*, not the cause.
 
 When a sweep's in-focus HFR falls below the detector's `MinHFR` gate (default 1.2 px), the whole core of the
 V-curve is rejected, the run objective is `0`, and the optimizer terminates having explored the space for
@@ -1569,6 +1584,18 @@ is not repeatedly investigated.
 The prepass writes `optimized_settings.json` back into the run folder as well as `--out`. That destroyed
 `bobp_m101`'s historical "row (a)" settings (`sens 50 / clip 9.5`) mid-investigation, leaving only the two knobs
 quoted in the write-up, so the baseline had to be reconstructed rather than reproduced.
+
+**It happened again in wave 3, on both banks at once (2026-08-03).** The F35 validation ran
+`optimize --per-run` over `D:\SyntheticAutofocusBank` and `D:\Autofocus Bank`, so every run's in-place
+`optimized_settings.json` in **both** banks is now the wave-3 landing. Nothing comparative was lost this time —
+the wave-1 control arms live in their own `--out` directories (`hf_f23\H_A`, `hf_f23\H_real_A`) and are
+untouched — but that was luck of workflow, not a property of the tool. **Any validation pass silently
+re-baselines the banks' stored settings**, and the only reason this one was harmless is that the comparison
+never read them.
+
+Note the interaction that makes this sharper than it looks: `bank-verify --opt-a/--opt-b` and
+`golden eval --params optimized` both read the **run folder** copy by default. So a prepass and a later scoring
+run that were meant to be independent can silently share an arm.
 
 **Next step.** Consider writing only to `--out` unless a flag opts into updating the run folder, or snapshot the
 previous file alongside it.

--- a/docs/synthetic-af-bank-followups-wave2-results.md
+++ b/docs/synthetic-af-bank-followups-wave2-results.md
@@ -175,6 +175,24 @@ The risk on the proposed fix stands and is worth restating: seeding `MinHFR` ben
 creates a knob the search has no gradient to climb back out of, so it should be seeded to a *measured* value,
 not a permissive one.
 
+### F35 — `MinHFR` seeding, measured after the fact
+
+Filed answering "how far can `MinHFR` safely come down?". Three results, all from
+`golden eval --min-hfr` sweeps (~40 s per config) rather than a bank run:
+
+- **F20's proposed trigger is circular.** "If the median in-focus HFR is at or below `MinHFR`, seed beneath it"
+  cannot run when the in-focus frame detects zero stars. The sweep **wings** are the only uncensored
+  measurement, and they already fit at R² = 0.911 on D01.
+- **Neither available HFR statistic can size the seed.** The wing fit over-predicts D01's vertex 2.3× (0.548 vs
+  0.238 px), and the surviving-star medians read 2.2–2.8× high because they are **left-censored at `MinHFR`
+  itself** — the same trap F23 wave 1 hit with marginal SNR censored at the Sensitivity gate.
+- **The safe floor is 0.25–0.35 px, with FP = 0 in all 32 configurations**, and `D05_tec140_1000mm` is flat at
+  0.985 across the whole range — so a well-sampled rig is provably unperturbed and the seed can be global.
+
+It also corrects F20's success criterion: lowering the gate moves D01's recall only 0.129 → 0.165, but puts 5
+stars on the vertex frame at 0.5, which clears the `NHard` = 3 hard floor and is the entire cause of
+`FinalJ = 0.00000`.
+
 ### F22 is unaffected
 
 A binning/HFR result, not a precision one. Still confirmed, its "calibrate out the bias" fix still ruled out

--- a/docs/synthetic-af-bank-followups-wave3-results.md
+++ b/docs/synthetic-af-bank-followups-wave3-results.md
@@ -297,6 +297,45 @@ star-shedding example now has its mechanism named — the clip escape route, not
 every rig that *does* have a gradient); any objective change (F32 shows the two banks disagree in sign, so
 nothing can be accepted on the synthetic bank alone); and any change to `SensitivityIsAtFloor` semantics.
 
+## Lessons
+
+Wave 1's was "reproducibility validates nothing". Wave 2's was "a metric can fail in two directions". Wave 3's
+are cheaper than both, which is the point — every one of them cost minutes and would have cost hours.
+
+**1. Read the thing before scheduling a run against it.** Three of this wave's stated inputs were wrong, and all
+three were settled by reading code or a landing file. The F35 trigger did not exist where the entry pointed; the
+`MinHFR` "grid" does not exist at all; F24's nine axes had never moved. A per-axis ablation would have burned an
+afternoon returning nine nulls.
+
+**2. The control dataset earns its place by being boring.** The first bank pass read 17/17 PASS, exit 0 where
+every prior pass exited 3 — and was wrong. Every headline number in it was defensible. The only row that
+revealed the defect was `D05`, whose entire job is *not to move*. **Design the control before the experiment,
+and read it first.**
+
+**3. A regression test that passes either way is worth nothing.** The first version of the `MinHfrSeed` unit test
+asserted `seed.MinHFR == SeedFloor` — it codified the bug and passed. Every regression test here was re-run with
+the fix reverted to confirm it fails.
+
+**4. `default` is not `neutral`.** `DonutMorphCloseSize` defaults to **5** and is neutral at **1**, so an arm
+that "leaves the axes alone" still runs a 5 px morphological close — 90% of the recall cost on D04. Any ablation
+must state which of the two it holds, per knob.
+
+**5. Mutating a caller's object is a cross-run bug, not a style issue.** One in-place write to `seed.MinHFR` was
+enough to re-gate sixteen datasets from one firing, because callers reuse a single params bundle across runs
+(`OptimizationDiagnosticRunner.cs:306` vs the loop at `:426`). It printed *one* log line while doing it, and the
+result depended on dataset order.
+
+**6. "It reproduces on the real bank" needs the CAUSE to reproduce, not the symptom.** F20's strongest claim was
+that `BaselineJ = 0` on real rigs proved the defect was not a render artifact. Measured: all four such runs have
+a vertex above the gate and the seed fires on none of them. Two different defects print the identical line.
+This is [F33](followups.md#f33--the-synthetic-bank-does-not-reproduce-the-real-banks-optimizer-failure-mode)'s
+rule applied to a *finding* rather than to a fix.
+
+**7. Check what your own validation run overwrote.** `optimize --per-run` writes landings back into the run
+folders ([F15](followups.md#f15--optimize---per-run-overwrites-each-runs-stored-settings)), so this wave's two
+validation passes silently re-baselined the stored settings of **both** banks. Harmless here only because the
+comparison read the `--out` copies — luck of workflow, not a property of the tool.
+
 ## Verification
 
 - Full suite **3371/3371, two consecutive clean runs**. One earlier run showed a single failure while two bank

--- a/docs/synthetic-af-bank-followups-wave3-results.md
+++ b/docs/synthetic-af-bank-followups-wave3-results.md
@@ -1,0 +1,323 @@
+# Synthetic AF bank — followups wave 3
+
+Plan: [`plans/synthetic-af-bank-followups-wave3-plan.md`](../plans/synthetic-af-bank-followups-wave3-plan.md).
+Wave 2: [`docs/synthetic-af-bank-followups-wave2-results.md`](synthetic-af-bank-followups-wave2-results.md).
+Register: [`docs/followups.md`](followups.md).
+
+*The question: ship F20's real fix (F35), re-score F24 against recall, and measure the objective's dynamic range
+on both banks before anyone proposes a new term for it.*
+
+## Headline
+
+| what | result |
+|---|---|
+| F35 — seed `MinHFR` out of the cold-start plateau | **Done.** D01/D02 `FinalJ=0` → **0.9902 / 0.9966**; 14/17 synthetic and **19/19 real** landings bit-identical to control |
+| …and the validation run caught a bug in it | The seed leaked across runs through a shared params object. **The D05 control is what exposed it** |
+| …and the real bank corrected F20 | F20's four `BaselineJ=0` real runs are **a different defect** — the seed fires on none of them |
+| F35 step 3 — "widen the low end of the axis" | **Won't fix.** The 0.25 grid does not exist; the axis already resolves to 0.03125 |
+| F24 restated — score the nine donut axes against Δrecall | **Not attributable to the search** — it moved none of the nine; the master's own defaults cost the recall |
+| F32 — measure `J`'s dynamic range | **Done.** Real bank trades **17.3 points of recall per unit `J`** at the median; worst case 3018 |
+| F33 — report the effective gate | **Done.** `mccomiskey` is 9.81, not the 7.5 on record — and it is not the only misread landing |
+| F36 (new) — do F1–F8/F18/F21/F25/F26 rest on the broken metric? | **Audited: no.** One clause in one entry, not eleven entries |
+
+## Three premises that did not survive contact with the code
+
+Wave 2's lesson was that a deterministic pipeline reproduces a systematic error perfectly. Wave 3's is narrower
+and cheaper: **read the thing before scheduling a run against it.** Three of this wave's inputs were wrong, and
+all three were settled by reading code or a landing file — no detector run, no bank pass.
+
+**1. The trigger statistic is not where F35 says it is.** `BestFit.Minimum.Y` is "already read by the wizard"
+only *after* the search (`StarDetectionOptimizerWizardVM.cs:3115`). The one seam all five optimizer callers
+share sees `RunEvaluationMetrics`, which carries the vertex **X only** (`BestFocusPosition`) and has no
+`Minimum.Y` field at all. Had the fix been written where the entry pointed, it would not have compiled; had it
+been written at the engine seam with an invented statistic, it would have been the circularity F35 exists to
+remove, one level down.
+
+**2. `Continuous` has no grid, so F35 step 3 is not a fix.** `OptimizerVariable.Quantize` is *identity + clamp*
+for `Continuous`; `InitialStep` is the **initial pattern-search stride**, halved on every non-improving sweep
+down to `InitialStep × StepFloorFraction` = **0.03125**. The "0.45 → 0.20 is a 2.25× jump" framing describes the
+first descent stride only. And it is moot in both directions on the rigs that motivated it: `MinHFR` is absent
+from Phase A (`CoarseGrid` covers `Sensitivity × StarClippingMultiplier`), so it moves only through
+strictly-improving Phase-B moves — which on D01/D02's flat `J` never happen **at any stride**. Retuning the
+stride would perturb every rig that *does* have a gradient while doing nothing for the ones the entry is about.
+
+**3. F24's nine axes never moved.** Reading the two config-B landings — one `json.tool` invocation, no run —
+shows the search left **all nine at their defaults** on D16, and moved only `DefocusDistortionSizeReference` by
+4% (30 → 28.75) on D04. A per-axis ablation would have produced nine null results and attributed nothing.
+
+The trap inside the trap: *default* is not the same as *neutral*. `DonutMorphCloseSize` defaults to **5** and is
+neutral at **1**, so an arm that "leaves the axes alone" is still running a 5 px morphological close — which
+turned out to be 90% of the cost on D04. See §F24.
+
+## F35 — the seed
+
+**The split that makes it implementable: the fit TRIGGERS, geometry SIZES.**
+
+The trigger is `BestFit.Minimum.Y <= MinHFR` from a fit taken *before* the search, computed by the two callers
+that already hold one (the wizard's seed guard; TestApp `optimize`'s `perRunBaseline`) and passed to the engine
+as `OptimizerSettings.MinHfrSeedFloor`. The engine applies the clamp once, ahead of θ0, so the seeded value
+flows into the seed evaluation, the never-regress floor, and `RevertNeutralAxes`. `synth-validate` and `tilt`
+fit no curve before optimizing, do not opt in, and stay bit-identical.
+
+**The size is a constant — 0.30 px in binned detection pixels — and it must not come from a measurement.** Both
+available statistics read high, in the direction that would make a fit-derived seed useless: the wing vertex
+over-predicts 2.3× (0.548 vs 0.238 on D01) and the survivor medians are **left-censored at `MinHFR` itself**.
+The run that shipped confirms the bias in the live path: D01's pre-search fit read **0.762 px** against a truth
+vertex of 0.238 — 3.2× high — and the seed worked anyway, because the fit only had to clear 1.2, not measure
+0.238. A rule like `0.8 × predicted` would have given 0.61 and gated the true vertex completely.
+
+`MinHFR` needs no arcsec/px conversion: from the software-binning stage the whole pipeline runs in binned pixels
+and every pixel-unit param "stays in the range it was calibrated for regardless of the rig"
+(`StarDetector.cs:483-486`). What bounds the seed is sampling — HFR cannot fall far below pixel quantization.
+
+Pre-check on the vertex frame (`golden eval --min-hfr 0.30`, D01): `TooLowHFR` falls **1877 → 10**, the vertex
+frame carries **5 stars** where it carried 0 — clearing the objective's `NHard` = 3 — and precision stays
+**1.000** on every frame. Every other gate is untouched, which is F35's own point: `TooLowHFR` was 1877 of
+~38500 missed stars, and the W class's recall is lost in candidate *formation* (`NO CANDIDATE` 18800,
+`TooSmall` 6398). **Recall does not recover and was never the criterion.**
+
+### The validation run caught a bug in the fix
+
+The first bank pass looked like a clean sweep: 17/17 hard-floor PASS, exit 0 where every prior pass exited 3.
+**It was wrong, and the control is what said so.**
+
+`D05_tec140_1000mm` landed at `MinHFR` **0.300** — the seed constant — against 1.450 in the wave-1 arm. D05's
+truth vertex is 1.804 px, comfortably above the 1.2 gate, so its trigger must never fire. Its entire purpose in
+F35 is to be the rig that proves an unaffected rig stays unaffected. Fourteen of seventeen datasets landed at
+exactly 0.300, while the log printed the "seeding" line exactly **once**.
+
+That pair of facts is the diagnosis. `OptimizeAsync` was writing `seed.MinHFR` **in place**, and callers reuse
+one `StarDetectorParams`: TestApp `optimize --per-run` builds its `RunDetectionContext` once
+(`OptimizationDiagnosticRunner.cs:306`) *outside* the per-dataset loop (`:426`), and the wizard passes a live
+reference to `runs[0].Seed`. So D01 — first alphabetically, and the one rig whose fit genuinely triggered —
+permanently re-gated the other sixteen. Each subsequent run then saw a seed *already* at the floor, so
+`Resolve` correctly returned null and printed nothing. **One real firing, sixteen silent ones, and a result that
+depended on dataset order.**
+
+Fixed by cloning the seed rather than mutating the caller's. The regression test asserts a second, non-triggering
+run starts from the original gate; it was confirmed to fail without the fix, because a regression test that
+passes either way is worth nothing. The first version of the unit test had itself asserted
+`seed.MinHFR == SeedFloor` — it codified the bug and passed.
+
+**The lesson is narrow and repeatable: the control dataset earned its place.** D05 exists in F35 purely to be
+boring, and a "boring" reading is the only thing that distinguished a working fix from one that had silently
+re-gated the entire bank. Every headline number in the first pass was defensible on its own; only the row that
+was supposed to *not* move revealed the defect.
+
+### Results, on the re-run with the leak fixed
+
+**Synthetic bank — 17/17, `EXIT=0` where the wave-1 arm exited 3 (hard-floor failure).**
+
+The seed fired on exactly **three** datasets, each off its own wing fit, and they are exactly the three
+undersampled rigs F20 and F35 name:
+
+| dataset | fitted vertex | seed? | `MinHFR` new / control | `FinalJ` new / control |
+|---|---|---|---|---|
+| `D01_ultrawide_40mm` | 0.762 px | **YES** | 0.100 / 1.200 | **0.99018 / 0.00000** |
+| `D02_rich_135mm` | 0.749 px | **YES** | 0.550 / 1.200 | **0.99656 / 0.00000** |
+| `D03_redcat_250mm` | 1.015 px | **YES** | 0.300 / 0.450 | 0.99549 / 0.99486 |
+| the other 14 | — | no | **identical** | **identical to 5 dp** |
+
+- **2 runs rescued**: D01 and D02 go from `FinalJ` exactly 0 to a real landing. That is F20's whole defect.
+- **14 of 17 landings are bit-identical to the wave-1 control**, `MinHFR` and `FinalJ` alike — including
+  `D05_tec140_1000mm` at 1.450, the control, and `D12`/`D16`/`D17` whose landings sit *above* the default gate.
+- **0 control violations**: no dataset that did not trigger landed at the seed constant.
+
+The 14/17 row is the strongest safety statement available: on every rig the change was not designed for, it is
+a **no-op**, not a small perturbation.
+
+Two things the run says that the register did not:
+
+**D17's `BaselineJ = 0` is a different defect.** It reads 0 like D01/D02, but its fit vertex is above the gate,
+the seed correctly declines, and its landing is unchanged at `MinHFR` 1.294 / `FinalJ` 0.97768 — it was already
+escaping on its own. A `BaselineJ` of 0 is not by itself evidence of the MinHFR collapse.
+
+**The trigger's censoring bias is visible and survivable.** D01's pre-search fit read 0.762 px against a truth
+vertex of 0.238 (3.2× high) and D02's read 0.749. Both still cleared 1.2, which is the entire reason a
+*trigger-only* use of the fit works where a *sizing* use would not: `0.8 × predicted` would have given 0.61 and
+0.60 and re-gated both rigs completely.
+
+**Real bank — 19/19 landings bit-identical to the control, and the seed fired on ZERO runs.**
+
+`MinHFR` and `FinalJ` match the wave-1 arm to five decimal places on every one of the nineteen runs. Zero
+rescued, zero violations, and the one hard-floor failure (`lumos`) is the same one the control produces.
+
+That is the strongest possible transfer result in the safe direction — **exactly inert, not "within noise"** —
+and it carries a correction that only a real-bank pass could produce.
+
+**F20's real-bank population is not the defect F35 fixes.** F20 says `BaselineJ = 0` on `Panos` and
+`LinwoodFocus` is "the same silent null result D01/D02 produce synthetically, on real frames from real rigs."
+Measured, it is not. All four real runs with `BaselineJ = 0` — `Panos`, `LinwoodFocus`, `SorenVance`, `lumos` —
+have a fit vertex **above** the 1.2 gate, so the trigger correctly declines and their landings are unchanged.
+Their `J = 0` comes from having almost no stars at all (`lumos` and `SorenVance` detect **zero** at C0; `Panos`
+33 and `LinwoodFocus` 13 across nine frames), not from stars being gated out for measuring too small.
+
+**Two defects were being read as one.** "The objective collapses to exactly zero" has at least two causes: the
+`MinHFR` gate emptying the curve's core (synthetic D01/D02, now fixed) and a frame that genuinely has no
+detectable signal (real `lumos`/`SorenVance`). They present identically in the log — `currentJ=0 bestJ=0
+hard-floor FAIL` — and only the first is a detector-configuration problem. F35 addresses the first and is
+provably inert on the second.
+
+So the honest summary of the fix's reach: **real, measured, and with an empty real-bank population on this
+bank.** The undersampled short-focal-length rigs it targets are exactly what the synthetic bank was built to
+contain and what the real bank happens not to have. That is an argument for the synthetic bank's value, not
+against the fix — but it does mean the user-facing benefit is unproven on real frames until such a rig appears
+in the bank, and it should not be claimed as proven.
+
+## F24 restated — the nine axes are not the mechanism; the master toggle's defaults are
+
+The task was to score the nine donut-gated axes against Δrecall on `D16_esprit550_ha3` and `D04_esprit_550mm`,
+two unobstructed 550 mm refractors where the donut relaxations should be inert and are not (−0.147 and −0.113
+under config B). **Reading the two landings first changed the experiment**: the search moved none of the nine.
+D16 landed every one at its default; D04 moved only `DefocusDistortionSizeReference` 30 → 28.75. A per-axis
+ablation of what the *search* chose would have returned nine nulls and attributed nothing.
+
+What it left behind is not inert, though: `DonutMorphCloseSize`'s default of 5 is **not** its neutral value of 1.
+So the question is not "which axis did the optimizer move" but "what does the master switch on when nobody
+touches anything" — and the arms below are built to answer that.
+
+So the arms hold every parameter at defaults and vary only what the **master toggle** turns on. `golden eval`,
+~40 s per arm, precision **1.000** and FP **0** on every one:
+
+| arm | D16 recall@high | D04 recall@high |
+|---|---|---|
+| A1 — master OFF | **0.821** (151/184) | **0.762** (16853/22109) |
+| A2 — master ON | 0.793 (−0.028) | 0.723 (−0.039) |
+| A3 — master ON, structure boost 0 | **0.821** (recovers all) | 0.732 (recovers 23%) |
+| A4 — master ON, size-ref 28.75 | 0.793 (**bit-identical to A2**) | 0.723 (**bit-identical to A2**) |
+| A5 — master ON, morph-close 1 | 0.799 (recovers 21%) | 0.758 (recovers 90%) |
+| **A6 — master ON, boost 0 + morph-close 1** | **0.821 (151/184)** | **0.762 (16853/22109)** |
+
+**A6 recovers the master-OFF recall exactly — the same star counts, not merely the same ratio — on both
+datasets.** So two mechanisms account for the master's entire recall cost here, and nothing else in it does:
+
+1. **The silent +2 structure boost.** With the master ON and `DefocusAwareStructure` OFF, `StarDetector.cs:610-615`
+   applies `DonutDefaultStructureLayerBoost = 2` anyway, taking `StructureLayers` 4 → 6. More wavelet layers
+   subtracted from the residual erases more small-star structure — precisely what a well-sampled refractor loses.
+   Dominant on D16 (100% of the cost).
+2. **The 5 px morph-close.** `DonutMorphCloseSize` **defaults to 5 and is neutral at 1**, so `--params default`
+   plus the master runs a morphological close that merges and reshapes compact stars. Dominant on D04 (90%).
+
+The one axis the search *did* move is provably inert: A4 is bit-identical to A2 on both datasets.
+
+**Two caveats, stated because the numbers invite a wrong comparison.** These arms run at default shared params
+(NC 4.0), so −0.028 / −0.039 is the master's own cost, **not** config B's −0.147 / −0.113, which is measured at
+NC 2 against B's whole landing. The master residue is roughly a fifth to a third of the observed config-B loss;
+the remainder is that B's search landed different values on the *shared* axes (D16 `MinHFR` 0.7, `PeakResponse`
+0.7; D04 `StarClip` 0.5, `MinHFR` 0.95).
+
+**And the closing link is F32.** Both mechanisms are reachable by the search — `DonutMorphCloseSize` is a curated
+axis, and `StructureLayerBoost` becomes settable once `DefocusAwareStructure` flips on. The optimizer simply
+never neutralizes them, because `J` does not pay for recall. F24's loss is not a missing knob; it is
+[F32](followups.md#f32--j-is-saturated-near-10-so-the-optimizer-trades-enormous-recall-for-numerically-trivial-gains)
+measured on two specific rigs.
+
+**Next step (not taken here):** consider making the master's structure boost and morph-close default to their
+neutral values on runs the donut heuristic did not flag, or fold recall into what the objective pays for. Both
+are objective/behaviour changes, so per F33 they must be scored on **both** banks.
+
+## F32 — the objective's dynamic range, measured on both banks
+
+All inputs were already on disk; `D:\hf_w3\f32_dynrange.py` reads them with no detector run. Recall comes from
+the `/5` synthetic verify and the `/3` real one — valid because `recallHigh` derives only from `match.Pairs`
+(`BankVerifyRunner.cs:488`) and the `/5` repair touched only the false-positive list. The real bank's
+**precision** from that run is void and is not read anywhere here.
+
+| arm | median `BaselineJ` | median Δ`J` | median Δrecall@≥12 | **median trade rate** |
+|---|---|---|---|---|
+| synthetic A | 0.952 | +0.0101 | **0.000** | **0.00** |
+| synthetic B | 0.992 | +0.0021 | −0.014 | **−1.01** |
+| **real A** | 0.977 | +0.0126 | **−0.243** | **−17.32** |
+
+Trade rate = Δrecall@≥12 per unit Δ`J`; negative means recall was given up to buy `J`.
+
+The median reproduces F32's headline exactly (−0.243). Two things it did not say:
+
+**The worst cases are far starker as a rate than as a pair of numbers.** `toml999` gives up **3018 points of
+recall per unit of `J`**; `uneven` −134, `CWhiteFocus` −116, `muggsie` −94. "Two ten-thousandths for 46 points"
+undersells it — at `BaselineJ` 0.998 the fourth decimal is not a rounding error, it is the entire remaining
+scale.
+
+**The two banks disagree in SIGN, not just magnitude.** Config A costs the synthetic bank **no recall at all**
+(median trade rate 0.00) while costing the real bank a quarter of it. So the synthetic bank cannot measure this
+defect — and F33's "never the synthetic alone" rule applies to a proposed *rescaling* exactly as much as to a
+new term. **Any candidate objective change must be shown to move the real-bank trade rate, and the synthetic
+bank cannot tell you whether it did.**
+
+## F33 — the effective gate, and how many landings it reclassifies
+
+`max(Sensitivity, PeakResponse × effective StarClip)` now ships as `StarDetector.EffectiveSensitivityGate`,
+reported wherever a landing's Sensitivity is quoted.
+
+**The register's own arithmetic was wrong, in the way the register warns about.** F33 computed `mccomiskey` as
+`0.75 × 10 = 7.5` using the *default* `PeakResponse`; that landing's own `StarPeakResponse` is **0.98**, so its
+effective gate is **9.81**. Both inputs are searched axes — the exact reason the entry gives for not hard-coding
+1.5, applied one level down.
+
+**And it is not one odd run.** Landings that read as "Sensitivity at the floor" but are not:
+
+| bank / arm | run | Sensitivity | effective gate | detections C0 → A |
+|---|---|---|---|---|
+| real A | `mccomiskey` | 0.0 | **9.81** | 3606 → 43 |
+| real A | `caboose` | 0.0 | **5.05** | 18 → 22 |
+| synthetic A | `D11_rc10_585_afbin2` | 0.0 | **2.36** | 217 → 406 |
+| synthetic A | `D12_c14_585_afbin2` | 0.0 | **2.10** | 186 → 475 |
+
+So **2 of the 6** synthetic "Sensitivity 0.0" landings F23 cites are not floor landings (D09/D10/D15/D17 are
+genuine, all below the 1.5 inert bound). Reported, not acted on: `SensitivityIsAtFloor` still drives UI
+visibility and whether `Recommend` runs at all, and changing that is a behaviour change rather than the
+reporting change F33 asks for.
+
+The `afbank-verify` schema is deliberately **not** bumped — the new `effectiveSensitivity` is additive and
+derived, no number changes, and the /4 and /5 bumps were for changes that made numbers non-comparable.
+
+## F36 — the audit that replaced a re-measurement pass
+
+"F1–F8, F18, F21, F25, F26 were measured on the landings F32/F33 reinterpret and may need what F23/F24 got" was
+an inference, not a check. Checked: **no entry's conclusion depends on the repaired precision metric.** They rest
+on σ_focus, recall, R², or landed parameter values, and `recallHigh` never went through the repaired path.
+
+The actual exposure is **one clause in one entry** — F26's "D12 S6 converges even though it fails its own
+precision gates", where those gates were the wave-1 `/3` ones. The convergence result stands; that half does not.
+
+Two entries are instead *strengthened* by F33's correction: **F8**'s three "non-reproducible" landings are
+27× apart by effective gate (0.19 / 5.2 / 30.1), not merely different corners; and **F3**'s `mccomiskey`
+star-shedding example now has its mechanism named — the clip escape route, not a floored Sensitivity.
+
+## What shipped
+
+| change | user-visible? |
+|---|---|
+| F35 — `MinHfrSeed` + `OptimizerSettings.MinHfrSeedFloor`, applied ahead of θ0 | **yes on an undersampled rig** — but no such rig exists in the real bank, so the benefit is measured only synthetically |
+| F35 — the seed must not leak across runs (clone, don't mutate the caller's seed) | no (correctness of the above) |
+| F33 — `StarDetector.EffectiveSensitivityGate`, reported at every landing-Sensitivity site | no (diagnostics) |
+| F32 / F36 / F24 — measurements and register corrections | no (docs) |
+
+**Deliberately not shipped:** F35 step 3 (the axis stride — the premise is refuted, and retuning it would perturb
+every rig that *does* have a gradient); any objective change (F32 shows the two banks disagree in sign, so
+nothing can be accepted on the synthetic bank alone); and any change to `SensitivityIsAtFloor` semantics.
+
+## Verification
+
+- Full suite **3371/3371, two consecutive clean runs**. One earlier run showed a single failure while two bank
+  passes were saturating the CPU; its name was not captured and it did not recur in four subsequent full runs.
+  Recorded as unidentified-intermittent rather than attributed to the known-flaky EAT transport test.
+- The seed-leak regression test was confirmed to **fail without the fix**. The first version of the unit test
+  asserted the buggy behaviour and passed — which is why the fail-without-fix check exists.
+- Both banks completed: synthetic 17/17 (`EXIT=0`, where the control arm exited 3), real 19/19 with one
+  hard-floor failure (`lumos`) that the control also produces.
+
+## Reproduce
+
+```
+# F35 — the seed, both banks (~55 min each, run detached; build to a separate -o dir, the exe is locked while running)
+TestApp optimize --per-run --runs "D:\SyntheticAutofocusBank" --out <dir> --max-evals 250
+TestApp optimize --per-run --runs "D:\Autofocus Bank"        --out <dir> --max-evals 250
+
+# F35 — the cheap pre-check (~40 s), which is how the vertex-frame star count was confirmed before spending an hour
+TestApp golden eval --runs "D:\SyntheticAutofocusBank\D01_ultrawide_40mm" --params default \
+    --min-hfr 0.30 --match centroid --out <dir>
+
+# F24 — the arm set (D:\hf_w3\run_f24_arms.sh)
+# F32/F33 — D:\hf_w3\f32_dynrange.py, reads files already on disk
+```

--- a/plans/synthetic-af-bank-followups-wave3-plan.md
+++ b/plans/synthetic-af-bank-followups-wave3-plan.md
@@ -1,0 +1,306 @@
+# Synthetic AF bank — followups wave 3 (plan)
+
+Wave 2: [`docs/synthetic-af-bank-followups-wave2-results.md`](../docs/synthetic-af-bank-followups-wave2-results.md).
+Register: [`docs/followups.md`](../docs/followups.md) — F35, F20, F32, F33.
+Branch: `ghilios/synth-bank-followups-wave3` (cut off `develop`, carries the F35 D03/D05 addendum).
+
+*The question: ship F20's real fix (F35), re-score F24 against the metric it should always have used, and
+measure the objective's dynamic range on both banks before anyone proposes a new term for it.*
+
+---
+
+## Two premises in the brief are wrong, and they change the work
+
+Both were checked in code before any of the plan below was written. Neither invalidates F35's measurements —
+the `golden eval --min-hfr` sweep stands exactly as recorded. What they change is *where the fix goes* and
+*whether part (c) is a fix at all*.
+
+### P1 — the trigger statistic is not available where F35 says it is
+
+F35 step 1 and the brief both say `BestFit.Minimum.Y` is "already computed and already read by the wizard as
+`baselineInFocusHfr`". It is — but **only after the search has finished**, in `BuildSummaryAsync`
+(`StarDetectionOptimizerWizardVM.cs:3115`). The seeding decision has to be made *before*.
+
+The engine seam cannot see it either. `StarDetectionOptimizer.OptimizeAsync`
+(`StarDetectionOptimizer.cs:92`) is the one place all five callers share, and its evaluator returns
+`RunEvaluationMetrics`, which carries the vertex **X only**:
+
+```
+RunEvaluationData.cs:817-818   var minX = bestFit.Minimum.X;
+                               metrics.BestFocusPosition = ... minX ...;
+```
+
+`RunEvaluationMetrics` has `SigmaFocus`, `RSquared`, `FrameStarCounts`, `BestFocusPosition`, `FrameStarHFRs` —
+**and no `Minimum.Y` of any kind**. So `BestFit.Minimum.Y <= MinHFR` is not expressible at the shared seam
+without a contract change affecting all five callers.
+
+It *is* cheaply available at the two callers that matter, because both already run a full fit before the search:
+
+| caller | pre-search fit | engine call |
+|---|---|---|
+| Wizard | `SeedFitIsUsableAsync:2796` → `AnalyzeWithProgressAsync:2912` returns `List<RunEvaluationResult>`, `BestFit` intact | `:3011` |
+| TestApp `optimize` | `perRunBaseline` built at `OptimizationDiagnosticRunner.cs:580-583` | `:640`, 57 lines later |
+| TestApp `synth-validate` | **none** — seed straight to search (`SynthValidateRunner.cs:667-700`) | `:700` |
+| TestApp `tilt` | **none** | `TiltCalibrationRunner.cs:469` |
+
+**Consequence for the design.** The trigger is computed by the caller (which has the fit) and the *clamp* is
+applied by the engine (which owns the axis bounds and `theta0`). That keeps one implementation of the rule and
+lets `synth-validate` / `tilt` opt out by simply not asking — rather than silently diverging, which is the
+failure shape the `--sensitivity-floor` precedent already has (`OptimizerVariable.cs:133-145`: TestApp passes a
+floor, the wizard silently takes the default).
+
+### P2 — the `MinHFR` axis has no 0.25 grid, so part (c) is not the fix it is described as
+
+F35 step 3 and the brief both say the axis is `Continuous(0.1, 5.0, step 0.25)` so "from 1.2 the reachable grid
+is 0.95 → 0.70 → 0.45 → 0.20" and "0.45 → 0.20 is a 2.25× jump in a sub-pixel regime".
+
+**`Continuous` is not quantized.** `OptimizerVariable.Quantize` (`:83-92`) is *identity + clamp* for
+`Continuous`; only `Integer` rounds. `InitialStep` is documented as "the initial pattern-search step"
+(`:54-55`), and Phase B **halves it on every sweep that finds no improving move**, down to
+`InitialStep × StepFloorFraction` = `0.25 × 0.125` = **0.03125**
+(`StarDetectionOptimizer.cs:464-467`, `:565`, `OptimizerSettings.StepFloorFraction:38`).
+
+So the axis already resolves to ~0.03 px near wherever the search lands. The 0.25 figure is the *first* descent
+stride, not the resolution.
+
+And on the motivating rigs it is irrelevant either way: `MinHFR` is **not** in Phase A — `CoarseGrid` is over
+`Sensitivity × StarClippingMultiplier` only (`:299-303`) — so it moves solely through Phase B, which requires a
+**strictly improving** move. On D01/D02, `J` is identically 0 across the neighbourhood, so no move ever improves,
+the steps contract in place, and `MinHFR` never moves at all. That is F20's cold-start plateau, and **no step
+size fixes it**. The seed does.
+
+**Consequence for the design.** Part (c) is demoted from "the third part of the fix" to a flagged correction in
+the register. Retuning `InitialStep` would change the first stride and the floor for every rig that *does* have a
+gradient — a live behaviour change on the whole bank, justified by nothing measured, and squarely the F28 lesson
+("verify a fix changes real OUTPUT before claiming a user benefit"). **We flag it; we do not ship it in this
+wave.** The one genuinely-needed piece survives: `MinHFRLower = 0.1` (`OptimizerVariable.cs:156`) silently
+clamps any seed below 0.1 at `theta0` (`StarDetectionOptimizer.cs:115`), so the seeding rule must either stay
+≥ 0.1 or lower that bound. At 0.25–0.35 it stays ≥ 0.1, so nothing is required.
+
+---
+
+## What the seed is sized from
+
+F35 (b) says size it from pixel scale and sampling, never from a measured HFR. The code makes this simpler than
+it sounds: **`MinHFR` is already dimensionally self-contained.** From `StarDetector.cs:483-486`:
+
+> "Software binning: from here the WHOLE pipeline runs in binned pixels, so every pixel-unit param (MinHFR,
+> MinimumStarBoundingBoxSize, NoiseReductionRadius, …) stays in the range it was calibrated for regardless of
+> the rig"
+
+So there is no arcsec/px conversion to apply — the seed is a **constant in binned detection pixels**, and its
+justification is a sampling argument rather than a per-rig computation:
+
+- HFR is bounded below by pixel quantization. A star whose flux lands in essentially one pixel measures a few
+  tenths of a pixel; it cannot measure near zero.
+- The measured floor is **0.25–0.35 px with FP = 0 in all 32 configurations** across D01/D02/D03/D05
+  (`docs/followups.md:999-1014`), and the gain saturates by 0.5.
+- `D05_tec140_1000mm` (truth vertex 1.80 px) is **flat at 0.985 recall from 1.2 all the way to 0.1** — a rig that
+  does not need the seed is provably unperturbed.
+
+**Chosen value: 0.30 px.** Mid-range of the measured-safe band, one full halving-step of margin above the
+`MinHFRLower = 0.1` clamp, and strictly below D01's 0.238 px truth vertex is *not* required — the gate is
+`star.HFR <= p.MinHFR` (inclusive, `StarDetector.cs:1873-1880`) and the sweep measures 5 vertex-frame stars
+surviving at 0.35, which already clears `NHard = 3`.
+
+This value is **not** derived from any measured HFR, so it inherits neither the wing-fit's 2.3× vertex
+over-prediction nor the survivor medians' left-censoring at `MinHFR` itself.
+
+---
+
+## Tasks
+
+### T1 — `MinHfrSeed`: the rule, as a pure function, test-first
+
+New `Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/MinHfrSeed.cs`.
+
+```csharp
+/// Returns the MinHFR to seed the search with, or null to leave the seed alone.
+public static double? Resolve(double fitVertexHfr, double currentMinHfr)
+```
+
+Rule: return `SeedFloor` (0.30) iff `fitVertexHfr` is finite **and** `fitVertexHfr <= currentMinHfr` **and**
+`SeedFloor < currentMinHfr`; else null.
+
+Tests (`$TS/StarDetection/Optimization/MinHfrSeedTests.cs`), written first:
+
+1. D01 shape — vertex 0.548 (the wing fit's own over-prediction), current 1.2 ⇒ 0.30.
+2. D05 shape — vertex 1.804, current 1.2 ⇒ **null** (untouched; this is the control the global seed rests on).
+3. Vertex NaN / ±∞ ⇒ null (a run with no fit must not be silently re-gated).
+4. Current already below the floor (0.2) ⇒ null — **never raises the gate**.
+5. Vertex exactly == current ⇒ seeds (the gate is inclusive, so a vertex *at* the gate is already being rejected).
+6. `SeedFloor` is ≥ `OptimizerVariable`'s `MinHFRLower`, asserted against the axis so the silent `theta0` clamp
+   at `StarDetectionOptimizer.cs:115` can never apply.
+
+### T2 — apply the seed: engine clamps, callers decide
+
+**Engine.** Add `public double? MinHfrSeedFloor { get; set; }` to `OptimizerSettings`
+(`StarDetectionOptimizer.cs:23-39`). In `OptimizeAsync`, between `:104` and `:112` (before `theta0` is read):
+
+```csharp
+if (settings.MinHfrSeedFloor is double floor && floor < seed.MinHFR) { seed.MinHFR = floor; }
+```
+
+Placed there so the seeded value flows into `theta0`, into `seedJ` (the never-regress floor), and into
+`RevertNeutralAxes`' notion of the seed — i.e. the search genuinely starts from it. One insertion, no new
+plumbing, and every caller that does not set the field is bit-identical.
+
+**Wizard.** `SeedFitIsUsableAsync` already holds `List<RunEvaluationResult>` with `BestFit` intact
+(`:2810`). Carry run 0's `BestFit?.Minimum.Y` to a field, and at `:2981` — immediately after the existing
+in-place seed mutation at `:2980`, the precedent for exactly this — set
+`optimizerSettings.MinHfrSeedFloor = MinHfrSeed.Resolve(...)`.
+
+**TestApp `optimize`.** `perRunBaseline` at `OptimizationDiagnosticRunner.cs:580-583` already holds the fits;
+set the same field before `:640`.
+
+**`synth-validate` / `tilt`.** Leave alone. Neither has a pre-search fit and neither is a user-facing focus
+path; both stay bit-identical. Recorded in the register so the divergence is deliberate and visible rather
+than discovered later.
+
+**Open decision — `--start-from-current`.** In that mode the seed *is* the user's stored `MinHFR`
+(`StarDetectionOptimizerWizardVM.cs:2972`, `OptimizationDiagnosticRunner.cs:239-242`), so stamping it discards
+an explicit user setting. The rule already only ever lowers, never raises; the plan takes **stamp anyway**, on
+the grounds that a user whose stored gate is destroying their curve is exactly the population F20 names. Flag
+for review.
+
+### T3 — validate against the success criterion that F35 actually states
+
+The criterion is **"the hard floor passes and the search gets a gradient"**, not recall.
+
+**Decided: both banks before the PR.** The safe-floor evidence is entirely synthetic (the sweep covers
+D01/D02/D03/D05), and F33's rule is that no objective-adjacent change may be accepted on the synthetic bank
+alone. Both runs go out detached, in parallel, against a build in its own `-o` directory (the exe is
+file-locked while running).
+
+```
+TestApp optimize --per-run --runs "D:\SyntheticAutofocusBank" --out D:\hf_w3\seed_A   --max-evals 250
+TestApp optimize --per-run --runs "D:\Autofocus Bank"        --out D:\hf_w3\seed_real --max-evals 250
+```
+
+Real-bank pass conditions: the four `BaselineJ = 0` runs (`Panos`, `LinwoodFocus`, `SorenVance`, `lumos`) are
+the population the seed targets — at least one must move — and **no other real run may regress**, measured as
+landed `MinHFR` unchanged wherever the trigger did not fire.
+
+Pass conditions:
+- **D01 and D02**: `BaselineJ` / `FinalJ` no longer both exactly 0 — i.e. `NHard = 3` clears. This is the whole
+  finding; currently both report `currentJ=0 bestJ=0 hard-floor FAIL`.
+- **D05**: landing and recall unchanged vs `D:\hf_f23\H_A` — the control.
+- **D03**: expected to benefit most (`0.393 → 0.585` in the sweep), so a *non*-improvement here means the seed
+  is not reaching the detector and the wiring is wrong.
+- Every other dataset: no recall regression beyond noise.
+
+Cheap pre-check first, before the ~55 min optimize run — confirm the constant does what the sweep says on the
+one frame that matters:
+
+```
+TestApp golden eval --runs "D:\SyntheticAutofocusBank\D01_ultrawide_40mm" --params default \
+    --min-hfr 0.30 --match centroid --out D:\hf_w3\f35_precheck\d01
+```
+
+(`--match-radius` is inert on this bank — each dataset's `synthetic_meta.json` carries `matchRadiusPx = 12.0`,
+which overrides the CLI at `GoldenEvalRunner.cs:179-181`.)
+
+### T4 — F24 restated: score the nine donut axes against ΔRecall
+
+Target: `D16_esprit550_ha3` (−0.147) and `D04_esprit_550mm` (−0.113) — unobstructed 550 mm refractors where the
+donut relaxations should be inert and are not.
+
+**No code change needed.** All nine axes have 1:1 `golden eval` flags (`GoldenEvalRunner.cs:461-483`):
+`--defocus-gates`, `--defocus-structure` + `--structure-layer-boost`, `--defocus-size-ref`,
+`--defocus-min-factor`, `--defocus-center-factor`, `--donut-morph-close`, `--donut-hole-fraction`,
+`--donut-streak-ecc`, `--donut-bloom-radius`.
+
+Four traps the arm design must respect, all verified in `StarDetector.cs`:
+
+1. **Under master-ON, `DefocusAwareGates` is provably inert** — `ComputeEffectiveMaxDistortion:1452`
+   short-circuits on `(!DefocusAwareDistortion && !DefocusAwareDonutDetection)`, and centering is the same OR at
+   `:1820`/`:1927`. Only **8 of 9** are separable. Say so rather than reporting a null result as a finding.
+2. **`--structure-layer-boost` alone is a no-op** — read only when `DefocusAwareStructure` (`:610-615`);
+   master-ON-flag-OFF silently applies `DonutDefaultStructureLayerBoost = 2` (`:114`). Neutral arm is
+   `--defocus-structure --structure-layer-boost 0`.
+3. **Master-ON carries three mechanisms no axis controls**: the default +2 structure boost, the
+   `EffectiveClipMultiplier` cap at 2.0 (`:1484-1490`), and the integrated-SNR relaxation for
+   `d >= DefocusDistortionSizeReference` (`:1793-1800`). So the arm set needs a **fourth arm — master ON, all
+   nine at neutral** — to isolate the un-gated residue. Without it the per-axis deltas will not sum to the
+   observed −0.147 and the gap will be misattributed.
+4. `golden eval` **silently ignores malformed numeric overrides** (`DiagnosticUtil.cs:34-51` — no unknown-flag
+   detection). Every arm must assert its `params:` / `+overrides[...]` line in `golden_eval.txt` before its
+   numbers are read. A typo yields a complete, plausible report at the un-overridden value.
+
+Arms: C0 (donut off) · master-ON-neutral · then one axis off-neutral per arm × 8 × 2 datasets. ~40 s each is the
+D01/D02/D03/D05 figure and is **unverified for D16/D04** (different frame counts and star densities) — measure
+one arm before scheduling the rest.
+
+### T5 — F32/F33: the measurement, and the one cheap reporting change
+
+**The measurement is done** (`scratchpad/f32_dynrange.py`, all inputs already on disk). Results in
+`docs/synthetic-af-bank-followups-wave3-results.md`; headline numbers in the register updates below. It reads
+recall from the `/3` real-bank run, which is valid: `recallHigh` derives only from `match.Pairs`
+(`BankVerifyRunner.cs:488`) and the `/5` repair touches only the false-positive list — precision from that run is
+void and is not read.
+
+**The reporting change (F33 step 1).** Report the effective gate `max(Sensitivity, PeakResponse × StarClip)`
+wherever a landing's Sensitivity is quoted. A helper already exists — `ExposureRecommender`'s F28
+`InertSensitivityBound` — so this is reuse, not new arithmetic.
+
+Scope it to **derive-on-read, no schema bump**: all five inputs are already in the schema-2/3 DTO, verified
+against the on-disk `mccomiskey` landing, so every landing already on disk gains the column for free. A stored
+*settable* field would trip `TiltAdapterWizardVMTests.cs:1274` (which reflects over every read+write property);
+a **get-only computed** property is filtered out by the `CanWrite` check at `:1296` — that is the cheap path.
+
+Sites: `OptimizedStarDetectionSettings`, the wizard's `VariantSensitivity`/`BaselineSensitivity` pair
+(`StarDetectionOptimizerWizardVM.cs:3174-3175`) and its XAML, `OptimizationDiagnosticRunner`'s `(AT FLOOR)`
+console lines (`:455-458`) and `optimize_summary.txt` (`:912`), and `BankVerifyRunner`'s `ConfigMetrics.sensitivity`
+(`:403`).
+
+**Report-only.** Do *not* change `SensitivityIsAtFloor` / `HasLowStarSignal` semantics — those drive UI
+visibility and whether `Recommend` is called at all, which is a behaviour change and not what "report alongside"
+asks for.
+
+### T6 — flag what wave 2 did not re-verify
+
+Register-only, no code. F1–F8, F18, F21, F25, F26 were measured on the same optimizer landings F32/F33
+reinterpret and have **not** been re-checked against the repaired metric. This is an inference from what changed,
+not a finding. Each gets a dated note saying so, naming whether it depends on precision (needs re-measurement at
+`/5`) or only on recall/σ (unaffected).
+
+### T7 — ship
+
+`docs/synthetic-af-bank-followups-wave3-results.md`, register updates, full suite
+(`dotnet.exe test ... -c Debug --nologo`, 3354 passing at the merge; the flaky
+`SendAsync_WritesOnABackgroundThread` is known-unrelated), PR to `develop`. Never push `develop`.
+
+---
+
+## Register corrections this wave must make
+
+Not new work — corrections to entries that are now measurably wrong. All FLAG-only per the wave-3 brief.
+
+1. **F35 step 3 is based on a non-existent grid** (P2 above). The axis resolves to 0.03125; the blocker is the
+   flat objective, not the stride.
+2. **F35 step 1 / F20 step 2 name a statistic that is not available pre-search** (P1 above).
+3. **F20's "the only two runs of nineteen" is wrong.** `BaselineJ` is exactly 0.0000 on **four** real-bank runs,
+   not two: `Panos`, `LinwoodFocus`, plus `SorenVance` and `lumos`. The latter two detect **zero** stars at C0, so
+   they are a different population (genuinely no signal) — and `SorenVance` climbs 0 → 0.9701 while `lumos` stays
+   at 0, which is direct evidence that the cold-start plateau is sometimes escapable.
+4. **F33's `mccomiskey` arithmetic uses the default PeakResponse, not the landed one.** The entry says
+   `0.75 × 10 = 7.5`; the landing's own `StarPeakResponse` is **0.98**, so the effective gate is **9.81**.
+5. **F33 names one misread landing; there are more.** `caboose` also lands Sensitivity 0.0 with an effective gate
+   of **5.05**. On the synthetic bank, 2 of the 6 "Sensitivity 0.0" landings F23 cites (D11 → 2.36, D12 → 2.10)
+   are likewise not floor landings.
+
+---
+
+## Risks
+
+- **The seed is a knob the search cannot climb back out of** (F20/F35, restated in the brief). Mitigated by: the
+  rule only ever lowers; it fires only when the fitted vertex is at or below the gate; the value is measured-safe
+  with FP = 0 across 32 configurations; and D05 is the control proving a rig that does not need it is unperturbed.
+  **Not** mitigated for the real bank — the `MinHFR` sweep is synthetic-only, and F33's whole lesson is that the
+  two banks disagree in sign. **Decided: T3 runs BOTH banks before the PR** (see T3).
+- **Stamping the seed changes the wizard's changed-parameters table** (`:3073-3082` diffs against
+  `runs[0].Baseline` via `CreateCuratedSet`). A seeded-then-unmoved `MinHFR` will display as a change the search
+  did not make. No existing convention covers this; `:2980` has the same property today for the donut master and
+  does not label it.
+- **`golden eval` cannot turn `LocallyAdaptiveBinarization` off** (`--adaptive-binarize` sets true only,
+  `GoldenEvalRunner.cs:420`); `bank-verify` can. If any F24 arm needs it off, that is a code change.


### PR DESCRIPTION
Wave 3 of the synthetic AF bank followups. Ships F20's real fix (F35), answers F24 against recall, measures the objective's dynamic range on both banks, and audits the entries wave 2 left unverified.

Plan: `plans/synthetic-af-bank-followups-wave3-plan.md` · Results: `docs/synthetic-af-bank-followups-wave3-results.md`

## Three premises did not survive the code

All three were settled by reading code or a landing file — no detector run.

- **F35's trigger statistic is not where the entry says.** `BestFit.Minimum.Y` is read by the wizard only *after* the search; the seam all five optimizer callers share sees `RunEvaluationMetrics`, which carries the vertex **X only**. Resolved by splitting the rule: the caller computes the trigger, the engine applies the clamp.
- **F35 step 3 rests on a grid that does not exist.** `Continuous` is not quantized (`Quantize` is identity+clamp) and `InitialStep` is a pattern-search stride halved to **0.03125**. `MinHFR` is also absent from Phase A, so it moves only on strictly-improving steps — which on D01/D02's flat `J` never happen *at any stride*. **Flagged, not shipped.**
- **F24's nine axes never moved.** Both config-B landings left them at defaults, so a per-axis ablation would have returned nine nulls.

## What shipped

**F35 — `MinHFR` seeding.** The fit *triggers*; geometry *sizes*. Both available HFR statistics read 2.2–3.2× high (the wing vertex over-predicts; survivor medians are left-censored at `MinHFR` itself), so the seed is a sampling constant of 0.30 px in binned detection pixels, measured safe at FP = 0 across 32 sweep configurations.

| bank | result |
|---|---|
| synthetic 17/17 | D01 `FinalJ` 0 → **0.99018**, D02 0 → **0.99656**; **14/17 landings bit-identical** to control; `EXIT=0` where the control arm exited 3 |
| real 19/19 | **all 19 bit-identical** to control; seed fired on **zero** runs |

**F33 — the effective gate.** `StarDetector.EffectiveSensitivityGate` = `max(Sensitivity, InertSensitivityBound)`, reported wherever a landed Sensitivity is quoted. Derived and get-only, so no schema bump and every landing already on disk gains it.

## What the runs corrected

- **The validation run caught a bug in the fix.** The first pass read 17/17 PASS and was wrong: D05 — the control whose job is to be boring — landed at the seed constant despite a vertex that must never trigger, while the log printed the seeding line exactly once. `OptimizeAsync` was mutating the caller's `seed`, and TestApp builds its context *outside* the per-dataset loop, so one real firing silently re-gated sixteen runs. Fixed by cloning; regression test **confirmed to fail without the fix**. The original unit test had asserted the buggy behaviour and passed.
- **F20's real-bank claim is not supported.** All four `BaselineJ = 0` real runs have a vertex *above* the gate. Their `J = 0` is "almost no stars at all" (`lumos`/`SorenVance` detect **zero**), not "stars gated out for measuring too small". Two different defects present identically in the log. **The fix is real and measured, but its real-bank population on this bank is empty** — the user-facing benefit is unproven on real frames and is not claimed.

## Measurements

- **F32** — the real bank trades a median **17.3 points of recall per unit `J`** (`toml999`: 3018); the synthetic bank's median trade rate is **0.00**. The banks disagree in *sign*, so F33's rule binds a rescaling as hard as a new term.
- **F33** — `mccomiskey`'s effective gate is **9.81**, not the 7.5 on record (that used the default `PeakResponse`, not the landed 0.98). `caboose`, D11 and D12 are misread the same way.
- **F24** — the recall cost is what the *master toggle* turns on: a silent +2 structure boost and a 5 px morph-close (whose default of 5 is not its neutral of 1). Neutralizing both recovers master-OFF recall **bit-identically** on D16 and D04. Both are reachable by the search, which never neutralizes them because `J` does not pay for recall — **F24 is F32**.
- **F36 (new)** — the assumption that F1–F8/F18/F21/F25/F26 needed re-verification was checked rather than inherited. None depends on the repaired precision metric; the exposure is one clause in F26. Two entries are instead *strengthened* by the F33 correction.

## Verification

- Full suite **3371/3371, two consecutive clean runs**. One earlier run showed a single failure while two bank passes saturated the CPU; its name was not captured and it did not recur in four subsequent full runs — recorded as unidentified-intermittent rather than attributed to the known flake.
- Both banks completed: synthetic 17/17, real 19/19 with one hard-floor failure (`lumos`) the control also produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7R7TUBTvPt5R44CWhu2HT

## Lessons (consolidated in the results doc)

1. **Read the thing before scheduling a run against it** — three stated inputs were wrong; all three were settled by reading code or a landing file.
2. **The control dataset earns its place by being boring** — the first bank pass read 17/17 PASS and was wrong; `D05`, whose job is not to move, is the only row that exposed the seed leak.
3. **A regression test that passes either way is worth nothing** — the first unit test asserted the buggy behaviour and passed; every regression test here was re-run with the fix reverted.
4. **`default` is not `neutral`** — `DonutMorphCloseSize` defaults to 5, is neutral at 1, and that gap was 90% of D04's recall cost.
5. **Mutating a caller's object is a cross-run bug** — one in-place write re-gated sixteen datasets from one firing, printing a single log line while doing it.
6. **"It reproduces on the real bank" needs the CAUSE to reproduce, not the symptom** — F33's rule applied to a finding rather than a fix.
7. **Check what your own validation run overwrote** — F15 fired again; both banks' in-place settings are now wave-3's.

## Register housekeeping

- **F20 re-scoped**: part 2 (seed) **done** via F35; **part 1 (the diagnostic) is still outstanding** and is the entry's actual title — nothing user-facing says "your stars are smaller than the minimum HFR", and `TooLowHFR` still has no `*Bounds` rect list.
- **F15 updated** with live evidence: this PR's validation passes re-baselined the in-place settings of both banks (control arms in `--out` dirs unaffected).
