### PR TITLE
fix(tilt): correct the inverted curvature-sign measurement; focuser step size from the driver

### DIFF
--- a/.claude/docs/tilt-domain.md
+++ b/.claude/docs/tilt-domain.md
@@ -23,7 +23,7 @@ Example: a screw at 0° (straight up from center) — turning it inward tilts th
 
 ## Guidance arrows vs rotation glyphs
 
-The inspector's Tilt Adapter Guidance table uses two glyph vocabularies that answer different questions. The ⬆/⬇ arrows describe adapter-plate **motion** (⬆ = that corner moves toward the objective) — pure physics, identical on every rig. The ⟳/⟲ glyphs (screws) and +/− step signs (steppers) on the numeric rows carry the rig-specific **rotation** that produces that motion, which depends on the adapter's direction setting (`ScrewInwardCurvatureSign`). Never present ⬆/⬇ as a rotation. The full contract and sign derivations are in `docs/tilt-guidance-motion-arrows-design.md`.
+The inspector's Tilt Adapter Guidance table uses two glyph vocabularies that answer different questions. The ⬆/⬇ arrows describe adapter-plate **motion** (⬆ = that corner moves toward the objective) — physics, identical on every rig *given the focuser-direction setting* (`IInspectorOptions.FocuserIncreasesTowardObjective`, the display-only `k`; translating a z-space quantity into "toward the objective" needs to know which way the focuser travels). The ⟳/⟲ glyphs (screws) and +/− step signs (steppers) on the numeric rows carry the rig-specific **rotation** that produces that motion, which depends on the adapter's direction setting (`ScrewInwardCurvatureSign`). Never present ⬆/⬇ as a rotation. The full contract and sign derivations are in `docs/tilt-guidance-motion-arrows-design.md`; the σ = m·k factorization, why the *measurement* needs no `k`, and the display-only contract are in `docs/focuser-direction-convention-design.md`.
 
 ## Live motor positions while a motorized device is being driven
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorOptionsTests.cs
@@ -34,6 +34,9 @@ public class InspectorOptionsTests {
             Assert.That(options.NumRegionsWide, Is.EqualTo(7));
             Assert.That(options.LoopingExposureAnalysisEnabled, Is.False);
             Assert.That(options.MicronsPerFocuserStep, Is.EqualTo(-1));
+            // Default k: standard focuser (increasing position moves the camera AWAY from the objective),
+            // which reproduces every caption exactly as it rendered before the setting existed.
+            Assert.That(options.FocuserIncreasesTowardObjective, Is.False);
             Assert.That(options.EccentricityColorMapEnabled, Is.True);
             Assert.That(options.MouseOnChartsEnabled, Is.True);
             Assert.That(options.SensorCurveModelEnabled, Is.False);
@@ -69,6 +72,7 @@ public class InspectorOptionsTests {
         options.DetailedAnalysisExposureSeconds = 4.0;
         options.LoopingExposureAnalysisEnabled = true;
         options.MicronsPerFocuserStep = 1.5;
+        options.FocuserIncreasesTowardObjective = true;
         options.EccentricityColorMapEnabled = false;
         options.MouseOnChartsEnabled = false;
         options.SensorCurveModelEnabled = true;
@@ -99,6 +103,7 @@ public class InspectorOptionsTests {
             Assert.That(store.Snapshot[nameof(InspectorOptions.NumRegionsWide)], Is.EqualTo(9));
             Assert.That(store.Snapshot[nameof(InspectorOptions.LoopingExposureAnalysisEnabled)], Is.True);
             Assert.That(store.Snapshot[nameof(InspectorOptions.MicronsPerFocuserStep)], Is.EqualTo(1.5));
+            Assert.That(store.Snapshot[nameof(InspectorOptions.FocuserIncreasesTowardObjective)], Is.True);
             Assert.That(store.Snapshot[nameof(InspectorOptions.EccentricityColorMapEnabled)], Is.False);
             Assert.That(store.Snapshot[nameof(InspectorOptions.MouseOnChartsEnabled)], Is.False);
             Assert.That(store.Snapshot[nameof(InspectorOptions.SensorCurveModelEnabled)], Is.True);
@@ -203,6 +208,7 @@ public class InspectorOptionsTests {
     [TestCase(nameof(InspectorOptions.CenterFocuserBeforeRun), true)]
     [TestCase(nameof(InspectorOptions.LoopingExposureAnalysisEnabled), true)]
     [TestCase(nameof(InspectorOptions.MicronsPerFocuserStep), 2.5)]
+    [TestCase(nameof(InspectorOptions.FocuserIncreasesTowardObjective), true)]
     [TestCase(nameof(InspectorOptions.SensorROI), 0.6)]
     [TestCase(nameof(InspectorOptions.UseRANSAC), false)]
     [TestCase(nameof(InspectorOptions.FrameReviewEnabled), true)]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorOptionsTests.cs
@@ -306,6 +306,135 @@ public class InspectorOptionsTests {
         Assert.That(options.CenterFocuserBeforeRun, Is.False);
     }
 
+    // ---- Focuser step size: driver value, override, and the mismatch flag -----------------------------
+    //
+    // docs/focuser-step-size-driver-design.md. The driver's reported StepSize is the default source; the
+    // persisted MicronsPerFocuserStep is an override. The governing constraint is that "unset" must never
+    // become silently WRONG — only ever missing — so the driver value is accepted on exactly one test
+    // (finite and > 0) and is never persisted.
+
+    [Test]
+    public void EffectiveMicronsPerFocuserStep_ResolvesOverrideThenDriverThenUnset() {
+        var (options, _, _) = Build();
+
+        Assert.Multiple(() => {
+            Assert.That(options.EffectiveMicronsPerFocuserStep, Is.EqualTo(-1.0), "neither set");
+
+            options.DriverMicronsPerFocuserStep = 2.5;
+            Assert.That(options.EffectiveMicronsPerFocuserStep, Is.EqualTo(2.5), "driver alone");
+
+            options.MicronsPerFocuserStep = 1.0;
+            Assert.That(options.EffectiveMicronsPerFocuserStep, Is.EqualTo(1.0), "the override wins");
+
+            options.MicronsPerFocuserStep = -1;
+            Assert.That(options.EffectiveMicronsPerFocuserStep, Is.EqualTo(2.5), "clearing the box returns to the driver");
+        });
+    }
+
+    [TestCase(0.0)]
+    [TestCase(-5.0)]
+    [TestCase(double.NaN)]
+    [TestCase(double.PositiveInfinity)]
+    [TestCase(double.NegativeInfinity)]
+    public void DriverMicronsPerFocuserStep_RejectsUnusableValues(double reported) {
+        // The three ways a driver declines to answer, plus infinity. NaN is the one that matters: it fails
+        // BOTH `> 0` and `<= 0`, so a `!(value <= 0)` guard would wave it through into the sensor model and
+        // produce an all-NaN fit with no error anywhere.
+        var (options, _, _) = Build();
+
+        options.DriverMicronsPerFocuserStep = reported;
+
+        Assert.Multiple(() => {
+            Assert.That(options.DriverMicronsPerFocuserStep, Is.EqualTo(-1.0));
+            Assert.That(options.EffectiveMicronsPerFocuserStep, Is.EqualTo(-1.0));
+        });
+    }
+
+    [Test]
+    public void DriverMicronsPerFocuserStep_IsStickyAcrossADisconnect() {
+        // A disconnected focuser reports StepSize = 0. Dropping that write is the whole stickiness mechanism:
+        // an in-flight analysis must not be rescaled because the focuser dropped off the bus.
+        var (options, _, _) = Build();
+        options.DriverMicronsPerFocuserStep = 3.5;
+
+        options.DriverMicronsPerFocuserStep = 0.0;
+
+        Assert.That(options.EffectiveMicronsPerFocuserStep, Is.EqualTo(3.5));
+    }
+
+    [Test]
+    public void DriverMicronsPerFocuserStep_IsNeverPersisted() {
+        var (options, store, _) = Build();
+
+        options.DriverMicronsPerFocuserStep = 3.5;
+
+        Assert.That(store.Snapshot.ContainsKey(nameof(IInspectorOptions.DriverMicronsPerFocuserStep)), Is.False,
+            "it is live device state — a persisted copy would go stale against a swapped focuser");
+    }
+
+    [Test]
+    public void ProfileChange_ClearsTheDriverValue_ButNotTheOverride() {
+        var profile = Substitute.For<IProfileService>();
+        var store = new InMemoryPluginOptionsAccessor();
+        var options = new InspectorOptions(profile, store);
+        options.MicronsPerFocuserStep = 1.25;
+        options.DriverMicronsPerFocuserStep = 3.5;
+
+        profile.ProfileChanged += Raise.Event<EventHandler>(profile, EventArgs.Empty);
+
+        Assert.Multiple(() => {
+            Assert.That(options.DriverMicronsPerFocuserStep, Is.EqualTo(-1.0), "a profile swap means a different rig");
+            Assert.That(options.MicronsPerFocuserStep, Is.EqualTo(1.25), "the override is persisted and survives");
+        });
+    }
+
+    [Test]
+    public void ResetDefaults_LeavesTheDriverValueAlone() {
+        var (options, _, _) = Build();
+        options.DriverMicronsPerFocuserStep = 3.5;
+
+        options.ResetDefaults();
+
+        Assert.Multiple(() => {
+            Assert.That(options.MicronsPerFocuserStep, Is.EqualTo(-1.0), "the override resets");
+            Assert.That(options.DriverMicronsPerFocuserStep, Is.EqualTo(3.5),
+                "the driver value is device state, not a default");
+        });
+    }
+
+    [TestCase(-1.0, 1.0, false, TestName = "Mismatch_NoOverride_NeverFlags")]
+    [TestCase(1.0, 0.0, false, TestName = "Mismatch_NoDriverValue_NeverFlags")]
+    [TestCase(1.0, double.NaN, false, TestName = "Mismatch_NaNDriverValue_NeverFlags")]
+    [TestCase(1.0, 1.005, false, TestName = "Mismatch_WithinOnePercent_Quiet")]
+    [TestCase(1.0, 2.0, true, TestName = "Mismatch_DoubleTheDriverValue_Flags")]
+    [TestCase(1.0, 0.5, true, TestName = "Mismatch_HalfTheDriverValue_Flags")]
+    public void HasFocuserStepSizeMismatch_Matrix(double overrideValue, double driverValue, bool expected) {
+        var (options, _, _) = Build();
+        options.MicronsPerFocuserStep = overrideValue;
+        options.DriverMicronsPerFocuserStep = driverValue;
+
+        Assert.That(options.HasFocuserStepSizeMismatch, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void FocuserStepSize_DerivedProperties_RaiseFromBothInputs() {
+        // The hint text and the mismatch flag bind to these, and both derived values read BOTH inputs — so
+        // either setter must re-raise both, or a driver update leaves a stale hint on screen.
+        var (options, _, _) = Build();
+        var raised = new List<string>();
+        options.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        options.MicronsPerFocuserStep = 1.0;
+        options.DriverMicronsPerFocuserStep = 3.5;
+
+        Assert.Multiple(() => {
+            Assert.That(raised.FindAll(n => n == nameof(InspectorOptions.EffectiveMicronsPerFocuserStep)),
+                Has.Count.EqualTo(2), "once per input");
+            Assert.That(raised.FindAll(n => n == nameof(InspectorOptions.HasFocuserStepSizeMismatch)),
+                Has.Count.EqualTo(2), "once per input");
+        });
+    }
+
     [Test]
     public void Constructor_ThrowsOnNullAccessor() {
         var profile = Substitute.For<IProfileService>();

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMFocuserDirectionTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMFocuserDirectionTests.cs
@@ -1,0 +1,135 @@
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.Inspection;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NSubstitute;
+using NUnit.Framework;
+using System.ComponentModel;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus;
+
+/// <summary>
+/// The structural half of docs/focuser-direction-convention-design.md §2.2: the display-only focuser
+/// convention k must change LABELS AND ARROWS and never a number, a glyph, a total, or a plan.
+///
+/// The design's central guarantee is that a wrong k produces wrong labels and never wrong motion. Placement
+/// (k lives on IInspectorOptions, and the math layer gains no k parameter) enforces it structurally; these
+/// tests are the executable half, so a future change that threads k into a computed quantity fails here
+/// rather than shipping.
+/// </summary>
+[TestFixture]
+[Apartment(System.Threading.ApartmentState.STA)]
+public class InspectorVMFocuserDirectionTests {
+
+    /// <summary>
+    /// Reuses the deterministic fixture from InspectorVMBehavioralTests.TiltGuidance_SigmaFlip: a pure +Y
+    /// tilt gradient (screw 1 at the top needs the largest CW correction) plus a positive-curvature
+    /// paraboloid whose corner curvature effect is +80 µm, above the large-arrow threshold.
+    /// </summary>
+    private static (MediatorBundle bundle, InspectorVM vm) BuildGuidanceFixture() {
+        var bundle = new MediatorBundle();
+        bundle.TiltAdapterOptions.IsCalibrated.Returns(true);
+        bundle.TiltAdapterOptions.ScrewCount.Returns(3);
+        bundle.TiltAdapterOptions.CalibratedScrewCount.Returns(3);
+        bundle.TiltAdapterOptions.ScrewInwardCurvatureSign.Returns(1);
+        bundle.TiltAdapterOptions.Screw1AngleDegrees.Returns(0.0);
+        bundle.TiltAdapterOptions.Screw2AngleDegrees.Returns(120.0);
+        bundle.TiltAdapterOptions.Screw3AngleDegrees.Returns(240.0);
+        bundle.TiltAdapterOptions.AdjustmentType.Returns(TiltAdjustmentType.Screws);
+        bundle.TiltAdapterOptions.ThreadPitchMicrons.Returns(100.0);
+        bundle.TiltAdapterOptions.ScrewRadiusMillimeters.Returns(30.0);
+
+        var vm = bundle.BuildInspectorVM();
+
+        var imageSize = new System.Drawing.Size(1000, 1000);
+        var tiltPlane = TiltPlaneModel.Create(
+            imageSize: imageSize, fRatio: 5.0, focuserStepSizeMicrons: 1.0,
+            centerFocuser: 5.0, topLeftFocuser: 0.0, topRightFocuser: 0.0,
+            bottomLeftFocuser: 10.0, bottomRightFocuser: 10.0);
+        vm.TiltModel.SelectedTiltHistoryModel = new SensorTiltHistoryModel(
+            historyId: 1, tiltPlaneModel: tiltPlane, backfocusFocuserPositionDelta: 0.0);
+
+        var paraboloid = new SensorParaboloidModel(x0: 0, y0: 0, z0: 0, gx: 0, gy: 1e-3, k: 1e-5);
+        vm.SensorModel.SelectedTiltHistoryModel = new SensorParaboloidTiltHistoryModel(
+            historyId: 1, imageSize: imageSize, pixelSizeMicrons: 4.0, fRatio: 5.0,
+            focuserSizeMicrons: 1.0, finalFocusPosition: 0.0, tiltEffectMicrons: 0.0,
+            curvatureEffectMicrons: 0.0, autoFocusOffset: 0.0, tiltPlaneModel: null,
+            sensorModel: paraboloid);
+
+        return (bundle, vm);
+    }
+
+    private static TiltAdapterGuidanceVM RebuildAtFocuserSetting(MediatorBundle bundle, InspectorVM vm, bool increasesTowardObjective) {
+        bundle.InspectorOptions.FocuserIncreasesTowardObjective.Returns(increasesTowardObjective);
+        bundle.InspectorOptions.PropertyChanged += Raise.Event<PropertyChangedEventHandler>(
+            bundle.InspectorOptions, new PropertyChangedEventArgs(nameof(IInspectorOptions.FocuserIncreasesTowardObjective)));
+        return vm.TiltGuidance;
+    }
+
+    [Test]
+    public void TiltGuidance_FocuserDirectionToggle_FlipsMotionArrowsAndNothingElse() {
+        var (bundle, vm) = BuildGuidanceFixture();
+
+        var standard = RebuildAtFocuserSetting(bundle, vm, increasesTowardObjective: false);
+        var standardTiltArrow = standard.Screw1TiltArrow;
+        var standardBackfocusArrow = standard.Screw1BackfocusArrow;
+        var standardTiltAmount = standard.Screw1TiltAmount;
+        var standardBackfocusAmount = standard.Screw1BackfocusAmount;
+        var standardTotal = standard.Screw1TotalAmount;
+        var standardLegend = standard.DirectionLegend;
+
+        var reversed = RebuildAtFocuserSetting(bundle, vm, increasesTowardObjective: true);
+
+        Assert.Multiple(() => {
+            Assert.That(standard.HasTiltGuidance, Is.True, "precondition: tilt arrow row rendered");
+            Assert.That(standard.HasBackfocusRow, Is.True, "precondition: backfocus arrow row rendered");
+            Assert.That(standard.HasNumericGuidance, Is.True, "precondition: numeric rows rendered");
+
+            // At the default k = +1 the guidance is bit-identical to what it rendered before the setting
+            // existed: screw 1 needs a CW turn, which on a σ = +1 rig moves it toward the camera.
+            Assert.That(standardTiltArrow, Is.EqualTo("⬇"));
+            Assert.That(standardBackfocusArrow, Is.EqualTo("⬆"));
+
+            // ARROWS FLIP — they are the only part of the panel that claims a physical direction.
+            Assert.That(reversed.Screw1TiltArrow, Is.EqualTo("⬆"), "tilt motion arrow flips with k");
+            Assert.That(reversed.Screw1BackfocusArrow, Is.EqualTo("⬇"), "backfocus motion arrow flips with k");
+
+            // EVERYTHING COMPUTED IS IDENTICAL. If any of these ever fail, k has leaked into the math.
+            Assert.That(reversed.Screw1TiltAmount, Is.EqualTo(standardTiltAmount), "tilt rotation glyph + amount are k-free");
+            Assert.That(reversed.Screw2TiltAmount, Is.EqualTo(standard.Screw2TiltAmount));
+            Assert.That(reversed.Screw3TiltAmount, Is.EqualTo(standard.Screw3TiltAmount));
+            Assert.That(reversed.Screw1BackfocusAmount, Is.EqualTo(standardBackfocusAmount), "backfocus rotation glyph + amount are k-free");
+            Assert.That(reversed.Screw1TotalAmount, Is.EqualTo(standardTotal), "signed totals are k-free");
+            Assert.That(reversed.Screw2TotalAmount, Is.EqualTo(standard.Screw2TotalAmount));
+            Assert.That(reversed.Screw3TotalAmount, Is.EqualTo(standard.Screw3TotalAmount));
+
+            // The legend DEFINES what ⬆ means, so its text is fixed; only the selection of ⬆ vs ⬇ moves.
+            Assert.That(reversed.DirectionLegend, Is.EqualTo(standardLegend), "legend text is a definition, not a claim about this rig");
+        });
+    }
+
+    [Test]
+    public void BackfocusDirection_FollowsTheFocuserSetting_WithoutTouchingTheDelta() {
+        var bundle = new MediatorBundle();
+        bundle.InspectorOptions.MicronsPerFocuserStep.Returns(-1.0);
+        var vm = bundle.BuildInspectorVM();
+
+        // Outer regions focusing above the centre. On a standard focuser that means the sensor sits too far
+        // from the flattener, so the advice is to move it TOWARDS; on a reversed focuser the same z-space
+        // measurement is the opposite physical situation.
+        vm.SetBackfocusMeasurementForTest(inner: 5000.0, outer: 5100.0);
+        var standardDirection = vm.BackfocusDirection;
+        var standardDelta = vm.BackfocusFocuserPositionDelta;
+
+        bundle.InspectorOptions.FocuserIncreasesTowardObjective.Returns(true);
+        bundle.InspectorOptions.PropertyChanged += Raise.Event<PropertyChangedEventHandler>(
+            bundle.InspectorOptions, new PropertyChangedEventArgs(nameof(IInspectorOptions.FocuserIncreasesTowardObjective)));
+
+        Assert.Multiple(() => {
+            Assert.That(standardDirection, Is.EqualTo("TOWARDS"), "default k reproduces the previous unconditional test");
+            Assert.That(vm.BackfocusDirection, Is.EqualTo("AWAY FROM"), "the word flips with k");
+            Assert.That(vm.BackfocusFocuserPositionDelta, Is.EqualTo(standardDelta),
+                "the measured delta is z-space and must not move");
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMFocuserStepSizeTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMFocuserStepSizeTests.cs
@@ -1,0 +1,116 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Equipment.Equipment.MyFocuser;
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NINA.Profile.Interfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus;
+
+/// <summary>
+/// InspectorVM is the single writer of the driver-reported focuser step size — it is the plugin's registered
+/// focuser consumer, and a Shared MEF singleton. See docs/focuser-step-size-driver-design.md §2.
+/// </summary>
+[TestFixture]
+[Apartment(System.Threading.ApartmentState.STA)]
+public class InspectorVMFocuserStepSizeTests {
+
+    // A real InspectorOptions rather than a substitute: the whole point of these tests is the setter's
+    // accept-only-valid guard, which a substitute would replace with a plain auto-property.
+    private static (MediatorBundle bundle, InspectorVM vm, InspectorOptions options) Build() {
+        var bundle = new MediatorBundle();
+        var options = new InspectorOptions(Substitute.For<IProfileService>(), new InMemoryPluginOptionsAccessor());
+        var vm = bundle.BuildInspectorVM(inspectorOptions: options);
+        return (bundle, vm, options);
+    }
+
+    [Test]
+    public void UpdateDeviceInfo_PublishesAUsableDriverStepSize() {
+        var (_, vm, options) = Build();
+
+        vm.UpdateDeviceInfo(new FocuserInfo { Connected = true, Position = 5000, StepSize = 3.5 });
+
+        Assert.Multiple(() => {
+            Assert.That(options.DriverMicronsPerFocuserStep, Is.EqualTo(3.5));
+            Assert.That(options.EffectiveMicronsPerFocuserStep, Is.EqualTo(3.5),
+                "with no override, the driver's value is what everything computes with");
+        });
+    }
+
+    [Test]
+    public void UpdateDeviceInfo_DisconnectDoesNotClearTheStepSize() {
+        // A disconnected focuser reports StepSize = 0. Dropping that write is what keeps an in-flight
+        // analysis from being silently rescaled when the focuser drops off the bus.
+        var (_, vm, options) = Build();
+        vm.UpdateDeviceInfo(new FocuserInfo { Connected = true, StepSize = 3.5 });
+
+        vm.UpdateDeviceInfo(new FocuserInfo { Connected = false, StepSize = 0.0 });
+
+        Assert.Multiple(() => {
+            Assert.That(options.EffectiveMicronsPerFocuserStep, Is.EqualTo(3.5));
+            Assert.That(vm.FocuserInfo.Connected, Is.False, "the disconnect itself still lands");
+        });
+    }
+
+    [Test]
+    public void UpdateDeviceInfo_DriverThatDoesNotImplementStepSize_LeavesTheInspectorUncalibrated() {
+        var (_, vm, options) = Build();
+
+        vm.UpdateDeviceInfo(new FocuserInfo { Connected = true, StepSize = 0.0 });
+
+        Assert.That(options.EffectiveMicronsPerFocuserStep, Is.EqualTo(-1.0),
+            "unset must stay unset — never a fabricated number");
+    }
+
+    [Test]
+    public void BackfocusDelta_UsesTheDriverStepSize_WhenThereIsNoOverride() {
+        // The end-to-end statement: a driver-supplied step size reaches a reported micron value with no user
+        // input at all, which is the point of the whole change.
+        var (_, vm, options) = Build();
+        vm.UpdateDeviceInfo(new FocuserInfo { Connected = true, StepSize = 2.0 });
+
+        vm.SetBackfocusMeasurementForTest(inner: 5000.0, outer: 5100.0);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.BackfocusFocuserPositionDelta, Is.EqualTo(100.0));
+            Assert.That(vm.BackfocusMicronDelta, Is.EqualTo(200.0), "100 steps x 2 µm/step");
+
+            // And the override still wins over it.
+            options.MicronsPerFocuserStep = 1.0;
+            vm.SetBackfocusMeasurementForTest(inner: 5000.0, outer: 5100.0);
+            Assert.That(vm.BackfocusMicronDelta, Is.EqualTo(100.0), "the override supersedes the driver");
+        });
+    }
+
+    [Test]
+    public void MismatchFlag_FiresOnlyWhenAnOverrideContradictsAValidDriverValue() {
+        var (_, vm, options) = Build();
+
+        Assert.Multiple(() => {
+            vm.UpdateDeviceInfo(new FocuserInfo { Connected = true, StepSize = 1.0 });
+            Assert.That(options.HasFocuserStepSizeMismatch, Is.False, "no override yet");
+
+            options.MicronsPerFocuserStep = 1.005;
+            Assert.That(options.HasFocuserStepSizeMismatch, Is.False,
+                "a calibration landing near the driver's round number must not nag");
+
+            // The failure this exists to catch: a driver reporting steps rather than microns.
+            options.MicronsPerFocuserStep = 3.6;
+            Assert.That(options.HasFocuserStepSizeMismatch, Is.True);
+            Assert.That(options.EffectiveMicronsPerFocuserStep, Is.EqualTo(3.6),
+                "advisory only — the override still wins");
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/SimulatedTiltAdapterVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/SimulatedTiltAdapterVMTests.cs
@@ -206,6 +206,29 @@ public class SimulatedTiltAdapterVMTests {
         });
     }
 
+    /// <summary>
+    /// The ABSOLUTE direction of the simulator's mean-focus shift — the pin that was missing while only the
+    /// antisymmetry below was asserted, which is exactly why the simulator could be built to satisfy an inverted
+    /// measurement without any test noticing.
+    ///
+    /// On a σ=+1 rig a CW/+ turn of every screw drives the plate toward the camera, increasing the sensor's
+    /// objective-distance, so best focus is reached at a LOWER focuser position
+    /// (docs/focuser-direction-convention-design.md §1(a)/(c)). This is what makes a simulated 6-step wizard run
+    /// measure σ correctly post-fix: the run's all-inward step reads a mean-focus DROP and
+    /// TiltCalibrationCalculator.ComputeCurvatureSign turns that back into σ = +1 = the configured rig.
+    /// </summary>
+    [Test]
+    public void BackfocusMove_CwOnPositiveRig_LowersOptimalFocuserPosition() {
+        var options = Configured(screwCount: 4, curvatureSign: +1);
+        options.OptimalFocuserPosition = 5000;
+
+        var vm = new SimulatedTiltAdapterVM(options, realAdapterOptions: null) { MovementMode = SimTiltMovementMode.Backfocus, AmountPerClick = 0.5 };
+        vm.TurnCommand.Execute(new ScrewTurn(0, +1)); // ⟳ on all four
+
+        Assert.That(options.OptimalFocuserPosition, Is.LessThan(5000),
+            "an all-screws CW turn on a σ=+1 rig moves the plate toward the camera, which LOWERS best focus");
+    }
+
     /// <summary>The focuser shift is the same piston, so it carries the same sign asymmetry.</summary>
     [Test]
     public void BackfocusMove_OnOppositeRigs_ShiftsTheFocuserInOppositeDirections() {
@@ -601,6 +624,8 @@ public class SimulatedTiltAdapterVMTests {
 
     [Test]
     public void FourScrewAngles_DeriveTheOppositePairAt180Degrees() {
+        // Configured() defaults to σ = +1, i.e. m = +1, so the image-space readout sits 180° from the
+        // stored response-convention angle (TiltScrewGeometry.PhysicalToStoredAngle).
         var options = Configured(screwCount: 4);
         var vm = new SimulatedTiltAdapterVM(options, realAdapterOptions: null);
 
@@ -610,7 +635,7 @@ public class SimulatedTiltAdapterVMTests {
         Assert.Multiple(() => {
             Assert.That(options.SimScrew3AngleDegrees, Is.EqualTo(190.0).Within(1e-9));
             Assert.That(options.SimScrew4AngleDegrees, Is.EqualTo(280.0).Within(1e-9));
-            Assert.That(vm.Screw3AngleDisplay, Is.EqualTo("190.0°"));
+            Assert.That(vm.Screw3AngleDisplay, Is.EqualTo("10.0°"));
         });
     }
 
@@ -839,18 +864,20 @@ public class SimulatedTiltAdapterVMTests {
         });
     }
 
-    // ---- Image-space (physical) angle display on −1 rigs -----------------------------------------------
+    // ---- Image-space (physical) angle display on m = +1 rigs -------------------------------------------
     //
     // SimScrew{N}AngleDegrees are RESPONSE-convention (SimulatedTiltAdapter's contract), 180° from the
-    // physical image position on "CW moves adapter toward the objective" (−1) rigs. The Screw 1 input,
-    // the derived-angle readouts, and the diagram are all image-space, so they must convert — otherwise a
-    // screw physically at the top is drawn/reported at the bottom on −1 rigs. Mirrors the wizard fix
+    // physical image position on "CW moves adapter toward the camera" rigs — m = σ·sign(k) = +1, which at
+    // the simulator's implicit standard focuser is σ = +1. The Screw 1 input, the derived-angle readouts,
+    // and the diagram are all image-space, so they must convert — otherwise a screw physically at the top
+    // is drawn/reported at the bottom. Mirrors the wizard fix
     // (docs/tilt-wizard-diagram-orientation-design.md); SimScrew stays response-convention internally so
-    // the physics / coherence badge / copy-to-adapter are untouched.
+    // the physics / coherence badge / copy-to-adapter are untouched. Which σ carries the offset was
+    // corrected on 2026-08-04 (docs/focuser-direction-convention-design.md §7).
 
     [Test]
-    public void Screw1AngleInput_NegativeSign_RoundTripsPhysicalToResponseConvention() {
-        var options = Configured(screwCount: 3, curvatureSign: -1);
+    public void Screw1AngleInput_OffsetRig_RoundTripsPhysicalToResponseConvention() {
+        var options = Configured(screwCount: 3, curvatureSign: 1);
         var vm = new SimulatedTiltAdapterVM(options, realAdapterOptions: null);
 
         vm.Screw1AngleDegrees = 0.0; // physical: screw 1 at the top of the image
@@ -862,8 +889,8 @@ public class SimulatedTiltAdapterVMTests {
     }
 
     [Test]
-    public void Screw1AngleInput_PositiveSign_IsIdentity() {
-        var options = Configured(screwCount: 3, curvatureSign: 1);
+    public void Screw1AngleInput_NoOffsetRig_IsIdentity() {
+        var options = Configured(screwCount: 3, curvatureSign: -1);
         var vm = new SimulatedTiltAdapterVM(options, realAdapterOptions: null);
 
         vm.Screw1AngleDegrees = 30.0;
@@ -875,9 +902,9 @@ public class SimulatedTiltAdapterVMTests {
     }
 
     [Test]
-    public void DerivedAngleDisplays_NegativeSign_ShowPhysicalImageAngles() {
-        // Stored 0/120/240 (response) → physical 180/300/60 on a −1 rig.
-        var options = Configured(screwCount: 3, curvatureSign: -1);
+    public void DerivedAngleDisplays_OffsetRig_ShowPhysicalImageAngles() {
+        // Stored 0/120/240 (response) → physical 180/300/60 on an m = +1 rig.
+        var options = Configured(screwCount: 3, curvatureSign: 1);
         var vm = new SimulatedTiltAdapterVM(options, realAdapterOptions: null);
 
         Assert.Multiple(() => {
@@ -887,8 +914,8 @@ public class SimulatedTiltAdapterVMTests {
     }
 
     [Test]
-    public void DerivedAngleDisplays_PositiveSign_Unchanged() {
-        var options = Configured(screwCount: 3, curvatureSign: 1);
+    public void DerivedAngleDisplays_NoOffsetRig_Unchanged() {
+        var options = Configured(screwCount: 3, curvatureSign: -1);
         var vm = new SimulatedTiltAdapterVM(options, realAdapterOptions: null);
 
         Assert.Multiple(() => {
@@ -898,10 +925,10 @@ public class SimulatedTiltAdapterVMTests {
     }
 
     [Test]
-    public void Diagram_NegativeSign_DrawsStoredResponseAngleAtItsPhysicalPosition() {
-        // Stored screw 1 = 0° (response) is physically at 180° on a −1 rig → must draw at the BOTTOM
-        // (cy = 100 − 75·cos180 = 175 → Y = 163), not the top.
-        var options = Configured(screwCount: 3, curvatureSign: -1);
+    public void Diagram_OffsetRig_DrawsStoredResponseAngleAtItsPhysicalPosition() {
+        // Stored screw 1 = 0° (response) is physically at 180° on an m = +1 rig → must draw at the
+        // BOTTOM (cy = 100 − 75·cos180 = 175 → Y = 163), not the top.
+        var options = Configured(screwCount: 3, curvatureSign: 1);
         var vm = new SimulatedTiltAdapterVM(options, realAdapterOptions: null);
 
         var screw1 = vm.ScrewDiagramItems.Single(i => i.Number == 1);
@@ -913,13 +940,13 @@ public class SimulatedTiltAdapterVMTests {
 
     [Test]
     public void AngleDisplaysAndDiagram_AdapterDirectionChange_FlipToTheOppositeSide() {
-        // Built +1: stored 0/120/240 == physical; screw 1 at the top.
-        var options = Configured(screwCount: 3, curvatureSign: 1);
+        // Built on m = −1 (σ = −1): stored 0/120/240 == physical; screw 1 at the top.
+        var options = Configured(screwCount: 3, curvatureSign: -1);
         var vm = new SimulatedTiltAdapterVM(options, realAdapterOptions: null);
         Assert.That(vm.ScrewDiagramItems.Single(i => i.Number == 1).Y, Is.EqualTo(13.0).Within(0.5));
         Assert.That(vm.Screw2AngleDisplay, Is.EqualTo("120.0°"));
 
-        options.SimScrewInwardCurvatureSign = -1; // reinterpret 180° away
+        options.SimScrewInwardCurvatureSign = 1; // reinterpret 180° away
 
         Assert.Multiple(() => {
             Assert.That(vm.ScrewDiagramItems.Single(i => i.Number == 1).Y, Is.EqualTo(163.0).Within(0.5), "screw 1 flips to the bottom");

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
@@ -17,6 +17,12 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
         public double DetailedAnalysisExposureSeconds { get; set; }
         public bool LoopingExposureAnalysisEnabled { get; set; }
         public double MicronsPerFocuserStep { get; set; }
+        public double DriverMicronsPerFocuserStep { get; set; } = -1;
+        public double EffectiveMicronsPerFocuserStep =>
+            MicronsPerFocuserStep > 0 ? MicronsPerFocuserStep
+            : DriverMicronsPerFocuserStep > 0 ? DriverMicronsPerFocuserStep
+            : -1;
+        public bool HasFocuserStepSizeMismatch => false;
         public bool FocuserIncreasesTowardObjective { get; set; }
         public bool EccentricityColorMapEnabled { get; set; }
         public bool MouseOnChartsEnabled { get; set; }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/FakeSensorModelOptions.cs
@@ -17,6 +17,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
         public double DetailedAnalysisExposureSeconds { get; set; }
         public bool LoopingExposureAnalysisEnabled { get; set; }
         public double MicronsPerFocuserStep { get; set; }
+        public bool FocuserIncreasesTowardObjective { get; set; }
         public bool EccentricityColorMapEnabled { get; set; }
         public bool MouseOnChartsEnabled { get; set; }
         public bool SensorCurveModelEnabled { get; set; }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorModelAberrationResultFocuserDirectionTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorModelAberrationResultFocuserDirectionTests.cs
@@ -1,0 +1,94 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Inspection;
+using NUnit.Framework;
+using System.Linq;
+using DrawingSize = System.Drawing.Size;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection;
+
+/// <summary>
+/// The spacer advice is caption site 5 of docs/focuser-direction-convention-design.md §3: the only thing the
+/// display-only focuser convention k may change here is the REMOVING/ADDING word. The acceptable verdict and
+/// the reported curvature magnitude are pure z-space and must be identical either way.
+/// </summary>
+[TestFixture]
+public class SensorModelAberrationResultFocuserDirectionTests {
+
+    private static SensorModelAnalysisResult CurvatureRowFor(int focuserSign, double k) {
+        var result = new SensorModelAberrationResult();
+        // A 1000×1000 px sensor at 4 µm/px; k > 0 puts the outer field above the centre (E_z > 0).
+        var model = new SensorParaboloidModel(x0: 0, y0: 0, z0: 0, gx: 0, gy: 0, k: k);
+        result.Update(
+            sensorModel: model,
+            imageSize: new DrawingSize(1000, 1000),
+            pixelSizeMicrons: 4.0,
+            fRatio: 5.0,
+            focuserStepSizeMicrons: 1.0,
+            finalFocusPosition: 0.0,
+            registeredStars: [],
+            acceptableRSquaredMin: 0.05,
+            focuserSign: focuserSign);
+        return result.AnalysisResults.Single(r => r.Name == "Curvature");
+    }
+
+    [Test]
+    public void SpacerAdvice_FlipsWithTheFocuserDirection_ButTheVerdictDoesNot() {
+        var standard = CurvatureRowFor(focuserSign: +1, k: 1e-5);
+        var reversed = CurvatureRowFor(focuserSign: -1, k: 1e-5);
+
+        Assert.Multiple(() => {
+            // E_z > 0 on a standard focuser means the sensor sits too far from the flattener.
+            Assert.That(standard.Details, Does.Contain("REMOVING"));
+            Assert.That(standard.Details, Does.Not.Contain("ADDING"));
+            // The same z-space measurement is the opposite physical situation on a reversed focuser.
+            Assert.That(reversed.Details, Does.Contain("ADDING"));
+            Assert.That(reversed.Details, Does.Not.Contain("REMOVING"));
+
+            // Everything else about the row is k-free.
+            Assert.That(reversed.Value, Is.EqualTo(standard.Value), "the curvature radius is a fitted quantity");
+            Assert.That(reversed.Acceptable, Is.EqualTo(standard.Acceptable), "the verdict is a magnitude test");
+        });
+    }
+
+    [Test]
+    public void SpacerAdvice_DefaultsToTheStandardFocuser() {
+        // Omitting the parameter must be identical to the standard convention, so every existing caller
+        // renders exactly as it did before k existed.
+        var result = new SensorModelAberrationResult();
+        var model = new SensorParaboloidModel(x0: 0, y0: 0, z0: 0, gx: 0, gy: 0, k: 1e-5);
+        result.Update(
+            sensorModel: model,
+            imageSize: new DrawingSize(1000, 1000),
+            pixelSizeMicrons: 4.0,
+            fRatio: 5.0,
+            focuserStepSizeMicrons: 1.0,
+            finalFocusPosition: 0.0,
+            registeredStars: [],
+            acceptableRSquaredMin: 0.05);
+
+        Assert.That(result.AnalysisResults.Single(r => r.Name == "Curvature").Details,
+            Is.EqualTo(CurvatureRowFor(focuserSign: +1, k: 1e-5).Details));
+    }
+
+    [Test]
+    public void SpacerAdvice_NegativeCurvature_ReadsTheOtherWayRound() {
+        var standard = CurvatureRowFor(focuserSign: +1, k: -1e-5);
+        var reversed = CurvatureRowFor(focuserSign: -1, k: -1e-5);
+
+        Assert.Multiple(() => {
+            Assert.That(standard.Details, Does.Contain("ADDING"));
+            Assert.That(reversed.Details, Does.Contain("REMOVING"));
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TestDoubles/MediatorBundle.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TestDoubles/MediatorBundle.cs
@@ -87,11 +87,17 @@ internal sealed class MediatorBundle {
         return this;
     }
 
+    /// <param name="inspectorOptions">
+    /// Overrides the bundle's substitute. Pass a real <c>InspectorOptions</c> when the behaviour under test
+    /// lives in the options class itself (e.g. the focuser step-size resolver's accept-only-valid setter,
+    /// which a substitute would flatten into a plain auto-property).
+    /// </param>
     public InspectorVM BuildInspectorVM(
         TiltDeviceConnectionService tiltDeviceConnectionService = null,
         Func<string, string, Task<bool>> confirmPromptAsync = null,
         Func<Func<bool, bool, TiltDevicePlanPreview>, bool, string, bool, double, Task<TiltDeviceAdjustmentChoice>> showAdjustmentPromptAsync = null,
-        Func<CancellationToken, Task<bool>> reRunAnalysisAsync = null) {
+        Func<CancellationToken, Task<bool>> reRunAnalysisAsync = null,
+        IInspectorOptions inspectorOptions = null) {
         return new InspectorVM(
             profileService: ProfileService,
             applicationStatusMediator: ApplicationStatusMediator,
@@ -102,7 +108,7 @@ internal sealed class MediatorBundle {
             telescopeMediator: TelescopeMediator,
             starDetectionOptions: StarDetectionOptions,
             starAnnotatorOptions: StarAnnotatorOptions,
-            inspectorOptions: InspectorOptions,
+            inspectorOptions: inspectorOptions ?? InspectorOptions,
             autoFocusOptions: AutoFocusOptions,
             autoFocusEngineFactory: AutoFocusEngineFactory,
             imageDataFactory: ImageDataFactory,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/FocuserDirectionFirewallTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/FocuserDirectionFirewallTests.cs
@@ -1,0 +1,84 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter;
+using NINA.Joko.Plugins.HocusFocus.Inspection;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard;
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard;
+
+/// <summary>
+/// docs/focuser-direction-convention-design.md §2.2, structural enforcement mechanism 1 — stated as a test
+/// so it cannot erode quietly.
+///
+/// The display-only focuser convention k lives on IInspectorOptions. The pure math layer takes no options
+/// object and must gain no k parameter on any computing function; the camera simulator reads only
+/// ICameraSimulatorOptions. Any future attempt to thread k into one of those signatures fails here — which
+/// is the whole point, because the design's guarantee ("a wrong k gives wrong labels, never wrong motion")
+/// rests on it.
+/// </summary>
+[TestFixture]
+public class FocuserDirectionFirewallTests {
+
+    private static readonly Type[] MathLayerTypes = {
+        typeof(TiltCalibrationCalculator),
+        typeof(TiltScrewGeometry),
+        typeof(TiltScrewTargets),
+        typeof(SimulatedTiltInjection),
+        typeof(SimulatedTiltAdapter),
+    };
+
+    [TestCaseSource(nameof(MathLayerTypes))]
+    public void MathLayer_TakesNoInspectorOptions(Type type) {
+        var offenders = type
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => m.GetParameters().Any(p => typeof(IInspectorOptions).IsAssignableFrom(p.ParameterType)))
+            .Select(m => m.Name)
+            .ToArray();
+
+        Assert.That(offenders, Is.Empty,
+            $"{type.Name} must not accept IInspectorOptions — the display-only focuser setting k lives there, " +
+            "and the math layer is the one place it must never reach. Compose σ·sign(k) at the presentation " +
+            "call site instead (design §2.2).");
+    }
+
+    [Test]
+    public void PlannerTargetComputation_TakesOnlyTheModelAndTheAdapterOptions() {
+        // Automation's target computation. It reads the fitted model and the adapter's own options and
+        // nothing else, so there is no parameter through which k could reach a planned move. Widening this
+        // signature is exactly the change the design forbids.
+        var method = typeof(InspectorVM).GetMethod(
+            nameof(InspectorVM.BuildPerScrewTargets), BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.That(method, Is.Not.Null, "BuildPerScrewTargets moved or was renamed — re-point this guard at it");
+        Assert.That(method.GetParameters().Select(p => p.ParameterType).ToArray(),
+            Is.EqualTo(new[] { typeof(SensorParaboloidModel), typeof(ITiltAdapterOptions) }));
+    }
+
+    [Test]
+    public void SimulatedTiltInjection_FoldTakesOnlyTheSimulatorOptionsAndTheDelta() {
+        // The simulator is on the math side of the wall (design §4): the focuser convention cancels out of
+        // both responses it folds, so it must not gain a knob.
+        var method = typeof(SimulatedTiltInjection).GetMethod(
+            nameof(SimulatedTiltInjection.Fold), BindingFlags.Public | BindingFlags.Static);
+
+        Assert.That(method, Is.Not.Null);
+        Assert.That(method.GetParameters().Select(p => p.ParameterType).ToArray(),
+            Is.EqualTo(new[] { typeof(ICameraSimulatorOptions), typeof(AberrationDelta), typeof(int) }));
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs
@@ -180,6 +180,81 @@ public class TiltAdapterOptionsTests {
         Assert.That(raised, Does.Contain(propertyName));
     }
 
+    // ---- One-time migration of measured curvature signs ------------------------------------------------
+    //
+    // Every ScrewInwardCurvatureSign a 6-step calibration wrote before 2026-08-04 came from an inverted
+    // ComputeCurvatureSign, so measured values are deterministically negated on load — exactly once per
+    // profile, guarded by a persisted marker (docs/focuser-direction-convention-design.md §5).
+
+    private const string MigratedKey = "CurvatureSignMeasurementMigrated";
+
+    [Test]
+    public void Migration_NegatesAMeasuredSignOnce_AndSetsTheMarker() {
+        var store = new InMemoryPluginOptionsAccessor();
+        store.SetValueInt32(nameof(TiltAdapterOptions.ScrewInwardCurvatureSign), 1);
+        store.SetValueBoolean(nameof(TiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured), true);
+
+        var options = new TiltAdapterOptions(Substitute.For<IProfileService>(), store);
+
+        Assert.Multiple(() => {
+            Assert.That(options.ScrewInwardCurvatureSign, Is.EqualTo(-1), "measured +1 loads as −1");
+            Assert.That(store.GetValueInt32(nameof(TiltAdapterOptions.ScrewInwardCurvatureSign), 0), Is.EqualTo(-1),
+                "and the correction is persisted, not just held in memory");
+            Assert.That(store.GetValueBoolean(MigratedKey, false), Is.True);
+            Assert.That(options.ScrewInwardCurvatureSignIsMeasured, Is.True, "provenance is preserved");
+        });
+
+        // A second construction over the same store must NOT negate again.
+        var reloaded = new TiltAdapterOptions(Substitute.For<IProfileService>(), store);
+        Assert.That(reloaded.ScrewInwardCurvatureSign, Is.EqualTo(-1), "the marker makes it idempotent");
+    }
+
+    [Test]
+    public void Migration_RunsOnlyOnceAcrossAProfileChange() {
+        var profile = Substitute.For<IProfileService>();
+        var store = new InMemoryPluginOptionsAccessor();
+        store.SetValueInt32(nameof(TiltAdapterOptions.ScrewInwardCurvatureSign), -1);
+        store.SetValueBoolean(nameof(TiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured), true);
+
+        var options = new TiltAdapterOptions(profile, store);
+        Assert.That(options.ScrewInwardCurvatureSign, Is.EqualTo(1), "precondition: migrated on construction");
+
+        // ProfileChanged re-runs InitializeOptions; the marker in the (same) store must suppress it.
+        profile.ProfileChanged += Raise.Event<EventHandler>(profile, EventArgs.Empty);
+
+        Assert.That(options.ScrewInwardCurvatureSign, Is.EqualTo(1), "a profile change must not negate again");
+    }
+
+    [Test]
+    public void Migration_LeavesAnUnmeasuredSignAlone_ButStillSetsTheMarker() {
+        var store = new InMemoryPluginOptionsAccessor();
+        store.SetValueInt32(nameof(TiltAdapterOptions.ScrewInwardCurvatureSign), 1);
+        store.SetValueBoolean(nameof(TiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured), false);
+
+        var options = new TiltAdapterOptions(Substitute.For<IProfileService>(), store);
+
+        Assert.Multiple(() => {
+            // Assumed or hand-set by the wizard's direction combo (which clears IsMeasured) — the user's
+            // value, never the buggy formula's.
+            Assert.That(options.ScrewInwardCurvatureSign, Is.EqualTo(1));
+            Assert.That(store.GetValueBoolean(MigratedKey, false), Is.True, "the marker is set regardless");
+        });
+    }
+
+    [Test]
+    public void Migration_LeavesAZeroSignAlone() {
+        var store = new InMemoryPluginOptionsAccessor();
+        store.SetValueInt32(nameof(TiltAdapterOptions.ScrewInwardCurvatureSign), 0);
+        store.SetValueBoolean(nameof(TiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured), true);
+
+        var options = new TiltAdapterOptions(Substitute.For<IProfileService>(), store);
+
+        Assert.Multiple(() => {
+            Assert.That(options.ScrewInwardCurvatureSign, Is.EqualTo(0), "negating the unset sentinel would be a no-op anyway");
+            Assert.That(store.GetValueBoolean(MigratedKey, false), Is.True);
+        });
+    }
+
     [Test]
     public void AngleDisplayUnit_DefaultsToTurns() {
         var (options, _, _) = Build();

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -692,11 +692,13 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         }
 
         [Test]
-        public void ApplyManualCalibration_WritesCalibrationState_PositiveSignStoresPhysicalAngles() {
-            // On +1 rigs the stored response-convention angles coincide with the physical angles the
-            // user typed, so 30° places the clockwise-numbered screws at 30/150/270.
+        public void ApplyManualCalibration_WritesCalibrationState_CwTowardObjectiveStoresPhysicalAngles() {
+            // σ = −1 at the standard focuser is m = −1 — a CW turn drives the plate toward the
+            // objective, RAISING best focus at that screw, so the response direction points along the
+            // screw and the stored angles coincide with the physical angles the user typed: 30° places
+            // the clockwise-numbered screws at 30/150/270.
             var (vm, options, _, _) = Build(screwCount: 3);
-            options.ScrewInwardCurvatureSign.Returns(1);
+            options.ScrewInwardCurvatureSign.Returns(-1);
             vm.ManualScrew1AngleDegrees = 30;
             vm.ManualNumberingClockwise = true;
 
@@ -719,13 +721,14 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         }
 
         [Test]
-        public void ApplyManualCalibration_NegativeSign_ConvertsPhysicalToResponseConvention() {
-            // On −1 rigs a CW turn drives the tilt gradient opposite the physical screw direction, so
-            // the stored (response-convention) angles are the typed physical angle + 180°: wizard runs
+        public void ApplyManualCalibration_CwTowardCamera_ConvertsPhysicalToResponseConvention() {
+            // σ = +1 at the standard focuser is m = +1 — a CW turn drives the plate toward the camera,
+            // LOWERING best focus at that screw, so the tilt gradient responds opposite the physical
+            // screw direction and the stored angles are the typed physical angle + 180°. Wizard runs
             // persist response-convention angles and the guidance math consumes them, so a manual
             // entry must convert or its arrows would invert on these rigs.
             var (vm, options, _, _) = Build(screwCount: 3);
-            options.ScrewInwardCurvatureSign.Returns(-1);
+            options.ScrewInwardCurvatureSign.Returns(1);
             vm.ManualScrew1AngleDegrees = 30;
             vm.ManualNumberingClockwise = true;
 
@@ -769,7 +772,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         // ---- Screw-angle display shows the PHYSICAL image position (readout + wizard diagram) --------------
         //
         // The persisted Screw{N}AngleDegrees are RESPONSE-convention angles (physical + 180° on
-        // "CW moves adapter toward the objective" / −1 rigs). Both the calibration readout and the
+        // "CW moves adapter toward the camera" rigs — m = σ·sign(k) = +1). Both the calibration readout and the
         // wizard diagram are labelled image-space ("0° points up; image as shown in NINA"), and must
         // therefore display the PHYSICAL angle — matching the Manual Calibration Entry field — not the
         // raw stored value. Regression guard for docs/tilt-wizard-diagram-orientation-design.md.
@@ -789,11 +792,12 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         }
 
         [Test]
-        public void RebuildDiagram_NegativeSign_PlacesPhysicalTopScrewAtCanvasTop() {
-            // −1 rig: screw 1 is physically at the TOP (physical 0°), stored as 0+180 = 180°. The
-            // diagram must draw it at canvas-top (cy = 100 − 75·cos0 = 25 → Y = 25 − 12 = 13), NOT at
-            // the bottom (the raw-stored 180° would give cy = 175). Screws 2/3 are physically 120/240.
-            var (vm, _) = BuildCalibrated(sign: -1, s1: 180, s2: 300, s3: 60);
+        public void RebuildDiagram_OffsetRig_PlacesPhysicalTopScrewAtCanvasTop() {
+            // m = +1 rig (σ = +1 at the standard focuser): screw 1 is physically at the TOP (physical
+            // 0°), stored as 0+180 = 180°. The diagram must draw it at canvas-top (cy = 100 − 75·cos0
+            // = 25 → Y = 25 − 12 = 13), NOT at the bottom (the raw-stored 180° would give cy = 175).
+            // Screws 2/3 are physically 120/240.
+            var (vm, _) = BuildCalibrated(sign: 1, s1: 180, s2: 300, s3: 60);
 
             var screw1 = vm.ScrewDiagramItems.Single(i => i.Number == 1);
             Assert.Multiple(() => {
@@ -804,10 +808,11 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         }
 
         [Test]
-        public void RebuildDiagram_PositiveSign_PlacesScrewsAtStoredAngles() {
-            // +1 rig: stored == physical, so the diagram is unchanged. Screw 1 stored 90° → right edge
-            // (cx = 175, cy = 100 → X = 163, Y = 88). Guards against a double 180° offset.
-            var (vm, _) = BuildCalibrated(sign: 1, s1: 90, s2: 210, s3: 330);
+        public void RebuildDiagram_NoOffsetRig_PlacesScrewsAtStoredAngles() {
+            // m = −1 rig (σ = −1 at the standard focuser): stored == physical, so the diagram plots the
+            // stored angles directly. Screw 1 stored 90° → right edge (cx = 175, cy = 100 → X = 163,
+            // Y = 88). Guards against a double 180° offset.
+            var (vm, _) = BuildCalibrated(sign: -1, s1: 90, s2: 210, s3: 330);
 
             var screw1 = vm.ScrewDiagramItems.Single(i => i.Number == 1);
             Assert.Multiple(() => {
@@ -818,9 +823,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         }
 
         [Test]
-        public void PhysicalScrewAngles_NegativeSign_ConvertStoredResponseAnglesToPhysical() {
-            // Readout binds these; on a −1 rig they must be the stored angle − 180° (self-inverse).
-            var (vm, _) = BuildCalibrated(sign: -1, s1: 180, s2: 300, s3: 60);
+        public void PhysicalScrewAngles_OffsetRig_ConvertStoredResponseAnglesToPhysical() {
+            // Readout binds these; on an m = +1 rig they must be the stored angle − 180° (self-inverse).
+            var (vm, _) = BuildCalibrated(sign: 1, s1: 180, s2: 300, s3: 60);
 
             Assert.Multiple(() => {
                 Assert.That(vm.PhysicalScrew1AngleDegrees, Is.EqualTo(0.0).Within(1e-9));
@@ -830,8 +835,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         }
 
         [Test]
-        public void PhysicalScrewAngles_PositiveSign_EqualStoredAngles() {
-            var (vm, _) = BuildCalibrated(sign: 1, s1: 90, s2: 210, s3: 330);
+        public void PhysicalScrewAngles_NoOffsetRig_EqualStoredAngles() {
+            var (vm, _) = BuildCalibrated(sign: -1, s1: 90, s2: 210, s3: 330);
 
             Assert.Multiple(() => {
                 Assert.That(vm.PhysicalScrew1AngleDegrees, Is.EqualTo(90.0).Within(1e-9));
@@ -844,20 +849,20 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         public void ScrewInwardCurvatureSignChange_RefreshesPhysicalAnglesAndDiagram() {
             // Changing the adapter-direction setting flips the physical interpretation by 180°, so both
             // the readout properties and the diagram must refresh when ScrewInwardCurvatureSign changes.
-            var (vm, options) = BuildCalibrated(sign: 1, s1: 0, s2: 120, s3: 240);
-            // Built on +1: screw 1 (stored 0° = physical top) starts at canvas-top.
+            var (vm, options) = BuildCalibrated(sign: -1, s1: 0, s2: 120, s3: 240);
+            // Built on m = −1 (no offset): screw 1 (stored 0° = physical top) starts at canvas-top.
             Assert.That(vm.ScrewDiagramItems.Single(i => i.Number == 1).Y, Is.EqualTo(13.0).Within(0.5));
 
             var raised = new System.Collections.Generic.List<string>();
             vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
-            options.ScrewInwardCurvatureSign.Returns(-1);
+            options.ScrewInwardCurvatureSign.Returns(1);
             options.PropertyChanged += Raise.Event<System.ComponentModel.PropertyChangedEventHandler>(
                 options, new System.ComponentModel.PropertyChangedEventArgs(nameof(ITiltAdapterOptions.ScrewInwardCurvatureSign)));
 
             Assert.Multiple(() => {
                 Assert.That(raised, Does.Contain(nameof(TiltAdapterWizardVM.PhysicalScrew1AngleDegrees)));
                 Assert.That(raised, Does.Contain(nameof(TiltAdapterWizardVM.PhysicalScrew2AngleDegrees)));
-                // Now interpreted as a −1 rig: physical = 0 + 180 = 180° → screw 1 moves to the bottom.
+                // Now interpreted as an m = +1 rig: physical = 0 + 180 = 180° → screw 1 moves to the bottom.
                 Assert.That(vm.ScrewDiagramItems.Single(i => i.Number == 1).Y, Is.EqualTo(163.0).Within(0.5));
             });
         }
@@ -936,17 +941,17 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         public void Constructor_PrefillsManualAngleAsPhysical() {
             // Stored calibration angles are response-convention; the manual-entry field holds the
             // PHYSICAL image angle, so the pre-fill must convert back (the conversion is self-inverse).
-            var (vmNeg, _, _, _) = Build(screwCount: 3, configureOptions: o => {
+            var (vmOffset, _, _, _) = Build(screwCount: 3, configureOptions: o => {
                 o.Screw1AngleDegrees.Returns(210.0);
-                o.ScrewInwardCurvatureSign.Returns(-1);
+                o.ScrewInwardCurvatureSign.Returns(1); // m = +1 ⇒ 180° offset
             });
-            Assert.That(vmNeg.ManualScrew1AngleDegrees, Is.EqualTo(30).Within(1e-9));
+            Assert.That(vmOffset.ManualScrew1AngleDegrees, Is.EqualTo(30).Within(1e-9));
 
-            var (vmPos, _, _, _) = Build(screwCount: 3, configureOptions: o => {
+            var (vmNoOffset, _, _, _) = Build(screwCount: 3, configureOptions: o => {
                 o.Screw1AngleDegrees.Returns(210.0);
-                o.ScrewInwardCurvatureSign.Returns(1);
+                o.ScrewInwardCurvatureSign.Returns(-1); // m = −1 ⇒ identity
             });
-            Assert.That(vmPos.ManualScrew1AngleDegrees, Is.EqualTo(210).Within(1e-9));
+            Assert.That(vmNoOffset.ManualScrew1AngleDegrees, Is.EqualTo(210).Within(1e-9));
         }
 
         [Test]
@@ -1044,7 +1049,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             var store = new InMemoryPluginOptionsAccessor();
             var options = new TiltAdapterOptions(profileService, store);
             // Old profile: measured "CW moves the adapter toward the objective" (stored sign −1 per the empirical
-            // anchor) with a calibrated screw 1 at stored angle 210° (physical 30° on a −1 rig).
+            // anchor) with a calibrated screw 1 at stored angle 210°. m = σ·sign(k) = −1 takes no offset, so the
+            // physical angle is 210° too.
             options.ScrewInwardCurvatureSign = -1;
             options.ScrewInwardCurvatureSignIsMeasured = true;
             options.Screw1AngleDegrees = 210.0;
@@ -1061,7 +1067,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 tiltAdapterOptions: options);
             Assert.Multiple(() => {
                 Assert.That(vm.CwMovesAdapterTowardObjective, Is.True, "precondition: old profile's direction");
-                Assert.That(vm.ManualScrew1AngleDegrees, Is.EqualTo(30).Within(1e-9), "precondition: ctor pre-fill");
+                Assert.That(vm.ManualScrew1AngleDegrees, Is.EqualTo(210).Within(1e-9), "precondition: ctor pre-fill");
             });
 
             // The new profile stores the opposite (assumed) direction and a different screw-1 angle.
@@ -1084,8 +1090,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 Assert.That(raised, Does.Contain(nameof(vm.IsCalibrationValid)));
                 Assert.That(raised, Does.Contain(nameof(vm.StepInstructions)));
                 Assert.That(raised, Does.Contain(nameof(vm.BaselineRecoveryInstructions)));
-                // The manual pre-fill re-runs against the new profile: sign +1 stores physical angles unchanged.
-                Assert.That(vm.ManualScrew1AngleDegrees, Is.EqualTo(90).Within(1e-9));
+                // The manual pre-fill re-runs against the new profile: sign +1 is m = +1, so stored 90° is
+                // physical 270°.
+                Assert.That(vm.ManualScrew1AngleDegrees, Is.EqualTo(270).Within(1e-9));
                 Assert.That(raised, Does.Contain(nameof(vm.ManualScrew1AngleDegrees)));
             });
         }
@@ -1166,7 +1173,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             var (vm, options, _, _) = Build(configureOptions: o => o.MeasureCurvatureDuringCalibration.Returns(true));
             vm.StartCommand.Execute(null);
 
-            // AllInward mean focus (990) below baseline (1000) => ComputeCurvatureSign(990, 1000) = −1.
+            // AllInward mean focus (990) below baseline (1000) => ComputeCurvatureSign(990, 1000) = +1:
+            // an all-screws-CW step that LOWERS the mean best focus is σ = +1
+            // (docs/focuser-direction-convention-design.md §1(c)).
             vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0);
             vm.SeedStepReading(WizardStep.AllInward, 0.0, 0.0, 990.0);
             vm.SeedStepReading(WizardStep.ReBaseline1, 0.0, 0.0, 1000.0);
@@ -1181,7 +1190,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
 
             Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Complete));
             Assert.Multiple(() => {
-                options.Received().ScrewInwardCurvatureSign = -1;
+                options.Received().ScrewInwardCurvatureSign = 1;
                 options.Received().ScrewInwardCurvatureSignIsMeasured = true;
                 options.Received().IsCalibrated = true;
             });

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -2677,6 +2677,101 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             options.DidNotReceive().MeasureCurvatureDuringCalibration = Arg.Any<bool>();
         }
 
+        // ---- Warning-only curvature-channel cross-check (design §2.4) --------------------------------------
+        //
+        // σ is measured from the mean best-focus change (geometric channel). The curvature effect responds to
+        // the same piston and σ is DEFINED as the sign of that response, so the two are now independent
+        // measurements of one quantity. A large, contradicting curvature change is worth surfacing — but only
+        // as information: the optical channel is usually drift-buried and must never veto the robust one, nor
+        // change the stored sign.
+
+        // Seeds a 6-step run whose mean-focus channel always measures σ = +1 (all-inward mean 990 < baseline
+        // 1000), with the curvature effect at screw radius supplied per step so the cross-check has a signal
+        // and a drift scale to compare it against.
+        private static (TiltAdapterWizardVM vm, ITiltAdapterOptions options) RunSixStepWithCurvature(
+                double baselineE, double allInwardE, double reBaseline1E, double reBaseline2E) {
+            var (vm, options, _, _) = Build(configureOptions: o => o.MeasureCurvatureDuringCalibration.Returns(true));
+            vm.StartCommand.Execute(null);
+
+            vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0, baselineE);
+            vm.SeedStepReading(WizardStep.AllInward, 0.0, 0.0, 990.0, allInwardE);
+            vm.SeedStepReading(WizardStep.ReBaseline1, 0.0, 0.0, 1000.0, reBaseline1E);
+            vm.SeedStepReading(WizardStep.Screw1, 0.5, 0.0, 1000.0, reBaseline1E);
+            vm.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 1000.0, reBaseline2E);
+            vm.SeedStepReading(WizardStep.Screw2, -0.25, 0.433, 1000.0, reBaseline2E);
+
+            for (int i = 0; i < 6; i++) {
+                vm.NextStep();
+            }
+            return (vm, options);
+        }
+
+        [Test]
+        public void CurvatureCrossCheck_ChannelsAgree_NoWarning() {
+            // σ = +1 from the mean-focus channel; the curvature effect rose by +100 µm on the same step, which
+            // is what σ = +1 means by definition. Nothing to report.
+            var (vm, _) = RunSixStepWithCurvature(baselineE: -400, allInwardE: -300, reBaseline1E: -395, reBaseline2E: -390);
+
+            Assert.Multiple(() => {
+                Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Complete));
+                Assert.That(vm.HasConfidenceWarning, Is.False);
+                Assert.That(vm.ConfidenceWarningText, Is.Empty);
+            });
+        }
+
+        [Test]
+        public void CurvatureCrossCheck_ContradictingButWithinDrift_NoWarning() {
+            // The curvature effect moved the "wrong" way, but only by 6 µm against re-baseline drifts of 20
+            // and 25 µm — exactly the drift-buried regime the reference session showed. Staying quiet here is
+            // the point: a noisy optical channel must not cast doubt on the robust one.
+            var (vm, _) = RunSixStepWithCurvature(baselineE: -400, allInwardE: -406, reBaseline1E: -380, reBaseline2E: -355);
+
+            Assert.Multiple(() => {
+                Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Complete));
+                Assert.That(vm.HasConfidenceWarning, Is.False);
+            });
+        }
+
+        [Test]
+        public void CurvatureCrossCheck_ContradictingAndLarge_WarnsWithoutChangingTheSign() {
+            // A 150 µm move the wrong way against ~5 µm of re-baseline drift. Surface it — and keep the
+            // measured sign exactly as the mean-focus channel set it.
+            var (vm, options) = RunSixStepWithCurvature(baselineE: -400, allInwardE: -550, reBaseline1E: -404, reBaseline2E: -398);
+
+            Assert.Multiple(() => {
+                Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Complete));
+                Assert.That(vm.HasConfidenceWarning, Is.True);
+                Assert.That(vm.ConfidenceWarningText, Does.Contain("cross-check"));
+                Assert.That(vm.ConfidenceWarningText, Does.Contain("informational"));
+                // Warning-only: the stored sign is still the mean-focus channel's verdict.
+                options.Received().ScrewInwardCurvatureSign = 1;
+                options.Received().ScrewInwardCurvatureSignIsMeasured = true;
+                options.Received().IsCalibrated = true;
+            });
+        }
+
+        [Test]
+        public void CurvatureCrossCheck_FourStepRun_NeverWarns() {
+            // No all-screws step ⇒ no curvature channel to compare against, and the configured sign is left
+            // untouched anyway.
+            var (vm, _, _, _) = Build(configureOptions: o => o.MeasureCurvatureDuringCalibration.Returns(false));
+            vm.StartCommand.Execute(null);
+
+            vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0, -400);
+            vm.SeedStepReading(WizardStep.Screw1, 0.5, 0.0, 1000.0, -400);
+            vm.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 1000.0, -400);
+            vm.SeedStepReading(WizardStep.Screw2, -0.25, 0.433, 1000.0, -400);
+
+            for (int i = 0; i < 4; i++) {
+                vm.NextStep();
+            }
+
+            Assert.Multiple(() => {
+                Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Complete));
+                Assert.That(vm.HasConfidenceWarning, Is.False);
+            });
+        }
+
         // ---- The focuser-direction setting k is display-only (design §2.2) ---------------------------------
 
         [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -36,7 +36,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
     [Apartment(System.Threading.ApartmentState.STA)]
     public class TiltAdapterWizardVMTests {
 
-        private static InspectorVM BuildInspector() {
+        private static InspectorVM BuildInspector(IInspectorOptions inspectorOptions = null) {
             return new InspectorVM(
                 profileService: Substitute.For<IProfileService>(),
                 applicationStatusMediator: Substitute.For<IApplicationStatusMediator>(),
@@ -47,7 +47,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 telescopeMediator: Substitute.For<ITelescopeMediator>(),
                 starDetectionOptions: Substitute.For<IStarDetectionOptions>(),
                 starAnnotatorOptions: Substitute.For<IStarAnnotatorOptions>(),
-                inspectorOptions: Substitute.For<IInspectorOptions>(),
+                inspectorOptions: inspectorOptions ?? Substitute.For<IInspectorOptions>(),
                 autoFocusOptions: Substitute.For<IAutoFocusOptions>(),
                 autoFocusEngineFactory: Substitute.For<IAutoFocusEngineFactory>(),
                 imageDataFactory: Substitute.For<IImageDataFactory>(),
@@ -61,7 +61,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         private static (TiltAdapterWizardVM vm, ITiltAdapterOptions options, ICameraMediator camera, IFocuserMediator focuser) Build(
             int screwCount = 3, IApplicationDispatcher dispatcher = null, System.Action<ITiltAdapterOptions> configureOptions = null,
             IProfileService profileService = null, TiltDeviceConnectionService tiltDeviceService = null,
-            ISerialPortProvider serialPortProvider = null, Func<Task<bool>> confirmIdleDisconnectAsync = null) {
+            ISerialPortProvider serialPortProvider = null, Func<Task<bool>> confirmIdleDisconnectAsync = null,
+            IInspectorOptions inspectorOptions = null) {
             profileService ??= Substitute.For<IProfileService>();
             var camera = Substitute.For<ICameraMediator>();
             var focuser = Substitute.For<IFocuserMediator>();
@@ -69,7 +70,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             options.ScrewCount.Returns(screwCount);
             options.MeasurementAverageCount.Returns(1);
             configureOptions?.Invoke(options);
-            var inspector = BuildInspector();
+            var inspector = BuildInspector(inspectorOptions);
             var vm = new TiltAdapterWizardVM(
                 profileService: profileService,
                 applicationStatusMediator: Substitute.For<IApplicationStatusMediator>(),
@@ -2674,6 +2675,110 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             Connect(vm);
 
             options.DidNotReceive().MeasureCurvatureDuringCalibration = Arg.Any<bool>();
+        }
+
+        // ---- The focuser-direction setting k is display-only (design §2.2) ---------------------------------
+
+        [Test]
+        public void SixStepRun_MeasuredCurvatureSign_IsIdenticalUnderEitherFocuserDirection() {
+            // THE INVARIANCE GUARD FOR THE MEASUREMENT. σ is measured from the mean best-focus change, and the
+            // focuser convention provably cancels out of that probe (design §1(c)) — m and k enter both σ and
+            // the probe only through their product. So a seeded 6-step run must store the SAME sign with k
+            // toggled either way. If this ever fails, k has leaked into the calibration math and the design's
+            // central guarantee ("a wrong k gives wrong labels, never wrong motion") is broken.
+            int MeasureWith(bool focuserIncreasesTowardObjective) {
+                var inspectorOptions = Substitute.For<IInspectorOptions>();
+                inspectorOptions.FocuserIncreasesTowardObjective.Returns(focuserIncreasesTowardObjective);
+                var (vm, options, _, _) = Build(
+                    configureOptions: o => o.MeasureCurvatureDuringCalibration.Returns(true),
+                    inspectorOptions: inspectorOptions);
+                vm.StartCommand.Execute(null);
+
+                vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0);
+                vm.SeedStepReading(WizardStep.AllInward, 0.0, 0.0, 990.0);
+                vm.SeedStepReading(WizardStep.ReBaseline1, 0.0, 0.0, 1000.0);
+                vm.SeedStepReading(WizardStep.Screw1, 0.5, 0.0, 1000.0);
+                vm.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 1000.0);
+                vm.SeedStepReading(WizardStep.Screw2, -0.25, 0.433, 1000.0);
+
+                int stored = 0;
+                options.When(o => o.ScrewInwardCurvatureSign = Arg.Any<int>())
+                    .Do(ci => stored = ci.Arg<int>());
+
+                for (int i = 0; i < 6; i++) {
+                    vm.NextStep();
+                }
+
+                Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Complete), "precondition: the run completed");
+                return stored;
+            }
+
+            var standard = MeasureWith(false);
+            var reversed = MeasureWith(true);
+
+            Assert.Multiple(() => {
+                Assert.That(standard, Is.EqualTo(1), "the all-screws step lowered mean focus ⇒ σ = +1");
+                Assert.That(reversed, Is.EqualTo(standard), "the measured σ must not depend on the focuser setting");
+            });
+        }
+
+        [Test]
+        public void CwMovesAdapterTowardObjective_ReversedFocuser_RoundTripsThroughTheOppositeSign() {
+            // The ONE deliberate exception (design §2.3): the combo asks about the adapter mechanics m, but
+            // stores σ = m·sign(k). On a reversed focuser the same mechanical answer therefore stores the
+            // opposite σ — which is what makes the manual path correct there, where a pinned k = +1
+            // conversion would store an inverted sign for an honest answer. It writes only the ASSUMED σ.
+            var inspectorOptions = Substitute.For<IInspectorOptions>();
+            inspectorOptions.FocuserIncreasesTowardObjective.Returns(true);
+            var (vm, options, _, _) = Build(inspectorOptions: inspectorOptions);
+
+            options.ScrewInwardCurvatureSign.Returns(0);
+            vm.CwMovesAdapterTowardObjective = true;
+            var storedForTowardObjective = TiltScrewGeometry.CurvatureSignForCwDirection(true) * -1;
+
+            Assert.Multiple(() => {
+                options.Received().ScrewInwardCurvatureSign = storedForTowardObjective;
+                options.Received().ScrewInwardCurvatureSignIsMeasured = false;
+
+                // And the getter reads it back consistently, so the combo never contradicts itself.
+                options.ScrewInwardCurvatureSign.Returns(storedForTowardObjective);
+                Assert.That(vm.CwMovesAdapterTowardObjective, Is.True);
+            });
+        }
+
+        [Test]
+        public void FocuserDirectionChange_RefreshesTheMechanicalWordingAndPhysicalAngles() {
+            // k is display-only, so a change must re-raise the wording and re-run the physical-angle
+            // conversion — and touch nothing stored.
+            var inspectorOptions = Substitute.For<IInspectorOptions>();
+            var (vm, options, _, _) = Build(configureOptions: o => {
+                o.IsCalibrated.Returns(true);
+                o.CalibratedScrewCount.Returns(3);
+                o.ScrewInwardCurvatureSign.Returns(1);
+                o.Screw1AngleDegrees.Returns(180.0);
+                o.Screw2AngleDegrees.Returns(300.0);
+                o.Screw3AngleDegrees.Returns(60.0);
+            }, inspectorOptions: inspectorOptions);
+
+            Assert.That(vm.PhysicalScrew1AngleDegrees, Is.EqualTo(0.0).Within(1e-9),
+                "precondition: σ = +1 on a standard focuser is m = +1, so stored 180° is physical 0°");
+            options.ClearReceivedCalls();
+
+            var raised = new List<string>();
+            vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+            inspectorOptions.FocuserIncreasesTowardObjective.Returns(true);
+            inspectorOptions.PropertyChanged += Raise.Event<System.ComponentModel.PropertyChangedEventHandler>(
+                inspectorOptions, new System.ComponentModel.PropertyChangedEventArgs(nameof(IInspectorOptions.FocuserIncreasesTowardObjective)));
+
+            Assert.Multiple(() => {
+                Assert.That(raised, Does.Contain(nameof(TiltAdapterWizardVM.CwMovesAdapterTowardObjective)));
+                Assert.That(raised, Does.Contain(nameof(TiltAdapterWizardVM.PhysicalScrew1AngleDegrees)));
+                Assert.That(vm.PhysicalScrew1AngleDegrees, Is.EqualTo(180.0).Within(1e-9),
+                    "σ = +1 on a reversed focuser is m = −1, so the offset drops and stored == physical");
+                options.DidNotReceive().ScrewInwardCurvatureSign = Arg.Any<int>();
+                options.DidNotReceive().Screw1AngleDegrees = Arg.Any<double>();
+                options.DidNotReceive().IsCalibrated = Arg.Any<bool>();
+            });
         }
 
         private static object SentinelFor(Type type, int index) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -1250,7 +1250,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         [Test]
         public void CaptureMeasurementContext_ReadsInspectorAndProfileValues() {
             var inspector = Substitute.For<IInspectorOptions>();
-            inspector.MicronsPerFocuserStep.Returns(3.6);
+            // The EFFECTIVE step size, not the raw override: a run captured while the focuser driver supplied
+            // the step size must record what it actually measured with, or a replay reinterprets it wrongly.
+            inspector.EffectiveMicronsPerFocuserStep.Returns(3.6);
             inspector.UseRANSAC.Returns(true);
             inspector.AcceptableRSquaredMin.Returns(0.8);
             inspector.SensorROI.Returns(1.0); inspector.CornersROI.Returns(1.0);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
@@ -96,12 +96,25 @@ public class TiltCalibrationCalculatorTests {
     }
 
     [Test]
-    public void ComputeCurvatureSign_PositiveWhenAllScrewsMeanHigher() {
+    public void ComputeCurvatureSign_PositiveWhenAllScrewsMeanLower() {
+        // σ = −sign(allScrewsMean − baselineMean): an all-screws-CW step that LOWERS the mean
+        // best-focus position is σ = +1 (docs/focuser-direction-convention-design.md §1(c)).
         Assert.Multiple(() => {
-            Assert.That(TiltCalibrationCalculator.ComputeCurvatureSign(1100, 1000), Is.EqualTo(1));
-            Assert.That(TiltCalibrationCalculator.ComputeCurvatureSign(900, 1000), Is.EqualTo(-1));
+            Assert.That(TiltCalibrationCalculator.ComputeCurvatureSign(1100, 1000), Is.EqualTo(-1));
+            Assert.That(TiltCalibrationCalculator.ComputeCurvatureSign(900, 1000), Is.EqualTo(1));
+            // Degenerate zero delta still resolves to +1, as it always has.
             Assert.That(TiltCalibrationCalculator.ComputeCurvatureSign(1000, 1000), Is.EqualTo(1));
         });
+    }
+
+    [Test]
+    public void ComputeCurvatureSign_Session20260803_BaselineHigherMeansTowardCamera() {
+        // Session 20260803-200647: a +150 backfocus step (vendor mnemonic — plate toward the
+        // CAMERA, so m = +1) on a standard focuser (k = +1) moved the mean best-focus position
+        // 5498.4 → 5136.6. σ = −sign(−361.8) = +1, which reads "clockwise moves the adapter toward
+        // the CAMERA" via m = σ·k — exactly the value the user had to set by hand before this fix
+        // to make corrections converge. This is the regression pin for that incident.
+        Assert.That(TiltCalibrationCalculator.ComputeCurvatureSign(5136.6, 5498.4), Is.EqualTo(1));
     }
 
     [Test]
@@ -261,7 +274,8 @@ public class TiltCalibrationCalculatorTests {
             Assert.That(r.Screw2AngleDegrees, Is.EqualTo(120).Within(1e-4));
             Assert.That(r.Screw3AngleDegrees, Is.EqualTo(240).Within(1e-4));
             Assert.That(r.MeasuredHardwareMicrons, Is.EqualTo(pitch).Within(1e-3));
-            Assert.That(r.CurvatureSign, Is.EqualTo(1));
+            // AllInward mean (1075) above baseline (1000) ⇒ σ = −1.
+            Assert.That(r.CurvatureSign, Is.EqualTo(-1));
         });
     }
 
@@ -285,7 +299,7 @@ public class TiltCalibrationCalculatorTests {
         var inputs = new TiltCalibrationInputs {
             ScrewCount = 3,
             Baseline = new TiltGradient(0, 0, 1000),
-            AllInward = new TiltGradient(0, 0, 1075), // all-screws-inward raised mean focus -> +1
+            AllInward = new TiltGradient(0, 0, 1075), // all-screws-inward raised mean focus -> −1
             Screw1 = SingleScrewReading(0, pitch, 3, 1000),
             Screw2 = SingleScrewReading(120, pitch, 3, 1000),
             ImageWidthPixels = ImgW,
@@ -303,7 +317,7 @@ public class TiltCalibrationCalculatorTests {
             Assert.That(r.Screw3AngleDegrees, Is.EqualTo(240).Within(1e-4));
             Assert.That(r.CalibratedScrewCount, Is.EqualTo(3));
             Assert.That(r.IsCalibrated, Is.True);
-            Assert.That(r.CurvatureSign, Is.EqualTo(1));
+            Assert.That(r.CurvatureSign, Is.EqualTo(-1));
             Assert.That(r.MeasuredHardwareMicrons, Is.EqualTo(pitch).Within(1e-3));
             Assert.That(r.Screw1DirectionDegrees, Is.EqualTo(0).Within(1e-4));
             Assert.That(r.Screw2DirectionDegrees, Is.EqualTo(120).Within(1e-4));

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltScrewGeometryTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltScrewGeometryTests.cs
@@ -177,20 +177,73 @@ public class TiltScrewGeometryTests {
     }
 
     [Test]
-    public void PhysicalToStoredAngle_RoundTripsAndFlipsOnNegativeSign() {
+    public void PhysicalToStoredAngle_OffsetBelongsToCwTowardCamera() {
         Assert.Multiple(() => {
-            // +1 rigs: a CW turn drives the tilt gradient along the physical screw direction,
-            // so stored (response-convention) and physical angles coincide.
-            Assert.That(TiltScrewGeometry.PhysicalToStoredAngle(30, +1), Is.EqualTo(30).Within(1e-12));
-            // −1 rigs (CW moves the adapter toward the objective): the response is inverted,
-            // so stored = physical + 180°.
-            Assert.That(TiltScrewGeometry.PhysicalToStoredAngle(30, -1), Is.EqualTo(210).Within(1e-12));
+            // The offset keys on the adapter mechanics m = σ·sign(k), not on σ directly.
+            // m = +1 (CW drives the plate toward the CAMERA): a CW turn LOWERS best focus at that
+            // screw, so the direction of steepest z-INCREASE — the stored convention — is opposite
+            // the screw's physical position. stored = physical + 180°.
+            Assert.That(TiltScrewGeometry.PhysicalToStoredAngle(30, +1), Is.EqualTo(210).Within(1e-12));
+            // m = −1 (CW toward the objective): the response points along the screw, so the two
+            // conventions coincide.
+            Assert.That(TiltScrewGeometry.PhysicalToStoredAngle(30, -1), Is.EqualTo(30).Within(1e-12));
             // Self-inverse: applying the conversion to a stored angle recovers the physical one.
-            Assert.That(TiltScrewGeometry.PhysicalToStoredAngle(210, -1), Is.EqualTo(30).Within(1e-12));
-            // Unknown sign (0) resolves to the default direction (+1 ⇒ identity).
-            Assert.That(TiltScrewGeometry.PhysicalToStoredAngle(30, 0), Is.EqualTo(30).Within(1e-12));
+            Assert.That(TiltScrewGeometry.PhysicalToStoredAngle(210, +1), Is.EqualTo(30).Within(1e-12));
+            // Unknown sign (0) resolves to the default direction (+1 ⇒ 180° offset).
+            Assert.That(TiltScrewGeometry.PhysicalToStoredAngle(30, 0), Is.EqualTo(210).Within(1e-12));
             // Result is normalized to [0, 360).
-            Assert.That(TiltScrewGeometry.PhysicalToStoredAngle(-30, -1), Is.EqualTo(150).Within(1e-12));
+            Assert.That(TiltScrewGeometry.PhysicalToStoredAngle(-30, +1), Is.EqualTo(150).Within(1e-12));
+        });
+    }
+
+    [Test]
+    public void PhysicalToStoredAngle_ReversedFocuserSwapsTheOffset() {
+        Assert.Multiple(() => {
+            // k = −1 flips m for a given σ, so it flips which σ carries the offset. This is the
+            // SECOND sanctioned path on which k reaches motion (Manual Calibration Entry) —
+            // docs/focuser-direction-convention-design.md §7.4.
+            Assert.That(TiltScrewGeometry.PhysicalToStoredAngle(30, +1, focuserSign: -1), Is.EqualTo(30).Within(1e-12));
+            Assert.That(TiltScrewGeometry.PhysicalToStoredAngle(30, -1, focuserSign: -1), Is.EqualTo(210).Within(1e-12));
+            // The default parameter is the standard focuser, so omitting it must be identical to +1.
+            Assert.That(TiltScrewGeometry.PhysicalToStoredAngle(30, +1, focuserSign: +1),
+                Is.EqualTo(TiltScrewGeometry.PhysicalToStoredAngle(30, +1)).Within(1e-12));
+            // Still self-inverse for every (σ, k) combination.
+            foreach (var sigma in new[] { -1, 0, +1 }) {
+                foreach (var k in new[] { -1, +1 }) {
+                    var stored = TiltScrewGeometry.PhysicalToStoredAngle(137.5, sigma, k);
+                    Assert.That(TiltScrewGeometry.PhysicalToStoredAngle(stored, sigma, k),
+                        Is.EqualTo(137.5).Within(1e-9), $"σ={sigma}, k={k}");
+                }
+            }
+        });
+    }
+
+    [Test]
+    public void PairedFlip_LeavesTheDisplayedScrewAngleUnchanged_Session20260803() {
+        // ACCEPTANCE CRITERION for the paired flip (design §7.3). Two inversions had been
+        // cancelling: ComputeCurvatureSign returned −σ, and PhysicalToStoredAngle assigned its 180°
+        // offset to m = −1 instead of m = +1. Correcting either ALONE rotates every displayed screw
+        // angle by 180°, so this asserts the PAIR, not each half.
+        //
+        // Session 20260803-200647: the four-corner plane deltas recover stored (response-frame)
+        // angles s1 = 219.4°, and screw 1 physically sits top-right at 39.4° (independently
+        // confirmed against EatWizardMapping, design §7.2).
+        const double storedScrew1 = 219.4;
+
+        // Post-fix: the probe measures σ = +1 (mean best focus 5498.4 → 5136.6 on the all-screws
+        // step) and the standard focuser is k = +1.
+        int sigmaNow = TiltCalibrationCalculator.ComputeCurvatureSign(5136.6, 5498.4);
+        Assert.That(sigmaNow, Is.EqualTo(+1));
+
+        double displayedNow = TiltScrewGeometry.PhysicalToStoredAngle(storedScrew1, sigmaNow, focuserSign: +1);
+
+        // Pre-fix the same run measured σ = −1 and the offset fired on σ = −1 — i.e. the old code
+        // displayed stored + 180°. Both paths must land on the same 39.4° top-right screw.
+        double displayedBefore = TiltCalibrationCalculator.NormalizeAngle(storedScrew1 + 180.0);
+
+        Assert.Multiple(() => {
+            Assert.That(displayedNow, Is.EqualTo(39.4).Within(1e-9));
+            Assert.That(displayedNow, Is.EqualTo(displayedBefore).Within(1e-9));
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -3300,8 +3300,23 @@
                                     Grid.ColumnSpan="3"
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Center"
-                                    FontStyle="Italic"
-                                    Text="Telescope is up, Sensor is down" />
+                                    FontStyle="Italic">
+                                    <!--
+                                        Up = a higher best-focus position, which is closer to the telescope only
+                                        on a standard focuser. Selected by the display-only focuser-direction
+                                        setting k (docs/focuser-direction-convention-design.md §3, site 2).
+                                    -->
+                                    <TextBlock.Style>
+                                        <Style BasedOn="{StaticResource StandardTextBlock}" TargetType="TextBlock">
+                                            <Setter Property="Text" Value="Telescope is up, Sensor is down" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding InspectorOptions.FocuserIncreasesTowardObjective}" Value="True">
+                                                    <Setter Property="Text" Value="Sensor is up, Telescope is down" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
                             </Grid>
                             <controls:SensorModelContourMapControl
                                 Grid.Row="1"
@@ -3674,8 +3689,24 @@
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Center"
                                 FontStyle="Italic"
-                                Text="Positive values = Move away from objective"
-                                TextWrapping="Wrap" />
+                                TextWrapping="Wrap">
+                                <!--
+                                    Positive Adj Steps = that corner's best focus sits above the mean, which puts
+                                    the corner closer to the objective only on a standard focuser. Selected by the
+                                    display-only focuser-direction setting k
+                                    (docs/focuser-direction-convention-design.md §3, site 1).
+                                -->
+                                <TextBlock.Style>
+                                    <Style BasedOn="{StaticResource StandardTextBlock}" TargetType="TextBlock">
+                                        <Setter Property="Text" Value="Positive values = Move away from objective" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding InspectorOptions.FocuserIncreasesTowardObjective}" Value="True">
+                                                <Setter Property="Text" Value="Positive values = Move toward objective" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
                             <DataGrid
                                 Grid.Row="2"
                                 Margin="5,5,5,0"
@@ -3743,6 +3774,7 @@
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Stretch"
                                 AxisColor="{Binding Path=Color, Source={StaticResource BorderBrush}}"
+                                FocuserIncreasesTowardObjective="{Binding InspectorOptions.FocuserIncreasesTowardObjective, Mode=OneWay}"
                                 PlotBackgroundColor="{Binding Path=Color, Source={StaticResource BackgroundBrush}}"
                                 PointColor="{Binding Path=Color, Source={StaticResource SecondaryBrush}}"
                                 SurfaceColor="{Binding Path=Color, Source={StaticResource ButtonBackgroundBrush}, Converter={StaticResource SetAlphaToColorConverter}, ConverterParameter=60}"
@@ -3873,8 +3905,24 @@
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Center"
                                 FontStyle="Italic"
-                                Text="Positive values = Move away from objective"
-                                TextWrapping="Wrap" />
+                                TextWrapping="Wrap">
+                                <!--
+                                    Positive Adj Steps = that corner's best focus sits above the mean, which puts
+                                    the corner closer to the objective only on a standard focuser. Selected by the
+                                    display-only focuser-direction setting k
+                                    (docs/focuser-direction-convention-design.md §3, site 1).
+                                -->
+                                <TextBlock.Style>
+                                    <Style BasedOn="{StaticResource StandardTextBlock}" TargetType="TextBlock">
+                                        <Setter Property="Text" Value="Positive values = Move away from objective" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding InspectorOptions.FocuserIncreasesTowardObjective}" Value="True">
+                                                <Setter Property="Text" Value="Positive values = Move toward objective" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
                             <DataGrid
                                 Grid.Row="3"
                                 Margin="5,5,5,0"
@@ -3930,6 +3978,7 @@
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Stretch"
                                 AxisColor="{Binding Path=Color, Source={StaticResource BorderBrush}}"
+                                FocuserIncreasesTowardObjective="{Binding InspectorOptions.FocuserIncreasesTowardObjective, Mode=OneWay}"
                                 PlotBackgroundColor="{Binding Path=Color, Source={StaticResource BackgroundBrush}}"
                                 PointColor="{Binding Path=Color, Source={StaticResource SecondaryBrush}}"
                                 SurfaceColor="{Binding Path=Color, Source={StaticResource ButtonBackgroundBrush}, Converter={StaticResource SetAlphaToColorConverter}, ConverterParameter=60}"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -31,7 +31,7 @@
     <TextBlock x:Key="FramesPerPoint_Tooltip" Text="How many exposures to average together for each focuser point. Uses the value set for AutoFocus if blank" />
     <TextBlock x:Key="AutoFocusTimeoutSeconds_Tooltip" Text="How long, in seconds, after which AutoFocus should time out and fail. Uses the value set for AutoFocus if blank" />
     <TextBlock x:Key="NumRegionsWide_Tooltip" Text="How many cells wide to divide the sensor pixels when generating a grid of eccentricity vectors. This value must be an odd, positive integer, and the height will be calculated proportionally from it based on the sensor resolution" />
-    <TextBlock x:Key="MicronsPerFocuserStep_Tooltip" Text="How much the focuser moves per step, in microns. If this is set, the adjustment chart will include adjustments in microns" />
+    <TextBlock x:Key="MicronsPerFocuserStep_Tooltip" Text="How much the focuser moves per step, in microns — the scale that turns every focuser measurement into microns. Leave this blank to use the value your focuser driver reports (shown greyed out in the box); type a value to override it. If neither is available, micron readouts are hidden rather than guessed." />
     <TextBlock x:Key="Inspector_FocuserDirection_Tooltip" Text="Which way your focuser travels: does a HIGHER focuser position move the camera away from the objective (standard), or toward it (reversed)? This affects direction LABELS AND DIAGRAMS ONLY — the &quot;move toward/away from the objective&quot; captions, the Telescope/Sensor labels on the sensor model, the spacer advice, and the up/down motion arrows in the tilt guidance. It can never change a measurement, a screw angle, or a correction: the tilt adapter's direction is measured in focuser units, and the focuser convention cancels out of that measurement entirely. So if these labels read backwards on your rig, flip this — nothing you have already calibrated is affected, and nothing will start turning the other way." />
     <TextBlock x:Key="EccentricityColorMapEnabled_Tooltip" Text="Enable color on the eccentricity map" />
     <TextBlock x:Key="MouseOnChartsEnabled_Tooltip" Text="Enable mouse events on charts to scroll, pan, and zoom. Disable this if you don't want the charts to intercept mouse actions" />
@@ -1789,13 +1789,18 @@
                             Grid.Row="0"
                             Grid.Column="3"
                             Orientation="Horizontal">
+                            <!--
+                                The box edits the OVERRIDE; the greyed hint shows what an EMPTY box resolves to
+                                — the focuser driver's reported step size, or "(not set)" when no driver
+                                supplies one (docs/focuser-step-size-driver-design.md §5).
+                            -->
                             <ninactrl:HintTextBox
                                 MinWidth="40"
                                 VerticalAlignment="Center"
                                 HorizontalContentAlignment="Left"
                                 VerticalContentAlignment="Center"
                                 Foreground="{StaticResource PrimaryBrush}"
-                                HintText="(disabled)"
+                                HintText="{Binding InspectorOptions.EffectiveMicronsPerFocuserStep, Converter={StaticResource HF_PositiveDoubleToHintTextConverter}, Mode=OneWay}"
                                 TextAlignment="Left"
                                 ToolTip="{StaticResource MicronsPerFocuserStep_Tooltip}">
                                 <ninactrl:HintTextBox.Text>
@@ -1812,6 +1817,16 @@
                                 VerticalAlignment="Center"
                                 Text="microns"
                                 ToolTip="{StaticResource MicronsPerFocuserStep_Tooltip}" />
+                            <!--  Advisory only: the override still wins. See the design doc §4.  -->
+                            <TextBlock
+                                Margin="6,0,0,0"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                FontStyle="Italic"
+                                Foreground="{StaticResource NotificationWarningBrush}"
+                                Text="⚠ differs from the focuser driver"
+                                ToolTip="{StaticResource FocuserStepSizeMismatch_Tooltip}"
+                                Visibility="{Binding InspectorOptions.HasFocuserStepSizeMismatch, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                         </StackPanel>
 
                         <TextBlock

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -32,6 +32,7 @@
     <TextBlock x:Key="AutoFocusTimeoutSeconds_Tooltip" Text="How long, in seconds, after which AutoFocus should time out and fail. Uses the value set for AutoFocus if blank" />
     <TextBlock x:Key="NumRegionsWide_Tooltip" Text="How many cells wide to divide the sensor pixels when generating a grid of eccentricity vectors. This value must be an odd, positive integer, and the height will be calculated proportionally from it based on the sensor resolution" />
     <TextBlock x:Key="MicronsPerFocuserStep_Tooltip" Text="How much the focuser moves per step, in microns. If this is set, the adjustment chart will include adjustments in microns" />
+    <TextBlock x:Key="Inspector_FocuserDirection_Tooltip" Text="Which way your focuser travels: does a HIGHER focuser position move the camera away from the objective (standard), or toward it (reversed)? This affects direction LABELS AND DIAGRAMS ONLY — the &quot;move toward/away from the objective&quot; captions, the Telescope/Sensor labels on the sensor model, the spacer advice, and the up/down motion arrows in the tilt guidance. It can never change a measurement, a screw angle, or a correction: the tilt adapter's direction is measured in focuser units, and the focuser convention cancels out of that measurement entirely. So if these labels read backwards on your rig, flip this — nothing you have already calibrated is affected, and nothing will start turning the other way." />
     <TextBlock x:Key="EccentricityColorMapEnabled_Tooltip" Text="Enable color on the eccentricity map" />
     <TextBlock x:Key="MouseOnChartsEnabled_Tooltip" Text="Enable mouse events on charts to scroll, pan, and zoom. Disable this if you don't want the charts to intercept mouse actions" />
     <TextBlock x:Key="SlewToZenith_Tooltip" Text="Slews to zenith while leaving tracking running. Doing this is optional, but you may find better seeing conditions and consistency as far from the horizon as possible" />
@@ -1926,6 +1927,44 @@
                             Grid.Column="1"
                             Orientation="Horizontal">
                             <CheckBox Margin="5,0,0,0" IsChecked="{Binding InspectorOptions.FixedSensorCenter}" />
+                        </StackPanel>
+
+                        <!--
+                            The focuser direction convention k — display-only by contract
+                            (docs/focuser-direction-convention-design.md §2.2). It drives the direction captions
+                            on this dock, the Telescope/Sensor labels, the spacer advice, and the tilt guidance's
+                            motion arrows; it never reaches a measurement, the planner, or the simulator. Also
+                            editable under Options → Hocus Focus → Auto Focus, like Focuser Step Size.
+                        -->
+                        <TextBlock
+                            Grid.Row="6"
+                            Grid.Column="2"
+                            Margin="5"
+                            VerticalAlignment="Center"
+                            Text="Increasing focuser position"
+                            ToolTip="{StaticResource Inspector_FocuserDirection_Tooltip}" />
+                        <StackPanel
+                            Grid.Row="6"
+                            Grid.Column="3"
+                            Orientation="Horizontal">
+                            <ComboBox
+                                MinWidth="40"
+                                Margin="5,0,0,0"
+                                VerticalAlignment="Center"
+                                SelectedValue="{Binding InspectorOptions.FocuserIncreasesTowardObjective}"
+                                SelectedValuePath="Tag"
+                                ToolTip="{StaticResource Inspector_FocuserDirection_Tooltip}">
+                                <ComboBoxItem Content="Moves camera away from objective (standard)">
+                                    <ComboBoxItem.Tag>
+                                        <s:Boolean>False</s:Boolean>
+                                    </ComboBoxItem.Tag>
+                                </ComboBoxItem>
+                                <ComboBoxItem Content="Moves camera toward objective (reversed)">
+                                    <ComboBoxItem.Tag>
+                                        <s:Boolean>True</s:Boolean>
+                                    </ComboBoxItem.Tag>
+                                </ComboBoxItem>
+                            </ComboBox>
                         </StackPanel>
 
                         <Expander

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
@@ -70,6 +70,10 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             numRegionsWide = optionsAccessor.GetValueInt32(nameof(NumRegionsWide), 7);
             loopingExposureAnalysisEnabled = optionsAccessor.GetValueBoolean(nameof(LoopingExposureAnalysisEnabled), false);
             micronsPerFocuserStep = optionsAccessor.GetValueDouble(nameof(MicronsPerFocuserStep), -1);
+            // Not loaded — it has no accessor key. Assigned to the FIELD, not the property, because the
+            // property's setter rejects non-positive values by design. This runs on construction and on every
+            // ProfileChanged, which is exactly where "a different rig, so forget the last focuser" belongs.
+            driverMicronsPerFocuserStep = -1;
             focuserIncreasesTowardObjective = optionsAccessor.GetValueBoolean(nameof(FocuserIncreasesTowardObjective), false);
             eccentricityColorMapEnabled = optionsAccessor.GetValueBoolean(nameof(EccentricityColorMapEnabled), true);
             mouseOnChartsEnabled = optionsAccessor.GetValueBoolean(nameof(MouseOnChartsEnabled), true);
@@ -266,6 +270,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
         private double micronsPerFocuserStep;
 
+        /// <inheritdoc cref="IInspectorOptions.MicronsPerFocuserStep"/>
         public double MicronsPerFocuserStep {
             get => micronsPerFocuserStep;
             set {
@@ -273,8 +278,67 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     micronsPerFocuserStep = value;
                     optionsAccessor.SetValueDouble(nameof(MicronsPerFocuserStep), micronsPerFocuserStep);
                     RaisePropertyChanged();
+                    RaiseFocuserStepSizeDerivedChanged();
                 }
             }
+        }
+
+        private double driverMicronsPerFocuserStep = -1;
+
+        /// <inheritdoc cref="IInspectorOptions.DriverMicronsPerFocuserStep"/>
+        /// <remarks>
+        /// No accessor key, by design — see the interface doc. The setter's guard IS the stickiness mechanism:
+        /// a disconnected focuser reports 0, the write is dropped, and the last known value stands. Keep the
+        /// filtering here and nowhere else, so the single writer stays a plain unconditional assignment and the
+        /// two cannot drift apart.
+        ///
+        /// <para><c>&gt; 0</c> and not <c>!(&lt;= 0)</c>: NaN fails BOTH comparisons, so only the positive form
+        /// rejects it. A NaN step size waved through here yields an all-NaN sensor model with no error
+        /// anywhere — the same trap documented on
+        /// <c>CameraSimulatorOptions.EffectiveFocuserStepSizeMicrons</c>.</para>
+        /// </remarks>
+        public double DriverMicronsPerFocuserStep {
+            get => driverMicronsPerFocuserStep;
+            set {
+                if (!(value > 0.0) || double.IsInfinity(value)) {
+                    return;
+                }
+                if (driverMicronsPerFocuserStep != value) {
+                    driverMicronsPerFocuserStep = value;
+                    RaisePropertyChanged();
+                    RaiseFocuserStepSizeDerivedChanged();
+                }
+            }
+        }
+
+        /// <inheritdoc cref="IInspectorOptions.EffectiveMicronsPerFocuserStep"/>
+        public double EffectiveMicronsPerFocuserStep =>
+            micronsPerFocuserStep > 0.0 ? micronsPerFocuserStep
+            : driverMicronsPerFocuserStep > 0.0 ? driverMicronsPerFocuserStep
+            : -1.0;
+
+        /// <summary>
+        /// How far the override may sit from the driver's reported step size before
+        /// <see cref="HasFocuserStepSizeMismatch"/> flags it, as a fraction of the driver's value.
+        ///
+        /// <para>Relative rather than absolute because real rigs span roughly 0.1–10 µm/step. 1% is loose
+        /// enough that a genuine calibration landing near the driver's round number stays quiet, and tight
+        /// enough to catch what this check exists for: a driver reporting steps rather than microns, or a 2×
+        /// error.</para>
+        /// </summary>
+        public const double FocuserStepSizeMismatchFraction = 0.01;
+
+        /// <inheritdoc cref="IInspectorOptions.HasFocuserStepSizeMismatch"/>
+        public bool HasFocuserStepSizeMismatch =>
+            micronsPerFocuserStep > 0.0 && driverMicronsPerFocuserStep > 0.0 &&
+            Math.Abs(micronsPerFocuserStep - driverMicronsPerFocuserStep) / driverMicronsPerFocuserStep
+                > FocuserStepSizeMismatchFraction;
+
+        // Both derived values read the override AND the driver value, so either input changing must re-raise
+        // both. Bindings (the hint text, the mismatch flag) depend on this.
+        private void RaiseFocuserStepSizeDerivedChanged() {
+            RaisePropertyChanged(nameof(EffectiveMicronsPerFocuserStep));
+            RaisePropertyChanged(nameof(HasFocuserStepSizeMismatch));
         }
 
         private bool focuserIncreasesTowardObjective;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorOptions.cs
@@ -70,6 +70,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             numRegionsWide = optionsAccessor.GetValueInt32(nameof(NumRegionsWide), 7);
             loopingExposureAnalysisEnabled = optionsAccessor.GetValueBoolean(nameof(LoopingExposureAnalysisEnabled), false);
             micronsPerFocuserStep = optionsAccessor.GetValueDouble(nameof(MicronsPerFocuserStep), -1);
+            focuserIncreasesTowardObjective = optionsAccessor.GetValueBoolean(nameof(FocuserIncreasesTowardObjective), false);
             eccentricityColorMapEnabled = optionsAccessor.GetValueBoolean(nameof(EccentricityColorMapEnabled), true);
             mouseOnChartsEnabled = optionsAccessor.GetValueBoolean(nameof(MouseOnChartsEnabled), true);
             sensorCurveModelEnabled = optionsAccessor.GetValueBoolean(nameof(SensorCurveModelEnabled), false);
@@ -104,6 +105,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             NumRegionsWide = 7;
             LoopingExposureAnalysisEnabled = false;
             MicronsPerFocuserStep = -1;
+            FocuserIncreasesTowardObjective = false;
             EccentricityColorMapEnabled = true;
             MouseOnChartsEnabled = true;
             SensorCurveModelEnabled = false;
@@ -270,6 +272,24 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 if (micronsPerFocuserStep != value) {
                     micronsPerFocuserStep = value;
                     optionsAccessor.SetValueDouble(nameof(MicronsPerFocuserStep), micronsPerFocuserStep);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool focuserIncreasesTowardObjective;
+
+        /// <summary>
+        /// The focuser direction convention k. DISPLAY-ONLY — see
+        /// <see cref="IInspectorOptions.FocuserIncreasesTowardObjective"/> for the full contract and the two
+        /// sanctioned exceptions.
+        /// </summary>
+        public bool FocuserIncreasesTowardObjective {
+            get => focuserIncreasesTowardObjective;
+            set {
+                if (focuserIncreasesTowardObjective != value) {
+                    focuserIncreasesTowardObjective = value;
+                    optionsAccessor.SetValueBoolean(nameof(FocuserIncreasesTowardObjective), focuserIncreasesTowardObjective);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -229,6 +229,14 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     e.PropertyName == nameof(IInspectorOptions.FramesPerPoint)) {
                     RaisePropertyChanged(nameof(SignalAmplificationSummary));
                 }
+                if (e.PropertyName == nameof(IInspectorOptions.FocuserIncreasesTowardObjective)) {
+                    // k is display-only, so this refreshes WORDS AND ARROWS ONLY: the backfocus
+                    // TOWARDS/AWAY FROM verdict, and the guidance's motion arrows. Every number, glyph and
+                    // total RebuildTiltGuidance produces is k-free by construction and comes out identical —
+                    // pinned by the invariance guards in InspectorVMFocuserDirectionTests.
+                    BackfocusDirection = BackfocusDirectionFor(BackfocusFocuserPositionDelta);
+                    RebuildTiltGuidance();
+                }
             };
             // SignalAmplificationSummary also reads the active profile's FocuserSettings (offset steps /
             // frames per point), which the user can edit in place without swapping profiles —
@@ -1669,11 +1677,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             InnerFocuserPosition = centerFocuser;
             OuterFocuserPosition = outerFocuserPositionSum / 4;
             BackfocusFocuserPositionDelta = OuterFocuserPosition - InnerFocuserPosition;
-            if (BackfocusFocuserPositionDelta > 0) {
-                BackfocusDirection = "TOWARDS";
-            } else {
-                BackfocusDirection = "AWAY FROM";
-            }
+            BackfocusDirection = BackfocusDirectionFor(BackfocusFocuserPositionDelta);
             if (InspectorOptions.MicronsPerFocuserStep > 0) {
                 BackfocusMicronDelta = BackfocusFocuserPositionDelta * InspectorOptions.MicronsPerFocuserStep;
             } else {
@@ -1684,6 +1688,35 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             InnerHFR = centerHFR;
             OuterHFR = outerHFRSum / 4;
             BackfocusHFR = OuterHFR - InnerHFR;
+        }
+
+        /// <summary>
+        /// The display-only focuser convention as a sign: +1 standard (increasing focuser position moves the
+        /// camera away from the objective), −1 reversed. Resolved fresh at each presentation call site; it
+        /// never leaves them (docs/focuser-direction-convention-design.md §2.2).
+        /// </summary>
+        internal int FocuserSign => inspectorOptions != null && inspectorOptions.FocuserIncreasesTowardObjective ? -1 : 1;
+
+        /// <summary>
+        /// "Move sensor TOWARDS / AWAY FROM the flattener" for a given outer-minus-inner focuser delta.
+        /// A positive delta means the outer regions focus at a higher position than the center, i.e. the
+        /// curvature effect E_z &gt; 0 — which calls for reducing the spacing only when a higher focuser
+        /// position means "farther from the objective". Hence sign(k)·E_z, which at the default k = +1 is
+        /// exactly the previous unconditional test (design §3, site 4).
+        /// </summary>
+        private string BackfocusDirectionFor(double focuserPositionDelta) =>
+            FocuserSign * focuserPositionDelta > 0 ? "TOWARDS" : "AWAY FROM";
+
+        /// <summary>
+        /// Test seam: the backfocus panel is normally filled by <see cref="UpdateBackfocusMeasurements"/> from a
+        /// completed AutoFocus result. This writes the same two measured positions directly, so the k-invariance
+        /// guard can assert the TOWARDS/AWAY FROM wording without staging a whole run.
+        /// </summary>
+        internal void SetBackfocusMeasurementForTest(double inner, double outer) {
+            InnerFocuserPosition = inner;
+            OuterFocuserPosition = outer;
+            BackfocusFocuserPositionDelta = outer - inner;
+            BackfocusDirection = BackfocusDirectionFor(BackfocusFocuserPositionDelta);
         }
 
         // The Inspector region report indexes RegionHFRs[1..5] (center = 1, corners = 2..5), so it needs the full
@@ -2046,6 +2079,11 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 // rule for the numeric rows.
                 int curvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign;
                 int resolvedSign = curvatureSign == 0 ? TiltScrewGeometry.DefaultScrewInwardCurvatureSign : curvatureSign;
+                // The display-only focuser convention. It touches the MOTION ARROWS only — the arrows are the
+                // one part of this panel that claims a physical direction ("toward the objective"), and
+                // translating a z-space quantity into that claim needs k. Everything else below (turns,
+                // glyphs, totals, the legend) is σ-frame and must not read it.
+                int focuserSign = FocuserSign;
 
                 var tiltPlane = TiltModel?.TiltPlaneModel;
                 if (tiltPlane != null) {
@@ -2074,8 +2112,10 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                                 tiltArrows[i] = "—";
                             } else {
                                 // turns[i] is CW-positive (the stored response-convention angles encode
-                                // the rig direction), so adapter MOTION toward the objective = −σ·turns.
-                                double ratio = (-resolvedSign * turns[i]) / maxAbs;
+                                // the rig direction). A CW turn drives the plate toward the camera iff
+                                // m = σ·sign(k) = +1, so adapter MOTION toward the objective is
+                                // −σ·sign(k)·turns — which at the default k = +1 is the previous −σ·turns.
+                                double ratio = (-resolvedSign * focuserSign * turns[i]) / maxAbs;
                                 if (ratio >= GuidanceLargeArrowThreshold) tiltArrows[i] = "⬆";
                                 else if (ratio >= GuidanceMinArrowThreshold) tiltArrows[i] = "↑";
                                 else if (ratio <= -GuidanceLargeArrowThreshold) tiltArrows[i] = "⬇";
@@ -2091,11 +2131,13 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     }
                 }
 
-                // Backfocus row: adapter MOTION needed to null the curvature effect. Toward the
-                // objective ⇔ the local best-focus position must decrease; the σ in "which rotation
-                // is needed" and the σ in "what a rotation does" cancel, so the motion arrow is
-                // sign(CurvatureEffectMicrons) — rig-independent physics (see
-                // docs/tilt-guidance-motion-arrows-design.md).
+                // Backfocus row: adapter MOTION needed to null the curvature effect. The σ in "which
+                // rotation is needed" and the σ in "what a rotation does" cancel, so the arrow does not
+                // depend on the adapter at all — but naming the resulting motion "toward the objective"
+                // still needs the focuser convention, so the test is sign(k)·E_z > 0. At the default
+                // k = +1 that is the previous sign(CurvatureEffectMicrons) (see
+                // docs/tilt-guidance-motion-arrows-design.md and
+                // docs/focuser-direction-convention-design.md §3, site 6).
                 if (SensorModel?.DisplayedSensorModel != null) {
                     double curvatureEffectMicrons = SensorModel.SensorModelResult.CurvatureEffectMicrons;
                     double absMicrons = Math.Abs(curvatureEffectMicrons);
@@ -2104,7 +2146,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                     if (absMicrons < BackfocusNoiseThresholdMicrons) {
                         backfocusArrow = "—";
                     } else {
-                        bool towardObjective = curvatureEffectMicrons > 0;
+                        bool towardObjective = focuserSign * curvatureEffectMicrons > 0;
                         string bigArrow = towardObjective ? "⬆" : "⬇";
                         string smallArrow = towardObjective ? "↑" : "↓";
                         backfocusArrow = absMicrons >= BackfocusLargeArrowThresholdMicrons ? bigArrow : smallArrow;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -659,7 +659,9 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             // Resolve the definitive review request from the SAME flag that gates this block (capture-time flag on replay).
             frameReviewRequestedForRun = IsFrameReviewRequested(inspectorOptions.FrameReviewEnabled, sensorCurveModelEnabled);
             if (sensorCurveModelEnabled) {
-                double focuserSizeMicrons = SensorModelFocuserSizeOverrideMicrons ?? InspectorOptions.MicronsPerFocuserStep;
+                // Layer 1 (a replay's captured step size) over the resolver's layers 2-4 (override, driver,
+                // unset) - docs/focuser-step-size-driver-design.md §2.
+                double focuserSizeMicrons = SensorModelFocuserSizeOverrideMicrons ?? InspectorOptions.EffectiveMicronsPerFocuserStep;
                 if (double.IsNaN(focuserSizeMicrons) || focuserSizeMicrons <= 0.0) {
                     if (!focuserStepSizeWarningShowed) {
                         Notification.ShowWarning("Focuser Step Size not set. Assuming 1 micron per focuser step. This message won't be shown again.");
@@ -1674,20 +1676,33 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
             var fRatio = profileService.ActiveProfile.TelescopeSettings.FocalRatio;
             CriticalFocusMicrons = 2.44 * fRatio * fRatio * 0.55;
-            InnerFocuserPosition = centerFocuser;
-            OuterFocuserPosition = outerFocuserPositionSum / 4;
-            BackfocusFocuserPositionDelta = OuterFocuserPosition - InnerFocuserPosition;
-            BackfocusDirection = BackfocusDirectionFor(BackfocusFocuserPositionDelta);
-            if (InspectorOptions.MicronsPerFocuserStep > 0) {
-                BackfocusMicronDelta = BackfocusFocuserPositionDelta * InspectorOptions.MicronsPerFocuserStep;
-            } else {
-                BackfocusMicronDelta = double.NaN;
-            }
-
-            BackfocusWithinCFZ = Math.Abs(BackfocusMicronDelta) < criticalFocusMicrons;
+            ApplyBackfocusMeasurement(inner: centerFocuser, outer: outerFocuserPositionSum / 4);
             InnerHFR = centerHFR;
             OuterHFR = outerHFRSum / 4;
             BackfocusHFR = OuterHFR - InnerHFR;
+        }
+
+        /// <summary>
+        /// Everything derived from the inner/outer best-focus positions: the raw focuser delta, the
+        /// TOWARDS/AWAY FROM wording, the micron conversion, and the critical-focus-zone verdict.
+        ///
+        /// <para>Extracted so the k-invariance guard and the focuser step-size tests drive the same derivation
+        /// the real run does, rather than a partial re-implementation that can silently disagree with it.</para>
+        ///
+        /// <para>The micron conversion reads the EFFECTIVE µm/step (override, else the driver's reported step
+        /// size, else unknown). Unknown stays NaN — the readout drops out rather than showing a fabricated
+        /// number, which is the same graceful degradation this had before the driver became a source.</para>
+        /// </summary>
+        private void ApplyBackfocusMeasurement(double inner, double outer) {
+            InnerFocuserPosition = inner;
+            OuterFocuserPosition = outer;
+            BackfocusFocuserPositionDelta = OuterFocuserPosition - InnerFocuserPosition;
+            BackfocusDirection = BackfocusDirectionFor(BackfocusFocuserPositionDelta);
+            var micronsPerStep = InspectorOptions.EffectiveMicronsPerFocuserStep;
+            BackfocusMicronDelta = micronsPerStep > 0
+                ? BackfocusFocuserPositionDelta * micronsPerStep
+                : double.NaN;
+            BackfocusWithinCFZ = Math.Abs(BackfocusMicronDelta) < criticalFocusMicrons;
         }
 
         /// <summary>
@@ -1709,15 +1724,11 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
         /// <summary>
         /// Test seam: the backfocus panel is normally filled by <see cref="UpdateBackfocusMeasurements"/> from a
-        /// completed AutoFocus result. This writes the same two measured positions directly, so the k-invariance
-        /// guard can assert the TOWARDS/AWAY FROM wording without staging a whole run.
+        /// completed AutoFocus result. This supplies the same two measured positions directly and runs the real
+        /// derivation, so tests exercise the shipping code rather than a copy of it.
         /// </summary>
-        internal void SetBackfocusMeasurementForTest(double inner, double outer) {
-            InnerFocuserPosition = inner;
-            OuterFocuserPosition = outer;
-            BackfocusFocuserPositionDelta = outer - inner;
-            BackfocusDirection = BackfocusDirectionFor(BackfocusFocuserPositionDelta);
-        }
+        internal void SetBackfocusMeasurementForTest(double inner, double outer) =>
+            ApplyBackfocusMeasurement(inner, outer);
 
         // The Inspector region report indexes RegionHFRs[1..5] (center = 1, corners = 2..5), so it needs the full
         // Inspector grid of at least 6 regions. Extracted + internal so the precondition is unit-testable.
@@ -2948,6 +2959,11 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
 
         public void UpdateDeviceInfo(FocuserInfo deviceInfo) {
             FocuserInfo = deviceInfo;
+            // The single writer of the driver-reported focuser step size (this VM is a Shared MEF singleton
+            // registered as the plugin's focuser consumer). Deliberately unconditional: the setter accepts
+            // only finite, positive values, so a disconnect's StepSize = 0 is dropped there and the last
+            // known value stands. Adding a second guard here would let the two drift apart.
+            InspectorOptions.DriverMicronsPerFocuserStep = deviceInfo.StepSize;
         }
 
         private FocuserInfo focuserInfo = DeviceInfo.CreateDefaultInstance<FocuserInfo>();

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltModel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltModel.cs
@@ -200,7 +200,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         }
 
         public void UpdateTiltModel(AutoFocusResult result, double fRatio, double backfocusFocuserPositionDelta) {
-            var micronsPerFocuserStep = inspectorOptions.MicronsPerFocuserStep > 0 ? inspectorOptions.MicronsPerFocuserStep : double.NaN;
+            var effective = inspectorOptions.EffectiveMicronsPerFocuserStep;
+            var micronsPerFocuserStep = effective > 0 ? effective : double.NaN;
             var tiltModel = TiltPlaneModel.Create(result, fRatio: fRatio, focuserStepSizeMicrons: micronsPerFocuserStep);
             UpdateTiltMeasurementsTable(tiltModel, backfocusFocuserPositionDelta);
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/CameraSimulatorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/CameraSimulatorOptions.cs
@@ -98,6 +98,11 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator {
                 RaisePropertyChanged(nameof(FocuserStepSizeMicrons));
                 // The hint text resolves through the same value, so it moves with it.
                 RaisePropertyChanged(nameof(EffectiveFocuserStepSizeMicrons));
+            } else if (e.PropertyName == nameof(IInspectorOptions.EffectiveMicronsPerFocuserStep)) {
+                // A driver-reported step size moves the render scale WITHOUT touching the override, so this
+                // arrives on its own. FocuserStepSizeMicrons (the editable override) is deliberately not
+                // re-raised here — it did not change.
+                RaisePropertyChanged(nameof(EffectiveFocuserStepSizeMicrons));
             }
         }
 
@@ -348,7 +353,13 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator {
             get {
                 // `> 0` and not `!(<= 0)`: NaN fails BOTH comparisons, so the `<=` form would wave it through into
                 // DefocusModel and produce an all-NaN frame with no error anywhere (see DefocusModel's ctor guards).
-                var configured = inspectorOptions.MicronsPerFocuserStep;
+                //
+                // Reads the Inspector's EFFECTIVE value, so a driver-reported step size reaches the render too.
+                // It has to: the simulator RENDERS defocus at k and the inspector RECOVERS tilt at k, the same k
+                // on both sides of an inverse. If the render used only the override while the inspector resolved
+                // through the driver, the inject⇄recover loop would break by exactly their ratio, silently — the
+                // original two-copies bug in a new disguise. The simulator's own default is last in the chain.
+                var configured = inspectorOptions.EffectiveMicronsPerFocuserStep;
                 return configured > 0.0 ? configured : DefaultFocuserStepSizeMicrons;
             }
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltAdapter.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltAdapter.cs
@@ -57,7 +57,10 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
     ///   would drive the simulator backwards on one of the two rig directions and the loop would diverge.
     ///
     /// • <b>The piston is the one place the rig direction survives</b> — see <see cref="PistonDirectionSign"/>.
-    ///   This mirrors the guidance exactly, which applies the curvature sign to its backfocus row only.
+    ///   This mirrors the guidance exactly, which applies the curvature sign to its backfocus row only. What that
+    ///   physical piston then DOES lives entirely in <see cref="SimulatedTiltInjection.Fold"/>: it lowers the
+    ///   mean best-focus position (−piston) and raises the curvature effect (+piston). The extra minus on the
+    ///   geometric shift is physics, not a frame convention, so it is stated there and not re-derived here.
     /// </summary>
     public sealed class SimulatedTiltAdapter {
         private readonly double[] anglesDegrees;
@@ -95,6 +98,10 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
         /// angle to absorb the flip and keeps the sign. This is the same asymmetry the guidance has, where
         /// <see cref="TiltScrewGeometry.SignedTotalAdjustment"/> applies the curvature sign to the backfocus
         /// component only; the two cancel, so backfocus guidance converges too.
+        ///
+        /// This converts the response frame to the physical frame and nothing more. How the resulting physical
+        /// piston splits into a mean-focus shift and a curvature-effect change — with opposite signs — belongs to
+        /// <see cref="SimulatedTiltInjection.Fold"/>.
         /// </summary>
         public int PistonDirectionSign => InwardCurvatureSign;
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltAdapterVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltAdapterVM.cs
@@ -462,7 +462,7 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
         /// Screw 1's PHYSICAL image angle (0° = straight up, increasing clockwise) — what the user enters and
         /// what the "Screw 1 angle" box shows. The stored <c>SimScrew1AngleDegrees</c> is response-convention
         /// (see <see cref="SimulatedTiltAdapter"/>), 180° from the physical position on "CW moves adapter toward
-        /// the objective" (−1) rigs; the self-inverse <see cref="TiltScrewGeometry.PhysicalToStoredAngle"/>
+        /// the camera" rigs; the self-inverse <see cref="TiltScrewGeometry.PhysicalToStoredAngle"/>
         /// converts both ways. Writing SimScrew1AngleDegrees re-derives screws 2..N and rebuilds the panel via
         /// <see cref="OnOptionsChanged"/>, which re-raises this property (through RebuildAll).
         /// </summary>
@@ -521,8 +521,10 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
             : Math.Sign(options.SimScrewInwardCurvatureSign);
 
         /// <summary>Converts a stored response-convention screw angle to its physical image angle (self-inverse;
-        /// identical on +1 rigs, 180° apart on −1). Every image-space display (Screw 1 input, derived readouts,
-        /// the diagram, the row labels) goes through this; the physics keeps consuming the raw stored angle.</summary>
+        /// 180° apart when CW moves the adapter toward the camera, identical otherwise). Every image-space
+        /// display (Screw 1 input, derived readouts, the diagram, the row labels) goes through this; the
+        /// physics keeps consuming the raw stored angle. No focuser sign is passed: the simulator is k-free by
+        /// design (docs/focuser-direction-convention-design.md §4), so it renders the standard convention.</summary>
         private double ToPhysicalAngle(double storedAngle) =>
             TiltScrewGeometry.PhysicalToStoredAngle(storedAngle, ResolvedCurvatureSign);
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltInjection.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltInjection.cs
@@ -51,6 +51,15 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
         /// component only; the two cancel, so backfocus guidance converges on both rig directions. Feeding the
         /// raw fitted constant in here is correct only on σ=+1 rigs and silently backwards on the other half —
         /// pinned by SimulatedTiltAdapterVMTests.BackfocusMove_OnOppositeRigs_MovesBackfocusInOppositeDirections.
+        ///
+        /// That physical piston then drives TWO responses with OPPOSITE signs, and the asymmetry is real physics,
+        /// not bookkeeping (docs/focuser-direction-convention-design.md §1 and §4):
+        ///   • the geometric mean-focus shift is <c>−pistonMicrons</c> — a plate move toward the camera increases
+        ///     the sensor's objective-distance, so best focus is reached at a LOWER focuser position (§1(a));
+        ///   • the curvature-effect (backfocus) response is <c>+pistonMicrons</c>, because σ is DEFINED as the
+        ///     sign of that response to a CW turn.
+        /// The simulator is pure z-space and never reads the display-only focuser-direction setting k: the
+        /// focuser convention cancels out of both responses (§1(c)), so no knob belongs here.
         /// </summary>
         public static bool Fold(ICameraSimulatorOptions options, AberrationDelta delta, int pistonDirectionSign) {
             var (halfW, halfH) = SensorHalfDimensionsMicrons(options);
@@ -71,13 +80,19 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
 
             var pistonMicrons = pistonDirectionSign * delta.PistonMicrons;
             if (pistonMicrons != 0.0) {
-                // The sensor moving axially both shifts best focus... Effective, not raw: the raw value is the -1
-                // "unset" sentinel on an uncalibrated Inspector, and the render uses Effective, so converting the
-                // piston with anything else would move best focus somewhere the star field is not defocused about.
-                options.OptimalFocuserPosition += (int)Math.Round(pistonMicrons / options.EffectiveFocuserStepSizeMicrons);
+                // The sensor moving axially both shifts best focus — and the shift OPPOSES the piston. A positive
+                // piston drives the plate toward the camera, which increases the sensor's objective-distance, so
+                // the focus point is reached at a LOWER focuser position: Δz̄ = −piston/step (design §1(a)/(c)).
+                // This line carried a + until 2026-08-04, built to satisfy the then-inverted ComputeCurvatureSign;
+                // both were corrected together, or a simulated 6-step run would measure −σ_config (design §4).
+                // Effective, not raw: the raw value is the -1 "unset" sentinel on an uncalibrated Inspector, and
+                // the render uses Effective, so converting the piston with anything else would move best focus
+                // somewhere the star field is not defocused about.
+                options.OptimalFocuserPosition -= (int)Math.Round(pistonMicrons / options.EffectiveFocuserStepSizeMicrons);
 
-                // ...and violates the optics' backfocus spacing. The curvature responds to the PISTON, not to any
-                // individual screw move, so a corner move (piston 0 by symmetry) correctly leaves it untouched.
+                // ...and violates the optics' backfocus spacing — this one WITH the piston, which is why the two
+                // signs differ. The curvature responds to the PISTON, not to any individual screw move, so a
+                // corner move (piston 0 by symmetry) correctly leaves it untouched.
                 // The proportionality is fixed by being the exact inverse of the inspector's backfocus row: it asks
                 // for an axial ΔZ0_phys = -CurvatureAt(R) = -K·R² per screw, which must null K exactly, so
                 // ΔK = ΔZ0_phys / R². Equivalently — and this is the independent check that fixes the sign —

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Controls/TiltModelControl.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Controls/TiltModelControl.cs
@@ -65,6 +65,28 @@ namespace NINA.Joko.Plugins.HocusFocus.Controls {
             set { SetValue(SurfaceLowExtremeColorProperty, value); }
         }
 
+        /// <summary>
+        /// The display-only focuser-direction setting k, bound from IInspectorOptions. The plot's z axis is a
+        /// focuser delta, so which end of it faces the telescope depends on the focuser convention: a higher
+        /// best-focus position is closer to the objective only when increasing focuser position moves the
+        /// camera away from it. False (default) = standard, which renders exactly as before this property
+        /// existed. Labels only — no plotted value reads it
+        /// (docs/focuser-direction-convention-design.md §3, site 3).
+        /// </summary>
+        public static readonly DependencyProperty FocuserIncreasesTowardObjectiveProperty = DependencyProperty.Register(
+            "FocuserIncreasesTowardObjective",
+            typeof(bool),
+            typeof(TiltModelControl),
+            new FrameworkPropertyMetadata(
+                false,
+                FrameworkPropertyMetadataOptions.AffectsRender,
+                OnAnyPropertyChanged));
+
+        public bool FocuserIncreasesTowardObjective {
+            get { return (bool)GetValue(FocuserIncreasesTowardObjectiveProperty); }
+            set { SetValue(FocuserIncreasesTowardObjectiveProperty, value); }
+        }
+
         public DrawingColor TopColor => DrawingColor.PaleVioletRed;
         public DrawingColor BottomColor => DrawingColor.LightGreen;
         public bool ColorCodeCorners => true;
@@ -139,8 +161,12 @@ namespace NINA.Joko.Plugins.HocusFocus.Controls {
                 if (Math.Abs(actualZMax) > 0.5d) {
                     model.ZTicks.Add(new PlotTick(actualZMax, actualZMax.ToString("0")));
                 }
-                model.ScreenLabels.Add(new ScreenLabel("Telescope", 0.5f, 0.05f, TextColor.ToDrawingColor()));
-                model.ScreenLabels.Add(new ScreenLabel("Sensor", 0.5f, 0.95f, TextColor.ToDrawingColor()));
+                // Top of the plot is the higher focuser delta. On a standard focuser that is nearer the
+                // telescope; on a reversed one the two labels swap. Nothing plotted above changes.
+                var topLabel = FocuserIncreasesTowardObjective ? "Sensor" : "Telescope";
+                var bottomLabel = FocuserIncreasesTowardObjective ? "Telescope" : "Sensor";
+                model.ScreenLabels.Add(new ScreenLabel(topLabel, 0.5f, 0.05f, TextColor.ToDrawingColor()));
+                model.ScreenLabels.Add(new ScreenLabel(bottomLabel, 0.5f, 0.95f, TextColor.ToDrawingColor()));
                 return model;
             } catch (Exception e) {
                 Logger.Error(e, "Failed updating tilt model visualization");

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Converters/PositiveDoubleToHintTextConverter.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Converters/PositiveDoubleToHintTextConverter.cs
@@ -1,0 +1,54 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace NINA.Joko.Plugins.HocusFocus.Converters {
+
+    /// <summary>
+    /// Formats a resolved fallback value for a <c>HintTextBox</c>'s greyed hint: the number when it is usable
+    /// (finite and &gt; 0), otherwise the ConverterParameter text (default "(not set)").
+    ///
+    /// <para>Written for the Focuser Step Size boxes, whose hint shows the value an EMPTY box will actually
+    /// resolve to — the focuser driver's reported step size, or nothing when no driver supplies one
+    /// (docs/focuser-step-size-driver-design.md §5). Without it, a user whose driver reports a step size sees
+    /// an empty box and concludes the feature is off.</para>
+    ///
+    /// <para><c>&gt; 0</c> and not <c>!(&lt;= 0)</c>: NaN fails BOTH comparisons, and only the positive form
+    /// routes it to the fallback text instead of rendering "NaN" at the user.</para>
+    /// </summary>
+    public class PositiveDoubleToHintTextConverter : IValueConverter {
+        private const string DefaultHint = "(not set)";
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
+            var fallback = parameter as string;
+            if (string.IsNullOrEmpty(fallback)) {
+                fallback = DefaultHint;
+            }
+            if (value == null) {
+                return fallback;
+            }
+            double resolved;
+            try {
+                resolved = System.Convert.ToDouble(value, culture);
+            } catch (Exception) {
+                return fallback;
+            }
+            return resolved > 0.0 ? resolved.ToString("0.###", culture) : fallback;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+            throw new NotSupportedException("The hint is display-only; bind the editable value separately.");
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
@@ -156,7 +156,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                     focuserStepSizeMicrons: focuserSizeMicrons,
                     finalFocusPosition: finalFocusPosition,
                     registeredStars: fitResult.RegisteredStars,
-                    acceptableRSquaredMin: inspectorOptions.AcceptableRSquaredMin);
+                    acceptableRSquaredMin: inspectorOptions.AcceptableRSquaredMin,
+                    focuserSign: FocuserSign);
 
                 var historyId = Interlocked.Increment(ref nextHistoryId);
                 SensorTiltHistoryModels.Insert(0, new SensorParaboloidTiltHistoryModel(
@@ -1481,12 +1482,21 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             return (registeredStars, totalRejectionsOnBrightness);
         }
 
+        /// <summary>
+        /// The display-only focuser convention as a sign: +1 standard, −1 reversed. Passed to
+        /// <see cref="SensorModelAberrationResult.Update"/> for the spacer advice's REMOVING/ADDING word and
+        /// nothing else — no fitted or reported value reads it
+        /// (docs/focuser-direction-convention-design.md §2.2).
+        /// </summary>
+        private int FocuserSign => inspectorOptions != null && inspectorOptions.FocuserIncreasesTowardObjective ? -1 : 1;
+
         private void UpdateTiltModels(SensorParaboloidTiltHistoryModel historyModel) {
             SensorModelResult.Update(
                 sensorModel: historyModel.SensorModel, imageSize: historyModel.ImageSize, pixelSizeMicrons: historyModel.PixelSizeMicrons,
                 fRatio: historyModel.FRatio, focuserStepSizeMicrons: historyModel.FocuserSizeMicrons, finalFocusPosition: historyModel.FinalFocusPosition,
                 registeredStars: [],
-                acceptableRSquaredMin: inspectorOptions.AcceptableRSquaredMin);
+                acceptableRSquaredMin: inspectorOptions.AcceptableRSquaredMin,
+                focuserSign: FocuserSign);
             DisplayedSensorModel = historyModel.SensorModel;
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModelAberrationResult.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModelAberrationResult.cs
@@ -275,7 +275,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             double focuserStepSizeMicrons,
             double finalFocusPosition,
             SensorModel.RegisteredStar[] registeredStars,
-            double acceptableRSquaredMin) {
+            double acceptableRSquaredMin,
+            int focuserSign = 1) {
             ImageSize = imageSize;
             FRatio = fRatio;
             PixelSizeMicrons = pixelSizeMicrons;
@@ -312,7 +313,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
 
             AnalysisResults.Clear();
             AnalyzeSensorModelFit(sensorModel, acceptableRSquaredMin);
-            AnalyzeCurvature(CurvatureRadiusMillimeters, CurvatureEffectMicrons, criticalFocusMicrons);
+            AnalyzeCurvature(CurvatureRadiusMillimeters, CurvatureEffectMicrons, criticalFocusMicrons, focuserSign);
             AnalyzeTilt(TiltEffectMicrons, Tilt, criticalFocusMicrons);
             AnalyzeCentering(sensorModel, pixelSizeMicrons);
 
@@ -389,8 +390,15 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             AnalysisResults.Add(result);
         }
 
-        private void AnalyzeCurvature(double curvatureRadius, double curvatureElevationMicrons, double criticalFocus) {
-            var direction = curvatureElevationMicrons > 0 ? "REMOVING" : "ADDING";
+        /// <summary>
+        /// The spacer advice. The ACCEPTABLE verdict and the reported magnitude are pure z-space and never read
+        /// <paramref name="focuserSign"/>; only the REMOVING/ADDING word does. A positive curvature effect means
+        /// the outer field focuses above the centre, which calls for REMOVING spacers only when a higher focuser
+        /// position means "farther from the objective" — hence sign(k)·E_z &gt; 0, which at the default k = +1 is
+        /// the previous unconditional test (docs/focuser-direction-convention-design.md §3, site 5).
+        /// </summary>
+        private void AnalyzeCurvature(double curvatureRadius, double curvatureElevationMicrons, double criticalFocus, int focuserSign) {
+            var direction = focuserSign * curvatureElevationMicrons > 0 ? "REMOVING" : "ADDING";
             var result = new SensorModelAnalysisResult() {
                 Name = "Curvature",
                 Value = $"{curvatureRadius:0.} mm",

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IInspectorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IInspectorOptions.cs
@@ -55,7 +55,55 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         double SimpleExposureSeconds { get; set; }
         double DetailedAnalysisExposureSeconds { get; set; }
         bool LoopingExposureAnalysisEnabled { get; set; }
+        /// <summary>
+        /// User OVERRIDE for the focuser step size, in µm of focuser travel per step. Non-positive (the −1
+        /// sentinel) means "not overridden" — read <see cref="EffectiveMicronsPerFocuserStep"/> for the value
+        /// anything actually computes with, which falls back to
+        /// <see cref="DriverMicronsPerFocuserStep"/>. Persisted per profile.
+        /// </summary>
         double MicronsPerFocuserStep { get; set; }
+
+        /// <summary>
+        /// The focuser step size the connected driver reports (ASCOM <c>Focuser.StepSize</c>, surfaced by NINA
+        /// as <c>FocuserInfo.StepSize</c>), in µm/step.
+        ///
+        /// <para>NOT AN OPTION and NEVER PERSISTED — it is live device state, re-read on every connect.
+        /// Persisting it would create a second copy that goes stale against a swapped focuser, which is the
+        /// exact failure the camera simulator's own step size was collapsed into
+        /// <see cref="MicronsPerFocuserStep"/> to eliminate.</para>
+        ///
+        /// <para>Written by exactly one place — <c>InspectorVM.UpdateDeviceInfo(FocuserInfo)</c>, the plugin's
+        /// registered focuser consumer. The setter accepts ONLY finite, positive values and silently ignores
+        /// everything else, which is what makes this sticky: a disconnect reports 0, that write is dropped,
+        /// and the last known value stands. So a focuser disconnecting mid-session cannot rescale an in-flight
+        /// analysis. Cleared on profile change (a profile swap means a different rig).</para>
+        ///
+        /// <para>Accepted cost of stickiness: swapping to a focuser that reports nothing leaves the previous
+        /// focuser's value in place for the rest of the session.</para>
+        /// </summary>
+        double DriverMicronsPerFocuserStep { get; set; }
+
+        /// <summary>
+        /// The focuser step size (µm/step) every consumer should compute with:
+        /// <see cref="MicronsPerFocuserStep"/> when overridden, else <see cref="DriverMicronsPerFocuserStep"/>
+        /// when the driver reports a usable one, else −1 ("unknown", the same graceful degradation as before —
+        /// micron readouts go NaN and the rows that need them drop out).
+        ///
+        /// <para>Callers replaying a saved run layer their own captured step size on top of this; see
+        /// <c>InspectorVM.SensorModelFocuserSizeOverrideMicrons</c>.</para>
+        /// </summary>
+        double EffectiveMicronsPerFocuserStep { get; }
+
+        /// <summary>
+        /// True when an override is set, the driver reports a usable value, and the two disagree by more than
+        /// <c>InspectorOptions.FocuserStepSizeMismatchFraction</c> relative to the driver's.
+        ///
+        /// <para>Advisory only: it changes no value and blocks nothing, and the override still wins. Its
+        /// purpose is that ASCOM <c>StepSize</c> is optional and a minority of drivers report a *plausible*
+        /// wrong number — commonly 1, meaning "one step per step" rather than one micron per step — which is
+        /// invisible without a second opinion.</para>
+        /// </summary>
+        bool HasFocuserStepSizeMismatch { get; }
 
         /// <summary>
         /// The focuser's direction convention <c>k</c>: false (default) = standard, increasing focuser

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IInspectorOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IInspectorOptions.cs
@@ -56,6 +56,30 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         double DetailedAnalysisExposureSeconds { get; set; }
         bool LoopingExposureAnalysisEnabled { get; set; }
         double MicronsPerFocuserStep { get; set; }
+
+        /// <summary>
+        /// The focuser's direction convention <c>k</c>: false (default) = standard, increasing focuser
+        /// position moves the camera AWAY from the objective (<c>sign(k) = +1</c>); true = reversed
+        /// (<c>sign(k) = −1</c>).
+        ///
+        /// DISPLAY-ONLY BY CONTRACT. It is consumed exclusively by the direction captions, the 3D/contour
+        /// "Telescope/Sensor" labels, the motion arrows, and the mechanical wording of the tilt guidance and
+        /// wizard — the sites enumerated in docs/focuser-direction-convention-design.md §3, and nothing else.
+        /// It must NEVER be passed into the TiltAdapterWizard math layer (TiltCalibrationCalculator,
+        /// TiltScrewGeometry's computing functions, TiltScrewTargets), the Automatic Adjustment planner's
+        /// target computation, or the camera simulator: the correction math needs only the measured σ, out of
+        /// which the focuser convention provably cancels (§1(c)).
+        ///
+        /// The guarantee this buys: a wrong <c>k</c> produces wrong LABELS and never wrong MOTION — a bounded,
+        /// visible failure instead of a silent inverted one. Two bounded exceptions are sanctioned and must
+        /// not be widened: the wizard's direction combo, which writes only the ASSUMED σ (§2.3), and
+        /// TiltScrewGeometry.PhysicalToStoredAngle via Manual Calibration Entry (§7.4).
+        ///
+        /// It lives here rather than on ITiltAdapterOptions deliberately — it is a focuser/rig property like
+        /// <see cref="MicronsPerFocuserStep"/>, and keeping it away from σ is what stops the two from being
+        /// fused into one opaque bit again (§2.2).
+        /// </summary>
+        bool FocuserIncreasesTowardObjective { get; set; }
         bool EccentricityColorMapEnabled { get; set; }
         bool MouseOnChartsEnabled { get; set; }
         bool SensorCurveModelEnabled { get; set; }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
@@ -29,6 +29,7 @@
     <hfconverters:DoubleNegativeToVisibilityConverter x:Key="HF_DoubleNegativeToVisibilityConverter" />
     <hfconverters:InverseDoubleNegativeToVisibilityConverter x:Key="HF_InverseDoubleNegativeToVisibilityConverter" />
     <hfconverters:DoubleNegativeToEmptyStringConverter x:Key="HF_DoubleNegativeToEmptyStringConverter" />
+    <hfconverters:PositiveDoubleToHintTextConverter x:Key="HF_PositiveDoubleToHintTextConverter" />
     <hfconverters:InterpolateColorConverter x:Key="HF_InterpolateColorConverter" />
     <hfconverters:InverseNaNToVisibilityCollapsedConverter x:Key="HF_InverseNaNToVisibilityCollapsedConverter" />
     <hfconverters:NullToVisibilityCollapsedConverter x:Key="HF_NullToVisibilityCollapsedConverter" />
@@ -527,6 +528,8 @@
     <TextBlock x:Key="MeasurementAverage_Tooltip" Text="Controls how the average star measurement across the frame is calculated. Median is robust to outliers, and is the default." />
     <TextBlock x:Key="MaxAutoFocusOutlierRejections_Tooltip" Text="Controls the maximum number of points that can be rejected as outliers during Auto Focus curve fitting." />
     <TextBlock x:Key="MaxBlindStepsPerDirection_Tooltip" Text="Maximum number of blind AutoFocus steps attempted in each direction before reversing to try the other side. Set to 0 to disable the cap." />
+    <!--  Declared here, not in AutoFocus/DataTemplates.xaml: that file MERGES this one, so a key defined here is visible to both rows that show the flag.  -->
+    <TextBlock x:Key="FocuserStepSizeMismatch_Tooltip" Text="Your focuser step size differs from what the driver reports by more than 1%. This is informational — your value is the one being used, and if you measured it yourself it is probably the better one. It is worth a look because some drivers report this field wrongly (a common case reports 1, meaning one step per step rather than one micron per step). Clear the box to use the driver's value instead." />
     <TextBlock x:Key="FocuserIncreasesTowardObjective_Tooltip" Text="Which way your focuser travels: does a HIGHER focuser position move the camera away from the objective (standard), or toward it (reversed)? This affects direction LABELS AND DIAGRAMS ONLY — the &quot;move toward/away from the objective&quot; captions, the Telescope/Sensor labels on the sensor model, the spacer advice, and the up/down motion arrows in the tilt guidance. It can never change a measurement, a screw angle, or a correction: the tilt adapter's direction is measured in focuser units, and the focuser convention cancels out of that measurement entirely. So if these labels read backwards on your rig, flip this — nothing you have already calibrated is affected, and nothing will start turning the other way." />
     <TextBlock x:Key="AutoFocusOutlierRejectionConfidence_Tooltip" Text="Confidence level for a two-tailed Grubbs statistical test of outliers to use during Auto Focus curve fitting. 95% is a reasonable default. Must be above 50% and below 100%." />
     <DataTemplate x:Key="HocusFocus_AutoFocus_Options">
@@ -3155,7 +3158,7 @@
           camera itself. Rig belongs with the device; only the observing settings are changed from this tab.  -->
     <TextBlock x:Key="CamSim_RigReadOnly_Tooltip" Text="Rig settings are edited in the camera's setup dialog — click the gear icon next to the camera in the Equipment &gt; Camera pane. They are shown here for reference only. Aperture and focal length show the value actually in effect, which is inferred from your NINA telescope settings when it has not been set explicitly." />
     <TextBlock x:Key="CamSim_OptimalFocuserPosition_Tooltip" Text="The focuser step position where best focus occurs (x0 in the defocus model). At this position stars render at their minimum HFR; moving the focuser away grows the donut. Set this to match the best-focus position of your connected (simulator) focuser." />
-    <TextBlock x:Key="CamSim_FocuserStepSizeMicrons_Tooltip" Text="How many microns of sensor-plane defocus one focuser step produces (k). Larger values make the HFR-vs-position curve steeper, so the star field defocuses faster as the focuser moves away from the optimal position. This is the same setting as the Aberration Inspector's Focuser Step Size: editing it here changes it there, and editing it there changes it here. That sharing is deliberate — the simulator renders defocus at this step size and the Aberration Inspector has to interpret that defocus at the same step size, or everything it measures back is wrong by the ratio between the two. Leave it blank if you have not calibrated it, and the simulator renders at the 2 µm/step shown greyed out in the box." />
+    <TextBlock x:Key="CamSim_FocuserStepSizeMicrons_Tooltip" Text="How many microns of sensor-plane defocus one focuser step produces (k). Larger values make the HFR-vs-position curve steeper, so the star field defocuses faster as the focuser moves away from the optimal position. This is the same setting as the Aberration Inspector's Focuser Step Size: editing it here changes it there, and editing it there changes it here. That sharing is deliberate — the simulator renders defocus at this step size and the Aberration Inspector has to interpret that defocus at the same step size, or everything it measures back is wrong by the ratio between the two. Leave it blank and the simulator renders at whatever the greyed-out hint shows: your focuser driver's reported step size if it supplies one, otherwise 2 µm/step." />
     <!--  The per-field rig tooltips moved to CameraSimulator/SetupDialog/SetupDataTemplates.xaml, next to the only
           controls that still edit those values. Here the rig renders read-only and shares CamSim_RigReadOnly_Tooltip.  -->
     <TextBlock x:Key="CamSim_Gain_Tooltip" Text="Sensor gain in ZWO-style 0.1 dB units. Higher gain lowers electrons-per-ADU (and read noise, down to the sensor's floor) but tightens digital saturation." />
@@ -3217,6 +3220,10 @@
                     "unset" is a real state here (-1), which the converter shows as an empty box with the value the
                     render will actually use as the hint. No FloatRangeRule: validation rules run on the RAW text
                     before the converter, so one would reject the blank/unset box outright.
+
+                    The hint now resolves override -> focuser driver -> the simulator's 2 µm default, because
+                    EffectiveFocuserStepSizeMicrons reads the Inspector's effective value. The render and the
+                    inspector's recovery must use the SAME k or the inject/recover loop breaks by their ratio.
                 -->
                 <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Text="Focuser Step Size" ToolTip="{StaticResource CamSim_FocuserStepSizeMicrons_Tooltip}" />
                 <StackPanel Grid.Row="1" Grid.Column="1" Margin="5,5,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" Orientation="Horizontal">
@@ -3238,6 +3245,16 @@
                         </ninactrl:HintTextBox.Text>
                     </ninactrl:HintTextBox>
                     <TextBlock Margin="3,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Center" Text="µm/step" ToolTip="{StaticResource CamSim_FocuserStepSizeMicrons_Tooltip}" />
+                    <!--  Advisory only: the override still wins. Same flag as the Aberration Inspector's row.  -->
+                    <TextBlock
+                        Margin="6,0,0,0"
+                        HorizontalAlignment="Left"
+                        VerticalAlignment="Center"
+                        FontStyle="Italic"
+                        Foreground="{StaticResource NotificationWarningBrush}"
+                        Text="⚠ differs from the focuser driver"
+                        ToolTip="{StaticResource FocuserStepSizeMismatch_Tooltip}"
+                        Visibility="{Binding InspectorOptions.HasFocuserStepSizeMismatch, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                 </StackPanel>
 
                 <!--  Rig (read-only here; edited in the camera's setup dialog). Bound to the Effective* values, not

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
@@ -527,6 +527,7 @@
     <TextBlock x:Key="MeasurementAverage_Tooltip" Text="Controls how the average star measurement across the frame is calculated. Median is robust to outliers, and is the default." />
     <TextBlock x:Key="MaxAutoFocusOutlierRejections_Tooltip" Text="Controls the maximum number of points that can be rejected as outliers during Auto Focus curve fitting." />
     <TextBlock x:Key="MaxBlindStepsPerDirection_Tooltip" Text="Maximum number of blind AutoFocus steps attempted in each direction before reversing to try the other side. Set to 0 to disable the cap." />
+    <TextBlock x:Key="FocuserIncreasesTowardObjective_Tooltip" Text="Which way your focuser travels: does a HIGHER focuser position move the camera away from the objective (standard), or toward it (reversed)? This affects direction LABELS AND DIAGRAMS ONLY — the &quot;move toward/away from the objective&quot; captions, the Telescope/Sensor labels on the sensor model, the spacer advice, and the up/down motion arrows in the tilt guidance. It can never change a measurement, a screw angle, or a correction: the tilt adapter's direction is measured in focuser units, and the focuser convention cancels out of that measurement entirely. So if these labels read backwards on your rig, flip this — nothing you have already calibrated is affected, and nothing will start turning the other way." />
     <TextBlock x:Key="AutoFocusOutlierRejectionConfidence_Tooltip" Text="Confidence level for a two-tailed Grubbs statistical test of outliers to use during Auto Focus curve fitting. 95% is a reasonable default. Must be above 50% and below 100%." />
     <DataTemplate x:Key="HocusFocus_AutoFocus_Options">
         <Grid Margin="5" VerticalAlignment="Top">
@@ -579,6 +580,7 @@
                 <RowDefinition />
                 <RowDefinition Style="{StaticResource ShowOnReducedChiSquaredCriterion}" />
                 <RowDefinition Style="{StaticResource ShowOnRSquaredCriterion}" />
+                <RowDefinition />
                 <RowDefinition />
             </Grid.RowDefinitions>
             <TextBlock
@@ -945,6 +947,41 @@
                     </Binding.ValidationRules>
                 </Binding>
             </ninactrl:UnitTextBox>
+
+            <!--
+                The focuser direction convention k. A rig/focuser property, so it sits with the other
+                focuser settings; it is persisted on InspectorOptions (NOT on ITiltAdapterOptions, where it
+                would be fused with the measured curvature sign again — docs/focuser-direction-convention-design.md
+                §2.2). Bool Tag pattern, mirroring the wizard's direction combo. The same setting is also
+                editable on the Aberration Inspector dock (AutoFocus/DataTemplates.xaml), like Focuser Step Size.
+            -->
+            <TextBlock
+                Grid.Row="17"
+                Grid.Column="0"
+                VerticalAlignment="Center"
+                Text="Increasing focuser position"
+                ToolTip="{StaticResource FocuserIncreasesTowardObjective_Tooltip}" />
+            <ComboBox
+                Grid.Row="17"
+                Grid.Column="1"
+                MinWidth="80"
+                Margin="5,5,0,0"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                SelectedValue="{Binding InspectorOptions.FocuserIncreasesTowardObjective}"
+                SelectedValuePath="Tag"
+                ToolTip="{StaticResource FocuserIncreasesTowardObjective_Tooltip}">
+                <ComboBoxItem Content="Moves camera away from objective (standard)">
+                    <ComboBoxItem.Tag>
+                        <s:Boolean>False</s:Boolean>
+                    </ComboBoxItem.Tag>
+                </ComboBoxItem>
+                <ComboBoxItem Content="Moves camera toward objective (reversed)">
+                    <ComboBoxItem.Tag>
+                        <s:Boolean>True</s:Boolean>
+                    </ComboBoxItem.Tag>
+                </ComboBoxItem>
+            </ComboBox>
         </Grid>
     </DataTemplate>
     <DataTemplate x:Key="HocusFocus_StarDetection_Options">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
@@ -11,6 +11,7 @@
 #endregion "copyright"
 
 using NINA.Core.Utility;
+using NINA.Core.Utility.Notification;
 using NINA.Joko.Plugins.HocusFocus.AutoFocus;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Profile;
@@ -81,6 +82,54 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             calibrationIsReliable = optionsAccessor.GetValueBoolean(nameof(CalibrationIsReliable), false);
             tiltDeviceShadowPositions = optionsAccessor.GetValueString(nameof(TiltDeviceShadowPositions), string.Empty);
             calibrationAppliedAmount = optionsAccessor.GetValueDouble(nameof(CalibrationAppliedAmount), -1.0);
+
+            MigrateMeasuredCurvatureSign();
+        }
+
+        // Persisted internal state, not a user option — same category as TiltDeviceShadowPositions /
+        // DeviceLinkedCalibrationDeviceName / CalibrationIsReliable, so it has no interface property and no
+        // control in Resources/OptionsDataTemplates.xaml.
+        private const string CurvatureSignMeasurementMigratedKey = "CurvatureSignMeasurementMigrated";
+
+        /// <summary>
+        /// One-time, per-profile correction of a MEASURED <see cref="ScrewInwardCurvatureSign"/>. Every sign
+        /// a 6-step calibration ever wrote before 2026-08-04 came from an inverted
+        /// <see cref="TiltCalibrationCalculator.ComputeCurvatureSign"/>, so those values are deterministically
+        /// negated (docs/focuser-direction-convention-design.md §5).
+        ///
+        /// Called from <see cref="InitializeOptions"/>, so it covers construction AND every profile change —
+        /// each profile carries its own marker, and the marker makes double-application impossible. Values
+        /// that were NOT measured are left alone: they are either the default assumption or a direction the
+        /// user set by hand through the wizard's direction combo (whose setter clears IsMeasured), and neither
+        /// came from the buggy formula.
+        ///
+        /// Downgrade hazard, accepted and documented: a migrated profile re-measured on an OLD plugin version
+        /// gets the inverted sign back. Nothing here can defend against running old code.
+        /// </summary>
+        private void MigrateMeasuredCurvatureSign() {
+            if (optionsAccessor.GetValueBoolean(CurvatureSignMeasurementMigratedKey, false)) {
+                return;
+            }
+
+            if (screwInwardCurvatureSignIsMeasured && screwInwardCurvatureSign != 0) {
+                int corrected = -screwInwardCurvatureSign;
+                Logger.Info(
+                    $"Tilt adapter: correcting this profile's MEASURED ScrewInwardCurvatureSign " +
+                    $"{screwInwardCurvatureSign:+0;-0} -> {corrected:+0;-0}. Every direction measured by a 6-step " +
+                    $"calibration before this version came from an inverted formula; see " +
+                    $"docs/focuser-direction-convention-design.md. Signs that were assumed or set by hand are not touched.");
+                screwInwardCurvatureSign = corrected;
+                optionsAccessor.SetValueInt32(nameof(ScrewInwardCurvatureSign), screwInwardCurvatureSign);
+                Notification.ShowInformation(
+                    "HocusFocus corrected the tilt adapter direction that a 6-step calibration measured for this " +
+                    "profile — it was measured with an inverted formula, which reversed the backfocus half of the " +
+                    "screw guidance. Automatic and manual corrections now turn the other way; the screw diagram and " +
+                    "the tilt numbers are unchanged. The Tilt Adapter Wizard still reports \"Direction was measured " +
+                    "by a calibration run.\" — re-run the 6-step calibration if you want to re-verify it.");
+            }
+
+            // Set even when nothing needed correcting, so the check never re-runs for this profile.
+            optionsAccessor.SetValueBoolean(CurvatureSignMeasurementMigratedKey, true);
         }
 
         private int screwCount;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -333,6 +333,17 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 this.tiltDeviceConnectionService.IdlePromptRequested += TiltDeviceConnectionService_IdlePromptRequested;
             }
 
+            // The display-only focuser convention k changes what the mechanical wording and the physical
+            // screw angles READ, never what is stored. Refresh exactly those (design §3, site 6).
+            if (this.inspector?.InspectorOptions != null) {
+                this.inspector.InspectorOptions.PropertyChanged += (s, e) => OnUIThread(() => {
+                    if (e.PropertyName == nameof(IInspectorOptions.FocuserIncreasesTowardObjective)) {
+                        RaisePropertyChanged(nameof(CwMovesAdapterTowardObjective));
+                        RebuildDiagram();
+                    }
+                });
+            }
+
             tiltAdapterOptions.PropertyChanged += (s, e) => OnUIThread(() => {
                 if (e.PropertyName == nameof(ITiltAdapterOptions.ScrewInwardCurvatureSign)) {
                     RaisePropertyChanged(nameof(HasCurvatureCalibration));
@@ -481,7 +492,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 // the previous value is kept, matching the constructor's NaN guard.
                 if (!double.IsNaN(tiltAdapterOptions.Screw1AngleDegrees)) {
                     ManualScrew1AngleDegrees = TiltScrewGeometry.PhysicalToStoredAngle(
-                        tiltAdapterOptions.Screw1AngleDegrees, tiltAdapterOptions.ScrewInwardCurvatureSign);
+                        tiltAdapterOptions.Screw1AngleDegrees, tiltAdapterOptions.ScrewInwardCurvatureSign, FocuserSign);
                 }
             });
 
@@ -493,7 +504,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // back (PhysicalToStoredAngle is self-inverse) with the current direction sign.
             if (!double.IsNaN(tiltAdapterOptions.Screw1AngleDegrees)) {
                 manualScrew1AngleDegrees = TiltScrewGeometry.PhysicalToStoredAngle(
-                    tiltAdapterOptions.Screw1AngleDegrees, tiltAdapterOptions.ScrewInwardCurvatureSign);
+                    tiltAdapterOptions.Screw1AngleDegrees, tiltAdapterOptions.ScrewInwardCurvatureSign, FocuserSign);
             }
 
             RebuildDiagram();
@@ -534,10 +545,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // self-inverse, so the same call converts stored→physical with the adapter-direction sign in
         // effect. RebuildDiagram() re-raises these (and the sign-change handler calls it) so the
         // readout tracks both a re-calibration and a direction change.
-        public double PhysicalScrew1AngleDegrees => TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw1AngleDegrees, tiltAdapterOptions.ScrewInwardCurvatureSign);
-        public double PhysicalScrew2AngleDegrees => TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw2AngleDegrees, tiltAdapterOptions.ScrewInwardCurvatureSign);
-        public double PhysicalScrew3AngleDegrees => TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw3AngleDegrees, tiltAdapterOptions.ScrewInwardCurvatureSign);
-        public double PhysicalScrew4AngleDegrees => TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw4AngleDegrees, tiltAdapterOptions.ScrewInwardCurvatureSign);
+        public double PhysicalScrew1AngleDegrees => TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw1AngleDegrees, tiltAdapterOptions.ScrewInwardCurvatureSign, FocuserSign);
+        public double PhysicalScrew2AngleDegrees => TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw2AngleDegrees, tiltAdapterOptions.ScrewInwardCurvatureSign, FocuserSign);
+        public double PhysicalScrew3AngleDegrees => TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw3AngleDegrees, tiltAdapterOptions.ScrewInwardCurvatureSign, FocuserSign);
+        public double PhysicalScrew4AngleDegrees => TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw4AngleDegrees, tiltAdapterOptions.ScrewInwardCurvatureSign, FocuserSign);
 
         public bool IsWizardRunning {
             get => isWizardRunning;
@@ -1060,17 +1071,39 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         public bool IsStepperAdjustment => tiltAdapterOptions.AdjustmentType == TiltAdjustmentType.StepperMotors;
 
+        /// <summary>
+        /// The display-only focuser convention k as a sign: +1 standard, −1 reversed. Read only by the
+        /// mechanical wording below and by the physical⇄stored angle conversions; it never reaches the
+        /// calibration math (docs/focuser-direction-convention-design.md §2.2).
+        /// </summary>
+        private int FocuserSign =>
+            inspector?.InspectorOptions != null && inspector.InspectorOptions.FocuserIncreasesTowardObjective ? -1 : 1;
+
         // Mechanical framing of ScrewInwardCurvatureSign: does a CW screw turn (or +steps) move the
         // adapter plate toward the objective? Editing writes the sign (and marks it assumed); a
         // 6-step wizard measurement overwrites the sign and this re-reads it.
+        //
+        // The stored σ fuses the adapter mechanics and the focuser convention, σ = m·sign(k), so translating
+        // it into this mechanical question needs k on BOTH sides: the getter shows m = σ·sign(k), and for the
+        // combo to round-trip the setter stores σ = m·sign(k).
+        //
+        // THE ONE DELIBERATE EXCEPTION to "k never influences motion" (design §2.3, accepted by the user
+        // 2026-08-04). Its exposure is narrow: it writes only the ASSUMED σ, which every guidance surface
+        // flags "(assumed)" and any 6-step measurement overwrites; at the default k = +1 it is bit-identical
+        // to the previous behavior; and on a genuinely reversed rig it makes the manual path CORRECT where a
+        // pinned k = +1 conversion would silently store an inverted σ for an honest answer about m. Without
+        // it the UI contradicts itself on reversed rigs — the user picks "toward the objective" and the
+        // readback immediately says "toward the camera". Accepted residual risk: a user who sets k wrong AND
+        // sets the direction by hand instead of running the 6-step wizard gets inverted motion. Do NOT widen
+        // this; the only other sanctioned path is TiltScrewGeometry.PhysicalToStoredAngle (§7.4).
         public bool CwMovesAdapterTowardObjective {
             get {
                 int sign = tiltAdapterOptions.ScrewInwardCurvatureSign;
                 if (sign == 0) sign = TiltScrewGeometry.DefaultScrewInwardCurvatureSign;
-                return TiltScrewGeometry.CwMovesAdapterTowardObjectiveForSign(sign);
+                return TiltScrewGeometry.CwMovesAdapterTowardObjectiveForSign(sign * FocuserSign);
             }
             set {
-                int sign = TiltScrewGeometry.CurvatureSignForCwDirection(value);
+                int sign = TiltScrewGeometry.CurvatureSignForCwDirection(value) * FocuserSign;
                 if (tiltAdapterOptions.ScrewInwardCurvatureSign != sign) {
                     tiltAdapterOptions.ScrewInwardCurvatureSign = sign;
                     tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured = false;
@@ -1137,7 +1170,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // sign = -1 rigs), and the guidance math consumes stored angles as response-convention.
             // Convert with the adapter-direction sign in effect now; if the user changes that setting
             // later they must click Apply again (the conversion is not retroactive).
-            double stored1 = TiltScrewGeometry.PhysicalToStoredAngle(manualScrew1AngleDegrees, tiltAdapterOptions.ScrewInwardCurvatureSign);
+            double stored1 = TiltScrewGeometry.PhysicalToStoredAngle(manualScrew1AngleDegrees, tiltAdapterOptions.ScrewInwardCurvatureSign, FocuserSign);
             var (s1, s2, s3, s4) = TiltCalibrationCalculator.ComputeManualScrewAngles(stored1, manualNumberingClockwise, n);
             tiltAdapterOptions.Screw1AngleDegrees = s1;
             tiltAdapterOptions.Screw2AngleDegrees = s2;
@@ -2648,11 +2681,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 // from the raw model solves. The curvature effects are logged alongside because they are the
                 // quantity the stored sign is DEFINED in terms of (see TiltScrewGeometry's empirical anchor),
                 // and a run where the two disagree is exactly the evidence needed to settle the convention.
+                // The raw σ is printed as-is (it is the stored, k-free quantity); only the mechanical
+                // OBJECTIVE/CAMERA word needs the focuser convention, because m = σ·sign(k) — hence the
+                // explicit "per the focuser direction setting" caveat (design §3, site 6).
                 Logger.Info(
                     $"Tilt calibration: adapter direction measured from the all-screws step. Mean best-focus position {a.Mean:F1} → {b.Mean:F1} " +
                     $"(Δ {b.Mean - a.Mean:+0.0;-0.0} focuser steps); curvature effect at screw radius {a.CurvatureEffectAtScrewRadiusMicrons:F1} → {b.CurvatureEffectAtScrewRadiusMicrons:F1} µm. " +
-                    $"ScrewInwardCurvatureSign = {curvatureSign:+0;-0} (clockwise/+steps moves the adapter toward the " +
-                    $"{(TiltScrewGeometry.CwMovesAdapterTowardObjectiveForSign(curvatureSign) ? "OBJECTIVE" : "CAMERA")}).");
+                    $"ScrewInwardCurvatureSign = {curvatureSign:+0;-0} (per the focuser direction setting, clockwise/+steps moves the adapter toward the " +
+                    $"{(TiltScrewGeometry.CwMovesAdapterTowardObjectiveForSign(curvatureSign * FocuserSign) ? "OBJECTIVE" : "CAMERA")}).");
                 tiltAdapterOptions.ScrewInwardCurvatureSign = curvatureSign;
                 tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured = true;
             }
@@ -3287,11 +3323,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // image as shown in NINA"), so plot the PHYSICAL position — 180° from stored on −1 rigs,
             // identical on +1. Self-inverse PhysicalToStoredAngle converts stored→physical.
             int sign = tiltAdapterOptions.ScrewInwardCurvatureSign;
+            int focuserSign = FocuserSign;
             var angles = new[] {
-                TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw1AngleDegrees, sign),
-                TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw2AngleDegrees, sign),
-                TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw3AngleDegrees, sign),
-                n == 4 ? TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw4AngleDegrees, sign) : double.NaN
+                TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw1AngleDegrees, sign, focuserSign),
+                TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw2AngleDegrees, sign, focuserSign),
+                TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw3AngleDegrees, sign, focuserSign),
+                n == 4 ? TiltScrewGeometry.PhysicalToStoredAngle(tiltAdapterOptions.Screw4AngleDegrees, sign, focuserSign) : double.NaN
             };
 
             var centers = new (double cx, double cy)[n];

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -1211,6 +1211,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             RebaselineDriftWarningText = string.Empty;
             HasConfidenceWarning = false;
             ConfidenceWarningText = string.Empty;
+            curvatureChannelDisagreement = null;
             ClearSummaryRows();
             RaiseHardwareSummaryChanged();
             RebuildDiagram();
@@ -1248,6 +1249,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             RebaselineDriftWarningText = string.Empty;
             HasConfidenceWarning = false;
             ConfidenceWarningText = string.Empty;
+            curvatureChannelDisagreement = null;
             ClearSummaryRows();
             RaiseHardwareSummaryChanged();
             RebuildDiagram();
@@ -2061,6 +2063,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             RebaselineDriftWarningText = string.Empty;
             HasConfidenceWarning = false;
             ConfidenceWarningText = string.Empty;
+            curvatureChannelDisagreement = null;
             HasWarning = false;
             WarningText = string.Empty;
             HasDeviceLinkDroppedWarning = false;
@@ -2691,6 +2694,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     $"{(TiltScrewGeometry.CwMovesAdapterTowardObjectiveForSign(curvatureSign * FocuserSign) ? "OBJECTIVE" : "CAMERA")}).");
                 tiltAdapterOptions.ScrewInwardCurvatureSign = curvatureSign;
                 tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured = true;
+                curvatureChannelDisagreement = EvaluateCurvatureChannelCrossCheck(a, b, c, e, curvatureSign);
+            } else {
+                curvatureChannelDisagreement = null;
             }
 
             // Screw angles from each move relative to its preceding re-baseline (c→d, e→f).
@@ -2864,9 +2870,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // screw geometry is dominated by measurement noise / between-step drift (typically too few stars or a
         // too-coarse focus step), regardless of how cleanly the screws were turned — warn the user not to apply it.
         private void EvaluateCalibrationConfidence(TiltCalibrationConfidence confidence) {
+            var disagreement = curvatureChannelDisagreement;
             if (confidence == null || confidence.IsReliable) {
-                HasConfidenceWarning = false;
-                ConfidenceWarningText = string.Empty;
+                HasConfidenceWarning = disagreement != null;
+                ConfidenceWarningText = disagreement ?? string.Empty;
                 return;
             }
             HasConfidenceWarning = true;
@@ -2874,7 +2881,75 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 $"Low calibration confidence: signal-to-noise {confidence.SignalToNoise:F1} (need ≥ {TiltCalibrationCalculator.MinReliableSignalToNoise:F0}), " +
                 $"predicted screw-direction error ±{confidence.PredictedAngleUncertaintyDeg:F0}°. The tilt-measurement noise rivals the " +
                 "screw-move signal — usually too few stars or a too-coarse focus step (calibrate on a star-rich field with a finer step), " +
-                "or drift between steps. Re-capture before applying these screw angles.";
+                "or drift between steps. Re-capture before applying these screw angles." +
+                (disagreement == null ? string.Empty : " " + disagreement);
+        }
+
+        // The disagreement text from the last 6-step run's cross-check, or null. Held between
+        // EvaluateCurvatureChannelCrossCheck (which runs early in RunCalibrationMath, where the step readings
+        // are in hand) and EvaluateCalibrationConfidence (which owns the banner).
+        private string curvatureChannelDisagreement;
+
+        /// <summary>
+        /// How many times larger than the drift scale the a→b curvature-effect change must be before a
+        /// disagreement is worth surfacing. The optical channel is usually drift-buried, so this is a coarse
+        /// "obviously bigger than the noise" test, not a statistical one.
+        /// </summary>
+        private const double CurvatureCrossCheckDriftMultiple = 2.0;
+
+        /// <summary>
+        /// WARNING-ONLY cross-check of the measured σ against the OTHER channel (design §2.4, Q3 resolved
+        /// "adopt" by the user 2026-08-04).
+        ///
+        /// σ is measured from the mean best-focus change of the all-screws step — the geometric channel. The
+        /// curvature effect responds to the same piston, and σ is DEFINED as the sign of that response, so the
+        /// two are independent measurements of one quantity: one geometric, one optical. Before the sign fix
+        /// they agreed by construction; corrected, a disagreement is real information.
+        ///
+        /// It NEVER blocks, never prompts, and never changes the stored sign. The optical channel is usually
+        /// buried in secular drift (in the reference session Kx slid monotonically across all six steps,
+        /// including pure-tilt moves that changed no spacing), so it must not be allowed to veto the robust
+        /// channel — which also means a quiet panel is weak evidence of agreement, not proof of it. Hence the
+        /// scale test: the change must clear <see cref="CurvatureCrossCheckDriftMultiple"/>× the drift seen
+        /// across the two re-baselines, which is the only per-run estimate of that drift available.
+        ///
+        /// Reads no focuser convention: both channels are z-space, so k is irrelevant here by construction.
+        /// </summary>
+        /// <returns>The warning text, or null when the channels agree or the change is within the noise.</returns>
+        private static string EvaluateCurvatureChannelCrossCheck(
+                StepReading baseline, StepReading allInward, StepReading reBaseline1, StepReading reBaseline2, int measuredSign) {
+            double deltaE = allInward.CurvatureEffectAtScrewRadiusMicrons - baseline.CurvatureEffectAtScrewRadiusMicrons;
+            if (!double.IsFinite(deltaE) || deltaE == 0.0 || measuredSign == 0) {
+                return null;
+            }
+
+            // The re-baselines return the adapter to a previously-held state, so any curvature-effect change
+            // across them is drift, not signal. RMS of the two, mirroring ComputeConfidence's noise estimate.
+            double drift1 = reBaseline1.CurvatureEffectAtScrewRadiusMicrons - baseline.CurvatureEffectAtScrewRadiusMicrons;
+            double drift2 = reBaseline2.CurvatureEffectAtScrewRadiusMicrons - reBaseline1.CurvatureEffectAtScrewRadiusMicrons;
+            if (!double.IsFinite(drift1) || !double.IsFinite(drift2)) {
+                return null;
+            }
+            double driftScale = Math.Sqrt((drift1 * drift1 + drift2 * drift2) / 2.0);
+
+            bool agrees = Math.Sign(deltaE) == Math.Sign(measuredSign);
+            bool clearsNoise = Math.Abs(deltaE) > CurvatureCrossCheckDriftMultiple * driftScale;
+            if (agrees || !clearsNoise) {
+                return null;
+            }
+
+            string text =
+                $"Direction cross-check disagrees: the all-screws step moved the curvature effect at screw radius by " +
+                $"{deltaE:+0.0;-0.0} µm (re-baseline drift ≈ {driftScale:F1} µm), which implies the opposite adapter direction " +
+                $"from the mean best-focus measurement that set ScrewInwardCurvatureSign = {measuredSign:+0;-0}. The mean-focus " +
+                "channel is the more robust of the two and has been kept; this is informational. If corrections turn out to " +
+                "make aberrations worse, re-run the 6-step calibration on a star-rich field.";
+            Logger.Warning(
+                $"Tilt calibration: curvature-effect cross-check disagrees with the measured direction. " +
+                $"ΔE(a→b) = {deltaE:+0.0;-0.0} µm at screw radius, re-baseline drifts {drift1:+0.0;-0.0} / {drift2:+0.0;-0.0} µm " +
+                $"(RMS {driftScale:F1}); measured ScrewInwardCurvatureSign = {measuredSign:+0;-0}. The stored sign is unchanged — " +
+                "the mean-focus channel is the robust one (see docs/focuser-direction-convention-design.md §2.4).");
+            return text;
         }
 
         private StepReading Reading(WizardStep step) =>
@@ -2883,8 +2958,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // Test seam: seeds a step reading with the fields the calibration math consumes, so unit tests can
         // exercise NextStep/RunCalibrationMath without running the inspector. StepReading and stepReadings
         // stay private — this is the only external write path.
-        internal void SeedStepReading(WizardStep step, double a, double b, double mean) {
-            stepReadings[step] = new StepReading { A = a, B = b, Mean = mean };
+        internal void SeedStepReading(WizardStep step, double a, double b, double mean,
+                double curvatureEffectAtScrewRadiusMicrons = 0.0) {
+            stepReadings[step] = new StepReading {
+                A = a,
+                B = b,
+                Mean = mean,
+                CurvatureEffectAtScrewRadiusMicrons = curvatureEffectAtScrewRadiusMicrons
+            };
         }
 
         // Test seam: set the abandoned-run latch directly, so a test can prove StartAsync clears it WITHOUT

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -2142,7 +2142,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         internal static TiltMeasurementContext CaptureMeasurementContext(
             IInspectorOptions inspector, IAutoFocusOptions af, double fRatio, double focalLengthMm) {
             return new TiltMeasurementContext {
-                MicronsPerFocuserStep = inspector.MicronsPerFocuserStep,
+                // The EFFECTIVE value, so a run captured under a driver-supplied step size records what it
+                // actually measured with. A replay restores this as SensorModelFocuserSizeOverrideMicrons,
+                // which sits above both the override and the driver in the resolver.
+                MicronsPerFocuserStep = inspector.EffectiveMicronsPerFocuserStep,
                 FocalRatio = fRatio,
                 FocalLengthMm = focalLengthMm,
                 UseRANSAC = inspector.UseRANSAC,
@@ -2175,11 +2178,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             return string.Join(", ", diffs);
         }
 
-        private double EffectiveFocuserStepMicrons() {
-            var v = inspector.InspectorOptions?.MicronsPerFocuserStep ?? -1;
-            if (v > 0) return v;
-            return focuserInfo.StepSize > 0 ? focuserInfo.StepSize : -1;
-        }
+        // Delegates to the shared resolver (docs/focuser-step-size-driver-design.md §2). This used to
+        // duplicate the override→driver fallback locally against the wizard's own live focuserInfo — the
+        // pattern that design generalized. The shared one differs in being STICKY: a focuser that drops off
+        // the bus mid-run no longer silently changes the step size a measurement is interpreted at.
+        private double EffectiveFocuserStepMicrons() =>
+            inspector.InspectorOptions?.EffectiveMicronsPerFocuserStep ?? -1;
 
         private async Task RunMeasurementAsync() {
             HasMeasurementConsistencyWarning = false;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
@@ -179,9 +179,36 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             };
         }
 
-        /// <summary>Curvature (backfocus) sign from the all-screws-inward vs baseline mean-focus delta.</summary>
+        /// <summary>
+        /// Curvature (backfocus) sign σ from the all-screws-inward vs baseline mean-focus delta:
+        /// <c>σ = −sign(allScrewsMean − baselineMean)</c>. A zero delta yields +1, matching the
+        /// long-standing degenerate behavior.
+        ///
+        /// DERIVATION (docs/focuser-direction-convention-design.md §1). σ is DEFINED — see
+        /// <see cref="TiltScrewGeometry"/>'s empirical anchor — as the sign of the curvature-effect
+        /// response to a CW/+ turn, where the curvature effect is the FITTED (z-space) quantity. It
+        /// therefore factors into the two independent bits it fuses,
+        /// <c>σ = sign(m)·sign(k)</c>: the adapter's plate response <c>m</c> to a CW turn
+        /// (<c>m &gt; 0</c> ⇔ CW moves the plate toward the camera) and the focuser convention
+        /// <c>k</c> (<c>k = +1</c> ⇔ increasing focuser position moves the camera away from the
+        /// objective).
+        ///
+        /// The all-screws step is pure piston (<c>Δb = m·r</c>), so
+        /// <c>Δz̄ = −m·r·(1 − q̄)/k</c> and hence <c>sign(Δz̄) = −sign(m)·sign(k) = −σ</c> for the
+        /// <c>|q̄| ≪ 1</c> regime every real optical train sits in. <c>m</c> and <c>k</c> enter σ
+        /// and the probe ONLY through their product, so the focuser convention CANCELS: this
+        /// measurement is correct on standard and inverted focusers alike, with zero user input.
+        ///
+        /// This returned the negated sign — i.e. <c>−σ</c>, inverted on EVERY rig — until
+        /// 2026-08-04. Session 20260803-200647 is the measurement that exposed it: a +150 backfocus
+        /// step (plate toward the camera, <c>m = +1</c>) on a standard focuser moved the mean best
+        /// focus 5498.4 → 5136.6, so <c>σ = −sign(−361.8) = +1</c> — exactly the value the user had
+        /// already had to set by hand to make corrections converge. The paired correction to
+        /// <see cref="TiltScrewGeometry.PhysicalToStoredAngle"/>'s 180° offset shipped in the same
+        /// commit; the two inversions had been cancelling in the screw diagram (design §7).
+        /// </summary>
         public static int ComputeCurvatureSign(double allScrewsMean, double baselineMean) {
-            return (allScrewsMean - baselineMean) >= 0 ? 1 : -1;
+            return (allScrewsMean - baselineMean) <= 0 ? 1 : -1;
         }
 
         /// <summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltScrewGeometry.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltScrewGeometry.cs
@@ -167,15 +167,40 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public static int DefaultScrewInwardCurvatureSign => CurvatureSignForCwDirection(false);
 
         /// <summary>Converts between the physical image angle and the wizard's stored response-convention
-        /// angle (self-inverse): identical when CW raises the curvature effect (+1); 180° apart when CW
-        /// lowers it (−1). A zero sign is treated as the default direction. The condition is written
-        /// against the empirical-anchor constant so an anchor flip keeps the mechanical meaning
-        /// coherent: the 180° offset belongs to the rigs where CW moves the adapter toward the
-        /// objective. NOTE: callers convert with the sign in effect at Apply time — if the adapter
-        /// direction setting changes afterwards, the conversion must be re-applied.</summary>
-        public static double PhysicalToStoredAngle(double angleDegrees, int curvatureSign) {
+        /// angle (self-inverse). The stored angle is the direction of steepest INCREASE in best-focus
+        /// position produced by a CW/+ turn of that screw, so it sits 180° from the screw's physical
+        /// position exactly when a CW turn LOWERS best focus there — i.e. when the turn drives that
+        /// corner of the plate toward the camera:
+        ///
+        ///     offset = 180°   iff   m = +1   iff   σ·sign(k) = +1
+        ///
+        /// where <c>m</c> is the adapter's plate response to a CW turn and <c>k</c> the focuser
+        /// convention (<paramref name="focuserSign"/>; +1 = standard, increasing focuser position
+        /// moves the camera away from the objective). The condition is written against the
+        /// empirical-anchor constant so an anchor flip keeps the mechanical meaning coherent: the
+        /// 180° offset belongs to the rigs where CW moves the adapter toward the CAMERA. A zero
+        /// curvature sign is treated as the default direction.
+        ///
+        /// This is the SECOND sanctioned path on which the display-only focuser-direction setting
+        /// <c>k</c> can reach motion — through Manual Calibration Entry, which converts a typed
+        /// physical angle into a stored one — alongside the wizard's direction combo (design §2.3).
+        /// See docs/focuser-direction-convention-design.md §7.4; do NOT widen it. The
+        /// wizard-measured path is immune: those angles are measured directly into the response
+        /// frame and never round-trip through here.
+        ///
+        /// Before 2026-08-04 the offset was assigned to <c>m = −1</c> — exactly inverted — and had
+        /// been cancelling against the equally inverted
+        /// <see cref="TiltCalibrationCalculator.ComputeCurvatureSign"/>. Both were corrected in the
+        /// same commit, so displayed angles on measured profiles are unchanged (design §7.3).
+        ///
+        /// NOTE: callers convert with the signs in effect at Apply time — if the adapter-direction
+        /// or focuser-direction setting changes afterwards, the conversion must be re-applied.</summary>
+        public static double PhysicalToStoredAngle(double angleDegrees, int curvatureSign, int focuserSign = 1) {
             int resolvedSign = curvatureSign == 0 ? DefaultScrewInwardCurvatureSign : curvatureSign;
-            double offset = resolvedSign == CurvatureSignWhenCwMovesAdapterTowardObjective ? 180.0 : 0.0;
+            int resolvedFocuserSign = focuserSign < 0 ? -1 : 1;
+            // m = σ·sign(k). "CW moves the adapter toward the objective" is m = −1 and takes no
+            // offset; the 180° offset belongs to its complement, m = +1 (CW toward the camera).
+            double offset = CwMovesAdapterTowardObjectiveForSign(resolvedSign * resolvedFocuserSign) ? 0.0 : 180.0;
             return TiltCalibrationCalculator.NormalizeAngle(angleDegrees + offset);
         }
     }

--- a/Joko.NINA.Plugins/TestApp/BankVerifyRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/BankVerifyRunner.cs
@@ -511,7 +511,7 @@ namespace TestApp {
                 Logger.Warning($"bank-verify {label}: {cm.truthViolations} scored false positives land within the match radius of a truth star (F31 regression)");
             }
             try {
-                var focuserSizeMicrons = inspectorOptions.MicronsPerFocuserStep > 0 ? inspectorOptions.MicronsPerFocuserStep : 1.0;
+                var focuserSizeMicrons = inspectorOptions.EffectiveMicronsPerFocuserStep > 0 ? inspectorOptions.EffectiveMicronsPerFocuserStep : 1.0;
                 var pixelSize = activeProfile.CameraSettings.PixelSize > 0 ? activeProfile.CameraSettings.PixelSize : 3.76;
                 var sortedFoc = loaded.Select(l => (double)l.focuser).OrderBy(x => x).ToList();
                 var finalFocus = sortedFoc[sortedFoc.Count / 2];

--- a/Joko.NINA.Plugins/TestApp/InspectAlignRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/InspectAlignRunner.cs
@@ -145,7 +145,7 @@ namespace TestApp {
             var sortedFocusers = frameFiles.Select(f => (double)f.focuser).OrderBy(x => x).ToList();
             var finalFocusPosition = sortedFocusers[sortedFocusers.Count / 2]; // median; alignment is independent of this
             var stepSize = sortedFocusers.Count > 1 ? (int)Math.Round(sortedFocusers[1] - sortedFocusers[0]) : 100;
-            var focuserSizeMicrons = inspectorOptions.MicronsPerFocuserStep > 0 ? inspectorOptions.MicronsPerFocuserStep : 1.0;
+            var focuserSizeMicrons = inspectorOptions.EffectiveMicronsPerFocuserStep > 0 ? inspectorOptions.EffectiveMicronsPerFocuserStep : 1.0;
             var pixelSize = activeProfile.CameraSettings.PixelSize > 0 ? activeProfile.CameraSettings.PixelSize : 3.76;
 
             var messages = new List<string>();

--- a/docs/focuser-direction-convention-design.md
+++ b/docs/focuser-direction-convention-design.md
@@ -1,7 +1,8 @@
 # Focuser Direction Convention: measured σ stays authoritative; explicit display-only k
 
-**Status:** design, revised after user review; the layered shape in §2 is user-approved. Open
-questions at the end still need answers. Builds on `docs/tilt-adapter-direction-sign-design.md`
+**Status:** design, revised after user review; the layered shape in §2 is user-approved, and every
+open question is now resolved (Q1/Q3 by the user, Q2 from log evidence in §7, Q4 folded into §2).
+Ready to execute. Builds on `docs/tilt-adapter-direction-sign-design.md`
 (the confirmed measurement inversion, session `20260803-200647`) and
 `docs/tilt-guidance-motion-arrows-design.md` (whose §"Two vocabularies" equivalence at line 25 this
 doc corrects).
@@ -13,8 +14,10 @@ graphics are rendered? (2) If such a toggle were added, should it *replace*
 
 **Answer, in three sentences.** The correction math needs exactly one sign — the measured z-space
 response σ — and the sign algebra (§1) shows the focuser convention *cancels out* of its
-measurement, so the core fix is an unconditional one-line flip of `ComputeCurvatureSign` with zero
-user input. A focuser toggle can never replace σ, because σ is the *product* of two independent
+measurement, so the core fix is an unconditional flip of `ComputeCurvatureSign` with zero user
+input — which **must ship together with the matching flip of `PhysicalToStoredAngle`'s offset
+(§7)**, because those two inversions have been cancelling and correcting either alone inverts the
+screw diagram for every user. A focuser toggle can never replace σ, because σ is the *product* of two independent
 bits, `σ = sign(m)·sign(k)` (adapter mechanics × focuser convention), and the toggle supplies only
 one factor. But the convention does **not** cancel out of the *labels* — every caption that renders
 z-space into physical words currently pins `k = +1` silently — so the approved design layers them:
@@ -400,23 +403,85 @@ control plus tooltip in `Resources/OptionsDataTemplates.xaml` (§2.2, plan step 
   accepted as a bounded exception: the combo keeps its mechanical wording and its setter stores
   `σ = m·sign(k)`, touching only the *assumed* σ. See §2.3 for the rejected alternatives and the
   accepted residual risk.
-- **Q2 — `PhysicalToStoredAngle` absolute offset** (TiltScrewGeometry.cs:169–180): its 0°-vs-180°
-  assignment per σ was justified with the same family of reasoning as the inverted equivalence.
-  Checked against §1: the stored (response-frame) angle is the direction of local z-increase for a
-  CW turn, which works out to `θ_physical + Δ_mech + (180° iff σ = +1)` — a function of **σ and the
-  adapter's lever mechanics `Δ_mech`**, with `k` entering only through σ. So, contrary to first
-  appearances, storing `k` does **not** settle this: the unverified bit is the lever mechanics
-  (does tightening a screw at θ locally raise or lower the plate at θ — the tilt-domain doc's
-  pivot description suggests it may flip), not the focuser. What the explicit `k` buys is precise
-  mechanical wording around the setting once the mechanics bit is verified. Wizard-measured
-  calibrations are immune (angles measured directly); only **Manual Calibration Entry** and the
-  physical-angle *display* consume it. Decisive check, no code: on your calibrated rig, do the
-  wizard's displayed physical screw angles match where the screws actually sit? If yes, leave it;
-  if they read 180° off, that is a separate one-line fix plus its own migration question. This
-  design deliberately does not touch it.
+- **Q2 — RESOLVED from log evidence (2026-08-04): the offset IS inverted, and it must flip in the
+  SAME commit as `ComputeCurvatureSign`.** See §7 for the derivation. Superseded text: this
+  question previously asked whether the 0°-vs-180° assignment in `PhysicalToStoredAngle`
+  (TiltScrewGeometry.cs:169–180) was correct, and concluded no in-software evidence could settle
+  it. The `20260803-200647` log settles it, because the raw per-step tilt gradients recover the
+  stored angles directly and `m` is now known independently.
 - **Q3 — RESOLVED (user, 2026-08-04): adopt it.** The warning-only σ-vs-curvature-change
   disagreement check goes in the wizard's confidence panel (§2.4), not log-only. It is a required
   step of the plan, not an optional one. Warning-only is the point: it must never gate or alter the
   measured σ, only surface a disagreement for the user to judge. Note the known weakness recorded
   in §2.4 — the check is often drift-buried (the reference session's `Kx` slid monotonically across
   all six steps), so a quiet panel is weak evidence of agreement, not proof of it.
+
+## 7. The second inversion: `PhysicalToStoredAngle` (resolved from log `20260803-200647`)
+
+Q2 originally concluded that no in-software evidence could settle whether `PhysicalToStoredAngle`'s
+0°/180° assignment is correct, because the unverified bit is the adapter's lever mechanics rather
+than the focuser. That was right about *what* the unknown is and wrong that it was unreachable: `m`
+is now known independently, and the log preserves the raw per-step tilt gradients the stored angles
+were computed from. Together they close it.
+
+### 7.1 Recovering the stored angles from the log
+
+`StepReading.A/.B` are not the paraboloid's `Gx/Gy`. They are the weights of the four-corner plane
+fit in `TiltModel.cs:140–165`, whose inputs are `(x/W, y/H)` with **y pointing down**, so
+`A = Gx·W`, `B = Gy·H` — width and height scale them *differently*, and using `Gx/Gy` directly
+would give a wrong angle. With `W×H = 9576×6388` and the six solves logged at 21:27:50–21:46:21
+(`SensorModel.cs:209`):
+
+    d1 = (ΔA, ΔB) = (−35.890, +28.371)      [ReBaseline1 → Screw1]
+    d2 = (ΔA, ΔB) = (+52.717, +26.977)      [ReBaseline2 → Screw2]
+
+Feeding these through `ComputeScrewAngles` (`atan2(ΔA, −ΔB)`, which is exactly the wizard's
+0°-up/clockwise convention for a y-down image frame) yields the **stored, response-frame** angles:
+
+    s1 = 219.4°   s2 = 129.4°   s3 = 39.4°   s4 = 309.4°
+
+### 7.2 Where screw 1 physically sits — derived without the corner labels
+
+The stored angle is the direction of steepest **increase** in best-focus position produced by that
+screw's move. From §1, `m = σ·k = (+1)(+1) = +1`: a `+` step drives that corner toward the camera,
+which *lowers* best focus there. The screw therefore lies **opposite** the z-increase direction:
+
+    θ_physical(screw 1) = 219.4° − 180° = 39.4°   → top-right
+
+This uses only the raw gradients and `m`. It never consults `EatWizardMapping`, and it therefore
+**independently confirms** that mapping's `wizard screw 1 == TR`. The motor→corner correspondence
+is correct.
+
+### 7.3 The inversion, and why it was invisible
+
+`PhysicalToStoredAngle` applies its 180° offset when `σ == −1`. At the time of the reference
+screenshot σ *was* −1 (the panel reads "Curvature ↓ (measured)"), so it displayed
+`219.4 + 180 = 39.4°` — top-right, correct. Fix `ComputeCurvatureSign` and σ becomes `+1`, the
+offset drops to 0, and the same screw renders at **219.4° — bottom-left. Wrong.**
+
+The offset must key on the mechanics, not on σ directly:
+
+    offset = 180°  iff  m = +1   i.e.  iff  σ·k = +1
+
+As coded it fires when `σ = −1`, which at `k = +1` reads "iff `m = −1`" — exactly inverted. **Two
+inversions have been cancelling.** Fixing either alone flips the screw diagram for every user.
+
+Confirming check, and the acceptance criterion for the change: with both corrected,
+`σ·k = +1` → offset 180° → display `219.4 + 180 = 39.4°`, unchanged and still correct. **The pair
+of flips is a no-op for what users see.** Any visible change in the screw diagram after this change
+means one of the two was missed.
+
+### 7.4 Consequences for the layered design
+
+`PhysicalToStoredAngle` becomes a legitimate consumer of `k` — but it writes stored angles via
+**Manual Calibration Entry**, so it is a *second* bounded exception to "k never reaches motion",
+alongside the direction combo accepted in §2.3. The same reasoning applies: the wizard-measured
+path is immune (angles are measured directly into the response frame and never round-trip), the
+exposure is confined to hand-entered angles, and a wrong `k` there produces a wrong stored angle
+rather than a silently wrong sign. It must be listed with §2.3's exception, not treated as routine.
+
+Note on the evidence: the reference screenshot is from a *different, later* run than this log —
+every angle sits a uniform **+3.5°** off the values above (42.9/312.9/222.9/132.9), and its
+reported magnitude ratio is 1.5× where this run computes 1.294×. Same structure, same quadrants,
+slightly different camera rotation. It does not affect the derivation, which depends only on which
+side of 180° the stored angle falls.

--- a/docs/focuser-direction-convention-design.md
+++ b/docs/focuser-direction-convention-design.md
@@ -1,0 +1,422 @@
+# Focuser Direction Convention: measured σ stays authoritative; explicit display-only k
+
+**Status:** design, revised after user review; the layered shape in §2 is user-approved. Open
+questions at the end still need answers. Builds on `docs/tilt-adapter-direction-sign-design.md`
+(the confirmed measurement inversion, session `20260803-200647`) and
+`docs/tilt-guidance-motion-arrows-design.md` (whose §"Two vocabularies" equivalence at line 25 this
+doc corrects).
+
+**Questions answered here:** (1) should there be a rig-level toggle configuring the focuser's
+direction convention, and should it also change how the sensor model and aberration-inspector
+graphics are rendered? (2) If such a toggle were added, should it *replace*
+`ScrewInwardCurvatureSign`?
+
+**Answer, in three sentences.** The correction math needs exactly one sign — the measured z-space
+response σ — and the sign algebra (§1) shows the focuser convention *cancels out* of its
+measurement, so the core fix is an unconditional one-line flip of `ComputeCurvatureSign` with zero
+user input. A focuser toggle can never replace σ, because σ is the *product* of two independent
+bits, `σ = sign(m)·sign(k)` (adapter mechanics × focuser convention), and the toggle supplies only
+one factor. But the convention does **not** cancel out of the *labels* — every caption that renders
+z-space into physical words currently pins `k = +1` silently — so the approved design layers them:
+**σ stays measured and authoritative for all motion; `k` is added as a persisted, display-only
+setting that makes the captions and the mechanical wording true instead of assumed.** The central
+guarantee: a wrong `k` produces wrong labels and never wrong motion — a bounded, visible failure
+instead of a silent inverted one.
+
+---
+
+## 1. Definitions and the sign algebra, written out
+
+Everything below is derived from five quantities. Signs are the whole point, so nothing is asserted
+without derivation.
+
+| Symbol | Meaning | Sign convention | Property of |
+|---|---|---|---|
+| `P` | focuser position, in µm-equivalents | as reported by the driver | — |
+| `k` | focuser convention: sensor's objective-distance is `D = S₀ + k·P + b` | `k = +1` standard (increasing P moves camera **away** from objective), `k = −1` inverted | the **focuser** (rig/profile) |
+| `b` | adapter spacing contribution, µm | larger `b` = sensor **farther** from objective (toward the camera side) | — |
+| `m` | plate response to a CW/+ turn: `db/dr = m` | `m > 0` ⇔ CW/+ moves the plate toward the **camera** | the **adapter** |
+| `q_E` | optical response of the field-curvature mismatch to spacing: `∂(f_c,edge − f_c,center)/∂b` | pure optics — no focuser involved | the optics |
+
+The optical focal surface sits at objective-distance `F₀ + f_c(field, b)`; a field point is in focus
+when `D = F₀ + f_c`, so the fitted best-focus surface (the sensor model's z-axis, in focuser units) is:
+
+```
+z(field) = (F₀ + f_c(field, b) − S₀ − b) / k
+```
+
+Four consequences, each used below:
+
+**(a) Toward the objective ⇔ best-focus position rises (standard k).**
+`∂z/∂b = (q − 1)/k` where `q = ∂f_c/∂b` locally; the geometric term dominates (`|q| ≪ 1`, checked
+against the session in §1.1), so `∂z/∂b ≈ −1/k`. For `k = +1`: `b` down (toward objective) ⇒ `z` up.
+This is the corrected equivalence — `docs/tilt-guidance-motion-arrows-design.md:25` states the
+inverse ("toward the objective ⇔ the local best-focus position decreases") and is wrong prose.
+
+**(b) The stored sign σ is the product of two independent bits: `σ = sign(m)·sign(k)`.**
+`ScrewInwardCurvatureSign` is *defined* (TiltScrewGeometry.cs:140–150) as the sign of the
+curvature-effect response to a CW turn, where the curvature effect `E` is the **fitted** (z-space)
+quantity `CurvatureAt(...)`. Since `E_z = (f_c,edge − f_c,center)/k`:
+
+```
+dE_z/dr = q_E · m / k      ⇒      σ = sign(q_E) · sign(m/k) = sign(m) · sign(k)
+```
+
+using `q_E > 0`, fixed by the empirical anchor (2026-07-02, measured on a standard-`k` rig: "moving
+the adapter toward the objective DECREASES the curvature effect", i.e. `Δb < 0 ⇒ ΔE_z < 0` with
+`k = +1`; `q_E` is optics, independent of the focuser). This factorization is the load-bearing fact
+of the whole design: σ fuses the adapter bit and the focuser bit into one number, and only the
+product is observable from z-space.
+
+**(c) The all-inward probe measures `−σ`, on every rig — the measurement needs no user input.**
+The 6-step wizard's a→b step turns every screw CW/+ by `r`: pure piston, `Δb = m·r`, so
+
+```
+Δz̄ = −m·r·(1 − q̄)/k      ⇒      sign(Δz̄) = −sign(m)·sign(k) = −σ        (for q̄ < 1)
+```
+
+`m` and `k` enter both σ and the probe only through their product, so the focuser convention
+**cancels for the math**. The correct measurement is therefore unconditional:
+
+```
+σ = −sign(allScrewsMean − baselineMean)
+```
+
+`ComputeCurvatureSign` (TiltCalibrationCalculator.cs:183–185) currently returns
+`sign(allScrewsMean − baselineMean)` = `−σ`: inverted on **every** rig, not just standard ones. This
+kills hypothesis 2 of the prior doc ("this rig's focuser is inverted; the code is right in
+general"): there is no focuser convention under which the current formula measures the sign the
+consumers need, because the consumers (§1.2) consume σ in the same z-space the probe reads.
+
+**(d) Mechanical wording needs `k`; nothing computed does.**
+Inverting (b): `sign(m) = σ · sign(k)`. So translating σ into "CW moves the plate toward the
+camera/objective" words requires knowing `k` — the convention cancels for the math and does **not**
+cancel for the labels. The anchor constant `CurvatureSignWhenCwMovesAdapterTowardObjective = −1`
+(TiltScrewGeometry.cs:150) *is* that translation, silently pinned at `k = +1` (from (b): CW toward
+objective ⇒ `m < 0`, `k = +1` ⇒ `σ = −1` ✓). The constant stays as is — it is empirically anchored,
+its pinned test stays, and under the layered design the presentation layer generalizes it by
+looking up `σ·sign(k)` instead of `σ` (§2.2), which reduces to today's behavior at the default
+`k = +1`.
+
+### 1.1 Check against the observed session (20260803-200647)
+
+- `bf,+150` (vendor mnemonic: increase backfocus = plate toward **camera**, `m > 0`) on a standard
+  focuser (`k = +1`, NiteCrawler: 0 = fully racked = closest to objective) moved `Z0`
+  5498.4 → 5136.6. Predicted `sign(Δz̄) = −sign(m)·sign(k) = −1` ✓ observed (−361.8 steps).
+- Corrected measurement: `σ = −sign(−361.8) = +1`, giving `m = σ·k = +1` = "toward the camera" —
+  exactly the manual setting that made corrections converge ✓.
+- Magnitude sanity: 150 EAT steps and 361.8 focuser steps both correspond to ≈ 96 µm on this rig's
+  step sizes — the geometric `−m/k` term at ~1:1, confirming `|q̄| ≪ 1` (the mean-focus probe is
+  dominated by geometry, not optics). Caveat recorded: an optical train with `q̄ > 1` (mean focal
+  shift responding *more* than µm-for-µm to spacing) would defeat any mean-focus-based direction
+  probe; no such system is known, and the probe's large observed SNR is itself a per-run check.
+- **Why not measure σ from the curvature-effect change directly** (it is, after all, the
+  definition)? The session shows why: `Kx` slid monotonically −1.33e−7 → −2.10e−7 across *all six*
+  steps — including pure single-screw tilt moves and re-baselines that changed no spacing — so the
+  a→b curvature change (−401 → −442 µm at screw radius) is dominated by secular drift
+  (temperature/seeing/fit coupling), not the probe. The mean-focus signal (362 steps against
+  re-baseline drifts of tens) is the robust channel. The prior doc's observation that the two
+  channels "agree by construction" dissolves under the corrected sign: they are now *independent*
+  (one geometric, one optical) — which enables the cross-check in §2.4, but only as a warning,
+  since the optical channel is usually drift-buried.
+
+### 1.2 Why every consumer is already in the cancelling frame (verified, no changes needed)
+
+- `TiltScrewTargets.ComputePerScrewTargets` (TiltScrewTargets.cs:72–86): backfocus rotation
+  `= σ·(−E_r)/unit`. Required rotation from (b): `r = −E_z/(dE_z/dr) ⇒ sign(r) = −σ·sign(E_z)` ✓
+  identical. `k`-free.
+- `TiltScrewGeometry.SignedTotalAdjustment` (TiltScrewGeometry.cs:115–119): same σ-on-backfocus-only
+  convention ✓.
+- Tilt turns (InspectorVM.cs:2064–2068 and the calibration that feeds them): rotation→gradient
+  response measured directly through the same focuser during calibration; target and measurement
+  both in z-space, `k` and `m` cancel ✓.
+- Automatic Adjustment planner (InspectorVM.cs:2418–2424): resolves σ exactly like the guidance
+  table and feeds the same `TiltScrewTargets` ✓.
+- The wizard's device-driven runs: device "+" *is* the CW of the response frame because the screw
+  angles and σ are measured from device-"+" moves themselves ✓.
+
+This is why "only the MEASUREMENT is inverted" holds exactly: the consumption graph is closed in
+z-space; the single place a z-space quantity was translated with a physical-space assumption is
+`ComputeCurvatureSign`.
+
+---
+
+## 2. The layered design (approved)
+
+### 2.1 Why the toggle cannot replace σ — and why σ must not be derived from user-supplied bits
+
+The user asked whether a focuser-direction toggle could *replace* `ScrewInwardCurvatureSign`. It
+cannot, and the reason is §1(b): `σ = sign(m)·sign(k)` is the product of two independent bits, and
+the toggle supplies only `k`. Two rigs with opposite adapters *and* opposite focusers produce the
+same σ and are indistinguishable to the correction math — which is fine, because σ alone is what
+the math needs.
+
+The instinct behind the question is still pointing at a real defect. The existing user-facing
+direction setting — `TiltAdapterWizardVM.CwMovesAdapterTowardObjective` (:1066–1080), the combo at
+`TiltAdapterWizard/DataTemplates.xaml:711`, described in code as the "Mechanical framing of
+ScrewInwardCurvatureSign" — asks the user a question about `m` but **stores σ**, with the
+`m ↔ σ` conversion silently pinned at `k = +1` through the anchor dictionary. The setting as it
+exists today is already `m` and `k` fused into one bit with the focuser half assumed; that fusion
+is the source of the opacity the user noticed.
+
+The tempting fix — store `m` and `k` as two user-settable bits and *derive* `σ = m·k` — is
+rejected outright, and this is the decisive safety argument: post-fix, σ is **measured** with zero
+user input and is correct on any focuser (§1(c)). Replacing one measured quantity with two
+user-entered conventions, where *either* being wrong inverts σ and drives unattended correction
+backwards, is a net safety regression in exactly the dimension this whole investigation is about.
+Direction conventions are precisely the thing humans get wrong — that is how this bug was born.
+
+### 2.2 The approved shape: measured σ for motion, explicit k for words
+
+Layer the two quantities, keeping `k` strictly non-load-bearing:
+
+- **MATH — unchanged, zero user input.** σ stays measured and authoritative. The unconditional
+  one-line flip of `ComputeCurvatureSign` (§1(c)) is the core fix. `k` never enters the correction
+  math, the planner, the wizard's measurement, or the simulator.
+- **PRESENTATION — `k` becomes an explicit, persisted, display-only setting** (default: standard).
+  It drives exactly the caption sites enumerated in §3, and it lets the UI display the *true*
+  mechanical direction as `m = σ·k` instead of asserting it under a hidden assumption. Concretely,
+  every presentation-side use of the anchor dictionary changes from
+  `CwMovesAdapterTowardObjectiveForSign(σ)` to `CwMovesAdapterTowardObjectiveForSign(σ·sign(k))`,
+  the tilt motion arrows become `−σ·sign(k)·turns` (InspectorVM.cs:2078), and the backfocus motion
+  arrow becomes `⬆ ⇔ sign(k)·E_z > 0` (InspectorVM.cs:2104–2110) — all reducing bit-for-bit to
+  today's behavior at the default `k = +1`.
+
+**The central guarantee, and the design's acceptance criterion: a wrong `k` produces wrong LABELS
+and never wrong MOTION.** A user who sets `k` backwards sees captions and arrows that contradict
+what their hands and their aberration numbers tell them — a bounded, visible, self-correcting
+failure. It can never re-create the silent inverted-automation failure, because no computed motion
+reads `k`.
+
+**Structural enforcement, not convention.** Two mechanisms:
+
+1. *Placement.* `k` lives on `IInspectorOptions` (it is a focuser/rig property, like
+   `MicronsPerFocuserStep` — and deliberately **not** on `ITiltAdapterOptions`, whose σ it would
+   otherwise sit next to and get fused with again). The pure math layer
+   (`TiltCalibrationCalculator`, `TiltScrewGeometry`, `TiltScrewTargets`) takes no options object
+   and gains no `k` parameter on any computing function; the only new σ·k composition points are
+   presentation call sites. Any future attempt to thread `k` into a math signature is visible in
+   review.
+2. *Pinned invariance tests.* New guard tests assert that with `k` toggled both ways and identical
+   inputs: the measured σ from a seeded 6-step run is identical; the numeric guidance rows, glyphs
+   and totals are identical; the Automatic Adjustment move plan is identical; only
+   arrows/captions/wording differ. (Plan step 6.)
+
+**Option shape:** `IInspectorOptions.FocuserIncreasesTowardObjective`, `bool`, default `false`
+(= standard convention, `sign(k) = +1`), persisted per profile via the standard accessor pattern.
+Per the project invariant it gets a UI control in `Resources/OptionsDataTemplates.xaml` (a two-item
+ComboBox, "Increasing focuser position: Moves camera away from objective (standard) / Moves camera
+toward objective (reversed)", next to the `MicronsPerFocuserStep` control, with a
+`FocuserIncreasesTowardObjective_Tooltip` resource stating explicitly that it affects direction
+labels and diagrams only and can never change a measurement or a correction).
+
+### 2.3 The one deliberate exception: the manual direction combo (DECIDED — accepted 2026-08-04)
+
+The wizard's direction combo is an *input* for the assumed-σ path (when no measurement exists).
+Under the layered design its getter shows `m = σ·k`; for the combo to round-trip coherently its
+setter must store `σ = m·sign(k)` — which makes `k` touch the **assumed** σ. This is the one place
+the "k never influences motion" rule is bent, and it is bent deliberately:
+
+- It only writes the *assumed* σ, which every guidance surface already flags "(assumed)" and any
+  6-step measurement overwrites.
+- At the default `k = +1` it is bit-identical to today's behavior; on a genuinely reversed rig it
+  makes the manual path *correct* where today it is silently wrong (today's pinned `k = +1`
+  conversion would store an inverted σ for an honest answer about `m`).
+- Without it the UI is self-contradictory on reversed rigs: the user selects "toward the
+  objective" and the readback (computed as `σ·k`) immediately displays "toward the camera".
+
+**Decision (user, 2026-08-04): accept the bounded exception.** The combo keeps its mechanical
+wording; the setter stores `σ = m·sign(k)`.
+
+Two alternatives were considered and rejected:
+
+- *Reword the combo to the convention-free z-space question* ("turning all screws clockwise moves
+  the best-focus position: lower (typical) / higher"), keeping `k` perfectly non-load-bearing.
+  Coherent, and the only option that preserves the guarantee absolutely — but it asks users exactly
+  the kind of frame-dependent question this design otherwise eliminates.
+- *Gate manual entry on an explicitly confirmed `k`*, so `k` is never silently defaulted on a path
+  that reaches motion. Preserves the guarantee in substance while keeping the intuitive wording, at
+  the cost of an extra confirmation step for users who skip the wizard.
+
+The accepted residual risk, stated plainly so it is not rediscovered later: a user who sets `k`
+wrong **and** sets direction by hand instead of running the 6-step wizard gets inverted motion. The
+exposure is narrow — the measurement overwrites the assumed σ, the default `k` is bit-identical to
+today, and a reversed rig is *better* off than today — but it is a real hole in the "wrong `k`
+never causes wrong motion" guarantee, and it is the only one. Implementations must not widen it.
+
+### 2.4 Retained from the prior revision (unchanged verdicts)
+
+- **Auto-derivation from NINA:** impossible; NINA/ASCOM expose no "which way is out". `k` is
+  therefore a user-set bit — acceptable *because* it is display-only.
+- **A separate probe move to establish `k`:** rejected; `k` is consumed only by captions, not worth
+  an automated slew. (The 6-step a→b step remains the probe for σ and needs no `k`.)
+- **Confirmation prompt at calibration end (prior doc's C):** no modal; the fix is correct by
+  construction, and the measured direction is already surfaced in the log
+  (TiltAdapterWizardVM.cs:2651–2655) and the "measured" provenance.
+- **Cross-check, warning-only (prior doc's D):** adopt optionally (Q3). When the a→b
+  curvature-effect change is large relative to the re-baseline drifts *and* its sign contradicts
+  the measured σ, warn in the wizard's confidence panel. Never block: the optical channel is
+  usually drift-buried (§1.1) and must not veto the robust one.
+
+**Fail-safe position:** the measurement is parameter-free; the assumed-σ default (`+1`) and its
+"(assumed)" labelling are unchanged; `k` defaults to standard, and being wrong about it is visible
+in captions and correctable at any time with no effect on stored calibrations or motion.
+
+---
+
+## 3. Rendering impact — investigated, with file:line
+
+The question: do the sensor model and inspector graphics depend on the focuser direction
+convention? Under the layered design this section doubles as the enumeration of `k`'s consumers:
+**these sites, and nothing else, read `k`.**
+
+**The fit and every computed number: no.** The sensor model is fit in pure z-space (best-focus
+focuser position vs. sensor x/y — `Inspection/SensorParaboloidModel.cs:93`, solver at :330–450);
+no physical-direction input exists anywhere in the pipeline. Invariant surfaces, verified:
+
+- Contour/heat map *values, shape, colors* — `Controls/SensorModelContourMapControl.cs:142–213`
+  plots `ValueAt − SensorMeanElevation` with z-axis label "Offset (microns)"; no directional claim
+  in the control itself.
+- Tilt tables' numbers (Position / Adj Steps / Adj Microns) — `AutoFocus/TiltModel.cs:55–74`
+  (`AdjustmentRequiredSteps = corner − mean`, raw focuser units).
+- Tilt history and "Backfocus Steps" — `AutoFocus/DataTemplates.xaml:3737–3792`,
+  `InspectorVM.cs:1671` (raw focuser delta).
+- Numeric guidance rows, ⟳/⟲ glyphs, signed stepper steps, totals — `TiltScrewTargets.cs`,
+  `TiltScrewGuidanceRow.cs:103–123` (σ-frame, §1.2).
+- Wizard saved-calibration "Curvature ↑/↓ (measured)" — `TiltAdapterWizardVM.cs:694–701`
+  (explicitly the curvature-effect direction, z-space by definition).
+- FWHM/eccentricity maps — `Controls/FWHMContourControl.cs` (arcsec/px, direction-free).
+- Automatic Adjustment plan/prompt — `InspectorVM.cs:2418–2424` and downstream (σ-frame).
+
+**The captions that translate z into physics: yes — six sites, all currently hardcoding
+`k = +1`.** For each, the standard-convention reading is *correct* under the §1 algebra — i.e.
+these labels independently corroborate that `ComputeCurvatureSign` was the outlier that assumed the
+inverted equivalence. Under the layered design each becomes `k`-driven and thereby **correct on
+every rig** rather than correct-by-assumption (this supersedes the previous revision's open
+question about adding "assumes standard focuser" caveat text — with an explicit `k` the captions
+become correct, so no caveat is needed):
+
+1. `AutoFocus/DataTemplates.xaml:3638` and `:3837` — "Positive values = Move away from objective"
+   (both tilt-corner tables). Positive `Adj Steps` ⇔ corner best-focus above mean ⇔ (§1(a)) corner
+   sits closer to the objective **iff `k = +1`**. Becomes: "Move away from" / "Move toward"
+   selected by `k`.
+2. `AutoFocus/DataTemplates.xaml:3265` — "Telescope is up, Sensor is down" caption over the
+   sensor-model surface/contour view. Up = higher best-focus ⇔ closer to the telescope iff
+   `k = +1`. Caption text selected by `k`.
+3. `Controls/TiltModelControl.cs:142–143` — `ScreenLabel("Telescope", …)` / `ScreenLabel("Sensor", …)`
+   on the 3D tilt visualization (z = focuser delta, :97). Same claim as (2); labels swap with `k`
+   (new dependency property bound from the options).
+4. `AutoFocus/InspectorVM.cs:1671–1676` + `AutoFocus/DataTemplates.xaml:2859–2861` — "Backfocus
+   Error … (Move sensor TOWARDS/AWAY FROM flattener)". Outer above inner ⇒ `E_z > 0` ⇒ (`q_E > 0`)
+   reduce spacing **iff `k = +1`**. The TOWARDS/AWAY FROM selection becomes `k`-aware.
+5. `Inspection/SensorModelAberrationResult.cs:393–401` — "Try REMOVING/ADDING spacers"
+   (`E_z > 0 ⇒ REMOVING`). Same physics as (4); the direction word becomes `k`-aware (a focuser
+   sign parameter threaded into `Update(...)`).
+6. The mechanical vocabulary of the guidance/wizard, all routed through the anchor dictionary
+   (`TiltScrewGeometry.cs:150–167`): tilt motion arrows `InspectorVM.cs:2078`
+   (`−σ·turns` → `−σ·sign(k)·turns`), backfocus motion arrow `:2104–2110`
+   (`E_z > 0` → `sign(k)·E_z > 0`), legend text `TiltScrewGuidanceRow.cs:88–90` (text unchanged —
+   "⬆ = adapter moves toward the objective" remains the definition; the *selection* of ⬆ vs ⬇ is
+   what becomes `k`-aware), wizard direction combo
+   `TiltAdapterWizard/DataTemplates.xaml:711–732` + `TiltAdapterWizardVM.cs:1066–1080` (getter
+   `m = σ·k`; setter per §2.3), and the calibration log's OBJECTIVE/CAMERA verdict
+   `TiltAdapterWizardVM.cs:2654–2655` (keep printing raw σ; the mechanical word uses `σ·k` and says
+   so). Given the default `k = +1`, every one of these renders exactly as today.
+
+**Prose that must be fixed regardless (it is wrong, not merely scoped):**
+- `docs/tilt-guidance-motion-arrows-design.md:25` — the inverted equivalence; re-justify the arrow
+  formulas from §1(d): a CW/+ turn moves the plate toward the camera iff `σ·k = +1`, hence
+  motion-toward-objective is `−σ·sign(k)·turns` for tilt and `sign(k)·E_z > 0` for backfocus, with
+  the shipped `k = +1` default reproducing the current formulas.
+- `.claude/docs/tilt-domain.md:26` — "pure physics, identical on every rig" overstates: identical
+  given the focuser-direction setting (previously: given the silent standard assumption).
+- `documentation/docs/overview/tilt-adapter-wizard.md:58–62` — says the 6-step run determines the
+  sign "from the curvature change"; it is measured from the mean best-focus change (and after this
+  fix, with the corrected sense). Also document the new focuser-direction setting and that the
+  direction combo now reflects it.
+- `documentation/docs/overview/tilt-aberration-inspector.md:111–112` — "the same on every rig",
+  same rewording as tilt-domain.md.
+
+---
+
+## 4. The camera simulator must flip with the measurement (unchanged finding)
+
+`SimulatedTiltInjection.Fold` (CameraSimulator/TiltAdapter/SimulatedTiltInjection.cs:72–93) folds an
+all-screws piston into **two** responses:
+
+- `OptimalFocuserPosition += pistonMicrons/step` (:77) — the geometric mean-focus shift. With
+  `pistonMicrons = σ·δ` for a CW move, the sim's mean focus moves by `+σ·δ`; real physics (§1(c))
+  moves it by `−σ·δ`. The sim was built to satisfy the buggy measurement and **must flip this line**
+  (to `−pistonMicrons`) in the same change, or a simulated 6-step run will measure `−σ_config`
+  after the calculator fix.
+- `BackfocusErrorMicrons += pistonMicrons·(hw²+hh²)/R²` (:86–91) — the curvature-effect response,
+  `+σ·δ` per the definition of σ. **Correct as is** (`q_E > 0` behavior); unchanged.
+
+The sim is pure z-space and never reads `k` — that stays true under the layered design (the sim is
+on the "math" side of the wall). The existing sim tests only pin the *antisymmetry* of the focuser
+shift across σ (`SimulatedTiltAdapterVMTests.BackfocusMove_OnOppositeRigs_ShiftsTheFocuserInOppositeDirections`,
+:210–228), so the flip keeps them green; the absolute direction was never pinned — a gap this change
+closes with a new test. The curvature-response pins
+(`BackfocusMove_ChangesBackfocusErrorWithTheSignOfTheRigDirection`, :172–182 and
+`…OnOppositeRigs_MovesBackfocusInOppositeDirections`, :188–207) are unaffected.
+
+---
+
+## 5. Migration (unchanged finding)
+
+Profiles where `ScrewInwardCurvatureSignIsMeasured == true` hold a deterministically inverted value:
+every measured σ ever written came from the inverted formula, and any user who *manually* corrected
+the direction afterwards (as this user did) went through the `CwMovesAdapterTowardObjective` setter,
+which clears `IsMeasured` (TiltAdapterWizardVM.cs:1074–1077). Therefore:
+
+- **Auto-negate σ once** for profiles with `IsMeasured == true`, guarded by a new persisted one-time
+  marker so it can never double-apply; log at Info and raise a one-time notification naming the
+  profile and both values.
+- `IsMeasured == false` (assumed or manually set) — **untouched**: the stored value is the user's
+  or the default's, not the buggy formula's.
+- The new `k` option needs no migration: it is introduced at its default (standard), which
+  reproduces today's rendering everywhere.
+- Replays: `TiltCalibrationMetadata` stores raw step readings and replays recompute through
+  `RunCalibrationMath` (TiltAdapterWizardVM.cs:3106/3117), so replaying an old saved run after the
+  fix yields the *correct* sign with no metadata change.
+- Known cosmetic side effect: the wizard's displayed "physical" screw angles
+  (`PhysicalToStoredAngle`, consumed at TiltAdapterWizardVM.cs:537–540) rotate 180° for migrated
+  profiles, because the display converts stored angles with the now-flipped σ. Guidance and
+  automation never consume physical angles, so this is display-only — but see Q2.
+- Downgrade hazard (accepted, documented): a migrated profile re-measured on an *old* plugin
+  version gets the inverted sign again; nothing in this design can defend against running old code.
+
+The migration marker is persisted internal state, not a user option — same category as
+`TiltDeviceShadowPositions` / `DeviceLinkedCalibrationDeviceName` / `CalibrationIsReliable`, none of
+which have (or should have) a control in `Resources/OptionsDataTemplates.xaml`. The one user-facing
+persisted option this design adds — `FocuserIncreasesTowardObjective` — carries the full invariant:
+control plus tooltip in `Resources/OptionsDataTemplates.xaml` (§2.2, plan step 5).
+
+---
+
+## 6. Open questions for the user
+
+- **Q1 — RESOLVED (user, 2026-08-04).** The manual direction combo's `k`-aware round-trip is
+  accepted as a bounded exception: the combo keeps its mechanical wording and its setter stores
+  `σ = m·sign(k)`, touching only the *assumed* σ. See §2.3 for the rejected alternatives and the
+  accepted residual risk.
+- **Q2 — `PhysicalToStoredAngle` absolute offset** (TiltScrewGeometry.cs:169–180): its 0°-vs-180°
+  assignment per σ was justified with the same family of reasoning as the inverted equivalence.
+  Checked against §1: the stored (response-frame) angle is the direction of local z-increase for a
+  CW turn, which works out to `θ_physical + Δ_mech + (180° iff σ = +1)` — a function of **σ and the
+  adapter's lever mechanics `Δ_mech`**, with `k` entering only through σ. So, contrary to first
+  appearances, storing `k` does **not** settle this: the unverified bit is the lever mechanics
+  (does tightening a screw at θ locally raise or lower the plate at θ — the tilt-domain doc's
+  pivot description suggests it may flip), not the focuser. What the explicit `k` buys is precise
+  mechanical wording around the setting once the mechanics bit is verified. Wizard-measured
+  calibrations are immune (angles measured directly); only **Manual Calibration Entry** and the
+  physical-angle *display* consume it. Decisive check, no code: on your calibrated rig, do the
+  wizard's displayed physical screw angles match where the screws actually sit? If yes, leave it;
+  if they read 180° off, that is a separate one-line fix plus its own migration question. This
+  design deliberately does not touch it.
+- **Q3 — RESOLVED (user, 2026-08-04): adopt it.** The warning-only σ-vs-curvature-change
+  disagreement check goes in the wizard's confidence panel (§2.4), not log-only. It is a required
+  step of the plan, not an optional one. Warning-only is the point: it must never gate or alter the
+  measured σ, only surface a disagreement for the user to judge. Note the known weakness recorded
+  in §2.4 — the check is often drift-buried (the reference session's `Kx` slid monotonically across
+  all six steps), so a quiet panel is weak evidence of agreement, not proof of it.

--- a/docs/focuser-step-size-driver-design.md
+++ b/docs/focuser-step-size-driver-design.md
@@ -1,0 +1,151 @@
+# Focuser step size from the driver, with the stored value as an override
+
+**Status:** design, user-approved 2026-08-04. Ready to execute.
+
+`IInspectorOptions.MicronsPerFocuserStep` is the µm of focuser travel per step — the scale factor that turns
+every focuser-space measurement into microns. Today it has exactly one source: a number the user types.
+Almost every focuser driver already reports it (ASCOM `Focuser.StepSize`, surfaced by NINA as
+`FocuserInfo.StepSize`), and HocusFocus ignores it.
+
+This design makes the driver the default source and demotes the stored value to an **override**, with a UI
+flag when the two disagree.
+
+## 1. Why this matters more than a convenience default
+
+The setting is not cosmetic. It scales:
+
+- the sensor-model fit's curvature effect and tilt effect, in microns;
+- the per-screw axial corrections, and therefore the screw turns / stepper steps the guidance prints;
+- `BackfocusMicronDelta` and the critical-focus-zone comparison;
+- the camera simulator's rendered defocus.
+
+Left unset it degrades gracefully — micron readouts go NaN and the affected rows drop out — so the current
+failure mode is *missing* information, not wrong information. That is the property to preserve: nothing in
+this design may turn "unset" into a silently wrong number.
+
+The reason to reach for the driver at all is that the value is genuinely knowable. A user who never opens the
+options page gets correct microns instead of no microns.
+
+The reason to keep the override is that the driver is frequently wrong. ASCOM `StepSize` is optional; drivers
+that do not implement it report `0` (handled — see §2), but a real minority report a *plausible* wrong number
+— commonly `1`, meaning "one step per step" rather than one micron per step. That class of error is invisible
+without a second opinion, which is what §4's flag exists to provide.
+
+## 2. The resolver
+
+Four layers, highest priority first:
+
+| # | Source | Condition | Persisted |
+|---|---|---|---|
+| 1 | `InspectorVM.SensorModelFocuserSizeOverrideMicrons` | set (replaying a saved run at its captured step size) | no — exists today, unchanged |
+| 2 | `IInspectorOptions.MicronsPerFocuserStep` | `> 0` | yes, per profile |
+| 3 | `IInspectorOptions.DriverMicronsPerFocuserStep` | finite and `> 0` | **no** |
+| 4 | unset (`-1`) | — | — |
+
+Layer 3 is new. Its acceptance test is exactly "finite and `> 0`", which rejects the three ways a driver
+declines to answer: `0`, a negative sentinel, and `NaN`. Note `> 0` rather than `!(<= 0)`: `NaN` fails both
+comparisons, and only the positive form rejects it — the same trap already documented on
+`CameraSimulatorOptions.EffectiveFocuserStepSizeMicrons`.
+
+Three new members sit beside `MicronsPerFocuserStep` on `IInspectorOptions`:
+
+- **`DriverMicronsPerFocuserStep`** — in-memory only, never written to the options accessor.
+- **`EffectiveMicronsPerFocuserStep`** — the resolver over layers 2–4. Read-only. This is what every consumer
+  that wants "the number to compute with" reads.
+- **`HasFocuserStepSizeMismatch`** — §4.
+
+### Why on `IInspectorOptions` and not a new service
+
+A dedicated `IFocuserStepSizeProvider` is the tidier abstraction in isolation, but it would have to be
+threaded through `InspectorOptions`, `CameraSimulatorOptions`, `SensorModel`, `TiltModel`,
+`TiltAdapterWizardVM` and both TestApp runners to reach the places that already hold an `IInspectorOptions`.
+The step size is *already* modelled as one shared variable living there — `CameraSimulatorOptions` takes an
+`IInspectorOptions` for the sole purpose of reaching it — so the resolver belongs next to the value it
+resolves.
+
+The cost is that `IInspectorOptions` gains one member that is not an option. The doc comment carries that
+contract explicitly, and a test asserts it never reaches the accessor.
+
+### Stickiness (decided: sticky last-known)
+
+`DriverMicronsPerFocuserStep` is **only ever written with a valid value**. A disconnect reports `StepSize = 0`,
+which fails the acceptance test and is therefore not written, so the last-known value stands. This is the
+whole mechanism — there is no separate "remember" step to get wrong.
+
+The consequence is deliberate: disconnecting a focuser mid-session does not rescale an in-flight analysis, and
+reconnecting the same focuser is a no-op. The accepted cost is that swapping to a focuser that reports nothing
+leaves the previous focuser's value in place for the rest of the session.
+
+It is cleared on **profile change** — a profile swap is the codebase's existing signal for "different rig", and
+`InitializeOptions` already runs there.
+
+## 3. Consumers
+
+Switch to `EffectiveMicronsPerFocuserStep` (these want the number to compute with):
+
+- `InspectorVM` — the sensor-model fit's `focuserSizeMicrons`, and `BackfocusMicronDelta`.
+- `TiltModel.RebuildAdjustments` — the per-corner adjustment microns.
+- `CameraSimulatorOptions.EffectiveFocuserStepSizeMicrons` — so the simulator renders at the same `k` the
+  inspector recovers with. Two independent `k`s do not drift harmlessly; they break the inject⇄recover loop by
+  exactly their ratio, silently. Its `2.0 µm` default moves to the end of the chain, after the driver.
+- `TiltAdapterWizardVM` — the captured `TiltMeasurementContext.MicronsPerFocuserStep` and the drift comparison
+  against it. A run captured under a driver-supplied step size must record what it actually used.
+- Both TestApp runners — no focuser is connected there, so `Effective` reduces to the raw value and the change
+  is a no-op that keeps the codebase on one accessor.
+
+Stay **raw** (these *are* the override, not the resolved value):
+
+- `InspectorOptions`' own load/store/reset.
+- `CameraSimulatorOptions.FocuserStepSizeMicrons` get/set — the editable pass-through.
+- `CameraSimulatorOptions`' legacy migration, which asks "is the *stored* value already calibrated?" and must
+  not be answered by a driver.
+- `TiltAdapterWizardVM.MicronsPerFocuserStepValue` — the wizard's editable box.
+- The two-way XAML bindings.
+
+## 4. The mismatch flag
+
+`HasFocuserStepSizeMismatch` is true when **all** of:
+
+- the override is set (`MicronsPerFocuserStep > 0`), and
+- the driver value is valid (finite, `> 0`), and
+- they differ by more than **1% relative** to the driver value.
+
+The tolerance exists so that a user whose measured calibration lands at 1.02 against a driver-reported 1.00
+does not carry a permanent badge, while the failure this check exists to catch — a driver reporting steps
+rather than microns, or a 2× error — flags loudly. Relative rather than absolute, because step sizes across
+real rigs span roughly 0.1–10 µm.
+
+It is **advisory only**. It changes no value, blocks nothing, and the override continues to win. A user who
+has deliberately measured their own step size and trusts it over the driver's claim is exactly right to, and
+the flag must read as information rather than as an error.
+
+Surfaced in both places the setting is editable — the Aberration Inspector dock's row and the plugin's Camera
+Simulator options tab — as inline text naming both numbers.
+
+## 5. Hint text
+
+Both boxes are already `HintTextBox`es showing a greyed fallback when empty. Their hint changes from
+`(disabled)` / the simulator's hardcoded default to the **effective** value, so an empty box shows what will
+actually be used. This is what makes the driver fallback discoverable at all: without it, a user with a
+driver-supplied step size sees an empty box and concludes the feature is off.
+
+## 6. What this design does not do
+
+- **No persistence of the driver value.** It is device state, re-read on every connect. Persisting it would
+  create a second copy that goes stale against a swapped focuser — the exact failure the simulator's
+  `FocuserStepSizeMicrons` was collapsed into `MicronsPerFocuserStep` to eliminate.
+- **No auto-adoption into the override.** The driver value is never written into the persisted setting, so
+  "clear the box" always means "go back to the driver" and is never a lossy operation.
+- **No prompt or modal on mismatch.** §4 is a label.
+
+## 7. Testing
+
+- Resolver precedence across all four layers, including the per-run override still winning.
+- Stickiness: a valid driver value survives a `StepSize = 0` disconnect; a profile change clears it.
+- Rejection: `0`, negative, and `NaN` driver values are never adopted — with `NaN` called out, since it is the
+  one that slips through a `<= 0` guard.
+- The driver value never reaches the options accessor.
+- Flag matrix: quiet at 1.00 vs 1.005; fires at 1.00 vs 2.00; never fires with no override; never fires with
+  no valid driver value.
+- `InspectorVM.UpdateDeviceInfo` writes a valid `FocuserInfo.StepSize` through and ignores an invalid one.
+- The simulator's inject⇄recover loop still closes when `k` comes from the driver rather than the override.

--- a/docs/tilt-adapter-direction-sign-design.md
+++ b/docs/tilt-adapter-direction-sign-design.md
@@ -1,6 +1,28 @@
 # Adapter direction (`ScrewInwardCurvatureSign`): the measured sign came out inverted
 
-**Status:** analysis + options. **Needs a decision before any code change** — this sign decides which way every
+**Status: RESOLVED — superseded by [`docs/focuser-direction-convention-design.md`](focuser-direction-convention-design.md), implemented 2026-08-04.**
+
+**Hypothesis 1 was confirmed, in a strengthened form.** `ComputeCurvatureSign` was not merely inverted on
+*this* rig — it was inverted on **every** rig. Writing the stored sign as `σ = sign(m)·sign(k)` (adapter
+mechanics × focuser convention) shows that `m` and `k` enter both σ and the all-screws probe only through
+their product, so the focuser convention **cancels out of the measurement**. That kills hypothesis 2 ("this
+rig's focuser is inverted; the code is right in general"): there is no focuser convention under which the old
+formula measured the sign the consumers need. The fix is therefore unconditional and needs no user input.
+
+The same factorization explains why the existing direction setting felt opaque: it asks the user a question
+about `m` but stores σ, with the `m ↔ σ` conversion silently pinned at `k = +1`. The resolution keeps σ
+measured and authoritative for all motion, and adds `k` as a separate, **display-only** setting so the
+mechanical wording is true rather than assumed.
+
+The investigation also turned up a **second** inversion hiding behind the first: `PhysicalToStoredAngle`
+assigned its 180° offset to the wrong half of the rigs, and the two had been cancelling in the screw diagram.
+They were corrected together.
+
+Retained below for the log evidence and the original reasoning.
+
+---
+
+**Original status:** analysis + options. **Needs a decision before any code change** — this sign decides which way every
 automated correction turns, and getting it wrong drives tilt in the wrong direction unattended.
 
 ## What happened
@@ -39,7 +61,11 @@ The convention is stated in `docs/tilt-guidance-motion-arrows-design.md` §"Two 
 
 > Because "adapter moves toward the objective" ⇔ "the local best-focus position decreases" …
 
-That equivalence is what `ComputeCurvatureSign` encodes. Working it through for a standard focuser (increasing
+(That quoted equivalence is itself backwards, and it has since been corrected in place — see
+`docs/focuser-direction-convention-design.md` §1(a). It is quoted here as it stood, because it is what
+`ComputeCurvatureSign` encoded.)
+
+Working it through for a standard focuser (increasing
 position = drawtube extends = camera moves **away** from the objective):
 
 - Let `S` be the objective→sensor distance. `S = k·P + B + const`, with `P` the focuser position and `B` the

--- a/docs/tilt-guidance-motion-arrows-design.md
+++ b/docs/tilt-guidance-motion-arrows-design.md
@@ -22,10 +22,25 @@ Two glyph vocabularies, each answering a different question:
 | ⬆ / ↑ / — / ↓ / ⬇ (arrows grid) | *What must the adapter do at this screw?* | ⬆ = this corner of the adapter plate moves **toward the objective**; ⬇ = toward the camera. Magnitude tiers (large/small/dash) keep today's threshold logic. |
 | ⟳ / ⟲ (numeric grid, screws) | *Which way do I turn this screw?* | ⟳ = clockwise (tighten); ⟲ = counter-clockwise (loosen). U+27F3 / U+27F2 text glyphs. |
 
-Because "adapter moves toward the objective" ⇔ "the local best-focus position decreases" (this is what `ScrewInwardCurvatureSign` σ together with the pinned constant `CurvatureSignWhenCwMovesAdapterTowardObjective = −1` encode — no new empirical input is needed), both vocabularies are computable from existing state:
+> **CORRECTED 2026-08-04** (`docs/focuser-direction-convention-design.md`). This paragraph originally
+> justified the arrow formulas with "adapter moves toward the objective ⇔ the local best-focus position
+> decreases". That equivalence is **backwards, and it is not convention-free**. Writing the sensor's
+> objective-distance as `D = S₀ + k·P + b` (focuser position `P`, focuser convention `k = ±1`, adapter
+> spacing `b`), the fitted best-focus surface is `z = (F₀ + f_c − S₀ − b)/k`, so `∂z/∂b ≈ −1/k`: on a
+> **standard** focuser (`k = +1`) moving the plate toward the objective *raises* the best-focus position.
+> The formulas below are correct as written; only the justification was wrong, and it needed a `k`.
 
-- **Tilt row** — rotation is σ-free (the calibrated screw angles already encode the rig's response direction): glyph ⟳ iff the CW-positive tilt turns value is positive. Motion needs σ: arrow ⬆ iff `σ · turns[i] < 0`.
-- **Backfocus row** — motion is σ-free (pure curvature physics): arrow ⬆ iff the backfocus correction calls for the local best-focus position to decrease (`BackfocusMicrons < 0` in the correction convention — verify the equivalent expression the VM already computes when implementing). Rotation needs σ: glyph ⟳ iff `σ · BackfocusMicrons > 0`.
+The right derivation. A CW/+ turn moves the plate toward the camera iff `m = +1`, where `m = σ·sign(k)` — the
+stored sign σ fuses the adapter's mechanics with the focuser convention, and only their product is observable
+from z-space. So the two vocabularies are computable from existing state, with `k` entering the *motion*
+claims and nothing else:
+
+- **Tilt row** — rotation is σ-free (the calibrated screw angles already encode the rig's response direction): glyph ⟳ iff the CW-positive tilt turns value is positive. Motion needs σ *and* `k`: arrow ⬆ iff `σ · sign(k) · turns[i] < 0`.
+- **Backfocus row** — motion is σ-free (the σ in "which rotation is needed" and the σ in "what a rotation does" cancel), but naming that motion still needs `k`: arrow ⬆ iff `sign(k) · E_z > 0`. Rotation needs σ: glyph ⟳ iff `σ · BackfocusMicrons > 0`.
+
+`k` is the display-only `IInspectorOptions.FocuserIncreasesTowardObjective`, and it ships defaulted to the
+standard convention (`sign(k) = +1`), at which both formulas reduce bit-for-bit to the ones this document
+originally specified. Nothing computed reads it.
 - **Total row** — rotation per the corrected PR #117 formula (`SignedTotalAdjustment`): glyph ⟳ iff `TiltMicrons + σ·BackfocusMicrons > 0`. (No motion arrow — the arrows grid has no Total row; unchanged.)
 
 Robustness property (state it in code comments and pin it in tests): with a **wrong** adapter-direction setting, the tilt *arrows* flip but the tilt *glyphs* stay correct, and the backfocus *arrows* stay correct while the backfocus *glyphs* flip. The old failure mode — two rotation indicators contradicting each other — cannot recur because arrows and glyphs no longer claim to answer the same question. The "(assumed …)" legend suffix remains the flag that σ is unverified.

--- a/documentation/docs/overview/camera-simulator.md
+++ b/documentation/docs/overview/camera-simulator.md
@@ -84,7 +84,7 @@ starts, so edits apply to the next frame.
 | Setting | Default | What it does |
 |---|---|---|
 | **Optimal Focuser Position** | 5000 steps | The focuser position at which stars are sharpest. Move the focuser away from it and stars defocus. |
-| **Focuser Step Size** | unset | Microns of defocus per focuser step. This is the same setting as the Aberration Inspector's **Focuser Step Size**; editing either changes both. Blank renders at 2 µm/step. |
+| **Focuser Step Size** | blank | Microns of defocus per focuser step. This is the same setting as the Aberration Inspector's **Focuser Step Size**; editing either changes both. Blank renders at whatever the greyed-out hint shows — your focuser driver's reported step size if it supplies one, otherwise 2 µm/step. |
 | **Gain** | 100 | Camera gain, on a ZWO-style scale. Affects e⁻/ADU and read noise, including the high-conversion-gain step. |
 | **Bias Pedestal** | 500 ADU | Offset added to every pixel. |
 | **Sensor Temperature** | −10 °C | Sets dark current, which doubles every 6.5 °C. |

--- a/documentation/docs/overview/tilt-aberration-inspector.md
+++ b/documentation/docs/overview/tilt-aberration-inspector.md
@@ -139,7 +139,7 @@ star-matching, outlier-rejection, and save-images settings (plus **Astigmatic fi
 | Setting | Default | Range | What it does |
 |---|---|---|---|
 | **Eccentricity Grid Width** | 7 | odd, positive | "How many cells wide to divide the sensor pixels when generating a grid of eccentricity vectors … the height will be calculated proportionally." |
-| **Focuser Step Size** | -1 (auto) | -1 or &gt;0 | "How much the focuser moves per step, in microns. If this is set, the adjustment chart will include adjustments in microns." |
+| **Focuser Step Size** | blank | blank or &gt;0 | µm of focuser travel per step. Blank uses the value your focuser driver reports (shown greyed out in the box); a value here overrides it. See [below](#where-the-focuser-step-size-comes-from). |
 | **Increasing focuser position** | Moves camera away from objective (standard) | standard / reversed | Which way your focuser travels. Affects direction labels and diagrams only — see [below](#which-way-does-your-focuser-travel). Also editable under Options → Hocus Focus → Auto Focus. |
 | **Sensor ROI** | 1.0 | 0.1–1.0 | "Uses only a centered portion of the full sensor when evaluating aberration. This is useful if you have a flattener that cannot produce a flat field for your sensor." |
 | **Corners ROI** | 1.0 | 0.1–1.0 | "Reduces the size of the corner regions when performing corners analysis … evaluate only stars closer to the corners than the full 1/9th region. This can be combined with Sensor ROI." |
@@ -170,6 +170,30 @@ star-matching, outlier-rejection, and save-images settings (plus **Astigmatic fi
 !!! tip "Sensor ROI protects the tilt fit"
     Restricting analysis to the well-corrected center (**Sensor ROI**) keeps a corner your
     flattener cannot correct from polluting the tilt fit.
+
+### Where the focuser step size comes from
+
+The focuser step size is the scale that turns everything the inspector measures — which is measured in
+focuser positions — into microns. It sets the curvature and tilt effects in µm, the per-screw corrections,
+and the backfocus error.
+
+It resolves in this order:
+
+1. **What you typed** in **Focuser Step Size**, if anything.
+2. **What your focuser driver reports**, if it reports a usable value. Most drivers do, so most people never
+   need to touch this. The greyed-out hint in the box shows the value that will be used.
+3. **Nothing** — micron readouts are hidden rather than guessed.
+
+!!! warning "⚠ differs from the focuser driver"
+    If you type a value and it disagrees with the driver's by more than 1%, the box shows this flag. It is
+    informational: **your** value is the one being used, and if you measured it yourself it is very likely the
+    better of the two.
+
+    It is worth a look, though, because the driver field is optional in ASCOM and some drivers fill it in
+    wrongly. The common failure is a driver reporting `1` — meaning "one step per step" rather than one micron
+    per step — which would scale every micron the inspector reports by whatever your real step size is.
+
+    To go back to the driver's value, clear the box.
 
 ### Which way does your focuser travel?
 

--- a/documentation/docs/overview/tilt-aberration-inspector.md
+++ b/documentation/docs/overview/tilt-aberration-inspector.md
@@ -109,7 +109,8 @@ hardware model, then converts the measured tilt into concrete screw-turn (or ste
 instructions. See [Tilt Adapter Wizard](tilt-adapter-wizard.md).
 
 The arrows describe what the adapter must do: ⬆ means that corner of the adapter plate moves toward
-the objective, ⬇ toward the camera — the same on every rig. The numeric rows each carry the screw
+the objective, ⬇ toward the camera — the same on every rig with the same **Increasing focuser
+position** setting ([below](#which-way-does-your-focuser-travel)). The numeric rows each carry the screw
 rotation that produces the move: `1.25 ⟳` means 1.25 turns clockwise (tighten), `0.50 ⟲`
 counter-clockwise (loosen); stepper adapters show signed steps (`+35 steps`) matching the wizard's
 prompts. A legend at the top of the section defines both conventions and is marked "(assumed)" until
@@ -139,6 +140,7 @@ star-matching, outlier-rejection, and save-images settings (plus **Astigmatic fi
 |---|---|---|---|
 | **Eccentricity Grid Width** | 7 | odd, positive | "How many cells wide to divide the sensor pixels when generating a grid of eccentricity vectors … the height will be calculated proportionally." |
 | **Focuser Step Size** | -1 (auto) | -1 or &gt;0 | "How much the focuser moves per step, in microns. If this is set, the adjustment chart will include adjustments in microns." |
+| **Increasing focuser position** | Moves camera away from objective (standard) | standard / reversed | Which way your focuser travels. Affects direction labels and diagrams only — see [below](#which-way-does-your-focuser-travel). Also editable under Options → Hocus Focus → Auto Focus. |
 | **Sensor ROI** | 1.0 | 0.1–1.0 | "Uses only a centered portion of the full sensor when evaluating aberration. This is useful if you have a flattener that cannot produce a flat field for your sensor." |
 | **Corners ROI** | 1.0 | 0.1–1.0 | "Reduces the size of the corner regions when performing corners analysis … evaluate only stars closer to the corners than the full 1/9th region. This can be combined with Sensor ROI." |
 | **Sensor Curve Model Enabled** | off | on/off | "Create a paraboloid model of the sensor by creating focus curves for every star. This enables calculation of centering error and curvature … similar to … CCD Inspector." |
@@ -168,6 +170,32 @@ star-matching, outlier-rejection, and save-images settings (plus **Astigmatic fi
 !!! tip "Sensor ROI protects the tilt fit"
     Restricting analysis to the well-corrected center (**Sensor ROI**) keeps a corner your
     flattener cannot correct from polluting the tilt fit.
+
+### Which way does your focuser travel?
+
+Everything the inspector measures is in focuser positions. Turning one of those measurements into a
+sentence about the real world — "move the sensor **towards** the flattener", "⬆ = toward the
+objective", "Telescope is up" — needs one more fact that no driver reports: whether a **higher**
+focuser position moves your camera *away* from the objective, or *toward* it.
+
+Almost every focuser is the first kind, so **Increasing focuser position** defaults to **Moves camera
+away from objective (standard)**. If your focuser is wired or geared the other way, set it to
+**reversed** and the labels follow.
+
+!!! info "This setting can only be wrong on a label"
+    It affects direction **labels and diagrams only**: the tilt-table captions, the Telescope/Sensor
+    labels on the sensor model, the spacer advice, the ⬆/⬇ motion arrows, and the wizard's direction
+    wording. It can never change a measurement, a stored screw angle, or a correction — the tilt
+    adapter's direction is measured in focuser units, and the focuser convention cancels out of that
+    measurement entirely.
+
+    So if the labels read backwards on your rig, just flip this. Nothing you have already calibrated
+    is affected, no numbers change, and nothing starts turning the other way.
+
+    One narrow exception, worth knowing about: if you skip the wizard's **Measure direction** step and
+    set the adapter direction by hand, that hand-entered direction *is* interpreted through this
+    setting. Running the six-step calibration overwrites it with a measurement that does not depend on
+    this setting at all.
 
 ## Running it from a sequence
 

--- a/documentation/docs/overview/tilt-adapter-wizard.md
+++ b/documentation/docs/overview/tilt-adapter-wizard.md
@@ -16,11 +16,13 @@ measure-and-correct loop before working on real hardware, see the
 
 Screw orientations are stored as angles measured **clockwise from straight up (12 o'clock)**: `0°` is
 the top of the sensor, `90°` is to the right, `180°` is the bottom, `270°` is to the left. The wizard
-stores one angle per screw (`Screw1AngleDegrees` … `Screw4AngleDegrees`). On adapters where a
-clockwise turn moves the plate toward the objective, the stored convention encodes that direction:
-the wizard's diagram and saved-calibration angles read 180° rotated from the screws' physical
-positions in the image, while [Manual Calibration Entry](#manual-calibration-entry) always takes the
-physical angle.
+stores one angle per screw (`Screw1AngleDegrees` … `Screw4AngleDegrees`). The stored angle is the
+direction the best-focus tilt *responds* in, not where the screw sits: on adapters where a clockwise
+turn moves the plate toward the **camera**, that turn lowers best focus at the screw, so the stored
+angle sits 180° from the screw's physical position in the image. The wizard's diagram and the
+saved-calibration readout always show the **physical** position, and [Manual Calibration
+Entry](#manual-calibration-entry) always takes the physical angle, so you never have to do that
+conversion yourself.
 
 !!! warning "Orientation is tracked in image space, not physically"
     A star diagonal, a mirror, or a rotator can flip the sensor's orientation inside the camera body,
@@ -57,10 +59,17 @@ comes from the adapter direction setting in the wizard's **Measurement** section
 moves adapter** (or **+ steps move adapter** for steppers):
 either **Toward the camera** (outward, the default) or **Toward the objective** (inward). Until it
 is measured, guidance marks the direction "(assumed)". To measure it, turn on **Measure direction**:
-this adds two steps (an all-screws-clockwise move plus a return to baseline) that determine the sign
-of the effect (`ScrewInwardCurvatureSign`) from the curvature change, and the saved calibration then
-reports the direction as measured. To average out seeing, set **Measurements to average** above 1; the wizard
+this adds two steps (an all-screws-clockwise move plus a return to baseline) and reads the direction
+off the **change in mean best-focus position** between them. Turning every screw clockwise is a pure
+piston, so if the mean best-focus position *drops*, the plate moved toward the camera — on a standard
+focuser, that means clockwise moves the adapter toward the camera. The saved calibration then reports
+the direction as measured. To average out seeing, set **Measurements to average** above 1; the wizard
 flags inconsistent repeats so you can re-run.
+
+The measurement itself needs no knowledge of which way your focuser travels — the focuser convention
+cancels out of it. Only the *wording* of the direction selector depends on it, so the selector reflects
+your **Increasing focuser position** setting (see [Aberration Inspector](tilt-aberration-inspector.md#which-way-does-your-focuser-travel));
+on a reversed focuser the same stored measurement reads as the opposite mechanical direction.
 
 ![The Tilt Adapter Wizard's Measurement section: Signal Amplification, Center Focuser First, the adapter-direction selector, and Measure direction](../assets/screenshots/wizard-measurement-section.png){ width=620 }
 

--- a/documentation/docs/overview/tilt-adapter-wizard.md
+++ b/documentation/docs/overview/tilt-adapter-wizard.md
@@ -87,11 +87,12 @@ would otherwise fail to register are not dropped from a step's model: the frame 
 its search instead (see [cross-frame
 registration](sensor-model.md#from-stars-to-data-points)).
 
-!!! note "Set Focuser Step Size for the best guidance"
-    Per its tooltip, *Focuser Step Size* is "how much the focuser moves per step, in microns.
-    If this is set, the adjustment chart will include adjustments in microns." Without it, adjustments
-    are still reported in focuser steps, and the tilt-angle calculation falls back to the connected
-    focuser's reported step size when available.
+!!! note "Focuser Step Size drives the micron figures"
+    *Focuser Step Size* is how far the focuser moves per step, in microns. It normally comes from your
+    focuser driver with no setup at all; you only need to type a value if your driver does not report one,
+    or reports it wrongly. See [where it comes
+    from](tilt-aberration-inspector.md#where-the-focuser-step-size-comes-from). Without any value at all,
+    adjustments are still reported in focuser steps.
 
 ## What the screws can fix
 

--- a/documentation/docs/quick-start.md
+++ b/documentation/docs/quick-start.md
@@ -19,10 +19,12 @@ how far your focuser moves per step.
 - **Focal length** (mm) — NINA's **Options → Equipment → Telescope** tab. Together with pixel size this
   gives your pixel scale (arcsec/px). The detector uses it directly, and knowing it tells you which
   Simple-mode [Pixel Scale preset](settings/advanced-debug.md#pixel-scale) to pick.
-- **Focuser Step Size** — set this in the
+- **Focuser Step Size** — how far the focuser moves per step, in microns, which is what lets the inspector
+  report tilt and backfocus adjustments in microns rather than bare focuser steps. **Usually nothing to do
+  here**: it comes from your focuser driver. Check the
   [Aberration Inspector options](overview/tilt-aberration-inspector.md#inspector-options) (the inspector
-  panel, not the main Options page). This tells the inspector how far the focuser moves per step, in
-  microns, so it can report tilt and backfocus adjustments in microns rather than bare focuser steps.
+  panel, not the main Options page) — if the greyed-out hint in the box shows a sensible number, you are
+  set. If it is empty, or your driver reports it wrongly, type the real value to override it.
 
 ## 2. Switch NINA over to Hocus Focus
 

--- a/plans/focuser-direction-convention-plan.md
+++ b/plans/focuser-direction-convention-plan.md
@@ -3,7 +3,9 @@
 Executes `docs/focuser-direction-convention-design.md` (revised, user-approved layered shape):
 **measured σ stays authoritative for all motion; a new display-only focuser-direction setting `k`
 drives the physical-direction captions and mechanical wording.** The change is (1) the
-unconditional measurement flip, (2) the matching camera-simulator piston flip, (3) a one-time
+unconditional measurement flip **paired in the same commit with `PhysicalToStoredAngle`'s offset
+flip — the two inversions have been cancelling, and correcting either alone inverts the screw
+diagram for every user (design §7)**, (2) the matching camera-simulator piston flip, (3) a one-time
 migration for measured-σ profiles, (4) the new `k` option + its presentation consumers +
 invariance guards, (5) prose/doc corrections, (6) required warning-only cross-check (resolved question
 Q3). Steps are ordered; each step ends green
@@ -33,7 +35,12 @@ output is bit-identical to today):
 
 ---
 
-## Step 1 — Flip the measurement
+## Step 1 — Flip the measurement (and, in the SAME commit, Step 1b)
+
+> **HARD CONSTRAINT — do not land Step 1 without Step 1b.** `PhysicalToStoredAngle`'s 180° offset
+> keys off σ with an inverted assignment, and the two inversions have been cancelling. Correcting
+> only the measurement flips every displayed screw angle by 180° (screw 1 would render bottom-left
+> instead of top-right). Derivation and the log evidence: design §7.
 
 **File:** `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs:183–185`
 
@@ -67,6 +74,39 @@ becomes `k`-aware later, in step 6).
   `ComputeCurvatureSign_Session20260803_BaselineHigherMeansTowardCamera` —
   `ComputeCurvatureSign(5136.6, 5498.4) == +1`, with a comment that +1 reads "toward the camera"
   on a standard focuser (`m = σ·k`) and is the value that made corrections converge.
+
+## Step 1b — Flip `PhysicalToStoredAngle`'s offset (SAME COMMIT as Step 1)
+
+**File:** `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltScrewGeometry.cs:169–180`
+
+The offset must key on the adapter mechanics `m`, not on σ directly. Required rule (design §7.3):
+
+    offset = 180°   iff   m = +1   i.e.   iff   σ·sign(k) = +1
+
+Today it fires when `σ == CurvatureSignWhenCwMovesAdapterTowardObjective` (−1), which at `k = +1`
+reads "iff `m = −1`" — exactly inverted. Two edits, both required:
+
+- invert the condition so the 180° offset belongs to `m = +1`;
+- take `k` into account via `σ·sign(k)` rather than σ alone, consistent with the anchor-dictionary
+  lookups introduced in step 6. Note in the XML doc that this makes `PhysicalToStoredAngle` the
+  **second** sanctioned path on which `k` can reach motion (through Manual Calibration Entry) —
+  design §7.4, alongside §2.3's direction combo. Do not widen it further.
+
+**Do NOT migrate stored angles.** They live in the response frame, which this change does not
+touch; only the physical⇄stored conversion moves. Migrating them would double-apply the fix.
+
+**Tests (same commit):**
+- Pin the paired-flip invariant directly, as the acceptance criterion from design §7.3: for the
+  session's stored angles `s1 = 219.4°` with the corrected `σ = +1, k = +1`, the displayed physical
+  angle must be `39.4°` (top-right) — **identical to what the old code produced with the old
+  inverted σ**. A test that passes with only one of the two flips applied is the bug this step
+  exists to prevent, so assert the pair, not each half.
+- Round-trip: `PhysicalToStoredAngle` is self-inverse for every `(σ, k)` combination.
+- Guard that the default `k = +1` path is bit-identical to today's behavior *after* Step 1's σ flip.
+
+**Verification beyond unit tests:** the pair of flips must be a **no-op for what users see**. Open
+the wizard's screw diagram on an existing calibrated profile before and after; any visible change
+means one of the two flips was missed or double-applied.
 
 ## Step 2 — Wizard VM tests that seed six-step runs
 

--- a/plans/focuser-direction-convention-plan.md
+++ b/plans/focuser-direction-convention-plan.md
@@ -1,0 +1,268 @@
+# Focuser Direction Convention / Curvature-Sign Measurement Fix — Implementation Plan
+
+Executes `docs/focuser-direction-convention-design.md` (revised, user-approved layered shape):
+**measured σ stays authoritative for all motion; a new display-only focuser-direction setting `k`
+drives the physical-direction captions and mechanical wording.** The change is (1) the
+unconditional measurement flip, (2) the matching camera-simulator piston flip, (3) a one-time
+migration for measured-σ profiles, (4) the new `k` option + its presentation consumers +
+invariance guards, (5) prose/doc corrections, (6) required warning-only cross-check (resolved question
+Q3). Steps are ordered; each step ends green
+(`dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`).
+
+**Persisted options touched:**
+- `IInspectorOptions.FocuserIncreasesTowardObjective` (new, user-facing, bool, default `false` =
+  standard convention). **Per the project invariant it gets a UI control plus tooltip resource in
+  `Resources/OptionsDataTemplates.xaml`** (step 5). Display-only by design: it must never be read
+  by `TiltCalibrationCalculator`, `TiltScrewGeometry`, `TiltScrewTargets`, the Automatic
+  Adjustment planner's target computation, or the camera simulator.
+- One new persisted *internal-state* key (the migration marker, step 4). Not a user option — same
+  category as `TiltDeviceShadowPositions` / `DeviceLinkedCalibrationDeviceName` /
+  `CalibrationIsReliable`, which have no `OptionsDataTemplates.xaml` controls — so no UI control.
+
+**Tests that must NOT change** (they pin the anchor and the σ-frame consumers, which this fix
+deliberately leaves alone; everything here runs at the default `k = +1`, where all presentation
+output is bit-identical to today):
+- `TiltScrewGeometryTests.CurvatureSignForCwDirection_MatchesEmpiricalAnchor` (anchor pinned).
+- `InspectorVMBehavioralTests.TiltGuidance_SigmaFlip_FlipsMotionArrowsNotTiltGlyphs` and the rest of
+  the σ-flip matrix.
+- `TiltScrewTargetsTests`, `SignedTotalAdjustment` tests (σ-on-backfocus-only convention).
+- `SimulatedTiltAdapterVMTests.BackfocusMove_ChangesBackfocusErrorWithTheSignOfTheRigDirection` and
+  `…OnOppositeRigs_MovesBackfocusInOppositeDirections` (curvature-effect response = +σ, unchanged).
+- `SimulatedTiltAdapterVMTests.BackfocusMove_OnOppositeRigs_ShiftsTheFocuserInOppositeDirections`
+  (pins antisymmetry only; stays green across step 3's flip).
+
+---
+
+## Step 1 — Flip the measurement
+
+**File:** `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs:183–185`
+
+Change `ComputeCurvatureSign` to return the corrected sense (all-inward CW/+ *lowering* the mean
+best-focus position ⇒ σ = +1), keeping the signature and the tie-breaking direction (a zero delta
+still yields +1, matching today's degenerate behavior):
+
+- from: `return (allScrewsMean - baselineMean) >= 0 ? 1 : -1;`
+- to:   `return (allScrewsMean - baselineMean) <= 0 ? 1 : -1;`
+
+Replace the one-line doc comment with the derivation summary (design §1): σ is defined as the
+fitted curvature-effect response to a CW turn; `σ = sign(m)·sign(k)`, the probe measures
+`sign(Δz̄) = −sign(m)·sign(k)`; the focuser convention cancels, so the flip is correct on standard
+and inverted focusers alike, with zero user input; cite the design doc and session
+`20260803-200647`. Do **not** swap the argument order to achieve the flip (booby trap), and do not
+touch the callers — `RunCalibrationMath` (TiltAdapterWizardVM.cs:2644) and `Calibrate`
+(TiltCalibrationCalculator.cs:326–328) inherit the fix; the log line at
+TiltAdapterWizardVM.cs:2651–2655 already prints the raw Δ plus the verdict (its mechanical wording
+becomes `k`-aware later, in step 6).
+
+**Tests (same commit):**
+- `Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs:99–103` — rename
+  `ComputeCurvatureSign_PositiveWhenAllScrewsMeanHigher` to
+  `ComputeCurvatureSign_PositiveWhenAllScrewsMeanLower`; expectations become
+  `(1100, 1000) → −1`, `(900, 1000) → +1`, `(1000, 1000) → +1`.
+- `:264` and `:306` (`Calibrate…RecoversAnglesPitchAndSign` fixtures, AllInward mean 1075 > baseline
+  1000): expectation `CurvatureSign == −1`, and update the inline comment at :289 ("raised mean
+  focus -> +1" is now "-> −1").
+- `:411/:426` (fallback path, 4-step) — unchanged (fallback is the configured sign, untouched).
+- **Add** a session-regression test pinning the incident:
+  `ComputeCurvatureSign_Session20260803_BaselineHigherMeansTowardCamera` —
+  `ComputeCurvatureSign(5136.6, 5498.4) == +1`, with a comment that +1 reads "toward the camera"
+  on a standard focuser (`m = σ·k`) and is the value that made corrections converge.
+
+## Step 2 — Wizard VM tests that seed six-step runs
+
+**File:** `Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs`
+
+- `:1165–1184 CompletingSixStepRun_WritesMeasuredCurvatureSignFromMeans` — AllInward 990 < baseline
+  1000 now yields **+1**; update the received-assignment assertion (`:1184`) and the comment
+  (`:1169`).
+- `:1145` (the other seeded run, AllInward 1010): update any sign assertion accordingly (baseline
+  1000 → 1010 rise now yields −1).
+- `:1207–1208` (4-step leaves sign untouched) — unchanged.
+- Sweep the two wizard test files for any other assertion coupling a seeded mean-focus delta to a
+  stored sign (`grep -n "SeedStepReading\|ScrewInwardCurvatureSign = " Tests/TiltAdapterWizard/*.cs`).
+
+## Step 3 — Camera simulator: flip the geometric piston, pin the absolute direction
+
+**File:** `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltInjection.cs`
+
+- `:77` — `options.OptimalFocuserPosition += (int)Math.Round(pistonMicrons / …)` becomes
+  `-= …` (equivalently `+= −pistonMicrons/…`): a plate move toward the camera must *lower* the mean
+  best-focus position (design §1(c)/§4). `:86–91` (`BackfocusErrorMicrons`, the curvature-effect
+  response `+σ·δ`) is **unchanged**.
+- Rewrite the sign-critical comments to the corrected physics: the block at `:41–54` ("THE SIGN,
+  stated once") and `:74–85` (the OptimalFocuserPosition/backfocus rationale), and the
+  `PistonDirectionSign` remarks in `SimulatedTiltAdapter.cs:59–60` and `:91–99` (the constant and
+  its value are unchanged; only the explanation of where the geometric shift's extra minus lives
+  moves into `Fold`). The simulator remains `k`-free (design §4): it must not gain a
+  focuser-direction knob in this change.
+
+**Tests:**
+- **Add** `SimulatedTiltAdapterVMTests.BackfocusMove_CwOnPositiveRig_LowersOptimalFocuserPosition`
+  (σ = +1, `TurnCommand(⟳)` ⇒ `OptimalFocuserPosition < start`) — the absolute-direction pin that
+  was missing; note in its doc comment that it is what makes a simulated 6-step run measure
+  σ correctly post-fix.
+- Confirm `BackfocusMove_OnOppositeRigs_ShiftsTheFocuserInOppositeDirections` (antisymmetry) and
+  the convergence tests (`InspectorBackfocusGuidance_…`) stay green — they must, per design §4; if
+  any fails, stop and re-derive rather than adjusting the test.
+- Sweep `Tests/CameraSimulator/SimulatedTiltActuatorTests.cs` and
+  `SimulatedTiltAdapterCapstoneTests.cs` for assertions on `OptimalFocuserPosition` direction
+  (none found in the survey; the capstone's `PistonDirectionSign * delta.PistonMicrons` assertion
+  at `:96` concerns the adapter's response frame and is unchanged).
+
+## Step 4 — One-time migration of measured signs
+
+**File:** `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs`
+
+In `InitializeOptions()` (runs at construction and on every profile change, so it is per-profile),
+after reading `screwInwardCurvatureSign` / `screwInwardCurvatureSignIsMeasured`:
+
+- New persisted key (raw accessor, internal state, **no interface property, no UI control** — see
+  header): `CurvatureSignMeasurementMigrated` (bool, default false).
+- If `!migrated`:
+  - if `screwInwardCurvatureSignIsMeasured && screwInwardCurvatureSign != 0`: negate the sign,
+    write it back through the accessor, `Logger.Info` both values, and raise a one-time
+    `Notification.ShowInformation` explaining that the measured adapter direction was corrected
+    (cite the wizard's "Direction was measured" provenance so the user can re-verify).
+  - set the marker true (also when nothing needed negating, so the check never re-runs).
+- `IsMeasured == false` values are never touched (manually-set or assumed — design §5).
+
+**Tests:** `Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs` —
+- measured +1 → loads as −1, marker set, second construction does not negate again;
+- measured value negated only once across a simulated profile change;
+- unmeasured value untouched, marker still set;
+- sign 0 untouched.
+(These need the injectable `IPluginOptionsAccessor` ctor that already exists at
+TiltAdapterOptions.cs:29.)
+
+**Documentation of side effect:** the wizard's displayed physical screw angles rotate 180° for
+migrated profiles (design §5, open question Q2) — add one sentence to the migration notification
+text suggesting the user glance at the wizard's screw diagram.
+
+## Step 5 — Add the focuser-direction setting `k` (persisted option + UI)
+
+**Files:**
+- `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IInspectorOptions.cs` — add
+  `bool FocuserIncreasesTowardObjective { get; set; }` with a doc comment stating the contract:
+  *display-only; consumed exclusively by direction captions and mechanical wording; must never be
+  passed into the TiltAdapterWizard math layer, the planner's target computation, or the
+  simulator* (the structural guarantee of design §2.2).
+- `AutoFocus/InspectorOptions.cs` — backing field + accessor persistence (default `false` =
+  standard, `sign(k) = +1`), load in `InitializeOptions`, reset in `ResetDefaults`.
+- `Resources/OptionsDataTemplates.xaml` — **the invariant control**: a labeled two-item ComboBox
+  next to the `MicronsPerFocuserStep` pass-through (~:3179), label "Increasing focuser position",
+  items "Moves camera away from objective (standard)" / "Moves camera toward objective
+  (reversed)", `SelectedValuePath=Tag` bound to `InspectorOptions.FocuserIncreasesTowardObjective`
+  (mirroring the wizard combo's bool-Tag pattern at TiltAdapterWizard/DataTemplates.xaml:711–732);
+  plus a `FocuserIncreasesTowardObjective_Tooltip` TextBlock resource near the other tooltips
+  stating it affects direction labels and diagrams only and can never change a measurement or a
+  correction.
+
+**Tests:** options round-trip + default in the inspector-options tests (follow the existing
+`MicronsPerFocuserStep` precedent).
+
+## Step 6 — Presentation layer consumes `k`; invariance guards
+
+Introduce one tiny presentation helper (suggested: `FocuserSign` resolved once per call site as
+`inspectorOptions.FocuserIncreasesTowardObjective ? -1 : +1`) and wire the six caption groups from
+design §3 — **and nothing else**:
+
+1. `AutoFocus/DataTemplates.xaml:3638` / `:3837` — caption becomes k-selected: "Positive values =
+   Move away from objective" ⟷ "…Move toward objective" (DataTrigger on the bound option or a
+   converter).
+2. `AutoFocus/DataTemplates.xaml:3265` — "Telescope is up, Sensor is down" ⟷ inverted wording,
+   same mechanism.
+3. `Controls/TiltModelControl.cs:142–143` — new bool DP (e.g. `FocuserIncreasesTowardObjective`)
+   bound from the options; swap the "Telescope"/"Sensor" `ScreenLabel` placement when set.
+4. `AutoFocus/InspectorVM.cs:1671–1676` — `BackfocusDirection` selection becomes
+   `delta > 0 ⇒ (k = +1 ? "TOWARDS" : "AWAY FROM")` etc.; raise on option change.
+5. `Inspection/SensorModelAberrationResult.cs:392–404` — `AnalyzeCurvature` direction word:
+   thread a `focuserSign` parameter (default `+1`) through `Update(...)` from the calling VM;
+   `REMOVING ⇔ sign(k)·E_z > 0`.
+6. Mechanical vocabulary via the anchor dictionary — presentation call sites compose `σ·sign(k)`
+   before the existing lookup (the dictionary itself and its pinned test are untouched):
+   - tilt motion arrows `InspectorVM.cs:2078`: `−resolvedSign·turns` → `−resolvedSign·focuserSign·turns`;
+   - backfocus motion arrow `InspectorVM.cs:2104–2110`: `towardObjective = focuserSign·curvatureEffectMicrons > 0`;
+   - wizard combo `TiltAdapterWizardVM.cs:1066–1080`: getter
+     `CwMovesAdapterTowardObjectiveForSign(σ·focuserSign)`; setter
+     `σ = CurvatureSignForCwDirection(value)·focuserSign` — **the one deliberate assumed-σ
+     exception. Q1 is RESOLVED (user, 2026-08-04): implement this bounded exception; the combo keeps
+     its mechanical wording. Do not widen it — this is the single sanctioned path on which `k` can
+     reach motion** (design §2.3);
+   - calibration log `TiltAdapterWizardVM.cs:2654–2655`: keep printing raw σ; the
+     OBJECTIVE/CAMERA word uses `σ·focuserSign` and the line says "per the focuser direction
+     setting";
+   - `RebuildTiltGuidance`/`FillNumericGuidance` re-run when the option changes (subscribe like the
+     existing `tiltAdapterOptions.PropertyChanged` path; use the non-blocking Post marshaling per
+     `.claude/docs/mvvm-patterns.md`).
+
+The wizard VM reaches the option via its existing `Inspector` reference (the wizard XAML already
+binds `Inspector.InspectorOptions.CenterFocuserBeforeRun`, TiltAdapterWizard/DataTemplates.xaml:651).
+
+**Invariance guard tests (the structural half of design §2.2 — must be added, not optional):**
+- Wizard: identical seeded 6-step run with `k` toggled both ways ⇒ identical stored
+  `ScrewInwardCurvatureSign`.
+- Inspector: identical model + calibration with `k` toggled ⇒ identical numeric guidance rows,
+  glyphs, totals; tilt/backfocus *arrows* flip; legend text unchanged.
+- Planner (`InspectorVMAutomaticAdjustmentTests`): identical move plan across `k`.
+- Simulator: no `k` dependency exists to test by construction (it reads only
+  `ICameraSimulatorOptions`); assert nothing new needed beyond step 3's pins.
+- Caption matrix: the six sites render the standard wording at `k = +1` (bit-identical to today)
+  and the swapped wording at `k = −1`.
+
+## Step 7 — Prose and documentation corrections
+
+- `docs/tilt-guidance-motion-arrows-design.md:25` — replace the inverted equivalence with the
+  corrected justification (design §3 "prose that must be fixed"): a CW/+ turn moves the plate
+  toward the camera iff `σ·k = +1`; motion-toward-objective is `−σ·sign(k)·turns` (tilt) and
+  `sign(k)·E_z > 0` (backfocus); the shipped `k = +1` default reproduces the previous formulas.
+- `.claude/docs/tilt-domain.md:26` — scope "pure physics, identical on every rig" to "given the
+  focuser-direction setting"; add a pointer to the new design doc.
+- `documentation/docs/overview/tilt-adapter-wizard.md:58–62` — the direction is measured from the
+  **mean best-focus change** of the all-screws step (not "the curvature change"), with the
+  corrected sense in user terms (all-screws-clockwise lowering best-focus ⇒ clockwise moves the
+  adapter toward the camera on a standard focuser); document that the direction combo now reflects
+  the focuser-direction setting.
+- `documentation/docs/overview/tilt-aberration-inspector.md:111–112` — "the same on every rig" →
+  scoped to the focuser-direction setting; document the new option and its display-only guarantee.
+- Document the new option wherever the inspector's options are listed in the manual.
+- `docs/tilt-adapter-direction-sign-design.md` — add a short "Resolved" header pointing at
+  `docs/focuser-direction-convention-design.md` (hypothesis 1 confirmed in strengthened,
+  convention-independent form; the σ = m·k factorization explains why the old setting felt
+  opaque).
+- Grep sweep before closing: `grep -rn "best-focus position decreases" docs .claude/docs documentation`
+  and `grep -rn "toward the objective" documentation/docs` — fix any stragglers consistent with the
+  above.
+- Run `mkdocs build --strict` for the manual changes.
+
+## Step 8 (REQUIRED — Q3 resolved "adopt", user 2026-08-04) — warning-only cross-check
+
+**File:** `TiltAdapterWizardVM.cs`, `RunCalibrationMath` (after the `measuredCurvature` block at
+:2643–2658).
+
+Compute the a→b curvature-effect delta (`CurvatureEffectAtScrewRadiusMicrons`, already logged at
+:2653) and the re-baseline curvature-effect drifts as the noise scale. If `|ΔE| > 2×` the drift
+scale **and** `sign(ΔE) != σ_measured`, log a Warning and surface it through the existing
+confidence/warning banner path (`EvaluateCalibrationConfidence` / `HasConfidenceWarning`). Never
+block, never modal, never change the stored sign — and never read `k` (both channels are z-space).
+Test with seeded readings: agreeing channels → no warning; contradicting-but-small ΔE → no
+warning; contradicting-and-large ΔE → warning. **Skip this step entirely unless the user answers
+Q3 "yes".**
+
+## Step 9 — Verification
+
+1. Full suite: `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo` (expect the
+   flipped-expectation tests from steps 1–2, the new pins from steps 1/3/4/6, and everything in the
+   "must NOT change" list untouched and green).
+2. `mkdocs build --strict` (step 7).
+3. Simulated end-to-end sanity (manual or scripted via the simulator): configure
+   `SimScrewInwardCurvatureSign = +1`, run a 6-step wizard calibration against the simulator, and
+   confirm the stored `ScrewInwardCurvatureSign` comes out **+1** with "measured" provenance — the
+   closed-loop statement that measurement and physics now agree. Repeat with −1. Toggle the new
+   focuser-direction setting during review and confirm only captions/arrows change (numbers,
+   glyphs, and any planned moves identical).
+4. On the real rig at next opportunity: re-run the 6-step calibration; the log line
+   (`TiltAdapterWizardVM.cs:2651`) should report a mean-focus **drop** on the all-inward step and
+   conclude "toward the CAMERA" (at the default standard focuser setting), matching the
+   manually-set value that already converges. No migration fires (the user's profile has
+   `IsMeasured == false` after their manual fix); verify a copy of a profile with a stale measured
+   value migrates once and logs it.

--- a/plans/focuser-step-size-driver-plan.md
+++ b/plans/focuser-step-size-driver-plan.md
@@ -1,0 +1,118 @@
+# Focuser step size from the driver — Implementation Plan
+
+Executes `docs/focuser-step-size-driver-design.md`. Steps are ordered; each ends green
+(`dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`).
+
+**Persisted options touched: none.** `DriverMicronsPerFocuserStep` is in-memory device state and must never
+reach the options accessor, so the "every new option needs a control in `Resources/OptionsDataTemplates.xaml`"
+invariant does not apply to it. The two *display* changes (hint text, mismatch flag) land in the existing
+Focuser Step Size controls.
+
+**The one-line trap, repeated because it is the whole correctness of the resolver:** the acceptance test is
+`value > 0`, never `!(value <= 0)`. `NaN` fails both comparisons; only the positive form rejects it. A `NaN`
+step size that slips through produces an all-NaN sensor model with no error anywhere.
+
+---
+
+## Step 1 — The resolver on `IInspectorOptions` / `InspectorOptions`
+
+**Files:** `Interfaces/IInspectorOptions.cs`, `AutoFocus/InspectorOptions.cs`
+
+Add beside `MicronsPerFocuserStep`:
+
+- `double DriverMicronsPerFocuserStep { get; set; }` — doc comment states: in-memory only, never persisted,
+  written solely by `InspectorVM.UpdateDeviceInfo`, sticky because only valid values are accepted, cleared on
+  profile change. The setter must accept only finite `> 0` values *and* silently ignore anything else, so
+  stickiness is a property of the setter rather than of every caller.
+- `double EffectiveMicronsPerFocuserStep { get; }` — `MicronsPerFocuserStep > 0 ? MicronsPerFocuserStep :
+  (DriverMicronsPerFocuserStep > 0 ? DriverMicronsPerFocuserStep : -1)`.
+- `bool HasFocuserStepSizeMismatch { get; }` — override `> 0` **and** driver `> 0` **and**
+  `Math.Abs(override - driver) / driver > 0.01`.
+- `const double FocuserStepSizeMismatchFraction = 0.01` on `InspectorOptions`, so the test and the tooltip
+  quote one number.
+
+Both new derived properties must be re-raised whenever either input changes: `MicronsPerFocuserStep`'s setter
+and `DriverMicronsPerFocuserStep`'s setter each raise `EffectiveMicronsPerFocuserStep` and
+`HasFocuserStepSizeMismatch` as well as themselves. `InitializeOptions` clears
+`DriverMicronsPerFocuserStep` (it runs on construction *and* `ProfileChanged` — that is what implements the
+profile-change clear).
+
+`ResetDefaults` leaves the driver value alone: it is not a default, it is device state.
+
+**Tests** (`Tests/AutoFocus/InspectorOptionsTests.cs`):
+- precedence: override wins over driver; driver used when override unset; `-1` when neither.
+- `0`, `-5`, `NaN`, `PositiveInfinity` are never adopted as the driver value.
+- the driver value never appears in `store.Snapshot`.
+- stickiness: set a valid driver value, then push `0` → the valid value stands.
+- profile change clears it (raise `ProfileChanged` on the substitute).
+- mismatch matrix: (1.00, 1.005) false; (1.00, 2.00) true; (unset, 1.00) false; (1.00, 0) false;
+  (1.00, NaN) false.
+- `PropertyChanged` for `EffectiveMicronsPerFocuserStep` / `HasFocuserStepSizeMismatch` fires from both setters.
+
+## Step 2 — `InspectorVM` writes the driver value
+
+**File:** `AutoFocus/InspectorVM.cs`
+
+`UpdateDeviceInfo(FocuserInfo)` (:2949) additionally assigns
+`InspectorOptions.DriverMicronsPerFocuserStep = deviceInfo.StepSize`. The setter's guard does the filtering, so
+this is unconditional here — do **not** add a second guard at the call site, or the two will drift.
+
+`InspectorVM` is a Shared MEF singleton already registered as a focuser consumer (:210), so this is the single
+writer. Nothing else may write it.
+
+**Tests** (`Tests/AutoFocus/InspectorVMBehavioralTests.cs` or a new focuser-step-size fixture): pushing a
+`FocuserInfo { StepSize = 3.5 }` sets the driver value; a subsequent `StepSize = 0` (disconnect) leaves 3.5.
+
+## Step 3 — Consumers read `Effective`
+
+- `AutoFocus/InspectorVM.cs:662` — `SensorModelFocuserSizeOverrideMicrons ?? InspectorOptions.EffectiveMicronsPerFocuserStep`
+  (the per-run override stays layer 1).
+- `AutoFocus/InspectorVM.cs:1681–1682` — `BackfocusMicronDelta`.
+- `AutoFocus/TiltModel.cs:203`.
+- `CameraSimulator/CameraSimulatorOptions.cs:347–354` — `EffectiveFocuserStepSizeMicrons` resolves
+  `inspectorOptions.EffectiveMicronsPerFocuserStep` first, falling back to `DefaultFocuserStepSizeMicrons`
+  only when that is non-positive. Its `InspectorOptions_PropertyChanged` (:96) must also re-raise on
+  `EffectiveMicronsPerFocuserStep` (a driver change moves the render scale without touching
+  `MicronsPerFocuserStep`).
+- `TiltAdapterWizard/TiltAdapterWizardVM.cs:2145` and `:2179` — captured metadata and drift comparison.
+- `TestApp/InspectAlignRunner.cs:148`, `TestApp/BankVerifyRunner.cs:514`.
+
+**Do NOT touch** (these are the override itself): `InspectorOptions`' load/store/reset,
+`CameraSimulatorOptions.FocuserStepSizeMicrons` (:341–344), the legacy migration (:212–216),
+`TiltAdapterWizardVM.MicronsPerFocuserStepValue` (:2020/:2025), and the two-way XAML bindings.
+
+**Tests:** the simulator's inject⇄recover loop closes with `k` supplied by the driver and no override
+(extend an existing `SimulatedTiltAdapterVMTests` convergence case, or add one); `CameraSimulatorOptions`
+resolves driver → default in the right order.
+
+## Step 4 — UI: hint text and the mismatch flag
+
+**Files:** `AutoFocus/DataTemplates.xaml` (Inspector dock, ~:1787–1814),
+`Resources/OptionsDataTemplates.xaml` (Camera Simulator tab, ~:3216–3240)
+
+- Hint text: bind to the effective value (`InspectorOptions.EffectiveMicronsPerFocuserStep` /
+  `CameraSimulatorOptions.EffectiveFocuserStepSizeMicrons`, both `Mode=OneWay`) instead of `(disabled)` / the
+  hardcoded default. Keep the existing `HF_DoubleNegativeToEmptyStringConverter` on the two-way `Text`
+  binding — the box still edits the raw override.
+- Mismatch flag: a `TextBlock` beside each box, `Visibility` bound to `HasFocuserStepSizeMismatch` via
+  `BooleanToVisibilityCollapsedConverter`, text naming both numbers. Style it as a warning consistent with the
+  existing warning text in each file (do not invent a new visual treatment).
+- Update `MicronsPerFocuserStep_Tooltip` (`AutoFocus/DataTemplates.xaml:34`) and
+  `CamSim_FocuserStepSizeMicrons_Tooltip` (`Resources/OptionsDataTemplates.xaml`) to state that the driver's
+  value is used when the box is empty, and that a value here overrides it.
+
+## Step 5 — Documentation
+
+- `documentation/docs/overview/tilt-aberration-inspector.md` — the **Focuser Step Size** options-table row
+  becomes "-1 (auto): uses the focuser driver's reported step size; set a value to override it", plus a
+  sentence on the mismatch flag and why a driver value can be wrong (steps-not-microns).
+- Check `documentation/docs/` for any other page that tells the user to set this by hand.
+- `mkdocs build --strict`.
+
+## Step 6 — Verification
+
+1. Full suite green.
+2. `mkdocs build --strict`.
+3. Manual: connect a focuser whose driver reports a step size, confirm the empty box hints that value and
+   micron readouts appear; type a 2× different override and confirm the flag appears and the numbers follow
+   the override; clear the box and confirm it returns to the driver's value.


### PR DESCRIPTION
Supersedes #176 — that PR's two design commits are ancestors of this branch, so this reviews and merges the design, the plan, and the implementation together. Close #176 as superseded when this lands.

Two independent pieces of work, in order.

---

## 1. The curvature-sign measurement was inverted — on every rig

A hands-off calibration measured the adapter direction, Automatic Adjustment then made aberration *worse*, and flipping the setting by hand made it better. The investigation (session `20260803-200647`) found `ComputeCurvatureSign` returning `sign(Δz̄)` where the physics gives `−sign(Δz̄)`.

Writing the stored sign as `σ = sign(m)·sign(k)` — adapter mechanics × focuser convention — shows `m` and `k` enter both σ and the all-screws probe **only through their product**, so the focuser convention cancels out of the measurement. That makes the fix unconditional and parameter-free, and it kills the "this rig's focuser is just inverted" hypothesis: there is no focuser convention under which the old formula measured the sign the consumers need.

**A second inversion was hiding behind the first.** `PhysicalToStoredAngle` assigned its 180° offset to `m = −1` instead of `m = +1`, and the two had been cancelling in the screw diagram. Correcting either alone rotates every displayed screw angle by 180°, so they land in one commit, with `PairedFlip_LeavesTheDisplayedScrewAngleUnchanged_Session20260803` asserting the pair rather than each half.

Also in this half:

- **Camera simulator piston flipped** with the measurement — a plate move toward the camera must *lower* mean best focus — or a simulated 6-step run would measure `−σ_config`. Adds the absolute-direction pin that was missing (only antisymmetry was ever asserted, which is how the simulator came to be built against the buggy measurement without any test noticing).
- **One-time per-profile migration** of measured signs, behind a persisted marker. Values with `IsMeasured == false` are untouched — they are the user's, not the buggy formula's.
- **New display-only setting `k`** (`FocuserIncreasesTowardObjective`, default standard). Every caption that turns a z-space quantity into a physical claim was silently pinned to the standard focuser; they now read `k` and are correct on any rig. At the default, every one renders bit-for-bit as before.
- **Warning-only cross-check**: corrected, the mean-focus and curvature-effect channels are independent measurements of one quantity, so a large contradicting curvature change is now real information. Never blocks, never changes the stored sign.

### The guarantee, and how it's enforced

**A wrong `k` produces wrong labels and never wrong motion.** Two mechanisms:

1. *Placement* — `k` lives on `IInspectorOptions`, deliberately not next to σ on `ITiltAdapterOptions` where the two would get fused into one opaque bit again (which is what made the old direction setting so hard to reason about).
2. *Tests* — a reflection firewall asserts the math layer and the simulator accept no `IInspectorOptions`, and that the planner's target computation still takes only `(fitted model, adapter options)`. Plus: a seeded 6-step run measures the same σ with `k` toggled either way; guidance numbers, glyphs and totals are identical across `k` while only the arrows flip.

Two bounded exceptions are sanctioned and documented at their call sites — the wizard's direction combo (writes only the *assumed* σ) and `PhysicalToStoredAngle` via Manual Calibration Entry. The residual risk is stated plainly in the design: a user who sets `k` wrong **and** sets the direction by hand instead of running the wizard gets inverted motion.

### Deliberately untouched

The empirical anchor `CurvatureSignWhenCwMovesAdapterTowardObjective`, its dictionary and pinned test; `InspectorVMBehavioralTests`' σ-flip matrix; `TiltScrewTargetsTests`; `InspectorVMAutomaticAdjustmentTests`; the simulator's curvature-response pins; and all stored screw angles (they live in the response frame, which this does not move — migrating them would double-apply the fix).

---

## 2. Focuser step size now comes from the driver

`MicronsPerFocuserStep` scales every micron the inspector reports, and its only source was a number the user typed. Most drivers already report it (ASCOM `Focuser.StepSize`), so it now resolves **override → driver → unset**.

The governing constraint: "unset" may become *correct*, but must never become silently *wrong*.

- Accepted on exactly one test, `> 0` **and** finite. `> 0` rather than `!(<= 0)` is load-bearing — NaN fails both, and only the positive form rejects it; a NaN step size waved through yields an all-NaN sensor model with no error anywhere.
- Never persisted, never written into the override, so clearing the box always means "go back to the driver".
- Unresolvable still means unresolvable: micron readouts stay NaN rather than being fabricated.

Sticky across a disconnect falls out of the setter's guard rather than a separate mechanism — a disconnect reports `0`, that write is dropped, the last known value stands — so a focuser dropping off the bus cannot rescale an in-flight analysis. Cleared on profile change.

The simulator resolves through the same effective value: it *renders* defocus at `k` while the inspector *recovers* tilt at `k`, and two different `k`s break the inject⇄recover loop by exactly their ratio, silently.

The UI hints the effective value (otherwise a driver-supplied one is undiscoverable) and flags an override disagreeing by >1%. Advisory only — the override still wins. The tolerance keeps a genuine calibration near the driver's round number quiet while catching what this exists for: drivers reporting `1`, meaning one step per step.

Note: `TiltAdapterWizardVM` had already grown a local copy of this fallback against its own live `focuserInfo`; it now delegates to the shared resolver, which additionally makes it sticky.

---

## Verification

- **3466 tests pass**, up 22 net. `mkdocs build --strict` clean.
- **Not verified**: the XAML compiles, but WPF resolves `StaticResource` at runtime, so nothing here proves the new hint text, the mismatch flag, or the focuser-direction combo actually render. Worth a look during review.
- **Still outstanding, needs hardware**: a simulated 6-step round-trip confirming `SimScrewInwardCurvatureSign = ±1` comes back with matching "measured" provenance, and a real-rig re-calibration confirming the log reports a mean-focus *drop* and concludes "toward the CAMERA".

## Reviewer's attention

This change is entirely about not getting a sign backwards, so the signs are the review surface:

- `TiltCalibrationCalculator.ComputeCurvatureSign` and `TiltScrewGeometry.PhysicalToStoredAngle` — do they still cancel? The paired-flip test says no, but a second pair of eyes on the derivation in design §1 and §7 is worth more than the test.
- `SimulatedTiltInjection.Fold` — the mean-focus shift is `−piston` and the curvature response is `+piston`. The opposite signs are real physics, not bookkeeping.
- Anywhere `σ·sign(k)` is composed: it must be at a presentation call site, never inside the math layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qxzJZcQivsWK6VSxAUW9V
