### PR TITLE
Tilt calibration accuracy: physical-space metrics, drift-symmetric deltas, estimator cross-checks

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/TiltPlaneModelTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/TiltPlaneModelTests.cs
@@ -1,4 +1,5 @@
 using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NUnit.Framework;
 using System;
 using System.Drawing;
@@ -207,6 +208,45 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus {
                 a: 0, b: 0, c: 1000, mean: 1000, focuserStepSizeMicrons: 5.0,
                 centerPosition: 1000, topLeftPosition: 1000, topRightPosition: 1000,
                 bottomLeftPosition: 1000, bottomRightPosition: 1000));
+        }
+
+        [Test]
+        public void Create_FromAutoFocusResult_UsesActualCornerRegionCenters() {
+            // Plane z = C + A*xn + B*yn over normalized [-0.5, 0.5]; corner regions centered at ±1/3.
+            const double A = 300.0, B = -120.0, C = 11200.0;
+            double At(double xn, double yn) => C + A * xn + B * yn;
+
+            var imageSize = new System.Drawing.Size(9576, 6388);
+            var result = new AutoFocusResult() {
+                Succeeded = true,
+                ImageSize = imageSize,
+                RegionResults = new[] {
+                    RegionResult(0, new RatioRect(0.0, 0.0, 1.0, 1.0), At(0, 0)),
+                    RegionResult(1, new RatioRect(1/3d, 1/3d, 1/3d, 1/3d), At(0, 0)),
+                    RegionResult(2, new RatioRect(0.0, 0.0, 1/3d, 1/3d), At(-1/3d, -1/3d)),   // TL
+                    RegionResult(3, new RatioRect(2/3d, 0.0, 1/3d, 1/3d), At(+1/3d, -1/3d)),  // TR
+                    RegionResult(4, new RatioRect(0.0, 2/3d, 1/3d, 1/3d), At(-1/3d, +1/3d)),  // BL
+                    RegionResult(5, new RatioRect(2/3d, 2/3d, 1/3d, 1/3d), At(+1/3d, +1/3d)), // BR
+                }
+            };
+
+            var model = TiltPlaneModel.Create(result, fRatio: 6.3, focuserStepSizeMicrons: 0.269);
+
+            Assert.Multiple(() => {
+                Assert.That(model.A, Is.EqualTo(A).Within(1e-9));  // old code returns 200.0 (A * 2/3)
+                Assert.That(model.B, Is.EqualTo(B).Within(1e-9));
+                Assert.That(model.C, Is.EqualTo(C).Within(1e-9));
+            });
+        }
+
+        private static AutoFocusRegionResult RegionResult(int index, RatioRect boundary, double focusPosition) {
+            return new AutoFocusRegionResult() {
+                RegionIndex = index,
+                Region = new StarDetectionRegion(boundary),
+                EstimatedFinalFocuserPosition = focusPosition,
+                EstimatedFinalHFR = 2.0,
+                Fittings = new AutoFocusFitting()
+            };
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorParaboloidModelTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorParaboloidModelTests.cs
@@ -320,6 +320,39 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
             Assert.That(analytic, Is.EqualTo(numeric).Within(Math.Abs(numeric) * 1e-9 + 1e-3));
         }
 
+        [Test]
+        public void Volume_AreaAveragePiston_GhiliosCorrectedRun_ShiftsPistonUnderHalfPercent() {
+            // ghilios_corrected (2026-08-04): the wizard's piston-implied pitch uses the fitted surface's
+            // CENTRE value (Z0, since MeanFocuserPosition's symmetric corner tilt terms cancel and the apex
+            // is pinned at the sensor centre). The proposed field-matched alternative is the surface's area
+            // average over the sensor, whose closed form is Volume(w,h)/(w·h) = Z0 + K·(w²+h²)/12 for a
+            // centre-pinned apex. On this run's own per-state fits the switch moves the piston-implied pitch
+            // 2.2332 -> 2.2238 um/step, only -0.42%: the fitted ΔK across the piston (+0.9e-8/um) is ~6x
+            // smaller than the honest region-AF ΔK (+5.6e-8/um), so almost none of the true sag change
+            // survives in the fitted K — the compression has already pushed it into ΔZ0. The area average is
+            // therefore a no-op today; it becomes the honest field-matched piston only once the per-star
+            // vertex estimator (design doc §8) stops compressing K.
+            double w = 9576 * 3.76, h = 6388 * 3.76;
+            const double applied = 150.0;
+            // Final per-state paraboloid fits (Z0 um, K um^-1) from the run's replay diagnostics. Gx/Gy do
+            // not enter the area average when the apex is pinned at (0,0); use the fitted values anyway.
+            var baseline = new SensorParaboloidModel(x0: 0, y0: 0, z0: 3035.279500, gx: -2.446780e-4, gy: -5.965910e-4, k: -9.732659e-8);
+            var allInward = new SensorParaboloidModel(x0: 0, y0: 0, z0: 2688.764211, gx: -7.895114e-4, gy: -6.835693e-4, k: -9.282100e-8);
+            var reBaseline1 = new SensorParaboloidModel(x0: 0, y0: 0, z0: 3012.208968, gx: 5.371334e-4, gy: -3.106165e-4, k: -1.063551e-7);
+
+            double AreaAverage(SensorParaboloidModel m) => m.Volume(w, h) / (w * h);
+            // Closed form for the pinned apex: Z0 + K·(w²+h²)/12.
+            Assert.That(AreaAverage(baseline), Is.EqualTo(baseline.Z0 + baseline.K * (w * w + h * h) / 12.0).Within(1e-6));
+
+            double centrePiston = Math.Abs(allInward.Z0 - 0.5 * (baseline.Z0 + reBaseline1.Z0)) / applied;
+            double areaPiston = Math.Abs(AreaAverage(allInward) - 0.5 * (AreaAverage(baseline) + AreaAverage(reBaseline1))) / applied;
+            Assert.Multiple(() => {
+                Assert.That(centrePiston, Is.EqualTo(2.2332).Within(1e-3));
+                Assert.That(areaPiston, Is.EqualTo(2.2238).Within(1e-3));
+                Assert.That(areaPiston / centrePiston - 1.0, Is.EqualTo(-0.0042).Within(2e-4));
+            });
+        }
+
         // ---- χ² acceptance statistic ----
 
         private static Func<double, double> GaussianNoise(int seed, double sigma) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatWizardMappingTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatWizardMappingTests.cs
@@ -189,6 +189,33 @@ public class EatWizardMappingTests {
         Assert.That(total, Is.EqualTo(new double[] { 0, 0, 0, 0 }));
     }
 
+    // --- Optional measured final re-baseline (Task 6): ReBaseline3 substitutes for Complete's restore move ---
+
+    [TestCase(150)]
+    public void FullSequence_WithFinalRebaseline_SumsToZeroPerCorner(int n) {
+        var executedSteps = new[] { WizardStep.AllInward, WizardStep.ReBaseline1, WizardStep.Screw1,
+                                    WizardStep.ReBaseline2, WizardStep.Screw2, WizardStep.ReBaseline3,
+                                    WizardStep.Complete };
+        var total = new double[] { 0, 0, 0, 0 };
+        foreach (var step in executedSteps) {
+            var move = EatWizardMapping.MoveForStep(step, n, measuredFinalRebaseline: true);
+            if (move == null) continue;   // Complete is a no-move when ReBaseline3 already restored
+            for (int i = 0; i < 4; i++) { total[i] += move.PerCornerSteps[i]; }
+        }
+        Assert.That(total, Is.EqualTo(new double[] { 0, 0, 0, 0 }));
+    }
+
+    [Test]
+    public void ReBaseline3_IsDiagonalBRestore_AndCompleteBecomesNoMove() {
+        var rb3 = EatWizardMapping.MoveForStep(WizardStep.ReBaseline3, 150, measuredFinalRebaseline: true);
+        Assert.Multiple(() => {
+            Assert.That(rb3.Axis, Is.EqualTo(TiltMoveAxis.DiagonalB));
+            Assert.That(rb3.Steps, Is.EqualTo(-150));
+            Assert.That(EatWizardMapping.MoveForStep(WizardStep.Complete, 150, measuredFinalRebaseline: true), Is.Null);
+            Assert.That(EatWizardMapping.MoveForStep(WizardStep.Complete, 150, measuredFinalRebaseline: false).Steps, Is.EqualTo(-150));
+        });
+    }
+
     // --- InverseMove ---
 
     [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs
@@ -39,6 +39,9 @@ public class TiltAdapterOptionsTests {
             Assert.That(options.DeviceName, Is.EqualTo("Manual"));
             Assert.That(options.ScrewInwardCurvatureSignIsMeasured, Is.False);
             Assert.That(options.MeasureCurvatureDuringCalibration, Is.False);
+            // Default ON (Task 6) -- unlike MeasureCurvatureDuringCalibration above, drift-symmetric
+            // referencing of screw 2 is recommended for every calibration, not an opt-in extra.
+            Assert.That(options.MeasureFinalRebaseline, Is.True);
             Assert.That(options.CalibrationIsManual, Is.False);
             Assert.That(options.TiltDeviceSerialPortName, Is.EqualTo(""));
             Assert.That(options.TiltDeviceMaxStepsPerCommand, Is.EqualTo(200));
@@ -56,10 +59,12 @@ public class TiltAdapterOptionsTests {
         var (options, store, _) = Build();
         options.ScrewInwardCurvatureSignIsMeasured = true;
         options.MeasureCurvatureDuringCalibration = true;
+        options.MeasureFinalRebaseline = false; // default is true, so false is the value that actually persists
         options.CalibrationIsManual = true;
         Assert.Multiple(() => {
             Assert.That(store.GetValueBoolean(nameof(TiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured), false), Is.True);
             Assert.That(store.GetValueBoolean(nameof(TiltAdapterOptions.MeasureCurvatureDuringCalibration), false), Is.True);
+            Assert.That(store.GetValueBoolean(nameof(TiltAdapterOptions.MeasureFinalRebaseline), true), Is.False);
             Assert.That(store.GetValueBoolean(nameof(TiltAdapterOptions.CalibrationIsManual), false), Is.True);
         });
     }
@@ -156,6 +161,7 @@ public class TiltAdapterOptionsTests {
     [TestCase(nameof(TiltAdapterOptions.ScrewInwardCurvatureSign), -1)]
     [TestCase(nameof(TiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured), true)]
     [TestCase(nameof(TiltAdapterOptions.MeasureCurvatureDuringCalibration), true)]
+    [TestCase(nameof(TiltAdapterOptions.MeasureFinalRebaseline), false)] // default is true, so false is the value that actually changes it
     [TestCase(nameof(TiltAdapterOptions.CalibrationIsManual), true)]
     [TestCase(nameof(TiltAdapterOptions.AdjustmentType), TiltAdjustmentType.StepperMotors)]
     [TestCase(nameof(TiltAdapterOptions.AngleDisplayUnit), TiltGuidanceAngleUnit.Degrees)]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -3273,7 +3273,19 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         // and a drift scale to compare it against.
         private static (TiltAdapterWizardVM vm, ITiltAdapterOptions options) RunSixStepWithCurvature(
                 double baselineE, double allInwardE, double reBaseline1E, double reBaseline2E) {
-            var (vm, options, _, _) = Build(configureOptions: o => o.MeasureCurvatureDuringCalibration.Returns(true));
+            // Deliberately isotropic UNIT geometry (1 µm pixels, 1 µm focuser step). ComputeConfidence converts
+            // its deltas to physical gradient space, where valid sensor/focuser geometry is a precondition — an
+            // unpopulated profile makes the conversion non-finite, which fails safe to an SNR warning and would
+            // drown out the curvature cross-check these tests are actually about. Unit geometry over the 1x1
+            // pseudo-sensor makes that conversion the identity, so the SNR here is exactly what raw (A,B) gives.
+            var profile = Substitute.For<IProfileService>();
+            profile.ActiveProfile.CameraSettings.PixelSize.Returns(1.0);
+            var inspectorOptions = Substitute.For<IInspectorOptions>();
+            inspectorOptions.EffectiveMicronsPerFocuserStep.Returns(1.0);
+            var (vm, options, _, _) = Build(
+                configureOptions: o => o.MeasureCurvatureDuringCalibration.Returns(true),
+                profileService: profile,
+                inspectorOptions: inspectorOptions);
             vm.StartCommand.Execute(null);
 
             vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0, baselineE);
@@ -3337,7 +3349,16 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         public void CurvatureCrossCheck_FourStepRun_NeverWarns() {
             // No all-screws step ⇒ no curvature channel to compare against, and the configured sign is left
             // untouched anyway.
-            var (vm, _, _, _) = Build(configureOptions: o => o.MeasureCurvatureDuringCalibration.Returns(false));
+            // Unit geometry for the same reason as RunSixStepWithCurvature: without it the physical-gradient
+            // conversion is non-finite and fails safe to an SNR warning, which is not what this test is about.
+            var profile = Substitute.For<IProfileService>();
+            profile.ActiveProfile.CameraSettings.PixelSize.Returns(1.0);
+            var inspectorOptions = Substitute.For<IInspectorOptions>();
+            inspectorOptions.EffectiveMicronsPerFocuserStep.Returns(1.0);
+            var (vm, _, _, _) = Build(
+                configureOptions: o => o.MeasureCurvatureDuringCalibration.Returns(false),
+                profileService: profile,
+                inspectorOptions: inspectorOptions);
             vm.StartCommand.Execute(null);
 
             vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0, -400);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -2728,6 +2728,88 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             });
         }
 
+        // --- Corner-region AF cross-check wiring (Task 5) -------------------------------------------------
+
+        // All three tests below share the same clean paraboloid geometry as the piston tests above (Screw1
+        // delta (0,-5e-5), Screw2 delta (5e-5,0) — equal magnitudes, a clean 90° gap, no AllInward/ReBaseline1
+        // step so no piston check contributes either) and the same isotropic 1x1 pseudo-sensor, so the ONLY
+        // thing that varies between them is the corner-region reading — isolating the cross-check from every
+        // other warning the same way the piston tests isolate PistonAgreement.
+        private static void SeedCleanParaboloidReadings(TiltAdapterWizardVM vm,
+            double screw1CornerA, double screw1CornerB, double screw2CornerA, double screw2CornerB) {
+            vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0, cornerA: 0.0, cornerB: 0.0, cornerMean: 1000.0);
+            vm.SeedStepReading(WizardStep.Screw1, 0.0, -0.00005, 1000.0, cornerA: screw1CornerA, cornerB: screw1CornerB, cornerMean: 1000.0);
+            vm.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 1000.0, cornerA: 0.0, cornerB: 0.0, cornerMean: 1000.0);
+            vm.SeedStepReading(WizardStep.Screw2, 0.00005, 0.0, 1000.0, cornerA: screw2CornerA, cornerB: screw2CornerB, cornerMean: 1000.0);
+        }
+
+        [Test]
+        public void RunCalibrationForTest_CornerCrossCheckAgreesWithin15Percent_NoNewWarningPart() {
+            var (vm, _, _, _) = Build(screwCount: 4);
+            // Corner deltas are a uniform 10% higher magnitude than the paraboloid's (0,-5.5e-5) / (5.5e-5,0)
+            // vs (0,-5e-5) / (5e-5,0): relative difference |5e-5 - 5.5e-5| / 5.5e-5 = 9.09% -- comfortably
+            // under the 15% threshold without being the trivial (identical-values) case.
+            SeedCleanParaboloidReadings(vm, screw1CornerA: 0.0, screw1CornerB: -0.000055, screw2CornerA: 0.000055, screw2CornerB: 0.0);
+
+            vm.RunCalibrationForTest(radiusMm: 44, pixelSizeMicrons: 1, focuserStepMicrons: 1,
+                tiltPlaneOverride: IsotropicPistonWarningTiltPlane());
+
+            Assert.Multiple(() => {
+                Assert.That(vm.HasWarning, Is.False);
+                Assert.That(vm.WarningText, Is.Empty);
+                // The cross-check estimate itself is still computed and displayed regardless of whether it
+                // disagrees enough to warn -- the display and the warning are separate signals (locked
+                // decision: flag/display, never silently blend).
+                Assert.That(vm.HasCornerCrossCheck, Is.True);
+                Assert.That(vm.CornerCrossCheckDisplay, Is.EqualTo("Corner-AF cross-check: 2.42 µm/turn"));
+            });
+        }
+
+        [Test]
+        public void RunCalibrationForTest_CornerMagnitudes25PercentHigherThanParaboloid_WarnsAndDisplaysCornerEstimate() {
+            var (vm, _, _, _) = Build(screwCount: 4);
+            // Corner deltas are a uniform 25% higher magnitude than the paraboloid's: (0,-6.25e-5) /
+            // (6.25e-5,0) vs (0,-5e-5) / (5e-5,0) -- relative difference |5e-5 - 6.25e-5| / 6.25e-5 = 20%,
+            // comfortably over the 15% threshold.
+            SeedCleanParaboloidReadings(vm, screw1CornerA: 0.0, screw1CornerB: -0.0000625, screw2CornerA: 0.0000625, screw2CornerB: 0.0);
+
+            vm.RunCalibrationForTest(radiusMm: 44, pixelSizeMicrons: 1, focuserStepMicrons: 1,
+                tiltPlaneOverride: IsotropicPistonWarningTiltPlane());
+
+            Assert.Multiple(() => {
+                Assert.That(vm.HasWarning, Is.True);
+                Assert.That(vm.WarningText, Does.Contain("the per-star model and the corner-region AF disagree on the screw moves by"));
+                Assert.That(vm.WarningText, Does.Contain("corner-AF estimate: 2.75 µm"));
+                Assert.That(vm.HasCornerCrossCheck, Is.True);
+                Assert.That(vm.CornerCrossCheckDisplay, Is.EqualTo("Corner-AF cross-check: 2.75 µm/turn"));
+            });
+        }
+
+        [Test]
+        public void RunCalibrationForTest_PartialCornerData_SkipsCrossCheckCleanly() {
+            var (vm, _, _, _) = Build(screwCount: 4);
+            // Same 25%-higher corner geometry as the disagreement test above -- WOULD warn if the cross-check
+            // ran -- but Screw1's corner reading is left at its NaN default (never seeded), simulating a step
+            // whose corner regions failed to fit / an older saved run captured before this feature shipped.
+            // A partially-available run must degrade to "no cross-check" cleanly: no NaN-contaminated warning
+            // text, no display, and — critically — no OTHER warning either (proving the missing corner data
+            // doesn't leak NaN into the rest of ValidateCalibrationQuality).
+            vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0, cornerA: 0.0, cornerB: 0.0, cornerMean: 1000.0);
+            vm.SeedStepReading(WizardStep.Screw1, 0.0, -0.00005, 1000.0); // corner NaN -- not seeded
+            vm.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 1000.0, cornerA: 0.0, cornerB: 0.0, cornerMean: 1000.0);
+            vm.SeedStepReading(WizardStep.Screw2, 0.00005, 0.0, 1000.0, cornerA: 0.0000625, cornerB: 0.0, cornerMean: 1000.0);
+
+            vm.RunCalibrationForTest(radiusMm: 44, pixelSizeMicrons: 1, focuserStepMicrons: 1,
+                tiltPlaneOverride: IsotropicPistonWarningTiltPlane());
+
+            Assert.Multiple(() => {
+                Assert.That(vm.HasWarning, Is.False);
+                Assert.That(vm.WarningText, Is.Empty);
+                Assert.That(vm.HasCornerCrossCheck, Is.False);
+                Assert.That(vm.CornerCrossCheckDisplay, Is.Empty);
+            });
+        }
+
         [Test]
         public void ApplyManualCalibrationCommand_SetsCalibrationIsReliableFalse() {
             // A manual entry has no confidence computation to reuse (no per-step tilt vectors) -- conservative

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -2585,7 +2585,13 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             vm.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 1000.0);
             vm.SeedStepReading(WizardStep.Screw2, -0.25, 0.433, 1000.0);
 
-            vm.RunCalibrationForTest(deviceDriven: true);
+            // No tiltPlaneOverride -> RunCalibrationMath's inputs fall back to a 1x1 image size, so real (any
+            // positive, equal-for-both-axes) pixel/focuser sizes must be supplied explicitly: PhysicalDelta has
+            // no fallback for a zero sensor size (geometry is a precondition -- see its doc comment), and
+            // BuildMotorized's mocked profile otherwise leaves PixelSize at its NSubstitute default of 0. A 1x1
+            // image size keeps the conversion isotropic, so the SNR ratio (and thus IsReliable) is unchanged
+            // from the pre-F2-fix raw-(A,B) computation this test was written against.
+            vm.RunCalibrationForTest(deviceDriven: true, pixelSizeMicrons: 3.76, focuserStepMicrons: 3.6);
 
             options.Received(1).CalibrationIsReliable = true;
         }
@@ -2602,11 +2608,52 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             vm.SeedStepReading(WizardStep.ReBaseline2, 0.4, 0.0, 1000.0);
             vm.SeedStepReading(WizardStep.Screw2, 0.9, 0.0, 1000.0);
 
-            vm.RunCalibrationForTest(deviceDriven: true);
+            // Explicit isotropic geometry -- see RunCalibrationForTest_DeviceDriven_ReliableCalibration_SetsCalibrationIsReliableTrue.
+            vm.RunCalibrationForTest(deviceDriven: true, pixelSizeMicrons: 3.76, focuserStepMicrons: 3.6);
 
             Assert.Multiple(() => {
                 options.Received(1).CalibrationIsReliable = false;
                 options.Received(1).DeviceLinkedCalibrationDeviceName = "ASG Electronic EAT - 90mm";
+            });
+        }
+
+        // F2 regression lock at the VM<->calculator seam: RunCalibrationMath must persist the PHYSICAL-space
+        // screw angles/ratio TiltCalibrationCalculator.Calibate() computes, not raw (A,B)-tilt-plane-coefficient
+        // values. The bug this refactor fixed (RunCalibrationMath hand-mirroring angle/ratio algebra in raw
+        // (A,B) space) manifested exactly at this seam, and the calculator-level anisotropic tests alone can't
+        // catch a future edit that bypasses Calibrate() again here.
+        //
+        // Two single-screw moves of EQUAL physical magnitude at physical directions 200 deg and 290 deg (90 deg
+        // apart -- this adapter's ideal 4-screw spacing) on a strongly non-square 6000x2000 image. Physically
+        // (what Calibrate() now correctly produces): Screw1 = 200 deg exactly, Screw2 = 290 deg exactly,
+        // RawAngleDiffDegrees = 90 deg, MoveMagnitudeRatio = 1.0 -- no warning.
+        // In raw (A,B) space (what the pre-refactor/pre-F2-fix inline math in RunCalibrationMath produced for
+        // these exact same deltas): Screw1 ~= 207.22 deg, Screw2 ~= 297.22 deg, RawAngleDiffDegrees ~= 49.4 deg,
+        // MoveMagnitudeRatio ~= 2.04 -- comfortably past the 1.5x "unequal tilt changes" warning threshold.
+        [Test]
+        public void RunCalibrationForTest_AnisotropicSensor_PersistsPhysicalSpaceScrewAnglesNotRawSpace() {
+            var (vm, options, _, _) = Build(screwCount: 4);
+            var tiltPlane = new TiltPlaneModel(new System.Drawing.Size(6000, 2000), fRatio: 7,
+                a: 0, b: 0, c: 0, mean: 1000, focuserStepSizeMicrons: 0.5,
+                centerPosition: 1000, topLeftPosition: 1000, topRightPosition: 1000,
+                bottomLeftPosition: 1000, bottomRightPosition: 1000);
+            vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw1, -30.86389773370834, 28.265954033240128, 1000.0);
+            vm.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw2, -84.79786209972038, -10.287965911236123, 1000.0);
+
+            vm.RunCalibrationForTest(pixelSizeMicrons: 3.76, focuserStepMicrons: 0.5, tiltPlaneOverride: tiltPlane);
+
+            Assert.Multiple(() => {
+                options.Received(1).Screw1AngleDegrees = Arg.Is<double>(v => Math.Abs(v - 200.0) < 0.01);
+                options.Received(1).Screw2AngleDegrees = Arg.Is<double>(v => Math.Abs(v - 290.0) < 0.01);
+                // MoveMagnitudeRatio has no direct public getter, but it feeds the very same
+                // ValidateCalibrationQuality warning check as the angle gap: the physical ratio (1.0) is
+                // nowhere near the 1.5x threshold, whereas the raw-(A,B) ratio (~2.04x) would have tripped it
+                // -- so a clean (no-warning) WarningText is itself evidence MoveMagnitudeRatio came from
+                // Calibrate()'s physical result, not a raw-(A,B) recomputation.
+                Assert.That(vm.HasWarning, Is.False);
+                Assert.That(vm.WarningText, Is.Empty);
             });
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -2563,6 +2563,86 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             }
         }
 
+        // Fix 4 (post-review): CornerTiltPlaneOverrideForTest mirrors CalibrationTiltPlaneOverrideForTest but
+        // was never exercised by a test -- ReplayAsync's corner-capture line only ever ran its null/NaN
+        // fallback. Sets BOTH overrides per replayed step (a fresh TiltPlaneModel each time, since
+        // ReplayStepOverrideForTest runs before ReplayAsync reads CalibrationTiltPlane/corner for that step) to
+        // the SAME 25%-higher-corner geometry as RunCalibrationForTest_CornerMagnitudes25PercentHigherThan-
+        // Paraboloid... above, proving the real capture site (not just the SeedStepReading test shortcut) wires
+        // through to the cross-check end to end. UseCaptureTimeSettingsInMemory (rather than UseCurrentSettings,
+        // used by the other ReplayAsync tests) so RunCalibrationMath's geometry comes entirely from `metadata`
+        // (radius/pixel/focuser-step/applied all under test control), matching the isotropic-sensor convention
+        // the seeded-reading tests use -- not from the unconfigured profile/options substitutes.
+        [Test]
+        public void ReplayAsync_CapturesCornerReadingsAndTheCrossCheckFires() {
+            var (vm, _, _, _) = Build(screwCount: 4);
+
+            string runRoot = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "hf-tilt-replay-corner-test-" + Guid.NewGuid().ToString("N"));
+            var stepFolders = new[] { "01_Baseline", "02_Screw1", "03_ReBaseline2", "04_Screw2" };
+            System.IO.Directory.CreateDirectory(runRoot);
+            try {
+                foreach (var stepFolder in stepFolders) {
+                    System.IO.Directory.CreateDirectory(System.IO.Path.Combine(runRoot, stepFolder));
+                }
+                var metadata = new TiltCalibrationMetadata {
+                    NumberOfScrews = 4,
+                    PixelSizeMicrons = 1,
+                    FocuserStepSizeMicrons = 1,
+                    ScrewRadiusMillimeters = 44,
+                    CalibrationAppliedAmount = 1.0,
+                    RunStepMapping = new List<TiltRunStepMapping> {
+                        new TiltRunStepMapping { Step = "Baseline", Folder = stepFolders[0] },
+                        new TiltRunStepMapping { Step = "Screw1", Folder = stepFolders[1] },
+                        new TiltRunStepMapping { Step = "ReBaseline2", Folder = stepFolders[2] },
+                        new TiltRunStepMapping { Step = "Screw2", Folder = stepFolders[3] },
+                    }
+                };
+                System.IO.File.WriteAllText(System.IO.Path.Combine(runRoot, "metadata.json"), metadata.Serialize());
+
+                // Paraboloid: clean (0,-5e-5)/(5e-5,0) deltas (magnitude 5e-5 each). Corner: the SAME deltas
+                // scaled 25% higher (magnitude 6.25e-5 each) -- identical numbers to the seeded-reading
+                // disagreement test, so the expected outputs below are the same known values (2.75 µm/turn).
+                var paraboloidByStep = new Dictionary<WizardStep, (double a, double b)> {
+                    [WizardStep.Baseline] = (0.0, 0.0),
+                    [WizardStep.Screw1] = (0.0, -0.00005),
+                    [WizardStep.ReBaseline2] = (0.0, 0.0),
+                    [WizardStep.Screw2] = (0.00005, 0.0),
+                };
+                var cornerByStep = new Dictionary<WizardStep, (double a, double b)> {
+                    [WizardStep.Baseline] = (0.0, 0.0),
+                    [WizardStep.Screw1] = (0.0, -0.0000625),
+                    [WizardStep.ReBaseline2] = (0.0, 0.0),
+                    [WizardStep.Screw2] = (0.0000625, 0.0),
+                };
+                TiltPlaneModel PlaneFor(double a, double b) => new TiltPlaneModel(new System.Drawing.Size(1, 1), fRatio: 7,
+                    a: a, b: b, c: 0, mean: 1000, focuserStepSizeMicrons: 1,
+                    centerPosition: 1000, topLeftPosition: 1000, topRightPosition: 1000,
+                    bottomLeftPosition: 1000, bottomRightPosition: 1000);
+
+                vm.SelectReplayFolderForTest = _ => runRoot;
+                vm.SelectReplaySettingsForTest = _ => Task.FromResult(ReplaySettingsChoice.UseCaptureTimeSettingsInMemory);
+                vm.ReplayStepOverrideForTest = (step, ct) => {
+                    var (pa, pb) = paraboloidByStep[step];
+                    vm.CalibrationTiltPlaneOverrideForTest = PlaneFor(pa, pb);
+                    var (ca, cb) = cornerByStep[step];
+                    vm.CornerTiltPlaneOverrideForTest = PlaneFor(ca, cb);
+                    return Task.FromResult(true);
+                };
+
+                ((AsyncRelayCommand)vm.ReplayCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+
+                Assert.Multiple(() => {
+                    Assert.That(vm.IsComplete, Is.True, "precondition: the replay actually completed (RunCalibrationMath was reached)");
+                    Assert.That(vm.HasCornerCrossCheck, Is.True);
+                    Assert.That(vm.CornerCrossCheckDisplay, Is.EqualTo("Corner-AF cross-check: 2.75 µm/turn"));
+                    Assert.That(vm.WarningText, Does.Contain("the per-star model and the corner-region AF disagree on the screw moves by"));
+                    Assert.That(vm.WarningText, Does.Contain("corner-AF estimate: 2.75 µm"));
+                });
+            } finally {
+                System.IO.Directory.Delete(runRoot, recursive: true);
+            }
+        }
+
         [Test]
         public void ApplyManualCalibrationCommand_ClearsDeviceLinkedMarker() {
             var (vm, options, _, _) = Build();
@@ -2807,6 +2887,36 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 Assert.That(vm.WarningText, Is.Empty);
                 Assert.That(vm.HasCornerCrossCheck, Is.False);
                 Assert.That(vm.CornerCrossCheckDisplay, Is.Empty);
+            });
+        }
+
+        [Test]
+        public void RunCalibrationForTest_StepEntirelyMissingFromReadings_SkipsCrossCheckCleanly() {
+            var (vm, _, _, _) = Build(screwCount: 4);
+            // Distinct from the partial-corner-data test above (which SEEDS Screw1 but leaves its corner
+            // fields at their NaN default): here Screw2 is never seeded AT ALL, so stepReadings has no entry
+            // for it. Reading(WizardStep.Screw2) then falls back to default(StepReading), whose CornerA/B/Mean
+            // are a struct-default 0.0 -- NOT NaN -- so a completeness check built on the non-NaN test alone
+            // would be fooled into treating this as a complete, valid (0,0,0) corner reading for Screw2 (Fix
+            // 2, post-review). Screw2's corner delta would then be (0,0) - ReBaseline2's corner (0,0) = (0,0),
+            // and 4-screw RecoverHardwareDetailed's own guard only rejects an overall measured <= 0 (not a
+            // per-screw zero) -- averaging that zero against Screw1's real corner move still yields a
+            // non-NaN, plausible-looking µm/turn, so this specific failure mode would NOT be caught by
+            // downstream NaN propagation; only the explicit stepReadings.ContainsKey/TryGetValue check does.
+            // (Screw2's paraboloid side is equally absent, which trips the UNRELATED screw-angle-gap warning
+            // -- expected, and not asserted against; this test only cares about the corner outputs.)
+            vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0, cornerA: 0.0, cornerB: 0.0, cornerMean: 1000.0);
+            vm.SeedStepReading(WizardStep.Screw1, 0.0, -0.00005, 1000.0, cornerA: 0.0, cornerB: -0.0000625, cornerMean: 1000.0);
+            vm.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 1000.0, cornerA: 0.0, cornerB: 0.0, cornerMean: 1000.0);
+            // WizardStep.Screw2 intentionally NEVER seeded.
+
+            vm.RunCalibrationForTest(radiusMm: 44, pixelSizeMicrons: 1, focuserStepMicrons: 1,
+                tiltPlaneOverride: IsotropicPistonWarningTiltPlane());
+
+            Assert.Multiple(() => {
+                Assert.That(vm.HasCornerCrossCheck, Is.False);
+                Assert.That(vm.CornerCrossCheckDisplay, Is.Empty);
+                Assert.That(vm.WarningText, Does.Not.Contain("corner-region AF disagree"));
             });
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -2830,8 +2830,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                     Assert.That(vm.IsComplete, Is.True, "precondition: the replay actually completed (RunCalibrationMath was reached)");
                     Assert.That(vm.HasCornerCrossCheck, Is.True);
                     Assert.That(vm.CornerCrossCheckDisplay, Is.EqualTo("Corner-AF cross-check: 2.75 µm/turn"));
-                    Assert.That(vm.WarningText, Does.Contain("the per-star model and the corner-region AF disagree on the screw moves by"));
-                    Assert.That(vm.WarningText, Does.Contain("corner-AF estimate: 2.75 µm"));
+                    Assert.That(vm.WarningText, Does.Contain("The per-star model and the corner-region AF differ by"));
+                    Assert.That(vm.WarningText, Does.Contain("corner-region AF puts the pitch at 2.75 µm"));
                 });
             } finally {
                 System.IO.Directory.Delete(runRoot, recursive: true);
@@ -2973,8 +2973,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             Assert.Multiple(() => {
                 Assert.That(vm.HasWarning, Is.True);
                 Assert.That(vm.WarningText, Does.Contain(
-                    "piston-implied hardware (2.86 µm) and tilt-derived (2.2 µm) disagree by more than 20% " +
-                    "— the tilt estimate may be unreliable"));
+                    "The piston-implied pitch (2.86 µm) and the tilt-derived pitch (2.2 µm) differ by 30%."));
                 Assert.That(vm.PistonPitchDisplay, Is.EqualTo("Piston-implied: 2.9 µm/turn"));
             });
         }
@@ -3053,8 +3052,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
 
             Assert.Multiple(() => {
                 Assert.That(vm.HasWarning, Is.True);
-                Assert.That(vm.WarningText, Does.Contain("the per-star model and the corner-region AF disagree on the screw moves by"));
-                Assert.That(vm.WarningText, Does.Contain("corner-AF estimate: 2.75 µm"));
+                Assert.That(vm.WarningText, Does.Contain("The per-star model and the corner-region AF differ by"));
+                Assert.That(vm.WarningText, Does.Contain("corner-region AF puts the pitch at 2.75 µm"));
                 Assert.That(vm.HasCornerCrossCheck, Is.True);
                 Assert.That(vm.CornerCrossCheckDisplay, Is.EqualTo("Corner-AF cross-check: 2.75 µm/turn"));
             });
@@ -3111,7 +3110,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             Assert.Multiple(() => {
                 Assert.That(vm.HasCornerCrossCheck, Is.False);
                 Assert.That(vm.CornerCrossCheckDisplay, Is.Empty);
-                Assert.That(vm.WarningText, Does.Not.Contain("corner-region AF disagree"));
+                Assert.That(vm.WarningText, Does.Not.Contain("corner-region AF differ"));
             });
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -539,6 +539,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 Assert.That(TiltAdapterWizardVM.StepIsAtBaseline(WizardStep.ReBaseline1), Is.True);
                 Assert.That(TiltAdapterWizardVM.StepIsAtBaseline(WizardStep.ReBaseline2), Is.True);
                 Assert.That(TiltAdapterWizardVM.StepIsAtBaseline(WizardStep.Complete), Is.True);
+                Assert.That(TiltAdapterWizardVM.StepIsAtBaseline(WizardStep.ReBaseline3), Is.True);
                 Assert.That(TiltAdapterWizardVM.StepIsAtBaseline(WizardStep.AllInward), Is.False);
                 Assert.That(TiltAdapterWizardVM.StepIsAtBaseline(WizardStep.Screw1), Is.False);
                 Assert.That(TiltAdapterWizardVM.StepIsAtBaseline(WizardStep.Screw2), Is.False);
@@ -579,11 +580,24 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         [Test]
         public void GetMeasurementSteps_FourStepFlowSkipsCurvatureSteps() {
             Assert.Multiple(() => {
-                Assert.That(TiltAdapterWizardVM.GetMeasurementSteps(measureCurvature: true), Is.EqualTo(new[] {
+                Assert.That(TiltAdapterWizardVM.GetMeasurementSteps(measureCurvature: true, measureFinalRebaseline: false), Is.EqualTo(new[] {
                     WizardStep.Baseline, WizardStep.AllInward, WizardStep.ReBaseline1,
                     WizardStep.Screw1, WizardStep.ReBaseline2, WizardStep.Screw2 }));
-                Assert.That(TiltAdapterWizardVM.GetMeasurementSteps(measureCurvature: false), Is.EqualTo(new[] {
+                Assert.That(TiltAdapterWizardVM.GetMeasurementSteps(measureCurvature: false, measureFinalRebaseline: false), Is.EqualTo(new[] {
                     WizardStep.Baseline, WizardStep.Screw1, WizardStep.ReBaseline2, WizardStep.Screw2 }));
+            });
+        }
+
+        // --- Task 6: optional measured final re-baseline appended to either base flow ---
+
+        [Test]
+        public void GetMeasurementSteps_WithFinalRebaseline_AppendsReBaseline3AsTheLastStep() {
+            Assert.Multiple(() => {
+                Assert.That(TiltAdapterWizardVM.GetMeasurementSteps(measureCurvature: true, measureFinalRebaseline: true), Is.EqualTo(new[] {
+                    WizardStep.Baseline, WizardStep.AllInward, WizardStep.ReBaseline1,
+                    WizardStep.Screw1, WizardStep.ReBaseline2, WizardStep.Screw2, WizardStep.ReBaseline3 }));
+                Assert.That(TiltAdapterWizardVM.GetMeasurementSteps(measureCurvature: false, measureFinalRebaseline: true), Is.EqualTo(new[] {
+                    WizardStep.Baseline, WizardStep.Screw1, WizardStep.ReBaseline2, WizardStep.Screw2, WizardStep.ReBaseline3 }));
             });
         }
 
@@ -600,6 +614,12 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                     Does.Contain("screw 1 CLOCKWISE").And.Contain("screw 3 COUNTER-CLOCKWISE"));
                 Assert.That(TiltAdapterWizardVM.StepInstructionsText(WizardStep.Screw2, 3, false, 1.5),
                     Does.Contain("screw 2 CLOCKWISE exactly 1.5 turns"));
+                // Task 6: the optional measured final re-baseline undoes screw 2's move (motor/screw 2 and,
+                // 4-screw, its opposite motor/screw 4) -- same shape as ReBaseline2's undo of screw 1, mirrored.
+                Assert.That(TiltAdapterWizardVM.StepInstructionsText(WizardStep.ReBaseline3, 3, false, 1.0),
+                    Does.Contain("screw 2 back COUNTER-CLOCKWISE").And.Contain("returning to the baseline position"));
+                Assert.That(TiltAdapterWizardVM.StepInstructionsText(WizardStep.ReBaseline3, 4, false, 1.0),
+                    Does.Contain("screw 2 back COUNTER-CLOCKWISE").And.Contain("screw 4 back CLOCKWISE"));
             });
         }
 
@@ -612,6 +632,11 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                     Does.Contain("−2 steps to motor 1"));
                 Assert.That(TiltAdapterWizardVM.StepInstructionsText(WizardStep.Screw1, 4, true, 2.0),
                     Does.Contain("+2 steps to motor 1").And.Contain("−2 steps to motor 3"));
+                // Task 6: stepper wording for the optional measured final re-baseline (motor 2 / motor 4).
+                Assert.That(TiltAdapterWizardVM.StepInstructionsText(WizardStep.ReBaseline3, 4, true, 2.0),
+                    Does.Contain("−2 steps to motor 2").And.Contain("+2 steps to motor 4"));
+                Assert.That(TiltAdapterWizardVM.StepInstructionsText(WizardStep.ReBaseline3, 3, true, 2.0),
+                    Does.Contain("−2 steps to motor 2").And.Not.Contain("motor 4"));
             });
         }
 
@@ -622,6 +647,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         [TestCase(WizardStep.ReBaseline2, "Return to Baseline")]
         [TestCase(WizardStep.Screw2, "Move Screw 2")]
         [TestCase(WizardStep.Complete, "Calibration Complete")]
+        [TestCase(WizardStep.ReBaseline3, "Return to Baseline")]
         public void StepTitleText_IsShortPerStepHeader(WizardStep step, string expected) {
             Assert.That(TiltAdapterWizardVM.StepTitleText(step), Is.EqualTo(expected));
         }
@@ -640,6 +666,26 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                     Does.Contain("Click Run Measurement"));
                 Assert.That(TiltAdapterWizardVM.DeviceStepInstructionsText(WizardStep.Screw1, 150, autoRunning: true),
                     Does.StartWith("Running automatically").And.Not.Contain("Click"));
+            });
+        }
+
+        [Test]
+        public void DeviceStepInstructionsText_Complete_NoMoveOnlyWhenMeasuredFinalRebaseline() {
+            // Default (measuredFinalRebaseline: false, the implicit default) -- unchanged from before Task 6:
+            // Complete's own restore move is described.
+            Assert.Multiple(() => {
+                Assert.That(TiltAdapterWizardVM.DeviceStepInstructionsText(WizardStep.Complete, 150, autoRunning: false),
+                    Does.Contain("diagonal-B (restore)").And.Contain("Click Run Measurement"));
+                Assert.That(TiltAdapterWizardVM.DeviceStepInstructionsText(WizardStep.Complete, 150, autoRunning: true),
+                    Does.Contain("diagonal-B (restore)"));
+
+                // measuredFinalRebaseline: true -- ReBaseline3 (an earlier ordinary step in this same run)
+                // already sent and measured the restore, so Complete becomes pure status/no-op wording, with
+                // no move description and no second restore mentioned.
+                Assert.That(TiltAdapterWizardVM.DeviceStepInstructionsText(WizardStep.Complete, 150, autoRunning: false, measuredFinalRebaseline: true),
+                    Is.EqualTo("Click Run Measurement to continue.").And.Not.Contain("diagonal-B"));
+                Assert.That(TiltAdapterWizardVM.DeviceStepInstructionsText(WizardStep.Complete, 150, autoRunning: true, measuredFinalRebaseline: true),
+                    Is.EqualTo("Running automatically — measuring…").And.Not.Contain("diagonal-B"));
             });
         }
 
@@ -885,6 +931,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 Assert.That(vm4.StepDescription(WizardStep.Screw1), Is.EqualTo("Screw 1 ⟳, Screw 3 ⟲"));
                 Assert.That(vm4.StepDescription(WizardStep.ReBaseline2), Is.EqualTo("Re-baseline (Screw 1 ⟲, Screw 3 ⟳)"));
                 Assert.That(vm4.StepDescription(WizardStep.Screw2), Is.EqualTo("Screw 2 ⟳, Screw 4 ⟲"));
+                // Task 6: the optional measured final re-baseline undoes screw 2's move.
+                Assert.That(vm3.StepDescription(WizardStep.ReBaseline3), Is.EqualTo("Re-baseline (Screw 2 ⟲)"));
+                Assert.That(vm4.StepDescription(WizardStep.ReBaseline3), Is.EqualTo("Re-baseline (Screw 2 ⟲, Screw 4 ⟳)"));
             });
         }
 
@@ -2563,6 +2612,59 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             }
         }
 
+        // Task 6: a saved run captured WITH the optional measured final re-baseline replays as a 5-step run
+        // (ReBaseline3 detected from RunStepMapping, exactly how AllInward's presence already detects the
+        // 6- vs 4-step curvature flow) -- the "think rather than transcribe" backward-compatibility point:
+        // a metadata file predating this feature simply has no "ReBaseline3" entry, so byStep.ContainsKey
+        // comes back false and this replays as an ordinary 4-step run (already covered by every OTHER
+        // ReplayAsync test above, none of which include a ReBaseline3 folder).
+        [Test]
+        public void ReplayAsync_WithReBaseline3InMetadata_ReplaysFiveStepsAndCompletes() {
+            var (vm, _, _, _) = Build(screwCount: 4);
+
+            string runRoot = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "hf-tilt-replay-rb3-test-" + Guid.NewGuid().ToString("N"));
+            var stepFolders = new[] { "01_Baseline", "02_Screw1", "03_ReBaseline2", "04_Screw2", "07_ReBaseline3" };
+            var steps = new[] { WizardStep.Baseline, WizardStep.Screw1, WizardStep.ReBaseline2, WizardStep.Screw2, WizardStep.ReBaseline3 };
+            System.IO.Directory.CreateDirectory(runRoot);
+            try {
+                foreach (var stepFolder in stepFolders) {
+                    System.IO.Directory.CreateDirectory(System.IO.Path.Combine(runRoot, stepFolder));
+                }
+                var metadata = new TiltCalibrationMetadata {
+                    NumberOfScrews = 4,
+                    PixelSizeMicrons = 3.76,
+                    FocuserStepSizeMicrons = 3.6,
+                    ScrewRadiusMillimeters = 44,
+                    CalibrationAppliedAmount = 1.0,
+                    RunStepMapping = steps.Select((s, i) => new TiltRunStepMapping { Step = s.ToString(), Folder = stepFolders[i] }).ToList()
+                };
+                System.IO.File.WriteAllText(System.IO.Path.Combine(runRoot, "metadata.json"), metadata.Serialize());
+
+                var tiltPlane = new TiltPlaneModel(new System.Drawing.Size(6248, 4176), fRatio: 7,
+                    a: 0.1, b: 0.05, c: 0, mean: 7000, focuserStepSizeMicrons: 3.6,
+                    centerPosition: 7000, topLeftPosition: 7000, topRightPosition: 7000,
+                    bottomLeftPosition: 7000, bottomRightPosition: 7000);
+                vm.CalibrationTiltPlaneOverrideForTest = tiltPlane;
+                vm.SelectReplayFolderForTest = _ => runRoot;
+                vm.SelectReplaySettingsForTest = _ => Task.FromResult(ReplaySettingsChoice.UseCurrentSettings);
+
+                var observedSteps = new List<WizardStep>();
+                vm.ReplayStepOverrideForTest = (step, ct) => {
+                    observedSteps.Add(step);
+                    return Task.FromResult(true);
+                };
+
+                ((AsyncRelayCommand)vm.ReplayCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+
+                Assert.Multiple(() => {
+                    Assert.That(vm.IsComplete, Is.True, "precondition: the replay actually ran to completion");
+                    Assert.That(observedSteps, Is.EqualTo(steps), "every saved step, including the optional ReBaseline3, is replayed in order");
+                });
+            } finally {
+                System.IO.Directory.Delete(runRoot, recursive: true);
+            }
+        }
+
         // Fix 4 (post-review): CornerTiltPlaneOverrideForTest mirrors CalibrationTiltPlaneOverrideForTest but
         // was never exercised by a test -- ReplayAsync's corner-capture line only ever ran its null/NaN
         // fallback. Sets BOTH overrides per replayed step (a fresh TiltPlaneModel each time, since
@@ -2918,6 +3020,82 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 Assert.That(vm.CornerCrossCheckDisplay, Is.Empty);
                 Assert.That(vm.WarningText, Does.Not.Contain("corner-region AF disagree"));
             });
+        }
+
+        // --- Task 6: optional measured final re-baseline wiring (RunCalibrationMath reads a seeded
+        // ReBaseline3 reading and passes it -- and HasFinalRebaseline -- through the SAME shared MakeInputs
+        // both the paraboloid and (Task 5) corner-cross-check estimators are built from) -----------------
+
+        [Test]
+        public void RunCalibrationForTest_ReBaseline3EqualToReBaseline2_MatchesRunWithoutFinalRebaseline() {
+            // When the seeded ReBaseline3 reading is IDENTICAL to ReBaseline2, the drift-cancelling midpoint
+            // mid(ReBaseline2, ReBaseline3) collapses to ReBaseline2 itself -- Screw2Delta becomes numerically
+            // identical to the no-final-rebaseline reference (Screw2 - ReBaseline2 alone). Proves
+            // RunCalibrationMath actually reads a seeded ReBaseline3 rather than ignoring it, without
+            // re-deriving the drift-cancelling algebra itself (already pinned exactly by
+            // TiltCalibrationCalculatorTests.Calibrate_WithFinalRebaseline_Screw2DeltaIsDriftImmune).
+            var (vmWithout, _, _, _) = Build(screwCount: 4);
+            vmWithout.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0);
+            vmWithout.SeedStepReading(WizardStep.Screw1, 0.0, -0.00005, 1000.0);
+            vmWithout.SeedStepReading(WizardStep.ReBaseline2, 0.0002, -0.0001, 1000.0);
+            vmWithout.SeedStepReading(WizardStep.Screw2, 0.00005, 0.0, 1000.0);
+            vmWithout.RunCalibrationForTest(radiusMm: 44, pixelSizeMicrons: 1, focuserStepMicrons: 1,
+                tiltPlaneOverride: IsotropicPistonWarningTiltPlane());
+
+            var (vmWith, _, _, _) = Build(screwCount: 4);
+            vmWith.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0);
+            vmWith.SeedStepReading(WizardStep.Screw1, 0.0, -0.00005, 1000.0);
+            vmWith.SeedStepReading(WizardStep.ReBaseline2, 0.0002, -0.0001, 1000.0);
+            vmWith.SeedStepReading(WizardStep.Screw2, 0.00005, 0.0, 1000.0);
+            vmWith.SeedStepReading(WizardStep.ReBaseline3, 0.0002, -0.0001, 1000.0); // identical to ReBaseline2
+            vmWith.RunCalibrationForTest(radiusMm: 44, pixelSizeMicrons: 1, focuserStepMicrons: 1,
+                tiltPlaneOverride: IsotropicPistonWarningTiltPlane());
+
+            Assert.Multiple(() => {
+                Assert.That(vmWith.MeasuredHardwareDisplay, Is.EqualTo(vmWithout.MeasuredHardwareDisplay));
+                Assert.That(vmWith.PitchUncertaintyDisplay, Is.EqualTo(vmWithout.PitchUncertaintyDisplay));
+            });
+        }
+
+        [Test]
+        public void RunCalibrationForTest_ReBaseline3DifferentFromReBaseline2_ChangesRecoveredHardware() {
+            // Now ReBaseline3 genuinely differs from ReBaseline2 -- Screw2Delta references
+            // mid(ReBaseline2, ReBaseline3) instead of ReBaseline2 alone, so the recovered hardware must
+            // differ from the no-ReBaseline3 run. Proves the wizard is actually READING and USING the
+            // seeded ReBaseline3 value (not silently ignoring it because HasFinalRebaseline never got wired).
+            var (vmWithout, _, _, _) = Build(screwCount: 4);
+            vmWithout.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0);
+            vmWithout.SeedStepReading(WizardStep.Screw1, 0.0, -0.00005, 1000.0);
+            vmWithout.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 1000.0);
+            vmWithout.SeedStepReading(WizardStep.Screw2, 0.00005, 0.0, 1000.0);
+            vmWithout.RunCalibrationForTest(radiusMm: 44, pixelSizeMicrons: 1, focuserStepMicrons: 1,
+                tiltPlaneOverride: IsotropicPistonWarningTiltPlane());
+
+            var (vmWith, _, _, _) = Build(screwCount: 4);
+            vmWith.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0);
+            vmWith.SeedStepReading(WizardStep.Screw1, 0.0, -0.00005, 1000.0);
+            vmWith.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 1000.0);
+            vmWith.SeedStepReading(WizardStep.Screw2, 0.00005, 0.0, 1000.0);
+            vmWith.SeedStepReading(WizardStep.ReBaseline3, 0.00002, 0.00002, 1000.0); // drifted from ReBaseline2
+            vmWith.RunCalibrationForTest(radiusMm: 44, pixelSizeMicrons: 1, focuserStepMicrons: 1,
+                tiltPlaneOverride: IsotropicPistonWarningTiltPlane());
+
+            Assert.That(vmWith.MeasuredHardwareDisplay, Is.Not.EqualTo(vmWithout.MeasuredHardwareDisplay));
+        }
+
+        [Test]
+        public void StartAsync_WithMeasureFinalRebaseline_ExtendsActiveStepsToFive() {
+            // StartAsync (the live-run caller of GetMeasurementSteps) must read BOTH options -- proves the
+            // wiring reaches the real entry point, not just the static GetMeasurementSteps helper tested
+            // directly above.
+            var (vm, _, _, _) = Build(configureOptions: o => {
+                o.MeasureCurvatureDuringCalibration.Returns(false);
+                o.MeasureFinalRebaseline.Returns(true);
+            });
+
+            vm.StartCommand.Execute(null);
+
+            Assert.That(vm.StepProgressDisplay, Is.EqualTo("Step 1 of 5"));
         }
 
         [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -1216,6 +1216,69 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 WizardStep.Screw1, WizardStep.ReBaseline2, WizardStep.Screw2, WizardStep.Complete }));
         }
 
+        // Task 6, code-quality follow-up (Fix 2): the shipped DEFAULT configuration (curvature measurement
+        // OFF, MeasureFinalRebaseline ON) is a 5-step run. RunCalibrationForTest bypasses activeMeasurementSteps/
+        // NextStep entirely (it seeds stepReadings directly and calls RunCalibrationMath), and ReplayAsync is a
+        // structurally different loop -- neither exercises the real production state machine every live user's
+        // default run actually walks. This mirrors NextStep_FourStepFlow_SkipsCurvatureStepsAndCompletes above,
+        // with ReBaseline3 appended.
+        [Test]
+        public void NextStep_FiveStepFlow_WithFinalRebaseline_WalksAndCompletes() {
+            var (vm, _, _, _) = Build(configureOptions: o => {
+                o.MeasureCurvatureDuringCalibration.Returns(false);
+                o.MeasureFinalRebaseline.Returns(true);
+            });
+            vm.StartCommand.Execute(null);
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Baseline));
+
+            vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw1, 0.5, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw2, -0.25, 0.433, 1000.0);
+            vm.SeedStepReading(WizardStep.ReBaseline3, 0.0, 0.0, 1000.0);
+
+            var walked = new List<WizardStep> { vm.CurrentStep };
+            for (int i = 0; i < 5; i++) {
+                vm.NextStep();
+                walked.Add(vm.CurrentStep);
+            }
+
+            Assert.Multiple(() => {
+                Assert.That(walked, Is.EqualTo(new[] {
+                    WizardStep.Baseline, WizardStep.Screw1, WizardStep.ReBaseline2,
+                    WizardStep.Screw2, WizardStep.ReBaseline3, WizardStep.Complete }));
+                Assert.That(vm.IsComplete, Is.True);
+            });
+        }
+
+        // Cheap to also cover: curvature ON + final re-baseline ON is a 7-step run.
+        [Test]
+        public void NextStep_SevenStepFlow_WithCurvatureAndFinalRebaseline_WalksAndCompletes() {
+            var (vm, _, _, _) = Build(configureOptions: o => {
+                o.MeasureCurvatureDuringCalibration.Returns(true);
+                o.MeasureFinalRebaseline.Returns(true);
+            });
+            vm.StartCommand.Execute(null);
+
+            vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.AllInward, 0.0, 0.0, 1010.0);
+            vm.SeedStepReading(WizardStep.ReBaseline1, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw1, 0.5, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw2, -0.25, 0.433, 1000.0);
+            vm.SeedStepReading(WizardStep.ReBaseline3, 0.0, 0.0, 1000.0);
+
+            var walked = new List<WizardStep> { vm.CurrentStep };
+            for (int i = 0; i < 7; i++) {
+                vm.NextStep();
+                walked.Add(vm.CurrentStep);
+            }
+
+            Assert.That(walked, Is.EqualTo(new[] {
+                WizardStep.Baseline, WizardStep.AllInward, WizardStep.ReBaseline1, WizardStep.Screw1,
+                WizardStep.ReBaseline2, WizardStep.Screw2, WizardStep.ReBaseline3, WizardStep.Complete }));
+        }
+
         // --- Curvature-sign persistence semantics at run completion ---
 
         [Test]
@@ -1918,6 +1981,10 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         [TestCase(WizardStep.ReBaseline2, TiltMoveAxis.DiagonalA, -150)]
         [TestCase(WizardStep.Screw2, TiltMoveAxis.DiagonalB, 150)]
         [TestCase(WizardStep.Complete, TiltMoveAxis.DiagonalB, -150)]
+        // Task 6, code-quality follow-up (Fix 1): ReBaseline3's move is unconditional in EatWizardMapping
+        // (only Complete branches on measuredFinalRebaseline), so this proves DiagonalB/-N is sent for it
+        // without needing StartCommand first (mirrors every other case above, none of which call it either).
+        [TestCase(WizardStep.ReBaseline3, TiltMoveAxis.DiagonalB, -150)]
         public void ExecuteDeviceMoveForCurrentStepAsync_EachStep_SendsExpectedMove(WizardStep step, TiltMoveAxis expectedAxis, int expectedSteps) {
             var (vm, options, service, controller, _, _) = BuildMotorized();
             options.CalibrationAppliedAmount.Returns(150.0);
@@ -1931,6 +1998,32 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 controller.Received(1).ExecuteMoveAsync(
                     Arg.Is<TiltAdapterMove>(m => m.Axis == expectedAxis && m.Steps == expectedSteps),
                     Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
+            });
+        }
+
+        // Task 6, code-quality follow-up (Fix 1): this is the wiring that decides what physically moves the
+        // hardware -- with MeasureFinalRebaseline active for THIS run (captured into activeMeasurementSteps by
+        // StartCommand, exactly as a live device-driven run would), ReBaseline3 (an earlier ordinary step in
+        // the same sequence) already sent and measured the restore, so Complete must send NOTHING to the
+        // controller here. A second DiagonalB(-N) would be a spurious, physically real move on real hardware.
+        [Test]
+        public void ExecuteDeviceMoveForCurrentStepAsync_Complete_SendsNothingWhenFinalRebaselineWasMeasured() {
+            var (vm, options, service, controller, _, _) = BuildMotorized();
+            options.CalibrationAppliedAmount.Returns(150.0);
+            StubSuccessfulMoves(controller);
+            Connect(vm);
+            // Connecting defaults MeasureCurvatureDuringCalibration ON (T11 item 4); re-assert false AFTER
+            // connecting so StartAsync (read fresh at Start) resolves the 4-step base flow this test wants,
+            // with ReBaseline3 appended by MeasureFinalRebaseline below.
+            options.MeasureCurvatureDuringCalibration.Returns(false);
+            options.MeasureFinalRebaseline.Returns(true);
+            vm.StartCommand.Execute(null); // captures activeMeasurementSteps INCLUDING ReBaseline3
+
+            bool result = vm.ExecuteDeviceMoveForCurrentStepAsync(WizardStep.Complete, CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.Multiple(() => {
+                Assert.That(result, Is.True, "Complete succeeds trivially -- there is nothing left to send");
+                controller.DidNotReceive().ExecuteMoveAsync(Arg.Any<TiltAdapterMove>(), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>());
             });
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -2657,6 +2657,77 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             });
         }
 
+        // --- Piston-implied-pitch warning wiring (Task 4) -------------------------------------------------
+
+        // Both piston tests share the same clean screw geometry: Screw1's delta is (0, -g), Screw2's is
+        // (g, 0) with g = 5e-5. A 1x1 isotropic tiltPlaneOverride + unit pixel size/focuser step (see
+        // RunCalibrationForTest below) makes PhysicalDelta byte-identical to these raw (A,B) seeds -- no
+        // forward/inverse conversion needed to reason about the numbers. That gives:
+        //  - equal magnitudes (ratio 1.0, comfortably under the 1.5x MagnitudeRatioWarnThreshold)
+        //  - a clean 90 deg gap (screw count 4's exact expected spacing, no angle warning)
+        //  - CalibrationAppliedAmount defaults to 1 turn (unconfigured options resolve to the VM's "Manual"
+        //    device-preset fallback -- see CalibrationAppliedAmount's getter), and the 4-screw lever arm is
+        //    the screw radius itself, so measured (tilt-derived) hardware = g * radiusMicrons / applied
+        //    = 0.00005 * 44000 / 1 = 2.2 um/turn.
+        // So the only thing that varies between the two tests below is AllInward's mean focuser position,
+        // which drives the piston-implied pitch relative to that fixed 2.2 um/turn -- isolating the piston
+        // check from the angle/magnitude checks (which never contribute a warning part in either case).
+        private static TiltPlaneModel IsotropicPistonWarningTiltPlane() =>
+            new TiltPlaneModel(new System.Drawing.Size(1, 1), fRatio: 7,
+                a: 0, b: 0, c: 0, mean: 1000, focuserStepSizeMicrons: 1,
+                centerPosition: 1000, topLeftPosition: 1000, topRightPosition: 1000,
+                bottomLeftPosition: 1000, bottomRightPosition: 1000);
+
+        [Test]
+        public void RunCalibrationForTest_PistonDisagreesWithMeasuredHardwareBy30Percent_WarnsAndDisplaysPiston() {
+            var (vm, _, _, _) = Build(screwCount: 4);
+            vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0);
+            // AllInward's mean sits 2.86 focuser units below the Baseline/ReBaseline1 midpoint (both 1000.0,
+            // so there is no drift to correct for): piston = |1000.0 - 997.14| * fStep(1) / applied(1) =
+            // 2.86 um/turn. Relative to measured = 2.2 um/turn, that is a 30% disagreement (2.86 / 2.2 =
+            // 1.3) -- comfortably over the 20% PistonDisagreementWarnThreshold.
+            vm.SeedStepReading(WizardStep.AllInward, 0.0, 0.0, 997.14);
+            vm.SeedStepReading(WizardStep.ReBaseline1, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw1, 0.0, -0.00005, 1000.0);
+            vm.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw2, 0.00005, 0.0, 1000.0);
+
+            vm.RunCalibrationForTest(radiusMm: 44, pixelSizeMicrons: 1, focuserStepMicrons: 1,
+                tiltPlaneOverride: IsotropicPistonWarningTiltPlane());
+
+            Assert.Multiple(() => {
+                Assert.That(vm.HasWarning, Is.True);
+                Assert.That(vm.WarningText, Does.Contain(
+                    "piston-implied hardware (2.86 µm) and tilt-derived (2.2 µm) disagree by more than 20% " +
+                    "— the tilt estimate may be unreliable"));
+                Assert.That(vm.PistonPitchDisplay, Is.EqualTo("Piston-implied: 2.9 µm/turn"));
+            });
+        }
+
+        [Test]
+        public void RunCalibrationForTest_PistonAgreesWithMeasuredHardwareWithin20Percent_NoWarning() {
+            var (vm, _, _, _) = Build(screwCount: 4);
+            vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0);
+            // Same fixed measured hardware (2.2 um/turn) as the disagreement test above, but AllInward's mean
+            // is only 2.53 focuser units below the Baseline/ReBaseline1 midpoint: piston = 2.53 um/turn, a
+            // 15% relative difference from measured (2.53 / 2.2 = 1.15) -- comfortably under the 20%
+            // threshold without being close to zero, so this is a meaningful negative case, not a trivial one.
+            vm.SeedStepReading(WizardStep.AllInward, 0.0, 0.0, 997.47);
+            vm.SeedStepReading(WizardStep.ReBaseline1, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw1, 0.0, -0.00005, 1000.0);
+            vm.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw2, 0.00005, 0.0, 1000.0);
+
+            vm.RunCalibrationForTest(radiusMm: 44, pixelSizeMicrons: 1, focuserStepMicrons: 1,
+                tiltPlaneOverride: IsotropicPistonWarningTiltPlane());
+
+            Assert.Multiple(() => {
+                Assert.That(vm.HasWarning, Is.False);
+                Assert.That(vm.WarningText, Is.Empty);
+                Assert.That(vm.PistonPitchDisplay, Is.EqualTo("Piston-implied: 2.5 µm/turn"));
+            });
+        }
+
         [Test]
         public void ApplyManualCalibrationCommand_SetsCalibrationIsReliableFalse() {
             // A manual entry has no confidence computation to reuse (no per-step tilt vectors) -- conservative

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
@@ -577,6 +577,28 @@ public class TiltCalibrationCalculatorTests {
         });
     }
 
+    [Test]
+    public void PistonImpliedMicronsPerStep_DriftCorrectedFromBracketingBaselines() {
+        var inputs = new TiltCalibrationInputs {
+            ScrewCount = 4, HasCurvatureMeasurement = true,
+            Baseline = new TiltGradient(0, 0, 11283.868653107538),
+            AllInward = new TiltGradient(0, 0, 9995.476157148303),
+            ReBaseline1 = new TiltGradient(0, 0, 11197.706101225354),
+            FocuserStepMicrons = 0.269, CalibrationAppliedAmount = 150.0,
+            ImageWidthPixels = 9576, ImageHeightPixels = 6388, PixelSizeMicrons = 3.76,
+            ScrewRadiusMillimeters = 55.0,
+        };
+        Assert.That(TiltCalibrationCalculator.PistonImpliedMicronsPerStep(inputs),
+            Is.EqualTo(2.233258).Within(1e-5));
+    }
+
+    [Test]
+    public void PistonImpliedMicronsPerStep_NaNWithoutCurvatureSteps() {
+        var inputs = new TiltCalibrationInputs { HasCurvatureMeasurement = false,
+            FocuserStepMicrons = 0.269, CalibrationAppliedAmount = 150.0 };
+        Assert.That(TiltCalibrationCalculator.PistonImpliedMicronsPerStep(inputs), Is.NaN);
+    }
+
     [TestCase(30.0, true, 3, 30.0, 150.0, 270.0, double.NaN)]
     [TestCase(30.0, false, 3, 30.0, 270.0, 150.0, double.NaN)]
     [TestCase(350.0, true, 4, 350.0, 80.0, 170.0, 260.0)]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
@@ -271,20 +271,23 @@ public class TiltCalibrationCalculatorTests {
 
     [Test]
     public void Calibrate_DerivesScrewDeltasFromReBaselineNotBaseline() {
-        // The screw moves are measured against the re-baseline that precedes them (c→d, e→f), so a drifted
+        // The screw moves are measured against the re-baseline(s), not the original baseline, so a drifted
         // re-baseline (offset from the original baseline) must NOT contaminate the recovered angles: the single
-        // screw move is added on top of the re-baseline reading and the delta isolates it.
+        // screw move is added on top of the re-baseline reading and the delta isolates it. Screw 1's reference is
+        // now mid(ReBaseline1, ReBaseline2) (drift-cancelling); constructing ReBaseline1 == ReBaseline2 here keeps
+        // that midpoint exactly equal to the drifted re-baseline, so the expectations stay exact and obviously
+        // correct (this is not testing drift-cancellation itself -- see Calibrate_LinearTiltDrift_CancelsExactlyForScrew1
+        // for that).
         const double pitch = 400.0;
-        var reBaseline1 = new TiltGradient(12.0, -7.0, 1000);  // c drifted from baseline a
-        var reBaseline2 = new TiltGradient(-4.0, 9.0, 1000);   // e drifted from c
+        var reBaseline = new TiltGradient(12.0, -7.0, 1000);  // c and e both drifted identically from baseline a
         var inputs = new TiltCalibrationInputs {
             ScrewCount = 3,
             Baseline = new TiltGradient(0, 0, 1000),
             AllInward = new TiltGradient(0, 0, 1075),
-            ReBaseline1 = reBaseline1,
-            Screw1 = Plus(reBaseline1, SingleScrewReading(0, pitch, 3)),
-            ReBaseline2 = reBaseline2,
-            Screw2 = Plus(reBaseline2, SingleScrewReading(120, pitch, 3)),
+            ReBaseline1 = reBaseline,
+            Screw1 = Plus(reBaseline, SingleScrewReading(0, pitch, 3)),
+            ReBaseline2 = reBaseline,
+            Screw2 = Plus(reBaseline, SingleScrewReading(120, pitch, 3)),
             ImageWidthPixels = ImgW,
             ImageHeightPixels = ImgH,
             PixelSizeMicrons = PixelSize,
@@ -302,6 +305,49 @@ public class TiltCalibrationCalculatorTests {
             // AllInward mean (1075) above baseline (1000) ⇒ σ = −1.
             Assert.That(r.CurvatureSign, Is.EqualTo(-1));
         });
+    }
+
+    [Test]
+    public void Calibrate_LinearTiltDrift_CancelsExactlyForScrew1() {
+        // A constant drift vector v is added per measurement interval. The screw-1 move D is bracketed
+        // by ReBaseline1 (2 intervals in) and ReBaseline2 (4 intervals in), with Screw1 at 3 intervals:
+        // Screw1 − mid(RB1, RB2) recovers D exactly. The old delta (Screw1 − RB1) is off by |v|.
+        var (vA, vB) = (9.0, -5.0);
+        var move1 = SingleScrewReading(0, 400.0, 4);      // D
+        var move2 = SingleScrewReading(90, 400.0, 4);     // E
+        TiltGradient Drift(TiltGradient g, int k) => new TiltGradient(g.A + k * vA, g.B + k * vB, g.MeanFocuserPosition);
+
+        var drifted = new TiltCalibrationInputs {
+            ScrewCount = 4,
+            Baseline = Drift(new TiltGradient(0, 0, 0), 0),
+            AllInward = Drift(new TiltGradient(0, 0, 100), 1),
+            ReBaseline1 = Drift(new TiltGradient(0, 0, 0), 2),
+            Screw1 = Drift(move1, 3),
+            ReBaseline2 = Drift(new TiltGradient(0, 0, 0), 4),
+            Screw2 = Drift(move2, 5),
+            ImageWidthPixels = ImgW, ImageHeightPixels = ImgH,
+            PixelSizeMicrons = PixelSize, FocuserStepMicrons = FStep,
+            ScrewRadiusMillimeters = RadiusMm, CalibrationAppliedAmount = 1.0,
+            IsStepperAdjustment = false,
+        };
+        // Same shape, but with zero drift applied at every step (k=0 everywhere) -- the drift-free reference.
+        var cleanInputs = new TiltCalibrationInputs {
+            ScrewCount = 4,
+            Baseline = Drift(new TiltGradient(0, 0, 0), 0),
+            AllInward = Drift(new TiltGradient(0, 0, 100), 0),
+            ReBaseline1 = Drift(new TiltGradient(0, 0, 0), 0),
+            Screw1 = Drift(move1, 0),
+            ReBaseline2 = Drift(new TiltGradient(0, 0, 0), 0),
+            Screw2 = Drift(move2, 0),
+            ImageWidthPixels = ImgW, ImageHeightPixels = ImgH,
+            PixelSizeMicrons = PixelSize, FocuserStepMicrons = FStep,
+            ScrewRadiusMillimeters = RadiusMm, CalibrationAppliedAmount = 1.0,
+            IsStepperAdjustment = false,
+        };
+        var clean = TiltCalibrationCalculator.Calibrate(cleanInputs);
+        var driftedResult = TiltCalibrationCalculator.Calibrate(drifted);
+        // screw-1 recovery is drift-immune; screw-2 (no final re-baseline yet) is allowed to differ.
+        Assert.That(driftedResult.Screw1DirectionDegrees, Is.EqualTo(clean.Screw1DirectionDegrees).Within(1e-9));
     }
 
     [Test]
@@ -425,10 +471,16 @@ public class TiltCalibrationCalculatorTests {
             // physical-space values (F2 fix): the old (A,B)-space pins (13.91 / 17.10 / 0.81 / 50.9°) were
             // computed on an implicitly-unit sensor; the real 6248x4176 anisotropy shifts SNR from 0.81 to
             // ~0.71 and the angle uncertainty from 50.9° to ~54.5° — still solidly noise-dominated/unreliable.
-            Assert.That(c.ScrewMoveSignal, Is.EqualTo(0.0026615).Within(0.00005));
+            // Drift-cancelling screw-1 reference (F3, this test): ScrewMoveSignal is the mean of the two
+            // single-screw move magnitudes, and screw 1's move is now referenced to mid(ReBaseline1,
+            // ReBaseline2) instead of ReBaseline1 alone; since RB1 != RB2 in this real run, the signal (and
+            // everything derived from it) shifts from 0.0026615 -> ~0.0032226. NoiseEstimate is untouched (the
+            // noise probes -- all-inward residual and both re-baseline drifts -- don't involve the screw-move
+            // reference). Still solidly noise-dominated/unreliable either way.
+            Assert.That(c.ScrewMoveSignal, Is.EqualTo(0.0032226).Within(0.00005));
             Assert.That(c.NoiseEstimate, Is.EqualTo(0.0037296).Within(0.00005));
-            Assert.That(c.SignalToNoise, Is.EqualTo(0.7136).Within(0.01));
-            Assert.That(c.PredictedAngleUncertaintyDeg, Is.EqualTo(54.49).Within(0.5));
+            Assert.That(c.SignalToNoise, Is.EqualTo(0.8641).Within(0.01));
+            Assert.That(c.PredictedAngleUncertaintyDeg, Is.EqualTo(49.17).Within(0.5));
             Assert.That(c.IsReliable, Is.False);
         });
     }
@@ -502,10 +554,14 @@ public class TiltCalibrationCalculatorTests {
         };
         var confidence = TiltCalibrationCalculator.ComputeConfidence(inputs);
         Assert.Multiple(() => {
-            // signal = mean(|0.10|, |0.10|) = 0.10; noise = |ReBaseline2 - ReBaseline1| = 0.01
-            Assert.That(confidence.ScrewMoveSignal, Is.EqualTo(0.10).Within(1e-9));
+            // Screw 1's move is referenced to mid(ReBaseline1, ReBaseline2) = mid((0,0), (0.01,0)) = (0.005,0):
+            // |Screw1 - mid| = |(0.095,0)| = 0.095. Screw 2 has no HasFinalRebaseline, so it's still referenced
+            // to ReBaseline2 alone: |Screw2 - ReBaseline2| = |(0,0.10)| = 0.10. signal = mean(0.095, 0.10) =
+            // 0.0975; noise = |ReBaseline2 - ReBaseline1| = 0.01 (unaffected -- it's a noise probe, not a
+            // screw-move delta).
+            Assert.That(confidence.ScrewMoveSignal, Is.EqualTo(0.0975).Within(1e-9));
             Assert.That(confidence.NoiseEstimate, Is.EqualTo(0.01).Within(1e-9));
-            Assert.That(confidence.SignalToNoise, Is.EqualTo(10.0).Within(1e-9));
+            Assert.That(confidence.SignalToNoise, Is.EqualTo(9.75).Within(1e-9));
             Assert.That(confidence.AllInwardTiltResidual, Is.NaN);
             Assert.That(confidence.Rebaseline1Drift, Is.NaN);
             Assert.That(confidence.Rebaseline2Drift, Is.EqualTo(0.01).Within(1e-9));

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
@@ -241,6 +241,31 @@ public class TiltCalibrationCalculatorTests {
         Assert.That(TiltCalibrationCalculator.Calibrate(inputs).MoveMagnitudeRatio, Is.EqualTo(2.0).Within(1e-6));
     }
 
+    [Test]
+    public void Calibrate_AnisotropicSensor_ReadsPhysicalGapAndEqualMagnitudes() {
+        // On a 3:2 sensor, equal-magnitude physical moves at 200° and 290° produce these (A,B) deltas.
+        // In raw (A,B) space they would read: gap 75.01°, magnitude ratio 1.354 — the F2 bug.
+        var inputs = new TiltCalibrationInputs {
+            ScrewCount = 4,
+            ReBaseline1 = new TiltGradient(0, 0, 0),
+            Screw1 = new TiltGradient(-77.1597, 141.3298, 0),
+            ReBaseline2 = new TiltGradient(0, 0, 0),
+            Screw2 = new TiltGradient(-211.9947, -51.4398, 0),
+            ImageWidthPixels = 6000, ImageHeightPixels = 4000,
+            PixelSizeMicrons = 3.76, FocuserStepMicrons = 0.5,
+            ScrewRadiusMillimeters = 44.0, CalibrationAppliedAmount = 1.0,
+            IsStepperAdjustment = false, HasCurvatureMeasurement = false, FallbackCurvatureSign = 1,
+        };
+        var result = TiltCalibrationCalculator.Calibrate(inputs);
+        Assert.Multiple(() => {
+            Assert.That(result.RawAngleDiffDegrees, Is.EqualTo(90.0).Within(0.01));
+            Assert.That(result.MoveMagnitudeRatio, Is.EqualTo(1.0).Within(0.001));
+            Assert.That(result.Screw1DirectionDegrees, Is.EqualTo(200.0).Within(0.01));
+            Assert.That(result.Screw2DirectionDegrees, Is.EqualTo(290.0).Within(0.01));
+            Assert.That(result.Screw1AngleDegrees, Is.EqualTo(200.0).Within(0.01));
+        });
+    }
+
     private static TiltGradient Plus(TiltGradient a, TiltGradient b) =>
         new TiltGradient(a.A + b.A, a.B + b.B, a.MeanFocuserPosition + b.MeanFocuserPosition);
 
@@ -329,6 +354,9 @@ public class TiltCalibrationCalculatorTests {
     [Test]
     public void ComputeConfidence_CleanMeasurement_HighSnrAndReliable() {
         // Baselines all identical (zero noise probes) and two clean equal screw moves -> infinite SNR, reliable.
+        // No sensor/focuser geometry is set here: PhysicalDelta degrades to the raw (A,B) delta when geometry
+        // is unpopulated (see its doc comment), so this pure noise-model algebra test is unaffected by the
+        // physical-gradient-space conversion (F2 fix).
         var inputs = new TiltCalibrationInputs {
             ScrewCount = 3,
             Baseline = new TiltGradient(0, 0, 1000),
@@ -351,6 +379,8 @@ public class TiltCalibrationCalculatorTests {
     [Test]
     public void ComputeConfidence_NoiseRivalsSignal_FlaggedUnreliable() {
         // A large all-inward tilt residual (a pure piston should give ~0) drives the noise floor near the signal.
+        // No geometry set (see ComputeConfidence_CleanMeasurement_HighSnrAndReliable) -> PhysicalDelta uses the
+        // raw (A,B) delta.
         var inputs = new TiltCalibrationInputs {
             ScrewCount = 3,
             Baseline = new TiltGradient(0, 0, 1000),
@@ -373,8 +403,12 @@ public class TiltCalibrationCalculatorTests {
     public void ComputeConfidence_RealAstrodet6Run_IsNoiseDominated() {
         // Regression lock on the real astrodet_6 calibration (D:\Tilt Calibration Bank\astrodet_6\...115023):
         // the per-step tilt vectors give SNR ~0.81 and ~51° predicted screw-direction error -> not reliable.
+        // Geometry: the astrodet rig's real camera/focuser (ASI2600 6248x4176 @ 3.76 µm, 3.6 µm focuser step —
+        // see docs/tilt-calibration-error-bounds-design.md's astrodet_6_2 companion run and the same values used
+        // elsewhere in this fixture for this rig family).
         var inputs = new TiltCalibrationInputs {
             ScrewCount = 3,
+            ImageWidthPixels = 6248, ImageHeightPixels = 4176, PixelSizeMicrons = 3.76, FocuserStepMicrons = 3.6,
             Baseline = new TiltGradient(-2.1105835080420547, 24.121199286798387, 591.0128980765176),
             AllInward = new TiltGradient(8.482652443992663, 6.478563541214388, 498.59261745105937),
             ReBaseline1 = new TiltGradient(3.575182052031437, 6.397250940705116, 599.5753346049264),
@@ -384,10 +418,13 @@ public class TiltCalibrationCalculatorTests {
         };
         var c = TiltCalibrationCalculator.ComputeConfidence(inputs);
         Assert.Multiple(() => {
-            Assert.That(c.ScrewMoveSignal, Is.EqualTo(13.91).Within(0.05));
-            Assert.That(c.NoiseEstimate, Is.EqualTo(17.10).Within(0.05));
-            Assert.That(c.SignalToNoise, Is.EqualTo(0.81).Within(0.02));
-            Assert.That(c.PredictedAngleUncertaintyDeg, Is.EqualTo(50.9).Within(0.5));
+            // physical-space values (F2 fix): the old (A,B)-space pins (13.91 / 17.10 / 0.81 / 50.9°) were
+            // computed on an implicitly-unit sensor; the real 6248x4176 anisotropy shifts SNR from 0.81 to
+            // ~0.71 and the angle uncertainty from 50.9° to ~54.5° — still solidly noise-dominated/unreliable.
+            Assert.That(c.ScrewMoveSignal, Is.EqualTo(0.0026615).Within(0.00005));
+            Assert.That(c.NoiseEstimate, Is.EqualTo(0.0037296).Within(0.00005));
+            Assert.That(c.SignalToNoise, Is.EqualTo(0.7136).Within(0.01));
+            Assert.That(c.PredictedAngleUncertaintyDeg, Is.EqualTo(54.49).Within(0.5));
             Assert.That(c.IsReliable, Is.False);
         });
     }
@@ -450,6 +487,8 @@ public class TiltCalibrationCalculatorTests {
         var drifted = new TiltGradient(0.01, 0, 1000); // ReBaseline2 drifts by 0.01 from ReBaseline1
         var inputs = new TiltCalibrationInputs {
             ScrewCount = 3,
+            // No geometry set (see ComputeConfidence_CleanMeasurement_HighSnrAndReliable) -> PhysicalDelta uses
+            // the raw (A,B) delta.
             HasCurvatureMeasurement = false,
             ReBaseline1 = baseline,
             Screw1 = new TiltGradient(0.10, 0, 1000),

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
@@ -599,6 +599,25 @@ public class TiltCalibrationCalculatorTests {
         Assert.That(TiltCalibrationCalculator.PistonImpliedMicronsPerStep(inputs), Is.NaN);
     }
 
+    // Mirrors RecoverHardwareMicrons_ReturnsNaN_OnNonPositiveInputs' TestCase shape for this method's other
+    // two guard branches (CalibrationAppliedAmount and FocuserStepMicrons); HasCurvatureMeasurement's guard
+    // is already covered above.
+    [TestCase(0.0, 0.269)]     // CalibrationAppliedAmount <= 0
+    [TestCase(-150.0, 0.269)]
+    [TestCase(150.0, 0.0)]     // FocuserStepMicrons <= 0
+    [TestCase(150.0, -0.269)]
+    public void PistonImpliedMicronsPerStep_NaN_OnNonPositiveApplicationOrStepSize(
+        double calibrationAppliedAmount, double focuserStepMicrons) {
+        var inputs = new TiltCalibrationInputs {
+            HasCurvatureMeasurement = true,
+            Baseline = new TiltGradient(0, 0, 11283.868653107538),
+            AllInward = new TiltGradient(0, 0, 9995.476157148303),
+            ReBaseline1 = new TiltGradient(0, 0, 11197.706101225354),
+            FocuserStepMicrons = focuserStepMicrons, CalibrationAppliedAmount = calibrationAppliedAmount,
+        };
+        Assert.That(TiltCalibrationCalculator.PistonImpliedMicronsPerStep(inputs), Is.NaN);
+    }
+
     [TestCase(30.0, true, 3, 30.0, 150.0, 270.0, double.NaN)]
     [TestCase(30.0, false, 3, 30.0, 270.0, 150.0, double.NaN)]
     [TestCase(350.0, true, 4, 350.0, 80.0, 170.0, 260.0)]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
@@ -731,6 +731,116 @@ public class TiltCalibrationCalculatorTests {
         Assert.That(TiltCalibrationCalculator.PistonImpliedMicronsPerStep(inputs), Is.NaN);
     }
 
+    // --- Synthetic full-wizard round trip: a known adapter (explicit pitch + radius) is pushed through the
+    // wizard's ACTUAL move sequence and Calibrate must recover the pitch exactly, and the tilt-derived and
+    // piston-implied pitches must agree exactly. The forward model here is deliberately NOT the calculator's
+    // lever-arm shortcut: each state is synthesized from per-corner plate heights (what the hardware
+    // physically does) and the definitional least-squares plane over the screw contact points,
+    // G = (2/(n·R²))·Σ hᵢ·pᵢ. For the 4-screw wizard move that plane is exact (it interpolates all four
+    // corners), so any constant-factor error in the recovery chain — e.g. treating the coupled ±d diagonal
+    // rock as a single-screw move (lever 2R instead of R), or vice versa for the 3-screw single-screw move
+    // (1.5R) — fails these tests by exactly that factor. Geometry is the real ghilios_corrected rig
+    // (9576x6388 @ 3.76 µm, 0.269 µm focuser step, R = 55 mm, 150 steps of a 1.8 µm/step stepper), so the
+    // numbers are directly comparable to that run's 1.84 (tilt) vs 2.23 (piston) discrepancy: the round
+    // trip proves the math introduces no such gap on its own.
+    private const double RunPixelSize = 3.76;
+    private const int RunImgW = 9576;
+    private const int RunImgH = 6388;
+    private const double RunFStep = 0.269;
+    private const double RunRadiusMm = 55.0;
+    private const double RunRadiusMicrons = RunRadiusMm * 1000.0;
+    private const double RunPitch = 1.8;      // µm per stepper step (the adapter spec)
+    private const double RunApplied = 150.0;  // steps per wizard calibration move
+
+    // Least-squares plane over the n screw contact points for the given per-corner axial plate heights
+    // (microns), returned as a TiltGradient (A, B in focuser steps per normalized coordinate) on top of a
+    // baseline gradient. The mean focuser position shifts by the piston component -h̄/fStep (all-screws-in
+    // lowers the mean on this rig, matching the real run's sign; PistonImplied takes |Δ| so only the
+    // magnitude matters).
+    private static TiltGradient StateFromCornerHeights(
+        TiltGradient baseline, double[] cornerHeightsMicrons, double[] cornerAnglesDeg, double baselineMeanSteps) {
+        int n = cornerAnglesDeg.Length;
+        double gx = 0, gy = 0, hBar = 0;
+        for (int i = 0; i < n; i++) {
+            var (px, py) = TiltScrewGeometry.ScrewPositionMicrons(cornerAnglesDeg[i], RunRadiusMicrons);
+            gx += 2.0 / (n * RunRadiusMicrons * RunRadiusMicrons) * cornerHeightsMicrons[i] * px;
+            gy += 2.0 / (n * RunRadiusMicrons * RunRadiusMicrons) * cornerHeightsMicrons[i] * py;
+            hBar += cornerHeightsMicrons[i] / n;
+        }
+        double a = gx * (RunImgW * RunPixelSize) / RunFStep;
+        double b = gy * (RunImgH * RunPixelSize) / RunFStep;
+        return new TiltGradient(baseline.A + a, baseline.B + b, baselineMeanSteps - hBar / RunFStep);
+    }
+
+    [TestCase(4)]
+    [TestCase(3)]
+    public void Calibrate_SyntheticWizardSequence_RoundTripsPitchExactly_TiltAgreesWithPiston(int screwCount) {
+        double d = RunApplied * RunPitch; // physical plate travel per moved corner, µm
+        double theta1 = 210.0;
+        double thetaStep = screwCount == 4 ? -90.0 : -120.0; // CCW winding, like the real run
+        var angles = new double[screwCount];
+        for (int i = 0; i < screwCount; i++) {
+            angles[i] = TiltCalibrationCalculator.NormalizeAngle(theta1 + i * thetaStep);
+        }
+        double theta2 = angles[1];
+
+        // The wizard's actual per-corner move pattern (EatWizardMapping for 4 screws): Screw1 is the coupled
+        // DiagonalA rock (+d at screw 1, -d at the opposite screw 3), Screw2 the DiagonalB rock. The 3-screw
+        // wizard turns a single screw with the others untouched.
+        double[] Heights(int movedIndex) {
+            var h = new double[screwCount];
+            h[movedIndex] = d;
+            if (screwCount == 4) {
+                h[(movedIndex + 2) % 4] = -d;
+            }
+            return h;
+        }
+        double[] allIn = new double[screwCount];
+        for (int i = 0; i < screwCount; i++) { allIn[i] = d; }
+
+        var baselineG = new TiltGradient(-30.0, -50.0, 0); // arbitrary non-zero starting tilt
+        const double baselineMean = 11280.0;
+        var inputs = new TiltCalibrationInputs {
+            ScrewCount = screwCount,
+            Baseline = new TiltGradient(baselineG.A, baselineG.B, baselineMean),
+            AllInward = StateFromCornerHeights(baselineG, allIn, angles, baselineMean),
+            ReBaseline1 = new TiltGradient(baselineG.A, baselineG.B, baselineMean),
+            Screw1 = StateFromCornerHeights(baselineG, Heights(0), angles, baselineMean),
+            ReBaseline2 = new TiltGradient(baselineG.A, baselineG.B, baselineMean),
+            Screw2 = StateFromCornerHeights(baselineG, Heights(1), angles, baselineMean),
+            ImageWidthPixels = RunImgW,
+            ImageHeightPixels = RunImgH,
+            PixelSizeMicrons = RunPixelSize,
+            FocuserStepMicrons = RunFStep,
+            ScrewRadiusMillimeters = RunRadiusMm,
+            CalibrationAppliedAmount = RunApplied,
+            IsStepperAdjustment = true
+        };
+
+        var r = TiltCalibrationCalculator.Calibrate(inputs);
+        var (_, screw1Pitch, screw2Pitch) = TiltCalibrationCalculator.RecoverHardwareDetailed(inputs);
+        Assert.Multiple(() => {
+            // The decisive assertions: the tilt path must return the pitch that produced the planes — no
+            // hidden constant factor from the gradient -> per-screw-displacement conversion — and it must
+            // equal the radius-free piston-implied pitch exactly. EACH screw's own recovered pitch is
+            // asserted, not just the mean: averaging is exactly what hid the ghilios_corrected run's bad
+            // screw-2 measurement behind a plausible-looking 1.84 (see PitchUncertaintyMicrons's doc).
+            Assert.That(screw1Pitch, Is.EqualTo(RunPitch).Within(1e-9));
+            Assert.That(screw2Pitch, Is.EqualTo(RunPitch).Within(1e-9));
+            Assert.That(r.MeasuredHardwareMicrons, Is.EqualTo(RunPitch).Within(1e-9));
+            Assert.That(r.PistonImpliedMicronsPerStep, Is.EqualTo(RunPitch).Within(1e-9));
+            Assert.That(r.PistonImpliedMicronsPerStep / r.MeasuredHardwareMicrons, Is.EqualTo(1.0).Within(1e-9));
+            Assert.That(r.PitchUncertaintyMicrons, Is.EqualTo(0).Within(1e-9));
+            Assert.That(r.MoveMagnitudeRatio, Is.EqualTo(1.0).Within(1e-9));
+            // Geometry sanity: the same synthetic run recovers the screw layout it was built from.
+            Assert.That(r.Screw1AngleDegrees, Is.EqualTo(theta1).Within(1e-6));
+            Assert.That(r.Screw2AngleDegrees, Is.EqualTo(theta2).Within(1e-6));
+            Assert.That(r.Screw1DirectionDegrees, Is.EqualTo(theta1).Within(1e-6));
+            // All-screws-inward lowered the mean best-focus position -> σ = +1.
+            Assert.That(r.CurvatureSign, Is.EqualTo(1));
+        });
+    }
+
     [TestCase(30.0, true, 3, 30.0, 150.0, 270.0, double.NaN)]
     [TestCase(30.0, false, 3, 30.0, 270.0, 150.0, double.NaN)]
     [TestCase(350.0, true, 4, 350.0, 80.0, 170.0, 260.0)]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
@@ -841,6 +841,125 @@ public class TiltCalibrationCalculatorTests {
         });
     }
 
+    // --- ghilios_corrected (2026-08-04): the run behind docs/tilt-calibration-pitch-nonlinearity-design.md.
+    // Same six measurement states fed through both estimators the wizard computes; every literal is taken
+    // from the run's own stored data (per-star paraboloid replay diagnostics; the wizard's live per-region
+    // AF reports for the corner planes; corner-plane A,B regressed against the true region centers at
+    // normalized ±1/3, mean = the 4-corner vertex average).
+    private static TiltCalibrationInputs GhiliosCorrectedInputs(
+        (double a, double b, double mean) baseline, (double a, double b, double mean) allInward,
+        (double a, double b, double mean) reBaseline1, (double a, double b, double mean) screw1,
+        (double a, double b, double mean) reBaseline2, (double a, double b, double mean) screw2) {
+        return new TiltCalibrationInputs {
+            ScrewCount = 4, HasCurvatureMeasurement = true, IsStepperAdjustment = true,
+            Baseline = new TiltGradient(baseline.a, baseline.b, baseline.mean),
+            AllInward = new TiltGradient(allInward.a, allInward.b, allInward.mean),
+            ReBaseline1 = new TiltGradient(reBaseline1.a, reBaseline1.b, reBaseline1.mean),
+            Screw1 = new TiltGradient(screw1.a, screw1.b, screw1.mean),
+            ReBaseline2 = new TiltGradient(reBaseline2.a, reBaseline2.b, reBaseline2.mean),
+            Screw2 = new TiltGradient(screw2.a, screw2.b, screw2.mean),
+            ImageWidthPixels = 9576, ImageHeightPixels = 6388, PixelSizeMicrons = 3.76,
+            FocuserStepMicrons = 0.269, ScrewRadiusMillimeters = 55.0,
+            CalibrationAppliedAmount = 150.0,
+        };
+    }
+
+    [Test]
+    public void Calibrate_GhiliosCorrectedRun_PistonCheckFiresOnParaboloidPairNotOnSameRadiusCornerPair() {
+        // The run's 21% piston-vs-tilt disagreement is NOT a field-radius systematic. Evaluating BOTH
+        // sides of the check from the same estimator family shows it: the corner-region pairing puts the
+        // piston (mean of the 4 corner vertices, field radius 14.43 mm) at exactly the same field radius
+        // as the corner tilt gradient, and that honestly field-matched pairing disagrees by only ~13.7%
+        // — under the 20% warning threshold. The paraboloid pairing disagrees by ~21.3% because the
+        // per-star tilt estimate is shrunk (the §8 vertex compression, Screw2 move ratio 1.53), which is
+        // exactly the failure the piston check exists to catch. Field-dependence of the focuser-to-plate
+        // frame factor moves the piston by only ~3.5% across the whole sensor (region AF: 2.343 at the
+        // centre vs 2.265 at the corner radius), so it cannot produce a 20%+ firing on its own.
+        var paraboloid = GhiliosCorrectedInputs(
+            baseline: (-32.7502, -53.2693, 11283.5669), allInward: (-105.6764, -61.0356, 9995.4060),
+            reBaseline1: (71.8955, -27.7348, 11197.8029), screw1: (-514.0233, 364.2764, 11157.2839),
+            reBaseline2: (-11.6299, -49.3158, 11137.9751), screw2: (391.7824, 181.4274, 11073.4907));
+        var corner = GhiliosCorrectedInputs(
+            baseline: (-12.3755, -55.6319, 11213.4757), allInward: (-63.3028, 4.7892, 9931.0006),
+            reBaseline1: (27.8136, -38.8674, 11174.7386), screw1: (-516.8488, 344.1753, 11089.9786),
+            reBaseline2: (-51.2544, -82.8465, 11072.6428), screw2: (454.2507, 205.6455, 11031.1524));
+
+        var parabolidResult = TiltCalibrationCalculator.Calibrate(paraboloid);
+        var cornerResult = TiltCalibrationCalculator.Calibrate(corner);
+        Assert.Multiple(() => {
+            // Paraboloid pairing: tilt-derived 1.841 vs piston-implied 2.233 -> 21.3% > 20% (fires).
+            Assert.That(parabolidResult.MeasuredHardwareMicrons, Is.EqualTo(1.8412).Within(1e-3));
+            Assert.That(parabolidResult.PistonImpliedMicronsPerStep, Is.EqualTo(2.2332).Within(1e-3));
+            double parabolidRelDiff = Math.Abs(parabolidResult.PistonImpliedMicronsPerStep - parabolidResult.MeasuredHardwareMicrons)
+                / parabolidResult.MeasuredHardwareMicrons;
+            Assert.That(parabolidRelDiff, Is.EqualTo(0.2129).Within(1e-3));
+            Assert.That(parabolidRelDiff, Is.GreaterThan(0.20));
+            // Same-radius corner pairing: tilt-derived 1.993 vs piston-implied 2.265 -> 13.7% < 20%.
+            Assert.That(cornerResult.MeasuredHardwareMicrons, Is.EqualTo(1.9930).Within(1e-3));
+            Assert.That(cornerResult.PistonImpliedMicronsPerStep, Is.EqualTo(2.2652).Within(1e-3));
+            double cornerRelDiff = Math.Abs(cornerResult.PistonImpliedMicronsPerStep - cornerResult.MeasuredHardwareMicrons)
+                / cornerResult.MeasuredHardwareMicrons;
+            Assert.That(cornerRelDiff, Is.EqualTo(0.1366).Within(1e-3));
+            Assert.That(cornerRelDiff, Is.LessThan(0.20));
+            // The paraboloid's Screw2 shrinkage is what separates the two pairings: its move ratio is 1.53
+            // (would fire the 1.5x unequal-turns warning) while the corner estimator reads 1.19.
+            Assert.That(parabolidResult.MoveMagnitudeRatio, Is.EqualTo(1.5296).Within(1e-3));
+            Assert.That(cornerResult.MoveMagnitudeRatio, Is.EqualTo(1.1872).Within(1e-3));
+        });
+    }
+
+    [Test]
+    public void RecoverHardware_LinearTiltDrift_ShortensScrew2PitchUntilFinalRebaseline() {
+        // Magnitude-space complement of Calibrate_LinearTiltDrift_CancelsExactlyForScrew1 (which pins the
+        // recovered DIRECTIONS): under a constant per-interval tilt drift v, screw 1's bracketed reference
+        // cancels the drift in its recovered per-screw pitch exactly, while screw 2's one-sided ReBaseline2
+        // reference leaves exactly one interval of drift (+v) inside its delta. With v anti-parallel to
+        // screw 2's move, its recovered pitch is short by exactly |v|'s share; a measured final re-baseline
+        // (ReBaseline3) restores the symmetric bracket and the exact pitch. This is the mechanism that made
+        // the ghilios_corrected run's screw-2 move read ~8% small on BOTH estimators (drift RB1->RB2 was
+        // ~16% of the screw-2 move, roughly anti-parallel to it), on top of the paraboloid-only shrinkage.
+        const double axial = 270.0;   // 150 steps x 1.8 um/step, per screw of the push-pull pair
+        const double applied = 150.0;
+        const double driftFraction = 0.08;
+
+        // Four-screw push-pull calibration move = single-screw reading doubled (opposite screw moves -d at
+        // p(theta+180) = -p, contributing the same gradient change).
+        TiltGradient FourScrewMove(double angleDeg, double mean = 0.0) {
+            var single = SingleScrewReading(angleDeg, axial, 4, mean);
+            return new TiltGradient(2 * single.A, 2 * single.B, mean);
+        }
+        var move2 = FourScrewMove(90);
+        double vA = -driftFraction * move2.A, vB = -driftFraction * move2.B;
+        TiltGradient Drift(TiltGradient g, int k) => new TiltGradient(g.A + k * vA, g.B + k * vB, g.MeanFocuserPosition);
+
+        TiltCalibrationInputs Build(bool withFinalRebaseline) => new TiltCalibrationInputs {
+            ScrewCount = 4,
+            Baseline = Drift(new TiltGradient(0, 0, 0), 0),
+            AllInward = Drift(new TiltGradient(0, 0, 100), 1),
+            ReBaseline1 = Drift(new TiltGradient(0, 0, 0), 2),
+            Screw1 = Drift(FourScrewMove(0), 3),
+            ReBaseline2 = Drift(new TiltGradient(0, 0, 0), 4),
+            Screw2 = Drift(move2, 5),
+            ReBaseline3 = withFinalRebaseline ? Drift(new TiltGradient(0, 0, 0), 6) : default,
+            HasFinalRebaseline = withFinalRebaseline,
+            ImageWidthPixels = ImgW, ImageHeightPixels = ImgH, PixelSizeMicrons = PixelSize,
+            FocuserStepMicrons = FStep, ScrewRadiusMillimeters = RadiusMm,
+            CalibrationAppliedAmount = applied, IsStepperAdjustment = true,
+        };
+
+        var (_, oneSided1, oneSided2) = TiltCalibrationCalculator.RecoverHardwareDetailed(Build(withFinalRebaseline: false));
+        var (_, bracketed1, bracketed2) = TiltCalibrationCalculator.RecoverHardwareDetailed(Build(withFinalRebaseline: true));
+        Assert.Multiple(() => {
+            // Screw 1 is drift-immune either way (mid(RB1, RB2) bracket).
+            Assert.That(oneSided1, Is.EqualTo(axial / applied).Within(1e-9));
+            Assert.That(bracketed1, Is.EqualTo(axial / applied).Within(1e-9));
+            // Screw 2 without RB3: exactly one drift interval anti-parallel to the move -> pitch short by 8%.
+            Assert.That(oneSided2, Is.EqualTo((1 - driftFraction) * axial / applied).Within(1e-9));
+            // Screw 2 with RB3: mid(RB2, RB3) bracket cancels the drift exactly, like screw 1.
+            Assert.That(bracketed2, Is.EqualTo(axial / applied).Within(1e-9));
+        });
+    }
+
     [TestCase(30.0, true, 3, 30.0, 150.0, 270.0, double.NaN)]
     [TestCase(30.0, false, 3, 30.0, 270.0, 150.0, double.NaN)]
     [TestCase(350.0, true, 4, 350.0, 80.0, 170.0, 260.0)]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
@@ -359,6 +359,60 @@ public class TiltCalibrationCalculatorTests {
     }
 
     [Test]
+    public void Calibrate_WithFinalRebaseline_Screw2DeltaIsDriftImmune() {
+        // Mirror of Calibrate_LinearTiltDrift_CancelsExactlyForScrew1 above, but with the optional measured
+        // final re-baseline (g) present: Screw2's move E is now bracketed by ReBaseline2 (4 intervals in) and
+        // ReBaseline3 (6 intervals in), with Screw2 at 5 intervals -- Screw2 - mid(RB2, RB3) recovers E
+        // exactly, drift-immune, the same way Screw1Delta already made screw 1's move drift-immune.
+        var (vA, vB) = (9.0, -5.0);
+        var move1 = SingleScrewReading(0, 400.0, 4);      // D
+        var move2 = SingleScrewReading(90, 400.0, 4);     // E
+        TiltGradient Drift(TiltGradient g, int k) => new TiltGradient(g.A + k * vA, g.B + k * vB, g.MeanFocuserPosition);
+
+        var drifted = new TiltCalibrationInputs {
+            ScrewCount = 4,
+            Baseline = Drift(new TiltGradient(0, 0, 0), 0),
+            AllInward = Drift(new TiltGradient(0, 0, 100), 1),
+            ReBaseline1 = Drift(new TiltGradient(0, 0, 0), 2),
+            Screw1 = Drift(move1, 3),
+            ReBaseline2 = Drift(new TiltGradient(0, 0, 0), 4),
+            Screw2 = Drift(move2, 5),
+            ReBaseline3 = Drift(new TiltGradient(0, 0, 0), 6),
+            HasFinalRebaseline = true,
+            ImageWidthPixels = ImgW, ImageHeightPixels = ImgH,
+            PixelSizeMicrons = PixelSize, FocuserStepMicrons = FStep,
+            ScrewRadiusMillimeters = RadiusMm, CalibrationAppliedAmount = 1.0,
+            IsStepperAdjustment = false,
+        };
+        // Same shape, but with zero drift applied at every step (k=0 everywhere) -- the drift-free reference.
+        var cleanInputs = new TiltCalibrationInputs {
+            ScrewCount = 4,
+            Baseline = Drift(new TiltGradient(0, 0, 0), 0),
+            AllInward = Drift(new TiltGradient(0, 0, 100), 0),
+            ReBaseline1 = Drift(new TiltGradient(0, 0, 0), 0),
+            Screw1 = Drift(move1, 0),
+            ReBaseline2 = Drift(new TiltGradient(0, 0, 0), 0),
+            Screw2 = Drift(move2, 0),
+            ReBaseline3 = Drift(new TiltGradient(0, 0, 0), 0),
+            HasFinalRebaseline = true,
+            ImageWidthPixels = ImgW, ImageHeightPixels = ImgH,
+            PixelSizeMicrons = PixelSize, FocuserStepMicrons = FStep,
+            ScrewRadiusMillimeters = RadiusMm, CalibrationAppliedAmount = 1.0,
+            IsStepperAdjustment = false,
+        };
+        var clean = TiltCalibrationCalculator.Calibrate(cleanInputs);
+        var driftedResult = TiltCalibrationCalculator.Calibrate(drifted);
+        Assert.Multiple(() => {
+            // Screw 1's move is unaffected by this change -- still bracketed by ReBaseline1/ReBaseline2, still drift-immune.
+            Assert.That(driftedResult.Screw1DirectionDegrees, Is.EqualTo(clean.Screw1DirectionDegrees).Within(1e-9));
+            // Screw 2 NOW has a measured final re-baseline (HasFinalRebaseline = true), so it gets the same
+            // symmetric bracketing as screw 1 and is drift-immune too -- this is the opposite assertion from
+            // the un-bracketed test above, and fails if HasFinalRebaseline stops being wired through.
+            Assert.That(driftedResult.Screw2DirectionDegrees, Is.EqualTo(clean.Screw2DirectionDegrees).Within(1e-9));
+        });
+    }
+
+    [Test]
     public void RebaselineDriftRatio_ZeroWhenNoDrift_GrowsWithDrift() {
         Assert.Multiple(() => {
             // No drift relative to a move of magnitude 10 -> 0.
@@ -573,7 +627,66 @@ public class TiltCalibrationCalculatorTests {
             Assert.That(confidence.AllInwardTiltResidual, Is.NaN);
             Assert.That(confidence.Rebaseline1Drift, Is.NaN);
             Assert.That(confidence.Rebaseline2Drift, Is.EqualTo(0.01).Within(1e-9));
+            // No measured final re-baseline (HasFinalRebaseline defaults false): the new Task-6 probe stays
+            // at its NaN default rather than silently contributing a spurious 0 to the RMS above.
+            Assert.That(confidence.Rebaseline3Drift, Is.NaN);
             Assert.That(confidence.IsReliable, Is.True);
+        });
+    }
+
+    [Test]
+    public void ComputeConfidence_WithFinalRebaseline_AddsFourthProbeToRms() {
+        // Mirror of ComputeConfidence_NoiseRivalsSignal_FlaggedUnreliable above, but with the optional
+        // measured final re-baseline present too: NoiseEstimate becomes RMS-of-4 (allInward, drift1=0,
+        // drift2=0, drift3) instead of RMS-of-3, and Rebaseline3Drift is populated instead of NaN.
+        var inputs = new TiltCalibrationInputs {
+            ScrewCount = 3,
+            ImageWidthPixels = 1, ImageHeightPixels = 1, PixelSizeMicrons = 1, FocuserStepMicrons = 1,
+            Baseline = new TiltGradient(0, 0, 1000),
+            AllInward = new TiltGradient(20, 0, 1075),  // 20-unit spurious tilt change on a piston move
+            ReBaseline1 = new TiltGradient(0, 0, 1000),
+            Screw1 = new TiltGradient(10, 0, 1000),
+            ReBaseline2 = new TiltGradient(0, 0, 1000),
+            Screw2 = new TiltGradient(0, 10, 1000),
+            ReBaseline3 = new TiltGradient(0, 20, 1000), // 20-unit drift from ReBaseline2
+            HasFinalRebaseline = true,
+        };
+        var c = TiltCalibrationCalculator.ComputeConfidence(inputs);
+        Assert.Multiple(() => {
+            Assert.That(c.AllInwardTiltResidual, Is.EqualTo(20).Within(1e-9));
+            Assert.That(c.Rebaseline1Drift, Is.EqualTo(0).Within(1e-9));
+            Assert.That(c.Rebaseline2Drift, Is.EqualTo(0).Within(1e-9));
+            Assert.That(c.Rebaseline3Drift, Is.EqualTo(20).Within(1e-9));
+            Assert.That(c.NoiseEstimate, Is.EqualTo(Math.Sqrt((400.0 + 0.0 + 0.0 + 400.0) / 4.0)).Within(1e-9));
+        });
+    }
+
+    [Test]
+    public void ComputeConfidence_WithoutCurvatureButWithFinalRebaseline_AveragesBothRebaselineDrifts() {
+        // Mirror of ComputeConfidence_WithoutCurvatureMeasurement_UsesOnlyRebaseline2Drift above, but with
+        // the optional measured final re-baseline present too: the 4-step flow's single-probe noise estimate
+        // (drift2 alone) becomes an RMS-of-2 (drift2, drift3).
+        var baseline = new TiltGradient(0, 0, 1000);
+        var drifted = new TiltGradient(0.01, 0, 1000);           // ReBaseline2 drifts by 0.01 from ReBaseline1
+        var driftedAgain = new TiltGradient(0.01, 0.02, 1000);   // ReBaseline3 drifts a further 0.02 from ReBaseline2
+        var inputs = new TiltCalibrationInputs {
+            ScrewCount = 3,
+            ImageWidthPixels = 1, ImageHeightPixels = 1, PixelSizeMicrons = 1, FocuserStepMicrons = 1,
+            HasCurvatureMeasurement = false,
+            ReBaseline1 = baseline,
+            Screw1 = new TiltGradient(0.10, 0, 1000),
+            ReBaseline2 = drifted,
+            Screw2 = new TiltGradient(0.01, 0.10, 1000),
+            ReBaseline3 = driftedAgain,
+            HasFinalRebaseline = true,
+        };
+        var confidence = TiltCalibrationCalculator.ComputeConfidence(inputs);
+        Assert.Multiple(() => {
+            Assert.That(confidence.Rebaseline2Drift, Is.EqualTo(0.01).Within(1e-9));
+            Assert.That(confidence.Rebaseline3Drift, Is.EqualTo(0.02).Within(1e-9));
+            Assert.That(confidence.NoiseEstimate, Is.EqualTo(Math.Sqrt((0.01 * 0.01 + 0.02 * 0.02) / 2.0)).Within(1e-9));
+            Assert.That(confidence.AllInwardTiltResidual, Is.NaN);
+            Assert.That(confidence.Rebaseline1Drift, Is.NaN);
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
@@ -346,8 +346,16 @@ public class TiltCalibrationCalculatorTests {
         };
         var clean = TiltCalibrationCalculator.Calibrate(cleanInputs);
         var driftedResult = TiltCalibrationCalculator.Calibrate(drifted);
-        // screw-1 recovery is drift-immune; screw-2 (no final re-baseline yet) is allowed to differ.
-        Assert.That(driftedResult.Screw1DirectionDegrees, Is.EqualTo(clean.Screw1DirectionDegrees).Within(1e-9));
+        Assert.Multiple(() => {
+            // Screw 1's move is bracketed by ReBaseline1/ReBaseline2, so its recovered direction is drift-immune.
+            Assert.That(driftedResult.Screw1DirectionDegrees, Is.EqualTo(clean.Screw1DirectionDegrees).Within(1e-9));
+            // Screw 2 has no measured final re-baseline (HasFinalRebaseline defaults false), so it keeps the old
+            // ReBaseline2-only reference and is NOT drift-immune -- this is an intentional lock on that asymmetry,
+            // not a caveat: it fails if a future change accidentally gives Screw2Delta symmetric behavior before
+            // Task 6 wires HasFinalRebaseline. The measured direction shift here is ~7.57 degrees (82.43 vs
+            // 90.00), comfortably beyond any floating-point tolerance.
+            Assert.That(driftedResult.Screw2DirectionDegrees, Is.Not.EqualTo(clean.Screw2DirectionDegrees).Within(1e-6));
+        });
     }
 
     [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs
@@ -354,11 +354,14 @@ public class TiltCalibrationCalculatorTests {
     [Test]
     public void ComputeConfidence_CleanMeasurement_HighSnrAndReliable() {
         // Baselines all identical (zero noise probes) and two clean equal screw moves -> infinite SNR, reliable.
-        // No sensor/focuser geometry is set here: PhysicalDelta degrades to the raw (A,B) delta when geometry
-        // is unpopulated (see its doc comment), so this pure noise-model algebra test is unaffected by the
-        // physical-gradient-space conversion (F2 fix).
+        // Deliberately isotropic unit geometry (1x1 sensor, 1 µm pixel, 1 µm focuser step): PhysicalDelta's
+        // gx = A*fStep/(W*pixelSize) = A*1/(1*1) = A (and same for B/gy), so this is byte-identical to raw
+        // (A,B) units — this pure noise-model algebra test is unaffected by the physical-gradient-space
+        // conversion (F2 fix). PhysicalDelta itself has no geometry fallback (see its doc comment): real
+        // geometry is a precondition everywhere, including here.
         var inputs = new TiltCalibrationInputs {
             ScrewCount = 3,
+            ImageWidthPixels = 1, ImageHeightPixels = 1, PixelSizeMicrons = 1, FocuserStepMicrons = 1,
             Baseline = new TiltGradient(0, 0, 1000),
             AllInward = new TiltGradient(0, 0, 1075),   // piston only: no tilt change vs baseline
             ReBaseline1 = new TiltGradient(0, 0, 1000),
@@ -379,10 +382,11 @@ public class TiltCalibrationCalculatorTests {
     [Test]
     public void ComputeConfidence_NoiseRivalsSignal_FlaggedUnreliable() {
         // A large all-inward tilt residual (a pure piston should give ~0) drives the noise floor near the signal.
-        // No geometry set (see ComputeConfidence_CleanMeasurement_HighSnrAndReliable) -> PhysicalDelta uses the
-        // raw (A,B) delta.
+        // Deliberately isotropic unit geometry (see ComputeConfidence_CleanMeasurement_HighSnrAndReliable) so
+        // PhysicalDelta is byte-identical to the raw (A,B) delta.
         var inputs = new TiltCalibrationInputs {
             ScrewCount = 3,
+            ImageWidthPixels = 1, ImageHeightPixels = 1, PixelSizeMicrons = 1, FocuserStepMicrons = 1,
             Baseline = new TiltGradient(0, 0, 1000),
             AllInward = new TiltGradient(20, 0, 1075),  // 20-unit spurious tilt change on a piston move
             ReBaseline1 = new TiltGradient(0, 0, 1000),
@@ -487,8 +491,9 @@ public class TiltCalibrationCalculatorTests {
         var drifted = new TiltGradient(0.01, 0, 1000); // ReBaseline2 drifts by 0.01 from ReBaseline1
         var inputs = new TiltCalibrationInputs {
             ScrewCount = 3,
-            // No geometry set (see ComputeConfidence_CleanMeasurement_HighSnrAndReliable) -> PhysicalDelta uses
-            // the raw (A,B) delta.
+            // Deliberately isotropic unit geometry (see ComputeConfidence_CleanMeasurement_HighSnrAndReliable)
+            // so PhysicalDelta is byte-identical to the raw (A,B) delta.
+            ImageWidthPixels = 1, ImageHeightPixels = 1, PixelSizeMicrons = 1, FocuserStepMicrons = 1,
             HasCurvatureMeasurement = false,
             ReBaseline1 = baseline,
             Screw1 = new TiltGradient(0.10, 0, 1000),

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationMetadataTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationMetadataTests.cs
@@ -33,11 +33,13 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                     new TiltPerStepResult {
                         Step = "Baseline", TiltPlaneA = 1.1, TiltPlaneB = -2.2, MeanFocuserPosition = 1000,
                         TiltAngleDeg = 0.5, DirectionDeg = 153.4,
-                        CurvatureRadiusMillimeters = 1234.5, CurvatureEffectMicronsAtScrewRadius = 5.5
+                        CurvatureRadiusMillimeters = 1234.5, CurvatureEffectMicronsAtScrewRadius = 5.5,
+                        CornerTiltPlaneA = 1.05, CornerTiltPlaneB = -2.35, CornerMeanFocuserPosition = 999.4
                     }
                 },
                 Calibration = new TiltCalibrationResultRecord {
-                    Screw1AngleDegrees = 10, Screw2AngleDegrees = 100, CurvatureSign = -1, MeasuredHardwareMicrons = 400
+                    Screw1AngleDegrees = 10, Screw2AngleDegrees = 100, CurvatureSign = -1, MeasuredHardwareMicrons = 400,
+                    CornerMeasuredHardwareMicrons = 410.5, EstimatorRelativeDifference = 0.0909
                 }
             };
 
@@ -54,8 +56,13 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 Assert.That(back.PerStep[0].TiltPlaneB, Is.EqualTo(-2.2).Within(1e-9));
                 Assert.That(back.PerStep[0].CurvatureRadiusMillimeters, Is.EqualTo(1234.5).Within(1e-9));
                 Assert.That(back.PerStep[0].CurvatureEffectMicronsAtScrewRadius, Is.EqualTo(5.5).Within(1e-9));
+                Assert.That(back.PerStep[0].CornerTiltPlaneA, Is.EqualTo(1.05).Within(1e-9));
+                Assert.That(back.PerStep[0].CornerTiltPlaneB, Is.EqualTo(-2.35).Within(1e-9));
+                Assert.That(back.PerStep[0].CornerMeanFocuserPosition, Is.EqualTo(999.4).Within(1e-9));
                 Assert.That(back.Calibration.MeasuredHardwareMicrons, Is.EqualTo(400).Within(1e-9));
                 Assert.That(back.Calibration.CurvatureSign, Is.EqualTo(-1));
+                Assert.That(back.Calibration.CornerMeasuredHardwareMicrons, Is.EqualTo(410.5).Within(1e-9));
+                Assert.That(back.Calibration.EstimatorRelativeDifference, Is.EqualTo(0.0909).Within(1e-9));
             });
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationMetadataTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationMetadataTests.cs
@@ -66,7 +66,8 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 FocuserStepSizeMicrons = 3.6, CalibrationAppliedAmount = 1.0,
                 Calibration = new TiltCalibrationResultRecord {
                     Screw1AngleDegrees = 67.1, SignalToNoise = 2.16,
-                    PredictedAngleUncertaintyDeg = 24.9, PitchUncertaintyMicrons = 43.0, ConfidenceIsReliable = true
+                    PredictedAngleUncertaintyDeg = 24.9, PitchUncertaintyMicrons = 43.0, ConfidenceIsReliable = true,
+                    PistonImpliedMicronsPerStep = 2.233258
                 }
             };
             var back = TiltCalibrationMetadata.Deserialize(meta.Serialize());
@@ -75,6 +76,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 Assert.That(back.Calibration.PredictedAngleUncertaintyDeg, Is.EqualTo(24.9).Within(1e-9));
                 Assert.That(back.Calibration.PitchUncertaintyMicrons, Is.EqualTo(43.0).Within(1e-9));
                 Assert.That(back.Calibration.ConfidenceIsReliable, Is.True);
+                Assert.That(back.Calibration.PistonImpliedMicronsPerStep, Is.EqualTo(2.233258).Within(1e-9));
             });
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -311,7 +311,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         ///
         /// <para><paramref name="includeExposureAnalysis"/> exists for callers that consume only the fitted sensor
         /// model, the Tilt Adapter Wizard's calibration steps above all: that validation exposure costs a further
-        /// <c>SimpleExposureSeconds</c> plus a full-frame PSF-modeling detection on EVERY step of a six-step run,
+        /// <c>SimpleExposureSeconds</c> plus a full-frame PSF-modeling detection on EVERY step of a calibration run,
         /// for panels the wizard neither reads nor shows — and, because a failure here fails the whole call, it
         /// could also fail a calibration step whose sensor model had already been fitted successfully.</para>
         /// </summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltModel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltModel.cs
@@ -116,10 +116,16 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             var topRightFocuser = result.RegionResults[3].EstimatedFinalFocuserPosition;
             var bottomLeftFocuser = result.RegionResults[4].EstimatedFinalFocuserPosition;
             var bottomRightFocuser = result.RegionResults[5].EstimatedFinalFocuserPosition;
+            // The corner-region samples sit at the REGION CENTERS (±1/3 normalized with default ROI), not at the
+            // frame corners. Regress against where the samples actually are, or A/B are attenuated by 2·|center|.
+            var tlBoundary = result.RegionResults[2].Region.OuterBoundary;
+            double cornerXNorm = Math.Abs(tlBoundary.StartX + tlBoundary.Width / 2.0 - 0.5);
+            double cornerYNorm = Math.Abs(tlBoundary.StartY + tlBoundary.Height / 2.0 - 0.5);
             var tiltPlaneModel = Create(
                 imageSize: result.ImageSize, fRatio: fRatio,
                 focuserStepSizeMicrons: focuserStepSizeMicrons, centerFocuser: centerFocuser, topLeftFocuser: topLeftFocuser,
-                topRightFocuser: topRightFocuser, bottomLeftFocuser: bottomLeftFocuser, bottomRightFocuser: bottomRightFocuser);
+                topRightFocuser: topRightFocuser, bottomLeftFocuser: bottomLeftFocuser, bottomRightFocuser: bottomRightFocuser,
+                cornerXNorm: cornerXNorm, cornerYNorm: cornerYNorm);
 
             tiltPlaneModel.Center.RSquared = result.RegionResults[1].Fittings.GetRSquared();
             tiltPlaneModel.TopLeft.RSquared = result.RegionResults[2].Fittings.GetRSquared();
@@ -137,17 +143,19 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             double topLeftFocuser,
             double topRightFocuser,
             double bottomLeftFocuser,
-            double bottomRightFocuser) {
+            double bottomRightFocuser,
+            double cornerXNorm = 0.5,
+            double cornerYNorm = 0.5) {
             var ols = new OrdinaryLeastSquares() {
                 UseIntercept = true
             };
 
             double[][] inputs =
             {
-                new double[] { -0.5, -0.5 },
-                new double[] { 0.5, -0.5 },
-                new double[] { -0.5, 0.5 },
-                new double[] { 0.5, 0.5 },
+                new double[] { -cornerXNorm, -cornerYNorm },
+                new double[] { cornerXNorm, -cornerYNorm },
+                new double[] { -cornerXNorm, cornerYNorm },
+                new double[] { cornerXNorm, cornerYNorm },
             };
             double[] outputs = { topLeftFocuser, topRightFocuser, bottomLeftFocuser, bottomRightFocuser };
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltAdapterOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltAdapterOptions.cs
@@ -55,6 +55,10 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         // 6 steps instead of 4. Off by default — the assumed/manual direction is used instead.
         bool MeasureCurvatureDuringCalibration { get; set; }
 
+        /// <summary>Measure one extra re-baseline after the final restore move so screw 2's move is referenced
+        /// symmetrically (drift-cancelling), at the cost of one more AF run. Default true.</summary>
+        bool MeasureFinalRebaseline { get; set; }
+
         // True when the current calibration came from Manual Calibration Entry, not a wizard run.
         bool CalibrationIsManual { get; set; }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatWizardMapping.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatWizardMapping.cs
@@ -50,16 +50,21 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
 
         /// <summary>
         /// The device move that realizes a calibration wizard step's instruction, or null for
-        /// <see cref="WizardStep.Baseline"/> (a measurement-only step -- no move). <paramref
-        /// name="appliedSteps"/> is N, the already-rounded integer step count (the wizard's persisted
-        /// per-calibration-step applied amount for a stepper device).
+        /// <see cref="WizardStep.Baseline"/> (a measurement-only step -- no move) and, when <paramref
+        /// name="measuredFinalRebaseline"/> is true, for <see cref="WizardStep.Complete"/> (the optional
+        /// measured <see cref="WizardStep.ReBaseline3"/> step already restored the device, so Complete has
+        /// nothing left to undo). <paramref name="appliedSteps"/> is N, the already-rounded integer step
+        /// count (the wizard's persisted per-calibration-step applied amount for a stepper device).
         ///
         /// Each case is annotated with the exact <c>StepInstructionsText</c> wording (four-screw,
-        /// isStepper) it realizes. The six executed moves (AllInward, ReBaseline1, Screw1, ReBaseline2,
-        /// Screw2, Complete) sum to (0,0,0,0) per corner -- the device returns to baseline at Complete; see
-        /// EatWizardMappingTests for the full-sequence regression that pins this.
+        /// isStepper) it realizes. Two variants of the executed sequence both sum to (0,0,0,0) per corner --
+        /// the device returns to baseline by the end either way; see EatWizardMappingTests for both
+        /// full-sequence regressions that pin this: the standard six-move sequence (AllInward, ReBaseline1,
+        /// Screw1, ReBaseline2, Screw2, Complete, <paramref name="measuredFinalRebaseline"/> false) and the
+        /// optional seven-move sequence that substitutes a measured ReBaseline3 restore for Complete's move
+        /// (<paramref name="measuredFinalRebaseline"/> true, Complete becomes a no-move).
         /// </summary>
-        public static TiltAdapterMove MoveForStep(WizardStep step, int appliedSteps) {
+        public static TiltAdapterMove MoveForStep(WizardStep step, int appliedSteps, bool measuredFinalRebaseline = false) {
             switch (step) {
                 case WizardStep.Baseline:
                     // "Ensure all screws are at their starting position, then click Run Measurement." --
@@ -102,13 +107,29 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
                         TiltMoveAxis.DiagonalB, appliedSteps, TiltMoveGroup.Tilt,
                         $"Wizard Screw 2: {FormatSigned(appliedSteps)} diagonal-B");
 
+                case WizardStep.ReBaseline3:
+                    // "Apply -N steps to motor 2 and +N steps to motor 4, returning to the baseline
+                    // position, then click Run Measurement." -- the optional MEASURED restore after Screw2
+                    // (gives screw 2 the same drift-cancelling re-baseline symmetry Screw1 already has) ->
+                    // undoes Screw2 -> (0,-N,0,+N) = DiagonalB(-N). Identical move to the un-measured
+                    // Complete restore below; the two are mutually exclusive per run (see
+                    // measuredFinalRebaseline).
+                    return new TiltAdapterMove(
+                        TiltMoveAxis.DiagonalB, -appliedSteps, TiltMoveGroup.Tilt,
+                        $"Wizard Re-Baseline 3: {FormatSigned(-appliedSteps)} diagonal-B (restore, measured)");
+
                 case WizardStep.Complete:
                     // "Return all motors to their original position." -- the restore move after Screw2 ->
                     // undoes Screw2 -> (0,-N,0,+N) = DiagonalB(-N). Confirmed by the full-sequence trace:
                     // this is exactly what returns the device to baseline (0,0,0,0) after the 6-step run.
-                    return new TiltAdapterMove(
-                        TiltMoveAxis.DiagonalB, -appliedSteps, TiltMoveGroup.Tilt,
-                        $"Wizard Complete: {FormatSigned(-appliedSteps)} diagonal-B (restore)");
+                    // When measuredFinalRebaseline is true, ReBaseline3 (above) already sent this exact
+                    // move and was itself measured (unlike this un-measured restore) -- Complete becomes a
+                    // no-move to avoid sending the restore twice.
+                    return measuredFinalRebaseline
+                        ? null
+                        : new TiltAdapterMove(
+                            TiltMoveAxis.DiagonalB, -appliedSteps, TiltMoveGroup.Tilt,
+                            $"Wizard Complete: {FormatSigned(-appliedSteps)} diagonal-B (restore)");
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(step), step, "Unknown wizard step.");

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -300,7 +300,7 @@
                 Margin="0,2"
                 VerticalAlignment="Center"
                 Columns="2"
-                ToolTip="The direction of the curvature response to clockwise screw turns (+ steps for stepper motors). Set by the adapter direction in the Measurement settings, or measured by a 6-step calibration run.">
+                ToolTip="The direction of the curvature response to clockwise screw turns (+ steps for stepper motors). Set by the adapter direction in the Measurement settings, or measured by a calibration run with direction measurement enabled.">
                 <UniformGrid.Style>
                     <Style TargetType="UniformGrid">
                         <Setter Property="Visibility" Value="Collapsed" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -1603,6 +1603,22 @@
                             </TextBlock.Style>
                         </TextBlock>
 
+                        <!--  Self-labeling ("Corner-AF cross-check: ...") row, mirrors the piston row above
+                              (Task 5): the corner-region AF plane's independent estimate of the same
+                              hardware, not a label/value pair.  -->
+                        <TextBlock Margin="0,4,0,0" Text="{Binding CornerCrossCheckDisplay}">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding HasCornerCrossCheck}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+
                         <Button
                             Margin="0,8,0,2"
                             HorizontalAlignment="Left"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -1616,7 +1616,7 @@
                               direct child of this StackPanel rather than another UniformGrid cell.  -->
                         <TextBlock Margin="0,4,0,0" Text="{Binding PistonPitchDisplay}">
                             <TextBlock.Style>
-                                <Style TargetType="TextBlock">
+                                <Style BasedOn="{StaticResource StandardTextBlock}" TargetType="TextBlock">
                                     <Setter Property="Visibility" Value="Collapsed" />
                                     <Style.Triggers>
                                         <DataTrigger Binding="{Binding HasPistonPitch}" Value="True">
@@ -1632,7 +1632,7 @@
                               hardware, not a label/value pair.  -->
                         <TextBlock Margin="0,4,0,0" Text="{Binding CornerCrossCheckDisplay}">
                             <TextBlock.Style>
-                                <Style TargetType="TextBlock">
+                                <Style BasedOn="{StaticResource StandardTextBlock}" TargetType="TextBlock">
                                     <Setter Property="Visibility" Value="Collapsed" />
                                     <Style.Triggers>
                                         <DataTrigger Binding="{Binding HasCornerCrossCheck}" Value="True">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -1586,8 +1586,22 @@
                             </StackPanel>
                             <TextBlock Text="Saved" />
                             <TextBlock Text="{Binding SavedHardwareDisplay}" />
-                            <TextBlock Margin="0,2,8,0" Text="{Binding PistonPitchDisplay}" />
                         </UniformGrid>
+
+                        <!--  Self-labeling ("Piston-implied: ...") row, not a label/value pair, so it is a
+                              direct child of this StackPanel rather than another UniformGrid cell.  -->
+                        <TextBlock Margin="0,4,0,0" Text="{Binding PistonPitchDisplay}">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding HasPistonPitch}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
 
                         <Button
                             Margin="0,8,0,2"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -1586,6 +1586,7 @@
                             </StackPanel>
                             <TextBlock Text="Saved" />
                             <TextBlock Text="{Binding SavedHardwareDisplay}" />
+                            <TextBlock Margin="0,2,8,0" Text="{Binding PistonPitchDisplay}" />
                         </UniformGrid>
 
                         <Button

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -597,6 +597,7 @@
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
@@ -761,6 +762,29 @@
                             FontStyle="Italic"
                             Opacity="0.7"
                             Text="Adds 2 extra measurement steps (6 instead of 4 — about 50% longer) to determine the direction automatically. Turn on if you don't know how your adapter behaves, or to verify the setting above."
+                            TextWrapping="Wrap" />
+
+                        <TextBlock
+                            Grid.Row="4"
+                            Grid.Column="0"
+                            Margin="0,2,5,2"
+                            VerticalAlignment="Center"
+                            Text="Measure final re-baseline (recommended)"
+                            ToolTip="Adds one extra measurement step after the final restore move so screw 2's move is referenced symmetrically, cancelling drift between steps the same way screw 1's move already is." />
+                        <CheckBox
+                            Grid.Row="4"
+                            Grid.Column="1"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            IsChecked="{Binding TiltAdapterOptions.MeasureFinalRebaseline}" />
+                        <TextBlock
+                            Grid.Row="4"
+                            Grid.Column="2"
+                            Margin="8,2,0,2"
+                            VerticalAlignment="Center"
+                            FontStyle="Italic"
+                            Opacity="0.7"
+                            Text="Adds 1 extra measurement step (~4 more minutes) so screw 2's move cancels drift between steps like screw 1's already does. Turn off to skip this extra measurement."
                             TextWrapping="Wrap" />
                     </Grid>
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterOptions.cs
@@ -58,6 +58,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             screwInwardCurvatureSign = optionsAccessor.GetValueInt32(nameof(ScrewInwardCurvatureSign), TiltScrewGeometry.DefaultScrewInwardCurvatureSign);
             screwInwardCurvatureSignIsMeasured = optionsAccessor.GetValueBoolean(nameof(ScrewInwardCurvatureSignIsMeasured), false);
             measureCurvatureDuringCalibration = optionsAccessor.GetValueBoolean(nameof(MeasureCurvatureDuringCalibration), false);
+            measureFinalRebaseline = optionsAccessor.GetValueBoolean(nameof(MeasureFinalRebaseline), true);
             calibrationIsManual = optionsAccessor.GetValueBoolean(nameof(CalibrationIsManual), false);
             adjustmentType = optionsAccessor.GetValueEnum(nameof(AdjustmentType), TiltAdjustmentType.Screws);
             angleDisplayUnit = optionsAccessor.GetValueEnum(nameof(AngleDisplayUnit), TiltGuidanceAngleUnit.Turns);
@@ -270,6 +271,19 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 if (measureCurvatureDuringCalibration != value) {
                     measureCurvatureDuringCalibration = value;
                     optionsAccessor.SetValueBoolean(nameof(MeasureCurvatureDuringCalibration), measureCurvatureDuringCalibration);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool measureFinalRebaseline;
+
+        public bool MeasureFinalRebaseline {
+            get => measureFinalRebaseline;
+            set {
+                if (measureFinalRebaseline != value) {
+                    measureFinalRebaseline = value;
+                    optionsAccessor.SetValueBoolean(nameof(MeasureFinalRebaseline), measureFinalRebaseline);
                     RaisePropertyChanged();
                 }
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -1197,7 +1197,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 ? "Direction was measured by a calibration run."
                 : tiltAdapterOptions.MeasureCurvatureDuringCalibration
                     ? "Direction will be measured on the next calibration run."
-                    : "Direction is assumed — enable the measurement below (or run a 6-step calibration) to verify it.";
+                    : "Direction is assumed — enable the measurement below (it adds the all-screws steps to the run) to verify it.";
 
         private double manualScrew1AngleDegrees;
 
@@ -1638,9 +1638,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     hasDefaultedMeasureCurvatureOnConnect = true;
                     if (!tiltAdapterOptions.MeasureCurvatureDuringCalibration && !userExplicitlyDisabledMeasureCurvatureThisSession) {
                         tiltAdapterOptions.MeasureCurvatureDuringCalibration = true;
-                        // Surface the silent 4→6-step change so the extra "all screws" steps aren't confusing.
-                        Notification.ShowInformation("Enabled direction measurement (6-step calibration) for the connected device — " +
-                            "recommended for hands-off runs. You can turn it off under the measurement settings.");
+                        // Surface the silent lengthening of the run so the extra "all screws" steps aren't confusing.
+                        // Don't quote a step count here: the run length also depends on MeasureFinalRebaseline.
+                        Notification.ShowInformation("Enabled direction measurement for the connected device — it adds the " +
+                            "all-screws steps to the run, and is recommended for hands-off runs. You can turn it off under " +
+                            "the measurement settings.");
                     }
                 }
                 RaisePropertyChanged(nameof(TiltDeviceStatusText));

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -3137,7 +3137,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             double foldedDiff = rawDiff <= 180.0 ? rawDiff : 360.0 - rawDiff;
             double deviation = Math.Abs(foldedDiff - expected);
             return deviation > 30.0
-                ? $"Screw 1→2 measured angle gap is {foldedDiff:F1}° (expected ~{expected}°)"
+                ? $"Screw 1 and screw 2 measured {foldedDiff:F1}° apart, but {expected:F0}° was expected."
                 : null;
         }
 
@@ -3147,7 +3147,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         private static string CheckMagnitudeRatio(double magnitudeRatio) =>
             !double.IsNaN(magnitudeRatio) && magnitudeRatio > MagnitudeRatioWarnThreshold
-                ? $"the two screw turns produced very unequal tilt changes ({magnitudeRatio:F1}× apart) — turn each screw the same amount"
+                ? $"The two screw moves changed the tilt by very unequal amounts ({magnitudeRatio:F1}× apart)."
                 : null;
 
         // The piston-implied pitch and the tilt-derived measured hardware are both focuser-frame quantities
@@ -3164,8 +3164,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // tilt-fit-independent value as the reference), not "how far apart are these two numbers" in the
             // abstract.
             double relativeDiff = Math.Abs(pistonImplied - measuredHardware) / measuredHardware;
+            // Percent is formatted by hand rather than with ":P0": the "P" specifier inserts a space before
+            // the sign in most cultures ("17 %"), which reads as a typo in running prose.
             return relativeDiff > PistonDisagreementWarnThreshold
-                ? $"piston-implied hardware ({pistonImplied:0.##} µm) and tilt-derived ({measuredHardware:0.##} µm) disagree by more than 20% — the tilt estimate may be unreliable"
+                ? $"The piston-implied pitch ({pistonImplied:0.##} µm) and the tilt-derived pitch ({measuredHardware:0.##} µm) differ by {relativeDiff * 100.0:F0}%."
                 : null;
         }
 
@@ -3181,21 +3183,33 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             if (double.IsNaN(estimatorRelDiff) || estimatorRelDiff <= EstimatorDisagreementWarnThreshold) {
                 return null;
             }
-            return $"the per-star model and the corner-region AF disagree on the screw moves by {estimatorRelDiff:P0} " +
-                $"— the measured hardware may be unreliable (corner-AF estimate: {cornerMeasuredHardwareMicrons:0.###} µm)";
+            return $"The per-star model and the corner-region AF differ by {estimatorRelDiff * 100.0:F0}% on the screw " +
+                $"moves, and the corner-region AF puts the pitch at {cornerMeasuredHardwareMicrons:0.###} µm.";
         }
 
         private void ValidateCalibrationQuality(double rawDiff, double magnitudeRatio, int screwCount,
             double measuredHardware, double pistonImplied, double estimatorRelDiff, double cornerMeasuredHardwareMicrons) {
-            var parts = new[] {
-                CheckScrewAngleGap(rawDiff, screwCount),
-                CheckMagnitudeRatio(magnitudeRatio),
-                CheckPistonAgreement(measuredHardware, pistonImplied),
-                CheckCornerCrossCheck(estimatorRelDiff, cornerMeasuredHardwareMicrons),
-            }.Where(p => p != null).ToList();
+            string angleGap = CheckScrewAngleGap(rawDiff, screwCount);
+            string ratio = CheckMagnitudeRatio(magnitudeRatio);
+            string piston = CheckPistonAgreement(measuredHardware, pistonImplied);
+            string corner = CheckCornerCrossCheck(estimatorRelDiff, cornerMeasuredHardwareMicrons);
+            var parts = new[] { angleGap, ratio, piston, corner }.Where(p => p != null).ToList();
 
             HasWarning = parts.Count > 0;
-            WarningText = HasWarning ? string.Join("; ", parts) + ". Consider recalibrating." : string.Empty;
+            if (!HasWarning) {
+                WarningText = string.Empty;
+                return;
+            }
+
+            // The closing advice depends on WHICH checks fired. An unequal-magnitude reading on its own is
+            // most likely what it looks like: the two turns really were different sizes. But when a second,
+            // independent estimator also disagrees with the per-star model, the screw moves are no longer the
+            // most likely culprit -- telling the user to re-turn the screws would send them after the wrong
+            // thing, and on a motorized run it is advice they cannot even act on.
+            string closing = piston != null || corner != null
+                ? "An independent estimator disagrees with the per-star model, so suspect the measurement before the hardware. Re-run on a star-rich field, or raise Measurements to average."
+                : "Turn each screw by the same amount and recalibrate.";
+            WarningText = string.Join(" ", parts) + " " + closing;
         }
 
         // Re-baseline drift: each re-baseline (c, e) should return close to the prior state. A large residual

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -2406,12 +2406,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             var latestModel = CalibrationTiltPlane;
             AppendSummaryRows(readings, stepDescription, latestModel, count, avgA, avgB);
 
+            var (avgGx, avgGy) = StateGradient(avgA, avgB, latestModel);
             var reading = new StepReading {
                 A = avgA,
                 B = avgB,
                 Mean = avgMean,
                 TiltAngleDeg = ComputeTiltAngleDeg(avgA, avgB, latestModel),
-                DirectionDeg = NormalizeAngle(Math.Atan2(avgA, -avgB) * 180.0 / Math.PI),
+                DirectionDeg = NormalizeAngle(Math.Atan2(avgGx, -avgGy) * 180.0 / Math.PI),
                 SaveFolder = saveOverride != null ? inspector.LastSaveFolder : null
             };
             PopulateCurvature(ref reading);
@@ -2490,8 +2491,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
         }
 
-        private double ComputeTiltAngleDeg(double a, double b, TiltPlaneModel model) {
-            if (model == null) return double.NaN;
+        // Converts a step's (A, B) tilt-plane reading (focuser steps per normalized image coordinate) into the
+        // physical best-focus gradient (gx, gy): microns of focuser travel per micron of sensor displacement.
+        // Shared by ComputeTiltAngleDeg (magnitude) and the per-state DirectionDeg (atan2(gx,-gy)) so both read
+        // the same physical space instead of the anisotropic (A,B) coefficients (the F2 bug) — mirrors
+        // TiltScrewGeometry.PlaneGradientToPhysical / TiltCalibrationCalculator.PhysicalDelta. (NaN, NaN) when the
+        // model or the focuser/pixel size inputs are unavailable.
+        private (double gx, double gy) StateGradient(double a, double b, TiltPlaneModel model) {
+            if (model == null) return (double.NaN, double.NaN);
             var pixelSizeMicrons = profileService.ActiveProfile.CameraSettings.PixelSize;
             var fStepMicrons = model.FocuserStepSizeMicrons;
             // Fall back to the connected focuser's reported step size when the inspector
@@ -2500,11 +2507,17 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 fStepMicrons = focuserInfo.StepSize;
             }
             if (double.IsNaN(fStepMicrons) || fStepMicrons <= 0 ||
-                double.IsNaN(pixelSizeMicrons) || pixelSizeMicrons <= 0) return double.NaN;
+                double.IsNaN(pixelSizeMicrons) || pixelSizeMicrons <= 0) return (double.NaN, double.NaN);
             // A and B are in focuser steps per normalized image coordinate (range [-0.5, 0.5]).
             // Convert to gradient in physical units: (steps * microns/step) / (pixels * microns/pixel).
             var gx = a * fStepMicrons / (model.ImageSize.Width * pixelSizeMicrons);
             var gy = b * fStepMicrons / (model.ImageSize.Height * pixelSizeMicrons);
+            return (gx, gy);
+        }
+
+        private double ComputeTiltAngleDeg(double a, double b, TiltPlaneModel model) {
+            var (gx, gy) = StateGradient(a, b, model);
+            if (double.IsNaN(gx) || double.IsNaN(gy)) return double.NaN;
             return Math.Atan(Math.Sqrt(gx * gx + gy * gy)) * 180.0 / Math.PI;
         }
 
@@ -2772,6 +2785,15 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
 
             EvaluateRebaselineDrift();
+            // ComputeConfidence now converts to physical gradient space (F2 fix) and so needs real sensor
+            // geometry, same as the hardware-recovery inputs above. Reuse the model's image size when a live/
+            // replayed tilt plane produced one; when it didn't (e.g. a seeded/test-only run with no model), fall
+            // back to a square 1x1 pseudo-sensor so the conversion stays isotropic (ratio-preserving) rather than
+            // aspect-distorted. If pixelSize/fStep are ALSO unavailable (fully geometry-less, e.g. an unconfigured
+            // test profile), PhysicalDelta's own fallback degrades further to the raw (A,B) delta — see its doc
+            // comment — instead of dividing by zero into a NaN that could get misread as "zero noise".
+            double confImageWidthPixels = model?.ImageSize.Width ?? 1;
+            double confImageHeightPixels = model?.ImageSize.Height ?? 1;
             lastConfidence = TiltCalibrationCalculator.ComputeConfidence(new TiltCalibrationInputs {
                 ScrewCount = screwCount,
                 Baseline = measuredCurvature ? new TiltGradient(a.A, a.B, a.Mean) : default,
@@ -2781,7 +2803,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 ReBaseline2 = new TiltGradient(e.A, e.B, e.Mean),
                 Screw2 = new TiltGradient(f.A, f.B, f.Mean),
                 HasCurvatureMeasurement = measuredCurvature,
-                FallbackCurvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign
+                FallbackCurvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign,
+                ImageWidthPixels = confImageWidthPixels,
+                ImageHeightPixels = confImageHeightPixels,
+                PixelSizeMicrons = pixelSize,
+                FocuserStepMicrons = fStep
             });
             EvaluateCalibrationConfidence(lastConfidence);
             // [CRITICAL GATE] Persist the confidence result as the automation-trust marker — the second half
@@ -3194,12 +3220,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                         Notification.ShowError($"Replay produced no sensor-curve-model tilt at step '{step}'. The per-star paraboloid could not be fit.{profileNotChangedNote}");
                         return;
                     }
+                    var (mGx, mGy) = StateGradient(m.A, m.B, m);
                     var reading = new StepReading {
                         A = m.A,
                         B = m.B,
                         Mean = m.MeanFocuserPosition,
                         TiltAngleDeg = ComputeTiltAngleDeg(m.A, m.B, m),
-                        DirectionDeg = NormalizeAngle(Math.Atan2(m.A, -m.B) * 180.0 / Math.PI)
+                        DirectionDeg = NormalizeAngle(Math.Atan2(mGx, -mGy) * 180.0 / Math.PI)
                     };
                     PopulateCurvature(ref reading);
                     stepReadings[step] = reading;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -67,7 +67,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         Screw1 = 3,       // d: screw 1 inward once (4-screw: + screw 3 outward)
         ReBaseline2 = 4,  // e: undo the screw-1 move (≈ c)
         Screw2 = 5,       // f: screw 2 inward once (4-screw: + screw 4 outward)
-        Complete = 6
+        Complete = 6,
+        ReBaseline3 = 7,  // g (optional): undo the screw-2 move, measured — screw 2's drift-symmetric reference
     }
 
     [PartCreationPolicy(CreationPolicy.Shared)]
@@ -226,15 +227,27 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         // The measurement steps in capture order. The 4-step flow (default) skips the two
         // curvature-direction steps; the Baseline reading then serves as the screw-1 reference
-        // (the ReBaseline1 role of the 6-step flow).
-        internal static WizardStep[] GetMeasurementSteps(bool measureCurvature) =>
-            measureCurvature
+        // (the ReBaseline1 role of the 6-step flow). measureFinalRebaseline (Task 6) appends the optional
+        // ReBaseline3 step to either flow: a MEASURED restore of the Screw2 move, giving screw 2 the same
+        // drift-cancelling re-baseline symmetry screw 1 always gets from mid(ReBaseline1, ReBaseline2). It
+        // is always the LAST measurement step (immediately before Complete) regardless of which base flow
+        // it is appended to.
+        internal static WizardStep[] GetMeasurementSteps(bool measureCurvature, bool measureFinalRebaseline) {
+            var baseSteps = measureCurvature
                 ? new[] { WizardStep.Baseline, WizardStep.AllInward, WizardStep.ReBaseline1,
                           WizardStep.Screw1, WizardStep.ReBaseline2, WizardStep.Screw2 }
                 : new[] { WizardStep.Baseline, WizardStep.Screw1, WizardStep.ReBaseline2, WizardStep.Screw2 };
+            if (!measureFinalRebaseline) {
+                return baseSteps;
+            }
+            var withFinalRebaseline = new WizardStep[baseSteps.Length + 1];
+            Array.Copy(baseSteps, withFinalRebaseline, baseSteps.Length);
+            withFinalRebaseline[baseSteps.Length] = WizardStep.ReBaseline3;
+            return withFinalRebaseline;
+        }
 
         // Captured at run start (StartAsync/ReplayAsync) so toggling the option mid-run is inert.
-        private WizardStep[] activeMeasurementSteps = GetMeasurementSteps(measureCurvature: false);
+        private WizardStep[] activeMeasurementSteps = GetMeasurementSteps(measureCurvature: false, measureFinalRebaseline: false);
 
         // Prose for the wizard's Signal Amplification row: per-sweep image estimate plus the total
         // for the whole calibration at current settings. Internal for tests.
@@ -382,6 +395,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     RaisePropertyChanged(nameof(CurvatureSignProvenance));
                 }
                 if (e.PropertyName == nameof(ITiltAdapterOptions.MeasureCurvatureDuringCalibration) ||
+                    e.PropertyName == nameof(ITiltAdapterOptions.MeasureFinalRebaseline) ||
                     e.PropertyName == nameof(ITiltAdapterOptions.MeasurementAverageCount)) {
                     RaisePropertyChanged(nameof(WizardSweepSummary));
                 }
@@ -631,6 +645,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 case WizardStep.ReBaseline2: return "Return to Baseline";
                 case WizardStep.Screw2: return "Move Screw 2";
                 case WizardStep.Complete: return "Calibration Complete";
+                case WizardStep.ReBaseline3: return "Return to Baseline";
                 default: return string.Empty;
             }
         }
@@ -912,7 +927,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             IsReplaying
                 ? ReplayStepInstructionsText(currentStep)
                 : (IsTiltDeviceConnected && IsMotorizedDevice)
-                    ? DeviceStepInstructionsText(currentStep, (int)Math.Round(CalibrationAppliedAmount), IsAutoRunningAll)
+                    ? DeviceStepInstructionsText(currentStep, (int)Math.Round(CalibrationAppliedAmount), IsAutoRunningAll,
+                        activeMeasurementSteps.Contains(WizardStep.ReBaseline3))
                     : StepInstructionsText(currentStep, tiltAdapterOptions.ScrewCount, IsStepperAdjustment, CalibrationAppliedAmount);
 
         // Replay wording: a replay re-analyzes already-captured frames, so every imperative in the live copy
@@ -924,10 +940,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         // Automated-status wording for a connected, device-driven run: describes what the wizard will send
         // (Move.Description) rather than what the user must do by hand. Baseline has no move (measurement
-        // only); every other step maps 1:1 via EatWizardMapping.MoveForStep. When <paramref name="autoRunning"/>
-        // (Auto Run All is active) the "click Run Measurement" imperatives are dropped — those buttons are
-        // hidden during an automated run, so telling the user to click them reads as a stalled manual run.
-        internal static string DeviceStepInstructionsText(WizardStep step, int appliedSteps, bool autoRunning) {
+        // only); every other step maps 1:1 via EatWizardMapping.MoveForStep -- including Complete, which
+        // becomes a no-move ("measuring…" / "Click Run Measurement to continue.") once <paramref
+        // name="measuredFinalRebaseline"/> is true, matching the move ExecuteDeviceMoveForCurrentStepAsync
+        // will actually (not) send. When <paramref name="autoRunning"/> (Auto Run All is active) the "click
+        // Run Measurement" imperatives are dropped — those buttons are hidden during an automated run, so
+        // telling the user to click them reads as a stalled manual run.
+        internal static string DeviceStepInstructionsText(WizardStep step, int appliedSteps, bool autoRunning, bool measuredFinalRebaseline = false) {
             if (step == WizardStep.Baseline) {
                 return autoRunning
                     ? "Running automatically — the wizard is driving the tilt adapter through the calibration. " +
@@ -936,7 +955,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                         "Ensure the device is at its starting position (as zeroed in the vendor app), then click Run Measurement " +
                         "or Auto Run All to begin.";
             }
-            var move = EatWizardMapping.MoveForStep(step, appliedSteps);
+            var move = EatWizardMapping.MoveForStep(step, appliedSteps, measuredFinalRebaseline);
             if (autoRunning) {
                 return move == null
                     ? "Running automatically — measuring…"
@@ -1000,6 +1019,17 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     return four
                         ? $"Turn screw 2 CLOCKWISE and screw 4 COUNTER-CLOCKWISE exactly {amt} each, then click Run Measurement."
                         : $"Turn screw 2 CLOCKWISE exactly {amt}, then click Run Measurement.";
+                case WizardStep.ReBaseline3:
+                    // Optional (Task 6): a MEASURED restore of the screw-2 move, giving screw 2 the same
+                    // drift-cancelling re-baseline symmetry screw 1 already gets from ReBaseline1/ReBaseline2.
+                    if (isStepper) {
+                        return four
+                            ? $"Apply −{amt} steps to motor 2 and +{amt} steps to motor 4, returning to the baseline position, then click Run Measurement."
+                            : $"Apply −{amt} steps to motor 2, returning to the baseline position, then click Run Measurement.";
+                    }
+                    return four
+                        ? $"Turn screw 2 back COUNTER-CLOCKWISE and screw 4 back CLOCKWISE exactly {amt} each, returning to the baseline position, then click Run Measurement."
+                        : $"Turn screw 2 back COUNTER-CLOCKWISE exactly {amt}, returning to the baseline position, then click Run Measurement.";
                 case WizardStep.Complete:
                     return isStepper
                         ? "Return all motors to their original position."
@@ -1016,6 +1046,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 case WizardStep.ReBaseline1:
                 case WizardStep.ReBaseline2:
                 case WizardStep.Complete:
+                case WizardStep.ReBaseline3:
                     return true;
                 default:
                     return false;
@@ -1293,7 +1324,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 var inspectorOptions = inspector.InspectorOptions;
                 if (inspectorOptions == null) return string.Empty;
                 return BuildSweepSummary(
-                    GetMeasurementSteps(tiltAdapterOptions.MeasureCurvatureDuringCalibration).Length,
+                    GetMeasurementSteps(tiltAdapterOptions.MeasureCurvatureDuringCalibration, tiltAdapterOptions.MeasureFinalRebaseline).Length,
                     tiltAdapterOptions.MeasurementAverageCount,
                     inspectorOptions.StepCount,
                     inspectorOptions.FramesPerPoint,
@@ -1808,9 +1839,15 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
 
             int appliedSteps = (int)Math.Round(CalibrationAppliedAmount);
-            var move = EatWizardMapping.MoveForStep(step, appliedSteps);
+            // measuredFinalRebaseline reflects THIS run's active sequence (captured at StartAsync), not just
+            // the live option: it must stay true for the whole run even if the option is toggled mid-run.
+            // When true, Complete becomes a no-move — ReBaseline3 (an ordinary step earlier in this same
+            // sequence) already sent and measured the restore, so sending it again here would be a second,
+            // spurious, physically real move.
+            bool measuredFinalRebaseline = activeMeasurementSteps.Contains(WizardStep.ReBaseline3);
+            var move = EatWizardMapping.MoveForStep(step, appliedSteps, measuredFinalRebaseline);
             if (move == null) {
-                return true; // Unreachable for a non-Baseline step today, but guard defensively.
+                return true; // Baseline, or Complete after a measured ReBaseline3 already restored the device.
             }
 
             try {
@@ -2140,7 +2177,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 }
             }
 
-            activeMeasurementSteps = GetMeasurementSteps(tiltAdapterOptions.MeasureCurvatureDuringCalibration);
+            activeMeasurementSteps = GetMeasurementSteps(tiltAdapterOptions.MeasureCurvatureDuringCalibration, tiltAdapterOptions.MeasureFinalRebaseline);
             CurrentStep = WizardStep.Baseline;
             IsWizardRunning = true;
             return Task.CompletedTask;
@@ -2345,11 +2382,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             RecordStepIntoMetadata(step, reading.Value);
             NextStep();
 
-            // T11: Complete's restore move (EatWizardMapping.MoveForStep(Complete, N) = DiagonalB(-N)) returns
-            // the device to baseline — sent automatically for ANY device-driven run, whether stepped manually
-            // (repeated "Run Measurement" clicks) or via AutoRunAllAsync's loop (which just calls this method
-            // repeatedly). The operation lease is released here, AFTER the restore move is attempted, so it
-            // still protects that final move — NOT in NextStep(), which runs synchronously and cannot await it.
+            // T11: Complete's restore move (EatWizardMapping.MoveForStep(Complete, N) = DiagonalB(-N), or null
+            // when this run's measuredFinalRebaseline is true — see ExecuteDeviceMoveForCurrentStepAsync)
+            // returns the device to baseline — sent automatically for ANY device-driven run, whether stepped
+            // manually (repeated "Run Measurement" clicks) or via AutoRunAllAsync's loop (which just calls
+            // this method repeatedly). The operation lease is released here, AFTER the restore move is
+            // attempted (or skipped), so it still protects that final move — NOT in NextStep(), which runs
+            // synchronously and cannot await it.
             if (CurrentStep == WizardStep.Complete && currentRunIsDeviceDriven) {
                 bool restored = await ExecuteDeviceMoveForCurrentStepAsync(WizardStep.Complete, CancellationToken.None);
                 ReleaseTiltDeviceOperationToken();
@@ -2374,11 +2413,21 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 case WizardStep.Screw1: return four ? "Screw 1 ⟳, Screw 3 ⟲" : "Screw 1 ⟳";
                 case WizardStep.ReBaseline2: return four ? "Re-baseline (Screw 1 ⟲, Screw 3 ⟳)" : "Re-baseline (Screw 1 ⟲)";
                 case WizardStep.Screw2: return four ? "Screw 2 ⟳, Screw 4 ⟲" : "Screw 2 ⟳";
+                case WizardStep.ReBaseline3: return four ? "Re-baseline (Screw 2 ⟲, Screw 4 ⟳)" : "Re-baseline (Screw 2 ⟲)";
                 default: return step.ToString();
             }
         }
 
-        private static string StepFolderName(WizardStep step) => $"{(int)step + 1:00}_{step}";
+        // ReBaseline3 = 7 sits numerically AFTER Complete = 6 (so Complete's ordinal never renumbers), but it
+        // is the 5th/7th step IN THE SEQUENCE (right before Complete) — special-cased here so its folder
+        // sorts and reads correctly ("07_ReBaseline3") rather than the generic "08_ReBaseline3" the enum's
+        // raw ordinal would produce.
+        private static string StepFolderName(WizardStep step) {
+            if (step == WizardStep.ReBaseline3) {
+                return "07_ReBaseline3";
+            }
+            return $"{(int)step + 1:00}_{step}";
+        }
 
         // Test seam: RunCalibrationForTest injects the tilt plane a live run would get from the inspector so the
         // hardware-recovery path is exercisable without running the paraboloid fit. Always null in production, so
@@ -2755,23 +2804,25 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
         }
 
-        // Runs the full calibration math from the six step readings and writes the results to the options. Shared
-        // by a live run (geometry from the current options/profile) and a replay (geometry from the metadata).
+        // Runs the full calibration math from the step readings (six, or seven with the optional measured
+        // final re-baseline) and writes the results to the options. Shared by a live run (geometry from the
+        // current options/profile) and a replay (geometry from the metadata).
         // deviceDriven: true only for a completed CONNECTED, device-driven (hands-off) run — the wizard sent
         // every step's move itself, so the wizard-screw <-> device-corner correspondence (EatWizardMapping) is
         // known to be correct. False for a disconnected/manual-clicking run, a replay, or the RunCalibrationForTest
         // seed path (its default) — see the [CRITICAL GATE] note on ITiltAdapterOptions.DeviceLinkedCalibrationDeviceName.
         // Shared by RunCalibrationMath's paraboloid `inputs` and its Task-5 corner-AF cross-check `cornerInputs`:
-        // every geometry/flag field is identical between the two estimators -- only the six gradient readings
-        // (baseline/all-inward/re-baselines/screw moves) differ. Factored so the two TiltCalibrationInputs
-        // objects cannot drift apart (a field added to one and forgotten on the other would silently bias the
-        // cross-check).
+        // every geometry/flag field is identical between the two estimators -- only the up-to-seven gradient
+        // readings (baseline/all-inward/re-baselines/screw moves, plus the Task-6 optional measured final
+        // re-baseline) differ. Factored so the two TiltCalibrationInputs objects cannot drift apart (a field
+        // added to one and forgotten on the other would silently bias the cross-check).
         private static TiltCalibrationInputs BuildCalibrationInputs(
             int screwCount, bool hasCurvatureMeasurement, int fallbackCurvatureSign,
             double imageWidthPixels, double imageHeightPixels, double pixelSize, double fStep,
             double radiusMm, double appliedAmount, bool isStepper,
             TiltGradient baseline, TiltGradient allInward, TiltGradient reBaseline1,
-            TiltGradient screw1, TiltGradient reBaseline2, TiltGradient screw2) {
+            TiltGradient screw1, TiltGradient reBaseline2, TiltGradient screw2,
+            TiltGradient reBaseline3, bool hasFinalRebaseline) {
             return new TiltCalibrationInputs {
                 ScrewCount = screwCount,
                 // 4-step runs never measured Baseline/AllInward as curvature probes: leave them default —
@@ -2791,7 +2842,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 FocuserStepMicrons = fStep,
                 ScrewRadiusMillimeters = radiusMm,
                 CalibrationAppliedAmount = appliedAmount,
-                IsStepperAdjustment = isStepper
+                IsStepperAdjustment = isStepper,
+                // Same "leave default when not measured" discipline as Baseline/AllInward above -- the
+                // calculator ignores ReBaseline3 whenever HasFinalRebaseline is false.
+                ReBaseline3 = hasFinalRebaseline ? reBaseline3 : default,
+                HasFinalRebaseline = hasFinalRebaseline
             };
         }
 
@@ -2814,12 +2869,19 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         private void RunCalibrationMath(int screwCount, double radiusMm, double pixelSize, double fStep,
             double appliedAmount, bool isStepper, bool deviceDriven) {
             bool measuredCurvature = stepReadings.ContainsKey(WizardStep.AllInward);
+            // Task 6: the optional measured final re-baseline. Presence in stepReadings (not activeMeasurementSteps)
+            // is the same "was it actually measured" test measuredCurvature above uses for AllInward -- correct for
+            // a replay too, since a saved run predating this feature (or captured with the option off) simply
+            // never has a ReBaseline3 entry, so this comes back false and Screw2Delta keeps its old ReBaseline2-only
+            // semantics (backward compatible).
+            bool hasFinalRebaseline = stepReadings.ContainsKey(WizardStep.ReBaseline3);
             var a = Reading(WizardStep.Baseline);
             var b = Reading(WizardStep.AllInward);
             var c = measuredCurvature ? Reading(WizardStep.ReBaseline1) : Reading(WizardStep.Baseline);
             var d = Reading(WizardStep.Screw1);
             var e = Reading(WizardStep.ReBaseline2);
             var f = Reading(WizardStep.Screw2);
+            var g = Reading(WizardStep.ReBaseline3);
 
             // Curvature (backfocus) sign from baseline (a) → all-inward (b) mean focus, only when
             // those steps ran; otherwise the configured/assumed sign is left untouched.
@@ -2870,21 +2932,23 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // would be non-NaN but physically meaningless.
             double imageWidthPixels = model?.ImageSize.Width ?? 1;
             double imageHeightPixels = model?.ImageSize.Height ?? 1;
-            // Local function closing over this run's shared geometry/flag locals (Fix 6, post-review): both
-            // the paraboloid `inputs` below and the Task-5 corner-cross-check `cornerInputs` further down call
-            // THIS one function, so only the six gradient readings can ever differ between the two
-            // TiltCalibrationInputs objects — nothing short of editing this one signature could let the
-            // ~10 shared leading arguments drift apart between the call sites.
+            // Local function closing over this run's shared geometry/flag locals (Fix 6, post-review; extended
+            // for Task 6's hasFinalRebaseline): both the paraboloid `inputs` below and the Task-5
+            // corner-cross-check `cornerInputs` further down call THIS one function, so only the up-to-seven
+            // gradient readings can ever differ between the two TiltCalibrationInputs objects — nothing short
+            // of editing this one signature could let the shared leading arguments (including
+            // hasFinalRebaseline) drift apart between the call sites.
             TiltCalibrationInputs MakeInputs(TiltGradient baseline, TiltGradient allInward, TiltGradient reBaseline1,
-                TiltGradient screw1, TiltGradient reBaseline2, TiltGradient screw2) =>
+                TiltGradient screw1, TiltGradient reBaseline2, TiltGradient screw2, TiltGradient reBaseline3) =>
                 BuildCalibrationInputs(
                     screwCount, measuredCurvature, tiltAdapterOptions.ScrewInwardCurvatureSign,
                     imageWidthPixels, imageHeightPixels, pixelSize, fStep, radiusMm, appliedAmount, isStepper,
-                    baseline, allInward, reBaseline1, screw1, reBaseline2, screw2);
+                    baseline, allInward, reBaseline1, screw1, reBaseline2, screw2, reBaseline3, hasFinalRebaseline);
             var inputs = MakeInputs(
                 new TiltGradient(a.A, a.B, a.Mean), new TiltGradient(b.A, b.B, b.Mean),
                 new TiltGradient(c.A, c.B, c.Mean), new TiltGradient(d.A, d.B, d.Mean),
-                new TiltGradient(e.A, e.B, e.Mean), new TiltGradient(f.A, f.B, f.Mean));
+                new TiltGradient(e.A, e.B, e.Mean), new TiltGradient(f.A, f.B, f.Mean),
+                new TiltGradient(g.A, g.B, g.Mean));
             var result = TiltCalibrationCalculator.Calibrate(inputs);
 
             tiltAdapterOptions.Screw1AngleDegrees = result.Screw1AngleDegrees;
@@ -2961,11 +3025,15 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 !double.IsNaN(r.CornerA) && !double.IsNaN(r.CornerB) && !double.IsNaN(r.CornerMean));
             if (cornerDataComplete) {
                 // Reuses the SAME MakeInputs local function the paraboloid `inputs` above was built with (Fix
-                // 6, post-review) — only the six gradient readings differ here.
+                // 6, post-review; extended for Task 6) — only the up-to-seven gradient readings differ here,
+                // and hasFinalRebaseline (closed over, not passed here) is identical for both estimators, so
+                // the corner cross-check stays apples-to-apples with the paraboloid even when the optional
+                // measured final re-baseline is present.
                 var cornerInputs = MakeInputs(
                     new TiltGradient(a.CornerA, a.CornerB, a.CornerMean), new TiltGradient(b.CornerA, b.CornerB, b.CornerMean),
                     new TiltGradient(c.CornerA, c.CornerB, c.CornerMean), new TiltGradient(d.CornerA, d.CornerB, d.CornerMean),
-                    new TiltGradient(e.CornerA, e.CornerB, e.CornerMean), new TiltGradient(f.CornerA, f.CornerB, f.CornerMean));
+                    new TiltGradient(e.CornerA, e.CornerB, e.CornerMean), new TiltGradient(f.CornerA, f.CornerB, f.CornerMean),
+                    new TiltGradient(g.CornerA, g.CornerB, g.CornerMean));
                 var cornerResult = TiltCalibrationCalculator.Calibrate(cornerInputs);
 
                 // Fix 5 (post-review) diagnostic: TiltCalibrationCalculator.EstimatorRelativeDifference's own
@@ -3341,9 +3409,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             var byStep = (metadata.RunStepMapping ?? new List<TiltRunStepMapping>())
                 .GroupBy(m => m.Step, StringComparer.OrdinalIgnoreCase)
                 .ToDictionary(g => g.Key, g => TiltCalibrationMetadata.ResolveStepFolder(folder, g.Last().Folder), StringComparer.OrdinalIgnoreCase);
-            // A run saved without the curvature steps replays as a 4-step run.
+            // A run saved without the curvature steps replays as a 4-step run; a run saved without the
+            // optional measured final re-baseline (older runs, or one captured with the option off) replays
+            // without ReBaseline3 -- so HasFinalRebaseline (read fresh from stepReadings in RunCalibrationMath)
+            // correctly comes back false for those, keeping Screw2Delta's old ReBaseline2-only semantics.
             bool replayHasCurvatureSteps = byStep.ContainsKey(WizardStep.AllInward.ToString());
-            var replaySteps = GetMeasurementSteps(replayHasCurvatureSteps);
+            bool replayHasFinalRebaseline = byStep.ContainsKey(WizardStep.ReBaseline3.ToString());
+            var replaySteps = GetMeasurementSteps(replayHasCurvatureSteps, replayHasFinalRebaseline);
             activeMeasurementSteps = replaySteps;
             RaisePropertyChanged(nameof(StepProgressDisplay)); // step count (4 vs 6) may differ from the prior run
             foreach (var step in replaySteps) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -203,6 +203,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         private double measuredHardwareMicrons = double.NaN;
         private TiltCalibrationConfidence lastConfidence;
         private double pitchUncertaintyMicrons = double.NaN;
+        private double pistonImpliedMicronsPerStep = double.NaN;
         private double calibrationPixelSizeMicrons;
         private double calibrationFocuserStepMicrons;
         private double calibrationScrewRadiusMm;
@@ -1204,6 +1205,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             measuredHardwareMicrons = double.NaN;
             lastConfidence = null;
             pitchUncertaintyMicrons = double.NaN;
+            pistonImpliedMicronsPerStep = double.NaN;
             lastRawAngleDiff = double.NaN;
             lastMoveMagnitudeRatio = double.NaN;
             HasWarning = false;
@@ -1242,6 +1244,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             measuredHardwareMicrons = double.NaN;
             lastConfidence = null;
             pitchUncertaintyMicrons = double.NaN;
+            pistonImpliedMicronsPerStep = double.NaN;
             lastRawAngleDiff = double.NaN;
             lastMoveMagnitudeRatio = double.NaN;
             HasWarning = false;
@@ -1315,6 +1318,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public string PitchUncertaintyDisplay =>
             double.IsNaN(pitchUncertaintyMicrons) ? string.Empty :
             $"± {pitchUncertaintyMicrons:F0} µm/{(IsStepperAdjustment ? "step" : "turn")}";
+
+        // Piston-implied pitch (frame-factor probe): a free, tilt-fit-independent hardware estimate from the
+        // AllInward piston alone (see TiltCalibrationCalculator.PistonImpliedMicronsPerStep). NaN for 4-step
+        // runs (no piston measured) — empty string collapses the row, same pattern as PitchUncertaintyDisplay.
+        public string PistonPitchDisplay =>
+            double.IsNaN(pistonImpliedMicronsPerStep) ? string.Empty
+            : $"Piston-implied: {pistonImpliedMicronsPerStep:0.###} µm/{(IsStepperAdjustment ? "step" : "turn")}";
 
         // Config-panel bindings. They wrap the persisted options, presenting thread pitch in mm and
         // showing 0 for the unset (-1) sentinel so the textboxes read cleanly.
@@ -2594,6 +2604,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             measuredHardwareMicrons = double.NaN;
             lastConfidence = null;
             pitchUncertaintyMicrons = double.NaN;
+            pistonImpliedMicronsPerStep = double.NaN;
             lastRawAngleDiff = double.NaN;
             lastMoveMagnitudeRatio = double.NaN;
             runRootFolder = null;
@@ -2784,7 +2795,6 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
             lastRawAngleDiff = result.RawAngleDiffDegrees;
             lastMoveMagnitudeRatio = result.MoveMagnitudeRatio;
-            ValidateCalibrationQuality(lastRawAngleDiff, lastMoveMagnitudeRatio, screwCount);
 
             // Recover the adapter hardware (µm/turn or µm/step) — Calibrate computes this via the same
             // RecoverHardwareDetailed math this method used to call directly, off the SAME inputs/result as
@@ -2809,6 +2819,17 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     }
                 }
             }
+
+            // Piston-implied pitch (frame-factor probe): unlike the hardware recovery above, this needs NO
+            // sensor geometry at all -- TiltCalibrationCalculator.PistonImpliedMicronsPerStep consumes only
+            // mean focuser positions, the focuser step size, and the applied amount, never the per-screw
+            // lever arm the model != null gate above exists to protect. So it is deliberately NOT gated on
+            // model != null: it is exactly as valid on a model-less (seeded/test-only) run as a real one, and
+            // gating it would just hide a perfectly good, geometry-independent cross-check on those runs.
+            pistonImpliedMicronsPerStep = result.PistonImpliedMicronsPerStep;
+
+            ValidateCalibrationQuality(lastRawAngleDiff, lastMoveMagnitudeRatio, screwCount,
+                measuredHardwareMicrons, pistonImpliedMicronsPerStep);
 
             EvaluateRebaselineDrift();
             lastConfidence = result.Confidence;
@@ -2837,6 +2858,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             RaisePropertyChanged(nameof(ConfidenceIsReliable));
             RaisePropertyChanged(nameof(ConfidenceSummaryDisplay));
             RaisePropertyChanged(nameof(PitchUncertaintyDisplay));
+            RaisePropertyChanged(nameof(PistonPitchDisplay));
             OnUIThread(() => ((RelayCommand)UseMeasuredHardwareCommand).NotifyCanExecuteChanged());
         }
 
@@ -2845,25 +2867,36 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // backlash) means the recovered geometry/hardware is unreliable — warn so the user recalibrates.
         private const double MagnitudeRatioWarnThreshold = 1.5; // larger move > 1.5x smaller => suspect
 
-        private void ValidateCalibrationQuality(double rawDiff, double magnitudeRatio, int screwCount) {
+        // The piston-implied pitch and the tilt-derived measured hardware are both focuser-frame quantities
+        // (see TiltCalibrationCalculator.PistonImpliedMicronsPerStep), so honest agreement is expected; a gap
+        // this large means the tilt estimator (or the mechanics on pull-side moves) is off.
+        private const double PistonDisagreementWarnThreshold = 0.20;
+
+        private void ValidateCalibrationQuality(double rawDiff, double magnitudeRatio, int screwCount,
+            double measuredHardware, double pistonImplied) {
             double expected = screwCount == 3 ? 120.0 : 90.0;
             // Fold the diff so it is in [0, 180] — both CW and CCW gaps compare to the same expected value.
             double foldedDiff = rawDiff <= 180.0 ? rawDiff : 360.0 - rawDiff;
             double deviation = Math.Abs(foldedDiff - expected);
             bool angleBad = deviation > 30.0;
             bool magnitudeBad = !double.IsNaN(magnitudeRatio) && magnitudeRatio > MagnitudeRatioWarnThreshold;
+            bool pistonBad = measuredHardware > 0 && pistonImplied > 0
+                && Math.Abs(pistonImplied - measuredHardware) / measuredHardware > PistonDisagreementWarnThreshold;
 
-            HasWarning = angleBad || magnitudeBad;
+            HasWarning = angleBad || magnitudeBad || pistonBad;
             if (!HasWarning) {
                 WarningText = string.Empty;
                 return;
             }
-            var parts = new List<string>(2);
+            var parts = new List<string>(3);
             if (angleBad) {
                 parts.Add($"Screw 1→2 measured angle gap is {foldedDiff:F1}° (expected ~{expected}°)");
             }
             if (magnitudeBad) {
                 parts.Add($"the two screw turns produced very unequal tilt changes ({magnitudeRatio:F1}× apart) — turn each screw the same amount");
+            }
+            if (pistonBad) {
+                parts.Add($"piston-implied hardware ({pistonImplied:0.##} µm) and tilt-derived ({measuredHardware:0.##} µm) disagree by more than 20% — the tilt estimate may be unreliable");
             }
             WarningText = string.Join("; ", parts) + ". Consider recalibrating.";
         }
@@ -3406,6 +3439,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 PredictedAngleUncertaintyDeg = lastConfidence?.PredictedAngleUncertaintyDeg ?? double.NaN,
                 PitchUncertaintyMicrons = pitchUncertaintyMicrons,
                 ConfidenceIsReliable = lastConfidence?.IsReliable ?? false,
+                PistonImpliedMicronsPerStep = pistonImpliedMicronsPerStep,
             };
             WriteMetadata();
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -209,6 +209,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         private double calibrationScrewRadiusMm;
         private double lastRawAngleDiff = double.NaN;
         private double lastMoveMagnitudeRatio = double.NaN;
+        // Task 5: corner-region AF cross-check of the paraboloid calibration. See RunCalibrationMath.
+        private double cornerMeasuredHardwareMicrons = double.NaN;
+        private double estimatorRelativeDifference = double.NaN;
 
         // Per-run save state (transient; only populated while saving AF runs for the current calibration run).
         private bool saveAFRuns;
@@ -256,6 +259,16 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             public double CurvatureRadiusMm;
             public double CurvatureEffectAtScrewRadiusMicrons;
             public string SaveFolder;
+
+            // Task 5: the inspector's 4-corner region plane for this same step (honest per-corner estimator
+            // since Task 1), captured alongside the paraboloid reading above for the corner-region AF
+            // cross-check (see RunCalibrationMath). NaN when the corner plane could not be fit for this step
+            // (or any of the averaged sub-measurements that make it up) -- a struct default of 0.0 would look
+            // like a valid zero-tilt corner reading and silently corrupt the cross-check, so every writer of
+            // this struct must set these explicitly rather than relying on the field default.
+            public double CornerA;
+            public double CornerB;
+            public double CornerMean;
         }
 
         [ImportingConstructor]
@@ -1265,6 +1278,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             pistonImpliedMicronsPerStep = double.NaN;
             lastRawAngleDiff = double.NaN;
             lastMoveMagnitudeRatio = double.NaN;
+            cornerMeasuredHardwareMicrons = double.NaN;
+            estimatorRelativeDifference = double.NaN;
         }
 
         public string WizardSweepSummary {
@@ -1338,6 +1353,19 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // Gates the piston-pitch row's visibility in DataTemplates.xaml (this file uses DataTrigger-driven
         // Visibility throughout, never converters) — true once a 6-step run has measured a piston.
         public bool HasPistonPitch => !double.IsNaN(pistonImpliedMicronsPerStep);
+
+        // Corner-region AF cross-check (Task 5): the adapter hardware recovered from the inspector's 4-corner
+        // region plane instead of the per-star paraboloid, a second independent estimator of the same screw
+        // moves (see RunCalibrationMath). Displayed unconditionally whenever it was computable, regardless of
+        // whether it agrees with the paraboloid reading — the disagreement warning (ValidateCalibrationQuality)
+        // is a separate, additional signal; this row never replaces MeasuredHardwareDisplay above. NaN when
+        // the run didn't capture a corner reading for every active step (see StepReading.CornerA).
+        public string CornerCrossCheckDisplay =>
+            double.IsNaN(cornerMeasuredHardwareMicrons) ? string.Empty
+            : $"Corner-AF cross-check: {cornerMeasuredHardwareMicrons:0.###} µm/{(IsStepperAdjustment ? "step" : "turn")}";
+
+        // Gates the corner-cross-check row's visibility in DataTemplates.xaml, same pattern as HasPistonPitch.
+        public bool HasCornerCrossCheck => !double.IsNaN(cornerMeasuredHardwareMicrons);
 
         // Config-panel bindings. They wrap the persisted options, presenting thread pitch in mm and
         // showing 0 for the unset (-1) sentinel so the textboxes read cleanly.
@@ -2366,6 +2394,16 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         private TiltPlaneModel CalibrationTiltPlane =>
             calibrationTiltPlaneOverrideForTest ?? inspector.SensorModel?.SensorModelResult?.TiltPlaneModel;
 
+        // Task 5: same override pattern as calibrationTiltPlaneOverrideForTest above, but for the inspector's
+        // 4-corner region plane (inspector.TiltModel.TiltPlaneModel) — captured alongside the paraboloid
+        // reading purely as a second, independent cross-check estimator (see RunCalibrationMath); it never
+        // feeds the production calibration itself. Always null in production.
+        private TiltPlaneModel cornerTiltPlaneOverrideForTest;
+        internal TiltPlaneModel CornerTiltPlaneOverrideForTest {
+            get => cornerTiltPlaneOverrideForTest;
+            set => cornerTiltPlaneOverrideForTest = value;
+        }
+
         // Runs the aberration inspector MeasurementAverageCount times, averages the tilt plane, appends summary
         // rows + the consistency warning, and captures the per-step field-curvature characterization. When saving
         // (live only), each step's run is redirected into its own folder and the saved location is recorded.
@@ -2374,6 +2412,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // dialog once per run), so the saved path runs a single pass regardless of the averaging count.
             int count = fromSaved ? 1 : Math.Max(1, tiltAdapterOptions.MeasurementAverageCount);
             var readings = new List<(double A, double B, double Mean)>(count);
+            // Task 5: parallel corner-region-plane readings, averaged the same way as the paraboloid readings
+            // above. NaN entries (the corner plane could not be fit for that sub-measurement) propagate through
+            // Average() into a NaN step average — deliberately: a partially-available corner reading for this
+            // step is not a valid basis for the cross-check, so the whole step degrades to "unavailable"
+            // rather than averaging over a biased subset of the sub-measurements.
+            var cornerReadings = new List<(double A, double B, double Mean)>(count);
 
             // Redirect this step's run into its own folder when saving — for both live capture and the
             // "Use Saved AF" path (re-analyzing a previously captured run still writes a replayable per-step run).
@@ -2423,11 +2467,16 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     return null;
                 }
                 readings.Add((m.A, m.B, m.MeanFocuserPosition));
+                var corner = cornerTiltPlaneOverrideForTest ?? inspector.TiltModel?.TiltPlaneModel;
+                cornerReadings.Add((corner?.A ?? double.NaN, corner?.B ?? double.NaN, corner?.MeanFocuserPosition ?? double.NaN));
             }
 
             double avgA = readings.Average(r => r.A);
             double avgB = readings.Average(r => r.B);
             double avgMean = readings.Average(r => r.Mean);
+            double avgCornerA = cornerReadings.Average(r => r.A);
+            double avgCornerB = cornerReadings.Average(r => r.B);
+            double avgCornerMean = cornerReadings.Average(r => r.Mean);
 
             var latestModel = CalibrationTiltPlane;
             AppendSummaryRows(readings, stepDescription, latestModel, count, avgA, avgB);
@@ -2439,7 +2488,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 Mean = avgMean,
                 TiltAngleDeg = ComputeTiltAngleDeg(avgA, avgB, latestModel),
                 DirectionDeg = NormalizeAngle(Math.Atan2(avgGx, -avgGy) * 180.0 / Math.PI),
-                SaveFolder = saveOverride != null ? inspector.LastSaveFolder : null
+                SaveFolder = saveOverride != null ? inspector.LastSaveFolder : null,
+                CornerA = avgCornerA,
+                CornerB = avgCornerB,
+                CornerMean = avgCornerMean
             };
             PopulateCurvature(ref reading);
 
@@ -2703,6 +2755,42 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // every step's move itself, so the wizard-screw <-> device-corner correspondence (EatWizardMapping) is
         // known to be correct. False for a disconnected/manual-clicking run, a replay, or the RunCalibrationForTest
         // seed path (its default) — see the [CRITICAL GATE] note on ITiltAdapterOptions.DeviceLinkedCalibrationDeviceName.
+        // Shared by RunCalibrationMath's paraboloid `inputs` and its Task-5 corner-AF cross-check `cornerInputs`:
+        // every geometry/flag field is identical between the two estimators -- only the six gradient readings
+        // (baseline/all-inward/re-baselines/screw moves) differ. Factored so the two TiltCalibrationInputs
+        // objects cannot drift apart (a field added to one and forgotten on the other would silently bias the
+        // cross-check).
+        private static TiltCalibrationInputs BuildCalibrationInputs(
+            int screwCount, bool hasCurvatureMeasurement, int fallbackCurvatureSign,
+            double imageWidthPixels, double imageHeightPixels, double pixelSize, double fStep,
+            double radiusMm, double appliedAmount, bool isStepper,
+            TiltGradient baseline, TiltGradient allInward, TiltGradient reBaseline1,
+            TiltGradient screw1, TiltGradient reBaseline2, TiltGradient screw2) {
+            return new TiltCalibrationInputs {
+                ScrewCount = screwCount,
+                // 4-step runs never measured Baseline/AllInward as curvature probes: leave them default —
+                // the calculator ignores them when HasCurvatureMeasurement is false (reBaseline1 carries the
+                // baseline reading instead).
+                Baseline = hasCurvatureMeasurement ? baseline : default,
+                AllInward = hasCurvatureMeasurement ? allInward : default,
+                ReBaseline1 = reBaseline1,
+                Screw1 = screw1,
+                ReBaseline2 = reBaseline2,
+                Screw2 = screw2,
+                HasCurvatureMeasurement = hasCurvatureMeasurement,
+                FallbackCurvatureSign = fallbackCurvatureSign,
+                ImageWidthPixels = imageWidthPixels,
+                ImageHeightPixels = imageHeightPixels,
+                PixelSizeMicrons = pixelSize,
+                FocuserStepMicrons = fStep,
+                ScrewRadiusMillimeters = radiusMm,
+                CalibrationAppliedAmount = appliedAmount,
+                IsStepperAdjustment = isStepper
+            };
+        }
+
+        private static double Mag(double x, double y) => Math.Sqrt(x * x + y * y);
+
         private void RunCalibrationMath(int screwCount, double radiusMm, double pixelSize, double fStep,
             double appliedAmount, bool isStepper, bool deviceDriven) {
             bool measuredCurvature = stepReadings.ContainsKey(WizardStep.AllInward);
@@ -2762,26 +2850,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // would be non-NaN but physically meaningless.
             double imageWidthPixels = model?.ImageSize.Width ?? 1;
             double imageHeightPixels = model?.ImageSize.Height ?? 1;
-            var inputs = new TiltCalibrationInputs {
-                ScrewCount = screwCount,
-                // 4-step runs never measured Baseline/AllInward as curvature probes: leave them default —
-                // the calculator ignores them when HasCurvatureMeasurement is false (c carries the baseline).
-                Baseline = measuredCurvature ? new TiltGradient(a.A, a.B, a.Mean) : default,
-                AllInward = measuredCurvature ? new TiltGradient(b.A, b.B, b.Mean) : default,
-                ReBaseline1 = new TiltGradient(c.A, c.B, c.Mean),
-                Screw1 = new TiltGradient(d.A, d.B, d.Mean),
-                ReBaseline2 = new TiltGradient(e.A, e.B, e.Mean),
-                Screw2 = new TiltGradient(f.A, f.B, f.Mean),
-                HasCurvatureMeasurement = measuredCurvature,
-                FallbackCurvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign,
-                ImageWidthPixels = imageWidthPixels,
-                ImageHeightPixels = imageHeightPixels,
-                PixelSizeMicrons = pixelSize,
-                FocuserStepMicrons = fStep,
-                ScrewRadiusMillimeters = radiusMm,
-                CalibrationAppliedAmount = appliedAmount,
-                IsStepperAdjustment = isStepper
-            };
+            var inputs = BuildCalibrationInputs(
+                screwCount, measuredCurvature, tiltAdapterOptions.ScrewInwardCurvatureSign,
+                imageWidthPixels, imageHeightPixels, pixelSize, fStep, radiusMm, appliedAmount, isStepper,
+                new TiltGradient(a.A, a.B, a.Mean), new TiltGradient(b.A, b.B, b.Mean),
+                new TiltGradient(c.A, c.B, c.Mean), new TiltGradient(d.A, d.B, d.Mean),
+                new TiltGradient(e.A, e.B, e.Mean), new TiltGradient(f.A, f.B, f.Mean));
             var result = TiltCalibrationCalculator.Calibrate(inputs);
 
             tiltAdapterOptions.Screw1AngleDegrees = result.Screw1AngleDegrees;
@@ -2841,8 +2915,63 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // geometry-dependent fields.
             pistonImpliedMicronsPerStep = result.PistonImpliedMicronsPerStep;
 
+            // ---- Task 5: corner-region AF cross-check ---------------------------------------------------
+            // The inspector's 4-corner region plane (an honest per-corner estimator since Task 1) is a second,
+            // independent measurement of the same screw moves. Only cross-check when EVERY active step
+            // captured a real corner reading -- a partially-available run (an older saved run captured before
+            // this feature, or a step whose corner regions failed to fit) degrades cleanly to "no cross-check"
+            // rather than NaN-contaminated arithmetic or (worse) a spurious warning built from a biased subset.
+            cornerMeasuredHardwareMicrons = double.NaN;
+            estimatorRelativeDifference = double.NaN;
+            bool cornerDataComplete = activeMeasurementSteps.All(step => {
+                var r = Reading(step);
+                return !double.IsNaN(r.CornerA) && !double.IsNaN(r.CornerB) && !double.IsNaN(r.CornerMean);
+            });
+            if (cornerDataComplete) {
+                var cornerInputs = BuildCalibrationInputs(
+                    screwCount, measuredCurvature, tiltAdapterOptions.ScrewInwardCurvatureSign,
+                    imageWidthPixels, imageHeightPixels, pixelSize, fStep, radiusMm, appliedAmount, isStepper,
+                    new TiltGradient(a.CornerA, a.CornerB, a.CornerMean), new TiltGradient(b.CornerA, b.CornerB, b.CornerMean),
+                    new TiltGradient(c.CornerA, c.CornerB, c.CornerMean), new TiltGradient(d.CornerA, d.CornerB, d.CornerMean),
+                    new TiltGradient(e.CornerA, e.CornerB, e.CornerMean), new TiltGradient(f.CornerA, f.CornerB, f.CornerMean));
+                var cornerResult = TiltCalibrationCalculator.Calibrate(cornerInputs);
+
+                // Per-screw move-magnitude comparison between the two estimators, in physical gradient space
+                // (mirrors Calibrate()'s own MoveMagnitudeRatio math via the same Screw1Delta/Screw2Delta/
+                // PhysicalDelta helpers, but compares the paraboloid's delta against the corner estimator's
+                // instead of screw1 against screw2 within one estimator). This is dimensionless (a ratio-like
+                // relative difference), so — like MoveMagnitudeRatio/angles/SNR above — it is safe under the
+                // 1x1 pseudo-sensor fallback (a uniform scale of both estimators' deltas) and is deliberately
+                // NOT gated on model != null; only the µm hardware number below needs a real lever arm.
+                var (p1x, p1y) = TiltCalibrationCalculator.PhysicalDelta(TiltCalibrationCalculator.Screw1Delta(inputs), inputs);
+                var (p2x, p2y) = TiltCalibrationCalculator.PhysicalDelta(TiltCalibrationCalculator.Screw2Delta(inputs), inputs);
+                var (c1x, c1y) = TiltCalibrationCalculator.PhysicalDelta(TiltCalibrationCalculator.Screw1Delta(cornerInputs), cornerInputs);
+                var (c2x, c2y) = TiltCalibrationCalculator.PhysicalDelta(TiltCalibrationCalculator.Screw2Delta(cornerInputs), cornerInputs);
+                double c1Mag = Mag(c1x, c1y);
+                double c2Mag = Mag(c2x, c2y);
+                // Guard the denominator: a ~0 corner magnitude means the corner estimator saw essentially no
+                // screw move at all, so a relative difference against it is meaningless (Infinity for any
+                // nonzero paraboloid move, NaN for a coincidentally-zero one) rather than a genuine
+                // disagreement either estimator can actually support -- leave the cross-check uncomputed (NaN,
+                // no warning) instead of asserting one from a degenerate reference. Same philosophy as
+                // MoveMagnitudeRatio's own zero-magnitude guard (TiltCalibrationCalculator.MoveMagnitudeRatio).
+                if (c1Mag > 0 && c2Mag > 0) {
+                    double rel1 = Math.Abs(Mag(p1x, p1y) - c1Mag) / c1Mag;
+                    double rel2 = Math.Abs(Mag(p2x, p2y) - c2Mag) / c2Mag;
+                    estimatorRelativeDifference = Math.Max(rel1, rel2);
+                }
+
+                // The recovered corner-AF hardware number needs the SAME model != null gate as the
+                // paraboloid's measuredHardwareMicrons above: a model-less run's 1x1 pseudo-sensor carries no
+                // real lever arm, so a µm/turn recovered against it (paraboloid OR corner) would be non-NaN
+                // but physically meaningless.
+                if (model != null && !double.IsNaN(cornerResult.MeasuredHardwareMicrons)) {
+                    cornerMeasuredHardwareMicrons = cornerResult.MeasuredHardwareMicrons;
+                }
+            }
+
             ValidateCalibrationQuality(lastRawAngleDiff, lastMoveMagnitudeRatio, screwCount,
-                measuredHardwareMicrons, pistonImpliedMicronsPerStep);
+                measuredHardwareMicrons, pistonImpliedMicronsPerStep, estimatorRelativeDifference, cornerMeasuredHardwareMicrons);
 
             EvaluateRebaselineDrift();
             lastConfidence = result.Confidence;
@@ -2873,6 +3002,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             RaisePropertyChanged(nameof(PitchUncertaintyDisplay));
             RaisePropertyChanged(nameof(PistonPitchDisplay));
             RaisePropertyChanged(nameof(HasPistonPitch));
+            RaisePropertyChanged(nameof(CornerCrossCheckDisplay));
+            RaisePropertyChanged(nameof(HasCornerCrossCheck));
             OnUIThread(() => ((RelayCommand)UseMeasuredHardwareCommand).NotifyCanExecuteChanged());
         }
 
@@ -2921,12 +3052,29 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 : null;
         }
 
+        // The corner-region AF plane is a second, independent estimator of the same screw moves (see the
+        // design doc's §2 investigation): on a real run the per-star paraboloid model was found to shrink one
+        // screw's gradient by a uniform factor relative to the corner estimator, producing a spurious "unequal
+        // screw turns" warning the corner estimator did not share. A large disagreement between the two
+        // doesn't say which estimator is right, but it does say the paraboloid-derived pitch reading may not
+        // be trustworthy — flag it for the user rather than silently trusting (or blending) either one.
+        private const double EstimatorDisagreementWarnThreshold = 0.15;
+
+        private static string CheckCornerCrossCheck(double estimatorRelDiff, double cornerMeasuredHardwareMicrons) {
+            if (double.IsNaN(estimatorRelDiff) || estimatorRelDiff <= EstimatorDisagreementWarnThreshold) {
+                return null;
+            }
+            return $"the per-star model and the corner-region AF disagree on the screw moves by {estimatorRelDiff:P0} " +
+                $"— the measured hardware may be unreliable (corner-AF estimate: {cornerMeasuredHardwareMicrons:0.###} µm)";
+        }
+
         private void ValidateCalibrationQuality(double rawDiff, double magnitudeRatio, int screwCount,
-            double measuredHardware, double pistonImplied) {
+            double measuredHardware, double pistonImplied, double estimatorRelDiff, double cornerMeasuredHardwareMicrons) {
             var parts = new[] {
                 CheckScrewAngleGap(rawDiff, screwCount),
                 CheckMagnitudeRatio(magnitudeRatio),
                 CheckPistonAgreement(measuredHardware, pistonImplied),
+                CheckCornerCrossCheck(estimatorRelDiff, cornerMeasuredHardwareMicrons),
             }.Where(p => p != null).ToList();
 
             HasWarning = parts.Count > 0;
@@ -3055,14 +3203,19 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         // Test seam: seeds a step reading with the fields the calibration math consumes, so unit tests can
         // exercise NextStep/RunCalibrationMath without running the inspector. StepReading and stepReadings
-        // stay private — this is the only external write path.
+        // stay private — this is the only external write path. The corner fields default to NaN (unavailable),
+        // matching production: a step whose corner plane wasn't captured never contributes a real reading.
         internal void SeedStepReading(WizardStep step, double a, double b, double mean,
-                double curvatureEffectAtScrewRadiusMicrons = 0.0) {
+                double curvatureEffectAtScrewRadiusMicrons = 0.0,
+                double cornerA = double.NaN, double cornerB = double.NaN, double cornerMean = double.NaN) {
             stepReadings[step] = new StepReading {
                 A = a,
                 B = b,
                 Mean = mean,
-                CurvatureEffectAtScrewRadiusMicrons = curvatureEffectAtScrewRadiusMicrons
+                CurvatureEffectAtScrewRadiusMicrons = curvatureEffectAtScrewRadiusMicrons,
+                CornerA = cornerA,
+                CornerB = cornerB,
+                CornerMean = cornerMean
             };
         }
 
@@ -3289,12 +3442,20 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                         return;
                     }
                     var (mGx, mGy) = StateGradient(m.A, m.B, m);
+                    // Task 5: a replay re-analyzes saved frames through the same inspector chain as a live run,
+                    // so the corner-region plane is captured the same way (single reading — replay has no
+                    // measurement-averaging loop to accumulate across). NaN when unavailable, same as the live
+                    // capture path in RunAveragedMeasurement.
+                    var corner = cornerTiltPlaneOverrideForTest ?? inspector.TiltModel?.TiltPlaneModel;
                     var reading = new StepReading {
                         A = m.A,
                         B = m.B,
                         Mean = m.MeanFocuserPosition,
                         TiltAngleDeg = ComputeTiltAngleDeg(m.A, m.B, m),
-                        DirectionDeg = NormalizeAngle(Math.Atan2(mGx, -mGy) * 180.0 / Math.PI)
+                        DirectionDeg = NormalizeAngle(Math.Atan2(mGx, -mGy) * 180.0 / Math.PI),
+                        CornerA = corner?.A ?? double.NaN,
+                        CornerB = corner?.B ?? double.NaN,
+                        CornerMean = corner?.MeanFocuserPosition ?? double.NaN
                     };
                     PopulateCurvature(ref reading);
                     stepReadings[step] = reading;
@@ -3451,7 +3612,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 TiltAngleDeg = reading.TiltAngleDeg,
                 DirectionDeg = reading.DirectionDeg,
                 CurvatureRadiusMillimeters = reading.CurvatureRadiusMm,
-                CurvatureEffectMicronsAtScrewRadius = reading.CurvatureEffectAtScrewRadiusMicrons
+                CurvatureEffectMicronsAtScrewRadius = reading.CurvatureEffectAtScrewRadiusMicrons,
+                CornerTiltPlaneA = reading.CornerA,
+                CornerTiltPlaneB = reading.CornerB,
+                CornerMeanFocuserPosition = reading.CornerMean
             });
             WriteMetadata();
         }
@@ -3472,6 +3636,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 PitchUncertaintyMicrons = pitchUncertaintyMicrons,
                 ConfidenceIsReliable = lastConfidence?.IsReliable ?? false,
                 PistonImpliedMicronsPerStep = pistonImpliedMicronsPerStep,
+                CornerMeasuredHardwareMicrons = cornerMeasuredHardwareMicrons,
+                EstimatorRelativeDifference = estimatorRelativeDifference,
             };
             WriteMetadata();
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -68,6 +68,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         ReBaseline2 = 4,  // e: undo the screw-1 move (≈ c)
         Screw2 = 5,       // f: screw 2 inward once (4-screw: + screw 4 outward)
         Complete = 6,
+        // ReBaseline3's ordinal (7) deliberately does NOT match its position in the flow: it runs BEFORE
+        // Complete (immediately after Screw2, when measured), not after it. Complete's ordinal must never be
+        // renumbered -- StepFolderName ((int)step + 1) persists it into saved-run folder names on disk
+        // ("06_Complete" would become e.g. "07_Complete") -- so this optional step was appended numerically
+        // last instead. StepFolderName special-cases ReBaseline3 -> "07_ReBaseline3" to sort correctly
+        // alongside it. The actual step ORDER everywhere else (NextStep, GetMeasurementSteps,
+        // activeMeasurementSteps) comes from an explicit array, never from this numeric value -- do not "fix"
+        // this ordinal to look sequential.
         ReBaseline3 = 7,  // g (optional): undo the screw-2 move, measured — screw 2's drift-symmetric reference
     }
 
@@ -617,8 +625,18 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // Steps that end with running the aberration inspector (measurement auto-advances)
         public bool IsOnMeasurementStep => activeMeasurementSteps.Contains(currentStep);
 
-        // "Step N of M" over the active measurement-step set (4- or 6-step, captured at run start). Empty on
-        // the terminal Complete panel, which shows its own "Calibration Complete!" header instead.
+        // Task 6: whether THIS run's active sequence includes the optional measured final re-baseline --
+        // captured into activeMeasurementSteps at run start (StartAsync/ReplayAsync), not read live off the
+        // option, so it stays correct for the whole run even if the option is toggled mid-run. Single named
+        // source for the two call sites that need to know whether Complete's own restore move should be
+        // suppressed (ReBaseline3 already sent and measured it): the device-instructions text (what the user
+        // is told will happen) and ExecuteDeviceMoveForCurrentStepAsync (what actually gets sent) -- both must
+        // agree, so both read this one property rather than re-deriving the Contains check separately.
+        private bool ActiveRunHasFinalRebaseline => activeMeasurementSteps.Contains(WizardStep.ReBaseline3);
+
+        // "Step N of M" over the active measurement-step set (4, 5, 6, or 7 steps depending on
+        // MeasureCurvatureDuringCalibration/MeasureFinalRebaseline, captured at run start). Empty on the
+        // terminal Complete panel, which shows its own "Calibration Complete!" header instead.
         public string StepProgressDisplay {
             get {
                 if (currentStep == WizardStep.Complete) {
@@ -928,7 +946,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 ? ReplayStepInstructionsText(currentStep)
                 : (IsTiltDeviceConnected && IsMotorizedDevice)
                     ? DeviceStepInstructionsText(currentStep, (int)Math.Round(CalibrationAppliedAmount), IsAutoRunningAll,
-                        activeMeasurementSteps.Contains(WizardStep.ReBaseline3))
+                        ActiveRunHasFinalRebaseline)
                     : StepInstructionsText(currentStep, tiltAdapterOptions.ScrewCount, IsStepperAdjustment, CalibrationAppliedAmount);
 
         // Replay wording: a replay re-analyzes already-captured frames, so every imperative in the live copy
@@ -1839,13 +1857,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
 
             int appliedSteps = (int)Math.Round(CalibrationAppliedAmount);
-            // measuredFinalRebaseline reflects THIS run's active sequence (captured at StartAsync), not just
-            // the live option: it must stay true for the whole run even if the option is toggled mid-run.
-            // When true, Complete becomes a no-move — ReBaseline3 (an ordinary step earlier in this same
-            // sequence) already sent and measured the restore, so sending it again here would be a second,
-            // spurious, physically real move.
-            bool measuredFinalRebaseline = activeMeasurementSteps.Contains(WizardStep.ReBaseline3);
-            var move = EatWizardMapping.MoveForStep(step, appliedSteps, measuredFinalRebaseline);
+            // When ActiveRunHasFinalRebaseline, Complete becomes a no-move — ReBaseline3 (an ordinary step
+            // earlier in this same sequence) already sent and measured the restore, so sending it again here
+            // would be a second, spurious, physically real move.
+            var move = EatWizardMapping.MoveForStep(step, appliedSteps, ActiveRunHasFinalRebaseline);
             if (move == null) {
                 return true; // Baseline, or Complete after a measured ReBaseline3 already restored the device.
             }
@@ -2869,11 +2884,17 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         private void RunCalibrationMath(int screwCount, double radiusMm, double pixelSize, double fStep,
             double appliedAmount, bool isStepper, bool deviceDriven) {
             bool measuredCurvature = stepReadings.ContainsKey(WizardStep.AllInward);
-            // Task 6: the optional measured final re-baseline. Presence in stepReadings (not activeMeasurementSteps)
-            // is the same "was it actually measured" test measuredCurvature above uses for AllInward -- correct for
-            // a replay too, since a saved run predating this feature (or captured with the option off) simply
-            // never has a ReBaseline3 entry, so this comes back false and Screw2Delta keeps its old ReBaseline2-only
-            // semantics (backward compatible).
+            // Task 6: the optional measured final re-baseline. Presence in stepReadings (NOT
+            // activeMeasurementSteps -- deliberately, for two independent reasons) is the same "was it
+            // actually measured" test measuredCurvature above uses for AllInward:
+            //  1. Replay: a saved run predating this feature (or captured with the option off) simply never
+            //     has a ReBaseline3 entry, so this comes back false and Screw2Delta keeps its old
+            //     ReBaseline2-only semantics (backward compatible) -- exactly like AllInward's replay case.
+            //  2. RunCalibrationForTest (the SeedStepReading test seam): it calls RunCalibrationMath directly
+            //     and never calls StartAsync/ReplayAsync, so activeMeasurementSteps is still sitting at its
+            //     ctor-time field-initializer default (the 4-step flow, no ReBaseline3) regardless of what
+            //     was actually seeded into stepReadings. Gating on activeMeasurementSteps here would make
+            //     every RunCalibrationForTest-based test seeding a ReBaseline3 reading silently ignore it.
             bool hasFinalRebaseline = stepReadings.ContainsKey(WizardStep.ReBaseline3);
             var a = Reading(WizardStep.Baseline);
             var b = Reading(WizardStep.AllInward);
@@ -3177,6 +3198,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         // Re-baseline drift: each re-baseline (c, e) should return close to the prior state. A large residual
         // relative to the subsequent screw move means backlash / an uneven undo contaminated the calibration.
+        // Deliberately does NOT evaluate ReBaseline3 (Task 6, optional): RebaselineDriftRatio needs a
+        // SUBSEQUENT screw move to form its ratio against (drift1 vs Screw1's move, drift2 vs Screw2's move),
+        // and ReBaseline3 has none -- it is immediately followed by Complete, which is itself a no-move once
+        // ReBaseline3 has run. Its magnitude is not lost, just measured differently: it feeds
+        // TiltCalibrationConfidence.Rebaseline3Drift, an absolute noise-probe term in ComputeConfidence's SNR
+        // RMS, rather than a relative-to-the-next-move ratio here. Do not "fix" this by inventing a ratio for
+        // it against some other reference -- there isn't a subsequent move to be honest about.
         private void EvaluateRebaselineDrift() {
             bool measuredCurvature = stepReadings.ContainsKey(WizardStep.AllInward);
             var a = Reading(WizardStep.Baseline);
@@ -3206,9 +3234,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     ". The undo between moves left residual tilt (backlash or an uneven turn); consider recalibrating.";
         }
 
-        // Overall calibration signal-to-noise from the six per-step tilt vectors. A low SNR means the recovered
-        // screw geometry is dominated by measurement noise / between-step drift (typically too few stars or a
-        // too-coarse focus step), regardless of how cleanly the screws were turned — warn the user not to apply it.
+        // Overall calibration signal-to-noise from the per-step tilt vectors (six, or seven with the optional
+        // measured final re-baseline). A low SNR means the recovered screw geometry is dominated by
+        // measurement noise / between-step drift (typically too few stars or a too-coarse focus step),
+        // regardless of how cleanly the screws were turned — warn the user not to apply it.
         private void EvaluateCalibrationConfidence(TiltCalibrationConfidence confidence) {
             var disagreement = curvatureChannelDisagreement;
             if (confidence == null || confidence.IsReliable) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -1202,12 +1202,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // Clear stale wizard-run display state (measured-hardware panel, per-run warnings, summary
             // rows — the same state Restart clears) that would otherwise describe the previous run next
             // to a manually entered calibration.
-            measuredHardwareMicrons = double.NaN;
-            lastConfidence = null;
-            pitchUncertaintyMicrons = double.NaN;
-            pistonImpliedMicronsPerStep = double.NaN;
-            lastRawAngleDiff = double.NaN;
-            lastMoveMagnitudeRatio = double.NaN;
+            ResetDerivedCalibrationReadouts();
             HasWarning = false;
             WarningText = string.Empty;
             HasMeasurementConsistencyWarning = false;
@@ -1241,12 +1236,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             tiltAdapterOptions.LastMeasuredThreadPitchMicrons = -1;
             tiltAdapterOptions.LastMeasuredStepperStepSizeMicrons = -1;
 
-            measuredHardwareMicrons = double.NaN;
-            lastConfidence = null;
-            pitchUncertaintyMicrons = double.NaN;
-            pistonImpliedMicronsPerStep = double.NaN;
-            lastRawAngleDiff = double.NaN;
-            lastMoveMagnitudeRatio = double.NaN;
+            ResetDerivedCalibrationReadouts();
             HasWarning = false;
             WarningText = string.Empty;
             HasMeasurementConsistencyWarning = false;
@@ -1259,6 +1249,22 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             ClearSummaryRows();
             RaiseHardwareSummaryChanged();
             RebuildDiagram();
+        }
+
+        // Shared by ApplyManualCalibration, ClearCalibration, and Restart: every path that invalidates the
+        // previous run's results without immediately running a new one. Resets exactly the derived-readout
+        // state RunCalibrationMath populates from a Calibrate() result -- NOT the warning-text/flag
+        // properties around it, which differ slightly per caller (e.g. Restart also clears
+        // HasDeviceLinkDroppedWarning, which the other two callers don't touch). Extracted so a field this
+        // task (or a future one, e.g. Task 5's corner-AF readouts) adds to the set can't be missed at one of
+        // the three call sites and leave a stale readout on screen after Clear/Restart/a manual entry.
+        private void ResetDerivedCalibrationReadouts() {
+            measuredHardwareMicrons = double.NaN;
+            lastConfidence = null;
+            pitchUncertaintyMicrons = double.NaN;
+            pistonImpliedMicronsPerStep = double.NaN;
+            lastRawAngleDiff = double.NaN;
+            lastMoveMagnitudeRatio = double.NaN;
         }
 
         public string WizardSweepSummary {
@@ -1321,10 +1327,17 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         // Piston-implied pitch (frame-factor probe): a free, tilt-fit-independent hardware estimate from the
         // AllInward piston alone (see TiltCalibrationCalculator.PistonImpliedMicronsPerStep). NaN for 4-step
-        // runs (no piston measured) — empty string collapses the row, same pattern as PitchUncertaintyDisplay.
+        // runs (no piston measured). The XAML row's visibility is gated on HasPistonPitch below (a
+        // standalone, self-labeling row -- not a shared label/value UniformGrid cell like the "Measured"/
+        // "Saved" rows above it), not on this string being empty.
         public string PistonPitchDisplay =>
             double.IsNaN(pistonImpliedMicronsPerStep) ? string.Empty
-            : $"Piston-implied: {pistonImpliedMicronsPerStep:0.###} µm/{(IsStepperAdjustment ? "step" : "turn")}";
+            : IsStepperAdjustment ? $"Piston-implied: {pistonImpliedMicronsPerStep:0.###} µm/step"
+            : $"Piston-implied: {pistonImpliedMicronsPerStep:0.#} µm/turn";
+
+        // Gates the piston-pitch row's visibility in DataTemplates.xaml (this file uses DataTrigger-driven
+        // Visibility throughout, never converters) — true once a 6-step run has measured a piston.
+        public bool HasPistonPitch => !double.IsNaN(pistonImpliedMicronsPerStep);
 
         // Config-panel bindings. They wrap the persisted options, presenting thread pitch in mm and
         // showing 0 for the unset (-1) sentinel so the textboxes read cleanly.
@@ -2601,12 +2614,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             appliedDeviceMovesThisRun.Clear();
             SaveAFRuns = false; // saving must be re-enabled explicitly for each run
             stepReadings.Clear();
-            measuredHardwareMicrons = double.NaN;
-            lastConfidence = null;
-            pitchUncertaintyMicrons = double.NaN;
-            pistonImpliedMicronsPerStep = double.NaN;
-            lastRawAngleDiff = double.NaN;
-            lastMoveMagnitudeRatio = double.NaN;
+            ResetDerivedCalibrationReadouts();
             runRootFolder = null;
             metadataPath = null;
             currentMetadata = null;
@@ -2824,8 +2832,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // sensor geometry at all -- TiltCalibrationCalculator.PistonImpliedMicronsPerStep consumes only
             // mean focuser positions, the focuser step size, and the applied amount, never the per-screw
             // lever arm the model != null gate above exists to protect. So it is deliberately NOT gated on
-            // model != null: it is exactly as valid on a model-less (seeded/test-only) run as a real one, and
-            // gating it would just hide a perfectly good, geometry-independent cross-check on those runs.
+            // model != null. This does NOT unlock a model-less UI/warning benefit -- the only display surface
+            // (the StackPanel this feeds, gated on HasMeasuredHardware) and the disagreement warning below
+            // (gated on measuredHardware > 0) both already require a real model indirectly, since
+            // measuredHardwareMicrons stays NaN without one. The actual benefit is narrower: the value still
+            // lands in FinalizeMetadata's persisted TiltCalibrationResultRecord (Task 7's offline consumer)
+            // on a model-less replay/test run, instead of silently dropping to NaN alongside the
+            // geometry-dependent fields.
             pistonImpliedMicronsPerStep = result.PistonImpliedMicronsPerStep;
 
             ValidateCalibrationQuality(lastRawAngleDiff, lastMoveMagnitudeRatio, screwCount,
@@ -2859,46 +2872,65 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             RaisePropertyChanged(nameof(ConfidenceSummaryDisplay));
             RaisePropertyChanged(nameof(PitchUncertaintyDisplay));
             RaisePropertyChanged(nameof(PistonPitchDisplay));
+            RaisePropertyChanged(nameof(HasPistonPitch));
             OnUIThread(() => ((RelayCommand)UseMeasuredHardwareCommand).NotifyCanExecuteChanged());
         }
 
-        // Two single-screw turns of the same amount should produce gradient changes that are ~equal in magnitude
-        // and the correct angular distance apart. A bad angle gap OR very unequal magnitudes (uneven turning /
-        // backlash) means the recovered geometry/hardware is unreliable — warn so the user recalibrates.
+        // Each check below is independent and returns null when it has nothing to say, so ValidateCalibrationQuality
+        // stays a simple "collect the non-null messages" join no matter how many checks it ends up with (Task 5
+        // adds a 4th, the corner-AF estimator disagreement, without growing this method's own logic). Behavior,
+        // wording, and thresholds are unchanged from the flat-boolean version this replaced.
+
+        // Two single-screw turns of the same amount should land at the adapter's exact expected angular spacing;
+        // a bad angle gap means the recovered screw geometry is unreliable.
+        private static string CheckScrewAngleGap(double rawDiff, int screwCount) {
+            double expected = screwCount == 3 ? 120.0 : 90.0;
+            // Fold the diff so it is in [0, 180] — both CW and CCW gaps compare to the same expected value.
+            double foldedDiff = rawDiff <= 180.0 ? rawDiff : 360.0 - rawDiff;
+            double deviation = Math.Abs(foldedDiff - expected);
+            return deviation > 30.0
+                ? $"Screw 1→2 measured angle gap is {foldedDiff:F1}° (expected ~{expected}°)"
+                : null;
+        }
+
+        // Two single-screw turns of the same amount should also produce ~equal gradient-change magnitudes; very
+        // unequal magnitudes (uneven turning / backlash) mean the recovered hardware is unreliable.
         private const double MagnitudeRatioWarnThreshold = 1.5; // larger move > 1.5x smaller => suspect
+
+        private static string CheckMagnitudeRatio(double magnitudeRatio) =>
+            !double.IsNaN(magnitudeRatio) && magnitudeRatio > MagnitudeRatioWarnThreshold
+                ? $"the two screw turns produced very unequal tilt changes ({magnitudeRatio:F1}× apart) — turn each screw the same amount"
+                : null;
 
         // The piston-implied pitch and the tilt-derived measured hardware are both focuser-frame quantities
         // (see TiltCalibrationCalculator.PistonImpliedMicronsPerStep), so honest agreement is expected; a gap
         // this large means the tilt estimator (or the mechanics on pull-side moves) is off.
         private const double PistonDisagreementWarnThreshold = 0.20;
 
+        private static string CheckPistonAgreement(double measuredHardware, double pistonImplied) {
+            if (measuredHardware <= 0 || pistonImplied <= 0) {
+                return null;
+            }
+            // Denominator is the tilt-derived measuredHardware, not a symmetric mean of the two: the question
+            // this check answers is "does the tilt estimate look unreliable" (framed against the piston's free,
+            // tilt-fit-independent value as the reference), not "how far apart are these two numbers" in the
+            // abstract.
+            double relativeDiff = Math.Abs(pistonImplied - measuredHardware) / measuredHardware;
+            return relativeDiff > PistonDisagreementWarnThreshold
+                ? $"piston-implied hardware ({pistonImplied:0.##} µm) and tilt-derived ({measuredHardware:0.##} µm) disagree by more than 20% — the tilt estimate may be unreliable"
+                : null;
+        }
+
         private void ValidateCalibrationQuality(double rawDiff, double magnitudeRatio, int screwCount,
             double measuredHardware, double pistonImplied) {
-            double expected = screwCount == 3 ? 120.0 : 90.0;
-            // Fold the diff so it is in [0, 180] — both CW and CCW gaps compare to the same expected value.
-            double foldedDiff = rawDiff <= 180.0 ? rawDiff : 360.0 - rawDiff;
-            double deviation = Math.Abs(foldedDiff - expected);
-            bool angleBad = deviation > 30.0;
-            bool magnitudeBad = !double.IsNaN(magnitudeRatio) && magnitudeRatio > MagnitudeRatioWarnThreshold;
-            bool pistonBad = measuredHardware > 0 && pistonImplied > 0
-                && Math.Abs(pistonImplied - measuredHardware) / measuredHardware > PistonDisagreementWarnThreshold;
+            var parts = new[] {
+                CheckScrewAngleGap(rawDiff, screwCount),
+                CheckMagnitudeRatio(magnitudeRatio),
+                CheckPistonAgreement(measuredHardware, pistonImplied),
+            }.Where(p => p != null).ToList();
 
-            HasWarning = angleBad || magnitudeBad || pistonBad;
-            if (!HasWarning) {
-                WarningText = string.Empty;
-                return;
-            }
-            var parts = new List<string>(3);
-            if (angleBad) {
-                parts.Add($"Screw 1→2 measured angle gap is {foldedDiff:F1}° (expected ~{expected}°)");
-            }
-            if (magnitudeBad) {
-                parts.Add($"the two screw turns produced very unequal tilt changes ({magnitudeRatio:F1}× apart) — turn each screw the same amount");
-            }
-            if (pistonBad) {
-                parts.Add($"piston-implied hardware ({pistonImplied:0.##} µm) and tilt-derived ({measuredHardware:0.##} µm) disagree by more than 20% — the tilt estimate may be unreliable");
-            }
-            WarningText = string.Join("; ", parts) + ". Consider recalibrating.";
+            HasWarning = parts.Count > 0;
+            WarningText = HasWarning ? string.Join("; ", parts) + ". Consider recalibrating." : string.Empty;
         }
 
         // Re-baseline drift: each re-baseline (c, e) should return close to the prior state. A large residual

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -2731,15 +2731,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             var model = CalibrationTiltPlane;
             // A model-less run (e.g. a seeded/test-only run with no live/replayed tilt plane) has no known
             // sensor size; fall back to a square 1x1 pseudo-sensor so the angle/ratio/confidence conversion
-            // stays isotropic instead of aspect-distorted. Every real (live or replayed) run has a model by the
-            // time this method is reached, so production calibrations always get their true geometry here — the
-            // fallback exists for test/degenerate inputs, not as a supported production mode. NOTE: hardware
-            // recovery (µm/turn) uses this SAME inputs object, so a hypothetical caller with a null model but
-            // otherwise-real pixelSize/fStep/radiusMm/appliedAmount would get a non-NaN but physically-meaningless
-            // µm/turn from the 1x1 fake sensor rather than the pre-refactor NaN; no current caller hits this
-            // combination (every RunCalibrationForTest scenario that omits a tiltPlaneOverride also leaves
-            // pixelSize/fStep at 0 from the unconfigured test profile, so RecoverHardwareDetailed's own
-            // radius/applied/pixelSize/fStep guard already returns NaN before geometry size matters).
+            // stays isotropic instead of aspect-distorted -- a uniform scale of the raw (A,B) delta reproduces
+            // the exact pre-refactor direction/ratio/SNR-ratio behavior for those outputs. Every real (live or
+            // replayed) run has a model by the time this method is reached, so production calibrations always
+            // get their true geometry here; the fallback exists for test/degenerate inputs, not as a supported
+            // production mode. This fallback is NOT safe for hardware recovery (see the model != null gate
+            // below): a fake 1-pixel-wide sensor carries no real lever arm, so µm/turn recovered against it
+            // would be non-NaN but physically meaningless.
             double imageWidthPixels = model?.ImageSize.Width ?? 1;
             double imageHeightPixels = model?.ImageSize.Height ?? 1;
             var inputs = new TiltCalibrationInputs {
@@ -2786,16 +2784,26 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             ValidateCalibrationQuality(lastRawAngleDiff, lastMoveMagnitudeRatio, screwCount);
 
             // Recover the adapter hardware (µm/turn or µm/step) — Calibrate computes this via the same
-            // RecoverHardwareDetailed math this method used to call directly; only assign the persisted
-            // "last measured" option when it's a real (non-NaN) recovery.
+            // RecoverHardwareDetailed math this method used to call directly, off the SAME inputs/result as
+            // the angles/confidence above. Consumption is re-gated on model != null (as it was pre-refactor):
+            // the 1x1 image-size fallback used to build `inputs` is isotropic and therefore safe for
+            // angles/ratio/confidence (direction- and ratio-preserving, so it reproduces the pre-refactor
+            // behavior exactly), but it carries no real lever arm for hardware -- an ungated 1x1 fake sensor
+            // with genuinely-real pixelSize/fStep would pass RecoverHardwareDetailed's >0 guard and yield a
+            // non-NaN, physically-meaningless µm/turn that could get persisted into LastMeasured*Microns. Kept
+            // local (not the distant CalibrationTiltPlane == null bail-outs in RunAveragedMeasurement/
+            // ReplayAsync) because Task 5 adds a second TiltCalibrationInputs to this same method.
             measuredHardwareMicrons = double.NaN;
-            pitchUncertaintyMicrons = result.PitchUncertaintyMicrons;
-            if (!double.IsNaN(result.MeasuredHardwareMicrons)) {
-                measuredHardwareMicrons = result.MeasuredHardwareMicrons;
-                if (isStepper) {
-                    tiltAdapterOptions.LastMeasuredStepperStepSizeMicrons = result.MeasuredHardwareMicrons;
-                } else {
-                    tiltAdapterOptions.LastMeasuredThreadPitchMicrons = result.MeasuredHardwareMicrons;
+            pitchUncertaintyMicrons = double.NaN;
+            if (model != null) {
+                pitchUncertaintyMicrons = result.PitchUncertaintyMicrons;
+                if (!double.IsNaN(result.MeasuredHardwareMicrons)) {
+                    measuredHardwareMicrons = result.MeasuredHardwareMicrons;
+                    if (isStepper) {
+                        tiltAdapterOptions.LastMeasuredStepperStepSizeMicrons = result.MeasuredHardwareMicrons;
+                    } else {
+                        tiltAdapterOptions.LastMeasuredThreadPitchMicrons = result.MeasuredHardwareMicrons;
+                    }
                 }
             }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -1391,9 +1391,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             lastConfidence == null ? string.Empty :
             $"Signal-to-noise {lastConfidence.SignalToNoise:F1} · screw-direction ±{lastConfidence.PredictedAngleUncertaintyDeg:F0}°";
 
+        // Precision follows MeasuredHardwareDisplay's convention rather than a fixed "F0". On a stepper the
+        // whole quantity lives near 1 µm/step, so "F0" rounded the screw-to-screw spread to a flat "± 0" --
+        // and that spread is the single most diagnostic number the calibration produces: it is what separates
+        // "both screws agree" from "one screw's move was measured badly and the mean is hiding it".
         public string PitchUncertaintyDisplay =>
             double.IsNaN(pitchUncertaintyMicrons) ? string.Empty :
-            $"± {pitchUncertaintyMicrons:F0} µm/{(IsStepperAdjustment ? "step" : "turn")}";
+            IsStepperAdjustment ? $"± {pitchUncertaintyMicrons:0.###} µm/step"
+            : $"± {pitchUncertaintyMicrons:0.#} µm/turn";
 
         // Piston-implied pitch (frame-factor probe): a free, tilt-fit-independent hardware estimate from the
         // AllInward piston alone (see TiltCalibrationCalculator.PistonImpliedMicronsPerStep). NaN for 4-step

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -264,8 +264,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // since Task 1), captured alongside the paraboloid reading above for the corner-region AF
             // cross-check (see RunCalibrationMath). NaN when the corner plane could not be fit for this step
             // (or any of the averaged sub-measurements that make it up) -- a struct default of 0.0 would look
-            // like a valid zero-tilt corner reading and silently corrupt the cross-check, so every writer of
-            // this struct must set these explicitly rather than relying on the field default.
+            // like a valid zero-tilt corner reading and silently corrupt the cross-check, so every WRITER of
+            // this struct (SeedStepReading, RunAveragedMeasurement, ReplayAsync) sets these explicitly rather
+            // than relying on the field default. That covers every step actually present in stepReadings, but
+            // NOT a step missing from it entirely: Reading(step) falls back to default(StepReading) for an
+            // absent key, which zero-inits CornerA/B/Mean to 0.0 too (C# struct defaults, not this comment's
+            // "writer" guarantee). RunCalibrationMath's completeness check therefore also requires
+            // stepReadings.ContainsKey(step) (via TryGetValue), not just the non-NaN test alone, so an
+            // entirely-unmeasured step can never be mistaken for a valid zero-tilt corner reading.
             public double CornerA;
             public double CornerB;
             public double CornerMean;
@@ -2789,7 +2795,21 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             };
         }
 
-        private static double Mag(double x, double y) => Math.Sqrt(x * x + y * y);
+        // Fix 5 (post-review): the EstimatorRelativeDifference guard goes silent whenever either alternate
+        // (corner) screw magnitude is ~0 -- correctly, when the primary (paraboloid) estimator ALSO saw ~no
+        // move for that screw (nothing to compare). But when the corner estimator saw ~no move for a screw the
+        // paraboloid says was clearly turned, that is itself a real, diagnostic disagreement the guard would
+        // otherwise hide entirely. The plan specifies exactly one user-facing warning string
+        // (CheckCornerCrossCheck's, documented in Task 8) -- this does NOT grow a second one; it logs to the
+        // NINA log only, where it is discoverable without inventing new UI text.
+        private static void LogDegenerateCornerScrewIfNeeded(int screwNumber, double paraboloidMagnitude, double cornerMagnitude) {
+            if (cornerMagnitude <= 0 && paraboloidMagnitude > 0) {
+                Logger.Warning(
+                    $"Tilt calibration: the corner-region AF plane saw essentially no move for screw {screwNumber} " +
+                    $"(magnitude {cornerMagnitude:0.###e+0}) while the per-star model measured {paraboloidMagnitude:0.###e+0} " +
+                    "-- the corner-AF cross-check cannot form a ratio for this screw and is being skipped.");
+            }
+        }
 
         private void RunCalibrationMath(int screwCount, double radiusMm, double pixelSize, double fStep,
             double appliedAmount, bool isStepper, bool deviceDriven) {
@@ -2850,9 +2870,18 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // would be non-NaN but physically meaningless.
             double imageWidthPixels = model?.ImageSize.Width ?? 1;
             double imageHeightPixels = model?.ImageSize.Height ?? 1;
-            var inputs = BuildCalibrationInputs(
-                screwCount, measuredCurvature, tiltAdapterOptions.ScrewInwardCurvatureSign,
-                imageWidthPixels, imageHeightPixels, pixelSize, fStep, radiusMm, appliedAmount, isStepper,
+            // Local function closing over this run's shared geometry/flag locals (Fix 6, post-review): both
+            // the paraboloid `inputs` below and the Task-5 corner-cross-check `cornerInputs` further down call
+            // THIS one function, so only the six gradient readings can ever differ between the two
+            // TiltCalibrationInputs objects — nothing short of editing this one signature could let the
+            // ~10 shared leading arguments drift apart between the call sites.
+            TiltCalibrationInputs MakeInputs(TiltGradient baseline, TiltGradient allInward, TiltGradient reBaseline1,
+                TiltGradient screw1, TiltGradient reBaseline2, TiltGradient screw2) =>
+                BuildCalibrationInputs(
+                    screwCount, measuredCurvature, tiltAdapterOptions.ScrewInwardCurvatureSign,
+                    imageWidthPixels, imageHeightPixels, pixelSize, fStep, radiusMm, appliedAmount, isStepper,
+                    baseline, allInward, reBaseline1, screw1, reBaseline2, screw2);
+            var inputs = MakeInputs(
                 new TiltGradient(a.A, a.B, a.Mean), new TiltGradient(b.A, b.B, b.Mean),
                 new TiltGradient(c.A, c.B, c.Mean), new TiltGradient(d.A, d.B, d.Mean),
                 new TiltGradient(e.A, e.B, e.Mean), new TiltGradient(f.A, f.B, f.Mean));
@@ -2917,49 +2946,46 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
             // ---- Task 5: corner-region AF cross-check ---------------------------------------------------
             // The inspector's 4-corner region plane (an honest per-corner estimator since Task 1) is a second,
-            // independent measurement of the same screw moves. Only cross-check when EVERY active step
-            // captured a real corner reading -- a partially-available run (an older saved run captured before
-            // this feature, or a step whose corner regions failed to fit) degrades cleanly to "no cross-check"
+            // independent measurement of the same screw moves. Only cross-check when EVERY active step is
+            // BOTH present in stepReadings AND carries a non-NaN corner reading -- Reading(step) falls back to
+            // default(StepReading) for a step missing from stepReadings entirely, which zero-inits CornerA/B/
+            // Mean to 0.0 (a struct default), NOT NaN, so the non-NaN test alone would be fooled into treating
+            // an unmeasured step as a valid zero-tilt corner reading. A partially-available run (an older saved
+            // run captured before this feature, a step whose corner regions failed to fit, or -- the reason for
+            // the explicit key check -- a step never measured at all) degrades cleanly to "no cross-check"
             // rather than NaN-contaminated arithmetic or (worse) a spurious warning built from a biased subset.
             cornerMeasuredHardwareMicrons = double.NaN;
             estimatorRelativeDifference = double.NaN;
-            bool cornerDataComplete = activeMeasurementSteps.All(step => {
-                var r = Reading(step);
-                return !double.IsNaN(r.CornerA) && !double.IsNaN(r.CornerB) && !double.IsNaN(r.CornerMean);
-            });
+            bool cornerDataComplete = activeMeasurementSteps.All(step =>
+                stepReadings.TryGetValue(step, out var r) &&
+                !double.IsNaN(r.CornerA) && !double.IsNaN(r.CornerB) && !double.IsNaN(r.CornerMean));
             if (cornerDataComplete) {
-                var cornerInputs = BuildCalibrationInputs(
-                    screwCount, measuredCurvature, tiltAdapterOptions.ScrewInwardCurvatureSign,
-                    imageWidthPixels, imageHeightPixels, pixelSize, fStep, radiusMm, appliedAmount, isStepper,
+                // Reuses the SAME MakeInputs local function the paraboloid `inputs` above was built with (Fix
+                // 6, post-review) — only the six gradient readings differ here.
+                var cornerInputs = MakeInputs(
                     new TiltGradient(a.CornerA, a.CornerB, a.CornerMean), new TiltGradient(b.CornerA, b.CornerB, b.CornerMean),
                     new TiltGradient(c.CornerA, c.CornerB, c.CornerMean), new TiltGradient(d.CornerA, d.CornerB, d.CornerMean),
                     new TiltGradient(e.CornerA, e.CornerB, e.CornerMean), new TiltGradient(f.CornerA, f.CornerB, f.CornerMean));
                 var cornerResult = TiltCalibrationCalculator.Calibrate(cornerInputs);
 
-                // Per-screw move-magnitude comparison between the two estimators, in physical gradient space
-                // (mirrors Calibrate()'s own MoveMagnitudeRatio math via the same Screw1Delta/Screw2Delta/
-                // PhysicalDelta helpers, but compares the paraboloid's delta against the corner estimator's
-                // instead of screw1 against screw2 within one estimator). This is dimensionless (a ratio-like
+                // Fix 5 (post-review) diagnostic: TiltCalibrationCalculator.EstimatorRelativeDifference's own
+                // zero-magnitude guard (below) goes silent whenever either corner screw magnitude is ~0 --
+                // correctly, when the paraboloid ALSO saw ~no move for that screw. But when the corner
+                // estimator saw ~no move for a screw the paraboloid says was clearly turned, that is itself
+                // the most diagnostic disagreement possible; log it (not a new user-facing warning -- see
+                // LogDegenerateCornerScrewIfNeeded) rather than letting the guard hide it entirely.
+                LogDegenerateCornerScrewIfNeeded(1,
+                    TiltCalibrationCalculator.ScrewMoveMagnitude(1, inputs), TiltCalibrationCalculator.ScrewMoveMagnitude(1, cornerInputs));
+                LogDegenerateCornerScrewIfNeeded(2,
+                    TiltCalibrationCalculator.ScrewMoveMagnitude(2, inputs), TiltCalibrationCalculator.ScrewMoveMagnitude(2, cornerInputs));
+
+                // The per-screw move-magnitude comparison itself is centralized in TiltCalibrationCalculator
+                // (Fix 1, post-review) so the wizard and TestApp's headless validator (Task 7) never
+                // hand-duplicate — and cannot drift on — this formula. It is dimensionless (a ratio-like
                 // relative difference), so — like MoveMagnitudeRatio/angles/SNR above — it is safe under the
                 // 1x1 pseudo-sensor fallback (a uniform scale of both estimators' deltas) and is deliberately
                 // NOT gated on model != null; only the µm hardware number below needs a real lever arm.
-                var (p1x, p1y) = TiltCalibrationCalculator.PhysicalDelta(TiltCalibrationCalculator.Screw1Delta(inputs), inputs);
-                var (p2x, p2y) = TiltCalibrationCalculator.PhysicalDelta(TiltCalibrationCalculator.Screw2Delta(inputs), inputs);
-                var (c1x, c1y) = TiltCalibrationCalculator.PhysicalDelta(TiltCalibrationCalculator.Screw1Delta(cornerInputs), cornerInputs);
-                var (c2x, c2y) = TiltCalibrationCalculator.PhysicalDelta(TiltCalibrationCalculator.Screw2Delta(cornerInputs), cornerInputs);
-                double c1Mag = Mag(c1x, c1y);
-                double c2Mag = Mag(c2x, c2y);
-                // Guard the denominator: a ~0 corner magnitude means the corner estimator saw essentially no
-                // screw move at all, so a relative difference against it is meaningless (Infinity for any
-                // nonzero paraboloid move, NaN for a coincidentally-zero one) rather than a genuine
-                // disagreement either estimator can actually support -- leave the cross-check uncomputed (NaN,
-                // no warning) instead of asserting one from a degenerate reference. Same philosophy as
-                // MoveMagnitudeRatio's own zero-magnitude guard (TiltCalibrationCalculator.MoveMagnitudeRatio).
-                if (c1Mag > 0 && c2Mag > 0) {
-                    double rel1 = Math.Abs(Mag(p1x, p1y) - c1Mag) / c1Mag;
-                    double rel2 = Math.Abs(Mag(p2x, p2y) - c2Mag) / c2Mag;
-                    estimatorRelativeDifference = Math.Max(rel1, rel2);
-                }
+                estimatorRelativeDifference = TiltCalibrationCalculator.EstimatorRelativeDifference(inputs, cornerInputs);
 
                 // The recovered corner-AF hardware number needs the SAME model != null gate as the
                 // paraboloid's measuredHardwareMicrons above: a model-less run's 1x1 pseudo-sensor carries no

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -54,8 +54,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
     /// <summary>
     /// The discrete calibration measurement steps. Each step is a single physical screw move followed by one
     /// measurement, so two changes are never compounded between measurements: the all-inward and per-screw moves
-    /// are each bracketed by an explicit re-baseline. Screw angles are derived from the move relative to the
-    /// re-baseline that immediately precedes it (c→d for screw 1, e→f for screw 2).
+    /// are each bracketed by an explicit re-baseline. Screw 1's angle is derived from the move relative to
+    /// mid(c, e) — the midpoint of the re-baselines that bracket it — which cancels a linear tilt drift across
+    /// the sequence exactly. Screw 2's angle is derived relative to e alone unless a measured final re-baseline
+    /// is present, in which case it gets the same midpoint symmetry (see
+    /// <see cref="TiltCalibrationCalculator.Screw2Delta"/>).
     /// </summary>
     public enum WizardStep {
         Baseline = 0,     // a

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -2716,15 +2716,58 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 curvatureChannelDisagreement = null;
             }
 
-            // Screw angles from each move relative to its preceding re-baseline (c→d, e→f).
-            double d1A = d.A - c.A, d1B = d.B - c.B;
-            double d2A = f.A - e.A, d2B = f.B - e.B;
-            var (s1, s2, s3, s4, rawDiff) = TiltCalibrationCalculator.ComputeScrewAngles(d1A, d1B, d2A, d2B, screwCount);
+            calibrationScrewRadiusMm = radiusMm;
+            calibrationPixelSizeMicrons = pixelSize;
+            calibrationFocuserStepMicrons = fStep;
 
-            tiltAdapterOptions.Screw1AngleDegrees = s1;
-            tiltAdapterOptions.Screw2AngleDegrees = s2;
-            tiltAdapterOptions.Screw3AngleDegrees = s3;
-            tiltAdapterOptions.Screw4AngleDegrees = s4;
+            // RunCalibrationMath is the SINGLE production consumer of TiltCalibrationCalculator.Calibrate: one
+            // TiltCalibrationInputs, one Calibrate() call, feeding the screw angles, raw gap/ratio, recovered
+            // hardware, and confidence alike. Do not hand-mirror any of that math back into this method — it
+            // used to (separate inline (A,B) angle/ratio algebra plus a separate RecoverHardwareDetailed call),
+            // which is exactly why the F2 physical-gradient-space fix didn't reach the wizard's persisted
+            // Screw1..4AngleDegrees or the "unequal tilt changes" warning until this refactor. Tasks 3-6 add
+            // fields to Calibrate's inputs/result; wiring them here (not duplicating them) is what makes them
+            // reach production automatically.
+            var model = CalibrationTiltPlane;
+            // A model-less run (e.g. a seeded/test-only run with no live/replayed tilt plane) has no known
+            // sensor size; fall back to a square 1x1 pseudo-sensor so the angle/ratio/confidence conversion
+            // stays isotropic instead of aspect-distorted. Every real (live or replayed) run has a model by the
+            // time this method is reached, so production calibrations always get their true geometry here — the
+            // fallback exists for test/degenerate inputs, not as a supported production mode. NOTE: hardware
+            // recovery (µm/turn) uses this SAME inputs object, so a hypothetical caller with a null model but
+            // otherwise-real pixelSize/fStep/radiusMm/appliedAmount would get a non-NaN but physically-meaningless
+            // µm/turn from the 1x1 fake sensor rather than the pre-refactor NaN; no current caller hits this
+            // combination (every RunCalibrationForTest scenario that omits a tiltPlaneOverride also leaves
+            // pixelSize/fStep at 0 from the unconfigured test profile, so RecoverHardwareDetailed's own
+            // radius/applied/pixelSize/fStep guard already returns NaN before geometry size matters).
+            double imageWidthPixels = model?.ImageSize.Width ?? 1;
+            double imageHeightPixels = model?.ImageSize.Height ?? 1;
+            var inputs = new TiltCalibrationInputs {
+                ScrewCount = screwCount,
+                // 4-step runs never measured Baseline/AllInward as curvature probes: leave them default —
+                // the calculator ignores them when HasCurvatureMeasurement is false (c carries the baseline).
+                Baseline = measuredCurvature ? new TiltGradient(a.A, a.B, a.Mean) : default,
+                AllInward = measuredCurvature ? new TiltGradient(b.A, b.B, b.Mean) : default,
+                ReBaseline1 = new TiltGradient(c.A, c.B, c.Mean),
+                Screw1 = new TiltGradient(d.A, d.B, d.Mean),
+                ReBaseline2 = new TiltGradient(e.A, e.B, e.Mean),
+                Screw2 = new TiltGradient(f.A, f.B, f.Mean),
+                HasCurvatureMeasurement = measuredCurvature,
+                FallbackCurvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign,
+                ImageWidthPixels = imageWidthPixels,
+                ImageHeightPixels = imageHeightPixels,
+                PixelSizeMicrons = pixelSize,
+                FocuserStepMicrons = fStep,
+                ScrewRadiusMillimeters = radiusMm,
+                CalibrationAppliedAmount = appliedAmount,
+                IsStepperAdjustment = isStepper
+            };
+            var result = TiltCalibrationCalculator.Calibrate(inputs);
+
+            tiltAdapterOptions.Screw1AngleDegrees = result.Screw1AngleDegrees;
+            tiltAdapterOptions.Screw2AngleDegrees = result.Screw2AngleDegrees;
+            tiltAdapterOptions.Screw3AngleDegrees = result.Screw3AngleDegrees;
+            tiltAdapterOptions.Screw4AngleDegrees = result.Screw4AngleDegrees;
             if (tiltAdapterOptions.ScrewCount != screwCount) {
                 tiltAdapterOptions.ScrewCount = screwCount; // replaying a run captured with a different screw count
             }
@@ -2738,77 +2781,26 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // calibration — err toward clearing whenever the run wasn't a fresh connected hands-off run.
             tiltAdapterOptions.DeviceLinkedCalibrationDeviceName = deviceDriven ? tiltAdapterOptions.DeviceName : string.Empty;
 
-            lastRawAngleDiff = rawDiff;
-            lastMoveMagnitudeRatio = TiltCalibrationCalculator.MoveMagnitudeRatio(d1A, d1B, d2A, d2B);
-            ValidateCalibrationQuality(rawDiff, lastMoveMagnitudeRatio, screwCount);
+            lastRawAngleDiff = result.RawAngleDiffDegrees;
+            lastMoveMagnitudeRatio = result.MoveMagnitudeRatio;
+            ValidateCalibrationQuality(lastRawAngleDiff, lastMoveMagnitudeRatio, screwCount);
 
-            // Recover the adapter hardware (µm/turn or µm/step).
+            // Recover the adapter hardware (µm/turn or µm/step) — Calibrate computes this via the same
+            // RecoverHardwareDetailed math this method used to call directly; only assign the persisted
+            // "last measured" option when it's a real (non-NaN) recovery.
             measuredHardwareMicrons = double.NaN;
-            lastConfidence = null;
-            pitchUncertaintyMicrons = double.NaN;
-            calibrationScrewRadiusMm = radiusMm;
-            calibrationPixelSizeMicrons = pixelSize;
-            calibrationFocuserStepMicrons = fStep;
-
-            var model = CalibrationTiltPlane;
-            if (model != null) {
-                var inputs = new TiltCalibrationInputs {
-                    ScrewCount = screwCount,
-                    // 4-step runs never measured Baseline/AllInward as curvature probes: leave them default —
-                    // the calculator ignores them when HasCurvatureMeasurement is false (c carries the baseline).
-                    Baseline = measuredCurvature ? new TiltGradient(a.A, a.B, a.Mean) : default,
-                    AllInward = measuredCurvature ? new TiltGradient(b.A, b.B, b.Mean) : default,
-                    ReBaseline1 = new TiltGradient(c.A, c.B, c.Mean),
-                    Screw1 = new TiltGradient(d.A, d.B, d.Mean),
-                    ReBaseline2 = new TiltGradient(e.A, e.B, e.Mean),
-                    Screw2 = new TiltGradient(f.A, f.B, f.Mean),
-                    HasCurvatureMeasurement = measuredCurvature,
-                    FallbackCurvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign,
-                    ImageWidthPixels = model.ImageSize.Width,
-                    ImageHeightPixels = model.ImageSize.Height,
-                    PixelSizeMicrons = pixelSize,
-                    FocuserStepMicrons = fStep,
-                    ScrewRadiusMillimeters = radiusMm,
-                    CalibrationAppliedAmount = appliedAmount,
-                    IsStepperAdjustment = isStepper
-                };
-                var (measured, hwDelta1, hwDelta2) = TiltCalibrationCalculator.RecoverHardwareDetailed(inputs);
-                pitchUncertaintyMicrons = double.IsNaN(hwDelta1) ? double.NaN : Math.Abs(hwDelta1 - hwDelta2) / 2.0;
-                if (!double.IsNaN(measured)) {
-                    measuredHardwareMicrons = measured;
-                    if (isStepper) {
-                        tiltAdapterOptions.LastMeasuredStepperStepSizeMicrons = measured;
-                    } else {
-                        tiltAdapterOptions.LastMeasuredThreadPitchMicrons = measured;
-                    }
+            pitchUncertaintyMicrons = result.PitchUncertaintyMicrons;
+            if (!double.IsNaN(result.MeasuredHardwareMicrons)) {
+                measuredHardwareMicrons = result.MeasuredHardwareMicrons;
+                if (isStepper) {
+                    tiltAdapterOptions.LastMeasuredStepperStepSizeMicrons = result.MeasuredHardwareMicrons;
+                } else {
+                    tiltAdapterOptions.LastMeasuredThreadPitchMicrons = result.MeasuredHardwareMicrons;
                 }
             }
 
             EvaluateRebaselineDrift();
-            // ComputeConfidence now converts to physical gradient space (F2 fix) and so needs real sensor
-            // geometry, same as the hardware-recovery inputs above. Reuse the model's image size when a live/
-            // replayed tilt plane produced one; when it didn't (e.g. a seeded/test-only run with no model), fall
-            // back to a square 1x1 pseudo-sensor so the conversion stays isotropic (ratio-preserving) rather than
-            // aspect-distorted. If pixelSize/fStep are ALSO unavailable (fully geometry-less, e.g. an unconfigured
-            // test profile), PhysicalDelta's own fallback degrades further to the raw (A,B) delta — see its doc
-            // comment — instead of dividing by zero into a NaN that could get misread as "zero noise".
-            double confImageWidthPixels = model?.ImageSize.Width ?? 1;
-            double confImageHeightPixels = model?.ImageSize.Height ?? 1;
-            lastConfidence = TiltCalibrationCalculator.ComputeConfidence(new TiltCalibrationInputs {
-                ScrewCount = screwCount,
-                Baseline = measuredCurvature ? new TiltGradient(a.A, a.B, a.Mean) : default,
-                AllInward = measuredCurvature ? new TiltGradient(b.A, b.B, b.Mean) : default,
-                ReBaseline1 = new TiltGradient(c.A, c.B, c.Mean),
-                Screw1 = new TiltGradient(d.A, d.B, d.Mean),
-                ReBaseline2 = new TiltGradient(e.A, e.B, e.Mean),
-                Screw2 = new TiltGradient(f.A, f.B, f.Mean),
-                HasCurvatureMeasurement = measuredCurvature,
-                FallbackCurvatureSign = tiltAdapterOptions.ScrewInwardCurvatureSign,
-                ImageWidthPixels = confImageWidthPixels,
-                ImageHeightPixels = confImageHeightPixels,
-                PixelSizeMicrons = pixelSize,
-                FocuserStepMicrons = fStep
-            });
+            lastConfidence = result.Confidence;
             EvaluateCalibrationConfidence(lastConfidence);
             // [CRITICAL GATE] Persist the confidence result as the automation-trust marker — the second half
             // of the automation gate alongside DeviceLinkedCalibrationDeviceName above. Unlike that marker,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
@@ -216,7 +216,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         /// re-baseline drifts in a 6-step run, only the single re-baseline drift in a 4-step run. All magnitudes are
         /// computed in physical gradient space (<see cref="PhysicalDelta"/>), not raw (A,B) — see the F2 fix. Screw
         /// moves use the same drift-cancelling reference as <see cref="Calibrate"/> (<see cref="Screw1Delta"/> /
-        /// <see cref="Screw2Delta"/>), so the signal is unaffected by linear tilt drift too.
+        /// <see cref="Screw2Delta"/>), so the signal is unaffected by linear tilt drift too. The noise probes
+        /// (all-inward residual, both re-baseline drifts) are deliberately left on their raw, non-midpoint
+        /// readings: they exist specifically to measure the drift/backlash the signal is now immune to, so
+        /// midpoint-referencing them would erase the very quantity they are there to detect.
         /// </summary>
         public static TiltCalibrationConfidence ComputeConfidence(TiltCalibrationInputs inputs) {
             var (s1x, s1y) = PhysicalDelta(Screw1Delta(inputs), inputs);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
@@ -144,26 +144,21 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         /// displacement). Angles and magnitude ratios MUST be computed here, not in (A,B) space —
         /// A and B are per-normalized-coordinate and distort directions on non-square sensors.
         ///
-        /// Production callers (the wizard's <c>TiltAdapterWizardVM.RunCalibrationMath</c>, TestApp's headless
-        /// validator) are expected to ALWAYS populate real sensor/focuser geometry (ImageWidthPixels,
-        /// ImageHeightPixels, PixelSizeMicrons, FocuserStepMicrons) — that is what makes this function's output
-        /// physically meaningful and is the entire point of the F2 fix. When geometry is left at its default
-        /// (all 0, e.g. a pure ratio/angle algebra unit test, or a test-only calibration run with no tilt-plane
-        /// model to read image size from), there is no physical space to convert into: this degrades to the raw
-        /// (A,B) delta (the pre-F2-fix behavior) rather than dividing by zero into NaN, so those geometry-less
-        /// callers stay well-defined instead of silently producing NaN — which downstream (e.g.
-        /// <see cref="ComputeConfidence"/>'s SNR) would otherwise risk being mis-signaled as "zero noise" /
-        /// infinite reliability. This degrade path is a test/degenerate-input affordance ONLY, not a supported
-        /// production mode: a real calibration with genuinely missing geometry should be treated as a bug to
-        /// fix at the call site, not silently tolerated here.</summary>
+        /// Geometry is a PRECONDITION, not an option: every caller — production (the wizard's
+        /// <c>TiltAdapterWizardVM.RunCalibrationMath</c>, TestApp's headless validator) and test alike — must
+        /// populate real ImageWidthPixels, ImageHeightPixels, PixelSizeMicrons, and FocuserStepMicrons. This
+        /// mirrors <see cref="RecoverHardwareDetailed"/>'s philosophy: one class of geometry precondition, one
+        /// failure behavior. There is deliberately NO fallback for invalid geometry (sensor size or focuser
+        /// step &lt;= 0) — it divides through and yields non-finite (Inf/NaN) gx/gy, which callers must treat as
+        /// unreliable (see <see cref="ComputeConfidence"/>'s NaN/Inf-safe SNR guard). A silent "degrade to raw
+        /// (A,B) units" fallback was tried and removed: on the production wizard path it would have let
+        /// mis-configured/zeroed geometry silently reintroduce the F2 bug (raw-(A,B)-space angles/ratio/SNR)
+        /// with no signal anywhere that anything was wrong.</summary>
         internal static (double gx, double gy) PhysicalDelta(TiltGradient to, TiltGradient from, TiltCalibrationInputs inputs) {
             double dA = to.A - from.A;
             double dB = to.B - from.B;
             double sensorW = inputs.ImageWidthPixels * inputs.PixelSizeMicrons;
             double sensorH = inputs.ImageHeightPixels * inputs.PixelSizeMicrons;
-            if (sensorW <= 0 || sensorH <= 0 || inputs.FocuserStepMicrons <= 0) {
-                return (dA, dB);
-            }
             return TiltScrewGeometry.PlaneGradientToPhysical(dA, dB, inputs.FocuserStepMicrons, sensorW, sensorH);
         }
 
@@ -199,12 +194,17 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 noise = drift2;
             }
 
-            // NaN-safe: PhysicalDelta divides by sensor/focuser geometry, so invalid geometry (e.g. a caller that
-            // forgot to populate ImageWidthPixels/PixelSizeMicrons/FocuserStepMicrons) propagates as NaN signal or
-            // noise. "noise > 0" is false for NaN, so without this guard a NaN noise would fall into the
-            // zero-noise branch and be misreported as infinite SNR — silently marking a bad measurement
-            // "reliable" instead of failing safe. This is a CRITICAL GATE (see TiltAdapterWizardVM.RunCalibrationMath).
-            double snr = double.IsNaN(signal) || double.IsNaN(noise)
+            // NaN/Inf-safe: PhysicalDelta has no fallback for invalid geometry (see its doc comment) — a caller
+            // that left ImageWidthPixels/PixelSizeMicrons/FocuserStepMicrons at 0 (or otherwise violated the
+            // geometry precondition) gets non-finite gx/gy (NaN from 0/0, +/-Infinity from a nonzero delta over
+            // a zero sensor size), which propagates into a non-finite signal and/or noise here. This guard is
+            // now the ONLY thing standing between bad geometry and a falsely "reliable" result, so it must catch
+            // BOTH: "noise > 0" is false for NaN, so an unguarded NaN noise would fall into the zero-noise
+            // branch and be misreported as infinite SNR; and an Infinite noise with an exactly-zero (or
+            // Infinite) signal could otherwise divide out to a deceptively finite or infinite ratio. Only when
+            // BOTH signal and noise are finite do we fall through to the normal ratio / exactly-zero-noise
+            // logic. This is a CRITICAL GATE (see TiltAdapterWizardVM.RunCalibrationMath).
+            double snr = !double.IsFinite(signal) || !double.IsFinite(noise)
                 ? double.NaN
                 : (noise > 0 ? signal / noise : double.PositiveInfinity);
             // A screw direction is atan2 of its move vector; transverse noise of ~noise on a signal of ~signal

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
@@ -330,6 +330,52 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             return m1 >= m2 ? m1 / m2 : m2 / m1;
         }
 
+        /// <summary>Physical-gradient-space move magnitude of a single screw's move (see <see cref="PhysicalDelta"/>),
+        /// referenced the same drift-cancelling way <see cref="Calibrate"/> itself does
+        /// (<see cref="Screw1Delta"/> / <see cref="Screw2Delta"/>). <paramref name="screwNumber"/> must be 1 or 2.
+        /// Exposed so callers that need to diagnose a specific screw (e.g. the wizard's corner-cross-check
+        /// degenerate-estimator log, see <see cref="EstimatorRelativeDifference"/>'s doc comment) can compare two
+        /// estimators' per-screw magnitudes without re-deriving the delta math themselves.</summary>
+        internal static double ScrewMoveMagnitude(int screwNumber, TiltCalibrationInputs inputs) {
+            var delta = screwNumber == 1 ? Screw1Delta(inputs) : Screw2Delta(inputs);
+            var (gx, gy) = PhysicalDelta(delta, inputs);
+            return Magnitude(gx, gy);
+        }
+
+        /// <summary>
+        /// Relative disagreement between two independent estimators of the same screw moves — e.g. the wizard's
+        /// corner-region-AF cross-check of the per-star paraboloid (see
+        /// <c>TiltAdapterWizardVM.RunCalibrationMath</c>) — as the LARGER of the two screws' relative differences
+        /// in physical-gradient-space move magnitude (see <see cref="ScrewMoveMagnitude"/>). Centralized here
+        /// (not hand-duplicated in the wizard VM and TestApp's headless validator) for the same reason every
+        /// other calibration formula lives in this class: the validator and the wizard must never drift.
+        /// <paramref name="alternate"/> is the reference each ratio is measured against — its magnitude is each
+        /// relative difference's denominator — so for the wizard's cross-check this is the corner-region AF
+        /// estimator (the one <paramref name="primary"/>, the paraboloid, is being sanity-checked against).
+        ///
+        /// Guarded against a ~0 <paramref name="alternate"/> magnitude for EITHER screw: a relative difference
+        /// against a near-zero reference is meaningless (Infinity for any nonzero <paramref name="primary"/>
+        /// move, NaN for a coincidentally-zero one), not a genuine, supportable disagreement — so the WHOLE pair
+        /// returns NaN rather than a one-screw-only evaluation, which would silently mix "no basis for
+        /// comparison" with "measured and found to agree." This guard can itself hide the most diagnostic
+        /// disagreement possible — the alternate estimator seeing ~no move for a screw the primary estimator
+        /// says was clearly turned — so a caller that wants to log/report that case specifically should compare
+        /// <see cref="ScrewMoveMagnitude"/>(1/2, primary) against ScrewMoveMagnitude(1/2, alternate) directly
+        /// rather than trying to recover it from this method's NaN.
+        /// </summary>
+        internal static double EstimatorRelativeDifference(TiltCalibrationInputs primary, TiltCalibrationInputs alternate) {
+            double p1Mag = ScrewMoveMagnitude(1, primary);
+            double p2Mag = ScrewMoveMagnitude(2, primary);
+            double a1Mag = ScrewMoveMagnitude(1, alternate);
+            double a2Mag = ScrewMoveMagnitude(2, alternate);
+            if (a1Mag <= 0 || a2Mag <= 0) {
+                return double.NaN;
+            }
+            double rel1 = Math.Abs(p1Mag - a1Mag) / a1Mag;
+            double rel2 = Math.Abs(p2Mag - a2Mag) / a2Mag;
+            return Math.Max(rel1, rel2);
+        }
+
         /// <summary>
         /// Per-screw position angles from the two single-screw gradient changes (screw move minus baseline), in
         /// physical gradient space (gx, gy) — see <see cref="PhysicalDelta"/>. Determines the winding direction

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
@@ -106,8 +106,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         /// is uncomputable.</summary>
         public double PitchUncertaintyMicrons { get; set; }
 
-        /// <summary>Focuser-frame µm-per-unit implied by the AllInward piston — a free, tilt-fit-independent
-        /// third estimate of the same hardware <see cref="MeasuredHardwareMicrons"/> reports. See
+        /// <summary>Focuser-frame µm-per-applied-unit implied by the AllInward piston — a free, tilt-fit-independent
+        /// third estimate of the same hardware <see cref="MeasuredHardwareMicrons"/> reports. "PerStep" names the
+        /// applied unit generically, same convention as <see cref="MeasuredHardwareMicrons"/>: it is a turn on
+        /// thread-pitch (screw) adapters, a step on stepper adapters. See
         /// <see cref="TiltCalibrationCalculator.PistonImpliedMicronsPerStep"/>. NaN for 4-step runs (no piston
         /// measured).</summary>
         public double PistonImpliedMicronsPerStep { get; set; }
@@ -420,15 +422,21 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public static double RecoverHardwareMicrons(TiltCalibrationInputs inputs) => RecoverHardwareDetailed(inputs).measured;
 
         /// <summary>
-        /// Focuser-frame µm-per-unit implied by the AllInward piston: all screws moved by the applied
-        /// amount, so mean best-focus shifts by (applied × unit) / frame-factor. Drift-corrected by
-        /// interpolating the baseline mean to AllInward's time as mid(Baseline, ReBaseline1) — the two
-        /// nominally-identical states that bracket it. This is measured in the SAME (focuser) frame as
-        /// the tilt-derived hardware, so honest values agree; a large gap means the tilt estimator (or
-        /// the mechanics on pull-side moves) is off. NaN for 4-step runs (no piston measured). Unlike
-        /// <see cref="RecoverHardwareMicrons"/>, this needs no sensor geometry at all (no PixelSizeMicrons,
-        /// ImageWidthPixels/Height, or ScrewRadiusMillimeters) — only mean focuser positions, the focuser
-        /// step size, and the applied amount — so it is a genuinely independent probe of the same quantity.
+        /// Focuser-frame µm-per-applied-unit implied by the AllInward piston: all screws moved by the applied
+        /// amount, so mean best-focus shifts by (applied × unit) / frame-factor. "PerStep" names the applied
+        /// unit generically, same convention as <see cref="RecoverHardwareMicrons"/>'s result: a turn on
+        /// thread-pitch (screw) adapters, a step on stepper adapters. Drift-corrected by interpolating the
+        /// baseline mean to AllInward's time as mid(Baseline, ReBaseline1) — the two nominally-identical
+        /// states that bracket it. This is measured in the SAME (focuser) frame as the tilt-derived hardware,
+        /// so honest values agree; a large gap means the tilt estimator (or the mechanics on pull-side moves)
+        /// is off. NaN for 4-step runs (no piston measured). Unlike <see cref="RecoverHardwareMicrons"/>, this
+        /// needs no sensor geometry at all (no PixelSizeMicrons, ImageWidthPixels/Height, or
+        /// ScrewRadiusMillimeters) — only mean focuser positions, the focuser step size, and the applied
+        /// amount — so it is a genuinely independent probe of the same quantity. The result is unsigned
+        /// (<see cref="Math.Abs"/> discards direction) because the piston's sign is derived separately by
+        /// <see cref="ComputeCurvatureSign"/>, which reads the raw <c>Baseline</c> mean directly rather than
+        /// this method's drift-corrected mid(Baseline, ReBaseline1) — a related but not identical reference
+        /// point.
         /// </summary>
         public static double PistonImpliedMicronsPerStep(TiltCalibrationInputs inputs) {
             if (!inputs.HasCurvatureMeasurement || inputs.CalibrationAppliedAmount <= 0 || inputs.FocuserStepMicrons <= 0) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
@@ -34,18 +34,21 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
     /// <summary>Geometry + per-step readings needed to calibrate a tilt adapter from a sequence of measurements.
     /// The discrete 6-step flow measures: Baseline (a), AllInward (b), ReBaseline1 (c), Screw1 (d), ReBaseline2 (e),
-    /// Screw2 (f). Each screw's angle/hardware is derived from the move relative to the re-baseline that immediately
-    /// precedes it (c→d for screw 1, e→f for screw 2), so a single physical move is isolated per measurement pair.
-    /// In the 4-step flow (no curvature steps) Baseline/AllInward are unset, HasCurvatureMeasurement is false, and
-    /// the baseline reading occupies the ReBaseline1 slot.
+    /// Screw2 (f). Screw 1's move is referenced to mid(c, e) — the re-baselines that bracket it symmetrically
+    /// (see <see cref="TiltCalibrationCalculator.Screw1Delta"/>), which cancels a linear tilt drift across the
+    /// sequence exactly. Screw 2's move is referenced to e alone unless a measured final re-baseline (g) is
+    /// present, in which case it gets the same mid(e, g) symmetry (see
+    /// <see cref="TiltCalibrationCalculator.Screw2Delta"/>). Either way a single physical move is isolated per
+    /// screw. In the 4-step flow (no curvature steps) Baseline/AllInward are unset, HasCurvatureMeasurement is
+    /// false, and the baseline reading occupies the ReBaseline1 slot.
     /// </summary>
     public sealed class TiltCalibrationInputs {
         public int ScrewCount { get; set; }                 // 3 or 4
         public TiltGradient Baseline { get; set; }          // a
         public TiltGradient AllInward { get; set; }         // b: all screws inward once; for the curvature (backfocus) sign (a→b)
-        public TiltGradient ReBaseline1 { get; set; }       // c: all screws back out once (≈ baseline); reference for screw 1
+        public TiltGradient ReBaseline1 { get; set; }       // c: all screws back out once (≈ baseline); first half of the screw-1 bracket
         public TiltGradient Screw1 { get; set; }            // d: screw 1 inward once (4-screw: + screw 3 outward)
-        public TiltGradient ReBaseline2 { get; set; }       // e: undo the screw-1 move (≈ c); reference for screw 2
+        public TiltGradient ReBaseline2 { get; set; }       // e: undo the screw-1 move (≈ c); second half of the screw-1 bracket, and reference for screw 2
         public TiltGradient Screw2 { get; set; }            // f: screw 2 inward once (4-screw: + screw 4 outward)
         public double ImageWidthPixels { get; set; }
         public double ImageHeightPixels { get; set; }
@@ -57,12 +60,23 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         /// <summary>False for a 4-step run that skipped the curvature-direction steps: Baseline and
         /// AllInward were never measured (leave them default) and the baseline reading is supplied
-        /// in the ReBaseline1 slot, which is the screw-1 reference in both flows.</summary>
+        /// in the ReBaseline1 slot, one of the two screw-1 reference points (mid(ReBaseline1,
+        /// ReBaseline2)) in both flows.</summary>
         public bool HasCurvatureMeasurement { get; set; } = true;
 
         /// <summary>Curvature sign carried into the result when HasCurvatureMeasurement is false
         /// (the configured/assumed ScrewInwardCurvatureSign; 0 = unknown).</summary>
         public int FallbackCurvatureSign { get; set; }
+
+        /// <summary>Optional final re-baseline (g): undo the screw-2 move (≈ e). Only measured when
+        /// <see cref="HasFinalRebaseline"/> is true, which lets <see cref="TiltCalibrationCalculator.Screw2Delta"/>
+        /// reference screw 2's move to mid(ReBaseline2, ReBaseline3) — the same drift-cancelling symmetry
+        /// screw 1 always gets from mid(ReBaseline1, ReBaseline2).</summary>
+        public TiltGradient ReBaseline3 { get; set; }
+
+        /// <summary>True when ReBaseline3 was actually measured (an optional extra step beyond the
+        /// standard 6-step flow). Default false: Screw2Delta falls back to referencing ReBaseline2 alone.</summary>
+        public bool HasFinalRebaseline { get; set; }
     }
 
     /// <summary>Result of calibrating a tilt adapter: per-screw position angles, curvature sign, and recovered hardware.</summary>
@@ -157,9 +171,42 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         internal static (double gx, double gy) PhysicalDelta(TiltGradient to, TiltGradient from, TiltCalibrationInputs inputs) {
             double dA = to.A - from.A;
             double dB = to.B - from.B;
+            return PhysicalDelta((dA, dB), inputs);
+        }
+
+        /// <summary>Overload of <see cref="PhysicalDelta(TiltGradient, TiltGradient, TiltCalibrationInputs)"/> for
+        /// callers that already have a raw (A, B) delta — e.g. the drift-cancelling <see cref="Screw1Delta"/> /
+        /// <see cref="Screw2Delta"/> helpers, which reference a midpoint rather than a single reading. Same
+        /// geometry precondition and no-fallback behavior as the two-reading overload.</summary>
+        internal static (double gx, double gy) PhysicalDelta((double dA, double dB) delta, TiltCalibrationInputs inputs) {
             double sensorW = inputs.ImageWidthPixels * inputs.PixelSizeMicrons;
             double sensorH = inputs.ImageHeightPixels * inputs.PixelSizeMicrons;
-            return TiltScrewGeometry.PlaneGradientToPhysical(dA, dB, inputs.FocuserStepMicrons, sensorW, sensorH);
+            return TiltScrewGeometry.PlaneGradientToPhysical(delta.dA, delta.dB, inputs.FocuserStepMicrons, sensorW, sensorH);
+        }
+
+        /// <summary>Screw-1 move referenced to the MIDPOINT of the re-baselines that bracket it (ReBaseline1 and
+        /// ReBaseline2). For a linear tilt drift across the measurement sequence, the midpoint of two readings
+        /// taken symmetrically before/after the screw-1 move is exactly the drift-free reference at the time of
+        /// the move, so the recovered move is drift-immune — unconditionally, no extra measurement required.
+        /// Works identically in the 4-step flow (the baseline reading sits in the ReBaseline1 slot; see
+        /// <see cref="TiltCalibrationInputs.HasCurvatureMeasurement"/>).</summary>
+        internal static (double dA, double dB) Screw1Delta(TiltCalibrationInputs inputs) {
+            double midA = (inputs.ReBaseline1.A + inputs.ReBaseline2.A) / 2.0;
+            double midB = (inputs.ReBaseline1.B + inputs.ReBaseline2.B) / 2.0;
+            return (inputs.Screw1.A - midA, inputs.Screw1.B - midB);
+        }
+
+        /// <summary>Screw-2 move. Gets the same drift-cancelling midpoint symmetry as <see cref="Screw1Delta"/>
+        /// (mid(ReBaseline2, ReBaseline3)) only when the optional measured final re-baseline actually ran
+        /// (<see cref="TiltCalibrationInputs.HasFinalRebaseline"/>); otherwise referenced to ReBaseline2 alone,
+        /// as before.</summary>
+        internal static (double dA, double dB) Screw2Delta(TiltCalibrationInputs inputs) {
+            if (inputs.HasFinalRebaseline) {
+                double midA = (inputs.ReBaseline2.A + inputs.ReBaseline3.A) / 2.0;
+                double midB = (inputs.ReBaseline2.B + inputs.ReBaseline3.B) / 2.0;
+                return (inputs.Screw2.A - midA, inputs.Screw2.B - midB);
+            }
+            return (inputs.Screw2.A - inputs.ReBaseline2.A, inputs.Screw2.B - inputs.ReBaseline2.B);
         }
 
         /// <summary>
@@ -167,11 +214,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         /// <see cref="TiltCalibrationConfidence"/> for the model: screw moves are the signal; the noise probes are
         /// independent quantities that are each ~0 in an ideal measurement — the all-inward piston residual and both
         /// re-baseline drifts in a 6-step run, only the single re-baseline drift in a 4-step run. All magnitudes are
-        /// computed in physical gradient space (<see cref="PhysicalDelta"/>), not raw (A,B) — see the F2 fix.
+        /// computed in physical gradient space (<see cref="PhysicalDelta"/>), not raw (A,B) — see the F2 fix. Screw
+        /// moves use the same drift-cancelling reference as <see cref="Calibrate"/> (<see cref="Screw1Delta"/> /
+        /// <see cref="Screw2Delta"/>), so the signal is unaffected by linear tilt drift too.
         /// </summary>
         public static TiltCalibrationConfidence ComputeConfidence(TiltCalibrationInputs inputs) {
-            var (s1x, s1y) = PhysicalDelta(inputs.Screw1, inputs.ReBaseline1, inputs);
-            var (s2x, s2y) = PhysicalDelta(inputs.Screw2, inputs.ReBaseline2, inputs);
+            var (s1x, s1y) = PhysicalDelta(Screw1Delta(inputs), inputs);
+            var (s2x, s2y) = PhysicalDelta(Screw2Delta(inputs), inputs);
             double s1 = Magnitude(s1x, s1y);
             double s2 = Magnitude(s2x, s2y);
             double signal = 0.5 * (s1 + s2);
@@ -333,12 +382,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             double radiusMicrons = radiusMm * 1000.0;
             int n = inputs.ScrewCount;
 
-            // Each screw move is measured relative to the re-baseline that immediately precedes it (c→d, e→f),
-            // isolating a single physical move per pair.
-            double d1A = inputs.Screw1.A - inputs.ReBaseline1.A;
-            double d1B = inputs.Screw1.B - inputs.ReBaseline1.B;
-            double d2A = inputs.Screw2.A - inputs.ReBaseline2.A;
-            double d2B = inputs.Screw2.B - inputs.ReBaseline2.B;
+            // Screw 1's move is measured relative to mid(ReBaseline1, ReBaseline2) — drift-cancelling (see
+            // Screw1Delta). Screw 2's move is relative to ReBaseline2 alone unless a measured final re-baseline
+            // (ReBaseline3) is present (see Screw2Delta), isolating a single physical move per screw either way.
+            var (d1A, d1B) = Screw1Delta(inputs);
+            var (d2A, d2B) = Screw2Delta(inputs);
 
             var (g1x, g1y) = TiltScrewGeometry.PlaneGradientToPhysical(d1A, d1B, fStep, sensorW, sensorH);
             var (g2x, g2y) = TiltScrewGeometry.PlaneGradientToPhysical(d2A, d2B, fStep, sensorW, sensorH);
@@ -379,10 +427,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         /// <summary>Runs the full calibration: screw angles, curvature sign, and recovered hardware. Angles,
         /// the raw gap, and the magnitude ratio are all computed in physical gradient space (see
-        /// <see cref="PhysicalDelta"/>), not raw (A,B) — see the F2 fix.</summary>
+        /// <see cref="PhysicalDelta"/>), not raw (A,B) — see the F2 fix. Screw 1's move is referenced to
+        /// mid(ReBaseline1, ReBaseline2) (see <see cref="Screw1Delta"/>), which cancels a linear tilt drift
+        /// across the measurement sequence exactly; screw 2 gets the same symmetry only once a measured final
+        /// re-baseline is present (see <see cref="Screw2Delta"/>).</summary>
         public static TiltCalibrationResult Calibrate(TiltCalibrationInputs inputs) {
-            var (d1x, d1y) = PhysicalDelta(inputs.Screw1, inputs.ReBaseline1, inputs);
-            var (d2x, d2y) = PhysicalDelta(inputs.Screw2, inputs.ReBaseline2, inputs);
+            var (d1x, d1y) = PhysicalDelta(Screw1Delta(inputs), inputs);
+            var (d2x, d2y) = PhysicalDelta(Screw2Delta(inputs), inputs);
 
             var (s1, s2, s3, s4, rawDiff) = ComputeScrewAngles(d1x, d1y, d2x, d2y, inputs.ScrewCount);
             var (measuredHardware, delta1PerApplied, delta2PerApplied) = RecoverHardwareDetailed(inputs);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
@@ -106,6 +106,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         /// is uncomputable.</summary>
         public double PitchUncertaintyMicrons { get; set; }
 
+        /// <summary>Focuser-frame µm-per-unit implied by the AllInward piston — a free, tilt-fit-independent
+        /// third estimate of the same hardware <see cref="MeasuredHardwareMicrons"/> reports. See
+        /// <see cref="TiltCalibrationCalculator.PistonImpliedMicronsPerStep"/>. NaN for 4-step runs (no piston
+        /// measured).</summary>
+        public double PistonImpliedMicronsPerStep { get; set; }
+
         /// <summary>Signal-to-noise / reliability of the whole calibration, derived from the per-step tilt vectors.
         /// Populated by <see cref="TiltCalibrationCalculator.Calibrate"/>.</summary>
         public TiltCalibrationConfidence Confidence { get; set; }
@@ -414,6 +420,26 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public static double RecoverHardwareMicrons(TiltCalibrationInputs inputs) => RecoverHardwareDetailed(inputs).measured;
 
         /// <summary>
+        /// Focuser-frame µm-per-unit implied by the AllInward piston: all screws moved by the applied
+        /// amount, so mean best-focus shifts by (applied × unit) / frame-factor. Drift-corrected by
+        /// interpolating the baseline mean to AllInward's time as mid(Baseline, ReBaseline1) — the two
+        /// nominally-identical states that bracket it. This is measured in the SAME (focuser) frame as
+        /// the tilt-derived hardware, so honest values agree; a large gap means the tilt estimator (or
+        /// the mechanics on pull-side moves) is off. NaN for 4-step runs (no piston measured). Unlike
+        /// <see cref="RecoverHardwareMicrons"/>, this needs no sensor geometry at all (no PixelSizeMicrons,
+        /// ImageWidthPixels/Height, or ScrewRadiusMillimeters) — only mean focuser positions, the focuser
+        /// step size, and the applied amount — so it is a genuinely independent probe of the same quantity.
+        /// </summary>
+        public static double PistonImpliedMicronsPerStep(TiltCalibrationInputs inputs) {
+            if (!inputs.HasCurvatureMeasurement || inputs.CalibrationAppliedAmount <= 0 || inputs.FocuserStepMicrons <= 0) {
+                return double.NaN;
+            }
+            double baselineAtAllInward = (inputs.Baseline.MeanFocuserPosition + inputs.ReBaseline1.MeanFocuserPosition) / 2.0;
+            double deltaSteps = inputs.AllInward.MeanFocuserPosition - baselineAtAllInward;
+            return Math.Abs(deltaSteps) * inputs.FocuserStepMicrons / inputs.CalibrationAppliedAmount;
+        }
+
+        /// <summary>
         /// Drift of a re-baseline relative to its reference, as a fraction of the subsequent screw-move magnitude.
         /// A good re-baseline returns close to the prior state, so this ratio is near 0; a large value means the
         /// undo/redo left residual tilt (backlash or an uneven turn) comparable to the screw-move signal, so the
@@ -456,6 +482,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 PitchUncertaintyMicrons = double.IsNaN(delta1PerApplied)
                     ? double.NaN
                     : Math.Abs(delta1PerApplied - delta2PerApplied) / 2.0,
+                PistonImpliedMicronsPerStep = PistonImpliedMicronsPerStep(inputs),
                 Screw1DirectionDegrees = NormalizeAngle(Math.Atan2(d1x, -d1y) * 180.0 / Math.PI),
                 Screw2DirectionDegrees = NormalizeAngle(Math.Atan2(d2x, -d2y) * 180.0 / Math.PI),
                 MoveMagnitudeRatio = MoveMagnitudeRatio(d1x, d1y, d2x, d2y),

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
@@ -124,10 +124,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
     /// needed. The screw-move magnitudes are the <i>signal</i>; quantities that must be ~0 in a noise-free,
     /// stationary measurement are <i>noise probes</i>: turning all screws inward equally is a pure piston (no net
     /// tilt change vs baseline), and each re-baseline should return to its predecessor (zero drift). A 6-step run
-    /// has all three noise probes; a 4-step run (no curvature steps) has only the single re-baseline drift, and
-    /// <see cref="AllInwardTiltResidual"/> / <see cref="Rebaseline1Drift"/> are NaN there. When the noise probes
-    /// rival the screw-move signal the recovered geometry is dominated by measurement noise / between step drift,
-    /// no matter how cleanly the screws were turned.
+    /// has all three base noise probes; a 4-step run (no curvature steps) has only the single re-baseline drift, and
+    /// <see cref="AllInwardTiltResidual"/> / <see cref="Rebaseline1Drift"/> are NaN there. Either base flow gains a
+    /// fourth (6-step) or second (4-step) probe, <see cref="Rebaseline3Drift"/>, when the optional measured final
+    /// re-baseline (Task 6) is present; NaN when it is not. When the noise probes rival the screw-move signal the
+    /// recovered geometry is dominated by measurement noise / between step drift, no matter how cleanly the screws
+    /// were turned.
     /// </summary>
     public sealed class TiltCalibrationConfidence {
         public double ScrewMoveSignal { get; set; }               // mean |single-screw move| magnitude in physical gradient units (µm/µm) (the signal)
@@ -137,6 +139,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public double AllInwardTiltResidual { get; set; }         // |AllInward − Baseline|, should be ~0 (pure piston); NaN for 4-step runs
         public double Rebaseline1Drift { get; set; }              // |ReBaseline1 − Baseline|, should be ~0; NaN for 4-step runs
         public double Rebaseline2Drift { get; set; }              // |ReBaseline2 − ReBaseline1|, should be ~0
+        public double Rebaseline3Drift { get; set; } = double.NaN; // |ReBaseline3 − ReBaseline2|, should be ~0; NaN unless HasFinalRebaseline
         public bool IsReliable { get; set; }                      // SignalToNoise >= MinReliableSignalToNoise
     }
 
@@ -221,13 +224,15 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         /// Estimates how trustworthy the calibration is from the per-step tilt vectors. See
         /// <see cref="TiltCalibrationConfidence"/> for the model: screw moves are the signal; the noise probes are
         /// independent quantities that are each ~0 in an ideal measurement — the all-inward piston residual and both
-        /// re-baseline drifts in a 6-step run, only the single re-baseline drift in a 4-step run. All magnitudes are
-        /// computed in physical gradient space (<see cref="PhysicalDelta"/>), not raw (A,B) — see the F2 fix. Screw
-        /// moves use the same drift-cancelling reference as <see cref="Calibrate"/> (<see cref="Screw1Delta"/> /
-        /// <see cref="Screw2Delta"/>), so the signal is unaffected by linear tilt drift too. The noise probes
-        /// (all-inward residual, both re-baseline drifts) are deliberately left on their raw, non-midpoint
-        /// readings: they exist specifically to measure the drift/backlash the signal is now immune to, so
-        /// midpoint-referencing them would erase the very quantity they are there to detect.
+        /// re-baseline drifts in a 6-step run, only the single re-baseline drift in a 4-step run, plus (either flow)
+        /// the optional measured final re-baseline's drift (<see cref="TiltCalibrationInputs.HasFinalRebaseline"/>,
+        /// Task 6) when present. All magnitudes are computed in physical gradient space (<see cref="PhysicalDelta"/>),
+        /// not raw (A,B) — see the F2 fix. Screw moves use the same drift-cancelling reference as
+        /// <see cref="Calibrate"/> (<see cref="Screw1Delta"/> / <see cref="Screw2Delta"/>), so the signal is
+        /// unaffected by linear tilt drift too. The noise probes (all-inward residual, every re-baseline drift) are
+        /// deliberately left on their raw, non-midpoint readings: they exist specifically to measure the
+        /// drift/backlash the signal is now immune to, so midpoint-referencing them would erase the very quantity
+        /// they are there to detect.
         /// </summary>
         public static TiltCalibrationConfidence ComputeConfidence(TiltCalibrationInputs inputs) {
             var (s1x, s1y) = PhysicalDelta(Screw1Delta(inputs), inputs);
@@ -238,6 +243,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
             var (drift2x, drift2y) = PhysicalDelta(inputs.ReBaseline2, inputs.ReBaseline1, inputs);
             double drift2 = Magnitude(drift2x, drift2y);
+            double drift3 = double.NaN;
+            if (inputs.HasFinalRebaseline) {
+                var (drift3x, drift3y) = PhysicalDelta(inputs.ReBaseline3, inputs.ReBaseline2, inputs);
+                drift3 = Magnitude(drift3x, drift3y);
+            }
             double allInward = double.NaN;
             double drift1 = double.NaN;
             double noise;
@@ -246,12 +256,17 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 allInward = Magnitude(aiX, aiY);
                 var (d1x, d1y) = PhysicalDelta(inputs.ReBaseline1, inputs.Baseline, inputs);
                 drift1 = Magnitude(d1x, d1y);
-                noise = Math.Sqrt((allInward * allInward + drift1 * drift1 + drift2 * drift2) / 3.0);
+                noise = inputs.HasFinalRebaseline
+                    ? Math.Sqrt((allInward * allInward + drift1 * drift1 + drift2 * drift2 + drift3 * drift3) / 4.0)
+                    : Math.Sqrt((allInward * allInward + drift1 * drift1 + drift2 * drift2) / 3.0);
             } else {
-                // 4-step run: the only available noise probe is the single re-baseline drift. A one-sample noise
-                // estimate makes the IsReliable gate looser than the 6-step RMS-of-3 — an accepted tradeoff of the
+                // 4-step run: the base noise probe is the single re-baseline drift; with the optional measured
+                // final re-baseline, both re-baseline drifts (RMS-of-2). A one- or two-sample noise estimate
+                // makes the IsReliable gate looser than the 6-step RMS-of-3/4 — an accepted tradeoff of the
                 // shorter flow.
-                noise = drift2;
+                noise = inputs.HasFinalRebaseline
+                    ? Math.Sqrt((drift2 * drift2 + drift3 * drift3) / 2.0)
+                    : drift2;
             }
 
             // NaN/Inf-safe: PhysicalDelta has no fallback for invalid geometry (see its doc comment) — a caller
@@ -279,6 +294,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 AllInwardTiltResidual = allInward,
                 Rebaseline1Drift = drift1,
                 Rebaseline2Drift = drift2,
+                Rebaseline3Drift = drift3,
                 IsReliable = snr >= MinReliableSignalToNoise
             };
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
@@ -143,13 +143,19 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         /// <summary>Screw-move delta in physical gradient space (µm focus travel per µm of sensor
         /// displacement). Angles and magnitude ratios MUST be computed here, not in (A,B) space —
         /// A and B are per-normalized-coordinate and distort directions on non-square sensors.
-        /// When the caller hasn't populated real sensor/focuser geometry (ImageWidthPixels,
-        /// ImageHeightPixels, PixelSizeMicrons, FocuserStepMicrons all default to 0), there is no physical
-        /// space to convert into — degrade to the raw (A,B) delta (the pre-F2-fix behavior) rather than
-        /// divide by zero into NaN. This keeps geometry-agnostic callers (pure ratio/angle algebra tests,
-        /// a calibration step run with no known sensor size) well-defined instead of silently producing NaN,
-        /// which downstream (e.g. <see cref="ComputeConfidence"/>'s SNR) would otherwise risk being
-        /// mis-signaled as "zero noise" / infinite reliability.</summary>
+        ///
+        /// Production callers (the wizard's <c>TiltAdapterWizardVM.RunCalibrationMath</c>, TestApp's headless
+        /// validator) are expected to ALWAYS populate real sensor/focuser geometry (ImageWidthPixels,
+        /// ImageHeightPixels, PixelSizeMicrons, FocuserStepMicrons) — that is what makes this function's output
+        /// physically meaningful and is the entire point of the F2 fix. When geometry is left at its default
+        /// (all 0, e.g. a pure ratio/angle algebra unit test, or a test-only calibration run with no tilt-plane
+        /// model to read image size from), there is no physical space to convert into: this degrades to the raw
+        /// (A,B) delta (the pre-F2-fix behavior) rather than dividing by zero into NaN, so those geometry-less
+        /// callers stay well-defined instead of silently producing NaN — which downstream (e.g.
+        /// <see cref="ComputeConfidence"/>'s SNR) would otherwise risk being mis-signaled as "zero noise" /
+        /// infinite reliability. This degrade path is a test/degenerate-input affordance ONLY, not a supported
+        /// production mode: a real calibration with genuinely missing geometry should be treated as a bug to
+        /// fix at the call site, not silently tolerated here.</summary>
         internal static (double gx, double gy) PhysicalDelta(TiltGradient to, TiltGradient from, TiltCalibrationInputs inputs) {
             double dA = to.A - from.A;
             double dB = to.B - from.B;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs
@@ -76,18 +76,20 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public double RawAngleDiffDegrees { get; set; }      // measured screw1->screw2 gap before the constrained fit
         public int CurvatureSign { get; set; }               // +1 / -1; 0 = unknown (4-step run whose fallback sign was never configured)
         public double MeasuredHardwareMicrons { get; set; }  // µm/turn (screws) or µm/step (steppers); NaN if uncomputable
-        public double Screw1DirectionDegrees { get; set; }   // raw measured direction of screw 1's move (atan2(dA,-dB))
-        public double Screw2DirectionDegrees { get; set; }   // raw measured direction of screw 2's move
+        public double Screw1DirectionDegrees { get; set; }   // measured direction of screw 1's move in physical gradient space (atan2(gx,-gy))
+        public double Screw2DirectionDegrees { get; set; }   // measured direction of screw 2's move in physical gradient space
 
-        /// <summary>Ratio (&gt;= 1) of the larger to the smaller single-screw gradient-change magnitude. For two
-        /// clean, equal single-screw moves this is ~1; a large value means the two calibration turns were unequal
-        /// (uneven turning / backlash) and the recovered pitch/step size is unreliable. NaN if a magnitude is 0.</summary>
+        /// <summary>Ratio (&gt;= 1) of the larger to the smaller single-screw gradient-change magnitude, computed
+        /// in physical gradient space (see <see cref="PhysicalDelta"/>). For two clean, equal single-screw moves
+        /// this is ~1; a large value means the two calibration turns were unequal (uneven turning / backlash) and
+        /// the recovered pitch/step size is unreliable. NaN if a magnitude is 0.</summary>
         public double MoveMagnitudeRatio { get; set; }
 
         /// <summary>Half the absolute difference of the two single-screw recovered pitches (µm/turn or µm/step).
-        /// This is the physical-space 1σ on the recovered hardware — it captures screw-to-screw disagreement the
-        /// (A,B) <see cref="MoveMagnitudeRatio"/> misses because the plane→physical conversion is anisotropic.
-        /// NaN when the hardware is uncomputable.</summary>
+        /// This is the physical-space 1σ on the recovered hardware, expressed as an absolute µm delta after the
+        /// per-screw lever-arm conversion — a differently-scaled, complementary view of the same screw-to-screw
+        /// disagreement <see cref="MoveMagnitudeRatio"/> reports as a dimensionless ratio. NaN when the hardware
+        /// is uncomputable.</summary>
         public double PitchUncertaintyMicrons { get; set; }
 
         /// <summary>Signal-to-noise / reliability of the whole calibration, derived from the per-step tilt vectors.
@@ -106,8 +108,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
     /// no matter how cleanly the screws were turned.
     /// </summary>
     public sealed class TiltCalibrationConfidence {
-        public double ScrewMoveSignal { get; set; }               // mean |single-screw move| magnitude (the signal)
-        public double NoiseEstimate { get; set; }                 // RMS of the noise probes below
+        public double ScrewMoveSignal { get; set; }               // mean |single-screw move| magnitude in physical gradient units (µm/µm) (the signal)
+        public double NoiseEstimate { get; set; }                 // RMS of the noise probes below, in physical gradient units (µm/µm)
         public double SignalToNoise { get; set; }                 // ScrewMoveSignal / NoiseEstimate (Inf if noise 0)
         public double PredictedAngleUncertaintyDeg { get; set; }  // ~1σ on each recovered screw direction
         public double AllInwardTiltResidual { get; set; }         // |AllInward − Baseline|, should be ~0 (pure piston); NaN for 4-step runs
@@ -124,7 +126,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
     /// results to its options; keeping the math here guarantees the validator and the wizard never drift.
     ///
     /// Angle convention matches the rest of the plugin: degrees clockwise from straight up (12 o'clock) in image
-    /// space (+x right, +y down), via <c>atan2(dA, -dB)</c>.
+    /// space (+x right, +y down), via <c>atan2(gx, -gy)</c> on the physical gradient (gx, gy) — see
+    /// <see cref="PhysicalDelta"/>. NOT the raw (A, B) tilt-plane coefficients: A and B are per-normalized-
+    /// coordinate and distort directions/magnitudes on a non-square sensor (the F2 bug).
     /// </summary>
     public static class TiltCalibrationCalculator {
 
@@ -136,24 +140,51 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         private static double Magnitude(double a, double b) => Math.Sqrt(a * a + b * b);
 
+        /// <summary>Screw-move delta in physical gradient space (µm focus travel per µm of sensor
+        /// displacement). Angles and magnitude ratios MUST be computed here, not in (A,B) space —
+        /// A and B are per-normalized-coordinate and distort directions on non-square sensors.
+        /// When the caller hasn't populated real sensor/focuser geometry (ImageWidthPixels,
+        /// ImageHeightPixels, PixelSizeMicrons, FocuserStepMicrons all default to 0), there is no physical
+        /// space to convert into — degrade to the raw (A,B) delta (the pre-F2-fix behavior) rather than
+        /// divide by zero into NaN. This keeps geometry-agnostic callers (pure ratio/angle algebra tests,
+        /// a calibration step run with no known sensor size) well-defined instead of silently producing NaN,
+        /// which downstream (e.g. <see cref="ComputeConfidence"/>'s SNR) would otherwise risk being
+        /// mis-signaled as "zero noise" / infinite reliability.</summary>
+        internal static (double gx, double gy) PhysicalDelta(TiltGradient to, TiltGradient from, TiltCalibrationInputs inputs) {
+            double dA = to.A - from.A;
+            double dB = to.B - from.B;
+            double sensorW = inputs.ImageWidthPixels * inputs.PixelSizeMicrons;
+            double sensorH = inputs.ImageHeightPixels * inputs.PixelSizeMicrons;
+            if (sensorW <= 0 || sensorH <= 0 || inputs.FocuserStepMicrons <= 0) {
+                return (dA, dB);
+            }
+            return TiltScrewGeometry.PlaneGradientToPhysical(dA, dB, inputs.FocuserStepMicrons, sensorW, sensorH);
+        }
+
         /// <summary>
         /// Estimates how trustworthy the calibration is from the per-step tilt vectors. See
         /// <see cref="TiltCalibrationConfidence"/> for the model: screw moves are the signal; the noise probes are
         /// independent quantities that are each ~0 in an ideal measurement — the all-inward piston residual and both
-        /// re-baseline drifts in a 6-step run, only the single re-baseline drift in a 4-step run.
+        /// re-baseline drifts in a 6-step run, only the single re-baseline drift in a 4-step run. All magnitudes are
+        /// computed in physical gradient space (<see cref="PhysicalDelta"/>), not raw (A,B) — see the F2 fix.
         /// </summary>
         public static TiltCalibrationConfidence ComputeConfidence(TiltCalibrationInputs inputs) {
-            double s1 = Magnitude(inputs.Screw1.A - inputs.ReBaseline1.A, inputs.Screw1.B - inputs.ReBaseline1.B);
-            double s2 = Magnitude(inputs.Screw2.A - inputs.ReBaseline2.A, inputs.Screw2.B - inputs.ReBaseline2.B);
+            var (s1x, s1y) = PhysicalDelta(inputs.Screw1, inputs.ReBaseline1, inputs);
+            var (s2x, s2y) = PhysicalDelta(inputs.Screw2, inputs.ReBaseline2, inputs);
+            double s1 = Magnitude(s1x, s1y);
+            double s2 = Magnitude(s2x, s2y);
             double signal = 0.5 * (s1 + s2);
 
-            double drift2 = Magnitude(inputs.ReBaseline2.A - inputs.ReBaseline1.A, inputs.ReBaseline2.B - inputs.ReBaseline1.B);
+            var (drift2x, drift2y) = PhysicalDelta(inputs.ReBaseline2, inputs.ReBaseline1, inputs);
+            double drift2 = Magnitude(drift2x, drift2y);
             double allInward = double.NaN;
             double drift1 = double.NaN;
             double noise;
             if (inputs.HasCurvatureMeasurement) {
-                allInward = Magnitude(inputs.AllInward.A - inputs.Baseline.A, inputs.AllInward.B - inputs.Baseline.B);
-                drift1 = Magnitude(inputs.ReBaseline1.A - inputs.Baseline.A, inputs.ReBaseline1.B - inputs.Baseline.B);
+                var (aiX, aiY) = PhysicalDelta(inputs.AllInward, inputs.Baseline, inputs);
+                allInward = Magnitude(aiX, aiY);
+                var (d1x, d1y) = PhysicalDelta(inputs.ReBaseline1, inputs.Baseline, inputs);
+                drift1 = Magnitude(d1x, d1y);
                 noise = Math.Sqrt((allInward * allInward + drift1 * drift1 + drift2 * drift2) / 3.0);
             } else {
                 // 4-step run: the only available noise probe is the single re-baseline drift. A one-sample noise
@@ -162,7 +193,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 noise = drift2;
             }
 
-            double snr = noise > 0 ? signal / noise : double.PositiveInfinity;
+            // NaN-safe: PhysicalDelta divides by sensor/focuser geometry, so invalid geometry (e.g. a caller that
+            // forgot to populate ImageWidthPixels/PixelSizeMicrons/FocuserStepMicrons) propagates as NaN signal or
+            // noise. "noise > 0" is false for NaN, so without this guard a NaN noise would fall into the
+            // zero-noise branch and be misreported as infinite SNR — silently marking a bad measurement
+            // "reliable" instead of failing safe. This is a CRITICAL GATE (see TiltAdapterWizardVM.RunCalibrationMath).
+            double snr = double.IsNaN(signal) || double.IsNaN(noise)
+                ? double.NaN
+                : (noise > 0 ? signal / noise : double.PositiveInfinity);
             // A screw direction is atan2 of its move vector; transverse noise of ~noise on a signal of ~signal
             // perturbs that direction by ~atan(noise/signal). Degenerate (no signal) => maximally uncertain.
             double angleUncertainty = signal > 0 ? Math.Atan2(noise, signal) * 180.0 / Math.PI : 90.0;
@@ -212,14 +250,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         }
 
         /// <summary>
-        /// Ratio (&gt;= 1) of the larger to the smaller single-screw gradient-change magnitude. Two clean, equal
-        /// single-screw calibration turns produce ~equal magnitudes (ratio ~1); a large ratio means the two turns
-        /// were unequal, so the recovered hardware (pitch/step size) is unreliable. Returns NaN if either magnitude
-        /// is 0.
+        /// Ratio (&gt;= 1) of the larger to the smaller single-screw gradient-change magnitude, in physical
+        /// gradient space (gx, gy) — see <see cref="PhysicalDelta"/>. Two clean, equal single-screw calibration
+        /// turns produce ~equal magnitudes (ratio ~1); a large ratio means the two turns were unequal, so the
+        /// recovered hardware (pitch/step size) is unreliable. Returns NaN if either magnitude is 0.
         /// </summary>
-        public static double MoveMagnitudeRatio(double d1A, double d1B, double d2A, double d2B) {
-            double m1 = Math.Sqrt(d1A * d1A + d1B * d1B);
-            double m2 = Math.Sqrt(d2A * d2A + d2B * d2B);
+        public static double MoveMagnitudeRatio(double g1x, double g1y, double g2x, double g2y) {
+            double m1 = Math.Sqrt(g1x * g1x + g1y * g1y);
+            double m2 = Math.Sqrt(g2x * g2x + g2y * g2y);
             if (m1 <= 0 || m2 <= 0) {
                 return double.NaN;
             }
@@ -227,16 +265,17 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         }
 
         /// <summary>
-        /// Per-screw position angles from the two single-screw gradient changes (screw move minus baseline).
-        /// Determines the winding direction from the measured data (image mirroring can flip clockwise/CCW), then
-        /// performs a constrained least-squares fit to equal angular spacing (120° for 3 screws; 90° with opposite
-        /// screws 180° apart for 4 screws). Returns the four screw angles (s4 = NaN for 3 screws) and the raw
-        /// measured screw1->screw2 gap (before the fit) for separation diagnostics.
+        /// Per-screw position angles from the two single-screw gradient changes (screw move minus baseline), in
+        /// physical gradient space (gx, gy) — see <see cref="PhysicalDelta"/>. Determines the winding direction
+        /// from the measured data (image mirroring can flip clockwise/CCW), then performs a constrained
+        /// least-squares fit to equal angular spacing (120° for 3 screws; 90° with opposite screws 180° apart for
+        /// 4 screws). Returns the four screw angles (s4 = NaN for 3 screws) and the raw measured screw1->screw2
+        /// gap (before the fit) for separation diagnostics.
         /// </summary>
         public static (double s1, double s2, double s3, double s4, double rawDiff) ComputeScrewAngles(
-            double d1A, double d1B, double d2A, double d2B, int screwCount) {
-            double angle1 = NormalizeAngle(Math.Atan2(d1A, -d1B) * 180.0 / Math.PI);
-            double angle2 = NormalizeAngle(Math.Atan2(d2A, -d2B) * 180.0 / Math.PI);
+            double g1x, double g1y, double g2x, double g2y, int screwCount) {
+            double angle1 = NormalizeAngle(Math.Atan2(g1x, -g1y) * 180.0 / Math.PI);
+            double angle2 = NormalizeAngle(Math.Atan2(g2x, -g2y) * 180.0 / Math.PI);
 
             double rawDiff = NormalizeAngle(angle2 - angle1);
             bool clockwise = rawDiff < 180.0;
@@ -332,14 +371,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             return driftMag / moveMag;
         }
 
-        /// <summary>Runs the full calibration: screw angles, curvature sign, and recovered hardware.</summary>
+        /// <summary>Runs the full calibration: screw angles, curvature sign, and recovered hardware. Angles,
+        /// the raw gap, and the magnitude ratio are all computed in physical gradient space (see
+        /// <see cref="PhysicalDelta"/>), not raw (A,B) — see the F2 fix.</summary>
         public static TiltCalibrationResult Calibrate(TiltCalibrationInputs inputs) {
-            double d1A = inputs.Screw1.A - inputs.ReBaseline1.A;
-            double d1B = inputs.Screw1.B - inputs.ReBaseline1.B;
-            double d2A = inputs.Screw2.A - inputs.ReBaseline2.A;
-            double d2B = inputs.Screw2.B - inputs.ReBaseline2.B;
+            var (d1x, d1y) = PhysicalDelta(inputs.Screw1, inputs.ReBaseline1, inputs);
+            var (d2x, d2y) = PhysicalDelta(inputs.Screw2, inputs.ReBaseline2, inputs);
 
-            var (s1, s2, s3, s4, rawDiff) = ComputeScrewAngles(d1A, d1B, d2A, d2B, inputs.ScrewCount);
+            var (s1, s2, s3, s4, rawDiff) = ComputeScrewAngles(d1x, d1y, d2x, d2y, inputs.ScrewCount);
             var (measuredHardware, delta1PerApplied, delta2PerApplied) = RecoverHardwareDetailed(inputs);
 
             return new TiltCalibrationResult {
@@ -357,9 +396,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 PitchUncertaintyMicrons = double.IsNaN(delta1PerApplied)
                     ? double.NaN
                     : Math.Abs(delta1PerApplied - delta2PerApplied) / 2.0,
-                Screw1DirectionDegrees = NormalizeAngle(Math.Atan2(d1A, -d1B) * 180.0 / Math.PI),
-                Screw2DirectionDegrees = NormalizeAngle(Math.Atan2(d2A, -d2B) * 180.0 / Math.PI),
-                MoveMagnitudeRatio = MoveMagnitudeRatio(d1A, d1B, d2A, d2B),
+                Screw1DirectionDegrees = NormalizeAngle(Math.Atan2(d1x, -d1y) * 180.0 / Math.PI),
+                Screw2DirectionDegrees = NormalizeAngle(Math.Atan2(d2x, -d2y) * 180.0 / Math.PI),
+                MoveMagnitudeRatio = MoveMagnitudeRatio(d1x, d1y, d2x, d2y),
                 Confidence = ComputeConfidence(inputs)
             };
         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
@@ -61,6 +61,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public double RawAngleDiffDegrees { get; set; }
         public double MoveMagnitudeRatio { get; set; }
 
+        /// <summary>Focuser-frame µm-per-unit implied by the AllInward piston — a free, tilt-fit-independent
+        /// cross-check of <see cref="MeasuredHardwareMicrons"/>. See
+        /// <see cref="TiltCalibrationCalculator.PistonImpliedMicronsPerStep"/>. NaN for 4-step runs (no piston
+        /// measured) or runs saved before this field existed.</summary>
+        public double PistonImpliedMicronsPerStep { get; set; } = double.NaN;
+
         // ---- Confidence (persisted so a saved/replayed run carries its reliability) ----
         public double SignalToNoise { get; set; } = double.NaN;
         public double PredictedAngleUncertaintyDeg { get; set; } = double.NaN;
@@ -96,7 +102,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
     /// </summary>
     public sealed class TiltCalibrationMetadata {
 
-        public const int CurrentSchemaVersion = 2;
+        public const int CurrentSchemaVersion = 3;
 
         /// <summary>The six discrete measurement steps, in capture order. Same for 3- and 4-screw adapters.</summary>
         public static readonly string[] StepOrder = {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
@@ -47,6 +47,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public double DirectionDeg { get; set; }
         public double CurvatureRadiusMillimeters { get; set; } = double.NaN;
         public double CurvatureEffectMicronsAtScrewRadius { get; set; } = double.NaN;
+
+        // ---- Task 5: corner-region AF cross-check (a second, independent tilt-plane reading for this same
+        // step, from the inspector's 4-corner region plane rather than the per-star paraboloid) ----
+        // NaN when the corner plane could not be fit for this step, or on a run saved before this shipped.
+        public double CornerTiltPlaneA { get; set; } = double.NaN;
+        public double CornerTiltPlaneB { get; set; } = double.NaN;
+        public double CornerMeanFocuserPosition { get; set; } = double.NaN;
     }
 
     /// <summary>The computed calibration result stored for reference (the wizard/validator re-derive this from
@@ -74,6 +81,20 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public double PredictedAngleUncertaintyDeg { get; set; } = double.NaN;
         public double PitchUncertaintyMicrons { get; set; } = double.NaN;
         public bool ConfidenceIsReliable { get; set; }
+
+        // ---- Task 5: corner-region AF cross-check of this same calibration ----
+        /// <summary>Adapter hardware (µm/turn or µm/step, same convention as <see cref="MeasuredHardwareMicrons"/>)
+        /// recovered from the inspector's 4-corner region plane instead of the per-star paraboloid — a second,
+        /// independent estimate of the same screw moves. NaN when the run didn't capture a corner reading for
+        /// every active step, or on a run saved before this shipped. See
+        /// <see cref="TiltCalibrationCalculator.Calibrate"/>.</summary>
+        public double CornerMeasuredHardwareMicrons { get; set; } = double.NaN;
+
+        /// <summary>Relative disagreement between the paraboloid- and corner-AF-derived per-screw move
+        /// magnitudes (the larger of the two screws' relative differences). Flags, but never replaces, the
+        /// paraboloid-measured pitch — see the design doc's §7 recommendation 2. NaN when uncomputable (missing
+        /// corner data, or a ~0 corner-estimated move magnitude).</summary>
+        public double EstimatorRelativeDifference { get; set; } = double.NaN;
     }
 
     /// <summary>Snapshot of the profile/inspector inputs the tilt measurement reads from live state, so a replay

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
@@ -61,8 +61,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public double RawAngleDiffDegrees { get; set; }
         public double MoveMagnitudeRatio { get; set; }
 
-        /// <summary>Focuser-frame µm-per-unit implied by the AllInward piston — a free, tilt-fit-independent
-        /// cross-check of <see cref="MeasuredHardwareMicrons"/>. See
+        /// <summary>Focuser-frame µm-per-applied-unit implied by the AllInward piston — a free, tilt-fit-independent
+        /// cross-check of <see cref="MeasuredHardwareMicrons"/>. "PerStep" names the applied unit generically,
+        /// same convention as <see cref="MeasuredHardwareMicrons"/>: it is a turn on thread-pitch (screw)
+        /// adapters, a step on stepper adapters. See
         /// <see cref="TiltCalibrationCalculator.PistonImpliedMicronsPerStep"/>. NaN for 4-step runs (no piston
         /// measured) or runs saved before this field existed.</summary>
         public double PistonImpliedMicronsPerStep { get; set; } = double.NaN;

--- a/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
@@ -270,9 +270,12 @@ namespace TestApp {
                     : $"    paraboloid fit FAILED: {ps.Status}");
             }
             TiltCalibrationResult paraboloidCalibration = null;
+            // Hoisted out of the `if` (rather than a `var` local to it) so WriteReport's Step 7.2 estimator
+            // comparison can reuse the SAME inputs object Calibrate() consumed here — not a re-derived copy.
+            TiltCalibrationInputs pinputs = null;
             if (paraboloidSteps.All(p => p.Fitted)) {
                 var pbyStep = paraboloidSteps.ToDictionary(s => s.Step, StringComparer.OrdinalIgnoreCase);
-                var pinputs = new TiltCalibrationInputs {
+                pinputs = new TiltCalibrationInputs {
                     ScrewCount = metadata.NumberOfScrews,
                     Baseline = hasCurvatureSteps ? pbyStep["Baseline"].Gradient : default,
                     AllInward = hasCurvatureSteps ? pbyStep["AllInward"].Gradient : default,
@@ -293,7 +296,7 @@ namespace TestApp {
                 paraboloidCalibration = TiltCalibrationCalculator.Calibrate(pinputs);
             }
 
-            WriteReport(outDir, metadata, optimizationSource, perStep, inputs, calibration, paraboloidSteps, paraboloidCalibration);
+            WriteReport(outDir, metadata, optimizationSource, perStep, inputs, calibration, paraboloidSteps, paraboloidCalibration, pinputs, regions);
             Console.WriteLine($"Wrote tilt_summary.txt and tilt_summary.json to {outDir}");
         }
 
@@ -580,10 +583,19 @@ namespace TestApp {
                     regionR2[ri] = rSquared;
                 }
 
+                // The corner-region samples sit at the REGION CENTERS BuildTiltRegions actually laid out (±1/3
+                // normalized with default ROI), not at the true frame corners (±0.5) the 8-arg overload defaults
+                // to for the paraboloid caller (which evaluates its surface AT the real corners). Passing the
+                // actual design points — mirroring TiltPlaneModel.Create(AutoFocusResult, ...)'s own Task-1 fix —
+                // makes the regressed A/B honest; leaving the defaulted ±0.5 in place here silently attenuates
+                // them by (design-point / 0.5), the ×0.62 magnitude scale on this harness's region-path move
+                // ratio and recovered step size that Task 7.1 removes.
+                var (cornerXNorm, cornerYNorm) = CornerDesignPoint(regions);
                 var model = TiltPlaneModel.Create(
                     imageSize: imageSize, fRatio: fRatio, focuserStepSizeMicrons: focuserStepMicrons,
                     centerFocuser: regionFinal[1], topLeftFocuser: regionFinal[2], topRightFocuser: regionFinal[3],
-                    bottomLeftFocuser: regionFinal[4], bottomRightFocuser: regionFinal[5]);
+                    bottomLeftFocuser: regionFinal[4], bottomRightFocuser: regionFinal[5],
+                    cornerXNorm: cornerXNorm, cornerYNorm: cornerYNorm);
 
                 double tiltAngleDeg = TiltAngleDegrees(model.A, model.B, imageSize, focuserStepMicrons, pixelSizeMicrons);
 
@@ -610,6 +622,11 @@ namespace TestApp {
             public int StarsInModel;
             public double RSquared;
             public double TiltAngleDeg;
+
+            // Isotropic curvature coefficient from the same paraboloid fit (SensorParaboloidModel.K): the
+            // surface's z += K·(x-X0)² + K·(y-Y0)² term, with x/y/z all in sensor/focuser MICRONS (see
+            // SensorModel.FitParaboloidModel). Used by the Step 7.2 curvature cross-check. NaN when !Fitted.
+            public double K = double.NaN;
             public bool Fitted;
             public string Status;           // why the fit failed, when !Fitted
         }
@@ -695,6 +712,7 @@ namespace TestApp {
                         StarsInModel = fit.StarsInModel,
                         RSquared = fit.GoodnessOfFit,
                         TiltAngleDeg = fit.Theta * 180.0 / Math.PI,
+                        K = fit.K,
                         Fitted = true
                     };
                 } catch (Exception ex) {
@@ -770,6 +788,17 @@ namespace TestApp {
             };
         }
 
+        /// <summary>The 4-corner region's design point — the actual center of the TL corner region
+        /// <see cref="BuildTiltRegions"/> laid out, in normalized [-0.5, 0.5] image coordinates — mirroring
+        /// <c>TiltPlaneModel.Create(AutoFocusResult, ...)</c>'s own derivation (Task 1). Used both to regress the
+        /// region plane against where the samples actually are (Step 7.1) and, at the SAME radius, to predict the
+        /// paraboloid's corner-vs-center curvature sag for the cross-check (Step 7.2) — one source of truth for
+        /// "where do the corner regions sit" so the two never disagree with each other.</summary>
+        private static (double xNorm, double yNorm) CornerDesignPoint(List<StarDetectionRegion> regions) {
+            var tl = regions[2].OuterBoundary;
+            return (Math.Abs(tl.StartX + tl.Width / 2.0 - 0.5), Math.Abs(tl.StartY + tl.Height / 2.0 - 0.5));
+        }
+
         private static int InferStepSize(IEnumerable<int> focusers) {
             var positions = focusers.Distinct().OrderBy(x => x).Take(2).ToList();
             return positions.Count > 1 ? Math.Abs(positions[0] - positions[1]) : 0;
@@ -780,7 +809,8 @@ namespace TestApp {
         private static void WriteReport(
             string outDir, TiltCalibrationMetadata metadata, string optimizationSource, List<StepResult> perStep,
             TiltCalibrationInputs inputs, TiltCalibrationResult calibration,
-            List<ParaboloidStepResult> paraboloidSteps, TiltCalibrationResult paraboloidCalibration) {
+            List<ParaboloidStepResult> paraboloidSteps, TiltCalibrationResult paraboloidCalibration,
+            TiltCalibrationInputs pinputs, List<StarDetectionRegion> regions) {
 
             bool isStepper = inputs.IsStepperAdjustment;
             double groundTruthHardware = isStepper ? metadata.StepperStepSizeMicrons : metadata.ScrewThreadPitchMicrons;
@@ -881,6 +911,89 @@ namespace TestApp {
             }
             Line();
 
+            // Estimator comparison (Task 7.2): physical-gradient-space move magnitudes for BOTH estimators, now
+            // that Step 7.1 makes the 4-corner (`calibration`/`inputs`) numbers honest (no more region-path ×0.62
+            // scale). Reuses the SAME shared helpers Calibrate() itself uses internally — Screw1Delta/Screw2Delta
+            // + PhysicalDelta, via ScrewMoveMagnitude — so this comparison can never drift from the wizard's math,
+            // and relDiff is computed the SAME way as EstimatorRelativeDifference (paraboloid vs. corner-AF as the
+            // reference), just kept per-screw here rather than collapsed to the pair's max.
+            double paraboloidMove1 = double.NaN, paraboloidMove2 = double.NaN;
+            double cornerMove1 = double.NaN, cornerMove2 = double.NaN;
+            double relDiff1 = double.NaN, relDiff2 = double.NaN;
+            double paraboloidHardwareMicrons = double.NaN;
+            if (paraboloidCalibration != null && pinputs != null) {
+                paraboloidMove1 = TiltCalibrationCalculator.ScrewMoveMagnitude(1, pinputs);
+                paraboloidMove2 = TiltCalibrationCalculator.ScrewMoveMagnitude(2, pinputs);
+                cornerMove1 = TiltCalibrationCalculator.ScrewMoveMagnitude(1, inputs);
+                cornerMove2 = TiltCalibrationCalculator.ScrewMoveMagnitude(2, inputs);
+                relDiff1 = cornerMove1 > 0 ? Math.Abs(paraboloidMove1 - cornerMove1) / cornerMove1 : double.NaN;
+                relDiff2 = cornerMove2 > 0 ? Math.Abs(paraboloidMove2 - cornerMove2) / cornerMove2 : double.NaN;
+                paraboloidHardwareMicrons = paraboloidCalibration.MeasuredHardwareMicrons;
+
+                Line("Estimator comparison (per-star paraboloid vs 4-corner region-AF; physical gradient-space move magnitudes):");
+                Line($"  Screw1 move: paraboloid={F(paraboloidMove1)}  corner-AF={F(cornerMove1)}  relDiff={F(relDiff1 * 100.0)}%");
+                Line($"  Screw2 move: paraboloid={F(paraboloidMove2)}  corner-AF={F(cornerMove2)}  relDiff={F(relDiff2 * 100.0)}%");
+                Line($"  Recovered {(isStepper ? "step size" : "pitch")}: paraboloid={F(paraboloidHardwareMicrons)} µm/{(isStepper ? "step" : "turn")}  " +
+                    $"corner-AF={F(measuredHardware)} µm/{(isStepper ? "step" : "turn")}");
+            } else {
+                Line("Estimator comparison not computed — paraboloid calibration unavailable (see above).");
+            }
+            double pistonImpliedMicronsPerStep = TiltCalibrationCalculator.PistonImpliedMicronsPerStep(inputs);
+            Line($"Piston-implied hardware: {pistonImpliedMicronsPerStep:0.###} µm/step");
+            Line();
+
+            // Curvature cross-check (Task 7.2): does the paraboloid's own K predict the same corner-vs-center sag
+            // the 4-corner region AF directly measured? K is SensorParaboloidModel's isotropic curvature
+            // coefficient — the surface's z += K·(x-X0)² + K·(y-Y0)² term, with x/y/z ALL IN SENSOR/FOCUSER
+            // MICRONS (SensorModel.FitParaboloidModel builds the solver with sensorSizeMicronsX/Y = pixels ×
+            // pixelSize and inFocusMicrons = focuserPosition × focuserStepMicrons) — so K·rEff² is already in
+            // MICRONS, no unit conversion needed on the predicted side. "measured" comes from THIS HARNESS'S OWN
+            // per-region re-detection + hyperbolic re-fit (RegionPositions, populated by MeasureTiltAsync/
+            // FitFinalFocus — always unweighted, "for robustness headless") — raw FOCUSER STEPS, so it needs ×
+            // FocuserStepMicrons before it is comparable to the predicted side. rEff is the corner-region's design
+            // point (the SAME cornerXNorm/cornerYNorm Step 7.1 regresses against, via CornerDesignPoint) converted
+            // to sensor microns — the radius the corner samples actually came from, not the true frame corner.
+            //
+            // COMPARABILITY CAVEAT (confirmed against ghilios_corrected's own 01_Baseline\...\attempt01\
+            // autofocus_report_Region{1..5}.json, which the wizard itself wrote during the live run): the region
+            // RECTS this harness uses are byte-identical to the wizard's own (both ±1/3-normalized boxes; verified
+            // OuterBoundary StartX/StartY/Width/Height match exactly at default ROI) — this is NOT a region-geometry
+            // mismatch. But the wizard's stored Region1 (center) CalculatedFocusPoint reads ~46 focuser steps higher
+            // than this harness's headless re-fit of the SAME frames, while the four corner regions differ by only
+            // 5-31 steps — so the design doc §4 sag (measured from the wizard's OWN stored per-region results:
+            // -147.2 steps / -39.6 µm on Baseline, ≈2× the paraboloid K's prediction) is NOT reproducible from
+            // RegionPositions here, because RegionPositions was never validated for ABSOLUTE per-region accuracy
+            // (only the SLOPE across the four corners was — see Step 7.1's recovered-step-size check, which is
+            // corner-only and excludes the center region entirely, and does land in the expected 2.0-2.2 range).
+            // The ratio below is therefore a same-run, self-consistent diagnostic (this harness's own measured sag
+            // vs. this harness's own paraboloid-predicted sag) — useful for noticing a large same-run disagreement,
+            // but its magnitude should NOT be expected to reproduce the design doc's live-AF-report-derived ×2.
+            var (cornerXNorm, cornerYNorm) = CornerDesignPoint(regions);
+            double sensorWidthMicrons = perStep[0].ImageSize.Width * metadata.PixelSizeMicrons;
+            double sensorHeightMicrons = perStep[0].ImageSize.Height * metadata.PixelSizeMicrons;
+            double rEffMicrons = Math.Sqrt(Math.Pow(cornerXNorm * sensorWidthMicrons, 2) + Math.Pow(cornerYNorm * sensorHeightMicrons, 2));
+            double rEffSquaredMicrons2 = rEffMicrons * rEffMicrons;
+
+            Line($"Curvature cross-check (this harness's OWN re-measured corner-AF sag vs. paraboloid K's predicted sag at rEff={F(rEffMicrons)} µm):");
+            Line("  NOTE: \"measured\" is this harness's independent headless per-region re-fit, not the wizard's stored");
+            Line("  per-region AF results — an absolute-position quantity like this sag is far more sensitive to that");
+            Line("  re-measurement noise than the slope-only 4-corner (A,B) tilt plane is, so this ratio is a same-run");
+            Line("  self-consistency check only; it is not expected to reproduce the design doc's §4 finding.");
+            Line($"  {"Step",-10} {"measured µm",12} {"predicted µm",13} {"ratio",7}");
+            for (int i = 0; i < perStep.Count && i < paraboloidSteps.Count; i++) {
+                var s = perStep[i];
+                var ps = paraboloidSteps[i];
+                if (!ps.Fitted) {
+                    continue;
+                }
+                double cornerSagSteps = (s.RegionPositions[2] + s.RegionPositions[3] + s.RegionPositions[4] + s.RegionPositions[5]) / 4.0 - s.RegionPositions[1];
+                double measuredMicrons = cornerSagSteps * metadata.FocuserStepSizeMicrons;
+                double predictedMicrons = ps.K * rEffSquaredMicrons2;
+                double ratio = (predictedMicrons != 0 && double.IsFinite(predictedMicrons)) ? measuredMicrons / predictedMicrons : double.NaN;
+                Line($"  {s.Step,-10} {F(measuredMicrons),12} {F(predictedMicrons),13} {F(ratio),7}");
+            }
+            Line();
+
             // Verdicts. The screw-1 angle and hardware checks need ground truth that a wizard-written metadata.json
             // does not carry; when absent they are reported "n/a" and do not fail the run.
             bool angleProvided = !double.IsNaN(metadata.ExpectedPositionAngleScrew1Deg);
@@ -891,7 +1004,9 @@ namespace TestApp {
             bool magnitudeOk = !double.IsNaN(calibration.MoveMagnitudeRatio) && calibration.MoveMagnitudeRatio <= 1.5;
             if (!magnitudeOk) {
                 Line("  NOTE: the two screw turns produced very unequal tilt changes — the recovered hardware/angles " +
-                    "are unreliable. Re-capture turning each screw the same amount.");
+                    "are unreliable. Re-capture turning each screw the same amount. If the corner-AF cross-check " +
+                    "above disagrees with the paraboloid magnitudes, suspect the per-star fit before suspecting " +
+                    "the hardware.");
             }
             bool confidenceOk = conf.IsReliable;
             string V(bool ok, bool provided) => !provided ? "n/a" : (ok ? "PASS" : "FAIL");
@@ -934,9 +1049,23 @@ namespace TestApp {
                 paraboloid = new {
                     perStep = paraboloidSteps.Select(p => new {
                         p.Step, p.Fitted, p.Status, p.StarsInModel, p.RSquared,
-                        A = p.Gradient.A, B = p.Gradient.B, p.TiltAngleDeg
+                        A = p.Gradient.A, B = p.Gradient.B, p.TiltAngleDeg, p.K
                     }),
                     calibration = paraboloidCalibration
+                },
+                // Additive (Task 7.2): both estimators' physical-gradient-space move magnitudes and recovered
+                // hardware, plus the geometry-free piston probe. NaN fields when the paraboloid calibration
+                // could not be computed (see the "Estimator comparison not computed" report line above).
+                estimatorComparison = new {
+                    paraboloidMove1,
+                    paraboloidMove2,
+                    cornerMove1,
+                    cornerMove2,
+                    relDiff1,
+                    relDiff2,
+                    cornerHardwareMicrons = measuredHardware,
+                    paraboloidHardwareMicrons,
+                    pistonImpliedMicronsPerStep
                 },
                 verdict = new { angleOk, gapOk, hardwareOk, magnitudeOk, confidenceOk }
             };

--- a/docs/tilt-calibration-pitch-nonlinearity-design.md
+++ b/docs/tilt-calibration-pitch-nonlinearity-design.md
@@ -163,31 +163,66 @@ size (1.376 µm/step) carries the known region-path scale issue and is not usabl
   RMS ≈ 15–17 µm/star); reduced χ² 4.4–8.7 everywhere means per-star σ is still understated ~2–3×
   even after the 46778b9 σ-floor — the weighting is still not honestly calibrated on real frames.
 
-## 7. Recommendations (not yet implemented)
+## 7. Recommendations
+
+Status as of `plans/tilt-calibration-accuracy-plan.md` Task 8 (items below are annotated inline;
+short SHAs refer to commits on `ghilios/tilt-calibration-accuracy`).
 
 1. **Compute calibration magnitudes/directions in physical gradient space** (gx, gy), not (A, B)
    space — closes F2 and makes `MoveMagnitudeRatio`, rawDiff, and SNR honest. (Known open item; the
    pitch math is already isotropic-correct.)
+   **Implemented:** `ffabeac` (the (A,B)→physical-gradient conversion in `TiltCalibrationCalculator`),
+   `059002e` (routed the wizard's `RunCalibrationMath` through a single `Calibrate()` call so the fix
+   reaches the live wizard, not just the calculator), `ee6eca3` (removed a geometry fallback in
+   `PhysicalDelta` and re-gated hardware recovery on it, a code-review follow-up).
 2. **Cross-check the paraboloid gradient against the corner-region AF planes per step** and flag
    (or blend) when they disagree beyond the region σ — the region data is already computed during
    each wizard AF run; this run's warning would have been avoided and the pitch would have read ~2.0.
+   **Implemented (flag, not blend):** `efc208d` (captures the corner-region plane per step and adds
+   the disagreement warning), `a98cc77` (code-review follow-up). Prerequisite fix: `60eefda`, which
+   found the corner-region estimator itself was regressing the 4-corner plane against the frame
+   corners instead of the actual region centers, attenuating it by 2/3 — without that fix the
+   cross-check would have been comparing against a biased reference.
 3. **Investigate the paraboloid fit's gradient/curvature shrinkage** on real (not simulated) data:
    Screw2-state gradient ×0.80, curvature ×0.5 vs region AF. The winsorized-clip + σ-floor fix
    (46778b9) improved scatter but a state-dependent shrink survives on real frames.
+   **Investigated, see §8.** Every candidate mechanism inside the paraboloid solver (clipping,
+   pruning, weighting, weight monopoly, the high-σ tail, forced isotropic curvature) was ruled out by
+   direct measurement; the compression is already present in the per-star best-focus values the
+   solver is handed, and correlates with how well each star's sweep brackets its vertex. The *fix*
+   (tightening the per-star vertex estimator's acceptance criteria) is out of scope for this plan and
+   deferred to its own follow-up plan — it needs a TDD cycle against the synthetic AF bank, not a
+   change to the paraboloid solver's robust loop.
 4. **Treat pitch/corrections frame-consistently.** Either (a) always drive corrections with the
    measured (focuser-frame) pitch and reframe the UI comparison ("effective µm/step through your
    optics — expected to differ from the mechanical spec"), or (b) measure F explicitly from the
    AllInward piston (Δmean-focus µm / commanded plate µm — both already recorded) and surface it.
    The piston probe is currently used only for the curvature *sign*; it contains the frame factor
    for free.
+   **Measurement half implemented** via item 5's piston probe (`c7fd73c`, `29e451e`) plus this task's
+   manual rewrite (`documentation/docs/overview/tilt-adapter-wizard.md`), which reframes the UI
+   comparison per option (a). Driving corrections from the measured value is deliberately left as a
+   user choice, not automatic: the wizard already exposed a **Use measured value** button before this
+   plan; the manual now explains why a rig can legitimately need it.
 5. **Use the piston-implied pitch as a third estimate** (346 µm/150 steps, no pull-side mechanics,
    no tilt fit involved) to sanity-check the two tilt-derived per-screw pitches.
+   **Implemented:** `c7fd73c` (`PistonImpliedMicronsPerStep`, the 20% disagreement warning, schema
+   v3), `29e451e` (code-review follow-up, XAML row placement).
 6. **Average out settling/drift**: measure each diagonal both directions (+150 and −150) and average
    the two deltas — cancels hysteresis and linear drift to first order; or raise
    `measurementAverageCount` for calibration runs.
+   **Implemented** (the symmetric-delta variant, not the ± remeasurement variant): `a4a7304`
+   (drift-cancelling `Screw1Delta` referenced to mid(ReBaseline1, ReBaseline2), unconditional),
+   `f33548c` (code-review follow-up), `970bfc8` (optional measured final re-baseline / `ReBaseline3`,
+   giving screw 2 the same symmetric reference, default on), `dab006a` (test coverage for the
+   device-driven RB3 move and the shipped 5-step default flow).
 7. **Backfocus correction undershoot (~2×)**: after (3), re-derive the expected backfocus step
    counts; the chronic "backfocus errors remained" experience during iterative correction is
    consistent with the model's curvature shrinkage.
+   **Still pending**, now blocked on the §8 follow-up plan's fix (the per-star vertex estimator), not
+   on item 3 in the abstract: §8 found the curvature shrinkage is downstream of the same vertex-level
+   compression as the gradient shrinkage, so re-deriving backfocus step counts before that fix lands
+   would be re-deriving them against a known-short curvature.
 
 ## 8. Shrinkage mechanism: it is not in the surface solver
 

--- a/docs/tilt-calibration-pitch-nonlinearity-design.md
+++ b/docs/tilt-calibration-pitch-nonlinearity-design.md
@@ -1,0 +1,199 @@
+# Tilt Wizard Calibration: Unequal Screw Responses and the Pitch "Non-Linearity" — Root-Cause Analysis
+
+**Run analyzed:** `D:\Tilt Calibration Bank\ghilios_corrected` (2026-08-04 00:15–00:38, 4-screw EAT
+steppers, spec 1.8 µm/step, applied 150 steps/move, full-frame IMX455-class sensor 9576×6388 @ 3.76 µm,
+screw radius 55 mm, focuser step 0.269 µm, f/6.3, 882 mm).
+
+**Observed symptoms:**
+1. The wizard warned *"the two screw turns produced very unequal tilt changes (1.5× apart)"* on a
+   run where the motors provably applied identical ±150-step diagonal moves.
+2. Empirically across runs, the measured screw pitch ≈ spec (1.864 vs 1.8) when aberrations were
+   almost fully corrected, and substantially larger than spec when tilt/backfocus errors were present.
+
+**Conclusion up front:** there is no single non-linearity. Four separable causes stack, and in this run
+two of them *cancel* to produce the misleadingly spec-like 1.864 µm/step:
+
+| # | Cause | Effect on this run | Status |
+|---|---|---|---|
+| 1 | Per-star sensor-model fit underestimates the Screw2-state gradient (×0.80) and the curvature (×0.5) | ratio 1.14→1.52 (fired the warning); pitch avg dragged 2.00→1.86 | **new finding** (survives the robust-weighting fix) |
+| 2 | Focuser-frame µm ≠ plate-frame µm on this rig (factor ≈ 1.25–1.30) | every µm readout (pitch, tilt µm, backfocus µm) inflated ~25–30% vs plate µm; honest pitch reads ≈ 2.2–2.3, not 1.8 | **new finding** (piston probe proves it) |
+| 3 | State-retention / drift between steps (residuals 43–90 A,B-units vs 600-unit signal) | corner-AF ratio 1.14 ± 0.09 — the true responses are statistically equal | inherent to single-shot ± pattern |
+| 4 | F2 anisotropic angle-space bug (known, open) | rawDiff 243.3° displayed vs 265–267° physical (expected 270°) | known |
+
+The user-facing implication (symptom 2) inverts: **the "too large" pitch readings in aberrated runs were
+probably the honest ones** (in the focuser frame, the only frame the wizard can measure); the spec-like
+1.864 in the corrected run is two errors cancelling. And because the aberration-correction math divides
+focuser-frame microns by the configured pitch, **corrections are only self-consistent when the honestly
+measured pitch is used — using the spec value on this rig overcorrects tilt by ~25–30%**, and the
+sensor-model curvature shrinkage makes backfocus corrections undershoot by ~2× on top of that.
+
+---
+
+## 1. Reconstruction of what the wizard computed
+
+All wizard arithmetic was reproduced exactly from the stored per-step tilt planes
+(`metadata.json`, `perStep[]`, A/B in focuser steps per normalized image coordinate):
+
+- Screw1 move (DiagonalA: TR +150, BL −150), model delta vs ReBaseline1: (−586.8, 392.2), |mag| 705.8
+- Screw2 move (DiagonalB: TL +150, BR −150), model delta vs ReBaseline2: (+403.8, 229.2), |mag| 464.3
+- ratio 705.8/464.3 = **1.520** ✓ (warning threshold 1.5)
+- per-screw implied pitch: **2.28 / 1.45 µm/step**, mean 1.864 ✓, `pitchUncertainty` 0.412 ✓
+- SNR = 585.1/89.9 = **6.51** ✓, angle uncertainty atan(noise/signal) = **8.74°** ✓
+- A,B-space move directions 236.2°/119.6° → rawDiff **243.3°** ✓; constrained fit → screw1 **222.9°** ✓
+
+The reported 1.864 ≈ spec is the average of two individually far-off numbers (2.28 and 1.45).
+
+## 2. Independent estimator: corner-region AF planes
+
+Each step's live AF also produced per-region hyperbolic fits (`autofocus_report_Region2..5.json`,
+corner boxes centered at ±1/3 normalized). Fitting tilt planes from the four corner AF vertices
+(curvature cancels exactly over symmetric corners; prior e2e work showed region AF reads truth):
+
+| quantity | per-star model | corner AF | corner AF σ |
+|---|---|---|---|
+| Screw1 delta mag | 705.8 (+6%) | 665.9 | ±34 |
+| Screw2 delta mag | 464.3 (**−20%**) | 582.0 | ±29 |
+| ratio | 1.52 | **1.14** | ±0.09 |
+| implied pitch 1 / 2 | 2.28 / 1.45 | 2.17 / 1.82 | |
+| physical move directions | 224.9°/130.4° | 223.5°/130.5° | |
+| physical gap | 265.4° | 267.0° | (expected 270°) |
+
+- The model's Screw2-state gradient is a **uniform ×0.80 shrink** (both components ×0.799/0.794,
+  direction preserved) — >3σ below the corner estimator. That single error creates most of the 1.52
+  warning ratio.
+- The corner ratio 1.14 ± 0.09 is statistically compatible with **equal** responses given the run's
+  own noise probes (cycle residuals 43.5 and 90.5 units; the two residuals point in unrelated
+  directions — 121.9° and 309.8° — so they are settling/hysteresis + drift, not a monotonic thermal
+  drift, and not obviously a pull-side spring shortfall either).
+- The screw ANGLES came out right despite the F2 bug: the anisotropic distortion (+11°/−11° on the
+  two near-diagonal moves) is antisymmetric here and cancels in the constrained equal-spacing fit.
+  Casualties are the displayed gap (243° vs 267°), the ratio/SNR metrics computed in A,B space, and
+  near-tripping the >30° angle warning (26.7° deviation shown; physically it was 3°).
+
+## 3. The piston probe: focuser microns ≠ plate microns (factor ≈ 1.25–1.30)
+
+The AllInward step commands +150 steps on all four motors = 270 µm plate translation (at spec
+1.8 µm/step). The measured mean best-focus moved **1288–1352 focuser steps = 346–364 µm**
+(corner-mean vs center; ~333–352 µm after removing the ~−45-step piston drift seen between
+re-baselines). Focuser-frame effective pitch:
+
+- piston, center region: **2.34 µm/step**; corner regions: **2.22 µm/step**
+- Screw1 tilt response (corner AF): 2.17 µm/step — consistent with the piston number
+- Screw2 tilt response (corner AF): 1.82 µm/step — low; within the settling/drift noise floor
+
+So on this rig, 1 µm of plate motion ⇒ ~1.25–1.30 µm of focuser-measured focus shift. Three
+degenerate explanations (indistinguishable from this data, same consequences): the focuser moves
+optics that re-image (reducer/flattener on the drawtube ⇒ longitudinal magnification ≠ 1); the
+configured focuser step size 0.269 µm is ~25% overstated; the EAT spec 1.8 µm/step is understated.
+In every case the wizard's implicit assumption *1 focuser-µm = 1 plate-µm* fails by F ≈ 1.25–1.30.
+
+**Why this matters for corrections:** the Aberration Inspector computes
+`steps = focuser-frame µm / unitMicrons` (`TiltScrewTargets.ComputePerScrewTargets`). The factor F
+**cancels iff `unitMicrons` is the honestly measured (focuser-frame) pitch**, because that pitch was
+recovered from the same focuser-frame gradients. Using the spec (plate-frame) pitch leaves the full
+F ≈ 1.25–1.30 as a systematic ~25–30% overcorrection on every tilt command. The wizard's
+"Measured vs saved (+3.6%)" comparison is therefore apples-to-oranges: it compares a focuser-frame
+measurement against a plate-frame spec and small deltas can mean two errors cancelled, not accuracy.
+
+**The genuine non-linearity (small on-sensor, conceptually important):** the field-curvature sag
+changes with focuser position (measured: corner−center sag went −147 → −78 steps during the piston,
+i.e. the focus surface "breathes" as the focuser moves optics). Solving the vertex equation with
+k(z) linearized gives a field-radius-dependent conversion `1/(s + k′r²)` — measured 1.35 at center
+vs 1.28 at the corner-region radius (~5–7% across the sensor). It also means a pure piston creates
+an apparent curvature change and, when the curvature apex is off-center, an apparent tilt change —
+which is what inflates the wizard's AllInward "pure piston" noise probe (residual 69–79 units) and
+degrades the reported SNR. These distortions grow with |backfocus error|, which is one mechanism
+by which aberrated states read differently than corrected states.
+
+## 4. Sensor-model curvature is ~2× smaller than region AF measures
+
+Baseline state: stored curvature radius 5125 mm ⇒ predicted corner-box-minus-center sag 20.3 µm;
+the live region AF measured **39.6 µm** (147.2 steps). Region-AF-implied curvature effect at the
+55 mm screw radius: **−576 µm** vs the model's −295 µm. If region AF is right, backfocus
+corrections computed from the sensor model undershoot by ~2×. (Caveats to verify: astigmatic
+curvature is disabled — `Kx=Ky` forced — and star-distribution weighting differs between the two
+estimators; but a factor 2 is far beyond those caveats' plausible size. This looks like the same
+gradient/curvature shrinkage family as the Screw2 ×0.80 underestimate.)
+
+## 5. Re-reading the empirical pitch-vs-aberration correlation
+
+- **Aberrated runs:** larger signals → relatively less model shrinkage → pitch reads near the honest
+  focuser-frame value ≈ F × 1.8 ≈ **2.2–2.3 µm/step** → looks "substantially larger than spec".
+- **Corrected run:** small state gradients → model shrinkage bites (Screw2 ×0.80) → 2.00 → 1.86 →
+  looks "close to spec". Two wrongs cancelling, not accuracy.
+
+The correlation is real but its sign was misread: the spec-like value is the corrupted one.
+
+## 6. TestApp replay confirmation
+
+`TestApp tilt --dataset "D:\Tilt Calibration Bank\ghilios_corrected"` (unbayered frames, so the
+headless replay applies; judge the paraboloid section — the TestApp region path has a known
+separate lever-arm/scale issue, visible again here as an overall ×0.62 magnitude scale on its
+4-corner numbers, which cancels in its move ratio).
+
+**The paraboloid path reproduces the wizard deterministically.** Per-step (A, B), replay vs stored:
+Baseline (−32.75, −53.27) vs (−32.74, −53.66); ReBaseline1 (71.90, −27.73) vs (72.32, −27.74);
+Screw1 (−514.02, 364.28) vs (−514.49, 364.45); ReBaseline2 (−11.63, −49.32) vs (−13.08, −49.35);
+Screw2 (391.78, 181.43) vs (390.72, 179.86). Calibration from these: **move ratio 1.5169, SNR 6.48,
+gap 243.55°** — the wizard's stored result to within noise. So the 1.52 warning is a systematic
+property of the per-star fit on these frames, not run-to-run scatter.
+
+**TestApp's own 4-corner estimator (independent third estimator) again says the moves were equal:
+move ratio 1.0833, SNR 9.44** (its per-region hyperbolic fits all R² ≥ 0.98). Its recovered step
+size (1.376 µm/step) carries the known region-path scale issue and is not usable, but the ratio is.
+
+**Per-step paraboloid fit diagnostics** (Solved surface model lines):
+
+| step | Gx | K (µm/µm²) | stars | R² | red. χ² |
+|---|---|---|---|---|---|
+| Baseline | −2.45e-4 | −9.73e-8 | 1435 | 0.466 | 7.41 |
+| AllInward | −7.90e-4 | −9.28e-8 | 1421 | 0.444 | 5.17 |
+| ReBaseline1 | +5.37e-4 | −10.64e-8 | 1464 | 0.446 | 7.46 |
+| Screw1 | −3.84e-3 | −10.63e-8 | 1498 | 0.916 | 8.68 |
+| ReBaseline2 | −0.87e-4 | −10.13e-8 | 1382 | 0.382 | 7.28 |
+| Screw2 | +2.93e-3 | −8.85e-8 | **1212** | 0.840 | 4.42 |
+
+- The Baseline K (−9.73e-8/µm) predicts a corner-box-minus-center sag of 20.2 µm; region AF
+  measured 39.6 µm — the **×2 curvature shrinkage confirmed with the replay's own K**, not just the
+  stored curvature radius.
+- The Screw2-state fit shed structure across the board: **12–19% fewer stars in the model** (1212 vs
+  1382–1498), **K 13% below its neighbors** (−8.85 vs −10.13 RB2), and the gradient ×0.80 vs the
+  corner estimator — a coherent "surface amplitude shrink", not an isolated gradient error.
+- Small-tilt states fit with R² ≈ 0.38–0.47 (surface signal barely above per-star vertex noise,
+  RMS ≈ 15–17 µm/star); reduced χ² 4.4–8.7 everywhere means per-star σ is still understated ~2–3×
+  even after the 46778b9 σ-floor — the weighting is still not honestly calibrated on real frames.
+
+## 7. Recommendations (not yet implemented)
+
+1. **Compute calibration magnitudes/directions in physical gradient space** (gx, gy), not (A, B)
+   space — closes F2 and makes `MoveMagnitudeRatio`, rawDiff, and SNR honest. (Known open item; the
+   pitch math is already isotropic-correct.)
+2. **Cross-check the paraboloid gradient against the corner-region AF planes per step** and flag
+   (or blend) when they disagree beyond the region σ — the region data is already computed during
+   each wizard AF run; this run's warning would have been avoided and the pitch would have read ~2.0.
+3. **Investigate the paraboloid fit's gradient/curvature shrinkage** on real (not simulated) data:
+   Screw2-state gradient ×0.80, curvature ×0.5 vs region AF. The winsorized-clip + σ-floor fix
+   (46778b9) improved scatter but a state-dependent shrink survives on real frames.
+4. **Treat pitch/corrections frame-consistently.** Either (a) always drive corrections with the
+   measured (focuser-frame) pitch and reframe the UI comparison ("effective µm/step through your
+   optics — expected to differ from the mechanical spec"), or (b) measure F explicitly from the
+   AllInward piston (Δmean-focus µm / commanded plate µm — both already recorded) and surface it.
+   The piston probe is currently used only for the curvature *sign*; it contains the frame factor
+   for free.
+5. **Use the piston-implied pitch as a third estimate** (346 µm/150 steps, no pull-side mechanics,
+   no tilt fit involved) to sanity-check the two tilt-derived per-screw pitches.
+6. **Average out settling/drift**: measure each diagonal both directions (+150 and −150) and average
+   the two deltas — cancels hysteresis and linear drift to first order; or raise
+   `measurementAverageCount` for calibration runs.
+7. **Backfocus correction undershoot (~2×)**: after (3), re-derive the expected backfocus step
+   counts; the chronic "backfocus errors remained" experience during iterative correction is
+   consistent with the model's curvature shrinkage.
+
+## Appendix: key numbers
+
+- Per-step tilt planes (stored model vs corner AF), µm frame = focuser steps per normalized coord:
+  see `metadata.json` `perStep[]`; corner-AF planes derived from `autofocus_report_Region{2..5}.json`
+  `CalculatedFocusPoint.Position`, corners at normalized (±1/3, ±1/3).
+- Piston: mean focus 11283.9 → 9995.5 (center-region 11360.7 → 10008.6); drift probes −86 to −91
+  steps per ~9 min interval (piston), tilt-state cycle residuals (+40.2,+16.7) then (−79.1,−43.9).
+- Error propagation: corner LOO stderr 4–29 steps/region ⇒ σ(delta mag) ≈ 29–34 units.

--- a/docs/tilt-calibration-pitch-nonlinearity-design.md
+++ b/docs/tilt-calibration-pitch-nonlinearity-design.md
@@ -189,6 +189,65 @@ size (1.376 µm/step) carries the known region-path scale issue and is not usabl
    counts; the chronic "backfocus errors remained" experience during iterative correction is
    consistent with the model's curvature shrinkage.
 
+## 8. Shrinkage mechanism: it is not in the surface solver
+
+§7 item 3 asked *what* shrinks the Screw2-state gradient ×0.80 and the curvature ×0.5 while Screw1's
+state fits honestly. The replay's per-state solver diagnostics (`diag/<Step>_iterations.csv`,
+`_points.csv`, `_stars.csv`) answer the question by elimination: **every candidate mechanism inside
+the paraboloid fit is ruled out, so the compression is already present in the per-star best-focus
+values the solver is handed.**
+
+### What was ruled out
+
+| Hypothesis | Test | Result |
+|---|---|---|
+| Robust clipping prunes the far-defocus side | Gx across winsorized iterations | Screw2 Gx 0.0028835 → 0.0029270 (**+1.5%**, it *grows*); Screw1 −0.0038379 → −0.0038403 (−0.06%). Flat. |
+| Pruning removes enough stars to matter | `enabledFinal` counts | 3–6.5% pruned in every state (Screw2 79 of 1291). Far too few for a 20% amplitude deficit. |
+| Weighting drags the gradient down | Refit the surviving points unweighted | Screw2 \|G\| moves **+3.6%**, Screw1 +2.8%. Not the mechanism. |
+| Weight monopoly (a milder repeat of the pre-46778b9 bug) | ESS = (Σw)²/Σw², w = 1/σ² | ESS/N = **0.47–0.56 in every state** (Screw2 0.47). No monopoly. |
+| The high-σ tail compresses the fit | Fit best-σ half vs worst-σ half separately | Screw2 0.003572 vs 0.003809 — agree within 4%, and the *worst* half reads larger. |
+| Forced isotropic curvature (Kx = Ky) leaks into the linear terms | Refit with free Kx, Ky, and with an xy cross term | \|G\| changes by **≤0.4%** in every state. Dropping curvature entirely moves Screw2 by 2.7%. |
+
+A hand reimplementation of the weighted solve reproduces the reported Gx to six digits for all six
+states, so these are tests of the real estimator, not of an approximation to it.
+
+### What the evidence points at instead
+
+The compression is in the per-star vertex (best-focus) estimates, and it scales with the state's tilt:
+
+- **Better-bracketed stars recover a larger gradient, and only on the tilted states.** Splitting each
+  state's accepted stars by `matchedFrames` and refitting: Screw2's best-bracketed stars give a
+  gradient **+8.8%** above its poorly-bracketed ones (0.003732 vs 0.003431); Screw1 gives +1.6%. The
+  near-flat states show no informative signal (their gradients are noise-dominated).
+- **Per-star σ correlates with position along the state's own tilt axis — uniquely on Screw2.**
+  corr(σ, projection on Ĝ) = **+0.314** for Screw2, vs −0.105 (Screw1), +0.115 (ReBaseline2), and
+  ≈0.01 for the flat states. Vertex quality degrades systematically across the tilt direction.
+- **Screw2 loses the most stars upstream of the fit**: 2243 detections → 916 rejected for fewer than
+  5 matched frames → **1291 accepted**, the fewest of any state (others 1434–1566). The deficit exists
+  before the solver's first iteration, not because of it.
+- Screw2's residual MAD is the *smallest* of all six states (2.07 vs Screw1's 3.15) at R² 0.84 — the
+  surface fit is internally consistent. It is faithfully fitting an input set whose amplitude is short.
+
+Note that +8.8% is a **lower bound** on the compression, not an estimate of it: the best-bracketed
+stars are preferentially those whose focus sits near the middle of the sweep, i.e. near the tilt's
+neutral axis, which is exactly where the lever arm is smallest.
+
+### Recommended next fix (needs its own plan)
+
+Attack the **per-star vertex estimator and its acceptance criteria**, not the paraboloid solver's
+robust loop — the loop is not where the error is:
+
+1. Replace the "≥5 matched frames" gate with a **bracketing** requirement: frames on both sides of the
+   estimated vertex, with a minimum span, so a star fit from a partial branch cannot enter the surface.
+2. Quantify the vertex estimator's compression against known truth on the synthetic AF bank (where the
+   true surface is prescribed), as a function of how the sweep brackets each star. That converts the
+   ≥8.8% lower bound into a calibrated number and tells us whether a correction is even needed once (1)
+   is in place.
+3. Re-run this dataset with more sweep positions to confirm the compression falls as bracketing improves.
+
+Until then, the corner-region AF cross-check added in this plan is the operative safeguard: it fires
+exactly on the states where this compression bites, which is what it was built for.
+
 ## Appendix: key numbers
 
 - Per-step tilt planes (stored model vs corner AF), µm frame = focuser steps per normalized coord:

--- a/documentation/docs/overview/motorized-tilt-adapter.md
+++ b/documentation/docs/overview/motorized-tilt-adapter.md
@@ -56,12 +56,16 @@ you must do.
 - **Steps applied per screw** defaults to 150 steps for the EAT presets (270 µm at 1.8 µm per step),
   large enough that each calibration move stands well above measurement noise. The value must fit
   within the [safety limits](#safety-limits) before a run will start.
-- The first time you connect in a session, the wizard turns on **Measure direction** (the six-step
-  calibration) and notifies you. Leaving it on is recommended: the adapter's direction is then
-  measured with the same backfocus command that Automatic Adjustment later sends. If you turn it
-  off, backfocus moves keep an "(assumed direction)" warning.
+- The first time you connect in a session, the wizard turns on **Measure direction**, adding 2 steps
+  to the run, and notifies you. With **Measure final re-baseline** also at its default (on), a
+  freshly-connected device runs the full 7-step calibration. Leaving Measure direction on is
+  recommended: the adapter's direction is then measured with the same backfocus command that
+  Automatic Adjustment later sends. If you turn it off, backfocus moves keep an "(assumed direction)"
+  warning.
 - **Auto Run All** drives every remaining step without further clicks: the wizard sends the step's
-  move, runs the measurement, advances, and finishes with a restore move that returns every motor to
+  move, runs the measurement, and advances. With **Measure final re-baseline** on, the last
+  measurement step already restores and measures every motor, so the run finishes there; with it
+  off, the wizard finishes with an additional, unmeasured restore move that returns every motor to
   its starting position. To step through manually instead, use **Run This Step** (the **Run
   Measurement** button is relabeled while a motorized device is connected), which sends one step's
   move and measurement at a time.

--- a/documentation/docs/overview/tilt-adapter-wizard.md
+++ b/documentation/docs/overview/tilt-adapter-wizard.md
@@ -45,16 +45,22 @@ The adapter type is set by the **Screws** field (default `3`).
 
 ## The calibration loop
 
-The wizard establishes the screw-to-tilt mapping empirically. The default run is **four steps**: a
-**baseline** measurement, a screw 1 move, a re-baseline, and a screw 2 move. The move steps prompt
-a known amount of motion, worded as clockwise/counter-clockwise (tighten/loosen) turns for screws
-(e.g., "Turn screw 1 CLOCKWISE exactly 1 full turn") and as signed +/− steps for stepper adapters;
-every step ends with a measurement. From the change in the tilt vector \((\Delta A, \Delta B)\) it
-computes each screw's angle. With a connected [motorized
+The wizard establishes the screw-to-tilt mapping empirically. The core run is **four steps**: a
+**baseline** measurement, a screw 1 move, a re-baseline, and a screw 2 move. By default the wizard adds
+a fifth: **Measure final re-baseline** (on by default, in the **Measurement** section) restores the
+screw 2 move and measures it once more. That gives screw 2's move the same bracketed reference screw
+1's already has, referenced to the midpoint of the re-baselines on either side of it, which cancels
+steady drift between steps instead of leaving it in the reading. Turn the setting off to skip the extra
+autofocus run if your setup is thermally stable and drift is not a concern.
+
+The move steps prompt a known amount of motion, worded as clockwise/counter-clockwise (tighten/loosen)
+turns for screws (e.g., "Turn screw 1 CLOCKWISE exactly 1 full turn") and as signed +/− steps for
+stepper adapters; every step ends with a measurement. From the change in the tilt vector \((\Delta A,
+\Delta B)\) it computes each screw's angle. With a connected [motorized
 adapter](motorized-tilt-adapter.md#hands-off-calibration), the wizard sends these moves itself
 instead of prompting for them.
 
-The four-step run does not measure which way a clockwise turn moves the adapter. That direction
+None of those steps measure which way a clockwise turn moves the adapter. That direction
 comes from the adapter direction setting in the wizard's **Measurement** section, labeled **Screw ⟳
 moves adapter** (or **+ steps move adapter** for steppers):
 either **Toward the camera** (outward, the default) or **Toward the objective** (inward). Until it
@@ -63,8 +69,9 @@ this adds two steps (an all-screws-clockwise move plus a return to baseline) and
 off the **change in mean best-focus position** between them. Turning every screw clockwise is a pure
 piston, so if the mean best-focus position *drops*, the plate moved toward the camera — on a standard
 focuser, that means clockwise moves the adapter toward the camera. The saved calibration then reports
-the direction as measured. To average out seeing, set **Measurements to average** above 1; the wizard
-flags inconsistent repeats so you can re-run.
+the direction as measured. That same all-screws step also feeds the **Piston-implied** pitch estimate
+described below. To average out seeing, set **Measurements to average** above 1; the wizard flags
+inconsistent repeats so you can re-run.
 
 The measurement itself needs no knowledge of which way your focuser travels — the focuser convention
 cancels out of it. Only the *wording* of the direction selector depends on it, so the selector reflects
@@ -138,8 +145,8 @@ adapter's **physical hardware model**:
 | Hardware field | Meaning |
 |---|---|
 | **Adjustment type** | Whether the adapter is adjusted by **Screws** (reported in turns) or **Stepper Motors** (reported in steps). |
-| **Thread pitch (µm/turn)** | Axial microns the sensor moves per full screw turn; used when Adjustment type is Screws. |
-| **Step size (µm/step)** | Axial microns per stepper step; used when Adjustment type is Stepper Motors. |
+| **Thread pitch (µm/turn)** | Axial microns the sensor moves per full screw turn, per the adapter's mechanical spec; used when Adjustment type is Screws. |
+| **Step size (µm/step)** | Axial microns per stepper step, per the adapter's mechanical spec; used when Adjustment type is Stepper Motors. |
 | **Screw radius (mm)** | Distance of each adjuster from the sensor center, in millimeters; converts a tilt *angle* into an axial movement at the screw. |
 
 **Device presets.** Rather than entering those numbers by hand, pick your adapter from the **Device**
@@ -170,12 +177,36 @@ corrections automatically. See [Motorized Tilt Adapter](motorized-tilt-adapter.m
 enter your adapter's adjustment type, screw count, thread pitch (or stepper step size), and screw
 radius yourself.
 
-!!! note "The wizard cross-checks the hardware values it measures"
-    A calibration run also *measures* an effective thread pitch / stepper step size from how far the
-    sensor actually moved. The wizard remembers the last measured value and **warns you if it diverges
-    from the configured value**, which usually means the wrong preset is selected or a number was
-    mistyped. Without a valid hardware model, adjustments are still reported in focuser steps (and, if
-    *Focuser Step Size* is set, in microns); you just do not get the turn/step figure.
+!!! note "Measured pitch is an effective value, and it can legitimately differ from the mechanical spec"
+    A calibration run also *measures* a thread pitch or stepper step size, from how far best focus
+    actually moved for a known screw or motor move. That measurement runs through the optics and the
+    focuser, not a ruler on the adapter: it is an **effective** µm/step in focus-shift terms, not
+    necessarily the mechanical spec entered in the Hardware table above. On a rig where focuser travel
+    and sensor travel are not exactly 1:1 (moving optics that re-image as the focuser travels, or a
+    reducer or flattener riding the drawtube), the measured value can sit well above or below the
+    mechanical spec. That is expected, not an error: moving-optics re-imaging, an overstated configured
+    *Focuser Step Size*, and an understated adapter spec all produce the same symptom, and a single
+    calibration run cannot tell them apart.
+
+    Corrections are computed in the same effective frame the wizard measured, so clicking **Use
+    measured value** keeps them self-consistent. Leaving the mechanical spec in place on a rig where
+    the two disagree over-corrects or under-corrects every tilt and backfocus adjustment by that same
+    ratio. The wizard remembers the last measured value and shows it next to the saved one, in the
+    **Measured Adapter Hardware** panel, so you can compare before deciding.
+
+    Two more readouts can appear in that panel, each hidden when the run did not produce it:
+
+    - **Piston-implied** is a second, independent estimate of the same effective pitch, from how far
+      best focus moved when all screws were driven the same amount (a pure piston, no tilt). It only
+      appears when **Measure direction** (above) was on for that run, since that setting is what adds
+      the all-screws step. The wizard warns when it disagrees with the tilt-derived measurement by more
+      than 20%.
+    - **Corner-AF cross-check** is the same measurement re-derived from the four corner regions' own
+      autofocus results instead of the per-star sensor model: a second estimator of the screw moves.
+      The wizard warns when it disagrees with the main reading by more than 15%.
+
+    Without a valid hardware model, adjustments are still reported in focuser steps (and, if *Focuser
+    Step Size* is set, in microns); you just do not get the turn/step figure.
 
 ## Saving and replaying a calibration run
 

--- a/documentation/docs/overview/tilt-adapter-wizard.md
+++ b/documentation/docs/overview/tilt-adapter-wizard.md
@@ -199,8 +199,9 @@ radius yourself.
     - **Piston-implied** is a second, independent estimate of the same effective pitch, from how far
       best focus moved when all screws were driven the same amount (a pure piston, no tilt). It only
       appears when **Measure direction** (above) was on for that run, since that setting is what adds
-      the all-screws step. The wizard warns when it disagrees with the tilt-derived measurement by more
-      than 20%.
+      the all-screws step. Measure direction is **off by default**, so a default run shows neither
+      this line nor its warning. When it does appear, the wizard warns if it disagrees with the
+      tilt-derived measurement by more than 20%.
     - **Corner-AF cross-check** is the same measurement re-derived from the four corner regions' own
       autofocus results instead of the per-star sensor model: a second estimator of the screw moves.
       The wizard warns when it disagrees with the main reading by more than 15%.

--- a/plans/tilt-calibration-accuracy-plan.md
+++ b/plans/tilt-calibration-accuracy-plan.md
@@ -520,11 +520,11 @@ The replay already wrote per-state solver diagnostics to `<scratch>/tilt_replay/
 **Files:**
 - Modify: `docs/tilt-calibration-pitch-nonlinearity-design.md` (findings section)
 
-- [ ] **Step 9.1:** From `Screw2_iterations.csv` vs `Screw1_iterations.csv`: does Gx start honest at iteration 0 and shrink across winsorized iterations (→ pruning/clipping mechanism), or start low (→ weighting/seed mechanism)? Plot/tabulate Gx, K, enabledCountAfter per iteration.
-- [ ] **Step 9.2:** From `Screw2_points.csv`: spatial pattern of `disabledAtIteration >= 0` stars — are pruned stars concentrated on the far-defocus side of the tilt (which would drag the gradient down)? Compute mean x,y of pruned vs kept stars, and the residual sign of pruned stars.
-- [ ] **Step 9.3:** From `*_stars.csv`: compare `sigma_used_um` distributions Screw1 vs Screw2 states; check whether the effective sample concentrates (ESS = (Σw)²/Σw² with w = 1/σ²) — a repeat of the pre-46778b9 weight-monopoly in milder form.
-- [ ] **Step 9.4:** Write the findings into the design doc (new section "§8 Shrinkage mechanism") with the concrete next fix (e.g., symmetric residual budget per tilt side, or gradient-preserving clip), sized as its own follow-up plan. **Do not** modify `SensorModel.cs` in this plan — the fix needs its own TDD cycle against sim + real regressions.
-- [ ] **Step 9.5: Commit** — `docs(tilt): paraboloid shrinkage mechanism findings`
+- [x] **Step 9.1:** From `Screw2_iterations.csv` vs `Screw1_iterations.csv`: does Gx start honest at iteration 0 and shrink across winsorized iterations (→ pruning/clipping mechanism), or start low (→ weighting/seed mechanism)? Plot/tabulate Gx, K, enabledCountAfter per iteration.
+- [x] **Step 9.2:** From `Screw2_points.csv`: spatial pattern of `disabledAtIteration >= 0` stars — are pruned stars concentrated on the far-defocus side of the tilt (which would drag the gradient down)? Compute mean x,y of pruned vs kept stars, and the residual sign of pruned stars.
+- [x] **Step 9.3:** From `*_stars.csv`: compare `sigma_used_um` distributions Screw1 vs Screw2 states; check whether the effective sample concentrates (ESS = (Σw)²/Σw² with w = 1/σ²) — a repeat of the pre-46778b9 weight-monopoly in milder form.
+- [x] **Step 9.4:** Write the findings into the design doc (new section "§8 Shrinkage mechanism") with the concrete next fix (e.g., symmetric residual budget per tilt side, or gradient-preserving clip), sized as its own follow-up plan. **Do not** modify `SensorModel.cs` in this plan — the fix needs its own TDD cycle against sim + real regressions.
+- [x] **Step 9.5: Commit** — `docs(tilt): paraboloid shrinkage mechanism findings`
 
 ---
 

--- a/plans/tilt-calibration-accuracy-plan.md
+++ b/plans/tilt-calibration-accuracy-plan.md
@@ -531,8 +531,8 @@ The replay already wrote per-state solver diagnostics to `<scratch>/tilt_replay/
 ### Task 10: Final gate
 
 - [x] **Step 10.1:** Full suite: `dotnet.exe test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo` (timeout 600000). All green — except `SendAsync_WritesOnABackgroundThread` may flake (known, unrelated; re-run it in isolation before dismissing, and do not pipe through `tail`, which masks the exit code).
-- [ ] **Step 10.2:** Re-run the Task 7 replay command once more from the final tree; eyeball the summary against the design doc's numbers (paraboloid ratio ~1.52 reported WITH the cross-check warning present; corner hardware ≈ 2.0; piston ≈ 2.23).
-- [ ] **Step 10.3:** Push branch, open PR to `develop` titled "Tilt calibration accuracy: physical-space metrics, drift-symmetric deltas, estimator cross-checks". PR body summarizes the four root causes from the design doc and maps each commit to a §7 item. End the body with the standard generated-with footer.
+- [x] **Step 10.2:** Re-run the Task 7 replay command once more from the final tree; eyeball the summary against the design doc's numbers (paraboloid ratio ~1.52 reported WITH the cross-check warning present; corner hardware ≈ 2.0; piston ≈ 2.23).
+- [x] **Step 10.3:** Push branch, open PR to `develop` titled "Tilt calibration accuracy: physical-space metrics, drift-symmetric deltas, estimator cross-checks". PR body summarizes the four root causes from the design doc and maps each commit to a §7 item. End the body with the standard generated-with footer.
 
 ---
 

--- a/plans/tilt-calibration-accuracy-plan.md
+++ b/plans/tilt-calibration-accuracy-plan.md
@@ -151,7 +151,7 @@ public static TiltPlaneModel Create(
 - Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs`
 - Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs`
 
-- [ ] **Step 2.1: Write the failing test** (values precomputed; f=0.5, 6000×4000 px, pixel 3.76 → two moves of EQUAL physical magnitude at physical directions 200° and 290°):
+- [x] **Step 2.1: Write the failing test** (values precomputed; f=0.5, 6000×4000 px, pixel 3.76 → two moves of EQUAL physical magnitude at physical directions 200° and 290°):
 
 ```csharp
 [Test]
@@ -180,9 +180,9 @@ public void Calibrate_AnisotropicSensor_ReadsPhysicalGapAndEqualMagnitudes() {
 }
 ```
 
-- [ ] **Step 2.2: Run** `--filter "FullyQualifiedName~TiltCalibrationCalculatorTests"` → new test FAILS (rawDiff ≈ 255.0 → folded 105.0... assert reports 255.0 vs 90.0; ratio 1.354). Existing tests still pass (they use a square sensor where (A,B) space is isotropic).
+- [x] **Step 2.2: Run** `--filter "FullyQualifiedName~TiltCalibrationCalculatorTests"` → new test FAILS (rawDiff ≈ 255.0 → folded 105.0... assert reports 255.0 vs 90.0; ratio 1.354). Existing tests still pass (they use a square sensor where (A,B) space is isotropic).
 
-- [ ] **Step 2.3: Implement.** In `TiltCalibrationCalculator`:
+- [x] **Step 2.3: Implement.** In `TiltCalibrationCalculator`:
 
 ```csharp
 /// <summary>Screw-move delta in physical gradient space (µm focus travel per µm of sensor
@@ -202,10 +202,10 @@ internal static (double gx, double gy) PhysicalDelta(TiltGradient to, TiltGradie
   - `Calibrate` — compute `var (d1x, d1y) = PhysicalDelta(inputs.Screw1, inputs.ReBaseline1, inputs);` (Task 3 will change the reference point) and same for screw 2; feed those to `ComputeScrewAngles`, `MoveMagnitudeRatio`, and the two `Screw*DirectionDegrees`.
   - `ScrewMoveSignal`/`NoiseEstimate` in `TiltCalibrationConfidence`: update the doc comments to say "physical gradient units (µm/µm)" — displayed only via the dimensionless SNR.
 
-- [ ] **Step 2.4: Run the calculator fixture** → all PASS. The existing square-sensor tests must pass without edits except signature-site updates if any test calls `ComputeScrewAngles`/`MoveMagnitudeRatio` directly with (A,B) values — convert those call sites with `a * FStep / SensorW` (constants already exist at the fixture top). `ComputeConfidence_RealAstrodet6Run_IsNoiseDominated` pins SNR 0.81/50.9° from literal TiltGradients: SNR is scale-invariant but NOT aniso-invariant — recompute the pinned values by running the test, and update the literals with a comment `// physical-space values (F2 fix)`.
-- [ ] **Step 2.5:** In `TiltAdapterWizardVM.RunAveragedMeasurement` (:2374) and `ReplayAsync` (:3080), the per-state `DirectionDeg` is `NormalizeAngle(Math.Atan2(avgA, -avgB) * 180.0 / Math.PI)` — change both to physical: reuse the gx/gy conversion already present in `ComputeTiltAngleDeg` (extract a small private helper `(double gx, double gy) StateGradient(double a, double b, TiltPlaneModel model)` from its body, then `DirectionDeg = NormalizeAngle(Math.Atan2(gx, -gy) * 180.0 / Math.PI)`).
-- [ ] **Step 2.6: Run** `--filter "FullyQualifiedName~TiltAdapterWizard"` → green.
-- [ ] **Step 2.7: Commit** — `fix(tilt): compute calibration angles, ratios, and SNR in physical gradient space (F2)`
+- [x] **Step 2.4: Run the calculator fixture** → all PASS. The existing square-sensor tests must pass without edits except signature-site updates if any test calls `ComputeScrewAngles`/`MoveMagnitudeRatio` directly with (A,B) values — convert those call sites with `a * FStep / SensorW` (constants already exist at the fixture top). `ComputeConfidence_RealAstrodet6Run_IsNoiseDominated` pins SNR 0.81/50.9° from literal TiltGradients: SNR is scale-invariant but NOT aniso-invariant — recompute the pinned values by running the test, and update the literals with a comment `// physical-space values (F2 fix)`.
+- [x] **Step 2.5:** In `TiltAdapterWizardVM.RunAveragedMeasurement` (:2374) and `ReplayAsync` (:3080), the per-state `DirectionDeg` is `NormalizeAngle(Math.Atan2(avgA, -avgB) * 180.0 / Math.PI)` — change both to physical: reuse the gx/gy conversion already present in `ComputeTiltAngleDeg` (extract a small private helper `(double gx, double gy) StateGradient(double a, double b, TiltPlaneModel model)` from its body, then `DirectionDeg = NormalizeAngle(Math.Atan2(gx, -gy) * 180.0 / Math.PI)`).
+- [x] **Step 2.6: Run** `--filter "FullyQualifiedName~TiltAdapterWizard"` → green.
+- [x] **Step 2.7: Commit** — `fix(tilt): compute calibration angles, ratios, and SNR in physical gradient space (F2)`
 
 ---
 

--- a/plans/tilt-calibration-accuracy-plan.md
+++ b/plans/tilt-calibration-accuracy-plan.md
@@ -1,0 +1,544 @@
+# Tilt Calibration Accuracy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the §7 recommendations of `docs/tilt-calibration-pitch-nonlinearity-design.md`: make the tilt wizard's calibration metrics honest (physical-space math, drift-cancelling deltas, corner-AF cross-check, piston-implied pitch) and fix the 4-corner plane's lever-arm bug, so unequal-screw warnings and pitch readouts reflect the hardware instead of estimator artifacts.
+
+**Architecture:** All calibration math stays centralized in `TiltCalibrationCalculator` + `TiltScrewGeometry` (pure, shared by wizard VM and TestApp). The wizard VM gains a second per-step reading (the corner-region plane the inspector already computes) and new display rows. `TiltPlaneModel.Create` learns its actual sample positions. Metadata schema goes 2→3 with additive fields only.
+
+**Tech Stack:** C# / .NET 8 (WPF plugin), NUnit 4.4 (`dotnet.exe test` via WSL interop), Newtonsoft JSON metadata, Accord OLS (existing).
+
+**Read first (execution session):** `docs/tilt-calibration-pitch-nonlinearity-design.md` (the spec), `.claude/docs/mvvm-patterns.md` (VM work), `.claude/docs/options-system.md` (Task 6 option), `.claude/docs/documentation-style.md` (Task 8).
+
+**Locked decisions (from the investigation, do not relitigate mid-execution):**
+- The corner cross-check **flags and displays** disagreement; it does NOT silently replace the paraboloid-measured pitch. Threshold: relative per-move magnitude difference > 0.15.
+- Piston-vs-measured pitch warning threshold: 0.20 (both are focuser-frame, so honest agreement is expected).
+- Symmetric screw-1 delta (`Screw1 − mid(ReBaseline1, ReBaseline2)`) becomes the default unconditionally (it cancels linear drift and needs no new data). Screw 2 gets symmetry only when the new optional measured final re-baseline ran.
+- New enum member `ReBaseline3 = 7` (AFTER `Complete = 6` numerically — never renumber `Complete`); its step folder is special-cased to `07_ReBaseline3`.
+- `TiltCalibrationMetadata.CurrentSchemaVersion` 2→3, all new fields additive with NaN defaults; `Validate()` untouched (verified: it checks no step names or versions).
+- Test cadence per user preference: run the focused test project filter after each task, full suite at Task 10 (final gate).
+
+**Branch:** all work on `ghilios/tilt-calibration-accuracy` off `develop`. Never push `develop`. Commits use:
+```bash
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" -m "<message>"
+```
+Test command template (WSL → Windows dotnet; ~40-60 s per run, timeout 600000):
+```bash
+dotnet.exe test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~<FixtureName>"
+```
+
+---
+
+### Task 0: Branch setup
+
+**Files:** none (git only)
+
+- [ ] **Step 0.1:** `git checkout develop && git pull && git checkout -b ghilios/tilt-calibration-accuracy`
+- [ ] **Step 0.2:** Confirm clean: `git status` → "nothing to commit".
+
+---
+
+### Task 1: Fix `TiltPlaneModel.Create` corner lever arms (×2/3 attenuation)
+
+The `Create(AutoFocusResult, …)` overload feeds corner-REGION AF vertices (region centers at normalized ±1/3 with default `SensorROI=CornersROI=1.0`) into an OLS whose design points are hard-coded to (±0.5, ±0.5) (`TiltModel.cs:145-151`). Result: A/B attenuated by 2/3, which propagates to the inspector's per-corner "adjustment required" values and TestApp's region-path pitch. The paraboloid path (`SensorModelAberrationResult.CreateTiltPlaneModel`) evaluates the surface AT the true corners and passes those values to the 8-arg overload — for it, ±0.5 is correct and must not change.
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltModel.cs:113-165`
+- Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/TiltPlaneModelTests.cs`
+
+- [ ] **Step 1.1: Read the existing test file and region types** to confirm construction patterns before writing the test:
+  - `Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/TiltPlaneModelTests.cs` (how tests build `TiltPlaneModel` today)
+  - The `StarDetectionRegion` + `RatioRect` types (grep: `grep -rn "class StarDetectionRegion\|class RatioRect" Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/ --include="*.cs"`), specifically the constructor and the `OuterBoundary.StartX/StartY/Width/Height` property names (these are the names serialized into the region reports, so they will match).
+  Adapt the ctor calls in Step 1.2's test to what you find; the assertions and values stay as written.
+
+- [ ] **Step 1.2: Write the failing test** — a synthetic plane sampled at the standard corner-region centers must round-trip A/B exactly:
+
+```csharp
+[Test]
+public void Create_FromAutoFocusResult_UsesActualCornerRegionCenters() {
+    // Plane z = C + A*xn + B*yn over normalized [-0.5, 0.5]; corner regions centered at ±1/3.
+    const double A = 300.0, B = -120.0, C = 11200.0;
+    double At(double xn, double yn) => C + A * xn + B * yn;
+
+    var imageSize = new System.Drawing.Size(9576, 6388);
+    var result = new AutoFocusResult() {
+        Succeeded = true,
+        ImageSize = imageSize,
+        RegionResults = new[] {
+            RegionResult(0, new RatioRect(0.0, 0.0, 1.0, 1.0), At(0, 0)),
+            RegionResult(1, new RatioRect(1/3d, 1/3d, 1/3d, 1/3d), At(0, 0)),
+            RegionResult(2, new RatioRect(0.0, 0.0, 1/3d, 1/3d), At(-1/3d, -1/3d)),   // TL
+            RegionResult(3, new RatioRect(2/3d, 0.0, 1/3d, 1/3d), At(+1/3d, -1/3d)),  // TR
+            RegionResult(4, new RatioRect(0.0, 2/3d, 1/3d, 1/3d), At(-1/3d, +1/3d)),  // BL
+            RegionResult(5, new RatioRect(2/3d, 2/3d, 1/3d, 1/3d), At(+1/3d, +1/3d)), // BR
+        }
+    };
+
+    var model = TiltPlaneModel.Create(result, fRatio: 6.3, focuserStepSizeMicrons: 0.269);
+
+    Assert.Multiple(() => {
+        Assert.That(model.A, Is.EqualTo(A).Within(1e-9));  // old code returns 200.0 (A * 2/3)
+        Assert.That(model.B, Is.EqualTo(B).Within(1e-9));
+        Assert.That(model.C, Is.EqualTo(C).Within(1e-9));
+    });
+}
+
+private static AutoFocusRegionResult RegionResult(int index, RatioRect boundary, double focusPosition) {
+    return new AutoFocusRegionResult() {
+        RegionIndex = index,
+        Region = new StarDetectionRegion(boundary),   // adapt to actual ctor found in Step 1.1
+        EstimatedFinalFocuserPosition = focusPosition,
+        EstimatedFinalHFR = 2.0,
+        Fittings = new AutoFocusFitting()             // GetRSquared() must not throw on defaults; verify in Step 1.1
+    };
+}
+```
+
+- [ ] **Step 1.3: Run it, verify it fails with A = 200** (the 2/3 attenuation):
+  `dotnet.exe test ... --filter "FullyQualifiedName~TiltPlaneModelTests"` → new test FAILS, expected 300 actual 200.
+
+- [ ] **Step 1.4: Implement.** In `TiltModel.cs`, generalize the 8-arg overload with corner design-point parameters (defaults preserve every existing caller), and make the `AutoFocusResult` overload pass the actual region centers:
+
+```csharp
+public static TiltPlaneModel Create(AutoFocusResult result, double fRatio, double focuserStepSizeMicrons) {
+    var centerFocuser = result.RegionResults[1].EstimatedFinalFocuserPosition;
+    var topLeftFocuser = result.RegionResults[2].EstimatedFinalFocuserPosition;
+    var topRightFocuser = result.RegionResults[3].EstimatedFinalFocuserPosition;
+    var bottomLeftFocuser = result.RegionResults[4].EstimatedFinalFocuserPosition;
+    var bottomRightFocuser = result.RegionResults[5].EstimatedFinalFocuserPosition;
+    // The corner-region samples sit at the REGION CENTERS (±1/3 normalized with default ROI), not at the
+    // frame corners. Regress against where the samples actually are, or A/B are attenuated by 2·|center|.
+    var tlBoundary = result.RegionResults[2].Region.OuterBoundary;
+    double cornerXNorm = Math.Abs(tlBoundary.StartX + tlBoundary.Width / 2.0 - 0.5);
+    double cornerYNorm = Math.Abs(tlBoundary.StartY + tlBoundary.Height / 2.0 - 0.5);
+    var tiltPlaneModel = Create(
+        imageSize: result.ImageSize, fRatio: fRatio,
+        focuserStepSizeMicrons: focuserStepSizeMicrons, centerFocuser: centerFocuser, topLeftFocuser: topLeftFocuser,
+        topRightFocuser: topRightFocuser, bottomLeftFocuser: bottomLeftFocuser, bottomRightFocuser: bottomRightFocuser,
+        cornerXNorm: cornerXNorm, cornerYNorm: cornerYNorm);
+    // ... RSquared assignments unchanged ...
+    return tiltPlaneModel;
+}
+
+public static TiltPlaneModel Create(
+    System.Drawing.Size imageSize, double fRatio, double focuserStepSizeMicrons,
+    double centerFocuser, double topLeftFocuser, double topRightFocuser,
+    double bottomLeftFocuser, double bottomRightFocuser,
+    double cornerXNorm = 0.5, double cornerYNorm = 0.5) {
+    var ols = new OrdinaryLeastSquares() { UseIntercept = true };
+    double[][] inputs = {
+        new double[] { -cornerXNorm, -cornerYNorm },
+        new double[] {  cornerXNorm, -cornerYNorm },
+        new double[] { -cornerXNorm,  cornerYNorm },
+        new double[] {  cornerXNorm,  cornerYNorm },
+    };
+    // ... rest unchanged ...
+}
+```
+
+- [ ] **Step 1.5: Run the fixture again** → PASS; also run `--filter "FullyQualifiedName~TiltModelTests|FullyQualifiedName~TiltPlaneModelTests"` → all green (existing 8-arg-overload tests are unaffected by the defaulted params).
+- [ ] **Step 1.6:** Note in the commit body that inspector per-corner "adjustment required" values grow ×1.5 with default ROI (they were understated).
+- [ ] **Step 1.7: Commit** — `fix(tilt): regress 4-corner plane against actual region centers, not frame corners`
+
+---
+
+### Task 2: Physical-gradient-space calibration metrics (F2 fix)
+
+`ComputeScrewAngles`, `MoveMagnitudeRatio`, and `ComputeConfidence` currently work in anisotropic (A,B) space; on a 3:2 sensor two equal physical moves 90° apart read as a ~75° gap and a 1.35× magnitude ratio. Pitch math (`RecoverHardwareDetailed`) is already physical and stays untouched.
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs`
+- Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs`
+
+- [ ] **Step 2.1: Write the failing test** (values precomputed; f=0.5, 6000×4000 px, pixel 3.76 → two moves of EQUAL physical magnitude at physical directions 200° and 290°):
+
+```csharp
+[Test]
+public void Calibrate_AnisotropicSensor_ReadsPhysicalGapAndEqualMagnitudes() {
+    // On a 3:2 sensor, equal-magnitude physical moves at 200° and 290° produce these (A,B) deltas.
+    // In raw (A,B) space they would read: gap 75.01°, magnitude ratio 1.354 — the F2 bug.
+    var inputs = new TiltCalibrationInputs {
+        ScrewCount = 4,
+        ReBaseline1 = new TiltGradient(0, 0, 0),
+        Screw1 = new TiltGradient(-77.1597, 141.3298, 0),
+        ReBaseline2 = new TiltGradient(0, 0, 0),
+        Screw2 = new TiltGradient(-211.9947, -51.4398, 0),
+        ImageWidthPixels = 6000, ImageHeightPixels = 4000,
+        PixelSizeMicrons = 3.76, FocuserStepMicrons = 0.5,
+        ScrewRadiusMillimeters = 44.0, CalibrationAppliedAmount = 1.0,
+        IsStepperAdjustment = false, HasCurvatureMeasurement = false, FallbackCurvatureSign = 1,
+    };
+    var result = TiltCalibrationCalculator.Calibrate(inputs);
+    Assert.Multiple(() => {
+        Assert.That(result.RawAngleDiffDegrees, Is.EqualTo(90.0).Within(0.01));
+        Assert.That(result.MoveMagnitudeRatio, Is.EqualTo(1.0).Within(0.001));
+        Assert.That(result.Screw1DirectionDegrees, Is.EqualTo(200.0).Within(0.01));
+        Assert.That(result.Screw2DirectionDegrees, Is.EqualTo(290.0).Within(0.01));
+        Assert.That(result.Screw1AngleDegrees, Is.EqualTo(200.0).Within(0.01));
+    });
+}
+```
+
+- [ ] **Step 2.2: Run** `--filter "FullyQualifiedName~TiltCalibrationCalculatorTests"` → new test FAILS (rawDiff ≈ 255.0 → folded 105.0... assert reports 255.0 vs 90.0; ratio 1.354). Existing tests still pass (they use a square sensor where (A,B) space is isotropic).
+
+- [ ] **Step 2.3: Implement.** In `TiltCalibrationCalculator`:
+
+```csharp
+/// <summary>Screw-move delta in physical gradient space (µm focus travel per µm of sensor
+/// displacement). Angles and magnitude ratios MUST be computed here, not in (A,B) space —
+/// A and B are per-normalized-coordinate and distort directions on non-square sensors.</summary>
+internal static (double gx, double gy) PhysicalDelta(TiltGradient to, TiltGradient from, TiltCalibrationInputs inputs) {
+    double sensorW = inputs.ImageWidthPixels * inputs.PixelSizeMicrons;
+    double sensorH = inputs.ImageHeightPixels * inputs.PixelSizeMicrons;
+    return TiltScrewGeometry.PlaneGradientToPhysical(to.A - from.A, to.B - from.B,
+        inputs.FocuserStepMicrons, sensorW, sensorH);
+}
+```
+
+  - `ComputeScrewAngles(double g1x, double g1y, double g2x, double g2y, int screwCount)` — rename parameters only; body unchanged (`atan2(g1x, -g1y)` etc.).
+  - `MoveMagnitudeRatio(double g1x, double g1y, double g2x, double g2y)` — rename parameters; body unchanged.
+  - `ComputeConfidence(TiltCalibrationInputs inputs)` — every `Magnitude(a-b, ...)` over raw A/B becomes a magnitude of `PhysicalDelta(...)`. Signal/noise stay dimensionless ratios; `SignalToNoise` and `PredictedAngleUncertaintyDeg` semantics unchanged.
+  - `Calibrate` — compute `var (d1x, d1y) = PhysicalDelta(inputs.Screw1, inputs.ReBaseline1, inputs);` (Task 3 will change the reference point) and same for screw 2; feed those to `ComputeScrewAngles`, `MoveMagnitudeRatio`, and the two `Screw*DirectionDegrees`.
+  - `ScrewMoveSignal`/`NoiseEstimate` in `TiltCalibrationConfidence`: update the doc comments to say "physical gradient units (µm/µm)" — displayed only via the dimensionless SNR.
+
+- [ ] **Step 2.4: Run the calculator fixture** → all PASS. The existing square-sensor tests must pass without edits except signature-site updates if any test calls `ComputeScrewAngles`/`MoveMagnitudeRatio` directly with (A,B) values — convert those call sites with `a * FStep / SensorW` (constants already exist at the fixture top). `ComputeConfidence_RealAstrodet6Run_IsNoiseDominated` pins SNR 0.81/50.9° from literal TiltGradients: SNR is scale-invariant but NOT aniso-invariant — recompute the pinned values by running the test, and update the literals with a comment `// physical-space values (F2 fix)`.
+- [ ] **Step 2.5:** In `TiltAdapterWizardVM.RunAveragedMeasurement` (:2374) and `ReplayAsync` (:3080), the per-state `DirectionDeg` is `NormalizeAngle(Math.Atan2(avgA, -avgB) * 180.0 / Math.PI)` — change both to physical: reuse the gx/gy conversion already present in `ComputeTiltAngleDeg` (extract a small private helper `(double gx, double gy) StateGradient(double a, double b, TiltPlaneModel model)` from its body, then `DirectionDeg = NormalizeAngle(Math.Atan2(gx, -gy) * 180.0 / Math.PI)`).
+- [ ] **Step 2.6: Run** `--filter "FullyQualifiedName~TiltAdapterWizard"` → green.
+- [ ] **Step 2.7: Commit** — `fix(tilt): compute calibration angles, ratios, and SNR in physical gradient space (F2)`
+
+---
+
+### Task 3: Drift-cancelling symmetric screw deltas
+
+`Screw1 − mid(ReBaseline1, ReBaseline2)` cancels a linear tilt drift exactly (readings bracket the move symmetrically); this needs no new measurements. Screw 2 gains the same property in Task 6 when the measured final re-baseline is present.
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs`
+- Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs`
+
+- [ ] **Step 3.1: Write the failing test:**
+
+```csharp
+[Test]
+public void Calibrate_LinearTiltDrift_CancelsExactlyForScrew1() {
+    // A constant drift vector v is added per measurement interval. The screw-1 move D is bracketed
+    // by ReBaseline1 (2 intervals in) and ReBaseline2 (4 intervals in), with Screw1 at 3 intervals:
+    // Screw1 − mid(RB1, RB2) recovers D exactly. The old delta (Screw1 − RB1) is off by |v|.
+    var (vA, vB) = (9.0, -5.0);
+    var move1 = SingleScrewReading(0, 400.0, 4);      // D
+    var move2 = SingleScrewReading(90, 400.0, 4);     // E
+    TiltGradient Drift(TiltGradient g, int k) => new TiltGradient(g.A + k * vA, g.B + k * vB, g.MeanFocuserPosition);
+
+    var inputs = new TiltCalibrationInputs {
+        ScrewCount = 4,
+        Baseline = Drift(new TiltGradient(0, 0, 0), 0),
+        AllInward = Drift(new TiltGradient(0, 0, 100), 1),
+        ReBaseline1 = Drift(new TiltGradient(0, 0, 0), 2),
+        Screw1 = Drift(move1, 3),
+        ReBaseline2 = Drift(new TiltGradient(0, 0, 0), 4),
+        Screw2 = Drift(move2, 5),
+        ImageWidthPixels = ImgW, ImageHeightPixels = ImgH,
+        PixelSizeMicrons = PixelSize, FocuserStepMicrons = FStep,
+        ScrewRadiusMillimeters = RadiusMm, CalibrationAppliedAmount = 1.0,
+        IsStepperAdjustment = false,
+    };
+    var clean = TiltCalibrationCalculator.Calibrate(inputs with-no-drift-equivalent);  // build a second inputs without Drift()
+    var drifted = TiltCalibrationCalculator.Calibrate(inputs);
+    // screw-1 recovery is drift-immune; screw-2 (no final re-baseline yet) is allowed to differ.
+    Assert.That(drifted.Screw1DirectionDegrees, Is.EqualTo(clean.Screw1DirectionDegrees).Within(1e-9));
+}
+```
+  (Build the "clean" inputs by calling the same initializer with `Drift(g, 0)` — write it out; `TiltCalibrationInputs` is a class, no `with` expression.)
+
+- [ ] **Step 3.2: Run** → FAILS (old delta uses RB1 only; drift shifts direction).
+- [ ] **Step 3.3: Implement.** Central delta helpers used by `Calibrate`, `RecoverHardwareDetailed`, and `ComputeConfidence` (replacing their four inline `Screw1.A - ReBaseline1.A` computations):
+
+```csharp
+/// <summary>Screw-1 move referenced to the MIDPOINT of the re-baselines that bracket it
+/// (c and e). For a linear tilt drift the midpoint is exactly the drift-free reference, so the
+/// recovered move is drift-immune. Works identically in the 4-step flow (Baseline sits in the
+/// ReBaseline1 slot).</summary>
+internal static (double dA, double dB) Screw1Delta(TiltCalibrationInputs inputs) {
+    double midA = (inputs.ReBaseline1.A + inputs.ReBaseline2.A) / 2.0;
+    double midB = (inputs.ReBaseline1.B + inputs.ReBaseline2.B) / 2.0;
+    return (inputs.Screw1.A - midA, inputs.Screw1.B - midB);
+}
+
+/// <summary>Screw-2 move. Symmetric (drift-immune) only when the optional measured final
+/// re-baseline ran; otherwise referenced to ReBaseline2 as before.</summary>
+internal static (double dA, double dB) Screw2Delta(TiltCalibrationInputs inputs) {
+    if (inputs.HasFinalRebaseline) {
+        double midA = (inputs.ReBaseline2.A + inputs.ReBaseline3.A) / 2.0;
+        double midB = (inputs.ReBaseline2.B + inputs.ReBaseline3.B) / 2.0;
+        return (inputs.Screw2.A - midA, inputs.Screw2.B - midB);
+    }
+    return (inputs.Screw2.A - inputs.ReBaseline2.A, inputs.Screw2.B - inputs.ReBaseline2.B);
+}
+```
+  Add to `TiltCalibrationInputs`: `public TiltGradient ReBaseline3 { get; set; }` and `public bool HasFinalRebaseline { get; set; }` (default false — Task 6 wires it). `PhysicalDelta` from Task 2 gains an overload taking `(dA, dB)` directly.
+
+- [ ] **Step 3.4:** Update `Calibrate_DerivesScrewDeltasFromReBaselineNotBaseline` (:235) — its intent ("not Baseline") still holds; its expected values shift to the midpoint reference. Recompute expectations from the helper semantics (the test constructs known moves; the midpoint of two identical re-baselines equals the old reference, so prefer constructing RB1 == RB2 there to keep it exact and obviously correct).
+- [ ] **Step 3.5: Run** the calculator fixture → all PASS.
+- [ ] **Step 3.6: Commit** — `feat(tilt): drift-cancelling symmetric screw-move deltas`
+
+---
+
+### Task 4: Piston-implied pitch (frame-factor probe)
+
+The AllInward piston contains a free, tilt-fit-independent, focuser-frame pitch estimate. Drift-corrected using the Baseline/ReBaseline1 means that bracket it. On the analyzed run: 2.2333 µm/step vs tilt-derived 1.864 — a >20% gap that would have exposed the estimator problem immediately.
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs`
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs` (schema 2→3)
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs`
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml` (~:1580 UniformGrid)
+- Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs`
+
+- [ ] **Step 4.1: Write the failing tests** (fixture numbers are the real ghilios_corrected means):
+
+```csharp
+[Test]
+public void PistonImpliedMicronsPerStep_DriftCorrectedFromBracketingBaselines() {
+    var inputs = new TiltCalibrationInputs {
+        ScrewCount = 4, HasCurvatureMeasurement = true,
+        Baseline = new TiltGradient(0, 0, 11283.868653107538),
+        AllInward = new TiltGradient(0, 0, 9995.476157148303),
+        ReBaseline1 = new TiltGradient(0, 0, 11197.706101225354),
+        FocuserStepMicrons = 0.269, CalibrationAppliedAmount = 150.0,
+        ImageWidthPixels = 9576, ImageHeightPixels = 6388, PixelSizeMicrons = 3.76,
+        ScrewRadiusMillimeters = 55.0,
+    };
+    Assert.That(TiltCalibrationCalculator.PistonImpliedMicronsPerStep(inputs),
+        Is.EqualTo(2.233258).Within(1e-5));
+}
+
+[Test]
+public void PistonImpliedMicronsPerStep_NaNWithoutCurvatureSteps() {
+    var inputs = new TiltCalibrationInputs { HasCurvatureMeasurement = false,
+        FocuserStepMicrons = 0.269, CalibrationAppliedAmount = 150.0 };
+    Assert.That(TiltCalibrationCalculator.PistonImpliedMicronsPerStep(inputs), Is.NaN);
+}
+```
+
+- [ ] **Step 4.2: Run** → FAIL (method missing).
+- [ ] **Step 4.3: Implement:**
+
+```csharp
+/// <summary>
+/// Focuser-frame µm-per-unit implied by the AllInward piston: all screws moved by the applied
+/// amount, so mean best-focus shifts by (applied × unit) / frame-factor. Drift-corrected by
+/// interpolating the baseline mean to AllInward's time as mid(Baseline, ReBaseline1) — the two
+/// nominally-identical states that bracket it. This is measured in the SAME (focuser) frame as
+/// the tilt-derived hardware, so honest values agree; a large gap means the tilt estimator (or
+/// the mechanics on pull-side moves) is off. NaN for 4-step runs (no piston measured).
+/// </summary>
+public static double PistonImpliedMicronsPerStep(TiltCalibrationInputs inputs) {
+    if (!inputs.HasCurvatureMeasurement || inputs.CalibrationAppliedAmount <= 0 || inputs.FocuserStepMicrons <= 0) {
+        return double.NaN;
+    }
+    double baselineAtAllInward = (inputs.Baseline.MeanFocuserPosition + inputs.ReBaseline1.MeanFocuserPosition) / 2.0;
+    double deltaSteps = inputs.AllInward.MeanFocuserPosition - baselineAtAllInward;
+    return Math.Abs(deltaSteps) * inputs.FocuserStepMicrons / inputs.CalibrationAppliedAmount;
+}
+```
+  Wire into `Calibrate`: new result field `public double PistonImpliedMicronsPerStep { get; set; }`.
+
+- [ ] **Step 4.4: Metadata:** `CurrentSchemaVersion = 3`; `TiltCalibrationResultRecord` gains `public double PistonImpliedMicronsPerStep { get; set; } = double.NaN;` — populated in `TiltAdapterWizardVM.FinalizeMetadata()` (:3243). Confirm `TiltCalibrationMetadataTests` round-trip test covers new fields (add the field to its fixture object).
+- [ ] **Step 4.5: VM display + warning.** In WizardVM: store the value in a new field `pistonImpliedMicronsPerStep` when `RunCalibrationMath` completes; add:
+
+```csharp
+public string PistonPitchDisplay =>
+    double.IsNaN(pistonImpliedMicronsPerStep) ? string.Empty
+    : $"Piston-implied: {pistonImpliedMicronsPerStep:0.###} µm/{(IsStepperAdjustment ? "step" : "turn")}";
+```
+  Raise it inside `RaiseHardwareSummaryChanged()` (:2753). Extend `ValidateCalibrationQuality` with a piston check: when both values are positive and `Math.Abs(piston - measured) / measured > 0.20`, append part:
+  `$"piston-implied hardware ({piston:0.##} µm) and tilt-derived ({measured:0.##} µm) disagree by more than 20% — the tilt estimate may be unreliable"`.
+  (Extend the method signature with `double measuredHardware, double pistonImplied`; both callers are in `RunCalibrationMath`.)
+- [ ] **Step 4.6: XAML.** In `DataTemplates.xaml` "Measured Adapter Hardware" `UniformGrid Columns="2"` (~:1580), after the `SavedHardwareDisplay` row add:
+```xml
+<TextBlock Text="{Binding PistonPitchDisplay}" Margin="0,2,8,0"
+           Visibility="{Binding PistonPitchDisplay, Converter={StaticResource StringToVisibilityConverter}}" />
+```
+  (Use whatever empty-string-collapse pattern the sibling rows use — check :1583-1588; if they rely on empty TextBlocks rather than a converter, do the same and skip the Visibility binding.)
+- [ ] **Step 4.7: Run** calculator + wizard filters → green. **Commit** — `feat(tilt): piston-implied pitch estimate + disagreement warning`
+
+---
+
+### Task 5: Corner-region cross-check in the wizard
+
+The inspector already computes the 4-corner region plane every wizard AF (`inspector.TiltModel.TiltPlaneModel`, honest after Task 1). Capture it per step alongside the paraboloid reading, run the same calibration math on it, and flag when the two estimators' move magnitudes disagree by >15%. On the analyzed run this reads pitch ≈ 2.0 µm/step vs paraboloid 1.86 and ratio 1.14 vs 1.52.
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs`
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs`
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml`
+- Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs`
+
+- [ ] **Step 5.1: Extend `StepReading`** (WizardVM:246-255) with `public double CornerA; public double CornerB; public double CornerMean;` (NaN when unavailable). Extend `SeedStepReading` (:2850) with optional `double cornerA = double.NaN, double cornerB = double.NaN, double cornerMean = double.NaN`.
+- [ ] **Step 5.2: Capture.** In `RunAveragedMeasurement` (:2306), next to the `CalibrationTiltPlane` read (:2354), read `var corner = cornerTiltPlaneOverrideForTest ?? inspector.TiltModel?.TiltPlaneModel;` and accumulate `(corner.A, corner.B, corner.MeanFocuserPosition)` into a parallel list; average like the paraboloid readings. Add the test seam next to `CalibrationTiltPlaneOverrideForTest` (:2286-2301):
+```csharp
+private TiltPlaneModel cornerTiltPlaneOverrideForTest;
+internal TiltPlaneModel CornerTiltPlaneOverrideForTest {
+    get => cornerTiltPlaneOverrideForTest;
+    set => cornerTiltPlaneOverrideForTest = value;
+}
+```
+  Do the same capture in `ReplayAsync` (:3070-3084).
+- [ ] **Step 5.3: Metadata.** `TiltPerStepResult` gains `public double CornerTiltPlaneA { get; set; } = double.NaN;`, `CornerTiltPlaneB`, `CornerMeanFocuserPosition` (NaN defaults). `RecordStepIntoMetadata` (:3216) fills them. `TiltCalibrationResultRecord` gains `public double CornerMeasuredHardwareMicrons { get; set; } = double.NaN;` and `public double EstimatorRelativeDifference { get; set; } = double.NaN;`.
+- [ ] **Step 5.4: Cross-check math.** In `RunCalibrationMath` (:2631), after the paraboloid `Calibrate` call: when every reading in `activeMeasurementSteps` has non-NaN corner values, build a second `TiltCalibrationInputs` from the corner readings (identical geometry fields) and run `TiltCalibrationCalculator.Calibrate`. Compute, using the Task-2/3 helpers:
+
+```csharp
+var (p1x, p1y) = TiltCalibrationCalculator.PhysicalDelta(TiltCalibrationCalculator.Screw1Delta(inputs), inputs);
+// ... p2, c1, c2 likewise for paraboloid (p) and corner (c) inputs ...
+double rel1 = Math.Abs(Mag(p1x, p1y) - Mag(c1x, c1y)) / Mag(c1x, c1y);
+double rel2 = Math.Abs(Mag(p2x, p2y) - Mag(c2x, c2y)) / Mag(c2x, c2y);
+double estimatorRelDiff = Math.Max(rel1, rel2);
+```
+  Store `cornerCalibration.MeasuredHardwareMicrons` + `estimatorRelDiff` in fields + metadata. Extend `ValidateCalibrationQuality` with: when `estimatorRelDiff > 0.15`, append part
+  `$"the per-star model and the corner-region AF disagree on the screw moves by {estimatorRelDiff:P0} — the measured hardware may be unreliable (corner-AF estimate: {cornerMeasuredHardwareMicrons:0.###} µm)"`.
+- [ ] **Step 5.5: Display.** New VM property, raised in `RaiseHardwareSummaryChanged`:
+```csharp
+public string CornerCrossCheckDisplay =>
+    double.IsNaN(cornerMeasuredHardwareMicrons) ? string.Empty
+    : $"Corner-AF cross-check: {cornerMeasuredHardwareMicrons:0.###} µm/{(IsStepperAdjustment ? "step" : "turn")}";
+```
+  XAML row next to Task 4's, same pattern.
+- [ ] **Step 5.6: Write VM tests** in `TiltAdapterWizardVMTests` (follow existing patterns found there; use `SeedStepReading` + `RunCalibrationMath` via whatever internal invocation the existing calibration tests use — read the test file first). Two cases: (a) corner readings agreeing within 15% → no new warning part; (b) corner magnitudes 25% higher → warning contains "corner-region AF disagree".
+- [ ] **Step 5.7: Run** wizard + metadata filters → green. **Commit** — `feat(tilt): corner-region AF cross-check of the paraboloid calibration`
+
+---
+
+### Task 6: Optional measured final re-baseline (ReBaseline3)
+
+Gives screw 2 the same drift-cancelling symmetry as screw 1 and adds a third re-baseline noise probe. One extra AF (~4 min) per calibration; default ON.
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs` (enum, sequence, folder name, instructions, replay)
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatWizardMapping.cs`
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/ITiltAdapterOptions.cs` + `TiltAdapterWizard/TiltAdapterOptions.cs`
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs` (confidence probe)
+- Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml` (Panel A checkbox)
+- Test: `Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatWizardMappingTests.cs`, `Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs`, `Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs`
+
+- [ ] **Step 6.1: Pre-check (read-only).** `grep -rn "(int)WizardStep\|(int)step\|(int)CurrentStep" Joko.NINA.Plugins/ --include="*.cs"` — confirm the only integer use is `StepFolderName` (WizardVM:2281). If any other numeric persistence of `WizardStep` exists, STOP and re-plan the enum placement with the user.
+- [ ] **Step 6.2: Failing tests first — mapping.** In `EatWizardMappingTests`:
+
+```csharp
+[TestCase(150)]
+public void FullSequence_WithFinalRebaseline_SumsToZeroPerCorner(int n) {
+    var executedSteps = new[] { WizardStep.AllInward, WizardStep.ReBaseline1, WizardStep.Screw1,
+                                WizardStep.ReBaseline2, WizardStep.Screw2, WizardStep.ReBaseline3,
+                                WizardStep.Complete };
+    var total = new double[] { 0, 0, 0, 0 };
+    foreach (var step in executedSteps) {
+        var move = EatWizardMapping.MoveForStep(step, n, measuredFinalRebaseline: true);
+        if (move == null) continue;   // Complete is a no-move when ReBaseline3 already restored
+        for (int i = 0; i < 4; i++) { total[i] += move.PerCornerSteps[i]; }
+    }
+    Assert.That(total, Is.EqualTo(new double[] { 0, 0, 0, 0 }));
+}
+
+[Test]
+public void ReBaseline3_IsDiagonalBRestore_AndCompleteBecomesNoMove() {
+    var rb3 = EatWizardMapping.MoveForStep(WizardStep.ReBaseline3, 150, measuredFinalRebaseline: true);
+    Assert.Multiple(() => {
+        Assert.That(rb3.Axis, Is.EqualTo(TiltMoveAxis.DiagonalB));
+        Assert.That(rb3.Steps, Is.EqualTo(-150));
+        Assert.That(EatWizardMapping.MoveForStep(WizardStep.Complete, 150, measuredFinalRebaseline: true), Is.Null);
+        Assert.That(EatWizardMapping.MoveForStep(WizardStep.Complete, 150, measuredFinalRebaseline: false).Steps, Is.EqualTo(-150));
+    });
+}
+```
+- [ ] **Step 6.3: Run** `--filter "FullyQualifiedName~EatWizardMappingTests"` → FAIL (no enum member / overload).
+- [ ] **Step 6.4: Implement enum + mapping.**
+  - `WizardStep`: add `ReBaseline3 = 7,  // g (optional): undo the screw-2 move, measured — screw 2's drift-symmetric reference` (AFTER `Complete = 6`; do not renumber).
+  - `StepFolderName` (:2281): `if (step == WizardStep.ReBaseline3) return "07_ReBaseline3";` before the generic format.
+  - `EatWizardMapping.MoveForStep(WizardStep step, int appliedSteps, bool measuredFinalRebaseline = false)`: `ReBaseline3` → `new TiltAdapterMove(TiltMoveAxis.DiagonalB, -appliedSteps, TiltMoveGroup.Tilt, $"Wizard Re-Baseline 3: {FormatSigned(-appliedSteps)} diagonal-B (restore, measured)")`; `Complete` → `measuredFinalRebaseline ? null : <existing DiagonalB(-N)>`. Update the class doc comment ("six executed moves" → describes both variants). Keep the existing two-arg call sites compiling via the default parameter, then update the wizard's call site to pass the real flag.
+- [ ] **Step 6.5: Option.** `ITiltAdapterOptions`: `bool MeasureFinalRebaseline { get; set; }` with doc comment `/// <summary>Measure one extra re-baseline after the final restore move so screw 2's move is referenced symmetrically (drift-cancelling), at the cost of one more AF run. Default true.</summary>`. `TiltAdapterOptions`: standard accessor pattern (`optionsAccessor.GetValueBoolean(nameof(MeasureFinalRebaseline), true)` in `InitializeOptions`, `SetValueBoolean` + `RaisePropertyChanged` in the setter — copy the `MeasureCurvatureDuringCalibration` implementation verbatim with the new name). UI: checkbox in wizard Panel A next to the `MeasureCurvatureDuringCalibration` binding (DataTemplates.xaml ~:716/:755), same visual pattern, label "Measure final re-baseline (recommended)". (Tilt-adapter options live in the wizard pane, not `Resources/OptionsDataTemplates.xaml` — established pattern for this options family.)
+- [ ] **Step 6.6: Sequence + flow.** `GetMeasurementSteps(bool measureCurvature, bool measureFinalRebaseline)` appends `WizardStep.ReBaseline3` to either array when true. Update both callers (`StartAsync` :2047, `ReplayAsync` :2952 — replay passes `byStep.ContainsKey(WizardStep.ReBaseline3.ToString())`). `MeasureStep`/`NextStep` need no structural change (RB3 is an ordinary measured step; `Complete` remains the terminal state that triggers `RunCalibrationMath`). `StepDescription`/`StepInstructionsText`: add ReBaseline3 wording — stepper: `"Apply -N steps to motor 2 and +N steps to motor 4, returning to the baseline position, then click Run Measurement."`; the device-driven path sends the RB3 move via the updated `MoveForStep`.
+- [ ] **Step 6.7: Calculator.** Wire `ReBaseline3`/`HasFinalRebaseline` (added in Task 3) from the wizard's readings in `RunCalibrationMath` (:2700-2705 and :2731-2736). `ComputeConfidence`: when `HasFinalRebaseline`, add probe `drift3 = |PhysicalDelta(ReBaseline3, ReBaseline2)|` into the RMS (divide by 4 instead of 3) and surface `public double Rebaseline3Drift { get; set; } = double.NaN;` on `TiltCalibrationConfidence`. Calculator test:
+
+```csharp
+[Test]
+public void Calibrate_WithFinalRebaseline_Screw2DeltaIsDriftImmune() {
+    // mirror of Calibrate_LinearTiltDrift_CancelsExactlyForScrew1 with ReBaseline3 = Drift(zero, 6)
+    // and HasFinalRebaseline = true; assert Screw2DirectionDegrees matches the drift-free run.
+}
+```
+  (Write it out fully by copying Task 3's test shape.)
+- [ ] **Step 6.8: Metadata/replay.** `RecordStepIntoMetadata` already keys by step name — "ReBaseline3" rows serialize with no schema change beyond v3. Verify `MapRunsToSteps`-equivalent replay path (WizardVM `ReplayAsync` :2947-2953) tolerates the extra step (it iterates `activeMeasurementSteps`, which now includes RB3 when present).
+- [ ] **Step 6.9: Run** EatWizardMapping + calculator + wizard filters → green. **Commit** — `feat(tilt): optional measured final re-baseline for drift-symmetric screw-2 delta`
+
+---
+
+### Task 7: TestApp — estimator comparison + fixed region path
+
+**Files:**
+- Modify: `Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs`
+
+- [ ] **Step 7.1:** Region path fix: at :583-586 the runner calls the 8-arg `TiltPlaneModel.Create(...)` with its own region fits (regions from `BuildTiltRegions`, corner centers at ±1/3 with default ROI). Pass the new corner design points: compute `cornerXNorm`/`cornerYNorm` from the `BuildTiltRegions` rects exactly as Task 1 does (`Math.Abs(tlRect.StartX + tlRect.Width / 2.0 - 0.5)`) and pass them. Its recovered step size and SNR become honest (the ×0.62 scale disappears).
+- [ ] **Step 7.2:** Add to `WriteReport` (:780), after the paraboloid section:
+  - a per-move comparison block: physical magnitudes of Screw1/Screw2 deltas for BOTH estimators (via `TiltCalibrationCalculator.Screw1Delta`/`Screw2Delta` + `PhysicalDelta`), their relative differences, and both `MeasuredHardwareMicrons`;
+  - `Line($"Piston-implied hardware: {TiltCalibrationCalculator.PistonImpliedMicronsPerStep(inputs):0.###} µm/step");`
+  - a curvature cross-check: per-step `cornerSagSteps = (TL+TR+BL+BR)/4 − center` from `RegionPositions` vs the paraboloid K's predicted sag at the corner-region radius (predicted = `K × rEff²` with `rEff²` computed from the region rects and pixel size — the design doc §4 shows the arithmetic; on ghilios_corrected this prints measured ≈ 2× predicted).
+  - json: extend the anonymous object with `estimatorComparison = new { paraboloidMove1, paraboloidMove2, cornerMove1, cornerMove2, relDiff1, relDiff2, cornerHardwareMicrons, paraboloidHardwareMicrons, pistonImpliedMicronsPerStep }`.
+- [ ] **Step 7.3:** Update the "NOTE: the two screw turns produced very unequal tilt changes" text (:893) to add: `"If the corner-AF cross-check above disagrees with the paraboloid magnitudes, suspect the per-star fit before suspecting the hardware."` Keep verdicts and exit codes unchanged (the comparison is informational).
+- [ ] **Step 7.4:** Rebuild and re-run the replay against the bank run; verify the new sections appear and the corner path's recovered step size lands near 2.0–2.2 µm/step (was 1.376 with the lever-arm bug):
+```bash
+dotnet.exe build Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo
+cd Joko.NINA.Plugins/TestApp/bin/Debug/net8.0-windows7.0 && \
+  TILT_FIT_TIMEOUT_SEC=600 WSLENV=TILT_FIT_TIMEOUT_SEC dotnet.exe TestApp.dll tilt \
+  --dataset 'D:\Tilt Calibration Bank\ghilios_corrected' --out <scratch>/tilt_replay_v2
+```
+  Expected: paraboloid section unchanged (ratio ~1.52); 4-corner recovered step size ≈ 2.0–2.2; estimator comparison prints relDiff ≈ 0.20 on move 2; piston-implied ≈ 2.23.
+- [ ] **Step 7.5: Commit** — `feat(testapp): estimator comparison, honest region lever arms, piston pitch in tilt validator`
+
+---
+
+### Task 8: Documentation
+
+**Files:**
+- Modify: `documentation/docs/overview/tilt-adapter-wizard.md` (hardware table :131-132, measured-pitch note :160-165)
+- Modify: `docs/tilt-calibration-pitch-nonlinearity-design.md` (status)
+
+- [ ] **Step 8.1:** Read `.claude/docs/documentation-style.md` (house voice) before editing the manual.
+- [ ] **Step 8.2:** In `tilt-adapter-wizard.md`, rewrite the measured-pitch note to explain the frame factor in the house voice. Content requirements (style per the doc guide, not verbatim):
+  - The wizard measures pitch through the optics and focuser — an *effective* µm/step in focus-shift terms. On rigs where focuser travel and sensor travel are not 1:1 (moving optics, reducer on the drawtube), the measured value can sit well above or below the mechanical spec **and that is not an error**.
+  - Corrections are computed in the same effective frame, so applying "Use measured value" makes them self-consistent; keeping the mechanical spec on such a rig over- or under-corrects by the frame ratio.
+  - The new "Piston-implied" line is an independent estimate of the same effective value; the wizard warns when the two disagree by more than 20%.
+  - Document the new "Measure final re-baseline" setting (one extra AF; makes the second screw measurement immune to steady drift).
+- [ ] **Step 8.3:** In the design doc, mark §7 items 1, 2, 5, 6 implemented (with commit refs), item 3 in progress (Task 9), item 7 pending Task 9's outcome.
+- [ ] **Step 8.4: Commit** — `docs(tilt): frame-factor explanation and new wizard fields in the manual`
+
+---
+
+### Task 9: Paraboloid shrinkage investigation (analysis, timeboxed)
+
+The replay already wrote per-state solver diagnostics to `<scratch>/tilt_replay/diag/` (`<Step>_iterations.csv`: per-iteration `Gx,Gy,K,GoF,residMedian,residMAD,lowerBound,upperBound,enabledCountAfter`; `<Step>_points.csv`: per-star position, sigma, residual, `disabledAtIteration`; `<Step>_stars.csv`: per-star sweep-fit quality and sigma). The question: what mechanism shrinks the Screw2-state gradient ×0.80 and K ×0.5 (vs region AF) while Screw1's state fits honestly?
+
+**Files:**
+- Modify: `docs/tilt-calibration-pitch-nonlinearity-design.md` (findings section)
+
+- [ ] **Step 9.1:** From `Screw2_iterations.csv` vs `Screw1_iterations.csv`: does Gx start honest at iteration 0 and shrink across winsorized iterations (→ pruning/clipping mechanism), or start low (→ weighting/seed mechanism)? Plot/tabulate Gx, K, enabledCountAfter per iteration.
+- [ ] **Step 9.2:** From `Screw2_points.csv`: spatial pattern of `disabledAtIteration >= 0` stars — are pruned stars concentrated on the far-defocus side of the tilt (which would drag the gradient down)? Compute mean x,y of pruned vs kept stars, and the residual sign of pruned stars.
+- [ ] **Step 9.3:** From `*_stars.csv`: compare `sigma_used_um` distributions Screw1 vs Screw2 states; check whether the effective sample concentrates (ESS = (Σw)²/Σw² with w = 1/σ²) — a repeat of the pre-46778b9 weight-monopoly in milder form.
+- [ ] **Step 9.4:** Write the findings into the design doc (new section "§8 Shrinkage mechanism") with the concrete next fix (e.g., symmetric residual budget per tilt side, or gradient-preserving clip), sized as its own follow-up plan. **Do not** modify `SensorModel.cs` in this plan — the fix needs its own TDD cycle against sim + real regressions.
+- [ ] **Step 9.5: Commit** — `docs(tilt): paraboloid shrinkage mechanism findings`
+
+---
+
+### Task 10: Final gate
+
+- [ ] **Step 10.1:** Full suite: `dotnet.exe test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo` (timeout 600000). All green — except `SendAsync_WritesOnABackgroundThread` may flake (known, unrelated; re-run it in isolation before dismissing, and do not pipe through `tail`, which masks the exit code).
+- [ ] **Step 10.2:** Re-run the Task 7 replay command once more from the final tree; eyeball the summary against the design doc's numbers (paraboloid ratio ~1.52 reported WITH the cross-check warning present; corner hardware ≈ 2.0; piston ≈ 2.23).
+- [ ] **Step 10.3:** Push branch, open PR to `develop` titled "Tilt calibration accuracy: physical-space metrics, drift-symmetric deltas, estimator cross-checks". PR body summarizes the four root causes from the design doc and maps each commit to a §7 item. End the body with the standard generated-with footer.
+
+---
+
+## Self-review notes (kept for the executor)
+
+- Spec coverage: §7.1 → Task 2; §7.2 → Tasks 1+5; §7.3 → Task 9 (analysis only, fix deliberately out of scope); §7.4 → Tasks 4+8; §7.5 → Task 4; §7.6 → Tasks 3+6; §7.7 → Task 9 outcome + Task 7's curvature cross-check line.
+- Type consistency: `PhysicalDelta` (Task 2) is used by Tasks 3, 5, 7; `Screw1Delta`/`Screw2Delta` (Task 3) by Tasks 5, 6, 7; `PistonImpliedMicronsPerStep` (Task 4) by Task 7. `HasFinalRebaseline`/`ReBaseline3` are introduced in Task 3 (inputs) and wired in Task 6.
+- Deliberate deviations an executor must not "fix": `ReBaseline3 = 7` sits numerically after `Complete = 6`; the corner cross-check warns but never replaces the measured pitch; TestApp verdicts/exit codes unchanged.
+- Steps 1.1, 5.6, and 6.1 are read-before-write checks because test-helper ctor shapes (`RatioRect`, `StarDetectionRegion`, VM test invocation) were confirmed to exist but not read line-by-line during planning. The assertions and math in those tests are fixed; only construction syntax may need adapting.

--- a/plans/tilt-calibration-accuracy-plan.md
+++ b/plans/tilt-calibration-accuracy-plan.md
@@ -375,8 +375,8 @@ The inspector already computes the 4-corner region plane every wizard AF (`inspe
 - Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml`
 - Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs`
 
-- [ ] **Step 5.1: Extend `StepReading`** (WizardVM:246-255) with `public double CornerA; public double CornerB; public double CornerMean;` (NaN when unavailable). Extend `SeedStepReading` (:2850) with optional `double cornerA = double.NaN, double cornerB = double.NaN, double cornerMean = double.NaN`.
-- [ ] **Step 5.2: Capture.** In `RunAveragedMeasurement` (:2306), next to the `CalibrationTiltPlane` read (:2354), read `var corner = cornerTiltPlaneOverrideForTest ?? inspector.TiltModel?.TiltPlaneModel;` and accumulate `(corner.A, corner.B, corner.MeanFocuserPosition)` into a parallel list; average like the paraboloid readings. Add the test seam next to `CalibrationTiltPlaneOverrideForTest` (:2286-2301):
+- [x] **Step 5.1: Extend `StepReading`** (WizardVM:246-255) with `public double CornerA; public double CornerB; public double CornerMean;` (NaN when unavailable). Extend `SeedStepReading` (:2850) with optional `double cornerA = double.NaN, double cornerB = double.NaN, double cornerMean = double.NaN`.
+- [x] **Step 5.2: Capture.** In `RunAveragedMeasurement` (:2306), next to the `CalibrationTiltPlane` read (:2354), read `var corner = cornerTiltPlaneOverrideForTest ?? inspector.TiltModel?.TiltPlaneModel;` and accumulate `(corner.A, corner.B, corner.MeanFocuserPosition)` into a parallel list; average like the paraboloid readings. Add the test seam next to `CalibrationTiltPlaneOverrideForTest` (:2286-2301):
 ```csharp
 private TiltPlaneModel cornerTiltPlaneOverrideForTest;
 internal TiltPlaneModel CornerTiltPlaneOverrideForTest {
@@ -385,8 +385,8 @@ internal TiltPlaneModel CornerTiltPlaneOverrideForTest {
 }
 ```
   Do the same capture in `ReplayAsync` (:3070-3084).
-- [ ] **Step 5.3: Metadata.** `TiltPerStepResult` gains `public double CornerTiltPlaneA { get; set; } = double.NaN;`, `CornerTiltPlaneB`, `CornerMeanFocuserPosition` (NaN defaults). `RecordStepIntoMetadata` (:3216) fills them. `TiltCalibrationResultRecord` gains `public double CornerMeasuredHardwareMicrons { get; set; } = double.NaN;` and `public double EstimatorRelativeDifference { get; set; } = double.NaN;`.
-- [ ] **Step 5.4: Cross-check math.** In `RunCalibrationMath` (:2631), after the paraboloid `Calibrate` call: when every reading in `activeMeasurementSteps` has non-NaN corner values, build a second `TiltCalibrationInputs` from the corner readings (identical geometry fields) and run `TiltCalibrationCalculator.Calibrate`. Compute, using the Task-2/3 helpers:
+- [x] **Step 5.3: Metadata.** `TiltPerStepResult` gains `public double CornerTiltPlaneA { get; set; } = double.NaN;`, `CornerTiltPlaneB`, `CornerMeanFocuserPosition` (NaN defaults). `RecordStepIntoMetadata` (:3216) fills them. `TiltCalibrationResultRecord` gains `public double CornerMeasuredHardwareMicrons { get; set; } = double.NaN;` and `public double EstimatorRelativeDifference { get; set; } = double.NaN;`.
+- [x] **Step 5.4: Cross-check math.** In `RunCalibrationMath` (:2631), after the paraboloid `Calibrate` call: when every reading in `activeMeasurementSteps` has non-NaN corner values, build a second `TiltCalibrationInputs` from the corner readings (identical geometry fields) and run `TiltCalibrationCalculator.Calibrate`. Compute, using the Task-2/3 helpers:
 
 ```csharp
 var (p1x, p1y) = TiltCalibrationCalculator.PhysicalDelta(TiltCalibrationCalculator.Screw1Delta(inputs), inputs);
@@ -397,15 +397,15 @@ double estimatorRelDiff = Math.Max(rel1, rel2);
 ```
   Store `cornerCalibration.MeasuredHardwareMicrons` + `estimatorRelDiff` in fields + metadata. Extend `ValidateCalibrationQuality` with: when `estimatorRelDiff > 0.15`, append part
   `$"the per-star model and the corner-region AF disagree on the screw moves by {estimatorRelDiff:P0} — the measured hardware may be unreliable (corner-AF estimate: {cornerMeasuredHardwareMicrons:0.###} µm)"`.
-- [ ] **Step 5.5: Display.** New VM property, raised in `RaiseHardwareSummaryChanged`:
+- [x] **Step 5.5: Display.** New VM property, raised in `RaiseHardwareSummaryChanged`:
 ```csharp
 public string CornerCrossCheckDisplay =>
     double.IsNaN(cornerMeasuredHardwareMicrons) ? string.Empty
     : $"Corner-AF cross-check: {cornerMeasuredHardwareMicrons:0.###} µm/{(IsStepperAdjustment ? "step" : "turn")}";
 ```
   XAML row next to Task 4's, same pattern.
-- [ ] **Step 5.6: Write VM tests** in `TiltAdapterWizardVMTests` (follow existing patterns found there; use `SeedStepReading` + `RunCalibrationMath` via whatever internal invocation the existing calibration tests use — read the test file first). Two cases: (a) corner readings agreeing within 15% → no new warning part; (b) corner magnitudes 25% higher → warning contains "corner-region AF disagree".
-- [ ] **Step 5.7: Run** wizard + metadata filters → green. **Commit** — `feat(tilt): corner-region AF cross-check of the paraboloid calibration`
+- [x] **Step 5.6: Write VM tests** in `TiltAdapterWizardVMTests` (follow existing patterns found there; use `SeedStepReading` + `RunCalibrationMath` via whatever internal invocation the existing calibration tests use — read the test file first). Two cases: (a) corner readings agreeing within 15% → no new warning part; (b) corner magnitudes 25% higher → warning contains "corner-region AF disagree".
+- [x] **Step 5.7: Run** wizard + metadata filters → green. **Commit** — `feat(tilt): corner-region AF cross-check of the paraboloid calibration`
 
 ---
 

--- a/plans/tilt-calibration-accuracy-plan.md
+++ b/plans/tilt-calibration-accuracy-plan.md
@@ -477,14 +477,14 @@ public void Calibrate_WithFinalRebaseline_Screw2DeltaIsDriftImmune() {
 **Files:**
 - Modify: `Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs`
 
-- [ ] **Step 7.1:** Region path fix: at :583-586 the runner calls the 8-arg `TiltPlaneModel.Create(...)` with its own region fits (regions from `BuildTiltRegions`, corner centers at ±1/3 with default ROI). Pass the new corner design points: compute `cornerXNorm`/`cornerYNorm` from the `BuildTiltRegions` rects exactly as Task 1 does (`Math.Abs(tlRect.StartX + tlRect.Width / 2.0 - 0.5)`) and pass them. Its recovered step size and SNR become honest (the ×0.62 scale disappears).
-- [ ] **Step 7.2:** Add to `WriteReport` (:780), after the paraboloid section:
+- [x] **Step 7.1:** Region path fix: at :583-586 the runner calls the 8-arg `TiltPlaneModel.Create(...)` with its own region fits (regions from `BuildTiltRegions`, corner centers at ±1/3 with default ROI). Pass the new corner design points: compute `cornerXNorm`/`cornerYNorm` from the `BuildTiltRegions` rects exactly as Task 1 does (`Math.Abs(tlRect.StartX + tlRect.Width / 2.0 - 0.5)`) and pass them. Its recovered step size and SNR become honest (the ×0.62 scale disappears).
+- [x] **Step 7.2:** Add to `WriteReport` (:780), after the paraboloid section:
   - a per-move comparison block: physical magnitudes of Screw1/Screw2 deltas for BOTH estimators (via `TiltCalibrationCalculator.Screw1Delta`/`Screw2Delta` + `PhysicalDelta`), their relative differences, and both `MeasuredHardwareMicrons`;
   - `Line($"Piston-implied hardware: {TiltCalibrationCalculator.PistonImpliedMicronsPerStep(inputs):0.###} µm/step");`
   - a curvature cross-check: per-step `cornerSagSteps = (TL+TR+BL+BR)/4 − center` from `RegionPositions` vs the paraboloid K's predicted sag at the corner-region radius (predicted = `K × rEff²` with `rEff²` computed from the region rects and pixel size — the design doc §4 shows the arithmetic; on ghilios_corrected this prints measured ≈ 2× predicted).
   - json: extend the anonymous object with `estimatorComparison = new { paraboloidMove1, paraboloidMove2, cornerMove1, cornerMove2, relDiff1, relDiff2, cornerHardwareMicrons, paraboloidHardwareMicrons, pistonImpliedMicronsPerStep }`.
-- [ ] **Step 7.3:** Update the "NOTE: the two screw turns produced very unequal tilt changes" text (:893) to add: `"If the corner-AF cross-check above disagrees with the paraboloid magnitudes, suspect the per-star fit before suspecting the hardware."` Keep verdicts and exit codes unchanged (the comparison is informational).
-- [ ] **Step 7.4:** Rebuild and re-run the replay against the bank run; verify the new sections appear and the corner path's recovered step size lands near 2.0–2.2 µm/step (was 1.376 with the lever-arm bug):
+- [x] **Step 7.3:** Update the "NOTE: the two screw turns produced very unequal tilt changes" text (:893) to add: `"If the corner-AF cross-check above disagrees with the paraboloid magnitudes, suspect the per-star fit before suspecting the hardware."` Keep verdicts and exit codes unchanged (the comparison is informational).
+- [x] **Step 7.4:** Rebuild and re-run the replay against the bank run; verify the new sections appear and the corner path's recovered step size lands near 2.0–2.2 µm/step (was 1.376 with the lever-arm bug):
 ```bash
 dotnet.exe build Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo
 cd Joko.NINA.Plugins/TestApp/bin/Debug/net8.0-windows7.0 && \
@@ -492,7 +492,7 @@ cd Joko.NINA.Plugins/TestApp/bin/Debug/net8.0-windows7.0 && \
   --dataset 'D:\Tilt Calibration Bank\ghilios_corrected' --out <scratch>/tilt_replay_v2
 ```
   Expected: paraboloid section unchanged (ratio ~1.52); 4-corner recovered step size ≈ 2.0–2.2; estimator comparison prints relDiff ≈ 0.20 on move 2; piston-implied ≈ 2.23.
-- [ ] **Step 7.5: Commit** — `feat(testapp): estimator comparison, honest region lever arms, piston pitch in tilt validator`
+- [x] **Step 7.5: Commit** — `feat(testapp): estimator comparison, honest region lever arms, piston pitch in tilt validator`
 
 ---
 
@@ -502,14 +502,14 @@ cd Joko.NINA.Plugins/TestApp/bin/Debug/net8.0-windows7.0 && \
 - Modify: `documentation/docs/overview/tilt-adapter-wizard.md` (hardware table :131-132, measured-pitch note :160-165)
 - Modify: `docs/tilt-calibration-pitch-nonlinearity-design.md` (status)
 
-- [ ] **Step 8.1:** Read `.claude/docs/documentation-style.md` (house voice) before editing the manual.
-- [ ] **Step 8.2:** In `tilt-adapter-wizard.md`, rewrite the measured-pitch note to explain the frame factor in the house voice. Content requirements (style per the doc guide, not verbatim):
+- [x] **Step 8.1:** Read `.claude/docs/documentation-style.md` (house voice) before editing the manual.
+- [x] **Step 8.2:** In `tilt-adapter-wizard.md`, rewrite the measured-pitch note to explain the frame factor in the house voice. Content requirements (style per the doc guide, not verbatim):
   - The wizard measures pitch through the optics and focuser — an *effective* µm/step in focus-shift terms. On rigs where focuser travel and sensor travel are not 1:1 (moving optics, reducer on the drawtube), the measured value can sit well above or below the mechanical spec **and that is not an error**.
   - Corrections are computed in the same effective frame, so applying "Use measured value" makes them self-consistent; keeping the mechanical spec on such a rig over- or under-corrects by the frame ratio.
   - The new "Piston-implied" line is an independent estimate of the same effective value; the wizard warns when the two disagree by more than 20%.
   - Document the new "Measure final re-baseline" setting (one extra AF; makes the second screw measurement immune to steady drift).
-- [ ] **Step 8.3:** In the design doc, mark §7 items 1, 2, 5, 6 implemented (with commit refs), item 3 in progress (Task 9), item 7 pending Task 9's outcome.
-- [ ] **Step 8.4: Commit** — `docs(tilt): frame-factor explanation and new wizard fields in the manual`
+- [x] **Step 8.3:** In the design doc, mark §7 items 1, 2, 5, 6 implemented (with commit refs), item 3 in progress (Task 9), item 7 pending Task 9's outcome.
+- [x] **Step 8.4: Commit** — `docs(tilt): frame-factor explanation and new wizard fields in the manual`
 
 ---
 
@@ -530,7 +530,7 @@ The replay already wrote per-state solver diagnostics to `<scratch>/tilt_replay/
 
 ### Task 10: Final gate
 
-- [ ] **Step 10.1:** Full suite: `dotnet.exe test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo` (timeout 600000). All green — except `SendAsync_WritesOnABackgroundThread` may flake (known, unrelated; re-run it in isolation before dismissing, and do not pipe through `tail`, which masks the exit code).
+- [x] **Step 10.1:** Full suite: `dotnet.exe test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo` (timeout 600000). All green — except `SendAsync_WritesOnABackgroundThread` may flake (known, unrelated; re-run it in isolation before dismissing, and do not pipe through `tail`, which masks the exit code).
 - [ ] **Step 10.2:** Re-run the Task 7 replay command once more from the final tree; eyeball the summary against the design doc's numbers (paraboloid ratio ~1.52 reported WITH the cross-check warning present; corner hardware ≈ 2.0; piston ≈ 2.23).
 - [ ] **Step 10.3:** Push branch, open PR to `develop` titled "Tilt calibration accuracy: physical-space metrics, drift-symmetric deltas, estimator cross-checks". PR body summarizes the four root causes from the design doc and maps each commit to a §7 item. End the body with the standard generated-with footer.
 

--- a/plans/tilt-calibration-accuracy-plan.md
+++ b/plans/tilt-calibration-accuracy-plan.md
@@ -217,7 +217,7 @@ internal static (double gx, double gy) PhysicalDelta(TiltGradient to, TiltGradie
 - Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationCalculator.cs`
 - Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs`
 
-- [ ] **Step 3.1: Write the failing test:**
+- [x] **Step 3.1: Write the failing test:**
 
 ```csharp
 [Test]
@@ -251,8 +251,8 @@ public void Calibrate_LinearTiltDrift_CancelsExactlyForScrew1() {
 ```
   (Build the "clean" inputs by calling the same initializer with `Drift(g, 0)` — write it out; `TiltCalibrationInputs` is a class, no `with` expression.)
 
-- [ ] **Step 3.2: Run** → FAILS (old delta uses RB1 only; drift shifts direction).
-- [ ] **Step 3.3: Implement.** Central delta helpers used by `Calibrate`, `RecoverHardwareDetailed`, and `ComputeConfidence` (replacing their four inline `Screw1.A - ReBaseline1.A` computations):
+- [x] **Step 3.2: Run** → FAILS (old delta uses RB1 only; drift shifts direction).
+- [x] **Step 3.3: Implement.** Central delta helpers used by `Calibrate`, `RecoverHardwareDetailed`, and `ComputeConfidence` (replacing their four inline `Screw1.A - ReBaseline1.A` computations):
 
 ```csharp
 /// <summary>Screw-1 move referenced to the MIDPOINT of the re-baselines that bracket it
@@ -278,9 +278,9 @@ internal static (double dA, double dB) Screw2Delta(TiltCalibrationInputs inputs)
 ```
   Add to `TiltCalibrationInputs`: `public TiltGradient ReBaseline3 { get; set; }` and `public bool HasFinalRebaseline { get; set; }` (default false — Task 6 wires it). `PhysicalDelta` from Task 2 gains an overload taking `(dA, dB)` directly.
 
-- [ ] **Step 3.4:** Update `Calibrate_DerivesScrewDeltasFromReBaselineNotBaseline` (:235) — its intent ("not Baseline") still holds; its expected values shift to the midpoint reference. Recompute expectations from the helper semantics (the test constructs known moves; the midpoint of two identical re-baselines equals the old reference, so prefer constructing RB1 == RB2 there to keep it exact and obviously correct).
-- [ ] **Step 3.5: Run** the calculator fixture → all PASS.
-- [ ] **Step 3.6: Commit** — `feat(tilt): drift-cancelling symmetric screw-move deltas`
+- [x] **Step 3.4:** Update `Calibrate_DerivesScrewDeltasFromReBaselineNotBaseline` (:235) — its intent ("not Baseline") still holds; its expected values shift to the midpoint reference. Recompute expectations from the helper semantics (the test constructs known moves; the midpoint of two identical re-baselines equals the old reference, so prefer constructing RB1 == RB2 there to keep it exact and obviously correct).
+- [x] **Step 3.5: Run** the calculator fixture → all PASS.
+- [x] **Step 3.6: Commit** — `feat(tilt): drift-cancelling symmetric screw-move deltas`
 
 ---
 

--- a/plans/tilt-calibration-accuracy-plan.md
+++ b/plans/tilt-calibration-accuracy-plan.md
@@ -295,7 +295,7 @@ The AllInward piston contains a free, tilt-fit-independent, focuser-frame pitch 
 - Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml` (~:1580 UniformGrid)
 - Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs`
 
-- [ ] **Step 4.1: Write the failing tests** (fixture numbers are the real ghilios_corrected means):
+- [x] **Step 4.1: Write the failing tests** (fixture numbers are the real ghilios_corrected means):
 
 ```csharp
 [Test]
@@ -321,8 +321,8 @@ public void PistonImpliedMicronsPerStep_NaNWithoutCurvatureSteps() {
 }
 ```
 
-- [ ] **Step 4.2: Run** → FAIL (method missing).
-- [ ] **Step 4.3: Implement:**
+- [x] **Step 4.2: Run** → FAIL (method missing).
+- [x] **Step 4.3: Implement:**
 
 ```csharp
 /// <summary>
@@ -344,8 +344,8 @@ public static double PistonImpliedMicronsPerStep(TiltCalibrationInputs inputs) {
 ```
   Wire into `Calibrate`: new result field `public double PistonImpliedMicronsPerStep { get; set; }`.
 
-- [ ] **Step 4.4: Metadata:** `CurrentSchemaVersion = 3`; `TiltCalibrationResultRecord` gains `public double PistonImpliedMicronsPerStep { get; set; } = double.NaN;` — populated in `TiltAdapterWizardVM.FinalizeMetadata()` (:3243). Confirm `TiltCalibrationMetadataTests` round-trip test covers new fields (add the field to its fixture object).
-- [ ] **Step 4.5: VM display + warning.** In WizardVM: store the value in a new field `pistonImpliedMicronsPerStep` when `RunCalibrationMath` completes; add:
+- [x] **Step 4.4: Metadata:** `CurrentSchemaVersion = 3`; `TiltCalibrationResultRecord` gains `public double PistonImpliedMicronsPerStep { get; set; } = double.NaN;` — populated in `TiltAdapterWizardVM.FinalizeMetadata()` (:3243). Confirm `TiltCalibrationMetadataTests` round-trip test covers new fields (add the field to its fixture object).
+- [x] **Step 4.5: VM display + warning.** In WizardVM: store the value in a new field `pistonImpliedMicronsPerStep` when `RunCalibrationMath` completes; add:
 
 ```csharp
 public string PistonPitchDisplay =>
@@ -355,13 +355,13 @@ public string PistonPitchDisplay =>
   Raise it inside `RaiseHardwareSummaryChanged()` (:2753). Extend `ValidateCalibrationQuality` with a piston check: when both values are positive and `Math.Abs(piston - measured) / measured > 0.20`, append part:
   `$"piston-implied hardware ({piston:0.##} µm) and tilt-derived ({measured:0.##} µm) disagree by more than 20% — the tilt estimate may be unreliable"`.
   (Extend the method signature with `double measuredHardware, double pistonImplied`; both callers are in `RunCalibrationMath`.)
-- [ ] **Step 4.6: XAML.** In `DataTemplates.xaml` "Measured Adapter Hardware" `UniformGrid Columns="2"` (~:1580), after the `SavedHardwareDisplay` row add:
+- [x] **Step 4.6: XAML.** In `DataTemplates.xaml` "Measured Adapter Hardware" `UniformGrid Columns="2"` (~:1580), after the `SavedHardwareDisplay` row add:
 ```xml
 <TextBlock Text="{Binding PistonPitchDisplay}" Margin="0,2,8,0"
            Visibility="{Binding PistonPitchDisplay, Converter={StaticResource StringToVisibilityConverter}}" />
 ```
   (Use whatever empty-string-collapse pattern the sibling rows use — check :1583-1588; if they rely on empty TextBlocks rather than a converter, do the same and skip the Visibility binding.)
-- [ ] **Step 4.7: Run** calculator + wizard filters → green. **Commit** — `feat(tilt): piston-implied pitch estimate + disagreement warning`
+- [x] **Step 4.7: Run** calculator + wizard filters → green. **Commit** — `feat(tilt): piston-implied pitch estimate + disagreement warning`
 
 ---
 

--- a/plans/tilt-calibration-accuracy-plan.md
+++ b/plans/tilt-calibration-accuracy-plan.md
@@ -34,8 +34,8 @@ dotnet.exe test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filt
 
 **Files:** none (git only)
 
-- [ ] **Step 0.1:** `git checkout develop && git pull && git checkout -b ghilios/tilt-calibration-accuracy`
-- [ ] **Step 0.2:** Confirm clean: `git status` → "nothing to commit".
+- [x] **Step 0.1:** `git checkout develop && git pull && git checkout -b ghilios/tilt-calibration-accuracy`
+- [x] **Step 0.2:** Confirm clean: `git status` → "nothing to commit".
 
 ---
 
@@ -47,12 +47,12 @@ The `Create(AutoFocusResult, …)` overload feeds corner-REGION AF vertices (reg
 - Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltModel.cs:113-165`
 - Test: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/TiltPlaneModelTests.cs`
 
-- [ ] **Step 1.1: Read the existing test file and region types** to confirm construction patterns before writing the test:
+- [x] **Step 1.1: Read the existing test file and region types** to confirm construction patterns before writing the test:
   - `Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/TiltPlaneModelTests.cs` (how tests build `TiltPlaneModel` today)
   - The `StarDetectionRegion` + `RatioRect` types (grep: `grep -rn "class StarDetectionRegion\|class RatioRect" Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/ --include="*.cs"`), specifically the constructor and the `OuterBoundary.StartX/StartY/Width/Height` property names (these are the names serialized into the region reports, so they will match).
   Adapt the ctor calls in Step 1.2's test to what you find; the assertions and values stay as written.
 
-- [ ] **Step 1.2: Write the failing test** — a synthetic plane sampled at the standard corner-region centers must round-trip A/B exactly:
+- [x] **Step 1.2: Write the failing test** — a synthetic plane sampled at the standard corner-region centers must round-trip A/B exactly:
 
 ```csharp
 [Test]
@@ -95,10 +95,10 @@ private static AutoFocusRegionResult RegionResult(int index, RatioRect boundary,
 }
 ```
 
-- [ ] **Step 1.3: Run it, verify it fails with A = 200** (the 2/3 attenuation):
+- [x] **Step 1.3: Run it, verify it fails with A = 200** (the 2/3 attenuation):
   `dotnet.exe test ... --filter "FullyQualifiedName~TiltPlaneModelTests"` → new test FAILS, expected 300 actual 200.
 
-- [ ] **Step 1.4: Implement.** In `TiltModel.cs`, generalize the 8-arg overload with corner design-point parameters (defaults preserve every existing caller), and make the `AutoFocusResult` overload pass the actual region centers:
+- [x] **Step 1.4: Implement.** In `TiltModel.cs`, generalize the 8-arg overload with corner design-point parameters (defaults preserve every existing caller), and make the `AutoFocusResult` overload pass the actual region centers:
 
 ```csharp
 public static TiltPlaneModel Create(AutoFocusResult result, double fRatio, double focuserStepSizeMicrons) {
@@ -137,9 +137,9 @@ public static TiltPlaneModel Create(
 }
 ```
 
-- [ ] **Step 1.5: Run the fixture again** → PASS; also run `--filter "FullyQualifiedName~TiltModelTests|FullyQualifiedName~TiltPlaneModelTests"` → all green (existing 8-arg-overload tests are unaffected by the defaulted params).
-- [ ] **Step 1.6:** Note in the commit body that inspector per-corner "adjustment required" values grow ×1.5 with default ROI (they were understated).
-- [ ] **Step 1.7: Commit** — `fix(tilt): regress 4-corner plane against actual region centers, not frame corners`
+- [x] **Step 1.5: Run the fixture again** → PASS; also run `--filter "FullyQualifiedName~TiltModelTests|FullyQualifiedName~TiltPlaneModelTests"` → all green (existing 8-arg-overload tests are unaffected by the defaulted params).
+- [x] **Step 1.6:** Note in the commit body that inspector per-corner "adjustment required" values grow ×1.5 with default ROI (they were understated).
+- [x] **Step 1.7: Commit** — `fix(tilt): regress 4-corner plane against actual region centers, not frame corners`
 
 ---
 

--- a/plans/tilt-calibration-accuracy-plan.md
+++ b/plans/tilt-calibration-accuracy-plan.md
@@ -421,8 +421,8 @@ Gives screw 2 the same drift-cancelling symmetry as screw 1 and adds a third re-
 - Modify: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml` (Panel A checkbox)
 - Test: `Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatWizardMappingTests.cs`, `Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs`, `Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs`
 
-- [ ] **Step 6.1: Pre-check (read-only).** `grep -rn "(int)WizardStep\|(int)step\|(int)CurrentStep" Joko.NINA.Plugins/ --include="*.cs"` — confirm the only integer use is `StepFolderName` (WizardVM:2281). If any other numeric persistence of `WizardStep` exists, STOP and re-plan the enum placement with the user.
-- [ ] **Step 6.2: Failing tests first — mapping.** In `EatWizardMappingTests`:
+- [x] **Step 6.1: Pre-check (read-only).** `grep -rn "(int)WizardStep\|(int)step\|(int)CurrentStep" Joko.NINA.Plugins/ --include="*.cs"` — confirm the only integer use is `StepFolderName` (WizardVM:2281). If any other numeric persistence of `WizardStep` exists, STOP and re-plan the enum placement with the user.
+- [x] **Step 6.2: Failing tests first — mapping.** In `EatWizardMappingTests`:
 
 ```csharp
 [TestCase(150)]
@@ -450,14 +450,14 @@ public void ReBaseline3_IsDiagonalBRestore_AndCompleteBecomesNoMove() {
     });
 }
 ```
-- [ ] **Step 6.3: Run** `--filter "FullyQualifiedName~EatWizardMappingTests"` → FAIL (no enum member / overload).
-- [ ] **Step 6.4: Implement enum + mapping.**
+- [x] **Step 6.3: Run** `--filter "FullyQualifiedName~EatWizardMappingTests"` → FAIL (no enum member / overload).
+- [x] **Step 6.4: Implement enum + mapping.**
   - `WizardStep`: add `ReBaseline3 = 7,  // g (optional): undo the screw-2 move, measured — screw 2's drift-symmetric reference` (AFTER `Complete = 6`; do not renumber).
   - `StepFolderName` (:2281): `if (step == WizardStep.ReBaseline3) return "07_ReBaseline3";` before the generic format.
   - `EatWizardMapping.MoveForStep(WizardStep step, int appliedSteps, bool measuredFinalRebaseline = false)`: `ReBaseline3` → `new TiltAdapterMove(TiltMoveAxis.DiagonalB, -appliedSteps, TiltMoveGroup.Tilt, $"Wizard Re-Baseline 3: {FormatSigned(-appliedSteps)} diagonal-B (restore, measured)")`; `Complete` → `measuredFinalRebaseline ? null : <existing DiagonalB(-N)>`. Update the class doc comment ("six executed moves" → describes both variants). Keep the existing two-arg call sites compiling via the default parameter, then update the wizard's call site to pass the real flag.
-- [ ] **Step 6.5: Option.** `ITiltAdapterOptions`: `bool MeasureFinalRebaseline { get; set; }` with doc comment `/// <summary>Measure one extra re-baseline after the final restore move so screw 2's move is referenced symmetrically (drift-cancelling), at the cost of one more AF run. Default true.</summary>`. `TiltAdapterOptions`: standard accessor pattern (`optionsAccessor.GetValueBoolean(nameof(MeasureFinalRebaseline), true)` in `InitializeOptions`, `SetValueBoolean` + `RaisePropertyChanged` in the setter — copy the `MeasureCurvatureDuringCalibration` implementation verbatim with the new name). UI: checkbox in wizard Panel A next to the `MeasureCurvatureDuringCalibration` binding (DataTemplates.xaml ~:716/:755), same visual pattern, label "Measure final re-baseline (recommended)". (Tilt-adapter options live in the wizard pane, not `Resources/OptionsDataTemplates.xaml` — established pattern for this options family.)
-- [ ] **Step 6.6: Sequence + flow.** `GetMeasurementSteps(bool measureCurvature, bool measureFinalRebaseline)` appends `WizardStep.ReBaseline3` to either array when true. Update both callers (`StartAsync` :2047, `ReplayAsync` :2952 — replay passes `byStep.ContainsKey(WizardStep.ReBaseline3.ToString())`). `MeasureStep`/`NextStep` need no structural change (RB3 is an ordinary measured step; `Complete` remains the terminal state that triggers `RunCalibrationMath`). `StepDescription`/`StepInstructionsText`: add ReBaseline3 wording — stepper: `"Apply -N steps to motor 2 and +N steps to motor 4, returning to the baseline position, then click Run Measurement."`; the device-driven path sends the RB3 move via the updated `MoveForStep`.
-- [ ] **Step 6.7: Calculator.** Wire `ReBaseline3`/`HasFinalRebaseline` (added in Task 3) from the wizard's readings in `RunCalibrationMath` (:2700-2705 and :2731-2736). `ComputeConfidence`: when `HasFinalRebaseline`, add probe `drift3 = |PhysicalDelta(ReBaseline3, ReBaseline2)|` into the RMS (divide by 4 instead of 3) and surface `public double Rebaseline3Drift { get; set; } = double.NaN;` on `TiltCalibrationConfidence`. Calculator test:
+- [x] **Step 6.5: Option.** `ITiltAdapterOptions`: `bool MeasureFinalRebaseline { get; set; }` with doc comment `/// <summary>Measure one extra re-baseline after the final restore move so screw 2's move is referenced symmetrically (drift-cancelling), at the cost of one more AF run. Default true.</summary>`. `TiltAdapterOptions`: standard accessor pattern (`optionsAccessor.GetValueBoolean(nameof(MeasureFinalRebaseline), true)` in `InitializeOptions`, `SetValueBoolean` + `RaisePropertyChanged` in the setter — copy the `MeasureCurvatureDuringCalibration` implementation verbatim with the new name). UI: checkbox in wizard Panel A next to the `MeasureCurvatureDuringCalibration` binding (DataTemplates.xaml ~:716/:755), same visual pattern, label "Measure final re-baseline (recommended)". (Tilt-adapter options live in the wizard pane, not `Resources/OptionsDataTemplates.xaml` — established pattern for this options family.)
+- [x] **Step 6.6: Sequence + flow.** `GetMeasurementSteps(bool measureCurvature, bool measureFinalRebaseline)` appends `WizardStep.ReBaseline3` to either array when true. Update both callers (`StartAsync` :2047, `ReplayAsync` :2952 — replay passes `byStep.ContainsKey(WizardStep.ReBaseline3.ToString())`). `MeasureStep`/`NextStep` need no structural change (RB3 is an ordinary measured step; `Complete` remains the terminal state that triggers `RunCalibrationMath`). `StepDescription`/`StepInstructionsText`: add ReBaseline3 wording — stepper: `"Apply -N steps to motor 2 and +N steps to motor 4, returning to the baseline position, then click Run Measurement."`; the device-driven path sends the RB3 move via the updated `MoveForStep`.
+- [x] **Step 6.7: Calculator.** Wire `ReBaseline3`/`HasFinalRebaseline` (added in Task 3) from the wizard's readings in `RunCalibrationMath` (:2700-2705 and :2731-2736). `ComputeConfidence`: when `HasFinalRebaseline`, add probe `drift3 = |PhysicalDelta(ReBaseline3, ReBaseline2)|` into the RMS (divide by 4 instead of 3) and surface `public double Rebaseline3Drift { get; set; } = double.NaN;` on `TiltCalibrationConfidence`. Calculator test:
 
 ```csharp
 [Test]
@@ -467,8 +467,8 @@ public void Calibrate_WithFinalRebaseline_Screw2DeltaIsDriftImmune() {
 }
 ```
   (Write it out fully by copying Task 3's test shape.)
-- [ ] **Step 6.8: Metadata/replay.** `RecordStepIntoMetadata` already keys by step name — "ReBaseline3" rows serialize with no schema change beyond v3. Verify `MapRunsToSteps`-equivalent replay path (WizardVM `ReplayAsync` :2947-2953) tolerates the extra step (it iterates `activeMeasurementSteps`, which now includes RB3 when present).
-- [ ] **Step 6.9: Run** EatWizardMapping + calculator + wizard filters → green. **Commit** — `feat(tilt): optional measured final re-baseline for drift-symmetric screw-2 delta`
+- [x] **Step 6.8: Metadata/replay.** `RecordStepIntoMetadata` already keys by step name — "ReBaseline3" rows serialize with no schema change beyond v3. Verify `MapRunsToSteps`-equivalent replay path (WizardVM `ReplayAsync` :2947-2953) tolerates the extra step (it iterates `activeMeasurementSteps`, which now includes RB3 when present).
+- [x] **Step 6.9: Run** EatWizardMapping + calculator + wizard filters → green. **Commit** — `feat(tilt): optional measured final re-baseline for drift-symmetric screw-2 delta`
 
 ---
 


### PR DESCRIPTION
Implements §7 of `docs/tilt-calibration-pitch-nonlinearity-design.md`. The wizard warned that "the two screw turns produced very unequal tilt changes (1.5× apart)" on a run where the motors provably applied identical ±150-step diagonal moves, and its measured pitch tracked how aberrated the rig was. Neither was the hardware.

## The four root causes, and what this branch does about each

| # | Cause | Fix |
|---|---|---|
| 1 | The per-star paraboloid underestimates one state's gradient (×0.80) and the curvature (×0.5) | Not fixed here — **diagnosed** (new §8) and cross-checked at runtime so it can no longer masquerade as a hardware fault |
| 2 | Focuser-frame µm ≠ plate-frame µm on some rigs (≈1.25–1.30 here), so every µm readout is inflated | Piston-implied pitch surfaces the same effective value independently; the manual explains why measured ≠ spec is expected and what to do |
| 3 | Settling/drift between steps, on a single-shot ± pattern | Screw moves are now bracketed symmetrically so a linear drift cancels |
| 4 | Angles, ratios and SNR computed in anisotropic (A,B) space (F2) | All of it moved to physical gradient space |

## Commits by §7 item

**§7.1 — physical gradient space (closes F2).** `ffabeac` moves angles, the magnitude ratio and SNR off the raw (A,B) tilt-plane coefficients, which are per-normalized-coordinate and distort direction on a non-square sensor (on 3:2, two equal moves 90° apart read as a 75° gap and a 1.35× ratio). `059002e` routes `TiltAdapterWizardVM.RunCalibrationMath` through a single `TiltCalibrationCalculator.Calibrate()` call — it had been duplicating the algebra inline, so without this the fix would have reached TestApp but not the wizard's persisted screw angles or the unequal-turns warning. `ee6eca3` removes a geometry fallback that could have silently reintroduced (A,B) units on a misconfigured run, and re-gates hardware recovery on a real tilt-plane model.

**§7.2 — cross-check the paraboloid against the corner-region AF.** `60eefda` first fixes the corner estimator itself: the 4-corner plane was regressed against the frame corners (±0.5) while its samples sit at the region centres (±1/3), attenuating A and B by 2/3. `efc208d` then captures that plane per step, runs the same calibration math on it, and warns when the two estimators disagree on a screw move by more than 15% — never blending or replacing the measured pitch. `a98cc77` moves the comparison math into the calculator so TestApp shares one definition, and fixes a latent case where an absent step read as a valid zero corner.

**§7.3 — the paraboloid's gradient/curvature shrinkage.** `6b1ad20` answers it by elimination against the solver's own per-iteration diagnostics: it is **not** the robust clipping (Gx is flat across winsorized iterations), not the weighting (an unweighted refit moves |G| by 3.6%), not a weight monopoly (ESS/N is 0.47–0.56 in every state, so the pre-46778b9 failure is not recurring), not the high-σ tail, and not the forced-isotropic curvature (freeing Kx/Ky moves |G| by ≤0.4%). The compression is already in the per-star best-focus values, and it scales with tilt. The fix belongs in the vertex estimator's bracketing criteria and is deferred to its own plan; `SensorModel.cs` is deliberately untouched.

**§7.4 / §7.5 — frame-consistent pitch, and a third estimate.** `c7fd73c` adds the piston-implied pitch: the all-screws-inward step is a free, tilt-fit-independent estimate in the same focuser frame, drift-corrected against the two baselines that bracket it. It warns when the two disagree by more than 20%. `29e451e` fixes review findings including a WPF layout bug where the new row landed in the label column of a label/value grid. `d49193b` and `762d581` rewrite the manual: a measured pitch differing from the mechanical spec is expected on rigs where focuser and sensor travel are not 1:1, corrections are only self-consistent when the measured value is used, and the three candidate causes are stated as indistinguishable rather than diagnosed.

**§7.6 — average out settling and drift.** `a4a7304` references screw 1 to the midpoint of the two re-baselines that bracket it, which cancels a linear drift exactly and needs no new data. `970bfc8` adds the optional measured final re-baseline (`ReBaseline3`, default on) so screw 2 gets the same symmetry, plus a third noise probe; `dab006a` covers the device-driven move and the new default flow at the state-machine level.

**§7.7 — backfocus undershoot.** Still pending, now explicitly blocked on §8's follow-up rather than on §7.3 in the abstract.

**TestApp.** `48ebd41` gives the validator the same honest lever arms, prints the estimator comparison, the piston-implied pitch, and a curvature self-consistency check.

## Verification

Full suite: **3450 passed, 0 failed**.

Replayed against the real bank run (`ghilios_corrected`) from the final tree. The paraboloid path reproduces digit-for-digit, so nothing regressed:

- paraboloid move ratio **1.5296×** — still fires the unequal-turns warning, but now alongside a corner-AF cross-check reporting **26.4%** disagreement on that same move, which points at the estimator instead of the hardware
- 4-corner recovered step size **2.0839 µm/step** (was 1.376 with the lever-arm bug)
- piston-implied **2.235 µm/step** — independently agrees with the corner-AF number, and both sit ~25% above the 1.8 µm/step mechanical spec, which is the frame factor
- verdicts and exit codes unchanged; the comparison is informational

## Known follow-ups

- The vertex-estimator fix from §8 needs its own plan.
- `RebaselineDriftRatio` still computes its ratio in raw (A,B) space — same F2 class, no task in this plan covered it.
- `PistonImpliedMicronsPerStep` reports µm per *applied unit*, which is µm/turn on thread-pitch adapters; the name says "PerStep". Documented in the doc comments rather than renamed, to keep the code matching the plan.
- `wizard-measurement-section.png` predates the new "Measure final re-baseline" checkbox and needs a fresh capture via the NINA MCP pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153hev5wNcmA1dBhuZk9qtM
