### PR TITLE
style(af-chart): fade the point-to-point connecting line to 50% alpha

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -199,11 +199,13 @@
                         ItemsSource="{Binding PlotCoreFocusPoints}"
                         MarkerFill="{Binding Path=Color, Source={StaticResource PrimaryBrush}}"
                         MarkerType="Circle" />
+                    <!--  Point-to-point connecting line, inherited from core's AF chart. Drawn at 50% alpha so it reads as
+                          a background cue for the raw sweep shape and does not compete with the fitted curve.  -->
                     <oxy:LineSeries
                         DataFieldX="FocusPosition"
                         DataFieldY="HFR"
                         ItemsSource="{Binding PlotFocusPoints}"
-                        Color="{Binding Path=Color, Source={StaticResource SecondaryBrush}}" />
+                        Color="{Binding Path=Color, Source={StaticResource SecondaryBrush}, Converter={StaticResource SetAlphaToColorConverter}, ConverterParameter=128}" />
                     <oxy:ScatterSeries
                         ItemsSource="{Binding PlotRejectedFocusPoints}"
                         MarkerType="Cross"


### PR DESCRIPTION
## What

The autofocus dockable chart draws a `LineSeries` connecting each measured HFR point in focuser order, on top of the fitted curve. This fades it to 50% alpha (`128/255`).

`AutoFocus/DataTemplates.xaml:202`:

```xml
Color="{Binding Path=Color, Source={StaticResource SecondaryBrush},
        Converter={StaticResource SetAlphaToColorConverter}, ConverterParameter=128}"
```

## Why

The connecting line is **not** a HocusFocus addition and not a 4.0 regression, which is what prompted the look. `git log -S "oxy:LineSeries"` on that file returns exactly one commit — `59fb739` "Initial commit" (2021-10-25) — where it appears with the same four attributes. It was never removed and re-added, it is present unchanged in `release/v3.0.0.26`, and the only commit to touch those lines since is `4c98adc` (2021-11-05), a pure re-indentation. It was inherited verbatim from NINA core's AF chart template, along with core's `PlotFocusPoints` collection (core's `LoadChart` writes straight into it — see the comment at `HocusFocusVM.cs:590`).

In core its job is a fit-independent read of the sweep: it shows the V while the sweep is still running and no fit exists yet, and it survives a rejected fit. That job does not need full opacity — and the chart has gotten busier around it lately:

- `d2d9ce0` (2026-07-09) — live AF curve during optimizer Live-source runs
- `3f4720a` (2026-07-25) — hollow-ring window-excluded overlay
- `a6c8b7d` (2026-07-29) — chart-state reconcile on loading a saved run

At full alpha the raw zig-zag competes with the fitted curve it is drawn over. Fading it keeps it as a background cue and lets the fit read as the foreground.

The `128` follows the 0–255 parameter convention `SetAlphaToColorConverter` already uses four times in this same `DataTemplate`: `60` for gridlines, `100` for the dimmed error bar, `150` for the hollow-ring stroke.

## Testing

- `dotnet build` — 0 errors; the 6 warnings are pre-existing (CS8632/CS0162/CS0067 in test fakes), none from this file.
- `dotnet test` — **3416 passed**, 0 failed.

**Caveat worth a reviewer's eye:** a bad `StaticResource` in XAML fails at runtime, not compile time, and `SetAlphaToColorConverter` is a NINA core resource not defined in this repo. It resolves here because the same converter is already bound four times inside this same `DataTemplate` — including on the `ScatterErrorSeries` immediately above (`ErrorBarColor` at :183, `MarkerStroke` at :189), which are `Color`-typed properties just like `LineSeries.Color`. Low risk, but only truly confirmed by looking at the chart in NINA.

If `128` reads too faint or still too loud against a given theme, it is a one-number change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qxzJZcQivsWK6VSxAUW9V