### PR TITLE
fix(tilt): resync the EAT serial link, live motor positions, and status/dialog cleanup

### DIFF
--- a/.claude/docs/tilt-domain.md
+++ b/.claude/docs/tilt-domain.md
@@ -25,6 +25,25 @@ Example: a screw at 0° (straight up from center) — turning it inward tilts th
 
 The inspector's Tilt Adapter Guidance table uses two glyph vocabularies that answer different questions. The ⬆/⬇ arrows describe adapter-plate **motion** (⬆ = that corner moves toward the objective) — pure physics, identical on every rig. The ⟳/⟲ glyphs (screws) and +/− step signs (steppers) on the numeric rows carry the rig-specific **rotation** that produces that motion, which depends on the adapter's direction setting (`ScrewInwardCurvatureSign`). Never present ⬆/⬇ as a rotation. The full contract and sign derivations are in `docs/tilt-guidance-motion-arrows-design.md`.
 
+## Live motor positions while a motorized device is being driven
+
+`TiltDeviceConnectionService` polls the device's per-motor counters (`cp`) every 5 s, but that poll is
+**suspended for the entire lifetime of a `TryBeginOperation` lease** — a wizard calibration run, or an
+Automatic Adjustment plan including its confirming inspector run and any revert. Anything that displays
+`CurrentPositions` therefore freezes for the whole operation unless the operation itself republishes.
+
+- **The lease holder must call `TiltDeviceConnectionService.PublishControllerPositions()` after every move it
+  sends** — forward moves, revert moves, and recovery sweeps alike. It publishes to `CurrentPositions` /
+  `PositionsKnown`, so *every* panel bound to them (inspector and wizard) updates from one call.
+- **Never issue a follow-up `cp` per move to get those numbers.** Every EAT move response already embeds a
+  fresh `***Get Current Positions***` block (`docs/asg-eat-serial-protocol-design.md` §4.2), which
+  `EatTiltMotionController.ExecuteMoveAsync` reconciles into the shadow and exposes as
+  `ITiltMotionController.LastKnownPositions`. `PublishControllerPositions` reads that — no I/O, no extra ~1 s
+  round trip, and no second chance for a read to come back unparseable and silently freeze the display.
+- Positions that were never confirmed read **"unknown"**; a publish that finds none deliberately leaves the
+  last published values alone (a mid-plan gap must not blank a display that was right a moment ago) and logs
+  a warning, so a stale panel is diagnosable rather than silent.
+
 ## Image mirroring
 
 Camera images may be mirrored horizontally and/or vertically depending on the optical train (e.g., a star diagonal introduces a mirror). **Do not assume that screws numbered clockwise around the physical adapter will appear clockwise around the sensor image.** The screw orientations must be determined from the actual image coordinates after accounting for any mirroring. Plans and features that involve tilt correction must track orientation in image-space, not physical-space.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMAutomaticAdjustmentTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMAutomaticAdjustmentTests.cs
@@ -18,6 +18,7 @@ using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt;
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
 using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NINA.Core.Model;
 using NINA.Core.Utility.SerialCommunication;
 using NSubstitute;
 using NUnit.Framework;
@@ -449,7 +450,33 @@ public class InspectorVMAutomaticAdjustmentTests {
         // reference for forward moves, by (axis, steps) for the freshly-constructed inverse moves reverts send.
         public Func<TiltAdapterMove, Exception> FailureForMove { get; set; }
 
+        // Every ApplicationStatus.Status the VM reported. ProgressFactory wraps the mediator in a Progress<T>,
+        // which -- with no SynchronizationContext installed (see the note on this fixture's synchronous style)
+        // -- delivers through the thread pool: arrival is both asynchronous AND unordered, so assertions poll
+        // and must not depend on which report landed last. What matters is that the clearing (empty) status is
+        // reported at all; NINA's real dispatcher context delivers in order.
+        private readonly object statusGate = new object();
+
+        private readonly List<string> reportedStatuses = new();
+
+        /// <summary>True once the flow has reported the empty status that clears NINA's status bar.</summary>
+        public bool ReportedAClearingStatus {
+            get {
+                lock (statusGate) {
+                    return reportedStatuses.Exists(string.IsNullOrEmpty);
+                }
+            }
+        }
+
         public AdjustmentFixture() {
+            Bundle.ApplicationStatusMediator
+                .When(m => m.StatusUpdate(Arg.Any<ApplicationStatus>()))
+                .Do(ci => {
+                    lock (statusGate) {
+                        reportedStatuses.Add(ci.Arg<ApplicationStatus>()?.Status ?? string.Empty);
+                    }
+                });
+
             Controller = Substitute.For<ITiltMotionController>();
             Controller.ConnectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
             Controller.QueryPositionsAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(TiltDevicePositions.Unknown));
@@ -1022,5 +1049,131 @@ public class InspectorVMAutomaticAdjustmentTests {
             Assert.That(fx.ExecutedMoves[2].Steps, Is.EqualTo(-moveA.Steps));
             Assert.That(vm.LastExecutedMeasurementGenerationForTest, Is.EqualTo(1));
         });
+    }
+
+    // --- Status bar: a transient per-move line must never outlive the operation -----------------------------
+    //
+    // ".claude/docs/mvvm-patterns.md" (UI Threading & Dispatcher Marshaling): "Status-bar lines don't clear
+    // themselves ... After a transient operation (a device move, a recovery sweep), clear it in a finally".
+    // Every exit from Automatic Adjustment is such an exit -- including the revert paths, which are exactly
+    // where a leftover "reverting move N of M" line was observed hanging in NINA's status bar forever.
+
+    [Test]
+    public void ApprovedPlan_WhenComplete_ClearsTheStatusBar() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm);
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        var move = Move(TiltMoveAxis.Backfocus, 10, TiltMoveGroup.Backfocus, "bf");
+        var plan = new TiltAdapterMovePlan(new[] { move }, new double[4], 0, 10);
+        fx.NextChoice = TiltDeviceAdjustmentChoice.Proceeded(true, true, plan);
+        fx.ConfirmAnswers.Enqueue(false); // decline the re-run prompt
+
+        vm.AutomaticAdjustmentCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+
+        Assert.That(() => fx.ReportedAClearingStatus, Is.True.After(2000).PollEvery(20),
+            "finishing the plan must report the empty status that clears NINA's status bar");
+    }
+
+    [Test]
+    public void ReRunConfirmed_TiltWorsened_AfterRevert_ClearsTheStatusBar() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm, gx: 0.001, gy: 0.0);
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        var moveA = Move(TiltMoveAxis.DiagonalA, 40, TiltMoveGroup.Tilt, "A");
+        var moveB = Move(TiltMoveAxis.Backfocus, 10, TiltMoveGroup.Backfocus, "B");
+        var plan = new TiltAdapterMovePlan(new[] { moveA, moveB }, new double[4], 0, 20);
+        fx.NextChoice = TiltDeviceAdjustmentChoice.Proceeded(true, true, plan);
+        fx.ConfirmAnswers.Enqueue(true); // accept the re-run
+        fx.ConfirmAnswers.Enqueue(true); // accept the worsening-revert offer
+        fx.OnReRun = () => fx.SeedValidModel(vm, gx: 0.01, gy: 0.0);
+
+        vm.AutomaticAdjustmentCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+
+        Assert.That(fx.ExecutedMoves, Has.Count.EqualTo(4), "precondition: 2 forward moves + 2 reverts");
+        Assert.That(() => fx.ReportedAClearingStatus, Is.True.After(2000).PollEvery(20),
+            "the 'reverting move N of M' line must not survive the revert");
+    }
+
+    [Test]
+    public void MidPlanFailure_RevertFailsPartway_StillClearsTheStatusBar() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm);
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        var moveA = Move(TiltMoveAxis.DiagonalA, 40, TiltMoveGroup.Tilt, "A");
+        var moveB = Move(TiltMoveAxis.DiagonalB, -12, TiltMoveGroup.Tilt, "B");
+        var moveC = Move(TiltMoveAxis.Backfocus, 8, TiltMoveGroup.Backfocus, "C");
+        var plan = new TiltAdapterMovePlan(new[] { moveA, moveB, moveC }, new double[4], 0, 30);
+        fx.NextChoice = TiltDeviceAdjustmentChoice.Proceeded(true, true, plan);
+        fx.FailureForMove = m => {
+            if (ReferenceEquals(m, moveC)) return new TiltDeviceCommandFailedException("ack timeout");
+            if (m.Axis == moveB.Axis && m.Steps == -moveB.Steps) return new TiltDeviceCommandFailedException("revert ack timeout");
+            return null;
+        };
+        fx.ConfirmAnswers.Enqueue(true); // confirm revert
+
+        vm.AutomaticAdjustmentCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+
+        Assert.That(() => fx.ReportedAClearingStatus, Is.True.After(2000).PollEvery(20),
+            "even a revert that bails out partway must leave the status bar clean");
+    }
+
+    // --- Live device positions ------------------------------------------------------------------------------
+    //
+    // The connection service's 'cp' poll is suspended for the WHOLE operation lease -- which spans the moves,
+    // the confirming Aberration Inspector re-run (minutes) and any revert -- so the panel's motor counters are
+    // frozen for the entire adjustment unless this flow refreshes them itself. The FakeTimeSource here never
+    // ticks, so a poll can never be what satisfies these tests.
+
+    [Test]
+    public void ApprovedPlan_RefreshesTheDisplayedMotorPositionsAfterEachMove() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm);
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        // What the device reports back as part of executing the move -- no follow-up query involved.
+        fx.Controller.LastKnownPositions.Returns(new TiltDevicePositions(new[] { 640, 600, 560, 600 }, known: true));
+        var move = Move(TiltMoveAxis.DiagonalA, 40, TiltMoveGroup.Tilt, "A");
+        var plan = new TiltAdapterMovePlan(new[] { move }, new double[4], 0, 10);
+        fx.NextChoice = TiltDeviceAdjustmentChoice.Proceeded(true, true, plan);
+        fx.ConfirmAnswers.Enqueue(false); // decline the re-run prompt
+
+        vm.AutomaticAdjustmentCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+
+        Assert.Multiple(() => {
+            Assert.That(vm.ScrewPositionTopRightDisplay, Is.EqualTo("640"), "TR = device motor 1 = index 0");
+            Assert.That(vm.ScrewPositionBottomRightDisplay, Is.EqualTo("560"), "BR = device motor 3 = index 2");
+        });
+    }
+
+    [Test]
+    public void ReRunConfirmed_TiltWorsened_AfterRevert_ShowsThePostRevertPositions() {
+        var fx = new AdjustmentFixture();
+        var vm = fx.BuildVM();
+        fx.SeedValidModel(vm, gx: 0.001, gy: 0.0);
+        vm.MeasurementGenerationForTest = 1;
+        fx.ConnectAsync().GetAwaiter().GetResult();
+        var move = Move(TiltMoveAxis.DiagonalA, 40, TiltMoveGroup.Tilt, "A");
+        var plan = new TiltAdapterMovePlan(new[] { move }, new double[4], 0, 10);
+        fx.NextChoice = TiltDeviceAdjustmentChoice.Proceeded(true, true, plan);
+        fx.ConfirmAnswers.Enqueue(true); // accept the re-run
+        fx.ConfirmAnswers.Enqueue(true); // accept the worsening-revert offer
+        fx.OnReRun = () => fx.SeedValidModel(vm, gx: 0.01, gy: 0.0);
+        // The forward move reports 640/600/560/600; the revert puts every motor back to 600.
+        fx.Controller.LastKnownPositions.Returns(
+            new TiltDevicePositions(new[] { 640, 600, 560, 600 }, known: true),
+            new TiltDevicePositions(new[] { 600, 600, 600, 600 }, known: true));
+
+        vm.AutomaticAdjustmentCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+
+        Assert.That(fx.ExecutedMoves, Has.Count.EqualTo(2), "precondition: 1 forward move + 1 revert");
+        Assert.That(vm.ScrewPositionTopRightDisplay, Is.EqualTo("600"),
+            "after a revert the panel must show the reverted position without waiting for the poll to resume");
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/SimulatedEatTransportTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/SimulatedEatTransportTests.cs
@@ -91,6 +91,20 @@ public class SimulatedEatTransportTests {
         Assert.That(EatResponses.ParseMoveAck(exchange), Is.True);
     }
 
+    // Real firmware embeds the post-move counters in the move's own response, which is what reconciles the
+    // shadow and drives the live position display without a follow-up query. The simulator emits the same
+    // block, in the device's WIRE order, so that path is exercised without hardware.
+    [Test]
+    public async Task SendAsync_Move_EmbedsThePostMovePositionBlockInDeviceOrder() {
+        var actuator = Actuator(new[] { 605, 600, 600, 595 }); // DEVICE order: TR, TL, BR, BL
+        var transport = new SimulatedEatTransport(actuator);
+
+        var exchange = await transport.SendAsync("tr,5", AnyTimeout, CancellationToken.None);
+
+        Assert.That(EatResponses.TryParseMovePositions(exchange, out var positions), Is.True);
+        Assert.That(positions.PerMotorSteps, Is.EqualTo(new[] { 605, 600, 600, 595 }));
+    }
+
     [Test]
     public void SendAsync_UnparseableCommand_Throws() {
         var transport = new SimulatedEatTransport(Actuator());

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatResponsesTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatResponsesTests.cs
@@ -25,24 +25,34 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterDevices.AsgEat;
 [TestFixture]
 public class EatResponsesTests {
 
-    // --- ParseMoveAck: tolerant on TimedOut only (no ack/error text recognized yet). ---
+    // --- ParseMoveAck: the device's move-completion sentinel is the ONLY evidence of success. ---
 
     [Test]
-    public void ParseMoveAck_NotTimedOut_ReturnsTrue() {
-        // LIVE-CAPTURE: "OK" is an assumed placeholder ack line -- the real ack text (if any) is unknown
-        // until T15. ParseMoveAck does not currently inspect line content at all; this fixture exists only
-        // to show a plausible non-timed-out exchange.
-        var exchange = new EatRawExchange("tr,50", new[] { "OK" }, timedOut: false);
+    public void ParseMoveAck_ResponseCarriesTheMoveSentinel_ReturnsTrue() {
+        var exchange = new EatRawExchange("tr,50",
+            new[] { "start_cmd: tr", "moving TR + 50.00", "***Save EEPROM***", "***finished movement***" }, timedOut: false);
         Assert.That(EatResponses.ParseMoveAck(exchange), Is.True);
     }
 
     [Test]
-    public void ParseMoveAck_NotTimedOut_NoLinesAtAll_StillReturnsTrue() {
-        // A quiet-period completion with zero lines (the device produced no output at all before going
-        // quiet) is still tolerated as success -- this is exactly the "move produces no terminating
-        // response" case the plan calls out; EatResponses treats it as success by default pre-T15.
+    public void ParseMoveAck_NotTimedOut_NoLinesAtAll_ReturnsFalse() {
+        // A move that produced no output at all is NOT evidence of success. It used to be treated as one
+        // ("did not time out" == acked), which is how a move that never ran got journaled as applied.
         var exchange = new EatRawExchange("bf,10", Array.Empty<string>(), timedOut: false);
-        Assert.That(EatResponses.ParseMoveAck(exchange), Is.True);
+        Assert.That(EatResponses.ParseMoveAck(exchange), Is.False);
+    }
+
+    // The desync case that made this check necessary: with the link running one response behind, a move read
+    // back the PREVIOUS 'cp' response, whose "***Action Processed***" is a terminal sentinel too. Accepting any
+    // terminal sentinel meant a move whose motors never confirmed anything was recorded as successfully
+    // applied -- on a device that persists every move to EEPROM.
+    [Test]
+    public void ParseMoveAck_ResponseIsAStaleQueryResponse_ReturnsFalse() {
+        var exchange = new EatRawExchange("bf,33",
+            new[] { "{UI|SET|ready_light.IndicatorColor=Red}", "***Get Current Positions***", "400", "400", "400", "400",
+                    "***End Current Positions***", "***Action Processed***" }, timedOut: false);
+        Assert.That(EatResponses.ParseMoveAck(exchange), Is.False,
+            "a query's sentinel must never acknowledge a move");
     }
 
     [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatSerialTransportTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatSerialTransportTests.cs
@@ -242,8 +242,12 @@ public class EatSerialTransportTests {
         });
     }
 
+    // A quiet gap in the middle of a response must NOT end the exchange. The device pauses mid-dump on a busy
+    // machine; treating that pause as completion abandoned a response partway, left its remainder in the port
+    // buffer, and desynced every later exchange by one response for the rest of the session (see the read-loop
+    // remarks on EatSerialTransport). Only the terminal sentinel — or the overall budget — ends a read.
     [Test]
-    public async Task SendAsync_CollectsLinesUntilQuietPeriod_ReturnsTimedOutFalse_AndReturnsEarly() {
+    public async Task SendAsync_QuietGapMidResponse_KeepsReading_UntilTheTerminalSentinel() {
         var (provider, port, readLine) = MakeFakeProvider();
         var transport = new EatSerialTransport(provider);
         await transport.OpenAsync("COM7", CancellationToken.None);
@@ -252,24 +256,79 @@ public class EatSerialTransportTests {
         readLine.Next = () => {
             callCount++;
             return callCount switch {
-                1 => "OK",
-                2 => "cp,100,200,300,400",
+                1 => "{UI|SET|ready_light.IndicatorColor=Red}",
+                2 => "***Get Current Positions***",
+                3 => throw new TimeoutException(), // the device pauses mid-dump -- NOT the end of the response
+                4 => "400",
+                5 => "400",
+                6 => "400",
+                7 => "400",
+                8 => "***End Current Positions***",
+                9 => "***Action Processed***",
                 _ => throw new TimeoutException()
             };
         };
 
-        var sw = System.Diagnostics.Stopwatch.StartNew();
-        // A generous overall budget -- the quiet-period race should end the exchange well before this
-        // elapses, which the elapsed-time assertion below verifies.
         var exchange = await transport.SendAsync("cp", TimeSpan.FromSeconds(10), CancellationToken.None);
-        sw.Stop();
 
         Assert.Multiple(() => {
             Assert.That(exchange.TimedOut, Is.False);
-            Assert.That(exchange.Lines, Is.EqualTo(new[] { "OK", "cp,100,200,300,400" }));
-            Assert.That(sw.Elapsed, Is.LessThan(TimeSpan.FromSeconds(5)),
-                "the quiet-period race should end the exchange well before the 10s overall budget elapses");
+            Assert.That(exchange.Lines, Is.EqualTo(new[] {
+                "{UI|SET|ready_light.IndicatorColor=Red}", "***Get Current Positions***",
+                "400", "400", "400", "400", "***End Current Positions***", "***Action Processed***" }),
+                "the lines after the pause belong to this response and must not be left for the next command to read");
+            Assert.That(EatResponses.ParseCpPositions(exchange).PerMotorSteps, Is.EqualTo(new[] { 400, 400, 400, 400 }));
         });
+    }
+
+    [Test]
+    public async Task SendAsync_ResponseNeverTerminates_ReportsTimedOut_RatherThanCallingItComplete() {
+        var (provider, port, readLine) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+        await transport.OpenAsync("COM7", CancellationToken.None);
+
+        var callCount = 0;
+        readLine.Next = () => callCount++ == 0 ? "***Get Current Positions***" : throw new TimeoutException();
+
+        var exchange = await transport.SendAsync("cp", TimeSpan.FromMilliseconds(600), CancellationToken.None);
+
+        Assert.That(exchange.TimedOut, Is.True,
+            "a response with no terminal sentinel is INCOMPLETE; reporting it as complete is what desynced the link");
+    }
+
+    // The self-healing half of the desync fix: anything already buffered when a command is about to be written
+    // can only be a previous exchange's unread remainder, and must be discarded so this command reads its OWN
+    // response. Without it, the only recovery in a real session was closing and reopening the port.
+    [Test]
+    public async Task SendAsync_StaleInputBuffered_IsDiscardedBeforeWriting() {
+        var (provider, port, readLine) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+        await transport.OpenAsync("COM7", CancellationToken.None);
+
+        port.BytesToRead.Returns(_ => 512); // leftover from an exchange that was abandoned mid-response
+        var callCount = 0;
+        readLine.Next = () => ++callCount == 1 ? "***Action Processed***" : throw new TimeoutException();
+
+        await transport.SendAsync("cp", TimeSpan.FromMilliseconds(600), CancellationToken.None);
+
+        Received.InOrder(() => {
+            port.DiscardInBuffer();
+            port.Write(Arg.Any<string>());
+        });
+    }
+
+    [Test]
+    public async Task SendAsync_NoStaleInput_DoesNotTouchTheBuffer() {
+        var (provider, port, readLine) = MakeFakeProvider();
+        var transport = new EatSerialTransport(provider);
+        await transport.OpenAsync("COM7", CancellationToken.None);
+
+        port.BytesToRead.Returns(_ => 0);
+        readLine.Next = () => "***Action Processed***";
+
+        await transport.SendAsync("cp", TimeSpan.FromMilliseconds(600), CancellationToken.None);
+
+        port.DidNotReceive().DiscardInBuffer();
     }
 
     // --- Boot-banner drain + terminal-sentinel completion (confirmed against firmware 7.1.0). ---
@@ -393,13 +452,23 @@ public class EatSerialTransportTests {
         var transport = new EatSerialTransport(provider);
         await transport.OpenAsync("COM7", CancellationToken.None);
 
-        var callerThreadId = Thread.CurrentThread.ManagedThreadId;
         int? writeThreadId = null;
         port.When(p => p.Write(Arg.Any<string>())).Do(_ => writeThreadId = Thread.CurrentThread.ManagedThreadId);
 
-        // A synchronous inline Write() could block the caller (e.g. the UI thread) for up to WriteTimeout
-        // under an XON/XOFF stall -- it must be offloaded, mirroring the already-offloaded read.
-        await transport.SendAsync("cp", TimeSpan.FromMilliseconds(300), CancellationToken.None);
+        // Driven from a DEDICATED thread, not the test's own: an async test continuation already runs on a
+        // thread-pool thread, and Task.Run is free to schedule the write onto that very same thread — so
+        // comparing against it makes the assertion a coin flip rather than a check that the write was
+        // offloaded. A dedicated thread is never a pool thread, so any pool thread proves the offload.
+        int callerThreadId = 0;
+        var caller = new Thread(() => {
+            callerThreadId = Thread.CurrentThread.ManagedThreadId;
+            // A synchronous inline Write() could block the caller (e.g. the UI thread) for up to WriteTimeout
+            // under a stalled link -- it must be offloaded, mirroring the already-offloaded read.
+            transport.SendAsync("cp", TimeSpan.FromMilliseconds(300), CancellationToken.None).GetAwaiter().GetResult();
+        });
+        caller.IsBackground = true;
+        caller.Start();
+        Assert.That(caller.Join(TimeSpan.FromSeconds(30)), Is.True, "the exchange should finish well within its budget");
 
         Assert.That(writeThreadId, Is.Not.Null);
         Assert.That(writeThreadId, Is.Not.EqualTo(callerThreadId));

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatTiltMotionControllerTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatTiltMotionControllerTests.cs
@@ -11,6 +11,9 @@
 #endregion "copyright"
 
 using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NINA.Core.Utility.SerialCommunication;
@@ -34,14 +37,21 @@ public class EatTiltMotionControllerTests {
     private static IEatTransport NewTransport() {
         var transport = Substitute.For<IEatTransport>();
         transport.OpenAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
-        // Default: any command acks immediately with no lines. For "cp" specifically this means
-        // ParseCpPositions finds zero integers and throws InvalidDeviceResponseException -- i.e. the
-        // GUARANTEED pre-T15 "positions unknown" case is the test default; tests that need a real position
-        // reading call WithCpResponse. For any move command this means ParseMoveAck (= !TimedOut) succeeds
-        // by default; tests that need a failed/timed-out ack call WithTimedOutResponse for that exact wire
-        // string (configured AFTER this default so it takes precedence for matching calls).
+        // Default per command: "cp" answers with no lines, so ParseCpPositions finds zero integers and throws
+        // InvalidDeviceResponseException -- the "positions unknown" case is the test default, and tests that
+        // need a real reading call WithCpResponse. Every other command (a move) answers with the device's
+        // move-completion sentinel and nothing else, which is the minimum ParseMoveAck accepts as success --
+        // a bare non-timed-out exchange no longer counts (see ParseMoveAck's remarks on why). Tests that need
+        // a failed/timed-out ack call WithTimedOutResponse for that exact wire string (configured AFTER this
+        // default so it takes precedence for matching calls).
         transport.SendAsync(Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
-            .Returns(callInfo => Task.FromResult(new EatRawExchange((string)callInfo[0], Array.Empty<string>(), timedOut: false)));
+            .Returns(callInfo => {
+                var command = (string)callInfo[0];
+                var lines = command == EatCommands.PositionQuery()
+                    ? Array.Empty<string>()
+                    : new[] { "***finished movement***" };
+                return Task.FromResult(new EatRawExchange(command, lines, timedOut: false));
+            });
         return transport;
     }
 
@@ -216,6 +226,72 @@ public class EatTiltMotionControllerTests {
     public void ExecuteMoveAsync_NullMove_Throws() {
         var controller = new EatTiltMotionController(NewTransport(), NewOptions());
         Assert.ThrowsAsync<ArgumentNullException>(async () => await controller.ExecuteMoveAsync(null, null, CancellationToken.None));
+    }
+
+    // --- ExecuteMoveAsync: positions the move itself reports ------------------------------------------------
+
+    // Real move responses embed their own "***Get Current Positions***" block (firmware 7.1.0, see
+    // docs/asg-eat-serial-protocol-design.md §4.2 — "a move doubles as a position read"). Those counters are
+    // the device's own report and must win over dead reckoning: it keeps the shadow self-correcting for
+    // excursion enforcement, and it is what lets a caller show live positions between the moves of a plan
+    // without paying for (or risking) a follow-up 'cp' per move.
+    private static void WithMoveResponse(IEatTransport transport, string command, params int[] wireOrderPositions) {
+        var lines = new List<string> { "start_cmd", "***Get Current Positions***" };
+        lines.AddRange(wireOrderPositions.Select(v => v.ToString(CultureInfo.InvariantCulture)));
+        lines.Add("***End Current Positions***");
+        lines.Add("***Save EEPROM***");
+        lines.Add("***finished movement***");
+        transport.SendAsync(command, Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new EatRawExchange(command, lines, timedOut: false)));
+    }
+
+    [Test]
+    public async Task ExecuteMoveAsync_ResponseCarriesPositionBlock_ReconcilesShadowFromTheDevicesOwnReport() {
+        var transport = NewTransport();
+        WithCpResponse(transport, 600, 600, 600, 600);
+        // Wire order is [TL, TR, BL, BR]; the device reports TR at 640 and BL at 560 after the move.
+        WithMoveResponse(transport, "bf,40", 600, 640, 560, 600);
+        var options = NewOptions(maxExcursionSteps: 1000);
+        var controller = new EatTiltMotionController(transport, options);
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+
+        await controller.ExecuteMoveAsync(new TiltAdapterMove(TiltMoveAxis.Backfocus, 40, TiltMoveGroup.Backfocus, "bf"), null, CancellationToken.None);
+
+        Assert.Multiple(() => {
+            // Device motor order is [TR, TL, BR, BL] -- the reported block, not 600+40 on every motor.
+            Assert.That(controller.LastKnownPositions.PerMotorSteps, Is.EqualTo(new[] { 640, 600, 600, 560 }));
+            Assert.That(controller.LastKnownPositions.Known, Is.True);
+            Assert.That(options.TiltDeviceShadowPositions,
+                Is.EqualTo(EatTiltMotionController.SerializeShadowPositions(true, new[] { 640, 600, 600, 560 })),
+                "the persisted shadow must be reconciled to the device's own report, not dead reckoned");
+        });
+    }
+
+    [Test]
+    public async Task ExecuteMoveAsync_ResponseWithoutPositionBlock_StillAdvancesShadowByTheCommandedDelta() {
+        var transport = NewTransport(); // default move response: acked, no lines at all
+        WithCpResponse(transport, 600, 600, 600, 600);
+        var options = NewOptions(maxExcursionSteps: 1000);
+        var controller = new EatTiltMotionController(transport, options);
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+
+        await controller.ExecuteMoveAsync(new TiltAdapterMove(TiltMoveAxis.Backfocus, 40, TiltMoveGroup.Backfocus, "bf"), null, CancellationToken.None);
+
+        Assert.That(controller.LastKnownPositions.PerMotorSteps, Is.EqualTo(new[] { 640, 640, 640, 640 }),
+            "a simulator/fixture response with no embedded block must fall back to advancing by the commanded delta");
+    }
+
+    [Test]
+    public async Task LastKnownPositions_BeforeAnythingIsConfirmed_IsUnknown() {
+        var transport = NewTransport(); // 'cp' does not parse -> nothing ever confirmed
+        var controller = new EatTiltMotionController(transport, NewOptions());
+        await controller.ConnectAsync("COM5", CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(controller.AbsolutePositionsKnown, Is.False, "precondition");
+            Assert.That(controller.LastKnownPositions.Known, Is.False,
+                "an unconfirmed estimate may back a travel-limit check, but must never be published as a known position");
+        });
     }
 
     // --- ExecuteMoveAsync: cap violation => NO send ---------------------------------------------------------

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -1645,10 +1645,12 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         public void DeviceMove_UpdatesScrewPositionDisplayWithDeltaFromStart() {
             var (vm, options, service, controller, _, _) = BuildMotorized();
             options.CalibrationAppliedAmount.Returns(150.0);
-            // First read is the run baseline (captured before the first move); second is the post-move position.
-            controller.QueryPositionsAsync(Arg.Any<CancellationToken>()).Returns(
-                Task.FromResult(new TiltDevicePositions(new[] { 0, 0, 0, 0 }, known: true)),
-                Task.FromResult(new TiltDevicePositions(new[] { 150, 150, 150, 150 }, known: true)));
+            // The counters come from the controller's own latest report, read once when the service connects,
+            // once for the run baseline (before the first move), and once per move (what the move itself carried).
+            controller.LastKnownPositions.Returns(
+                new TiltDevicePositions(new[] { 0, 0, 0, 0 }, known: true),
+                new TiltDevicePositions(new[] { 0, 0, 0, 0 }, known: true),
+                new TiltDevicePositions(new[] { 150, 150, 150, 150 }, known: true));
 
             vm.SelectedPortName = "COM3";
             ((AsyncRelayCommand)vm.ConnectDeviceCommand).ExecuteAsync(null).GetAwaiter().GetResult();
@@ -1657,6 +1659,69 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
 
             // TR = motor 1 = index 0: shows the live position plus the delta from the run's baseline.
             Assert.That(vm.ScrewPositionTopRightDisplay, Does.Contain("150").And.Contain("Δ").And.Contain("+150"));
+        }
+
+        // The run baseline is captured ONCE (before the run's first move), so every later step's display must
+        // keep counting from it -- the delta is "since this calibration run started", not "since the last move".
+        [Test]
+        public void DeviceMove_LaterStepsInSameRun_KeepUpdatingAgainstTheRunBaseline() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            controller.LastKnownPositions.Returns(
+                new TiltDevicePositions(new[] { 0, 0, 0, 0 }, known: true),         // read when the service connects
+                new TiltDevicePositions(new[] { 0, 0, 0, 0 }, known: true),         // run baseline
+                new TiltDevicePositions(new[] { 150, 150, 150, 150 }, known: true), // after step 1
+                new TiltDevicePositions(new[] { 300, 150, 150, 0 }, known: true));  // after step 2
+
+            vm.SelectedPortName = "COM3";
+            ((AsyncRelayCommand)vm.ConnectDeviceCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+
+            vm.ExecuteDeviceMoveForCurrentStepAsync(WizardStep.AllInward, CancellationToken.None).GetAwaiter().GetResult();
+            vm.ExecuteDeviceMoveForCurrentStepAsync(WizardStep.Screw1, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.That(vm.ScrewPositionTopRightDisplay, Does.Contain("300").And.Contain("+300"));
+        }
+
+        // The device reports its new counters as part of the move it just acknowledged, so a step must never
+        // depend on a follow-up position query: that query was a wasted round trip AND an extra failure point
+        // that, when it came back unparseable, silently froze the position/Δ display at its pre-move values.
+        [Test]
+        public void DeviceMove_UpdatesTheDisplayWithoutASeparatePositionQuery() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            controller.LastKnownPositions.Returns(
+                new TiltDevicePositions(new[] { 0, 0, 0, 0 }, known: true),
+                new TiltDevicePositions(new[] { 0, 0, 0, 0 }, known: true),
+                new TiltDevicePositions(new[] { 150, 150, 150, 150 }, known: true));
+
+            vm.SelectedPortName = "COM3";
+            ((AsyncRelayCommand)vm.ConnectDeviceCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+
+            vm.ExecuteDeviceMoveForCurrentStepAsync(WizardStep.AllInward, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.Multiple(() => {
+                Assert.That(vm.ScrewPositionTopRightDisplay, Does.Contain("150").And.Contain("+150"));
+                controller.DidNotReceive().QueryPositionsAsync(Arg.Any<CancellationToken>());
+            });
+        }
+
+        // A run whose counters are not confirmed (nothing has ever parsed a position report) must keep the last
+        // snapshot rather than blanking the panel mid-run -- and the service logs it, so a frozen display is
+        // diagnosable instead of silent.
+        [Test]
+        public void DeviceMove_PositionsNeverConfirmed_KeepsTheLastSnapshotInsteadOfBlanking() {
+            var (vm, options, service, controller, _, _) = BuildMotorized(
+                polledPositions: new TiltDevicePositions(new[] { 7, 7, 7, 7 }, known: true));
+            options.CalibrationAppliedAmount.Returns(150.0);
+            controller.LastKnownPositions.Returns(TiltDevicePositions.Unknown);
+
+            vm.SelectedPortName = "COM3";
+            ((AsyncRelayCommand)vm.ConnectDeviceCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+            service.PublishControllerPositions(); // no-op: nothing confirmed
+            vm.ExecuteDeviceMoveForCurrentStepAsync(WizardStep.AllInward, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.That(vm.ScrewPositionTopRightDisplay, Is.EqualTo("unknown"),
+                "an unconfirmed position must read 'unknown', never a stale number presented as current");
         }
 
         [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/DialogTextTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/DialogTextTests.cs
@@ -1,0 +1,86 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NUnit.Framework;
+using System;
+using System.Linq;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Utility;
+
+// NINA's MyMessageBox does not wrap its message, so the window grows to fit the longest line. A device-error
+// prompt on one long line therefore stretched the modal past both screen edges and clipped the very question
+// the user had to answer. These pin the wrapping that prevents that.
+[TestFixture]
+public class DialogTextTests {
+
+    private static int LongestLine(string text) =>
+        text.Split('\n').Max(l => l.TrimEnd('\r').Length);
+
+    [Test]
+    public void Wrap_LongSingleLine_BreaksItBelowTheColumnLimit() {
+        var message =
+            "Automatic Adjustment failed after 3 move(s) were sent: EAT command 'bf,33' (Backfocus: +33 steps " +
+            "(part 2 of 2)) did not acknowledge success within 20s. Device state is ambiguous; positions were " +
+            "NOT advanced -- treat as a potential state-dirty condition.";
+
+        var wrapped = DialogText.Wrap(message);
+
+        Assert.Multiple(() => {
+            Assert.That(LongestLine(wrapped), Is.LessThanOrEqualTo(DialogText.DefaultWrapColumns));
+            Assert.That(wrapped.Replace("\n", " "), Is.EqualTo(message), "wrapping must not lose or alter any text");
+        });
+    }
+
+    [Test]
+    public void Wrap_PreservesAuthoredLineBreaks() {
+        // The blank line separating a failure description from its question is deliberate structure.
+        var message = "Something failed.\n\nRevert the applied move(s) now?";
+        Assert.That(DialogText.Wrap(message), Is.EqualTo(message));
+    }
+
+    [Test]
+    public void Wrap_ShortText_IsUnchanged() {
+        Assert.That(DialogText.Wrap("Disconnect the device?"), Is.EqualTo("Disconnect the device?"));
+    }
+
+    [Test]
+    public void Wrap_WordLongerThanTheLimit_IsLeftIntactRatherThanSplit() {
+        // Breaking a path/URL mid-token would corrupt what it names; a single over-long line is the lesser evil.
+        var path = new string('x', DialogText.DefaultWrapColumns + 40);
+        var wrapped = DialogText.Wrap("Saved to " + path);
+        Assert.That(wrapped.Split('\n'), Does.Contain(path));
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    public void Wrap_NullOrEmpty_IsReturnedUnchanged(string text) {
+        Assert.That(DialogText.Wrap(text), Is.EqualTo(text));
+    }
+
+    [Test]
+    public void Wrap_CrLfInput_KeepsItsCarriageReturns() {
+        var message = "First line.\r\nSecond line.";
+        Assert.That(DialogText.Wrap(message), Is.EqualTo(message));
+    }
+
+    [Test]
+    public void Wrap_EveryWrappedLineIsNonEmpty_AndNoTextIsDuplicated() {
+        var message = string.Join(" ", Enumerable.Repeat("word", 200));
+        var wrapped = DialogText.Wrap(message);
+        Assert.Multiple(() => {
+            Assert.That(wrapped.Split('\n'), Has.All.Not.Empty);
+            Assert.That(wrapped.Split('\n').Sum(l => l.Split(' ').Length), Is.EqualTo(200));
+            Assert.That(LongestLine(wrapped), Is.LessThanOrEqualTo(DialogText.DefaultWrapColumns));
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -296,8 +296,19 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         // Adapter Wizard reads this to record each calibration step's saved location for later replay.
         public string LastSaveFolder { get; private set; }
 
-        public async Task<bool> AnalyzeAutoFocus(CancellationToken token, bool captureCameraBlock = false, AutoFocusSaveOverride saveOverride = null) {
-            var task = AnalyzeAutoFocusImpl(captureCameraBlock, saveOverride);
+        /// <summary>
+        /// Runs the full Aberration Inspector analysis: the multi-region AutoFocus sweep, the sensor model fitted
+        /// from it, and — unless <paramref name="includeExposureAnalysis"/> is false — a final validation exposure
+        /// analyzed for the FWHM-contour and eccentricity panels.
+        ///
+        /// <para><paramref name="includeExposureAnalysis"/> exists for callers that consume only the fitted sensor
+        /// model, the Tilt Adapter Wizard's calibration steps above all: that validation exposure costs a further
+        /// <c>SimpleExposureSeconds</c> plus a full-frame PSF-modeling detection on EVERY step of a six-step run,
+        /// for panels the wizard neither reads nor shows — and, because a failure here fails the whole call, it
+        /// could also fail a calibration step whose sensor model had already been fitted successfully.</para>
+        /// </summary>
+        public async Task<bool> AnalyzeAutoFocus(CancellationToken token, bool captureCameraBlock = false, AutoFocusSaveOverride saveOverride = null, bool includeExposureAnalysis = true) {
+            var task = AnalyzeAutoFocusImpl(captureCameraBlock, saveOverride, includeExposureAnalysis);
             token.Register(() => analyzeCts?.Cancel());
             return await task;
         }
@@ -456,7 +467,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             }
         }
 
-        private async Task<bool> AnalyzeAutoFocusImpl(bool captureCameraBlock, AutoFocusSaveOverride saveOverride = null) {
+        private async Task<bool> AnalyzeAutoFocusImpl(bool captureCameraBlock, AutoFocusSaveOverride saveOverride = null, bool includeExposureAnalysis = true) {
             var localAnalyzeTask = analyzeTask;
             if (localAnalyzeTask != null && !localAnalyzeTask.IsCompleted) {
                 Notification.ShowError("Analysis still in progress");
@@ -552,14 +563,21 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                         return false;
                     }
                     ActivateTiltMeasurement();
-                    var exposureAnalysisResult = await TakeAndAnalyzeExposureImpl(autoFocusEngine, analyzeCts.Token);
-                    if (!exposureAnalysisResult) {
-                        InspectorErrorText = "Exposure Analysis Failed. View saved AF report in the AutoFocus tab.";
-                        Notification.ShowError("Exposure Analysis Failed");
-                        DeactivateAutoFocusAnalysis();
-                        return false;
+                    if (includeExposureAnalysis) {
+                        var exposureAnalysisResult = await TakeAndAnalyzeExposureImpl(autoFocusEngine, analyzeCts.Token);
+                        if (!exposureAnalysisResult) {
+                            InspectorErrorText = "Exposure Analysis Failed. View saved AF report in the AutoFocus tab.";
+                            Notification.ShowError("Exposure Analysis Failed");
+                            DeactivateAutoFocusAnalysis();
+                            return false;
+                        }
+                        ActivateExposureAnalysis();
+                    } else {
+                        // Hidden rather than left showing: those panels would otherwise still be displaying the
+                        // PREVIOUS run's validation exposure next to a freshly fitted sensor model, which reads as
+                        // if they belonged to it.
+                        DeactivateExposureAnalysis();
                     }
-                    ActivateExposureAnalysis();
                     Notification.ShowInformation("Aberration Inspection Complete");
                     return true;
                 } finally {
@@ -2558,70 +2576,92 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             Exception failure = null;
             var moveProgress = new Progress<string>(text => this.progress.Report(new ApplicationStatus { Status = $"Automatic Adjustment: {text}" }));
 
-            for (int i = 0; i < moves.Count; i++) {
-                var move = moves[i];
-                this.progress.Report(new ApplicationStatus { Status = $"Automatic Adjustment: move {i + 1} of {moves.Count} — {move.Description}" });
-                try {
-                    await controller.ExecuteMoveAsync(move, moveProgress, CancellationToken.None);
-                    journal.Add(move);
-                } catch (Exception ex) {
-                    failure = ex;
-                    break;
+            // Everything below reports transient per-move status text, and NINA's status bar shows the last
+            // reported line until something reports an empty one (.claude/docs/mvvm-patterns.md, "Status-bar
+            // lines don't clear themselves"). EVERY exit from here — success, cancellation, a failed plan, a
+            // revert, or a revert that itself failed partway — must therefore land in this finally, or the
+            // last "move N of M" / "reverting move N of M" line hangs in the corner of NINA forever.
+            try {
+                for (int i = 0; i < moves.Count; i++) {
+                    var move = moves[i];
+                    this.progress.Report(new ApplicationStatus { Status = $"Automatic Adjustment: move {i + 1} of {moves.Count} — {move.Description}" });
+                    try {
+                        await controller.ExecuteMoveAsync(move, moveProgress, CancellationToken.None);
+                        journal.Add(move);
+                        // The 'cp' poll is suspended for this whole lease, so the panel's motor counters only
+                        // advance if the moves themselves publish them (see PublishControllerPositions).
+                        RefreshDevicePositionDisplays();
+                    } catch (Exception ex) {
+                        failure = ex;
+                        break;
+                    }
                 }
-            }
 
-            // Consumed once execution has STARTED (>= 1 move sent), regardless of what happens next (success,
-            // failure, or a later revert) — the same measurement can never drive a second plan.
-            if (journal.Count > 0) {
-                lastExecutedMeasurementGeneration = capturedGeneration;
-                AutomaticAdjustmentCommand?.NotifyCanExecuteChanged();
-            }
-
-            if (failure != null) {
-                Logger.Error(failure, "Automatic Adjustment: move execution failed");
-                await HandleExecutionFailureAsync(controller, journal, failure);
-                return;
-            }
-
-            this.progress.Report(new ApplicationStatus { Status = "Automatic Adjustment: complete" });
-            Notification.ShowInformation($"Automatic Adjustment complete: {journal.Count} move(s) sent.");
-
-            bool confirmRerun = await confirmPromptAsync(
-                "Automatic Adjustment finished sending the approved moves. Re-run the Aberration Inspector to confirm the improvement?",
-                "Confirm Adjustment");
-            if (!confirmRerun) {
-                return;
-            }
-
-            bool analyzed = await reRunAnalysisAsync(CancellationToken.None);
-            if (!analyzed) {
-                Notification.ShowWarning("The confirming Aberration Inspector run did not complete; verify the result manually before adjusting again.");
-                return;
-            }
-
-            var afterModel = SensorModel?.DisplayedSensorModel;
-            double afterTiltMagnitude = TiltMagnitude(afterModel);
-            if (TiltWorsened(beforeTiltMagnitude, afterTiltMagnitude)) {
-                Notification.ShowError(
-                    "Tilt got WORSE after this Automatic Adjustment. This can indicate a stale calibration, a rotated camera/adapter, " +
-                    "or an incorrect curvature-sign setting — investigate before adjusting again.");
-                bool confirmRevert = await confirmPromptAsync(
-                    "Tilt appears WORSE after the moves just applied. Revert them now (send the inverse of each move, in reverse order)?",
-                    "Tilt Worsened — Revert?");
-                if (confirmRevert) {
-                    await RevertJournalAsync(controller, journal, "post-adjustment worsening");
-
-                    // The confirming re-run above incremented measurementGeneration (a new completed
-                    // analysis), but lastExecutedMeasurementGeneration is still stamped with the PRE-revert
-                    // generation this plan was computed from. Left unbumped, the canExecute gate
-                    // (currentGeneration > lastExecutedGeneration) would immediately re-enable the button
-                    // against the STALE, now-reverted DisplayedSensorModel — a second plan computed before
-                    // the user has looked at fresh (post-revert) numbers could over-correct an already-reverted
-                    // device. Consume the confirming measurement so a genuinely NEW analysis is required.
-                    lastExecutedMeasurementGeneration = measurementGeneration;
+                // Consumed once execution has STARTED (>= 1 move sent), regardless of what happens next (success,
+                // failure, or a later revert) — the same measurement can never drive a second plan.
+                if (journal.Count > 0) {
+                    lastExecutedMeasurementGeneration = capturedGeneration;
                     AutomaticAdjustmentCommand?.NotifyCanExecuteChanged();
                 }
+
+                if (failure != null) {
+                    Logger.Error(failure, "Automatic Adjustment: move execution failed");
+                    await HandleExecutionFailureAsync(controller, journal, failure);
+                    return;
+                }
+
+                this.progress.Report(new ApplicationStatus { Status = "Automatic Adjustment: complete" });
+                Notification.ShowInformation($"Automatic Adjustment complete: {journal.Count} move(s) sent.");
+
+                bool confirmRerun = await confirmPromptAsync(
+                    "Automatic Adjustment finished sending the approved moves. Re-run the Aberration Inspector to confirm the improvement?",
+                    "Confirm Adjustment");
+                if (!confirmRerun) {
+                    return;
+                }
+
+                bool analyzed = await reRunAnalysisAsync(CancellationToken.None);
+                if (!analyzed) {
+                    Notification.ShowWarning("The confirming Aberration Inspector run did not complete; verify the result manually before adjusting again.");
+                    return;
+                }
+
+                var afterModel = SensorModel?.DisplayedSensorModel;
+                double afterTiltMagnitude = TiltMagnitude(afterModel);
+                if (TiltWorsened(beforeTiltMagnitude, afterTiltMagnitude)) {
+                    Notification.ShowError(
+                        "Tilt got WORSE after this Automatic Adjustment. This can indicate a stale calibration, a rotated camera/adapter, " +
+                        "or an incorrect curvature-sign setting — investigate before adjusting again.");
+                    bool confirmRevert = await confirmPromptAsync(
+                        "Tilt appears WORSE after the moves just applied. Revert them now (send the inverse of each move, in reverse order)?",
+                        "Tilt Worsened — Revert?");
+                    if (confirmRevert) {
+                        await RevertJournalAsync(controller, journal, "post-adjustment worsening");
+
+                        // The confirming re-run above incremented measurementGeneration (a new completed
+                        // analysis), but lastExecutedMeasurementGeneration is still stamped with the PRE-revert
+                        // generation this plan was computed from. Left unbumped, the canExecute gate
+                        // (currentGeneration > lastExecutedGeneration) would immediately re-enable the button
+                        // against the STALE, now-reverted DisplayedSensorModel — a second plan computed before
+                        // the user has looked at fresh (post-revert) numbers could over-correct an already-reverted
+                        // device. Consume the confirming measurement so a genuinely NEW analysis is required.
+                        lastExecutedMeasurementGeneration = measurementGeneration;
+                        AutomaticAdjustmentCommand?.NotifyCanExecuteChanged();
+                    }
+                }
+            } finally {
+                this.progress.Report(new ApplicationStatus { Status = string.Empty });
             }
+        }
+
+        /// <summary>
+        /// Publishes the device's post-move counters to the panel without any extra device round trip (see
+        /// <see cref="TiltDeviceConnectionService.PublishControllerPositions"/>). Called after every move this
+        /// VM sends — forward and revert alike — because position polling stays suspended for the whole
+        /// Automatic Adjustment lease, which spans the plan, the confirming analysis run, and the revert.
+        /// </summary>
+        private void RefreshDevicePositionDisplays() {
+            tiltDeviceConnectionService?.PublishControllerPositions();
         }
 
         private async Task HandleExecutionFailureAsync(ITiltMotionController controller, List<TiltAdapterMove> journal, Exception failure) {
@@ -2658,6 +2698,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 try {
                     this.progress.Report(new ApplicationStatus { Status = $"Automatic Adjustment: reverting move {journal.Count - i} of {journal.Count} — {inverse.Description}" });
                     await controller.ExecuteMoveAsync(inverse, null, CancellationToken.None);
+                    // Same reason as the forward moves: the panel's counters have to walk back down with the
+                    // revert instead of freezing at the pre-revert values until the lease is released.
+                    RefreshDevicePositionDisplays();
                 } catch (Exception ex) {
                     // Revert itself failed partway: the device's tracked position can no longer be trusted.
                     // There is no interface member to force-invalidate a controller's shadow position, so the
@@ -2717,7 +2760,10 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         // Default answer is No for every caller of confirmPromptAsync in this file — never proceed with an
         // irreversible hardware action (re-run, revert) just because a dialog was dismissed.
         private static Task<bool> ShowYesNoPromptAsync(string message, string title) {
-            var result = MyMessageBox.Show(message, title, MessageBoxButton.YesNo, MessageBoxResult.No);
+            // Wrapped because these messages quote device errors verbatim (a failed command, its 20 s ack
+            // timeout, the state-dirty warning) on one long line, and MyMessageBox does not wrap: the modal
+            // grows past the screen edge and clips the very question the user has to answer. See DialogText.
+            var result = MyMessageBox.Show(DialogText.Wrap(message), title, MessageBoxButton.YesNo, MessageBoxResult.No);
             return Task.FromResult(result == MessageBoxResult.Yes);
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedEatTransport.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedEatTransport.cs
@@ -13,6 +13,7 @@
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -33,7 +34,10 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
     /// is decoded with <see cref="EatCommands.TryParse"/> back into its axis + steps, turned into the wizard-
     /// order per-corner effect (<see cref="TiltAdapterMove.UnitEffect"/> × steps — the exact vector the
     /// controller formatted from), applied to the actuator, and acknowledged (an exchange that did not time out,
-    /// which <see cref="EatResponses.ParseMoveAck"/> treats as success).</para>
+    /// which <see cref="EatResponses.ParseMoveAck"/> treats as success). A move's acknowledgement also carries
+    /// the post-move position block real firmware embeds, in the same wire order ([TL, TR, BL, BR]) — so the
+    /// simulator rehearses the production path in which the device's own report, not dead reckoning, is what
+    /// reconciles the shadow and drives the live position display between the moves of a run.</para>
     /// </summary>
     public sealed class SimulatedEatTransport : IEatTransport {
         private readonly ISimulatedTiltActuator actuator;
@@ -79,8 +83,19 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
             }
             actuator.ApplyWizardScrewSteps(wizardSteps);
 
-            // Empty, non-timed-out exchange = success ack (EatResponses.ParseMoveAck returns !TimedOut).
-            return Task.FromResult(new EatRawExchange(command, Array.Empty<string>(), timedOut: false));
+            // Non-timed-out exchange = success ack (EatResponses.ParseMoveAck returns !TimedOut), carrying the
+            // post-move position block a real move response embeds. The actuator's counters are DEVICE order
+            // (TR, TL, BR, BL); the block is emitted in the device's WIRE order (TL, TR, BL, BR), which is the
+            // pairwise swap EatResponses undoes -- so the simulator is parsed by exactly the same code path as
+            // the hardware, including the actuator's own clamping at its travel limits.
+            var afterMove = actuator.GetPerMotorPositions();
+            var lines = new List<string> { "***Get Current Positions***" };
+            foreach (var index in new[] { 1, 0, 3, 2 }) {
+                lines.Add(afterMove[index].ToString(CultureInfo.InvariantCulture));
+            }
+            lines.Add("***End Current Positions***");
+            lines.Add("***finished movement***");
+            return Task.FromResult(new EatRawExchange(command, lines, timedOut: false));
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltMotionController.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltMotionController.cs
@@ -118,6 +118,19 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         Task<TiltDevicePositions> QueryPositionsAsync(CancellationToken ct);
 
         /// <summary>
+        /// The per-motor counters as of the most recent device interaction that reported them — a parsed
+        /// position query, or the position block a move response embeds — with NO further I/O.
+        /// <see cref="TiltDevicePositions.Unknown"/> until the device has confirmed positions at least once.
+        ///
+        /// <para>This is what lets a caller executing a multi-move plan (a calibration run, an Automatic
+        /// Adjustment) show live counters between moves. Position polling is suspended for the whole lifetime
+        /// of that plan's exclusive operation lease, and a follow-up query per move would be both a wasted
+        /// round trip and an extra failure point — the device already reported its new positions as part of
+        /// the move it just acknowledged.</para>
+        /// </summary>
+        TiltDevicePositions LastKnownPositions { get; }
+
+        /// <summary>
         /// Orders <paramref name="moves"/> (a small plan) to minimize the peak per-motor excursion across
         /// every intermediate state, starting from the device's current (shadow-tracked) position.
         /// Pure/side-effect-free: does not touch device state and sends nothing. Callers (e.g. the

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatResponses.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatResponses.cs
@@ -31,23 +31,35 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
     public static class EatResponses {
 
         // Move-ack policy, confirmed against ASG EAT firmware 7.1.0 (see docs/asg-eat-serial-protocol-design.md):
-        // a successful move ends with a "***finished movement***" sentinel line, and EatSerialTransport's read
-        // loop returns as soon as it sees that sentinel (TimedOut=false). A move that never completes leaves the
-        // read loop to exhaust its timeout budget (TimedOut=true). So "did not time out" IS the ack signal here --
-        // the sentinel recognition has already happened one layer down, in the transport. SimulatedEatTransport
-        // likewise returns a non-timed-out exchange for a successful move. NOTE: an explicit device-side ERROR
-        // response format was not captured (see the doc's open items), so a rejected move that still returns a
-        // terminal sentinel is not yet distinguished; tighten here if such a response is ever captured.
+        // a successful move ends with a "***finished movement***" sentinel line. NOTE: an explicit device-side
+        // ERROR response format was not captured (see the doc's open items), so a rejected move that still
+        // returns the move sentinel is not yet distinguished; tighten here if such a response is ever captured.
+        private const string MoveCompleteMarker = "finished movement";
+
         /// <summary>
-        /// Interpretation of a move command's response: success unless <paramref name="exchange"/> timed out.
-        /// The completion decision (reading through to "***finished movement***") lives in the transport's read
-        /// loop; this only maps that outcome to success/failure.
+        /// Interpretation of a move command's response: success only when the exchange did not time out AND
+        /// actually contains the device's move-completion sentinel.
+        ///
+        /// <para>Requiring the sentinel — rather than the old "did not time out", which trusted whichever
+        /// terminal marker the transport happened to see — is what stops a MOVE from being acknowledged by a
+        /// QUERY's sentinel. In a real session where the link had fallen one response behind, every move read
+        /// back a previous <c>cp</c>'s "***Action Processed***" and was journaled as successfully applied while
+        /// the motors had done something else entirely. A move is safety-critical and EEPROM-persisted: an
+        /// unconfirmed one must surface as ambiguous (the caller's state-dirty path), never as success.</para>
         /// </summary>
         public static bool ParseMoveAck(EatRawExchange exchange) {
             if (exchange == null) {
                 throw new ArgumentNullException(nameof(exchange));
             }
-            return !exchange.TimedOut;
+            if (exchange.TimedOut) {
+                return false;
+            }
+            foreach (var line in exchange.Lines) {
+                if (line != null && line.Contains(MoveCompleteMarker)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         // `cp` reply layout, confirmed against ASG EAT firmware 7.1.0 (see docs/asg-eat-serial-protocol-design.md):
@@ -106,6 +118,27 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
             }
 
             return new TiltDevicePositions(values, known: true);
+        }
+
+        /// <summary>
+        /// Extracts the position block that every MOVE response embeds (confirmed, firmware 7.1.0: a move
+        /// prints its own <c>***Get Current Positions***</c> block just before <c>***Save EEPROM***</c> — see
+        /// the design doc's §4.2 note that "a move doubles as a position read"). Deliberately TOLERANT and
+        /// non-throwing, unlike <see cref="ParseCpPositions"/>: a move's success must never hinge on its
+        /// embedded block parsing, so an absent or malformed block simply returns false and the caller falls
+        /// back to advancing its own shadow by the commanded delta.
+        /// </summary>
+        public static bool TryParseMovePositions(EatRawExchange exchange, out TiltDevicePositions positions) {
+            positions = null;
+            if (exchange == null) {
+                return false;
+            }
+            try {
+                return TryParseMarkedPositionBlock(exchange, out positions);
+            } catch (InvalidDeviceResponseException) {
+                positions = null;
+                return false;
+            }
         }
 
         /// <summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatSerialTransport.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatSerialTransport.cs
@@ -96,20 +96,23 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
     /// block for a long time and a write timeout must be a hard, visible failure. See the design doc's
     /// "Key reuse" note.
     ///
-    /// Read-loop design: after writing the command (+ line terminator), lines are collected by repeatedly
-    /// calling the underlying port's blocking <c>ReadLine()</c> (each call bounded by the port's configured
-    /// read timeout -- reused here as the "quiet window" -- see <see cref="QuietWindow"/>). Two races decide
-    /// when the exchange ends:
-    ///   1. QUIET PERIOD: once at least one line has been received, a subsequent poll that produces nothing
-    ///      within <see cref="QuietWindow"/> is treated as "the device has gone quiet, the response is
-    ///      complete" -- the exchange returns immediately with <c>TimedOut = false</c>, without waiting out
-    ///      the full budget. This lets fast commands (e.g. <c>cp</c>) return promptly.
-    ///   2. OVERALL TIMEOUT: before any line has arrived, a quiet poll does NOT end the exchange -- a move
-    ///      that produces no output at all for several seconds is normal, not an error, so the loop keeps
-    ///      polling until the caller's <c>timeout</c> budget (move commands pass >= 15 s, per plan task T7)
-    ///      is exhausted. Only then does the exchange end with <c>TimedOut = true</c>.
-    /// This is a design decision made under an unknown protocol, not a confirmed device behavior --
-    /// see the LIVE-CAPTURE markers below.
+    /// <para><b>Read-loop design: an exchange ends ONLY at a terminal sentinel.</b> After writing the command
+    /// (+ line terminator), lines are collected by repeatedly calling the underlying port's blocking
+    /// <c>ReadLine()</c> (each call bounded by the port's read timeout, <see cref="QuietWindow"/>) until the
+    /// device's own end-of-response marker arrives (<see cref="MoveCompleteSentinel"/> /
+    /// <see cref="QueryCompleteSentinel"/>, both confirmed against firmware 7.1.0), or the caller's overall
+    /// budget is exhausted -- which means the response is INCOMPLETE (<c>TimedOut = true</c>), never "finished
+    /// without a sentinel".</para>
+    ///
+    /// <para><b>A quiet gap is not end-of-response.</b> This transport used to treat "at least one line, then
+    /// <see cref="QuietWindow"/> of silence" as completion. On a loaded machine the device pauses mid-dump for
+    /// longer than that, and a real session shows the consequence: a <c>cp</c> response abandoned after 3 of
+    /// its ~22 lines, its unread remainder becoming the head of the next command's response, and every exchange
+    /// for the following hour running exactly one behind -- position queries returning a previous dump's
+    /// counters (so displays froze), and moves "acknowledged" by an earlier command's sentinel (so a move that
+    /// never completed was journaled as successful). It survived until the port was closed and reopened.
+    /// <see cref="DrainStaleInputAsync"/> is the second half of that fix: it clears (and reports) leftover input
+    /// before each command, so a link that does fall out of step resynchronizes itself.</para>
     /// </summary>
     public sealed class EatSerialTransport : IEatTransport, IDisposable {
 
@@ -144,6 +147,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
         // pauses mid-response (e.g. a slow multi-second move whose heartbeat gaps could otherwise look "quiet").
         internal const string MoveCompleteSentinel = "***finished movement***";
         internal const string QueryCompleteSentinel = "***Action Processed***";
+
+        // Emitted repeatedly while motors are running (hundreds per move). Carries no information beyond "still
+        // moving", so the read loop counts them and logs one summary line instead of one line each.
+        internal const string MotionHeartbeat = "***moving***";
+
+        // Cap on the resynchronizing drain that runs before a command when the input buffer is not empty (see
+        // DrainStaleInputAsync). Only ever spent on a link that is already out of step.
+        internal static readonly TimeSpan ResyncTimeout = TimeSpan.FromSeconds(3);
 
         // The "quiet window" -- the per-poll ReadLine() timeout (passed as `readTimeout` to GetSerialPort) and
         // the gap-since-last-line the read loop treats as "response complete" once at least one line has arrived
@@ -277,6 +288,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
                     throw new InvalidOperationException("The EAT transport is not open; call OpenAsync first.");
                 }
 
+                // Start every exchange from a known-empty input buffer -- see DrainStaleInputAsync.
+                await DrainStaleInputAsync(port, command, ct).ConfigureAwait(false);
                 await WriteCommandAsync(port, command, ct).ConfigureAwait(false);
                 var (lines, timedOut) = await ReadResponseAsync(port, timeout, ct).ConfigureAwait(false);
                 return new EatRawExchange(command, lines, timedOut);
@@ -346,46 +359,101 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
             }
         }
 
-        /// <summary>See the class remarks for the full quiet-period/overall-timeout read-loop contract.</summary>
+        /// <summary>See the class remarks for the full read-loop contract.</summary>
         private async Task<(List<string> Lines, bool TimedOut)> ReadResponseAsync(ISerialPort port, TimeSpan timeout, CancellationToken ct) {
             var lines = new List<string>();
             var deadline = DateTime.UtcNow + timeout;
+            int heartbeats = 0;
             while (true) {
                 ct.ThrowIfCancellationRequested();
                 if (DateTime.UtcNow >= deadline) {
-                    // Overall budget exhausted. LIVE-CAPTURE: a silent-but-successful move (no terminating
-                    // response at all) is indistinguishable, on the wire, from one that genuinely failed --
-                    // this transport cannot tell them apart. EatResponses.ParseMoveAck's tolerant policy is
-                    // the seam T15 tightens once the real ack behavior is known.
+                    // Overall budget exhausted with no terminal sentinel: the response is INCOMPLETE, not
+                    // "finished without a sentinel". Whatever the device still had to say stays in the port
+                    // buffer, which is precisely the desync the next command's DrainStaleInputAsync clears.
+                    LogHeartbeats(heartbeats);
                     return (lines, true);
                 }
 
                 try {
                     var line = await ReadLineOrThrowIfClosedAsync(port, ct).ConfigureAwait(false);
-                    Logger.Info($"EAT RX: {line}");
+                    if (IsHeartbeatLine(line)) {
+                        // A single move emits hundreds of these; logging each one buries the rest of the
+                        // transcript (one observed session logged 43k of them). Counted and logged once.
+                        heartbeats++;
+                    } else {
+                        LogHeartbeats(heartbeats);
+                        heartbeats = 0;
+                        Logger.Info($"EAT RX: {line}");
+                    }
                     lines.Add(line);
                     if (IsTerminalResponseLine(line)) {
-                        // The device signalled end-of-response -- return immediately instead of waiting out a
-                        // quiet window. Robust even if a slow move's "***moving***" heartbeats pause longer than
-                        // QuietWindow before the terminating sentinel arrives.
+                        LogHeartbeats(heartbeats);
                         return (lines, false);
                     }
                 } catch (TimeoutException) {
-                    if (lines.Count > 0) {
-                        // FALLBACK completion path: at least one line arrived, no terminal sentinel appeared, and
-                        // the device has now gone quiet for a full window. The normal path is the sentinel check
-                        // above; this only fires for a response that ends without a recognized sentinel.
-                        return (lines, false);
-                    }
-                    // Nothing received yet -- a still-executing multi-second move with no output so far is
-                    // expected, not an error. Keep polling until the overall timeout elapses.
+                    // A quiet window is NOT end-of-response. It only means nothing has arrived yet -- normal for
+                    // a still-executing multi-second move, and (as a real session proved) also for a device that
+                    // simply pauses mid-dump while the machine is busy. Treating quiet as "complete" abandoned a
+                    // response after 3 of its ~22 lines; the unread remainder then became the head of the NEXT
+                    // command's response, and every exchange for the rest of the session was one behind -- moves
+                    // "acked" by a previous command's sentinel, positions read from a stale dump. Only a
+                    // terminal sentinel (or the overall budget) ends an exchange.
                 }
             }
+        }
+
+        private static void LogHeartbeats(int count) {
+            if (count > 0) {
+                Logger.Info($"EAT RX: {MotionHeartbeat} x{count}");
+            }
+        }
+
+        /// <summary>
+        /// Discards anything still sitting in the input buffer before a command is written. Non-empty here can
+        /// only mean output from an earlier exchange this transport gave up on (it never reads unsolicited), so
+        /// keeping it would make this command read the previous command's response — the permanent one-behind
+        /// desync that, in a real session, made every position query return stale counters and every move ack a
+        /// previous command's sentinel, recoverable only by disconnecting and reconnecting the port.
+        ///
+        /// <para>Costs nothing on a healthy link (the buffer is empty and this returns immediately). When there
+        /// IS leftover data the device may still be mid-transmission, so the drain confirms the line has gone
+        /// quiet for a full <see cref="QuietWindow"/> before returning, bounded by <see cref="ResyncTimeout"/>.</para>
+        /// </summary>
+        private async Task<int> DrainStaleInputAsync(ISerialPort port, string command, CancellationToken ct) {
+            int buffered;
+            try {
+                buffered = port.BytesToRead;
+            } catch (InvalidOperationException ex) {
+                throw new SerialPortClosedException(
+                    $"Serial port '{port.PortName ?? "unknown"}' was closed while checking for stale input.", ex);
+            }
+            if (buffered <= 0) {
+                return 0;
+            }
+
+            port.DiscardInBuffer();
+            int discardedLines = 0;
+            var deadline = DateTime.UtcNow + ResyncTimeout;
+            while (DateTime.UtcNow < deadline) {
+                try {
+                    await ReadLineOrThrowIfClosedAsync(port, ct).ConfigureAwait(false);
+                    ++discardedLines; // Still arriving: the device was mid-transmission. Keep draining.
+                } catch (TimeoutException) {
+                    break; // Quiet for a full window -- the stream is back in step.
+                }
+            }
+            Logger.Warning(
+                $"EAT transport: discarded {buffered} stale byte(s){(discardedLines > 0 ? $" plus {discardedLines} trailing line(s)" : string.Empty)} " +
+                $"left over from a previous exchange before sending '{command}'. The link had fallen out of step (a response was abandoned before its terminal sentinel); it has been resynchronized.");
+            return discardedLines;
         }
 
         /// <summary>True if <paramref name="line"/> is one of the device's end-of-response sentinels (see <see cref="MoveCompleteSentinel"/> / <see cref="QueryCompleteSentinel"/>).</summary>
         private static bool IsTerminalResponseLine(string line) =>
             line != null && (line.Contains(MoveCompleteSentinel) || line.Contains(QueryCompleteSentinel));
+
+        /// <summary>True for the repeated in-motion heartbeat, which is summarized rather than logged per line.</summary>
+        private static bool IsHeartbeatLine(string line) => line != null && line.Contains(MotionHeartbeat);
 
         /// <summary>
         /// Wraps the underlying (synchronous, blocking) <see cref="ISerialPort.ReadLine"/> in a background

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatTiltMotionController.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatTiltMotionController.cs
@@ -172,6 +172,17 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
         /// </summary>
         public bool AbsolutePositionsKnown => shadowValid;
 
+        /// <inheritdoc/>
+        /// <remarks>
+        /// Backed by the shadow, which <see cref="ExecuteMoveAsync"/> reconciles from the position block every
+        /// move response embeds — so this is the device's own report after a move, not dead reckoning, and it
+        /// costs no I/O. <see cref="TiltDevicePositions.Unknown"/> while <see cref="AbsolutePositionsKnown"/>
+        /// is false: an unconfirmed estimate is good enough to enforce a travel limit against, but must never
+        /// be displayed as if it were a known position.
+        /// </remarks>
+        public TiltDevicePositions LastKnownPositions =>
+            shadowValid ? new TiltDevicePositions(shadowPositions, known: true) : TiltDevicePositions.Unknown;
+
         public async Task ConnectAsync(string portName, CancellationToken ct) {
             if (string.IsNullOrWhiteSpace(portName)) {
                 throw new ArgumentException("Port name must not be null or empty.", nameof(portName));
@@ -309,7 +320,18 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
 
             // Success: advance + persist shadow ONLY here -- the throw above (ack failure/timeout) never
             // reaches this line, so a failed/timed-out move never advances the shadow.
-            ApplyMoveDeltaToShadow(deviceDelta);
+            //
+            // Ground truth beats dead reckoning: every real move response embeds a fresh
+            // "***Get Current Positions***" block (confirmed, firmware 7.1.0), so reconcile the shadow from
+            // what the device just reported. That both self-corrects any accumulated drift for excursion
+            // enforcement AND gives callers live counters via LastKnownPositions with no follow-up 'cp'.
+            // Responses without the block (the simulator, pre-capture fixtures) fall back to advancing by
+            // the commanded delta, exactly as before.
+            if (EatResponses.TryParseMovePositions(exchange, out var reportedPositions)) {
+                ApplyKnownPositions(reportedPositions);
+            } else {
+                ApplyMoveDeltaToShadow(deviceDelta);
+            }
             progress?.Report($"{wire} acknowledged");
 
             double settleSeconds = options.TiltDeviceSettleSeconds;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/TiltDeviceConnectionService.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/TiltDeviceConnectionService.cs
@@ -249,7 +249,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices {
                 // a fresh connect.
                 RecordUserActivity();
                 SetConnected(true);
-                SetPositionsUnknown(); // Nothing polled yet under the new connection; the next timer tick populates it.
+                SetPositionsUnknown(); // Drop the previous connection's counters before republishing below.
+                // A controller's own ConnectAsync queries positions as part of connecting, so publish what it
+                // already knows instead of showing "unknown" until the first poll tick. No-op (leaving
+                // "unknown") when that query could not confirm them.
+                PublishControllerPositions();
                 RaisePropertyChanged(nameof(Controller));
             } finally {
                 hardwareLock.Release();
@@ -288,6 +292,38 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices {
                 Interlocked.Exchange(ref idlePromptOutstandingFlag, 0);
                 RaisePropertyChanged(nameof(Controller));
             }
+        }
+
+        /// <summary>
+        /// Publishes the connected controller's latest known per-motor counters (see
+        /// <see cref="ITiltMotionController.LastKnownPositions"/>) to <see cref="CurrentPositions"/> /
+        /// <see cref="PositionsKnown"/> immediately, with NO device I/O.
+        ///
+        /// <para>Position polling is suspended for the entire lifetime of a <see cref="TryBeginOperation"/>
+        /// lease — which spans a whole calibration run or adjustment plan, including its confirming analysis
+        /// and any revert. Without this, every panel's counters would sit frozen at their pre-operation values
+        /// for minutes, and then silently jump once the lease was released. The lease holder therefore calls
+        /// this after each executed move: because a move response already carries the device's fresh counters,
+        /// the controller has them in hand and no extra round trip (nor its failure modes) is involved.</para>
+        ///
+        /// <para>Returns the published positions, or null when the controller has no confirmed positions — in
+        /// which case the previously published values are deliberately LEFT in place rather than flipped to
+        /// "unknown", so a mid-plan gap does not blank a display that was correct a moment ago.</para>
+        /// </summary>
+        public IReadOnlyList<int> PublishControllerPositions() {
+            var controller = Controller;
+            if (controller == null) {
+                return null;
+            }
+            var positions = controller.LastKnownPositions;
+            if (positions == null || !positions.Known || positions.PerMotorSteps.Count < 4) {
+                // Worth a warning, not silence: this is exactly the state in which a panel keeps showing
+                // counters that no longer match the hardware, which is indistinguishable from "nothing moved".
+                Logger.Warning("Tilt device positions could not be refreshed from the controller (none confirmed yet); displayed counters may be stale.");
+                return null;
+            }
+            ApplyPositions(positions);
+            return currentPositions;
         }
 
         /// <summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -30,6 +30,7 @@ using NINA.Joko.Plugins.HocusFocus.StarDetection;
 using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
+using NINA.Joko.Plugins.HocusFocus.Utility;
 using NINA.Profile.Interfaces;
 using NINA.WPF.Base.Interfaces.Mediator;
 using NINA.WPF.Base.ViewModel;
@@ -1418,27 +1419,25 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             RaisePropertyChanged(nameof(ScrewPositionBottomLeftDisplay));
         }
 
-        // Refresh the wizard's live device-position snapshot straight from the controller. Used during a run,
-        // when the connection service's cp poll is paused (the run holds the operation lease). Optionally
-        // (re)captures the "delta since start" baseline. Best-effort: a failed/unknown read leaves the last
-        // snapshot in place so the display simply keeps showing the previous value.
-        private async Task RefreshRunDevicePositionsAsync(ITiltMotionController controller, bool captureBaseline) {
-            if (controller == null) {
-                return;
+        // Refresh the wizard's live device-position snapshot from the controller's own latest counters, and
+        // publish them through the connection service so every other panel (e.g. the inspector's) updates too.
+        // Used during a run, when the service's cp poll is paused (the run holds the operation lease).
+        // Optionally (re)captures the "delta since start" baseline.
+        //
+        // Deliberately NO device I/O: a move response already carries the device's fresh counters (see
+        // EatTiltMotionController.ExecuteMoveAsync), so a follow-up 'cp' per move was both a wasted ~1 s round
+        // trip and an extra failure point — one that failed silently, freezing the position and Δ display at
+        // its pre-move values with nothing in the log to say so.
+        private void RefreshRunDevicePositions(bool captureBaseline) {
+            var positions = tiltDeviceConnectionService?.PublishControllerPositions();
+            if (positions == null || positions.Count < 4) {
+                return; // Already logged by the service; keep the previous snapshot rather than blanking the display.
             }
-            try {
-                var positions = await controller.QueryPositionsAsync(CancellationToken.None).ConfigureAwait(true);
-                if (positions == null || !positions.Known) {
-                    return;
-                }
-                deviceDisplayPositions = positions.PerMotorSteps.ToArray();
-                if (captureBaseline || calibrationBaselinePositions == null) {
-                    calibrationBaselinePositions = deviceDisplayPositions.ToArray();
-                }
-                RaiseScrewPositionDisplays();
-            } catch (Exception ex) {
-                Logger.Warning($"Failed to read tilt device positions for the wizard display: {ex.Message}");
+            deviceDisplayPositions = positions;
+            if (captureBaseline || calibrationBaselinePositions == null) {
+                calibrationBaselinePositions = positions.ToArray();
             }
+            RaiseScrewPositionDisplays();
         }
 
         private IReadOnlyList<string> EnumeratePortNames() {
@@ -1672,8 +1671,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // Production "change the simulator config?" prompt: NINA's Yes/No message box, default No (a dismissed
         // dialog must never silently rewrite the simulator's configuration).
         private static Task<bool> ShowSimConfigChangePromptAsync(string message, string title) {
+            // Wrapped: this message enumerates every mismatched simulator setting on one line, and MyMessageBox
+            // does not wrap — an unwrapped long line stretches the modal past the screen edge. See DialogText.
             var result = MyMessageBox.Show(
-                message, title, System.Windows.MessageBoxButton.YesNo, System.Windows.MessageBoxResult.No);
+                DialogText.Wrap(message), title, System.Windows.MessageBoxButton.YesNo, System.Windows.MessageBoxResult.No);
             return Task.FromResult(result == System.Windows.MessageBoxResult.Yes);
         }
 
@@ -1720,14 +1721,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             try {
                 if (calibrationBaselinePositions == null) {
                     // Capture the "delta since start" baseline before this run's first move.
-                    await RefreshRunDevicePositionsAsync(controller, captureBaseline: true).ConfigureAwait(true);
+                    RefreshRunDevicePositions(captureBaseline: true);
                 }
                 progress.Report(new ApplicationStatus { Status = $"Tilt Adapter Wizard: {move.Description}" });
                 StatusText = move.Description;
                 await controller.ExecuteMoveAsync(move, moveProgress, ct).ConfigureAwait(true);
                 appliedDeviceMovesThisRun.Add(move);
                 // Refresh the live position display + delta after the move (the poll is paused during the run).
-                await RefreshRunDevicePositionsAsync(controller, captureBaseline: false).ConfigureAwait(true);
+                RefreshRunDevicePositions(captureBaseline: false);
                 return true;
             } catch (Exception ex) {
                 Logger.Error(ex, $"Tilt adapter device move failed for wizard step {step}.");
@@ -1757,6 +1758,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
             try {
                 await controller.ExecuteMoveAsync(inverse, moveProgress, CancellationToken.None).ConfigureAwait(true);
+                RefreshRunDevicePositions(captureBaseline: false);
             } catch (Exception ex) {
                 Logger.Error(ex, "Failed to recover tilt adapter device position after a failed move; the device may not be at its expected position.");
             }
@@ -1798,6 +1800,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                         progress.Report(new ApplicationStatus { Status = $"Tilt Adapter Wizard: recovering — {inverse.Description}" });
                         await controller.ExecuteMoveAsync(inverse, moveProgress, CancellationToken.None).ConfigureAwait(true);
                         anyRolledBack = true;
+                        RefreshRunDevicePositions(captureBaseline: false);
                     } catch (Exception ex) {
                         Logger.Error(ex, "Failed to fully recover tilt adapter device position after an automated-run cancellation/failure.");
                         MeasurementFailureText = $"Recovery failed while returning the device to its original position: {ex.Message}. Verify screw/motor positions before continuing.";
@@ -2337,7 +2340,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                         // until the user has confirmed a selection.
                         ok = await inspector.AnalyzeAutoFocusFromSaved(token, onFolderSelected: () => IsMeasuring = true, saveOverride: saveOverride);
                     } else {
-                        ok = await inspector.AnalyzeAutoFocus(token, captureCameraBlock: true, saveOverride);
+                        // includeExposureAnalysis: false — a calibration step consumes ONLY the sensor model fitted
+                        // from the sweep (CalibrationTiltPlane, below). The inspector's closing validation exposure
+                        // feeds the FWHM-contour/eccentricity panels, which this wizard never reads, and it costs a
+                        // further SimpleExposureSeconds plus a full-frame PSF detection on every one of the six
+                        // steps — ~18 s per step on the rig this was measured on.
+                        ok = await inspector.AnalyzeAutoFocus(token, captureCameraBlock: true, saveOverride, includeExposureAnalysis: false);
                     }
                 } finally {
                     inspector.ForceSensorCurveModelGeneration = prevForce;
@@ -2633,7 +2641,19 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // Curvature (backfocus) sign from baseline (a) → all-inward (b) mean focus, only when
             // those steps ran; otherwise the configured/assumed sign is left untouched.
             if (measuredCurvature) {
-                tiltAdapterOptions.ScrewInwardCurvatureSign = TiltCalibrationCalculator.ComputeCurvatureSign(b.Mean, a.Mean);
+                int curvatureSign = TiltCalibrationCalculator.ComputeCurvatureSign(b.Mean, a.Mean);
+                // This one number decides which way EVERY later automated correction turns, and it is derived
+                // from a single comparison — so log the comparison itself, not just the verdict. Without it,
+                // checking a suspect direction against a night's log means reconstructing mean-focus positions
+                // from the raw model solves. The curvature effects are logged alongside because they are the
+                // quantity the stored sign is DEFINED in terms of (see TiltScrewGeometry's empirical anchor),
+                // and a run where the two disagree is exactly the evidence needed to settle the convention.
+                Logger.Info(
+                    $"Tilt calibration: adapter direction measured from the all-screws step. Mean best-focus position {a.Mean:F1} → {b.Mean:F1} " +
+                    $"(Δ {b.Mean - a.Mean:+0.0;-0.0} focuser steps); curvature effect at screw radius {a.CurvatureEffectAtScrewRadiusMicrons:F1} → {b.CurvatureEffectAtScrewRadiusMicrons:F1} µm. " +
+                    $"ScrewInwardCurvatureSign = {curvatureSign:+0;-0} (clockwise/+steps moves the adapter toward the " +
+                    $"{(TiltScrewGeometry.CwMovesAdapterTowardObjectiveForSign(curvatureSign) ? "OBJECTIVE" : "CAMERA")}).");
+                tiltAdapterOptions.ScrewInwardCurvatureSign = curvatureSign;
                 tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured = true;
             }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/DialogText.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/DialogText.cs
@@ -1,0 +1,104 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NINA.Joko.Plugins.HocusFocus.Utility {
+
+    /// <summary>
+    /// Text preparation for NINA's <c>MyMessageBox</c>. Its message <c>TextBlock</c> does not wrap, so the
+    /// window simply grows to fit the longest line: a single long sentence (e.g. a device error quoting the
+    /// failed command and its recovery advice) stretches the modal past the screen edge and clips its own text
+    /// at BOTH ends, leaving the user unable to read the thing they are being asked to answer.
+    ///
+    /// <para>Hard-wrapping the message before it is handed to the dialog is the fix that is actually in this
+    /// plugin's control. Wrap at the call site of every message box whose text is not a short, fixed
+    /// string.</para>
+    /// </summary>
+    public static class DialogText {
+
+        /// <summary>Conservative column count: comfortably readable, and narrow enough that the resulting modal fits a 1080p screen at typical DPI.</summary>
+        public const int DefaultWrapColumns = 90;
+
+        /// <summary>
+        /// Hard-wraps <paramref name="text"/> so no line exceeds <paramref name="columns"/> characters, without
+        /// reflowing the author's own structure: existing line breaks (e.g. the blank line between a failure
+        /// description and the question that follows it) are preserved exactly, and only over-long lines are
+        /// broken — at whitespace where possible. A single word longer than the limit (a path, a URL) is left
+        /// intact on its own line rather than split, since breaking it would corrupt what it names.
+        /// </summary>
+        public static string Wrap(string text, int columns = DefaultWrapColumns) {
+            if (string.IsNullOrEmpty(text) || columns <= 0) {
+                return text;
+            }
+
+            var result = new StringBuilder(text.Length + 32);
+            // Split on \n and keep any \r as part of the line so CRLF input round-trips unchanged.
+            var lines = text.Split('\n');
+            for (int i = 0; i < lines.Length; ++i) {
+                if (i > 0) {
+                    result.Append('\n');
+                }
+                var line = lines[i];
+                bool endsWithCr = line.EndsWith("\r", StringComparison.Ordinal);
+                if (endsWithCr) {
+                    line = line.Substring(0, line.Length - 1);
+                }
+                AppendWrappedLine(result, line, columns);
+                if (endsWithCr) {
+                    result.Append('\r');
+                }
+            }
+            return result.ToString();
+        }
+
+        private static void AppendWrappedLine(StringBuilder result, string line, int columns) {
+            if (line.Length <= columns) {
+                result.Append(line);
+                return;
+            }
+
+            foreach (var segment in WrapSegments(line, columns)) {
+                result.Append(segment);
+            }
+        }
+
+        private static IEnumerable<string> WrapSegments(string line, int columns) {
+            int lineStart = 0;
+            bool first = true;
+            while (lineStart < line.Length) {
+                int remaining = line.Length - lineStart;
+                if (remaining <= columns) {
+                    yield return (first ? string.Empty : "\n") + line.Substring(lineStart);
+                    yield break;
+                }
+
+                // Break at the last space that fits; if there is none, the word itself is longer than the
+                // limit, so take it whole (up to the next space) rather than splitting it mid-token.
+                int breakAt = line.LastIndexOf(' ', lineStart + columns, columns);
+                if (breakAt <= lineStart) {
+                    breakAt = line.IndexOf(' ', lineStart);
+                    if (breakAt < 0) {
+                        yield return (first ? string.Empty : "\n") + line.Substring(lineStart);
+                        yield break;
+                    }
+                }
+
+                yield return (first ? string.Empty : "\n") + line.Substring(lineStart, breakAt - lineStart);
+                first = false;
+                lineStart = breakAt + 1; // Consume the space the break happened at.
+            }
+        }
+    }
+}

--- a/docs/asg-eat-serial-protocol-design.md
+++ b/docs/asg-eat-serial-protocol-design.md
@@ -141,7 +141,7 @@ moving BL - -5.00
 - **`start_cmd:` / `tilt_value:`** provide a free confirmation that the device parsed our command as intended (useful as a validation hook).
 - **`moving <MOTOR> <sign> <value>`** lines are the authoritative per-motor report of what physically moved. Backfocus reports as a single `moving Backfocus  + <value>` line (all four motors, one line).
 - Every move ends with **`***Save EEPROM***`** then **`***finished movement***`**. The EEPROM save confirms our whole no-undo safety model.
-- A response also embeds a fresh `***Get Current Positions***` block, so a move doubles as a position read (no separate `cp` needed after a move).
+- A response also embeds a fresh `***Get Current Positions***` block, so a move doubles as a position read (no separate `cp` needed after a move). **Implemented:** `EatResponses.TryParseMovePositions` + `EatTiltMotionController.ExecuteMoveAsync` reconcile the shadow from this block (falling back to advancing by the commanded delta only when it is absent, e.g. the simulator), and expose it as `LastKnownPositions` — which is what drives the live per-motor display between the moves of a run, with no follow-up `cp`.
 
 ### 4.3 Mnemonic → motor mapping
 

--- a/docs/tilt-adapter-direction-sign-design.md
+++ b/docs/tilt-adapter-direction-sign-design.md
@@ -1,0 +1,104 @@
+# Adapter direction (`ScrewInwardCurvatureSign`): the measured sign came out inverted
+
+**Status:** analysis + options. **Needs a decision before any code change** — this sign decides which way every
+automated correction turns, and getting it wrong drives tilt in the wrong direction unattended.
+
+## What happened
+
+Session `20260803-200647` (NINA log). The first hands-off calibration run measured the adapter direction as
+**"+ steps move the adapter toward the objective"**. Automatic Adjustment then made aberration *worse*.
+Manually flipping the setting to **"toward the camera"** made subsequent adjustments *improve* the result.
+
+## What the log shows
+
+The run's six steps, with the fitted sensor model's `Z0` (the best-focus focuser position at the sensor centre)
+and the curvature coefficient `Kx = Ky`:
+
+| Time | Step | Device move | `Z0` (focuser steps) | `Kx` |
+|---|---|---|---|---|
+| 21:27:50 | Baseline (a) | — | 5498.4 | −1.3271e−07 |
+| 21:32:12 | AllInward (b) | `bf,+150` | **5136.6** | −1.4604e−07 |
+| 21:35:57 | ReBaseline1 | `bf,−150` | 5445.5 | −1.4176e−07 |
+| 21:39:30 | Screw1 | `tr,+150` | 5383.8 | −1.5247e−07 |
+| 21:42:53 | ReBaseline2 | `tr,−150` | 5373.8 | −1.7403e−07 |
+| 21:46:21 | Screw2 | `tl,+150` | 5359.8 | −2.0968e−07 |
+
+`RunCalibrationMath` computes the direction as
+`ComputeCurvatureSign(b.Mean, a.Mean) = sign(b.Mean − a.Mean)`, where `Mean` is `MeanFocuserPosition`:
+
+    sign(5136.6 − 5498.4) = sign(−361.8) = −1
+
+`CurvatureSignWhenCwMovesAdapterTowardObjective = −1`, so −1 reads as **"CW moves the adapter toward the
+objective"** — exactly what the user saw, and the opposite of what their rig actually does. The measurement was
+not corrupted by the serial desync fixed alongside this: the physical moves did execute, and the AF/sensor-model
+readings are independent of the serial link.
+
+## Why it can come out inverted
+
+The convention is stated in `docs/tilt-guidance-motion-arrows-design.md` §"Two vocabularies":
+
+> Because "adapter moves toward the objective" ⇔ "the local best-focus position decreases" …
+
+That equivalence is what `ComputeCurvatureSign` encodes. Working it through for a standard focuser (increasing
+position = drawtube extends = camera moves **away** from the objective):
+
+- Let `S` be the objective→sensor distance. `S = k·P + B + const`, with `P` the focuser position and `B` the
+  adapter's spacing contribution.
+- The objective's focal plane `F` is fixed. In focus, `S = F`.
+- If the adapter moves the sensor **toward the objective** (`B` decreases by Δ), restoring `S = F` requires
+  `k·P` to *increase* by Δ → **the best-focus focuser position increases.**
+
+So on a standard focuser the equivalence runs the other way: *toward the objective ⇔ best-focus position
+**increases***. The log agrees with the standard reading and disagrees with the code's: `bf,+150` — which the
+vendor's own mnemonic calls *increasing backfocus*, i.e. the camera moving away from the objective — lowered the
+best-focus position by 362 steps, and the user's rig confirms "+ = toward the camera".
+
+Note the two rules in the codebase are not independent: the curvature-effect anchor
+(`TiltScrewGeometry`: "moving the adapter toward the objective DECREASES the curvature effect", user measurement
+2026-07-02) and the focuser-position rule are two faces of the same stored sign, so the log's curvature change
+(effect at the screw radius went −401 µm → −442 µm, i.e. decreased) agrees with the code's conclusion by
+construction. It is not independent confirmation.
+
+**Therefore one of these is true, and the log alone cannot separate them:**
+
+1. **The convention is inverted.** The equivalence above (and hence the 2026-07-02 anchor derived with it) has
+   the wrong sense, and every rig has been getting the direction backwards whenever it was measured rather than
+   set by hand. The physics argument above says this is the most likely one.
+2. **This rig's focuser is inverted.** Its driver reports increasing position as moving *toward* the objective.
+   Then the code is right in general and needs to learn the focuser's convention rather than assume it.
+3. **The inversion is downstream.** The sign is measured correctly but consumed with the wrong sense in
+   `TiltScrewTargets.ComputePerScrewTargets` (or the guidance arrows), and flipping the *setting* merely
+   cancels that bug — in which case the displayed mechanical direction is now wrong even though corrections
+   improved.
+
+## The decisive experiment (≈10 minutes, no code)
+
+On the affected rig, with the device connected:
+
+1. Note the current best-focus focuser position.
+2. Send `bf,+150` (or use the wizard's all-screws step) and re-run autofocus. Note the new position.
+3. Independently establish which way the plate physically moved — caliper across the adapter, or the vendor
+   app's own backfocus labelling.
+4. Also note whether the focuser's position increases as the drawtube extends.
+
+That fixes the mapping for this rig and, with (4), separates option 1 from option 2. Repeating on a second rig
+with a known-standard focuser settles it outright.
+
+## Options
+
+| # | Change | Pros | Cons |
+|---|---|---|---|
+| A | **Flip the equivalence** in `ComputeCurvatureSign` (and correct the anchor + motion-arrows doc) | One-line fix at the true root if option 1 holds; every future calibration is right | Wrong if the real cause is 2 or 3; silently inverts existing stored calibrations, so it needs a migration/re-measure prompt |
+| B | **Derive the sign from the focuser's own convention** rather than assuming it | Rig-independent and correct by construction | NINA does not expose "which way is out"; would need a user-answered question or a probe move |
+| C | **Confirm with the user during calibration** — show the measured direction and the evidence, ask them to confirm before it is stored | Cheap, safe, and puts a human on the one decision that silently inverts automation | Breaks the hands-off promise of the 6-step run (one prompt at the end) |
+| D | **Cross-check the two signals and warn on disagreement** — measure via focuser mean *and* via the curvature effect's magnitude, and refuse to mark the sign "measured" when they disagree | Turns a silent wrong answer into a visible one | They are not independent under the current anchor, so this only helps once the anchor is settled |
+
+**Recommendation:** run the experiment, then take **A** if it confirms option 1 (with a one-time "re-measure
+your adapter direction" prompt for existing profiles), plus **C** as a permanent backstop — the cost of a single
+confirmation prompt is trivial against an unattended correction that drives tilt the wrong way.
+
+## Already done (no behaviour change)
+
+`RunCalibrationMath` now logs the decision and its inputs — the mean-focus positions on both sides, the
+curvature effects, the resulting sign, and the mechanical direction in words. Reaching this analysis previously
+required reconstructing `Z0` values from raw model solves; the next run answers it from one line.


### PR DESCRIPTION
Diagnosed from the real session log (`20260803-200647`). Three reported symptoms — a status line that never cleared, tilt-adapter positions that never updated, and an Automatic Adjustment that made tilt worse — all trace to **one defect in the serial transport**, plus some genuine UX problems alongside it.

## The root cause: a permanent stream desync

`EatSerialTransport` treated "at least one line, then 200 ms of silence" as end-of-response. On a busy machine the device pauses mid-dump for longer than that. At **20:51:09** a `cp` reply was abandoned after **3 of its ~22 lines** (the log line immediately before is a camera update cycle overrunning its poll interval). The unread remainder stayed in the port buffer and became the head of the *next* command's response.

From then on **every exchange ran exactly one behind, for the rest of the session**:

| Time | Sent | What was actually read |
|---|---|---|
| 21:28:08 | `bf,150` | a `cp` dump, arriving in **0.5 ms**, positions still 400/400/400/400 |
| 21:28:11 | `cp` | another stale dump — so the post-move display never changed |
| 21:46:45 | `cp` | **that move's** real response (`start_cmd: bf` / `moving Backfocus + 150.00`), 18 minutes late |

Corroborating counts across the session: **33 moves sent, only 23 `***finished movement***` ever read.** Because `ParseMoveAck` accepted "did not time out", moves were acknowledged by a *previous command's* sentinel and journaled as applied — on a device that persists every move to EEPROM. At **21:52:48** the revert of `tr,9` timed out against a backlog of `***moving***` heartbeats, so the revert reported by the user as "complete" had in fact **failed partway**. Closing the port was the only recovery, which is why disconnect/reconnect appeared to fix the positions.

## What changed

**Serial layer** (`EatSerialTransport`, `EatResponses`)
- An exchange now ends **only** at a terminal sentinel, or at the overall budget — which means *incomplete*, never "finished without a sentinel".
- **Stale input is discarded and logged before each command**, so a link that does slip resynchronizes itself instead of needing a reconnect. Costs nothing when the buffer is clean.
- `ParseMoveAck` requires `***finished movement***`. A query's sentinel can never acknowledge a move.
- The in-motion heartbeat is counted, not logged per line — that session emitted **43,264** of them (6.5 MB), burying everything else.

**Live positions** (reported: counters frozen during a run and after the revert)
- `ITiltMotionController.LastKnownPositions` exposes the counters the device already reports inside every move response (protocol doc §4.2, "a move doubles as a position read"). `ExecuteMoveAsync` reconciles the shadow from that block rather than dead-reckoning — better for excursion enforcement too.
- `TiltDeviceConnectionService.PublishControllerPositions()` publishes them with **no device I/O**. The `cp` poll is suspended for the *whole* operation lease — moves + the confirming analysis run + the revert — so the lease holder republishes after each move. One call updates both the inspector and wizard panels. The wizard's per-move `cp` is gone.

**Status bar** (reported: `reverting move 3 of 4` never cleared)
- Automatic Adjustment clears its status in a `finally` covering every exit, including a revert that bails out partway. This was already codified in `.claude/docs/mvvm-patterns.md`; the wizard complied, the inspector never did.

**Also**
- `MyMessageBox` doesn't wrap, so a device error on one long line stretched the modal past both screen edges and clipped the question being asked. Messages are hard-wrapped (`DialogText`, unit-tested).
- Calibration steps no longer run the inspector's closing validation exposure: `SimpleExposureSeconds` + a full-frame PSF detection on **18 of 18** analyses in the log, ~18 s per step × 6 steps, feeding panels the wizard never reads — and a failure there failed a step whose sensor model had already fitted successfully.

## Needs your decision (no behaviour changed)

`docs/tilt-adapter-direction-sign-design.md`. The first calibration measured the adapter direction as "toward the objective"; you flipped it to "toward the camera" and adjustments improved. The log confirms the measurement (`Z0` 5498.4 → 5136.6 after `bf,+150` → sign −1) and shows the convention it rests on — *"toward the objective ⇔ best-focus position decreases"* — is the opposite of what a standard focuser does. Three explanations survive the log; the doc has the evidence, a ~10-minute decisive experiment, and four options. `RunCalibrationMath` now **logs** the decision and its inputs (this previously required reconstructing `Z0` from raw model solves), but the math is untouched.

## Review notes

- **Contract changes to check:** a quiet gap no longer completes an exchange; `ParseMoveAck` requires the move sentinel. Both tightenings turn a silent wrong answer into a visible failure — worth confirming you want that trade on your hardware.
- The simulator now emits the post-move position block in the device's wire order, so the sim exercises the same parse path as hardware.
- Not covered by a new test: skipping the validation exposure. Reaching that branch needs a full `AutoFocusResult` + sensor-model fit, which the harness can't reach — any test I could add cheaply would pass vacuously. Verified by the log evidence and a green suite; the real confirmation is your next run showing no 10 s exposure between the model solve and the move.

Full suite green: **3378 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qxzJZcQivsWK6VSxAUW9V
