### PR TITLE
Backfocus correction gain: analysis, design and plan (docs only)

### DIFF
--- a/docs/backfocus-correction-gain-design.md
+++ b/docs/backfocus-correction-gain-design.md
@@ -299,3 +299,44 @@ The override control is a checkbox plus an always-visible-but-disabled TextBox d
   spacing; a corrector that leaves residual curvature by design has a non-zero target.
 - Whether γ should eventually be measured at two piston offsets within one calibration, which would
   give the local slope without relying on the drift correction being right.
+
+---
+
+## Appendix: what else the same capture showed
+
+Two findings from the same 2026-08-04 session that belong to the *tilt calibration accuracy* work
+(PR #178), recorded here because that is where the data lives. Neither changes this design.
+
+### The measured final re-baseline did not help on this run
+
+`ReBaseline3` was added on the hypothesis that screw 2's move is contaminated by drift, because it is
+referenced to `ReBaseline2` alone while screw 1 is bracketed by two re-baselines. This run is the
+first captured with it. Recomputing the *same* run with and without the RB3 reference isolates its
+contribution exactly:
+
+| estimator | ratio without RB3 | ratio with RB3 | spread without | spread with |
+|---|---|---|---|---|
+| per-star paraboloid | **1.017** | 1.054 | ±0.018 | ±0.055 |
+| corner-region AF | 1.108 | **1.094** | ±0.107 | ±0.094 |
+
+RB3 contributed essentially nothing, and slightly *degraded* the paraboloid. The run's headline
+improvement over `ghilios_corrected` (move ratio 1.054 against 1.457, estimator disagreement 2.1%
+against 26%, SNR 15.7 against 7.2) came from **run quality, not from RB3**. The drift structure shows
+why: this run's re-baseline steps are 24 and 48 units at 23.7° apart (small, monotonic), where the
+earlier run's were 108 and 86 units at 179° apart (large, reversing).
+
+There is also a design limitation the original argument missed: **RB3's own reading carries the
+hysteresis of undoing the DiagonalB move**, so `mid(ReBaseline2, ReBaseline3)` is not a clean drift
+interpolation when the endpoint has its own settling. The case for interpolation over extrapolation
+assumed clean bracketing endpoints; that assumption is not free.
+
+Verdict: RB3 is cheap insurance that helps on drifty runs and is mildly harmful on clean ones.
+Keeping it default-ON remains defensible, but this dataset does not validate it, and the claim that
+it would fix screw 2 should not be repeated without evidence.
+
+### Field dependence of the frame factor is smaller than previously estimated
+
+Measured drift-immune as the difference between the centre and corner-mean piston slopes (8.700 vs
+8.634 focuser steps per motor step): **0.76%** out to r = 14.43 mm. This supersedes the 3.5% ± 1.3%
+figure derived earlier from separately drift-corrected centre and corner pistons, and it tightens the
+conclusion that field dependence contributes almost nothing to the piston-versus-tilt gap.

--- a/docs/backfocus-correction-gain-design.md
+++ b/docs/backfocus-correction-gain-design.md
@@ -1,6 +1,6 @@
 # Backfocus Correction Gain: Why the Recommended Move Is ~7× Too Small
 
-**Status:** design, not yet implemented. Companion plan: `plans/backfocus-correction-gain-plan.md`.
+**Status:** design, not yet implemented. §8 (apply-time UX) reflects a UX design pass. Companion plan: `plans/backfocus-correction-gain-plan.md`.
 
 **Datasets:** `D:\TiltCalibrationDebug\WithExtraBaseline` (7-step calibration, schema 3) and
 `D:\TiltCalibrationDebug\Minus_{100..500}` (five aberration-inspector runs at cumulative piston
@@ -141,10 +141,10 @@ the honest handling is to apply the corrected value and make the choice visible 
    figure as the recommendation and the uncorrected one alongside it for comparison, labelled with γ
    and its provenance. At the point of applying, the user can override the amount or scale it back —
    the corrected move is a floor (§6) and iterating is the intended workflow, so a partial apply must
-   be a first-class action rather than a workaround. The detailed UX is specified in §9.
+   be a first-class action rather than a workaround. The detailed UX is specified in §8.
 6. **Hands-off automation follows a pre-set policy.** Automatic Adjustment applies without a user
    present, so its behaviour is decided in advance in settings rather than at apply time, including
-   what it does when γ is unavailable. See §9.
+   what it does when γ is unavailable. See §8.5.
 7. **Default `MeasureCurvatureDuringCalibration` to ON.** It is now the source of three distinct
    quantities — adapter direction, piston-implied pitch, and γ — and without it most users never get
    an accurate backfocus number. Both optional measurement steps gain explanatory copy stating what
@@ -172,7 +172,7 @@ determined even when the extrapolation to zero sag is not.
   silently. That was reversed: continuing to apply a figure measured to be 7× too small is not
   caution, it is a known defect left in place. The correct handling is to apply the corrected value,
   keep the uncorrected one visible for comparison, and make overriding or scaling back a first-class
-  action at apply time (§9).
+  action at apply time (§8).
 - **Sanity band before persistence**, so a bad run cannot poison later runs that rely on the
   persisted value.
 - **γ is reported as a gain, not folded into the pitch.** They are independent quantities measured by
@@ -180,14 +180,117 @@ determined even when the extrapolation to zero sag is not.
 - **No change to the tilt term.** Gain 1.0 is correct there and is validated by the synthetic
   round-trip test added in PR #178.
 
-## 9. Apply-time UX
+## 8. Apply-time UX
 
-Being designed; this section will carry the panel layout, the control for overriding or scaling back
-the move, the out-of-range (spacer-not-adapter) treatment, and the hands-off automation policy and
-its default. Until it lands, §5.5 and §5.6 state the intent and §7 records why the earlier
-"never auto-apply" position was reversed.
+### 8.1 The three apply surfaces, and the invariant between them
 
-## 8. Open questions
+- **The Tilt Adapter Guidance table.** For a hand-turned adapter *the table is the apply surface* —
+  the user's hands execute it. There is no software control to attach a choice to.
+- **Automatic Adjustment (T14).** `RunAutomaticAdjustmentAsync` unconditionally awaits
+  `showAdjustmentPromptAsync` — **there is always an approval dialog**. This corrects a premise in
+  the brief that produced this design: there is no unattended apply path today.
+- **The Manual Adjustment pad.** Raw user-typed steps, not guidance-driven. Untouched.
+
+`BuildPerScrewTargets` was deliberately written so the planner "can never diverge from the guidance
+table the user actually approved". **That single-pipeline property is a safety feature and this
+design preserves it**: there is one resolved backfocus figure, and both the table and the planner use
+it. The apply-time *choice* therefore lives only where software sends moves — the approval dialog.
+
+### 8.2 The corrected figure owns the table
+
+The Backfocus and Total rows show the **gain-corrected** amounts. The uncorrected figure appears as a
+single comparison line beneath the table, **not** as a parallel column: two per-screw Totals would
+leave a manual user with two instructions and no recommendation. This resolves an ambiguity in §5.5,
+whose wording permitted the worse layout.
+
+```
+  Backfocus  +974 steps  +974 steps  +974 steps  +974 steps
+  Total      +992 steps  +967 steps  +956 steps  +981 steps
+  Backfocus is gain-corrected: γ = 0.140 (measured) · uncorrected: +137 steps
+```
+
+When γ is unavailable the table shows the uncorrected figure and the line reads: *"Backfocus is a
+lower bound: the gain is unmeasured, and plate travel rarely changes curvature 1:1 — the real move is
+usually several times larger. Run a calibration with Measure direction on to measure it."*
+
+### 8.3 The apply-time control
+
+The approval dialog's Apply row gains an amount selector beside the Backfocus checkbox — a ComboBox
+of four fixed presets, recomputed per invocation and **never persisted** (a remembered scale-back
+would silently degrade every later session):
+
+```
+Apply  [x] Tilt correction  [x] Backfocus correction  [Corrected · +974 steps ▾]  γ = 0.140 (measured)
+                                                       │ Half · +487 steps
+                                                       │ Quarter · +244 steps
+                                                       │ Uncorrected · +137 steps (gain 1.0)
+```
+
+Default is Corrected. Changing the selection re-invokes the replanner so the move list stays WYSIWYG,
+honouring the contract `ApplyTilt`/`ApplyBackfocus` already keep. With γ unavailable the ComboBox
+collapses to `+137 steps (lower bound — gain unmeasured)`.
+
+**Presets rather than a percentage or free step entry.** A bare percentage hides the physical number
+being approved; free entry duplicates the Manual Adjustment pad, which already exists for arbitrary
+amounts; presets make the choice auditable as one token in the log. "Uncorrected" is included as an
+honestly-labelled continuity option, not disguised as a percentage. Because the corrected figure is a
+floor (§6), partial application is the *intended* workflow — Half and Quarter are normal iteration
+granularity, not expressions of distrust.
+
+### 8.4 Out of range means a spacer, not a bigger command
+
+The per-command cap is **not** the right trigger: 974 steps against a 200-step cap simply means the
+planner emits five chunked commands, which `TiltMovePlanner.ApplyCap` already handles correctly. The
+quantity a human can act on is **common-mode plate travel in millimetres**, with a fixed **1.0 mm**
+advisory threshold (a constant, not an option — it needs no per-rig tuning).
+
+The advisory is **never blocking**. It appears under the guidance table and, tracking the selected
+preset, in the dialog. The existing hard travel limit (`TiltDeviceMaxExcursionSteps`) remains the only
+thing that stops Proceed. Text:
+
+> The corrected backfocus move is about {0:0.00} mm of plate travel — more than a tilt adapter is
+> meant to take up. Change the camera spacing by about that amount (in the direction the Backfocus
+> arrows show) and keep the adapter for the remaining trim. The corrected figure is a lower bound, so
+> re-measure after adjusting.
+
+γ applies to spacers identically: the §2 mechanism is spacing → refocus → magnification, however the
+spacing changes.
+
+### 8.5 Automation policy: deliberately no new setting
+
+**Automatic Adjustment applies 100% of the same resolved figure the guidance table shows.** There is
+no `AutomationBackfocusPolicy` enum, and one must not be added later — it would break the
+single-pipeline invariant in §8.1, letting the table say one thing and the hardware do another.
+
+Full application is right because the corrected figure is a floor (§6): the magnitude it converts is
+itself under-read, so even 100% under-shoots in expectation. Overshoot could only come from a
+mis-measured γ, which the sanity band caps, the AllInward/sweep cross-validation supports (2.1%
+agreement), and the excursion limit physically bounds. Defaulting automation to Half would rebuild
+the same defect at 2× instead of 7×.
+
+When γ is unavailable, automation applies the uncorrected figure labelled a lower bound — today's
+behaviour. Skipping backfocus entirely would regress unmeasured rigs, and under-moving is
+directionally safe: each cycle re-measures, so gain-1 application still converges, just slowly.
+
+**The escape hatch is the γ override, with its range widened to [0.05, 1.0].** The *measurement* band
+stays [0.05, 0.5] — that band encodes "γ ≈ 1 is physically implausible as a measurement". A manual
+override is a user assertion, not a measurement, and capping it at 0.5 would leave no way to request
+legacy behaviour. Override = 1.0 exactly reproduces pre-change behaviour and is documented as such.
+
+### 8.6 Provenance
+
+One short parenthetical wherever γ appears; the mechanism lives in tooltips. The inspector says
+`measured` or `manual override` (it cannot distinguish this run from an earlier one and should not
+pretend to). The wizard's results panel shows a self-labelling row in the `PistonPitchDisplay`
+pattern, **including the rejected case** — silently treating an out-of-band γ as unmeasured is right
+for persistence but confusing as display:
+
+> Backfocus gain: rejected (measured 0.62, outside 0.05–0.5) — not saved; guidance keeps the previous value.
+
+The override control is a checkbox plus an always-visible-but-disabled TextBox driven by a
+`DataTrigger`, keeping `TiltAdapterWizard/DataTemplates.xaml` converter-free per its THEME HAZARD note.
+
+## 9. Open questions
 
 - Whether γ is stable across focuser position. It is measured near the calibration focus; the
   required correction may be millimetres away, where m — and therefore γ — differs. The measured 1.3%

--- a/docs/backfocus-correction-gain-design.md
+++ b/docs/backfocus-correction-gain-design.md
@@ -1,0 +1,181 @@
+# Backfocus Correction Gain: Why the Recommended Move Is ~7× Too Small
+
+**Status:** design, not yet implemented. Companion plan: `plans/backfocus-correction-gain-plan.md`.
+
+**Datasets:** `D:\TiltCalibrationDebug\WithExtraBaseline` (7-step calibration, schema 3) and
+`D:\TiltCalibrationDebug\Minus_{100..500}` (five aberration-inspector runs at cumulative piston
+offsets of −100 … −500 motor steps on all four screws), captured 2026-08-04 on a 4-screw ASG EAT
+(spec 1.8 µm/step, radius 55 mm) with an IMX455-class sensor (9576×6388 @ 3.76 µm), focuser step
+0.269 µm, f/6.3, 882 mm, corrector mounted on the drawtube.
+
+---
+
+## 1. The defect
+
+`TiltScrewGeometry.ScrewCorrectionMicrons` computes the backfocus component as the fitted
+paraboloid's curvature sag evaluated at the screw position:
+
+```csharp
+double backfocusCorrection = -(kx * cx * cx + ky * cy * cy);
+```
+
+`SignedTotalAdjustment` then divides by µm-per-step to get a screw move. The method's own doc
+comment states the assumption plainly: *"Both are in axial best-focus microns (the same unit as
+physical screw travel), so the total is simply their sum."*
+
+That is an **implicit gain of 1.0** — move the plate by X microns, remove X microns of curvature.
+
+For the **tilt** term the assumption is exactly right: displacing a screw by X tilts the plane by X
+at that screw, by construction. The code applies the same reasoning to the **curvature** term, where
+it does not hold. Translating a flat sensor along the optical axis cannot make it match a curved
+focal surface; it only re-centres the defocus. What actually changes the field curvature is a
+second-order effect, and it is much weaker than 1:1.
+
+**Measured gain on this rig: 0.140.** The backfocus recommendation therefore understates the
+required move by **7.1×**.
+
+| | steps | plate travel |
+|---|---|---|
+| what the model recommends today | 137 | 0.25 mm |
+| what the measurement says is required | 974 | 1.75 mm |
+
+## 2. The mechanism
+
+The chain matters, because it determines when the gain is non-zero at all.
+
+1. The tilt adapter sits between the corrector and the sensor, so moving the plate by δ is a pure
+   image-space displacement: defocus changes by δ, coefficient 1.
+2. Restoring focus moves the focuser by δ/m², where m is the corrector's transverse magnification
+   (the focuser moves corrector *and* camera together, so in the corrector's frame the object moves
+   and the image follows with longitudinal magnification m²).
+3. **Because the corrector rides the drawtube, that focuser move changes the corrector-to-focal-plane
+   distance**, and therefore changes m: `dm = −(m/f)·Δ = −δ/(m·f)`.
+4. A corrector only cancels the telescope's field curvature exactly at its design magnification. The
+   change in m leaves residual curvature, which is what the sensor measures as a change in sag.
+
+So the backfocus gain is a *composite* quantity: field-curvature sensitivity to corrector position,
+mediated by the refocus that the plate move forces.
+
+**Consequence worth stating explicitly:** on a rig where the corrector is threaded to the telescope
+and only the camera moves, step 3 does not happen, m never changes, and γ ≈ 0 — the tilt adapter
+could not correct backfocus at all, at any travel. The correction only works because the corrector
+moves with the focuser.
+
+## 3. Can γ be predicted from the reducer ratio?
+
+**No — not from the ratio alone.** From §2, γ ∝ (1/f)·(dSag/dm). Predicting it requires:
+
+- the corrector's **focal length** f (not the reducer ratio), and
+- **dSag/dm**, how much residual field curvature a unit change in magnification produces — a property
+  of the corrector's internal design (element powers and spacings), not of its net magnification.
+
+Two correctors with the same 0.9× ratio can have quite different γ. Working the numbers backwards on
+this rig: closing the measured 25.08 µm of sag at r = 14.43 mm needs Δm ≈ 0.0116 (a 1.2% change in
+magnification), which implies dSag/dm ≈ 2172 µm at that radius. Nothing in "0.9×" predicts that.
+
+**What *can* seed γ without measuring it:** manufacturers commonly publish a backfocus tolerance
+("55 mm ± 0.5 mm"). That tolerance is γ in disguise — it is the spacing error at which residual
+curvature becomes visually unacceptable. If a user knows their corrector's tolerance and the sag
+threshold it implies, γ can be estimated to within a factor of ~2. That is far better than the
+current 7× error, and it is the basis for the manual-override path in §5.
+
+The measurement remains strictly better, and it is already free (§4).
+
+## 4. The calibration run already measures γ
+
+The **AllInward** step is a controlled piston: all four screws move by a known amount, and the
+curvature effect is measured before and after. That is exactly the experiment needed.
+
+It must be **drift-corrected**, using the same `mid(Baseline, ReBaseline1)` reference the piston-implied
+pitch already uses — the curvature itself drifts substantially over a run (−268.6 → −194.1 µm across
+this run's four baseline-equivalent states, ≈ +3.1 µm/min):
+
+| | value |
+|---|---|
+| Baseline curvature effect at r = 55 mm | −268.6 µm |
+| ReBaseline1 | −223.7 µm |
+| drift-corrected reference, mid(Baseline, ReBaseline1) | **−246.11 µm** |
+| AllInward | −208.2 µm |
+| Δ over 150 steps | **+37.88 µm → 0.2526 µm/step** |
+
+**Validation against an independent experiment.** The five-run piston sweep (−100 … −500, a 3.3×
+larger excursion in the opposite direction) gives **0.258 µm/step**. The two agree to **2.1%**.
+
+Drift correction is not optional: uncorrected, the AllInward delta reads 0.402 µm/step, **59% too
+high**. The same sweep, uncorrected, reads 1.958 µm/step for the piston pitch instead of 2.32 —
+thermal drift of −26.2 focuser steps/min ate 18% of the signal.
+
+### Supporting results from the same datasets
+
+- **Piston pitch cross-validated.** AllInward (single +150 push) gives 2.3058 µm/step; the
+  drift-corrected 5-run sweep (−500 pull) gives 2.3226–2.3404. Agreement ~1% across opposite
+  directions and a 3× range difference.
+- **Frame factor F = 1.29–1.30 → m ≈ 0.88**, consistent with a ~0.9× corrector.
+- **The piston response is linear to ~1.3%** over 930 µm of focuser travel. The residual quadratic
+  has the sign and magnitude predicted by F = 1/m² with the corrector moving. Non-linearity is real
+  but is not a significant error source at these excursions.
+- **Field dependence of F is 0.76%** out to r = 14.43 mm, measured drift-immune as the difference
+  between the centre and corner-mean piston slopes (8.700 vs 8.634 focuser steps per motor step).
+  This is tighter than, and supersedes, the 3.5% ± 1.3% figure derived earlier from separately
+  drift-corrected centre and corner pistons.
+
+## 5. Design
+
+**γ is measured, persisted, and shown — and the corrected number is presented alongside the current
+one rather than replacing it.** The 7× change is too large to apply silently on the strength of one
+measurement per run.
+
+1. **Compute γ** in `TiltCalibrationCalculator`, from the drift-corrected AllInward curvature delta,
+   as a dimensionless gain (µm of curvature effect per µm of plate travel). NaN when no piston ran.
+2. **Sanity-band it.** Accept only γ ∈ [0.05, 0.5]. Outside that, treat it as unmeasured — a
+   mis-measured γ is the principal risk of this change, and one noisy run must not produce a
+   multi-millimetre recommendation.
+3. **Persist** the last accepted γ alongside the measured pitch, so runs that skip the piston step
+   still benefit. Record its provenance (measured this run / persisted from an earlier run /
+   manual override / unavailable).
+4. **Manual override.** Let the user enter γ directly, for rigs where the corrector's published
+   backfocus tolerance is the best available information (§3), or where they have measured it
+   themselves.
+5. **Show both values.** The guidance displays the current (gain = 1) backfocus figure and the
+   gain-corrected figure side by side, labelled with γ and its provenance. The user chooses. This is
+   deliberately not an auto-apply: see §7.
+6. **Default `MeasureCurvatureDuringCalibration` to ON.** It is now the source of three distinct
+   quantities — adapter direction, piston-implied pitch, and γ — and without it most users never get
+   an accurate backfocus number. Both optional measurement steps gain explanatory copy stating what
+   the extra autofocus runs buy.
+
+## 6. What this does not fix
+
+γ corrects the **conversion**. It does not correct the **curvature magnitude** being converted, and
+the two errors compound.
+
+The magnitude comes from the fitted paraboloid, which §4 of
+`tilt-calibration-pitch-nonlinearity-design.md` shows under-reads curvature. On this run the
+paraboloid puts the baseline curvature effect at −246 µm while the corner-region AF puts it at
+−364 µm — a factor of 1.48, which is the difference between a 1.75 mm and a 2.54 mm recommendation.
+
+So after this change the recommendation should still be expected to land low, and should be treated
+as a floor rather than a target until the vertex-estimator work in §8 of that document is done.
+Iterating (apply, re-measure, refit) converges regardless, because the *local* gain is well
+determined even when the extrapolation to zero sag is not.
+
+## 7. Deliberate decisions
+
+- **Show both values rather than auto-applying.** A 7× change in a recommendation that drives
+  physical hardware adjustment should not switch over silently on one run's measurement.
+- **Sanity band before persistence**, so a bad run cannot poison later runs that rely on the
+  persisted value.
+- **γ is reported as a gain, not folded into the pitch.** They are independent quantities measured by
+  different parts of the same step, and conflating them would make both harder to debug.
+- **No change to the tilt term.** Gain 1.0 is correct there and is validated by the synthetic
+  round-trip test added in PR #178.
+
+## 8. Open questions
+
+- Whether γ is stable across focuser position. It is measured near the calibration focus; the
+  required correction may be millimetres away, where m — and therefore γ — differs. The measured 1.3%
+  non-linearity in the piston response suggests the drift is small over ~1 mm, but this is untested.
+- Whether the sag target is exactly zero. The design assumes the corrector fully flattens at correct
+  spacing; a corrector that leaves residual curvature by design has a non-zero target.
+- Whether γ should eventually be measured at two piston offsets within one calibration, which would
+  give the local slope without relying on the drift correction being right.

--- a/docs/backfocus-correction-gain-design.md
+++ b/docs/backfocus-correction-gain-design.md
@@ -121,9 +121,10 @@ thermal drift of −26.2 focuser steps/min ate 18% of the signal.
 
 ## 5. Design
 
-**γ is measured, persisted, and shown — and the corrected number is presented alongside the current
-one rather than replacing it.** The 7× change is too large to apply silently on the strength of one
-measurement per run.
+**γ is measured, persisted, and used** — the corrected figure is what the apply path acts on. The
+uncorrected figure stays visible for comparison, and the user can override or scale back the move at
+the point of applying. Applying a known-wrong number by default is not a defensible conservatism;
+the honest handling is to apply the corrected value and make the choice visible and adjustable.
 
 1. **Compute γ** in `TiltCalibrationCalculator`, from the drift-corrected AllInward curvature delta,
    as a dimensionless gain (µm of curvature effect per µm of plate travel). NaN when no piston ran.
@@ -136,10 +137,15 @@ measurement per run.
 4. **Manual override.** Let the user enter γ directly, for rigs where the corrector's published
    backfocus tolerance is the best available information (§3), or where they have measured it
    themselves.
-5. **Show both values.** The guidance displays the current (gain = 1) backfocus figure and the
-   gain-corrected figure side by side, labelled with γ and its provenance. The user chooses. This is
-   deliberately not an auto-apply: see §7.
-6. **Default `MeasureCurvatureDuringCalibration` to ON.** It is now the source of three distinct
+5. **Apply the corrected value, with the choice exposed.** The guidance shows the gain-corrected
+   figure as the recommendation and the uncorrected one alongside it for comparison, labelled with γ
+   and its provenance. At the point of applying, the user can override the amount or scale it back —
+   the corrected move is a floor (§6) and iterating is the intended workflow, so a partial apply must
+   be a first-class action rather than a workaround. The detailed UX is specified in §9.
+6. **Hands-off automation follows a pre-set policy.** Automatic Adjustment applies without a user
+   present, so its behaviour is decided in advance in settings rather than at apply time, including
+   what it does when γ is unavailable. See §9.
+7. **Default `MeasureCurvatureDuringCalibration` to ON.** It is now the source of three distinct
    quantities — adapter direction, piston-implied pitch, and γ — and without it most users never get
    an accurate backfocus number. Both optional measurement steps gain explanatory copy stating what
    the extra autofocus runs buy.
@@ -161,14 +167,25 @@ determined even when the extrapolation to zero sag is not.
 
 ## 7. Deliberate decisions
 
-- **Show both values rather than auto-applying.** A 7× change in a recommendation that drives
-  physical hardware adjustment should not switch over silently on one run's measurement.
+- **Apply the corrected value rather than the known-wrong one.** An earlier draft of this design kept
+  the uncorrected figure as what gets applied, on the grounds that a 7× change should not switch over
+  silently. That was reversed: continuing to apply a figure measured to be 7× too small is not
+  caution, it is a known defect left in place. The correct handling is to apply the corrected value,
+  keep the uncorrected one visible for comparison, and make overriding or scaling back a first-class
+  action at apply time (§9).
 - **Sanity band before persistence**, so a bad run cannot poison later runs that rely on the
   persisted value.
 - **γ is reported as a gain, not folded into the pitch.** They are independent quantities measured by
   different parts of the same step, and conflating them would make both harder to debug.
 - **No change to the tilt term.** Gain 1.0 is correct there and is validated by the synthetic
   round-trip test added in PR #178.
+
+## 9. Apply-time UX
+
+Being designed; this section will carry the panel layout, the control for overriding or scaling back
+the move, the out-of-range (spacer-not-adapter) treatment, and the hands-off automation policy and
+its default. Until it lands, §5.5 and §5.6 state the intent and §7 records why the earlier
+"never auto-apply" position was reversed.
 
 ## 8. Open questions
 

--- a/plans/backfocus-correction-gain-plan.md
+++ b/plans/backfocus-correction-gain-plan.md
@@ -1,0 +1,154 @@
+# Backfocus Correction Gain Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the Aberration Inspector's backfocus guidance understating the required move by ~7×. Measure the backfocus correction gain γ from the calibration run's own AllInward piston, persist it, and present the gain-corrected move **alongside** today's figure rather than replacing it.
+
+**Architecture:** γ is computed in `TiltCalibrationCalculator` (pure, shared by wizard and TestApp) from the drift-corrected AllInward curvature delta, sanity-banded, and surfaced on `TiltCalibrationResult` + metadata. `TiltAdapterOptions` persists the last accepted γ with its provenance and offers a manual override. `TiltScrewGeometry` gains a gain-aware backfocus overload; the existing gain-1.0 path is untouched so both numbers can be shown. Guidance renders both.
+
+**Tech Stack:** C# / .NET 8 (WPF plugin), NUnit 4.4 (`dotnet.exe test` via WSL interop), Newtonsoft JSON metadata.
+
+**Read first (execution session):** `docs/backfocus-correction-gain-design.md` (the spec — §2 for the mechanism, §4 for the measurement and its validation, §5 for the design, §7 for what must not be "simplified"), `docs/tilt-calibration-pitch-nonlinearity-design.md` §4 and §8 (the compounding curvature under-read), `.claude/docs/mvvm-patterns.md`, `.claude/docs/options-system.md`, `.claude/docs/wpf-xaml.md`, `.claude/docs/documentation-style.md`.
+
+**Locked decisions (from the investigation — do not relitigate mid-execution):**
+- γ is **shown alongside** the current figure, never silently substituted. A 7× change to a number that drives physical hardware adjustment does not switch over on one run's measurement.
+- **Automation keeps today's behaviour.** T14 Automatic Adjustment and any hands-off apply path continue to use the gain-1.0 value in this plan. Changing what automation applies is a separate, deliberate decision.
+- Sanity band γ ∈ **[0.05, 0.5]**. Outside it, γ is treated as unmeasured and is **not** persisted.
+- γ is drift-corrected against **mid(Baseline, ReBaseline1)** — the same reference `PistonImpliedMicronsPerStep` already uses. Uncorrected it reads 59% high; this is not optional.
+- γ is a **dimensionless gain** (µm of curvature effect per µm of plate travel), reported separately from the pitch. Do not fold it into `unitMicrons`.
+- The **tilt** term keeps gain 1.0. It is correct there and is locked by the synthetic round-trip test from PR #178.
+- `MeasureCurvatureDuringCalibration` **default flips to ON**.
+- Metadata `CurrentSchemaVersion` 3→4, all new fields additive with NaN/empty defaults.
+
+**Branch:** all work on `ghilios/backfocus-correction-gain` off `develop`. Never push `develop`. Commits use:
+```bash
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" -m "<message>"
+```
+Test command template (WSL → Windows dotnet; timeout 600000, never pipe through `tail`):
+```bash
+dotnet.exe test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo --filter "FullyQualifiedName~<FixtureName>"
+```
+
+**Reference numbers** (from `D:\TiltCalibrationDebug\WithExtraBaseline`, for tests and validation):
+Baseline curvature effect at r=55 mm −268.6 µm; ReBaseline1 −223.7; mid = −246.11; AllInward −208.2;
+Δ = +37.88 µm over 150 steps → **0.2526 µm/step → γ = 0.1403**. Independent 5-run sweep: 0.258 µm/step → γ = 0.1433 (agree 2.1%).
+
+---
+
+### Task 0: Branch setup
+
+- [ ] **Step 0.1:** `git checkout develop && git pull && git checkout -b ghilios/backfocus-correction-gain`
+- [ ] **Step 0.2:** Confirm clean: `git status` → "nothing to commit".
+
+---
+
+### Task 1: Compute γ in the calculator
+
+**Files:** Modify `TiltAdapterWizard/TiltCalibrationCalculator.cs`; Test `Tests/TiltAdapterWizard/TiltCalibrationCalculatorTests.cs`
+
+- [ ] **Step 1.1: Read first.** `PistonImpliedMicronsPerStep` (the drift-correction pattern to mirror) and `TiltCalibrationInputs` — confirm whether the per-step **curvature effect at screw radius** is already an input. It is currently carried on the wizard's `StepReading` as `CurvatureEffectAtScrewRadiusMicrons` but may not be on `TiltCalibrationInputs`. If absent, add `BaselineCurvatureEffectMicrons`, `AllInwardCurvatureEffectMicrons`, `ReBaseline1CurvatureEffectMicrons` (NaN defaults). Report what you found.
+- [ ] **Step 1.2: Write the failing tests** — the real run's numbers, plus the guards:
+  - `BackfocusGain_DriftCorrectedFromBracketingBaselines`: baseline −268.6, reBaseline1 −223.7, allInward −208.2, applied 150, pitch 1.8 → γ = 0.1403 within 1e-3.
+  - `BackfocusGain_NaNWithoutCurvatureSteps`: `HasCurvatureMeasurement = false` → NaN.
+  - `BackfocusGain_OutsideSanityBand_ReturnsNaN`: `[TestCase]` values that produce γ = 0.01 and γ = 0.9 → NaN.
+  - `BackfocusGain_UncorrectedWouldRead59PercentHigh`: assert the drift-corrected value differs from the naive `AllInward − Baseline` value by the expected margin, so a future "simplification" that drops the drift correction fails loudly.
+- [ ] **Step 1.3: Run** `--filter "FullyQualifiedName~TiltCalibrationCalculatorTests"` → the new tests FAIL (method missing).
+- [ ] **Step 1.4: Implement** `public static double BackfocusCorrectionGain(TiltCalibrationInputs inputs)` returning the dimensionless gain: drift-corrected Δcurvature ÷ (applied × unitMicrons). Return NaN when no curvature measurement, when applied/unit are non-positive, or when the result falls outside [0.05, 0.5]. Doc comment must state the §2 mechanism in brief (the gain exists only because the corrector rides the drawtube) and why the drift correction is load-bearing.
+- [ ] **Step 1.5:** Add `public double BackfocusCorrectionGain { get; set; }` to `TiltCalibrationResult`, populated in `Calibrate`.
+- [ ] **Step 1.6: Run** the fixture → green. **Commit** — `feat(tilt): measure the backfocus correction gain from the AllInward piston`
+
+---
+
+### Task 2: Gain-aware backfocus correction
+
+**Files:** Modify `TiltAdapterWizard/TiltScrewGeometry.cs`; Test `Tests/TiltAdapterWizard/TiltScrewGeometryTests.cs`
+
+- [ ] **Step 2.1: Read** `ScrewCorrectionMicrons` and `SignedTotalAdjustment`. Note that with a centred apex (`fixedSensorCenter = true`, so x0 = y0 = 0) and isotropic curvature (astigmatic disabled, kx = ky), every screw at the same radius gets an **identical** backfocus correction — so the gain-corrected figure is one number, not four. Confirm this before designing the API.
+- [ ] **Step 2.2: Write failing tests** proving (a) the existing gain-1.0 result is unchanged when no gain is supplied, and (b) supplying γ = 0.1403 scales the backfocus component by 1/γ ≈ 7.13 while leaving the **tilt** component bit-identical.
+- [ ] **Step 2.3: Implement** an additive overload carrying γ. Do **not** modify the existing signature's behaviour — both numbers must remain computable side by side. The tilt term must not be touched.
+- [ ] **Step 2.4: Run** → green. **Commit** — `feat(tilt): gain-aware backfocus correction alongside the existing one`
+
+---
+
+### Task 3: Persist γ, its provenance, and a manual override
+
+**Files:** Modify `Interfaces/ITiltAdapterOptions.cs`, `TiltAdapterWizard/TiltAdapterOptions.cs`, `TiltAdapterWizard/DataTemplates.xaml`; Test `Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs`
+
+- [ ] **Step 3.1:** Add `LastMeasuredBackfocusGain` (double, default NaN) and `BackfocusGainOverride` (double, default NaN) following the `LastMeasuredStepperStepSizeMicrons` accessor pattern verbatim.
+- [ ] **Step 3.2:** Add a resolver — override, else last-measured, else NaN — returning both the value and a provenance enum (`Manual`, `MeasuredThisRun`, `Persisted`, `Unavailable`). Unit-test each branch.
+- [ ] **Step 3.3:** UI: a numeric override field in the wizard's hardware section, next to the measured-pitch controls, with the file's established `BasedOn="{StaticResource StandardTextBlock}"` pattern (see the THEME HAZARD note at the top of `DataTemplates.xaml`).
+- [ ] **Step 3.4:** `RunCalibrationMath` writes `LastMeasuredBackfocusGain` only when the computed γ is non-NaN (i.e. passed the sanity band).
+- [ ] **Step 3.5: Run** options + wizard filters → green. **Commit** — `feat(tilt): persist the backfocus gain with provenance and a manual override`
+
+---
+
+### Task 4: Show both figures in the guidance
+
+**Files:** Modify `AutoFocus/InspectorVM.cs`, the tilt-guidance VM and its DataTemplates; Test `Tests/AutoFocus/InspectorVMBehavioralTests.cs`
+
+- [ ] **Step 4.1: Read** `ComputePerScrewTargets` and how `Screw*BackfocusAmount` reaches the guidance table, before designing the presentation.
+- [ ] **Step 4.2:** Compute both backfocus figures. Surface the gain-corrected one as a **single** value (per Step 2.1) with a label carrying γ and its provenance, e.g. *"Backfocus (gain-corrected, γ = 0.140 measured): 974 steps"*. Keep the existing per-screw column exactly as it is.
+- [ ] **Step 4.3:** When γ is unavailable, show only today's figure and label it a **lower bound** — do not silently imply it is the answer.
+- [ ] **Step 4.4:** Add a note when the gain-corrected move exceeds `TiltDeviceMaxStepsPerCommand` or plausible adapter travel, stating that a spacer change is indicated rather than an adapter move. On the reference rig this fires: 974 steps ≈ 1.75 mm against a 200-step per-command cap.
+- [ ] **Step 4.5: Write VM tests:** both figures present with a measured γ; lower-bound labelling with no γ; the spacer note firing past the cap.
+- [ ] **Step 4.6: Run** inspector + wizard filters → green. **Commit** — `feat(inspector): show the gain-corrected backfocus move alongside the uncorrected one`
+
+---
+
+### Task 5: Metadata and TestApp
+
+**Files:** Modify `TiltAdapterWizard/TiltCalibrationMetadata.cs`, `TestApp/TiltCalibrationRunner.cs`; Tests as appropriate
+
+- [ ] **Step 5.1:** `CurrentSchemaVersion` 3→4. `TiltCalibrationResultRecord` gains `BackfocusCorrectionGain` (NaN default); per-step records gain the curvature-effect fields if Task 1 needed them. Extend the existing round-trip tests the way Task 4 of the previous plan did — assert the new fields, don't just set them.
+- [ ] **Step 5.2:** TestApp `tilt` prints γ, its drift-corrected inputs, and the implied backfocus move next to the existing piston line. Extend the JSON additively.
+- [ ] **Step 5.3: Run** metadata + calculator filters → green. **Commit** — `feat(testapp): report the backfocus correction gain in the tilt validator`
+
+---
+
+### Task 6: Default the piston step ON, with explanatory copy
+
+**Files:** Modify `TiltAdapterWizard/TiltAdapterOptions.cs`, `TiltAdapterWizard/DataTemplates.xaml`, `documentation/docs/overview/tilt-adapter-wizard.md`
+
+- [ ] **Step 6.1:** Flip `MeasureCurvatureDuringCalibration` default to `true`. Update every test that assumed the 4-step default flow — expect several; check `GetMeasurementSteps` callers and the `NextStep_*` walks.
+- [ ] **Step 6.2:** Apply the tooltip strings and manual passage drafted for this task (they explain what the extra autofocus runs buy for **Measure direction** and **Measure final re-baseline**). Do not write fresh copy without reading `.claude/docs/documentation-style.md`.
+- [ ] **Step 6.3:** Update any remaining step-count prose made stale by the new default (`motorized-tilt-adapter.md` was corrected once already for the ReBaseline3 default — check it again).
+- [ ] **Step 6.4: Run** the full wizard filter → green. `mkdocs build --strict` clean. **Commit** — `feat(tilt): measure direction by default, and explain what the extra runs buy`
+
+---
+
+### Task 7: Validate against the captured datasets
+
+**Files:** Test only
+
+- [ ] **Step 7.1:** Add a run-literal regression test pinning γ = 0.1403 from `WithExtraBaseline`'s stored curvature effects through the production `Calibrate` path.
+- [ ] **Step 7.2:** Add a test documenting the independent cross-check: the 5-run piston sweep gives 0.258 µm/step against AllInward's 0.2526, agreeing to 2.1%. Pin both constants with a comment citing the design doc, so a future change that breaks the agreement is visible.
+- [ ] **Step 7.3:** Verify the end-to-end number: the reference rig's −246.11 µm curvature effect with γ = 0.1403 yields 974 steps ≈ 1.75 mm, against today's 137 steps ≈ 0.25 mm.
+- [ ] **Step 7.4: Run** → green. **Commit** — `test(tilt): pin the backfocus gain against both captured datasets`
+
+---
+
+### Task 8: Documentation
+
+- [ ] **Step 8.1:** In `tilt-adapter-wizard.md` and the inspector's backfocus documentation, explain that plate travel and curvature change are **not** one-for-one, that the ratio is rig-specific and measured, and how to read the two figures.
+- [ ] **Step 8.2:** State plainly that the recommendation remains a **floor** until the vertex-estimator work lands, because the curvature magnitude is separately under-read (design doc §6). Cross-reference `tilt-calibration-pitch-nonlinearity-design.md` §4/§8.
+- [ ] **Step 8.3:** Mark the design doc's §5 items implemented with commit refs.
+- [ ] **Step 8.4: Commit** — `docs(tilt): explain the backfocus correction gain and how to read both figures`
+
+---
+
+### Task 9: Final gate
+
+- [ ] **Step 9.1:** Full suite: `dotnet.exe test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`. All green (`SendAsync_WritesOnABackgroundThread` may flake — re-run in isolation before dismissing).
+- [ ] **Step 9.2:** Re-run the TestApp tilt replay against `D:\TiltCalibrationDebug\WithExtraBaseline` from the final tree; confirm γ prints as 0.140 and the implied move as ~974 steps.
+- [ ] **Step 9.3:** Push branch, open PR to `develop` titled "Backfocus correction gain: stop understating the required move by 7×". Body explains the gain-1.0 defect, the mechanism, the measurement and its independent validation, and states explicitly that automation behaviour is unchanged. End with the standard generated-with footer.
+
+---
+
+## Self-review notes (kept for the executor)
+
+- Spec coverage: §5.1 → Task 1; §5.2 → Task 1 (band) + Task 3 (persistence gate); §5.3 → Task 3; §5.4 → Task 3; §5.5 → Task 4; §5.6 → Task 6.
+- Type flow: `BackfocusCorrectionGain` is introduced on `TiltCalibrationResult` (Task 1), persisted via options (Task 3), consumed by `TiltScrewGeometry`'s new overload (Task 2) through the guidance (Task 4), serialized (Task 5).
+- Deliberate deviations an executor must not "fix": both figures are shown (no auto-apply); automation keeps gain 1.0; the tilt term keeps gain 1.0; γ stays separate from `unitMicrons`.
+- Steps 1.1, 2.1 and 4.1 are read-before-write checks: the curvature-effect plumbing into `TiltCalibrationInputs`, the per-screw-identical claim, and the guidance rendering path were reasoned about but not read line by line during planning.
+- Highest-risk task is 6: flipping a default changes the flow length and will break tests that assume 4 steps. Budget for that rather than being surprised by it.

--- a/plans/backfocus-correction-gain-plan.md
+++ b/plans/backfocus-correction-gain-plan.md
@@ -2,18 +2,20 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Stop the Aberration Inspector's backfocus guidance understating the required move by ~7×. Measure the backfocus correction gain γ from the calibration run's own AllInward piston, persist it, and present the gain-corrected move **alongside** today's figure rather than replacing it.
+**Goal:** Stop the Aberration Inspector's backfocus guidance understating the required move by ~7×. Measure the backfocus correction gain γ from the calibration run's own AllInward piston, persist it, and **apply** the gain-corrected move — with the uncorrected figure kept visible for comparison and the amount adjustable at the point of applying.
 
-**Architecture:** γ is computed in `TiltCalibrationCalculator` (pure, shared by wizard and TestApp) from the drift-corrected AllInward curvature delta, sanity-banded, and surfaced on `TiltCalibrationResult` + metadata. `TiltAdapterOptions` persists the last accepted γ with its provenance and offers a manual override. `TiltScrewGeometry` gains a gain-aware backfocus overload; the existing gain-1.0 path is untouched so both numbers can be shown. Guidance renders both.
+**Architecture:** γ is computed in `TiltCalibrationCalculator` (pure, shared by wizard and TestApp) from the drift-corrected AllInward curvature delta, sanity-banded, and surfaced on `TiltCalibrationResult` + metadata. `TiltAdapterOptions` persists the last accepted γ with its provenance and offers a manual override. `TiltScrewGeometry` gains a gain-aware backfocus overload; the existing gain-1.0 path is untouched so the comparison figure stays computable. The corrected figure owns the guidance table, and the approval dialog carries a preset selector for applying less than all of it.
 
 **Tech Stack:** C# / .NET 8 (WPF plugin), NUnit 4.4 (`dotnet.exe test` via WSL interop), Newtonsoft JSON metadata.
 
-**Read first (execution session):** `docs/backfocus-correction-gain-design.md` (the spec — §2 for the mechanism, §4 for the measurement and its validation, §5 for the design, §7 for what must not be "simplified"), `docs/tilt-calibration-pitch-nonlinearity-design.md` §4 and §8 (the compounding curvature under-read), `.claude/docs/mvvm-patterns.md`, `.claude/docs/options-system.md`, `.claude/docs/wpf-xaml.md`, `.claude/docs/documentation-style.md`.
+**Read first (execution session):** `docs/backfocus-correction-gain-design.md` (the spec — §2 for the mechanism, §4 for the measurement and its validation, §5 for the design, §7 for what must not be "simplified", §8 for the apply-time UX), `docs/tilt-calibration-pitch-nonlinearity-design.md` §4 and §8 (the compounding curvature under-read), `.claude/docs/mvvm-patterns.md`, `.claude/docs/options-system.md`, `.claude/docs/wpf-xaml.md`, `.claude/docs/documentation-style.md`.
 
 **Locked decisions (from the investigation — do not relitigate mid-execution):**
-- γ is **shown alongside** the current figure, never silently substituted. A 7× change to a number that drives physical hardware adjustment does not switch over on one run's measurement.
-- **Automation keeps today's behaviour.** T14 Automatic Adjustment and any hands-off apply path continue to use the gain-1.0 value in this plan. Changing what automation applies is a separate, deliberate decision.
-- Sanity band γ ∈ **[0.05, 0.5]**. Outside it, γ is treated as unmeasured and is **not** persisted.
+- **The corrected figure is what gets applied.** It owns the guidance table's Backfocus and Total rows; the uncorrected figure appears as a single comparison line beneath, never as a parallel column (two per-screw Totals would leave a hand-turning user with no recommendation). Design §8.2.
+- **Automatic Adjustment applies 100% of the same resolved figure**, with **no** new policy setting. `RunAutomaticAdjustmentAsync` always awaits the approval prompt, so the apply-time control covers it. Do **not** add an `AutomationBackfocusPolicy` enum — it would break the single-pipeline property that stops the planner diverging from the approved table. Design §8.5.
+- **Apply-time choice is four fixed presets** in the approval dialog (Corrected / Half / Quarter / Uncorrected), default Corrected, **never persisted**. Design §8.3.
+- **Out-of-range is judged in millimetres of plate travel, not the per-command cap** — 1.0 mm fixed advisory threshold, never blocking. The cap is a chunk size the planner already satisfies. Design §8.4.
+- Sanity band for a **measured** γ is **[0.05, 0.5]**; outside it γ is treated as unmeasured and is **not** persisted. The **manual override** range is **[0.05, 1.0]**, with 1.0 documented as restoring legacy behaviour — a measurement band and a user assertion are different things.
 - γ is drift-corrected against **mid(Baseline, ReBaseline1)** — the same reference `PistonImpliedMicronsPerStep` already uses. Uncorrected it reads 59% high; this is not optional.
 - γ is a **dimensionless gain** (µm of curvature effect per µm of plate travel), reported separately from the pitch. Do not fold it into `unitMicrons`.
 - The **tilt** term keeps gain 1.0. It is correct there and is locked by the synthetic round-trip test from PR #178.
@@ -75,9 +77,9 @@ Baseline curvature effect at r=55 mm −268.6 µm; ReBaseline1 −223.7; mid = �
 
 **Files:** Modify `Interfaces/ITiltAdapterOptions.cs`, `TiltAdapterWizard/TiltAdapterOptions.cs`, `TiltAdapterWizard/DataTemplates.xaml`; Test `Tests/TiltAdapterWizard/TiltAdapterOptionsTests.cs`
 
-- [ ] **Step 3.1:** Add `LastMeasuredBackfocusGain` (double, default NaN) and `BackfocusGainOverride` (double, default NaN) following the `LastMeasuredStepperStepSizeMicrons` accessor pattern verbatim.
+- [ ] **Step 3.1:** Add `LastMeasuredBackfocusGain` (double, default NaN), `BackfocusGainOverrideEnabled` (bool, default false) and `BackfocusGainOverride` (double, default NaN), following the `LastMeasuredStepperStepSizeMicrons` accessor pattern verbatim. Use an explicit enabled flag rather than a NaN sentinel — the UI is a checkbox plus an always-visible-but-disabled TextBox (design §8.6), which keeps `DataTemplates.xaml` converter-free.
 - [ ] **Step 3.2:** Add a resolver — override, else last-measured, else NaN — returning both the value and a provenance enum (`Manual`, `MeasuredThisRun`, `Persisted`, `Unavailable`). Unit-test each branch.
-- [ ] **Step 3.3:** UI: a numeric override field in the wizard's hardware section, next to the measured-pitch controls, with the file's established `BasedOn="{StaticResource StandardTextBlock}"` pattern (see the THEME HAZARD note at the top of `DataTemplates.xaml`).
+- [ ] **Step 3.3:** UI: checkbox + numeric override field in the wizard's hardware section, next to the measured-pitch controls, enabled via `Style` + `DataTrigger` on the bool. Range 0.05–1.0. Every local `TextBlock.Style` must carry `BasedOn="{StaticResource StandardTextBlock}"` (THEME HAZARD note at the top of `DataTemplates.xaml`). Caption per design §8.6.
 - [ ] **Step 3.4:** `RunCalibrationMath` writes `LastMeasuredBackfocusGain` only when the computed γ is non-NaN (i.e. passed the sanity band).
 - [ ] **Step 3.5: Run** options + wizard filters → green. **Commit** — `feat(tilt): persist the backfocus gain with provenance and a manual override`
 
@@ -88,13 +90,24 @@ Baseline curvature effect at r=55 mm −268.6 µm; ReBaseline1 −223.7; mid = �
 **Files:** Modify `AutoFocus/InspectorVM.cs`, the tilt-guidance VM and its DataTemplates; Test `Tests/AutoFocus/InspectorVMBehavioralTests.cs`
 
 - [ ] **Step 4.1: Read** `ComputePerScrewTargets` and how `Screw*BackfocusAmount` reaches the guidance table, before designing the presentation.
-- [ ] **Step 4.2:** Compute both backfocus figures. Surface the gain-corrected one as a **single** value (per Step 2.1) with a label carrying γ and its provenance, e.g. *"Backfocus (gain-corrected, γ = 0.140 measured): 974 steps"*. Keep the existing per-screw column exactly as it is.
+- [ ] **Step 4.2:** The **corrected** figure populates the existing Backfocus and Total rows. Add one comparison line beneath the table: `Backfocus is gain-corrected: γ = 0.140 (measured) · uncorrected: +137 steps`. Do **not** add a parallel per-screw column — design §8.2 explains why.
 - [ ] **Step 4.3:** When γ is unavailable, show only today's figure and label it a **lower bound** — do not silently imply it is the answer.
-- [ ] **Step 4.4:** Add a note when the gain-corrected move exceeds `TiltDeviceMaxStepsPerCommand` or plausible adapter travel, stating that a spacer change is indicated rather than an adapter move. On the reference rig this fires: 974 steps ≈ 1.75 mm against a 200-step per-command cap.
+- [ ] **Step 4.4:** Add the spacer advisory when the corrected move is **≥ 1.0 mm of plate travel** (fixed constant). Do **not** trigger on `TiltDeviceMaxStepsPerCommand` — that cap is a chunk size `TiltMovePlanner.ApplyCap` already satisfies, and firing on it would cry wolf. Advisory only, never blocking; the existing `TiltDeviceMaxExcursionSteps` limit stays the sole blocker. Text per design §8.4. On the reference rig this fires at 1.75 mm.
 - [ ] **Step 4.5: Write VM tests:** both figures present with a measured γ; lower-bound labelling with no γ; the spacer note firing past the cap.
 - [ ] **Step 4.6: Run** inspector + wizard filters → green. **Commit** — `feat(inspector): show the gain-corrected backfocus move alongside the uncorrected one`
 
 ---
+
+### Task 4b: Apply-time preset selector in the approval dialog
+
+**Files:** Modify `TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptVM.cs`, `TiltDeviceAdjustmentPromptControl.xaml`, `TiltDeviceAdjustmentChoice.cs`, and the replanner path through `InspectorVM.BuildPlanPreview` / `TiltDevicePlanPreviewBuilder.cs`; Test `Tests/TiltAdapterDevices/Prompt/*`
+
+- [ ] **Step 4b.1: Read** how `ApplyTilt`/`ApplyBackfocus` re-invoke the replanner today, so the preset follows the same WYSIWYG contract — the move list must always match the selection.
+- [ ] **Step 4b.2:** Add the four-preset ComboBox beside the Backfocus checkbox (design §8.3), default Corrected, recomputed per invocation and never persisted. Carry the chosen scale on `TiltDeviceAdjustmentChoice`.
+- [ ] **Step 4b.3:** Collapse the ComboBox when γ is unavailable, showing the lower-bound caption instead.
+- [ ] **Step 4b.4:** Make the spacer advisory in the dialog track the **selected** preset, not the full corrected figure.
+- [ ] **Step 4b.5: Write tests:** each preset produces the expected scaled move list; the choice reaches the planner; the advisory follows the selection; γ-unavailable collapses the control.
+- [ ] **Step 4b.6: Run** the prompt + inspector filters → green. **Commit** — `feat(tilt): choose how much of the backfocus correction to apply`
 
 ### Task 5: Metadata and TestApp
 
@@ -134,7 +147,8 @@ Baseline curvature effect at r=55 mm −268.6 µm; ReBaseline1 −223.7; mid = �
 
 ### Task 8: Documentation
 
-- [ ] **Step 8.1:** In `tilt-adapter-wizard.md` and the inspector's backfocus documentation, explain that plate travel and curvature change are **not** one-for-one, that the ratio is rig-specific and measured, and how to read the two figures.
+- [ ] **Step 8.1:** In `tilt-adapter-wizard.md` and the inspector's backfocus documentation, explain that plate travel and curvature change are **not** one-for-one, that the ratio is rig-specific and measured, and how to read the corrected figure and its comparison line.
+- [ ] **Step 8.1b:** Add a tooltip/manual note to the **"Backfocus Error"** readout stating it is focal-surface sag, **not** plate travel, and that γ is the conversion. After this change users will see "Backfocus Error: 364 µm" a few rows above a 1.75 mm move instruction and will reasonably ask why they differ. Also update `motorized-tilt-adapter.md` (~line 96) for the new amount selector, and `tilt-adapter-wizard.md` (~line 111) whose "reads it as a spacing error and derives a backfocus correction" wording encodes the 1:1 assumption.
 - [ ] **Step 8.2:** State plainly that the recommendation remains a **floor** until the vertex-estimator work lands, because the curvature magnitude is separately under-read (design doc §6). Cross-reference `tilt-calibration-pitch-nonlinearity-design.md` §4/§8.
 - [ ] **Step 8.3:** Mark the design doc's §5 items implemented with commit refs.
 - [ ] **Step 8.4: Commit** — `docs(tilt): explain the backfocus correction gain and how to read both figures`
@@ -177,8 +191,8 @@ work lands). Do not restore those phrasings.
 
 ## Self-review notes (kept for the executor)
 
-- Spec coverage: §5.1 → Task 1; §5.2 → Task 1 (band) + Task 3 (persistence gate); §5.3 → Task 3; §5.4 → Task 3; §5.5 → Task 4; §5.6 → Task 6.
+- Spec coverage: §5.1 → Task 1; §5.2 → Task 1 (band) + Task 3 (persistence gate); §5.3 → Task 3; §5.4 → Task 3; §5.5 → Tasks 4 + 4b; §5.6 → Task 4b; §5.7 → Task 6; §8.2 → Task 4; §8.3 → Task 4b; §8.4 → Tasks 4.4 + 4b.4; §8.5 → Task 4b (explicitly by adding nothing); §8.6 → Task 3.
 - Type flow: `BackfocusCorrectionGain` is introduced on `TiltCalibrationResult` (Task 1), persisted via options (Task 3), consumed by `TiltScrewGeometry`'s new overload (Task 2) through the guidance (Task 4), serialized (Task 5).
-- Deliberate deviations an executor must not "fix": both figures are shown (no auto-apply); automation keeps gain 1.0; the tilt term keeps gain 1.0; γ stays separate from `unitMicrons`.
+- Deliberate deviations an executor must not "fix": the corrected figure owns the table and one comparison line sits beneath it (not a second column); automation adds no policy enum; the tilt term keeps gain 1.0; γ stays separate from `unitMicrons`; the override band is wider than the measurement band on purpose.
 - Steps 1.1, 2.1 and 4.1 are read-before-write checks: the curvature-effect plumbing into `TiltCalibrationInputs`, the per-screw-identical claim, and the guidance rendering path were reasoned about but not read line by line during planning.
 - Highest-risk task is 6: flipping a default changes the flow length and will break tests that assume 4 steps. Budget for that rather than being surprised by it.

--- a/plans/backfocus-correction-gain-plan.md
+++ b/plans/backfocus-correction-gain-plan.md
@@ -111,8 +111,12 @@ Baseline curvature effect at r=55 mm −268.6 µm; ReBaseline1 −223.7; mid = �
 **Files:** Modify `TiltAdapterWizard/TiltAdapterOptions.cs`, `TiltAdapterWizard/DataTemplates.xaml`, `documentation/docs/overview/tilt-adapter-wizard.md`
 
 - [ ] **Step 6.1:** Flip `MeasureCurvatureDuringCalibration` default to `true`. Update every test that assumed the 4-step default flow — expect several; check `GetMeasurementSteps` callers and the `NextStep_*` walks.
-- [ ] **Step 6.2:** Apply the tooltip strings and manual passage drafted for this task (they explain what the extra autofocus runs buy for **Measure direction** and **Measure final re-baseline**). Do not write fresh copy without reading `.claude/docs/documentation-style.md`.
-- [ ] **Step 6.3:** Update any remaining step-count prose made stale by the new default (`motorized-tilt-adapter.md` was corrected once already for the ReBaseline3 default — check it again).
+- [ ] **Step 6.2:** Apply the tooltip strings and manual passage from **Appendix A** below (already drafted against the house style guide). Use them as written — two lines were corrected after drafting to match this plan's locked decisions, and reverting to the originals would reintroduce claims the design explicitly rejects.
+- [ ] **Step 6.3:** Reword the three places that assume a default-OFF **Measure direction**, all identified during drafting:
+  - `documentation/docs/overview/tilt-adapter-wizard.md` ~line 203 — the measured-pitch admonition says "Measure direction is **off by default**, so a default run shows neither this line nor its warning".
+  - `documentation/docs/overview/tilt-adapter-wizard.md` ~line 67 — the calibration-loop paragraph's "To measure it, turn on **Measure direction**" framing.
+  - `TiltAdapterWizard/DataTemplates.xaml` — the italic caption beside the checkbox, "Turn on if you don't know how your adapter behaves, or to verify the setting above".
+  Also re-check `motorized-tilt-adapter.md`, which was corrected once already for the ReBaseline3 default.
 - [ ] **Step 6.4: Run** the full wizard filter → green. `mkdocs build --strict` clean. **Commit** — `feat(tilt): measure direction by default, and explain what the extra runs buy`
 
 ---
@@ -142,6 +146,32 @@ Baseline curvature effect at r=55 mm −268.6 µm; ReBaseline1 −223.7; mid = �
 - [ ] **Step 9.1:** Full suite: `dotnet.exe test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo`. All green (`SendAsync_WritesOnABackgroundThread` may flake — re-run in isolation before dismissing).
 - [ ] **Step 9.2:** Re-run the TestApp tilt replay against `D:\TiltCalibrationDebug\WithExtraBaseline` from the final tree; confirm γ prints as 0.140 and the implied move as ~974 steps.
 - [ ] **Step 9.3:** Push branch, open PR to `develop` titled "Backfocus correction gain: stop understating the required move by 7×". Body explains the gain-1.0 defect, the mechanism, the measurement and its independent validation, and states explicitly that automation behaviour is unchanged. End with the standard generated-with footer.
+
+---
+
+## Appendix A: drafted copy for Task 6
+
+Written against `.claude/docs/documentation-style.md`. **Two sentences were corrected after drafting**
+to match this plan's locked decisions — the original draft said the guidance figures "are scaled by"
+γ (this plan shows both figures instead of scaling) and that the measurement "is what makes the
+recommended backfocus move trustworthy" (per design §6 it remains a floor until the vertex-estimator
+work lands). Do not restore those phrasings.
+
+### Tooltip — Measure direction (`MeasureCurvatureDuringCalibration`)
+
+> Adds two steps (an all-screws move and a return to baseline) so the calibration measures which way a clockwise turn moves the adapter instead of assuming it. The same steps measure how much the field curvature actually changes when the plate moves, which sets the scale of the backfocus recommendation, and give an independent µm/step estimate that cross-checks the tilt-derived pitch.
+
+### Tooltip — Measure final re-baseline (`MeasureFinalRebaseline`)
+
+> Adds one measurement after the screw 2 move is undone, so that move is bracketed by re-baselines on both sides just as screw 1's is. Steady drift between steps then cancels out of both screw readings. On a thermally stable run it changes little; it is cheap insurance, not a guaranteed improvement.
+
+### Manual passage — `documentation/docs/overview/tilt-adapter-wizard.md`, Measurement section
+
+> Two settings in the **Measurement** section add autofocus runs in exchange for measuring what a minimal calibration has to assume. Both are on by default; turn either off to shorten the run. **Measure direction** adds two steps: every screw is moved the same amount in the same direction, then returned to baseline. An all-screws move is pure piston (the plate shifts without tilting), so the change in mean best-focus position tells the wizard which way a clockwise turn, or a positive step on motorized adapters, moves the plate, and guidance reports the direction as measured instead of "(assumed)". The same steps yield the **Piston-implied** pitch, a second estimate of the adapter's effective µm/step that involves no tilt fit and no screw radius, so it cross-checks the tilt-derived value.
+>
+> The same all-screws move also calibrates the backfocus recommendation, and this is the strongest reason to leave the setting on. Moving the plate does not change the measured field curvature one-for-one: the ratio is set by the optical design, and it varies from rig to rig. On one measured rig only about 14% of the plate motion showed up as curvature change, so a recommendation that treated the two as equal would have understated the required move by roughly a factor of seven. The all-screws step measures the ratio directly on your rig, and guidance reports the corrected move alongside the uncorrected one so you can see the difference the measurement makes. Treat the corrected figure as a lower bound and re-measure after adjusting: the curvature it is derived from is itself under-reported, so the move required is usually a little larger again.
+>
+> **Measure final re-baseline** adds one step at the end. The core sequence brackets screw 1's move with baseline measurements on both sides, but screw 2's move ends the run with a one-sided reference. This setting measures the position restored after the screw 2 move is undone instead of assuming it, so both screw moves are referenced to the midpoint of the re-baselines around them and steady drift between steps cancels out of the readings. On a run with real settling between steps that matters; on a clean, thermally stable run it makes little difference. One extra autofocus run is cheap insurance, not a guaranteed improvement.
 
 ---
 


### PR DESCRIPTION
**Documentation only — no code changes.** This is analysis, a design, and an implementation plan for review. Nothing is implemented.

## The defect

`TiltScrewGeometry.ScrewCorrectionMicrons` computes the backfocus correction as the fitted curvature sag at the screw, and divides by µm-per-step to get a move. That is an **implicit gain of 1.0**: move the plate by X microns, remove X microns of curvature. Its own doc comment says so — *"Both are in axial best-focus microns (the same unit as physical screw travel)."*

For the **tilt** term that is exactly right. For **curvature** it is not. Translating a flat sensor along the axis cannot make it match a curved focal surface.

**Measured gain: 0.140.** The recommendation understates the required move by **7.1×** — 137 steps (0.25 mm) recommended against 974 steps (1.75 mm) required. This is consistent with the long-standing "backfocus errors remained" experience, and with §7.7 of the tilt-calibration root-cause analysis.

## The mechanism, and when it applies at all

Moving the tilt adapter does **not** change the corrector's magnification — it only moves the sensor relative to the corrector. The chain is indirect:

1. the plate move changes defocus 1:1
2. refocusing moves the focuser
3. **because the corrector rides the drawtube**, that changes the corrector-to-focal-plane distance, and so changes m
4. the corrector only cancels field curvature exactly at its design magnification, so the change in m leaves residual curvature

On a rig where the corrector is threaded to the telescope and only the camera moves, step 3 never happens and γ ≈ 0 — the tilt adapter could not correct backfocus at all. This is why γ is rig-specific and cannot be derived from the reducer ratio: it needs the corrector's focal length and its curvature-versus-magnification sensitivity, both internal design properties.

## The calibration run already measures it

The **AllInward** step is a controlled piston. Drift-corrected against `mid(Baseline, ReBaseline1)` — the same reference the piston-implied pitch already uses — it gives **0.2526 µm/step**.

Validated against an independent five-run piston sweep (−100 … −500 steps, a 3.3× larger excursion in the opposite direction): **0.258 µm/step**. The two agree to **2.1%**.

Drift correction is not optional. Uncorrected, the AllInward delta reads 59% high, and the sweep reads 1.958 µm/step for the piston pitch instead of 2.32 — thermal drift of −26.2 focuser steps/min ate 18% of the signal.

## Design summary

- γ computed in `TiltCalibrationCalculator`, sanity-banded to [0.05, 0.5], persisted with provenance, manual override allowed to 1.0 (which restores legacy behaviour exactly)
- the **corrected** figure owns the guidance table; the uncorrected one is a single comparison line beneath it, never a parallel column
- the approval dialog gains a four-preset amount selector (Corrected / Half / Quarter / Uncorrected), default Corrected, never persisted
- **no automation policy setting** — `RunAutomaticAdjustmentAsync` always awaits the approval prompt, so the apply-time control covers it, and adding an enum would break the property that the planner cannot diverge from the approved table
- out-of-range is judged in **millimetres of plate travel** (1.0 mm advisory), not the per-command cap, which is a chunk size the planner already satisfies
- `MeasureCurvatureDuringCalibration` default flips ON — it now supplies three things

## What this does not fix

γ corrects the **conversion**, not the **magnitude** being converted, and the two errors compound. The curvature comes from the fitted paraboloid, which under-reads: −246 µm against the corner-region AF's −364 µm on this run. That is the difference between a 1.75 mm and a 2.54 mm recommendation.

So the corrected figure remains a **floor** until the vertex-estimator work lands. Both documents say so, and the UX is built around iterating rather than presenting a single authoritative number.

## Also recorded

An appendix documents that **the measured final re-baseline (`ReBaseline3`, shipped default-ON in #178) did not help on this run** — recomputing the same data with and without it moves the paraboloid ratio 1.017 → 1.054, slightly worse. The improvement over the earlier run came from run quality, not from RB3. It also notes a limitation the original argument missed: RB3's own reading carries the hysteresis of undoing the move it brackets, so the midpoint is not a clean drift interpolation. Recorded because the claim should not be repeated without evidence.

## Review notes

The plan is 11 tasks. Highest risk is Task 6 — flipping `MeasureCurvatureDuringCalibration` to ON changes the default flow length and several tests assume the 4-step default.

Two decisions worth a second look: **automation applies 100% of the corrected figure** (reversed mid-design from an earlier "never auto-apply" position — the reasoning for the reversal is recorded in §7), and the **manual override band is wider than the measurement band**, on the grounds that a user assertion and a measurement are different claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153hev5wNcmA1dBhuZk9qtM
