### PR TITLE
Manual adjustment for a connected motorized tilt adapter

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/Manual/ManualAdjustmentTargetTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/Manual/ManualAdjustmentTargetTests.cs
@@ -1,0 +1,169 @@
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Manual;
+using NUnit.Framework;
+using System.Linq;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterDevices.Manual;
+
+/// <summary>
+/// Pins the manual pad's nine cells to the exact per-screw effect and wire command each one produces.
+///
+/// <para>This is the anchor test for the manual adjustment feature, in the same spirit as
+/// <c>TiltAdapterMoveTests</c>' unit-effect assertions. A sign error in <see cref="ManualAdjustmentTarget.All"/>
+/// is not a rendering bug: it is a motor driven the wrong way, persisted to the device's EEPROM, with no undo
+/// available in the plugin. Every cell is asserted in BOTH directions, and the expectations below are written
+/// out longhand from the physical corner names rather than derived from the table under test.</para>
+/// </summary>
+[TestFixture]
+public class ManualAdjustmentTargetTests {
+
+    // Expected per-screw effect for direction "+", amount 1, in WIZARD screw order (s1=TR, s2=TL, s3=BL, s4=BR).
+    private static readonly object[] PadExpectations = {
+        //           key,      axis,                        s1(TR) s2(TL) s3(BL) s4(BR)
+        new object[] { "TR", TiltMoveAxis.DiagonalA, new double[] { 1, 0, -1, 0 } },
+        new object[] { "BL", TiltMoveAxis.DiagonalA, new double[] { -1, 0, 1, 0 } },
+        new object[] { "TL", TiltMoveAxis.DiagonalB, new double[] { 0, 1, 0, -1 } },
+        new object[] { "BR", TiltMoveAxis.DiagonalB, new double[] { 0, -1, 0, 1 } },
+        new object[] { "Top", TiltMoveAxis.EdgeVertical, new double[] { 1, 1, -1, -1 } },
+        new object[] { "Bottom", TiltMoveAxis.EdgeVertical, new double[] { -1, -1, 1, 1 } },
+        new object[] { "Right", TiltMoveAxis.EdgeHorizontal, new double[] { 1, -1, -1, 1 } },
+        new object[] { "Left", TiltMoveAxis.EdgeHorizontal, new double[] { -1, 1, 1, -1 } },
+        new object[] { "All", TiltMoveAxis.Backfocus, new double[] { 1, 1, 1, 1 } },
+    };
+
+    [TestCaseSource(nameof(PadExpectations))]
+    public void PerScrewEffect_PositiveDirection_MatchesTheDeclaredCorners(string key, TiltMoveAxis expectedAxis, double[] expectedUnitEffect) {
+        var target = ManualAdjustmentTarget.ByKey(key);
+        var effect = target.PerScrewEffect(positiveDirection: true, amount: 20);
+
+        Assert.Multiple(() => {
+            Assert.That(target.Axis, Is.EqualTo(expectedAxis));
+            Assert.That(effect.ToArray(), Is.EqualTo(expectedUnitEffect.Select(v => v * 20).ToArray()));
+        });
+    }
+
+    [TestCaseSource(nameof(PadExpectations))]
+    public void PerScrewEffect_NegativeDirection_IsTheExactNegation(string key, TiltMoveAxis expectedAxis, double[] expectedUnitEffect) {
+        var target = ManualAdjustmentTarget.ByKey(key);
+        var effect = target.PerScrewEffect(positiveDirection: false, amount: 20);
+
+        Assert.Multiple(() => {
+            Assert.That(target.Axis, Is.EqualTo(expectedAxis));
+            Assert.That(effect.ToArray(), Is.EqualTo(expectedUnitEffect.Select(v => v * -20).ToArray()));
+        });
+    }
+
+    /// <summary>
+    /// The wire command must come from EatCommands, never be assembled from the pad label: the default sign
+    /// encoding signs the ARGUMENT rather than switching to the opposite mnemonic, so "BL +20" really goes out
+    /// as <c>tr,-20</c>. A chip built from the label would name a command the device never receives.
+    /// </summary>
+    [TestCase("TR", true, "tr,20")]
+    [TestCase("TR", false, "tr,-20")]
+    [TestCase("BL", true, "tr,-20")]
+    [TestCase("BL", false, "tr,20")]
+    [TestCase("TL", true, "tl,20")]
+    [TestCase("BR", true, "tl,-20")]
+    [TestCase("Top", true, "tp,20")]
+    [TestCase("Bottom", true, "tp,-20")]
+    [TestCase("Right", true, "rt,20")]
+    [TestCase("Left", true, "rt,-20")]
+    [TestCase("All", true, "bf,20")]
+    [TestCase("All", false, "bf,-20")]
+    public void BuildMove_ProducesTheWireCommandTheDeviceWillActuallyReceive(string key, bool positive, string expectedWire) {
+        var move = ManualAdjustmentTarget.ByKey(key).BuildMove(positive, 20);
+
+        Assert.That(EatCommands.Format(move), Is.EqualTo(expectedWire));
+    }
+
+    [Test]
+    public void BuildMove_PerCornerStepsAlwaysAgreeWithPerScrewEffect() {
+        foreach (var target in ManualAdjustmentTarget.All) {
+            foreach (bool positive in new[] { true, false }) {
+                var move = target.BuildMove(positive, 7);
+                var effect = target.PerScrewEffect(positive, 7);
+                Assert.That(move.PerCornerSteps.ToArray(), Is.EqualTo(effect.ToArray()), $"{target.Key} ({(positive ? "+" : "-")})");
+            }
+        }
+    }
+
+    [Test]
+    public void PadIsTheFullNineCellGrid_RowMajor() {
+        Assert.Multiple(() => {
+            Assert.That(ManualAdjustmentTarget.All.Count, Is.EqualTo(9));
+            Assert.That(ManualAdjustmentTarget.All.Select(t => t.Key),
+                Is.EqualTo(new[] { "TL", "Top", "TR", "Left", "All", "Right", "BL", "Bottom", "BR" }));
+            // Row-major: the declaration order must match the 3x3 layout the ItemsControl renders.
+            for (int i = 0; i < 9; ++i) {
+                var t = ManualAdjustmentTarget.All[i];
+                Assert.That(t.PadRow, Is.EqualTo(i / 3), $"{t.Key} row");
+                Assert.That(t.PadColumn, Is.EqualTo(i % 3), $"{t.Key} column");
+            }
+        });
+    }
+
+    [Test]
+    public void BackfocusIsTheOnlyBackfocusGroupedCell() {
+        foreach (var target in ManualAdjustmentTarget.All) {
+            var move = target.BuildMove(positiveDirection: true, amount: 5);
+            var expected = target.Key == "All" ? TiltMoveGroup.Backfocus : TiltMoveGroup.Tilt;
+            Assert.That(move.Group, Is.EqualTo(expected), target.Key);
+        }
+    }
+
+    [Test]
+    public void DescribeMove_NamesBothCouplesCornersWithTheirMotorNumbers() {
+        var move = ManualAdjustmentTarget.ByKey("TR").BuildMove(positiveDirection: true, amount: 20);
+
+        // Display order is TL, TR, BL, BR, so the moving pair reads TR then BL.
+        Assert.That(move.Description, Is.EqualTo("TR (Motor 1) +20 · BL (Motor 4) −20 steps"));
+    }
+
+    [Test]
+    public void DescribeMove_BackfocusSaysAllFourMoveTogether() {
+        var move = ManualAdjustmentTarget.ByKey("All").BuildMove(positiveDirection: false, amount: 50);
+
+        Assert.That(move.Description, Is.EqualTo("All four motors −50 steps together"));
+    }
+
+    // ------------------------------------------------------------------------------------------------------
+    // The three index spaces. Cross-checked against EatWizardMapping (the wizard's own corner labels) and
+    // EatTiltMotionController's device motor order, so this table cannot drift from either.
+    // ------------------------------------------------------------------------------------------------------
+
+    [TestCase(1, "TR", 1)]
+    [TestCase(2, "TL", 2)]
+    [TestCase(3, "BL", 4)]
+    [TestCase(4, "BR", 3)]
+    public void CornerTable_MapsWizardScrewToLabelAndDeviceMotor(int wizardScrew, string expectedLabel, int expectedMotor) {
+        var corner = TiltAdapterCorner.ForWizardScrew(wizardScrew);
+
+        Assert.Multiple(() => {
+            Assert.That(corner.Label, Is.EqualTo(expectedLabel));
+            Assert.That(corner.DeviceMotorNumber, Is.EqualTo(expectedMotor));
+            Assert.That(corner.WizardScrewNumber, Is.EqualTo(wizardScrew));
+            // The wizard's own mapping is the authority for the label.
+            Assert.That(EatWizardMapping.CornerLabelForWizardScrew(wizardScrew), Is.EqualTo(expectedLabel));
+        });
+    }
+
+    [Test]
+    public void CornerTable_DeviceMotorOrderMatchesTheControllerPermutation() {
+        // PermuteWizardToDeviceMotorOrder is [w0, w1, w3, w2]; applying it to a vector tagged by wizard index
+        // must land each corner at its declared device motor slot.
+        var wizardTagged = new double[] { 1, 2, 3, 4 }; // value == wizard screw number
+        var deviceOrder = EatTiltMotionController.PermuteWizardToDeviceMotorOrder(wizardTagged);
+
+        for (int deviceIndex = 0; deviceIndex < 4; ++deviceIndex) {
+            var corner = TiltAdapterCorner.InDeviceMotorOrder[deviceIndex];
+            Assert.That(deviceOrder[deviceIndex], Is.EqualTo((double)corner.WizardScrewNumber),
+                $"device motor {deviceIndex + 1} ({corner.Label})");
+        }
+    }
+
+    [Test]
+    public void CornerTable_DisplayOrderIsTheTwoByTwoReadingOrder() {
+        Assert.That(TiltAdapterCorner.InDisplayOrder.Select(c => c.Label), Is.EqualTo(new[] { "TL", "TR", "BL", "BR" }));
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/Manual/TiltAdapterManualAdjustmentVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/Manual/TiltAdapterManualAdjustmentVMTests.cs
@@ -1,0 +1,818 @@
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Manual;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt;
+using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NINA.Profile.Interfaces;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterDevices.Manual;
+
+/// <summary>
+/// Behaviour of the Tilt Adapter Wizard's Manual Adjustment panel. The fixture wires a real
+/// <see cref="TiltDeviceConnectionService"/> (so the exclusive lease and position publishing are the production
+/// ones) to an NSubstitute <see cref="ITiltMotionController"/>, and drives the VM through a synchronous
+/// dispatcher so every refresh has landed by the time an assertion runs.
+/// </summary>
+[TestFixture]
+public class TiltAdapterManualAdjustmentVMTests {
+
+    private const string PresetName = "ASG Electronic EAT - 90mm";
+    private const double StepMicrons = 1.8;
+
+    private sealed class FakeTimeSource : ITiltDeviceTimeSource {
+        public DateTimeOffset UtcNow { get; } = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        public event EventHandler Tick;
+
+        public void Dispose() => Tick = null;
+    }
+
+    private sealed class Fixture : IDisposable {
+        public ITiltAdapterOptions Options { get; }
+        public ITiltMotionController Controller { get; }
+        public TiltDeviceConnectionService Service { get; }
+        public TiltAdapterManualAdjustmentVM VM { get; private set; }
+
+        public List<TiltAdapterMove> ExecutedMoves { get; } = new();
+        public int PublishCallCount { get; private set; }
+
+        /// <summary>
+        /// Return non-null to fail that move. Evaluated BEFORE the move is recorded, so
+        /// <see cref="ExecutedMoves"/> holds exactly the moves that succeeded and its count is the index of the
+        /// move about to run.
+        /// </summary>
+        public Func<TiltAdapterMove, Exception> FailureForMove { get; set; }
+
+        /// <summary>Invoked after each successful move with the 1-based number of moves completed so far.</summary>
+        public Action<int> AfterMove { get; set; }
+
+        public TiltDeviceAdjustmentChoice NextChoice { get; set; } = TiltDeviceAdjustmentChoice.Cancelled;
+        public int PromptCallCount { get; private set; }
+        public Func<bool, bool, TiltDevicePlanPreview> LastReplanner { get; private set; }
+
+        private int[] positions = { 500, 500, 500, 500 }; // device motor order: TR, TL, BR, BL
+
+        /// <summary>False until a position read or a move has confirmed the counters.</summary>
+        public bool PositionsConfirmed { get; private set; }
+
+        public Fixture(int maxExcursion = 2000, int maxStepsPerCommand = 200) {
+            Options = Substitute.For<ITiltAdapterOptions>();
+            Options.DeviceName.Returns(PresetName);
+            Options.ScrewCount.Returns(4);
+            Options.AdjustmentType.Returns(TiltAdjustmentType.StepperMotors);
+            Options.StepperStepSizeMicrons.Returns(StepMicrons);
+            Options.TiltDeviceMaxExcursionSteps.Returns(maxExcursion);
+            Options.TiltDeviceMaxStepsPerCommand.Returns(maxStepsPerCommand);
+            Options.TiltDeviceSettleSeconds.Returns(0.0);
+
+            Controller = Substitute.For<ITiltMotionController>();
+            Controller.ConnectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+            Controller.DisconnectAsync(Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+            Controller.QueryPositionsAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(TiltDevicePositions.Unknown));
+            // Unknown until something confirms them, exactly like a freshly connected device whose first
+            // position read has not landed yet.
+            Controller.LastKnownPositions.Returns(_ => PositionsConfirmed
+                ? new TiltDevicePositions(positions.ToArray(), known: true)
+                : TiltDevicePositions.Unknown);
+            // Identity ordering by default: the manual panel's target mode is about the decomposition, and a
+            // reordering/bias fixture would obscure which assertions are about which.
+            Controller.OrderForMinimalPeakExcursion(Arg.Any<IReadOnlyList<TiltAdapterMove>>())
+                .Returns(ci => ci.Arg<IReadOnlyList<TiltAdapterMove>>());
+            Controller.ExecuteMoveAsync(Arg.Any<TiltAdapterMove>(), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>())
+                .Returns(ci => {
+                    // The real controller checks the token at entry and nowhere else — once past this line a
+                    // move always runs to completion, which is what makes "stop" mean "send nothing further".
+                    ci.Arg<CancellationToken>().ThrowIfCancellationRequested();
+                    var move = ci.Arg<TiltAdapterMove>();
+                    var failure = FailureForMove?.Invoke(move);
+                    if (failure != null) {
+                        throw failure;
+                    }
+                    ExecutedMoves.Add(move);
+                    // Mirror the real controller: a move response carries fresh counters, so the shadow advances.
+                    PositionsConfirmed = true;
+                    var delta = EatTiltMotionController.PermuteWizardToDeviceMotorOrder(move.PerCornerSteps);
+                    for (int i = 0; i < 4; ++i) {
+                        positions[i] += (int)Math.Round(delta[i]);
+                    }
+                    AfterMove?.Invoke(ExecutedMoves.Count);
+                    return Task.CompletedTask;
+                });
+
+            Service = new TiltDeviceConnectionService(Substitute.For<IProfileService>(), Options, (name, opts) => Controller, new FakeTimeSource());
+            Service.PropertyChanged += (s, e) => {
+                if (e.PropertyName == nameof(TiltDeviceConnectionService.CurrentPositions)) {
+                    ++PublishCallCount;
+                }
+            };
+        }
+
+        public async Task<TiltAdapterManualAdjustmentVM> BuildConnectedAsync(bool publishPositions = true) {
+            await Service.ConnectAsync(PresetName, "COM5", CancellationToken.None);
+            if (publishPositions) {
+                PositionsConfirmed = true;
+                Service.PublishControllerPositions();
+            }
+            PublishCallCount = 0;
+            return BuildVM();
+        }
+
+        public TiltAdapterManualAdjustmentVM BuildVM() {
+            VM = new TiltAdapterManualAdjustmentVM(Options, Service, new SynchronousApplicationDispatcher(), ShowPromptAsync);
+            return VM;
+        }
+
+        private Task<TiltDeviceAdjustmentChoice> ShowPromptAsync(Func<bool, bool, TiltDevicePlanPreview> replanner, double unitMicrons) {
+            ++PromptCallCount;
+            LastReplanner = replanner;
+            return Task.FromResult(NextChoice);
+        }
+
+        /// <summary>Overwrites the device's counters and republishes them, as a poll or a foreign move would.</summary>
+        public void SetPositions(int tr, int tl, int br, int bl) {
+            positions = new[] { tr, tl, br, bl };
+            PositionsConfirmed = true;
+            Service.PublishControllerPositions();
+        }
+
+        public int[] Positions => positions.ToArray();
+
+        public void Dispose() {
+            VM?.Dispose();
+            Service.DisconnectAsync().GetAwaiter().GetResult();
+        }
+    }
+
+    private static void Pick(TiltAdapterManualAdjustmentVM vm, string key, bool positive = true, int amount = 20) {
+        vm.SelectedTargetKey = key;
+        vm.PositiveDirection = positive;
+        vm.AmountText = amount.ToString();
+    }
+
+    private static void SetTargets(TiltAdapterManualAdjustmentVM vm, int tl, int tr, int bl, int br) {
+        // TargetCells are in display order TL, TR, BL, BR.
+        var values = new[] { tl, tr, bl, br };
+        for (int i = 0; i < 4; ++i) {
+            vm.TargetCells[i].TargetText = values[i].ToString();
+        }
+    }
+
+    // ======================================================================================================
+    // Expander, summary, connection state
+    // ======================================================================================================
+
+    [Test]
+    public async Task Expander_IsCollapsedByDefault() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+
+        Assert.Multiple(() => {
+            Assert.That(vm.IsExpanded, Is.False);
+            Assert.That(vm.SummaryText, Is.EqualTo("Nudge a corner or set target positions"));
+        });
+    }
+
+    [Test]
+    public void Disconnected_ReplacesTheBodyAndSaysSoInTheSummary() {
+        using var f = new Fixture();
+        var vm = f.BuildVM();
+
+        Assert.Multiple(() => {
+            Assert.That(vm.IsDeviceConnected, Is.False);
+            Assert.That(vm.SummaryText, Is.EqualTo("Connect to enable"));
+            Assert.That(vm.NotConnectedText, Is.EqualTo("Connect the device above to make adjustments."));
+        });
+    }
+
+    [Test]
+    public async Task DeviceBusyElsewhere_BlocksBothModesWithTheOperationName() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+        Pick(vm, "TR");
+
+        using var foreignLease = f.Service.TryBeginOperation("Tilt Adapter Wizard Calibration");
+        // The service raises INPC for the lease, which the VM's handler picks up.
+
+        Assert.Multiple(() => {
+            Assert.That(vm.SendDisabledReason, Is.EqualTo("Device busy — Tilt Adapter Wizard Calibration. Wait for it to finish."));
+            Assert.That(vm.CanSend, Is.False);
+            Assert.That(vm.SummaryText, Is.EqualTo("Device busy — Tilt Adapter Wizard Calibration"));
+        });
+    }
+
+    // ======================================================================================================
+    // Single move — preview
+    // ======================================================================================================
+
+    [Test]
+    public async Task Preview_PredictsEveryMotorInDeviceOrder_AndNamesTheCoupledPair() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+        f.SetPositions(tr: 480, tl: 512, br: 505, bl: 470);
+
+        Pick(vm, "TR", positive: true, amount: 20);
+
+        Assert.Multiple(() => {
+            // Device motor order: [0]=TR, [1]=TL, [2]=BR, [3]=BL. Only TR and BL move.
+            Assert.That(vm.PredictedPositions, Is.EqualTo(new[] { 500, 512, 505, 450 }));
+            Assert.That(vm.PreviewSemanticText, Is.EqualTo("TR (Motor 1) +20 · BL (Motor 4) −20 steps"));
+            Assert.That(vm.PreviewWireCommand, Is.EqualTo("tr,20"));
+            Assert.That(vm.PreviewKindLabel, Is.EqualTo("Corner"));
+        });
+
+        // Cells are in display order TL, TR, BL, BR.
+        var cells = vm.PreviewCells;
+        Assert.Multiple(() => {
+            Assert.That(cells.Select(c => c.Corner.Label), Is.EqualTo(new[] { "TL", "TR", "BL", "BR" }));
+            Assert.That(cells[0].ValueText, Is.EqualTo("512 → 512"));
+            Assert.That(cells[0].IsMoving, Is.False);
+            Assert.That(cells[1].ValueText, Is.EqualTo("480 → 500 (+20)"));
+            Assert.That(cells[1].IsMoving, Is.True);
+            Assert.That(cells[2].ValueText, Is.EqualTo("470 → 450 (-20)"));
+            Assert.That(cells[2].IsMoving, Is.True);
+            Assert.That(cells[3].IsMoving, Is.False);
+        });
+    }
+
+    [Test]
+    public async Task Preview_SideMoveMovesAllFourMotorsInTwoPairs() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+        f.SetPositions(tr: 500, tl: 500, br: 500, bl: 500);
+
+        Pick(vm, "Top", positive: true, amount: 30);
+
+        Assert.Multiple(() => {
+            // Top edge up: TR & TL +30, BL & BR -30.
+            Assert.That(vm.PredictedPositions, Is.EqualTo(new[] { 530, 530, 470, 470 }));
+            Assert.That(vm.PreviewWireCommand, Is.EqualTo("tp,30"));
+            Assert.That(vm.PreviewKindLabel, Is.EqualTo("Side"));
+            Assert.That(vm.PreviewCells.All(c => c.IsMoving), Is.True);
+        });
+    }
+
+    [Test]
+    public async Task Preview_BackfocusMovesAllFourTheSameWayAndSaysTiltIsUnchanged() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+        f.SetPositions(500, 500, 500, 500);
+
+        Pick(vm, "All", positive: true, amount: 20);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.PredictedPositions, Is.EqualTo(new[] { 520, 520, 520, 520 }));
+            Assert.That(vm.PreviewWireCommand, Is.EqualTo("bf,20"));
+            Assert.That(vm.ConsequenceText, Is.EqualTo("Changes sensor spacing by 36.0 µm; tilt unchanged."));
+        });
+    }
+
+    [Test]
+    public async Task Preview_TiltConsequenceIsTwiceTheAmount_BecauseTheMoveIsDifferential() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+
+        Pick(vm, "TR", positive: true, amount: 20);
+
+        // TR +20 and BL -20 => the TR-vs-BL spacing changes by 40 steps = 72 µm.
+        Assert.That(vm.ConsequenceText, Is.EqualTo("Changes TR-vs-BL spacing by 72.0 µm of screw travel."));
+    }
+
+    [Test]
+    public async Task Preview_TagsPositionsNearEitherEndOfTheTravelWindow() {
+        using var f = new Fixture(maxExcursion: 2000);
+        var vm = await f.BuildConnectedAsync();
+        // 5% of 2000 = 100. Put TR just inside the top band and BL just inside the bottom one after the move.
+        f.SetPositions(tr: 1890, tl: 500, br: 500, bl: 110);
+
+        Pick(vm, "TR", positive: true, amount: 20);
+
+        var byLabel = vm.PreviewCells.ToDictionary(c => c.Corner.Label);
+        Assert.Multiple(() => {
+            Assert.That(byLabel["TR"].LimitTag, Is.EqualTo("near max"));
+            Assert.That(byLabel["TR"].Severity, Is.EqualTo(ManualLimitSeverity.Near));
+            Assert.That(byLabel["BL"].LimitTag, Is.EqualTo("near 0"));
+            Assert.That(byLabel["TL"].HasLimitTag, Is.False);
+            Assert.That(vm.CanSend, Is.True, "a near-limit tag is advisory, not blocking");
+        });
+    }
+
+    [Test]
+    public async Task Preview_BlocksAMoveThatWouldDriveAMotorBelowZero() {
+        using var f = new Fixture(maxExcursion: 2000);
+        var vm = await f.BuildConnectedAsync();
+        f.SetPositions(tr: 500, tl: 500, br: 500, bl: 10);
+
+        Pick(vm, "TR", positive: true, amount: 20);
+
+        var bl = vm.PreviewCells.Single(c => c.Corner.Label == "BL");
+        Assert.Multiple(() => {
+            Assert.That(bl.LimitTag, Is.EqualTo("below 0"));
+            Assert.That(bl.IsBlocking, Is.True);
+            Assert.That(vm.CanSend, Is.False);
+            Assert.That(vm.SendDisabledReason,
+                Is.EqualTo("This move would drive Motor 4 (BL) below 0. Reduce the amount, or send an All + move first to lift all motors."));
+        });
+    }
+
+    [Test]
+    public async Task Preview_BlocksAMoveThatWouldExceedTheMaxExcursion() {
+        using var f = new Fixture(maxExcursion: 600);
+        var vm = await f.BuildConnectedAsync();
+        f.SetPositions(tr: 590, tl: 300, br: 300, bl: 300);
+
+        Pick(vm, "TR", positive: true, amount: 20);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.CanSend, Is.False);
+            Assert.That(vm.SendDisabledReason,
+                Is.EqualTo("This move would drive Motor 1 (TR) past the max excursion (600). Reduce the amount, or lower all motors with an All − move first."));
+        });
+    }
+
+    [Test]
+    public async Task Preview_SplitsAnAmountAboveThePerCommandCapIntoSameAxisChunks() {
+        using var f = new Fixture(maxStepsPerCommand: 200);
+        var vm = await f.BuildConnectedAsync();
+
+        Pick(vm, "All", positive: true, amount: 450);
+
+        var moves = vm.PlannedSingleMoves;
+        Assert.Multiple(() => {
+            Assert.That(moves.Count, Is.EqualTo(3));
+            Assert.That(moves.Select(m => m.Steps), Is.EqualTo(new[] { 200, 200, 50 }));
+            Assert.That(moves.All(m => m.Axis == TiltMoveAxis.Backfocus), Is.True);
+            Assert.That(vm.SendButtonText, Is.EqualTo("Send 3 moves"));
+            Assert.That(vm.MoveCountAndDurationText, Is.EqualTo("3 moves · ~30 s"));
+        });
+    }
+
+    [Test]
+    public async Task PositionsUnknown_IsAdvisoryForSingleMove_NotABlock() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync(publishPositions: false);
+
+        Pick(vm, "TR");
+
+        Assert.Multiple(() => {
+            Assert.That(vm.PositionsKnown, Is.False);
+            Assert.That(vm.PositionsUnknownAdvisoryVisible, Is.True);
+            Assert.That(vm.PredictedPositions, Is.Null);
+            Assert.That(vm.PreviewCells.All(c => c.ValueText == "unknown → unknown"), Is.True);
+            Assert.That(vm.CanSend, Is.True);
+            Assert.That(vm.SendDisabledReason, Is.Empty);
+        });
+    }
+
+    // ======================================================================================================
+    // Disabled reasons
+    // ======================================================================================================
+
+    [Test]
+    public async Task SendDisabledReason_NoSelection() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+
+        Assert.Multiple(() => {
+            Assert.That(vm.SendDisabledReason, Is.EqualTo("Pick a corner, side, or All to move."));
+            Assert.That(vm.PreviewVisible, Is.False);
+            Assert.That(vm.CanSend, Is.False);
+        });
+    }
+
+    [TestCase("")]
+    [TestCase("0")]
+    [TestCase("-5")]
+    [TestCase("abc")]
+    [TestCase("2.5")]
+    public async Task SendDisabledReason_InvalidAmount(string amountText) {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+        vm.SelectedTargetKey = "TR";
+        vm.AmountText = amountText;
+
+        Assert.Multiple(() => {
+            Assert.That(vm.SendDisabledReason, Is.EqualTo("Enter an amount of at least 1 step."));
+            Assert.That(vm.CanSend, Is.False);
+        });
+    }
+
+    [Test]
+    public async Task SendDisabledReason_DeviceBusyOutranksAMissingSelection() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+
+        using var foreignLease = f.Service.TryBeginOperation("Automatic Adjustment");
+
+        Assert.That(vm.SendDisabledReason, Is.EqualTo("Device busy — Automatic Adjustment. Wait for it to finish."));
+    }
+
+    // ======================================================================================================
+    // Target positions
+    // ======================================================================================================
+
+    [Test]
+    public async Task TargetMode_PrefillsFromCurrentPositions() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+        f.SetPositions(tr: 480, tl: 512, br: 505, bl: 470);
+
+        vm.Mode = ManualAdjustmentMode.TargetPositions;
+
+        // Display order TL, TR, BL, BR.
+        Assert.Multiple(() => {
+            Assert.That(vm.TargetCells.Select(c => c.TargetText), Is.EqualTo(new[] { "512", "480", "470", "505" }));
+            Assert.That(vm.TargetCells.Select(c => c.NowText), Is.EqualTo(new[] { "now 512", "now 480", "now 470", "now 505" }));
+            Assert.That(vm.TargetHintText, Is.EqualTo("Targets match the current positions — nothing to move."));
+            Assert.That(vm.CanReview, Is.False);
+        });
+    }
+
+    /// <summary>
+    /// Regression: the hint line and the disabled-reason line both used to render "Targets match the current
+    /// positions — nothing to move.", stuttering the same sentence twice, one directly under the other. Caught
+    /// in the live app, not by a unit test — hence this one.
+    /// </summary>
+    [Test]
+    public async Task TargetMode_NothingToMoveIsSaidOnce_NotTwice() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+        f.SetPositions(500, 500, 500, 500);
+
+        vm.Mode = ManualAdjustmentMode.TargetPositions;
+
+        Assert.Multiple(() => {
+            Assert.That(vm.TargetHintText, Is.EqualTo(TiltAdapterManualAdjustmentVM.NothingToMoveCopy));
+            Assert.That(vm.ReviewDisabledReason, Is.Empty, "the hint line already carries this sentence");
+            Assert.That(vm.ReviewDisabledReasonVisible, Is.False);
+            Assert.That(vm.CanReview, Is.False, "it must still block Review");
+        });
+    }
+
+    [Test]
+    public async Task TargetMode_DecomposesAPureCornerRequestIntoOneDiagonalMove() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+        f.SetPositions(500, 500, 500, 500);
+        vm.Mode = ManualAdjustmentMode.TargetPositions;
+
+        // TR up 40, BL down 40 — a pure DiagonalA request.
+        SetTargets(vm, tl: 500, tr: 540, bl: 460, br: 500);
+
+        var preview = vm.TargetPlanPreview;
+        Assert.Multiple(() => {
+            Assert.That(preview, Is.Not.Null);
+            Assert.That(preview.Plan.Moves.Count, Is.EqualTo(1));
+            Assert.That(preview.Plan.Moves[0].Axis, Is.EqualTo(TiltMoveAxis.DiagonalA));
+            Assert.That(preview.Plan.Moves[0].Steps, Is.EqualTo(40));
+            Assert.That(vm.TargetHintText, Is.EqualTo("Becomes 1 move · ~10 s."));
+            Assert.That(vm.TwistWarningVisible, Is.False);
+            Assert.That(vm.CanReview, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task TargetMode_APureLiftBecomesASingleBackfocusMove() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+        f.SetPositions(500, 500, 500, 500);
+        vm.Mode = ManualAdjustmentMode.TargetPositions;
+
+        SetTargets(vm, tl: 560, tr: 560, bl: 560, br: 560);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.TargetPlanPreview.Plan.Moves.Single().Axis, Is.EqualTo(TiltMoveAxis.Backfocus));
+            Assert.That(vm.TargetPlanPreview.Plan.Moves.Single().Steps, Is.EqualTo(60));
+            Assert.That(vm.TargetHintText, Is.EqualTo("Becomes 1 move · ~10 s."));
+        });
+    }
+
+    [Test]
+    public async Task TargetMode_TwistIsReportedBeforeTheDialog_AndCellsShowWhatTheyWillActuallyReach() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+        f.SetPositions(500, 500, 500, 500);
+        vm.Mode = ManualAdjustmentMode.TargetPositions;
+
+        // s = (s1..s4) in wizard order = (TR, TL, BL, BR) = (+40, -40, +40, -40): pure twist, a = b = f = 0,
+        // t = (40 + 40 + 40 + 40)/4 = 40. No rigid plane can produce it.
+        SetTargets(vm, tl: 460, tr: 540, bl: 540, br: 460);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.TwistWarningVisible, Is.True);
+            Assert.That(vm.TwistWarningBody, Does.StartWith("These four targets differ from a rigid plane by ±40 steps (about 72.0 µm across the sensor)."));
+            // Nothing is reachable, so every motor stays where it is.
+            Assert.That(vm.TargetCells.Select(c => c.WillReachText),
+                Is.EqualTo(new[] { "will reach 500", "will reach 500", "will reach 500", "will reach 500" }));
+        });
+    }
+
+    [Test]
+    public async Task TargetMode_NoTwistMeansNoWillReachClutter() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+        f.SetPositions(500, 500, 500, 500);
+        vm.Mode = ManualAdjustmentMode.TargetPositions;
+
+        SetTargets(vm, tl: 500, tr: 540, bl: 460, br: 500);
+
+        Assert.That(vm.TargetCells.All(c => !c.HasWillReach), Is.True);
+    }
+
+    [Test]
+    public async Task TargetMode_BlocksWhenPositionsAreUnknown() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync(publishPositions: false);
+
+        vm.Mode = ManualAdjustmentMode.TargetPositions;
+
+        Assert.Multiple(() => {
+            Assert.That(vm.CanReview, Is.False);
+            Assert.That(vm.ReviewDisabledReason,
+                Is.EqualTo("Motor positions are unknown — targets need a known starting point. They update after a successful poll or move."));
+        });
+    }
+
+    [TestCase("-1")]
+    [TestCase("2001")]
+    [TestCase("nope")]
+    public async Task TargetMode_BlocksAndFlagsAnOutOfRangeOrNonNumericTarget(string bad) {
+        using var f = new Fixture(maxExcursion: 2000);
+        var vm = await f.BuildConnectedAsync();
+        f.SetPositions(500, 500, 500, 500);
+        vm.Mode = ManualAdjustmentMode.TargetPositions;
+
+        vm.TargetCells[0].TargetText = bad;
+
+        Assert.Multiple(() => {
+            Assert.That(vm.TargetCells[0].HasError, Is.True);
+            Assert.That(vm.CanReview, Is.False);
+            Assert.That(vm.ReviewDisabledReason, Is.EqualTo("Targets must be whole numbers between 0 and 2000 steps."));
+        });
+    }
+
+    [Test]
+    public async Task TargetMode_ResetToCurrentRestoresEveryCell() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+        f.SetPositions(500, 500, 500, 500);
+        vm.Mode = ManualAdjustmentMode.TargetPositions;
+        SetTargets(vm, tl: 100, tr: 200, bl: 300, br: 400);
+
+        vm.ResetToCurrentCommand.Execute(null);
+
+        Assert.That(vm.TargetCells.Select(c => c.TargetText), Is.EqualTo(new[] { "500", "500", "500", "500" }));
+    }
+
+    [Test]
+    public async Task TargetMode_BackgroundPositionChangeUpdatesNowAndDelta_ButNeverOverwritesTypedTargets() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+        f.SetPositions(500, 500, 500, 500);
+        vm.Mode = ManualAdjustmentMode.TargetPositions;
+        SetTargets(vm, tl: 500, tr: 540, bl: 460, br: 500);
+
+        // Something else moved the motors (a poll, another surface).
+        f.SetPositions(tr: 510, tl: 500, br: 500, bl: 500);
+
+        var tr = vm.TargetCells.Single(c => c.Corner.Label == "TR");
+        Assert.Multiple(() => {
+            Assert.That(tr.TargetText, Is.EqualTo("540"), "typed targets must survive a background refresh");
+            Assert.That(tr.NowText, Is.EqualTo("now 510"));
+            Assert.That(tr.DeltaText, Is.EqualTo("Δ +30 (54.0 µm)"));
+        });
+    }
+
+    [Test]
+    public async Task TargetMode_ReviewCancelled_SendsNothing() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+        f.SetPositions(500, 500, 500, 500);
+        vm.Mode = ManualAdjustmentMode.TargetPositions;
+        SetTargets(vm, tl: 500, tr: 540, bl: 460, br: 500);
+        f.NextChoice = TiltDeviceAdjustmentChoice.Cancelled;
+
+        await vm.ReviewTargetsAsync();
+
+        Assert.Multiple(() => {
+            Assert.That(f.PromptCallCount, Is.EqualTo(1));
+            Assert.That(f.ExecutedMoves, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task TargetMode_ProceedSendsExactlyTheReviewedPlan_ThenReprefillsFromWhereTheMotorsLanded() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+        f.SetPositions(500, 500, 500, 500);
+        vm.Mode = ManualAdjustmentMode.TargetPositions;
+        SetTargets(vm, tl: 500, tr: 540, bl: 460, br: 500);
+
+        var reviewed = vm.TargetPlanPreview.Plan;
+        f.NextChoice = TiltDeviceAdjustmentChoice.Proceeded(applyTilt: true, applyBackfocus: true, finalPlan: reviewed);
+
+        await vm.ReviewTargetsAsync();
+
+        Assert.Multiple(() => {
+            Assert.That(f.ExecutedMoves.Select(m => (m.Axis, m.Steps)), Is.EqualTo(new[] { (TiltMoveAxis.DiagonalA, 40) }));
+            Assert.That(f.Positions, Is.EqualTo(new[] { 540, 500, 500, 460 }));
+            Assert.That(vm.TargetCells.Select(c => c.TargetText), Is.EqualTo(new[] { "500", "540", "460", "500" }));
+            Assert.That(vm.SuccessText, Does.StartWith("Adjustment complete — 1 move sent"));
+            Assert.That(vm.SummaryText, Does.StartWith("Last sent: 1 move at"));
+        });
+    }
+
+    // ======================================================================================================
+    // Execution
+    // ======================================================================================================
+
+    [Test]
+    public async Task Send_TakesTheLeaseUnderTheManualAdjustmentName_AndReleasesIt() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+        Pick(vm, "All", amount: 20);
+
+        string nameDuringSend = null;
+        f.Controller.When(c => c.ExecuteMoveAsync(Arg.Any<TiltAdapterMove>(), Arg.Any<IProgress<string>>(), Arg.Any<CancellationToken>()))
+            .Do(_ => nameDuringSend ??= f.Service.CurrentOperationName);
+
+        await vm.SendSingleMoveAsync();
+
+        Assert.Multiple(() => {
+            Assert.That(nameDuringSend, Is.EqualTo("Manual Adjustment"));
+            Assert.That(f.Service.IsOperationActive, Is.False, "the lease must be released when the send ends");
+        });
+    }
+
+    [Test]
+    public async Task Send_PublishesPositionsAfterEveryMove() {
+        using var f = new Fixture(maxStepsPerCommand: 200);
+        var vm = await f.BuildConnectedAsync();
+        Pick(vm, "All", amount: 450); // 3 commands
+
+        await vm.SendSingleMoveAsync();
+
+        Assert.Multiple(() => {
+            Assert.That(f.ExecutedMoves.Count, Is.EqualTo(3));
+            Assert.That(f.PublishCallCount, Is.EqualTo(3));
+            Assert.That(f.Positions, Is.EqualTo(new[] { 950, 950, 950, 950 }));
+        });
+    }
+
+    [Test]
+    public async Task Send_LeavesTheInputsAloneSoRepeatNudgingIsOneClick() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+        Pick(vm, "TR", positive: true, amount: 20);
+
+        await vm.SendSingleMoveAsync();
+
+        Assert.Multiple(() => {
+            Assert.That(vm.SelectedTargetKey, Is.EqualTo("TR"));
+            Assert.That(vm.PositiveDirection, Is.True);
+            Assert.That(vm.AmountText, Is.EqualTo("20"));
+            Assert.That(vm.CanSend, Is.True);
+            Assert.That(vm.SuccessText, Does.StartWith("Sent TR (Motor 1) +20 · BL (Motor 4) −20 steps · 1 move"));
+            // The header summary is deliberately the short form, not a second copy of the body line.
+            Assert.That(vm.SummaryText, Does.StartWith("Last sent: TR +20 at"));
+        });
+    }
+
+    [Test]
+    public async Task Send_LeaseUnavailable_ReportsBusyAndSendsNothing() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+        Pick(vm, "All", amount: 20);
+
+        using var foreignLease = f.Service.TryBeginOperation("Automatic Adjustment");
+        await vm.SendSingleMoveAsync();
+
+        Assert.Multiple(() => {
+            Assert.That(f.ExecutedMoves, Is.Empty);
+            Assert.That(vm.CanSend, Is.False);
+        });
+    }
+
+    [Test]
+    public async Task Stop_SkipsTheUnsentMovesAndSaysWhatWasAlreadyApplied() {
+        using var f = new Fixture(maxStepsPerCommand: 200);
+        var vm = await f.BuildConnectedAsync();
+        Pick(vm, "All", amount: 450); // 3 commands
+
+        // Stop once the first command has completed; the rest must never be sent (ExecuteMoveAsync only honours
+        // the token at entry, so cancellation can never interrupt an in-flight move).
+        f.AfterMove = completed => {
+            if (completed == 1) {
+                vm.StopCommand.Execute(null);
+            }
+        };
+
+        await vm.SendSingleMoveAsync();
+
+        Assert.Multiple(() => {
+            Assert.That(f.ExecutedMoves.Count, Is.EqualTo(1));
+            Assert.That(vm.ResultTitle, Is.EqualTo("Stopped after 1 of 3 moves"));
+            Assert.That(vm.ResultBody, Does.Contain("there is no automatic undo"));
+            Assert.That(vm.ResultIsError, Is.False);
+            Assert.That(vm.IsExpanded, Is.True, "a result the user has not dismissed must force the panel open");
+        });
+    }
+
+    [Test]
+    public async Task Send_SingleCommandFailure_SaysTheCountersWereNotAdvanced() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+        Pick(vm, "All", amount: 20);
+        f.FailureForMove = _ => new TiltDeviceCommandFailedException("no ack within 20s");
+
+        await vm.SendSingleMoveAsync();
+
+        Assert.Multiple(() => {
+            Assert.That(vm.ResultTitle, Is.EqualTo("Move failed"));
+            Assert.That(vm.ResultBody, Does.Contain("The command 'bf,20' got no valid response"));
+            Assert.That(vm.ResultBody, Does.Contain("were not advanced"));
+            Assert.That(vm.ResultIsError, Is.True);
+            Assert.That(vm.SummaryText, Is.EqualTo("Last move failed — see details"));
+        });
+    }
+
+    [Test]
+    public async Task Send_SplitNudgePartialFailure_TellsTheUserTheExactRemainingAmount() {
+        using var f = new Fixture(maxStepsPerCommand: 200);
+        var vm = await f.BuildConnectedAsync();
+        Pick(vm, "All", amount: 450); // 200 + 200 + 50; fail the third command.
+        f.FailureForMove = _ => f.ExecutedMoves.Count >= 2 ? new TiltDeviceCommandFailedException("link died") : null;
+        Assert.That(vm.PlannedSingleMoves.Count, Is.EqualTo(3), "fixture precondition");
+
+        await vm.SendSingleMoveAsync();
+
+        Assert.Multiple(() => {
+            Assert.That(vm.ResultTitle, Is.EqualTo("Adjustment stopped after 2 of 3 moves"));
+            Assert.That(vm.ResultBody, Does.Contain("Sent 2 of 3 moves (400 of 450 steps)"));
+            Assert.That(vm.ResultBody, Does.Contain("set Amount to 50 and press Send to finish"));
+            Assert.That(vm.ResultIsError, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task TargetMode_PartialFailure_PointsAtReviewingAgainFromWhereTheMotorsActuallyAre() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+        f.SetPositions(500, 500, 500, 500);
+        vm.Mode = ManualAdjustmentMode.TargetPositions;
+        // Both diagonals move => two moves.
+        SetTargets(vm, tl: 530, tr: 540, bl: 460, br: 470);
+
+        var reviewed = vm.TargetPlanPreview.Plan;
+        Assert.That(reviewed.Moves.Count, Is.EqualTo(2), "fixture precondition");
+        f.NextChoice = TiltDeviceAdjustmentChoice.Proceeded(true, true, reviewed);
+        f.FailureForMove = _ => f.ExecutedMoves.Count >= 1 ? new TiltDeviceCommandFailedException("link died") : null;
+
+        await vm.ReviewTargetsAsync();
+
+        Assert.Multiple(() => {
+            Assert.That(f.ExecutedMoves.Count, Is.EqualTo(1));
+            Assert.That(vm.ResultTitle, Is.EqualTo("Adjustment stopped after 1 of 2 moves"));
+            Assert.That(vm.ResultBody, Does.Contain("press Review moves"));
+            Assert.That(vm.ResultIsError, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task DismissResult_ClearsThePanelAndLetsItCollapseAgain() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+        Pick(vm, "All", amount: 20);
+        f.FailureForMove = _ => new TiltDeviceCommandFailedException("boom");
+        await vm.SendSingleMoveAsync();
+        Assert.That(vm.IsExpanded, Is.True, "precondition");
+
+        vm.DismissResultCommand.Execute(null);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.ResultVisible, Is.False);
+            Assert.That(vm.IsExpanded, Is.False);
+        });
+    }
+
+    [Test]
+    public async Task Send_NeverAsksTheControllerToReorderOrBias() {
+        using var f = new Fixture();
+        var vm = await f.BuildConnectedAsync();
+        f.SetPositions(500, 500, 500, 500);
+        Pick(vm, "TR", amount: 20);
+
+        await vm.SendSingleMoveAsync();
+
+        // A single adjustment must be exactly the one move previewed — no silently prepended backfocus lift.
+        f.Controller.DidNotReceive().OrderForMinimalPeakExcursion(Arg.Any<IReadOnlyList<TiltAdapterMove>>());
+        Assert.That(f.ExecutedMoves.Single().Axis, Is.EqualTo(TiltMoveAxis.DiagonalA));
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -2480,14 +2480,10 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         }
 
         /// <summary>
-        /// Builds one replanner invocation's preview: plans the moves for the given group toggles, then asks
-        /// the controller (via the interface — never a downcast) to order them for minimal peak excursion so
-        /// the approval dialog shows the EXACT execution order (WYSIWYG). A TiltDeviceLimitException from the
-        /// ordering call means either a single move exceeds the per-command cap or every ordering would
-        /// exceed the max excursion — surfaced as a blocking preview (unordered moves shown, matching the
-        /// design doc) rather than propagated, so the dialog can display it instead of crashing. Residuals,
-        /// twist, and the time estimate are unaffected by ordering, so they carry over unchanged from the
-        /// original plan.
+        /// Builds one replanner invocation's preview. The implementation lives in
+        /// <see cref="TiltDevicePlanPreviewBuilder.Build"/> because the wizard's Manual Adjustment panel drives
+        /// the device from a target vector too, and the two surfaces must mean exactly the same thing by "the
+        /// plan"; this stays as the Automatic Adjustment call site's name for it.
         /// </summary>
         internal static TiltDevicePlanPreview BuildPlanPreview(
             IReadOnlyList<double> sPerScrew,
@@ -2496,41 +2492,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             double unitMicrons,
             int maxStepsPerCommand,
             ITiltMotionController controller) {
-            var plan = TiltMovePlanner.Plan(sPerScrew, includeTilt, includeBackfocus, unitMicrons, maxStepsPerCommand);
-            try {
-                var ordered = controller.OrderForMinimalPeakExcursion(plan.Moves);
-                // The controller may PREPEND a backfocus bias so a differential tilt correction never drives a
-                // motor below 0. That bias is a genuine piston -- it shifts backfocus -- so the residual has to
-                // be recomputed from what will actually be sent. Carrying the unbiased plan's residual here
-                // would silently under-report the very backfocus error the bias introduces.
-                var applied = new double[4];
-                foreach (var move in ordered) {
-                    for (int i = 0; i < 4; ++i) {
-                        applied[i] += move.PerCornerSteps[i];
-                    }
-                }
-                var residual = new double[4];
-                for (int i = 0; i < 4; ++i) {
-                    residual[i] = (applied[i] - sPerScrew[i]) * unitMicrons;
-                }
-
-                // The bias is the uniform surplus the controller added on top of what was planned; it lands
-                // equally on all four corners (it is a piston), so the smallest per-corner surplus is it.
-                var planned = new double[4];
-                foreach (var move in plan.Moves) {
-                    for (int i = 0; i < 4; ++i) {
-                        planned[i] += move.PerCornerSteps[i];
-                    }
-                }
-                int biasSteps = (int)Math.Round(Enumerable.Range(0, 4).Min(i => applied[i] - planned[i]));
-                // A prepended bias also adds real execution time; scale the estimate by the per-move rate the
-                // planner used rather than carrying a move count that no longer matches.
-                double perMoveSeconds = plan.Moves.Count > 0 ? plan.EstimatedSeconds / plan.Moves.Count : 0.0;
-                var orderedPlan = new TiltAdapterMovePlan(ordered, residual, plan.TwistResidualSteps, ordered.Count * perMoveSeconds, Math.Max(0, biasSteps));
-                return new TiltDevicePlanPreview(orderedPlan, hardLimitViolated: false, limitWarning: string.Empty);
-            } catch (TiltDeviceLimitException ex) {
-                return new TiltDevicePlanPreview(plan, hardLimitViolated: true, limitWarning: ex.Message);
-            }
+            return TiltDevicePlanPreviewBuilder.Build(sPerScrew, includeTilt, includeBackfocus, unitMicrons, maxStepsPerCommand, controller);
         }
 
         private async Task RunAutomaticAdjustmentAsync() {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Manual/ManualAdjustmentTarget.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Manual/ManualAdjustmentTarget.cs
@@ -1,0 +1,320 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Manual {
+
+    /// <summary>Which vocabulary a manual pad target belongs to — mirrors the approval dialog's Corner / Side / Backfocus badge.</summary>
+    public enum ManualMoveKind {
+        Corner,
+        Side,
+        Backfocus
+    }
+
+    /// <summary>
+    /// Static description of one physical corner of a 4-corner coupled adapter, in all three index spaces at
+    /// once. The plugin carries three different orderings for the same four motors (see
+    /// <c>.claude/docs/tilt-domain.md</c>) and hand-converting between them is the single most repeated bug in
+    /// this feature, so every manual-panel readout resolves its labels through this table instead:
+    ///
+    ///   corner label  TR   TL   BL   BR
+    ///   device motor   1    2    4    3
+    ///   wizard screw   1    2    3    4
+    /// </summary>
+    public sealed class TiltAdapterCorner {
+
+        private TiltAdapterCorner(string label, int deviceMotorNumber, int wizardScrewNumber, int padRow, int padColumn) {
+            Label = label;
+            DeviceMotorNumber = deviceMotorNumber;
+            WizardScrewNumber = wizardScrewNumber;
+            PadRow = padRow;
+            PadColumn = padColumn;
+        }
+
+        /// <summary>Corner label as printed everywhere in the tilt UI: TR, TL, BL, BR.</summary>
+        public string Label { get; }
+
+        /// <summary>1-based device motor number (the order <c>TiltDeviceConnectionService.CurrentPositions</c> uses).</summary>
+        public int DeviceMotorNumber { get; }
+
+        /// <summary>1-based wizard screw number (the order <c>TiltAdapterMove.PerCornerSteps</c> and the planner's <c>sPerScrew</c> use).</summary>
+        public int WizardScrewNumber { get; }
+
+        /// <summary>Row of this corner in the 2×2 spatial grid the UI draws (0 = top).</summary>
+        public int PadRow { get; }
+
+        /// <summary>Column of this corner in the 2×2 spatial grid the UI draws (0 = left).</summary>
+        public int PadColumn { get; }
+
+        /// <summary>"TL · Motor 2" — the heading the position/target/preview cells share.</summary>
+        public string CellHeading => string.Format(CultureInfo.CurrentCulture, "{0} · Motor {1}", Label, DeviceMotorNumber);
+
+        private static readonly TiltAdapterCorner TopRight = new TiltAdapterCorner("TR", deviceMotorNumber: 1, wizardScrewNumber: 1, padRow: 0, padColumn: 1);
+        private static readonly TiltAdapterCorner TopLeft = new TiltAdapterCorner("TL", deviceMotorNumber: 2, wizardScrewNumber: 2, padRow: 0, padColumn: 0);
+        private static readonly TiltAdapterCorner BottomLeft = new TiltAdapterCorner("BL", deviceMotorNumber: 4, wizardScrewNumber: 3, padRow: 1, padColumn: 0);
+        private static readonly TiltAdapterCorner BottomRight = new TiltAdapterCorner("BR", deviceMotorNumber: 3, wizardScrewNumber: 4, padRow: 1, padColumn: 1);
+
+        /// <summary>The four corners indexed by wizard screw index [0..3] — the order of <c>PerCornerSteps</c> and <c>sPerScrew</c>.</summary>
+        public static readonly IReadOnlyList<TiltAdapterCorner> InWizardScrewOrder =
+            Array.AsReadOnly(new[] { TopRight, TopLeft, BottomLeft, BottomRight });
+
+        /// <summary>The four corners indexed by device motor index [0..3] — the order of <c>CurrentPositions</c> and <c>TiltDevicePositions.PerMotorSteps</c>.</summary>
+        public static readonly IReadOnlyList<TiltAdapterCorner> InDeviceMotorOrder =
+            Array.AsReadOnly(new[] { TopRight, TopLeft, BottomRight, BottomLeft });
+
+        /// <summary>The four corners in the reading order the 2×2 UI grid lays them out: TL, TR, BL, BR.</summary>
+        public static readonly IReadOnlyList<TiltAdapterCorner> InDisplayOrder =
+            Array.AsReadOnly(new[] { TopLeft, TopRight, BottomLeft, BottomRight });
+
+        public static TiltAdapterCorner ForWizardScrew(int wizardScrewNumber) {
+            if (wizardScrewNumber < 1 || wizardScrewNumber > 4) {
+                throw new ArgumentOutOfRangeException(nameof(wizardScrewNumber), wizardScrewNumber, "Wizard screw index must be 1-4.");
+            }
+            return InWizardScrewOrder[wizardScrewNumber - 1];
+        }
+
+        public static TiltAdapterCorner ForDeviceMotor(int deviceMotorNumber) {
+            if (deviceMotorNumber < 1 || deviceMotorNumber > 4) {
+                throw new ArgumentOutOfRangeException(nameof(deviceMotorNumber), deviceMotorNumber, "Device motor number must be 1-4.");
+            }
+            return InDeviceMotorOrder[deviceMotorNumber - 1];
+        }
+    }
+
+    /// <summary>
+    /// One cell of the manual adjustment pad: the nine things a 4-corner coupled adapter can be told to move
+    /// (four corners, four sides, all together). Each cell is exactly one <see cref="TiltMoveAxis"/> plus a
+    /// sign, so a pad click is always a single device command — never a decomposition.
+    ///
+    /// THE TABLE IN <see cref="All"/> IS A CORRECTNESS ANCHOR, like <c>TiltAdapterMove</c>'s unit-effect
+    /// vectors. A sign error here is an EEPROM-persisted wrong-way motor move that the user cannot undo. Do
+    /// not edit it without re-deriving against <c>TiltAdapterMove.UnitEffect</c> and re-running
+    /// <c>ManualAdjustmentTargetTests</c>, which pins every cell in both directions.
+    /// </summary>
+    public sealed class ManualAdjustmentTarget {
+
+        private ManualAdjustmentTarget(
+            string key,
+            string label,
+            ManualMoveKind kind,
+            TiltMoveAxis axis,
+            int axisSign,
+            int padRow,
+            int padColumn,
+            string movedLabel,
+            string oppositeLabel,
+            string tooltip) {
+            Key = key;
+            Label = label;
+            Kind = kind;
+            Axis = axis;
+            AxisSign = axisSign;
+            PadRow = padRow;
+            PadColumn = padColumn;
+            MovedLabel = movedLabel;
+            OppositeLabel = oppositeLabel;
+            Tooltip = tooltip;
+        }
+
+        /// <summary>Stable identifier used by tests and session state; never shown to the user.</summary>
+        public string Key { get; }
+
+        /// <summary>Text on the pad button.</summary>
+        public string Label { get; }
+
+        public ManualMoveKind Kind { get; }
+
+        /// <summary>The single generator axis this cell drives.</summary>
+        public TiltMoveAxis Axis { get; }
+
+        /// <summary>
+        /// Sign applied to <see cref="Axis"/> when the user picks direction "+". Because the axes are signed,
+        /// two pad cells share each tilt axis (TR/BL share DiagonalA) and differ only here — the pad exists so
+        /// the user never has to work out that "BL +" and "TR −" are the same move.
+        /// </summary>
+        public int AxisSign { get; }
+
+        /// <summary>Row of this cell in the 3×3 pad (0 = top).</summary>
+        public int PadRow { get; }
+
+        /// <summary>Column of this cell in the 3×3 pad (0 = left).</summary>
+        public int PadColumn { get; }
+
+        /// <summary>The element that receives the signed amount, as it reads in prose ("TR", "top"). Null for Backfocus.</summary>
+        public string MovedLabel { get; }
+
+        /// <summary>The coupled element that receives the negated amount ("BL", "bottom"). Null for Backfocus.</summary>
+        public string OppositeLabel { get; }
+
+        public string Tooltip { get; }
+
+        /// <summary>Screen-reader name: the first clause of the tooltip plus the cell's own label.</summary>
+        public string AutomationName {
+            get {
+                int sentenceEnd = Tooltip.IndexOf('.');
+                string firstSentence = sentenceEnd < 0 ? Tooltip : Tooltip.Substring(0, sentenceEnd);
+                return string.Format(CultureInfo.CurrentCulture, "{0} — {1}", Label, firstSentence);
+            }
+        }
+
+        /// <summary>
+        /// Signed magnitude to command on <see cref="Axis"/> for a pad click. <paramref name="amount"/> is
+        /// always positive (the amount box is strictly positive); the sign comes from the cell and the
+        /// direction toggle together.
+        /// </summary>
+        public int SignedAxisSteps(bool positiveDirection, int amount) {
+            return AxisSign * (positiveDirection ? 1 : -1) * amount;
+        }
+
+        /// <summary>
+        /// The per-screw step effect of this pad click, in WIZARD screw indices 1..4 at [0..3] — the same
+        /// space as <c>TiltAdapterMove.PerCornerSteps</c>. Derived from <c>TiltAdapterMove.UnitEffect</c>, so
+        /// it cannot drift from what the device actually does.
+        /// </summary>
+        public IReadOnlyList<double> PerScrewEffect(bool positiveDirection, int amount) {
+            int steps = SignedAxisSteps(positiveDirection, amount);
+            var unit = TiltAdapterMove.UnitEffect(Axis);
+            var effect = new double[unit.Count];
+            for (int i = 0; i < unit.Count; ++i) {
+                effect[i] = unit[i] * steps;
+            }
+            return Array.AsReadOnly(effect);
+        }
+
+        /// <summary>
+        /// The device move for a pad click. Throws <see cref="ArgumentOutOfRangeException"/> for a
+        /// non-positive amount — the panel gates on that before ever calling here, and a zero-magnitude move
+        /// would be rejected by <c>EatCommands.Format</c> anyway.
+        /// </summary>
+        public TiltAdapterMove BuildMove(bool positiveDirection, int amount) {
+            if (amount < 1) {
+                throw new ArgumentOutOfRangeException(nameof(amount), amount, "A manual move amount must be at least 1 step.");
+            }
+            int steps = SignedAxisSteps(positiveDirection, amount);
+            var group = Axis == TiltMoveAxis.Backfocus ? TiltMoveGroup.Backfocus : TiltMoveGroup.Tilt;
+            return new TiltAdapterMove(Axis, steps, group, DescribeMove(steps));
+        }
+
+        /// <summary>
+        /// "TR (Motor 1) +20 · BL (Motor 4) −20 steps" — the semantic line for a pad click, in the panel's own
+        /// corner-and-motor vocabulary rather than the approval dialog's wizard-screw one. This becomes the
+        /// move's <c>Description</c>, so it is also what the controller's progress text and any limit
+        /// exception quote back at the user.
+        /// </summary>
+        public string DescribeMove(int signedAxisSteps) {
+            var effect = TiltAdapterMove.UnitEffect(Axis);
+            if (Axis == TiltMoveAxis.Backfocus) {
+                return string.Format(CultureInfo.CurrentCulture, "All four motors {0} steps together", FormatSigned(signedAxisSteps));
+            }
+
+            var parts = new List<string>(4);
+            // Wizard screw order, but rendered in the 2×2 display order so the sentence reads the way the grid
+            // above it looks.
+            foreach (var corner in TiltAdapterCorner.InDisplayOrder) {
+                double perScrew = effect[corner.WizardScrewNumber - 1] * signedAxisSteps;
+                if (Math.Abs(perScrew) < 0.5) {
+                    continue;
+                }
+                parts.Add(string.Format(
+                    CultureInfo.CurrentCulture, "{0} (Motor {1}) {2}", corner.Label, corner.DeviceMotorNumber, FormatSigned((int)Math.Round(perScrew))));
+            }
+            return string.Join(" · ", parts) + " steps";
+        }
+
+        private static string FormatSigned(int value) {
+            // U+2212 MINUS SIGN, matching the rest of the tilt UI's signed readouts.
+            return value < 0
+                ? "−" + Math.Abs(value).ToString(CultureInfo.CurrentCulture)
+                : "+" + value.ToString(CultureInfo.CurrentCulture);
+        }
+
+        // ---------------------------------------------------------------------------------------------------
+        // The nine pad cells. Layout (matching the sensor as imaged in NINA):
+        //
+        //     TL   Top    TR
+        //     Left All    Right
+        //     BL   Bottom BR
+        //
+        // Axis + sign per cell, cross-checked against TiltAdapterMove.UnitEffect (wizard screws s1..s4):
+        //     DiagonalA      (+1,  0, -1,  0)   s1 = TR, s3 = BL
+        //     DiagonalB      ( 0, +1,  0, -1)   s2 = TL, s4 = BR
+        //     EdgeVertical   (+1, +1, -1, -1)   top pair s1,s2 = TR,TL
+        //     EdgeHorizontal (+1, -1, -1, +1)   right pair s1,s4 = TR,BR
+        //     Backfocus      (+1, +1, +1, +1)
+        // ---------------------------------------------------------------------------------------------------
+        public static readonly IReadOnlyList<ManualAdjustmentTarget> All = new ReadOnlyCollection<ManualAdjustmentTarget>(new[] {
+            new ManualAdjustmentTarget(
+                key: "TL", label: "TL", kind: ManualMoveKind.Corner, axis: TiltMoveAxis.DiagonalB, axisSign: 1,
+                padRow: 0, padColumn: 0, movedLabel: "TL", oppositeLabel: "BR",
+                tooltip: "Tilts along the TL–BR diagonal. Motor 2 (TL) gets the signed amount; Motor 3 (BR) gets the opposite. One command."),
+            new ManualAdjustmentTarget(
+                key: "Top", label: "Top", kind: ManualMoveKind.Side, axis: TiltMoveAxis.EdgeVertical, axisSign: 1,
+                padRow: 0, padColumn: 1, movedLabel: "top", oppositeLabel: "bottom",
+                tooltip: "Tilts top vs bottom. Motors 2 & 1 (TL, TR) get the signed amount; Motors 4 & 3 (BL, BR) get the opposite. One command."),
+            new ManualAdjustmentTarget(
+                key: "TR", label: "TR", kind: ManualMoveKind.Corner, axis: TiltMoveAxis.DiagonalA, axisSign: 1,
+                padRow: 0, padColumn: 2, movedLabel: "TR", oppositeLabel: "BL",
+                tooltip: "Tilts along the TR–BL diagonal. Motor 1 (TR) gets the signed amount; Motor 4 (BL) gets the opposite. One command."),
+
+            new ManualAdjustmentTarget(
+                key: "Left", label: "Left", kind: ManualMoveKind.Side, axis: TiltMoveAxis.EdgeHorizontal, axisSign: -1,
+                padRow: 1, padColumn: 0, movedLabel: "left", oppositeLabel: "right",
+                tooltip: "Tilts right vs left. Motors 2 & 4 (TL, BL) get the signed amount; Motors 1 & 3 (TR, BR) get the opposite. One command."),
+            new ManualAdjustmentTarget(
+                key: "All", label: "All", kind: ManualMoveKind.Backfocus, axis: TiltMoveAxis.Backfocus, axisSign: 1,
+                padRow: 1, padColumn: 1, movedLabel: null, oppositeLabel: null,
+                tooltip: "Moves all four motors together by the signed amount — changes sensor spacing (backfocus), not tilt. One command."),
+            new ManualAdjustmentTarget(
+                key: "Right", label: "Right", kind: ManualMoveKind.Side, axis: TiltMoveAxis.EdgeHorizontal, axisSign: 1,
+                padRow: 1, padColumn: 2, movedLabel: "right", oppositeLabel: "left",
+                tooltip: "Tilts right vs left. Motors 1 & 3 (TR, BR) get the signed amount; Motors 2 & 4 (TL, BL) get the opposite. One command."),
+
+            new ManualAdjustmentTarget(
+                key: "BL", label: "BL", kind: ManualMoveKind.Corner, axis: TiltMoveAxis.DiagonalA, axisSign: -1,
+                padRow: 2, padColumn: 0, movedLabel: "BL", oppositeLabel: "TR",
+                tooltip: "Tilts along the TR–BL diagonal. Motor 4 (BL) gets the signed amount; Motor 1 (TR) gets the opposite. One command."),
+            new ManualAdjustmentTarget(
+                key: "Bottom", label: "Bottom", kind: ManualMoveKind.Side, axis: TiltMoveAxis.EdgeVertical, axisSign: -1,
+                padRow: 2, padColumn: 1, movedLabel: "bottom", oppositeLabel: "top",
+                tooltip: "Tilts top vs bottom. Motors 4 & 3 (BL, BR) get the signed amount; Motors 2 & 1 (TL, TR) get the opposite. One command."),
+            new ManualAdjustmentTarget(
+                key: "BR", label: "BR", kind: ManualMoveKind.Corner, axis: TiltMoveAxis.DiagonalB, axisSign: -1,
+                padRow: 2, padColumn: 2, movedLabel: "BR", oppositeLabel: "TL",
+                tooltip: "Tilts along the TL–BR diagonal. Motor 3 (BR) gets the signed amount; Motor 2 (TL) gets the opposite. One command."),
+        });
+
+        public static ManualAdjustmentTarget ByKey(string key) {
+            var match = All.FirstOrDefault(t => string.Equals(t.Key, key, StringComparison.Ordinal));
+            if (match == null) {
+                throw new ArgumentOutOfRangeException(nameof(key), key, "Unknown manual adjustment pad target.");
+            }
+            return match;
+        }
+
+        /// <summary>The badge text the preview shows, matching the approval dialog's Corner / Side / Backfocus vocabulary.</summary>
+        public string KindLabel {
+            get {
+                switch (Kind) {
+                    case ManualMoveKind.Corner: return "Corner";
+                    case ManualMoveKind.Side: return "Side";
+                    case ManualMoveKind.Backfocus: return "Backfocus";
+                    default: throw new ArgumentOutOfRangeException(nameof(Kind), Kind, "Unknown manual move kind.");
+                }
+            }
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Manual/TiltAdapterManualAdjustmentVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Manual/TiltAdapterManualAdjustmentVM.cs
@@ -1,0 +1,1391 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Utility;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using AsyncRelayCommand = CommunityToolkit.Mvvm.Input.AsyncRelayCommand;
+using RelayCommand = CommunityToolkit.Mvvm.Input.RelayCommand;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Manual {
+
+    /// <summary>Which of the panel's two entry modes is showing.</summary>
+    public enum ManualAdjustmentMode {
+
+        /// <summary>Pick a pad cell + direction + amount; one click sends exactly one generator move.</summary>
+        SingleMove,
+
+        /// <summary>Type absolute per-motor end positions; the delta is decomposed and reviewed in the approval dialog.</summary>
+        TargetPositions
+    }
+
+    /// <summary>How close a predicted position sits to the ends of the travel window.</summary>
+    public enum ManualLimitSeverity {
+        None,
+        Near,
+        Blocking
+    }
+
+    /// <summary>
+    /// One cell of the single-move preview's 2×2 predicted-position grid. Read-only projection rebuilt on
+    /// every input or position change.
+    /// </summary>
+    public sealed class ManualPreviewCell {
+
+        public ManualPreviewCell(TiltAdapterCorner corner, string valueText, bool isMoving, string limitTag, ManualLimitSeverity severity, string tooltip) {
+            Corner = corner;
+            ValueText = valueText ?? string.Empty;
+            IsMoving = isMoving;
+            LimitTag = limitTag ?? string.Empty;
+            Severity = severity;
+            Tooltip = tooltip ?? string.Empty;
+        }
+
+        public TiltAdapterCorner Corner { get; }
+
+        public string Heading => Corner.CellHeading;
+
+        /// <summary>"512 → 512" when unchanged, "480 → 500 (+20)" when this motor moves, "unknown → unknown" when positions are unknown.</summary>
+        public string ValueText { get; }
+
+        public bool IsMoving { get; }
+
+        /// <summary>"near max" / "near 0" / "below 0" / "over max", or empty. Text, never colour alone.</summary>
+        public string LimitTag { get; }
+
+        public bool HasLimitTag => !string.IsNullOrEmpty(LimitTag);
+
+        public ManualLimitSeverity Severity { get; }
+
+        public bool IsBlocking => Severity == ManualLimitSeverity.Blocking;
+
+        public string Tooltip { get; }
+    }
+
+    /// <summary>
+    /// One cell of the 3×3 pad, bound by the UI. A per-VM wrapper rather than a flag on
+    /// <see cref="ManualAdjustmentTarget"/>, because that table is a shared static — selection is view state
+    /// and must not be written into it.
+    /// </summary>
+    public sealed class ManualPadItem : BaseINPC {
+        private readonly Action<ManualPadItem> onSelected;
+        private bool isSelected;
+
+        internal ManualPadItem(ManualAdjustmentTarget target, Action<ManualPadItem> onSelected) {
+            Target = target;
+            this.onSelected = onSelected;
+        }
+
+        public ManualAdjustmentTarget Target { get; }
+
+        public bool IsSelected {
+            get => isSelected;
+            set {
+                if (isSelected != value) {
+                    isSelected = value;
+                    RaisePropertyChanged();
+                    if (value) {
+                        onSelected?.Invoke(this);
+                    }
+                }
+            }
+        }
+
+        /// <summary>Sets selection without re-entering the VM's selection handler (used when another cell wins).</summary>
+        internal void SetSelectedSilently(bool value) {
+            if (isSelected != value) {
+                isSelected = value;
+                RaisePropertyChanged(nameof(IsSelected));
+            }
+        }
+    }
+
+    /// <summary>
+    /// One editable cell of the target-positions 2×2 grid: the live "now" value, the user's absolute target,
+    /// the resulting delta, and — when the request contains twist the adapter cannot make — the position this
+    /// motor will actually reach.
+    /// </summary>
+    public sealed class ManualTargetCell : BaseINPC {
+        private readonly Action onTargetChanged;
+        private string targetText = string.Empty;
+        private string nowText = "unknown";
+        private string deltaText = string.Empty;
+        private string willReachText = string.Empty;
+        private bool hasError;
+
+        internal ManualTargetCell(TiltAdapterCorner corner, Action onTargetChanged) {
+            Corner = corner;
+            this.onTargetChanged = onTargetChanged;
+        }
+
+        public TiltAdapterCorner Corner { get; }
+
+        public string Heading => Corner.CellHeading;
+
+        /// <summary>"Wizard screw 3" — the third index space, kept visible so this grid joins up with the approval dialog's rows.</summary>
+        public string WizardScrewCaption => string.Format(CultureInfo.InvariantCulture, "Wizard screw {0}", Corner.WizardScrewNumber);
+
+        /// <summary>The user's absolute target, as typed. Parsed by the VM so it can own the error copy.</summary>
+        public string TargetText {
+            get => targetText;
+            set {
+                if (targetText != value) {
+                    targetText = value ?? string.Empty;
+                    RaisePropertyChanged();
+                    onTargetChanged?.Invoke();
+                }
+            }
+        }
+
+        /// <summary>Sets the target without re-entering the VM's recompute (used by prefill/reset, which recompute once at the end).</summary>
+        internal void SetTargetSilently(string value) {
+            targetText = value ?? string.Empty;
+            RaisePropertyChanged(nameof(TargetText));
+        }
+
+        /// <summary>"now 512" — live, refreshed by the position poll; never overwrites <see cref="TargetText"/>.</summary>
+        public string NowText {
+            get => nowText;
+            internal set { if (nowText != value) { nowText = value; RaisePropertyChanged(); } }
+        }
+
+        public string DeltaText {
+            get => deltaText;
+            internal set { if (deltaText != value) { deltaText = value; RaisePropertyChanged(); RaisePropertyChanged(nameof(HasDelta)); } }
+        }
+
+        public bool HasDelta => !string.IsNullOrEmpty(deltaText);
+
+        /// <summary>"will reach 546" — only populated when the request contains unreachable twist.</summary>
+        public string WillReachText {
+            get => willReachText;
+            internal set { if (willReachText != value) { willReachText = value; RaisePropertyChanged(); RaisePropertyChanged(nameof(HasWillReach)); } }
+        }
+
+        public bool HasWillReach => !string.IsNullOrEmpty(willReachText);
+
+        public bool HasError {
+            get => hasError;
+            internal set { if (hasError != value) { hasError = value; RaisePropertyChanged(); } }
+        }
+    }
+
+    /// <summary>
+    /// The Tilt Adapter Wizard's "Manual adjustment" panel: hand control of a connected 4-corner coupled
+    /// motorized adapter, in two modes.
+    ///
+    /// <para><b>Single move</b> sends exactly one generator command — one pad cell is one axis plus a sign (see
+    /// <see cref="ManualAdjustmentTarget"/>). It deliberately does NOT run the planner and never lets the
+    /// controller prepend a backfocus bias: "a single adjustment" must mean precisely the one move previewed.
+    /// A move that would leave the travel window is blocked with a reason instead, and the user lifts with an
+    /// explicit All move.</para>
+    ///
+    /// <para><b>Target positions</b> takes absolute per-motor end positions, subtracts the live positions, and
+    /// runs the result through the same <see cref="TiltDevicePlanPreviewBuilder"/> and approval dialog the
+    /// Aberration Inspector's Automatic Adjustment uses — so the decomposition, ordering, residual grid, and
+    /// warnings are literally the same code and the same UI.</para>
+    ///
+    /// <para>Neither mode requires a fitted sensor model, a device-linked calibration, or
+    /// <c>CalibrationIsReliable</c>: this is raw hardware control, not a correction derived from a
+    /// measurement, so Automatic Adjustment's gates do not apply.</para>
+    ///
+    /// <para>All state here is session-scoped on purpose — nothing this panel remembers is worth a persisted
+    /// per-profile option (and would then owe a control in the global options screen).</para>
+    /// </summary>
+    public sealed class TiltAdapterManualAdjustmentVM : BaseINPC, IDisposable {
+
+        /// <summary>Operation-lease name; surfaces in the connection status line as "Connected on COM7 — Manual Adjustment".</summary>
+        internal const string OperationName = "Manual Adjustment";
+
+        /// <summary>Seconds attributed to one command for the duration estimate — the same rate <see cref="TiltMovePlanner"/> defaults to.</summary>
+        internal const double PerMoveSeconds = 10.0;
+
+        /// <summary>Fraction of the travel window within which a predicted position earns a "near 0" / "near max" tag.</summary>
+        internal const double NearLimitFraction = 0.05;
+
+        internal const string CautionCopy =
+            "Moves are physical and the device remembers every move (stored in EEPROM). There is no automatic undo.";
+
+        internal const string NotConnectedCopy = "Connect the device above to make adjustments.";
+
+        internal const string NothingToMoveCopy = "Targets match the current positions — nothing to move.";
+
+        private readonly ITiltAdapterOptions options;
+        private readonly TiltDeviceConnectionService connectionService;
+        private readonly IApplicationDispatcher applicationDispatcher;
+        private readonly Func<Func<bool, bool, TiltDevicePlanPreview>, double, Task<TiltDeviceAdjustmentChoice>> showAdjustmentPromptAsync;
+
+        private readonly RelayCommand sendCommand;
+        private readonly RelayCommand reviewCommand;
+        private readonly RelayCommand stopCommand;
+
+        private bool userExpanded;
+        private ManualAdjustmentMode mode = ManualAdjustmentMode.SingleMove;
+
+        private ManualAdjustmentTarget selectedTarget;
+        private bool positiveDirection = true;
+        private string amountText = "10";
+
+        private bool isSending;
+        private string progressText = string.Empty;
+        private int remainingMoveCount;
+        private string successText = string.Empty;
+        private string lastSentSummary = string.Empty;
+        private string resultTitle = string.Empty;
+        private string resultBody = string.Empty;
+        private bool resultIsError;
+        private CancellationTokenSource sendCts;
+
+        private IReadOnlyList<int> lastKnownPositions;
+
+        public TiltAdapterManualAdjustmentVM(
+            ITiltAdapterOptions options,
+            TiltDeviceConnectionService connectionService,
+            IApplicationDispatcher applicationDispatcher,
+            Func<Func<bool, bool, TiltDevicePlanPreview>, double, Task<TiltDeviceAdjustmentChoice>> showAdjustmentPromptAsync) {
+            this.options = options ?? throw new ArgumentNullException(nameof(options));
+            this.connectionService = connectionService;
+            this.applicationDispatcher = applicationDispatcher;
+            this.showAdjustmentPromptAsync = showAdjustmentPromptAsync ?? throw new ArgumentNullException(nameof(showAdjustmentPromptAsync));
+
+            TargetCells = TiltAdapterCorner.InDisplayOrder
+                .Select(c => new ManualTargetCell(c, OnTargetCellChanged))
+                .ToList();
+            // Row-major over the 3×3 pad, which is the order ManualAdjustmentTarget.All is declared in.
+            PadItems = ManualAdjustmentTarget.All
+                .Select(t => new ManualPadItem(t, OnPadItemSelected))
+                .ToList();
+
+            sendCommand = new RelayCommand(() => RunGuarded(SendSingleMoveAsync, "send"), () => CanSend);
+            reviewCommand = new RelayCommand(() => RunGuarded(ReviewTargetsAsync, "review"), () => CanReview);
+            stopCommand = new RelayCommand(RequestStop, () => CanStop);
+            ResetToCurrentCommand = new RelayCommand(ResetTargetsToCurrent);
+            DismissResultCommand = new RelayCommand(DismissResult);
+
+            if (this.connectionService != null) {
+                this.connectionService.PropertyChanged += OnConnectionServiceChanged;
+            }
+            this.options.PropertyChanged += OnOptionsChanged;
+
+            CaptureCurrentPositions();
+            PrefillTargetsFromCurrent();
+            RefreshAll();
+        }
+
+        #region Wiring
+
+        private void OnConnectionServiceChanged(object sender, PropertyChangedEventArgs e) {
+            // Fires from the 5 s poll thread and from move completions. Post (never blocking-dispatch): the
+            // poll path is one the UI thread can transitively wait on.
+            OnUIThread(() => {
+                CaptureCurrentPositions();
+                if (!IsDeviceConnected) {
+                    // Targets are meaningless against a device that is gone; the next connect re-prefills them.
+                    ClearTargets();
+                }
+                RefreshAll();
+            });
+        }
+
+        private void OnOptionsChanged(object sender, PropertyChangedEventArgs e) {
+            // Travel window / per-command cap / step size all feed the preview, the split count and the limit
+            // checks, so any of them changing has to re-derive the whole panel.
+            OnUIThread(RefreshAll);
+        }
+
+        private void OnUIThread(Action action) {
+            if (applicationDispatcher == null) {
+                action();
+                return;
+            }
+            applicationDispatcher.PostSynchronizationContext(action);
+        }
+
+        public void Dispose() {
+            if (connectionService != null) {
+                connectionService.PropertyChanged -= OnConnectionServiceChanged;
+            }
+            options.PropertyChanged -= OnOptionsChanged;
+            sendCts?.Dispose();
+            sendCts = null;
+        }
+
+        #endregion Wiring
+
+        #region Device / options state
+
+        public bool IsDeviceConnected => connectionService?.Connected ?? false;
+
+        private ITiltMotionController Controller => connectionService?.Controller;
+
+        /// <summary>True only while another surface (a wizard run, Automatic Adjustment) holds the device lease.</summary>
+        public bool IsDeviceBusyElsewhere => !isSending && (connectionService?.IsOperationActive ?? false);
+
+        public bool PositionsKnown => lastKnownPositions != null && lastKnownPositions.Count >= 4;
+
+        private int MaxExcursionSteps => options.TiltDeviceMaxExcursionSteps;
+
+        private int MaxStepsPerCommand => Math.Max(1, options.TiltDeviceMaxStepsPerCommand);
+
+        private double UnitMicrons {
+            get {
+                double unit = options.AdjustmentType == TiltAdjustmentType.StepperMotors
+                    ? options.StepperStepSizeMicrons
+                    : options.ThreadPitchMicrons;
+                return unit > 0 ? unit : 0.0;
+            }
+        }
+
+        private bool HasUnitMicrons => UnitMicrons > 0;
+
+        private void CaptureCurrentPositions() {
+            var svc = connectionService;
+            if (svc == null || !svc.Connected || !svc.PositionsKnown) {
+                lastKnownPositions = null;
+                return;
+            }
+            var positions = svc.CurrentPositions;
+            lastKnownPositions = (positions != null && positions.Count >= 4) ? positions : null;
+        }
+
+        #endregion Device / options state
+
+        #region Expander + summary
+
+        /// <summary>
+        /// Collapsed by default and two-way bound so a user's toggle sticks for the session — but force-open
+        /// while a send is running or an undismissed failure is on screen, so the panel can never hide the
+        /// consequence of something it started.
+        /// </summary>
+        public bool IsExpanded {
+            get => userExpanded || isSending || ResultVisible;
+            set {
+                if (userExpanded != value) {
+                    userExpanded = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>Dim one-liner beside the header, so the collapsed state still says something useful.</summary>
+        public string SummaryText {
+            get {
+                if (isSending) {
+                    return progressText;
+                }
+                if (ResultVisible && resultIsError) {
+                    return "Last move failed — see details";
+                }
+                if (IsDeviceBusyElsewhere) {
+                    string op = connectionService?.CurrentOperationName;
+                    return string.IsNullOrEmpty(op) ? "Device busy" : string.Format(CultureInfo.InvariantCulture, "Device busy — {0}", op);
+                }
+                if (!IsDeviceConnected) {
+                    return "Connect to enable";
+                }
+                // Deliberately shorter than the body's success line: the header is what a COLLAPSED panel shows,
+                // and when the panel is open the two sit inches apart, where the full sentence twice reads as a
+                // stutter.
+                if (!string.IsNullOrEmpty(lastSentSummary)) {
+                    return lastSentSummary;
+                }
+                return "Nudge a corner or set target positions";
+            }
+        }
+
+        public string CautionText => CautionCopy;
+
+        public string NotConnectedText => NotConnectedCopy;
+
+        #endregion Expander + summary
+
+        #region Mode
+
+        public ManualAdjustmentMode Mode {
+            get => mode;
+            set {
+                if (mode != value) {
+                    mode = value;
+                    if (mode == ManualAdjustmentMode.TargetPositions) {
+                        PrefillTargetsFromCurrent();
+                    }
+                    RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(IsSingleMoveMode));
+                    RaisePropertyChanged(nameof(IsTargetPositionsMode));
+                    RefreshAll();
+                }
+            }
+        }
+
+        // Two settable bools rather than an enum converter: RadioButton.IsChecked binds to these directly, and
+        // WPF pushes false to the losing option before true to the winning one, so ignore the false edge.
+        public bool IsSingleMoveMode {
+            get => mode == ManualAdjustmentMode.SingleMove;
+            set { if (value) Mode = ManualAdjustmentMode.SingleMove; }
+        }
+
+        public bool IsTargetPositionsMode {
+            get => mode == ManualAdjustmentMode.TargetPositions;
+            set { if (value) Mode = ManualAdjustmentMode.TargetPositions; }
+        }
+
+        #endregion Mode
+
+        #region Single move — inputs
+
+        public IReadOnlyList<ManualAdjustmentTarget> PadTargets => ManualAdjustmentTarget.All;
+
+        /// <summary>The nine pad cells with their selection state, row-major over the 3×3 grid.</summary>
+        public IReadOnlyList<ManualPadItem> PadItems { get; }
+
+        private void OnPadItemSelected(ManualPadItem winner) {
+            foreach (var item in PadItems) {
+                if (!ReferenceEquals(item, winner)) {
+                    item.SetSelectedSilently(false);
+                }
+            }
+            SelectedTarget = winner.Target;
+        }
+
+        /// <summary>The selected pad cell, or null until the user picks one (there is deliberately no default).</summary>
+        public ManualAdjustmentTarget SelectedTarget {
+            get => selectedTarget;
+            set {
+                if (!ReferenceEquals(selectedTarget, value)) {
+                    selectedTarget = value;
+                    foreach (var item in PadItems) {
+                        item.SetSelectedSilently(ReferenceEquals(item.Target, value));
+                    }
+                    RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(SelectedTargetKey));
+                    RefreshAll();
+                }
+            }
+        }
+
+        /// <summary>Pad selection as a key, for the ToggleButton bindings and for tests.</summary>
+        public string SelectedTargetKey {
+            get => selectedTarget?.Key ?? string.Empty;
+            set => SelectedTarget = string.IsNullOrEmpty(value) ? null : ManualAdjustmentTarget.ByKey(value);
+        }
+
+        public bool HasSelection => selectedTarget != null;
+
+        public bool PositiveDirection {
+            get => positiveDirection;
+            set {
+                if (positiveDirection != value) {
+                    positiveDirection = value;
+                    RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(NegativeDirection));
+                    RefreshAll();
+                }
+            }
+        }
+
+        public bool NegativeDirection {
+            get => !positiveDirection;
+            set { if (value) PositiveDirection = false; }
+        }
+
+        public string AmountText {
+            get => amountText;
+            set {
+                if (amountText != value) {
+                    amountText = value ?? string.Empty;
+                    RaisePropertyChanged();
+                    RefreshAll();
+                }
+            }
+        }
+
+        /// <summary>The parsed amount, or null when the box does not hold a whole number of at least 1.</summary>
+        internal int? Amount {
+            get {
+                if (int.TryParse(amountText, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsed) && parsed >= 1) {
+                    return parsed;
+                }
+                return null;
+            }
+        }
+
+        /// <summary>"= 18.0 µm of screw travel", or empty when the preset's step size is unknown.</summary>
+        public string AmountMicronsHint {
+            get {
+                var amount = Amount;
+                if (amount == null || !HasUnitMicrons) {
+                    return string.Empty;
+                }
+                return string.Format(CultureInfo.InvariantCulture, "= {0:0.0} µm of screw travel", amount.Value * UnitMicrons);
+            }
+        }
+
+        public string AmountTooltip =>
+            HasUnitMicrons
+                ? string.Format(CultureInfo.InvariantCulture,
+                    "How far each affected motor moves, in device steps. 1 step = {0:0.#} µm of screw travel. Amounts above the per-command cap ({1}) are sent as several same-direction commands.",
+                    UnitMicrons, MaxStepsPerCommand)
+                : string.Format(CultureInfo.InvariantCulture,
+                    "How far each affected motor moves, in device steps. Amounts above the per-command cap ({0}) are sent as several same-direction commands.",
+                    MaxStepsPerCommand);
+
+        #endregion Single move — inputs
+
+        #region Single move — preview
+
+        /// <summary>The commands a Send would issue right now, in order. Empty when the inputs are incomplete.</summary>
+        internal IReadOnlyList<TiltAdapterMove> PlannedSingleMoves {
+            get {
+                var target = selectedTarget;
+                var amount = Amount;
+                if (target == null || amount == null) {
+                    return Array.Empty<TiltAdapterMove>();
+                }
+
+                int signedSteps = target.SignedAxisSteps(positiveDirection, amount.Value);
+                var chunks = TiltMovePlanner.SplitStepsForCap(signedSteps, MaxStepsPerCommand);
+                var group = target.Axis == TiltMoveAxis.Backfocus ? TiltMoveGroup.Backfocus : TiltMoveGroup.Tilt;
+                var moves = new List<TiltAdapterMove>(chunks.Count);
+                for (int i = 0; i < chunks.Count; ++i) {
+                    string description = chunks.Count == 1
+                        ? target.DescribeMove(chunks[i])
+                        : string.Format(CultureInfo.InvariantCulture, "{0} (part {1} of {2})", target.DescribeMove(chunks[i]), i + 1, chunks.Count);
+                    moves.Add(new TiltAdapterMove(target.Axis, chunks[i], group, description));
+                }
+                return moves;
+            }
+        }
+
+        public bool PreviewVisible => HasSelection && Amount != null;
+
+        public string NoSelectionText => "Pick a corner, side, or All to move.";
+
+        public string PreviewKindLabel => selectedTarget?.KindLabel ?? string.Empty;
+
+        /// <summary>"TR (Motor 1) +20 · BL (Motor 4) −20 steps".</summary>
+        public string PreviewSemanticText {
+            get {
+                var target = selectedTarget;
+                var amount = Amount;
+                if (target == null || amount == null) {
+                    return string.Empty;
+                }
+                return target.DescribeMove(target.SignedAxisSteps(positiveDirection, amount.Value));
+            }
+        }
+
+        /// <summary>
+        /// The exact wire string, straight from <see cref="EatCommands.Format(TiltAdapterMove, EatSignEncoding)"/>.
+        /// Never hand-built: the default encoding signs the argument rather than switching mnemonic, so a "BL +20"
+        /// pad click really sends <c>tr,-20</c>, and a chip assembled from the pad label would name a command
+        /// that is never issued. Shows the first command when a large amount is split.
+        /// </summary>
+        public string PreviewWireCommand {
+            get {
+                var moves = PlannedSingleMoves;
+                return moves.Count == 0 ? string.Empty : EatCommands.Format(moves[0]);
+            }
+        }
+
+        public string PreviewWireCommandTooltip => "The exact command string sent to the device.";
+
+        /// <summary>Predicted end positions for all four motors, in the 2×2 display order the live grid uses.</summary>
+        public IReadOnlyList<ManualPreviewCell> PreviewCells { get; private set; } = Array.Empty<ManualPreviewCell>();
+
+        /// <summary>Per-motor predicted end positions in DEVICE motor order, or null when positions are unknown.</summary>
+        internal int[] PredictedPositions {
+            get {
+                if (!PositionsKnown) {
+                    return null;
+                }
+                var target = selectedTarget;
+                var amount = Amount;
+                if (target == null || amount == null) {
+                    return null;
+                }
+                var effectWizard = target.PerScrewEffect(positiveDirection, amount.Value);
+                var effectDevice = EatTiltMotionController.PermuteWizardToDeviceMotorOrder(effectWizard);
+                var predicted = new int[4];
+                for (int i = 0; i < 4; ++i) {
+                    predicted[i] = lastKnownPositions[i] + (int)Math.Round(effectDevice[i], MidpointRounding.AwayFromZero);
+                }
+                return predicted;
+            }
+        }
+
+        private IReadOnlyList<ManualPreviewCell> BuildPreviewCells() {
+            var target = selectedTarget;
+            var amount = Amount;
+            if (target == null || amount == null) {
+                return Array.Empty<ManualPreviewCell>();
+            }
+
+            var effectWizard = target.PerScrewEffect(positiveDirection, amount.Value);
+            var effectDevice = EatTiltMotionController.PermuteWizardToDeviceMotorOrder(effectWizard);
+            var predicted = PredictedPositions;
+            int max = MaxExcursionSteps;
+            double nearBand = max * NearLimitFraction;
+
+            var cells = new List<ManualPreviewCell>(4);
+            foreach (var corner in TiltAdapterCorner.InDisplayOrder) {
+                int deviceIndex = corner.DeviceMotorNumber - 1;
+                int delta = (int)Math.Round(effectDevice[deviceIndex], MidpointRounding.AwayFromZero);
+                bool moving = delta != 0;
+
+                if (predicted == null) {
+                    cells.Add(new ManualPreviewCell(
+                        corner,
+                        valueText: "unknown → unknown",
+                        isMoving: moving,
+                        limitTag: string.Empty,
+                        severity: ManualLimitSeverity.None,
+                        tooltip: "Motor positions are unknown, so the travel window cannot be checked for this move."));
+                    continue;
+                }
+
+                int from = lastKnownPositions[deviceIndex];
+                int to = predicted[deviceIndex];
+                string valueText = moving
+                    ? string.Format(CultureInfo.InvariantCulture, "{0} → {1} ({2})", from, to, delta.ToString("+0;-0;0", CultureInfo.InvariantCulture))
+                    : string.Format(CultureInfo.InvariantCulture, "{0} → {1}", from, to);
+
+                string tag = string.Empty;
+                var severity = ManualLimitSeverity.None;
+                if (to < 0) {
+                    tag = "below 0";
+                    severity = ManualLimitSeverity.Blocking;
+                } else if (to > max) {
+                    tag = "over max";
+                    severity = ManualLimitSeverity.Blocking;
+                } else if (to <= nearBand) {
+                    tag = "near 0";
+                    severity = ManualLimitSeverity.Near;
+                } else if (to >= max - nearBand) {
+                    tag = "near max";
+                    severity = ManualLimitSeverity.Near;
+                }
+
+                string tooltip = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Travel window 0 to {0}. This move ends at {1}, leaving {2} to the max and {3} to zero.",
+                    max, to, max - to, to);
+
+                cells.Add(new ManualPreviewCell(corner, valueText, moving, tag, severity, tooltip));
+            }
+            return cells;
+        }
+
+        /// <summary>Plain-physics summary of what the move changes. Never claims a "toward/away" direction — that is rig-dependent.</summary>
+        public string ConsequenceText {
+            get {
+                var target = selectedTarget;
+                var amount = Amount;
+                if (target == null || amount == null) {
+                    return string.Empty;
+                }
+
+                if (target.Kind == ManualMoveKind.Backfocus) {
+                    return HasUnitMicrons
+                        ? string.Format(CultureInfo.InvariantCulture, "Changes sensor spacing by {0:0.0} µm; tilt unchanged.", amount.Value * UnitMicrons)
+                        : string.Format(CultureInfo.InvariantCulture, "Changes sensor spacing by {0} steps; tilt unchanged.", amount.Value);
+                }
+
+                // A tilt move is differential: the named element goes one way by `amount` and its opposite goes
+                // the other way by the same amount, so the spacing between them changes by twice the amount.
+                int differential = 2 * amount.Value;
+                return HasUnitMicrons
+                    ? string.Format(CultureInfo.InvariantCulture, "Changes {0}-vs-{1} spacing by {2:0.0} µm of screw travel.", target.MovedLabel, target.OppositeLabel, differential * UnitMicrons)
+                    : string.Format(CultureInfo.InvariantCulture, "Changes {0}-vs-{1} spacing by {2} steps of screw travel.", target.MovedLabel, target.OppositeLabel, differential);
+            }
+        }
+
+        public string LegendText =>
+            HasUnitMicrons
+                ? string.Format(CultureInfo.InvariantCulture, "+ = clockwise / tighten (the wizard's positive direction); − = the opposite. 1 step = {0:0.#} µm.", UnitMicrons)
+                : "+ = clockwise / tighten (the wizard's positive direction); − = the opposite.";
+
+        public string MoveCountAndDurationText {
+            get {
+                int count = PlannedSingleMoves.Count;
+                if (count == 0) {
+                    return string.Empty;
+                }
+                string moves = count == 1 ? "1 move" : string.Format(CultureInfo.InvariantCulture, "{0} moves", count);
+                return string.Format(CultureInfo.InvariantCulture, "{0} · {1}", moves, TiltDeviceAdjustmentPromptVM.FormatDuration(count * PerMoveSeconds));
+            }
+        }
+
+        public string SendButtonText {
+            get {
+                int count = PlannedSingleMoves.Count;
+                return count <= 1
+                    ? "Send 1 move"
+                    : string.Format(CultureInfo.InvariantCulture, "Send {0} moves", count);
+            }
+        }
+
+        public bool PositionsUnknownAdvisoryVisible => IsDeviceConnected && !PositionsKnown && mode == ManualAdjustmentMode.SingleMove;
+
+        public string PositionsUnknownAdvisory =>
+            "Motor positions are unknown — travel limits can't be checked for this move. Verify positions in the vendor app before sending.";
+
+        #endregion Single move — preview
+
+        #region Target positions
+
+        public IReadOnlyList<ManualTargetCell> TargetCells { get; }
+
+        public string TargetModeCaption => "Type where each motor should end up, in device steps. Current positions are filled in to start.";
+
+        private void OnTargetCellChanged() => RefreshAll();
+
+        private void PrefillTargetsFromCurrent() {
+            if (!PositionsKnown) {
+                return;
+            }
+            foreach (var cell in TargetCells) {
+                cell.SetTargetSilently(lastKnownPositions[cell.Corner.DeviceMotorNumber - 1].ToString(CultureInfo.InvariantCulture));
+            }
+        }
+
+        private void ClearTargets() {
+            foreach (var cell in TargetCells) {
+                cell.SetTargetSilently(string.Empty);
+            }
+        }
+
+        private void ResetTargetsToCurrent() {
+            PrefillTargetsFromCurrent();
+            RefreshAll();
+        }
+
+        public ICommand ResetToCurrentCommand { get; }
+
+        /// <summary>Parsed absolute targets in DEVICE motor order, or null when any cell is empty/invalid/out of range.</summary>
+        internal int[] ParsedTargets {
+            get {
+                var result = new int[4];
+                foreach (var cell in TargetCells) {
+                    if (!int.TryParse(cell.TargetText, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value)) {
+                        return null;
+                    }
+                    if (value < 0 || value > MaxExcursionSteps) {
+                        return null;
+                    }
+                    result[cell.Corner.DeviceMotorNumber - 1] = value;
+                }
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// The requested per-screw step delta in WIZARD screw order [0..3] — the planner's <c>sPerScrew</c>
+        /// space. Null when positions are unknown or any target is invalid.
+        /// </summary>
+        internal double[] TargetDeltaPerScrew {
+            get {
+                var targets = ParsedTargets;
+                if (targets == null || !PositionsKnown) {
+                    return null;
+                }
+                var delta = new double[4];
+                for (int wizardIndex = 0; wizardIndex < 4; ++wizardIndex) {
+                    int deviceIndex = TiltAdapterCorner.InWizardScrewOrder[wizardIndex].DeviceMotorNumber - 1;
+                    delta[wizardIndex] = targets[deviceIndex] - lastKnownPositions[deviceIndex];
+                }
+                return delta;
+            }
+        }
+
+        /// <summary>Preview of the full (tilt + backfocus) plan for the current targets, or null when it cannot be built.</summary>
+        internal TiltDevicePlanPreview TargetPlanPreview {
+            get {
+                var delta = TargetDeltaPerScrew;
+                var controller = Controller;
+                if (delta == null || controller == null || delta.All(d => Math.Abs(d) < 0.5)) {
+                    return null;
+                }
+                return TiltDevicePlanPreviewBuilder.Build(delta, includeTilt: true, includeBackfocus: true, unitMicrons: UnitMicrons, maxStepsPerCommand: MaxStepsPerCommand, controller: controller);
+            }
+        }
+
+        public string TargetHintText { get; private set; } = string.Empty;
+
+        public bool TargetHintVisible => !string.IsNullOrEmpty(TargetHintText);
+
+        public bool TargetHintIsError { get; private set; }
+
+        public bool TwistWarningVisible { get; private set; }
+
+        public string TwistWarningTitle => "Twist can't be made";
+
+        public string TwistWarningBody { get; private set; } = string.Empty;
+
+        #endregion Target positions
+
+        #region Commands + gating
+
+        public ICommand SendCommand => sendCommand;
+
+        public ICommand ReviewMovesCommand => reviewCommand;
+
+        public ICommand StopCommand => stopCommand;
+
+        public ICommand DismissResultCommand { get; }
+
+        public string ReviewButtonText => "Review moves…";
+
+        public bool CanSend => mode == ManualAdjustmentMode.SingleMove && string.IsNullOrEmpty(SendDisabledReason) && !isSending && PlannedSingleMoves.Count > 0;
+
+        public bool CanReview => mode == ManualAdjustmentMode.TargetPositions && string.IsNullOrEmpty(ReviewBlockReason) && !isSending;
+
+        public bool CanStop => isSending && remainingMoveCount > 1 && !(sendCts?.IsCancellationRequested ?? true);
+
+        /// <summary>
+        /// The single reason line shown above Send, or empty when Send is available. Order is the panel's
+        /// documented precedence: device state first, then inputs, then the travel window.
+        /// </summary>
+        public string SendDisabledReason {
+            get {
+                if (!IsDeviceConnected || isSending) {
+                    return string.Empty; // the replaced body / the progress line already explains these.
+                }
+                if (IsDeviceBusyElsewhere) {
+                    return BusyReason;
+                }
+                if (selectedTarget == null) {
+                    return "Pick a corner, side, or All to move.";
+                }
+                if (Amount == null) {
+                    return "Enter an amount of at least 1 step.";
+                }
+
+                var predicted = PredictedPositions;
+                if (predicted != null) {
+                    int max = MaxExcursionSteps;
+                    for (int i = 0; i < 4; ++i) {
+                        var corner = TiltAdapterCorner.ForDeviceMotor(i + 1);
+                        if (predicted[i] < 0) {
+                            return string.Format(
+                                CultureInfo.InvariantCulture,
+                                "This move would drive Motor {0} ({1}) below 0. Reduce the amount, or send an All + move first to lift all motors.",
+                                corner.DeviceMotorNumber, corner.Label);
+                        }
+                        if (predicted[i] > max) {
+                            return string.Format(
+                                CultureInfo.InvariantCulture,
+                                "This move would drive Motor {0} ({1}) past the max excursion ({2}). Reduce the amount, or lower all motors with an All − move first.",
+                                corner.DeviceMotorNumber, corner.Label, max);
+                        }
+                    }
+                }
+                return string.Empty;
+            }
+        }
+
+        public bool SendDisabledReasonVisible => !string.IsNullOrEmpty(SendDisabledReason);
+
+        /// <summary>
+        /// Why Review is unavailable, for the gate. Not all of these are worth displaying — see
+        /// <see cref="ReviewDisabledReason"/>.
+        /// </summary>
+        private string ReviewBlockReason {
+            get {
+                if (!IsDeviceConnected || isSending) {
+                    return string.Empty;
+                }
+                if (IsDeviceBusyElsewhere) {
+                    return BusyReason;
+                }
+                if (!PositionsKnown) {
+                    return "Motor positions are unknown — targets need a known starting point. They update after a successful poll or move.";
+                }
+                if (ParsedTargets == null) {
+                    return string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Targets must be whole numbers between 0 and {0} steps.",
+                        MaxExcursionSteps);
+                }
+                var delta = TargetDeltaPerScrew;
+                if (delta != null && delta.All(d => Math.Abs(d) < 0.5)) {
+                    return NothingToMoveCopy;
+                }
+                return string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// The single reason line shown above Review, or empty when Review is available — or when the reason is
+        /// already on screen. "Nothing to move" is the hint line's job (it describes what the targets amount to,
+        /// which is where the eye already is); repeating it as a disabled-reason directly underneath just
+        /// stutters the same sentence twice.
+        /// </summary>
+        public string ReviewDisabledReason {
+            get {
+                string reason = ReviewBlockReason;
+                return string.Equals(reason, NothingToMoveCopy, StringComparison.Ordinal) ? string.Empty : reason;
+            }
+        }
+
+        public bool ReviewDisabledReasonVisible => !string.IsNullOrEmpty(ReviewDisabledReason);
+
+        private string BusyReason {
+            get {
+                string op = connectionService?.CurrentOperationName;
+                return string.IsNullOrEmpty(op)
+                    ? "Device busy. Wait for it to finish."
+                    : string.Format(CultureInfo.InvariantCulture, "Device busy — {0}. Wait for it to finish.", op);
+            }
+        }
+
+        #endregion Commands + gating
+
+        #region Status / result
+
+        public bool IsSending => isSending;
+
+        public string ProgressText => progressText;
+
+        public bool ProgressVisible => isSending;
+
+        public string StopButtonText => "Stop after this move";
+
+        public string StopButtonTooltip => "The move already sent can't be recalled. Nothing further will be sent.";
+
+        public string SuccessText => successText;
+
+        public bool SuccessVisible => !isSending && !ResultVisible && !string.IsNullOrEmpty(successText);
+
+        public bool ResultVisible => !string.IsNullOrEmpty(resultTitle);
+
+        public string ResultTitle => resultTitle;
+
+        public string ResultBody => resultBody;
+
+        public bool ResultIsError => resultIsError;
+
+        private void SetResult(string title, string body, bool isError) {
+            resultTitle = title ?? string.Empty;
+            resultBody = body ?? string.Empty;
+            resultIsError = isError;
+        }
+
+        private void DismissResult() {
+            SetResult(string.Empty, string.Empty, false);
+            RefreshAll();
+        }
+
+        #endregion Status / result
+
+        #region Execution
+
+        private void RequestStop() {
+            try {
+                sendCts?.Cancel();
+            } catch (ObjectDisposedException) {
+                // The send finished between the button being enabled and the click landing — nothing left to stop.
+            }
+            RefreshAll();
+        }
+
+        /// <summary>
+        /// Runs a send from a synchronous command without leaving an unobserved faulted task behind. Everything
+        /// inside <see cref="ExecuteMovesAsync"/> is already handled; this catches the paths around it (the
+        /// approval dialog, the lease) so a surprise there surfaces as a dismissible panel rather than a
+        /// silently swallowed crash.
+        /// </summary>
+        private void RunGuarded(Func<Task> work, string context) {
+            _ = Task.Run(async () => {
+                try {
+                    await work().ConfigureAwait(false);
+                } catch (Exception ex) {
+                    Logger.Error(ex, $"Manual Adjustment: {context} failed");
+                    isSending = false;
+                    SetResult("Manual adjustment failed", ex.Message, isError: true);
+                    OnUIThread(RefreshAll);
+                }
+            });
+        }
+
+        /// <summary>Internal so tests can await the send instead of racing the fire-and-forget command.</summary>
+        internal async Task SendSingleMoveAsync() {
+            var target = selectedTarget;
+            var amount = Amount;
+            var moves = PlannedSingleMoves;
+            if (!CanSend || target == null || amount == null || moves.Count == 0) {
+                return;
+            }
+
+            var now = DateTime.Now;
+            string summaryOnSuccess = string.Format(
+                CultureInfo.InvariantCulture, "Sent {0} · {1} · finished at {2:HH:mm}.",
+                target.DescribeMove(target.SignedAxisSteps(positiveDirection, amount.Value)),
+                moves.Count == 1 ? "1 move" : string.Format(CultureInfo.InvariantCulture, "{0} moves", moves.Count),
+                now);
+            string headerSummary = string.Format(
+                CultureInfo.InvariantCulture, "Last sent: {0} {1} at {2:HH:mm}",
+                target.Label, target.SignedAxisSteps(positiveDirection, amount.Value).ToString("+0;-0;0", CultureInfo.InvariantCulture), now);
+
+            await ExecuteMovesAsync(moves, summaryOnSuccess, headerSummary, splitAmount: moves.Count > 1 ? amount : null).ConfigureAwait(false);
+        }
+
+        /// <summary>Internal so tests can await the review-and-send round trip.</summary>
+        internal async Task ReviewTargetsAsync() {
+            var delta = TargetDeltaPerScrew;
+            var controller = Controller;
+            if (!CanReview || delta == null || controller == null) {
+                return;
+            }
+
+            TiltDevicePlanPreview Replanner(bool includeTilt, bool includeBackfocus) =>
+                TiltDevicePlanPreviewBuilder.Build(delta, includeTilt, includeBackfocus, UnitMicrons, MaxStepsPerCommand, controller);
+
+            // The assumed-direction and pitch-mismatch warnings exist because Automatic Adjustment INFERS screw
+            // motion from a measured curvature. Here the user commanded absolute steps, so nothing is inferred
+            // and firing those warnings would be a lie; positions are known by the CanReview gate.
+            var choice = await showAdjustmentPromptAsync(Replanner, UnitMicrons).ConfigureAwait(false);
+            if (choice == null || !choice.Proceed || choice.FinalPlan == null || choice.FinalPlan.Moves.Count == 0) {
+                return;
+            }
+
+            var now = DateTime.Now;
+            int moveCount = choice.FinalPlan.Moves.Count;
+            string summaryOnSuccess = string.Format(
+                CultureInfo.InvariantCulture, "Adjustment complete — {0} sent · finished at {1:HH:mm}.",
+                moveCount == 1 ? "1 move" : string.Format(CultureInfo.InvariantCulture, "{0} moves", moveCount), now);
+            string headerSummary = string.Format(
+                CultureInfo.InvariantCulture, "Last sent: {0} at {1:HH:mm}",
+                moveCount == 1 ? "1 move" : string.Format(CultureInfo.InvariantCulture, "{0} moves", moveCount), now);
+
+            await ExecuteMovesAsync(choice.FinalPlan.Moves, summaryOnSuccess, headerSummary, splitAmount: null).ConfigureAwait(false);
+
+            OnUIThread(() => {
+                // Re-prefill from where the motors actually landed, so the cells read Δ 0 (± the residual the
+                // dialog predicted) rather than still showing the request.
+                PrefillTargetsFromCurrent();
+                RefreshAll();
+            });
+        }
+
+        /// <summary>
+        /// Sends <paramref name="moves"/> sequentially under the device lease. There is no device abort, so
+        /// cancellation only ever skips moves that have not been sent — <c>ExecuteMoveAsync</c> honours the
+        /// token at entry and not after. Every move republishes the controller's counters so the live grid,
+        /// the preview and the target cells all track the device while the 5 s poll is suspended by our lease.
+        /// </summary>
+        private async Task ExecuteMovesAsync(IReadOnlyList<TiltAdapterMove> moves, string summaryOnSuccess, string headerSummary, int? splitAmount) {
+            var svc = connectionService;
+            var controller = Controller;
+            if (svc == null || controller == null) {
+                return;
+            }
+
+            using var operationToken = svc.TryBeginOperation(OperationName);
+            if (operationToken == null) {
+                SetResult("Device busy", BusyReason, isError: false);
+                OnUIThread(RefreshAll);
+                return;
+            }
+
+            // State is written on whatever thread we are called from and only the NOTIFICATION is marshalled.
+            // Posting the state change instead would let the loop below start — and the first move go out —
+            // before isSending/sendCts were even set, which would leave Stop pointing at a disposed token and
+            // the panel claiming to be idle mid-send.
+            var cts = new CancellationTokenSource();
+            var previousCts = sendCts;
+            sendCts = cts;
+            previousCts?.Dispose();
+            isSending = true;
+            successText = string.Empty;
+            lastSentSummary = string.Empty;
+            SetResult(string.Empty, string.Empty, false);
+            remainingMoveCount = moves.Count;
+            progressText = string.Format(CultureInfo.InvariantCulture, "Move 1 of {0} — starting…", moves.Count);
+            OnUIThread(RefreshAll);
+
+            int sent = 0;
+            Exception failure = null;
+            bool stopped = false;
+            try {
+                for (int i = 0; i < moves.Count; ++i) {
+                    int moveNumber = i + 1;
+                    var progress = new Progress<string>(text => {
+                        progressText = string.Format(CultureInfo.InvariantCulture, "Move {0} of {1} — {2}", moveNumber, moves.Count, text);
+                        OnUIThread(() => {
+                            RaisePropertyChanged(nameof(ProgressText));
+                            RaisePropertyChanged(nameof(SummaryText));
+                        });
+                    });
+
+                    remainingMoveCount = moves.Count - i;
+                    OnUIThread(RefreshAll);
+
+                    try {
+                        await controller.ExecuteMoveAsync(moves[i], progress, cts.Token).ConfigureAwait(false);
+                    } catch (OperationCanceledException) {
+                        // The device has no abort: cancellation is only ever honoured at the next move's entry,
+                        // so this always means "nothing further was sent", never "the last move was interrupted".
+                        stopped = true;
+                        break;
+                    }
+                    ++sent;
+                    // No follow-up 'cp': the move response already carried fresh counters.
+                    svc.PublishControllerPositions();
+                }
+            } catch (Exception ex) {
+                failure = ex;
+                Logger.Error(ex, $"Manual Adjustment: move {sent + 1} of {moves.Count} failed");
+            } finally {
+                isSending = false;
+                remainingMoveCount = 0;
+                progressText = string.Empty;
+                if (failure != null) {
+                    SetResult(
+                        BuildFailureTitle(sent, moves.Count),
+                        BuildFailureBody(moves, sent, failure, splitAmount),
+                        isError: true);
+                } else if (stopped) {
+                    SetResult(
+                        string.Format(CultureInfo.InvariantCulture, "Stopped after {0} of {1} moves", sent, moves.Count),
+                        string.Format(
+                            CultureInfo.InvariantCulture,
+                            "The moves already sent are applied — there is no automatic undo. Nothing after move {0} was sent. Positions above show where the motors are now.",
+                            sent),
+                        isError: false);
+                } else {
+                    successText = summaryOnSuccess;
+                    lastSentSummary = headerSummary;
+                }
+                if (ReferenceEquals(sendCts, cts)) {
+                    sendCts = null;
+                }
+                cts.Dispose();
+                OnUIThread(RefreshAll);
+            }
+        }
+
+        private static string BuildFailureTitle(int sent, int total) {
+            if (total == 1) {
+                return "Move failed";
+            }
+            return sent == 0
+                ? "Adjustment failed before any move was sent"
+                : string.Format(CultureInfo.InvariantCulture, "Adjustment stopped after {0} of {1} moves", sent, total);
+        }
+
+        private string BuildFailureBody(IReadOnlyList<TiltAdapterMove> moves, int sent, Exception failure, int? splitAmount) {
+            string failedWire = sent < moves.Count ? EatCommands.Format(moves[sent]) : string.Empty;
+
+            if (moves.Count == 1) {
+                return string.Format(
+                    CultureInfo.InvariantCulture,
+                    "The command '{0}' got no valid response. It may or may not have reached the device, so the position counters above were not advanced — they re-sync on the next successful poll. If in doubt, check the vendor app before sending more moves.\n\n{1}",
+                    failedWire, failure.Message);
+            }
+
+            if (splitAmount != null) {
+                // A split nudge: every command is the same axis and sign, so the remainder is expressible as a
+                // smaller amount the user can simply re-send.
+                int sentSteps = moves.Take(sent).Sum(m => Math.Abs(m.Steps));
+                int remainingSteps = splitAmount.Value - sentSteps;
+                return string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Sent {0} of {1} moves ({2} of {3} steps). The steps already sent are applied — there is no automatic undo. The remaining {4} steps were not sent; set Amount to {4} and press Send to finish.\n\n{5}",
+                    sent, moves.Count, sentSteps, splitAmount.Value, remainingSteps, failure.Message);
+            }
+
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "The first {0} moves were sent and are applied — there is no automatic undo. Move {1} ('{2}') failed and nothing after it was sent. Once the positions above re-sync, press Review moves — the plan recomputes from wherever the motors actually are, so it will finish the remainder.\n\n{3}",
+                sent, sent + 1, failedWire, failure.Message);
+        }
+
+        #endregion Execution
+
+        #region Refresh
+
+        /// <summary>
+        /// Re-derives every projection and re-raises the lot. The panel is small and each readout is a pure
+        /// function of (device state, options, inputs), so a single blanket refresh is both simpler and
+        /// impossible to get subtly out of sync — which matters when a wrong number here becomes a physical
+        /// move that cannot be undone.
+        /// </summary>
+        private void RefreshAll() {
+            PreviewCells = BuildPreviewCells();
+            RefreshTargetProjections();
+
+            RaisePropertyChanged(nameof(IsExpanded));
+            RaisePropertyChanged(nameof(SummaryText));
+            RaisePropertyChanged(nameof(IsDeviceConnected));
+            RaisePropertyChanged(nameof(IsDeviceBusyElsewhere));
+            RaisePropertyChanged(nameof(PositionsKnown));
+
+            RaisePropertyChanged(nameof(HasSelection));
+            RaisePropertyChanged(nameof(AmountMicronsHint));
+            RaisePropertyChanged(nameof(AmountTooltip));
+            RaisePropertyChanged(nameof(PreviewVisible));
+            RaisePropertyChanged(nameof(PreviewKindLabel));
+            RaisePropertyChanged(nameof(PreviewSemanticText));
+            RaisePropertyChanged(nameof(PreviewWireCommand));
+            RaisePropertyChanged(nameof(PreviewCells));
+            RaisePropertyChanged(nameof(ConsequenceText));
+            RaisePropertyChanged(nameof(LegendText));
+            RaisePropertyChanged(nameof(MoveCountAndDurationText));
+            RaisePropertyChanged(nameof(SendButtonText));
+            RaisePropertyChanged(nameof(PositionsUnknownAdvisoryVisible));
+
+            RaisePropertyChanged(nameof(TargetHintText));
+            RaisePropertyChanged(nameof(TargetHintVisible));
+            RaisePropertyChanged(nameof(TargetHintIsError));
+            RaisePropertyChanged(nameof(TwistWarningVisible));
+            RaisePropertyChanged(nameof(TwistWarningBody));
+
+            RaisePropertyChanged(nameof(CanSend));
+            RaisePropertyChanged(nameof(CanReview));
+            RaisePropertyChanged(nameof(CanStop));
+            RaisePropertyChanged(nameof(SendDisabledReason));
+            RaisePropertyChanged(nameof(SendDisabledReasonVisible));
+            RaisePropertyChanged(nameof(ReviewDisabledReason));
+            RaisePropertyChanged(nameof(ReviewDisabledReasonVisible));
+
+            RaisePropertyChanged(nameof(IsSending));
+            RaisePropertyChanged(nameof(ProgressText));
+            RaisePropertyChanged(nameof(ProgressVisible));
+            RaisePropertyChanged(nameof(SuccessText));
+            RaisePropertyChanged(nameof(SuccessVisible));
+            RaisePropertyChanged(nameof(ResultVisible));
+            RaisePropertyChanged(nameof(ResultTitle));
+            RaisePropertyChanged(nameof(ResultBody));
+            RaisePropertyChanged(nameof(ResultIsError));
+
+            // CanExecuteChanged must be raised on the UI thread; every caller of RefreshAll already arrives via
+            // OnUIThread (or is the constructor, before the VM is bound).
+            sendCommand.NotifyCanExecuteChanged();
+            reviewCommand.NotifyCanExecuteChanged();
+            stopCommand.NotifyCanExecuteChanged();
+        }
+
+        private void RefreshTargetProjections() {
+            // Only while the mode is showing: building the hint runs the planner and asks the controller to
+            // order the result, and doing that on every keystroke of a single-move amount would be both wasted
+            // work and a device call nothing on screen is asking for.
+            if (mode != ManualAdjustmentMode.TargetPositions) {
+                return;
+            }
+
+            int max = MaxExcursionSteps;
+            foreach (var cell in TargetCells) {
+                int deviceIndex = cell.Corner.DeviceMotorNumber - 1;
+                cell.NowText = PositionsKnown
+                    ? string.Format(CultureInfo.InvariantCulture, "now {0}", lastKnownPositions[deviceIndex])
+                    : "now unknown";
+
+                bool parsed = int.TryParse(cell.TargetText, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value);
+                cell.HasError = !string.IsNullOrEmpty(cell.TargetText) && (!parsed || value < 0 || value > max);
+
+                if (parsed && !cell.HasError && PositionsKnown) {
+                    int delta = value - lastKnownPositions[deviceIndex];
+                    cell.DeltaText = HasUnitMicrons
+                        ? string.Format(CultureInfo.InvariantCulture, "Δ {0} ({1:0.0} µm)", delta.ToString("+0;-0;0", CultureInfo.InvariantCulture), Math.Abs(delta) * UnitMicrons)
+                        : string.Format(CultureInfo.InvariantCulture, "Δ {0}", delta.ToString("+0;-0;0", CultureInfo.InvariantCulture));
+                } else {
+                    cell.DeltaText = string.Empty;
+                }
+                cell.WillReachText = string.Empty;
+            }
+
+            TargetHintText = string.Empty;
+            TargetHintIsError = false;
+            TwistWarningVisible = false;
+            TwistWarningBody = string.Empty;
+
+            var delta4 = TargetDeltaPerScrew;
+            if (delta4 == null) {
+                return;
+            }
+            if (delta4.All(d => Math.Abs(d) < 0.5)) {
+                TargetHintText = NothingToMoveCopy;
+                return;
+            }
+
+            var preview = TargetPlanPreview;
+            if (preview == null) {
+                return;
+            }
+
+            if (preview.HardLimitViolated) {
+                TargetHintText = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "These targets can't be reached without leaving the travel window (0 to {0}).",
+                    max);
+                TargetHintIsError = true;
+            } else {
+                int count = preview.Plan.Moves.Count;
+                string moves = count == 1 ? "1 move" : string.Format(CultureInfo.InvariantCulture, "{0} moves", count);
+                TargetHintText = preview.Plan.BiasSteps > 0
+                    ? string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Becomes {0} · {1}, including a +{2}-step lift to keep all motors above 0.",
+                        moves, TiltDeviceAdjustmentPromptVM.FormatDuration(preview.Plan.EstimatedSeconds), preview.Plan.BiasSteps)
+                    : string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Becomes {0} · {1}.",
+                        moves, TiltDeviceAdjustmentPromptVM.FormatDuration(preview.Plan.EstimatedSeconds));
+            }
+
+            // Twist: the component of the requested delta that no rigid plane can produce. Reported before the
+            // user ever opens the dialog, because they typed four numbers and only three of the four degrees of
+            // freedom are physically available.
+            double twist = TiltMovePlanner.Decompose(delta4).t;
+            if (Math.Abs(twist) < 1.0) {
+                return;
+            }
+
+            TwistWarningVisible = true;
+            TwistWarningBody = HasUnitMicrons
+                ? string.Format(
+                    CultureInfo.InvariantCulture,
+                    "These four targets differ from a rigid plane by ±{0:0.#} steps (about {1:0.0} µm across the sensor). The adapter can tilt the sensor and change its spacing, but it cannot twist it. Each corner above shows the position it will actually reach.",
+                    Math.Abs(twist), Math.Abs(twist) * UnitMicrons)
+                : string.Format(
+                    CultureInfo.InvariantCulture,
+                    "These four targets differ from a rigid plane by ±{0:0.#} steps. The adapter can tilt the sensor and change its spacing, but it cannot twist it. Each corner above shows the position it will actually reach.",
+                    Math.Abs(twist));
+
+            // "Will reach" is taken from the plan's own moves rather than re-deriving the twist share, so it
+            // folds in step rounding and any prepended bias exactly as executed.
+            var applied = new double[4];
+            foreach (var move in preview.Plan.Moves) {
+                for (int i = 0; i < 4; ++i) {
+                    applied[i] += move.PerCornerSteps[i];
+                }
+            }
+            foreach (var cell in TargetCells) {
+                int deviceIndex = cell.Corner.DeviceMotorNumber - 1;
+                int wizardIndex = cell.Corner.WizardScrewNumber - 1;
+                int reached = lastKnownPositions[deviceIndex] + (int)Math.Round(applied[wizardIndex], MidpointRounding.AwayFromZero);
+                cell.WillReachText = string.Format(CultureInfo.InvariantCulture, "will reach {0}", reached);
+            }
+        }
+
+        #endregion Refresh
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/TiltDevicePlanPreviewBuilder.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/TiltDevicePlanPreviewBuilder.cs
@@ -1,0 +1,84 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices {
+
+    /// <summary>
+    /// Turns a per-screw step target into the exact <see cref="TiltDevicePlanPreview"/> the approval dialog
+    /// shows and the executor sends. Shared by every surface that drives the device from a target vector —
+    /// the Aberration Inspector's Automatic Adjustment and the wizard's Manual Adjustment panel — so the two
+    /// can never diverge in what "the plan" means.
+    /// </summary>
+    public static class TiltDevicePlanPreviewBuilder {
+
+        /// <summary>
+        /// Builds one replanner invocation's preview: plans the moves for the given group toggles, then asks
+        /// the controller (via the interface — never a downcast) to order them for minimal peak excursion so
+        /// the approval dialog shows the EXACT execution order (WYSIWYG). A TiltDeviceLimitException from the
+        /// ordering call means either a single move exceeds the per-command cap or every ordering would
+        /// exceed the max excursion — surfaced as a blocking preview (unordered moves shown, matching the
+        /// design doc) rather than propagated, so the dialog can display it instead of crashing. Residuals,
+        /// twist, and the time estimate are unaffected by ordering, so they carry over unchanged from the
+        /// original plan.
+        /// </summary>
+        public static TiltDevicePlanPreview Build(
+            IReadOnlyList<double> sPerScrew,
+            bool includeTilt,
+            bool includeBackfocus,
+            double unitMicrons,
+            int maxStepsPerCommand,
+            ITiltMotionController controller) {
+            var plan = TiltMovePlanner.Plan(sPerScrew, includeTilt, includeBackfocus, unitMicrons, maxStepsPerCommand);
+            try {
+                var ordered = controller.OrderForMinimalPeakExcursion(plan.Moves);
+                // The controller may PREPEND a backfocus bias so a differential tilt correction never drives a
+                // motor below 0. That bias is a genuine piston -- it shifts backfocus -- so the residual has to
+                // be recomputed from what will actually be sent. Carrying the unbiased plan's residual here
+                // would silently under-report the very backfocus error the bias introduces.
+                var applied = new double[4];
+                foreach (var move in ordered) {
+                    for (int i = 0; i < 4; ++i) {
+                        applied[i] += move.PerCornerSteps[i];
+                    }
+                }
+                var residual = new double[4];
+                for (int i = 0; i < 4; ++i) {
+                    residual[i] = (applied[i] - sPerScrew[i]) * unitMicrons;
+                }
+
+                // The bias is the uniform surplus the controller added on top of what was planned; it lands
+                // equally on all four corners (it is a piston), so the smallest per-corner surplus is it.
+                var planned = new double[4];
+                foreach (var move in plan.Moves) {
+                    for (int i = 0; i < 4; ++i) {
+                        planned[i] += move.PerCornerSteps[i];
+                    }
+                }
+                int biasSteps = (int)Math.Round(Enumerable.Range(0, 4).Min(i => applied[i] - planned[i]));
+                // A prepended bias also adds real execution time; scale the estimate by the per-move rate the
+                // planner used rather than carrying a move count that no longer matches.
+                double perMoveSeconds = plan.Moves.Count > 0 ? plan.EstimatedSeconds / plan.Moves.Count : 0.0;
+                var orderedPlan = new TiltAdapterMovePlan(ordered, residual, plan.TwistResidualSteps, ordered.Count * perMoveSeconds, Math.Max(0, biasSteps));
+                return new TiltDevicePlanPreview(orderedPlan, hardLimitViolated: false, limitWarning: string.Empty);
+            } catch (TiltDeviceLimitException ex) {
+                return new TiltDevicePlanPreview(plan, hardLimitViolated: true, limitWarning: ex.Message);
+            }
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -105,6 +105,569 @@
     </DataTemplate>
 
     <!--
+        ============================ Manual adjustment (DataContext = TiltAdapterManualAdjustmentVM) =========
+        Hand control of the connected motorized adapter. Collapsed by default (IsExpanded is TwoWay so a click
+        sticks for the session; the VM's getter force-opens it while a send runs or an undismissed failure is on
+        screen). Two modes: a 3×3 pad that sends exactly one generator command, and absolute target positions
+        that decompose through the same planner + approval dialog the inspector's Automatic Adjustment uses.
+
+        Visibility is driven by Style.Triggers throughout, matching the rest of this file — a directly-set
+        Visibility attribute would win over the trigger, and every local TextBlock.Style carries
+        BasedOn="{StaticResource StandardTextBlock}" per the THEME HAZARD note at the top of this file.
+    -->
+    <DataTemplate x:Key="HF_TiltManualAdjustmentPanel">
+        <Expander Margin="0,8,0,0" IsExpanded="{Binding IsExpanded, Mode=TwoWay}">
+            <Expander.Header>
+                <WrapPanel>
+                    <TextBlock FontWeight="Bold" Text="Manual adjustment" />
+                    <TextBlock Margin="8,0,0,0" Opacity="0.6" Text="{Binding SummaryText}" />
+                </WrapPanel>
+            </Expander.Header>
+            <StackPanel Margin="4,6,0,0">
+
+                <!--  No undo: the counters live in the device's EEPROM and there is no abort command.  -->
+                <TextBlock
+                    Margin="0,0,0,6"
+                    FontStyle="Italic"
+                    Opacity="0.75"
+                    Text="{Binding CautionText}"
+                    TextWrapping="Wrap" />
+
+                <!--  Disconnected: the whole body collapses to one line.  -->
+                <TextBlock Opacity="0.7" Text="{Binding NotConnectedText}" TextWrapping="Wrap">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock" BasedOn="{StaticResource StandardTextBlock}">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsDeviceConnected}" Value="False">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+
+                <StackPanel>
+                    <StackPanel.Style>
+                        <Style TargetType="StackPanel">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsDeviceConnected}" Value="True">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </StackPanel.Style>
+
+                    <!--  Mode switch. Caption is a sibling TextBlock, never control Content.  -->
+                    <WrapPanel Margin="0,0,0,6">
+                        <TextBlock VerticalAlignment="Center" Text="Mode" />
+                        <RadioButton
+                            Margin="8,0,0,0"
+                            VerticalAlignment="Center"
+                            AutomationProperties.Name="Single move mode"
+                            Content="Single move"
+                            GroupName="HFManualAdjustMode"
+                            IsChecked="{Binding IsSingleMoveMode, Mode=TwoWay}"
+                            ToolTip="Send one adjustment now: a corner, a side, or all four motors together." />
+                        <RadioButton
+                            Margin="10,0,0,0"
+                            VerticalAlignment="Center"
+                            AutomationProperties.Name="Target positions mode"
+                            Content="Target positions"
+                            GroupName="HFManualAdjustMode"
+                            IsChecked="{Binding IsTargetPositionsMode, Mode=TwoWay}"
+                            ToolTip="Type where each motor should end, review the moves it takes to get there, then send them." />
+                    </WrapPanel>
+
+                    <!--  ================================ Single move ================================  -->
+                    <StackPanel>
+                        <StackPanel.Style>
+                            <Style TargetType="StackPanel">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsSingleMoveMode}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </StackPanel.Style>
+
+                        <TextBlock Margin="0,0,0,3" Text="What to move" />
+                        <!--  3×3 pad laid out as the sensor is imaged: corners drive the diagonal axes, edges
+                              the edge axes, centre the backfocus axis. The selection ring is drawn by the
+                              wrapping Border rather than relying on the theme's ToggleButton checked chrome.  -->
+                        <ItemsControl HorizontalAlignment="Left" ItemsSource="{Binding PadItems}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <UniformGrid Columns="3" Rows="3" />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Border Margin="1" BorderThickness="2" CornerRadius="4">
+                                        <Border.Style>
+                                            <Style TargetType="Border">
+                                                <Setter Property="BorderBrush" Value="Transparent" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                                        <Setter Property="BorderBrush" Value="{StaticResource PrimaryBrush}" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Border.Style>
+                                        <ToggleButton
+                                            MinWidth="62"
+                                            AutomationProperties.Name="{Binding Target.AutomationName}"
+                                            IsChecked="{Binding IsSelected, Mode=TwoWay}"
+                                            ToolTip="{Binding Target.Tooltip}">
+                                            <TextBlock Margin="8,5" HorizontalAlignment="Center" Text="{Binding Target.Label}">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock" BasedOn="{StaticResource StandardTextBlock}">
+                                                        <Setter Property="Foreground" Value="{StaticResource ButtonForegroundBrush}" />
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                                                <Setter Property="FontWeight" Value="Bold" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </ToggleButton>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+
+                        <!--  Direction. Deliberately "+ / −" and never "up / down": which way a positive step
+                              physically moves a corner is rig-dependent, which is why the approval dialog also
+                              speaks signed steps. The legend under the preview carries the meaning.  -->
+                        <WrapPanel Margin="0,8,0,0">
+                            <TextBlock VerticalAlignment="Center" Text="Direction" />
+                            <RadioButton
+                                Margin="8,0,0,0"
+                                VerticalAlignment="Center"
+                                AutomationProperties.Name="Positive direction"
+                                Content="+"
+                                GroupName="HFManualAdjustDirection"
+                                IsChecked="{Binding PositiveDirection, Mode=TwoWay}"
+                                ToolTip="The wizard's positive step direction (clockwise / tighten) on the highlighted motors; the coupled motors move the opposite way." />
+                            <RadioButton
+                                Margin="10,0,0,0"
+                                VerticalAlignment="Center"
+                                AutomationProperties.Name="Negative direction"
+                                Content="−"
+                                GroupName="HFManualAdjustDirection"
+                                IsChecked="{Binding NegativeDirection, Mode=TwoWay}"
+                                ToolTip="The opposite of the wizard's positive step direction on the highlighted motors." />
+                        </WrapPanel>
+
+                        <WrapPanel Margin="0,6,0,0">
+                            <TextBlock VerticalAlignment="Center" Text="Amount" ToolTip="{Binding AmountTooltip}" />
+                            <TextBox
+                                MinWidth="60"
+                                Margin="8,0,0,0"
+                                VerticalAlignment="Center"
+                                AutomationProperties.Name="Move amount in device steps"
+                                Text="{Binding AmountText, UpdateSourceTrigger=LostFocus}"
+                                ToolTip="{Binding AmountTooltip}" />
+                            <TextBlock Margin="6,0,0,0" VerticalAlignment="Center" Text="steps" />
+                            <TextBlock
+                                Margin="8,0,0,0"
+                                VerticalAlignment="Center"
+                                FontStyle="Italic"
+                                Opacity="0.6"
+                                Text="{Binding AmountMicronsHint}" />
+                        </WrapPanel>
+
+                        <!--  Nothing picked yet: no preview, no Send.  -->
+                        <TextBlock Margin="0,8,0,0" Opacity="0.6" Text="{Binding NoSelectionText}">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock" BasedOn="{StaticResource StandardTextBlock}">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding PreviewVisible}" Value="True">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+
+                        <!--  Preview: what this click will do, before it is clicked. There is no undo, so the
+                              consequence has to be unmistakable here.  -->
+                        <Border
+                            Margin="0,8,0,0"
+                            Padding="6"
+                            BorderBrush="{StaticResource BorderBrush}"
+                            BorderThickness="1"
+                            CornerRadius="3">
+                            <Border.Style>
+                                <Style TargetType="Border">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding PreviewVisible}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Border.Style>
+                            <StackPanel>
+                                <!--  Kind badge + semantic line, with the wire command demoted to an
+                                      auditability chip on the right (same hierarchy as the approval dialog).  -->
+                                <DockPanel>
+                                    <Border
+                                        Margin="0,0,6,0"
+                                        Padding="5,1"
+                                        DockPanel.Dock="Left"
+                                        BorderBrush="{StaticResource BorderBrush}"
+                                        BorderThickness="1"
+                                        CornerRadius="2">
+                                        <TextBlock FontSize="10" Text="{Binding PreviewKindLabel}" />
+                                    </Border>
+                                    <TextBlock
+                                        Margin="6,0,0,0"
+                                        DockPanel.Dock="Right"
+                                        FontFamily="Consolas"
+                                        FontSize="10"
+                                        Opacity="0.55"
+                                        Text="{Binding PreviewWireCommand}"
+                                        ToolTip="{Binding PreviewWireCommandTooltip}" />
+                                    <TextBlock FontWeight="SemiBold" Text="{Binding PreviewSemanticText}" TextWrapping="Wrap" />
+                                </DockPanel>
+
+                                <!--  Predicted end positions for ALL FOUR motors, in the same 2×2 layout as the
+                                      live grid above — this is what makes the mechanical coupling (clicking TR
+                                      also moves BL) visible before every send.  -->
+                                <ItemsControl Margin="0,6,0,0" HorizontalAlignment="Left" MinWidth="280" ItemsSource="{Binding PreviewCells}">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <UniformGrid Columns="2" Rows="2" />
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <Border Margin="1" Padding="5,3" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="3">
+                                                <StackPanel ToolTip="{Binding Tooltip}">
+                                                    <TextBlock FontSize="10" Opacity="0.7" Text="{Binding Heading}" />
+                                                    <TextBlock Text="{Binding ValueText}">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock" BasedOn="{StaticResource StandardTextBlock}">
+                                                                <Setter Property="Opacity" Value="0.6" />
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding IsMoving}" Value="True">
+                                                                        <Setter Property="Opacity" Value="1.0" />
+                                                                        <Setter Property="FontWeight" Value="Bold" />
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                    <!--  Limit state is a TEXT tag, never colour alone.  -->
+                                                    <TextBlock FontSize="10" Text="{Binding LimitTag}">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock" BasedOn="{StaticResource StandardTextBlock}">
+                                                                <Setter Property="Visibility" Value="Collapsed" />
+                                                                <Setter Property="Foreground" Value="{StaticResource NotificationWarningBrush}" />
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding HasLimitTag}" Value="True">
+                                                                        <Setter Property="Visibility" Value="Visible" />
+                                                                    </DataTrigger>
+                                                                    <DataTrigger Binding="{Binding IsBlocking}" Value="True">
+                                                                        <Setter Property="Foreground" Value="{StaticResource NotificationErrorBrush}" />
+                                                                        <Setter Property="FontWeight" Value="Bold" />
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                </StackPanel>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+
+                                <TextBlock Margin="0,6,0,0" Text="{Binding ConsequenceText}" TextWrapping="Wrap" />
+                                <TextBlock
+                                    Margin="0,3,0,0"
+                                    FontSize="10"
+                                    Opacity="0.6"
+                                    Text="{Binding LegendText}"
+                                    TextWrapping="Wrap" />
+
+                                <!--  Positions unknown is advisory here, not blocking: the controller still
+                                      enforces the travel window, just against a possibly-stale estimate.  -->
+                                <TextBlock
+                                    Margin="0,6,0,0"
+                                    Foreground="{StaticResource NotificationWarningBrush}"
+                                    Text="{Binding PositionsUnknownAdvisory}"
+                                    TextWrapping="Wrap">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock" BasedOn="{StaticResource StandardTextBlock}">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding PositionsUnknownAdvisoryVisible}" Value="True">
+                                                    <Setter Property="Visibility" Value="Visible" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+
+                                <TextBlock
+                                    Margin="0,6,0,0"
+                                    Foreground="{StaticResource NotificationWarningBrush}"
+                                    Text="{Binding SendDisabledReason}"
+                                    TextWrapping="Wrap">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock" BasedOn="{StaticResource StandardTextBlock}">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding SendDisabledReasonVisible}" Value="True">
+                                                    <Setter Property="Visibility" Value="Visible" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+
+                                <DockPanel Margin="0,6,0,0">
+                                    <Button
+                                        DockPanel.Dock="Right"
+                                        AutomationProperties.Name="Send the previewed move"
+                                        Command="{Binding SendCommand}">
+                                        <TextBlock Margin="12,5" Foreground="{StaticResource ButtonForegroundBrush}" Text="{Binding SendButtonText}" />
+                                    </Button>
+                                    <TextBlock VerticalAlignment="Center" Opacity="0.7" Text="{Binding MoveCountAndDurationText}" />
+                                </DockPanel>
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+
+                    <!--  ============================== Target positions ==============================  -->
+                    <StackPanel>
+                        <StackPanel.Style>
+                            <Style TargetType="StackPanel">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsTargetPositionsMode}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </StackPanel.Style>
+
+                        <TextBlock Margin="0,0,0,6" Opacity="0.7" Text="{Binding TargetModeCaption}" TextWrapping="Wrap" />
+
+                        <ItemsControl HorizontalAlignment="Left" MinWidth="300" ItemsSource="{Binding TargetCells}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <UniformGrid Columns="2" Rows="2" />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Border Margin="1" Padding="5,4" BorderBrush="{StaticResource BorderBrush}" BorderThickness="1" CornerRadius="3">
+                                        <StackPanel>
+                                            <TextBlock FontWeight="Bold" Text="{Binding Heading}" />
+                                            <TextBlock FontSize="10" Opacity="0.7" Text="{Binding WizardScrewCaption}" />
+                                            <TextBlock Margin="0,2,0,0" FontSize="10" Opacity="0.7" Text="{Binding NowText}" />
+                                            <DockPanel Margin="0,3,0,0">
+                                                <TextBlock VerticalAlignment="Center" DockPanel.Dock="Left" Text="Target" />
+                                                <TextBox
+                                                    MinWidth="60"
+                                                    Margin="5,0,0,0"
+                                                    VerticalAlignment="Center"
+                                                    AutomationProperties.Name="{Binding Heading}"
+                                                    Text="{Binding TargetText, UpdateSourceTrigger=LostFocus}">
+                                                    <TextBox.Style>
+                                                        <Style TargetType="TextBox">
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding HasError}" Value="True">
+                                                                    <Setter Property="BorderBrush" Value="{StaticResource NotificationErrorBrush}" />
+                                                                    <Setter Property="BorderThickness" Value="2" />
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBox.Style>
+                                                </TextBox>
+                                            </DockPanel>
+                                            <TextBlock Margin="0,3,0,0" FontWeight="SemiBold" Text="{Binding DeltaText}">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock" BasedOn="{StaticResource StandardTextBlock}">
+                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding HasDelta}" Value="True">
+                                                                <Setter Property="Visibility" Value="Visible" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                            <!--  Only present when the request contains twist: the position this
+                                                  motor will actually reach, which is not the one typed above.  -->
+                                            <TextBlock FontSize="10" Foreground="{StaticResource NotificationWarningBrush}" Text="{Binding WillReachText}">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock" BasedOn="{StaticResource StandardTextBlock}">
+                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding HasWillReach}" Value="True">
+                                                                <Setter Property="Visibility" Value="Visible" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </StackPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+
+                        <TextBlock Margin="0,6,0,0" Text="{Binding TargetHintText}" TextWrapping="Wrap">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock" BasedOn="{StaticResource StandardTextBlock}">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding TargetHintVisible}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding TargetHintIsError}" Value="True">
+                                            <Setter Property="Foreground" Value="{StaticResource NotificationErrorBrush}" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+
+                        <!--  Four numbers, three degrees of freedom: a rigid plane cannot twist.  -->
+                        <Border
+                            Margin="0,6,0,0"
+                            Padding="6"
+                            BorderBrush="{StaticResource NotificationWarningBrush}"
+                            BorderThickness="1"
+                            CornerRadius="3">
+                            <Border.Style>
+                                <Style TargetType="Border">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding TwistWarningVisible}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Border.Style>
+                            <StackPanel>
+                                <TextBlock FontWeight="Bold" Text="{Binding TwistWarningTitle}" />
+                                <TextBlock Margin="0,2,0,0" Text="{Binding TwistWarningBody}" TextWrapping="Wrap" />
+                            </StackPanel>
+                        </Border>
+
+                        <TextBlock
+                            Margin="0,6,0,0"
+                            Foreground="{StaticResource NotificationWarningBrush}"
+                            Text="{Binding ReviewDisabledReason}"
+                            TextWrapping="Wrap">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock" BasedOn="{StaticResource StandardTextBlock}">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding ReviewDisabledReasonVisible}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+
+                        <WrapPanel Margin="0,6,0,0">
+                            <Button
+                                AutomationProperties.Name="Reset targets to the current positions"
+                                Command="{Binding ResetToCurrentCommand}"
+                                ToolTip="Fill every target from the current motor positions.">
+                                <TextBlock Margin="12,5" Foreground="{StaticResource ButtonForegroundBrush}" Text="Reset to current" />
+                            </Button>
+                            <Button
+                                Margin="8,0,0,0"
+                                AutomationProperties.Name="Review the moves these targets require"
+                                Command="{Binding ReviewMovesCommand}"
+                                ToolTip="Decomposes the difference between the targets and the current positions, then opens the move-approval dialog. Nothing is sent until you approve it there.">
+                                <TextBlock Margin="12,5" Foreground="{StaticResource ButtonForegroundBrush}" Text="{Binding ReviewButtonText}" />
+                            </Button>
+                        </WrapPanel>
+                    </StackPanel>
+
+                    <!--  ============================== Status / result ==============================  -->
+                    <DockPanel Margin="0,8,0,0">
+                        <DockPanel.Style>
+                            <Style TargetType="DockPanel">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding ProgressVisible}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </DockPanel.Style>
+                        <Button
+                            Margin="8,0,0,0"
+                            DockPanel.Dock="Right"
+                            AutomationProperties.Name="Stop after the move now in flight"
+                            Command="{Binding StopCommand}"
+                            ToolTip="{Binding StopButtonTooltip}">
+                            <TextBlock Margin="12,5" Foreground="{StaticResource ButtonForegroundBrush}" Text="{Binding StopButtonText}" />
+                        </Button>
+                        <TextBlock VerticalAlignment="Center" Text="{Binding ProgressText}" TextWrapping="Wrap" />
+                    </DockPanel>
+
+                    <TextBlock Margin="0,8,0,0" FontStyle="Italic" Opacity="0.75" Text="{Binding SuccessText}" TextWrapping="Wrap">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource StandardTextBlock}">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding SuccessVisible}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <!--  Stopped / failed. Stays until dismissed, and the VM keeps the expander open while it is
+                          here, so a failure can never be hidden by a collapse.  -->
+                    <Border Margin="0,8,0,0" Padding="6" BorderThickness="1" CornerRadius="3">
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Setter Property="BorderBrush" Value="{StaticResource NotificationWarningBrush}" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding ResultVisible}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding ResultIsError}" Value="True">
+                                        <Setter Property="BorderBrush" Value="{StaticResource NotificationErrorBrush}" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <StackPanel>
+                            <TextBlock FontWeight="Bold" Text="{Binding ResultTitle}" TextWrapping="Wrap" />
+                            <TextBlock Margin="0,3,0,0" Text="{Binding ResultBody}" TextWrapping="Wrap" />
+                            <Button
+                                Margin="0,6,0,0"
+                                HorizontalAlignment="Left"
+                                AutomationProperties.Name="Dismiss this result"
+                                Command="{Binding DismissResultCommand}">
+                                <TextBlock Margin="12,5" Foreground="{StaticResource ButtonForegroundBrush}" Text="Dismiss" />
+                            </Button>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+            </StackPanel>
+        </Expander>
+    </DataTemplate>
+
+    <!--
         Sensor frame outline (10px thick border, EvenOdd) plus three diamond-shaped screw
         indicators at the 0° / 120° / 240° positions of a standard 3-screw tilt adapter.
     -->
@@ -432,6 +995,11 @@
                                 Margin="0,8,0,0"
                                 Content="{Binding}"
                                 ContentTemplate="{StaticResource HF_TiltDevicePositionsGrid}" />
+
+                            <!--  Manual adjustment: hand control of the connected adapter. Sits directly under
+                                  the positions grid because that grid is the shared state both of its modes read
+                                  against, and above the safety limits it enforces. Collapsed by default.  -->
+                            <ContentControl Content="{Binding ManualAdjustment}" ContentTemplate="{StaticResource HF_TiltManualAdjustmentPanel}" />
 
                             <!--  Persisted per-profile device safety limits (project invariant: every
                                   persisted option gets a UI control — these three were deferred here

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -30,6 +30,8 @@ using NINA.Joko.Plugins.HocusFocus.StarDetection;
 using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices;
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Manual;
+using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Prompt;
 using NINA.Joko.Plugins.HocusFocus.Utility;
 using NINA.Profile.Interfaces;
 using NINA.WPF.Base.Interfaces.Mediator;
@@ -376,6 +378,25 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 this.tiltDeviceConnectionService.PropertyChanged += TiltDeviceConnectionService_PropertyChanged;
                 this.tiltDeviceConnectionService.IdlePromptRequested += TiltDeviceConnectionService_IdlePromptRequested;
             }
+
+            // Hand control of the connected adapter. Lives in Panel A's connection GroupBox, so it is never on
+            // screen during a wizard run; it still takes the device lease like every other surface, so a run and
+            // a manual move can't interleave. Its approval dialog is the same modal the inspector's Automatic
+            // Adjustment uses, hosted through this VM's window service factory.
+            ManualAdjustment = new TiltAdapterManualAdjustmentVM(
+                tiltAdapterOptions,
+                this.tiltDeviceConnectionService,
+                applicationDispatcher,
+                (replanner, unitMicrons) => TiltDeviceAdjustmentPrompt.ShowAsync(
+                    windowServiceFactory,
+                    replanner,
+                    // Nothing about a hand-typed absolute target is inferred from the calibration, so the
+                    // "assumed backfocus direction" and pitch-mismatch advisories would both be false here.
+                    screwInwardCurvatureSignIsMeasured: true,
+                    pitchMismatchWarning: string.Empty,
+                    // Target mode is gated on known positions, so this can never be true when the dialog opens.
+                    positionsUnknown: false,
+                    unitMicrons: unitMicrons));
 
             // The display-only focuser convention k changes what the mechanical wording and the physical
             // screw angles READ, never what is stored. Refresh exactly those (design §3, site 6).
@@ -1462,6 +1483,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 RaisePropertyChanged();
             }
         }
+
+        /// <summary>
+        /// The collapsed-by-default "Manual adjustment" panel in the connection GroupBox: hand control of the
+        /// connected motorized adapter (single generator moves, or absolute target positions decomposed through
+        /// the same planner and approval dialog Automatic Adjustment uses).
+        /// </summary>
+        public TiltAdapterManualAdjustmentVM ManualAdjustment { get; }
 
         // Device presets. Selecting a non-Manual device fills and locks the hardware fields.
         public IReadOnlyList<string> DeviceNames => TiltAdapterDevicePreset.All.Select(p => p.Name).ToList();

--- a/docs/motorized-tilt-manual-adjustment-ux-design.md
+++ b/docs/motorized-tilt-manual-adjustment-ux-design.md
@@ -1,0 +1,446 @@
+# Manual Adjustment UX Spec — Motorized Tilt Adapter (ASG EAT)
+
+**Status:** approved 2026-08-04. Produced with Fable (`claude-fable-5`) against the actual XAML/VMs.
+**Scope:** UX only — no XAML, no C#. The panel lives in the Tilt Adapter Wizard dockable, Panel A,
+inside the "Motorized Device Connection" GroupBox. Implementation plan (architecture, reuse,
+correctness anchors, tests): `plans/motorized-tilt-manual-adjustment-plan.md`.
+
+## 1. Scope and placement
+
+A new collapsed-by-default **Manual adjustment** section for driving a connected ASG EAT tilt
+adapter by hand. It lives inside `GroupBox Header="Motorized Device Connection"` in Panel A
+(`!IsWizardRunning`), **directly below the live motor-positions grid**
+(`HF_TiltDevicePositionsGrid`) and **above the "Safety Limits" header**. Rationale: the positions
+grid is the shared state display both modes read against, so the adjustment controls sit
+immediately under it; the safety-limit fields it enforces stay below.
+
+Because Panel A is hidden entirely while the wizard runs, this section can never be on screen
+during a wizard run — no special coexistence state is needed beyond the device lease (§4.3).
+
+Two modes, switched by a segmented radio (same idiom as the simulator's Corner/Side/Backfocus
+radios):
+
+1. **Single move** — pick corner / side / all on a 3×3 pad, a direction, an amount; live inline
+   preview; one click sends. No modal.
+2. **Target positions** — four absolute per-motor targets in the 2×2 corner arrangement,
+   prefilled from live positions; submit opens the existing `TiltDeviceAdjustmentPromptControl`
+   modal with the decomposed move queue and residual analysis.
+
+## 2. The expander
+
+Follows the simulator's collapsed-expander pattern (`TiltAdapterDataTemplates.xaml` ~489):
+bold header text + dim one-line summary sibling in the header; `IsExpanded` two-way bound to a
+session-scoped VM property (default **false**); a getter that force-opens it when there is
+something the user must see.
+
+**Header text:** `Manual adjustment` (bold), followed by the dim summary.
+
+**Collapsed summary line** (dim, one line, priority order — first match wins):
+
+| State | Summary text |
+|---|---|
+| Send from this panel in progress | `Sending move 2 of 3…` (expander is force-open anyway; header still reads this) |
+| Last send failed, not yet dismissed | `Last move failed — see details` |
+| Device busy with another operation | `Device busy — Tilt Adapter Wizard Calibration` (uses `CurrentOperationName`) |
+| Not connected | `Connect to enable` |
+| Connected, something sent this session | `Last sent: TR +20 · BL −20 at 21:14` |
+| Connected, nothing sent yet | `Nudge a corner or set target positions` |
+
+**Force-open rule:** the expander reports expanded (regardless of the user's toggle) while
+(a) a send started from this panel is executing, or (b) the last send ended in failure and the
+failure panel has not been dismissed. Otherwise the user's last toggle sticks for the session.
+
+## 3. Panel skeleton (both modes)
+
+Top to bottom inside the expander:
+
+1. **Caution line** (dim, italic, wraps): `Moves are physical and the device remembers every
+   move (stored in EEPROM). There is no automatic undo.`
+2. **Mode switch** — segmented radio, sibling label `Mode`, options `Single move` ·
+   `Target positions`. Selection persists for the session; default `Single move`.
+3. **Mode body** (§5 or §6).
+4. **Shared status area** (§7): progress line + Stop button during sends; success line or
+   failure/stopped result panel after; hidden when idle with nothing to report.
+
+When the device is **not connected**, items 2–4 are replaced by a single dim line:
+`Connect the device above to make adjustments.` (An undismissed failure panel from a send that
+ended in disconnect stays visible above this line — §7.5.)
+
+## 4. Shared state layer
+
+### 4.1 Live positions
+The existing 2×2 positions grid directly above the expander is the single source of truth for
+"where the motors are now". The panel never duplicates it as a static copy; the Single-move
+preview (§5.5) and Target cells (§6.2) render *predictions/targets* in the same 2×2 spatial
+arrangement so the three surfaces read as one map. All position-derived text in the panel
+(previews, deltas, hints) recomputes automatically whenever the polled positions change.
+
+### 4.2 Positions unknown
+`PositionsKnown == false` (never confirmed since connect, or unparsed `cp`):
+- Positions grid already reads `unknown` per corner (existing).
+- **Single move:** allowed, with an amber advisory (§5.7) — matches the existing modal's
+  treatment of unknown positions as advisory, not blocking. Predicted end positions read
+  `unknown → unknown`.
+- **Target positions:** blocked (§8) — an absolute target needs a known starting point.
+
+### 4.3 Device busy (exclusive lease)
+Any active operation lease (`IsOperationActive`) disables both primary buttons with reason
+`Device busy — {CurrentOperationName}. Wait for it to finish.` Sends from this panel take the
+lease with operation name **`Manual Adjustment`**, so the existing status line reads
+`Connected on COM7 — Manual Adjustment` while it runs, and every other surface (wizard,
+inspector) is excluded for the duration.
+
+### 4.4 Disconnected
+§3's replacement line. The expander header summary reads `Connect to enable`.
+
+## 5. Mode 1 — Single move
+
+### 5.1 Layout
+
+```
+What to move                         (sibling label)
+   ┌──────┬──────┬──────┐
+   │  TL  │ Top  │  TR  │            3×3 pad of toggle buttons,
+   ├──────┼──────┼──────┤            spatial = sensor as imaged in NINA
+   │ Left │ All  │ Right│            (same orientation as the positions grid)
+   ├──────┼──────┼──────┤
+   │  BL  │Bottom│  BR  │
+   └──────┴──────┴──────┘
+Direction   [ + ] [ − ]              segmented pair, sibling label
+Amount      [   10 ] steps  = 18.0 µm of screw travel
+┌─ Preview ────────────────────────────────────────────┐
+│ [Corner]  TR (Motor 1) +20 · BL (Motor 4) −20 steps   tr,20 │
+│   TL · M2  512 → 512        TR · M1  480 → 500 (+20)  │
+│   BL · M4  470 → 450 (−20)  BR · M3  505 → 505        │
+│ Changes TR-vs-BL spacing by 72 µm of screw travel.    │
+│ + = clockwise / tighten (the wizard's positive        │
+│ direction); − = the opposite. 1 step = 1.8 µm.        │
+│ 1 move · ~10 s                        [ Send 1 move ] │
+└──────────────────────────────────────────────────────┘
+```
+
+### 5.2 The pad
+Nine toggle buttons in a 3×3 grid (~40 px cells; a thin border around the grid so it reads as
+the sensor). Cell texts: `TL` `Top` `TR` / `Left` `All` `Right` / `BL` `Bottom` `BR`. Exactly one
+cell selected at a time; **no default selection** — until one is picked the preview area shows
+only the dim line `Pick a corner, side, or All to move.` and Send is disabled. Selection,
+direction and amount all persist for the session (repeat-nudging = click Send again).
+
+Cell semantics (direction `+`; `−` is the same move the other way):
+
+| Cell | Kind | Motors + | Motors − | Wire (dir +) |
+|---|---|---|---|---|
+| TR | Corner | Motor 1 (TR) | Motor 4 (BL) | `tr,N` |
+| TL | Corner | Motor 2 (TL) | Motor 3 (BR) | `tl,N` |
+| BL | Corner | Motor 4 (BL) | Motor 1 (TR) | `bl,N` |
+| BR | Corner | Motor 3 (BR) | Motor 2 (TL) | `br,N` |
+| Top | Side | Motors 2 & 1 (TL, TR) | Motors 4 & 3 (BL, BR) | `tp,N` |
+| Bottom | Side | Motors 4 & 3 (BL, BR) | Motors 2 & 1 (TL, TR) | `bt,N` |
+| Right | Side | Motors 1 & 3 (TR, BR) | Motors 2 & 4 (TL, BL) | `rt,N` |
+| Left | Side | Motors 2 & 4 (TL, BL) | Motors 1 & 3 (TR, BR) | `lt,N` |
+| All | Backfocus | all four | — | `bf,N` |
+
+The rule the pad teaches: *the named element gets the signed amount; its coupled opposite gets
+the negative* (except All, where all four get the signed amount). The preview makes the
+coupling unmissable on every selection — the user who clicks `TR` sees BL move too, every time,
+before anything is sent.
+
+Pad tooltips (text equivalents for every cell; also `AutomationProperties.Name`):
+- `TR`: `Tilts along the TR–BL diagonal. Motor 1 (TR) gets the signed amount; Motor 4 (BL) gets the opposite. One command.`
+- `TL`: `Tilts along the TL–BR diagonal. Motor 2 (TL) gets the signed amount; Motor 3 (BR) gets the opposite. One command.`
+- `BL`: `Tilts along the TR–BL diagonal. Motor 4 (BL) gets the signed amount; Motor 1 (TR) gets the opposite. One command.`
+- `BR`: `Tilts along the TL–BR diagonal. Motor 3 (BR) gets the signed amount; Motor 2 (TL) gets the opposite. One command.`
+- `Top`: `Tilts top vs bottom. Motors 2 & 1 (TL, TR) get the signed amount; Motors 4 & 3 (BL, BR) get the opposite. One command.`
+- `Bottom`: `Tilts top vs bottom. Motors 4 & 3 (BL, BR) get the signed amount; Motors 2 & 1 (TL, TR) get the opposite. One command.`
+- `Right`: `Tilts right vs left. Motors 1 & 3 (TR, BR) get the signed amount; Motors 2 & 4 (TL, BL) get the opposite. One command.`
+- `Left`: `Tilts right vs left. Motors 2 & 4 (TL, BL) get the signed amount; Motors 1 & 3 (TR, BR) get the opposite. One command.`
+- `All`: `Moves all four motors together by the signed amount — changes sensor spacing (backfocus), not tilt. One command.`
+
+### 5.3 Direction
+Segmented pair of toggle buttons `+` and `−` (exactly one selected; default `+`), sibling label
+`Direction`. No up/down words anywhere — whether + physically raises or lowers a corner is
+rig-dependent, exactly the reason the approval modal speaks signed steps. The legend line in
+the preview carries the meaning. Tooltips / automation names:
+- `+`: `The wizard's positive step direction (clockwise / tighten) on the highlighted motors; the coupled motors move the opposite way.`
+- `−`: `The opposite of the wizard's positive step direction on the highlighted motors.`
+
+### 5.4 Amount
+Numeric box, sibling label `Amount`, unit `steps`, strictly positive integer (1 …
+`TiltDeviceMaxExcursionSteps`), default **10**, updates on focus loss / Enter (codebase
+convention). Sibling dim hint: `= 18.0 µm of screw travel` (amount × 1.8, one decimal; hidden
+if the preset's step size is unknown). One number, one meaning — sign lives in Direction
+(same reasoning as the simulator's strictly-positive amount-per-click).
+Tooltip: `How far each affected motor moves, in device steps. 1 step = 1.8 µm of screw travel. Amounts above the per-command cap ({TiltDeviceMaxStepsPerCommand}) are sent as several same-direction commands.`
+
+### 5.5 Inline preview (always current, recomputes on any input or position change)
+A bordered block, top to bottom:
+
+1. **Semantic line** with kind badge: `[Corner] TR (Motor 1) +20 · BL (Motor 4) −20 steps`,
+   `[Side] Top: TL +20 · TR +20 · BL −20 · BR −20 steps`,
+   `[Backfocus] All four motors +20 steps together`. Right-aligned dim monospace wire chip
+   (`tr,20`), tooltip `The exact command string sent to the device.` — same demotion as the modal.
+2. **Predicted end positions**, 2×2 grid mirroring the positions grid: each cell
+   `TL · M2  512 → 512` (dim, unchanged) or `TR · M1  480 → 500 (+20)` (emphasized, moving).
+   With positions unknown: `unknown → unknown`. Per-cell tooltip:
+   `Travel window 0 to {max}. This move ends at {p}, leaving {max−p} to the max and {p} to zero.`
+   Per-cell limit tag (text, not color alone): `near max` / `near 0` (amber) when the predicted
+   position is within 5 % of the travel window of either end; `below 0` / `over max` (red) when
+   outside — red blocks Send (§8).
+3. **Consequence line** (rig-safe, no toward/away claims):
+   - Corner: `Changes TR-vs-BL spacing by 72 µm of screw travel.`
+   - Side: `Changes top-vs-bottom spacing by 72 µm of screw travel.` (or right-vs-left)
+   - All: `Changes sensor spacing by 36 µm; tilt unchanged.`
+4. **Legend** (dim): `+ = clockwise / tighten (the wizard's positive direction); − = the opposite. 1 step = 1.8 µm.`
+5. **Footer**: `{n} move(s) · ~{duration}` + primary button `Send 1 move` / `Send {n} moves`
+   (n > 1 only when the amount exceeds the per-command cap and is split into same-axis
+   commands). Duration = commands × (move + settle), formatted like the modal (`~10 s`,
+   `~1 min`). When Send is disabled, a single reason line (§8) sits directly above the button.
+
+### 5.6 No bias, no decomposition
+Single move sends **exactly the one generator move requested** — never an auto-prepended
+backfocus bias. If the move would drive a motor below 0, Send is blocked with the reason in §8
+(`…send an All + move first to lift all motors.`). The user stays in full control of every step
+sent; the "lift first" recovery is one pad click away.
+
+### 5.7 Single-move advisories (amber one-liners above the footer)
+- Positions unknown: `Motor positions are unknown — travel limits can't be checked for this
+  move. Verify positions in the vendor app before sending.` (Send stays enabled.)
+- Near limit: covered per-cell by the `near max` / `near 0` tags; no separate banner.
+- No assumed-direction advisory here: a nudge is commanded in signed steps, and no copy in this
+  mode asserts a physical toward/away direction, so nothing is assumed that could be wrong. The
+  advisory remains where intent-vs-hardware mismatch is possible: the Target-mode modal.
+
+### 5.8 Repeat-nudge feel
+After a successful send: selection, direction, and amount are untouched; the positions grid and
+preview update from the per-move position report; the button re-enables after settle + refresh.
+Repeating the same nudge is a single click. The status area's success line (§7.3) doubles as the
+collapsed-summary "Last sent" source.
+
+## 6. Mode 2 — Target positions
+
+### 6.1 Concept
+`Type where each motor should end up, in device steps. Current positions are filled in to
+start.` (caption, dim, under the mode switch). The user edits absolute targets; the panel shows
+the per-corner delta, how many moves it becomes, and whether the four numbers contain twist the
+adapter cannot make. `Review moves…` opens the existing approval modal — the same analysis + UI
+used during automatic tilt adjustment — seeded with the delta (target − current at open).
+
+### 6.2 Target cells
+2×2 grid, same arrangement and headers as the positions grid. Each cell:
+
+```
+TL · Motor 2          (bold)
+Wizard screw 2        (dim, small)
+now 512               (dim, live — updates with the poll)
+Target: [  550 ]      (integer TextBox, updates on focus loss / Enter)
+Δ +38 (68.4 µm)       (accent when ≠ 0, dim when 0)
+will reach 546        (dim amber; only when the request contains twist, §6.4)
+```
+
+Prefill: on entering Target mode, and after a completed run (§7.4), targets fill from live
+positions. Background position changes (idle poll, another surface's moves) update the `now`
+line and recompute Δ/hints but **never overwrite typed targets** — the plan is always
+target − current-at-review, so stale-looking targets stay honest.
+
+Validation per cell: whole number in [0, `TiltDeviceMaxExcursionSteps`]; out-of-range or
+non-numeric shows the standard red validation and blocks Review (§8).
+
+Buttons row: secondary `Reset to current` (tooltip: `Fill every target from the current motor
+positions.`) + primary `Review moves…` (ellipsis = opens the review dialog; nothing is sent
+without it).
+
+### 6.3 Pre-submit hint line
+Runs the same planner the modal uses (both groups on) on the current delta; one line under the
+cells, recomputed with Δ:
+- Normal: `Becomes 2 moves · ~20 s.`
+- Nothing to do: `Targets match the current positions — nothing to move.` (Review disabled.)
+- Planner hard limit (rare — targets are already range-checked, but move ordering can still be
+  unreachable): red line `These targets can't be reached without leaving the travel window
+  (0 to {max}).` Review **stays enabled** so the user can open the modal and read the full
+  blocking explanation; Proceed is disabled there. Review is inspection; Proceed is the guarded
+  action.
+- If the plan includes a lift: `Becomes 3 moves · ~30 s, including a +{b}-step lift to keep all
+  motors above 0.` (the modal's bias warning gives the full story).
+
+### 6.4 Twist — four numbers, three degrees of freedom
+The delta decomposes as a = (s1−s3)/2, b = (s2−s4)/2, f = mean, t = (s1−s2+s3−s4)/4. When
+|t| ≥ 1 step, an amber panel appears under the hint line:
+
+> **Twist can't be made**
+> `These four targets differ from a rigid plane by ±{t} steps (about {t×1.8:0.0} µm across the
+> sensor). The adapter can tilt the sensor and change its spacing, but it cannot twist it. Each
+> corner above shows the position it will actually reach.`
+
+and each cell gains the `will reach {n}` line (target minus its twist share, t·(+1,−1,+1,−1) on
+wizard screws 1..4, rounded). The user learns *before* the modal that they typed an unreachable
+shape and exactly what they will get instead; the modal's residual grid then confirms it in µm
+(including step rounding).
+
+### 6.5 The review modal (reused as-is)
+`Review moves…` opens `TiltDeviceAdjustmentPromptControl` unchanged: title + no-undo caution;
+Apply `Tilt correction` / `Backfocus correction` toggles that live-replan (here: tilt = the a/b
+components, backfocus = the f component of the user's delta); MOVES TO SEND with badges,
+semantic rows, wire chips; the 2×2 residual grid; the severity-ordered warning stack (travel
+limit, assumed backfocus direction, twist, bias, pitch mismatch — positions-unknown never fires
+here because Target mode requires known positions); footer with count, duration, disabled
+reason, Cancel, `Send N moves`.
+
+Cancel returns to the panel with targets preserved. Proceed starts execution (§7).
+
+## 7. During and after a send (both modes)
+
+### 7.1 Progress
+The shared status area shows one line per in-flight command, prefixed with the plan position:
+`Move 2 of 3 — {controller progress text}` (e.g. `Move 2 of 3 — sending bf,50… settling (3 s)`).
+The primary buttons, pad, direction, amount, and target boxes are disabled for the duration; the
+expander is force-open. The GroupBox status line reads `Connected on COM7 — Manual Adjustment`.
+
+### 7.2 Stop (multi-move sends only)
+A `Stop after this move` button appears beside the progress line whenever more than one command
+remains. Tooltip: `The move already sent can't be recalled. Nothing further will be sent.`
+There is no device abort — this only skips unsent moves (cancellation is honored before each
+send). After stopping, an amber result panel:
+
+> **Stopped after {k} of {n} moves**
+> `The moves already sent are applied — there is no automatic undo. Nothing after move {k} was
+> sent. Positions above show where the motors are now.`
+
+Single-command sends show no Stop button.
+
+### 7.3 Success
+Positions refresh per move from the move response (no extra query); the grid and every
+position-derived readout update as the plan runs. On completion the status area shows a dim
+success line, which persists until the next action and feeds the collapsed summary:
+- Single move: `Sent TR +20 · BL −20 · 1 move · finished at 21:14.`
+- Targets: `Adjustment complete — 3 moves sent · finished at 21:22.` Targets re-prefill from
+  the reached positions, so the cells now read Δ 0 (± the residual the modal predicted).
+
+### 7.4 Failure and partial failure
+A command failure (write timeout / no valid response) leaves device state ambiguous and the
+plugin's counters un-advanced — the red result panel says exactly that and stays until
+dismissed (`Dismiss` button; expander force-open until then):
+
+- Single command failed:
+  > **Move failed**
+  > `The command '{wire}' got no valid response. It may or may not have reached the device, so
+  > the position counters above were not advanced — they re-sync on the next successful poll.
+  > If in doubt, check the vendor app before sending more moves.`
+- Multi-move plan, k of n sent (target mode):
+  > **Adjustment stopped after {k} of {n} moves**
+  > `The first {k} moves were sent and are applied — there is no automatic undo. Move {k+1}
+  > ('{wire}') failed and nothing after it was sent. Once the positions above re-sync, press
+  > Review moves — the plan recomputes from wherever the motors actually are, so it will
+  > finish the remainder.`
+  (This recovery is the payoff of absolute targets: re-planning from refreshed positions
+  naturally yields "the rest of the journey".)
+- Split nudge, k of n commands sent:
+  > **Sent {k} of {n} moves ({k×cap} of {amount} steps)**
+  > `The steps already sent are applied — there is no automatic undo. The remaining
+  > {amount − k×cap} steps were not sent; set Amount to {remaining} and press Send to finish.`
+
+### 7.5 Disconnect mid-send
+The in-flight command fails as above; the panel body flips to the disconnected line (§3) but
+the failure panel remains above it until dismissed, so the explanation survives the state
+change.
+
+## 8. Disabled/blocked states — exact reasons
+
+One reason line at a time, directly above the mode's primary button; highest row wins.
+(Red = blocking validation styling; plain = dim.)
+
+| # | Condition | Applies to | Reason line |
+|---|---|---|---|
+| 1 | Not connected | both | (panel body replaced) `Connect the device above to make adjustments.` |
+| 2 | Operation lease held elsewhere | both | `Device busy — {CurrentOperationName}. Wait for it to finish.` |
+| 3 | Send from this panel in progress | both | (no reason line — the progress line explains it) |
+| 4 | No pad cell selected | Single move | `Pick a corner, side, or All to move.` |
+| 5 | Amount empty / < 1 / not a whole number | Single move | `Enter an amount of at least 1 step.` |
+| 6 | Predicted position < 0 | Single move | (red) `This move would drive Motor {n} ({corner}) below 0. Reduce the amount, or send an All + move first to lift all motors.` |
+| 7 | Predicted position > max excursion | Single move | (red) `This move would drive Motor {n} ({corner}) past the max excursion ({max}). Reduce the amount, or lower all motors with an All − move first.` |
+| 8 | Positions unknown | Target positions | `Motor positions are unknown — targets need a known starting point. They update after a successful poll or move.` |
+| 9 | Any target invalid / out of range | Target positions | (red, per-cell validation plus) `Targets must be whole numbers between 0 and {max} steps.` |
+| 10 | All deltas zero | Target positions | `Targets match the current positions — nothing to move.` |
+
+Positions unknown in Single move is an **advisory**, not a block (§5.7). Planner hard-limit in
+Target mode does **not** disable Review (§6.3); it disables Proceed in the modal.
+
+## 9. Copy inventory (everything not already quoted above)
+
+- Expander header: `Manual adjustment`
+- Mode label: `Mode` · options `Single move`, `Target positions`
+  - `Single move` tooltip: `Send one adjustment now: a corner, a side, or all four motors together.`
+  - `Target positions` tooltip: `Type where each motor should end, review the moves it takes to get there, then send them.`
+- Pad label: `What to move`
+- Amount unit: `steps`; µm hint format: `= {amount×1.8:0.0} µm of screw travel`
+- Send button: `Send 1 move` / `Send {n} moves`
+- Stop button: `Stop after this move`
+- Reset button: `Reset to current`
+- Review button: `Review moves…`
+- Dismiss button (result panels): `Dismiss`
+- Caution line: `Moves are physical and the device remembers every move (stored in EEPROM). There is no automatic undo.`
+- Wire chip tooltip: `The exact command string sent to the device.`
+- All µm values one decimal with `µm`; durations via the modal's formatter (`~10 s`, `~1 min 35 s`); step values signed (`+20`, `−20`) where they are deltas, unsigned where they are positions.
+
+## 10. Accessibility and theming
+
+- **No CheckBoxes** in this panel (NINA's themed CheckBox often fails to render
+  `CheckBox.Content`); the two-state controls here are RadioButtons and ToggleButtons, whose
+  content renders. Every caption is still a **sibling TextBlock**, never control Content, for
+  the labels (`Mode`, `Direction`, `Amount`, `What to move`).
+- Every pad cell, direction toggle, and mode radio carries `AutomationProperties.Name` with the
+  full text of its tooltip's first sentence (e.g. `Top-right corner — tilts along the TR–BL diagonal`).
+- No color-only signals: `near max` / `below 0` / `will reach {n}` are text tags with the amber/red
+  styling on top, and the moving-vs-unchanged distinction in the predicted grid pairs weight
+  (bold + signed delta) with the color.
+- Panel A renders in the active NINA theme (unlike the modal's self-contained dark palette):
+  every locally-styled `TextBlock.Style` must be `BasedOn={StaticResource StandardTextBlock}`
+  (documented theme hazard at the top of `DataTemplates.xaml`), and the amber/red panel brushes
+  need light-theme-legible counterparts rather than reusing the modal's fixed dark-background
+  hex values.
+- All interactive controls tab-reachable in reading order: mode → pad (row-major) → direction →
+  amount → preview button / target cells (TL, TR, BL, BR) → reset → review.
+- Glyph-free: `+`, `−`, `⟳` (existing rescan button) are the only symbols, each with a text
+  tooltip; no icon-only actions.
+
+## 11. Edge cases
+
+- **Options changed mid-session** (per-command cap, max excursion, settle): previews, splits,
+  durations, and limit checks recompute immediately; an in-flight plan keeps the values it was
+  planned with.
+- **Amount > per-command cap** in Single move: allowed; preview and button state the split
+  (`2 moves · ~20 s`, `Send 2 moves`).
+- **Positions become known mid-edit** (first successful poll): Single-move advisory clears and
+  predictions populate; Target mode unblocks and prefills (only cells the user hasn't edited).
+- **Another surface moves the motors while Target mode has edits**: `now` values and deltas
+  update live; typed targets untouched (§6.2).
+- **Settle time set to 0**: durations shorten accordingly; no other change.
+- **Decomposition halves land on .5 steps** (odd corner deltas): planner rounding applies; the
+  panel's `will reach` and the modal's residual grid absorb it — no special copy.
+- **Expander collapsed when a background failure would matter**: impossible — sends only start
+  from this panel, and it force-opens for the whole send and any undismissed failure.
+
+## 12. Concerns
+
+1. **One-click sends with no undo (accepted decision, flagged residual risk).** The inline
+   preview + hard travel blocks are the whole safety net for Single move — there is no
+   confirmation step. Mitigations baked in: no default pad selection (first send requires a
+   deliberate pick), small default amount (10 steps = 18 µm), the predicted-positions grid, and
+   red hard-stops at the travel window. If field feedback shows misfires, the cheapest retrofit
+   is a hold-to-confirm on the Send button, not a modal.
+2. **Nudging with unknown positions is allowed** (consistent with the existing modal's
+   advisory-only treatment), but here there is no modal gate in front of it. A defensible
+   stricter rule would block Single move until one successful position poll after connect. The
+   spec keeps consistency with the modal; flagging in case the implementer/user prefers strict.
+3. **Single move never auto-prepends a backfocus bias** (§5.6), unlike the automatic-adjustment
+   path. This is deliberate — "single adjustment" should mean exactly one generator move — but
+   it is a behavioral asymmetry between the two paths that the reason-line copy has to teach
+   (`…send an All + move first to lift all motors.`).
+4. **Vocabulary spans three index spaces.** The panel leads with corner + motor number
+   (matching the positions grid); the modal's move rows lead with wizard screw numbers. The
+   modal already appends corners (`Screw 1 (TR)`), so the join exists, but a user reading a
+   Target-mode plan still crosses vocabularies once. Unifying the modal rows to corner-first is
+   out of scope here (it is shared with the wizard/inspector flows) — noted, not redesigned.
+5. **Twist by accident is easy in Target mode** — any hand-typed four numbers almost always
+   contain some t. The ≥ 1-step threshold keeps rounding noise quiet, and the per-cell
+   `will reach` line shows the honest outcome pre-review; still, users expecting four exact
+   positions will sometimes get four near-misses, and the copy has to carry that expectation.

--- a/documentation/docs/overview/motorized-tilt-adapter.md
+++ b/documentation/docs/overview/motorized-tilt-adapter.md
@@ -119,6 +119,67 @@ before sending; there is no automatic undo.
     offers to revert, sending the inverse of each move in reverse order. A failure partway through
     a plan brings the same revert offer.
 
+## Manual adjustment
+
+Automatic Adjustment corrects a tilt the plugin has just measured. When you want to move the adapter
+yourself — to lift motors away from 0, to dial in backfocus, to apply a correction you worked out
+elsewhere, or to finish an adjustment that stopped partway — open **Manual adjustment** in the
+**Motorized Device Connection** section, directly under the motor positions. It is collapsed by
+default, and its header line says what it last did.
+
+Unlike Automatic Adjustment, it needs no measurement and no calibration: it drives the hardware
+directly, so it works as soon as the device is connected.
+
+Every move here is physical and is stored in the adapter's EEPROM. There is no automatic undo.
+
+### Single move
+
+Pick what to move on the 3×3 pad, which is laid out the way the sensor is imaged:
+
+|  |  |  |
+|---|---|---|
+| **TL** | **Top** | **TR** |
+| **Left** | **All** | **Right** |
+| **BL** | **Bottom** | **BR** |
+
+The four corners tilt along a diagonal, the four edges tilt one side against the other, and **All**
+moves every motor together — a backfocus change, not a tilt. Each is a single command to the device.
+
+Set **Direction** (`+` is the wizard's positive step direction; `−` is its opposite) and **Amount**
+in steps, and the preview below shows exactly what the click will do: which motors move and by how
+much, where all four will end up, how much of the travel window that leaves, and the change in
+microns. Because the adapter's corners are mechanically coupled, choosing `TR` also moves `BL` — the
+preview always shows both, so the coupling is visible before you send anything.
+
+**Send** issues the move. Nothing else changes, so repeating the same nudge is one more click. An
+amount larger than **Max steps per command** is sent as several commands in the same direction, and
+the button says how many.
+
+A move that would carry a motor outside the travel window is refused before anything is sent, and
+the panel names the motor and suggests the fix — usually an `All +` move to lift everything first.
+Positions that end near either end of the window are tagged **near 0** or **near max**; those are
+advisories, not refusals.
+
+### Target positions
+
+Switch **Mode** to **Target positions** to say where each motor should end up rather than how far to
+move it. The four boxes are filled in from the current positions; edit the ones you want to change
+and the panel shows the difference per corner and how many moves it will take.
+
+**Review moves…** decomposes the difference and opens the same **Review motor commands** dialog that
+[Automatic Adjustment](#automatic-adjustment) uses, with the same move list, residuals and warnings.
+Nothing is sent until you approve it there.
+
+!!! note "Four numbers, three degrees of freedom"
+    A tilt adapter can tilt the sensor plane and change its spacing, but it cannot **twist** it — no
+    rigid plane can. Most sets of four hand-typed positions ask for a little twist, and that part
+    simply cannot happen. When the request contains a whole step of twist or more, the panel says so
+    before you open the dialog and each corner shows the position it will actually reach.
+
+If a plan stops partway — a failed command, or **Stop after this move** — the moves already sent
+stay applied. Because the targets are absolute, pressing **Review moves…** again once the positions
+have re-synced re-plans from wherever the motors actually are, which finishes the remainder.
+
 ## Safety limits
 
 Three persisted settings in the **Motorized Device Connection** section, under **Safety Limits**,
@@ -150,9 +211,9 @@ The approval dialog shows the bias as its own move and warns that it is present.
 
 The bias is not free. Moving all four screws together *is* a backfocus change, so it shifts your
 backfocus by the bias amount, and that shift is included in the residuals the dialog reports. To
-avoid it, give the motors room to work before adjusting, so corrections have travel underneath
-them: raise the motors away from zero in the vendor's app, or apply a positive backfocus move of
-your own.
+avoid it, give the motors room to work before adjusting, so corrections have travel underneath them:
+send an `All` `+` move from [Manual adjustment](#manual-adjustment), or raise the motors away from
+zero in the vendor's app.
 
 ## The Simulator port
 

--- a/plans/motorized-tilt-manual-adjustment-plan.md
+++ b/plans/motorized-tilt-manual-adjustment-plan.md
@@ -1,0 +1,258 @@
+# Manual Adjustment Panel for a Connected Motorized Tilt Adapter
+
+## Context
+
+The motorized tilt-adapter (ASG EAT) feature can only drive the hardware in two fully-automatic
+flows: the wizard's **Auto Run All** calibration sequence, and the Inspector's **Automatic
+Adjustment**, which computes a correction from a fitted sensor model. There is **no way to move the
+adapter by hand** — the only manual jog UI in the product drives the *simulated* adapter
+(`CameraSimulator/TiltAdapter/SimulatedTiltAdapterVM.cs`), not real hardware.
+
+That leaves real gaps: recovering a motor that sits too near 0 or the excursion cap, applying a
+correction you worked out yourself, dialing in backfocus, or re-running the tail of an adjustment
+that failed partway. Today all of those require the vendor app.
+
+This adds a **collapsed-by-default "Manual adjustment" section** to the Tilt Adapter Wizard's
+*Motorized Device Connection* group box, with two modes:
+
+1. **Single move** — pick a corner / side / all on a spatial pad, a direction, an amount; see the
+   consequence inline; one click sends it.
+2. **Target positions** — type absolute per-motor end positions; the delta is decomposed by the
+   existing planner and reviewed in the existing approval modal, exactly as Automatic Adjustment
+   does.
+
+Both are raw hardware control: **neither requires a fitted sensor model, a device-linked
+calibration, or `CalibrationIsReliable`** — the gates that gate Automatic Adjustment do not apply
+here.
+
+## UX spec
+
+Fable produced the full UX spec (layout, all copy, every state, edge cases, concerns). It is at:
+
+`docs/motorized-tilt-manual-adjustment-ux-design.md`
+
+Build the UI from that document — it is the source of truth for wording and layout; this plan
+covers architecture, reuse, correctness anchors, and tests.
+
+Shape, in brief:
+
+```
+GroupBox "Motorized Device Connection"
+  Serial port / Connect / Disconnect / status          (existing)
+  HF_TiltDevicePositionsGrid  — live 2x2 motor positions (existing)
+  ▸ Manual adjustment   <dim summary line>             (NEW, collapsed by default)
+       caution: moves are physical, stored in EEPROM, no automatic undo
+       Mode: (•) Single move   ( ) Target positions
+       ── Single move ──────────────────────────────────────
+       What to move   [TL][Top][TR]     Direction [+][−]
+                      [Left][All][Right]  Amount [ 10 ] steps = 18.0 µm
+                      [BL][Bottom][BR]
+       Preview: [Corner] TR (Motor 1) +20 · BL (Motor 4) −20 steps      tr,20
+                TL·M2 512→512    TR·M1 480→500 (+20)
+                BL·M4 470→450 (−20)  BR·M3 505→505
+                1 move · ~10 s                        [ Send 1 move ]
+       ── Target positions ─────────────────────────────────
+       2x2 target boxes prefilled from live positions, Δ per corner,
+       "Becomes 2 moves · ~20 s", twist panel + per-cell "will reach"
+                          [ Reset to current ]  [ Review moves… ]
+  Safety Limits …                                      (existing)
+```
+
+## Architecture — reuse, don't rebuild
+
+Everything needed already exists. The new VM is a thin composition layer.
+
+| Need | Reuse |
+|---|---|
+| Move type + per-corner effect | `TiltAdapterDevices/TiltAdapterMove.cs` — `TiltMoveAxis`, `TiltAdapterMove.UnitEffect(axis)` |
+| Delta → ordered move list | `TiltAdapterDevices/TiltMovePlanner.cs` — `Plan(...)`, and `Decompose` for the twist term |
+| Ordering + non-negative bias | `ITiltMotionController.OrderForMinimalPeakExcursion` |
+| Plan + residual + bias preview | `InspectorVM.BuildPlanPreview` — **extract to shared** (below) |
+| Approval modal | `TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPrompt.ShowAsync(...)` — unchanged |
+| Wire command text | `AsgEat/EatCommands.Format(move)` — **never hand-build the chip** |
+| Corner labels | `AsgEat/EatWizardMapping.CornerLabelForWizardScrew(int)` |
+| Connection, lease, positions | `TiltDeviceConnectionService`: `Connected`, `Controller`, `CurrentPositions`, `PositionsKnown`, `IsOperationActive`, `CurrentOperationName`, `TryBeginOperation(name)`, `PublishControllerPositions()` |
+| Execution | `ITiltMotionController.ExecuteMoveAsync(move, progress, ct)` |
+| Positions grid template | `HF_TiltDevicePositionsGrid` in `TiltAdapterWizard/DataTemplates.xaml` |
+| Collapsed-expander idiom | `SimulatedTiltAdapterVM.IsInjectionExpanded` + header summary (`CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml` ~489) |
+
+### One small extraction
+
+`InspectorVM.BuildPlanPreview` (`AutoFocus/InspectorVM.cs:2492`) is exactly what target mode needs
+(plan → order → recompute residual from what will actually be sent → derive `BiasSteps` → rescale
+duration → catch `TiltDeviceLimitException` into a blocking preview). Move the body verbatim to a
+new `TiltAdapterDevices/TiltDevicePlanPreviewBuilder.cs` (`internal static TiltDevicePlanPreview
+Build(...)`) and leave `InspectorVM.BuildPlanPreview` as a one-line forwarder so
+`InspectorVMAutomaticAdjustmentTests` keeps compiling untouched. Do not otherwise modify the
+Automatic Adjustment path.
+
+### New files
+
+- `TiltAdapterDevices/Manual/TiltAdapterManualAdjustmentVM.cs` — the panel VM (`BaseINPC`, plain
+  class, constructed by `TiltAdapterWizardVM`; **not** a MEF export).
+- `TiltAdapterDevices/Manual/ManualAdjustmentTarget.cs` — the pad's 9 selectable targets and the
+  correctness-anchor mapping table (below).
+- `TiltAdapterDevices/TiltDevicePlanPreviewBuilder.cs` — the extraction above.
+
+### Modified files
+
+- `TiltAdapterWizard/TiltAdapterWizardVM.cs` — construct + expose
+  `public TiltAdapterManualAdjustmentVM ManualAdjustment { get; }`; dispose/unsubscribe with the VM.
+- `TiltAdapterWizard/DataTemplates.xaml` — new keyed `DataTemplate` (e.g.
+  `HF_TiltManualAdjustmentPanel`) plus a `<ContentControl Content="{Binding ManualAdjustment}"
+  ContentTemplate="{StaticResource HF_TiltManualAdjustmentPanel}" />` inserted in the *Motorized
+  Device Connection* group box **between the `HF_TiltDevicePositionsGrid` ContentControl and the
+  "Safety Limits" header** (~line 430).
+- `AutoFocus/InspectorVM.cs` — forwarder only.
+
+### No new persisted options
+
+Expander state, mode, pad selection, direction, amount and typed targets are **session-scoped VM
+state**. This is deliberate: it keeps the project invariant "every persisted option gets a control
+in `Resources/OptionsDataTemplates.xaml`" from pulling jog defaults into the global options screen.
+
+## Correctness anchors
+
+**The pad mapping table.** Nine targets, each one axis + sign. This is the file's equivalent of
+`TiltAdapterMove`'s unit-effect table — a sign error here is an EEPROM-persisted wrong-way move.
+Encode it as a static table in `ManualAdjustmentTarget.cs` and pin it with a table-driven test.
+
+| Pad cell | Axis | Sign for `+` | Wizard screws that get `+amount` |
+|---|---|---|---|
+| TR | DiagonalA | +1 | s1 (TR); s3 (BL) gets −amount |
+| BL | DiagonalA | −1 | s3 (BL); s1 (TR) gets −amount |
+| TL | DiagonalB | +1 | s2 (TL); s4 (BR) gets −amount |
+| BR | DiagonalB | −1 | s4 (BR); s2 (TL) gets −amount |
+| Top | EdgeVertical | +1 | s1, s2 (TR, TL); s3, s4 get −amount |
+| Bottom | EdgeVertical | −1 | s3, s4 (BL, BR); s1, s2 get −amount |
+| Right | EdgeHorizontal | +1 | s1, s4 (TR, BR); s2, s3 get −amount |
+| Left | EdgeHorizontal | −1 | s2, s3 (TL, BL); s1, s4 get −amount |
+| All | Backfocus | +1 | all four |
+
+**Three index spaces** (`.claude/docs/tilt-domain.md`): corners TR/TL/BR/BL; device motors
+TR=1, TL=2, BR=3, BL=4; wizard screws TR=1, TL=2, **BL=3, BR=4**. `TiltAdapterMove.PerCornerSteps`
+and `TiltMovePlanner`'s `sPerScrew` are in **wizard screw** order;
+`TiltDeviceConnectionService.CurrentPositions` is in **device motor** order. Convert with
+`EatTiltMotionController.PermuteWizardToDeviceMotorOrder` (`[w0, w1, w3, w2]`, *not* identity) —
+never by hand. Prefer rendering by corner label via `EatWizardMapping.CornerLabelForWizardScrew`.
+
+**Wire chips come from `EatCommands.Format(move)`.** The default sign encoding is
+`SignedArgument`, so a "BL +20" pad click sends `tr,-20`, not `bl,20`. Formatting the chip by hand
+from the pad label would print a command that is never sent.
+
+**"Will reach" values come from the plan, not from re-deriving twist.**
+`TiltAdapterMovePlan.ResidualMicronsPerCorner[i] = (applied[i] − target[i]) × unitMicrons`, so
+`willReach[i] = target[i] + residual[i] / unitMicrons`. That is exact and already folds in twist,
+step rounding, *and* any prepended bias. Use `TiltMovePlanner.Decompose(...).t` only for the
+"is there twist worth warning about" test (|t| ≥ 1 step).
+
+**Single move sends exactly one generator move** — it goes straight to `ExecuteMoveAsync` (split
+into same-axis chunks by `TiltMovePlanner.SplitStepsForCap` when the amount exceeds
+`TiltDeviceMaxStepsPerCommand`), never through `OrderForMinimalPeakExcursion`, so no backfocus bias
+is ever silently prepended. A move that would carry a motor below 0 is blocked with a reason line
+telling the user to send an `All +` move first.
+
+**Travel-window prediction.** Mirror `EatTiltMotionController.ExecuteMoveAsync`'s check
+(`AsgEat/EatTiltMotionController.cs:267–293`): predicted = current + permuted delta, window
+`[0, TiltDeviceMaxExcursionSteps]`, asymmetric. Note the controller enforces this **even when
+positions are unknown** (against the persisted estimate, with a "degraded" note in the message) —
+which is why unknown positions are an *advisory* for Single move rather than a block, while Target
+mode blocks (an absolute target is meaningless without a known start).
+
+**Modal parameters for target mode.** Call
+`TiltDeviceAdjustmentPrompt.ShowAsync(windowServiceFactory, replanner, screwInwardCurvatureSignIsMeasured: true, pitchMismatchWarning: string.Empty, positionsUnknown: false, unitMicrons)`.
+The assumed-direction and pitch-mismatch warnings exist because Automatic Adjustment *infers* screw
+motion from a measured curvature; in target mode the user commanded steps directly, so nothing is
+assumed and firing those warnings would be false. `positionsUnknown` is always false because the
+mode is gated on `PositionsKnown`.
+
+**UI-thread rules** (`.claude/docs/mvvm-patterns.md`, memory): `NotifyCanExecuteChanged` must be
+raised on the UI thread; use `applicationDispatcher.PostSynchronizationContext` (Post, never a
+blocking Dispatch) when republishing from the poll/move path.
+
+**Publish positions after every move** (`.claude/docs/tilt-domain.md`): the 5 s `cp` poll is
+suspended for the whole lease, so the panel must call
+`TiltDeviceConnectionService.PublishControllerPositions()` after each `ExecuteMoveAsync` — one call
+updates every bound surface. Never issue a follow-up `cp`.
+
+## Tasks
+
+1. **Move the UX spec** to `docs/motorized-tilt-manual-adjustment-ux-design.md`. *(done)*
+2. **Extract `TiltDevicePlanPreviewBuilder`**; leave `InspectorVM.BuildPlanPreview` as a forwarder.
+   Run the suite — `InspectorVMAutomaticAdjustmentTests` must be untouched and green.
+3. **`ManualAdjustmentTarget.cs`** — the 9-target table (label, kind, axis, sign, tooltip text) plus
+   `IReadOnlyList<double> PerScrewEffect(target, direction, amount)`. Pure, no dependencies.
+4. **`TiltAdapterManualAdjustmentVM` — shared + Single move.** Connection/lease/positions state,
+   expander + summary line, mode switch, pad/direction/amount, live preview (semantic line, wire
+   chip, predicted 2×2 end positions with `near max`/`near 0`/`below 0`/`over max` tags,
+   consequence line, legend, count + duration), the disabled-reason table, `SendCommand`.
+5. **Execution + status.** Take `TryBeginOperation("Manual Adjustment")`; run split commands
+   sequentially with a `CancellationTokenSource` for *Stop after this move* (the token is only
+   honored at `ExecuteMoveAsync` entry — there is no device abort); `PublishControllerPositions()`
+   after each; progress line `Move k of n — {controller text}`; success / stopped / failed /
+   partial-failure result panels per the spec, with force-open-until-dismissed.
+6. **Target positions mode.** 2×2 absolute target cells prefilled from live positions (background
+   position updates refresh `now`/Δ but never overwrite typed targets), per-corner Δ in steps + µm,
+   validation, hint line from the planner (`Becomes N moves · ~T`, nothing-to-do, hard-limit,
+   bias-included), twist panel + per-cell "will reach", `Reset to current`, `Review moves…` →
+   modal → same executor as task 5.
+7. **XAML.** Keyed `DataTemplate` + `ContentControl` insertion. Theme-correct: Panel A renders in
+   the active NINA theme (unlike the modal's self-contained palette) — every local
+   `TextBlock.Style` must be `BasedOn="{StaticResource StandardTextBlock}"`, and warning colors
+   need light-theme-legible brushes. No `CheckBox` (NINA's themed template frequently drops
+   `CheckBox.Content`); use `RadioButton`/`ToggleButton` with **sibling** `TextBlock` captions and
+   `AutomationProperties.Name` on every control.
+8. **Manual documentation.** Add a section to `documentation/docs/overview/motorized-tilt-adapter.md`
+   per `.claude/docs/documentation-style.md`.
+
+## Testing
+
+New `Tests/TiltAdapterDevices/Manual/TiltAdapterManualAdjustmentVMTests.cs` (NUnit 4, existing
+seams: fake `ITiltMotionController`, `ITiltDeviceTimeSource`, an injectable prompt delegate mirroring
+`InspectorVM`'s `showAdjustmentPromptAsync`):
+
+- **Pad mapping table** — all 9 targets × both directions → expected `PerScrewEffect` vector and
+  expected `EatCommands.Format` wire string. Table-driven; this is the anchor test.
+- Preview predicted end positions in **device motor order** for each target (catches a permutation
+  slip); `near max` / `near 0` tags at the 5 % thresholds; `below 0` / `over max` block `Send`.
+- Amount > `TiltDeviceMaxStepsPerCommand` splits into same-axis chunks summing to the amount, and
+  the button/duration text reflects the count.
+- Every row of the disabled-reason table produces its exact reason string; precedence order holds.
+- Target mode: delta → expected move list; zero-delta disables Review; out-of-range target blocks;
+  `PositionsKnown == false` blocks with the right reason.
+- Twist: a target vector with |t| ≥ 1 step raises the twist panel, and `willReach` equals
+  `target + residual/unitMicrons` from the plan.
+- Execution: lease acquired/released (including on throw); `PublishControllerPositions` called once
+  per move; Stop skips remaining moves; a `TiltDeviceCommandFailedException` on move k of n yields
+  the partial-failure panel with the right k/n and does **not** auto-revert.
+- Regression: existing `InspectorVMAutomaticAdjustmentTests`, `TiltMovePlannerTests`,
+  `TiltAdapterMoveTests`, `Tests/TiltAdapterDevices/Prompt/` unchanged and green.
+
+Full suite (memory: no `dotnet` in WSL — use Windows `dotnet.exe` via interop, `wslpath -w` the
+solution, timeout 600000). Run at milestones (after tasks 2, 5, 7) and as a final gate, not after
+every edit. Note the flaky `SendAsync_WritesOnABackgroundThread` in the EAT serial transport tests
+is pre-existing and unrelated.
+
+## Verification (end-to-end)
+
+1. `dotnet.exe test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo` — green.
+2. NINA → **Tilt Adapter Wizard**, select an ASG EAT preset, Connect to **`Simulator`** (the
+   in-process `SimulatedEatTransport` runs the entire real EAT stack unchanged, so this exercises
+   the true command path with no hardware):
+   - The *Manual adjustment* expander is **collapsed** on first open, with the summary line.
+   - Single move: click `TR`, `+`, 20 → preview names Motor 1 and Motor 4, shows both predicted
+     positions, and the chip reads `tr,20`; Send moves the live positions grid by exactly ±20.
+   - Click `BL`, `+`, 20 → chip reads `tr,-20` (sign encoding), and the move reverses the previous.
+   - `All`, `+`, 50 → all four counters +50, consequence line says spacing not tilt.
+   - Set Amount above the per-command cap → preview shows the split and `Send N moves`.
+   - Drive a motor near 0 → `below 0` tag appears and Send is blocked with the "lift first" reason.
+   - Target mode: prefilled from current; edit two corners asymmetrically so the request contains
+     twist → twist panel + per-cell "will reach"; `Review moves…` opens the existing modal with the
+     decomposed queue and 2×2 residual grid; Proceed executes and the counters land on the "will
+     reach" values.
+   - Start a wizard run → Panel A (and the panel) disappears; with a run's lease held, both primary
+     buttons read `Device busy — …`.
+3. Hardware pass on COM7 with the real EAT: one small `All +10`, confirm the counters and the
+   physical adapter agree, then `All −10` back.
+4. Confirm the Inspector's **Automatic Adjustment** still works unchanged (the extraction in task 2
+   is the only thing this plan touches in that path).


### PR DESCRIPTION
## Context

The motorized tilt adapter (ASG EAT) could only be driven by two fully-automatic flows: the wizard's **Auto Run All**, and the inspector's **Automatic Adjustment**, which corrects a tilt it has just measured. There was no way to move it by hand — lifting motors away from 0, dialing in backfocus, applying a correction worked out elsewhere, or finishing an adjustment that stopped partway all meant reaching for the vendor app. (The only manual jog UI in the product drives the *simulated* adapter.)

## What this adds

A collapsed-by-default **Manual adjustment** section in the wizard's *Motorized Device Connection* group box, directly under the live motor positions, with two modes.

**Single move** — a 3×3 pad laid out the way the sensor is imaged:

|  |  |  |
|---|---|---|
| TL | Top | TR |
| Left | **All** | Right |
| BL | Bottom | BR |

Corners drive the diagonal axes, edges the edge axes, centre the backfocus axis. One pad cell is exactly one generator axis plus a sign, so a click is always a **single device command** — never a decomposition, and never an auto-prepended backfocus bias. The preview shows the semantic move, the wire command, predicted end positions for **all four** motors (so the mechanical coupling — clicking `TR` also moves `BL` — is visible every time), the travel-window margin, and the change in µm. There is no undo, so the consequence is on screen before the click. A move that would leave the `[0, max]` window is refused with the fix named.

**Target positions** — absolute per-motor end positions, prefilled from the live ones. The delta runs through the same planner and the same **Review motor commands** dialog Automatic Adjustment uses, so the decomposition, ordering, residual grid and warnings are literally the same code. Twist — the part of any four hand-typed numbers that no rigid plane can produce — is surfaced *before* the dialog, with each corner showing the position it will really reach. Because the targets are absolute, re-planning after a partial failure naturally finishes the remainder.

Neither mode requires a fitted sensor model, a device-linked calibration, or `CalibrationIsReliable` — this is raw hardware control, so Automatic Adjustment's gates don't apply. All panel state is session-scoped, so nothing new lands in the global options screen.

## Notes for review

- **`ManualAdjustmentTarget.All` is a correctness anchor.** A sign error there is an EEPROM-persisted wrong-way motor move with no undo. It is pinned in both directions against `TiltAdapterMove.UnitEffect` and `EatCommands.Format` — including the case where the signed-argument encoding sends "BL +20" as `tr,-20`, which is exactly why the wire chip is never assembled from the pad label.
- **`InspectorVM.BuildPlanPreview` moved** to a shared `TiltDevicePlanPreviewBuilder`; `InspectorVM` keeps a one-line forwarder so `InspectorVMAutomaticAdjustmentTests` is untouched. That is the only change to the Automatic Adjustment path.
- The three index spaces (corner label / device motor / wizard screw) are resolved through one table rather than converted by hand — that mapping is the most repeated bug in this feature.
- Execution state is written on the calling thread and only the *notification* is marshalled; posting the state change would let the first move go out before `isSending`/`sendCts` were set.

## Testing

- `dotnet test … -c Debug` — **3589 passed, 0 failed**.
- 110 new tests: the nine-cell pad table in both directions, predicted positions in device motor order, near/blocking limit tags, split-by-cap, every disabled-reason row and its precedence, target decomposition, twist + will-reach, and execution (lease taken and released, positions published per move, stop, partial failure).
- **Verified end to end in NINA against the `Simulator` port**: collapsed by default; the disconnected line; a `TR +10` nudge moving TR 1000→1010 and BL 1000→990 with the other two untouched and the summary reading back the move; target mode prefill; and a twist-contaminated target set reporting ±20 steps (36.0 µm) with all four will-reach values correct.

Two defects were found by that live pass and fixed here: "Targets match the current positions" rendered twice (hint line *and* disabled-reason line), and the header summary duplicated the body's success sentence verbatim.

## Docs

- `docs/motorized-tilt-manual-adjustment-ux-design.md` — the UX spec (produced with Fable against the real XAML/VMs).
- `plans/motorized-tilt-manual-adjustment-plan.md` — the implementation plan.
- A **Manual adjustment** section in the user manual, plus a cross-reference from the backfocus-bias explanation (the "lift the motors first" advice now points at this panel instead of the vendor app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017KJFFSHXgBoJfsyKLhpdM8