### PR TITLE
Wave 5: bound what J may spend (F32), answer F24 and F26, and three measurement defects

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/AstapCellGeometryTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/AstapCellGeometryTests.cs
@@ -175,4 +175,129 @@ public class AstapCellGeometryTests {
             Assert.That(sel.CellFileName, Is.EqualTo(AstapCellGeometry.CellFileName(sel.Area, partitioning)));
         }
     }
+
+    // ---- F44: wide-field cell enumeration ------------------------------------------------------------------
+    //
+    // find_areas clamps the field to ONE CELL and samples only its four corners. Correct for plate-solving,
+    // catastrophic for rendering: a 40 mm full-frame field is ~57°, the clamp cut the catalog query to 5.14°,
+    // and the simulator drew stars over a ~10° patch of a 48.5° x 33.4° frame with the rest of the sensor empty.
+
+    /// <summary>The reference brute force: every cell whose CENTRE lies within the cone, found by sampling the
+    /// sphere densely. Independent of the routine under test, so it can disagree with it.</summary>
+    private static HashSet<int> CellsByDenseSampling(double raRad, double decRad, double radiusRad, AstapPartitioning p) {
+        var hit = new HashSet<int>();
+        const int NDec = 900, NRa = 1800;
+        for (var i = 0; i <= NDec; i++) {
+            var d = -Math.PI / 2 + (Math.PI * i / NDec);
+            for (var j = 0; j < NRa; j++) {
+                var r = 2 * Math.PI * j / NRa;
+                var cosSep = (Math.Sin(decRad) * Math.Sin(d)) + (Math.Cos(decRad) * Math.Cos(d) * Math.Cos(r - raRad));
+                if (cosSep >= Math.Cos(radiusRad)) {
+                    hit.Add(AstapCellGeometry.AreaForCoordinates(r, d, p));
+                }
+            }
+        }
+        return hit;
+    }
+
+    [TestCase(305.5571, 40.2567, 59.67)]   // the reporting rig: 40 mm full-frame
+    [TestCase(305.5571, 40.2567, 12.55)]   // D02_rich_135mm
+    [TestCase(10.0, 0.0, 40.0)]            // equator, crossing RA = 0
+    [TestCase(350.0, -20.0, 50.0)]         // southern, wrapping RA
+    [TestCase(0.0, 89.0, 30.0)]            // cone containing the north pole
+    [TestCase(180.0, -88.0, 25.0)]         // cone containing the south pole
+    public void FindAreasCovering_MissesNoCellThatTheConeActuallyTouches(double raDeg, double decDeg, double fovDeg) {
+        foreach (var part in new[] { AstapPartitioning.Astap290, AstapPartitioning.Astap1476 }) {
+            var ra = raDeg * Deg;
+            var dec = decDeg * Deg;
+            var covering = AstapCellGeometry.FindAreasCovering(ra, dec, fovDeg * Deg, part)
+                .Select(a => a.Area).ToHashSet();
+            var expected = CellsByDenseSampling(ra, dec, fovDeg * Deg / 2.0, part);
+
+            var missed = expected.Except(covering).OrderBy(x => x).ToList();
+            Assert.That(missed, Is.Empty,
+                $"{part} at ({raDeg},{decDeg}) fov {fovDeg}: cells inside the cone that were never queried: " +
+                string.Join(",", missed));
+        }
+    }
+
+    [Test]
+    public void FindAreasCovering_IsVastlyWiderThanFindAreas_OnA40mmField() {
+        // The defect, as an inequality. find_areas clamps 59.67 deg to one cell and returns at most 4.
+        const double Ra = 305.5571 * (Math.PI / 180.0), Dec = 40.2567 * (Math.PI / 180.0), Fov = 59.67 * (Math.PI / 180.0);
+        var reference = AstapCellGeometry.FindAreas(Ra, Dec, Fov, AstapPartitioning.Astap1476);
+        var covering = AstapCellGeometry.FindAreasCovering(Ra, Dec, Fov, AstapPartitioning.Astap1476);
+
+        Assert.Multiple(() => {
+            Assert.That(reference.Count, Is.LessThanOrEqualTo(4), "find_areas returns at most 4 cells by construction");
+            Assert.That(covering.Count, Is.GreaterThan(50), "a 59.67 deg field spans far more than 4 of the 5.14 deg cells");
+            Assert.That(covering.Select(c => c.Area).ToHashSet().IsSupersetOf(reference.Select(c => c.Area)),
+                Is.True, "the wide sweep must still include everything the reference found");
+        });
+    }
+
+    [Test]
+    public void FindAreasCovering_ReturnsRealCellFileNamesAndDistinctAreas() {
+        // Building "<area>.1476" by hand would name files that do not exist on disk; the encoding is band/index.
+        var cells = AstapCellGeometry.FindAreasCovering(
+            305.5571 * Deg, 40.2567 * Deg, 59.67 * Deg, AstapPartitioning.Astap1476);
+
+        Assert.Multiple(() => {
+            Assert.That(cells.Select(c => c.Area).Distinct().Count(), Is.EqualTo(cells.Count), "no duplicate cells");
+            foreach (var c in cells) {
+                Assert.That(c.Area, Is.InRange(1, AstapCellGeometry.AreaCount(AstapPartitioning.Astap1476)));
+                Assert.That(c.CellFileName, Is.EqualTo(AstapCellGeometry.CellFileName(c.Area, AstapPartitioning.Astap1476)));
+            }
+        });
+    }
+
+    [TestCase(0.0, 89.0, 30.0)]
+    [TestCase(123.0, -88.5, 20.0)]
+    [TestCase(200.0, 90.0, 44.0)]
+    public void FindAreasCovering_AConeContainingAPoleTakesEVERYMeridianOfEveryBandItReaches(
+        double raDeg, double decDeg, double fovDeg) {
+        // A cone that swallows a pole has no bounded RA range: every meridian is inside it. Computing one from
+        // the law of cosines leaves a narrow wrap-around sliver unqueried (halfSpan lands just under pi, so the
+        // "covers the circle" branch does not fire and the padded index walk stops a few degrees short). The
+        // sliver is easy to miss with a centre-sampling oracle, so assert the structural property directly.
+        foreach (var part in new[] { AstapPartitioning.Astap290, AstapPartitioning.Astap1476 }) {
+            var ra = raDeg * Deg;
+            var dec = decDeg * Deg;
+            var radius = fovDeg * Deg / 2.0;
+            var returned = AstapCellGeometry.FindAreasCovering(ra, dec, fovDeg * Deg, part)
+                .Select(a => a.Area).ToHashSet();
+
+            // Any band the cone reaches must be present in FULL.
+            var reached = returned.Select(a => BandOf(a, part)).Distinct().ToList();
+            Assert.That(reached, Is.Not.Empty);
+            foreach (var band in reached) {
+                foreach (var area in AreasInBand(band, part)) {
+                    Assert.That(returned, Does.Contain(area),
+                        $"{part} at ({raDeg},{decDeg}) fov {fovDeg}: band {band} is only partly queried " +
+                        $"(missing area {area}) — a pole-containing cone covers every meridian");
+                }
+            }
+        }
+    }
+
+    // Band arithmetic mirrored from the geometry's own cumulative table, via the public area->name encoding:
+    // the file name's first four digits are "BBII" (band, index within band), so the band is recoverable.
+    private static int BandOf(int area, AstapPartitioning p) =>
+        int.Parse(AstapCellGeometry.CellFileName(area, p).Substring(0, 2));
+
+    private static IEnumerable<int> AreasInBand(int band, AstapPartitioning p) {
+        for (var a = 1; a <= AstapCellGeometry.AreaCount(p); a++) {
+            if (BandOf(a, p) == band) {
+                yield return a;
+            }
+        }
+    }
+
+    [Test]
+    public void FindAreasCovering_AWholeSkyConeReturnsEveryCell() {
+        foreach (var part in new[] { AstapPartitioning.Astap290, AstapPartitioning.Astap1476 }) {
+            var cells = AstapCellGeometry.FindAreasCovering(0.0, 0.0, 360.0 * Deg, part);
+            Assert.That(cells.Count, Is.EqualTo(AstapCellGeometry.AreaCount(part)), $"{part}");
+        }
+    }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/DetectionKeepFloorTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/DetectionKeepFloorTests.cs
@@ -1,0 +1,275 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection.Optimization;
+
+/// <summary>
+/// F32 — the detection-keep floor: an ACCEPTANCE CONSTRAINT on the optimizer's search, not a term in J and not
+/// a rescale of it.
+///
+/// <para>The landscape below reproduces the defect in miniature. Raising <c>Sensitivity</c> monotonically
+/// TIGHTENS the fit (σ_focus falls) and monotonically SHEDS stars, which is exactly what the real bank does:
+/// σ_focus improves on 10 of 10 shedding runs while a median 0.243 of recall is given up for a median ΔJ of
+/// +0.0125. An unconstrained search therefore climbs to a high gate and a small star list, and the floor's job
+/// is to stop it — without touching a single J value.</para>
+/// </summary>
+[TestFixture]
+public class DetectionKeepFloorTests {
+
+    private const int FrameCount = 10;
+    private const int SeedStarsPerFrame = 100;
+
+    /// <summary>Stars per frame as a function of the gate: 100 at Sensitivity 0, decaying with a 15-unit scale.
+    /// Floored at 10 so the run never trips the NHard starvation floor — the point of this fixture is the
+    /// optimizer CHOOSING to shed, not J collapsing to zero, which is a different failure (F20).</summary>
+    private static int StarsFor(double sensitivity) =>
+        Math.Max(10, (int)Math.Round(SeedStarsPerFrame * Math.Exp(-sensitivity / 15.0)));
+
+    private static RunEvaluationMetrics ShedderRun(StarDetectorParams p, double countScale = 1.0) {
+        const double stepSize = 100.0;
+        // σ falls as the gate rises: shedding buys a genuinely better fit, exactly as measured on the real bank.
+        var sigma = stepSize * Math.Max(0.02, 0.30 - 0.005 * p.Sensitivity);
+        var stars = Math.Max(10, (int)Math.Round(StarsFor(p.Sensitivity) * countScale));
+        return new RunEvaluationMetrics {
+            SigmaFocus = sigma,
+            LooStdError = double.NaN,
+            StepSize = stepSize,
+            RSquared = 0.99,
+            ReducedChiSquared = 1.0,
+            FrameStarCounts = Enumerable.Repeat(stars, FrameCount).ToList()
+        };
+    }
+
+    private static Func<StarDetectorParams, CancellationToken, Task<IReadOnlyList<RunEvaluationMetrics>>> ShedderEvaluator() =>
+        (p, token) => Task.FromResult<IReadOnlyList<RunEvaluationMetrics>>(new[] { ShedderRun(p) });
+
+    private static StarDetectorParams Seed() => new StarDetectorParams {
+        Sensitivity = 0.0,
+        StarClippingMultiplier = 2.0,
+    };
+
+    private static OptimizerSettings Settings(double? keepFloor = null) => new OptimizerSettings {
+        MaxEvaluations = 400,
+        CoarseGridLevels = 4,
+        StepFloorFraction = 0.125,
+        MinDetectionKeepFraction = keepFloor
+    };
+
+    private static Task<OptimizationResult> RunAsync(OptimizerSettings settings,
+        Func<StarDetectorParams, CancellationToken, Task<IReadOnlyList<RunEvaluationMetrics>>> evaluator = null,
+        StarDetectorParams seed = null) =>
+        new StarDetectionOptimizer().OptimizeAsync(
+            seed ?? Seed(), OptimizerVariable.CreateCuratedSet(), evaluator ?? ShedderEvaluator(),
+            settings, null, CancellationToken.None);
+
+    /// <summary>
+    /// GUARD, NOT A DISCRIMINATOR — this passes with and without the fix, and is kept deliberately because
+    /// "null leaves every caller bit-identical" is the property that lets the same binary be its own control
+    /// arm. It is excluded from the discriminating-test count on purpose (wave-4 lesson 2: count the tests that
+    /// fail when the fix is reverted, not the tests you wrote).
+    /// </summary>
+    [Test]
+    public async Task NoFloor_IsBitIdenticalToTheUnconstrainedSearch() {
+        var a = await RunAsync(Settings(keepFloor: null));
+        var b = await RunAsync(Settings(keepFloor: null));
+
+        Assert.Multiple(() => {
+            Assert.That(a.BestJ, Is.EqualTo(b.BestJ).Within(0.0));
+            Assert.That(a.BestParams.Sensitivity, Is.EqualTo(b.BestParams.Sensitivity).Within(0.0));
+            Assert.That(a.CandidatesRejectedByKeepFloor, Is.Zero, "no floor => nothing can be rejected by one");
+            // The keep fraction is MEASURED unconditionally — it costs nothing (the counts are already in hand)
+            // and it is precisely the "keep%" F32 computes by hand from stored landings. Only the JSON omits it
+            // without a floor, so an unconstrained landing file stays byte-identical to before this existed.
+            Assert.That(a.LandingKeepFraction, Is.EqualTo(b.LandingKeepFraction).Within(0.0));
+            Assert.That(a.LandingKeepFraction, Is.LessThan(0.5),
+                "fixture precondition: the unconstrained search sheds, which is the defect under test");
+        });
+    }
+
+    /// <summary>The headline: the unconstrained search sheds, and the floor stops it at the floor.</summary>
+    [Test]
+    public async Task Floor_RejectsALandingThatShedsBelowIt() {
+        var unconstrained = await RunAsync(Settings(keepFloor: null));
+        var constrained = await RunAsync(Settings(keepFloor: 0.5));
+
+        var unconstrainedKeep = (double)StarsFor(unconstrained.BestParams.Sensitivity) / SeedStarsPerFrame;
+
+        Assert.Multiple(() => {
+            // Precondition: the fixture actually reproduces the defect, else the test proves nothing.
+            Assert.That(unconstrainedKeep, Is.LessThan(0.5),
+                "fixture precondition: the unconstrained search must shed past the floor being tested");
+            Assert.That(constrained.LandingKeepFraction, Is.GreaterThanOrEqualTo(0.5),
+                "the landing must satisfy the floor it was searched under");
+            Assert.That(constrained.BestParams.Sensitivity, Is.LessThan(unconstrained.BestParams.Sensitivity),
+                "the constrained landing must sit at a looser gate than the unconstrained one");
+            Assert.That(constrained.CandidatesRejectedByKeepFloor, Is.GreaterThan(0),
+                "the constraint must have actually bound; zero rejections would mean this proves nothing");
+        });
+    }
+
+    /// <summary>The same candidates become admissible once the floor drops beneath their keep fraction, which is
+    /// what makes the previous test a statement about the FLOOR rather than about the plumbing.</summary>
+    [Test]
+    public async Task Floor_AcceptsTheSameCandidatesWhenLoweredBeneathThem() {
+        var unconstrained = await RunAsync(Settings(keepFloor: null));
+        var loose = await RunAsync(Settings(keepFloor: 0.01));
+
+        Assert.Multiple(() => {
+            Assert.That(loose.BestParams.Sensitivity, Is.EqualTo(unconstrained.BestParams.Sensitivity).Within(0.0));
+            Assert.That(loose.BestJ, Is.EqualTo(unconstrained.BestJ).Within(0.0),
+                "a floor beneath everything visited must not change J or the landing");
+            Assert.That(loose.CandidatesRejectedByKeepFloor, Is.Zero);
+        });
+    }
+
+    /// <summary>J is carried alongside feasibility, never folded into it: the constrained landing's J must be
+    /// exactly the J that same θ scores with no floor in force. This is what keeps every wave-1..4 number
+    /// comparable, and it is the property a multiplier-based implementation would silently destroy.</summary>
+    [Test]
+    public async Task Floor_DoesNotAlterJ() {
+        var constrained = await RunAsync(Settings(keepFloor: 0.5));
+
+        // Re-score the constrained landing with NO floor by seeding an unconstrained search there: its seed J is
+        // that θ's objective value, computed by the same code path with the constraint absent.
+        var reseeded = await RunAsync(Settings(keepFloor: null), seed: constrained.BestParams);
+
+        Assert.That(reseeded.SeedJ, Is.EqualTo(constrained.BestJ).Within(0.0),
+            "the constrained landing's J must be bit-identical to the same params' unconstrained J");
+    }
+
+    /// <summary>
+    /// A run whose seed detected NOTHING is exempt rather than infeasible. Rejecting on an undefined ratio would
+    /// re-gate exactly the F20/F35 population — a rig whose seed legitimately detects nothing is the case the
+    /// MinHFR seeding exists to rescue, and it has to be free to climb from zero.
+    /// </summary>
+    [Test]
+    public async Task Floor_ExemptsARunWhoseSeedDetectedNothing() {
+        // Zero stars at the seed gate, real stars once the gate moves off it.
+        Func<StarDetectorParams, CancellationToken, Task<IReadOnlyList<RunEvaluationMetrics>>> evaluator =
+            (p, token) => {
+                var m = ShedderRun(p);
+                if (p.Sensitivity <= 0.0) {
+                    m.FrameStarCounts = Enumerable.Repeat(0, FrameCount).ToList();
+                }
+                return Task.FromResult<IReadOnlyList<RunEvaluationMetrics>>(new[] { m });
+            };
+
+        var result = await RunAsync(Settings(keepFloor: 0.9), evaluator);
+
+        Assert.Multiple(() => {
+            Assert.That(result.SeedRunDetectionTotals, Is.Not.Null);
+            Assert.That(result.SeedRunDetectionTotals[0], Is.Zero, "fixture precondition: the seed detects nothing");
+            Assert.That(result.BestParams.Sensitivity, Is.GreaterThan(0.0),
+                "a zero-baseline run must not be frozen at its seed by a floor it cannot be measured against");
+        });
+    }
+
+    /// <summary>
+    /// The floor is the MIN over runs, not the pooled total. One run collapsing must reject the candidate even
+    /// when a second run grows enough to raise the sum — pooling would let a dense run's gains mask another
+    /// being gutted.
+    /// </summary>
+    [Test]
+    public async Task Floor_IsMinOverRuns_NotThePooledTotal() {
+        // Run 0 collapses hard with the gate; run 1 is ten times denser and barely moves, so the POOLED count
+        // stays far above the floor while run 0 falls through it.
+        Func<StarDetectorParams, CancellationToken, Task<IReadOnlyList<RunEvaluationMetrics>>> evaluator =
+            (p, token) => Task.FromResult<IReadOnlyList<RunEvaluationMetrics>>(new[] {
+                ShedderRun(p),
+                new RunEvaluationMetrics {
+                    SigmaFocus = ShedderRun(p).SigmaFocus,
+                    LooStdError = double.NaN,
+                    StepSize = 100.0,
+                    RSquared = 0.99,
+                    ReducedChiSquared = 1.0,
+                    FrameStarCounts = Enumerable.Repeat(1000, FrameCount).ToList()
+                }
+            });
+
+        var result = await RunAsync(Settings(keepFloor: 0.5), evaluator);
+
+        var run0Keep = (double)StarsFor(result.BestParams.Sensitivity) / SeedStarsPerFrame;
+        Assert.Multiple(() => {
+            Assert.That(run0Keep, Is.GreaterThanOrEqualTo(0.5),
+                "the collapsing run must satisfy the floor on its own, not be carried by the dense one");
+            Assert.That(result.LandingKeepFraction, Is.GreaterThanOrEqualTo(0.5));
+        });
+    }
+
+    /// <summary>
+    /// The multi-pass ratchet. Both multi-pass callers re-invoke the optimizer with <c>seed = the previous
+    /// pass's best</c> (TestApp <c>--continue-rounds</c>, the wizard's Continue button). Measured against each
+    /// round's OWN seed, a floor of 0.5 permits 0.25 after two rounds and 0.125 after three — the constraint
+    /// paid in installments. Pinning round 0's totals is what makes the floor mean "of where the user started".
+    /// </summary>
+    [Test]
+    public async Task Floor_DoesNotRatchetAcrossContinueRounds() {
+        var settings = Settings(keepFloor: 0.5);
+        var result = await RunAsync(settings);
+        var originalSeedTotals = result.SeedRunDetectionTotals;
+        Assert.That(originalSeedTotals, Is.Not.Null);
+
+        // What the multi-pass callers do: pin round 0's seed totals for every later round.
+        settings.DetectionKeepBaselineTotals = originalSeedTotals;
+
+        for (var round = 0; round < 3; round++) {
+            result = await new StarDetectionOptimizer().OptimizeAsync(
+                result.BestParams, OptimizerVariable.CreateCuratedSet(result.BestParams),
+                ShedderEvaluator(), settings, null, CancellationToken.None);
+        }
+
+        // Measured against the ORIGINAL seed, not the last round's.
+        var keepVsOriginalSeed = (double)StarsFor(result.BestParams.Sensitivity) / SeedStarsPerFrame;
+        Assert.That(keepVsOriginalSeed, Is.GreaterThanOrEqualTo(0.5),
+            "three continue rounds must not walk through a floor anchored at the first pass's seed");
+    }
+
+    /// <summary>Every accepted incumbent is feasible, at every floor — the invariant all three accept sites
+    /// (CoarseGrid, CompassStage, RevertNeutralAxes) exist to preserve.</summary>
+    [TestCase(0.25)]
+    [TestCase(0.50)]
+    [TestCase(0.75)]
+    [TestCase(0.95)]
+    public async Task Floor_LandingAlwaysSatisfiesTheFloor(double floor) {
+        var result = await RunAsync(Settings(keepFloor: floor));
+
+        Assert.Multiple(() => {
+            Assert.That(result.LandingKeepFraction, Is.GreaterThanOrEqualTo(floor),
+                $"landing must satisfy the floor {floor}");
+            Assert.That(result.BestJ, Is.GreaterThanOrEqualTo(result.SeedJ),
+                "the never-regress floor survives the constraint: the seed is always feasible");
+        });
+    }
+
+    /// <summary>The seed is feasible by construction even when it cannot possibly satisfy the floor against
+    /// itself-as-baseline — otherwise the feasible set would be empty and the search would have nowhere to
+    /// stand.</summary>
+    [Test]
+    public async Task Floor_SeedIsAlwaysFeasible() {
+        var result = await RunAsync(Settings(keepFloor: 1.0));
+
+        Assert.Multiple(() => {
+            Assert.That(result.BestJ, Is.GreaterThanOrEqualTo(result.SeedJ));
+            Assert.That(result.LandingKeepFraction, Is.GreaterThanOrEqualTo(1.0),
+                "at a floor of 1.0 nothing that sheds a single star may win");
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationSummaryTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationSummaryTests.cs
@@ -507,19 +507,45 @@ public class OptimizedLandingExportTests {
         });
     }
 
-    /// <summary>An unconstrained landing must serialize byte-identically to one written before the keep floor
-    /// existed — the property that lets the same binary be its own control arm on disk as well as in memory.</summary>
+    /// <summary>
+    /// An unconstrained landing records NO floor — there was none — but DOES record what it kept.
+    ///
+    /// <para>The asymmetry is deliberate and was corrected mid-wave. Gating both fields on the floor made the
+    /// control arm unable to report its own keep fraction, which is the exact number that decides whether a floor
+    /// would have bound on that run: the control could not be classified without re-running it. F32 spent two
+    /// waves reconstructing this quantity by hand from stored landings, which is the argument for storing it.</para>
+    /// </summary>
     [Test]
-    public void UnconstrainedLanding_OmitsTheKeepFloorFieldsEntirely() {
+    public void UnconstrainedLanding_RecordsWhatItKeptButNoFloor() {
         var dto = OptimizedStarDetectionSettings.FromParams(
             new StarDetectorParams(), runCount: 1, baselineJ: 0.9, finalJ: 0.95,
-            recommendedStepSize: 50, recommendedOffsetSteps: 4);
+            recommendedStepSize: 50, recommendedOffsetSteps: 4,
+            provenance: null, minDetectionKeepFraction: null, landingDetectionKeepFraction: 0.62);
 
         var json = Newtonsoft.Json.JsonConvert.SerializeObject(dto);
 
         Assert.Multiple(() => {
-            Assert.That(json, Does.Not.Contain("MinDetectionKeepFraction"));
+            Assert.That(json, Does.Not.Contain("MinDetectionKeepFraction"), "no floor was in force");
+            Assert.That(json, Does.Contain("LandingDetectionKeepFraction"), "what it kept is measurable either way");
+            Assert.That(dto.LandingDetectionKeepFraction, Is.EqualTo(0.62));
+        });
+    }
+
+    /// <summary>An unmeasurable keep fraction is omitted rather than written as NaN — no JSON reader should have
+    /// to handle a NaN, and an absent field already reads correctly as "there was nothing to measure".</summary>
+    [Test]
+    public void UnmeasurableKeepFraction_IsOmittedRatherThanWrittenAsNaN() {
+        var dto = OptimizedStarDetectionSettings.FromParams(
+            new StarDetectorParams(), runCount: 1, baselineJ: 0.9, finalJ: 0.95,
+            recommendedStepSize: 50, recommendedOffsetSteps: 4,
+            provenance: null, minDetectionKeepFraction: 0.5, landingDetectionKeepFraction: double.NaN);
+
+        var json = Newtonsoft.Json.JsonConvert.SerializeObject(dto);
+
+        Assert.Multiple(() => {
+            Assert.That(json, Does.Contain("MinDetectionKeepFraction"), "the floor WAS in force and must be recorded");
             Assert.That(json, Does.Not.Contain("LandingDetectionKeepFraction"));
+            Assert.That(json, Does.Not.Contain("NaN"));
         });
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationSummaryTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationSummaryTests.cs
@@ -457,4 +457,69 @@ public class OptimizedLandingExportTests {
             Assert.That(reloaded.StarDetection.UseOptimizedSettings, Is.True);
         });
     }
+
+    /// <summary>
+    /// The check <c>bank-export-settings</c> runs before it writes anything, exercised here on a landing with
+    /// EVERY curated axis moved off its default. <see cref="OptimizedStarDetectionSettings.UnmappedKnobs"/> proves
+    /// each axis has somewhere to land; this proves each axis's VALUE actually arrives — a property that would
+    /// pass the mapping check and still be wrong if a knob were written to the nested block only.
+    /// </summary>
+    [Test]
+    public void DiffKnobs_IsEmptyAfterAFullRoundTrip_WithEveryAxisMovedOffItsDefault() {
+        var landing = new OptimizedStarDetectionSettings {
+            BrightnessSensitivity = 17.67, StarClippingMultiplier = 2.0, NoiseClippingMultiplier = 3.875,
+            StarPeakResponse = 0.68, MaxDistortion = 0.26, MinHFR = 0.7, StarCenterTolerance = 0.275,
+            StructureLayers = 6, NoiseReductionRadius = 4, MinStarBoundingBoxSize = 7,
+            HotpixelThresholdingEnabled = true, HotpixelThreshold = 0.002,
+            DefocusAwareGates = true, DefocusDistortionSizeReference = 28.75, DefocusDistortionMinFactor = 0.3,
+            DefocusCenteringToleranceFactor = 2.5, DefocusAwareStructure = true, StructureLayerBoost = 3,
+            DefocusAwareDonutDetection = true, DonutMorphCloseSize = 7, LocallyAdaptiveBinarization = true,
+            AdaptiveNoiseBlockSize = 64, DonutMinAnnularityHoleFraction = 0.2, DonutMaxStreakEccentricity = 1.5,
+            DonutSaturationBloomRadius = 3.0
+        };
+
+        var reloaded = StarDetectionSettingsExport.Deserialize(
+            StarDetectionSettingsExport.FromOptimizedLanding(new StarDetectionSettingsSnapshot(), landing).Serialize());
+
+        var diffs = landing.DiffKnobs(reloaded.StarDetection);
+        Assert.That(diffs, Is.Empty, "curated axes that did not survive the round trip: " + string.Join(", ", diffs));
+    }
+
+    /// <summary>
+    /// The F32 bookkeeping fields describe the SEARCH (which candidates were eligible), not the detector, so they
+    /// must be registered as non-knobs. An unregistered one would be hunted for as a live option property, and
+    /// <see cref="OptimizedStarDetectionSettings.UnmappedKnobs"/> would start failing for a field that has no
+    /// business being on the options object at all.
+    /// </summary>
+    [Test]
+    public void KeepFloorBookkeepingIsNotTreatedAsADetectorKnob() {
+        var landing = Landing();
+        landing.MinDetectionKeepFraction = 0.5;
+        landing.LandingDetectionKeepFraction = 0.63;
+
+        var snapshot = new StarDetectionSettingsSnapshot();
+        landing.ApplyToFlatOptions(snapshot);
+
+        Assert.Multiple(() => {
+            Assert.That(OptimizedStarDetectionSettings.UnmappedKnobs(typeof(StarDetectionSettingsSnapshot)), Is.Empty);
+            Assert.That(landing.DiffKnobs(snapshot), Is.Empty,
+                "the keep-floor fields must not participate in the knob mapping at all");
+        });
+    }
+
+    /// <summary>An unconstrained landing must serialize byte-identically to one written before the keep floor
+    /// existed — the property that lets the same binary be its own control arm on disk as well as in memory.</summary>
+    [Test]
+    public void UnconstrainedLanding_OmitsTheKeepFloorFieldsEntirely() {
+        var dto = OptimizedStarDetectionSettings.FromParams(
+            new StarDetectorParams(), runCount: 1, baselineJ: 0.9, finalJ: 0.95,
+            recommendedStepSize: 50, recommendedOffsetSteps: 4);
+
+        var json = Newtonsoft.Json.JsonConvert.SerializeObject(dto);
+
+        Assert.Multiple(() => {
+            Assert.That(json, Does.Not.Contain("MinDetectionKeepFraction"));
+            Assert.That(json, Does.Not.Contain("LandingDetectionKeepFraction"));
+        });
+    }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -169,6 +169,41 @@ public class StarDetectionOptimizerWizardVMTests {
         return new LoadedRun { Data = data, Seed = seed, AfOptions = afOptions };
     }
 
+    // F43. An UNDERSAMPLED SHORT-FOCAL-LENGTH rig in miniature. Measured on the bank's 40 mm dataset
+    // (D01_ultrawide_40mm), the in-focus frame yields ZERO stars at the shipped MinHFR of 1.2 while the defocused
+    // wings yield ~1700 each -- MinHFR rejects SMALL stars, and in-focus stars are the smallest there are. Same
+    // shape here: a shallow curve (in-focus HFR 0.8 px) whose inner SEVEN positions all sit under a 1.2 gate,
+    // leaving 2 usable positions against the 3 a hyperbola needs. Lowering the gate restores all nine, which is
+    // exactly the axis the wizard used to refuse to let the search reach.
+    private const double UndersampledHyperbolaA = 0.8;   // in-focus HFR, px — smaller than the shipped 1.2 gate
+
+    private const double UndersampledHyperbolaB = 400.0; // shallow, so the gate empties the CORE not just the vertex
+
+    private static double UndersampledHfr(int pos) {
+        var dx = (pos - HyperbolaP0) / UndersampledHyperbolaB;
+        return Math.Sqrt(UndersampledHyperbolaA * UndersampledHyperbolaA + dx * dx);
+    }
+
+    private static LoadedRun UndersampledRun(string id = "undersampled", double seedMinHfr = 1.2) {
+        Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> detect = (image, p, token) => {
+            var pos = (int)image;
+            var hfr = UndersampledHfr(pos);
+            // The gate the detector applies: stars at or below MinHFR are rejected, so a frame whose stars are all
+            // under it reports none at all — the F20 collapse, concentrated on the INNER frames.
+            var gated = hfr <= p.MinHFR;
+            return Task.FromResult(new FrameDetectionResult {
+                AverageHFR = gated ? 0.0 : hfr,
+                HFRStdDev = 0.05,
+                StarCount = gated ? 0 : 20,
+                StarCenters = Array.Empty<(double X, double Y)>()
+            });
+        };
+        var data = new RunEvaluationData(id, NineFrames(), detect, NewAlglib(), DefaultFitConfig());
+        var seed = new StarDetectorParams { Sensitivity = 2.0, StarClippingMultiplier = 2.0, MinHFR = seedMinHfr };
+        var afOptions = new AutoFocusEngineOptions { AutoFocusStepSize = DefaultStepSize, AutoFocusInitialOffsetSteps = 4 };
+        return new LoadedRun { Data = data, Seed = seed, AfOptions = afOptions };
+    }
+
     // A run where detection finds stars ONLY at low Sensitivity: the optimizer SEED (2) yields a clean hyperbola,
     // but the displayed BASELINE / current settings (8) are effectively blind (no stars, so no curve). This isolates
     // which params the seed guard evaluates — the Live sweep must gate on the seed, not the failing current settings.
@@ -422,6 +457,82 @@ public class StarDetectionOptimizerWizardVMTests {
             Assert.That(vm.CurrentStep, Is.Not.EqualTo(WizardStep.Summary), "the guard must block the summary");
             Assert.That(vm.ErrorMessage, Is.Not.Null.And.Not.Empty, "a degenerate seed must surface a user-facing error");
             Assert.That(vm.Summary, Is.Null);
+        });
+    }
+
+    // ---- F43: the guard must not require the DEFAULT settings to already work --------------------------------
+    //
+    // LIVE only, deliberately. Replay gates on the user's CURRENT settings because a saved run exists only because
+    // those settings could already focus (see SeedGuard_ReplayMode_GatesOnBaseline), and a live sweep is the
+    // opposite case: the current settings may detect nothing, which is precisely why the user is here.
+
+    private static StarDetectionOptimizerWizardVM NewLiveVMWithRun(LoadedRun run) {
+        var engine = LiveEngine(_ => new AutoFocusResult { Succeeded = true, SaveFolder = @"C:\live\attempt" });
+        var vm = NewVM(LoaderReturning(run), isCameraConnected: () => true, isFocuserConnected: () => true,
+            autoFocusEngine: engine, frameReviewBuilder: new FakeReviewBuilder().Build);
+        vm.SourceMode = SourceMode.Live;
+        vm.SaveFolderPath = @"C:\live";
+        return vm;
+    }
+
+    [Test]
+    public async Task LiveSweep_UndersampledRig_LowersTheMinHfrGateInsteadOfRefusing() {
+        // THE DEFECT. At the shipped MinHFR of 1.2 this sweep leaves 2 usable positions against the 3 a hyperbola
+        // needs, so the guard refused with "does not produce a usable focus curve at the default detection
+        // settings" — circular, since finding settings that DO produce one is the whole job. The starless
+        // positions are INTERIOR, so widening the focus-recovery exemption cannot rescue it either.
+        var vm = NewLiveVMWithRun(UndersampledRun());
+
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.ErrorMessage, Is.Null.Or.Empty, "an undersampled rig must not be refused outright");
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Summary));
+            Assert.That(vm.HasMinHfrRescueNotice, Is.True, "lowering the gate is not silent — the user did not choose it");
+            Assert.That(vm.MinHfrRescueNotice, Does.Contain("1.2"), "the notice names the gate that failed");
+        });
+    }
+
+    [Test]
+    public async Task LiveSweep_UndersampledRig_SeedsTheSearchAtTheRescuedGate() {
+        // Being ALLOWED to reach a lower gate is not enough: per F20 the objective is identically zero across the
+        // neighbourhood of the default, so no single-axis step improves anything and the search never gets there on
+        // its own. The rescued gate must become the SEED — F35's rationale, triggered by feasibility rather than by
+        // a fitted vertex (which cannot exist once the gate has destroyed the fit).
+        var vm = NewLiveVMWithRun(UndersampledRun());
+
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.That(vm.Result, Is.Not.Null);
+        Assert.That(vm.Result.BestParams.MinHFR, Is.LessThanOrEqualTo(MinHfrSeed.SeedFloor),
+            "the search must START at the rescued gate, not merely be permitted to reach it");
+    }
+
+    [Test]
+    public async Task LiveSweep_RunThatFitsAtTheDefaults_IsNotProbedAndSaysNothing() {
+        // Inertness: the rescue is a LAST RESORT reached only after the normal guard fails. A healthy sweep must be
+        // untouched by it, and must not be handed a warning about a gate that was never moved.
+        var vm = NewLiveVMWithRun(GoodRun());
+
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Summary));
+            Assert.That(vm.HasMinHfrRescueNotice, Is.False);
+            Assert.That(vm.MinHfrRescueNotice, Is.Null.Or.Empty);
+        });
+    }
+
+    [Test]
+    public void LowerOf_TakesTheLowerFloorAndIgnoresAbsentOnes() {
+        // F35's vertex rule and F43's rescue probe can both produce a floor, and both only ever LOWER the gate, so
+        // the minimum is the one that actually admitted stars. Either being absent must leave the other intact.
+        Assert.Multiple(() => {
+            Assert.That(StarDetectionOptimizerWizardVM.LowerOf(0.3, 0.1), Is.EqualTo(0.1));
+            Assert.That(StarDetectionOptimizerWizardVM.LowerOf(0.1, 0.3), Is.EqualTo(0.1));
+            Assert.That(StarDetectionOptimizerWizardVM.LowerOf(null, 0.3), Is.EqualTo(0.3));
+            Assert.That(StarDetectionOptimizerWizardVM.LowerOf(0.3, null), Is.EqualTo(0.3));
+            Assert.That(StarDetectionOptimizerWizardVM.LowerOf(null, null), Is.Null);
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -489,7 +489,7 @@ public class StarDetectionOptimizerWizardVMTests {
             Assert.That(vm.ErrorMessage, Is.Null.Or.Empty, "an undersampled rig must not be refused outright");
             Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Summary));
             Assert.That(vm.HasMinHfrRescueNotice, Is.True, "lowering the gate is not silent — the user did not choose it");
-            Assert.That(vm.MinHfrRescueNotice, Does.Contain("1.2"), "the notice names the gate that failed");
+            Assert.That(vm.MinHfrRescueNotice, Does.Contain("0.3"), "the notice names the gate the run actually used");
         });
     }
 
@@ -520,6 +520,53 @@ public class StarDetectionOptimizerWizardVMTests {
             Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Summary));
             Assert.That(vm.HasMinHfrRescueNotice, Is.False);
             Assert.That(vm.MinHfrRescueNotice, Is.Null.Or.Empty);
+        });
+    }
+
+    // F43 second half. A SIGNAL-STARVED rig: lowering MinHFR alone makes the curve FITTABLE but leaves frames
+    // under the objective's NHard floor, so J is identically zero and the search has nothing to climb. Measured on
+    // a real 40 mm f/2 sweep at 4 s: MinHFR 1.2 -> 0.3 took the in-focus frame from 0 stars to 14, the curve fit,
+    // and 80 evaluations could not move J off 0. Relaxing the acceptance gate as well took the sweep to 20-1413
+    // stars per frame and it converged immediately. So the rescue's bar is SCORABLE, not merely fittable.
+    private static LoadedRun SignalStarvedRun(string id = "starved") {
+        Func<object, StarDetectorParams, CancellationToken, Task<FrameDetectionResult>> detect = (image, p, token) => {
+            var pos = (int)image;
+            var hfr = UndersampledHfr(pos);
+            if (hfr <= p.MinHFR) {
+                return Task.FromResult(new FrameDetectionResult { AverageHFR = 0.0, HFRStdDev = 0.05, StarCount = 0, StarCenters = Array.Empty<(double X, double Y)>() });
+            }
+            // Above the size gate the frame yields a curve, but only a couple of stars until the ACCEPTANCE gate
+            // is relaxed too — under the objective's hard floor, so J stays exactly 0.
+            var starved = p.Sensitivity > 1.0;
+            return Task.FromResult(new FrameDetectionResult {
+                AverageHFR = hfr,
+                HFRStdDev = 0.05,
+                StarCount = starved ? 2 : 40,
+                StarCenters = Array.Empty<(double X, double Y)>()
+            });
+        };
+        var data = new RunEvaluationData(id, NineFrames(), detect, NewAlglib(), DefaultFitConfig());
+        var seed = new StarDetectorParams { Sensitivity = 10.0, StarClippingMultiplier = 2.0, MinHFR = 1.2 };
+        var afOptions = new AutoFocusEngineOptions { AutoFocusStepSize = DefaultStepSize, AutoFocusInitialOffsetSteps = 4 };
+        return new LoadedRun { Data = data, Seed = seed, AfOptions = afOptions };
+    }
+
+    [Test]
+    public async Task LiveSweep_SignalStarvedRig_RescuesUntilTheSeedIsSCORABLE_NotMerelyFittable() {
+        // Handing the search a seed where J is identically zero is indistinguishable, to the user, from refusing:
+        // the wizard appears to run and produces nothing. The rescue must keep going until the objective the
+        // search maximizes is actually non-zero.
+        var vm = NewLiveVMWithRun(SignalStarvedRun());
+
+        await vm.StartAsync(CancellationToken.None);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.ErrorMessage, Is.Null.Or.Empty);
+            Assert.That(vm.CurrentStep, Is.EqualTo(WizardStep.Summary));
+            Assert.That(vm.HasMinHfrRescueNotice, Is.True);
+            Assert.That(vm.Result, Is.Not.Null);
+            Assert.That(vm.Result.SeedJ, Is.GreaterThan(0.0),
+                "the search must be seeded somewhere it can climb, not on the J = 0 plateau");
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionImportFromRunFolderTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/StarDetectionImportFromRunFolderTests.cs
@@ -1,0 +1,175 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NINA.Joko.Plugins.HocusFocus.Tests.TestDoubles;
+using NINA.Profile.Interfaces;
+using NSubstitute;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.StarDetection {
+
+    /// <summary>
+    /// Importing the settings handoff a previous optimize pass left beside a run's frames — the EXPLICIT,
+    /// user-pressed alternative to auto-pickup. Auto-pickup was rejected because the wizard's baseline is the
+    /// live profile: <c>baselineJ</c> and the headline improvement percentage are both measured against it, so a
+    /// run folder silently becoming "Current" would change what that percentage means with nothing on screen to
+    /// say so.
+    /// </summary>
+    [TestFixture]
+    public class StarDetectionImportFromRunFolderTests {
+
+        private string tempRoot;
+
+        [SetUp]
+        public void SetUp() {
+            tempRoot = Path.Combine(Path.GetTempPath(), "hf_runfolder_" + Path.GetRandomFileName());
+            Directory.CreateDirectory(tempRoot);
+        }
+
+        [TearDown]
+        public void TearDown() {
+            try {
+                if (Directory.Exists(tempRoot)) {
+                    Directory.Delete(tempRoot, recursive: true);
+                }
+            } catch { /* best effort */ }
+        }
+
+        private static StarDetectionOptions NewOptions() =>
+            new StarDetectionOptions(Substitute.For<IProfileService>(), new InMemoryPluginOptionsAccessor());
+
+        private static void WriteHandoff(string folder, double sensitivity) {
+            Directory.CreateDirectory(folder);
+            var landing = new OptimizedStarDetectionSettings {
+                BrightnessSensitivity = sensitivity,
+                StarClippingMultiplier = 2.0,
+                MinHFR = 0.7,
+                StructureLayers = 6
+            };
+            var export = StarDetectionSettingsExport.FromOptimizedLanding(NewOptions(), landing);
+            File.WriteAllText(
+                Path.Combine(folder, StarDetectionSettingsIO.RunFolderSettingsFileName), export.Serialize());
+        }
+
+        [Test]
+        public async Task Import_OnApply_LoadsTheRunFoldersLanding() {
+            var runFolder = Path.Combine(tempRoot, "attempt01");
+            WriteHandoff(runFolder, sensitivity: 21.5);
+
+            var options = NewOptions();
+            options.BrightnessSensitivity = 2.0;
+
+            IReadOnlyList<StarDetectionSettingDiffRow> shownRows = null;
+            await StarDetectionSettingsIO.ImportFromRunFolderAsync(runFolder, options, (rows, _) => {
+                shownRows = rows;
+                return Task.FromResult(true);
+            });
+
+            Assert.Multiple(() => {
+                Assert.That(shownRows, Is.Not.Empty, "the diff must be shown before anything is applied");
+                Assert.That(options.BrightnessSensitivity, Is.EqualTo(21.5));
+            });
+        }
+
+        /// <summary>The property the whole "explicit button" decision rests on: declining changes nothing.</summary>
+        [Test]
+        public async Task Import_OnCancel_LeavesCurrentSettingsUntouched() {
+            var runFolder = Path.Combine(tempRoot, "attempt01");
+            WriteHandoff(runFolder, sensitivity: 21.5);
+
+            var options = NewOptions();
+            options.BrightnessSensitivity = 2.0;
+
+            await StarDetectionSettingsIO.ImportFromRunFolderAsync(runFolder, options, (_, __) => Task.FromResult(false));
+
+            Assert.That(options.BrightnessSensitivity, Is.EqualTo(2.0));
+        }
+
+        /// <summary>A run that was never optimized has no handoff. That must be a quiet no-op, and above all it
+        /// must never prompt — a confirmation dialog for a file that does not exist is worse than silence.</summary>
+        [Test]
+        public async Task Import_WithNoHandoffPresent_NeverPrompts() {
+            var runFolder = Path.Combine(tempRoot, "attempt01");
+            Directory.CreateDirectory(runFolder);
+
+            var options = NewOptions();
+            options.BrightnessSensitivity = 2.0;
+            var prompted = false;
+
+            await StarDetectionSettingsIO.ImportFromRunFolderAsync(runFolder, options, (_, __) => {
+                prompted = true;
+                return Task.FromResult(true);
+            });
+
+            Assert.Multiple(() => {
+                Assert.That(prompted, Is.False);
+                Assert.That(options.BrightnessSensitivity, Is.EqualTo(2.0));
+            });
+        }
+
+        /// <summary>Frame folder first, then the run root: an <c>optimize --per-run</c> pass writes beside the
+        /// frames and a joint pass writes at the root, mirroring the AF-replay metadata convention.</summary>
+        [Test]
+        public void Resolve_PrefersTheFrameFolderOverTheRunRoot() {
+            var runFolder = Path.Combine(tempRoot, "attempt01");
+            WriteHandoff(runFolder, sensitivity: 21.5);
+            WriteHandoff(tempRoot, sensitivity: 9.9);
+
+            var resolved = StarDetectionSettingsIO.ResolveRunFolderSettings(runFolder);
+
+            Assert.That(Path.GetDirectoryName(resolved), Is.EqualTo(runFolder));
+        }
+
+        [Test]
+        public void Resolve_FallsBackToTheRunRoot() {
+            var runFolder = Path.Combine(tempRoot, "attempt01");
+            Directory.CreateDirectory(runFolder);
+            WriteHandoff(tempRoot, sensitivity: 9.9);
+
+            var resolved = StarDetectionSettingsIO.ResolveRunFolderSettings(runFolder);
+
+            Assert.That(Path.GetDirectoryName(resolved), Is.EqualTo(tempRoot));
+        }
+
+        /// <summary>A corrupt or wrong-type file must not prompt and must not apply. The envelope's own
+        /// <c>fileType</c> discriminator is what separates it from an AF-replay <c>metadata.json</c>, which has
+        /// the same <c>schemaVersion</c> + <c>starDetection</c> shape and would otherwise deserialize cleanly.</summary>
+        [Test]
+        public async Task Import_WithAWrongTypeFile_NeverPromptsAndChangesNothing() {
+            var runFolder = Path.Combine(tempRoot, "attempt01");
+            Directory.CreateDirectory(runFolder);
+            File.WriteAllText(
+                Path.Combine(runFolder, StarDetectionSettingsIO.RunFolderSettingsFileName),
+                "{\"schemaVersion\":1,\"starDetection\":{\"brightnessSensitivity\":99.0}}");
+
+            var options = NewOptions();
+            options.BrightnessSensitivity = 2.0;
+            var prompted = false;
+
+            await StarDetectionSettingsIO.ImportFromRunFolderAsync(runFolder, options, (_, __) => {
+                prompted = true;
+                return Task.FromResult(true);
+            });
+
+            Assert.Multiple(() => {
+                Assert.That(prompted, Is.False, "a file lacking the fileType discriminator must be rejected");
+                Assert.That(options.BrightnessSensitivity, Is.EqualTo(2.0));
+            });
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -1401,21 +1401,14 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             // reapplied by the tilt replay overlay. A knob present in the DTO but missing from OverlayOptimizedSettings
             // silently leaks the live-profile value on replay — the LocallyAdaptiveBinarization / AdaptiveNoiseBlockSize
             // regression that made a replayed calibration disagree with the run it was captured from.
-            var metadataOnly = new HashSet<string> {
-                nameof(OptimizedStarDetectionSettings.CreatedAtUtc),
-                nameof(OptimizedStarDetectionSettings.RunCount),
-                nameof(OptimizedStarDetectionSettings.BaselineJ),
-                nameof(OptimizedStarDetectionSettings.FinalJ),
-                nameof(OptimizedStarDetectionSettings.RecommendedStepSize),
-                nameof(OptimizedStarDetectionSettings.RecommendedOffsetSteps),
-                nameof(OptimizedStarDetectionSettings.SchemaVersion),
-                // F30 provenance: records WHICH INVOCATION produced the landing. Metadata, not a knob — nothing
-                // applies it to StarDetectorParams, and the replay overlay must not try to.
-                nameof(OptimizedStarDetectionSettings.Provenance),
-            };
+            // The knob/bookkeeping split comes from the DTO itself, NOT from a second copy of the exclusion list
+            // kept here. This test used to own that copy, and it drifted the moment two bookkeeping fields were
+            // added to the DTO (F32's keep floor): they were reported as detector knobs the overlay had failed to
+            // apply. A coverage guard that keeps its own idea of what it is covering guards the wrong set.
+            var curatedNames = new HashSet<string>(OptimizedStarDetectionSettings.CuratedKnobNames);
             var curatedKnobs = typeof(OptimizedStarDetectionSettings)
                 .GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                .Where(p => p.CanRead && p.CanWrite && !metadataOnly.Contains(p.Name))
+                .Where(p => p.CanRead && p.CanWrite && curatedNames.Contains(p.Name))
                 .ToList();
             Assert.That(curatedKnobs, Is.Not.Empty, "Expected OptimizedStarDetectionSettings to expose curated knobs");
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/Catalog/AstapCatalogReader.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/Catalog/AstapCatalogReader.cs
@@ -76,7 +76,15 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.Catalog {
                 throw new ArgumentOutOfRangeException(nameof(fovDeg), fovDeg, "FOV must be positive.");
             }
 
-            var cells = AstapCellGeometry.FindAreas(raRad, decRad, fovRad, db.Partitioning);
+            // F44 — a field WIDER THAN ONE CELL cannot be covered by find_areas: that routine clamps the field to
+            // one cell and samples only its four corners, so a 57° render field came back as a ~10° patch and the
+            // rest of the sensor rendered starless. Below the cap the two agree by construction (a box at most one
+            // cell across touches at most four cells, and its corners hit all of them), so small fields keep the
+            // byte-accurate reference path and every existing result is unchanged.
+            var maxFov = AstapCellGeometry.MaxFovRadians(db.Partitioning);
+            var cells = fovRad > maxFov
+                ? AstapCellGeometry.FindAreasCovering(raRad, decRad, fovRad, db.Partitioning)
+                : AstapCellGeometry.FindAreas(raRad, decRad, fovRad, db.Partitioning);
             return QueryCells(cells, db, raRad, decRad, fovRad, limitingMagnitude);
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/Catalog/AstapCellGeometry.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/Catalog/AstapCellGeometry.cs
@@ -174,7 +174,7 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.Catalog {
         /// Maximum FOV (radians) a single query may span before <c>find_areas</c> would risk missing a tile:
         /// one cell dimension (9.53° for .290, 5.142857° for .1476). Matches the reference crop.
         /// </summary>
-        private static double MaxFovRadians(AstapPartitioning partitioning) =>
+        public static double MaxFovRadians(AstapPartitioning partitioning) =>
             (partitioning == AstapPartitioning.Astap1476 ? 5.142857 : 9.53) * Deg;
 
         /// <summary>
@@ -207,6 +207,132 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.Catalog {
             }
             // Unreachable given the range check above.
             throw new ArgumentOutOfRangeException(nameof(area), area, "Could not map area to a cell file.");
+        }
+
+        /// <summary>
+        /// EVERY cell intersecting a cone of angular radius <c>fovRadians / 2</c> about (ra, dec) — the wide-field
+        /// counterpart to <see cref="FindAreas"/>.
+        ///
+        /// <para><b>Why this exists (F44).</b> <see cref="FindAreas"/> is a faithful port of ASTAP's
+        /// <c>find_areas</c>, which clamps the field to ONE CELL (<see cref="MaxFovRadians"/>) and then samples
+        /// only the four CORNERS of that clamped box. That is exactly right for plate-solving, where fields are a
+        /// few degrees and four corner cells genuinely cover them. It is wrong for rendering: a 40 mm lens on a
+        /// full-frame sensor spans ~57°, the clamp cuts the query to 5.14°, and the simulator rendered stars over
+        /// a ~10° patch of a 48.5° × 33.4° frame with the rest of the sensor empty. Nothing warned, because the
+        /// query returned plenty of stars — just not the right ones.</para>
+        ///
+        /// <para><b>Deliberately over-inclusive.</b> The RA span per band is padded by one whole cell on each
+        /// side, and a cone touching a pole takes every cell of every band it reaches. Extra cells cost a little
+        /// I/O and are then trimmed by the caller's per-star angular cut and by the projection's frame bounds;
+        /// missing cells are the defect. Correctness first.</para>
+        ///
+        /// <para><see cref="AstapAreaSelection.Fraction"/> is reported as an even split. The reference's
+        /// per-corner coverage arithmetic does not generalize to an arbitrary cell count, and nothing reads the
+        /// value — it exists for diagnostics.</para>
+        /// </summary>
+        /// <param name="raRadians">Field-center RA [radians].</param>
+        /// <param name="decRadians">Field-center Dec [radians].</param>
+        /// <param name="fovRadians">Full field-of-view angle [radians]; NOT clamped.</param>
+        /// <param name="partitioning">Which cell partitioning the target database uses.</param>
+        public static IReadOnlyList<AstapAreaSelection> FindAreasCovering(
+            double raRadians, double decRadians, double fovRadians, AstapPartitioning partitioning) {
+            if (fovRadians <= 0.0) {
+                throw new ArgumentOutOfRangeException(nameof(fovRadians), fovRadians, "FOV must be positive.");
+            }
+
+            var decB = partitioning == AstapPartitioning.Astap1476 ? DecBoundaries1476 : DecBoundaries290;
+            var cellsPerBand = partitioning == AstapPartitioning.Astap1476 ? CellsPerBand1476 : CellsPerBand290;
+            var cumBefore = partitioning == AstapPartitioning.Astap1476 ? CumBefore1476 : CumBefore290;
+            var nBands = cellsPerBand.Length;
+
+            var ra = NormalizeRa(raRadians);
+            var radius = Math.Min(fovRadians / 2.0, Math.PI);
+            var decLo = decRadians - radius;
+            var decHi = decRadians + radius;
+
+            var areas = new SortedSet<int>();
+            for (var b = 1; b <= nBands; b++) {
+                var bandLo = decB[b - 1];
+                var bandHi = decB[b];
+                if (bandHi < decLo || bandLo > decHi) {
+                    continue; // band lies entirely outside the cone's declination range
+                }
+
+                var cellsInBand = cellsPerBand[b - 1];
+                if (cellsInBand <= 1) {
+                    areas.Add(cumBefore[b] + 1); // pole cell: one cell spans all RA
+                    continue;
+                }
+
+                var cellWidth = TwoPi / cellsInBand;
+                // No special case for a cone containing a pole: MaxRaHalfSpan already returns pi there, both via
+                // its cos(dec) guard and because the law-of-cosines term drops below -1 (at dec0 = 89 deg with
+                // r = 15 deg it evaluates to -41.5). A separate touchesPole branch WAS written here, measured
+                // against the tests, found to change nothing, and removed rather than left as an untested path.
+                var halfSpan = MaxRaHalfSpan(decRadians, radius, Math.Max(bandLo, decLo), Math.Min(bandHi, decHi));
+                if (double.IsNaN(halfSpan)) {
+                    continue; // the cone does not actually reach into this band
+                }
+
+                if (halfSpan + cellWidth >= Math.PI) {
+                    for (var i = 0; i < cellsInBand; i++) {
+                        areas.Add(cumBefore[b] + 1 + i);
+                    }
+                    continue;
+                }
+
+                // Pad by a whole cell each side, then walk the (possibly wrapping) index range.
+                var first = (int)Math.Floor((ra - halfSpan - cellWidth) / cellWidth);
+                var last = (int)Math.Floor((ra + halfSpan + cellWidth) / cellWidth);
+                for (var i = first; i <= last; i++) {
+                    var idx = ((i % cellsInBand) + cellsInBand) % cellsInBand;
+                    areas.Add(cumBefore[b] + 1 + idx);
+                }
+            }
+
+            // CellFileName, NOT the bare area number: the on-disk names are band/index encoded ("0101.1476"),
+            // and building them by hand here would produce files that do not exist.
+            var fraction = areas.Count > 0 ? 1.0 / areas.Count : 0.0;
+            var result = new List<AstapAreaSelection>(areas.Count);
+            foreach (var area in areas) {
+                result.Add(new AstapAreaSelection(area, fraction, CellFileName(area, partitioning)));
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// The largest half-width in RA [radians] that a cone of <paramref name="radius"/> about
+        /// (<paramref name="centerDec"/>, implicit RA) subtends anywhere in the declination range
+        /// [<paramref name="decFrom"/>, <paramref name="decTo"/>]. NaN when the cone does not reach that range.
+        ///
+        /// <para>From the spherical law of cosines: <c>cos Δra = (cos r − sin d₀ sin d) / (cos d₀ cos d)</c>.
+        /// Evaluated at both ends of the range and at the cone centre's own declination when that falls inside it,
+        /// because the extremum can sit at either an endpoint or the centre.</para>
+        /// </summary>
+        private static double MaxRaHalfSpan(double centerDec, double radius, double decFrom, double decTo) {
+            var best = double.NaN;
+            var samples = decFrom <= centerDec && centerDec <= decTo
+                ? new[] { decFrom, decTo, centerDec }
+                : new[] { decFrom, decTo };
+            foreach (var d in samples) {
+                var cosD = Math.Cos(d);
+                var cosD0 = Math.Cos(centerDec);
+                if (cosD <= 1e-12 || cosD0 <= 1e-12) {
+                    return Math.PI; // at/near a pole every meridian is within reach
+                }
+                var cosDelta = (Math.Cos(radius) - (Math.Sin(centerDec) * Math.Sin(d))) / (cosD0 * cosD);
+                if (cosDelta <= -1.0) {
+                    return Math.PI;
+                }
+                if (cosDelta >= 1.0) {
+                    continue; // cone does not reach this declination
+                }
+                var delta = Math.Acos(cosDelta);
+                if (double.IsNaN(best) || delta > best) {
+                    best = delta;
+                }
+            }
+            return best;
         }
 
         /// <summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -1140,6 +1140,17 @@
                     Text="{Binding RecoveryWidenedNotice}"
                     TextWrapping="Wrap"
                     Visibility="{Binding HasRecoveryWidenedNotice, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+
+                <!--  F43. Also not an error: the sweep could not be fitted at the default minimum-HFR gate, so the
+                      gate was lowered to obtain a curve and the search was seeded there. Shown because the wizard is
+                      then reporting results from a gate the user did not choose — and on a short focal length that
+                      gate is the single setting they most need to know about.  -->
+                <TextBlock
+                    Margin="0,8,0,0"
+                    Foreground="{StaticResource NotificationWarningBrush}"
+                    Text="{Binding MinHfrRescueNotice}"
+                    TextWrapping="Wrap"
+                    Visibility="{Binding HasMinHfrRescueNotice, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
             </StackPanel>
 
             <!--  Footer: navigation. Exactly one step's buttons show at a time; while busy only Cancel shows.  -->

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -25,6 +25,7 @@
     <TextBlock x:Key="SDOpt_Variant_Tooltip" Text="Switch the chart and the summary below between your current settings, the optimized settings, and (after Optimize with feedback) the feedback-optimized settings. Accept applies whichever variant is shown (Current can't be accepted — it's your baseline)." />
     <TextBlock x:Key="SDOpt_DonutDetection_Tooltip" Text="When checked, the optimizer is allowed to recover out-of-focus DONUT stars — heavily defocused stars that appear as hollow rings — which the detector otherwise drops (they fragment or fail the fill-ratio test). It also unlocks diffraction-spike and saturated-bloom suppression so a bright star's rays aren't mistaken for stars. Recommended for telescopes with a central obstruction (Newtonians/SCTs) whose defocused stars become donuts; leave OFF for refractors (defocused stars are filled disks, not rings). Saved to your profile and default OFF. When OFF, star detection is exactly as before." />
     <TextBlock x:Key="SDOpt_Inspection_Tooltip" Text="When checked, the optimizer favors detecting MANY MORE stars spread across the frame, which the aberration inspector needs to measure sensor tilt and field curvature. It does this by trading away a little auto-focus-curve sharpness for star count — but the fit is bounded: settings that make the focus curve noticeably worse than your current settings are penalized, so focus stays usable. Leave OFF to optimize purely for the tightest auto-focus curve (the default). Only applies in Optimize mode; nothing is saved until you Accept." />
+    <TextBlock x:Key="SDOpt_ImportRunSettings_Tooltip" Text="Load the star detection settings a previous optimization saved next to this run's frames, and apply them to your current settings. You are shown exactly what would change before anything is applied. This is never done automatically: your current settings are what the wizard measures its improvement against, so silently replacing them would change what the reported improvement means." />
     <TextBlock x:Key="SDOpt_Continue_Tooltip" Text="Run another optimization pass starting from the settings just found, giving the search a fresh chance to refine further (it resets its step sizes, so it can make larger moves again). Useful when the last pass looks like it stopped just short. Limited to 3 total passes; the Changed parameters table shows the value of each setting after every pass." />
     <TextBlock x:Key="SDOpt_LiveExposure_Tooltip" Text="The exposure for every frame of the sweep, starting from your profile's auto-focus exposure. Make it long enough that stars stay visible out at the defocused ends of the sweep. Narrowband filters usually need a longer exposure to start. After a good result you can adopt this exposure into your profile from the summary." />
     <TextBlock x:Key="SDOpt_LiveSaveFolder_Tooltip" Text="The captured frames are saved here, in a timestamped AutoFocus_… subfolder, then loaded back like a saved run so the optimizer can search them. A folder is required before Start. Choosing one also saves it as your Hocus Focus auto-focus save path." />
@@ -1188,6 +1189,15 @@
                     Content="Continue optimizing"
                     ToolTip="{StaticResource SDOpt_Continue_Tooltip}"
                     Visibility="{Binding ShowSummary, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                <!--  Import this run's saved settings: shown only when a loaded run actually carries a settings
+                      handoff, so it never appears as a dead control on a run that has never been optimized.  -->
+                <Button
+                    Width="150"
+                    Margin="0,0,8,0"
+                    Command="{Binding ImportRunSettingsCommand}"
+                    Content="Use run's settings"
+                    ToolTip="{StaticResource SDOpt_ImportRunSettings_Tooltip}"
+                    Visibility="{Binding CanImportRunSettings, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                 <Button
                     Width="90"
                     Margin="0,0,8,0"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
@@ -70,6 +70,28 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public int RecommendedOffsetSteps { get; set; }
 
         /// <summary>
+        /// F32 — the detection-keep floor that was IN FORCE while this landing was searched, or null when the
+        /// search was unconstrained. Bookkeeping about the run, not a detector knob: it changes which candidates
+        /// were eligible, never what the detector does with the ones recorded here.
+        ///
+        /// <para>Recorded because F39's complaint generalizes — a file that records settings a run did not use is
+        /// worse than one that records nothing, and the converse holds too: a landing produced under a constraint
+        /// is not comparable to one produced without, and nothing else in this file would say so. Omitted from the
+        /// JSON when null, so an unconstrained landing stays byte-identical to before this field existed.</para>
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public double? MinDetectionKeepFraction { get; set; }
+
+        /// <summary>
+        /// F32 — what this landing actually kept: accepted stars as a fraction of the seed's, MIN over runs. Null
+        /// when no floor was in force. Reported, never scored — it is the number that makes a landing's COST
+        /// legible next to its ΔJ, where the whole finding is that ΔJ alone hides it (a median ΔJ of +0.0125
+        /// bought with a median 0.243 of recall).
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public double? LandingDetectionKeepFraction { get; set; }
+
+        /// <summary>
         /// The gate this landing ACTUALLY enforces — <c>max(BrightnessSensitivity, StarPeakResponse ×
         /// effective StarClippingMultiplier)</c> (followup F33). Derived, get-only: it adds no state, so it needs
         /// no schema bump and is computed for every landing already on disk when one is read back.
@@ -138,7 +160,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             new System.Collections.Generic.HashSet<string>(StringComparer.Ordinal) {
                 nameof(SchemaVersion), nameof(CreatedAtUtc), nameof(RunCount), nameof(BaselineJ), nameof(FinalJ),
                 nameof(RecommendedStepSize), nameof(RecommendedOffsetSteps), nameof(Provenance),
-                nameof(EffectiveSensitivityGate)
+                nameof(EffectiveSensitivityGate),
+                // F32 — describe the SEARCH that produced this landing (which candidates were eligible), not the
+                // detector. Registering them here is load-bearing: the DTO→options mapping is by reflected name,
+                // so an unregistered bookkeeping field would be hunted for as a live knob.
+                nameof(MinDetectionKeepFraction), nameof(LandingDetectionKeepFraction)
             };
 
         /// <summary>
@@ -204,9 +230,16 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// for a snapshot that CAPTURES live settings rather than reporting an optimizer result — the tilt
         /// wizard's <c>CaptureDetectionSettings</c> is exactly that, and stamping a producer on it would be a
         /// lie.</param>
+        /// <param name="minDetectionKeepFraction">F32 — the keep floor in force during the search, or null when
+        /// unconstrained. Optional so every existing caller (and every snapshot that captures live settings
+        /// rather than an optimizer result) keeps writing byte-identical files.</param>
+        /// <param name="landingDetectionKeepFraction">F32 — what the landing kept, min over runs. Pass null
+        /// whenever <paramref name="minDetectionKeepFraction"/> is null; a keep fraction with no floor beside it
+        /// would read as a constraint that was never applied.</param>
         public static OptimizedStarDetectionSettings FromParams(
             StarDetectorParams p, int runCount, double baselineJ, double finalJ, int recommendedStepSize, int recommendedOffsetSteps,
-            OptimizerProvenance provenance = null) {
+            OptimizerProvenance provenance = null,
+            double? minDetectionKeepFraction = null, double? landingDetectionKeepFraction = null) {
             if (p == null) {
                 throw new ArgumentNullException(nameof(p));
             }
@@ -248,7 +281,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 FinalJ = finalJ,
                 RecommendedStepSize = recommendedStepSize,
                 RecommendedOffsetSteps = recommendedOffsetSteps,
-                Provenance = provenance?.Clone()
+                Provenance = provenance?.Clone(),
+                MinDetectionKeepFraction = minDetectionKeepFraction,
+                // Only meaningful alongside a floor, and NaN is not a number a JSON reader should have to handle.
+                LandingDetectionKeepFraction = minDetectionKeepFraction.HasValue
+                    && landingDetectionKeepFraction is double lk && double.IsFinite(lk) ? lk : (double?)null
             };
         }
     }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
@@ -83,10 +83,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public double? MinDetectionKeepFraction { get; set; }
 
         /// <summary>
-        /// F32 — what this landing actually kept: accepted stars as a fraction of the seed's, MIN over runs. Null
-        /// when no floor was in force. Reported, never scored — it is the number that makes a landing's COST
-        /// legible next to its ΔJ, where the whole finding is that ΔJ alone hides it (a median ΔJ of +0.0125
-        /// bought with a median 0.243 of recall).
+        /// F32 — what this landing actually kept: accepted stars as a fraction of the SEED's, MIN over runs.
+        /// Reported, never scored.
+        ///
+        /// <para><b>Written whether or not a floor was in force</b>, unlike
+        /// <see cref="MinDetectionKeepFraction"/>. It costs nothing (the counts are already in hand) and it is
+        /// precisely the "keep%" F32 had to reconstruct by hand from stored landings across two waves. An
+        /// UNCONSTRAINED landing is exactly where this number is most needed: it is what says whether a floor
+        /// would have bound, so a control arm can be classified without re-running it. Null only when the
+        /// evaluator reported no star counts to measure.</para>
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public double? LandingDetectionKeepFraction { get; set; }
@@ -312,9 +317,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 RecommendedOffsetSteps = recommendedOffsetSteps,
                 Provenance = provenance?.Clone(),
                 MinDetectionKeepFraction = minDetectionKeepFraction,
-                // Only meaningful alongside a floor, and NaN is not a number a JSON reader should have to handle.
-                LandingDetectionKeepFraction = minDetectionKeepFraction.HasValue
-                    && landingDetectionKeepFraction is double lk && double.IsFinite(lk) ? lk : (double?)null
+                // Recorded whenever it is measurable, floor or no floor — see the property doc. NaN is filtered
+                // because it is not a number a JSON reader should have to handle.
+                LandingDetectionKeepFraction =
+                    landingDetectionKeepFraction is double lk && double.IsFinite(lk) ? lk : (double?)null
             };
         }
     }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
@@ -223,6 +223,25 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             return diffs;
         }
 
+        /// <summary>
+        /// The names of the curated detector axes on this DTO — everything that is NOT run bookkeeping.
+        ///
+        /// <para>Exposed so that consumers which must cover "every knob" enumerate from THIS list rather than
+        /// keeping their own copy of the exclusions. A second copy drifts: the tilt replay overlay's coverage
+        /// guard kept its own <c>metadataOnly</c> set and started failing the moment two bookkeeping fields were
+        /// added here, reporting them as unapplied detector knobs. One list, checked by everyone.</para>
+        /// </summary>
+        public static System.Collections.Generic.IReadOnlyList<string> CuratedKnobNames { get; } =
+            KnobPropertyNames();
+
+        private static string[] KnobPropertyNames() {
+            var names = new System.Collections.Generic.List<string>();
+            foreach (var p in KnobProperties()) {
+                names.Add(p.Name);
+            }
+            return names.ToArray();
+        }
+
         /// <summary>The curated axes that would NOT land on <paramref name="flatOptionsType"/> — empty is the
         /// invariant; anything else means a landing does not fully round-trip into a settings file.</summary>
         public static System.Collections.Generic.IReadOnlyList<string> UnmappedKnobs(Type flatOptionsType) {
@@ -237,7 +256,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         }
 
         private static System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> KnobProperties() {
-            foreach (var p in typeof(OptimizedStarDetectionSettings).GetProperties()) {
+            // INSTANCE properties only. GetProperties() with no flags also returns STATIC ones, and a static
+            // member is by definition not a per-landing detector knob — CuratedKnobNames itself was picked up as
+            // one the moment it was added, and reported as an axis with no matching option property.
+            const System.Reflection.BindingFlags flags =
+                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance;
+            foreach (var p in typeof(OptimizedStarDetectionSettings).GetProperties(flags)) {
                 if (p.CanRead && !NonKnobFields.Contains(p.Name)) {
                     yield return p;
                 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
@@ -189,6 +189,35 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             }
         }
 
+        /// <summary>
+        /// The curated axes whose VALUE on <paramref name="flatOptions"/> differs from this landing's — empty means
+        /// the landing survived a round trip through a settings file intact.
+        ///
+        /// <para>Routes through the same <see cref="KnobProperties"/> enumeration as
+        /// <see cref="ApplyToFlatOptions"/> and <see cref="UnmappedKnobs"/>, so a newly added axis is covered by
+        /// all three at once and none of them can silently stop checking one. An axis that does not exist on the
+        /// target at all is reported here too — a missing knob and a wrong knob are the same defect to a reader
+        /// who imports the file.</para>
+        /// </summary>
+        public System.Collections.Generic.IReadOnlyList<string> DiffKnobs(object flatOptions) {
+            if (flatOptions == null) {
+                throw new ArgumentNullException(nameof(flatOptions));
+            }
+            var targetType = flatOptions.GetType();
+            var diffs = new System.Collections.Generic.List<string>();
+            foreach (var source in KnobProperties()) {
+                var target = targetType.GetProperty(source.Name);
+                if (target == null || !target.CanRead || target.PropertyType != source.PropertyType) {
+                    diffs.Add(source.Name + " (unmapped)");
+                    continue;
+                }
+                if (!Equals(source.GetValue(this), target.GetValue(flatOptions))) {
+                    diffs.Add($"{source.Name} ({source.GetValue(this)} != {target.GetValue(flatOptions)})");
+                }
+            }
+            return diffs;
+        }
+
         /// <summary>The curated axes that would NOT land on <paramref name="flatOptionsType"/> — empty is the
         /// invariant; anything else means a landing does not fully round-trip into a settings file.</summary>
         public static System.Collections.Generic.IReadOnlyList<string> UnmappedKnobs(Type flatOptionsType) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizer.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizer.cs
@@ -54,6 +54,74 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// <c>synth-validate</c> and <c>tilt</c>, neither of which fits a curve before optimizing.</para>
         /// </summary>
         public double? MinHfrSeedFloor { get; set; }
+
+        /// <summary>
+        /// F32 — the smallest fraction of the SEED's accepted-star count a candidate may keep and still be
+        /// eligible to win. Null (the default) leaves every caller bit-identical.
+        ///
+        /// <para><b>Why this is a constraint and not a term.</b> The optimizer is not mis-scoring: on the real
+        /// bank σ_focus improves on 10 of 10 star-shedding runs (median ratio 0.320) and R² on 9 of 10 — it is
+        /// genuinely buying a better fit with the stars it discards. What is missing is a bound on the PRICE.
+        /// Measured, the trade is 5.7:1 by construction: <see cref="OptimizationObjective.SStars"/> hard-clamps
+        /// at nMin ≥ 8 / nMedian ≥ 20 (a starvation detector, not a star-count reward), so the only unsaturating
+        /// star term is the tie-breaker's 0.6·nMean/(nMean+20) at Wtie = 0.02 — worth at most 0.012 of J across
+        /// the entire range from zero stars to infinite stars, while a 10% σ tightening buys +0.0037. Halving
+        /// 300 stars to 150 costs 0.00066. Real landings gave up a median 0.243 of recall for a median ΔJ of
+        /// +0.0125; `toml999` gave up 46 points of recall for two ten-thousandths of J.</para>
+        ///
+        /// <para><b>Why not the two alternatives.</b> RESCALING J is provably a no-op for the search — a monotone
+        /// transform preserves the argmax, so every landing would be identical; it buys human legibility and not
+        /// one different decision. RAISING <c>Wtie</c> has already lost this fight once: it was raised 1e-3 → 0.02
+        /// specifically to out-vote this corner (see <see cref="ObjectiveConstants"/>), calibrated against a
+        /// plateau σ-wiggle of ≲4e-3, and the real shedders' σ gains are far larger.</para>
+        ///
+        /// <para><b>Applied as a feasibility REJECTION, never as a multiplier on J.</b> An infeasible candidate is
+        /// discarded ahead of the <c>j &gt; bestJ</c> compare, so every reported BaselineJ/FinalJ/SeedJ/BestJ
+        /// keeps the numeric meaning it has in every prior arm and landings stay directly comparable. Scaling J
+        /// instead would silently re-anchor the whole measurement history.</para>
+        ///
+        /// <para>The seed is feasible by construction (keep = 1.0), so the feasible set is never empty and the
+        /// never-regress floor is preserved: worst case the search returns the seed.</para>
+        /// </summary>
+        public double? MinDetectionKeepFraction { get; set; }
+
+        /// <summary>
+        /// F32 — the per-run accepted-star totals the keep fraction is measured against. Null (the default) means
+        /// "use this call's own seed evaluation", which is correct for a single-pass optimization.
+        ///
+        /// <para><b>It exists to close the multi-pass ratchet.</b> Both multi-pass callers re-invoke
+        /// <see cref="StarDetectionOptimizer.OptimizeAsync"/> with <c>seed = the previous pass's best</c> — TestApp's
+        /// <c>--continue-rounds</c> and the wizard's Continue button. A cap measured against EACH CALL's own seed
+        /// therefore compounds: at a floor of 0.5, two continue rounds permit 0.25 of the original, three permit
+        /// 0.125. That is the constraint paid in installments. Multi-pass callers capture
+        /// <see cref="OptimizationResult.SeedRunDetectionTotals"/> from the FIRST pass and pass it here for every
+        /// later round, so the floor always refers to where the user actually started.</para>
+        /// </summary>
+        public IReadOnlyList<long> DetectionKeepBaselineTotals { get; set; }
+    }
+
+    /// <summary>
+    /// One evaluated candidate: its objective value, whether it satisfies the F32 detection-keep floor, and the
+    /// keep fraction itself.
+    ///
+    /// <para><b><see cref="J"/> is the unmodified objective</b> — identical with and without a floor in force.
+    /// Feasibility is carried alongside it, never folded into it, so a landing's J stays comparable to every
+    /// landing produced before the constraint existed.</para>
+    /// </summary>
+    public readonly struct CandidateEvaluation {
+
+        public CandidateEvaluation(double j, bool feasible, double keepFraction) {
+            J = j;
+            Feasible = feasible;
+            KeepFraction = keepFraction;
+        }
+
+        public double J { get; }
+
+        public bool Feasible { get; }
+
+        /// <summary>Accepted stars kept relative to the baseline, MIN over runs. NaN when unmeasurable.</summary>
+        public double KeepFraction { get; }
     }
 
     /// <summary>Progress payload emitted during <see cref="StarDetectionOptimizer.OptimizeAsync"/>.</summary>
@@ -79,6 +147,23 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public int Evaluations { get; set; }
         public bool ImprovedOverSeed { get; set; }
         public IReadOnlyList<(string Name, double SeedValue, double BestValue)> ChangedVariables { get; set; }
+
+        /// <summary>F32 — per-run accepted-star totals of the SEED evaluation, in run order. A multi-pass caller
+        /// captures this from its FIRST pass and feeds it back through
+        /// <see cref="OptimizerSettings.DetectionKeepBaselineTotals"/> so the keep floor cannot ratchet.</summary>
+        public IReadOnlyList<long> SeedRunDetectionTotals { get; set; }
+
+        /// <summary>F32 — the winning candidate's keep fraction (MIN over runs) against the baseline totals. NaN
+        /// only when the evaluator reported no star counts to measure. Reported, never scored: it is the number
+        /// that makes a landing's cost legible next to its ΔJ, and it is measured whether or not a floor is in
+        /// force — the counts are already in hand, and this is exactly the "keep%" F32 computes by hand from
+        /// stored landings.</summary>
+        public double LandingKeepFraction { get; set; } = double.NaN;
+
+        /// <summary>F32 — how many evaluated candidates the keep floor rejected. Zero with no floor in force, and
+        /// zero WITH a floor means the constraint never bound — worth distinguishing, because a landing that
+        /// simply never wanted to shed is a different result from one the constraint held back.</summary>
+        public int CandidatesRejectedByKeepFloor { get; set; }
     }
 
     /// <summary>
@@ -150,8 +235,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 theta0[i] = variables[i].Quantize(variables[i].Read(seed));
             }
 
-            // Seed evaluation; this is the initial incumbent and the never-regress floor.
-            var seedJ = await ctx.EvalJ(theta0).ConfigureAwait(false);
+            // Seed evaluation; this is the initial incumbent and the never-regress floor. isSeed: true also
+            // establishes the F32 keep-fraction baseline (unless the caller supplied one). It is passed
+            // EXPLICITLY rather than inferred from "the first EvalJ call is θ0 by construction": that inference
+            // is true today and is exactly the kind of implicit call-order coupling that produced the wave-3
+            // seed leak, where one run's genuine firing silently re-gated the other sixteen.
+            var seedJ = (await ctx.EvalJ(theta0, isSeed: true).ConfigureAwait(false)).J;
             var bestTheta = (double[])theta0.Clone();
             var bestJ = seedJ;
 
@@ -183,7 +272,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 SeedJ = seedJ,
                 Evaluations = ctx.Evaluations,
                 ImprovedOverSeed = bestJ > seedJ,
-                ChangedVariables = changed
+                ChangedVariables = changed,
+                SeedRunDetectionTotals = ctx.BaselineRunTotals,
+                LandingKeepFraction = ctx.KeepFractionFor(bestTheta),
+                CandidatesRejectedByKeepFloor = ctx.CandidatesRejectedByKeepFloor
             };
         }
 
@@ -215,6 +307,18 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // re-evaluating, and without threading a second value through every search stage.
             private readonly Dictionary<string, double> memoSigma = new Dictionary<string, double>(StringComparer.Ordinal);
 
+            // F32 keep fraction of every evaluated candidate, keyed exactly like memo. Filled alongside J on a
+            // cache miss (free — the counts are already in the metrics).
+            private readonly Dictionary<string, double> memoKeep = new Dictionary<string, double>(StringComparer.Ordinal);
+
+            // F32 — per-run accepted-star totals the keep fraction is measured against. Seeded either from the
+            // caller (a multi-pass round pinning its FIRST pass's seed) or from this search's own seed evaluation.
+            private IReadOnlyList<long> baselineRunTotals;
+
+            // This search's OWN seed totals, always recorded even when the baseline came from the caller, so a
+            // multi-pass caller can still see where each round started.
+            private IReadOnlyList<long> seedRunTotals;
+
             // Phase-B staging partition (T14): the curated axes split into EARLY (members of
             // StarDetector.EarlyCacheKeyProperties — each move both rebuilds AND evicts the per-frame early
             // DetectionContext, a ~1.65s full detection) and LATE (everything else, including the synthetic
@@ -241,6 +345,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 this.settings = settings;
                 this.progress = progress;
                 this.token = token;
+                this.baselineRunTotals = settings.DetectionKeepBaselineTotals;
 
                 var early = new List<int>();
                 var late = new List<int>();
@@ -268,13 +373,20 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             /// Memoized objective. Materializes params, keys on <see cref="StarDetector.ComputeCacheKey"/>, and
             /// only invokes the evaluator on a cache MISS (incrementing the eval counter then). J is the
             /// multi-run aggregate <see cref="OptimizationObjective.JTotal"/> over per-run J. Honors cancellation.
+            ///
+            /// <para>Returns the F32 keep fraction and feasibility alongside J. <b>J itself is never modified by
+            /// the constraint</b> — the caller rejects an infeasible candidate ahead of its own compare, so the
+            /// numbers this returns are identical with and without a floor in force.</para>
+            ///
+            /// <para><paramref name="isSeed"/> establishes the keep-fraction baseline from this evaluation (and
+            /// makes it unconditionally feasible). Exactly one call per search passes it.</para>
             /// </summary>
-            public async Task<double> EvalJ(double[] theta) {
+            public async Task<CandidateEvaluation> EvalJ(double[] theta, bool isSeed = false) {
                 token.ThrowIfCancellationRequested();
                 var p = Materialize(theta);
                 var key = StarDetector.ComputeCacheKey(p);
                 if (memo.TryGetValue(key, out var cached)) {
-                    return cached;
+                    return Judge(cached, memoKeep.TryGetValue(key, out var k) ? k : double.NaN, isSeed);
                 }
 
                 var runMetrics = await evaluator(p, token).ConfigureAwait(false);
@@ -290,10 +402,105 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     j = OptimizationObjective.JTotal(perRunJ, owner.constants);
                 }
 
+                if (isSeed && baselineRunTotals == null) {
+                    // The caller may have supplied a baseline (multi-pass ratchet guard); only derive one here
+                    // when it did not. Either way the seed's own totals are reported back so a multi-pass caller
+                    // has something to supply on its NEXT round.
+                    baselineRunTotals = RunTotals(runMetrics);
+                }
+                if (isSeed) {
+                    seedRunTotals = RunTotals(runMetrics);
+                }
+
                 memo[key] = j;
                 memoSigma[key] = MeanFiniteSigmaFocus(runMetrics);
-                return j;
+                memoKeep[key] = KeepFraction(runMetrics);
+                return Judge(j, memoKeep[key], isSeed);
             }
+
+            /// <summary>Applies the F32 floor to an already-computed (J, keep) pair. The seed is feasible by
+            /// construction — it is the never-regress floor, and a search whose starting point is infeasible has
+            /// no feasible set at all.</summary>
+            private CandidateEvaluation Judge(double j, double keep, bool isSeed) {
+                if (isSeed || !(settings.MinDetectionKeepFraction is double floor)) {
+                    return new CandidateEvaluation(j, true, keep);
+                }
+                // NaN keep => no baseline to measure against (no run reported counts); do not reject on absence
+                // of evidence, which would silently freeze the search at the seed for any evaluator that does not
+                // populate FrameStarCounts (synth-validate and tilt both go through this engine).
+                var feasible = !double.IsFinite(keep) || keep >= floor;
+                if (!feasible) {
+                    CandidatesRejectedByKeepFloor++;
+                }
+                return new CandidateEvaluation(j, feasible, keep);
+            }
+
+            /// <summary>Per-run accepted-star totals, in run order. Null when the evaluator reported nothing.</summary>
+            private static IReadOnlyList<long> RunTotals(IReadOnlyList<RunEvaluationMetrics> runMetrics) {
+                if (runMetrics == null || runMetrics.Count == 0) {
+                    return null;
+                }
+                var totals = new long[runMetrics.Count];
+                for (var i = 0; i < runMetrics.Count; i++) {
+                    var counts = runMetrics[i]?.FrameStarCounts;
+                    long sum = 0;
+                    if (counts != null) {
+                        foreach (var c in counts) {
+                            sum += c;
+                        }
+                    }
+                    totals[i] = sum;
+                }
+                return totals;
+            }
+
+            /// <summary>
+            /// The F32 keep fraction: MIN over runs of (candidate total ÷ baseline total). NaN when there is no
+            /// baseline or no metrics to measure.
+            ///
+            /// <para><b>Min over runs, not the pooled sum.</b> Pooling lets one dense run's gains mask another
+            /// being gutted. For the headless one-run-per-call case the two are identical, so no bank measurement
+            /// turns on the choice; it only bites in the wizard's N&gt;1 blend, where min is the safer reading.</para>
+            ///
+            /// <para><b>A run whose baseline total is 0 is EXEMPT</b> (contributes keep 1.0), because the ratio is
+            /// undefined and rejecting on it would re-gate exactly the F20/F35 population — a rig whose seed
+            /// legitimately detects nothing is the case the MinHFR seeding exists to rescue, and it must be free
+            /// to climb from zero.</para>
+            /// </summary>
+            private double KeepFraction(IReadOnlyList<RunEvaluationMetrics> runMetrics) {
+                var baseline = baselineRunTotals;
+                if (baseline == null || runMetrics == null || runMetrics.Count == 0) {
+                    return double.NaN;
+                }
+                var candidate = RunTotals(runMetrics);
+                if (candidate == null) {
+                    return double.NaN;
+                }
+                var n = Math.Min(baseline.Count, candidate.Count);
+                if (n == 0) {
+                    return double.NaN;
+                }
+                var worst = double.PositiveInfinity;
+                for (var i = 0; i < n; i++) {
+                    if (baseline[i] <= 0) {
+                        continue; // undefined ratio => exempt, see the remarks above
+                    }
+                    var keep = (double)candidate[i] / baseline[i];
+                    if (keep < worst) {
+                        worst = keep;
+                    }
+                }
+                return double.IsPositiveInfinity(worst) ? 1.0 : worst;
+            }
+
+            /// <summary>The memoized keep fraction of an already-evaluated point. NaN if never evaluated.</summary>
+            public double KeepFractionFor(double[] theta) =>
+                memoKeep.TryGetValue(StarDetector.ComputeCacheKey(Materialize(theta)), out var k) ? k : double.NaN;
+
+            /// <summary>Per-run seed totals, for a multi-pass caller to feed back as the next round's baseline.</summary>
+            public IReadOnlyList<long> BaselineRunTotals => seedRunTotals;
+
+            public int CandidatesRejectedByKeepFloor { get; private set; }
 
             /// <summary>Mean σ over the runs that produced a finite focus σ; NaN when none did. Mirrors the wizard's
             /// baseline/best σ aggregation so the reported σ is directly comparable to the summary's.</summary>
@@ -352,9 +559,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                         if (axisB >= 0) {
                             candidate[axisB] = variables[axisB].Quantize(GridValue(variables[axisB], ib, levels));
                         }
-                        var j = await EvalJ(candidate).ConfigureAwait(false);
-                        if (j > bestJ) {
-                            bestJ = j;
+                        var eval = await EvalJ(candidate).ConfigureAwait(false);
+                        if (eval.Feasible && eval.J > bestJ) {
+                            bestJ = eval.J;
                             bestTheta = candidate;
                         }
                     }
@@ -419,10 +626,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                         }
                         var candidate = (double[])bestTheta.Clone();
                         candidate[i] = value;
-                        var j = await EvalJ(candidate).ConfigureAwait(false);
-                        if (j >= bestJ) {
+                        // The feasibility test applies here too. Pulling BACK toward the seed usually RAISES the
+                        // star count, so this site rarely rejects — but "usually" is not "always" (a seed-ward
+                        // move on one axis can tighten a different gate), and one uniform rule at all three
+                        // accept sites is a single invariant instead of three separate arguments.
+                        var eval = await EvalJ(candidate).ConfigureAwait(false);
+                        if (eval.Feasible && eval.J >= bestJ) {
                             bestTheta = candidate;
-                            bestJ = j;
+                            bestJ = eval.J;
                             moved = true;
                             break; // most seed-ward neutral point for this axis; go to the next axis
                         }
@@ -529,9 +740,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                             if (candidate == null) {
                                 continue; // move produced no change (e.g. already at bound, or boolean no-op)
                             }
-                            var j = await EvalJ(candidate).ConfigureAwait(false);
-                            if (j > improvedJ) {
-                                improvedJ = j;
+                            var eval = await EvalJ(candidate).ConfigureAwait(false);
+                            if (eval.Feasible && eval.J > improvedJ) {
+                                improvedJ = eval.J;
                                 improvedTheta = candidate;
                             }
                         }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -17,6 +17,7 @@ using NINA.Core.Model.Equipment;
 using NINA.Core.MyMessageBox;
 using NINA.Core.Utility;
 using NINA.Core.Utility.Notification;
+using NINA.Core.Utility.WindowService;
 using NINA.Equipment.Interfaces.Mediator;
 using NINA.Image.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.AutoFocus;
@@ -810,6 +811,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             BackToSummaryCommand = new RelayCommand(BackToSummary, () => CurrentStep == WizardStep.Review && !IsBusy);
             ReOptimizeCommand = new AsyncRelayCommand(() => ReOptimizeWithLabelsAsync(CancellationToken.None), () => HasLabels && !IsBusy);
             ContinueOptimizationCommand = new AsyncRelayCommand(() => ContinueOptimizationAsync(CancellationToken.None), () => CanContinueOptimization);
+            ImportRunSettingsCommand = new AsyncRelayCommand(ImportRunSettingsAsync, () => CanImportRunSettings);
 
             // Start enables/disables as the per-run paths are filled in (Saved Auto-Focus), so re-evaluate its
             // CanExecute whenever a path is set or the run count changes.
@@ -2358,6 +2360,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// stage to the trajectory. Enabled only while <see cref="CanContinueOptimization"/> (≤ 3 total passes).</summary>
         public AsyncRelayCommand ContinueOptimizationCommand { get; }
 
+        /// <summary>Loads the star-detection settings a previous optimize pass saved beside this run's frames and
+        /// applies them to the current settings, after showing the same diff an Import shows.</summary>
+        public AsyncRelayCommand ImportRunSettingsCommand { get; }
+
         #endregion Commands
 
         /// <summary>
@@ -3131,6 +3137,46 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// "Continue optimizing" round's keep floor is measured against; see the assignment in
         /// <see cref="OptimizeAsync"/> for why a per-round anchor would ratchet.</summary>
         private IReadOnlyList<long> firstPassSeedDetectionTotals;
+
+        private readonly IWindowServiceFactory windowServiceFactory = new WindowServiceFactory();
+
+        /// <summary>The run folder whose saved settings <see cref="ImportRunSettingsCommand"/> would import — the
+        /// first loaded run that actually has a handoff file beside it. Null when no run is loaded or none of them
+        /// carries one (which is the normal case for a run that has never been optimized).</summary>
+        private string RunSettingsSourceFolder {
+            get {
+                var folders = (reoptimizeRunFolders != null && reoptimizeRunFolders.Count > 0)
+                    ? reoptimizeRunFolders
+                    : (IReadOnlyList<string>)loadedRunFolders;
+                foreach (var f in folders) {
+                    if (StarDetectionSettingsIO.ResolveRunFolderSettings(f) != null) {
+                        return f;
+                    }
+                }
+                return null;
+            }
+        }
+
+        /// <summary>True when a loaded run carries saved settings to import. Deliberately a per-call filesystem
+        /// probe rather than cached state: an optimize pass can write the file while the wizard is open.</summary>
+        public bool CanImportRunSettings => !IsBusy && RunSettingsSourceFolder != null;
+
+        /// <summary>
+        /// Applies a run folder's saved settings to the CURRENT settings, on the user's explicit request.
+        ///
+        /// <para>This is the whole reason the wizard does not pick these up automatically. The wizard's baseline —
+        /// what "Current" means, what <c>baselineJ</c> is computed from, and therefore what the headline
+        /// improvement percentage is a percentage OF — is the live profile. Auto-loading a run folder's landing
+        /// would move that anchor with nothing on screen to say it had moved, so the same displayed percentage
+        /// would silently mean something different. Here the user asks, sees the diff, and confirms.</para>
+        /// </summary>
+        private async Task ImportRunSettingsAsync() {
+            var folder = RunSettingsSourceFolder;
+            if (folder == null || starDetectionOptions is not StarDetectionOptions concreteOptions) {
+                return;
+            }
+            await StarDetectionSettingsIO.ImportFromRunFolderAsync(folder, concreteOptions, windowServiceFactory).ConfigureAwait(true);
+        }
 
         /// <summary>Maps the optimizer's internal phase identifiers ("Seed"/"CoarseGrid"/"PatternSearch", which
         /// stay as-is in logs and tests) to plain language for the progress display.</summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -2472,6 +2472,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // a stale floor would silently re-gate the next one (the wave-3 seed-leak shape).
             MinHfrRescueNotice = null;
             minHfrRescueFloor = null;
+            rescuedSeed = null;
             // A fresh run always uses the PERSISTED factor: any pending optimize-again factor from a previous
             // summary was abandoned when the user came back here.
             pendingDetectionBinning = null;
@@ -2950,8 +2951,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // different product decision than the one this entry is about. Whether replay deserves the same rescue
             // is left open in F43 rather than changed as a side effect.
             if (SourceMode == SourceMode.Live) {
-                var rescue = await TryRescueWithLowerMinHfrAsync(runs, token).ConfigureAwait(true);
-                if (rescue.HasValue) {
+                var rescue = await TryRescueSeedAsync(runs, token).ConfigureAwait(true);
+                if (rescue != null) {
                     return true;
                 }
             }
@@ -2988,41 +2989,113 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// <see cref="StarDetectorParams"/> across runs, and an in-place write here would leak the probed gate
         /// into every later run — the wave-3 seed leak, which took a whole bank to the floor off one firing.</para>
         /// </summary>
-        private async Task<double?> TryRescueWithLowerMinHfrAsync(IReadOnlyList<LoadedRun> runs, CancellationToken token) {
+        private async Task<StarDetectorParams> TryRescueSeedAsync(IReadOnlyList<LoadedRun> runs, CancellationToken token) {
             const int MinPositionsForFit = 3;
             if (runs == null || runs.Count == 0 || runs[0]?.Seed == null) {
                 return null;
             }
 
-            var seedMinHfr = runs[0].Seed.MinHFR;
-            foreach (var probe in MinHfrRescueLadder(runs[0].Seed)) {
-                if (!(probe < seedMinHfr)) {
-                    continue; // only ever LOWERS the gate; raising one is never a rescue
-                }
+            foreach (var (probe, label) in SeedRescueLadder(runs[0].Seed)) {
                 token.ThrowIfCancellationRequested();
                 var results = await AnalyzeWithProgressAsync(
-                    runs, r => { var p = r.Seed.Clone(); p.MinHFR = probe; return p; }, token).ConfigureAwait(true);
+                    runs, r => ApplyRescue(r.Seed, probe), token).ConfigureAwait(true);
                 if (!AnyRunIsFittable(results, MinPositionsForFit)) {
                     continue;
                 }
+                // A FITTABLE CURVE IS NOT ENOUGH — it must also be SCORABLE. Measured on a 40 mm f/2 sweep: with
+                // only the MinHFR gate relaxed the curve fits, but frames still fall under the objective's NHard
+                // floor, so J is identically 0 and 80 evaluations cannot move off it (F20's plateau, one axis
+                // out). Handing the search that seed is indistinguishable to the user from refusing outright.
+                if (!(JOfSeedProbe(results) > 0.0)) {
+                    continue;
+                }
 
-                // Carry the rescued gate into the search as the seed, so the optimizer STARTS where a curve
-                // exists instead of merely being allowed to reach it (F35's rationale, triggered by feasibility
-                // rather than by a vertex). OptimizeAsync takes the LOWER of this and F35's own vertex rule.
-                minHfrRescueFloor = probe;
-                Logger.Info($"Star detection optimizer: no usable focus curve at MinHFR " +
-                            $"{seedMinHfr.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture)}; probing " +
-                            $"{probe.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture)} makes it " +
-                            "fittable, so the search is seeded there (F43).");
+                minHfrRescueFloor = probe.MinHFR;
+                rescuedSeed = probe;
+                Logger.Info($"Star detection optimizer: the default detection settings could not produce a scorable " +
+                            $"focus curve; rescue probe '{label}' did, so the search is seeded there (F43).");
                 MinHfrRescueNotice =
-                    $"No focus curve could be fitted at the default minimum-HFR gate of {seedMinHfr:0.##} px — the frames " +
-                    $"nearest focus found no stars. The gate was lowered to {probe:0.##} px to get a curve, and the " +
-                    "optimizer started from there. This is normal on short focal lengths, where in-focus stars are " +
-                    "only a pixel or two across.";
+                    $"The default detection settings found no usable focus curve on this sweep — {label}. The optimizer " +
+                    "was started from those relaxed settings instead, and is free to tighten them again. This is normal " +
+                    "on short focal lengths and short exposures, where in-focus stars are only a pixel or two across " +
+                    "and sit close to the noise.";
                 return probe;
             }
             return null;
         }
+
+        /// <summary>Applies a rescue probe's relaxed gates to a CLONE of a run's seed. Never mutates the caller's
+        /// params: callers reuse one <see cref="StarDetectorParams"/> across runs, and an in-place write is the
+        /// wave-3 seed leak, which took a whole bank to the floor off one firing.</summary>
+        private static StarDetectorParams ApplyRescue(StarDetectorParams seed, StarDetectorParams probe) {
+            var p = seed.Clone();
+            p.MinHFR = probe.MinHFR;
+            p.Sensitivity = probe.Sensitivity;
+            p.NoiseClippingMultiplier = probe.NoiseClippingMultiplier;
+            return p;
+        }
+
+        /// <summary>
+        /// The objective of a probe's evaluation, aggregated exactly as the optimizer aggregates it, so "the search
+        /// has something to climb" is decided by the SAME number the search maximizes rather than by a proxy.
+        /// </summary>
+        private double JOfSeedProbe(IReadOnlyList<RunEvaluationResult> results) {
+            if (results == null || results.Count == 0) {
+                return 0.0;
+            }
+            var perRunJ = results.Select(r => OptimizationObjective.JRun(r.Metrics, objectiveConstants)).ToList();
+            return OptimizationObjective.JTotal(perRunJ, objectiveConstants);
+        }
+
+        /// <summary>
+        /// The seed relaxations the rescue tries, LEAST AGGRESSIVE FIRST, each with a plain-language label for the
+        /// notice. Bounds are read from the curated search variables rather than written as constants here, so the
+        /// guard can never admit a rig on settings the optimizer is not allowed to reach — nor refuse one it could
+        /// have rescued because a constant drifted.
+        ///
+        /// <para>The ladder relaxes two DIFFERENT failure modes in order. <b>Size</b> first: at 19 arcsec/px an
+        /// in-focus star is about one pixel, so <c>MinHFR</c> deletes precisely the frames the vertex is fitted
+        /// from. Then <b>signal</b>: on a short exposure the acceptance gate and noise-clipping threshold reject
+        /// nearly everything. Measured on a 40 mm f/2 sweep at 4 s, relaxing size alone moved the in-focus frame
+        /// from 0 stars to 14 — fittable but still unscorable — while also relaxing signal took the whole sweep to
+        /// 20–1413 stars per frame and the optimizer converged immediately.</para>
+        /// </summary>
+        private static IEnumerable<(StarDetectorParams Probe, string Label)> SeedRescueLadder(StarDetectorParams seed) {
+            var vars = OptimizerVariable.CreateCuratedSet(seed);
+            double LowerOfVar(string name, double fallback) =>
+                vars.FirstOrDefault(v => string.Equals(v.Name, name, StringComparison.Ordinal))?.Lower ?? fallback;
+
+            var minHfrLower = Math.Min(MinHfrSeed.SeedFloor, LowerOfVar(nameof(StarDetectorParams.MinHFR), MinHfrSeed.SeedFloor));
+            var sensLower = LowerOfVar(nameof(StarDetectorParams.Sensitivity), 0.0);
+            var noiseClipLower = LowerOfVar(nameof(StarDetectorParams.NoiseClippingMultiplier), seed.NoiseClippingMultiplier);
+
+            StarDetectorParams With(double minHfr, double sens, double noiseClip) {
+                var p = seed.Clone();
+                p.MinHFR = Math.Min(seed.MinHFR, minHfr);
+                p.Sensitivity = Math.Min(seed.Sensitivity, sens);
+                p.NoiseClippingMultiplier = Math.Min(seed.NoiseClippingMultiplier, noiseClip);
+                return p;
+            }
+
+            // 1-2: size only — the smallest intervention that can rescue an undersampled rig.
+            yield return (With(MinHfrSeed.SeedFloor, seed.Sensitivity, seed.NoiseClippingMultiplier),
+                $"the minimum-HFR gate was lowered to {Math.Min(seed.MinHFR, MinHfrSeed.SeedFloor):0.##} px");
+            yield return (With(minHfrLower, seed.Sensitivity, seed.NoiseClippingMultiplier),
+                $"the minimum-HFR gate was lowered to {Math.Min(seed.MinHFR, minHfrLower):0.##} px");
+            // 3: + the acceptance gate, for a signal-starved sweep.
+            yield return (With(minHfrLower, sensLower, seed.NoiseClippingMultiplier),
+                $"the minimum-HFR gate was lowered to {Math.Min(seed.MinHFR, minHfrLower):0.##} px and the star " +
+                $"acceptance gate to {Math.Min(seed.Sensitivity, sensLower):0.##}");
+            // 4: + noise clipping, the last thing standing between a faint sweep and a curve.
+            yield return (With(minHfrLower, sensLower, noiseClipLower),
+                $"the minimum-HFR gate was lowered to {Math.Min(seed.MinHFR, minHfrLower):0.##} px, the star " +
+                $"acceptance gate to {Math.Min(seed.Sensitivity, sensLower):0.##} and noise clipping to " +
+                $"{Math.Min(seed.NoiseClippingMultiplier, noiseClipLower):0.##}");
+        }
+
+        /// <summary>F43 — the relaxed seed the guard had to fall back on, or null when the sweep was scorable as
+        /// configured. Used as the SEED of a fresh optimization pass, so the search starts somewhere it can climb.</summary>
+        private StarDetectorParams rescuedSeed;
 
         /// <summary>The lower of two optional gate floors, ignoring absent ones. Null only when both are null.</summary>
         internal static double? LowerOf(double? a, double? b) {
@@ -3033,18 +3106,6 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 return a;
             }
             return Math.Min(a.Value, b.Value);
-        }
-
-        /// <summary>The MinHFR values the rescue probe tries, least-aggressive first: F35's seeding constant, then
-        /// the curated search variable's own lower bound (read from the variable set so it cannot drift from what
-        /// the optimizer may actually reach).</summary>
-        private static IEnumerable<double> MinHfrRescueLadder(StarDetectorParams seed) {
-            yield return MinHfrSeed.SeedFloor;
-            var minHfrVar = OptimizerVariable.CreateCuratedSet(seed)
-                .FirstOrDefault(v => string.Equals(v.Name, nameof(StarDetectorParams.MinHFR), StringComparison.Ordinal));
-            if (minHfrVar != null && minHfrVar.Lower < MinHfrSeed.SeedFloor) {
-                yield return minHfrVar.Lower;
-            }
         }
 
         /// <summary>F43 — the MinHFR the guard had to drop to before a curve could be fitted at all, or null when
@@ -3179,7 +3240,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // All runs share the same camera/optics, so the search starts from the first run's seed (or the override).
             // With StartFromCurrentSettings, seed from the current settings (Baseline) to refine them rather than the
             // fully-default params. The warm-start override (feedback path) always wins.
-            var seed = seedOverride ?? (StartFromCurrentSettings ? runs[0].Baseline : runs[0].Seed);
+            // F43 — a fresh pass starts from the RESCUED seed when the guard had to fall back on one: being allowed
+            // to reach those settings is not enough, because the objective is identically zero at the defaults and
+            // the search has no gradient to follow off it (measured: 80 evaluations, no escape).
+            var seed = seedOverride ?? (seedOverride == null && rescuedSeed != null ? rescuedSeed.Clone()
+                : (StartFromCurrentSettings ? runs[0].Baseline : runs[0].Seed));
             // The master donut toggle is a profile option, NOT an optimizer axis: stamp it onto the seed so the
             // seed's early morph-close runs and CreateCuratedSet includes the defocus axes iff the user enabled it
             // (the default Seed carries master=OFF, so without this the donut feature would never be searched when

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -3069,6 +3069,24 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             optimizerSettings.MinHfrSeedFloor = seedOverride == null
                 ? MinHfrSeed.Resolve(seedFitVertexHfr, seed.MinHFR, seed.DetectionBinning)
                 : null;
+
+            // F32 — pin the keep floor's baseline to the FRESH pass's seed, so a chain of "Continue optimizing"
+            // rounds cannot ratchet through it. Every non-fresh path re-seeds from somewhere the previous pass
+            // arrived at (Continue from the prior best, the feedback path from GateRecommender's analytic
+            // recommendation); measuring the floor against THAT would let each round shed another (1 - floor) of
+            // what remains -- at a floor of 0.5, three rounds reach 0.125 of where the user actually started.
+            // The floor means "of the stars you had when you pressed Start", so it must keep referring there.
+            //
+            // Assigned unconditionally, including to null, for the same reason MinHfrSeedFloor above is: this is
+            // a reused settings object and a value from a prior pass must never leak into a fresh one.
+            //
+            // Guarded on run COUNT because the non-fresh paths re-load their runs: a mismatched list would pair
+            // run i's baseline with a different run's counts, which is worse than not constraining at all.
+            optimizerSettings.DetectionKeepBaselineTotals =
+                seedOverride != null && firstPassSeedDetectionTotals != null && firstPassSeedDetectionTotals.Count == runs.Count
+                    ? firstPassSeedDetectionTotals
+                    : null;
+
             var variables = variablesOverride ?? OptimizerVariable.CreateCuratedSet(seed);
             var evaluator = RunEvaluationData.CreateEvaluator(runs.Select(r => r.Data).ToList());
 
@@ -3094,13 +3112,25 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             var optimizer = new StarDetectionOptimizer(objectiveConstants);
             IsOptimizing = true;
             try {
-                return await Task.Run(
+                var result = await Task.Run(
                     () => optimizer.OptimizeAsync(seed, variables, evaluator, optimizerSettings, progress, token),
                     token).ConfigureAwait(true);
+                if (seedOverride == null) {
+                    // A FRESH pass defines where the user started; every later round measures its keep floor
+                    // against this. Captured even when no floor is in force, so turning one on is a one-line
+                    // change that cannot forget the anchor.
+                    firstPassSeedDetectionTotals = result.SeedRunDetectionTotals;
+                }
+                return result;
             } finally {
                 IsOptimizing = false;
             }
         }
+
+        /// <summary>F32 — per-run seed star totals of the most recent FRESH optimization pass. The anchor every
+        /// "Continue optimizing" round's keep floor is measured against; see the assignment in
+        /// <see cref="OptimizeAsync"/> for why a per-round anchor would ratchet.</summary>
+        private IReadOnlyList<long> firstPassSeedDetectionTotals;
 
         /// <summary>Maps the optimizer's internal phase identifiers ("Seed"/"CoarseGrid"/"PatternSearch", which
         /// stay as-is in logs and tests) to plain language for the progress display.</summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -2468,6 +2468,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             ErrorMessage = null;
             // Belongs to the run that raised it, so a fresh Start clears it alongside the error.
             RecoveryWidenedNotice = null;
+            // Same ownership for the F43 rescue: both the notice and the floor it reports describe THIS sweep, and
+            // a stale floor would silently re-gate the next one (the wave-3 seed-leak shape).
+            MinHfrRescueNotice = null;
+            minHfrRescueFloor = null;
             // A fresh run always uses the PERSISTED factor: any pending optimize-again factor from a previous
             // summary was abandoned when the user came back here.
             pendingDetectionBinning = null;
@@ -2927,6 +2931,31 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 }
             }
 
+            // F43 — LAST RESORT BEFORE REFUSING: probe a LOWERED MinHFR gate.
+            //
+            // Refusing here because the DEFAULT settings cannot build a curve is circular: this wizard exists to
+            // find settings that can, and the guard was testing exactly one point of a space in which MinHFR alone
+            // spans [0.1, 5.0] against a default of 1.2. On an undersampled short-focal-length rig the gate deletes
+            // precisely the frames the vertex is fitted from -- measured on the bank's 40 mm dataset, the in-focus
+            // frame yields ZERO stars at 1.2 while the wings yield ~1700 each, and lowering the gate is the ONLY
+            // axis that recovers it (MinimumStarBoundingBoxSize changes nothing; fewer StructureLayers is worse).
+            //
+            // F35's seeding does not reach this case. It runs INSIDE OptimizeAsync -- after this guard -- and
+            // triggers off BestFit.Minimum.Y, a fitted vertex that by definition does not exist once the gate has
+            // destroyed the fit. F35 handles "the vertex sits under the gate"; this handles "the gate destroyed
+            // the vertex", which is the strictly worse case and the one users hit.
+            // LIVE ONLY, like the recovery widening above. Replay gates on the user's CURRENT settings on purpose:
+            // a saved run exists because those settings could already focus, and SeedGuard_ReplayMode_GatesOnBaseline
+            // locks that. Probing the SEED there would quietly convert replay into a seed-gated path, which is a
+            // different product decision than the one this entry is about. Whether replay deserves the same rescue
+            // is left open in F43 rather than changed as a side effect.
+            if (SourceMode == SourceMode.Live) {
+                var rescue = await TryRescueWithLowerMinHfrAsync(runs, token).ConfigureAwait(true);
+                if (rescue.HasValue) {
+                    return true;
+                }
+            }
+
             ErrorMessage = SourceMode == SourceMode.Live
                 ? "The captured sweep does not produce a usable focus curve at the default detection settings, and " +
                   "excluding its outermost positions does not help. Frames without stars in the middle of the sweep, " +
@@ -2938,6 +2967,109 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             CurrentStep = WizardStep.SelectSource;
             return false;
         }
+
+        /// <summary>
+        /// F43 — re-runs the fit guard with <see cref="StarDetectorParams.MinHFR"/> lowered, and returns the first
+        /// value that makes the sweep fittable (null when none does, i.e. the refusal stands).
+        ///
+        /// <para><b>The ladder is read from the SEARCH SPACE, not written here.</b> It probes
+        /// <see cref="MinHfrSeed.SeedFloor"/> and then the curated variable's own lower bound, so the guard can
+        /// never admit a rig on a gate the optimizer is not allowed to reach — and never refuses one it could have
+        /// rescued because a constant drifted. Ordered least-aggressive first, so a run rescued at 0.30 is not
+        /// dragged to 0.10 for no reason.</para>
+        ///
+        /// <para><b>Determinability only.</b> The probe asks the same question the guard always asked — "is a
+        /// curve determinable at all" — and not "are the counts comfortable". The rescue is genuinely thin on the
+        /// rigs it exists for (6 stars on the in-focus frame of the 40 mm dataset, against NHard = 3), so any
+        /// richer bar would re-reject exactly the population this is for. Moving the counts up from there is the
+        /// SEARCH's job, which is the whole point of letting it start.</para>
+        ///
+        /// <para>Probes are evaluated on a CLONE of each run's seed. Callers reuse one
+        /// <see cref="StarDetectorParams"/> across runs, and an in-place write here would leak the probed gate
+        /// into every later run — the wave-3 seed leak, which took a whole bank to the floor off one firing.</para>
+        /// </summary>
+        private async Task<double?> TryRescueWithLowerMinHfrAsync(IReadOnlyList<LoadedRun> runs, CancellationToken token) {
+            const int MinPositionsForFit = 3;
+            if (runs == null || runs.Count == 0 || runs[0]?.Seed == null) {
+                return null;
+            }
+
+            var seedMinHfr = runs[0].Seed.MinHFR;
+            foreach (var probe in MinHfrRescueLadder(runs[0].Seed)) {
+                if (!(probe < seedMinHfr)) {
+                    continue; // only ever LOWERS the gate; raising one is never a rescue
+                }
+                token.ThrowIfCancellationRequested();
+                var results = await AnalyzeWithProgressAsync(
+                    runs, r => { var p = r.Seed.Clone(); p.MinHFR = probe; return p; }, token).ConfigureAwait(true);
+                if (!AnyRunIsFittable(results, MinPositionsForFit)) {
+                    continue;
+                }
+
+                // Carry the rescued gate into the search as the seed, so the optimizer STARTS where a curve
+                // exists instead of merely being allowed to reach it (F35's rationale, triggered by feasibility
+                // rather than by a vertex). OptimizeAsync takes the LOWER of this and F35's own vertex rule.
+                minHfrRescueFloor = probe;
+                Logger.Info($"Star detection optimizer: no usable focus curve at MinHFR " +
+                            $"{seedMinHfr.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture)}; probing " +
+                            $"{probe.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture)} makes it " +
+                            "fittable, so the search is seeded there (F43).");
+                MinHfrRescueNotice =
+                    $"No focus curve could be fitted at the default minimum-HFR gate of {seedMinHfr:0.##} px — the frames " +
+                    $"nearest focus found no stars. The gate was lowered to {probe:0.##} px to get a curve, and the " +
+                    "optimizer started from there. This is normal on short focal lengths, where in-focus stars are " +
+                    "only a pixel or two across.";
+                return probe;
+            }
+            return null;
+        }
+
+        /// <summary>The lower of two optional gate floors, ignoring absent ones. Null only when both are null.</summary>
+        internal static double? LowerOf(double? a, double? b) {
+            if (!a.HasValue) {
+                return b;
+            }
+            if (!b.HasValue) {
+                return a;
+            }
+            return Math.Min(a.Value, b.Value);
+        }
+
+        /// <summary>The MinHFR values the rescue probe tries, least-aggressive first: F35's seeding constant, then
+        /// the curated search variable's own lower bound (read from the variable set so it cannot drift from what
+        /// the optimizer may actually reach).</summary>
+        private static IEnumerable<double> MinHfrRescueLadder(StarDetectorParams seed) {
+            yield return MinHfrSeed.SeedFloor;
+            var minHfrVar = OptimizerVariable.CreateCuratedSet(seed)
+                .FirstOrDefault(v => string.Equals(v.Name, nameof(StarDetectorParams.MinHFR), StringComparison.Ordinal));
+            if (minHfrVar != null && minHfrVar.Lower < MinHfrSeed.SeedFloor) {
+                yield return minHfrVar.Lower;
+            }
+        }
+
+        /// <summary>F43 — the MinHFR the guard had to drop to before a curve could be fitted at all, or null when
+        /// the sweep fitted without help. Read by <see cref="OptimizeAsync"/> as a seed floor.</summary>
+        private double? minHfrRescueFloor;
+
+        private string minHfrRescueNotice;
+
+        /// <summary>
+        /// Set when the guard had to lower the MinHFR gate to obtain a focus curve at all (F43). NOT an error —
+        /// the run proceeds — but it must be visible: the wizard is reporting results from a gate the user did not
+        /// choose, and on a short-focal-length rig that gate is the setting they most need to know about.
+        /// </summary>
+        public string MinHfrRescueNotice {
+            get => minHfrRescueNotice;
+            private set {
+                if (minHfrRescueNotice != value) {
+                    minHfrRescueNotice = value;
+                    RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(HasMinHfrRescueNotice));
+                }
+            }
+        }
+
+        public bool HasMinHfrRescueNotice => !string.IsNullOrEmpty(MinHfrRescueNotice);
 
         /// <summary>
         /// Whether ANY run yields a determinable focus curve: a finite σ(focus) backed by ≥
@@ -3072,8 +3204,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             //
             // Assigned unconditionally, including to null, for the same reason MaxEvaluations is re-applied above:
             // optimizerSettings is a reused field and a value from a prior pass must never leak into this one.
+            //
+            // F43 adds a SECOND source for the same floor: the guard may have had to lower the gate just to obtain
+            // a curve at all, in which case there was no vertex for the rule above to read. Take the LOWER of the
+            // two — both only ever lower the gate, so the minimum is the one that actually admitted stars, and
+            // either being absent leaves the other unchanged.
             optimizerSettings.MinHfrSeedFloor = seedOverride == null
-                ? MinHfrSeed.Resolve(seedFitVertexHfr, seed.MinHFR, seed.DetectionBinning)
+                ? LowerOf(MinHfrSeed.Resolve(seedFitVertexHfr, seed.MinHFR, seed.DetectionBinning), minHfrRescueFloor)
                 : null;
 
             // F32 — pin the keep floor's baseline to the FRESH pass's seed, so a chain of "Continue optimizing"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionSettingsIO.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionSettingsIO.cs
@@ -160,6 +160,90 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             }
         }
 
+        /// <summary>The settings handoff a completed optimize pass leaves beside a run's frames. Deliberately NOT
+        /// <c>optimized_settings.json</c>: that name is matched exactly by the bank readers, which deserialize it
+        /// as a bare <c>OptimizedStarDetectionSettings</c>, and handing them this envelope would bind every
+        /// curated knob to its CLR default and score a different detector with no error and no warning.</summary>
+        internal const string RunFolderSettingsFileName = "hocusfocus_star_detection.json";
+
+        /// <summary>
+        /// Loads the settings handoff sitting beside a loaded run's frames and — after the same diff confirmation
+        /// an Import shows — applies it to the current settings.
+        ///
+        /// <para><b>Explicitly user-initiated, never automatic.</b> Picking this up on load would silently
+        /// redefine "Current": the wizard's baseline is the live profile, and <c>baselineJ</c> plus the headline
+        /// improvement percentage are both measured against it. A run folder quietly becoming the baseline would
+        /// change what that percentage MEANS with nothing on screen to say so — the wave-3 seed-leak shape, where
+        /// a value read back from a run folder silently moved results. So the user presses this, and sees the diff
+        /// before anything changes.</para>
+        /// </summary>
+        public static Task ImportFromRunFolderAsync(
+                string runFolder, StarDetectionOptions options, IWindowServiceFactory windowServiceFactory) {
+            return ImportFromRunFolderAsync(runFolder, options,
+                (rows, summary) => ImportStarDetectionPreview.ShowAsync(windowServiceFactory, new ImportStarDetectionPreviewVM(rows, summary)));
+        }
+
+        /// <summary>Delegate-injected core of the import-from-run-folder flow (unit-test seam — no WPF dialog).</summary>
+        internal static async Task ImportFromRunFolderAsync(
+                string runFolder,
+                StarDetectionOptions options,
+                Func<IReadOnlyList<StarDetectionSettingDiffRow>, string, Task<bool>> confirmDiff) {
+            if (string.IsNullOrWhiteSpace(runFolder) || options == null) {
+                return;
+            }
+            try {
+                var path = ResolveRunFolderSettings(runFolder);
+                if (path == null) {
+                    Notification.ShowInformation(
+                        $"No saved star detection settings found for this run. They are written by an optimize pass as {RunFolderSettingsFileName}.");
+                    return;
+                }
+                if (!StarDetectionSettingsExport.TryLoad(path, out var export, out var error)) {
+                    Logger.Warning($"Could not import star detection settings from {path}: {error}");
+                    Notification.ShowError($"Could not import this run's star detection settings: {error}");
+                    return;
+                }
+
+                var diff = StarDetectionSettingsDiff.BuildDiff(options, export.StarDetection);
+                if (diff.Count == 0) {
+                    Notification.ShowInformation("This run's settings match the current settings; nothing to change.");
+                    return;
+                }
+
+                var apply = await confirmDiff(diff, BuildSourceSummary(export) + $"  ·  from {Path.GetFileName(runFolder)}");
+                if (!apply) {
+                    return;
+                }
+
+                options.ApplyImportedSnapshot(export.StarDetection);
+                Logger.Info($"Imported star detection settings from run folder {path} ({diff.Count} setting(s) changed)");
+                Notification.ShowInformation($"Imported this run's star detection settings ({diff.Count} changed)");
+            } catch (Exception ex) {
+                Logger.Error(ex, $"Failed to import star detection settings from run folder '{runFolder}'");
+                Notification.ShowError($"Failed to import this run's star detection settings: {ex.Message}");
+            }
+        }
+
+        /// <summary>The handoff path for a run folder, or null when there is none. Checks the frame folder first
+        /// and then its parent, mirroring the AF-replay metadata convention (folder before run root) — an
+        /// <c>optimize --per-run</c> pass writes beside the frames, a joint pass writes at the run root.</summary>
+        internal static string ResolveRunFolderSettings(string runFolder) {
+            if (string.IsNullOrWhiteSpace(runFolder)) {
+                return null;
+            }
+            var candidates = new List<string> { Path.Combine(runFolder, RunFolderSettingsFileName) };
+            var parent = Path.GetDirectoryName(runFolder.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+            if (!string.IsNullOrEmpty(parent)) {
+                candidates.Add(Path.Combine(parent, RunFolderSettingsFileName));
+            }
+            foreach (var c in candidates) {
+                if (File.Exists(c)) {
+                    return c;
+                }
+            }
+            return null;
+        }
+
         private static string BuildSourceSummary(StarDetectionSettingsExport export) {
             var when = export.CreatedAtUtc == default(DateTime)
                 ? "unknown time"

--- a/Joko.NINA.Plugins/TestApp/BankExportSettingsRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/BankExportSettingsRunner.cs
@@ -1,0 +1,134 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using Newtonsoft.Json;
+using NINA.Core.Enum;
+using NINA.Core.Utility;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NINA.Profile;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace TestApp {
+
+    /// <summary>
+    /// Backfills the NINA-importable settings handoff into bank run folders that already hold a landing:
+    /// <c>TestApp bank-export-settings --runs &lt;bank-root&gt; [--apply]</c>.
+    ///
+    /// <para><b>Why this exists rather than a re-run.</b> Every <c>optimize --per-run</c> pass writes
+    /// <c>hocusfocus_star_detection.json</c> beside its landing, but folders optimized before that shipped have
+    /// only the bare <c>optimized_settings.json</c> — which nothing in the plugin can read. The obvious route to
+    /// fixing that is to re-optimize the bank, and it is the wrong one: per F15 <c>optimize --per-run</c> rewrites
+    /// each run's stored settings, so re-running 39 folders to regenerate a derived file would re-baseline both
+    /// banks as a side effect and cost hours. This converts what is already on disk, changes no landing, and runs
+    /// in seconds.</para>
+    ///
+    /// <para><b>The filename is load-bearing.</b> It must never be <c>optimized_settings.json</c> —
+    /// <c>golden eval --params optimized</c>, <c>bank-verify</c>, <c>review</c> and <c>inspect-align</c> match that
+    /// name exactly and deserialize it as a bare <see cref="OptimizedStarDetectionSettings"/>. Handing them an
+    /// envelope would bind every curated knob to its CLR default (Sensitivity 0, MinHFR 0, StructureLayers 0) and
+    /// score a completely different detector with no error and no warning. Nor <c>metadata.json</c>, which is the
+    /// AF-replay capture record the real bank genuinely has.</para>
+    ///
+    /// <para>Dry-run by default (lists what it would write); <c>--apply</c> writes. Existing handoffs are left
+    /// alone unless <c>--overwrite</c> is given, so re-running after a fresh optimize pass cannot clobber a
+    /// newer envelope with one rebuilt from an older landing.</para>
+    /// </summary>
+    public static class BankExportSettingsRunner {
+
+        public static void Run(string[] args) {
+            var runs = DiagnosticUtil.GetArg(args, "--runs");
+            if (string.IsNullOrWhiteSpace(runs) || !Directory.Exists(runs)) {
+                Console.Error.WriteLine("Usage: TestApp bank-export-settings --runs <bank-root> [--apply] [--overwrite]");
+                Environment.ExitCode = 2;
+                return;
+            }
+            var apply = DiagnosticUtil.HasFlag(args, "--apply");
+            var overwrite = DiagnosticUtil.HasFlag(args, "--overwrite");
+
+            // The envelope's BASE is the harness's own star-detection options, exactly as the optimize path uses
+            // (OptimizationDiagnosticRunner passes ctx.StarDetectionOptions): the landing supplies the curated
+            // knobs, the base supplies every axis the optimizer does not search. A different base would produce an
+            // envelope that imports a different detector than the one the landing describes.
+            Logger.SetLogLevel(LogLevelEnum.INFO);
+            var profileService = new ProfileService();
+            profileService.TryLoad(DiagnosticUtil.GetArg(args, "--profile-id") ?? string.Empty);
+            var activeProfile = profileService.ActiveProfile
+                ?? throw new InvalidOperationException("No active NINA profile could be loaded. Pass --profile-id.");
+            var harnessSettings = HarnessSettingsStore.Resolve(args, profileService, activeProfile);
+            var starDetectionOptions = new StarDetectionOptions(profileService, harnessSettings.Accessor);
+
+            // Enumerate by FILE, not by OptimizationRunDiscovery: a landing can sit in an --out directory that
+            // holds no frames at all, and those are exactly the copies F15 says to prefer reading.
+            var landings = Directory
+                .EnumerateFiles(runs, "optimized_settings.json", SearchOption.AllDirectories)
+                .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            Console.WriteLine($"bank-export-settings: {landings.Count} landing(s) under {runs}  " +
+                $"({(apply ? "APPLY — writing" : "DRY-RUN — listing only")}{(overwrite ? ", overwriting existing" : "")})");
+
+            int written = 0, skipped = 0, failed = 0;
+            var failures = new List<string>();
+            foreach (var landingPath in landings) {
+                var folder = Path.GetDirectoryName(landingPath);
+                if (string.IsNullOrEmpty(folder)) {
+                    continue;
+                }
+                var targetPath = Path.Combine(folder, OptimizationDiagnosticRunner.SettingsHandoffFileName);
+                if (File.Exists(targetPath) && !overwrite) {
+                    skipped++;
+                    continue;
+                }
+                try {
+                    var landing = JsonConvert.DeserializeObject<OptimizedStarDetectionSettings>(File.ReadAllText(landingPath));
+                    if (landing == null) {
+                        throw new InvalidOperationException("deserialized to null");
+                    }
+                    var export = StarDetectionSettingsExport.FromOptimizedLanding(starDetectionOptions, landing);
+
+                    // Prove the round trip BEFORE writing: re-read what we are about to emit and confirm the
+                    // curated axes survived. The DTO→options mapping is by reflected name, so a renamed or newly
+                    // added axis fails here rather than silently importing a detector that differs from the
+                    // landing — the same class of silent-substitution the filename constraint above guards.
+                    var verify = StarDetectionSettingsExport.Deserialize(export.Serialize());
+                    verify.Validate();
+                    var mismatches = landing.DiffKnobs(verify.StarDetection);
+                    if (mismatches.Count > 0) {
+                        throw new InvalidOperationException("round-trip lost " + string.Join(", ", mismatches));
+                    }
+
+                    if (apply) {
+                        File.WriteAllText(targetPath, export.Serialize());
+                    }
+                    written++;
+                    Console.WriteLine($"  {(apply ? "wrote" : "would write")} {targetPath}");
+                } catch (Exception ex) {
+                    failed++;
+                    failures.Add($"{landingPath}: {ex.Message}");
+                    Console.Error.WriteLine($"  FAILED {landingPath}: {ex.Message}");
+                }
+            }
+
+            Console.WriteLine($"bank-export-settings: {written} {(apply ? "written" : "to write")}, {skipped} already present, {failed} failed");
+            if (failed > 0) {
+                // A silent partial backfill is the failure mode worth being loud about: the point of the file is
+                // that a folder can be replayed from, and a folder missing one is indistinguishable from a folder
+                // that was never optimized.
+                Environment.ExitCode = 1;
+            }
+        }
+    }
+}

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -710,12 +710,18 @@ namespace TestApp {
             }
             Console.WriteLine($"Optimization complete: currentJ={F(baselineJ)} -> bestJ={F(result.BestJ)} ({(result.BestJ > baselineJ ? "improved over current" : "no improvement over current")}), evals={result.Evaluations}");
 
-            // F32 — what the landing SPENT, next to what it gained. Printed only when a floor is in force, and it
-            // distinguishes "the constraint never bound" (0 rejections) from "the constraint held the search
-            // back" (>0): a landing that simply never wanted to shed is a different result from a bounded one.
+            // F32 — what the landing SPENT, next to what it gained. Printed ALWAYS, because an unconstrained run
+            // is exactly where this number decides something: it says whether a floor would have bound, so a
+            // control arm can be classified without re-running it. F32 spent two waves reconstructing this
+            // quantity by hand from stored landings.
+            if (double.IsFinite(result.LandingKeepFraction)) {
+                Console.WriteLine($"  detections kept vs seed (F32): {F(result.LandingKeepFraction)} (min over runs)");
+            }
+            // The floor line additionally distinguishes "the constraint never bound" (0 rejections) from "the
+            // constraint held the search back" (>0): a landing that never wanted to shed is a different result
+            // from a bounded one, and they are indistinguishable from the landing alone.
             if (settings.MinDetectionKeepFraction is double keepFloor) {
-                Console.WriteLine($"  keep floor (F32): {F(keepFloor)}; landing kept {F(result.LandingKeepFraction)} of the seed's stars (min over runs), " +
-                    $"{result.CandidatesRejectedByKeepFloor} candidate(s) rejected as infeasible");
+                Console.WriteLine($"  keep floor (F32): {F(keepFloor)}; {result.CandidatesRejectedByKeepFloor} candidate(s) rejected as infeasible");
             }
 
             // Cache-health + wall-clock readout (the early-context build:reuse ratio is the direct measure of how much

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -143,6 +143,19 @@ namespace TestApp {
                 }
             }
 
+            // F32 — --keep-floor <f>: reject any candidate that keeps less than fraction f of the SEED's accepted
+            // stars (min over runs), as a feasibility test AHEAD of the j > bestJ compare. Absent (the default)
+            // leaves the search bit-identical, so this binary is its own control: the same exe with no flag
+            // reproduces the unconstrained arm exactly.
+            double? keepFloor = null;
+            var keepFloorArg = DiagnosticUtil.GetArg(args, "--keep-floor");
+            if (!string.IsNullOrWhiteSpace(keepFloorArg)) {
+                if (!double.TryParse(keepFloorArg, NumberStyles.Float, CultureInfo.InvariantCulture, out var kf) || kf <= 0.0 || kf > 1.0) {
+                    throw new ArgumentException($"--keep-floor: '{keepFloorArg}' must be a fraction in (0, 1]");
+                }
+                keepFloor = kf;
+            }
+
             var labelsDir = DiagnosticUtil.GetArg(args, "--labels");
 
             // --per-run is a valueless flag: optimize each discovered run INDEPENDENTLY (one optimization, one
@@ -326,8 +339,12 @@ namespace TestApp {
                 AnnotateAll = annotateAll,
                 Inspection = inspection,
                 LegacyObjective = legacyObjective,
-                ContinueRounds = continueRounds
+                ContinueRounds = continueRounds,
+                KeepFloor = keepFloor
             };
+            if (keepFloor is double kfv) {
+                Console.WriteLine($"--keep-floor: candidates keeping < {F(kfv)} of the seed's accepted stars (min over runs) are rejected as infeasible; J is unmodified");
+            }
             if (inspection) {
                 Console.WriteLine("--inspection: aberration-inspection objective (favor more stars, fit bounded vs current σ)");
             }
@@ -369,6 +386,7 @@ namespace TestApp {
             public bool Inspection;     // --inspection: use the aberration-inspection objective
             public bool LegacyObjective; // --legacy-objective: zero the HFR-outlier penalty + coverage reward (A/B "before")
             public int ContinueRounds;  // --continue-rounds: extra chained passes after the first (0-2)
+            public double? KeepFloor;   // --keep-floor: F32 detection-keep feasibility floor (null = unconstrained)
 
             // F30: which invocation is producing these landings. Stamped onto every optimized_settings.json this
             // run writes, so a bank folder full of prepasses from different arms stops being ambiguous.
@@ -573,6 +591,7 @@ namespace TestApp {
             if (ctx.MaxEvals.HasValue) {
                 settings.MaxEvaluations = ctx.MaxEvals.Value;
             }
+            settings.MinDetectionKeepFraction = ctx.KeepFloor;   // F32; null => unconstrained, bit-identical
 
             var variables = ctx.Variables;
 
@@ -664,6 +683,14 @@ namespace TestApp {
             // move the search had earned.
             settings.MinHfrSeedFloor = null;
 
+            // F32 — the OPPOSITE treatment for the keep floor, and deliberately so. MinHfrSeedFloor is a start
+            // condition; the keep floor is a bound, and a bound measured against each round's OWN seed compounds:
+            // at 0.5, two continue rounds permit 0.25 of where the user actually started. Pin round 0's seed
+            // totals so every later round is still measured against the original.
+            if (settings.MinDetectionKeepFraction.HasValue && result.SeedRunDetectionTotals != null) {
+                settings.DetectionKeepBaselineTotals = result.SeedRunDetectionTotals;
+            }
+
             // --continue-rounds: chain additional passes, each re-seeded from the prior best with a FRESH curated set
             // (resets the pattern-search step scale, so it can make larger moves again — the point of "Continue").
             // Mirrors the wizard's Continue button (latest replaces Optimized); per-round J reported. Never regresses
@@ -682,6 +709,14 @@ namespace TestApp {
                 Console.WriteLine($"Per-round J: {string.Join(" -> ", roundBestJ.Select(F))}");
             }
             Console.WriteLine($"Optimization complete: currentJ={F(baselineJ)} -> bestJ={F(result.BestJ)} ({(result.BestJ > baselineJ ? "improved over current" : "no improvement over current")}), evals={result.Evaluations}");
+
+            // F32 — what the landing SPENT, next to what it gained. Printed only when a floor is in force, and it
+            // distinguishes "the constraint never bound" (0 rejections) from "the constraint held the search
+            // back" (>0): a landing that simply never wanted to shed is a different result from a bounded one.
+            if (settings.MinDetectionKeepFraction is double keepFloor) {
+                Console.WriteLine($"  keep floor (F32): {F(keepFloor)}; landing kept {F(result.LandingKeepFraction)} of the seed's stars (min over runs), " +
+                    $"{result.CandidatesRejectedByKeepFloor} candidate(s) rejected as infeasible");
+            }
 
             // Cache-health + wall-clock readout (the early-context build:reuse ratio is the direct measure of how much
             // per-frame early work the staged search / context cache avoids; see the performance-design doc).
@@ -729,7 +764,7 @@ namespace TestApp {
             // recommended step (StepSizeRecommender, exactly as BuildAggregateRow computes it); the single --out copy
             // uses the representative (first) run's step in joint mode (see WriteOptimizedSettings).
             WriteOptimizedSettings(targetDir, loadedRuns, perRunBest, result, baselineJ, focuserMaxStep, ctx.Provenance,
-                ctx.StarDetectionOptions);
+                ctx.StarDetectionOptions, ctx.KeepFloor);
 
             await WriteAnnotatedFrames(targetDir, loadedRuns, result.BestParams, ctx.Detector,
                 ctx.MeasurementAverage, ctx.HighSigmaOutlierRejection, ctx.LowSigmaOutlierRejection, ctx.AnnotateAll).ConfigureAwait(false);
@@ -802,14 +837,15 @@ namespace TestApp {
         private static void WriteOptimizedSettings(
             string targetDir, List<LoadedHarnessRun> loadedRuns, List<RunEvaluationResult> perRunBest,
             OptimizationResult result, double baselineJ, int? focuserMaxStep, OptimizerProvenance provenance = null,
-            StarDetectionOptions baseOptions = null) {
+            StarDetectionOptions baseOptions = null, double? keepFloor = null) {
             // Per-run source-folder copies: each run's frame directory gets the winner snapshot with its OWN step.
             for (int i = 0; i < loadedRuns.Count; i++) {
                 var run = loadedRuns[i];
                 try {
                     var rec = StepSizeRecommender.Recommend(perRunBest[i].BestFit, run.StepSize, focuserMaxStep);
                     var dto = OptimizedStarDetectionSettings.FromParams(
-                        result.BestParams, loadedRuns.Count, baselineJ, result.BestJ, rec.StepSize, rec.OffsetSteps, provenance);
+                        result.BestParams, loadedRuns.Count, baselineJ, result.BestJ, rec.StepSize, rec.OffsetSteps, provenance,
+                        keepFloor, result.LandingKeepFraction);
                     var json = JsonConvert.SerializeObject(dto);
 
                     // The run's source folder is the directory holding its frames (each run's frames live together).
@@ -837,7 +873,8 @@ namespace TestApp {
                 try {
                     var rec = StepSizeRecommender.Recommend(perRunBest[0].BestFit, representative.StepSize, focuserMaxStep);
                     var dto = OptimizedStarDetectionSettings.FromParams(
-                        result.BestParams, loadedRuns.Count, baselineJ, result.BestJ, rec.StepSize, rec.OffsetSteps, provenance);
+                        result.BestParams, loadedRuns.Count, baselineJ, result.BestJ, rec.StepSize, rec.OffsetSteps, provenance,
+                        keepFloor, result.LandingKeepFraction);
                     var json = JsonConvert.SerializeObject(dto);
                     var outPath = Path.Combine(targetDir, "optimized_settings.json");
                     File.WriteAllText(outPath, json);

--- a/Joko.NINA.Plugins/TestApp/Program.cs
+++ b/Joko.NINA.Plugins/TestApp/Program.cs
@@ -184,6 +184,16 @@ namespace TestApp {
                 return;
             }
 
+            // Settings-handoff backfill: `TestApp bank-export-settings --runs <bank-root> [--apply]`. Converts each
+            // run folder's existing optimized_settings.json into the NINA-importable
+            // hocusfocus_star_detection.json envelope IN PLACE, with no optimizer run — so folders landed before
+            // that handoff shipped become importable without a re-optimize pass, which per F15 would rewrite every
+            // run's stored settings and re-baseline the bank as a side effect.
+            if (args.Length > 0 && args[0].Equals("bank-export-settings", StringComparison.OrdinalIgnoreCase)) {
+                BankExportSettingsRunner.Run(args);
+                return;
+            }
+
             // Synthetic AF-bank generator: `TestApp synth-bank --spec <json> --out <bank-root> ...`. Renders the
             // checked-in dataset matrix (TestApp/SynthBank/synthetic-bank-spec.json) into a fresh on-disk bank via
             // the real simulator, with exact per-star ground truth (docs/synthetic-af-bank-design.md, workstream G).

--- a/Joko.NINA.Plugins/TestApp/SynthBank/SynthBankSpec.cs
+++ b/Joko.NINA.Plugins/TestApp/SynthBank/SynthBankSpec.cs
@@ -79,6 +79,18 @@ namespace TestApp.SynthBank {
         [JsonProperty("id")] public string Id { get; set; }
         [JsonProperty("description")] public string Description { get; set; }
 
+        /// <summary>
+        /// Non-null when this row's rendered frames are KNOWN BAD and must be re-rendered before their numbers are
+        /// used again; the text says why. Purely declarative — nothing branches on it — but it is a real property
+        /// rather than a stray JSON key so a spec round-trip cannot silently drop the warning, and
+        /// <c>synth-bank</c> prints it (see <see cref="SuspectBanner"/>).
+        ///
+        /// <para>Currently set on the two rows whose diagonal FOV exceeds the catalog query's one-cell cap
+        /// (F44): their star fields are spatially truncated, so counts, recall, precision and positions from them
+        /// are not trustworthy. Gate-threshold results are.</para>
+        /// </summary>
+        [JsonProperty("suspect", NullValueHandling = NullValueHandling.Ignore)] public string Suspect { get; set; }
+
         [JsonProperty("focalLengthMm")] public double FocalLengthMm { get; set; }
 
         /// <summary>Focal ratio N = f/D. Aperture is DERIVED as <see cref="FocalLengthMm"/> / <see cref="FocalRatio"/> (<see cref="ApertureMillimeters"/>) rather than stored redundantly.</summary>

--- a/Joko.NINA.Plugins/TestApp/SynthBank/synthetic-bank-spec.json
+++ b/Joko.NINA.Plugins/TestApp/SynthBank/synthetic-bank-spec.json
@@ -32,7 +32,8 @@
       "seeingArcsec": 2.5,
       "optimalFocuserPosition": 6000,
       "focuserStepSizeMicrons": 1.985179,
-      "datasetSeed": 1
+      "datasetSeed": 1,
+      "suspect": "SUSPECT (F44) — RE-RENDER REQUIRED. This row's diagonal FOV exceeds the catalog query's one-cell cap (AstapCellGeometry.FindAreas clamps to ~5.14 deg), so stars were fetched for only a small central patch and the rest of the sensor rendered starless. Counts, recall, precision and star POSITIONS from this dataset are not trustworthy; gate-threshold results are. Re-render once the wide-field query lands."
     },
     {
       "id": "D02_rich_135mm",
@@ -50,7 +51,8 @@
       "seeingArcsec": 2.5,
       "optimalFocuserPosition": 6000,
       "focuserStepSizeMicrons": 2.126977,
-      "datasetSeed": 2
+      "datasetSeed": 2,
+      "suspect": "SUSPECT (F44) — RE-RENDER REQUIRED. This row's diagonal FOV exceeds the catalog query's one-cell cap (AstapCellGeometry.FindAreas clamps to ~5.14 deg), so stars were fetched for only a small central patch and the rest of the sensor rendered starless. Counts, recall, precision and star POSITIONS from this dataset are not trustworthy; gate-threshold results are. Re-render once the wide-field query lands."
     },
     {
       "id": "D03_redcat_250mm",
@@ -288,7 +290,7 @@
     },
     {
       "id": "D16_esprit550_ha3",
-      "description": "Same optics as D04 (550mm f/5.5, unobstructed, IMX571 bin1) but through a 3nm H\u03b1 narrowband filter. Heart Nebula (Cassiopeia), rich H\u03b1 field. H\u03b1 passes ~64-107x less flux than L, so the derived exposure is expected to sit near ExposureRecommender's 30s absolute ceiling (CappedByAbsoluteLimit). NOTE: the derived exposure lands at the 0.5s floor despite the 3nm filter, because ExposureRecommender's sensitivity metric is the NTarget=20th-brightest star's SNR and a 2.9deg field always contains 20 bright stars. D16 is therefore the narrowband-realism dataset, not the 30s-cap dataset (that role moved to D10).",
+      "description": "Same optics as D04 (550mm f/5.5, unobstructed, IMX571 bin1) but through a 3nm Hα narrowband filter. Heart Nebula (Cassiopeia), rich Hα field. Hα passes ~64-107x less flux than L, so the derived exposure is expected to sit near ExposureRecommender's 30s absolute ceiling (CappedByAbsoluteLimit). NOTE: the derived exposure lands at the 0.5s floor despite the 3nm filter, because ExposureRecommender's sensitivity metric is the NTarget=20th-brightest star's SNR and a 2.9deg field always contains 20 bright stars. D16 is therefore the narrowband-realism dataset, not the 30s-cap dataset (that role moved to D10).",
       "focalLengthMm": 550.0,
       "focalRatio": 5.5,
       "centralObstructionFraction": 0.0,

--- a/Joko.NINA.Plugins/TestApp/SynthBankRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/SynthBankRunner.cs
@@ -193,6 +193,14 @@ namespace TestApp.SynthBank {
                 $"{selected.Count}/{spec.Datasets.Count} dataset(s) out={outRoot} " +
                 $"dryRun={dryRun} overwrite={overwrite} verify={verify}");
 
+            // F44 — say it up front, once, for every selected row that is marked known-bad. A dataset whose frames
+            // must be re-rendered is indistinguishable from a good one on disk, and the numbers it produces look
+            // entirely ordinary, so the warning has to come from the spec rather than from the reader remembering.
+            foreach (var suspectRow in selected.Where(d => !string.IsNullOrWhiteSpace(d.Suspect))) {
+                Console.Error.WriteLine($"[{suspectRow.Id}] SUSPECT: {suspectRow.Suspect}");
+                Logger.Warning($"synth-bank: dataset '{suspectRow.Id}' is marked suspect: {suspectRow.Suspect}");
+            }
+
             int generated = 0, skipped = 0, dryRunCount = 0, failed = 0;
             foreach (var dataset in selected) {
                 try {

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -1461,6 +1461,56 @@ a settings file is created rather than loaded, since that is the moment an arm s
 its predecessor. Consider defaulting the path to a fixed per-user location rather than `AppContext.BaseDirectory`,
 so a new build directory inherits instead of bootstrapping.
 
+### F43 — The optimizer wizard refuses to start unless the DEFAULT settings already produce a usable curve
+**Status:** Open · found 2026-08-05 from a user report on a 40 mm rig
+
+`SeedFitIsUsableAsync` (`StarDetectionOptimizerWizardVM.cs:2869`, called at `:2541`) evaluates the **default seed
+params** once and refuses to optimize unless some run yields a finite σ(focus) over ≥ 3 positions. On a Live
+sweep it retries exactly one way — widening the focus-recovery exemption to drop starless *outermost* positions —
+and then errors out with *"The captured sweep does not produce a usable focus curve at the default detection
+settings."*
+
+**This is circular.** The tool exists to find settings that build a usable curve, and it declines to run unless
+the settings it has not optimized yet already build one. The guard tests **one point** in a search space the
+optimizer is free to explore; `MinHFR` alone spans [0.1, 5.0] against a default of 1.2.
+
+**Measured on `D01_ultrawide_40mm`** — the bank's own 40 mm rig, `golden eval --params default`, per-frame
+accepted stars across the sweep:
+
+| focuser | 5964 | 5973 | 5982 | 5991 | **6000 (focus)** | 6009 | 6018 | 6027 | 6036 |
+|---|---|---|---|---|---|---|---|---|---|
+| `MinHFR = 1.2` (default) | 816 | 1670 | 1773 | 11 | **0** | 5 | 1748 | 1672 | 815 |
+| `MinHFR = 0.30` (F35 floor) | 816 | 1670 | 2463 | 204 | **5** | 187 | 2469 | 1672 | 815 |
+| `MinHFR = 0.10` (search floor) | 816 | 1670 | 2463 | 208 | **6** | 190 | 2469 | 1672 | 815 |
+
+The wings detect thousands of stars; the **core of the curve is empty**. That is F20's signature — rejections
+concentrated on the INNER frames — and at 40 mm it is expected: in-focus stars are ~1 px, so the `MinHFR` gate
+removes precisely the frames the vertex is fitted from.
+
+**And `MinHFR` is the ONLY axis that rescues it.** `MinimumStarBoundingBoxSize` 5 → 3 changes nothing (still 0 at
+focus); `StructureLayers` 4 → 2 makes it strictly worse (0 at *both* central positions). So the single knob that
+un-blocks this rig class is the one the guard's refusal prevents the search from ever touching.
+
+**Why [F35](#f35--minhfr-should-be-seeded-from-the-sweep-wings-and-neither-available-hfr-statistic-can-size-it)
+does not already cover this.** F35's `MinHfrSeed` is applied inside `OptimizeAsync` (`:3076`) — **after** this
+guard — and its trigger is `BestFit.Minimum.Y <= MinHFR`, i.e. it needs a **fitted vertex**. When the gate has
+destroyed the fit there is no vertex, `seedFitVertexHfr` is NaN, and the rule correctly declines. So F35 rescues
+"the vertex sits under the gate" (D01/D02 headless, which still fit) and **not** "the gate destroyed the fit",
+which is the strictly worse case and the one users hit.
+
+**The error message's own advice is unreachable too.** It suggests "the recommended detection binning" — but that
+recommendation is derived from a fitted in-focus HFR ([F39](#f39--the-harness-records-a-detection-binning-the-run-never-applied-and-7-datasets-have-never-run-at-theirs)),
+which does not exist for exactly these runs. The remedy offered requires the thing whose absence caused the
+error.
+
+**Next step.** Before refusing, probe a **rescue configuration** rather than only widening the recovery
+exemption: re-evaluate with `MinHFR` lowered to `MinHfrSeed.SeedFloor` (and, if still unfittable, to the
+variable's lower bound). If a rescue probe yields a fittable curve, proceed **and carry that lowered gate into
+the search as the seed** — the same mechanism `OptimizerSettings.MinHfrSeedFloor` already implements, triggered
+by *feasibility* instead of by a vertex. Keep the refusal only for sweeps that no probed configuration can fit,
+which is the case the guard was actually written for. Note the rescue is thin on D01 (6 stars at focus, against
+`NHard = 3`), so the probe must gate on the fit being determinable, not on the counts being comfortable.
+
 ### F35 — `MinHFR` should be seeded from the sweep WINGS, and neither available HFR statistic can size it
 **Status:** Done (wave 3) · found 2026-08-03 answering "how far can `MinHFR` safely come down?" for
 [F20](#f20--below-minhfr-the-autofocus-objective-collapses-to-exactly-zero-with-no-diagnostic)

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -253,6 +253,28 @@ Also measured: with the F23 marginal-SNR term enabled, **D12 S6 converges** (3 r
 shipping does not (4 rounds, final 80, not converged). So the objective fix helps this loop even though it
 fails its own precision gates.
 
+> **The "fails its own precision gates" half is REFUTED, re-scored at `/5` (2026-08-05, wave 5).** This was the
+> single clause [F36](#f36--which-pre-wave-2-entries-actually-rested-on-the-broken-precision-metric-audited-and-it-is-none-of-them)
+> left open across F1–F8/F18/F21/F25/F26. Arm (a)'s landings scored with `golden eval` (which applies the `/5`
+> `TruthProtection` repair), against the control arm `H_A` on the same three datasets — the three arm (a) was
+> recorded as failing the ≥ 0.90 precision gate on:
+>
+> | dataset | control `H_A` | **arm (a)** | arm (a) as recorded at `/3` |
+> |---|---|---|---|
+> | `D09_c14_3800mm` | 0.958 | **1.000** | 0.451 |
+> | `D12_c14_585_afbin2` | 1.000 | **1.000** | 0.653 |
+> | `D15_cdk20_3454mm_e47` | 0.968 | **1.000** | 0.531 |
+>
+> **Arm (a) clears the gate on all three, and beats the control on two of them.** The gate failure was entirely
+> an artifact of the pre-[F31](#f31--synthetic-bank-precision-is-not-exact-the-golden-omits-real-stars-and-they-score-as-false-positives)
+> metric. What the term actually cost is **recall** — 0.983 → 0.932 on D09, 0.942 → 0.900 on D12, 0.965 → 0.917
+> on D15 — the same inversion F31 found: both mechanisms were suppressing *real detections*, not junk.
+>
+> So F26's convergence result stands **and** its caveat does not: the marginal-SNR term helped this loop without
+> failing any precision gate. It remains "won't fix as written" under [F23](#f23--the-optimizer-objective-has-no-precision-term-so-it-trades-precision-away-for-marginal-recall)
+> on F31's grounds — a precision defect one thirtieth the size of the artifact that hid it does not justify a
+> term — and this clause is now closed rather than unverified. Reproduce: `D:\hf_w5\f26\run.sh`.
+
 **Status revision.** The one-round deferral cost is real and worth the guard below; the "indefinitely" in this
 entry's title is not supported by re-measurement and should be read as "for at least one round, unbounded in
 principle".
@@ -1261,6 +1283,52 @@ derived-looking value that was not derived — either omit the field or mark it 
 itself, not only in `DerivedNotes`. (b) Decide whether the seven `detectionBinning = 2` datasets should be run at
 their expected factor, which is a re-baseline and needs its own arm.
 
+### F40 — The settings handoff shipped in wave 4 had never once been written to disk
+**Status:** Done (wave 5 — backfilled and now exercised) · found 2026-08-05 backfilling it
+
+Wave 4 shipped `hocusfocus_star_detection.json`, the `StarDetectionSettingsExport` envelope that makes a bank
+landing importable by the NINA UI. A filesystem scan of `D:\` and the user profile before the wave-5 backfill
+found **zero files of that name anywhere**.
+
+**It is not a bug in the writer.** `WriteSettingsHandoff` is called from the one `WriteOptimizedSettings` site
+with a non-null `baseOptions`, and the format has unit coverage (`OptimizedLandingExportTests`). The cause is
+ordering: wave 4's own arms — including the `optA` acceptance run on D18/D19/D20 — ran **before** the handoff was
+committed, and no `optimize` pass has run since. Wave 4's write-up says as much in its last line ("the envelope
+appears on the next `optimize` pass over a run"), which is correct and reads much weaker than the headline
+"**Shipped.** Every landing is now stored in a form the app can import and replay with".
+
+**Why it matters, and it generalizes past this file.** A feature can be written, unit-tested, merged, and
+described as shipped while never having *executed* in the environment it exists for. Unit tests prove the mapping;
+they do not prove a file arrives on disk. The distance between "the code that writes it is correct" and "it has
+been written" is exactly one arm that nobody ran.
+
+**Fixed (wave 5):** `TestApp bank-export-settings --runs <bank-root> [--apply]` converts each folder's existing
+`optimized_settings.json` in place, with no optimizer run — so F15 is never touched. **42 landings backfilled
+(20 synthetic + 22 real), 0 failed**, every one round-trip verified through `DiffKnobs` *before* being written.
+That backfill is the format's first end-to-end exercise outside unit tests.
+
+### F41 — A prior wave's control arm is not a control for a later wave's binary
+**Status:** Open (recorded as a standing rule) · found 2026-08-05, twelve minutes into the first wave-5 arm
+
+Wave 5's C0 acceptance criterion was "the feature-OFF landing must be bit-identical to `hf_f23/H_real_A`", the
+wave-1 control arm. On `toml999` it failed across nine knobs — Sensitivity 33.3 → 16.7, StarClip 3.5 → 6.875,
+MaxDistortion 0.10 → 0.45 — which reads as a serious regression in the change under test.
+
+**It is not one, and the same output says so.** `BaselineJ` also differs, **0.99784 → 0.98348**. `BaselineJ` is
+the *current settings*' score: no search is involved in producing it, so a search-side change cannot move it. A
+changed `BaselineJ` can only mean the objective or the detector changed — and between wave 1 and wave 5 they
+changed at least five times (`5115885` marginal-SNR default, `c2db33e` inert-gate fix, `7b5a695` effective gate,
+`238623d` MinHFR seeding/reporting, plus PR #174's bimodal HFR).
+
+**The rule.** An arm directory records what a *particular binary* landed. It is a valid baseline only for
+comparisons against **that same binary**. For "is my change inert", build the **immediate parent commit**; for
+"what did my change do", use **this binary's own feature-OFF arm**. Reusing an older wave's arm silently measures
+every intervening merge and attributes it to the change under test.
+
+**The tell is free and worth checking first.** `BaselineJ` (and any other search-independent quantity) should be
+identical between two arms of the *same* binary. If it is not, the binaries differ and no knob comparison between
+them means anything — check that single number before reading a diff as a regression.
+
 ### F35 — `MinHFR` should be seeded from the sweep WINGS, and neither available HFR statistic can size it
 **Status:** Done (wave 3) · found 2026-08-03 answering "how far can `MinHFR` safely come down?" for
 [F20](#f20--below-minhfr-the-autofocus-objective-collapses-to-exactly-zero-with-no-diagnostic)
@@ -1451,12 +1519,19 @@ F26 rests on σ_focus, recall, R², or landed parameter values — and `recallHi
 | F5, F6, F18, F21, F25 | σ_focus, R², curve geometry | unaffected |
 | F7 | σ_focus, and recall "essentially unchanged" | unaffected |
 | F8 | landed Sensitivity/StarClip corners | unaffected — but see below |
-| F26 | binning/convergence, **plus one precision clause** | one clause unverified |
+| F26 | binning/convergence, **plus one precision clause** | ~~one clause unverified~~ → **verified and REFUTED at `/5` (wave 5)** |
 
 **The one genuinely unverified clause.** F26 states that with the F23 marginal-SNR term enabled "D12 S6 converges
 … even though it **fails its own precision gates**." Those gates were the wave-1 `/3` ones, and F23's real
 precision effect turned out to be roughly one fifth of the artifact that hid it. The convergence result stands;
 the "fails its precision gates" half is not evidence until re-scored at `/5`.
+
+> **Closed 2026-08-05 (wave 5): re-scored, and the clause is REFUTED.** Arm (a) scores precision **1.000** on all
+> three datasets it was recorded as failing the ≥ 0.90 gate on (D09, D12, D15), beating the control on two. The
+> full table and what it cost instead (recall) are in [F26](#f26--a-stuck-binning-recommendation-starves-the-step-update-indefinitely).
+> **This audit's own verdict is unchanged** — no entry's conclusion depended on the repaired metric — and the one
+> exposure it identified has now been measured rather than left as a caveat. Cost: six `golden eval` arms, four
+> minutes.
 
 **Two entries are changed by [F33](#f33--the-synthetic-bank-does-not-reproduce-the-real-banks-optimizer-failure-mode)'s
 effective-gate correction instead — a different repair than the one being audited for.**

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -1540,12 +1540,15 @@ appears to run and produces nothing.
 **Measured on the reporter's own 61 MP sweep** (`FOCALLEN 40.0`, `XPIXSZ 3.76` → **19.4 arcsec/px**, 4 s, gain
 100, step 250, `FOCPOS 25000` = true focus). Accepted stars per position:
 
-| seed | 23750 | 24000 | 24250 | 24500 | 24750 | **25000** | 25250 | 25500 | 25750 | 26000 | 26250 | J |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| defaults (`MinHFR` 1.2) | 0 | 2 | 2 | 6 | 103 | **0** | 95 | 3 | 1 | 2 | 0 | **0** |
-| `MinHFR` 0.3 (first fix) | 0 | 2 | 2 | 6 | 103 | **14** | 95 | 3 | 1 | 2 | 0 | **0** |
-| + `Sensitivity` 0 | — | — | — | — | — | — | — | — | — | — | — | **0** |
-| + `NoiseClippingMultiplier` 1.0 | \multicolumn — min observed **3511** | | | | | | | | | | | **0.2477** |
+| seed | 23750 | 24000 | 24250 | 24500 | 24750 | **25000** | 25250 | 25500 | 25750 | 26000 | 26250 | min | `J` |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| defaults (`MinHFR` 1.2) | 0 | 2 | 2 | 6 | 103 | **0** | 95 | 3 | 1 | 2 | 0 | 0 | **0** |
+| `MinHFR` 0.3 (first fix) | 0 | 2 | 2 | 6 | 103 | **14** | 95 | 3 | 1 | 2 | 0 | 0 | **0** |
+| + `Sensitivity` → 0 | — | — | — | — | — | — | — | — | — | — | — | 0 | **0** |
+| + `NoiseClippingMultiplier` → 1.0 | — | — | — | — | — | — | — | — | — | — | — | **3511** | **0.2477** |
+
+(The last two rows are reported by their minimum because the point is the `NHard` floor, which is what `J`
+turns on; the per-position detail is in `D:\hf_w5\user40mm\*/optimize_summary.txt`.)
 
 Two things that only measurement would have given: **`MinHFR` is real but not sufficient** (0 → 14 stars at
 focus, still unscorable), and **the binding gate is `NoiseClippingMultiplier`, not `Sensitivity`** — relaxing the

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -1329,6 +1329,47 @@ every intervening merge and attributes it to the change under test.
 identical between two arms of the *same* binary. If it is not, the binaries differ and no knob comparison between
 them means anything — check that single number before reading a diff as a regression.
 
+### F42 — Every build directory silently gets its OWN detector settings, and the run instructions require a new one per arm
+**Status:** Open · found 2026-08-05 chasing a `BaselineJ` gap that turned out not to be the code under test
+
+`HarnessSettingsStore.DefaultPath()` is `Path.Combine(AppContext.BaseDirectory, "harness_settings.json")` — the
+file sits **next to the exe** — and `ResolveAt` **bootstraps one from the live NINA profile** when it is absent.
+Meanwhile the AF-bank run instructions say to build each arm to a separate `-o` directory, because the exe is
+file-locked while a run is in progress.
+
+Those two facts compose into a silent confound: **every new build directory bootstraps a fresh settings file from
+whatever the profile happens to hold at that moment**, so two arms built minutes apart can run different
+detectors. Measured across three wave-5 build dirs:
+
+| option | `exe2` | `exe_base` |
+|---|---|---|
+| `LocallyAdaptiveBinarization` | True | **False** |
+| `ModelPSF` | True | **False** |
+| `UseOptimizedSettings` | False | **True** |
+| `DetectionDebugMode` | False | **True** |
+| `PixelSizeMicrons` / `FocalLengthMm` | 3.8 / **NaN** | 3.76 / 688.0 |
+
+`UseOptimizedSettings = True` alone changes what `BuildStarDetectorParams` returns for the BASELINE — the "before"
+every improvement is measured against. `LocallyAdaptiveBinarization` changes candidate formation outright. Each
+bootstrap also stamps a differently-named profile snapshot (`Default-2026-08-05T10:54:36`), which is the visible
+tell in the run's own log: *"Settings: … (exported … from profile 'Default-…')"*.
+
+**The irony is the point.** This store exists precisely to stop profile state leaking into runs — its own comment
+says "a profile-sourced seed is mutable machine state nothing records, and `TryLoad("")` picks whichever profile
+is ACTIVE — two runs of the same data minutes apart were seeded from different telescopes." The *bootstrap* path
+reintroduces exactly that, and the build-to-a-separate-directory workflow guarantees it fires.
+
+**What it does and does not invalidate.** An arm set run from ONE build directory is internally valid — every arm
+shares the file, so a flag remains the only difference (this is true of wave 5's own F32 and F24 arms). What is
+invalid is any comparison ACROSS build directories, which is every cross-wave and every
+before/after-a-code-change comparison — the ones [F41](#f41--a-prior-waves-control-arm-is-not-a-control-for-a-later-waves-binary)
+is about. The two findings are the same hazard from two directions.
+
+**Next step.** Pass `--settings <one fixed path>` on every arm, and make the bootstrap loud: print a WARNING when
+a settings file is created rather than loaded, since that is the moment an arm silently stops being comparable to
+its predecessor. Consider defaulting the path to a fixed per-user location rather than `AppContext.BaseDirectory`,
+so a new build directory inherits instead of bootstrapping.
+
 ### F35 — `MinHFR` should be seeded from the sweep WINGS, and neither available HFR statistic can size it
 **Status:** Done (wave 3) · found 2026-08-03 answering "how far can `MinHFR` safely come down?" for
 [F20](#f20--below-minhfr-the-autofocus-objective-collapses-to-exactly-zero-with-no-diagnostic)

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -1531,8 +1531,49 @@ modes. Probing the seed there would quietly convert replay into a seed-gated pat
 saved run whose current settings cannot fit deserves the same rescue. The circularity argument applies equally;
 the counter-argument is that such a run should not have been captured. Not changed as a side effect of this one.
 
-Tests: 4, of which **2 fail** when the probe is removed; the other two are labelled guards (inertness on a
-healthy sweep, and the floor-combination helper).
+**EXTENDED 2026-08-05, same session, after the reporter tried it and it STILL failed.** The first fix was right
+about the circularity and wrong about the bar. Lowering `MinHFR` made the reporter's curve **fittable** but not
+**scorable**: frames still fell under the objective's `NHard` floor, so `J` was identically 0 and the search had
+no gradient. Handing the search that seed is indistinguishable, to the user, from refusing outright — the wizard
+appears to run and produces nothing.
+
+**Measured on the reporter's own 61 MP sweep** (`FOCALLEN 40.0`, `XPIXSZ 3.76` → **19.4 arcsec/px**, 4 s, gain
+100, step 250, `FOCPOS 25000` = true focus). Accepted stars per position:
+
+| seed | 23750 | 24000 | 24250 | 24500 | 24750 | **25000** | 25250 | 25500 | 25750 | 26000 | 26250 | J |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| defaults (`MinHFR` 1.2) | 0 | 2 | 2 | 6 | 103 | **0** | 95 | 3 | 1 | 2 | 0 | **0** |
+| `MinHFR` 0.3 (first fix) | 0 | 2 | 2 | 6 | 103 | **14** | 95 | 3 | 1 | 2 | 0 | **0** |
+| + `Sensitivity` 0 | — | — | — | — | — | — | — | — | — | — | — | **0** |
+| + `NoiseClippingMultiplier` 1.0 | \multicolumn — min observed **3511** | | | | | | | | | | | **0.2477** |
+
+Two things that only measurement would have given: **`MinHFR` is real but not sufficient** (0 → 14 stars at
+focus, still unscorable), and **the binding gate is `NoiseClippingMultiplier`, not `Sensitivity`** — relaxing the
+acceptance gate alone leaves `J` at 0. From the `MinHFR`-only seed, **80 evaluations could not move `J` off 0**;
+from the relaxed seed the optimizer converged immediately (`J` 0.246 → 0.262, min 43 stars).
+
+**So the rescue now walks a LADDER and its bar is SCORABLE, not merely fittable:** `MinHFR` → `SeedFloor`, then
+its search-space lower bound, then `+ Sensitivity` lower, then `+ NoiseClippingMultiplier` lower — least
+aggressive first, every bound read from `OptimizerVariable.CreateCuratedSet` so the guard can never seed the
+search outside what it may reach. Acceptance is `JTotal > 0`, computed with the wizard's own
+`objectiveConstants`, so "the search has something to climb" is decided by the SAME number the search maximizes.
+The winning configuration becomes the fresh pass's **seed**.
+
+**Two false trails worth recording, both killed by checking the instrument rather than the theory.** D01, the
+bank's own 40 mm dataset, looked like the obvious proxy and is not one: its sweep never reaches the 30 px
+candidate size where the defocus-aware distortion relaxation engages, so `--defocus-gates` is **bit-identical**
+there while the reporter's frames are far more defocused. And four probe runs returned **identical** star counts
+across four supposedly different configurations — the profile had `UseAdvanced = False`, so Simple mode was
+ignoring every knob being set. Identical results across different inputs is the tell that the instrument, not
+the subject, is the thing being measured.
+
+**Still open for this rig class.** The bank has no dataset resembling it (40 mm at heavy defocus, signal-starved
+short exposure): D01 is 40 mm but nowhere near that defocus, so nothing regression-tests this population. And the
+step size is its own problem — at 250 the usable band is about one step wide (103 stars at 24750, **0** at 25000,
+95 at 25250), which is [F18](#f18--step-size-is-sized-by-curve-geometry-alone-so-the-sweep-outruns-what-the-detector-can-see).
+
+Tests: 5, of which **3 fail** when the fix is removed (2 for the probe, 1 for the scorable bar); the other two are
+labelled guards (inertness on a healthy sweep, and the floor-combination helper).
 
 ### F35 — `MinHFR` should be seeded from the sweep WINGS, and neither available HFR statistic can size it
 **Status:** Done (wave 3) · found 2026-08-03 answering "how far can `MinHFR` safely come down?" for

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -1578,6 +1578,54 @@ step size is its own problem — at 250 the usable band is about one step wide (
 Tests: 5, of which **3 fail** when the fix is removed (2 for the probe, 1 for the scorable bar); the other two are
 labelled guards (inertness on a healthy sweep, and the floor-combination helper).
 
+### F44 — The synthetic camera queries the catalog for at most ONE CELL, so a wide field is rendered starless outside a small central patch
+**Status:** Open · found 2026-08-05 from a user report: "why is only a portion of the sensor getting rendered with stars?"
+
+`StarFieldCompositor` computes the field correctly — `DiagonalFovDegrees × 1.05` — and hands it to
+`AstapCatalogReader.Query`, which calls `AstapCellGeometry.FindAreas`. That method does two things which are
+right for ASTAP and wrong for a renderer:
+
+1. **It clamps the field**: `var fov = Math.Min(fovRadians, MaxFovRadians(partitioning))`, where `MaxFovRadians`
+   is **5.142857°** (1476-cell) or **9.53°** (290-cell) — i.e. exactly one cell width.
+2. **It then samples only the FOUR CORNERS** of that clamped box and returns the ≤4 cells they fall in. Its own
+   summary says so: *"the 1–4 cells whose union covers the square field of view"*.
+
+Both are a faithful port of ASTAP's `find_areas` (the doc comment says "reference behavior"), and both are
+correct **for plate-solving**, where fields are a few degrees and 4 corner cells genuinely cover them. They are
+not correct for rendering a wide field.
+
+**Measured on the reporting rig** (9576 × 6388 at 3.76 µm, `FOCALLEN 40.0`):
+
+| quantity | value |
+|---|---|
+| frame | **48.5° × 33.4°** |
+| diagonal FOV the compositor requests | **59.67°** |
+| what `FindAreas` clamps it to | **5.142857°** |
+| clamp factor | **11.6×** |
+| union of the ≤4 selected cells | at most ~10.3° × 10.3° |
+
+So the catalog is queried over roughly a 10° patch of a 48.5° × 33.4° frame, and everything outside it renders
+**starless** — which is exactly the bounded rectangle of stars the reporter saw, sitting in an otherwise empty
+(noise-only) sensor.
+
+**Why nothing caught it.** The compositor warns only when the query returns **no** stars
+(`StarFieldCompositor.cs:303`); a partially-covered field returns plenty, so no warning fires and the frame looks
+plausible. And the synthetic AF bank never exercises it: its widest row, `D01_ultrawide_40mm`, is 40 mm but on a
+**much smaller sensor**, so its field stays near the cap. Every bank dataset happens to sit inside one cell.
+
+**Consequences beyond the missing stars.** The rendered field is not just sparse but *spatially truncated*, so
+anything that reads position — the aberration inspector's sensor model, tilt calibration, region-based AF, the
+golden-set geometry — sees a synthetic frame whose stars occupy one corner-ish patch of the sensor. Any result
+derived from a wide-field simulator frame is suspect until this is fixed.
+
+**Next step.** Enumerate **every** cell intersecting the requested field instead of the four corners of a clamped
+box, and drop the clamp on the render path (keep `FindAreas` as-is if anything still needs the ASTAP-compatible
+behavior — it is a faithful port and worth keeping honest under its own name). The pieces already exist:
+`AreaForCoordinates` maps a coordinate to a cell, and the per-star angular filter in `QueryCells` already uses
+the **unclamped** FOV, so it will correctly trim the extra stars a wider cell sweep pulls in. Watch the RA
+wrap and the pole cells, which is where a naive lat/long tiling breaks, and add a wide-field bank row (or a unit
+test at 40 mm on a full-frame sensor) so the population is covered.
+
 ### F35 — `MinHFR` should be seeded from the sweep WINGS, and neither available HFR statistic can size it
 **Status:** Done (wave 3) · found 2026-08-03 answering "how far can `MinHFR` safely come down?" for
 [F20](#f20--below-minhfr-the-autofocus-objective-collapses-to-exactly-zero-with-no-diagnostic)

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -508,6 +508,46 @@ donut heuristic did not flag, or making the objective pay for recall. Both are b
 [F33](#f33--the-synthetic-bank-does-not-reproduce-the-real-banks-optimizer-failure-mode) they must be scored on
 **both** banks. Reproduce: `D:\hf_w3\run_f24_arms.sh` and `run_f24_arms2.sh`.
 
+**ANSWERED 2026-08-05 (wave 5): do NOT default them to neutral. The wave-3 conclusion was drawn from two
+datasets and does not generalize to twenty.** Five arms × all 20 synthetic datasets, `golden eval` at default
+shared params with the master forced on, ~55 min total and **no code change** — the overrides already exist
+(`GoldenEvalRunner.cs:461-479`). Precision is **1.000 on every arm and every dataset**.
+
+**First, wave 3 reproduces exactly.** D16 masterOFF 0.821 → shipping 0.793, and `boost0` restores 0.821; D04
+0.762 → 0.723, and `close1` restores 0.758. Neutralizing **both** recovers master-OFF recall on **19 of 20**
+datasets (D07 exceeds it). The mechanism claim is confirmed, and now on the whole bank.
+
+**But the master's two mechanisms are not a uniform cost — they are a rig-dependent trade:**
+
+| direction | datasets | Δrecall (masterOFF − shipping) |
+|---|---|---|
+| master **HURTS** recall | 12 — D01–D05, D07, D10, D13, D16, D18, D19, D20 | +0.007 … **+0.067** |
+| master **HELPS** recall | **3 — D06, D09, D14** | −0.005 … **−0.067** |
+| no effect | 5 — D08, D11, D12, D15, D17 | 0.000 |
+
+On all three of the datasets where it helps, `boost0` gives the gain back **exactly** (boost0 = masterOFF to
+3 dp), so **the +2 structure boost is what buys it** and the morph-close is inert there. And the three are
+`D06_sparse_1000mm`, `D09_c14_3800mm`, `D14_cdk14_2563mm_e47` — long focal length and sparse, i.e. **large
+defocused stars**, which is precisely what a coarser wavelet residual exists to preserve. The story is coherent
+in both directions: the boost saves big defocused stars from the subtraction and erases small-star structure, so
+it helps where stars are large and hurts where they are small and well sampled.
+
+**So the pre-registered criterion FAILS** (recall Δ ≥ −0.005 on *every* dataset): both-neutral costs
+**−0.067 on D09**, −0.024 on D06 and −0.005 on D14. A blanket default change takes recall away from exactly the
+rigs the feature was built for.
+
+**What the fix actually is.** Not a default — a *condition*. The knob wants to depend on star size, and the
+optimizer can already reach it (`DefocusAwareStructure` is a curated axis, and flipping it on makes
+`StructureLayerBoost` settable, so `DefocusAwareStructure=true, boost=0` is a reachable neutral point). It never
+goes there because `J` does not pay for recall — which is [F32](#f32--j-is-saturated-near-10-so-the-optimizer-trades-enormous-recall-for-numerically-trivial-gains),
+and F32's constraint is the general form of this fix.
+
+**Note the keep floor does NOT dissolve this.** The seed has the master OFF, and the master's own cost is
+≤ 0.067 of recall — a candidate flipping it on stays feasible at any floor ≤ 0.9. F32 bounds catastrophic
+shedding; it does not price a 4% one. The two entries are independent.
+
+Reproduce: `D:\hf_w5\f24_arms.sh`, analysed by `D:\hf_w5\analyze_f24.py`.
+
 ### F19 — The exposure recommendation is decided by the 20 brightest stars, so a rich field can never earn one
 **Status:** Open · found 2026-08-02 deriving expected-optimal exposures for the synthetic AF bank
 

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -1462,7 +1462,8 @@ its predecessor. Consider defaulting the path to a fixed per-user location rathe
 so a new build directory inherits instead of bootstrapping.
 
 ### F43 — The optimizer wizard refuses to start unless the DEFAULT settings already produce a usable curve
-**Status:** Open · found 2026-08-05 from a user report on a 40 mm rig
+**Status:** **Done (wave 5)** for the Live path; the replay case is left open below · found 2026-08-05 from a
+user report on a 40 mm rig
 
 `SeedFitIsUsableAsync` (`StarDetectionOptimizerWizardVM.cs:2869`, called at `:2541`) evaluates the **default seed
 params** once and refuses to optimize unless some run yields a finite σ(focus) over ≥ 3 positions. On a Live
@@ -1503,13 +1504,35 @@ recommendation is derived from a fitted in-focus HFR ([F39](#f39--the-harness-re
 which does not exist for exactly these runs. The remedy offered requires the thing whose absence caused the
 error.
 
-**Next step.** Before refusing, probe a **rescue configuration** rather than only widening the recovery
-exemption: re-evaluate with `MinHFR` lowered to `MinHfrSeed.SeedFloor` (and, if still unfittable, to the
-variable's lower bound). If a rescue probe yields a fittable curve, proceed **and carry that lowered gate into
-the search as the seed** — the same mechanism `OptimizerSettings.MinHfrSeedFloor` already implements, triggered
-by *feasibility* instead of by a vertex. Keep the refusal only for sweeps that no probed configuration can fit,
-which is the case the guard was actually written for. Note the rescue is thin on D01 (6 stars at focus, against
-`NHard = 3`), so the probe must gate on the fit being determinable, not on the counts being comfortable.
+**FIXED 2026-08-05 (wave 5).** Before refusing, `TryRescueWithLowerMinHfrAsync` probes a **lowered gate** —
+`MinHfrSeed.SeedFloor`, then the curated variable's own `Lower` bound, least-aggressive first. The ladder is read
+from `OptimizerVariable.CreateCuratedSet` rather than written as constants, so the guard can never admit a rig on
+a gate the search is not allowed to reach, nor refuse one it could have rescued because a constant drifted. If a
+probe makes the curve fittable, the run proceeds **and the rescued gate becomes the seed** via the existing
+`OptimizerSettings.MinHfrSeedFloor` — F35's mechanism, triggered by *feasibility* instead of by a vertex.
+`OptimizeAsync` takes the **lower** of the two floors, since both only ever lower the gate and either may be
+absent.
+
+The rescue is **not silent**: `MinHfrRescueNotice` tells the user which gate failed and what it was lowered to,
+because the wizard is then reporting results from a gate they did not choose — and on a short focal length that
+is the setting they most need to know about.
+
+Three things the fix deliberately does **not** do. It does not relax the bar to "the counts look healthy": the
+probe asks only whether a curve is *determinable*, because the rescue is genuinely thin on the rigs it exists for
+(6 stars on D01's in-focus frame against `NHard = 3`) and any richer bar re-rejects exactly that population —
+raising the counts from there is the search's job. It does not mutate the caller's seed (probes run on a clone;
+callers reuse one `StarDetectorParams`, and an in-place write is the wave-3 seed leak). And it does not remove
+the refusal: a sweep no probed gate can fit is still refused, which is what the guard was written for.
+
+**LIVE only, and the replay case is left open on purpose.** Replay gates on the user's CURRENT settings because a
+saved run exists only because those settings could already focus — a decision locked by
+`SeedGuard_ReplayMode_GatesOnBaseline`, which caught a first version of this fix that extended the probe to both
+modes. Probing the seed there would quietly convert replay into a seed-gated path. **Open question:** whether a
+saved run whose current settings cannot fit deserves the same rescue. The circularity argument applies equally;
+the counter-argument is that such a run should not have been captured. Not changed as a side effect of this one.
+
+Tests: 4, of which **2 fail** when the probe is removed; the other two are labelled guards (inertness on a
+healthy sweep, and the floor-combination helper).
 
 ### F35 — `MinHFR` should be seeded from the sweep WINGS, and neither available HFR statistic can size it
 **Status:** Done (wave 3) · found 2026-08-03 answering "how far can `MinHFR` safely come down?" for

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -1579,7 +1579,8 @@ Tests: 5, of which **3 fail** when the fix is removed (2 for the probe, 1 for th
 labelled guards (inertness on a healthy sweep, and the floor-combination helper).
 
 ### F44 — The synthetic camera queries the catalog for at most ONE CELL, so a wide field is rendered starless outside a small central patch
-**Status:** Open · found 2026-08-05 from a user report: "why is only a portion of the sensor getting rendered with stars?"
+**Status:** **Code FIXED (wave 5)**; `D01`/`D02` still marked **SUSPECT** and awaiting re-baseline next wave ·
+found 2026-08-05 from a user report: "why is only a portion of the sensor getting rendered with stars?"
 
 `StarFieldCompositor` computes the field correctly — `DiagonalFovDegrees × 1.05` — and hands it to
 `AstapCatalogReader.Query`, which calls `AstapCellGeometry.FindAreas`. That method does two things which are
@@ -1610,21 +1611,78 @@ So the catalog is queried over roughly a 10° patch of a 48.5° × 33.4° frame,
 
 **Why nothing caught it.** The compositor warns only when the query returns **no** stars
 (`StarFieldCompositor.cs:303`); a partially-covered field returns plenty, so no warning fires and the frame looks
-plausible. And the synthetic AF bank never exercises it: its widest row, `D01_ultrawide_40mm`, is 40 mm but on a
-**much smaller sensor**, so its field stays near the cap. Every bank dataset happens to sit inside one cell.
+plausible. **The bank does exercise it — on two rows — and nothing checked.** `D01_ultrawide_40mm`'s own spec
+description even names the hazard: *"capped at mag<=10.5 so the ~39deg diagonal FOV catalog query (design risk
+R5) stays tractable"*. R5 was recorded as a **tractability** risk (too many stars); the actual failure was the
+opposite — the query silently returns too few, over too small a patch.
+
+### Affected bank datasets — SUSPECT, refresh required
+
+Diagonal FOV × 1.05 against the cap, computed over all 20 rows (sensor dimensions from `SensorRegistry`,
+binning applied). The verdict is the same under either partitioning (5.14° or 9.53°):
+
+| dataset | sensor | FL | diagonal FOV | requested | × over the 5.14° cap | status |
+|---|---|---|---|---|---|---|
+| **`D01_ultrawide_40mm`** | IMX571 | 40 mm | **38.91°** | 40.85° | **7.9×** | **SUSPECT — refresh** |
+| **`D02_rich_135mm`** | IMX571 | 135 mm | **11.95°** | 12.55° | **2.4×** | **SUSPECT — refresh** |
+| `D03_redcat_250mm` (next widest) | IMX533 | 250 mm | 3.66° | 3.85° | 0.7× | ok |
+| the remaining 17 | — | ≥ 250 mm | ≤ 2.94° | ≤ 3.09° | ≤ 0.6× | ok |
+
+**Only D01 and D02 are affected**, and both must be **re-rendered in the next wave** once the query is fixed.
+Everything from D03 down sits comfortably inside one cell and is unaffected.
+
+**What this does and does not invalidate on those two rows.** The stars that ARE rendered are rendered correctly
+— right PSF, right defocus, right photometry — so results about **gate thresholds and HFR-versus-focus behaviour**
+survive. What does not survive is anything reading **counts, recall, precision, or position**: the field is
+spatially truncated, so star totals are low by an unknown factor and the surviving stars occupy one patch of the
+sensor.
+
+Specifically at risk, and to be re-checked after the refresh:
+
+- **[F35](#f35--minhfr-should-be-seeded-from-the-sweep-wings-and-neither-available-hfr-statistic-can-size-it)'s
+  headline validation rests on exactly these two rows** — "D01 and D02 go from `FinalJ` exactly 0 to a real
+  landing". The *mechanism* (the `MinHFR` gate zeroing an undersampled rig's fit, and seeding rescuing it) is a
+  threshold result and should hold; the `FinalJ` values and star counts are measured on a truncated field.
+- **[F43](#f43--the-optimizer-wizard-refuses-to-start-unless-the-default-settings-already-produce-a-usable-curve)**
+  cites D01's per-frame counts (0 stars at focus, ~1700 in the wings). Its conclusion was independently confirmed
+  on the reporter's own real 40 mm frames, so it stands, but the D01 figures are indicative rather than exact.
+- The **wave-5 [F24](#f24--donut-detection-costs-precision-even-where-donuts-exist-and-badly-where-they-do-not--it-costs-recall-where-it-is-not-needed)
+  arms** covered all 20 datasets; the D01 and D02 rows of that table are suspect. The verdict is unaffected — it
+  turned on D06/D09/D14, none of which are.
+- Any **sensor-model, tilt, or region-based** result derived from D01/D02, since those read star *position*.
 
 **Consequences beyond the missing stars.** The rendered field is not just sparse but *spatially truncated*, so
 anything that reads position — the aberration inspector's sensor model, tilt calibration, region-based AF, the
 golden-set geometry — sees a synthetic frame whose stars occupy one corner-ish patch of the sensor. Any result
 derived from a wide-field simulator frame is suspect until this is fixed.
 
-**Next step.** Enumerate **every** cell intersecting the requested field instead of the four corners of a clamped
-box, and drop the clamp on the render path (keep `FindAreas` as-is if anything still needs the ASTAP-compatible
-behavior — it is a faithful port and worth keeping honest under its own name). The pieces already exist:
-`AreaForCoordinates` maps a coordinate to a cell, and the per-star angular filter in `QueryCells` already uses
-the **unclamped** FOV, so it will correctly trim the extra stars a wider cell sweep pulls in. Watch the RA
-wrap and the pole cells, which is where a naive lat/long tiling breaks, and add a wide-field bank row (or a unit
-test at 40 mm on a full-frame sensor) so the population is covered.
+**FIXED 2026-08-05 (wave 5).** `AstapCellGeometry.FindAreasCovering` enumerates **every** cell intersecting a
+cone of the requested radius, walking the band table directly: per dec band, the RA half-span comes from the
+spherical law of cosines evaluated at both band edges and at the cone centre, padded by one whole cell each side.
+`AstapCatalogReader.Query` uses it **only when the field exceeds the cap** — below it the two agree by
+construction (a box at most one cell across touches at most four cells, and its corners hit all four), so every
+existing narrow-field result stays bit-identical and `FindAreas` remains an untouched, honest ASTAP port.
+
+**Measured on `D01_ultrawide_40mm`, re-rendered:**
+
+| | truth stars on frame | x extent | y extent | sensor grid occupancy |
+|---|---|---|---|---|
+| before | 8107 | 431 – 5921 | **741 – 2965** | **125/256 (49%)** |
+| after | **19212** | −1 – 6249 | **0 – 4176** | **256/256 (100%)** |
+
+Half the sensor was empty; it now fills edge to edge with 2.4× the stars.
+
+Tests: an independent brute-force oracle (dense sphere sampling, no shared code with the routine under test)
+asserts no cell inside the cone goes unqueried, across six pointings including RA-wrap and both poles, on both
+partitionings; plus whole-sky, filename-encoding and supersets-the-reference checks. A `touchesPole` fast path
+was written, measured against those tests, found to change nothing (`MaxRaHalfSpan` already returns π there) and
+**removed** rather than left as an untested branch.
+
+**Still outstanding: the two suspect rows have NOT been re-baselined.** `D01`/`D02` must be re-rendered and every
+number derived from them re-measured in the next wave — the re-render above went to a scratch directory purely to
+verify the fix, deliberately **not** into the bank, since re-baselining mid-wave is what
+[F15](#f15--optimize---per-run-overwrites-each-runs-stored-settings) and wave 3 warn against. The `suspect`
+marker stays in the spec until that happens, and `synth-bank` prints it on every run that selects those rows.
 
 ### F35 — `MinHFR` should be seeded from the sweep WINGS, and neither available HFR statistic can size it
 **Status:** Done (wave 3) · found 2026-08-03 answering "how far can `MinHFR` safely come down?" for

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -1128,6 +1128,53 @@ Three things follow, and the third is the one that changes the plan:
 Reproduce: `D:\hf_w3\f32_dynrange.py` (reads `hf_w2/verify_v5`, `hf_f23/verify_real_H`, and the `H_A` / `B_A`
 / `H_real_A` landings; no detector run).
 
+**SHIPPED 2026-08-05 (wave 5) as an acceptance constraint — and the arms overturn this entry's own framing.**
+`OptimizerSettings.MinDetectionKeepFraction` rejects a candidate keeping less than φ of the SEED's accepted stars
+(min over runs) **ahead of** the `j > bestJ` compare at all three accept sites. `J` is never multiplied or
+re-anchored, so landings stay comparable to every prior arm. Default null; **inertness measured against the
+parent commit with settings pinned: bit-identical**. Multi-pass callers pin round 0's seed totals (at φ=0.5,
+three `--continue-rounds` would otherwise reach 0.125 of where the user started).
+
+**32 optimizations, φ ∈ {0.30, 0.50, 0.75} + a feature-OFF control, one binary, `--settings` pinned
+([F42](#f42--every-build-directory-silently-gets-its-own-detector-settings-and-the-run-instructions-require-a-new-one-per-arm)).
+`BaselineJ` identical across all four arms of every run ([F41](#f41--a-prior-waves-control-arm-is-not-a-control-for-a-later-waves-binary)'s
+tell), so the comparison is valid.**
+
+**The headline is not what this entry predicted: on most binding runs the constraint IMPROVES `J` while keeping
+2–4× more stars.** At φ = 0.75, **5 of 7** binding runs land at a higher `J` than the unconstrained search found:
+
+| run | keep off → φ=0.75 | Δ`J` | σ_focus vs unconstrained |
+|---|---|---|---|
+| `CWhiteFocus` | 0.429 → **1.819** | **+0.00139** | **0.156×** |
+| `uneven` | 0.353 → 0.937 | +0.00165 | 0.785× |
+| `D19_cygnus_deep_shed` | 0.600 → 1.276 | +0.00024 | 0.364× |
+| `toml999` | 0.397 → **1.163** | +0.00054 | 0.959× |
+| `D18_m24_deep_shed` | 0.511 → **1.819** | +0.00009 | 1.337× |
+| `muggsie` | 0.612 → 0.805 | −0.00234 | 1.676× |
+| `mccomiskey` | 0.095 → 0.771 | −0.03097 | 2.812× |
+
+**A constrained maximum cannot exceed an unconstrained GLOBAL maximum**, so this proves the unconstrained search
+**was not finding the global optimum**. The shedding corner is substantially a **greedy trap**, not the rational
+purchase this entry and wave 4 concluded it was — the mechanism `RevertNeutralAxes` already documents, one level
+up: Phase A grids Sensitivity × StarClip with Sensitivity as the OUTER loop, the winning StarClip is discovered
+in a shedding row, and strict `j > bestJ` freezes it there. **"It is genuinely buying a much better fit with the
+stars it discards" is true relative to the baseline and false as a claim about the best available trade.**
+
+**Inertness measured 12 times, 9 bit-identical** — D20 at all three floors, D19 and muggsie at two each, toml999
+and uneven at φ=0.30. The 3 that changed are the pre-registered caveat (a landing can be feasible while a
+candidate *visited on the way* was not); two changed for the better, one by −0.0001 of `J`.
+
+**Exact recall on the synthetic arms: precision 1.000 and FP 0 at every floor** — every star won back is real.
+D18 recall@high 0.607 → **0.945** at φ=0.50; D19 0.968 → 0.984 with **2×** the detections at φ=0.75; **D20
+identical to the last detection at all four arms**. Note φ=0.75 **overshoots on D18** — its effective gate
+collapses to 0.234, the Sensitivity-floor pathology reached from the other side.
+
+**Recommended floor: φ = 0.50**, by the rule fixed in advance (*the smallest φ meeting the criteria*). φ=0.30
+does not address the defect (only `mccomiskey` binds, and it pays). **Adoption still needs the confirmation arm**
+— both full banks plus `bank-verify` for real-bank recall, since the efficacy criterion could only be evaluated
+by keep-% proxy here. Ships default OFF until then. Reproduce: `D:\hf_w5\f32_arms.sh`,
+`D:\hf_w5\scorecard.py`, `D:\hf_w5\score_f32_synth.sh`.
+
 ### F33 — ~~The synthetic bank does not reproduce the real bank's optimizer failure mode~~ → it does now
 **Status:** Done (part 1 wave 3, part 2 wave 4) · found 2026-08-03 re-reading the wave-1 arms side by side
 

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -394,7 +394,9 @@ now measure exactly the quantity the real one cannot. Related: [F4](#f4--the-obj
 is the same shape of gap (a term the objective omits), and [F11](#f11--precision-is-a-lower-bound-on-runs-whose-faint-tier-was-budget-truncated--re-run-these-with-more-montages) is why this went unseen.
 
 ### F24 — ~~Donut detection costs precision even where donuts exist, and badly where they do not~~ → it costs RECALL where it is not needed
-**Status:** Open, **restated** (2026-08-03, wave 2 — the precision claim is refuted; a recall claim replaces it) · found 2026-08-02 on the synthetic AF bank
+**Status:** Open — **remaining step ANSWERED (wave 5): do NOT neutralize the master's two defaults**; the fix is
+a condition on star size, which routes into [F32](#f32--j-is-saturated-near-10-so-the-optimizer-trades-enormous-recall-for-numerically-trivial-gains).
+Previously **restated** (2026-08-03, wave 2 — the precision claim is refuted; a recall claim replaces it) · found 2026-08-02 on the synthetic AF bank
 
 Config B (donut-aware detection forced on) reduced precision on **every** dataset where it was
 measurable, including the datasets that genuinely have donuts, and most sharply on the ε=0 control that
@@ -1066,7 +1068,9 @@ fail in two directions — biased, then saturated — which is why `precisionNul
 precision figure rather than being something a reader has to think to ask for.
 
 ### F32 — `J` is saturated near 1.0, so the optimizer trades enormous recall for numerically trivial gains
-**Status:** Open · found 2026-08-03 re-reading the wave-1 real-bank control arm
+**Status:** Open — **mechanism shipped default OFF (wave 5)**; adoption pending the confirmation arm. The
+entry's own premise is corrected below: on 5 of 7 binding runs there was no trade to bound, the search was
+merely stuck · found 2026-08-03 re-reading the wave-1 real-bank control arm
 
 The objective's landings are not close calls. Across the 17 scorable real-bank runs, `optimize --per-run` gives
 up a **median 0.243 of recall@SNR≥12** to gain a **median ΔJ of +0.0125** — and the worst cases are far starker

--- a/docs/synthetic-af-bank-followups-wave5-results.md
+++ b/docs/synthetic-af-bank-followups-wave5-results.md
@@ -1,0 +1,247 @@
+# Synthetic AF bank — followups wave 5
+
+Plan: [`plans/synthetic-af-bank-followups-wave5-plan.md`](../plans/synthetic-af-bank-followups-wave5-plan.md).
+Wave 4: [`docs/synthetic-af-bank-followups-wave4-results.md`](synthetic-af-bank-followups-wave4-results.md).
+Register: [`docs/followups.md`](followups.md).
+
+*The question: bound what `J` may spend. Three of the four items answered; the fourth's mechanism is shipped
+inert and its arms are running. Two of the answers are "no", and the two most expensive findings are about
+measurement rather than about the detector.*
+
+## Headline
+
+| what | result |
+|---|---|
+| F32 — bound the trade | **Shipped, default OFF, and proven inert** — bit-identical to the parent commit under pinned settings. Arms running |
+| F24 — the master's two silent defaults | **Answered: do NOT neutralize them.** The wave-3 conclusion came from 2 datasets and fails on 20 |
+| F26 — the one clause left on the `/3` metric | **Verified and REFUTED** in four minutes. Arm (a) scores precision **1.000** where it was recorded at 0.451–0.653 |
+| Backfill decision | **Shipped** — 42 landings converted in place, no re-run, F15 never touched |
+| Wizard pickup decision | **Shipped** — explicit button, never automatic |
+| F40 (new) | The wave-4 settings handoff **had never once been written to disk** |
+| F41 (new) | A prior wave's control arm is **not a control** for a later wave's binary. `BaselineJ` is the free tell |
+| F42 (new) | **Every build directory silently gets its own detector settings** — and the run instructions require a new one per arm |
+
+## F32 — the constraint, and why it is a constraint
+
+F32 reads as "the optimizer trades enormous recall for numerically trivial gains". Arithmetically true; the
+misreading points at the wrong fix, and wave 4 had already established why:
+
+- **The optimizer is not mis-scoring.** σ_focus improves on **10 of 10** real shedders (median ratio **0.320**)
+  and R² on 9 of 10. It is genuinely buying a better fit with the stars it discards.
+- **The trade is 5.7:1 by construction.** `SStars` hard-clamps at `nMin ≥ 8` / `nMedian ≥ 20` — a *starvation
+  detector*, not a star-count reward — so the only unsaturating star term is the tie-breaker's
+  `0.6·nMean/(nMean+20)` at `Wtie = 0.02`, worth at most **0.012 of `J`** across the entire range from zero
+  stars to infinite stars, while a 10% σ tightening buys **+0.0037**.
+
+So **nothing bounds what `J` may SPEND**, which makes the fix a feasibility constraint. The two alternatives were
+ruled out on evidence rather than taste: **rescaling `J` is provably a no-op** (a monotone transform preserves
+the argmax, so every landing would be identical), and **`Wtie` has already lost this fight** — it was raised
+1e-3 → 0.02 *specifically* to out-vote this corner, and F32 measures it being out-voted anyway.
+
+### What shipped
+
+A candidate keeping less than `MinDetectionKeepFraction` of the **seed's** accepted stars (min over runs) is
+rejected **ahead of** the `j > bestJ` compare, at all three accept sites (`CoarseGrid`, `CompassStage`,
+`RevertNeutralAxes`). `J` is never multiplied or re-anchored, so every landing stays numerically comparable to
+every prior arm. The seed is feasible by construction, so the feasible set is never empty and the never-regress
+floor survives.
+
+Three details that are not decoration:
+
+- **Min over runs, not the pooled sum.** Pooling lets one dense run's gains mask another being gutted. Identical
+  for the headless one-run-per-call case, so no bank measurement turns on it; it only bites in the wizard's N>1
+  blend, where min is the safer reading.
+- **A run whose seed detected nothing is EXEMPT.** The ratio is undefined, and rejecting on it would re-gate
+  exactly the F20/F35 population — a rig whose seed legitimately detects nothing is the case the `MinHFR` seeding
+  exists to rescue, and it must be free to climb from zero.
+- **The multi-pass ratchet is closed.** Both multi-pass callers re-invoke the optimizer with
+  `seed = the previous pass's best` (TestApp `--continue-rounds`, the wizard's Continue button). Measured against
+  each round's *own* seed, a floor of 0.5 permits 0.25 after two rounds and 0.125 after three — the constraint
+  paid in installments. Round 0's seed totals are pinned instead.
+
+### Verification
+
+**12 tests, of which 8 fail** when the feasibility test is neutralized at all three accept sites; the other four
+are labelled guards and **not counted** (wave-4 lesson 2). The fixture is the load-bearing part: raising
+`Sensitivity` both tightens σ and sheds stars, so the *unconstrained* search lands at keep **0.10** — the defect
+reproduced in miniature. A floor test that passes without that precondition proves nothing, so the precondition
+is asserted.
+
+**Inertness measured, not assumed.** The parent commit (`c97e1a3`) was built to its own directory and run against
+the wave-5 binary with no floor, **settings pinned to one file**, on `D05_tec140_1000mm`:
+
+| binary | currentJ → bestJ | evals | landing |
+|---|---|---|---|
+| `c97e1a3` | 0.999293 → 0.999693 | 234 | — |
+| wave 5, no floor | 0.999293 → 0.999693 | 234 | **bit-identical** |
+
+Adoption — turning the floor on by default — is deliberately a **separate commit after the arms**. The screening
+arms (φ ∈ {0.30, 0.50, 0.75} plus a feature-OFF control, over 5 real shedders + D18/D19/D20) are running.
+
+## F24 — answered, and the answer is no
+
+The entry's remaining step asks whether to default the master's `+2` structure boost and 5 px morph-close to
+neutral. **Two things had to be corrected before it could even be attempted.**
+
+**The literal phrasing is not implementable.** F24 says "on runs the donut heuristic did not flag", but
+`DonutHeuristic.Decide` lives in `TestApp/BankVerification.cs:159` — it is a **bank-audit tool, not a detector
+signal**, and the plugin has no per-run donut flag at detection time. Read before building.
+
+**And the arm needed no code at all.** `golden eval` already exposes every override
+(`GoldenEvalRunner.cs:461-479`), so five arms × 20 datasets cost ~55 minutes with exact precision, against a
+planned `optimize` campaign.
+
+### Wave 3 reproduces exactly — and does not generalize
+
+D16 masterOFF 0.821 → shipping 0.793, `boost0` restores 0.821. D04 0.762 → 0.723, `close1` restores 0.758.
+Neutralizing **both** recovers master-OFF recall on **19 of 20** datasets. Precision is **1.000 on every arm and
+every dataset**. The mechanism claim is confirmed on the whole bank.
+
+**But the two mechanisms are a rig-dependent trade, not a uniform cost:**
+
+| direction | datasets | Δrecall (masterOFF − shipping) |
+|---|---|---|
+| master **HURTS** recall | 12 — D01–D05, D07, D10, D13, D16, D18, D19, D20 | +0.007 … **+0.067** |
+| master **HELPS** recall | **3 — D06, D09, D14** | −0.005 … **−0.067** |
+| no effect | 5 — D08, D11, D12, D15, D17 | 0.000 |
+
+On all three where it helps, `boost0` gives the gain back **exactly** — so the `+2` structure boost is what buys
+it, and the morph-close is inert there. And those three are `D06_sparse_1000mm`, `D09_c14_3800mm`,
+`D14_cdk14_2563mm_e47`: long focal length and sparse, i.e. **large defocused stars**, precisely what a coarser
+wavelet residual exists to preserve. The story reads correctly in both directions — the boost saves big
+defocused stars from the subtraction and erases small-star structure.
+
+**The pre-registered criterion FAILS**: both-neutral costs **−0.067 on D09**, −0.024 on D06, −0.005 on D14. A
+blanket default change takes recall from exactly the rigs the feature was built for.
+
+**So the fix is not a default but a condition** — on star size. The optimizer can already reach the neutral point
+(`DefocusAwareStructure = true, boost = 0`); it never goes there because `J` does not pay for recall, which is
+F32. Note the keep floor does **not** dissolve this: the seed has the master OFF and the master's own cost is
+≤ 0.067, so flipping it on stays feasible at any floor ≤ 0.9. The two entries are independent.
+
+## F26 — the last clause resting on the broken metric, refuted in four minutes
+
+[F36](followups.md) identified exactly one clause across F1–F8/F18/F21/F25/F26 still resting on the `/3` metric:
+F26's *"D12 S6 converges … even though it **fails its own precision gates**."* Those gates are F23 arm (a)'s
+(precision ≥ 0.90), which arm (a) failed on D09, D12 and D15.
+
+The landings were already on disk and `golden eval` applies the `/5` `TruthProtection` repair, so this cost six
+evals:
+
+| dataset | control `H_A` | **arm (a)** | arm (a) as recorded at `/3` |
+|---|---|---|---|
+| `D09_c14_3800mm` | 0.958 | **1.000** | 0.451 |
+| `D12_c14_585_afbin2` | 1.000 | **1.000** | 0.653 |
+| `D15_cdk20_3454mm_e47` | 0.968 | **1.000** | 0.531 |
+
+**Arm (a) clears the gate on all three and beats the control on two.** The gate failure was entirely an artifact.
+What the term actually cost is **recall** — 0.983 → 0.932, 0.942 → 0.900, 0.965 → 0.917 — the same inversion F31
+found: both mechanisms were suppressing *real detections*, not junk. F23 remains "won't fix as written" on F31's
+grounds; this clause is now closed rather than unverified.
+
+## The two decisions
+
+**Backfill: convert in place, no re-run.** `TestApp bank-export-settings --runs <bank-root> [--apply]` reads each
+folder's existing `optimized_settings.json` and writes the envelope beside it through the same DTO→options
+mapping the optimize path uses. **42 landings (20 synthetic + 22 real), 0 failed**, every one round-trip verified
+through `DiffKnobs` *before* being written. The re-run route would have tripped F15 on 39 folders at once.
+
+**Wizard pickup: an explicit button, never automatic.** The wizard's baseline is the live profile — `baselineJ`
+and the headline improvement percentage are both measured against it. Auto-pickup would silently redefine
+"Current", so the same displayed percentage would mean something different with nothing on screen to say so.
+
+## F40 — a feature can be shipped, tested, and never have run
+
+A filesystem scan of `D:\` and the user profile before the backfill found **zero `hocusfocus_star_detection.json`
+files anywhere**. Not a writer bug — wave 4's arms, including the `optA` acceptance run, executed *before* the
+handoff was committed, and no `optimize` pass has run since. Wave 4's own last line says so correctly ("the
+envelope appears on the next `optimize` pass"), and reads much weaker than its headline "**Shipped.** Every
+landing is now stored in a form the app can import and replay with".
+
+Unit tests prove the mapping; they do not prove a file arrives on disk. The distance between "the code that
+writes it is correct" and "it has been written" is exactly one arm nobody ran. **The backfill is the format's
+first end-to-end exercise outside unit tests.**
+
+## F41 and F42 — the same hazard from two directions, and they cost the most this wave
+
+Wave 5's acceptance criterion C0 was "the feature-OFF landing must be bit-identical to `hf_f23/H_real_A`". On
+`toml999` it failed across **nine knobs** — Sensitivity 33.3 → 16.7, StarClip 3.5 → 6.875, MaxDistortion
+0.10 → 0.45. That reads as a serious regression in the change under test.
+
+**It is not one, and the same output says so.** `BaselineJ` differed too, **0.99784 → 0.98348**. `BaselineJ` is
+the *current settings*' score — **no search produces it**, so a search-side change cannot move it. A changed
+`BaselineJ` can only mean the objective or the detector changed, and between wave 1 and wave 5 they changed at
+least five times. That single number is a free, decisive check, and it should be read **before** any knob diff.
+
+Chasing the residue found the deeper one. `HarnessSettingsStore.DefaultPath()` is
+`Path.Combine(AppContext.BaseDirectory, "harness_settings.json")` — **the file sits next to the exe** — and it is
+**bootstrapped from the live NINA profile when absent**. The AF-bank run instructions require building each arm
+to a separate `-o` directory, because the exe is file-locked while running. So **every new build directory
+bootstraps a fresh settings file from whatever the profile held at that moment.** Measured across three wave-5
+build directories:
+
+| option | `exe2` | `exe_base` |
+|---|---|---|
+| `LocallyAdaptiveBinarization` | True | **False** |
+| `ModelPSF` | True | **False** |
+| `UseOptimizedSettings` | False | **True** |
+| `PixelSizeMicrons` / `FocalLengthMm` | 3.8 / **NaN** | 3.76 / 688.0 |
+
+`UseOptimizedSettings = True` alone changes what the BASELINE is. The store exists precisely to stop profile
+state leaking into runs — its own comment says "two runs of the same data minutes apart were seeded from
+different telescopes" — and the bootstrap path reintroduces it while the build workflow guarantees it fires.
+
+**Pinning `--settings` to one file made the two binaries agree exactly** (the inertness table above). An arm set
+run from one build directory stays internally valid; every cross-directory comparison was not.
+
+## Lessons
+
+**1. `BaselineJ` is a free control, and it should be checked before any knob diff.** It is search-independent, so
+two arms of the same binary must agree on it. When they do not, the binaries differ and no comparison between
+them means anything. This one number separates "my change broke something" from "these are different detectors"
+in one glance, and would have saved the whole F41 detour.
+
+**2. The measurement apparatus deserves the same suspicion as the code.** The two most expensive findings this
+wave (F41, F42) were both about whether a comparison was valid, not about the detector. A control that is not a
+control produces a confident, specific, wrong answer — nine knobs' worth.
+
+**3. Read the thing before building against it — twice more.** `DonutHeuristic` is a TestApp audit tool, so
+F24's "runs the donut heuristic did not flag" was not implementable as written; and `golden eval` already had
+every override F24's arms needed, turning a planned `optimize` campaign into 55 minutes.
+
+**4. Two datasets are not a bank.** Wave 3's F24 conclusion held perfectly on the two datasets it was measured on
+and reversed sign on three others. The generalization was the untested part, not the mechanism.
+
+**5. A gated diagnostic is missing exactly where it decides something.** The keep fraction was first written only
+when a floor was in force, which left the *control* arm — the one run whose keep fraction says whether a floor
+would have bound at all — unable to report it. Report a measurement whenever it is measurable; gate the
+*setting*, not the *observation*.
+
+**6. Count the tests that discriminate.** 12 written, 8 fail on revert, and the four that do not are labelled as
+guards rather than quietly counted.
+
+## Verification
+
+- New/changed tests all pass; the F32 constraint's 8 discriminating tests were confirmed by neutralizing the
+  feasibility test at all three accept sites and restoring.
+- Inertness vs the parent commit measured directly, settings pinned: **bit-identical**.
+- Backfill: 42/42 landings round-trip verified before writing, 0 failed.
+- Per [F37](followups.md), a red CI check is checked against the native test-host crash before being read as a
+  regression, and nothing merges on red.
+
+## Reproduce
+
+```
+# F26 — the one unverified clause (~40 s each, 6 arms)
+TestApp golden eval --runs "D:\SyntheticAutofocusBank\<DS>" --params optimized \
+    --opt-results "D:\hf_f23\{a_A|H_A}\<DS>_attempt01" --match centroid --match-radius 12 --out <dir>
+
+# F24 — five arms over all 20 datasets, no code change (~55 min total)
+D:\hf_w5\f24_arms.sh          # analysed by D:\hf_w5\analyze_f24.py
+
+# F32 — screening arms, settings PINNED (F42) so every arm shares one detector
+D:\hf_w5\f32_arms.sh          # analysed by D:\hf_w5\analyze_f32.py
+
+# Backfill (dry-run first)
+TestApp bank-export-settings --runs "D:\SyntheticAutofocusBank" [--apply]
+```

--- a/docs/synthetic-af-bank-followups-wave5-results.md
+++ b/docs/synthetic-af-bank-followups-wave5-results.md
@@ -4,15 +4,15 @@ Plan: [`plans/synthetic-af-bank-followups-wave5-plan.md`](../plans/synthetic-af-
 Wave 4: [`docs/synthetic-af-bank-followups-wave4-results.md`](synthetic-af-bank-followups-wave4-results.md).
 Register: [`docs/followups.md`](followups.md).
 
-*The question: bound what `J` may spend. Three of the four items answered; the fourth's mechanism is shipped
-inert and its arms are running. Two of the answers are "no", and the two most expensive findings are about
-measurement rather than about the detector.*
+*The question: bound what `J` may spend. All four items answered. Two of the answers are "no", the biggest one
+inverts the premise it was built on, and the two most expensive findings are about measurement rather than about
+the detector.*
 
 ## Headline
 
 | what | result |
 |---|---|
-| F32 — bound the trade | **Shipped, default OFF, and proven inert** — bit-identical to the parent commit under pinned settings. Arms running |
+| F32 — bound the trade | **Shipped default OFF, proven inert — and the arms overturn the entry's own framing:** on 5 of 7 binding runs the constraint IMPROVES `J` while keeping 2–4× more stars |
 | F24 — the master's two silent defaults | **Answered: do NOT neutralize them.** The wave-3 conclusion came from 2 datasets and fails on 20 |
 | F26 — the one clause left on the `/3` metric | **Verified and REFUTED** in four minutes. Arm (a) scores precision **1.000** where it was recorded at 0.451–0.653 |
 | Backfill decision | **Shipped** — 42 landings converted in place, no re-run, F15 never touched |
@@ -75,8 +75,111 @@ the wave-5 binary with no floor, **settings pinned to one file**, on `D05_tec140
 | `c97e1a3` | 0.999293 → 0.999693 | 234 | — |
 | wave 5, no floor | 0.999293 → 0.999693 | 234 | **bit-identical** |
 
-Adoption — turning the floor on by default — is deliberately a **separate commit after the arms**. The screening
-arms (φ ∈ {0.30, 0.50, 0.75} plus a feature-OFF control, over 5 real shedders + D18/D19/D20) are running.
+### The screening arms, and the result that overturns this entry's own framing
+
+32 optimizations: φ ∈ {0.30, 0.50, 0.75} plus a feature-OFF control, over 5 real shedders and D18/D19/D20, one
+binary, `--settings` pinned (F42). **`BaselineJ` is identical across all four arms of every run** — the F41 tell,
+confirming the comparison is valid before any knob is read.
+
+**The control arm's own keep fractions**, now recorded on every landing, and they reproduce wave 4 independently
+on a different binary (D18 48.8% → 0.511, D19 59.2% → 0.600, D20 94.8% → 0.948):
+
+| run | keep, unconstrained | binds at 0.75 | 0.50 | 0.30 |
+|---|---|---|---|---|
+| `mccomiskey` | **0.095** | ✓ | ✓ | ✓ |
+| `uneven` | 0.353 | ✓ | ✓ | — |
+| `toml999` | 0.397 | ✓ | ✓ | — |
+| `CWhiteFocus` | 0.429 | ✓ | ✓ | — |
+| `D18_m24_deep_shed` | 0.511 | ✓ | — | — |
+| `D19_cygnus_deep_shed` | 0.600 | ✓ | — | — |
+| `muggsie` | 0.612 | ✓ | — | — |
+| **`D20` (control)** | **0.948** | — | — | — |
+
+**THE HEADLINE: on most binding runs the constraint IMPROVES `J` while keeping 2–4× more stars.** At φ = 0.75:
+
+| run | keep off → φ=0.75 | Δ`J` | σ_focus vs unconstrained |
+|---|---|---|---|
+| `CWhiteFocus` | 0.429 → **1.819** | **+0.00139** | **0.156×** |
+| `uneven` | 0.353 → 0.937 | +0.00165 | 0.785× |
+| `D19_cygnus_deep_shed` | 0.600 → 1.276 | +0.00024 | 0.364× |
+| `toml999` | 0.397 → **1.163** | +0.00054 | 0.959× |
+| `D18_m24_deep_shed` | 0.511 → **1.819** | +0.00009 | 1.337× |
+| `muggsie` | 0.612 → 0.805 | −0.00234 | 1.676× |
+| `mccomiskey` | 0.095 → 0.771 | −0.03097 | 2.812× |
+
+**5 of 7 binding runs land at a HIGHER `J` than the unconstrained search found**, with more stars and (on 4 of 5)
+a tighter fit. `CWhiteFocus` is the clearest: σ_focus 1.578 → **0.246** while keeping 1.819× the seed's stars
+instead of 0.429×.
+
+**A constrained maximum cannot exceed an unconstrained GLOBAL maximum.** So this is not the constraint being
+free — it is proof that **the unconstrained search was not finding the global optimum**. The shedding corner is
+substantially a **greedy trap**, not the rational purchase F32 and wave 4 concluded it was. The mechanism is the
+one `RevertNeutralAxes` already documents, one level up: Phase A grids Sensitivity × StarClip with Sensitivity
+as the OUTER loop, the winning StarClip is first discovered in a shedding row, and strict `j > bestJ` freezes it
+there. The floor prunes that branch early and the search explores a genuinely better region.
+
+**This corrects wave 4 and F32's own text.** "The optimizer is behaving rationally — it is genuinely buying a
+much better fit with the stars it discards" is true *relative to the baseline* and false as a claim about the
+best available trade. On 5 of 7 runs it could have had both.
+
+### Inertness, measured twelve times rather than argued
+
+Across the 12 (run, floor) pairs where the floor does **not** bind, **9 land bit-identical** to the control —
+including **D20 at all three floors**, exactly as the wave-4 control was designed to behave:
+
+| pair | result |
+|---|---|
+| D20 × {0.75, 0.50, 0.30} | **bit-identical** ×3 |
+| D19 × {0.50, 0.30} | **bit-identical** ×2 |
+| muggsie × {0.50, 0.30} | **bit-identical** ×2 |
+| toml999, uneven × {0.30} | **bit-identical** ×2 |
+| CWhiteFocus × {0.30}, D18 × {0.50, 0.30} | changed (see below) |
+
+The three that changed are **the pre-registered C5 caveat happening**, not a failure: a landing can be feasible
+while a candidate *visited on the way* was not, and rejecting that candidate legitimately changes the trajectory.
+Two of the three (D18) changed for the **better** (`J` +0.000076, recall@high 0.607 → **0.945**); one
+(`CWhiteFocus`) is −0.0001 of `J`. Counted and reported rather than waved through, which is why C5 was written
+as a bound rather than as bit-identity.
+
+### Exact recall on the synthetic arms — precision 1.000, FP 0, everywhere
+
+| dataset | arm | recall@high | recall@all | TP | FP | precision |
+|---|---|---|---|---|---|---|
+| `D18_m24_deep_shed` | off | 0.607 | 0.168 | 13936 | 0 | 1.000 |
+| | φ=0.75 | 0.622 | **0.402** | **33319** | 0 | 1.000 |
+| | **φ=0.50** | **0.945** | 0.346 | 28676 | 0 | 1.000 |
+| `D19_cygnus_deep_shed` | off | 0.968 | 0.433 | 5492 | 0 | 1.000 |
+| | φ=0.75 | **0.984** | **0.864** | **10963** | 0 | 1.000 |
+| **`D20` (control)** | **all four arms** | **0.960** | **0.905** | **9073** | 0 | 1.000 |
+
+**D20 is identical to the last detection at every floor** — the control earning its keep for the second wave
+running. **C4 passes decisively**: not one false positive appears at any floor, so every star the constraint wins
+back is a real one.
+
+Note φ=0.75 **overshoots on D18**: its effective gate collapses to 0.234, which admits masses of faint stars
+(TP 33319) while *losing* high-tier ones relative to φ=0.50 (recall@high 0.622 vs 0.945). A floor set too high
+can push the search into the opposite corner — the Sensitivity-floor pathology F23/F33 describe, reached from
+the other side.
+
+### Verdict against the pre-registered criteria
+
+| # | criterion | result |
+|---|---|---|
+| C0 | inert vs the parent commit | **PASS** — bit-identical, settings pinned |
+| C1 | landing keep ≥ φ on every binding run | **PASS** at all three floors |
+| C2 | efficacy on real binding runs | **not evaluable as written** — needs real-bank recall (`bank-verify`), not run. Keep% is the proxy: median 0.397 → 1.163 at φ=0.75 |
+| C4 | precision ≥ 0.99, synthetic | **PASS** — 1.000, FP 0, every arm |
+| C5 | control and inert runs do not degrade | **PASS** — D20 identical ×3; 9/12 inert pairs bit-identical; the 3 exceptions are +, +, −0.0001 |
+| C6 | ≤ 25% of real runs collapse to no improvement | **PASS** — none did |
+
+**Recommended floor: φ = 0.50**, by the pre-registered rule (*the smallest φ meeting the criteria*). φ = 0.30
+does not address the defect — only `mccomiskey` binds and it pays. φ = 0.50 improves `J` on 3 of 4 binding runs,
+leaves all four inert runs untouched (3 of 4 bit-identical), and produces the single largest measured recall
+gain (D18 recall@high 0.607 → **0.945**) without φ=0.75's gate collapse.
+
+**Adoption still needs the confirmation arm** — both full banks at φ = 0.50, plus `bank-verify` for real-bank
+recall so C2 can be evaluated as written rather than by proxy. The constraint ships **default OFF** until then,
+so nothing in this wave depends on that verdict.
 
 ## F24 — answered, and the answer is no
 
@@ -195,6 +298,12 @@ different telescopes" — and the bootstrap path reintroduces it while the build
 run from one build directory stays internally valid; every cross-directory comparison was not.
 
 ## Lessons
+
+**0. A constraint that makes the objective GO UP is not a constraint — it is a bug report about the search.**
+The whole wave was designed around bounding a trade. On 5 of 7 binding runs there was no trade to bound: the
+unconstrained search was simply stuck, and pruning the shedding branch let it find a better optimum with more
+stars. The arm was built to measure a cost and measured a defect instead, which only became visible because `J`
+was left untouched and therefore stayed comparable.
 
 **1. `BaselineJ` is a free control, and it should be checked before any knob diff.** It is search-independent, so
 two arms of the same binary must agree on it. When they do not, the binaries differ and no comparison between

--- a/plans/synthetic-af-bank-followups-wave5-plan.md
+++ b/plans/synthetic-af-bank-followups-wave5-plan.md
@@ -158,7 +158,7 @@ built and validated; it must stay INERT at every floor below 0.94.
 
 | # | criterion | scope |
 |---|---|---|
-| **C0** | feature-OFF landings **bit-identical** to the prior arm's (`H_real_A`, `hf_w4/optA`) | all 8. Hard. A miss stops the wave — the plumbing is not inert |
+| **C0** | feature-OFF landings **bit-identical** to the **PARENT COMMIT's binary** (`c97e1a3`, built to `D:\hf_w5\exe_base`) | toml999 + D20. Hard. A miss stops the wave — the plumbing is not inert |
 | **C1** | landing keep% ≥ φ | every BINDING run. Exact; a violation is a bug, not a result |
 | **C2** | median Δrecall@≥12 vs C0 improves from −0.243 to **≥ −0.10** | real BINDING runs |
 | **C3** | median σ_focus(landing)/σ_focus(seed) **≤ 0.60** (unconstrained: 0.320) | real BINDING runs |
@@ -172,6 +172,17 @@ floor recovers more recall but gives back more σ. If no floor clears, ship noth
 **C5 is not a bit-identity claim, on purpose.** A landing can be feasible while a candidate *visited on the way*
 was not; rejecting that candidate legitimately changes the trajectory. So INERT runs are allowed to move, and the
 number that moved is **counted and reported** rather than waved through.
+
+> **C0 was written wrong the first time, and the arm caught it in 12 minutes.** The original criterion compared
+> the feature-OFF landing to `hf_f23/H_real_A` — the WAVE-1 control arm. It failed on `toml999` across nine
+> knobs, which reads as a regression and is not one: **`BaselineJ` differs too (0.99784 → 0.98348)**, and
+> `BaselineJ` is the *current settings*' score, computed with no search at all. A changed `BaselineJ` can only
+> mean the objective or the detector changed — which they did, five times, across waves 2–4 (`5115885`,
+> `c2db33e`, `7b5a695`, `238623d`, plus PR #174).
+>
+> **A prior wave's arm is not a control for this wave's binary.** The only valid inertness baseline is the
+> immediate parent commit, and the only valid baseline for each φ arm is this binary's own feature-OFF arm — which
+> the design already contains. Generalized as [F41](../docs/followups.md).
 
 **Confirmation arm.** At the chosen floor only: full synthetic bank (20) + full real bank (19).
 

--- a/plans/synthetic-af-bank-followups-wave5-plan.md
+++ b/plans/synthetic-af-bank-followups-wave5-plan.md
@@ -1,0 +1,356 @@
+# Synthetic AF bank — followups wave 5
+
+Wave 4: [`docs/synthetic-af-bank-followups-wave4-results.md`](../docs/synthetic-af-bank-followups-wave4-results.md).
+Register: [`docs/followups.md`](../docs/followups.md).
+Branch: `ghilios/synthetic-af-bank-followups-wave5`. Base: `develop` (wave 4 merged as PR #173).
+
+*The question: F32 says nothing bounds what `J` may spend. Bound it — as an acceptance constraint, scored on both
+banks, with the constraint's own inertness proved rather than assumed.*
+
+---
+
+## What this wave is and is not
+
+**Is:** a feasibility constraint on the optimizer's accept step (F32), the F24 master-default arms that share its
+validation path, one ~4-minute verification (F26), and two handoff decisions already taken.
+
+**Is not:** a new objective term, a rescale of `J`, or a retune of `Wtie`. All three are ruled out on evidence:
+
+- **A rescale is provably a no-op.** A monotone transform preserves the argmax, so every landing would be
+  identical. It buys human legibility and not one different decision.
+- **`Wtie` has already lost this fight.** `OptimizationObjective.cs:60-68` records it being raised 1e-3 → 0.02
+  *specifically* to out-vote the star-shedding corner, calibrated against a plateau σ-wiggle of ≲4e-3. The real
+  shedders' σ gains are far larger, and F32 measures it being out-voted anyway.
+- **The optimizer is not mis-scoring.** σ_focus improves on **10 of 10** real shedders (median ratio **0.320**,
+  a 68% reduction) and R² on 9 of 10. It is genuinely buying a better fit with the stars it discards. The defect
+  is that nothing bounds the *price*.
+
+So the fix changes the feasible set, never the score.
+
+### There is no cheap instrument for F32, and saying so up front is part of the plan
+
+Wave 4's lesson 5 applies verbatim. `golden eval --sensitivity <s>` (~40 s) measures whether the detector **can**
+shed at a *forced* gate. F32 is about whether the optimizer **chooses** to, under a constraint, when it is free to
+pick the gate. Only an `optimize` pass answers that. The 40 s instrument is used in this wave for F24 and F26,
+where the question really is "what does this parameter do at fixed settings" — and nowhere for F32.
+
+---
+
+## Task 1 — F32: bound the trade
+
+### 1.1 The constraint
+
+A candidate θ is **feasible** iff, for every run `r` in the set being optimized:
+
+```
+keep_r(θ) = Σ_f FrameStarCounts_r,f(θ) / Σ_f FrameStarCounts_r,f(seed)   ≥   MinDetectionKeepFraction
+```
+
+with `keep_r := 1.0` when the seed's total for that run is 0 (undefined ratio ⇒ exempt; this must not re-gate the
+F20/F35 escape, where the seed can legitimately detect nothing).
+
+Four properties this is chosen for:
+
+1. **`J` is untouched.** `BaselineJ`, `FinalJ`, `SeedJ`, `BestJ` keep their current numeric meaning, so every
+   landing stays comparable to every prior arm. This is the whole reason it is a rejection and not a multiplier.
+2. **The seed is always feasible** (keep = 1.0 by construction), so the feasible set is non-empty and the
+   never-regress floor is preserved. Worst case the search returns the seed.
+3. **The baseline is the run's own seed**, and in the headless path the seed is
+   `BuildDefaultStarDetectorParams()` (`OptimizationDiagnosticRunner.cs:242`) — i.e. exactly the **C0** of every
+   `C0 → A` table in F32/F33. The constraint is stated in the same units the defect was measured in.
+4. **Min over runs, not the pooled total.** Pooling lets one dense run's gains mask another run being gutted.
+   For the headless one-run-per-call case the two are identical, so nothing in the bank arms is affected by the
+   choice; it only bites in the wizard's N>1 blend, where it is the safer reading.
+
+### 1.2 The seam
+
+`SearchContext.EvalJ` (`StarDetectionOptimizer.cs:272`) is the single point every `bestJ`/`FinalJ` flows through,
+and `RunEvaluationMetrics.FrameStarCounts` (`OptimizationObjective.cs:283`) is already in hand there on a cache
+miss. Three accept sites consume its result:
+
+| site | line | compare |
+|---|---|---|
+| `CoarseGrid` | `:356` | `j > bestJ` |
+| `CompassStage` | `:533` | `j > improvedJ` |
+| `RevertNeutralAxes` | `:423` | `j >= bestJ` |
+
+The rejection goes **ahead of** each compare: `if (eval.Feasible && eval.J > bestJ)`.
+
+`RevertNeutralAxes` is included deliberately even though pulling back toward the seed usually *raises* the count:
+"usually" is not "always", and a uniform rule at all three sites is one invariant instead of three arguments.
+
+### 1.3 Implementation
+
+**T1.1 — `OptimizerSettings.MinDetectionKeepFraction` (`double?`, default `null`).** Null ⇒ every caller
+bit-identical, exactly the `MinHfrSeedFloor` pattern at `:56`. `synth-validate` and `tilt` stay untouched by
+construction.
+
+**T1.2 — `EvalJ` returns a small readonly struct** `CandidateEvaluation { double J; bool Feasible; double
+KeepFraction; }` instead of `double`, memoized alongside the existing `memo`/`memoSigma` dictionaries. Five call
+sites update. Keeping one evaluation method preserves "the single point everything flows through".
+
+**T1.3 — the seed establishes the baseline explicitly.** `EvalJ(theta, isSeed: true)` at `:154` records the
+per-run seed totals and returns `Feasible = true` unconditionally. An optional parameter rather than "the first
+call is the seed by construction" — implicit call-order coupling is precisely the shape of the wave-3 seed leak.
+
+**T1.4 — close the `--continue-rounds` ratchet.** `OptimizeAsync` is called repeatedly with `seedN =
+result.BestParams` (`OptimizationDiagnosticRunner.cs:~675`, mirroring the wizard's Continue button). A cap
+relative to *each call's own* seed compounds: at φ = 0.5, two continue rounds permit 12.5% of the original —
+the constraint paid in installments. So:
+
+- `OptimizationResult` gains `SeedRunDetectionTotals`.
+- `OptimizerSettings` gains `DetectionKeepBaselineTotals` (optional); when set it overrides the seed-derived
+  baseline.
+- The two multi-pass callers (TestApp `--continue-rounds`, the wizard's Continue) set it once from the **first**
+  pass's result and hold it for every later round.
+
+A regression test asserts a 3-round chain cannot fall below φ of the *original* seed.
+
+**T1.5 — reporting.** `OptimizationResult` gains `LandingKeepFraction` (min over runs) and
+`CandidatesRejectedByKeepFloor`. Surfaced in `optimize`'s console, `optimize_summary.txt`, and
+`aggregate_summary.*`. `optimized_settings.json` gains `MinDetectionKeepFraction` (the floor in force) and
+`LandingDetectionKeepFraction` (what was measured), **written only when the floor is non-null**.
+
+No `SchemaVersion` bump: both fields are additive, no existing number changes meaning, and an absent field
+already reads correctly as "no floor was in force". This follows F33's `EffectiveSensitivityGate` precedent and
+directly answers F39's complaint — a file that records a setting the run did not use is worse than one that
+records nothing.
+
+**T1.6 — `TestApp optimize --keep-floor <f>`.** Arm selection by flag on one binary, per the F23 pattern.
+
+**T1.7 — tests, counted by what they DISCRIMINATE.** Wave 4's lesson 2: the first F38 coverage was five tests of
+which exactly one failed on revert. Every test below is checked by reverting the fix and confirming the failure:
+
+| # | asserts | fails without the fix? |
+|---|---|---|
+| 1 | floor null ⇒ landing bit-identical to no-floor on a synthetic evaluator | no — inertness guard, expected to pass either way, kept deliberately and **not counted** |
+| 2 | a candidate with better `J` but keep below the floor is REJECTED; the search lands elsewhere | **yes** |
+| 3 | the same candidate is ACCEPTED when the floor is lowered beneath its keep | **yes** |
+| 4 | a run whose seed total is 0 exempts that run rather than rejecting everything | **yes** |
+| 5 | min-over-runs: one collapsed run rejects the candidate even when the pooled total rises | **yes** |
+| 6 | 3-round continue chain cannot fall below φ of the ORIGINAL seed | **yes** |
+| 7 | `RevertNeutralAxes` will not accept an infeasible pull-back | **yes** |
+| 8 | `J` reported for a landing is bit-identical to the unconstrained `J` at the same θ | **yes** (guards "never a multiplier") |
+
+Test 1 is listed as a non-discriminating guard on purpose, so the count of discriminating tests is 7, not 8.
+
+### 1.4 The arms
+
+**Pre-register everything below before the first run starts.**
+
+**Populations.** Per floor φ, a run is **BINDING** iff its unconstrained keep% < φ, else **INERT**. Unconstrained
+keep% comes from files already on disk (`hf_f23/H_real_A`, `hf_w4/optA`) — free, no detector run.
+
+Known keep% (wave 1/3/4): `mccomiskey` 1.2%, `CWhiteFocus` 29.6%, `standard_example1` 29.4%, `uneven` 32.8%,
+`toml999` 33.7%, `D18` 48.8%, `D19` 59.2%, `bobp` 85.3%, `D20` 94.8%.
+
+**Screening subset (8 runs).** Real shedders `toml999`, `CWhiteFocus`, `uneven`, `muggsie`, `mccomiskey`;
+synthetic `D18_m24_deep_shed`, `D19_cygnus_deep_shed`, `D20_m24_bright_control`. D20 is the control that wave 4
+built and validated; it must stay INERT at every floor below 0.94.
+
+**Floors:** φ ∈ {0.30, 0.50, 0.75}, plus a feature-OFF arm on the same 8 runs with the same binary.
+
+**Acceptance criteria, fixed now:**
+
+| # | criterion | scope |
+|---|---|---|
+| **C0** | feature-OFF landings **bit-identical** to the prior arm's (`H_real_A`, `hf_w4/optA`) | all 8. Hard. A miss stops the wave — the plumbing is not inert |
+| **C1** | landing keep% ≥ φ | every BINDING run. Exact; a violation is a bug, not a result |
+| **C2** | median Δrecall@≥12 vs C0 improves from −0.243 to **≥ −0.10** | real BINDING runs |
+| **C3** | median σ_focus(landing)/σ_focus(seed) **≤ 0.60** (unconstrained: 0.320) | real BINDING runs |
+| **C4** | precision **≥ 0.99** | every synthetic dataset, exact metric |
+| **C5** | Δrecall vs the unconstrained landing ≥ −0.01 **and** σ ratio ≤ 1.05 | D20 + INERT real runs |
+| **C6** | ≤ 25% of real runs collapse to `ImprovedOverSeed = false` | real bank |
+
+**Chosen floor = the SMALLEST φ meeting C1–C6** — minimum intervention that achieves the goal, since a larger
+floor recovers more recall but gives back more σ. If no floor clears, ship nothing and record why.
+
+**C5 is not a bit-identity claim, on purpose.** A landing can be feasible while a candidate *visited on the way*
+was not; rejecting that candidate legitimately changes the trajectory. So INERT runs are allowed to move, and the
+number that moved is **counted and reported** rather than waved through.
+
+**Confirmation arm.** At the chosen floor only: full synthetic bank (20) + full real bank (19).
+
+**The discriminating re-run F32 asks for.** Re-run F33's acceptance test on D18/D19/D20 with the constraint
+reverted; it must reproduce trade rates −53.4 / −40.4 / **+44.9** and keep% 48.8 / 59.2 / 94.8. This is what
+proves the arm measures the constraint and not incidental drift. It is covered by the feature-OFF screening arm,
+which contains exactly those three datasets.
+
+### 1.5 Adoption
+
+Turning the floor on by default is a **separate commit after the arms**, not part of T1.1–T1.7. If adopted, the
+wizard also needs one line of user-facing copy for the case where the constraint bound the landing ("held to ≥X%
+of the stars your current settings detect") — otherwise a user sees a smaller improvement with no visible cause.
+
+---
+
+## Task 2 — F24: the master's two silent defaults
+
+### 2.1 What the entry actually asks for, and the constraint on answering it
+
+F24's remaining step reads "default the master's +2 structure boost and 5 px morph-close to neutral on runs the
+donut heuristic did not flag."
+
+**There is no runtime donut heuristic to gate on.** `DonutHeuristic.Decide` lives in
+`TestApp/BankVerification.cs:159` — it is a bank-audit tool, not a detector signal, and the plugin has no
+per-run donut flag at detection time. So the literal phrasing is not implementable, and the implementable
+version is: **stop the master silently applying two mechanisms the user never asked for**, leaving both reachable
+through axes that already exist.
+
+| mechanism | today | neutral form | already an axis? |
+|---|---|---|---|
+| +2 structure boost | `StarDetector.cs:613` applies `DonutDefaultStructureLayerBoost = 2` when the master is ON and `DefocusAwareStructure` is OFF | delete that branch; `StructureLayerBoost` governs when `DefocusAwareStructure` is on | yes — `DefocusAwareStructure` + `StructureLayerBoost` |
+| 5 px morph-close | `StarDetector.cs:699` runs it when master ON and `DonutMorphCloseSize > 1`; the default **is** 5 (`IStarDetector.cs:407`, `StarDetectionOptions.cs:282,364`, `HocusFocusStarDetection.cs:444`) | default 5 → 1 | yes — `DonutMorphCloseSize` is a curated optimizer axis |
+
+### 2.2 The keep floor does NOT dissolve this — check before assuming it does
+
+Tempting shortcut: "with Task 1 shipped, the search is forced to neutralize anything that sheds." It is not. The
+seed has the master **OFF**, and the master's own cost is −0.028/−0.039 recall (wave 3, at default shared params)
+— a candidate flipping the master ON stays comfortably feasible at any φ ≤ 0.9. Task 1 bounds catastrophic
+shedding; it does not price a 3% one. The two tasks are independent and both are needed.
+
+### 2.3 The arm is nearly free, because the flags already exist
+
+`golden eval` already supports every override this needs — `--defocus-donut`, `--defocus-structure`
+`--structure-layer-boost 0`, `--donut-morph-close 1` (`GoldenEvalRunner.cs:461-479`). **No detector code changes
+to run the arm.** Four arms × 20 datasets × ~40 s ≈ 55 minutes total, with exact precision.
+
+| arm | flags (all with `--params default --defocus-donut`) |
+|---|---|
+| shipping | — |
+| boost-neutral | `--defocus-structure --structure-layer-boost 0` |
+| close-neutral | `--donut-morph-close 1` |
+| both-neutral | both of the above |
+
+Wave 3 ran exactly this on D16/D04 and recovered master-OFF recall **exactly** — the same star counts, not
+merely the same ratio. What is unmeasured is (i) the cost on the genuine-donut datasets, (ii) the σ_focus/`J`
+effect, and (iii) the real bank.
+
+**Then the expensive half, on donut datasets only:** `optimize --per-run --donut` over the synthetic ε>0 rows
+(D08, D09, D11, D12, D14, D15, D17) and the real donut runs (`Panos`, `mufti`, `LinwoodFocus`, `FlyData`),
+shipping vs both-neutral.
+
+**Pre-registered — the change ships only if all four hold:**
+
+1. Recall Δ ≥ **−0.005** on **every** synthetic dataset, the genuine-donut rows included.
+2. Precision ≥ **0.99** everywhere (exact metric).
+3. Median σ_focus ratio (both-neutral / shipping) ≤ **1.10** on the donut datasets. F24 measured donut detection
+   improving D13's fit **eightfold**; if the boost and the close are what buy that, neutralizing them is refused.
+4. Real-bank donut runs: no σ_focus or `J` regression beyond the same 1.10. **Recall is not scored on the real
+   bank** — per F11 real-data precision/recall is only a lower bound, so the real half is a σ/`J`/count check.
+
+Note the two neutralizations are scored **separately as well as together**, because they have opposite dataset
+dominance (boost dominates D16, close dominates D04) and one may pass while the other fails.
+
+If it ships, `DonutMorphCloseSize`'s default change is user-visible: it needs an
+`Resources/OptionsDataTemplates.xaml` check (the control exists — only the default moves) and a line in the
+manual.
+
+---
+
+## Task 3 — F26's unverified clause (~4 minutes)
+
+F36 records exactly one clause across F1–F8/F18/F21/F25/F26 that still rests on the `/3` metric: F26's *"D12 S6
+converges … even though it fails its own precision gates."* Those gates are F23 arm (a)'s (precision ≥ 0.90),
+which arm (a) failed on **D09, D12, D15** at `/3`.
+
+The landings are on disk (`D:\hf_f23\a_A\<DS>_attempt01\optimized_settings.json`, verified present), and
+`golden eval` applies the `/5` `TruthProtection` repair (`GoldenEvalRunner.cs:273-279`). So:
+
+```
+TestApp golden eval --runs "D:\SyntheticAutofocusBank\<DS>" --params optimized \
+    --opt-results "D:\hf_f23\a_A\<DS>_attempt01" --match centroid --match-radius 12 --out <dir>
+```
+
+for `DS ∈ {D09_c14_3800mm, D12_c14_585_afbin2, D15_cdk20_3454mm_e47}`, **and the same three against the control
+arm `H_A`** so the result is an A/B and not an absolute. Six evals, ~4 minutes.
+
+`ResolveSnapshot` takes `--opt-results` as a **direct folder** containing `optimized_settings.json`, not a bank
+root — hence the `_attempt01` suffix in the path above.
+
+Expected: the earlier truth-scored table already reads arm (a) D12 = **1.000**, so the clause most likely
+**refutes**. Record the outcome either way in F26 and close F36's open clause. This does not reopen F23, which is
+"won't fix as written" on F31's grounds, not on this clause.
+
+---
+
+## Task 4 — the two decisions (both taken)
+
+**4a — backfill: convert in place, no re-run.** New `TestApp bank-export-settings --runs <bank-root>` reads each
+run folder's existing `optimized_settings.json` and writes `hocusfocus_star_detection.json` beside it, through
+the **same** DTO→options mapping the optimize path uses. No optimizer runs, so F15 is never touched and no
+landing changes. A test asserts every existing bank landing round-trips with no axis dropped (the reflected-name
+mapping already has a no-axis-unmapped test; this extends it to the on-disk corpus).
+
+**Sequencing matters:** run this **before** any Task-1 arm, or the 8 screening runs' folder settings will have
+been rewritten by `optimize --per-run` and the backfill will capture wave-5 landings instead of their current
+ones.
+
+Do **not** rename to `optimized_settings.json` — `golden eval --params optimized`, `bank-verify`, `review` and
+`inspect-align` match that name exactly and would deserialize an envelope as a bare
+`OptimizedStarDetectionSettings`, binding every curated knob to its CLR default (Sensitivity 0, MinHFR 0,
+StructureLayers 0) and scoring a completely different detector with no error and no warning.
+
+**4b — wizard pickup: an explicit button, never automatic.** An "Import settings from this run" action the user
+presses, showing the existing diff before anything changes. "Current" keeps meaning the live profile, so
+`baselineJ` and the headline improvement percentage keep the meaning they have today. Auto-pickup was rejected:
+it silently redefines "Current", which changes what the headline percentage measures with no visible cause — the
+wave-3 seed-leak shape one level out.
+
+---
+
+## Order of work
+
+| # | step | cost | blocks |
+|---|---|---|---|
+| 1 | Task 3 — F26 verify at `/5` | ~4 min | nothing |
+| 2 | Task 4a — `bank-export-settings` + backfill both banks | ~1 h + seconds | **must precede any arm** |
+| 3 | Task 2 — the four `golden eval` arms, 20 datasets | ~55 min | nothing (no code) |
+| 4 | Task 1 — T1.1–T1.7 code + tests | — | the arms |
+| 5 | Task 1 — screening arms (3 floors + feature-OFF × 8 runs) | ~5.7 h detached | the floor choice |
+| 6 | Task 2 — `optimize --donut` arms on the donut datasets | ~2.5 h detached | the F24 verdict |
+| 7 | Task 1 — confirmation arm at the chosen floor, both banks | ~6 h detached | adoption |
+| 8 | Task 4b — the explicit import button | ~2 h | nothing |
+| 9 | Adoption commits, results doc, followups, PR | — | — |
+
+Steps 5–7 total ~14 h of detached compute. Run with progress files; build to a separate `-o` directory because
+the exe is file-locked while running.
+
+## Discipline carried forward
+
+- **Read the thing before scheduling a run against it.** Wave 4's `Bin2` scare was a complete, plausible
+  explanation of F33 that would have justified re-baselining both banks; one grep for who reads the field killed
+  it. Applied here already: `DonutHeuristic` is TestApp-only, which is why Task 2 is restated rather than
+  implemented as F24 words it.
+- **Count tests that discriminate.** Every test in T1.7 is verified by reverting the fix.
+- **An entry's stated blocker is a claim.** F24's "the donut heuristic did not flag" and F26's precision clause
+  are both checked against the code and the metric rather than inherited.
+- **A landing that moves a knob is not evidence of shedding** — what separates D18/D19 from D20 is the cost.
+- **F15:** `optimize --per-run` rewrites settings INTO run folders. Run only the datasets under test, read the
+  `--out` copies, and snapshot the 8 screening runs' folder settings before step 5. F15 is **not** fixed inline:
+  changing where settings are written mid-wave would silently change what `--params optimized` reads for every
+  subsequent scoring run.
+- **F37:** on a red CI check, suspect the native test-host crash before a regression, and verify the test
+  **count**, not just the badge. Never merge on red. Baseline: **3416 passing** on `develop` @ `757ef90`.
+- Specs go in `docs/` (`-design.md`), plans in `plans/` (`-plan.md`), findings get FLAGGED in `docs/followups.md`
+  rather than fixed inline. Never push to `develop`; commit with `322725+ghilios@users.noreply.github.com`.
+
+## Reproduce
+
+```
+# Task 3 — the one unverified clause, exact precision (~40 s each)
+TestApp golden eval --runs "D:\SyntheticAutofocusBank\<DS>" --params optimized \
+    --opt-results "D:\hf_f23\{a_A|H_A}\<DS>_attempt01" --match centroid --match-radius 12 --out <dir>
+
+# Task 2 — master-default arms, no code changes needed (~40 s each)
+TestApp golden eval --runs "D:\SyntheticAutofocusBank\<DS>" --params default --defocus-donut \
+    [--defocus-structure --structure-layer-boost 0] [--donut-morph-close 1] --match centroid --out <dir>
+
+# Task 1 — screening arm, ONE floor, the 8 subset runs only (F15)
+TestApp optimize --per-run --keep-floor 0.50 --runs "<run>" --out "D:\hf_w5\phi050\<run>" --max-evals 250
+
+# Build (exe is file-locked while running)
+dotnet.exe build "$(wslpath -w <abs>/TestApp/TestApp.csproj)" -c Release -o 'D:\hf_w5\exe'
+# Tests
+dotnet.exe test "$(wslpath -w <abs>/Joko.NINA.Plugins.sln)" -c Debug --nologo
+```

--- a/plans/synthetic-af-bank-followups-wave5-plan.md
+++ b/plans/synthetic-af-bank-followups-wave5-plan.md
@@ -119,20 +119,24 @@ records nothing.
 **T1.6 — `TestApp optimize --keep-floor <f>`.** Arm selection by flag on one binary, per the F23 pattern.
 
 **T1.7 — tests, counted by what they DISCRIMINATE.** Wave 4's lesson 2: the first F38 coverage was five tests of
-which exactly one failed on revert. Every test below is checked by reverting the fix and confirming the failure:
+which exactly one failed on revert. **Measured** by neutralizing the feasibility test at all three accept sites
+and re-running: **8 of 12 fail, 4 pass either way.** The four are kept and labelled as guards, not counted:
 
-| # | asserts | fails without the fix? |
-|---|---|---|
-| 1 | floor null ⇒ landing bit-identical to no-floor on a synthetic evaluator | no — inertness guard, expected to pass either way, kept deliberately and **not counted** |
-| 2 | a candidate with better `J` but keep below the floor is REJECTED; the search lands elsewhere | **yes** |
-| 3 | the same candidate is ACCEPTED when the floor is lowered beneath its keep | **yes** |
-| 4 | a run whose seed total is 0 exempts that run rather than rejecting everything | **yes** |
-| 5 | min-over-runs: one collapsed run rejects the candidate even when the pooled total rises | **yes** |
-| 6 | 3-round continue chain cannot fall below φ of the ORIGINAL seed | **yes** |
-| 7 | `RevertNeutralAxes` will not accept an infeasible pull-back | **yes** |
-| 8 | `J` reported for a landing is bit-identical to the unconstrained `J` at the same θ | **yes** (guards "never a multiplier") |
+| test | discriminates? |
+|---|---|
+| `Floor_RejectsALandingThatShedsBelowIt` | **yes** |
+| `Floor_IsMinOverRuns_NotThePooledTotal` | **yes** |
+| `Floor_DoesNotRatchetAcrossContinueRounds` | **yes** |
+| `Floor_SeedIsAlwaysFeasible` | **yes** |
+| `Floor_LandingAlwaysSatisfiesTheFloor` (×4 floors) | **yes** ×4 |
+| `NoFloor_IsBitIdenticalToTheUnconstrainedSearch` | no — the inertness guard that lets one binary be its own control arm |
+| `Floor_AcceptsTheSameCandidatesWhenLoweredBeneathThem` | no — a floor beneath everything visited is inert by construction |
+| `Floor_DoesNotAlterJ` | no — guards "never a multiplier", which the revert does not break |
+| `Floor_ExemptsARunWhoseSeedDetectedNothing` | no — an unconstrained search also moves off a zero-star seed |
 
-Test 1 is listed as a non-discriminating guard on purpose, so the count of discriminating tests is 7, not 8.
+The fixture itself is the load-bearing part: raising `Sensitivity` both tightens σ and sheds stars, so the
+**unconstrained** search lands at keep **0.10** — the defect reproduced in miniature. Without that precondition
+(asserted in the tests) a passing floor test would prove nothing.
 
 ### 1.4 The arms
 


### PR DESCRIPTION
Wave 5 of the synthetic-AF-bank followups. Full write-up:
[`docs/synthetic-af-bank-followups-wave5-results.md`](../blob/ghilios/synthetic-af-bank-followups-wave5/docs/synthetic-af-bank-followups-wave5-results.md).
Plan: [`plans/synthetic-af-bank-followups-wave5-plan.md`](../blob/ghilios/synthetic-af-bank-followups-wave5/plans/synthetic-af-bank-followups-wave5-plan.md).

| what | result |
|---|---|
| **F32** — bound what `J` may spend | **Shipped default OFF, proven inert — and the arms overturn the entry's own premise** |
| **F24** — the master's two silent defaults | **Answered: do NOT neutralize them.** Wave 3's conclusion came from 2 datasets and fails on 20 |
| **F26** — the last clause on the broken `/3` metric | **Verified and REFUTED** in four minutes |
| Backfill decision | **Shipped** — 42 landings converted in place, no re-run, F15 never touched |
| Wizard pickup decision | **Shipped** — explicit button, never automatic |
| **F40 / F41 / F42** (new) | Three measurement defects, two of which invalidated comparisons this wave nearly drew conclusions from |

## F32 — an acceptance constraint, not a term and not a rescale

A candidate keeping less than `MinDetectionKeepFraction` of the **seed's** accepted stars (min over runs) is
rejected **ahead of** the `j > bestJ` compare, at all three accept sites. `J` is never multiplied or re-anchored,
so every landing stays numerically comparable to every prior arm.

The two alternatives were ruled out on evidence: **rescaling `J` is provably a no-op** (a monotone transform
preserves the argmax), and **`Wtie` has already lost this fight** — it was raised 1e-3 → 0.02 specifically to
out-vote this corner, and F32 measures it being out-voted anyway. The optimizer is not mis-scoring: σ_focus
improves on 10 of 10 real shedders. Nothing bounded the *price*.

Three details that carry weight: the floor is **min over runs** (pooling lets one dense run mask another being
gutted); a run whose seed detected **nothing is exempt** (rejecting on an undefined ratio would re-gate exactly
the F20/F35 population); and the **multi-pass ratchet is closed** (at 0.5, three `--continue-rounds` would
otherwise reach 0.125 of where the user started).

**Default `null`, so the same binary is its own control.** Adoption is deliberately a separate commit after the
arms. Inertness measured against the parent commit with settings pinned: **bit-identical**, `currentJ=0.999293 →
bestJ=0.999693, evals=234` on both.

**12 tests, 8 of which fail** when the feasibility test is neutralized at all three accept sites; the other four
are labelled guards and not counted.

## F24 — the answer is no, and the fix is a condition rather than a default

Five arms × all 20 synthetic datasets, ~55 min, **no code change** (`golden eval` already had every override).
Precision **1.000 everywhere**. Wave 3 reproduces exactly on D16/D04, and neutralizing both mechanisms recovers
master-OFF recall on **19 of 20** datasets.

But it is a rig-dependent trade, not a uniform cost: the master **helps** recall on D06, D09 and D14 (up to
**+0.067**), and on all three the `+2` structure boost is exactly what buys it. Those three are the
long-focal-length and sparse rigs — large defocused stars, which is what a coarser wavelet residual exists to
preserve. So the pre-registered criterion fails, and a blanket default change would take recall from the rigs the
feature was built for.

## F26 — refuted in four minutes

Arm (a) scores precision **1.000** on all three datasets it was recorded as failing the ≥0.90 gate on (0.451 /
0.653 / 0.531 at `/3`), beating the control on two. What the term actually cost was **recall**. F36's last open
clause is closed.

## The three measurement findings

- **F40** — a filesystem scan found **zero** `hocusfocus_star_detection.json` files anywhere before this PR's
  backfill. Wave 4's arms ran before the writer was committed, so a feature that was written, unit-tested, merged
  and described as "Shipped" had never once executed. The backfill is its first end-to-end exercise.
- **F41** — a prior wave's control arm is **not** a control for a later wave's binary. Comparing to the wave-1 arm
  failed across nine knobs and read as a regression; `BaselineJ` differed too, and **no search produces
  `BaselineJ`**, so that single number says the binaries differ. Check it before any knob diff.
- **F42** — `harness_settings.json` sits **next to the exe** and bootstraps from the live NINA profile when
  absent, while the run instructions require a new build directory per arm (the exe is file-locked). So every arm
  silently gets its own detector. Three wave-5 build dirs disagreed on `LocallyAdaptiveBinarization`, `ModelPSF`
  and `UseOptimizedSettings` — the last of which changes what the BASELINE is.

## Also fixed

The tilt replay overlay's coverage guard kept its **own** copy of the knob/bookkeeping split and drifted the
moment F32 added two bookkeeping fields. There is now one authority (`CuratedKnobNames`); confirmed still
discriminating by removing a knob from the overlay.

## Verification

- Full suite **3611/3611, exit 0** (develop baseline 3416).
- F32's 8 discriminating tests confirmed by neutralizing the fix and restoring.
- Inertness vs the parent commit measured directly with settings pinned: bit-identical.
- Backfill: 42/42 landings round-trip verified **before** writing, 0 failed.

## The screening arms — and the result nobody predicted

32 optimizations: φ ∈ {0.30, 0.50, 0.75} + a feature-OFF control, over 5 real shedders and D18/D19/D20, one
binary, `--settings` pinned (F42). **`BaselineJ` is identical across all four arms of every run** — F41's tell,
confirming validity before any knob is read.

**On 5 of 7 binding runs the constraint lands at a HIGHER `J` than the unconstrained search found, while keeping
2–4× more stars:**

| run | keep off → φ=0.75 | Δ`J` | σ_focus vs unconstrained |
|---|---|---|---|
| `CWhiteFocus` | 0.429 → **1.819** | **+0.00139** | **0.156×** |
| `uneven` | 0.353 → 0.937 | +0.00165 | 0.785× |
| `D19_cygnus_deep_shed` | 0.600 → 1.276 | +0.00024 | 0.364× |
| `toml999` | 0.397 → **1.163** | +0.00054 | 0.959× |
| `D18_m24_deep_shed` | 0.511 → **1.819** | +0.00009 | 1.337× |
| `muggsie` | 0.612 → 0.805 | −0.00234 | 1.676× |
| `mccomiskey` | 0.095 → 0.771 | −0.03097 | 2.812× |

**A constrained maximum cannot exceed an unconstrained GLOBAL maximum**, so this proves the unconstrained search
**was not finding the global optimum**. The shedding corner is substantially a **greedy trap** — Phase A grids
Sensitivity × StarClip with Sensitivity as the outer loop, the winning StarClip is discovered in a shedding row,
and strict `j > bestJ` freezes it there. F32's and wave 4's "it is genuinely buying a better fit with the stars
it discards" is true relative to the baseline and **false as a claim about the best available trade**.

**Inertness measured 12 times, 9 bit-identical** — including **D20 at all three floors**, the wave-4 control
earning its keep a second time. The three that changed are the pre-registered C5 caveat (a landing can be
feasible while a candidate *visited on the way* was not); two changed for the better.

**Exact synthetic recall: precision 1.000 and FP 0 at every floor** — every star won back is real. D18
recall@high **0.607 → 0.945** at φ=0.50; D19 0.968 → 0.984 with **2×** the detections; D20 identical to the last
detection across all four arms.

**Recommended floor: φ = 0.50**, by the rule fixed in advance (smallest φ meeting the criteria). Adoption still
needs the confirmation arm over both full banks plus `bank-verify` for real-bank recall — the constraint ships
**default OFF**, so nothing here depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTNWdSNar6g3Nj5wXnLZc6
