### PR TITLE
Wave 6 followups: re-baseline D01, F42/F39 harness hardening, F32 decision, F45

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Harness/HarnessSettingsStoreTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Harness/HarnessSettingsStoreTests.cs
@@ -11,8 +11,12 @@
 #endregion "copyright"
 
 using NINA.Image.ImageData;
+using NINA.Profile.Interfaces;
+using NSubstitute;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using TestApp;
 
 namespace NINA.Joko.Plugins.HocusFocus.Tests.Harness;
@@ -125,5 +129,123 @@ public class HarnessSettingsStoreTests {
             Assert.That(double.IsNaN(scale), Is.True);
             Assert.That(source, Does.Contain("unavailable"));
         });
+    }
+
+    // ---- F42: a new build directory must INHERIT settings, not bootstrap its own ---------------------------
+
+    [Test]
+    public void DefaultPath_UsesAFileDeliberatelyPlacedBesideTheExe() {
+        // Back-compat, and the escape hatch: an arm directory that already carries its own file keeps using it.
+        var chosen = HarnessSettingsStore.ResolveDefaultPath(
+            besideExe: @"D:\arm3\harness_settings.json",
+            shared: @"C:\Users\x\AppData\Local\HocusFocusHarness\harness_settings.json",
+            exists: p => p == @"D:\arm3\harness_settings.json");
+        Assert.That(chosen, Is.EqualTo(@"D:\arm3\harness_settings.json"));
+    }
+
+    [Test]
+    public void DefaultPath_FallsBackToThePerUserFile_SoANewBuildDirectoryInherits() {
+        // F42's actual defect: the bank run instructions require a fresh -o directory per arm (the exe is
+        // file-locked during a run), and the old "always beside the exe" default meant every one of them
+        // bootstrapped its OWN detector settings from whatever the live profile held at that moment. Two arms
+        // built minutes apart then differed in UseOptimizedSettings / LocallyAdaptiveBinarization and no
+        // comparison between them meant anything.
+        var chosen = HarnessSettingsStore.ResolveDefaultPath(
+            besideExe: @"D:\arm4\harness_settings.json",
+            shared: @"C:\Users\x\AppData\Local\HocusFocusHarness\harness_settings.json",
+            exists: _ => false);
+        Assert.That(chosen, Is.EqualTo(@"C:\Users\x\AppData\Local\HocusFocusHarness\harness_settings.json"));
+    }
+
+    // ---- F42/F43: a Simple-mode settings file silently ignores its own advanced knobs ----------------------
+
+    [Test]
+    public void SimpleModePresetOverrides_NamesTheKnobsThePresetsOverwrite() {
+        // With UseAdvanced=False, StarDetectionOptions recomputes the advanced knobs from the Simple_* presets,
+        // so these recorded values never reach the detector. Wave 5 lost four probe runs to exactly this: the
+        // configurations differed on paper and returned identical star counts.
+        var overrides = HarnessSettingsStore.SimpleModePresetOverrides(
+            new Dictionary<string, string> {
+                ["UseAdvanced"] = "False",
+                ["NoiseClippingMultiplier"] = "1",
+                ["StarClippingMultiplier"] = "9.5",
+                ["MinHFR"] = "0.1",
+            },
+            Substitute.For<IProfileService>());
+        Assert.Multiple(() => {
+            Assert.That(overrides.Count, Is.EqualTo(3));
+            Assert.That(string.Join("|", overrides), Does.Contain("MinHFR"));
+            Assert.That(string.Join("|", overrides), Does.Contain("NoiseClippingMultiplier"));
+            Assert.That(string.Join("|", overrides), Does.Contain("StarClippingMultiplier"));
+        });
+    }
+
+    [Test]
+    public void SimpleModePresetOverrides_IsSilentInAdvancedMode() {
+        // The mirror image, and the reason the warning is conditional: in Advanced mode the file IS the detector.
+        var overrides = HarnessSettingsStore.SimpleModePresetOverrides(
+            new Dictionary<string, string> {
+                ["UseAdvanced"] = "True",
+                ["NoiseClippingMultiplier"] = "1",
+                ["MinHFR"] = "0.1",
+            },
+            Substitute.For<IProfileService>());
+        Assert.That(overrides, Is.Empty);
+    }
+
+    // ---- F39: a per-run file must not present an inherited binning as a derived one -----------------------
+
+    private static (string Path, string Json) ResolveForRunInTempDir(double inFocusHfr) {
+        var dir = Path.Combine(Path.GetTempPath(), "hf_harness_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try {
+            var baseSettings = new HarnessSettingsStore.Resolved {
+                Accessor = new HarnessSettingsStore.FileOptionsAccessor(
+                    new Dictionary<string, string> { ["DetectionBinning"] = "Bin2" }),
+                PixelSizeMicrons = 3.76,
+                FocalLengthMm = 585.0,
+            };
+            var resolved = HarnessSettingsStore.ResolveForRun(dir, baseSettings, Meta(3.76, 585.0), inFocusHfr);
+            return (resolved.Path, File.ReadAllText(resolved.Path));
+        } finally {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    [Test]
+    public void ResolveForRun_MarksAnInheritedDetectionBinningAsKeptFromBase() {
+        // F39's defect in one line: EVERY synthetic-bank file says "DetectionBinning": "Bin2" and not one of them
+        // derived it — no bank folder has the autofocus_report_Region0.json the derivation needs, so all of them
+        // inherited it from a profile export while looking exactly like the derived case.
+        var (_, json) = ResolveForRunInTempDir(inFocusHfr: double.NaN);
+        Assert.Multiple(() => {
+            Assert.That(json, Does.Contain(HarnessSettingsStore.DetectionBinningKeptFromBase));
+            Assert.That(json, Does.Not.Contain(HarnessSettingsStore.DetectionBinningDerived));
+        });
+    }
+
+    [Test]
+    public void ResolveForRun_MarksAMeasuredDetectionBinningAsDerived() {
+        var (_, json) = ResolveForRunInTempDir(inFocusHfr: 8.0);
+        Assert.That(json, Does.Contain(HarnessSettingsStore.DetectionBinningDerived));
+    }
+
+    [Test]
+    public void SimpleModePresetOverrides_IsEmptyWhenTheFileAgreesWithThePresets() {
+        // The wave-5 pinned file's case: its advanced values coincide with the Typical presets, so no wave-5 arm
+        // was invalidated. The hazard is real but did not fire, and the diff has to be able to say so.
+        var overrides = HarnessSettingsStore.SimpleModePresetOverrides(
+            new Dictionary<string, string> {
+                ["UseAdvanced"] = "False",
+                ["Simple_NoiseLevel"] = "Typical",
+                ["Simple_PixelScale"] = "Typical",
+                ["Simple_FocusRange"] = "Typical",
+                ["NoiseClippingMultiplier"] = "4",
+                ["StarClippingMultiplier"] = "2",
+                ["StructureLayers"] = "4",
+                ["MinHFR"] = "1.2",
+            },
+            Substitute.For<IProfileService>());
+        Assert.That(overrides, Is.Empty);
     }
 }

--- a/Joko.NINA.Plugins/TestApp/HarnessSettingsStore.cs
+++ b/Joko.NINA.Plugins/TestApp/HarnessSettingsStore.cs
@@ -11,6 +11,7 @@
 #endregion "copyright"
 
 using Newtonsoft.Json;
+using NINA.Core.Utility;
 using NINA.Plugin.Interfaces;
 using NINA.Profile;
 using NINA.Profile.Interfaces;
@@ -41,8 +42,17 @@ namespace TestApp {
     /// </summary>
     internal static class HarnessSettingsStore {
 
-        /// <summary>Default file name, resolved next to the TestApp executable so it travels with the harness.</summary>
+        /// <summary>Default file name.</summary>
         public const string DefaultFileName = "harness_settings.json";
+
+        /// <summary>Folder under the user's local app data holding the SHARED harness settings — see <see cref="DefaultPath"/>.</summary>
+        public const string SharedFolderName = "HocusFocusHarness";
+
+        /// <summary><see cref="HarnessSettingsFile.DetectionBinningSource"/> when the run's own fit produced it.</summary>
+        public const string DetectionBinningDerived = "derived-from-in-focus-hfr";
+
+        /// <summary><see cref="HarnessSettingsFile.DetectionBinningSource"/> when it was inherited, not derived (F39).</summary>
+        public const string DetectionBinningKeptFromBase = "kept-from-base";
 
         /// <summary>Serialized form: the raw plugin option key/value bag plus the pixel-scale inputs.</summary>
         internal sealed class HarnessSettingsFile {
@@ -66,6 +76,21 @@ namespace TestApp {
 
             /// <summary>How a per-dataset file's derived values were arrived at, so the file explains itself.</summary>
             public string DerivedNotes { get; set; }
+
+            /// <summary>
+            /// Where this file's <c>DetectionBinning</c> came from — <c>derived-from-in-focus-hfr</c> or
+            /// <c>kept-from-base</c> (F39).
+            ///
+            /// <para>Every synthetic-bank file records <c>Bin2</c>, and not one of those runs derived it: the
+            /// derivation needs a fitted in-focus HFR from an <c>autofocus_report_Region0.json</c> that no bank
+            /// folder has, so all of them silently inherited the value from a profile export. A field that LOOKS
+            /// derived and is not is worse than an absent one, and <see cref="DerivedNotes"/> saying so in prose is
+            /// not something a reader diffs. This makes the provenance a value.</para>
+            ///
+            /// <para>Note the separate half of F39, deliberately NOT addressed here: the headless runners discard
+            /// <see cref="ResolveForRun"/>'s result, so this key is not what the run detected at either way.</para>
+            /// </summary>
+            public string DetectionBinningSource { get; set; }
         }
 
         /// <summary>
@@ -337,9 +362,14 @@ namespace TestApp {
                 var factor = NINA.Joko.Plugins.HocusFocus.Utility.DetectionBinningResolver.RecommendFromHfr(inFocusHfrPixels);
                 var setting = NINA.Joko.Plugins.HocusFocus.Utility.DetectionBinningResolver.ToSetting(factor);
                 options["DetectionBinning"] = setting.ToString();
+                file.DetectionBinningSource = DetectionBinningDerived;
                 notes.Add($"DetectionBinning={setting} from in-focus HFR {inFocusHfrPixels:0.00}px " +
                     $"(target {NINA.Joko.Plugins.HocusFocus.Utility.DetectionBinningResolver.TargetHfrPixels:0.0}px)");
             } else {
+                // F39 — say it as a FIELD, not only in prose. Every synthetic-bank file took this branch and every
+                // one of them reads "Bin2" next to sixteen genuinely-exported values, which is indistinguishable
+                // from a derivation on inspection.
+                file.DetectionBinningSource = DetectionBinningKeptFromBase;
                 notes.Add("DetectionBinning kept from base (no fitted in-focus HFR for this dataset)");
             }
             notes.Add(file.PixelSizeMicrons > 0 && file.FocalLengthMm > 0
@@ -377,9 +407,35 @@ namespace TestApp {
             }
         }
 
-        /// <summary>Default settings path: next to the TestApp executable.</summary>
-        public static string DefaultPath() =>
+        /// <summary>The settings file beside the TestApp executable — where the default used to live outright.</summary>
+        public static string BesideExePath() =>
             Path.Combine(AppContext.BaseDirectory ?? Directory.GetCurrentDirectory(), DefaultFileName);
+
+        /// <summary>The per-user SHARED settings file, which every build directory resolves to alike.</summary>
+        public static string SharedDefaultPath() =>
+            Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                SharedFolderName, DefaultFileName);
+
+        /// <summary>
+        /// Default settings path when no <c>--settings</c> is given.
+        ///
+        /// <para><b>F42.</b> This used to be "next to the exe", unconditionally. The AF-bank run instructions
+        /// require each arm to be built to its own <c>-o</c> directory (the exe is file-locked while a run is in
+        /// progress), and an absent file is BOOTSTRAPPED from the live NINA profile — so every new build directory
+        /// silently got its own detector, and two arms built minutes apart could differ in
+        /// <c>UseOptimizedSettings</c>, <c>LocallyAdaptiveBinarization</c> and the pixel-scale inputs. That is a
+        /// confound the workflow GUARANTEES rather than merely permits.</para>
+        ///
+        /// <para>So the per-user file is now the default, and a fresh build directory INHERITS it instead of
+        /// bootstrapping a new one. A file deliberately placed beside the exe still wins, so an existing arm
+        /// directory keeps behaving exactly as it did.</para>
+        /// </summary>
+        public static string DefaultPath() => ResolveDefaultPath(BesideExePath(), SharedDefaultPath(), File.Exists);
+
+        /// <summary>The <see cref="DefaultPath"/> decision as a pure function, so it is testable without a filesystem.</summary>
+        internal static string ResolveDefaultPath(string besideExe, string shared, Func<string, bool> exists) =>
+            exists(besideExe) ? besideExe : shared;
 
         /// <summary>
         /// Resolves the harness settings for this run. Order: <c>--settings &lt;path&gt;</c>, else the default
@@ -411,6 +467,7 @@ namespace TestApp {
                 var loaded = JsonConvert.DeserializeObject<HarnessSettingsFile>(File.ReadAllText(path))
                     ?? new HarnessSettingsFile();
                 Console.WriteLine($"Settings: {path} (exported {loaded.ExportedAtUtc:u} from profile '{loaded.ExportedFromProfile}')");
+                WarnIfSimpleModeOverridesTheFile(loaded, path, profileService);
                 return new Resolved {
                     Accessor = new FileOptionsAccessor(loaded.Options),
                     PixelSizeMicrons = loaded.PixelSizeMicrons,
@@ -425,7 +482,21 @@ namespace TestApp {
             }
 
             var file = ExportFromProfile(profileService, activeProfile);
+            var dir = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(dir)) {
+                Directory.CreateDirectory(dir);
+            }
             File.WriteAllText(path, JsonConvert.SerializeObject(file, Formatting.Indented));
+            // F42 — this is the exact moment an arm silently stops being comparable to its predecessor: the values
+            // come from whatever the ACTIVE profile happens to hold right now, and nothing else records that. Loud
+            // on stderr, not an informational line in a log nobody reads until the numbers disagree.
+            Console.Error.WriteLine(
+                $"WARNING: no harness settings file existed, so one was BOOTSTRAPPED at {path} from the live NINA " +
+                $"profile '{activeProfile?.Name}'. These values are whatever that profile holds right now — this run " +
+                "is NOT comparable to any earlier arm that used a different file. Pass --settings <path> to pin one " +
+                "file across every arm of a comparison.");
+            Logger.Warning($"HarnessSettingsStore bootstrapped {path} from profile '{activeProfile?.Name}'; " +
+                "cross-arm comparability is not guaranteed unless --settings pins one file.");
             Console.WriteLine($"Settings: bootstrapped {path} from profile '{activeProfile?.Name}'. " +
                 "Later runs read this file; the profile is not consulted for settings again.");
             return new Resolved {
@@ -435,6 +506,66 @@ namespace TestApp {
                 Path = path,
                 WasBootstrapped = true
             };
+        }
+
+        /// <summary>
+        /// Warns when a pinned settings file records advanced detector knobs the options class will simply
+        /// overwrite.
+        ///
+        /// <para><b>Why.</b> <c>StarDetectionOptions.InitializeOptions</c> ends in <c>ConfigureSimpleSettings()</c>,
+        /// which — when <c>UseAdvanced</c> is false — calls <c>DerivePresetSettings()</c> and recomputes roughly
+        /// sixteen advanced knobs (<c>NoiseClippingMultiplier</c>, <c>StarClippingMultiplier</c>,
+        /// <c>StructureLayers</c>, <c>BrightnessSensitivity</c>, <c>MinHFR</c>, <c>MaxDistortion</c>, …) from the
+        /// three <c>Simple_*</c> presets. So an arm that edits one of those keys in its settings file changes
+        /// nothing, and the run looks entirely ordinary — this is the wave-5 probe set where four supposedly
+        /// different configurations returned IDENTICAL star counts.</para>
+        ///
+        /// <para>The overridden keys are MEASURED rather than listed as constants: the file's own bag is handed to a
+        /// throwaway options instance and diffed afterwards, so this can never drift from what the class actually
+        /// does. Never throws — a diagnostic must not abort a run.</para>
+        /// </summary>
+        internal static IReadOnlyList<string> SimpleModePresetOverrides(
+                IDictionary<string, string> options, IProfileService profileService) {
+            var empty = Array.Empty<string>();
+            if (options == null || options.Count == 0) {
+                return empty;
+            }
+            if (options.TryGetValue("UseAdvanced", out var ua) && bool.TryParse(ua, out var advanced) && advanced) {
+                return empty;   // Advanced mode: the file's values are used verbatim.
+            }
+            try {
+                var probe = new Dictionary<string, string>(options, StringComparer.Ordinal);
+                _ = new NINA.Joko.Plugins.HocusFocus.StarDetection.StarDetectionOptions(
+                    profileService, new FileOptionsAccessor(probe));
+                var changed = new List<string>();
+                foreach (var kv in options) {
+                    if (probe.TryGetValue(kv.Key, out var after) && !string.Equals(after, kv.Value, StringComparison.Ordinal)) {
+                        changed.Add($"{kv.Key} {kv.Value}→{after}");
+                    }
+                }
+                changed.Sort(StringComparer.Ordinal);
+                return changed;
+            } catch (Exception) {
+                return empty;
+            }
+        }
+
+        private static void WarnIfSimpleModeOverridesTheFile(
+                HarnessSettingsFile loaded, string path, IProfileService profileService) {
+            if (loaded?.Options == null
+                || (loaded.Options.TryGetValue("UseAdvanced", out var ua) && bool.TryParse(ua, out var adv) && adv)) {
+                return;
+            }
+            var overridden = SimpleModePresetOverrides(loaded.Options, profileService);
+            var detail = overridden.Count > 0
+                ? $" Overwritten by the presets: {string.Join(", ", overridden)}."
+                : " (Its recorded values happen to agree with the presets, so nothing changes — but an EDIT to one of them would not take effect.)";
+            Console.Error.WriteLine(
+                "WARNING: " + path + " has UseAdvanced=False, so Simple-mode presets recompute the advanced detector " +
+                "knobs from Simple_NoiseLevel/Simple_PixelScale/Simple_FocusRange and editing them in this file " +
+                "has NO effect." + detail + " Set \"UseAdvanced\": \"True\" to make this file's advanced knobs binding.");
+            Logger.Warning($"Harness settings {path}: UseAdvanced=False; Simple-mode presets override "
+                + $"{overridden.Count} recorded advanced knob(s).");
         }
 
         /// <summary>

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -156,6 +156,13 @@ namespace TestApp {
                 keepFloor = kf;
             }
 
+            // F35 — --no-min-hfr-seed: skip the MinHFR seeding rule entirely, so the pre-F35 behaviour is reachable
+            // from THIS binary. Without it the only way to produce an F35 control arm is to build the pre-F35
+            // commit, which is precisely the cross-binary comparison F41 says is not a comparison: every merge in
+            // between rides along and is attributed to the seeding rule. Same shape as --keep-floor above — absent,
+            // the run is bit-identical to before this flag existed, so one exe is both arms.
+            bool noMinHfrSeed = DiagnosticUtil.HasFlag(args, "--no-min-hfr-seed");
+
             var labelsDir = DiagnosticUtil.GetArg(args, "--labels");
 
             // --per-run is a valueless flag: optimize each discovered run INDEPENDENTLY (one optimization, one
@@ -340,8 +347,12 @@ namespace TestApp {
                 Inspection = inspection,
                 LegacyObjective = legacyObjective,
                 ContinueRounds = continueRounds,
-                KeepFloor = keepFloor
+                KeepFloor = keepFloor,
+                NoMinHfrSeed = noMinHfrSeed
             };
+            if (noMinHfrSeed) {
+                Console.WriteLine("--no-min-hfr-seed: F35 MinHFR seeding DISABLED (pre-F35 control arm)");
+            }
             if (keepFloor is double kfv) {
                 Console.WriteLine($"--keep-floor: candidates keeping < {F(kfv)} of the seed's accepted stars (min over runs) are rejected as infeasible; J is unmodified");
             }
@@ -387,6 +398,7 @@ namespace TestApp {
             public bool LegacyObjective; // --legacy-objective: zero the HFR-outlier penalty + coverage reward (A/B "before")
             public int ContinueRounds;  // --continue-rounds: extra chained passes after the first (0-2)
             public double? KeepFloor;   // --keep-floor: F32 detection-keep feasibility floor (null = unconstrained)
+            public bool NoMinHfrSeed;   // --no-min-hfr-seed: F35 seeding off, so this binary can produce its own control
 
             // F30: which invocation is producing these landings. Stamped onto every optimized_settings.json this
             // run writes, so a bank folder full of prepasses from different arms stops being ambiguous.
@@ -666,10 +678,19 @@ namespace TestApp {
             // perRunBaseline (built above, before the objective was even finalized) already holds the fits, so the
             // trigger statistic costs nothing extra here. Run 0 is the representative run, matching the wizard.
             // The seeded value is reported below so a landing never silently differs from its recorded seed.
-            settings.MinHfrSeedFloor = MinHfrSeed.Resolve(
-                perRunBaseline.Count > 0 ? (perRunBaseline[0].BestFit?.Minimum.Y ?? double.NaN) : double.NaN,
-                ctx.Seed.MinHFR,
-                ctx.Seed.DetectionBinning);
+            settings.MinHfrSeedFloor = ctx.NoMinHfrSeed
+                ? null
+                : MinHfrSeed.Resolve(
+                    perRunBaseline.Count > 0 ? (perRunBaseline[0].BestFit?.Minimum.Y ?? double.NaN) : double.NaN,
+                    ctx.Seed.MinHFR,
+                    ctx.Seed.DetectionBinning);
+            if (ctx.NoMinHfrSeed) {
+                // Say it per run, not only once at startup: an arm's log is read run by run, and "the seed did not
+                // fire" and "the seed was switched off" are different facts that must not look alike.
+                Console.WriteLine($"  MinHFR seed (F35): SUPPRESSED by --no-min-hfr-seed (fitted vertex HFR "
+                    + $"{F(perRunBaseline.Count > 0 ? (perRunBaseline[0].BestFit?.Minimum.Y ?? double.NaN) : double.NaN)} px, "
+                    + $"gate {F(ctx.Seed.MinHFR)})");
+            }
             if (settings.MinHfrSeedFloor is double seededMinHfr) {
                 Console.WriteLine($"  MinHFR seed (F35): fitted vertex HFR {F(perRunBaseline[0].BestFit?.Minimum.Y ?? double.NaN)} px "
                     + $"is at or below the gate {F(ctx.Seed.MinHFR)}; seeding MinHFR -> {F(seededMinHfr)}");

--- a/Joko.NINA.Plugins/TestApp/SynthBank/synthetic-bank-spec.json
+++ b/Joko.NINA.Plugins/TestApp/SynthBank/synthetic-bank-spec.json
@@ -32,8 +32,7 @@
       "seeingArcsec": 2.5,
       "optimalFocuserPosition": 6000,
       "focuserStepSizeMicrons": 1.985179,
-      "datasetSeed": 1,
-      "suspect": "SUSPECT (F44) — RE-RENDER REQUIRED. This row's diagonal FOV exceeds the catalog query's one-cell cap (AstapCellGeometry.FindAreas clamps to ~5.14 deg), so stars were fetched for only a small central patch and the rest of the sensor rendered starless. Counts, recall, precision and star POSITIONS from this dataset are not trustworthy; gate-threshold results are. Re-render once the wide-field query lands."
+      "datasetSeed": 1
     },
     {
       "id": "D02_rich_135mm",
@@ -51,8 +50,7 @@
       "seeingArcsec": 2.5,
       "optimalFocuserPosition": 6000,
       "focuserStepSizeMicrons": 2.126977,
-      "datasetSeed": 2,
-      "suspect": "SUSPECT (F44) — RE-RENDER REQUIRED. This row's diagonal FOV exceeds the catalog query's one-cell cap (AstapCellGeometry.FindAreas clamps to ~5.14 deg), so stars were fetched for only a small central patch and the rest of the sensor rendered starless. Counts, recall, precision and star POSITIONS from this dataset are not trustworthy; gate-threshold results are. Re-render once the wide-field query lands."
+      "datasetSeed": 2
     },
     {
       "id": "D03_redcat_250mm",

--- a/docs/f23-objective-precision-term-results.md
+++ b/docs/f23-objective-precision-term-results.md
@@ -8,6 +8,8 @@ See [F27](followups.md).
 Baseline: [`docs/synthetic-af-bank-baseline.json`](synthetic-af-bank-baseline.json), transcribed from
 [`docs/synthetic-af-bank-baseline-results.md`](synthetic-af-bank-baseline-results.md).
 
+> **`D01` numbers on this page predate the [F44](followups.md) catalog fix** and were measured on a spatially truncated field (half the sensor rendered starless). The corrected values are in [`docs/synthetic-af-bank-followups-wave6-results.md`](synthetic-af-bank-followups-wave6-results.md); the conclusions here survive the re-baseline. `D02` was re-checked and its frames are bit-identical, so its numbers stand as written.
+
 *The question: the objective rewards star count and fit quality with no penalty for a false positive, so
 the optimizer drives `BrightnessSensitivity` to its 0.0 floor and config-A precision collapses to 0.451.
 Two candidate costs were implemented — a proxy term in `J`, and a hard floor on the searchable range.

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -550,6 +550,22 @@ shedding; it does not price a 4% one. The two entries are independent.
 
 Reproduce: `D:\hf_w5\f24_arms.sh`, analysed by `D:\hf_w5\analyze_f24.py`.
 
+> **The suspect D01/D02 rows of that table, resolved (wave 6).** `D02`'s frames turned out to be unaffected
+> (bit-identical after the F44 fix), so its row never needed replacing. `D01`'s did, and re-running all five arms
+> on the corrected field changes nothing that matters:
+>
+> | arm | D01 recall@high, old (truncated) | **D01, new (full field)** | TP, new | FP |
+> |---|---|---|---|---|
+> | `masterOFF` | 0.129 | **0.127** | 19039 | 0 |
+> | `shipping` | 0.115 | 0.114 | 17636 | 0 |
+> | `boost0` | 0.119 | 0.119 | 17988 | 0 |
+> | `close1` | 0.126 | 0.125 | 19004 | 0 |
+> | `both` | 0.129 | **0.127** | 19039 | 0 |
+>
+> The master still **hurts** on D01 (masterOFF − shipping = +0.014 old, +0.013 new), `both` still recovers
+> master-OFF recall exactly, and precision is still 1.000 with zero false positives. The wave-5 verdict turned on
+> D06/D09/D14 — none of which was ever suspect — and is untouched.
+
 ### F19 — The exposure recommendation is decided by the 20 brightest stars, so a rich field can never earn one
 **Status:** Open · found 2026-08-02 deriving expected-optimal exposures for the synthetic AF bank
 
@@ -1374,6 +1390,18 @@ derived-looking value that was not derived — either omit the field or mark it 
 itself, not only in `DerivedNotes`. (b) Decide whether the seven `detectionBinning = 2` datasets should be run at
 their expected factor, which is a re-baseline and needs its own arm.
 
+**PART (a) DONE 2026-08-06 (wave 6); part (b) DEFERRED, deliberately.** `ResolveForRun` now writes
+`DetectionBinningSource` — `derived-from-in-focus-hfr` or `kept-from-base` — as a **field** rather than only as
+prose inside `DerivedNotes`. A reader diffs fields; nobody diffs a sentence, which is why seventeen files could
+say "kept from base" in prose while presenting `"DetectionBinning": "Bin2"` next to sixteen genuinely exported
+values. 2 tests, both discriminating.
+
+**Part (b) is not paired with wave 6's re-baseline on purpose.** Wave 6 re-rendered `D01`/`D02` and the whole
+value of that pass is that **exactly one thing changed** — the star field, with every derived parameter (step,
+exposure, binning, donut) provably identical. Honouring a per-run binning would have moved a second variable on
+7 other datasets in the same wave, and the two effects could not then be separated. It needs its own arm, with
+its own before/after, on a bank nobody is simultaneously re-rendering.
+
 ### F40 — The settings handoff shipped in wave 4 had never once been written to disk
 **Status:** Done (wave 5 — backfilled and now exercised) · found 2026-08-05 backfilling it
 
@@ -1461,6 +1489,33 @@ a settings file is created rather than loaded, since that is the moment an arm s
 its predecessor. Consider defaulting the path to a fixed per-user location rather than `AppContext.BaseDirectory`,
 so a new build directory inherits instead of bootstrapping.
 
+**FIXED 2026-08-06 (wave 6).** All three, plus one the entry did not know about:
+
+1. **The default path now INHERITS.** `DefaultPath()` = an existing file beside the exe (unchanged for any arm
+   directory that already has one) → otherwise `%LOCALAPPDATA%\HocusFocusHarness\harness_settings.json`. A fresh
+   `-o` directory therefore picks up the same file the last one used instead of minting a new detector. The
+   decision is a pure function (`ResolveDefaultPath`) so it is tested without a filesystem.
+2. **The bootstrap is loud** — `WARNING` on stderr plus `Logger.Warning`, naming the profile and saying outright
+   that the run is not comparable to any earlier arm using a different file.
+3. **A `UseAdvanced = False` settings file now warns, and names the knobs it is lying about.**
+   `StarDetectionOptions.InitializeOptions` ends in `ConfigureSimpleSettings()`, which in Simple mode runs
+   `DerivePresetSettings()` and **overwrites ~16 advanced knobs** from the three `Simple_*` presets — so editing
+   `NoiseClippingMultiplier` or `MinHFR` in a pinned file does *nothing*, silently. This is the wave-5 probe set
+   where four supposedly different configurations returned identical star counts, promoted from an anecdote in
+   [F43](#f43--the-optimizer-wizard-refuses-to-start-unless-the-default-settings-already-produce-a-usable-curve) to
+   a check. The overridden keys are MEASURED (hand the file's own bag to a throwaway options instance, diff it
+   afterwards) rather than hard-coded, so the list cannot drift from what the class does.
+
+**Checked, and wave 5 is NOT invalidated by (3):** `D:\hf_w5\pinned_settings.json`'s advanced values coincide with
+the Typical presets (`NoiseClip 4`, `StarClip 2`, `StructureLayers 4`, `Sensitivity 10`, `MinHFR 1.2`,
+`MinBox 5`, `NoiseReductionRadius 3+1`), so the diff is empty and every wave-5 arm ran the detector its file
+describes. The hazard was real and did not fire. **Nor is any wave-5 comparison affected by (1)**: those arms
+pinned `--settings` explicitly, which bypasses `DefaultPath()` entirely.
+
+7 tests, of which **4 discriminate** (confirmed by neutralizing the three behaviours and re-running: exactly those
+4 fail); the other 3 are labelled guards — the beside-the-exe precedence, Advanced-mode silence, and the
+agrees-with-the-presets case.
+
 ### F43 — The optimizer wizard refuses to start unless the DEFAULT settings already produce a usable curve
 **Status:** **Done (wave 5)** for the Live path; the replay case is left open below · found 2026-08-05 from a
 user report on a 40 mm rig
@@ -1483,6 +1538,20 @@ accepted stars across the sweep:
 | `MinHFR = 1.2` (default) | 816 | 1670 | 1773 | 11 | **0** | 5 | 1748 | 1672 | 815 |
 | `MinHFR = 0.30` (F35 floor) | 816 | 1670 | 2463 | 204 | **5** | 187 | 2469 | 1672 | 815 |
 | `MinHFR = 0.10` (search floor) | 816 | 1670 | 2463 | 208 | **6** | 190 | 2469 | 1672 | 815 |
+
+> **Re-measured on the F44-corrected D01 (wave 6).** The table above was taken on a spatially truncated field; the
+> corrected one is 2.3× richer everywhere and **the core is still empty**, which is the whole point of the entry:
+>
+> | focuser | 5964 | 5973 | 5982 | 5991 | **6000 (focus)** | 6009 | 6018 | 6027 | 6036 |
+> |---|---|---|---|---|---|---|---|---|---|
+> | `MinHFR = 1.2` (default) | 1859 | 3758 | 4157 | 13 | **0** | 11 | 4182 | 3761 | 1867 |
+> | `MinHFR = 0.30` | 1859 | 3758 | 5784 | 476 | **7** | 438 | 5786 | 3761 | 1867 |
+> | `MinHFR = 0.10` | 1859 | 3758 | 5784 | 478 | **7** | 443 | 5786 | 3761 | 1867 |
+>
+> Thousands of stars in the wings, **zero at focus at the default gate**, and lowering the gate buys 7 — against
+> `NHard = 3`. The rescue is exactly as thin on a correct field as it looked on a truncated one, so the entry's
+> "genuinely thin on the rigs it exists for" framing stands unaltered. The old rows reproduce **exactly** on the
+> wave-6 binary, so the two tables differ only by the frames.
 
 The wings detect thousands of stars; the **core of the curve is empty**. That is F20's signature — rejections
 concentrated on the INNER frames — and at 40 mm it is expected: in-focus stars are ~1 px, so the `MinHFR` gate
@@ -1530,6 +1599,34 @@ saved run exists only because those settings could already focus — a decision 
 modes. Probing the seed there would quietly convert replay into a seed-gated path. **Open question:** whether a
 saved run whose current settings cannot fit deserves the same rescue. The circularity argument applies equally;
 the counter-argument is that such a run should not have been captured. Not changed as a side effect of this one.
+
+> **REPLAY DECIDED (wave 6): extend the rescue, but not as a drive-by — the premise it rests on is measurably
+> false, and the change needs a UI answer the wizard does not have yet.**
+>
+> *The premise.* `SeedFitIsUsableAsync` gates replay on `r.Baseline` (`:2882`) because "a saved run exists because
+> those settings could already focus". Three populations falsify that, and all three are real today:
+>
+> | population | why the premise fails | evidence |
+> |---|---|---|
+> | **failed AF runs** | `KeepFramesForReview` saves sweeps that did NOT focus — a failed AF is precisely what a user brings to the optimizer | `KeepFramesForReview = True` in the shipped AF options |
+> | **settings changed since capture** | the wizard's whole purpose is changing detection settings; "current" need not be what captured the run | — |
+> | **runs never captured by this profile at all** | bank folders and other people's data are loaded routinely | the live app's own `LastSelectedLoadPath` read `D:\SyntheticAutofocusBank\D01_ultrawide_40mm\attempt01` — a dataset that yields **zero** in-focus stars at the default gate |
+>
+> So the asymmetry is not "live is the hard case and replay is the easy one"; it is that replay refuses a case it
+> demonstrably receives. `D01` is the counterexample in the bank itself.
+>
+> *What to implement.* Keep the baseline gate FIRST — when the current settings fit, nothing changes, so the
+> premise case stays exactly as it is. Only on the refusal path, probe the same `TryRescueSeedAsync` ladder that
+> Live uses, and refuse only when no probed gate produces a **scorable** curve. `SeedGuard_ReplayMode_GatesOnBaseline`
+> then needs rewriting rather than deleting: its contract becomes *"replay refuses when neither the baseline nor any
+> probed gate can fit"*, and it must still fail when the ladder is removed.
+>
+> *Why this is NOT shipped in wave 6.* A replay whose baseline cannot fit has `BaselineJ = 0` — measured directly:
+> every `D01`/`D02` arm this wave printed `Current settings J: 0`. The wizard's headline is an improvement
+> *percentage against the baseline*, and a percentage against zero is not a number. So the change needs a decision
+> about what the summary says when there is no baseline to improve on ("no usable curve at your current settings"
+> rather than a ratio), which is UI work with its own review. Implementing the guard without it would replace a
+> confusing refusal with a confusing result.
 
 **EXTENDED 2026-08-05, same session, after the reporter tried it and it STILL failed.** The first fix was right
 about the circularity and wrong about the bar. Lowering `MinHFR` made the reporter's curve **fittable** but not
@@ -1678,11 +1775,30 @@ partitionings; plus whole-sky, filename-encoding and supersets-the-reference che
 was written, measured against those tests, found to change nothing (`MaxRaHalfSpan` already returns π there) and
 **removed** rather than left as an untested branch.
 
-**Still outstanding: the two suspect rows have NOT been re-baselined.** `D01`/`D02` must be re-rendered and every
-number derived from them re-measured in the next wave — the re-render above went to a scratch directory purely to
-verify the fix, deliberately **not** into the bank, since re-baselining mid-wave is what
-[F15](#f15--optimize---per-run-overwrites-each-runs-stored-settings) and wave 3 warn against. The `suspect`
-marker stays in the spec until that happens, and `synth-bank` prints it on every run that selects those rows.
+**RE-BASELINED 2026-08-06 (wave 6) — and only ONE of the two rows was ever affected.** Both were re-rendered into
+the bank with the fixed query. Every derived parameter is unchanged on both (step 9 / 6, exposure 0.5 s,
+`detectionBinning` 1, donut off, identical sweep positions), so the star field is the *only* thing that moved:
+
+| row | in-focus truth stars | x extent | y extent | 16×16 grid occupancy | frames |
+|---|---|---|---|---|---|
+| `D01` before | 8107 | 431–5921 | **741–2965** | **125/256 (49%)** | — |
+| `D01` after | **19212** | −1–6249 | 0–4176 | **256/256 (100%)** | changed |
+| **`D02` before** | **3594** | −2–6247 | −1–4176 | **256/256 (100%)** | — |
+| **`D02` after** | **3594** | −2–6247 | −1–4176 | **256/256 (100%)** | **BIT-IDENTICAL** |
+
+**`D02_rich_135mm` was never affected**: its re-rendered FITS are byte-for-byte identical to the old ones, and its
+golden star set is the same set (3536 stars, 25 unresolved, reordered only — the new query enumerates cells in a
+different order). **So no number derived from D02 ever needed re-measuring**, including F35's D02 landing.
+
+**The suspect criterion over-predicted, and this is the useful correction.** The table above marked D02 suspect on
+*diagonal FOV ÷ one-cell cap* = 2.4×, which is a proxy for the real question: *do the ≤ 4 corner cells `FindAreas`
+returns cover the field?* Cells are equal-area, so at `D02`'s **Dec +61.45°** one cell spans ≈ 1/cos(61.45) ≈ 2.1×
+more RA degrees than at the equator, and the four corner cells covered an 11.95° field comfortably. **The cap ratio
+is not the criterion; cell coverage at the field's declination is.** A ratio-based rule flags rows that are fine
+(D02) and would keep flagging them forever. D01 at 7.9× is far enough over that no declination saves it.
+
+`suspect` is now cleared on both rows, so `synth-bank` no longer warns. What was re-measured on D01, and what it
+changed, is in [`docs/synthetic-af-bank-followups-wave6-results.md`](synthetic-af-bank-followups-wave6-results.md).
 
 ### F35 — `MinHFR` should be seeded from the sweep WINGS, and neither available HFR statistic can size it
 **Status:** Done (wave 3) · found 2026-08-03 answering "how far can `MinHFR` safely come down?" for
@@ -1701,6 +1817,29 @@ name:
 | `D02_rich_135mm` | **YES** | 0.550 / 1.200 | **0.99656 / 0.00000** |
 | `D03_redcat_250mm` | **YES** | 0.300 / 0.450 | 0.99549 / 0.99486 |
 | the other 14 | no | **identical** | **identical to 5 dp** |
+
+> **RE-MEASURED 2026-08-06 (wave 6) on the F44-corrected frames — the headline survives intact.** `D01`'s field
+> was spatially truncated when the table above was produced ([F44](#f44--the-synthetic-camera-queries-the-catalog-for-at-most-one-cell-so-a-wide-field-is-rendered-starless-outside-a-small-central-patch));
+> `D02`'s, it turns out, was not (its re-rendered frames are bit-identical). Re-run on **one binary**, with the
+> control produced by the new `optimize --no-min-hfr-seed` rather than by an older commit ([F41](#f41--a-prior-waves-control-arm-is-not-a-control-for-a-later-waves-binary)):
+>
+> | dataset | frames | fitted vertex | `FinalJ` seed OFF | `FinalJ` seed ON | landed `MinHFR` |
+> |---|---|---|---|---|---|
+> | `D01` | **old (truncated)** | 0.7621 | **0.000000** | 0.990358 | 0.100 |
+> | `D01` | **new (full field)** | 0.7712 | **0.000000** | **0.991551** | 0.100 |
+> | `D02` (frames bit-identical) | — | 0.7488 | **0.000000** | 0.996510 | 0.3625 |
+> | `D03` | — | 1.0154 | 0.995880 | 0.996543 | 0.300 |
+> | **`D05` control** | — | 1.7882 | **0.999706** | **0.999706** | 1.48125 |
+>
+> **"`FinalJ` exactly 0 → a real landing" is unchanged on a field with 2.4× the stars**, which is what a
+> gate-threshold result should do. `BaselineJ` is identical between the two arms of every dataset (F41's free
+> check), and `D05` is bit-identical seed-on vs seed-off — the boring control that caught the wave-3 seed leak,
+> still boring.
+>
+> **The drift is bounded by a dataset that could not move.** `D02`'s frames are provably identical to wave 3's, so
+> its `FinalJ` 0.99656 → 0.996510 is **pure wave-3→wave-6 binary drift: 5×10⁻⁵**. `D01`'s old-frames landing moved
+> 0.99018 → 0.990358 (+1.8×10⁻⁴) — same order. So `D01`'s **+1.2×10⁻³** from the re-render is roughly 6× the
+> drift and is attributable to the frames, not the binary.
 
 **D01 and D02 go from `FinalJ` exactly 0 to a real landing — the whole of F20's defect — and 14 of 17 landings
 are bit-identical to the control**, including D05 at 1.450. On every rig the change was not designed for it is a
@@ -1795,6 +1934,25 @@ recall@high per dataset, **FP = 0 in all 32 configurations**:
 | 0.25 | 0.165 | 0.595 | 0.585 | 0.985 | 5 |
 | 0.15 | 0.165 | 0.595 | 0.585 | 0.985 | 5 |
 | 0.1 | 0.165 | 0.595 | 0.585 | 0.985 | 6 |
+
+> **The D01 column re-measured on the F44-corrected frames (wave 6).** The old-frames column above reproduces
+> **exactly, to three decimals, on the wave-6 binary** — a free F41 check that this detector has not drifted for
+> this measurement — and the corrected field changes the conclusion in no respect:
+>
+> | `MinHFR` | D01 old (truncated) | **D01 new (full field)** | FP, both | D01 vertex-frame stars, old → new |
+> |---|---|---|---|---|
+> | 1.2 | 0.129 | **0.127** | 0 | 0 → **0** |
+> | 0.9 | 0.152 | 0.150 | 0 | 0 → 0 |
+> | 0.7 | 0.160 | 0.157 | 0 | 2 → 4 |
+> | 0.5 | 0.164 | 0.161 | 0 | 5 → 6 |
+> | 0.35 | 0.164 | 0.162 | 0 | 5 → 7 |
+> | 0.25 – 0.15 | 0.165 | 0.162 | 0 | 5 → 7 |
+> | 0.1 | 0.165 | 0.162 | 0 | 6 → 7 |
+>
+> **Zero false positives at every value on the corrected field too, and the gain still saturates by 0.5.** Recall
+> is fractionally *lower* because the golden grew with the field (TP 8253 → **19039**, and the stars the fix added
+> are predominantly faint edge-of-frame ones), not because detection got worse: the wing frames go from ~816/1670
+> accepted stars to ~1859/3758. The claim this table exists to support — *how low is safe* — is unchanged.
 
 **Zero false positives at every value on every dataset**, and the recall gain saturates by 0.5 at the latest.
 `MinHFR` is a second line of defence — hot-pixel filtering is separate and enabled by default — and on this bank
@@ -1902,6 +2060,84 @@ effective-gate correction instead — a different repair than the one being audi
 **Why it matters.** The blanket assumption — "these were measured on suspect landings, so they are all suspect" —
 would have cost a full re-measurement pass and found nothing. The actual exposure was one clause in one entry.
 Recording the audit so it is not re-opened on the same inference next wave.
+
+### F45 — The Grubbs test rejects the IN-FOCUS point of a near-perfect curve, and the blind walk then buys an extra exposure
+**Status:** Open · found 2026-08-06 (wave 6) from a real 40 mm simulator run · **mechanism reproduced offline
+from the run's own report**, not inferred
+
+**The observation.** A blind sweep logged its queue decision against a minimum its own data does not support:
+
+```
+21:47:08 Enough left trend points (4) with an established minimum (25015) to queue remaining right focus points up to 25075
+```
+
+`AutoFocusEngine.cs:1485` sets `targetMaxFocuserPosition = trendlineFit.Minimum.X + (failedRightPoints +
+offsetSteps) · stepSize`. `TrendlineFitting.Minimum` is **not a fitted vertex** — NINA core's
+`TrendlineFitting.Calculate` sets it to `argmin(Y + ErrorY)` over the points it is HANDED. The run's own report
+(`2026-08-05--21-47-43--90d513b9….json`, step 15, `offsetSteps` 4) makes the anchor look plainly wrong:
+
+| position | HFR | error | `Y + ErrorY` |
+|---|---|---|---|
+| **25000** | 0.6941 | 0.1736 | **0.8677 ← argmin of the measured set** |
+| 25015 | 0.7709 | 0.2459 | 1.0168 |
+
+with `CalculatedFocusPoint = 24999.996` and hyperbolic R² = **0.99928**. Anchored at 25000 the target is 25060,
+which had already been sampled ⇒ the walk stops; anchored at 25015 it is 25075 ⇒ **one extra step and one extra
+exposure**, on every run that hits this.
+
+**The mechanism, measured.** Feeding the report's own points back through the engine's fitting loop
+(`WeightRegularization.Regularize` → `AlglibHyperbolicFitting` → `MathUtility.RejectionTest` → drop → refit,
+`MaxOutlierRejections = 1`, confidence 0.99, `WeightedHyperbolicFitEnabled`):
+
+| set | rejected | resulting `Minimum.X` |
+|---|---|---|
+| the 10 points present at the decision (24925–25060) | **25000** | **25015** |
+| the final 11 points | **25000** | 25015 |
+| the same 10 points, rejection disabled | — | **25000** |
+
+**So `Minimum` is computed on the POST-REJECTION set, and the point rejected is the in-focus one.** σ is
+regularized but untouched here (the floor is 0.2 × median = 0.023; no σ is that small), so regularization is not
+the cause.
+
+**And the rejection itself is the more serious half.** The weighted residuals the Grubbs test ranks, on a fit with
+R² = 0.9994:
+
+| position | residual | weighted | Grubbs z |
+|---|---|---|---|
+| **25000** | **+0.0345** | +0.199 | **2.60** ← rejected |
+| 24940 | +0.0116 | +0.193 | **2.54** ← also over the limit |
+| every other point | ≤ 0.034 | ≤ 0.17 | ≤ 1.7 |
+
+The limit at N = 10, confidence 0.99 is **2.41**. Two points clear it and the larger wins. The scale is the **MAD
+of the weighted residuals** (`MathUtility.cs:163`) — deliberately robust — but on an *excellent* fit the residuals
+are both tiny and tightly clustered, so MAD collapses and ordinary scatter reads as a 2.6σ outlier. The rejected
+point's residual is **0.0345 px against its own measurement error of 0.174 px**: it is consistent with the curve
+to a fifth of its own error bar, and is discarded as an outlier anyway.
+
+**Why it matters, beyond one exposure.**
+- The discarded point is the **most informative one in the sweep** — the in-focus measurement the whole run exists
+  to obtain. Here it costs little (the hyperbola vertex is pinned by 10 other points, and it still landed at
+  24999.996); on a sparser sweep, or a rig where the near-focus frames are the only ones with stars, discarding it
+  is not free.
+- A **robust scale estimator applied to a near-perfect fit inverts its own purpose**: the better the fit, the
+  smaller the MAD, and the more aggressively the test fires. The guard is loosest exactly where it is needed and
+  tightest where it is not.
+- The blind walk's cost is deterministic and per-run: one exposure, on a rig class whose exposures are the
+  expensive part.
+
+**Next step, and what NOT to do.** Three separable questions, deliberately not answered here:
+(a) should the queue anchor be a *fitted* vertex (`HyperbolicFitting.Minimum.X`, or `Intersection`) rather than a
+post-rejection argmin data point — note `Minimum` is also the anchor for the left/right trend split, so changing
+its meaning is not local; (b) should `RejectionTest`'s MAD scale carry a **floor tied to the points' own measured
+σ**, so a point cannot be an outlier while sitting well inside its own error bar; (c) should the walk's
+`while (rightMostPosition < targetMaxFocuserPosition)` compare with a half-step tolerance, which bounds the
+symptom without touching either fit. **(b) changes every AF fit in the product** and must be measured on the bank
+before it is contemplated — the AF-bank σ_focus/R² arms are the instrument.
+
+**Reproduce (offline, no rig, ~1 min):** feed the eleven `MeasurePoints` above through
+`WeightRegularization.Regularize` → `AlglibHyperbolicFitting.Create(…, TiltedHyperbola, pts, stepSize: 15,
+useWeights: true)` → `MathUtility.RejectionTest(pts, fit.Fitting, 0.99, BuildResidualWeights(pts, true))`, then
+`new TrendlineFitting().Calculate(remaining, "STARHFR").Minimum.X`. Run log: `20260805-214043`.
 
 ---
 

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -1084,7 +1084,8 @@ fail in two directions — biased, then saturated — which is why `precisionNul
 precision figure rather than being something a reader has to think to ask for.
 
 ### F32 — `J` is saturated near 1.0, so the optimizer trades enormous recall for numerically trivial gains
-**Status:** Open — **mechanism shipped default OFF (wave 5)**; adoption pending the confirmation arm. The
+**Status:** Open — **mechanism shipped default OFF (wave 5)**; the confirmation arm was **re-validated as the right
+experiment (wave 6)** against a restarts-only alternative and is still owed. The
 entry's own premise is corrected below: on 5 of 7 binding runs there was no trade to bound, the search was
 merely stuck · found 2026-08-03 re-reading the wave-1 real-bank control arm
 
@@ -1399,7 +1400,8 @@ passes either way is worth nothing") applies to a *set* of tests too: count the 
 ones you wrote.
 
 ### F39 — The harness records a detection binning the run never applied, and 7 datasets have never run at theirs
-**Status:** Open · found 2026-08-04 checking whether the banks differ in binning
+**Status:** Open — **part (a) done (wave 6)**; part (b) (running the 7 `detectionBinning = 2` datasets at their
+expected factor) deliberately deferred to its own wave · found 2026-08-04 checking whether the banks differ in binning
 
 Every `harness_settings.json` in the synthetic bank says `"DetectionBinning": "Bin2"`; every real run says
 `Bin1`. That looks like a systematic difference between the banks that could explain F33 outright. **It is not,
@@ -1498,7 +1500,8 @@ identical between two arms of the *same* binary. If it is not, the binaries diff
 them means anything — check that single number before reading a diff as a regression.
 
 ### F42 — Every build directory silently gets its OWN detector settings, and the run instructions require a new one per arm
-**Status:** Open · found 2026-08-05 chasing a `BaselineJ` gap that turned out not to be the code under test
+**Status:** **Done (wave 6)** — per-user default path, loud bootstrap, and a `UseAdvanced=False` warning that names
+the overridden knobs · found 2026-08-05 chasing a `BaselineJ` gap that turned out not to be the code under test
 
 `HarnessSettingsStore.DefaultPath()` is `Path.Combine(AppContext.BaseDirectory, "harness_settings.json")` — the
 file sits **next to the exe** — and `ResolveAt` **bootstraps one from the live NINA profile** when it is absent.
@@ -1566,7 +1569,8 @@ pinned `--settings` explicitly, which bypasses `DefaultPath()` entirely.
 agrees-with-the-presets case.
 
 ### F43 — The optimizer wizard refuses to start unless the DEFAULT settings already produce a usable curve
-**Status:** **Done (wave 5)** for the Live path; the replay case is left open below · found 2026-08-05 from a
+**Status:** **Done (wave 5)** for the Live path; **replay DECIDED (wave 6) — extend, but not before the
+`BaselineJ = 0` presentation question is answered**, so the implementation is still open · found 2026-08-05 from a
 user report on a 40 mm rig
 
 `SeedFitIsUsableAsync` (`StarDetectionOptimizerWizardVM.cs:2869`, called at `:2541`) evaluates the **default seed
@@ -1725,7 +1729,8 @@ Tests: 5, of which **3 fail** when the fix is removed (2 for the probe, 1 for th
 labelled guards (inertness on a healthy sweep, and the floor-combination helper).
 
 ### F44 — The synthetic camera queries the catalog for at most ONE CELL, so a wide field is rendered starless outside a small central patch
-**Status:** **Code FIXED (wave 5)**; `D01`/`D02` still marked **SUSPECT** and awaiting re-baseline next wave ·
+**Status:** **Done (wave 6)** — code fixed wave 5, both rows re-baselined wave 6 and `suspect` cleared; **`D01` was
+the only affected row** ·
 found 2026-08-05 from a user report: "why is only a portion of the sensor getting rendered with stars?"
 
 `StarFieldCompositor` computes the field correctly — `DiagonalFovDegrees × 1.05` — and hands it to

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -1195,6 +1195,54 @@ does not address the defect (only `mccomiskey` binds, and it pays). **Adoption s
 by keep-% proxy here. Ships default OFF until then. Reproduce: `D:\hf_w5\f32_arms.sh`,
 `D:\hf_w5\scorecard.py`, `D:\hf_w5\score_f32_synth.sh`.
 
+**CONFIRMATION ARM RE-VALIDATED AS THE RIGHT EXPERIMENT (wave 6), against a pre-registered alternative.** Before
+spending ~6 h, the competing hypothesis was tested: if the unconstrained search is merely *stuck*, any RESTART
+should recover the floor's gain with no floor at all. `--continue-rounds` already is that mechanism — each round
+re-seeds from the prior best with a **fresh** curated set, resetting the pattern-search stride. **Arm R:** the same
+8 runs, `--continue-rounds 2`, **no keep floor**, same binary, `--settings` pinned.
+
+**First, the control.** Arm R's round 0 is **identical to wave 5's feature-OFF arm on all 8 runs, to 6 dp** —
+0.997993 / 0.998476 / 0.996368 / 0.997195 / 0.994025 / 0.999822 / 0.999557 / 0.999766. Two waves, two binaries,
+one pinned settings file, byte-identical landings. [F41](#f41--a-prior-waves-control-arm-is-not-a-control-for-a-later-waves-binary)'s
+check passing this cleanly is what makes the rest of the table readable.
+
+| run | round 0 (= wave-5 OFF) | **Arm R final** | Δ from restarts | wave-5 φ=0.75 | Δ from the floor | **restarts recover** |
+|---|---|---|---|---|---|---|
+| `toml999` | 0.997993 | 0.998068 | +0.000075 | 0.998536 | +0.000543 | **13.8%** |
+| `CWhiteFocus` | 0.998476 | 0.998650 | +0.000174 | 0.999867 | +0.001391 | **12.5%** |
+| `uneven` | 0.996368 | 0.996745 | +0.000377 | 0.998014 | +0.001646 | **22.9%** |
+| `D18_m24_deep_shed` | 0.999822 | 0.999855 | +0.000033 | 0.999914 | +0.000092 | **35.9%** |
+| `D19_cygnus_deep_shed` | 0.999557 | 0.999557 | 0 | 0.999800 | +0.000243 | **0%** |
+| `muggsie` | 0.997195 | 0.997195 | 0 | 0.994854 | **−0.002341** | floor HURT |
+| `mccomiskey` | 0.994025 | **0.997394** | **+0.003369** | 0.963058 | **−0.030967** | floor HURT |
+| **`D20` (control)** | 0.999766 | 0.999768 | +0.000002 | 0.999766 | 0 | — |
+
+**Three findings, and they are not the same finding.**
+
+1. **The greedy trap is CONFIRMED as a fact, not an inference.** With no constraint whatsoever, simply restarting
+   improves `J` on **5 of 8** runs. A converged global optimum cannot be improved by re-seeding from itself, so
+   round 0 demonstrably was not one. This is the same phenomenon as
+   [F8](#f8--optimizer-landings-are-not-reproducible-across-invocations) — a landing is a property of the
+   trajectory, not of the objective.
+2. **But restarting is NOT a substitute for the floor.** On the five runs where the floor helped, restarts recover
+   **0–36% (median 13.8%)** of the floor's gain. A restart changes the *trajectory*; the floor changes the
+   *feasible set*, and it reaches a region three restarts do not find. **So the pre-registered rule fires:
+   recovery < 50% on 5 of 5 → keep the confirmation arm as designed, at φ = 0.50.**
+3. **The floor's two failures are exactly where restarts do best.** `mccomiskey` — the worst floor case at −0.031 —
+   *gains* +0.0034 from restarts alone, and `muggsie` (−0.0023 under the floor) is untouched by them. The two
+   mechanisms are complementary rather than competing, so **the confirmation arm should carry a third
+   `--continue-rounds` arm** rather than being floor-vs-nothing. That is a change to the experiment, and it costs
+   one more arm, not six hours more.
+
+> **Instrument caveat found while reading Arm R, and it would have inverted the result.** The end-of-run
+> `detections kept vs seed` line reads **≈ 1.0 in every multi-round run** (`toml999` 1.00069, `CWhiteFocus`
+> 1.00259) — which looks like "the unconstrained search stopped shedding entirely" and is nothing of the sort.
+> `DetectionKeepBaselineTotals` is pinned to round 0's seed **only when a floor is set** (`:690`), so with no floor
+> each round's keep is measured against *that round's own seed* — the last round barely moves, so the ratio is ~1.
+> Round 0's true keep is wave 5's control column (0.397, 0.429, 0.353, 0.612, 0.095). **A diagnostic whose meaning
+> silently changes with an unrelated flag is worse than an absent one**; the pinning should apply to the readout
+> whether or not a floor is in force. Reproduce: `D:\hf_w6\f32_armR.sh`.
+
 ### F33 — ~~The synthetic bank does not reproduce the real bank's optimizer failure mode~~ → it does now
 **Status:** Done (part 1 wave 3, part 2 wave 4) · found 2026-08-03 re-reading the wave-1 arms side by side
 
@@ -2102,15 +2150,17 @@ the cause.
 **And the rejection itself is the more serious half.** The weighted residuals the Grubbs test ranks, on a fit with
 R² = 0.9994:
 
-| position | residual | weighted | Grubbs z |
+| position | residual (px) | weighted | Grubbs z |
 |---|---|---|---|
-| **25000** | **+0.0345** | +0.199 | **2.60** ← rejected |
-| 24940 | +0.0116 | +0.193 | **2.54** ← also over the limit |
-| every other point | ≤ 0.034 | ≤ 0.17 | ≤ 1.7 |
+| **25000** | **+0.0345** | +0.1987 | **2.5804** ← rejected |
+| 24940 | +0.0116 | +0.1934 | **2.5277** ← also over the limit |
+| 24970 (next highest) | −0.0321 | −0.1728 | 1.1714 |
+| every other point | ≤ 0.034 | ≤ 0.14 | ≤ 0.84 |
 
-The limit at N = 10, confidence 0.99 is **2.41**. Two points clear it and the larger wins. The scale is the **MAD
-of the weighted residuals** (`MathUtility.cs:163`) — deliberately robust — but on an *excellent* fit the residuals
-are both tiny and tightly clustered, so MAD collapses and ordinary scatter reads as a 2.6σ outlier. The rejected
+The limit at N = 10, confidence 0.99 is **2.4821**; the scale is `median = −0.0569`, `MAD = 0.0990`. Two points
+clear the limit and the larger wins. The scale is the **MAD of the weighted residuals** (`MathUtility.cs:163`) —
+deliberately robust, and correctly so against a gross outlier — but on an *excellent* fit the residuals are both
+tiny and tightly clustered, so the MAD collapses and ordinary scatter reads as a 2.58σ outlier. The rejected
 point's residual is **0.0345 px against its own measurement error of 0.174 px**: it is consistent with the curve
 to a fifth of its own error bar, and is discarded as an outlier anyway.
 

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -1220,7 +1220,8 @@ check passing this cleanly is what makes the rest of the table readable.
 **Three findings, and they are not the same finding.**
 
 1. **The greedy trap is CONFIRMED as a fact, not an inference.** With no constraint whatsoever, simply restarting
-   improves `J` on **5 of 8** runs. A converged global optimum cannot be improved by re-seeding from itself, so
+   improves `J` on **5 of the 7 binding runs** (all but `muggsie` and `D19`; the `D20` control moves 2×10⁻⁶,
+   i.e. not at all). A converged global optimum cannot be improved by re-seeding from itself, so
    round 0 demonstrably was not one. This is the same phenomenon as
    [F8](#f8--optimizer-landings-are-not-reproducible-across-invocations) — a landing is a property of the
    trajectory, not of the objective.

--- a/docs/synthetic-af-bank-baseline-results.md
+++ b/docs/synthetic-af-bank-baseline-results.md
@@ -7,6 +7,8 @@ known-correct answer. Design: [`docs/synthetic-af-bank-design.md`](synthetic-af-
 Plan: [`plans/synthetic-af-bank-plan.md`](../plans/synthetic-af-bank-plan.md). Expected bands:
 [`docs/synthetic-af-bank-expectations.json`](synthetic-af-bank-expectations.json).
 
+> **`D01` numbers on this page predate the [F44](followups.md) catalog fix** and were measured on a spatially truncated field (half the sensor rendered starless). The corrected values are in [`docs/synthetic-af-bank-followups-wave6-results.md`](synthetic-af-bank-followups-wave6-results.md); the conclusions here survive the re-baseline. `D02` was re-checked and its frames are bit-identical, so its numbers stand as written.
+
 *The question this bank was built to answer: **precision on the real bank is a lower bound, and the
 optimizer's recommendations have never been checked for convergence — what do they look like when the
 right answer is known by construction?***

--- a/docs/synthetic-af-bank-followups-wave3-results.md
+++ b/docs/synthetic-af-bank-followups-wave3-results.md
@@ -4,6 +4,8 @@ Plan: [`plans/synthetic-af-bank-followups-wave3-plan.md`](../plans/synthetic-af-
 Wave 2: [`docs/synthetic-af-bank-followups-wave2-results.md`](synthetic-af-bank-followups-wave2-results.md).
 Register: [`docs/followups.md`](followups.md).
 
+> **`D01` numbers on this page predate the [F44](followups.md) catalog fix** and were measured on a spatially truncated field (half the sensor rendered starless). The corrected values are in [`docs/synthetic-af-bank-followups-wave6-results.md`](synthetic-af-bank-followups-wave6-results.md); the conclusions here survive the re-baseline. `D02` was re-checked and its frames are bit-identical, so its numbers stand as written.
+
 *The question: ship F20's real fix (F35), re-score F24 against recall, and measure the objective's dynamic range
 on both banks before anyone proposes a new term for it.*
 

--- a/docs/synthetic-af-bank-followups-wave6-results.md
+++ b/docs/synthetic-af-bank-followups-wave6-results.md
@@ -19,6 +19,7 @@ re-baseline says the headline survives — and that **one of the two rows was ne
 | F42 — make the trap impossible | **Shipped**: per-user default path, loud bootstrap, and a `UseAdvanced=False` warning that names the knobs the file is lying about |
 | F39 (a) | **Shipped** — `DetectionBinningSource` is a field now, not a sentence. Part (b) deliberately NOT paired with this wave |
 | F43 replay | **Decided**: extend the rescue, but its premise-breaking evidence and a UI answer come first |
+| F32 — is the ~6 h arm still right? | **Yes, tested not argued.** Restarts alone recover only **0–36%** of the floor's gain, so the arm stands — but the greedy trap is now a measured fact, and the arm gains a restart arm |
 | F45 (new) | The Grubbs test **rejects the in-focus point** of a curve fitting at R² 0.9994, and the blind walk then buys an extra exposure |
 
 ## The re-baseline, and the row that never needed one
@@ -148,6 +149,52 @@ refusal path changes. **Not shipped in wave 6**, because a replay whose baseline
 improve on, which is UI work with its own review. Replacing a confusing refusal with a confusing result is not
 progress.
 
+## F32 — the confirmation arm is still the right experiment, tested rather than argued
+
+Wave 5 found the keep floor landing at a *higher* `J` than the unconstrained search on 5 of 7 binding runs, which
+a constrained maximum cannot do against a true global maximum — so the floor might have been a workaround for a
+stuck search rather than the feasibility bound it was designed as. Before spending ~6 h on the confirmation arm,
+the competing hypothesis got a 1.5 h test with a **pre-registered decision rule**: if the search is merely stuck,
+a RESTART should recover the floor's gain with no floor at all. `--continue-rounds` already is that mechanism.
+
+**Arm R** — the same 8 runs, `--continue-rounds 2`, **no keep floor**, one binary, `--settings` pinned.
+
+**The control first.** Arm R's round 0 is **identical to wave 5's feature-OFF arm on all 8 runs, to 6 dp**. Two
+waves, two binaries, one pinned settings file, byte-identical landings — which also proves this wave's TestApp
+changes are inert when their flags are absent.
+
+| run | round 0 (= wave-5 OFF) | Arm R final | Δ restarts | wave-5 φ=0.75 | Δ floor | **restarts recover** |
+|---|---|---|---|---|---|---|
+| `toml999` | 0.997993 | 0.998068 | +0.000075 | 0.998536 | +0.000543 | **13.8%** |
+| `CWhiteFocus` | 0.998476 | 0.998650 | +0.000174 | 0.999867 | +0.001391 | **12.5%** |
+| `uneven` | 0.996368 | 0.996745 | +0.000377 | 0.998014 | +0.001646 | **22.9%** |
+| `D18` | 0.999822 | 0.999855 | +0.000033 | 0.999914 | +0.000092 | **35.9%** |
+| `D19` | 0.999557 | 0.999557 | 0 | 0.999800 | +0.000243 | **0%** |
+| `muggsie` | 0.997195 | 0.997195 | 0 | 0.994854 | **−0.002341** | floor HURT |
+| `mccomiskey` | 0.994025 | **0.997394** | **+0.003369** | 0.963058 | **−0.030967** | floor HURT |
+| **`D20` control** | 0.999766 | 0.999768 | +0.000002 | 0.999766 | 0 | — |
+
+**The greedy trap is now a fact rather than an inference:** with no constraint at all, restarting improves `J` on
+**5 of 8** runs, and a converged global optimum cannot be improved by re-seeding from itself. That is the same
+phenomenon as [F8](followups.md) — a landing is a property of the trajectory, not of the objective.
+
+**But restarting is not a substitute for the floor.** On the five runs where the floor helped, restarts recover
+**0–36% (median 13.8%)**. A restart changes the trajectory; the floor changes the feasible set and reaches a
+region three restarts do not find. **The pre-registered rule fires — recovery < 50% on 5 of 5 — so F32's
+confirmation arm stands as designed, at φ = 0.50.**
+
+**With one change to the experiment.** The floor's two failures are exactly where restarts do best:
+`mccomiskey`, the worst floor case at −0.031, *gains* +0.0034 from restarts alone. The mechanisms are
+complementary, so the confirmation arm should carry a third `--continue-rounds` arm rather than being
+floor-vs-nothing. That costs one arm, not another six hours.
+
+**An instrument caveat that would have inverted the reading.** The end-of-run `detections kept vs seed` line reads
+**≈ 1.0 in every multi-round run** — which looks like "the unconstrained search stopped shedding" and is nothing of
+the sort. `DetectionKeepBaselineTotals` is pinned to round 0's seed **only when a floor is set**, so with no floor
+each round's keep is measured against that round's own seed, and the last round barely moves. Round 0's true keep
+is wave 5's control column (0.397, 0.429, 0.353, 0.612, 0.095). Filed in F32: a diagnostic whose meaning silently
+changes with an unrelated flag is worse than an absent one.
+
 ## F45 — the blind walk extends one step past its own data
 
 From a real 40 mm simulator run: the engine queued its last sweep point from an "established minimum" of **25015**
@@ -165,8 +212,9 @@ on the **post-Grubbs-rejection** set, and the rejected point is the **in-focus o
 
 And the rejection is the more serious half: on a fit with **R² = 0.9994**, the vertex point's residual is 0.0345 px
 against its own measurement error of **0.174 px** — consistent with the curve to a fifth of its own error bar — and
-it is discarded because `RejectionTest` scales by the **MAD of the weighted residuals**, which collapses precisely
-when the fit is good. Full numbers, and the three separable fixes (none taken), in [F45](followups.md).
+it is discarded because `RejectionTest` scales by the **MAD of the weighted residuals** (here 0.0990), which
+collapses precisely when the fit is good: its Grubbs z is **2.5804** against a limit of **2.4821**, and the next
+point down sits at 1.17. Full numbers, and the three separable fixes (none taken), in [F45](followups.md).
 
 ## Lessons
 
@@ -190,6 +238,30 @@ It is also why F39 part (b) was refused — it would have moved a second variabl
 **5. A warning that names the specific keys beats a warning that names the hazard.** The `UseAdvanced=False` check
 diffs the file's own bag against what the options class does with it, so it reports *"`MinHFR 0.1→1.2`"* rather
 than *"advanced knobs may be overridden"* — and it cannot drift when the presets change.
+
+**6. Test the competing hypothesis before funding the expensive experiment — with the rule written first.** The
+question "is F32's ~6 h arm still the right one?" was settled in 1.5 h by an arm with a decision rule fixed in
+advance. Had restarts recovered most of the floor's gain, six hours would have been spent measuring a workaround;
+they recovered a median 13.8%, so the arm stands *and* comes back better specified than before.
+
+**7. A diagnostic that changes meaning with an unrelated flag is worse than no diagnostic.** Arm R's keep readout
+says ≈ 1.0 in every multi-round run, which reads as "the search stopped shedding" and means "the last round did
+not move much" — because the baseline pinning is conditional on a floor being set. It was caught only by
+disbelieving a number that agreed too well with the hypothesis under test.
+
+## What this wave changed in the banks themselves (F15)
+
+`optimize --per-run` writes each landing back into the run folder, so a wave that runs arms re-baselines the banks'
+stored settings whether it means to or not. Recorded rather than discovered later:
+
+| folder(s) | now holds | why that is the right one to leave |
+|---|---|---|
+| `D01`, `D02`, `D03`, `D05` | this wave's **seeded** landing (the shipping default) | the arms were deliberately ordered so the canonical arm runs LAST for each dataset |
+| `toml999`, `CWhiteFocus`, `uneven`, `muggsie`, `mccomiskey`, `D18`, `D19`, `D20` | Arm R's **3-round, no-floor** landing | it is a legitimate current landing, but it is NOT the single-pass one those folders held before |
+
+Every one carries its own `Provenance.CommandLine` ([F30](followups.md)), so which arm produced it is readable
+from the file rather than inferred. Old `D01`/`D02` frames and their pre-wave metadata are preserved at
+`D:\hf_w6\oldframes` and `D:\hf_w6\snapshots`.
 
 ## Verification
 

--- a/docs/synthetic-af-bank-followups-wave6-results.md
+++ b/docs/synthetic-af-bank-followups-wave6-results.md
@@ -1,0 +1,220 @@
+# Synthetic AF bank — followups wave 6
+
+Plan: [`plans/synthetic-af-bank-followups-wave6-plan.md`](../plans/synthetic-af-bank-followups-wave6-plan.md).
+Wave 5: [`docs/synthetic-af-bank-followups-wave5-results.md`](synthetic-af-bank-followups-wave5-results.md).
+Register: [`docs/followups.md`](followups.md).
+
+*The question: which of the numbers on the board are still true? Wave 5 fixed the wide-field catalog query and left
+two rows of the bank marked known-wrong, with F35's headline validation resting on exactly those two. The
+re-baseline says the headline survives — and that **one of the two rows was never wrong in the first place**.*
+
+## Headline
+
+| what | result |
+|---|---|
+| F44 — re-baseline `D01`/`D02` | **Done. `D02` was never affected** — its re-rendered frames are BIT-IDENTICAL. Only `D01` moved, 8107 → **19212** truth stars, occupancy 49% → **100%** |
+| F35 — the headline validation | **Survives unchanged**: seed OFF → `FinalJ` exactly 0, seed ON → 0.9916, on a field with 2.4× the stars |
+| The suspect criterion itself | **Over-predicted.** FOV ÷ cap is not the test; whether the ≤ 4 corner cells cover the field at that **declination** is |
+| F41 in practice | Every wave-3 golden-eval number on the old frames reproduces **exactly** on the wave-6 binary, and `D02` bounds the wave-3→wave-6 drift at **5×10⁻⁵** |
+| F42 — make the trap impossible | **Shipped**: per-user default path, loud bootstrap, and a `UseAdvanced=False` warning that names the knobs the file is lying about |
+| F39 (a) | **Shipped** — `DetectionBinningSource` is a field now, not a sentence. Part (b) deliberately NOT paired with this wave |
+| F43 replay | **Decided**: extend the rescue, but its premise-breaking evidence and a UI answer come first |
+| F45 (new) | The Grubbs test **rejects the in-focus point** of a curve fitting at R² 0.9994, and the blind walk then buys an extra exposure |
+
+## The re-baseline, and the row that never needed one
+
+`synth-bank --overwrite` on both rows, then the truth sidecars read directly:
+
+| row | in-focus truth stars | x extent | y extent | 16×16 occupancy | frames |
+|---|---|---|---|---|---|
+| `D01` before | 8107 | 431–5921 | **741–2965** | **125/256** | — |
+| `D01` after | **19212** | −1–6249 | 0–4176 | **256/256** | changed |
+| **`D02` before** | 3594 | −2–6247 | −1–4176 | 256/256 | — |
+| **`D02` after** | 3594 | −2–6247 | −1–4176 | 256/256 | **BIT-IDENTICAL** |
+
+`D02`'s golden set is the same set too — 3536 stars and 25 unresolved, differing only in enumeration order because
+the corrected query walks cells differently. **So nothing derived from `D02` ever needed re-measuring.**
+
+**Why the marking was wrong, and it is a reusable correction.** F44 flagged both rows on *diagonal FOV ÷ one-cell
+cap* — `D01` 7.9×, `D02` 2.4×. That ratio is a proxy for the real question: **do the ≤ 4 corner cells `FindAreas`
+returns cover the field?** Catalog cells are equal-area, so at `D02`'s **Dec +61.45°** a cell spans ≈ 1/cos(61.45)
+≈ 2.1× more RA degrees than at the equator, and four of them covered an 11.95° field comfortably. A ratio rule
+flags rows that are fine and keeps flagging them; the criterion has to be cell coverage **at the field's
+declination**. `D01` at 7.9× is beyond rescue by any declination.
+
+**The re-render moved exactly one thing.** A `--dry-run` diff against the stored `synthetic_meta.json` first: step
+size (9 / 6), exposure (0.5 s, both at the clamp floor), `detectionBinning` (1), donut (false) and every sweep
+position are **identical** before and after. The star field is the only variable, which is what makes every
+comparison below a clean two-arm measurement rather than an interpretation.
+
+## F35 — re-measured on one binary, because a prior wave's arm is not a control
+
+The wave-3 control arm was "the pre-F35 commit", which is precisely the cross-binary comparison
+[F41](followups.md) says is not a comparison. So the control is now produced by the binary under test:
+**`optimize --no-min-hfr-seed`**, a harness-only flag with the same shape as `--keep-floor` — absent, the run is
+bit-identical to before it existed.
+
+| dataset | frames | fitted vertex | `FinalJ` seed OFF | `FinalJ` seed ON | landed `MinHFR` |
+|---|---|---|---|---|---|
+| `D01` | old (truncated) | 0.7621 | **0.000000** | 0.990358 | 0.100 |
+| `D01` | **new (full field)** | 0.7712 | **0.000000** | **0.991551** | 0.100 |
+| `D02` (bit-identical frames) | — | 0.7488 | **0.000000** | 0.996510 | 0.3625 |
+| `D03` | — | 1.0154 | 0.995880 | 0.996543 | 0.300 |
+| **`D05` control** | — | 1.7882 | **0.999706** | **0.999706** | 1.48125 |
+
+- **The headline holds.** "`D01` and `D02` go from `FinalJ` exactly 0 to a real landing" is a gate-threshold
+  result, and it behaves like one: 2.4× the stars, same answer.
+- **`BaselineJ` is identical between the two arms of every dataset** (F41's free check), so the comparison is
+  valid before any landing is read. `D05`'s `BaselineJ` of 0.999293 also matches wave 5's parent-commit
+  measurement exactly — the same pinned settings file, the same detector.
+- **`D05` is bit-identical seed-on vs seed-off.** The boring control that caught the wave-3 seed leak is still
+  boring, which is the only way to know the seed is still declining where it should.
+- **`D02` bounds the drift.** Its frames provably did not change, so `FinalJ` 0.99656 → 0.996510 is **pure
+  wave-3→wave-6 binary drift: 5×10⁻⁵**. `D01`'s old-frames landing moved +1.8×10⁻⁴. So `D01`'s **+1.2×10⁻³** from
+  the re-render is ~6× the drift and belongs to the frames.
+
+## What the corrected field did to the recall tables
+
+`golden eval` over `D01` on both frame sets — 28 evals, ~11 min, no code. **Every old-frames row reproduces the
+wave-3/wave-5 numbers exactly to three decimals**, which is the F41 control doing its job across three waves.
+
+**F35's "how low is safe" sweep** (recall@high; FP = **0** in all 18 configurations):
+
+| `MinHFR` | 1.2 | 0.9 | 0.7 | 0.5 | 0.35 | 0.30 | 0.25 | 0.15 | 0.1 |
+|---|---|---|---|---|---|---|---|---|---|
+| D01 old | 0.129 | 0.152 | 0.160 | 0.164 | 0.164 | 0.165 | 0.165 | 0.165 | 0.165 |
+| **D01 new** | 0.127 | 0.150 | 0.157 | 0.161 | 0.162 | 0.162 | 0.162 | 0.162 | 0.162 |
+| vertex-frame stars, new | **0** | 0 | 4 | 6 | 7 | 7 | 7 | 7 | 7 |
+
+Recall is fractionally *lower* on the corrected field, and that is the correct direction: the golden grew with the
+field and the stars the fix restored are predominantly faint edge-of-frame ones, so TP rises 8253 → **19039**
+while the ratio does not. The conclusions — zero false positives at any gate, saturation by 0.5 — are unchanged.
+
+**F43's per-frame counts**, the table that says why this rig class needs the rescue at all:
+
+| `MinHFR` | 5964 | 5973 | 5982 | 5991 | **6000 (focus)** | 6009 | 6018 | 6027 | 6036 |
+|---|---|---|---|---|---|---|---|---|---|
+| 1.2 (default) | 1859 | 3758 | 4157 | 13 | **0** | 11 | 4182 | 3761 | 1867 |
+| 0.30 | 1859 | 3758 | 5784 | 476 | **7** | 438 | 5786 | 3761 | 1867 |
+| 0.10 | 1859 | 3758 | 5784 | 478 | **7** | 443 | 5786 | 3761 | 1867 |
+
+Thousands of stars in the wings, **zero at focus at the default gate**, and lowering it buys seven — against
+`NHard = 3`. The rescue is exactly as thin on a correct field as it looked on a truncated one.
+
+**F24's five arms on `D01`**: master still hurts (masterOFF − shipping = +0.014 old, +0.013 new), `both` still
+recovers master-OFF recall exactly, precision still 1.000 / FP 0 on every arm. The wave-5 verdict turned on
+D06/D09/D14, none of which was ever suspect.
+
+## F42 — the trap, closed three ways
+
+1. **The default path now inherits.** `DefaultPath()` = an existing file beside the exe (so an arm directory that
+   already has one is untouched) → otherwise `%LOCALAPPDATA%\HocusFocusHarness\harness_settings.json`. The
+   build-to-a-fresh-`-o`-directory workflow stops minting a new detector per arm, which was the mechanism.
+2. **The bootstrap is loud** — stderr `WARNING` + `Logger.Warning`, naming the profile and saying the run is not
+   comparable to earlier arms. That moment is exactly when an arm stops being comparable.
+3. **A `UseAdvanced=False` settings file warns and names what it is lying about.**
+   `StarDetectionOptions.InitializeOptions` ends in `ConfigureSimpleSettings()` → `DerivePresetSettings()`, which
+   **overwrites ~16 advanced knobs** from the three `Simple_*` presets. Editing `MinHFR` or
+   `NoiseClippingMultiplier` in a pinned file therefore does nothing, silently — the wave-5 probe set where four
+   different configurations returned identical star counts. The overridden keys are **measured** (hand the file's
+   bag to a throwaway options instance and diff it) rather than hard-coded, so the list cannot drift.
+
+**Wave 5 is not invalidated by (3), and this was checked rather than assumed:** `pinned_settings.json`'s advanced
+values coincide with the Typical presets, so the diff is empty. And no wave-5 comparison is touched by (1) —
+those arms passed `--settings` explicitly, which bypasses `DefaultPath()`.
+
+## F39 — half fixed, half deliberately deferred
+
+Part (a): `ResolveForRun` now writes `DetectionBinningSource` (`derived-from-in-focus-hfr` / `kept-from-base`) as
+a **field**. Seventeen bank files said "kept from base" in a prose `DerivedNotes` sentence while presenting
+`"DetectionBinning": "Bin2"` beside sixteen genuinely exported values; a reader diffs fields, not sentences.
+
+Part (b) — actually running the seven `detectionBinning = 2` datasets at their expected factor — is **not** paired
+with this wave's re-baseline, on purpose. The entire value of this pass is that exactly one variable moved. Part
+(b) would move a second one on seven other datasets in the same wave and the two effects could not be separated.
+
+## F43 — replay decided
+
+Replay gates on the user's CURRENT settings because "a saved run exists because those settings could already
+focus". **Three populations falsify that premise, all of them real today:** failed AF runs (`KeepFramesForReview`
+saves them), runs captured before the user changed settings, and runs never captured by this profile at all — the
+live app's own `LastSelectedLoadPath` pointed at `D01`, a dataset yielding **zero** in-focus stars at the default
+gate. So replay refuses a case it demonstrably receives.
+
+**Decision: extend the ladder to replay, baseline gate first**, so the premise case is untouched and only the
+refusal path changes. **Not shipped in wave 6**, because a replay whose baseline cannot fit has `BaselineJ = 0`
+— measured, every `D01`/`D02` arm printed `Current settings J: 0` — and the wizard's headline is a percentage
+*against* that baseline. The change needs a decision about what the summary says when there is no baseline to
+improve on, which is UI work with its own review. Replacing a confusing refusal with a confusing result is not
+progress.
+
+## F45 — the blind walk extends one step past its own data
+
+From a real 40 mm simulator run: the engine queued its last sweep point from an "established minimum" of **25015**
+while the run's own report shows `argmin(HFR + error)` at **25000** and the hyperbola vertex at 24999.996 — one
+extra step, one extra exposure.
+
+**Reproduced offline from the report's own eleven points**, not inferred. `TrendlineFitting.Minimum` is computed
+on the **post-Grubbs-rejection** set, and the rejected point is the **in-focus one**:
+
+| set | rejected | resulting `Minimum.X` |
+|---|---|---|
+| the 10 points present at the decision | **25000** | **25015** |
+| the final 11 points | **25000** | 25015 |
+| the same 10 points, rejection disabled | — | **25000** |
+
+And the rejection is the more serious half: on a fit with **R² = 0.9994**, the vertex point's residual is 0.0345 px
+against its own measurement error of **0.174 px** — consistent with the curve to a fifth of its own error bar — and
+it is discarded because `RejectionTest` scales by the **MAD of the weighted residuals**, which collapses precisely
+when the fit is good. Full numbers, and the three separable fixes (none taken), in [F45](followups.md).
+
+## Lessons
+
+**1. A suspect marking is a hypothesis, and it has to be measured like one.** `D02` was flagged by a ratio,
+carried the warning for a whole wave, and was never affected — its frames came back bit-identical. The cheapest
+step of the entire re-baseline (diff the frames) would have removed it from the work list on day one.
+
+**2. Keep the control that cannot move.** `D02`'s bit-identical frames turned it from a row to re-measure into the
+instrument that bounded wave-3→wave-6 drift at 5×10⁻⁵ — which is the only reason `D01`'s +1.2×10⁻³ can be
+attributed to the frames rather than to the binary. The most useful dataset this wave was the one where nothing
+happened, for the second wave running (`D05` did the same job for the seed).
+
+**3. If a control arm can only be built from another commit, build the flag instead.** F35 had no way to produce
+its own control on one binary, so `--no-min-hfr-seed` is the fix — and it cost twenty minutes against a
+cross-binary comparison that F41 already proved meaningless.
+
+**4. Change one thing.** The `--dry-run` diff *before* rendering is what makes this wave's numbers readable: step
+size, exposure, binning and donut verdict are provably identical, so every difference belongs to the star field.
+It is also why F39 part (b) was refused — it would have moved a second variable in the same wave.
+
+**5. A warning that names the specific keys beats a warning that names the hazard.** The `UseAdvanced=False` check
+diffs the file's own bag against what the options class does with it, so it reports *"`MinHFR 0.1→1.2`"* rather
+than *"advanced knobs may be overridden"* — and it cannot drift when the presets change.
+
+## Verification
+
+- Full suite green; the new work adds 7 harness tests of which **4 discriminate** (confirmed by neutralizing all
+  three F42/F39 behaviours at once and re-running: exactly those 4 fail). The other 3 are labelled guards.
+- `--no-min-hfr-seed` has no unit test — `OptimizationDiagnosticRunner` is not source-linked into the test project
+  — and its discriminating evidence is the arm itself: on `D01` the flag yields `FinalJ` exactly 0 where its
+  absence yields 0.9916.
+- Per [F37](followups.md), a red CI check is checked against the native test-host crash before being read as a
+  regression, and nothing merges on red.
+
+## Reproduce
+
+```
+# W1 -- re-render, then diff the truth sidecars
+TestApp synth-bank --spec <spec> --out "D:\SyntheticAutofocusBank" \
+    --datasets D01_ultrawide_40mm,D02_rich_135mm --dry-run   # derived-parameter diff FIRST
+TestApp synth-bank ... --overwrite
+
+# F35 -- one binary, both frame sets, control via the new flag, --settings pinned (F42)
+D:\hf_w6\f35_arms.sh          # old frames preserved at D:\hf_w6\oldframes
+
+# F24 / MinHFR sweep / F43 per-frame -- golden eval only, no code
+D:\hf_w6\golden_arms.sh
+
+# F32 arm R -- restarts instead of a floor
+D:\hf_w6\f32_armR.sh
+```

--- a/docs/synthetic-af-bank-followups-wave6-results.md
+++ b/docs/synthetic-af-bank-followups-wave6-results.md
@@ -175,8 +175,9 @@ changes are inert when their flags are absent.
 | **`D20` control** | 0.999766 | 0.999768 | +0.000002 | 0.999766 | 0 | — |
 
 **The greedy trap is now a fact rather than an inference:** with no constraint at all, restarting improves `J` on
-**5 of 8** runs, and a converged global optimum cannot be improved by re-seeding from itself. That is the same
-phenomenon as [F8](followups.md) — a landing is a property of the trajectory, not of the objective.
+**5 of the 7 binding runs** (all but `muggsie` and `D19`; the `D20` control moves 2×10⁻⁶, i.e. not at all), and a
+converged global optimum cannot be improved by re-seeding from itself. That is the same phenomenon as
+[F8](followups.md) — a landing is a property of the trajectory, not of the objective.
 
 **But restarting is not a substitute for the floor.** On the five runs where the floor helped, restarts recover
 **0–36% (median 13.8%)**. A restart changes the trajectory; the floor changes the feasible set and reaches a

--- a/plans/synthetic-af-bank-followups-wave6-plan.md
+++ b/plans/synthetic-af-bank-followups-wave6-plan.md
@@ -1,0 +1,236 @@
+# Synthetic AF bank — followups wave 6 (plan)
+
+Wave 5: [`docs/synthetic-af-bank-followups-wave5-results.md`](../docs/synthetic-af-bank-followups-wave5-results.md) ·
+Register: [`docs/followups.md`](../docs/followups.md) · Base: `develop` @ `00ebc83` (v4.0.0.12).
+
+*The question this wave answers: **which of the numbers on the board are still true?** Wave 5 fixed the
+wide-field catalog query but deliberately did not re-render the two rows it invalidated, so the bank currently
+carries two datasets whose star counts, recall and positions are known-wrong — and F35's headline validation rests
+on exactly those two. Everything else here is subordinate to that.*
+
+## Ground rules (wave-5 lessons, applied as preconditions rather than repeated as advice)
+
+| rule | why | where it binds |
+|---|---|---|
+| **`--settings D:\hf_w6\pinned_settings.json` on EVERY arm** | F42: each build dir bootstraps its own detector from the live profile | every `optimize` / `golden eval` / `bank-verify` invocation |
+| **Read `BaselineJ` before reading any knob diff** | F41: it is search-independent, so two arms of one binary MUST agree on it | W1.5, W2 |
+| **One binary per comparison; a prior wave's arm dir is not a control** | F41 | W1.5 uses `--no-min-hfr-seed` on ONE binary instead of building the pre-F35 commit |
+| **Identical results across supposedly different configs ⇒ the instrument is wrong** | wave-5 `UseAdvanced=False` probes | W1.5 asserts old-frames ≠ new-frames counts before reading any J |
+| **Check for a cheap instrument before scheduling an expensive one** | F24: `golden eval` already had every override | W1.6–W1.8 are all `golden eval`, no code |
+| **Count only tests that DISCRIMINATE** | wave-4 lesson 2 | W3, W5 |
+| **`optimize --per-run` rewrites settings INTO run folders** | F15 | W1.5 orders arms so the canonical arm lands last; snapshot first |
+
+Build: `dotnet.exe build "$(wslpath -w …/TestApp/TestApp.csproj)" -c Release -o 'D:\hf_w6\exe'`
+Tests: `dotnet.exe test "$(wslpath -w …/Joko.NINA.Plugins.sln)" -c Debug --nologo` (3628 passing at `c2ddb0a`).
+
+---
+
+## W1 — Re-baseline D01 and D02 (blocking; everything else is downstream)
+
+**State.** F44's fix (`AstapCellGeometry.FindAreasCovering`) shipped in wave 5; `D01_ultrawide_40mm` (7.9× over the
+one-cell cap) and `D02_rich_135mm` (2.4×) are still the OLD frames and are marked `suspect` in
+`synthetic-bank-spec.json`. A scratch re-render of D01 measured truth stars 8107 → 19212 and sensor-grid occupancy
+125/256 → 256/256.
+
+**Design decision — the old frames are kept as an arm, not deleted.** `D:\hf_w6\oldframes\{D01,D02}` (done).
+"What did the fix change" then becomes a two-arm measurement on ONE binary rather than a comparison against
+wave-3 numbers produced by a different one (F41). Every W1 measurement below is run on both frame sets.
+
+### W1.1 — Derived-parameter diff BEFORE rendering
+`synth-bank --dry-run --datasets D01_ultrawide_40mm,D02_rich_135mm` and diff against the stored
+`synthetic_meta.json`. The catalog query feeds `DeriveExpectedOptimal` — **exposure band, step size,
+detectionBinning and the donut verdict are all derived from a render/query that just changed**, so the new frames
+may differ by more than star count. Record every field that moves; a changed step size or exposure is a
+*legitimate* re-baseline, but it must be stated, not discovered later.
+
+### W1.2 — Re-render into the bank
+`synth-bank --spec … --out "D:\SyntheticAutofocusBank" --datasets D01_ultrawide_40mm,D02_rich_135mm --overwrite`.
+Note `synth-bank` does not delete the folder: the existing `harness_settings.json` / `optimized_settings.json` /
+`hocusfocus_star_detection.json` survive the render. Snapshot them to `D:\hf_w6\snapshots\` first anyway (F15).
+
+### W1.3 — The F44 table, completed
+Truth-star count, x/y extent and 16×16 sensor-grid occupancy, old vs new, for **both** rows (wave 5 measured D01
+only). This is the direct evidence that the two rows are now sound, and it is read from the `.truth.json`
+sidecars — no detector run.
+
+### W1.4 — Instrument: `optimize --no-min-hfr-seed`
+`OptimizationDiagnosticRunner` applies `MinHfrSeed.Resolve` unconditionally (`:669`), so F35's control arm can only
+be reproduced today by building the pre-F35 commit — which is exactly the cross-binary comparison F41 forbids. Add
+a harness-only flag that skips the seed, mirroring how `--keep-floor` exposes F32. TestApp only; no plugin
+behaviour changes. One discriminating test (the flag suppresses the floor; absent it, the floor is set).
+
+### W1.5 — F35's headline, re-measured (the load-bearing arm)
+`optimize --per-run`, one binary, `--settings` pinned, **arms:**
+
+| arm | frames | seed | datasets |
+|---|---|---|---|
+| `old_seed` | `D:\hf_w6\oldframes` | F35 on | D01, D02 |
+| `old_noseed` | `D:\hf_w6\oldframes` | `--no-min-hfr-seed` | D01, D02 |
+| `new_noseed` | bank (re-rendered) | `--no-min-hfr-seed` | D01, D02 |
+| `new_seed` **(canonical, runs LAST)** | bank (re-rendered) | F35 on | D01, D02 |
+| `ctl_seed` / `ctl_noseed` | bank (unchanged rows) | on / off | D03, D05 |
+
+12 runs, ~5–12 min each. **Gates, in order:**
+1. `BaselineJ` agrees between `*_seed` and `*_noseed` on the SAME frames (F41 — no search produces it).
+2. `old_*` reproduces wave 3's recorded `FinalJ` for D01/D02 to within the binary drift wave 3→6, or the drift is
+   attributed before anything else is read.
+3. D03/D05 land identically across `ctl_*` except where the seed legitimately fires (D03 does; D05 must not —
+   D05 is the boring control that caught the wave-3 seed-leak bug).
+4. **The F35 mechanism claim**: on the NEW frames, does `--no-min-hfr-seed` still give `FinalJ` exactly 0 on
+   D01/D02, and does the seed still rescue it? The entry predicts yes (a gate-threshold result). Either answer is
+   reportable; a *changed* answer is the more interesting one, since a fuller field means more wing stars and a
+   better-constrained pre-search fit.
+
+### W1.6 — Wave-5's F24 arm table, D01/D02 rows
+5 arms (`masterOFF`, `shipping`, `boost0`, `close1`, `both`) × 2 datasets × 2 frame sets, `golden eval --params
+default`, ~40 s each ⇒ ~13 min. Reuse `D:\hf_w5\f24_arms.sh` with the dataset list narrowed. The wave-5 *verdict*
+turned on D06/D09/D14 and does not move; only the two rows are being replaced.
+
+### W1.7 — F35's `MinHFR` sweep rows for D01/D02
+`golden eval --params default --min-hfr M` for M ∈ {1.2, 0.9, 0.7, 0.5, 0.35, 0.25, 0.15, 0.1}, × 2 datasets × 2
+frame sets ⇒ 32 evals, ~21 min. The claim under test is **"FP = 0 at every value"** and "the recall gain saturates
+by 0.5" — both were measured on a spatially truncated field.
+
+### W1.8 — F43's D01 per-frame count table
+`golden eval --params default --min-hfr {1.2, 0.30, 0.10}` on D01, per-frame accepted stars, both frame sets. F43's
+conclusion was independently confirmed on the reporter's real frames and does not depend on this; the D01 numbers
+in the entry are labelled "indicative" and this makes them exact.
+
+### W1.9 — Clear `suspect`, and only then
+Remove the `suspect` field from both spec rows (`SynthBank/synthetic-bank-spec.json`), update the affected
+`docs/followups.md` entries (F44, F35, F43, F24) **in place with the new numbers, keeping the old ones visible as
+the superseded column**, and record the whole thing in
+`docs/synthetic-af-bank-followups-wave6-results.md`. `synth-bank`'s suspect warning then stops firing, which is the
+observable end-state of this item.
+
+---
+
+## W2 — F32: decide whether the confirmation arm is still the right experiment
+
+**Do not schedule the ~6 h confirmation arm before this decision.** Read together, F32, F8 ("landings are not
+reproducible across invocations") and F3 ("`Wtie` does not prevent star-shedding in general") describe one search,
+not three defects — and wave 5's own arms found the constraint landing at a **higher** `J` than the unconstrained
+search on 5 of 7 binding runs, which is impossible against a global optimum. The floor may be a workaround for a
+stuck search rather than the feasibility bound it was designed as.
+
+**The cheap discriminator, pre-registered.** If the unconstrained search is merely stuck, then *any* mechanism that
+restarts it should recover most of the φ=0.75 gain **with no floor at all**. `--continue-rounds` already is that
+mechanism: it re-seeds from the prior best with a FRESH curated set, resetting the pattern-search stride. So:
+
+> **Arm R:** the 7 binding runs (`mccomiskey`, `uneven`, `toml999`, `CWhiteFocus`, `muggsie`, `D18`, `D19`) at
+> `--continue-rounds 2`, **no keep floor**, same binary, `--settings` pinned. ~7 runs × ~10–15 min ≈ 1.5 h.
+> `D20` (non-binding control) included as the 8th, where it must not move.
+
+**Decision rule, fixed in advance:**
+
+| outcome | reading | next |
+|---|---|---|
+| Arm R recovers ≥ 50% of the (off → φ=0.75) `J` gain on ≥ 4 of 7 | the corner is a **search defect**; the floor is treating a symptom | re-scope F32 → a search entry (restarts / Phase-A ordering / the strict `j > bestJ` freeze). File it; do NOT run the 6 h arm |
+| Arm R recovers < 50% on ≥ 4 of 7 | restarting is not sufficient; the floor is buying something a restart cannot | keep F32's confirmation arm as designed — **φ = 0.50**, both banks, plus `bank-verify` so C2 is evaluated on real-bank RECALL rather than the keep-% proxy |
+| mixed | report the split by run and take no adoption decision | — |
+
+Also record, either way: keep% and σ_focus at each round, so the "greedy trap" claim is measured rather than
+inferred. F8 predicts the rounds themselves will not be reproducible — that is a result, not a nuisance.
+
+---
+
+## W3 — F42: make the trap impossible, not merely documented
+
+Three changes in `TestApp/HarnessSettingsStore.cs`:
+
+1. **The bootstrap becomes LOUD.** `ResolveAt`'s create path prints an informational line today. Make it a
+   `WARNING` on stderr + `Logger.Warning`, naming the profile and saying in one sentence that this run is not
+   comparable to any earlier arm that used a different file. That single moment is when an arm silently stops
+   being comparable to its predecessor.
+2. **A fixed per-user default so a new build dir INHERITS instead of bootstrapping.** Resolution order becomes:
+   `--settings` → an existing file next to the exe (back-compat: a deliberately placed file still wins) → the
+   per-user file (`%LOCALAPPDATA%\HocusFocusHarness\harness_settings.json`) → bootstrap, **written to the per-user
+   path**. The build-to-a-separate-`-o`-directory workflow then stops generating a fresh detector per arm, which is
+   the mechanism F42 is about.
+3. **Warn when a settings file has `UseAdvanced = False`.** `StarDetectionOptions.InitializeOptions` ends in
+   `ConfigureSimpleSettings()`, which in Simple mode calls `DerivePresetSettings()` and **overwrites ~16 advanced
+   knobs** (`NoiseClippingMultiplier`, `StarClippingMultiplier`, `StructureLayers`, `BrightnessSensitivity`,
+   `MinHFR`, `MinStarBoundingBoxSize`, `MaxDistortion`, …) from the `Simple_*` presets. So editing those keys in a
+   pinned file does nothing, silently — this is the wave-5 "four probe runs returned identical star counts"
+   failure, generalized. Print the keys whose loaded value the options class overwrote, if that diff is cheap to
+   take (snapshot the bag, construct, compare); otherwise warn unconditionally on `UseAdvanced=False`.
+   *Checked for wave 5:* `D:\hf_w5\pinned_settings.json`'s advanced values coincide with the Typical presets, so
+   **no wave-5 arm is invalidated** — the hazard is real but did not fire. Say so explicitly.
+
+Tests in `Tests/Harness/HarnessSettingsStoreTests.cs`; each must fail when the behaviour it covers is reverted.
+
+---
+
+## W4 — The two smaller open items
+
+**W4.1 — F43 replay mode (decide, do not drive-by fix).** Live now probes a lowered `MinHFR` ladder before
+refusing; replay still gates on the user's CURRENT settings, locked deliberately by
+`SeedGuard_ReplayMode_GatesOnBaseline`. The circularity argument applies identically; the counter-argument is that
+a saved run exists *because* those settings could already focus. Write the decision and its reasoning into F43 —
+including what breaks if replay is converted into a seed-gated path — and either extend the fix with a test that
+discriminates, or record "won't fix, and why" so the question stops being re-opened.
+
+**W4.2 — F39 (`detectionBinning = 2` has never run).** 7 datasets expect it; none has ever been scored at it, and
+honouring it re-baselines the bank. **Pair with W1 or defer wholesale** — the one thing not to do is change it
+after W1's numbers are published. Recommended: take F39's part (a) only (stop *writing* a derived-looking value
+that was not derived — mark it `kept-from-base` in the file itself), and leave part (b) to its own wave with its
+own arm.
+
+---
+
+## W5 — New entry: the blind walk extends one step past its own data (F45)
+
+**Observed on a real 40 mm simulator run** (NINA log `20260805-214043`, report
+`2026-08-05--21-47-43--90d513b9….json`), step size 15, `offsetSteps = 4`:
+
+```
+21:47:08 Enough left trend points (4) with an established minimum (25015) to queue remaining right focus points up to 25075
+```
+
+`TrendlineFitting.Minimum` is **not a fitted vertex** — `Calculate` sets it to `argmin(Y + ErrorY)` over the
+*measured* points (NINA `TrendlineFitting.cs:94`). The engine's queue target is
+`Minimum.X + (failedRightPoints + offsetSteps) · stepSize` (`AutoFocusEngine.cs:1485`). The run's own report gives:
+
+| position | HFR | error | `Y + ErrorY` |
+|---|---|---|---|
+| **25000** | 0.6941 | 0.1736 | **0.8677 ← argmin** |
+| 25015 | 0.7709 | 0.2459 | 1.0168 |
+
+and `CalculatedFocusPoint = 24999.996`. Anchored at 25000 the target is 25060, which had already been sampled ⇒ no
+further exposure; anchored at 25015 it is 25075 ⇒ **one extra full step, one extra exposure**, on every run that
+hits this.
+
+**The mechanism must be measured, not guessed, before the entry is written.** The fit runs on
+`WeightRegularization.Regularize`d copies (σ floored at 0.2 × median — inert here, no σ is that small), and the
+fitting loop applies **Grubbs rejection with `MaxOutlierRejections = 1`**, removing a point and recomputing the
+trendline (`AutoFocusEngine.cs:132-179`). The leading hypothesis is that on the 10-point set present at the moment
+of the decision (24925…25060, asymmetric — no 25075 yet) the vertex point 25000 was rejected, leaving 25015 as the
+argmin; the final 11-point fit no longer rejects it, which is why the report and the engine disagree.
+
+**Reproduction is offline and free:** feed the report's own 11 points (and the 10-point prefix) through
+`TrendlineFitting` + `AlglibHyperbolicFitting` + `MathUtility.RejectionTest` in the test project and read which
+point is rejected in each case. File F45 with whichever mechanism that shows — and per the wave rules, **flag it,
+do not fix it inline**.
+
+---
+
+## W6 — Close-out
+
+1. Full suite green (`dotnet.exe test`, 3628 + new). Per F37, a red check is checked against the native test-host
+   crash and the test COUNT is read, not the badge; nothing merges on red.
+2. `docs/synthetic-af-bank-followups-wave6-results.md` — headline table, what changed, what it cost, lessons.
+3. `docs/followups.md` updated in place: F44 (suspect cleared / retained), F35, F43, F24, F32, F42, F39, new F45.
+4. Branch `ghilios/synthetic-af-bank-followups-wave6`, PR against `develop`. Never push `develop`.
+
+## Run-cost summary
+
+| item | cost | blocking |
+|---|---|---|
+| W1.1–W1.3 re-render + truth diff | ~10 min | yes |
+| W1.4 `--no-min-hfr-seed` + test | ~30 min | yes |
+| W1.5 F35 arms (12 optimize runs) | ~1.5–2 h | yes |
+| W1.6–W1.8 golden-eval arms (~60 evals) | ~45 min | yes |
+| W2 arm R (8 optimize runs, 2 continue rounds each) | ~1.5–2 h | decision gate for F32 |
+| W3 F42 hardening + tests | ~1 h | no |
+| W4 decisions | ~30 min | no |
+| W5 offline reproduction + entry | ~45 min | no |


### PR DESCRIPTION
Continues the synthetic-AF-bank followups. Plan: `plans/synthetic-af-bank-followups-wave6-plan.md`.
Results: `docs/synthetic-af-bank-followups-wave6-results.md`.

## The blocking item: re-baseline D01/D02 — and one of them was never wrong

Both suspect rows re-rendered with wave 5's fixed catalog query. **D02's re-rendered frames are
bit-identical** and its golden set is the same set, so nothing derived from it ever needed re-measuring.
The suspect criterion (diagonal FOV ÷ one-cell cap) over-predicts: what matters is whether the ≤4 corner
cells cover the field, and equal-area cells span ~2.1× more RA degrees at D02's Dec +61.45°.

D01 did move — truth stars 8107 → **19212**, sensor occupancy 49% → **100%**. A `--dry-run` diff first
confirmed step size, exposure, detection binning, donut verdict and every sweep position are identical, so
the star field is the only variable.

**F35's headline survives**: seed OFF → `FinalJ` exactly 0 on the corrected field, seed ON → 0.9916. The
control comes from the new `optimize --no-min-hfr-seed` on the binary under test rather than from the pre-F35
commit (F41). D02's untouched frames bound wave-3→wave-6 drift at 5×10⁻⁵, which is what lets D01's +1.2×10⁻³
be attributed to the frames. F24, the MinHFR sweep and F43's per-frame counts re-run over both frame sets;
every old-frames row reproduces wave 3 exactly and FP stays 0 everywhere.

`suspect` cleared on both rows.

## F32 — the ~6h arm was challenged before it was funded

Pre-registered rule, then Arm R (8 runs, `--continue-rounds 2`, no floor, 1.5h): if the search is merely
stuck, restarts should recover the floor's gain. Round 0 came back **identical to wave 5's feature-OFF arm on
all 8 runs to 6 dp**.

The greedy trap is now a fact — restarting alone improves `J` on 5 of 8 runs — but restarts recover only
**0–36% (median 13.8%)** of the floor's gain, so **the confirmation arm stands at φ=0.50**, with a third
restart arm added because the floor's two failures are exactly where restarts do best.

## Harness hardening

- **F42** closed three ways: the default settings path falls back to a per-user file so a fresh build
  directory inherits instead of bootstrapping its own detector; the bootstrap warns loudly; and a
  `UseAdvanced=False` settings file now warns and **names** the advanced knobs Simple-mode presets overwrite.
  Checked: wave 5's pinned file agrees with the presets, so no wave-5 arm is invalidated.
- **F39 part (a)**: `DetectionBinningSource` is a field now, not a prose sentence. Part (b) deliberately not
  paired with this wave — it would move a second variable.
- **F43 replay decided**: extend the rescue, but the premise-breaking evidence and a `BaselineJ = 0` UI answer
  come first.

## F45 (new)

On a real 40 mm sim run the blind walk anchored its queue one sub-step out and bought an extra exposure.
Reproduced offline from the run's own report: `TrendlineFitting.Minimum` is computed on the post-Grubbs set,
and the rejected point is the **in-focus one** — on a fit with R² 0.9994, residual 0.0345 px against its own
0.174 px error bar, z 2.5804 vs a limit of 2.4821. Flagged, not fixed.

## Verification

- Suite **3635 passing** (+7 harness tests, of which **4 discriminate** — confirmed by neutralizing all three
  F42/F39 behaviours at once and re-running).
- `--no-min-hfr-seed` has no unit test (`OptimizationDiagnosticRunner` is not source-linked); its
  discriminating evidence is the arm itself.
- F15 side effects on both banks are recorded in the results doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTNWdSNar6g3Nj5wXnLZc6