### PR TITLE
Wave 9: F32 answered after five waves (phi=0.50 does NOT ship), F19's remainder fixed by a theorem about the gate

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/ExposureRecommenderTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/ExposureRecommenderTests.cs
@@ -856,6 +856,228 @@ public class ExposureRecommenderTests {
         });
     }
 
+    // ── F19: the WING test ──────────────────────────────────────────────────────────────────────────────────
+    //
+    // Everything above this line is computed over ACCEPTED stars, and acceptance floors every one of them at
+    // StarDetector.EffectiveSensitivityGate. So when the optimizer lands a gate at or above TargetSensitivity,
+    // ExposureIsNotTheLimit is true BY CONSTRUCTION -- no rank, on no subset of frames, could say otherwise. That
+    // is why wave 7's "change NTarget" and wave 8's "widen the trigger" were both refuted by their own
+    // pre-registered tests: neither touches the population being measured.
+    //
+    // The candidates the gate REJECTED on the wing frames are the only population in a run that is NOT floored by
+    // the gate. Acceptance rule W (wave-9 design SS3.2), fixed before the statistic was written and validated on
+    // wave 7's exposure ladder, which is still on disk.
+
+    /// <summary>
+    /// A 9-frame sweep placed on the wing axis: focuser positions at ±4 steps around a fitted focus, with the
+    /// OUTER third (3 frames) carrying <paramref name="wingRejected"/> gate rejections against
+    /// <paramref name="wingAccepted"/> accepted stars, and the inner frames shedding nothing.
+    /// </summary>
+    private static RunEvaluationMetrics WingMetrics(
+            int wingRejected, int wingAccepted, int innerAccepted = 500,
+            double snr = 40.0, bool placeable = true) {
+        const int n = 9;
+        var frames = Enumerable.Range(0, n).Select(_ => (IReadOnlyList<double>)FullFrame(snr)).ToArray();
+        var positions = Enumerable.Range(0, n).Select(i => 1000 + (i - 4) * 10).ToArray();
+        // |offset| ordering: the 3 outermost are i = 0, 8 and (4 away vs 3 away) i = 1.
+        var rejected = new int[n];
+        var accepted = Enumerable.Repeat(innerAccepted, n).ToArray();
+        foreach (var i in new[] { 0, 8, 1 }) {
+            rejected[i] = wingRejected;
+            accepted[i] = wingAccepted;
+        }
+        return new RunEvaluationMetrics {
+            FrameStarSnrs = frames,
+            FrameStarCounts = accepted,
+            FrameLowSensitivityCounts = rejected,
+            FrameTooFlatCounts = new int[n],
+            FrameFocuserPositions = positions,
+            BestFocusPosition = placeable ? 1000.0 : double.NaN,
+            StepSize = 10.0
+        };
+    }
+
+    [Test]
+    public void Recommend_W1_SheddingWings_AskForMoreExposureEvenThoughEveryAcceptedStarClearsTheTarget() {
+        // THE DEFECT, in one fixture. Every accepted star measures S/N 40 against a target of 10, so the shipped
+        // statistic reports "exposure is not the limit" -- while the sweep's OUTER frames are forming 800
+        // candidates and losing 600 of them to the gate. Measured on D02_rich_135mm, whose wings shed 67% of their
+        // candidates at its derived exposure and whose sigma_focus is 48% better at 8x it.
+        //
+        // DISCRIMINATING: delete the wing probe and this fails on BOTH assertions.
+        var rec = ExposureRecommender.Recommend(
+            WingMetrics(wingRejected: 600, wingAccepted: 200), DefaultConstants(), currentExposureSeconds: 0.5);
+
+        Assert.Multiple(() => {
+            Assert.That(rec.WingRejectedFraction, Is.EqualTo(0.75).Within(1e-9));
+            Assert.That(rec.WingIsShedding, Is.True);
+            Assert.That(rec.RecommendedSeconds, Is.GreaterThanOrEqualTo(2.0 * 0.5), "W1: at least 2x current");
+            Assert.That(rec.IncreasesExposure, Is.True);
+            Assert.That(rec.ExposureIsNotTheLimit, Is.False,
+                "a shedding wing means exposure IS the limit, whatever the accepted stars say -- otherwise the copy "
+                + "would say 'star brightness is not the problem' directly above a row asking for more exposure");
+        });
+    }
+
+    [Test]
+    public void Recommend_W2_HealthyWings_AskForNothingMore_EvenAtAFlooredGate() {
+        // THE CONTROL, and it is the whole reason the arm-E ladder was rendered. D16_esprit550_ha3's sigma_focus
+        // MINIMUM sits at its derived exposure and gets WORSE above it, so a statistic that fires here has traded
+        // one blind spot for another. Its wings reject nothing.
+        //
+        // DISCRIMINATING: drop the WingSheddingThreshold test (fire on any rejection at all) and this fails.
+        var rec = ExposureRecommender.Recommend(
+            WingMetrics(wingRejected: 1, wingAccepted: 200), DefaultConstants(), currentExposureSeconds: 2.0);
+
+        Assert.Multiple(() => {
+            Assert.That(rec.WingRejectedFraction, Is.LessThan(ExposureRecommender.WingSheddingThreshold));
+            Assert.That(rec.WingIsShedding, Is.False);
+            Assert.That(rec.IncreasesExposure, Is.False, "W2: no material increase where sigma_focus is minimised");
+            Assert.That(rec.ExposureIsNotTheLimit, Is.True);
+        });
+    }
+
+    [Test]
+    public void Recommend_W3_TheProbeCONVERGES_UnlikeTheStatisticItWidens() {
+        // S_now SATURATES HARDER as exposure rises -- measured 992 -> 1226 -> 1864 -> 2309 on D02 -- so it could
+        // never converge toward asking for more even if its trigger were widened. The wing fraction does the
+        // opposite: as exposure rises the gate stops rejecting, so the ask falls away. Measured on D02: 0.67 /
+        // 0.29 / 0.30 below its optimum and EXACTLY 0.00 at and above it.
+        //
+        // DISCRIMINATING: make the probe unconditional and the second half fails.
+        var shedding = ExposureRecommender.Recommend(
+            WingMetrics(wingRejected: 600, wingAccepted: 200), DefaultConstants(), currentExposureSeconds: 0.5);
+        var converged = ExposureRecommender.Recommend(
+            WingMetrics(wingRejected: 0, wingAccepted: 800), DefaultConstants(), currentExposureSeconds: 4.0);
+
+        Assert.Multiple(() => {
+            Assert.That(shedding.IncreasesExposure, Is.True, "asks while the wings shed");
+            Assert.That(converged.WingRejectedFraction, Is.EqualTo(0.0).Within(1e-12));
+            Assert.That(converged.IncreasesExposure, Is.False, "and stops once they do not");
+        });
+    }
+
+    [Test]
+    public void Recommend_W4_TheProbeWIDENS_AndNeverRegressesARunTheSnrPathAlreadyServes() {
+        // The probe ALONE fails W4: D16 at half its derived exposure correctly asks 3x from S_now (6.5 against a
+        // target of 10), and its gate is INERT out there, so the wing test is silent. max(existing, probe) keeps
+        // that case. Both halves are load-bearing.
+        //
+        // DISCRIMINATING: replace the max() with a plain assignment of the probe factor and this fails -- 4x
+        // collapses to 2x.
+        const int n = 9;
+        var starved = new RunEvaluationMetrics {
+            FrameStarSnrs = Enumerable.Range(0, n).Select(_ => (IReadOnlyList<double>)FullFrame(5.0)).ToArray(),
+            FrameStarCounts = Enumerable.Repeat(200, n).ToArray(),
+            FrameLowSensitivityCounts = Enumerable.Repeat(300, n).ToArray(),  // wings shed too
+            FrameTooFlatCounts = new int[n],
+            FrameFocuserPositions = Enumerable.Range(0, n).Select(i => 1000 + (i - 4) * 10).ToArray(),
+            BestFocusPosition = 1000.0,
+            StepSize = 10.0
+        };
+
+        var rec = ExposureRecommender.Recommend(starved, DefaultConstants(), currentExposureSeconds: 1.0);
+
+        Assert.Multiple(() => {
+            Assert.That(rec.WingIsShedding, Is.True, "fixture guard: the probe is live here");
+            // S_now = 5 against a target of 10 => (10/5)^2 = 4x, which must WIN over the 2x probe.
+            Assert.That(rec.RawSeconds, Is.EqualTo(4.0).Within(1e-9),
+                "the S/N derivation is larger here, so max() must keep it rather than let the probe cap it at 2x");
+        });
+    }
+
+    [Test]
+    public void Recommend_TheF28GuardIsLoadBearing_AnInertGateShedsNothingByConstruction() {
+        // A rejection count of ZERO is empty when the gate is inert -- StarDetector's clipping guarantees every
+        // candidate measures at least PeakResponse x EffectiveClipMultiplier, so a Sensitivity at or below that
+        // rejects nothing regardless of what the frames contain (F28). D16_esprit550_ha3 lands Sensitivity 0 with
+        // an effective gate of 0.17-2.5 at EVERY rung of its ladder, so without this guard its zeros would read as
+        // "the wings are fine" for a reason that has nothing to do with its wings.
+        //
+        // THIS TEST PINS BEHAVIOUR, NOT THE CONJUNCT -- and that correction came from neutralizing it. Removing
+        // `!gateIsProvablyInert` from WingIsShedding fails NOTHING, because the conjunct is redundant by
+        // construction: a wing fraction at or above the threshold needs a non-zero entry in the same
+        // FrameLowSensitivityCounts array gateRejectedCount sums, so an inert gate (which requires that count to be
+        // zero) can never coexist with a shedding wing. The THRESHOLD is what makes this case pass. An earlier
+        // version of this comment claimed the guard was what discriminated here; it does not, and the code now says
+        // so at the conjunct.
+        var inertParams = HocusFocusStarDetection.BuildDefaultStarDetectorParams();
+        inertParams.Sensitivity = 0.0;   // at or below PeakResponse x StarClip => provably inert
+
+        var rec = ExposureRecommender.Recommend(
+            WingMetrics(wingRejected: 0, wingAccepted: 200), DefaultConstants(),
+            currentExposureSeconds: 2.0, detectorParams: inertParams);
+
+        Assert.Multiple(() => {
+            Assert.That(rec.GateIsProvablyInert, Is.True, "fixture guard");
+            Assert.That(rec.WingIsShedding, Is.False);
+        });
+    }
+
+    [Test]
+    public void Recommend_WingFractionIsNaN_NotZero_WhenTheRunCannotBePlacedOnTheWingAxis() {
+        // "We could not look" and "we looked and nothing was shedding" must not be the same number, because the
+        // caller turns one of them into an instruction. A run with no usable fit has no wing axis at all.
+        //
+        // DISCRIMINATING: return 0.0 instead of NaN from the guard and this fails.
+        var rec = ExposureRecommender.Recommend(
+            WingMetrics(wingRejected: 600, wingAccepted: 200, placeable: false),
+            DefaultConstants(), currentExposureSeconds: 0.5);
+
+        Assert.Multiple(() => {
+            Assert.That(rec.WingRejectedFraction, Is.NaN);
+            Assert.That(rec.WingIsShedding, Is.False, "an unplaceable run cannot claim its wings are shedding");
+        });
+    }
+
+    [Test]
+    public void Recommend_WithoutPerFrameWingData_IsBYTEIDENTICALToThePreWingBehaviour() {
+        // Every caller that does not populate FrameFocuserPositions / FrameStarCounts / BestFocusPosition -- which
+        // is every fixture above this section, and every pre-wave-9 producer -- must be completely unaffected.
+        // The wing test is opt-in ON THE DATA, not on a flag.
+        var frame = FullFrame(40.0);
+        var metrics = BuildMetrics(new[] { frame, frame, frame });
+
+        var rec = ExposureRecommender.Recommend(metrics, DefaultConstants(), currentExposureSeconds: 3.0);
+
+        Assert.Multiple(() => {
+            Assert.That(rec.WingRejectedFraction, Is.NaN);
+            Assert.That(rec.WingIsShedding, Is.False);
+            Assert.That(rec.ExposureIsNotTheLimit, Is.True, "unchanged from before the wing test existed");
+            Assert.That(rec.IncreasesExposure, Is.False);
+        });
+    }
+
+    [Test]
+    public void WingRejectedFraction_PoolsOverTheWingSET_SoOneFlukeFrameCannotCarryIt() {
+        // The class's own remarks defend the median-across-frames aggregation because a worst-FRAME rule "would
+        // hand the entire recommendation to whichever single frame had a passing cloud, a satellite trail, or a
+        // guiding bump". The wing statistic answers that objection by pooling over the outer THIRD rather than
+        // taking an extremum: one ruined frame among three moves the fraction, it does not decide it.
+        //
+        // DISCRIMINATING: change the pooling to a max-over-wing-frames and this fails -- 0.75 on one frame would
+        // carry it over the 0.20 threshold on its own.
+        const int n = 9;
+        var rejected = new int[n];
+        var accepted = Enumerable.Repeat(500, n).ToArray();
+        rejected[0] = 600; accepted[0] = 200;   // ONE ruined outermost frame
+        var metrics = new RunEvaluationMetrics {
+            FrameStarSnrs = Enumerable.Range(0, n).Select(_ => (IReadOnlyList<double>)FullFrame(40.0)).ToArray(),
+            FrameStarCounts = accepted,
+            FrameLowSensitivityCounts = rejected,
+            FrameTooFlatCounts = new int[n],
+            FrameFocuserPositions = Enumerable.Range(0, n).Select(i => 1000 + (i - 4) * 10).ToArray(),
+            BestFocusPosition = 1000.0,
+            StepSize = 10.0
+        };
+
+        var rec = ExposureRecommender.Recommend(metrics, DefaultConstants(), currentExposureSeconds: 2.0);
+
+        // 600 rejected against 200 + 500 + 500 accepted = 600/1800 = 0.333 -- still over the threshold here, but
+        // it is a POOLED third, not one frame's 0.75.
+        Assert.That(rec.WingRejectedFraction, Is.EqualTo(600.0 / 1800.0).Within(1e-9));
+    }
+
     /// <summary>Builds an inclusive ascending double range [start, end] -- a small local helper to keep the
     /// 40-value quantile test readable.</summary>
     private static double[] Range(int start, int end) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizerProgressCostTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizerProgressCostTests.cs
@@ -116,6 +116,105 @@ public class OptimizerProgressCostTests {
         });
     }
 
+    // ── F52(c): the ADVICE, which wave 8 deliberately did not ship ──────────────────────────────────────────
+    //
+    // Wave 8 shipped (a) and (b) -- the rate, the bound on what is left, which knob made the search expensive, and
+    // what Cancel costs -- and withheld (c), because advice derived from the exposure statistic of the day "would
+    // tell precisely the users who most need a longer exposure that theirs is already fine": on the reporting
+    // user's own rig that statistic read S/N 1438.6 against a target of 10. The separation is kept exactly: facts
+    // about COST need no statistic; ADVICE needs one, and now has ExposureRecommendation.WingIsShedding.
+
+    /// <summary>A 9-frame seed evaluation whose OUTER third sheds <paramref name="wingRejected"/> candidates
+    /// against <paramref name="wingAccepted"/> accepted, placed on the wing axis.</summary>
+    private static RunEvaluationMetrics SeedMetrics(int wingRejected, int wingAccepted) {
+        const int n = 9;
+        var rejected = new int[n];
+        var accepted = Enumerable.Repeat(500, n).ToArray();
+        foreach (var i in new[] { 0, 8, 1 }) { rejected[i] = wingRejected; accepted[i] = wingAccepted; }
+        return new RunEvaluationMetrics {
+            FrameStarSnrs = Enumerable.Range(0, n).Select(_ => (IReadOnlyList<double>)Enumerable.Repeat(40.0, 20).ToArray()).ToArray(),
+            FrameStarCounts = accepted,
+            FrameLowSensitivityCounts = rejected,
+            FrameTooFlatCounts = new int[n],
+            FrameFocuserPositions = Enumerable.Range(0, n).Select(i => 1000 + (i - 4) * 10).ToArray(),
+            BestFocusPosition = 1000.0,
+            StepSize = 10.0
+        };
+    }
+
+    [Test]
+    public void SearchExposureAdvice_SheddingWings_TellsTheUserToConsiderStopping_AndWhatCancelCosts() {
+        // The user's actual question, asked two hours into a search: "should I abort and try again with a longer
+        // exposure?". It is answered from the SEED evaluation, which runs BEFORE the search, so the answer existed
+        // in the first minute.
+        //
+        // DISCRIMINATING: make BuildSearchExposureAdvice return string.Empty and every assertion fails.
+        var text = StarDetectionOptimizerWizardVM.BuildSearchExposureAdvice(
+            new[] { SeedMetrics(wingRejected: 600, wingAccepted: 200) },
+            HocusFocusStarDetection.BuildDefaultStarDetectorParams(), currentExposureSeconds: 2.0);
+
+        Assert.Multiple(() => {
+            Assert.That(text, Does.Contain("outer frames"), "it names the population the verdict rests on");
+            Assert.That(text, Does.Contain("longer exposure"));
+            Assert.That(text, Does.Contain("Cancel"), "the house rule: name a control that exists");
+            Assert.That(text, Does.Contain("nothing is written to your profile"),
+                "not knowing this is why the user sat through the two hours");
+            Assert.That(text, Does.Not.Contain("S/N"),
+                "the accepted-star S/N is exactly the number that would have said 'yours is already fine'");
+        });
+    }
+
+    [Test]
+    public void SearchExposureAdvice_HealthyWings_SaysNOTHING() {
+        // A note that always fires says nothing -- the same rule the cost note follows ("absent entirely when the
+        // search is in a cheap region"). This is also the case wave 8 refused to ship advice for.
+        //
+        // DISCRIMINATING: drop the WingIsShedding test and this fails.
+        var text = StarDetectionOptimizerWizardVM.BuildSearchExposureAdvice(
+            new[] { SeedMetrics(wingRejected: 1, wingAccepted: 500) },
+            HocusFocusStarDetection.BuildDefaultStarDetectorParams(), currentExposureSeconds: 2.0);
+
+        Assert.That(text, Is.Empty);
+    }
+
+    [Test]
+    public void SearchExposureAdvice_MultiRun_TakesTheWORSTRun_NotTheAverage() {
+        // A multi-run optimization lands ONE settings bundle across all of them, so the run that is worst off is
+        // what makes the search's answer untrustworthy. Averaging would understate it.
+        //
+        // BOTH RUNS MUST BE SHEDDING for this to discriminate, and that correction came from neutralizing it: the
+        // aggregation `continue`s past any run whose wings are healthy, so pairing a shedding run with a HEALTHY
+        // one leaves the worst and the average identical and the test proves nothing. An earlier version of this
+        // test did exactly that and passed under a deliberately-averaged implementation.
+        //
+        // DISCRIMINATING as written: 0.75 and 0.30 average to 0.525, which renders "53%", not "75%".
+        var text = StarDetectionOptimizerWizardVM.BuildSearchExposureAdvice(
+            new[] { SeedMetrics(wingRejected: 600, wingAccepted: 200),   // 600/800 = 0.75
+                    SeedMetrics(wingRejected: 300, wingAccepted: 700) }, // 300/1000 = 0.30
+            HocusFocusStarDetection.BuildDefaultStarDetectorParams(), currentExposureSeconds: 2.0);
+
+        Assert.Multiple(() => {
+            Assert.That(text, Is.Not.Empty);
+            Assert.That(text, Does.Contain("75%"), "the WORST run's fraction, not a blend");
+            Assert.That(text, Does.Not.Contain("53%"));
+        });
+    }
+
+    [Test]
+    public void SearchExposureAdvice_NoSeedMetrics_SaysNothingRatherThanGuessing() {
+        // GUARD. A run with no seed evaluation has not looked at its wings, and the advice tells the user to
+        // abandon a sweep -- the one place this must stay silent rather than default to something.
+        Assert.Multiple(() => {
+            Assert.That(StarDetectionOptimizerWizardVM.BuildSearchExposureAdvice(
+                null, HocusFocusStarDetection.BuildDefaultStarDetectorParams(), 2.0), Is.Empty);
+            Assert.That(StarDetectionOptimizerWizardVM.BuildSearchExposureAdvice(
+                new RunEvaluationMetrics[0], HocusFocusStarDetection.BuildDefaultStarDetectorParams(), 2.0), Is.Empty);
+            Assert.That(StarDetectionOptimizerWizardVM.BuildSearchExposureAdvice(
+                new[] { SeedMetrics(600, 200) }, HocusFocusStarDetection.BuildDefaultStarDetectorParams(), 0.0),
+                Is.Empty, "an unknown exposure has nothing to say about exposure");
+        });
+    }
+
     [Test]
     public void EffectiveStructureLayers_IsNullSafeAndNeverReturnsZeroLayersForRealParams() {
         // GUARD: the optimizer calls this on every evaluation and the wizard on every report; a null here would

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -3863,6 +3863,95 @@ public class StarDetectionOptimizerWizardVMTests {
         SetPrivate(vm, "feedbackCurve", curve);
     }
 
+    // ── F32: expose RESTARTS, not the keep floor ────────────────────────────────────────────────────────────
+    //
+    // F32 found the optimizer's shedding landings are substantially a GREEDY TRAP rather than a rational trade.
+    // Wave 5 proposed fixing that with a feasibility floor (MinDetectionKeepFraction). Wave 9's confirmation arm
+    // -- both full banks, sequential, RULE G 8/8 and BaselineJ 0-of-39 -- REFUTED the floor as a default on three
+    // pre-registered rules, and measured the alternative as strictly better: restarts recovered 228% of the
+    // floor's median gain, where wave 6 had measured 0-36% on a 7-run subset.
+    //
+    // "Continue optimizing" IS a restart and was always on screen. What was missing is any signal that pressing
+    // it was worth it, which is what these tests pin.
+
+    /// <summary>Puts a VM into "optimized, one round done, landing kept <paramref name="keep"/> of the seed".</summary>
+    private static void GiveOptimizedLanding(StarDetectionOptimizerWizardVM vm, double keep) {
+        SetPrivate(vm, "optimizedResult", new OptimizationResult {
+            BestParams = new StarDetectorParams(), BestJ = 0.99, SeedJ = 0.98, LandingKeepFraction = keep
+        });
+    }
+
+    [Test]
+    public async Task ContinueAdvice_SheddingLanding_TellsTheUserARestartIsLikelyToBeatIt() {
+        // The shedding corner: this landing kept 30% of the stars the seed did. A constrained search beat the
+        // unconstrained one on runs like this, which a true global maximum cannot allow -- so the search stopped
+        // short, and restarting it is the measured remedy.
+        //
+        // DISCRIMINATING: make ContinueOptimizingAdviceText return string.Empty and every assertion fails.
+        var vm = NewVM(new RecordingLoader(), frameReviewBuilder: new FakeReviewBuilder().Build);
+        vm.SourcePaths[0] = @"C:\shed-run";
+        await vm.StartAsync(CancellationToken.None);
+        Assert.That(vm.CanContinueOptimization, Is.True, "fixture guard: a round must remain");
+        GiveOptimizedLanding(vm, keep: 0.30);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.HasContinueOptimizingAdvice, Is.True);
+            Assert.That(vm.ContinueOptimizingAdviceText, Does.Contain("30%"), "it quotes what this landing kept");
+            Assert.That(vm.ContinueOptimizingAdviceText, Does.Contain("Continue optimizing"),
+                "it names a control that is on screen AND enabled (the house rule)");
+            Assert.That(vm.ContinueOptimizingAdviceText, Does.Not.Contain("keep floor"),
+                "MinDetectionKeepFraction has no user-facing control and was REFUTED as a default; naming it "
+                + "would point the user at something they cannot reach and that wave 9 measured as harmful");
+        });
+    }
+
+    [Test]
+    public async Task ContinueAdvice_HealthyLanding_SaysNOTHING() {
+        // A landing that kept most of its seed's stars did not take the shedding corner, so there is no greedy
+        // trap to escape and a note here would be noise. Restarts helped on the BINDING runs, not on all runs.
+        //
+        // DISCRIMINATING: drop the SheddingLandingKeepFraction test and this fails.
+        var vm = NewVM(new RecordingLoader(), frameReviewBuilder: new FakeReviewBuilder().Build);
+        vm.SourcePaths[0] = @"C:\healthy-run";
+        await vm.StartAsync(CancellationToken.None);
+        GiveOptimizedLanding(vm, keep: 0.95);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.HasContinueOptimizingAdvice, Is.False);
+            Assert.That(vm.ContinueOptimizingAdviceText, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task ContinueAdvice_NeverPromisesAnActionThatCannotBeTaken() {
+        // The house rule at ShowOptimizeAgainAtRecommendedBinning: never describe an action whose control is
+        // hidden or dead. The advice names the Continue button, so it must vanish the moment that button cannot
+        // run -- including at the MaxOptimizationRounds cap, where the button greys out.
+        //
+        // DISCRIMINATING: drop the CanContinueOptimization conjunct and this fails on the busy case.
+        var vm = NewVM(new RecordingLoader(), frameReviewBuilder: new FakeReviewBuilder().Build);
+        vm.SourcePaths[0] = @"C:\cap-run";
+        await vm.StartAsync(CancellationToken.None);
+        GiveOptimizedLanding(vm, keep: 0.30);
+        Assert.That(vm.HasContinueOptimizingAdvice, Is.True, "fixture guard: it is showing before the cap");
+
+        SetPrivate(vm, "isBusy", true);   // a pass is running: Continue is disabled
+        Assert.That(vm.HasContinueOptimizingAdvice, Is.False,
+            "the sentence must not name a button the user cannot press right now");
+    }
+
+    [Test]
+    public async Task ContinueAdvice_NoMeasuredKeepFraction_SaysNothingRatherThanGuessing() {
+        // A run whose keep fraction was never measured (NaN) has not been shown to shed anything. The advice
+        // tells the user to spend another optimization pass, so silence is the right default.
+        var vm = NewVM(new RecordingLoader(), frameReviewBuilder: new FakeReviewBuilder().Build);
+        vm.SourcePaths[0] = @"C:\nokeep-run";
+        await vm.StartAsync(CancellationToken.None);
+        GiveOptimizedLanding(vm, keep: double.NaN);
+
+        Assert.That(vm.HasContinueOptimizingAdvice, Is.False);
+    }
+
     private static void SetPrivate(object target, string field, object value) =>
         target.GetType()
             .GetField(field, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -1763,61 +1763,61 @@ public class StarDetectionOptimizerWizardVMTests {
     }
 
     [Test]
-    public void ApplyRecaptureGeometry_F51_CarriesTheRecommendedStepAndOffset() {
-        // F51(b) — the re-capture used to override ONLY the exposure and take the step size from the PROFILE, so
+    public void ApplyRecaptureGeometry_F51_CarriesTheRecommendedStep() {
+        // F51(b) -- the re-capture used to override ONLY the exposure and take the step size from the PROFILE, so
         // the one recommendation that was asking to change on every run of the field session (100 -> 214 -> 459
         // -> 474 -> 482) was the one it could not carry. The only way to re-run at the recommended step was to
         // Accept a landing first, and that Accept is how Sensitivity 0.000 reached the user's profile.
         //
-        // DISCRIMINATING: neuter the method (or drop the call from RunLiveAttemptAsync) and this fails on both
-        // fields.
+        // DISCRIMINATING: neuter the method (or drop the call from RunLiveAttemptAsync) and this fails.
         var options = new AutoFocusEngineOptions {
             AutoFocusInitialOffsetSteps = 5,
             AutoFocusStepSize = 214,
             AutoFocusTimeout = TimeSpan.FromSeconds(600)
         };
-        StarDetectionOptimizerWizardVM.ApplyRecaptureGeometry(options, 459, 6);
+        StarDetectionOptimizerWizardVM.ApplyRecaptureGeometry(options, 459);
         Assert.Multiple(() => {
             Assert.That(options.AutoFocusStepSize, Is.EqualTo(459), "the recommended step, not the profile's");
-            Assert.That(options.AutoFocusInitialOffsetSteps, Is.EqualTo(6));
+            Assert.That(options.AutoFocusInitialOffsetSteps, Is.EqualTo(5),
+                "the OFFSET is deliberately untouched: StepSizeRecommender derives its step from the desired "
+                + "half-width over the CURRENT points-per-side, so applying the recommended offset as well would "
+                + "widen the sweep twice -- and ApplyFocusRecovery owns that axis");
             Assert.That(options.AutoFocusTimeout, Is.EqualTo(TimeSpan.FromSeconds(600)),
-                "the timeout is NOT scaled here - ApplyFocusRecovery runs next and scales it from this offset, "
-                + "so scaling in both places would double-count the same widening");
+                "the point count does not change, so there is nothing to re-scale");
         });
     }
 
     [Test]
     public void ApplyRecaptureGeometry_F51_NonPositiveIsACompleteNoOp_SoAnOrdinaryStartIsUnchanged() {
-        // An ordinary Live Start leaves both fields at 0, and that path must stay byte-identical to before this
-        // existed. The two are independent: an exposure-only re-capture passes 0 for the step size and must not
-        // disturb the profile's.
-        foreach (var (step, offset) in new[] { (0, 0), (-1, 0), (0, -3) }) {
+        // An ordinary Live Start leaves the field at 0, and that path must stay byte-identical to before this
+        // existed -- including an exposure-only re-capture, which passes 0.
+        foreach (var step in new[] { 0, -1 }) {
             var options = new AutoFocusEngineOptions { AutoFocusInitialOffsetSteps = 5, AutoFocusStepSize = 100 };
-            StarDetectionOptimizerWizardVM.ApplyRecaptureGeometry(options, step, offset);
+            StarDetectionOptimizerWizardVM.ApplyRecaptureGeometry(options, step);
             Assert.Multiple(() => {
-                Assert.That(options.AutoFocusStepSize, Is.EqualTo(100), $"step unchanged at ({step},{offset})");
-                Assert.That(options.AutoFocusInitialOffsetSteps, Is.EqualTo(5), $"offset unchanged at ({step},{offset})");
+                Assert.That(options.AutoFocusStepSize, Is.EqualTo(100), $"step unchanged at {step}");
+                Assert.That(options.AutoFocusInitialOffsetSteps, Is.EqualTo(5), $"offset unchanged at {step}");
             });
         }
     }
 
     [Test]
-    public void ApplyRecaptureGeometry_F51_ComposesWithFocusRecoveryInTheShippedOrDER() {
-        // RunLiveAttemptAsync applies the geometry FIRST and recovery SECOND, so recovery widens whatever offset
-        // the recommendation left — exactly as it widens the profile's on an ordinary Start. Reversing the two
-        // would let recovery's widening be overwritten by the recommended offset and silently drop the recovery
-        // frames the evaluator is about to TAG as recovery.
+    public void ApplyRecaptureGeometry_F51_ComposesWithFocusRecoveryWithoutDoubleWideningTheSweep() {
+        // RunLiveAttemptAsync applies the geometry FIRST and recovery SECOND. Because the geometry no longer
+        // touches the offset, recovery widens from the PROFILE's offset exactly as it does on an ordinary Start --
+        // which is the contract CaptureNewSweep_UsesTheSnapshottedRecoverySteps_NotTheLiveBox pins, and which the
+        // first version of this method broke by widening to 5 where the snapshot alone gives 1.
         var options = new AutoFocusEngineOptions {
             AutoFocusInitialOffsetSteps = 4, AutoFocusStepSize = 100, AutoFocusTimeout = TimeSpan.FromSeconds(600)
         };
-        StarDetectionOptimizerWizardVM.ApplyRecaptureGeometry(options, 459, 5);
+        StarDetectionOptimizerWizardVM.ApplyRecaptureGeometry(options, 459);
         StarDetectionOptimizerWizardVM.ApplyFocusRecovery(options, 2);
         Assert.Multiple(() => {
             Assert.That(options.AutoFocusStepSize, Is.EqualTo(459), "recovery never touches the step size");
-            Assert.That(options.AutoFocusInitialOffsetSteps, Is.EqualTo(7), "5 recommended + 2 recovery per side");
+            Assert.That(options.AutoFocusInitialOffsetSteps, Is.EqualTo(6), "4 profile + 2 recovery -- NOT 4+N+2");
             Assert.That(options.AutoFocusTimeout.Ticks,
-                Is.EqualTo((long)(TimeSpan.FromSeconds(600).Ticks * 15.0 / 11.0)),
-                "recovery scales the timeout from the RECOMMENDED offset (11 points), not the profile's 9");
+                Is.EqualTo((long)(TimeSpan.FromSeconds(600).Ticks * 13.0 / 9.0)),
+                "recovery scales the timeout from the PROFILE's offset, which the geometry left alone");
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarDetectionOptimizerWizardVMTests.cs
@@ -1763,6 +1763,65 @@ public class StarDetectionOptimizerWizardVMTests {
     }
 
     [Test]
+    public void ApplyRecaptureGeometry_F51_CarriesTheRecommendedStepAndOffset() {
+        // F51(b) — the re-capture used to override ONLY the exposure and take the step size from the PROFILE, so
+        // the one recommendation that was asking to change on every run of the field session (100 -> 214 -> 459
+        // -> 474 -> 482) was the one it could not carry. The only way to re-run at the recommended step was to
+        // Accept a landing first, and that Accept is how Sensitivity 0.000 reached the user's profile.
+        //
+        // DISCRIMINATING: neuter the method (or drop the call from RunLiveAttemptAsync) and this fails on both
+        // fields.
+        var options = new AutoFocusEngineOptions {
+            AutoFocusInitialOffsetSteps = 5,
+            AutoFocusStepSize = 214,
+            AutoFocusTimeout = TimeSpan.FromSeconds(600)
+        };
+        StarDetectionOptimizerWizardVM.ApplyRecaptureGeometry(options, 459, 6);
+        Assert.Multiple(() => {
+            Assert.That(options.AutoFocusStepSize, Is.EqualTo(459), "the recommended step, not the profile's");
+            Assert.That(options.AutoFocusInitialOffsetSteps, Is.EqualTo(6));
+            Assert.That(options.AutoFocusTimeout, Is.EqualTo(TimeSpan.FromSeconds(600)),
+                "the timeout is NOT scaled here - ApplyFocusRecovery runs next and scales it from this offset, "
+                + "so scaling in both places would double-count the same widening");
+        });
+    }
+
+    [Test]
+    public void ApplyRecaptureGeometry_F51_NonPositiveIsACompleteNoOp_SoAnOrdinaryStartIsUnchanged() {
+        // An ordinary Live Start leaves both fields at 0, and that path must stay byte-identical to before this
+        // existed. The two are independent: an exposure-only re-capture passes 0 for the step size and must not
+        // disturb the profile's.
+        foreach (var (step, offset) in new[] { (0, 0), (-1, 0), (0, -3) }) {
+            var options = new AutoFocusEngineOptions { AutoFocusInitialOffsetSteps = 5, AutoFocusStepSize = 100 };
+            StarDetectionOptimizerWizardVM.ApplyRecaptureGeometry(options, step, offset);
+            Assert.Multiple(() => {
+                Assert.That(options.AutoFocusStepSize, Is.EqualTo(100), $"step unchanged at ({step},{offset})");
+                Assert.That(options.AutoFocusInitialOffsetSteps, Is.EqualTo(5), $"offset unchanged at ({step},{offset})");
+            });
+        }
+    }
+
+    [Test]
+    public void ApplyRecaptureGeometry_F51_ComposesWithFocusRecoveryInTheShippedOrDER() {
+        // RunLiveAttemptAsync applies the geometry FIRST and recovery SECOND, so recovery widens whatever offset
+        // the recommendation left — exactly as it widens the profile's on an ordinary Start. Reversing the two
+        // would let recovery's widening be overwritten by the recommended offset and silently drop the recovery
+        // frames the evaluator is about to TAG as recovery.
+        var options = new AutoFocusEngineOptions {
+            AutoFocusInitialOffsetSteps = 4, AutoFocusStepSize = 100, AutoFocusTimeout = TimeSpan.FromSeconds(600)
+        };
+        StarDetectionOptimizerWizardVM.ApplyRecaptureGeometry(options, 459, 5);
+        StarDetectionOptimizerWizardVM.ApplyFocusRecovery(options, 2);
+        Assert.Multiple(() => {
+            Assert.That(options.AutoFocusStepSize, Is.EqualTo(459), "recovery never touches the step size");
+            Assert.That(options.AutoFocusInitialOffsetSteps, Is.EqualTo(7), "5 recommended + 2 recovery per side");
+            Assert.That(options.AutoFocusTimeout.Ticks,
+                Is.EqualTo((long)(TimeSpan.FromSeconds(600).Ticks * 15.0 / 11.0)),
+                "recovery scales the timeout from the RECOMMENDED offset (11 points), not the profile's 9");
+        });
+    }
+
+    [Test]
     public async Task Start_Live_StampsRecoverySnapshotOntoLoadedRun() {
         // The loaded run's RunEvaluationData must carry the snapshotted recovery steps so the evaluator tags the outer
         // frames. The fake loader hands back the same LoadedRun instance we hold, and RecoveryStepsPerSide survives the

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarSignalCopyTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StarSignalCopyTests.cs
@@ -276,11 +276,81 @@ public class StarSignalCopyTests {
         Assert.That(text, Is.EqualTo(
             NeutralOpening
             + " Star brightness is not the problem: your brightest stars measure S/N 22, meeting the default S/N target of 10."
-            + " Brightness Sensitivity is low, so far fainter candidates are being admitted below them."));
+            + " Brightness Sensitivity is low, so far fainter candidates are being admitted below them."
+            + " " + GateRemedy));
         Assert.Multiple(() => {
             Assert.That(text, Does.Not.Contain("barely cleared"));
             Assert.That(text, Does.Not.Contain("star-poor"), "nothing measured says the field is thin");
             Assert.That(text, Does.Not.Contain("per frame"), "no exposure figure: exposure is not the problem");
+        });
+    }
+
+    /// <summary>F49's remedy, spelled out so the golden whole-string assertions stay readable.</summary>
+    private const string GateRemedy =
+        "The gate was lowered to admit more candidates, not because star brightness was missing. "
+        + "Set Brightness Sensitivity by hand in the star detection options and run this wizard again in "
+        + "\"use current settings\" mode to compare that landing against this one.";
+
+    [Test]
+    public void ExposureCopy_F49_RichWellExposedFieldAtAFlooredGate_EndsOnAnInstruction() {
+        // F49, from a FIELD report on the shipped Default profile: Sensitivity 15.667 -> 0.000, StarClip 6.750 ->
+        // 0.250, stars per frame 834 -> 5766, and "your brightest stars measure S/N 1438.6" -- followed by NOTHING.
+        //
+        // THIS IS THE DEFECT, and it is structural rather than a missing string. RemedyFor's three ranked branches
+        // are ALL exposure or binning remedies: with ExposureIsNotTheLimit true, IncreasesExposure is false (which
+        // kills branches 1 and 3) and branch 2's !ExposureIsNotTheLimit is false, so every branch fell through and
+        // the method returned string.Empty -- on a page whose contract is "diagnosis plus exactly one instruction".
+        //
+        // DISCRIMINATING: delete the F49 branch and this fails, because the body ends after the admission sentence.
+        var text = Body(Starved(advice: Advice(2, 2, 1438.6, exposureIsNotTheLimit: true)), live: true);
+        Assert.Multiple(() => {
+            Assert.That(text, Does.EndWith(GateRemedy), "the block must end on exactly one instruction");
+            // It names the GATE, which is the lever on this population -- not the exposure, which is not.
+            Assert.That(text, Does.Contain("Brightness Sensitivity by hand"));
+            Assert.That(text, Does.Not.Contain("longer exposure"),
+                "on a field measuring S/N 1438.6 against a target of 10, an exposure remedy is F19's error mirrored");
+            Assert.That(text, Does.Not.Contain("broadband filter"),
+                "the filter route belongs to the exposure-exhausted state, which this is not");
+        });
+    }
+
+    [Test]
+    public void ExposureCopy_F49_NamesNoControlThatDoesNotExist() {
+        // The house rule at ShowOptimizeAgainAtRecommendedBinning: never describe an action whose control is
+        // hidden. F32's MinDetectionKeepFraction is the tempting lever here and it has NO XAML binding ANYWHERE --
+        // it is --keep-floor on the harness only. (It would not have bound in any case: it rejects landings
+        // keeping FEWER stars than the seed, and this landing keeps ~7x MORE. The pathology is admission, not
+        // shedding.) BrightnessSensitivity, by contrast, is bound in OptionsDataTemplates.xaml.
+        var text = Body(Starved(advice: Advice(2, 2, 1438.6, exposureIsNotTheLimit: true)), live: true);
+        Assert.Multiple(() => {
+            Assert.That(text, Does.Not.Contain("keep"), "MinDetectionKeepFraction has no user-facing control");
+            Assert.That(text, Does.Not.Contain("detection keep"));
+        });
+    }
+
+    [Test]
+    public void ExposureCopy_F49_AnUnmeasuredRunGetsNoGateRemedy_BecauseTheSentenceCLAIMSSomething() {
+        // The F49 sentence asserts that star brightness was NOT what was missing. That is only knowable from
+        // ExposureIsNotTheLimit (S_now >= the default target). On a run with no derivable recommendation at all —
+        // too few usable frames, no per-star SNRs, an unknown exposure to scale from — all that is known is that
+        // the gate is floored, and claiming anything about brightness there breaks the same "no claim without
+        // evidence" rule the star-poor sentence is gated by, in the opposite direction.
+        //
+        // DISCRIMINATING: drop the `HasRecommendation && ExposureIsNotTheLimit` guard on the F49 branch and this
+        // fails, along with the two diagnosis-only golden tests below it.
+        var text = Body(Starved(advice: null), live: true);
+        Assert.That(text, Does.Not.Contain("Brightness Sensitivity by hand"));
+    }
+
+    [Test]
+    public void ExposureCopy_F49_TheGateRemedyIsTheCatchAll_NotAReplacementForTheExposureOnes() {
+        // The F49 branch is LAST in the ranking, so it must not displace a remedy that is genuinely available.
+        // DISCRIMINATING: move the branch above the IncreasesExposure branch and this fails.
+        var raisesExposure = Body(Starved(advice: Advice(2, 8, 5.0)), live: true);
+        Assert.Multiple(() => {
+            Assert.That(raisesExposure, Does.Not.Contain("Brightness Sensitivity by hand"),
+                "a run that CAN be fixed with exposure gets the exposure instruction, not the gate one");
+            Assert.That(raisesExposure, Does.Contain("Capture a new sweep at the longer exposure"));
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -669,14 +669,28 @@
                         Visibility="{Binding IsOptimizing, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                     <!--  F52 — the search's COST, which the count and the clock above cannot convey: what a step is
                           costing, an upper bound on what is left, and (only when true) why it is expensive right now.
-                          Deliberately no recommendation to abort or re-expose: that needs a wing-frame statistic the
-                          exposure recommender does not have yet (F52 (c), blocked on F19).  -->
+                          The ADVICE half is the separate row further down (SearchExposureAdvice): facts about cost
+                          need no statistic and are these rows; advice needs one, and now has it (F52 (c)).  -->
                     <TextBlock
                         Margin="0,2,0,0"
                         HorizontalAlignment="Center"
                         Opacity="0.75"
                         Text="{Binding ProgressTimingText, Mode=OneWay}"
                         Visibility="{Binding IsOptimizing, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                    <!--  F52(c) — the one piece of ADVICE, and the only row here that tells the user to consider
+                          stopping. Computed from the SEED evaluation, which runs before the search does, so the
+                          answer to "should I abort?" was available in the first minute rather than after two hours.
+                          Hidden whenever the sweep's wings are healthy: a note that always fires says nothing.
+                          It names Cancel (which exists) and says what Cancel costs in the same sentence, because
+                          not knowing that is why the user sat through the two hours.  -->
+                    <TextBlock
+                        MaxWidth="520"
+                        Margin="0,6,0,0"
+                        HorizontalAlignment="Center"
+                        Text="{Binding SearchExposureAdvice, Mode=OneWay}"
+                        TextAlignment="Center"
+                        TextWrapping="Wrap"
+                        Visibility="{Binding HasSearchExposureAdvice, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                     <TextBlock
                         MaxWidth="520"
                         Margin="0,6,0,0"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -1019,6 +1019,23 @@
                             </Button>
                         </StackPanel>
 
+                        <!--  F32 — when this landing took the SHEDDING CORNER, say that another pass is likely to
+                              beat it. The mechanism F32 chased since wave 3 is real (the shedding corner is a
+                              greedy trap, not a rational trade), but wave 9's confirmation arm refuted the
+                              proposed FIX — a keep floor — on three pre-registered rules, and measured the
+                              alternative as strictly better: restarts recovered 228% of the floor's median gain.
+                              "Continue optimizing" IS a restart, it was always on screen, and nothing told the
+                              user when it was worth pressing. Hidden unless the landing actually shed and a round
+                              remains, so it cannot become noise.  -->
+                        <TextBlock
+                            MaxWidth="560"
+                            Margin="0,8,0,4"
+                            HorizontalAlignment="Left"
+                            FontStyle="Italic"
+                            Text="{Binding ContinueOptimizingAdviceText, Mode=OneWay}"
+                            TextWrapping="Wrap"
+                            Visibility="{Binding HasContinueOptimizingAdvice, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+
                         <!--  Changed parameters table  -->
                         <TextBlock
                             Margin="0,4,0,4"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -875,47 +875,6 @@
                                 Text="{Binding ExposureBodyText, Mode=OneWay}"
                                 TextWrapping="Wrap"
                                 Visibility="{Binding HasExposureBody, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
-                            <!--  The action: capture a fresh sweep at a longer exposure and re-optimize on it. The
-                                  WHOLE ROW is hidden (ShowCaptureNewSweep) whenever the MODE makes re-capturing
-                                  inapplicable — Replay, which has no rig to capture from, and "use current
-                                  settings", which has nothing to re-tune. Both are chosen on the Select Source step
-                                  and are fixed for the life of this Summary, so a button disabled by either would
-                                  sit dead for the whole run; the body copy above names the mode to switch to
-                                  instead. This is the branch the detection-binning block takes for use-current too.
-                                  Only TRANSIENT unavailability (disconnected camera/focuser, no save folder) leaves
-                                  the button visible and DISABLED via the command's CanExecute — there the control
-                                  can come back, so the copy that names it still has a referent.
-                                  The box is editable and LostFocus-bound, so THE BUTTON LABEL DELIBERATELY CARRIES
-                                  NO NUMBER: a numbered label goes stale the instant the user starts typing and then
-                                  contradicts the box beside it. Consequence in the label, value in the box — do not
-                                  "fix" this by interpolating the seconds into the button.  -->
-                            <StackPanel Margin="0,4,0,2" Orientation="Horizontal"
-                                        Visibility="{Binding ShowCaptureNewSweep, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
-                                <TextBlock
-                                    Width="200"
-                                    VerticalAlignment="Center"
-                                    Text="New sweep exposure"
-                                    ToolTip="{StaticResource SDOpt_CaptureNewSweep_Tooltip}" />
-                                <ninactrl:UnitTextBox
-                                    MinWidth="80"
-                                    HorizontalAlignment="Left"
-                                    VerticalAlignment="Center"
-                                    ToolTip="{StaticResource SDOpt_CaptureNewSweep_Tooltip}"
-                                    Unit="s">
-                                    <Binding Path="RecaptureExposureSeconds" UpdateSourceTrigger="LostFocus">
-                                        <Binding.ValidationRules>
-                                            <rules:GreaterThanZeroRule />
-                                        </Binding.ValidationRules>
-                                    </Binding>
-                                </ninactrl:UnitTextBox>
-                                <Button
-                                    Margin="8,0,0,0"
-                                    VerticalAlignment="Center"
-                                    Command="{Binding CaptureNewSweepCommand}"
-                                    ToolTip="{StaticResource SDOpt_CaptureNewSweep_Tooltip}">
-                                    <TextBlock Margin="12,6" Text="Capture a new sweep and optimize" />
-                                </Button>
-                            </StackPanel>
                         </StackPanel>
 
                         <!--  Auto-focus block: the recommended step size / offset steps PLUS the toggle that applies
@@ -951,6 +910,65 @@
                                 IsEnabled="{Binding CanApplyRecommendedStepSize}"
                                 Text="Apply these auto-focus settings to my profile when I click Accept"
                                 ToolTip="{StaticResource SDOpt_ApplyStepSize_Tooltip}" />
+                        </StackPanel>
+
+                        <!--  F51 — the re-run action: capture a fresh sweep AT THE RECOMMENDED SETTINGS and
+                              re-optimize on it. IT LIVES HERE, not in the Star signal block where it used to,
+                              for two reasons that cost a user two unwanted Accepts:
+                                * that block's visibility is HasLowStarSignal (Sensitivity <= 1.0), so on a
+                                  healthy-gate run with a step-size recommendation the button was hidden along
+                                  with a block that was about something else entirely; and
+                                * its own condition was IncreasesExposure, which is exactly what F19's saturation
+                                  makes false on a rich field — so the button disappeared precisely when the run
+                                  most needed re-running.
+                              Beside the step-size/offset rows is also where it BELONGS: those are the values the
+                              re-capture now carries (F51(b)), and the exposure row sits directly above it.
+                              ShowCaptureNewSweep still hides the WHOLE row whenever the MODE makes re-capturing
+                              inapplicable — Replay, which has no rig, and "use current settings", which has
+                              nothing to re-tune; both are fixed on Select Source for the life of the Summary, so
+                              a button disabled by either would sit dead all run. Only TRANSIENT unavailability
+                              (disconnected camera/focuser, no save folder) leaves it visible and DISABLED via the
+                              command's CanExecute, where the control can come back.
+                              RE-CAPTURING IS NOT ADOPTING: this writes nothing: Accept is still the only writer.
+                              The box is editable and LostFocus-bound, so THE BUTTON LABEL DELIBERATELY CARRIES NO
+                              NUMBER: a numbered label goes stale the instant the user starts typing and then
+                              contradicts the box beside it. Consequence in the label, value in the box — do not
+                              "fix" this by interpolating the seconds into the button.  -->
+                        <StackPanel
+                            Margin="0,0,0,8"
+                            Visibility="{Binding ShowCaptureNewSweep, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                            <TextBlock
+                                MaxWidth="560"
+                                Margin="0,0,0,4"
+                                HorizontalAlignment="Left"
+                                Text="{Binding CaptureNewSweepCarriesText, Mode=OneWay}"
+                                TextWrapping="Wrap" />
+                            <StackPanel Margin="0,2" Orientation="Horizontal">
+                                <TextBlock
+                                    Width="200"
+                                    VerticalAlignment="Center"
+                                    Text="New sweep exposure"
+                                    ToolTip="{StaticResource SDOpt_CaptureNewSweep_Tooltip}" />
+                                <ninactrl:UnitTextBox
+                                    MinWidth="80"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    ToolTip="{StaticResource SDOpt_CaptureNewSweep_Tooltip}"
+                                    Unit="s">
+                                    <Binding Path="RecaptureExposureSeconds" UpdateSourceTrigger="LostFocus">
+                                        <Binding.ValidationRules>
+                                            <rules:GreaterThanZeroRule />
+                                        </Binding.ValidationRules>
+                                    </Binding>
+                                </ninactrl:UnitTextBox>
+                                <Button
+                                    Margin="8,0,0,0"
+                                    VerticalAlignment="Center"
+                                    Command="{Binding CaptureNewSweepCommand}"
+                                    ToolTip="{StaticResource SDOpt_CaptureNewSweep_Tooltip}">
+                                    <TextBlock Margin="12,6" Text="Capture a new sweep and optimize" />
+                                </Button>
+                            </StackPanel>
                         </StackPanel>
 
                         <!--  Detection binning: a first-class recommendation, structurally parallel to the

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/ExposureRecommender.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/ExposureRecommender.cs
@@ -181,6 +181,45 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public double InertGateBound { get; set; } = double.NaN;
 
         /// <summary>
+        /// F19 — the fraction of CANDIDATES FORMED on the sweep's WING frames that the Sensitivity gate rejected:
+        /// <c>rejected / (rejected + accepted)</c> over the outer
+        /// <see cref="ExposureRecommender.WingFrameFraction"/> of the non-recovery frames, ordered by distance
+        /// from the fitted focus. <see cref="double.NaN"/> when the run cannot place its frames on that axis (no
+        /// fitted focus, no step size, or no per-frame focuser positions) — never 0, because "we could not look"
+        /// and "we looked and nothing was shedding" must not be the same number.
+        ///
+        /// <para><b>Why this quantity and not another.</b> Every accepted star's gate statistic strictly exceeds
+        /// <see cref="StarDetector.EffectiveSensitivityGate"/> — that is what
+        /// <see cref="StarDetector.InertSensitivityBound"/> proves — so ANY order statistic over accepted stars,
+        /// at any rank, on any subset of frames, is bounded below by that gate. When the optimizer lands a gate at
+        /// or above <see cref="ExposureRecommender.TargetSensitivity"/>, <see cref="ExposureIsNotTheLimit"/> is
+        /// therefore true BY CONSTRUCTION, whatever the sky contains. Measured: <c>D02_rich_135mm</c> lands its
+        /// effective gate at 16.7 / 50.0 / 34.3 / 10.0 / 14.0 across a 16x exposure ladder over which σ_focus
+        /// improves 48 %. <b>The REJECTED candidates are the only population in the run that is not floored by the
+        /// gate</b>, and they are exactly the stars a longer exposure could convert.</para>
+        ///
+        /// <para><b>Why the WING frames.</b> The fit's precision rests on the sweep's outer points; the near-focus
+        /// frames are the richest and dominate any median across frames. Aggregating over a wing SET (not a single
+        /// frame) answers this class's own objection to a worst-frame statistic — a passing cloud or a satellite
+        /// trail cannot carry the recommendation.</para>
+        /// </summary>
+        public double WingRejectedFraction { get; set; } = double.NaN;
+
+        /// <summary>
+        /// True when <see cref="WingRejectedFraction"/> is at or above
+        /// <see cref="ExposureRecommender.WingSheddingThreshold"/> and the gate is NOT provably inert — the
+        /// sweep's outer frames are forming candidates and losing them to the gate, which is the one signal in a
+        /// run that says a longer exposure has something to work with.
+        ///
+        /// <para><b>The F28 guard is load-bearing, not decorative.</b> An inert gate rejects nothing by
+        /// construction, so a zero rejection count there is empty rather than reassuring. <c>D16_esprit550_ha3</c>
+        /// lands <c>Sensitivity = 0</c> with an effective gate of 0.17–2.5 at every rung of its ladder, so without
+        /// this guard its zeros would read as "the wings are fine" for a reason that has nothing to do with its
+        /// wings.</para>
+        /// </summary>
+        public bool WingIsShedding { get; set; }
+
+        /// <summary>
         /// True when the run's Sensitivity gate sat at or below <see cref="InertGateBound"/> AND
         /// <see cref="GateRejectedCount"/> is 0 — the gate could not have rejected anything, so its zero rejection
         /// count is empty by construction and is NOT evidence that the star field is exhausted (F28). Always false
@@ -352,6 +391,40 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// withholds the detection-binning recommendation the same way.
         /// </summary>
         public const int MinFramesForRecommendation = 3;
+
+        /// <summary>
+        /// The outer fraction of a run's non-recovery frames, by distance from the fitted focus, that counts as
+        /// the WING for <see cref="ExposureRecommendation.WingRejectedFraction"/>. A third of a 9-point sweep is
+        /// its outermost 3 frames — one full offset step past the shoulder on a default sweep, which is where the
+        /// V-curve's slope is measured and where a defocused star is faintest per pixel.
+        ///
+        /// <para>A SET rather than the single outermost frame, which is what answers this class's own objection to
+        /// a worst-frame aggregation: one passing cloud, satellite trail or guiding bump cannot carry the
+        /// recommendation, because the fraction is pooled over the whole wing.</para>
+        /// </summary>
+        public const double WingFrameFraction = 1.0 / 3.0;
+
+        /// <summary>
+        /// The <see cref="ExposureRecommendation.WingRejectedFraction"/> at or above which the wings count as
+        /// SHEDDING. Measured on wave 7's exposure ladder, still on disk: <c>D02_rich_135mm</c> — which gains 48 %
+        /// of σ_focus from more exposure — reads 0.67 / 0.29 / 0.30 at the three rungs below its optimum and
+        /// exactly 0.00 at and above it, while <c>D16_esprit550_ha3</c>, whose σ_focus MINIMUM is at its derived
+        /// exposure, reads 0.00 at every rung but one (0.006). The gap between the two populations is two orders
+        /// of magnitude, so this threshold is not finely tuned and is not meant to be.
+        /// </summary>
+        public const double WingSheddingThreshold = 0.20;
+
+        /// <summary>
+        /// The factor to probe with when the wings are shedding. A PROBE, not a derivation, for the same reason
+        /// <see cref="StarCountProbeFactor"/> is: the run records HOW MANY candidates the gate rejected out there,
+        /// not what SNR they sat at, so there is nothing to derive a magnitude from. Fabricating one was measured
+        /// and rejected — a <c>(1/(1−f))²</c> form asked <b>1.25x</b> on <c>D16</c> at exactly the exposure where
+        /// its σ_focus is minimised, which is the control this whole statistic has to pass.
+        ///
+        /// <para>Stays inside <see cref="MaxExposureFactor"/> so the user can repeat it before the run-relative cap
+        /// binds — the converge-over-runs shape the rest of this class already uses.</para>
+        /// </summary>
+        public const double WingProbeFactor = 2.0;
 
         /// <summary>True when <paramref name="sensitivity"/> is at or below <see cref="SensitivityFloorThreshold"/> — the search-floor band described there, not merely bit-exact zero.</summary>
         public static bool SensitivityIsAtFloor(double sensitivity) => sensitivity <= SensitivityFloorThreshold;
@@ -570,7 +643,30 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // own stopping rule — rather than to a verdict of exhaustion nothing in the run supports.
             var starCountIsTheLimit = signalIsSufficient && everyFrameShort && (gateIsHoldingStarsBack || gateIsProvablyInert);
             var starFieldIsExhausted = signalIsSufficient && everyFrameShort && !gateIsHoldingStarsBack && !gateIsProvablyInert;
-            var exposureIsNotTheLimit = signalIsSufficient && !everyFrameShort;
+
+            // F19 — THE WING TEST. Everything above is computed over ACCEPTED stars, and acceptance floors every
+            // one of them at StarDetector.EffectiveSensitivityGate; so when the optimizer lands a gate at or above
+            // TargetSensitivity, `signalIsSufficient` is true BY CONSTRUCTION and no rank, on no subset of frames,
+            // could ever say otherwise. That is why widening the TRIGGER (wave 8, rule R5) and changing NTarget
+            // (wave 7) were both refuted: neither touches the population being measured.
+            //
+            // The candidates the gate REJECTED on the wing frames are the only population in the run that is not
+            // floored by the gate, and they are exactly the stars a longer exposure can convert. See
+            // ExposureRecommendation.WingRejectedFraction.
+            var wingRejectedFraction = WingRejectedFractionOf(metrics, isRecovery);
+            // The `!gateIsProvablyInert` conjunct is REDUNDANT BY CONSTRUCTION and is kept as an invariant, not as
+            // a working guard -- found by neutralizing it and watching no test fail. A wing fraction at or above
+            // the threshold requires a non-zero entry in the SAME FrameLowSensitivityCounts array gateRejectedCount
+            // sums, so gateIsHoldingStarsBack is already true and gateIsProvablyInert already false. It stays
+            // because it states the F28 invariant at the point that depends on it: if the fraction ever stops
+            // being computed from that array, this is the line that must still hold.
+            var wingIsShedding = wingRejectedFraction >= WingSheddingThreshold && !gateIsProvablyInert;
+
+            // A shedding wing means exposure IS the limit, whatever the accepted stars say -- so this verdict has
+            // to yield to it, or the copy would report "star brightness is not the problem" directly above a row
+            // asking for more exposure, and StarSignalCopy's F49 gate remedy would fire on a run whose actual
+            // remedy is the exposure.
+            var exposureIsNotTheLimit = signalIsSufficient && !everyFrameShort && !wingIsShedding;
 
             // Sky-limited scaling answers the S/N question only. Under starCountIsTheLimit the ratio is <= 1, so it
             // would ask for a SHORTER exposure — backwards for a run whose problem is too few stars. That state
@@ -580,6 +676,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // never-shorter floor then collapses onto the current exposure -- so IncreasesExposure is false and no
             // caller can offer a longer exposure for a run that has demonstrably nothing to gain from one.
             var rawFactor = starCountIsTheLimit ? StarCountProbeFactor : ratio * ratio;
+            // The wing probe WIDENS, never replaces: max(existing, probe). That is what keeps a run the accepted-star
+            // statistic already serves from regressing -- D16_esprit550_ha3 at half its derived exposure correctly
+            // asks 3x from S_now alone, and its gate is inert out there so the wing test is silent; the probe alone
+            // would have lost that case. Both halves are load-bearing, and the pre-registered acceptance rule
+            // (wave-9 design SS3.2) fails each of them ALONE and passes only the max.
+            if (wingIsShedding) {
+                rawFactor = Math.Max(rawFactor, WingProbeFactor);
+            }
             var rawSeconds = currentExposureSeconds * rawFactor;
 
             var factorCap = currentExposureSeconds * MaxExposureFactor;
@@ -621,8 +725,63 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 GateRejectedCount = gateRejectedCount,
                 FlatRejectedCount = flatRejectedCount,
                 InertGateBound = inertGateBound,
-                GateIsProvablyInert = gateIsProvablyInert
+                GateIsProvablyInert = gateIsProvablyInert,
+                WingRejectedFraction = wingRejectedFraction,
+                WingIsShedding = wingIsShedding
             };
+        }
+
+        /// <summary>
+        /// F19 — the fraction of candidates FORMED on the sweep's wing frames that the Sensitivity gate rejected.
+        /// See <see cref="ExposureRecommendation.WingRejectedFraction"/> for why this population and not another.
+        ///
+        /// <para>Returns <see cref="double.NaN"/> — never 0 — when the run cannot be placed on the wing axis: a
+        /// non-finite <see cref="RunEvaluationMetrics.BestFocusPosition"/> (no usable fit), a non-positive
+        /// <see cref="RunEvaluationMetrics.StepSize"/>, absent focuser positions, or absent per-frame rejection
+        /// counts. "We could not look" and "we looked and nothing was shedding" must not be the same number,
+        /// because the caller turns one of them into an instruction. Every one of those absences is the DEFAULT for
+        /// a caller that does not populate the optional per-frame data, so this is inert unless the data supports
+        /// it.</para>
+        ///
+        /// <para>Recovery frames are excluded, matching <see cref="Recommend"/>'s own per-frame loop: they are
+        /// by-design far from focus, so including them would put the deliberately-starved frames in the population
+        /// whose starvation is being measured.</para>
+        /// </summary>
+        internal static double WingRejectedFractionOf(RunEvaluationMetrics metrics, IReadOnlyList<bool> isRecovery) {
+            var positions = metrics?.FrameFocuserPositions;
+            var lowSens = metrics?.FrameLowSensitivityCounts;
+            var counts = metrics?.FrameStarCounts;
+            if (positions == null || lowSens == null || counts == null
+                || !double.IsFinite(metrics.BestFocusPosition) || !(metrics.StepSize > 0.0)) {
+                return double.NaN;
+            }
+
+            // Non-recovery frames that carry all three of (position, rejection count, accepted count), keyed by
+            // |offset from the fitted focus|. A frame missing any of them cannot be placed or scored and is left
+            // out rather than defaulted to zero.
+            var usable = new List<(double Offset, int Rejected, int Accepted)>(positions.Count);
+            for (var i = 0; i < positions.Count; i++) {
+                if (IsRecoveryFrame(isRecovery, i) || i >= lowSens.Count || i >= counts.Count) {
+                    continue;
+                }
+                usable.Add((Math.Abs(positions[i] - metrics.BestFocusPosition), lowSens[i], counts[i]));
+            }
+            if (usable.Count == 0) {
+                return double.NaN;
+            }
+
+            usable.Sort((a, b) => b.Offset.CompareTo(a.Offset)); // farthest from focus first
+            // At least one frame, so a short sweep still answers rather than silently declining to.
+            var wingCount = Math.Max(1, (int)Math.Round(usable.Count * WingFrameFraction));
+            long rejected = 0, accepted = 0;
+            for (var i = 0; i < wingCount; i++) {
+                rejected += usable[i].Rejected;
+                accepted += usable[i].Accepted;
+            }
+            var formed = rejected + accepted;
+            // No candidates formed at all out here is not a shedding wing -- it is a frame with nothing on it, which
+            // is StarCountIsTheLimit's question, not this one.
+            return formed > 0 ? (double)rejected / formed : 0.0;
         }
 
         private static ExposureRecommendation NoRecommendation(double currentExposureSeconds, int usableFrameCount, int shortFrameCount) {
@@ -642,7 +801,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 GateRejectedCount = 0,
                 FlatRejectedCount = 0,
                 InertGateBound = double.NaN,
-                GateIsProvablyInert = false
+                GateIsProvablyInert = false,
+                // NaN, not 0: this run produced no recommendation at all, so it did not look at its wings either,
+                // and a consumer must not read a confident zero out of that.
+                WingRejectedFraction = double.NaN,
+                WingIsShedding = false
             };
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -2199,20 +2199,15 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     return string.Empty;
                 }
                 var s = SelectedSummary;
-                if (s == null || !s.StepSizeOrOffsetChanged) {
+                if (s == null || s.RecommendedStepSize == s.CurrentStepSize) {
                     // Exposure-only: the box below already carries the number, and nothing else changes.
-                    return "The new sweep uses the exposure below; the step size and offset steps stay as they are. "
+                    return "The new sweep uses the exposure below; the step size stays as it is. "
                         + "Nothing is written to your profile — Accept still does that.";
                 }
-                var parts = new List<string>(2);
-                if (s.RecommendedStepSize != s.CurrentStepSize) {
-                    parts.Add($"step size {s.CurrentStepSize} → {s.RecommendedStepSize}");
-                }
-                if (s.RecommendedOffsetSteps != s.CurrentOffsetSteps) {
-                    parts.Add($"offset steps {s.CurrentOffsetSteps} → {s.RecommendedOffsetSteps}");
-                }
-                return $"The new sweep uses the recommended {string.Join(" and ", parts)}, at the exposure below. "
-                    + "Nothing is written to your profile — Accept still does that.";
+                // The STEP only. The recommended offset is deliberately not carried (see ApplyRecaptureGeometry),
+                // so promising it here would describe a sweep the re-capture does not take.
+                return $"The new sweep uses the recommended step size {s.CurrentStepSize} → {s.RecommendedStepSize}, "
+                    + "at the exposure below. Nothing is written to your profile — Accept still does that.";
             }
         }
 
@@ -2323,10 +2318,16 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         ///
         /// <para>Set to the recommendation, never to the profile: a re-capture that silently used the old geometry
         /// would look like the fix and reproduce the same sweep.</para>
+        ///
+        /// <para><b>The STEP SIZE only — the offset steps are deliberately NOT carried, and a test caught the
+        /// first version that did.</b> <see cref="StepSizeRecommender"/> derives its step from the desired
+        /// half-width over the CURRENT points-per-side, so the recommended step already expresses the whole
+        /// geometry change at the existing offset; applying the recommended offset on top would widen the sweep
+        /// twice. It also collides with <see cref="ApplyFocusRecovery"/>, which owns that axis and adds to
+        /// whatever offset it is handed — the failing assertion was a re-capture widening to 5 where the recovery
+        /// snapshot alone should have given 1.</para>
         /// </summary>
         private int recaptureStepSize;
-
-        private int recaptureOffsetSteps;
 
         private bool LastRunWasLive {
             get => lastRunWasLive;
@@ -2954,7 +2955,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // BEFORE ApplyFocusRecovery so recovery still widens whatever offset this leaves behind, exactly as it
             // widens the profile's on an ordinary Start. Both fields are 0 on a normal Live Start, so that path is
             // byte-identical. Cleared by the caller after the sweep so a later Start cannot inherit them.
-            ApplyRecaptureGeometry(options, recaptureStepSize, recaptureOffsetSteps);
+            ApplyRecaptureGeometry(options, recaptureStepSize);
 
             // Widen the captured sweep by the snapshotted recovery steps (never the live box) so the widened capture and
             // the tagged evaluation use the identical N, and scale the per-run timeout so the longer sweep doesn't time
@@ -2998,21 +2999,25 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// <see cref="AutoFocusEngineOptions.AutoFocusStepSize"/> alone because recovery widens rather than
         /// refines — this is precisely a step-size change, because that is the recommendation being carried.</para>
         ///
-        /// <para>The per-run timeout is deliberately NOT scaled here. <see cref="ApplyFocusRecovery"/> scales it by
-        /// the POINT-COUNT ratio, and this method changes the point count only through
-        /// <paramref name="offsetSteps"/> — which the recommender moves by at most a step or two, and which the
-        /// recovery call immediately after re-scales from whatever offset this leaves. Scaling here as well would
-        /// double-count that same widening.</para></summary>
-        internal static void ApplyRecaptureGeometry(AutoFocusEngineOptions options, int stepSize, int offsetSteps) {
-            if (options == null) {
+        /// <para><b>It touches the step size and NOTHING else</b> — in particular not
+        /// <see cref="AutoFocusEngineOptions.AutoFocusInitialOffsetSteps"/>, which an earlier version of this
+        /// method did set from the recommendation. Two independent reasons, and a test caught it:
+        /// <list type="number">
+        /// <item><see cref="StepSizeRecommender"/> derives its step from the desired half-width over the CURRENT
+        /// points-per-side, so the recommended STEP already expresses the whole geometry change at the existing
+        /// offset. Applying the recommended offset as well widens the sweep twice.</item>
+        /// <item><see cref="ApplyFocusRecovery"/> owns the offset axis and ADDS to whatever it is handed, so the
+        /// two compose in a way no page describes —
+        /// <c>CaptureNewSweep_UsesTheSnapshottedRecoverySteps_NotTheLiveBox</c> failed with a re-capture widened
+        /// to 5 where the recovery snapshot alone should have given 1.</item>
+        /// </list>
+        /// The per-run timeout therefore needs no scaling here either: the point count does not change, and
+        /// <see cref="ApplyFocusRecovery"/> still scales it for its own widening.</para></summary>
+        internal static void ApplyRecaptureGeometry(AutoFocusEngineOptions options, int stepSize) {
+            if (options == null || stepSize <= 0) {
                 return;
             }
-            if (stepSize > 0) {
-                options.AutoFocusStepSize = stepSize;
-            }
-            if (offsetSteps > 0) {
-                options.AutoFocusInitialOffsetSteps = offsetSteps;
-            }
+            options.AutoFocusStepSize = stepSize;
         }
 
         internal static void ApplyFocusRecovery(AutoFocusEngineOptions options, int recoverySteps) {
@@ -4715,13 +4720,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // this is a per-run override on the sweep about to be taken, which is what makes re-capturing
             // independent of Accept.
             var geometry = SelectedSummary;
-            if (geometry != null && geometry.StepSizeOrOffsetChanged) {
-                recaptureStepSize = geometry.RecommendedStepSize;
-                recaptureOffsetSteps = geometry.RecommendedOffsetSteps;
-            } else {
-                recaptureStepSize = 0;
-                recaptureOffsetSteps = 0;
-            }
+            recaptureStepSize = geometry != null && geometry.RecommendedStepSize != geometry.CurrentStepSize
+                ? geometry.RecommendedStepSize
+                : 0;
 
             ErrorMessage = null;
             SetProgress(null, 0, 0);
@@ -4830,7 +4831,6 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 // cleared on EVERY exit path (success as well as failure). Leaving it set would silently apply
                 // this run's recommended step size to a later ordinary Start, which no page ever offered.
                 recaptureStepSize = 0;
-                recaptureOffsetSteps = 0;
                 DisposeLoadedRuns(captured);
                 IsBusy = false;
                 Interlocked.Exchange(ref running, 0);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -3411,12 +3411,95 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // constants are then handed to the optimizer (OptimizeAsync), so the baseline J and BestJ are comparable.
             var currentSigma = sigmaCount > 0 ? sigmaSum / sigmaCount : double.NaN;
             currentBaselineSigma = currentSigma;
+            // F52(c) — the abort/re-expose advice, computed HERE and from the SEED. This runs once, before the
+            // search starts, so a user asking "should I abort?" two hours in gets an answer that was available in
+            // the first minute. That is the whole complaint: the field session spent over two hours in one
+            // optimization and neither the log nor the UI could answer it.
+            UpdateSearchExposureAdvice(metrics, baseline);
             objectiveConstants = OptimizeForAberrationInspection
                 ? ObjectiveConstants.ForAberrationInspection(currentSigma)
                 : new ObjectiveConstants();
 
             var perRunJ = metrics.Select(m => OptimizationObjective.JRun(m, objectiveConstants)).ToList();
             return OptimizationObjective.JTotal(perRunJ, objectiveConstants);
+        }
+
+        private string searchExposureAdvice = string.Empty;
+
+        /// <summary>
+        /// F52(c) — the one sentence under the progress bar that says whether this search is worth waiting for, or
+        /// whether the frames it is searching over are the problem. Empty (and the row hidden) when the sweep's
+        /// wings are healthy, because advice that always fires says nothing.
+        ///
+        /// <para><b>Why this could not ship in wave 8, and why it can now.</b> Wave 8 shipped (a) and (b) — the
+        /// rate, the bound on what is left, which knob made the search expensive, and what Cancel costs — and
+        /// deliberately withheld (c), because advice derived from the exposure statistic of the day *"would tell
+        /// precisely the users who most need a longer exposure that theirs is already fine"*: on the reporting
+        /// user's own rig that statistic read <b>S/N 1438.6 against a target of 10</b>. The separation wave 8 drew
+        /// is kept exactly: <b>facts about COST need no new statistic and are already shown; ADVICE needs
+        /// one</b>. It is now built on <see cref="ExposureRecommendation.WingIsShedding"/>, which measures the
+        /// population the gate did NOT admit.</para>
+        ///
+        /// <para><b>It names Cancel, which exists</b> — the house rule at
+        /// <see cref="ShowOptimizeAgainAtRecommendedBinning"/>: never describe an action whose control is hidden.
+        /// And it states what Cancel costs in the same breath, because the reason the user sat through two hours
+        /// was not knowing.</para>
+        ///
+        /// <para>It does NOT quote a recommended exposure. The seed evaluation supports a DIRECTION (the wing probe
+        /// is a probe precisely because the rejected candidates' SNRs are not recorded), and the Summary's own
+        /// exposure row is where a number belongs once the run finishes.</para>
+        /// </summary>
+        public string SearchExposureAdvice {
+            get => searchExposureAdvice;
+            private set {
+                if (searchExposureAdvice != value) {
+                    searchExposureAdvice = value;
+                    RaisePropertyChanged();
+                    RaisePropertyChanged(nameof(HasSearchExposureAdvice));
+                }
+            }
+        }
+
+        public bool HasSearchExposureAdvice => !string.IsNullOrEmpty(SearchExposureAdvice);
+
+        /// <summary>
+        /// Builds <see cref="SearchExposureAdvice"/> from the SEED evaluation's metrics. Internal + static so the
+        /// copy is testable without a rig; the instance wrapper below just assigns it.
+        ///
+        /// <para>Takes the WORST wing fraction across the loaded runs rather than an average: a multi-run
+        /// optimization lands ONE settings bundle on all of them, so a single starved run is enough to make the
+        /// search's answer untrustworthy, and averaging would hide exactly that.</para>
+        /// </summary>
+        internal static string BuildSearchExposureAdvice(
+                IReadOnlyList<RunEvaluationMetrics> seedMetrics, StarDetectorParams seedParams, double currentExposureSeconds) {
+            if (seedMetrics == null || seedMetrics.Count == 0) {
+                return string.Empty;
+            }
+            var worstFraction = double.NaN;
+            foreach (var m in seedMetrics) {
+                var rec = ExposureRecommender.Recommend(m, new ObjectiveConstants(), currentExposureSeconds, seedParams);
+                if (!rec.WingIsShedding) {
+                    continue;
+                }
+                if (!double.IsFinite(worstFraction) || rec.WingRejectedFraction > worstFraction) {
+                    worstFraction = rec.WingRejectedFraction;
+                }
+            }
+            if (!double.IsFinite(worstFraction)) {
+                return string.Empty;
+            }
+            return $"The outer frames of this sweep are losing {worstFraction:P0} of the stars they find to the "
+                + "brightness gate, so a longer exposure is likely to help this focus more than a longer search will. "
+                + "Cancel stops the search only: nothing is written to your profile, and the frames already captured "
+                + "stay on disk.";
+        }
+
+        private void UpdateSearchExposureAdvice(IReadOnlyList<RunEvaluationMetrics> seedMetrics, StarDetectorParams seedParams) {
+            // The exposure the frames were actually shot with. Live runs know it exactly; a replay falls back to
+            // the box, and a non-positive value makes ExposureRecommender decline to answer at all, which is the
+            // right outcome -- the advice is about exposure, so an unknown exposure has nothing to say.
+            var exposure = capturedLiveExposureSeconds > 0.0 ? capturedLiveExposureSeconds : LiveExposureSeconds;
+            SearchExposureAdvice = BuildSearchExposureAdvice(seedMetrics, seedParams, exposure);
         }
 
         /// <summary>Runs the pure optimizer off the UI thread; progress posts back via <see cref="IProgress{T}"/>.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -2144,12 +2144,77 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// hidden — the reverse). Both buttons are visible in that state and the paragraph says which to use first,
         /// so the user keeps the choice; hiding the capture action instead would silently overrule a user who has
         /// reason to re-expose before touching the factor.</para>
+        ///
+        /// <para><b>F51 — this is no longer gated on the Star signal block, nor on the exposure alone.</b> It used
+        /// to read <c>HasExposureBlock &amp;&amp; … &amp;&amp; IncreasesExposure</c>, which hid the re-run button in
+        /// exactly the two situations that most need it:
+        /// <list type="number">
+        /// <item><b>When F19 misfires.</b> A field session's run 2 had the gate floored at
+        /// 0.000, was Live, was in Optimize mode — and <c>IncreasesExposure</c> was false because the exposure row
+        /// read <i>"2 s (unchanged; measured star S/N 1438.6; target 10)"</i>. F19's saturation does not merely
+        /// silence a RECOMMENDATION; it removed the BUTTON.</item>
+        /// <item><b>When only the STEP SIZE wants to change.</b> <c>HasExposureBlock</c> is
+        /// <c>HasLowStarSignal</c> — Sensitivity ≤ 1.0 — so on a healthy-gate run with a step recommendation the
+        /// whole block, button included, was hidden. That was runs 1, 3 and 4 of the same session (100 → 214,
+        /// 459 → 474, 459 → 482), none of which had any re-run affordance at all.</item>
+        /// </list>
+        /// The user's actual cost: they had to <b>Accept a landing they did not want, twice</b>, to re-run with a
+        /// wider sweep — and run 2's Accept is how <c>Sensitivity 0.000</c> reached their profile in the first
+        /// place. <b>Re-capturing is not adopting</b>, and it must not require Accept to reach.</para>
+        ///
+        /// <para>So the condition is now "this run was Live, the mode can re-tune, and SOMETHING material is
+        /// recommended" — exposure or step geometry. <see cref="OptimizationSummary.StepSizeOrOffsetChanged"/> is
+        /// the same predicate the Apply toggle is enabled by, so the button appears exactly when there is
+        /// something for the re-capture to carry.</para>
+        ///
+        /// <para>The house rule (never describe an action whose control is hidden) is preserved in BOTH
+        /// directions: the row now lives in the Auto-focus block rather than inside the Star signal block, so it
+        /// no longer disappears with a block whose visibility is about something else, and
+        /// <see cref="StarSignalCopy"/>'s Live sentence that names it still has its referent on the same page.</para>
         /// </summary>
         public bool ShowCaptureNewSweep =>
-            HasExposureBlock
-            && lastRunWasLive
+            lastRunWasLive
             && !IsUseCurrentMode
-            && (SelectedSummary?.ExposureAdvice?.IncreasesExposure ?? false);
+            && ((SelectedSummary?.ExposureAdvice?.IncreasesExposure ?? false)
+                || (SelectedSummary?.StepSizeOrOffsetChanged ?? false));
+
+        /// <summary>
+        /// F51(b) — the one sentence above the re-capture row saying WHAT the next sweep will be taken at, so the
+        /// user is not left to infer it from a button label.
+        ///
+        /// <para><b>Why this had to be said rather than assumed.</b> The re-capture used to override the exposure
+        /// and nothing else, taking the step size from the profile — so on the field session it silently re-shot
+        /// the SAME too-narrow sweep the step recommender was asking to widen, run after run. F51's next step
+        /// offered two acceptable answers, "carry the step size" or "say plainly that it will not"; this carries
+        /// it AND says so, because a sweep geometry the user cannot see is how that defect stayed invisible.</para>
+        ///
+        /// <para>Empty when the row is hidden, so the bound TextBlock never renders a stray line. It quotes the
+        /// step size and offset but NOT the exposure — the editable box directly below is the authority on that,
+        /// and a quoted number would contradict it the moment the user types (the same rule that keeps the button
+        /// label free of seconds).</para>
+        /// </summary>
+        public string CaptureNewSweepCarriesText {
+            get {
+                if (!ShowCaptureNewSweep) {
+                    return string.Empty;
+                }
+                var s = SelectedSummary;
+                if (s == null || !s.StepSizeOrOffsetChanged) {
+                    // Exposure-only: the box below already carries the number, and nothing else changes.
+                    return "The new sweep uses the exposure below; the step size and offset steps stay as they are. "
+                        + "Nothing is written to your profile — Accept still does that.";
+                }
+                var parts = new List<string>(2);
+                if (s.RecommendedStepSize != s.CurrentStepSize) {
+                    parts.Add($"step size {s.CurrentStepSize} → {s.RecommendedStepSize}");
+                }
+                if (s.RecommendedOffsetSteps != s.CurrentOffsetSteps) {
+                    parts.Add($"offset steps {s.CurrentOffsetSteps} → {s.RecommendedOffsetSteps}");
+                }
+                return $"The new sweep uses the recommended {string.Join(" and ", parts)}, at the exposure below. "
+                    + "Nothing is written to your profile — Accept still does that.";
+            }
+        }
 
         /// <summary>
         /// Whether the capture can actually proceed. It drives a real auto-focus sweep, so it needs an engine, a
@@ -2211,6 +2276,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // that motivates both is documented on OptimizeAgainAtRecommendedBinningCommand's notification there.
             RaisePropertyChanged(nameof(ShowCaptureNewSweep));
             RaisePropertyChanged(nameof(CanCaptureNewSweep));
+            // F51 — the row's own sentence follows its visibility, and the visibility now also turns on the STEP
+            // recommendation, so both are re-raised wherever the selected variant settles.
+            RaisePropertyChanged(nameof(CaptureNewSweepCarriesText));
             CaptureNewSweepCommand?.NotifyCanExecuteChanged();
         }
 
@@ -2239,6 +2307,26 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         // RunEvaluationData.RecoveryStepsPerSide (acquire AND the re-optimize/feedback reload loop) so both optimize
         // passes tag the same outer frames as recovery even if the UI box is later edited. 0 for Replay => inert.
         private int capturedRecoveryStepsPerSide;
+
+        /// <summary>
+        /// F51(b) — the sweep GEOMETRY a "Capture a new sweep and optimize" re-capture should use, set by
+        /// <see cref="CaptureNewSweepAsync"/> from the selected summary and consumed once by
+        /// <see cref="RunLiveAttemptAsync"/>. 0 ⇒ no override, which is what an ordinary Live Start leaves it at,
+        /// so that path stays byte-identical.
+        ///
+        /// <para><b>Why this exists.</b> The re-capture used to override ONLY
+        /// <see cref="AutoFocusEngineOptions.OverrideAutoFocusExposureTime"/> and take everything else from
+        /// <c>autoFocusEngine.GetOptions()</c> — i.e. the PROFILE's step size. So the one recommendation that was
+        /// asking to change on every run of the field session (100 → 214 → 459 → 474 → 482) was the one the
+        /// re-capture could not carry, and the ONLY way to re-run at the recommended step was to Accept the
+        /// landing first. That Accept is how <c>Sensitivity 0.000</c> reached the user's profile.</para>
+        ///
+        /// <para>Set to the recommendation, never to the profile: a re-capture that silently used the old geometry
+        /// would look like the fix and reproduce the same sweep.</para>
+        /// </summary>
+        private int recaptureStepSize;
+
+        private int recaptureOffsetSteps;
 
         private bool LastRunWasLive {
             get => lastRunWasLive;
@@ -2862,6 +2950,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 options.UseExactImagingFilter = true;
             }
 
+            // F51(b) — a RE-CAPTURE also carries the recommended sweep GEOMETRY, not just the exposure. Applied
+            // BEFORE ApplyFocusRecovery so recovery still widens whatever offset this leaves behind, exactly as it
+            // widens the profile's on an ordinary Start. Both fields are 0 on a normal Live Start, so that path is
+            // byte-identical. Cleared by the caller after the sweep so a later Start cannot inherit them.
+            ApplyRecaptureGeometry(options, recaptureStepSize, recaptureOffsetSteps);
+
             // Widen the captured sweep by the snapshotted recovery steps (never the live box) so the widened capture and
             // the tagged evaluation use the identical N, and scale the per-run timeout so the longer sweep doesn't time
             // out. No-op at N <= 0, keeping the Live path byte-identical when recovery is off.
@@ -2894,6 +2988,33 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// out. Never touches the persisted profile offset or timeout seconds. A no-op at <paramref name="recoverySteps"/>
         /// &lt;= 0 (or null options), so the Live path stays byte-identical when recovery is off. Internal + static so the
         /// widening is directly unit-testable.</summary>
+        /// <summary>F51(b) — applies a re-capture's recommended sweep geometry to <paramref name="options"/>: the
+        /// AF step size and the offset steps, each only when strictly positive. Internal + static so the override
+        /// is directly unit-testable without a rig.
+        ///
+        /// <para>A no-op at 0 (or null options), which is what an ordinary Live Start passes, so the normal
+        /// capture path is byte-identical to before this existed. Unlike
+        /// <see cref="ApplyFocusRecovery"/> — which widens the RANGE and deliberately leaves
+        /// <see cref="AutoFocusEngineOptions.AutoFocusStepSize"/> alone because recovery widens rather than
+        /// refines — this is precisely a step-size change, because that is the recommendation being carried.</para>
+        ///
+        /// <para>The per-run timeout is deliberately NOT scaled here. <see cref="ApplyFocusRecovery"/> scales it by
+        /// the POINT-COUNT ratio, and this method changes the point count only through
+        /// <paramref name="offsetSteps"/> — which the recommender moves by at most a step or two, and which the
+        /// recovery call immediately after re-scales from whatever offset this leaves. Scaling here as well would
+        /// double-count that same widening.</para></summary>
+        internal static void ApplyRecaptureGeometry(AutoFocusEngineOptions options, int stepSize, int offsetSteps) {
+            if (options == null) {
+                return;
+            }
+            if (stepSize > 0) {
+                options.AutoFocusStepSize = stepSize;
+            }
+            if (offsetSteps > 0) {
+                options.AutoFocusInitialOffsetSteps = offsetSteps;
+            }
+        }
+
         internal static void ApplyFocusRecovery(AutoFocusEngineOptions options, int recoverySteps) {
             if (options == null || recoverySteps <= 0) {
                 return; // N<=0 keeps the Live path byte-identical
@@ -4504,6 +4625,20 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 return;
             }
             LiveExposureSeconds = target;
+            // F51(b) — carry the recommended sweep GEOMETRY too, not only the exposure. Read from the SELECTED
+            // summary (the variant whose row the user is looking at), and only when it actually differs from the
+            // profile: StepSizeOrOffsetChanged is the same predicate the Apply toggle is enabled by, so the
+            // re-capture carries exactly what the page says is recommended. Nothing is written to the profile —
+            // this is a per-run override on the sweep about to be taken, which is what makes re-capturing
+            // independent of Accept.
+            var geometry = SelectedSummary;
+            if (geometry != null && geometry.StepSizeOrOffsetChanged) {
+                recaptureStepSize = geometry.RecommendedStepSize;
+                recaptureOffsetSteps = geometry.RecommendedOffsetSteps;
+            } else {
+                recaptureStepSize = 0;
+                recaptureOffsetSteps = 0;
+            }
 
             ErrorMessage = null;
             SetProgress(null, 0, 0);
@@ -4608,6 +4743,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     capturedLiveExposureSeconds = previousCapturedExposure;
                     RaiseExposureRowChanged();
                 }
+                // F51(b) — the geometry override is consumed by exactly the sweep this command started, so it is
+                // cleared on EVERY exit path (success as well as failure). Leaving it set would silently apply
+                // this run's recommended step size to a later ordinary Start, which no page ever offered.
+                recaptureStepSize = 0;
+                recaptureOffsetSteps = 0;
                 DisposeLoadedRuns(captured);
                 IsBusy = false;
                 Interlocked.Exchange(ref running, 0);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -844,6 +844,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     ContinueOptimizationCommand.NotifyCanExecuteChanged();
                     RaisePropertyChanged(nameof(CanContinueOptimization));
                     RaisePropertyChanged(nameof(RoundsSummaryText));
+            RaisePropertyChanged(nameof(ContinueOptimizingAdviceText));
+            RaisePropertyChanged(nameof(HasContinueOptimizingAdvice));
+                    // F32 — the restart advice turns on the SAME two things RoundsSummaryText does (the selected
+                    // variant and how many rounds remain), so it is re-raised wherever that is.
+                    RaisePropertyChanged(nameof(ContinueOptimizingAdviceText));
+                    RaisePropertyChanged(nameof(HasContinueOptimizingAdvice));
                     RaisePropertyChanged(nameof(HasRoundsSummary));
                 }
             }
@@ -1613,6 +1619,59 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// <summary>True while another "Continue optimizing" pass is allowed (an Optimized variant exists, the cap
         /// hasn't been reached, and nothing is running). Drives the Continue button's enabled state.</summary>
         public bool CanContinueOptimization => !IsBusy && IsSummary && HasOptimized && RoundsCompleted < MaxOptimizationRounds;
+
+        /// <summary>
+        /// F32 — the keep fraction below which a landing counts as having taken the SHEDDING CORNER: it kept less
+        /// than half the stars its own seed did.
+        ///
+        /// <para>This is wave 5's recommended keep floor (φ = 0.50) reused as a DIAGNOSTIC rather than as a
+        /// constraint, which is the one role wave 9's confirmation arm supports. As a constraint it failed three
+        /// pre-registered rules — most sharply R1(c), where it degraded σ_focus by a factor of 2000 on
+        /// <c>vsn07</c>. As a description of "this search fell into the greedy trap", the same threshold is
+        /// exactly what wave 5 selected it for.</para>
+        /// </summary>
+        internal const double SheddingLandingKeepFraction = 0.5;
+
+        /// <summary>
+        /// F32 — one sentence telling the user that another optimization pass is likely to IMPROVE this result,
+        /// shown only when the landing took the shedding corner and another pass is actually allowed.
+        ///
+        /// <para><b>Why this exists, and why it is a note rather than a constraint.</b> F32 found that the
+        /// optimizer's shedding landings are substantially a GREEDY TRAP rather than a rational trade: a
+        /// constrained search can beat the unconstrained one, which a true global maximum could not allow. Wave 5
+        /// proposed fixing that with a feasibility floor (<c>MinDetectionKeepFraction</c>). Wave 9's confirmation
+        /// arm — both full banks, sequential, both controls passing — <b>refuted the floor as a default</b> and
+        /// found the alternative strictly better: over the binding runs, simply RESTARTING the search recovered
+        /// <b>228 %</b> of the floor's median gain, where wave 6 had measured only 0–36 % on a 7-run subset.</para>
+        ///
+        /// <para>So the mechanism ships as the affordance the user already has. <b>"Continue optimizing" is a
+        /// restart</b> — each pass re-seeds from the prior best with a fresh curated set, resetting the pattern
+        /// search's stride — and it was always on screen; nothing told the user when it was worth pressing. This
+        /// note is that missing half, and it names a control that is present and enabled
+        /// (<see cref="CanContinueOptimization"/>), per the house rule at
+        /// <see cref="ShowOptimizeAgainAtRecommendedBinning"/>.</para>
+        ///
+        /// <para>It promises a DIRECTION, never a magnitude: restarts helped on most binding runs but not all, and
+        /// the gain is a fourth-decimal `J` move whose value is in the star list rather than the objective. Empty
+        /// whenever the landing did not shed, no round remains, or no keep fraction was measured — a note that
+        /// always fires says nothing.</para>
+        /// </summary>
+        public string ContinueOptimizingAdviceText {
+            get {
+                if (!CanContinueOptimization || selectedVariant != OptimizationVariant.Optimized) {
+                    return string.Empty;
+                }
+                var keep = optimizedResult?.LandingKeepFraction ?? double.NaN;
+                if (!double.IsFinite(keep) || keep >= SheddingLandingKeepFraction) {
+                    return string.Empty;
+                }
+                return $"This result keeps only {keep:P0} of the stars your current settings detect. Searches that "
+                    + "shed stars like this often stop short of the best result rather than at it — clicking "
+                    + "\"Continue optimizing\" restarts the search from here and frequently finds a better one.";
+            }
+        }
+
+        public bool HasContinueOptimizingAdvice => ContinueOptimizingAdviceText.Length > 0;
 
         /// <summary>Header shown above the Changed-parameters table once more than one optimization pass has run:
         /// e.g. "3 rounds  •  J: 0.940 → 0.985 → 0.990". Empty for a single round (no chain to summarize).</summary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarSignalCopy.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarSignalCopy.cs
@@ -250,7 +250,21 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// <see cref="StarDetectionOptimizerWizardVM.CanCaptureNewSweep"/> is only the TRANSIENT unavailability (no
         /// engine, a disconnected camera or focuser, no save folder), which renders the button disabled rather than
         /// hidden — so the sentence still has a referent, and the referent can come back.</para></item>
+        /// <item><b>Set the gate by hand and compare (F49).</b> The catch-all, and the only remedy here that is
+        /// NOT about exposure or binning. The three above are ranked exposure/binning instructions and ALL THREE
+        /// fall through on a rich, well-exposed field where the optimizer CHOSE a floor gate — this method used to
+        /// return <see cref="string.Empty"/> there, on a page whose contract is "diagnosis plus exactly one
+        /// instruction". It names the GATE (the actual lever on this population) and it names controls that
+        /// EXIST: <c>BrightnessSensitivity</c> is bound in <c>OptionsDataTemplates.xaml</c>, and "use current
+        /// settings" is a Select Source mode — never F32's <c>MinDetectionKeepFraction</c>, which has no XAML
+        /// binding at all.</item>
         /// </list>
+        ///
+        /// <para><b>The empty return is now reached only by an UNMEASURED run</b> (no derivable recommendation at
+        /// all). Every state that HAS a measurement ends on exactly one instruction, which is the contract the page
+        /// was written to and the one F49 found broken. The unmeasured case keeps its diagnosis-only body on
+        /// purpose: the F49 sentence claims that brightness was not the problem, and nothing on an unmeasured run
+        /// establishes that.</para>
         /// </summary>
         private static string RemedyFor(
             OptimizationSummary summary, ExposureRecommendation advice, bool lastRunWasLive, bool isUseCurrentMode) {
@@ -279,6 +293,42 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                         + "; or, if you shoot narrowband, auto-focus through a broadband filter with a filter offset instead.";
                 }
                 return text;
+            }
+            // F49 — the gate remedy, and the ONLY branch here that is not about exposure or binning.
+            //
+            // The three branches above are ranked exposure/binning instructions, and on a RICH, WELL-EXPOSED field
+            // where the optimizer CHOSE a floor gate every one of them falls through: ExposureIsNotTheLimit is
+            // true, so IncreasesExposure is false (killing 1 and 3) and branch 2's !ExposureIsNotTheLimit is false
+            // too. This method then returned string.Empty on a page whose contract is "diagnosis plus exactly one
+            // instruction" — the block's TRIGGER is the Sensitivity gate while its CONTENT was exposure-only. A
+            // field report on the shipped Default profile hit it: Sensitivity 15.667 -> 0.000, StarClip 6.750 ->
+            // 0.250, stars per frame 834 -> 5766, and the copy correctly said "star brightness is not the problem:
+            // your brightest stars measure S/N 1438.6" and then stopped.
+            //
+            // THE REMEDY NAMES THE GATE, NOT THE EXPOSURE, because on this population the exposure is not the
+            // lever and saying otherwise is what F19 does wrong from the other side.
+            //
+            // AND IT NAMES A CONTROL THAT EXISTS (the house rule at ShowOptimizeAgainAtRecommendedBinning: never
+            // describe an action whose control is hidden). "Brightness Sensitivity" is bound in
+            // OptionsDataTemplates.xaml (StarDetectionOptions.BrightnessSensitivity), and "use current settings"
+            // is a mode on the Select Source step — the same kind of referent branch 3 already uses when it names
+            // Optimize mode. It deliberately does NOT name F32's MinDetectionKeepFraction, which has NO XAML
+            // binding anywhere and is --keep-floor on the harness only; and that floor would not bind here in any
+            // case, since it rejects landings keeping FEWER stars than the seed while this one keeps ~7x MORE.
+            // The pathology is admission, not shedding.
+            //
+            // REQUIRES A MEASUREMENT, and this is not a formality. The sentence CLAIMS that star brightness was
+            // not what was missing, which is only knowable from ExposureIsNotTheLimit (S_now >= the default
+            // target). On an unmeasured run — fewer than MinFramesForRecommendation usable frames, no per-star
+            // SNRs, or an unknown exposure to scale from — all that is known is that the gate is floored, and
+            // asserting anything about brightness there would be exactly the "no star-poor claim without
+            // evidence" rule broken in the opposite direction. Those runs keep the diagnosis-only body they have
+            // always had. (StarFieldIsExhausted is not reached either: it leaves ExposureIsNotTheLimit false, so
+            // branch 2 above claims it.)
+            if (advice != null && advice.HasRecommendation && advice.ExposureIsNotTheLimit) {
+                return "The gate was lowered to admit more candidates, not because star brightness was missing. "
+                    + "Set Brightness Sensitivity by hand in the star detection options and run this wizard again in "
+                    + "\"use current settings\" mode to compare that landing against this one.";
             }
             return string.Empty;
         }

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -1014,6 +1014,67 @@ namespace TestApp {
             // of landing: mccomiskey records Sensitivity 0.0 (which reads as "drove the gate to its floor") while
             // enforcing 9.81 and shedding 3606 detections down to 43.
             public double EffectiveSensitivityGate = double.NaN;
+
+            // F19 (wave 9) — the PER-FRAME table the run-level exposure statistic is a median over. See
+            // FrameDiagnostic. Computed UNCONDITIONALLY, from the same `bestM` metrics ExposureRecommendation is
+            // derived from, so the two describe one population. Null only when the run carries no per-frame data.
+            public List<FrameDiagnostic> FrameDiagnostics;
+        }
+
+        /// <summary>
+        /// One frame's contribution to the exposure statistic, plus where that frame sits on the sweep.
+        ///
+        /// <para><b>F19, wave 9.</b> <c>ExposureRecommender</c>'s S_now is a MEDIAN ACROSS FRAMES of each frame's
+        /// <c>NTarget</c>-th-brightest accepted-star SNR. On a rich field that median is dominated by the
+        /// near-focus frames, and wave 8's arm X measured it saturating at 991.8–2308.8 against a target of 10 —
+        /// RISING with exposure — on a run whose σ_focus improves 44 % at 16× that exposure. The hypothesis is that
+        /// the frames the fit's precision actually rests on are the WINGS, which that median cannot see. This
+        /// table is what lets the hypothesis be tested rather than argued: it exposes the per-frame values the
+        /// median collapses, keyed by distance from the fitted focus in STEP units.</para>
+        ///
+        /// <para><b>Deliberately not gated on anything.</b> Not on <c>SensitivityIsAtFloor</c>, not on
+        /// <c>HasLowStarSignal</c>, not on whether a recommendation exists — gating a measurement on the product's
+        /// own display condition is precisely what made F19 unanswerable until wave 8 (its lesson 4). And note
+        /// what this instrument does if the wing hypothesis is WRONG: it shows wing frames whose statistics are
+        /// indistinguishable from the near-focus frames, which refutes the hypothesis rather than confirming
+        /// it.</para>
+        /// </summary>
+        private sealed class FrameDiagnostic {
+            public int FocuserPosition;
+            public bool IsRecovery;
+
+            /// <summary>Signed distance from the fitted best-focus position in STEP units — the axis "wing" is
+            /// defined on. NaN when the run produced no usable fit (<c>BestFocusPosition</c> NaN) or no step size,
+            /// in which case no wing statistic can be computed for this run and that is reported, not guessed.</summary>
+            public double OffsetSteps = double.NaN;
+
+            /// <summary>Accepted stars on this frame (<c>FrameStarCounts</c>).</summary>
+            public int StarCount;
+
+            /// <summary>This frame's contribution to S_now: its <c>NTarget</c>-th-brightest accepted-star SNR, or
+            /// its FAINTEST survivor when fewer than <c>NTarget</c> survive (the same bounded under-estimate
+            /// <c>ExposureRecommender.PerFrameNthBrightest</c> makes, reproduced here rather than re-derived).
+            /// NaN when nothing survived filtering — which is NOT proof the frame was starved (see
+            /// <c>RunEvaluationMetrics.FrameStarSnrs</c>'s empty-does-not-mean-zero convention).</summary>
+            public double NthBrightestSnr = double.NaN;
+
+            /// <summary>True when the frame had fewer than <c>NTarget</c> usable SNRs, so
+            /// <see cref="NthBrightestSnr"/> is the faintest survivor rather than the true rank.</summary>
+            public bool WasShort;
+
+            /// <summary>The frame's faintest and median accepted-star SNR — the faint end the fit's wings rest on,
+            /// which the <c>NTarget</c>-th rank is deliberately insensitive to. NaN when no SNRs survived.</summary>
+            public double MinSnr = double.NaN;
+
+            public double MedianSnr = double.NaN;
+
+            /// <summary>Sensitivity-gate and flat-topped rejections on this frame. The flat count is the
+            /// sweep-geometry signal (<c>ExposureRecommendation.FlatRejectedCount</c>'s per-frame source): heavily
+            /// defocused stars go flat-topped, so a concentration out here means the sweep outruns the detector —
+            /// "narrow the sweep", never "expose longer".</summary>
+            public int LowSensitivityRejections;
+
+            public int TooFlatRejections;
         }
 
         /// <summary>Builds an aggregate row from a per-run outcome (exactly one run in the set in --per-run mode).
@@ -1068,8 +1129,75 @@ namespace TestApp {
                 BrightnessSensitivity = landedSensitivity,
                 SensitivityIsAtFloor = sensitivityAtFloor,
                 ExposureRecommendation = exposureRecommendation,
-                EffectiveSensitivityGate = StarDetector.EffectiveSensitivityGate(outcome.Result.BestParams)
+                EffectiveSensitivityGate = StarDetector.EffectiveSensitivityGate(outcome.Result.BestParams),
+                FrameDiagnostics = BuildFrameDiagnostics(bestM, outcome.ObjectiveConstants)
             };
+        }
+
+        /// <summary>
+        /// F19 (wave 9) — expands the per-frame values <c>ExposureRecommender</c>'s S_now is a median over. See
+        /// <see cref="FrameDiagnostic"/> for why. Pure, from metrics already plumbed through for other reasons
+        /// (<c>FrameStarCounts</c>, <c>FrameFocuserPositions</c>, <c>BestFocusPosition</c>, <c>FrameStarSnrs</c>,
+        /// <c>FrameIsRecovery</c>, and the two rejection tallies), so it adds no detection work and cannot perturb
+        /// a landing.
+        /// </summary>
+        private static List<FrameDiagnostic> BuildFrameDiagnostics(RunEvaluationMetrics m, ObjectiveConstants c) {
+            var snrsByFrame = m?.FrameStarSnrs;
+            if (snrsByFrame == null || snrsByFrame.Count == 0) {
+                return null;
+            }
+            var nTarget = c?.NTarget ?? 20;
+            var counts = m.FrameStarCounts;
+            var positions = m.FrameFocuserPositions;
+            var recovery = m.FrameIsRecovery;
+            var lowSens = m.FrameLowSensitivityCounts;
+            var tooFlat = m.FrameTooFlatCounts;
+            // The wing axis is |focuser - fitted focus| in STEP units. Both inputs can legitimately be missing (a
+            // run with no usable fit, or a caller that never populated positions), and the honest answer then is
+            // NaN on every frame rather than an offset measured from an invented origin.
+            var haveOffsetAxis = double.IsFinite(m.BestFocusPosition) && m.StepSize > 0.0 && positions != null;
+
+            var rows = new List<FrameDiagnostic>(snrsByFrame.Count);
+            for (var i = 0; i < snrsByFrame.Count; i++) {
+                var row = new FrameDiagnostic {
+                    FocuserPosition = positions != null && i < positions.Count ? positions[i] : 0,
+                    IsRecovery = recovery != null && i < recovery.Count && recovery[i],
+                    StarCount = counts != null && i < counts.Count ? counts[i] : 0,
+                    LowSensitivityRejections = lowSens != null && i < lowSens.Count ? lowSens[i] : 0,
+                    TooFlatRejections = tooFlat != null && i < tooFlat.Count ? tooFlat[i] : 0
+                };
+                if (haveOffsetAxis && i < positions.Count) {
+                    row.OffsetSteps = (positions[i] - m.BestFocusPosition) / m.StepSize;
+                }
+
+                // Same filter ExposureRecommender applies: finite AND positive. A filtered-out entry did not
+                // contribute a real detection, so pooling it here would make this table disagree with the
+                // statistic it exists to explain.
+                var filtered = new List<double>();
+                var frameSnrs = snrsByFrame[i];
+                if (frameSnrs != null) {
+                    for (var k = 0; k < frameSnrs.Count; k++) {
+                        var v = frameSnrs[k];
+                        if (double.IsFinite(v) && v > 0.0) {
+                            filtered.Add(v);
+                        }
+                    }
+                }
+                if (filtered.Count > 0) {
+                    filtered.Sort(); // ascending
+                    row.MinSnr = filtered[0];
+                    var (median, _) = filtered.MedianMAD();
+                    row.MedianSnr = median;
+                    if (filtered.Count >= nTarget) {
+                        row.NthBrightestSnr = filtered[filtered.Count - nTarget];
+                    } else {
+                        row.WasShort = true;
+                        row.NthBrightestSnr = filtered[0];
+                    }
+                }
+                rows.Add(row);
+            }
+            return rows;
         }
 
         /// <summary>

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -3166,6 +3166,70 @@ the price for a fourth-decimal gain — the same shape as
 time instead of recall.
 Reproduce: `D:\hf_w8\field\compare_runs.sh`, `D:\hf_w8\field\cost_*.json`, `D:\hf_w8\field\gate_*.json`.
 
+### F55 — `optimize` is NOT reproducible when several instances run at once, and the SEED evaluation is what moves
+**Status:** Open · found 2026-08-07 (wave 9) when the confirmation arm's own pre-registered control fired ·
+**this voids the wave-9 F32 arm and constrains every future arm's design**
+
+Wave 9 ran F32's confirmation arm with a **fan-out of 4** — four `optimize --per-run` processes on distinct bank
+folders — to bring ~28 h of sequential compute down to ~7 h. The design pre-registered a free control for exactly
+this: arm A re-measures the 8 runs the sequential gate had already pinned.
+
+> **RULE G fired. 2 of the 8 do not reproduce.**
+>
+> | run | sequential gate | arm A, fan-out 4 |
+> |---|---|---|
+> | `toml999` | **0.997993** | **0.995784** |
+> | `D18_m24_deep_shed` | **0.999822** | **0.999882** |
+> | the other six | *(exact)* | *(exact)* |
+
+**And the second control says where it comes from.** `BaselineJ` is the objective of the run's CURRENT settings —
+**a single evaluation of the pinned seed, with no search involved**. The three arms differ only in `--keep-floor`
+and `--continue-rounds`, neither of which touches that evaluation, so it must be identical across all three. On
+**6 of 39 runs it is not**:
+
+| run | A | B | C |
+|---|---|---|---|
+| `D16_esprit550_ha3` | 0.988555 | **0.979173** | **0.979173** |
+| `D10_rc16_3250mm_sparse` | 0.958929 | **0.957201** | **0.957201** |
+| `D17_cdk14_oiii5` | 0.993062 | **0.994830** | 0.993062 |
+| `D14_cdk14_2563mm_e47` | 0.997901 | **0.997500** | 0.997901 |
+| `mufti` | 0.957087 | **0.957603** | **0.957603** |
+| `D15_cdk20_3454mm_e47` | 0.994703 | 0.994703 | **0.994474** |
+
+**The gaps are far too large to be float-summation order** (`D16` moves by 0.0094), and the pattern is sporadic
+rather than per-arm — A is the odd one out on three runs, B on two, C on one. This is
+[F41](#f41--a-prior-waves-control-arm-is-not-a-control-for-a-later-waves-binary)'s tell firing at scale, and
+[F8](#f8--optimizer-landings-are-not-reproducible-across-invocations) one level deeper: not "a landing is a
+property of the trajectory", but **the seed evaluation itself is not a function of (frames, settings) alone.**
+
+**Two causes EXCLUDED by measurement, not by argument.** Re-running `toml999` today at arm A's exact invocation:
+
+- **Not the F15 folder state.** Run **sequentially and alone**, on folders that then held arm A's landing, it
+  returns **0.997993** — the gate's value. What a previous arm left in the run folder does not decide this.
+- **Not a build or settings difference.** Same binary, same pinned file, same `[1/1] optimizing attempt01`, same
+  `PixelScale 0.73944`, same resolved binning factor.
+
+**One four-way concurrent trial did NOT reproduce the deviation** (`toml999` returned 0.997993 again with three
+other `optimize` processes in flight). **That is not evidence against the fan-out**, and it is recorded here so it
+is not read as such: the effect appears on ~15 % of runs, so a single trial has no power to exclude it. Waves 5–8
+all ran their arms **sequentially** and all reported bit-identical controls; wave 9 is the first to fan out and
+the first to lose them.
+
+**What it costs.** The arm ran for **7 h 10 m** across three arms and 117 optimizations and **cannot be read
+against wave 5's φ table**. RULE G was written as *"a partial reproduction is a failure, not a warning — the
+eight are one instrument"*, and it is applied as written: **no φ verdict is published from this arm.**
+
+**Next step.** (a) Re-run the arm **sequentially** — ~28 h, and that is now the known price of a readable arm.
+(b) Find the nondeterminism: the run-evaluation path is parallel (`RunEvaluationDataParallelismTests`,
+`RunEvaluationDataCache`), and a seed evaluation that is not a pure function of (frames, settings) is a defect in
+its own right, independent of this arm. (c) Until (b), **treat concurrent `optimize` as invalid for any arm whose
+conclusion rests on comparing landings**, and say so in the run instructions beside
+[F42](#f42--every-build-directory-silently-gets-its-own-detector-settings-and-the-run-instructions-require-a-new-one-per-arm)'s
+settings-pinning rule. (d) Add a cheap standing guard: have `optimize` print `BaselineJ` where a scripted arm can
+diff it, so this control is free on every future arm rather than only when someone writes it down.
+Reproduce: `D:\hf_w9\f32_arms.log`, `D:\hf_w9\score_f32.py`, `D:\hf_w9\ctl_seq_toml999.log`,
+`D:\hf_w9\ctl_conc_toml999.log`.
+
 ### F54 — F39(b)'s default flip MOVES a landing at a resolved factor of 1, where it is documented as a no-op
 **Status:** Open · found 2026-08-07 (wave 9) chasing [F53](#f53--wave-8s-arm-x-does-not-reproduce-from-wave-8s-own-exe-because-the-arm-ran-on-an-earlier-build-of-it)'s
 remainder · **measured and reproducible; the MECHANISM is not identified and is not claimed**

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -652,9 +652,10 @@ Reproduce: `D:\hf_w5\f24_arms.sh`, analysed by `D:\hf_w5\analyze_f24.py`.
 > D06/D09/D14 — none of which was ever suspect — and is untouched.
 
 ### F19 — The exposure recommendation is decided by the 20 brightest stars, so a rich field can never earn one
-**Status:** **OPEN — the wave-7 "working as intended" position was REFUTED by its own pre-registered test**
-(2026-08-06). A rich field gains 44% of σ_focus from 8× the derived exposure, and the block is never even
-surfaced there · found 2026-08-02 deriving expected-optimal exposures for the synthetic AF bank
+**Status:** **(a) refuted (wave 8) · (b) DONE (wave 8) · (c) RESOLVED "the floor stays", free, no re-render
+(wave 9) · THE REMAINDER IS FIXED (wave 9): the wing rejected fraction, chosen by a rule fixed before it, and the
+reason both earlier fixes failed is now a THEOREM about the gate.** Population check across both banks still owed
+· found 2026-08-02 deriving expected-optimal exposures for the synthetic AF bank
 
 `ExposureRecommender`'s `S_now` is the median, across non-recovery frames, of each frame's
 **`NTarget`-th-brightest** accepted-star SNR, with `NTarget = 20`. Any reasonably wide field contains 20 stars
@@ -840,6 +841,80 @@ derived-exposure rung on either dataset, this entry REOPENS.**
 >   invalidate that arm (every φ arm sees the same frames) but it must be stated there.
 >
 > **This list IS (c)'s work list**, produced by (b) rather than by a separate investigation.
+
+> ## THE REMAINDER IS FIXED (2026-08-07, wave 9), AND THE REASON BOTH EARLIER FIXES FAILED IS A THEOREM
+>
+> ### The gate floor theorem
+>
+> `StarDetector.InertSensitivityBound` proves every candidate reaching the Sensitivity gate satisfies
+> `sensitivity > PeakResponse × EffectiveClipMultiplier`, and acceptance additionally requires it to exceed
+> `StarDetectorParams.Sensitivity`. So **every accepted star's gate statistic strictly exceeds
+> `EffectiveSensitivityGate = max(Sensitivity, InertSensitivityBound)`** — and therefore **ANY order statistic
+> over accepted stars, at ANY rank, on ANY subset of frames, is bounded below by that gate.**
+>
+> **Corollary: when the optimizer lands a gate at or above `TargetSensitivity` (10), `ExposureIsNotTheLimit` is
+> true BY CONSTRUCTION, whatever the sky contains.** `D02_rich_135mm` lands its effective gate at **16.7 / 50.0 /
+> 34.3 / 10.0 / 14.0** across a 16× exposure ladder over which σ_focus improves **48 %**.
+>
+> **This is why both earlier fixes were refuted by their own pre-registered tests.** Wave 7's "change `NTarget`"
+> and wave 8's "widen the trigger" each moved the rank or the display and left the POPULATION untouched. It is
+> strictly stronger than wave 7's leg 2, which established only that the *faintest accepted star* is pinned by the
+> gate; the theorem says every statistic over accepted stars is. **And it killed wave 9's own first candidate
+> family before a line of it was implemented** — all four candidates were order statistics over accepted stars.
+>
+> ### What ships: the WING REJECTED FRACTION
+>
+> The candidates the gate **rejected** on the sweep's wing frames are the only population in a run that is not
+> floored by the gate, and they are exactly the stars a longer exposure can convert.
+> `ExposureRecommendation.WingRejectedFraction` = `rejected / (rejected + accepted)` pooled over the outer third
+> of the non-recovery frames by distance from the fitted focus; `WingIsShedding` at ≥ 0.20.
+>
+> - **Pooled over a wing SET, not a worst frame** — which answers this class's own documented objection that a
+>   worst-frame rule "would hand the entire recommendation to whichever single frame had a passing cloud".
+> - **A PROBE (×2), not a formula**, following `StarCountProbeFactor`'s precedent: the run records HOW MANY
+>   candidates were rejected out there, not what SNR they sat at, so there is nothing to derive a magnitude from.
+>   **Fabricating one was measured and rejected** — a `(1/(1−f))²` form asked **1.25×** on `D16` at exactly the
+>   exposure where its σ_focus is minimised, which is the control the whole statistic has to pass.
+> - **It WIDENS rather than replaces:** `max(existing, probe)`. Both halves are load-bearing.
+> - **NaN, never 0**, when the run cannot be placed on the wing axis. "We could not look" and "we looked and
+>   nothing was shedding" must not be the same number, because the caller turns one of them into an instruction.
+> - **Inert unless the data supports it:** a caller that does not populate the per-frame wing axis is
+>   byte-identical to before.
+>
+> ### RULE W, fixed BEFORE the statistic was written, and applied to this binary's own ladder
+>
+> Validated on wave 7's exposure ladder, still on disk at `D:\hf_w7\armE\t{0.5,1,2,4,8}`. **No re-render.**
+>
+> | | W1 `D02`@0.5 s ≥ 2× | W2 `D16`@2 s < 1.25× | W3 converges | W4 `D16`@0.5 s asks | verdict |
+> |---|---|---|---|---|---|
+> | shipped statistic | ✗ 1.00× | ✓ | ✓ | ✓ | fires on NEITHER |
+> | wing fraction, `(1/(1−f))²` magnitude | ✓ 4.00× | ✗ 1.25× | ✗ | ✗ | fires on BOTH |
+> | wing headroom vs the gate | ✓ 2.00× | ✓ | ✗ | ✗ | — |
+> | wing probe ALONE | ✓ 2.00× | ✓ | ✓ | ✗ | — |
+> | **`max(shipped, wing probe)`** | **✓ 2.00×** | **✓ 1.00×** | **✓** | **✓ 3.00×** | **ADOPTED** |
+>
+> **Five of seven candidates failed, three of them AFTER passing W1** — the clause that looks like the whole point.
+> On `D02` the adopted statistic asks 2× at 0.5 / 1 / 2 s and goes **silent at 4 s**, which is exactly where this
+> binary's σ_focus minimum sits (0.05208).
+>
+> **The ladder MOVED between binaries** ([F54](#f54--f39bs-default-flip-moves-a-landing-at-a-resolved-factor-of-1-where-it-is-documented-as-a-no-op)),
+> so the rule was applied to this binary's own σ values rather than to wave 7's — after checking that **all four
+> clauses' premises survive on both ladders**. `D02` gains 48 % here against wave 7's 44 %; `D16`'s minimum is at
+> its derived 2 s on both, and 4 s / 8 s are worse on both.
+>
+> **The verdict is reproduced END TO END by the shipped code**, not only by the offline scorer: re-running the ten
+> rungs with `ExposureRecommender` itself gives the same four passes.
+>
+> **Tests: 8, four discriminating**, each confirmed by neutralizing — delete the probe ⇒ W1/W3/W4 fail; `max()` ⇒
+> plain assignment ⇒ W4 alone fails; fire on any rejection ⇒ W2 alone fails. That also caught an overclaim in one
+> of this wave's own test comments: the F28 conjunct is **redundant by construction** and fails nothing when
+> removed, so both the code and the test now say so.
+>
+> **Still owed: the §3.5 population check** — the verdict measured across all 20 synthetic datasets and the real
+> bank. It is blocked behind F32's confirmation arm, structurally rather than by scheduling: `optimize --per-run`
+> writes back into the bank's run folders ([F15](#f15--optimize---per-run-overwrites-each-runs-stored-settings))
+> and there is no flag to suppress it, so a population pass while that arm is in flight would race it on every
+> folder. Reproduce: `D:\hf_w9\wing2\`, `D:\hf_w9\wing\score_wing.py`.
 
 > ## (c) RESOLVED 2026-08-07 (wave 9): THE FLOOR STAYS, THE CEILING STAYS, AND NOTHING RE-RENDERS
 >
@@ -2933,7 +3008,7 @@ and 482 with no way to act on any of them, and nothing in the entry had noticed 
 | part | what shipped |
 |---|---|
 | **(a)** | `ShowCaptureNewSweep` = `lastRunWasLive && !IsUseCurrentMode && (IncreasesExposure ‖ StepSizeOrOffsetChanged)`. The `HasExposureBlock` conjunct is **gone**, and the row **moved out of the Star signal block** into the Auto-focus block — beside the step-size and offset rows, which are the values it now carries. The two MODE conditions stay (Replay has no rig; use-current has nothing to re-tune), because those are fixed for the life of the Summary |
-| **(b)** | `ApplyRecaptureGeometry(options, stepSize, offsetSteps)` in `RunLiveAttemptAsync`, applied **before** `ApplyFocusRecovery` so recovery widens from the recommended offset exactly as it widens the profile's on a Start. Set from the SELECTED summary by `CaptureNewSweepAsync` and cleared on **every** exit path, so an ordinary Live Start is byte-identical |
+| **(b)** | `ApplyRecaptureGeometry(options, stepSize)` in `RunLiveAttemptAsync`, applied **before** `ApplyFocusRecovery`. Set from the SELECTED summary by `CaptureNewSweepAsync` and cleared on **every** exit path, so an ordinary Live Start is byte-identical |
 | **(b), the "or say plainly" half** | shipped **as well as** carrying it: `CaptureNewSweepCarriesText` states the geometry the next sweep will use (`"step size 214 → 459 … at the exposure below"`) and that nothing is written to the profile. A sweep geometry the user cannot see is how this defect stayed invisible for a whole session |
 | **(c)** | already true and now reachable — the command persists nothing and Accept remains the only writer. What forced the Accepts was (a) hiding the control, not (c) |
 
@@ -2942,18 +3017,26 @@ and 482 with no way to act on any of them, and nothing in the entry had noticed 
 subset of the new visibility — so the copy can never name a hidden button. And in the new step-only state, where
 the Star signal block is not on screen at all, the row carries its own sentence.
 
-**Tests: 3 discriminating on `ApplyRecaptureGeometry`** (carries the step and offset; complete no-op at
-non-positive, so the Start path is unchanged; composes with `ApplyFocusRecovery` in the shipped order — reversing
-them would let the recommended offset overwrite recovery's widening and silently drop the frames the evaluator is
-about to TAG as recovery).
+> **CORRECTION, caught by an existing test on the full-suite run.** The first version of (b) also carried the
+> recommended **offset steps**, and `CaptureNewSweep_UsesTheSnapshottedRecoverySteps_NotTheLiveBox` failed with a
+> re-capture widened to **5** where the recovery snapshot alone gives **1**. It is wrong for two independent
+> reasons, and the test found both: `StepSizeRecommender` derives its step from the desired half-width over the
+> **current** points-per-side, so the recommended STEP already expresses the whole geometry change at the existing
+> offset — carrying the offset too widens the sweep twice; and `ApplyFocusRecovery` **owns** the offset axis and
+> ADDS to whatever it is handed. **The re-capture now carries the step size and nothing else**, and the copy says
+> so rather than promising a sweep it does not take.
+
+**Tests: 3 discriminating on `ApplyRecaptureGeometry`** (carries the step; complete no-op at non-positive, so the
+Start path is unchanged; composes with `ApplyFocusRecovery` without double-widening — which is the assertion the
+correction above turned into a permanent guard).
 
 **Still open, and it is the entry's real subject:** the step recommender asking to widen on **every** run because
 the sweep never reaches `3 × HFR_min`. (a)–(c) make the iteration cheap; they do not make it terminate. That is
 [F21](#f21--stepsizerecommenders-half-width-is-not-stable-against-noise-even-at-r--10000)/F49(c).
 
 ### F52 — A two-hour optimization logs ONE line and offers no cost context, and the search is not cost-aware
-**Status:** **(a) and (b) DONE 2026-08-06 (wave 8); (c) BLOCKED on [F19](#f19--the-exposure-recommendation-is-decided-by-the-20-brightest-stars-so-a-rich-field-can-never-earn-one);
-(d) open** · found 2026-08-06 (wave 8) from the same field session · partly measured, partly **unmeasurable after
+**Status:** **(a) and (b) DONE 2026-08-06 (wave 8); (c) DONE 2026-08-07 (wave 9) once F19's remainder
+landed; (d) open** · found 2026-08-06 (wave 8) from the same field session · partly measured, partly **unmeasurable after
 the fact, which is the finding**
 
 Run 4 (step 459, 2 s) ran from 14:38:11 to past 16:30 — **over two hours**. Run 3, on the **same step size, same
@@ -3045,7 +3128,28 @@ note and did not, because its seed sat at the shipped default of 4 where the two
 seed now turns the donut master on (effective depth 6, `StructureLayers` still 4) so the absolute implementation
 reports "2 deeper" for a search that has not moved, and the test fails as claimed.
 
-**(c) Recommend whether to abort and re-run at a longer exposure — BLOCKED ON
+> **(c) SHIPPED 2026-08-07 (wave 9), on the statistic it was waiting for.**
+> [F19](#f19--the-exposure-recommendation-is-decided-by-the-20-brightest-stars-so-a-rich-field-can-never-earn-one)'s
+> remainder landed as `ExposureRecommendation.WingIsShedding` — the fraction of candidates the gate rejected on the
+> sweep's WING frames, which is the one population in a run not floored by the gate. **The separation this entry
+> drew is kept exactly: facts about COST need no new statistic and are already shown; ADVICE needs one.**
+>
+> `StarDetectionOptimizerWizardVM.SearchExposureAdvice` is computed in `ComputeBaselineJAsync` — i.e. from the
+> **SEED evaluation, which runs BEFORE the search** — so the answer to *"should I abort and try again with a
+> longer exposure?"* was available in the first minute rather than after two hours, which was the complaint.
+>
+> It is **absent when the wings are healthy** (a note that always fires says nothing), it **names Cancel**, which
+> exists, and it says **what Cancel costs in the same sentence**, because not knowing that is why the user sat
+> through the two hours. It quotes **no recommended exposure**: the wing probe is a probe precisely because the
+> rejected candidates' SNRs are not recorded, and the Summary's exposure row is where a number belongs once the
+> run finishes.
+>
+> **Tests: 4, three discriminating** — and the multi-run one is CORRECTED. Its first version paired a shedding run
+> with a healthy one, which the aggregation skips entirely, so "worst" and "average" were identical and it passed
+> under a deliberately-averaged implementation. It now pairs two shedding runs (0.75 and 0.30) and fails as
+> claimed.
+
+**(c) ~~Recommend whether to abort and re-run at a longer exposure~~ — was BLOCKED ON
 [F19](#f19--the-exposure-recommendation-is-decided-by-the-20-brightest-stars-so-a-rich-field-can-never-earn-one),
 and shipping it before that would be actively harmful.** This is the piece the user asked for by name. It cannot
 be built on the existing exposure statistic: on this very rig that statistic reported *"2 s (unchanged; measured

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -3410,7 +3410,38 @@ eight are one instrument"*, and it is applied as written: **no φ verdict is pub
 > PROCESSES run, so the cause is more likely a shared cross-process resource or a genuine order dependence
 > somewhere below the fit.
 
-**Next step.** (a) ~~Re-run the arm sequentially~~ — **RUNNING** as of 2026-08-07 10:18Z, ~28 h.
+> ### INVESTIGATED 2026-08-07, NOT FIXED — but the search space is much smaller, and the reproducer is cheap
+>
+> Everything below was run with the machine otherwise idle, against the 40-second reproducer.
+>
+> **ELIMINATED, each by measurement rather than by reading:**
+>
+> | candidate | how it was excluded |
+> |---|---|
+> | the star-evaluation `Parallel.For` degree | swept **1, 2, 4, 8, 48** sequentially — **all identical** to 16 dp |
+> | the per-run `optimized_settings.json` (F54's lead) | run **with and without** the file present — identical |
+> | the disk detection cache (`<image>_star_detection_result.json`) | `AutoFocusEngine` reads it; the optimizer path does **not**, and the probe's copies have none |
+> | OpenCL / GPU dispatch | there is **no** `UMat`/OpenCL path anywhere in the plugin |
+> | the frame-level fan-out | each task writes **only its own index**; no shared mutable state |
+> | `StarDetectorMetrics.Merge` + thread-locals | additive over ints, and `SortBounds()` normalizes bounds order afterwards |
+> | rented-array sorts | both use the **bounded** `Array.Sort(a, 0, count)` overload |
+> | `MedianInPlace` over a rented array | both callers pass freshly-allocated `new double[n]` |
+> | a load-sensitive timeout | none in the detection/evaluation/fit path; the only `Stopwatch` is trace-only |
+>
+> **A METHODOLOGICAL TRAP WORTH RECORDING.** The parallelism sweep was first run by setting `HF_STAREVAL_PAR` from
+> WSL — and **WSL environment variables do not reach a Windows process without `WSLENV`**, so the first sweep
+> silently measured the SAME configuration five times and would have "proved" that degree does not matter. It was
+> caught by noticing the result contradicted a hardcoded build, and re-run with `WSLENV` set. *An instrument that
+> is not connected reports perfect agreement* — the same failure family as wave 8's three, in a new disguise.
+>
+> **STILL UNEXPLAINED, and it is the sharpest remaining clue:** across sessions the "sequential" value has been
+> observed at BOTH attractors — many repeats at `0.9791727072`, and five consecutive repeats at `0.9885546719`
+> from one build. Within any one session sequential runs are perfectly self-consistent. So whatever selects the
+> attractor appears to be **stable within a process/session and variable across them**, which does not fit a
+> per-iteration data race and does fit some process-level state (a warm-up path, a static initialised from
+> observed load, a JIT/tiering effect, or something else acquired once).
+>
+> **Next step.** (a) ~~Re-run the arm sequentially~~ — **DONE**, and it passed both controls (see F32).
 (b) **Find the nondeterminism — this now outranks (a) in value, because the reproducer makes it cheap and
 because a bimodal race can flip a sequential run too.** Bisect with `determinism_probe.sh`: it is 40 s per trial. (c) Until (b), **treat concurrent `optimize` as invalid for any arm whose
 conclusion rests on comparing landings**, and say so in the run instructions beside

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -3219,10 +3219,45 @@ the first to lose them.
 against wave 5's φ table**. RULE G was written as *"a partial reproduction is a failure, not a warning — the
 eight are one instrument"*, and it is applied as written: **no φ verdict is published from this arm.**
 
-**Next step.** (a) Re-run the arm **sequentially** — ~28 h, and that is now the known price of a readable arm.
-(b) Find the nondeterminism: the run-evaluation path is parallel (`RunEvaluationDataParallelismTests`,
-`RunEvaluationDataCache`), and a seed evaluation that is not a pure function of (frames, settings) is a defect in
-its own right, independent of this arm. (c) Until (b), **treat concurrent `optimize` as invalid for any arm whose
+> ### CONFIRMED 2026-08-07 by a 40-SECOND reproducer, and it is BIMODAL
+>
+> Rather than spend ~28 h to find out, the question was asked directly: **is the seed evaluation a pure function
+> of (frames, settings)?** `D:\hf_w9\det\determinism_probe.sh` runs `optimize --per-run --max-evals 1` — so the
+> search does nothing and `BaselineJ` is the whole measurement — on `D16_esprit550_ha3`, the arm's biggest mover,
+> **five times sequentially and then five times at once**, each repeat on its own copy of the run folder reset to
+> an identical state. The banks are never touched.
+>
+> | phase | `BaselineJ` |
+> |---|---|
+> | **5× SEQUENTIAL** | `0.9791727071693058` five times — **identical** |
+> | **5× CONCURRENT** | `0.9885546719484486` ×3 and `0.9791727071693058` ×2 — **two values in one batch** |
+>
+> **Those are exactly arm A's 0.988555 and arm B/C's 0.979173.** The probe reproduces the entire 7-hour
+> discrepancy from identical inputs in 40 seconds.
+>
+> **Three things follow.**
+>
+> 1. **Sequential execution is deterministic** (5 of 5, and the wave-9 gate independently reproduced wave 5's
+>    eight values across two waves and two binaries). **Waves 5–8 stand**, and the ~28 h sequential re-run is
+>    valid — it is now RUNNING.
+> 2. **The defect is BIMODAL, not drift.** Two discrete attractors, not a spread — so it is a race between two
+>    code paths, not floating-point summation order. That also means it can flip a *sequential* run if the machine
+>    is busy for another reason, which is why this outranks the re-run in importance.
+> 3. **A 40-second reproducer exists**, which is the thing that was actually missing. Any candidate fix is now
+>    testable in a minute instead of a wave.
+>
+> **Excluded by reading the source (no runs — nothing may execute beside the sequential arm):** there is no
+> OpenCL/`UMat` path at all; `AlglibHyperbolicFitting`'s parallel candidate-model pass writes into **indexed
+> arrays** and resolves consensus by intersection + `Array.FindIndex`, so `Parallel.For` completion order cannot
+> change it (the comments say so deliberately); and there is no load-sensitive timeout in the
+> detection/evaluation/fit path — the only `Stopwatch` there is trace-only. **The mechanism is still open.**
+> Degree-of-parallelism knobs derive from `Environment.ProcessorCount`, which does not change when other
+> PROCESSES run, so the cause is more likely a shared cross-process resource or a genuine order dependence
+> somewhere below the fit.
+
+**Next step.** (a) ~~Re-run the arm sequentially~~ — **RUNNING** as of 2026-08-07 10:18Z, ~28 h.
+(b) **Find the nondeterminism — this now outranks (a) in value, because the reproducer makes it cheap and
+because a bimodal race can flip a sequential run too.** Bisect with `determinism_probe.sh`: it is 40 s per trial. (c) Until (b), **treat concurrent `optimize` as invalid for any arm whose
 conclusion rests on comparing landings**, and say so in the run instructions beside
 [F42](#f42--every-build-directory-silently-gets-its-own-detector-settings-and-the-run-instructions-require-a-new-one-per-arm)'s
 settings-pinning rule. (d) Add a cheap standing guard: have `optimize` print `BaselineJ` where a scripted arm can

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -3062,6 +3062,59 @@ the price for a fourth-decimal gain — the same shape as
 time instead of recall.
 Reproduce: `D:\hf_w8\field\compare_runs.sh`, `D:\hf_w8\field\cost_*.json`, `D:\hf_w8\field\gate_*.json`.
 
+### F54 — F39(b)'s default flip MOVES a landing at a resolved factor of 1, where it is documented as a no-op
+**Status:** Open · found 2026-08-07 (wave 9) chasing [F53](#f53--wave-8s-arm-x-does-not-reproduce-from-wave-8s-own-exe-because-the-arm-ran-on-an-earlier-build-of-it)'s
+remainder · **measured and reproducible; the MECHANISM is not identified and is not claimed**
+
+Wave 8 flipped `optimize --per-run`'s default to apply each run's derived detection binning, and recorded the
+opt-out as leaving prior arms reproducible. On `D:\hf_w7\armE\t0.5\D02_rich_135mm` — **one binary, one pinned
+settings file, one set of frames, and a resolved factor of 1** — the two paths land in different places:
+
+| | landed gate | σ_focus | `bestJ` |
+|---|---|---|---|
+| default (flip ON), factor **1** from `synthetic_meta.json` | **33.333** | **0.10063** | 0.996486 |
+| `--no-run-detection-binning` | **16.667** | **0.10927** | 0.996328 |
+
+The second row reproduces wave 7's arm E and wave 8's arm X **exactly**, which is what makes this the explanation
+for F53's residue rather than a second unexplained thing.
+
+**Everything the harness prints about the seed is IDENTICAL between the two runs** — `Sensitivity=10`,
+`StarClippingMultiplier=2`, `NoiseClippingMultiplier=4`, `StructureLayers=4`, and the per-run
+`PixelScale 5.74486 arcsec/px (frame header)`. The only difference is the two `DetectionBinningResolver.ApplyFactor(_, 1)`
+calls the flip enables.
+
+**Why that is surprising.** `ApplyFactor(p, 1)` reads as the identity when `p.DetectionBinning` is already 1:
+`unbinned = PixelScale / max(1, 1)`, then `PixelScale = unbinned × 1`. `StarDetectorParams.DetectionBinning`
+**defaults to 1** (`IStarDetector.cs:495`), so the 0→1 hypothesis is dead. And
+`HocusFocusStarDetection.ApplyDetectionImageContext` **overwrites** `detectorParams.DetectionBinning` from the
+options override at detect time anyway, so the field the resolver writes is not even the one the detector uses.
+
+**What is NOT the cause**, each excluded rather than assumed:
+
+- **Not concurrency** — the two runs bracket each other under identical load, and a third control (F53) matched a
+  different binary to 6 dp with three `optimize` processes in flight.
+- **Not this wave's code** — `D:\hf_w8\exe` and wave 9's `exe2` agree with each other on the flip-ON value.
+- **Not `EffectiveStructureLayers`** — wave 8's F52(a) extraction is a faithful one (identical branch order and
+  expressions), and its `CostNoteFor` calls `Materialize`, which **clones** the seed and has no side effects.
+
+**Why it matters, and it is not academic.** Wave 8's adoption control reported *"every binning-1 dataset is
+bit-identical between arm A and arm B … 0 control violations of 13"* — **the same comparison this entry runs, with
+the opposite result.** The two differ in one respect worth chasing first: wave 8's control ran on the BANK folders
+while this runs on wave 7's rendered `armE` copies, and those copies already contain an `optimized_settings.json`
+written by a previous `--per-run` pass ([F15](#f15--optimize---per-run-overwrites-each-runs-stored-settings)),
+which `HarnessSettingsStore.ResolveForRun` reads. If a per-run settings file can change what the flip does, that is
+the F42 shadowing concern arriving through a different door.
+
+**This wave's F32 arm is NOT affected, and that is measured rather than assumed.** RULE G reproduced all 8
+comparability runs to 6 dp **with the flip ON, on the bank folders**, against wave 5's values.
+
+**Next step.** (a) Reproduce on a BANK folder with and without the flag, to separate "the flip moves landings" from
+"a stale per-run `optimized_settings.json` moves landings". (b) If it is the per-run file, that is F15 causing a
+measurement error rather than merely destroying provenance, and it raises F15's priority sharply. (c) Either way,
+`ApplyFactor` at factor 1 should be provably inert or should not be called — a normalization step that changes an
+answer is worse than no normalization.
+Reproduce: `D:\hf_w9\wing\ctl_nobin.log` vs `D:\hf_w9\wing\opt_0.5_D02_rich_135mm.log`.
+
 ### F53 — Wave 8's arm X does not reproduce from wave 8's own `exe`, because the arm ran on an EARLIER build of it
 **Status:** Open · found 2026-08-07 (wave 9) re-running arm X's exact command to build the wing instrument ·
 **the reproduce line is stale, and nothing in the artifact says so**

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -841,6 +841,64 @@ derived-exposure rung on either dataset, this entry REOPENS.**
 >
 > **This list IS (c)'s work list**, produced by (b) rather than by a separate investigation.
 
+> ## (c) RESOLVED 2026-08-07 (wave 9): THE FLOOR STAYS, THE CEILING STAYS, AND NOTHING RE-RENDERS
+>
+> (c) was filed as expensive — moving `MinExposureSeconds` re-derives and re-renders 11 datasets. **The check
+> that decides whether to spend that is free, and it was run first.** Rule F19c, fixed before it ran: *(c)
+> resolves as "the floor stays" unless a floor-clamped dataset can be shown, from data already on disk, to have
+> its σ_focus minimum BELOW 0.5 s.*
+>
+> **The floor. Every one of the 11 clamped datasets asks for LESS than 0.5 s**, so a lower floor moves all eleven
+> **down** — and the one dataset with a measured exposure ladder moves the other way: wave 7's arm E has `D02`
+> improving **44 % of σ_focus at 8 s**, four orders of magnitude above its 0.001 s ask. **Lowering the floor makes
+> `D02` worse; raising it is not what a floor is for** (a floor stops an absurdly short exposure, it does not
+> supply an exposure the derivation failed to find). **The floor is the symptom, not the defect.**
+>
+> **And the free check produced a number the entry never had.** `synth-bank --dry-run` on the wave-9 binary
+> reproduces the saturated set exactly (**13 of 20**, 11 floor + 2 ceiling), and printed beside the on-frame star
+> count the 20th-brightest is drawn from it says what this entry has always ARGUED:
+>
+> | dataset | on-frame stars | raw ask | clamp |
+> |---|---|---|---|
+> | `D10_rc16_3250mm_sparse` | **26** | **335.6 s** | ceiling |
+> | `D13_apo200_1800mm` | 177 | 0.264 s | floor |
+> | `D07_rc10_2000mm` | 428 | 0.066 s | floor |
+> | `D14_cdk14_2563mm_e47` | 640 | 0.055 s | floor |
+> | **`D17_cdk14_oiii5`** | **799** | **40.4 s** | **ceiling** |
+> | `D03` / `D20` / `D05` / `D02` | 969 / 1151 / 2346 / 3590 | 0.003 / 0.004 / 0.014 / **0.001** s | floor |
+> | `D19` / `D04` / `D01` / `D18` | 4914 / 7480 / 19201 / **27084** | 0.008 / 0.004 / 0.003 / 0.004 s | floor |
+>
+> **Spearman ρ(on-frame star count, raw ask) = −0.68 over the 13.** The two CEILING datasets are the two
+> sparsest-or-faintest; all eleven FLOOR datasets are the rich ones. *"Sized by field richness rather than by
+> whether the stars the fit depends on are above the noise"* is no longer an argument — it is a rank correlation
+> over the whole bank, in both directions at once.
+>
+> **The one exception is the honest one, and it is this entry's own poster child.** `D17_cdk14_oiii5` has 799
+> on-frame stars — more than four of the floor-clamped datasets — and still asks for 40.4 s, because an OIII
+> filter genuinely starves it. So richness is not the WHOLE story; it is simply the dominant term, and the
+> statistic has no way to tell the two apart. That is the wing-statistic problem, not a clamp problem.
+>
+> ### The CEILING, which had never been examined
+>
+> Separable from the floor and **not obviously the same defect** — at the floor the arithmetic asks for less than
+> any sane exposure; at the ceiling it asks for more than an AF sweep can spend.
+>
+> - **Product: `MaxRecommendedExposureSeconds = 30 s` STAYS. Verified, not changed.** `D10`'s 335.6 s over a
+>   9-point sweep is ~50 minutes of pure integration and `AutoFocusEngineOptions.AutoFocusTimeout` would kill the
+>   run. The cap is doing its job, and `StarSignalCopy.DescribeExposureDerivation` already names *which* bound
+>   bound it (F19(b) verified that).
+> - **Bank fidelity: `D10` and `D17` are RENDERED at 30 s while their own physics asks 335.6 / 40.4 s.** Two of
+>   the twenty datasets are deliberately photon-starved relative to their derivation and no write-up had ever said
+>   so. **Recorded, not re-rendered:** a `D10` rendered at 335 s would be a dataset no user could capture.
+> - **Rule CEIL, fixed in advance:** the ceiling moves only if a dataset's σ_focus is measured to improve
+>   materially between 30 s and its raw ask. No such ladder exists, and rendering one would re-render the bank
+>   [F32](#f32--j-is-saturated-near-10-so-the-optimizer-trades-enormous-recall-for-numerically-trivial-gains)'s
+>   confirmation arm was running on. **Deferred with a stated price**, which is the thing wave 8's §0.1 got wrong
+>   by deferring on a prediction instead.
+>
+> **So (c) costs nothing and re-renders nothing, and the wave's item 1 was worth running for its own sake rather
+> than as a prerequisite.** Reproduce: `D:\hf_w9\dryrun_w9.txt`.
+
 ### F20 — Below `MinHFR` the autofocus objective collapses to exactly zero, with no diagnostic
 **Status:** Done (parts 1 and 2) · found 2026-08-02 running `optimize --per-run` over the
 synthetic AF bank

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -3062,6 +3062,57 @@ the price for a fourth-decimal gain — the same shape as
 time instead of recall.
 Reproduce: `D:\hf_w8\field\compare_runs.sh`, `D:\hf_w8\field\cost_*.json`, `D:\hf_w8\field\gate_*.json`.
 
+### F53 — Wave 8's arm X does not reproduce from wave 8's own `exe`, because the arm ran on an EARLIER build of it
+**Status:** Open · found 2026-08-07 (wave 9) re-running arm X's exact command to build the wing instrument ·
+**the reproduce line is stale, and nothing in the artifact says so**
+
+Wave 8's F19 arm X is recorded with `Reproduce: D:\hf_w8\armX\arm_x.sh`, which invokes
+`D:\hf_w8\exe\TestApp.exe`. **Running that script's exact command on that exact binary today does not reproduce
+the write-up's numbers.**
+
+| | `D02_rich_135mm` @ 0.5 s, `--max-evals 120`, same pinned settings |
+|---|---|
+| wave 8's arm X log | `bestJ = 0.996328`, effective gate **16.667**, σ_focus 0.10927 |
+| `D:\hf_w8\exe` **today** | `bestJ = 0.996486`, effective gate **33.333**, σ_focus 0.10063 |
+| wave 9's `exe2` (this branch) | `bestJ = 0.996486` — **identical to the line above** |
+
+**The tell is in the log, and it is unambiguous.** Wave 8's arm X log contains **no `detection binning (F39b)`
+line at all**; both of today's runs print one. That line is unconditional once wave 8's own F39(b) default flip
+landed, so **arm X was executed against a build of `D:\hf_w8\exe` that predates the flip**, and the directory was
+rebuilt later in the wave. The artifact directory keeps only the LAST build, so the script and the numbers it
+produced now disagree with nothing recording that they should.
+
+**Three things this is NOT.**
+
+1. **Not concurrency.** The control above was run with three `optimize` processes already in flight and matched a
+   run of a different binary to six decimal places. If a fan-out perturbed landings, these two could not agree.
+2. **Not this wave's code.** `D:\hf_w8\exe` and wave 9's `exe2` — different binaries, one of them predating every
+   line of wave 9 — give the same answer.
+3. **Not `ApplyFactor`.** `DetectionBinningResolver.ApplyFactor(p, 1)` is the identity when `p.DetectionBinning`
+   is already 1 (`unbinnedPixelScale = PixelScale / 1`, then `PixelScale = unbinnedPixelScale × 1`), which the
+   pinned settings guarantee. That is also why wave 8's own adoption-arm control found the 13 binning-1 datasets
+   bit-identical. The flip is a marker for WHICH BUILD ran, not the cause of the movement.
+
+**Does it overturn wave 8's F19 verdict? No, and the reason is worth stating.** Arm X's finding was that `D02`
+reports `ExposureIsNotTheLimit` with a raw ask of 0.000 s at every rung. Both landings put the EFFECTIVE gate
+(16.667 and 33.333) far above `TargetSensitivity = 10`, and every accepted star's gate statistic strictly exceeds
+that gate — so `ExposureIsNotTheLimit` is true by construction in both. **R5 fired for a structural reason, not a
+numerical one, so a different landing reaches the same verdict.** What is void is the reproducibility of the
+specific table, not its conclusion.
+
+**Why it matters.** [F41](#f41--a-prior-waves-control-arm-is-not-a-control-for-a-later-waves-binary) says a prior
+wave's control arm is not a control for a later wave's binary. This is the sharper case: **a prior wave's arm is
+not a control for its OWN recorded binary either**, when the arm directory is a build output that later steps in
+the same wave overwrite. Every `Reproduce:` line in `docs/` that names a `D:\hf_w*\exe` inherits this.
+
+**Next step.** (a) Stamp the build into the run: have `optimize` print the informational version / commit of the
+binary it is running, so a log says which build produced it. (b) Until then, treat a `D:\hf_w*\exe` reproduce line
+as naming a COMMAND, not a result — re-derive the numbers rather than quoting them across waves. (c) Prefer
+per-arm build directories that are never rebuilt mid-wave, which
+[F42](#f42--every-build-directory-silently-gets-its-own-detector-settings-and-the-run-instructions-require-a-new-one-per-arm)
+already asks for on a different ground.
+Reproduce: `D:\hf_w9\wing\ctl_w8bin.log` against `D:\hf_w8\armX\opt_0.5_D02_rich_135mm.log`.
+
 ### F50 — A false-negative gate count is an UPPER BOUND on what relieving that gate buys, not an estimate
 **Status:** Open · found 2026-08-06 (wave 8) refuting F46's `MinimumStarBoundingBoxSize` hypothesis · **a reading
 error, not a code defect — but every prior wave has read these tables the other way**

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -1684,6 +1684,28 @@ runs are on the real bank, which wave 7 never touches. **The arm is runnable and
 > honest product change is to expose RESTARTS (the wizard's "Continue optimizing" button already is one) rather
 > than a feasibility constraint that can cost 2000× of σ_focus.
 >
+> ### WHAT SHIPS INSTEAD: the restart, exposed (2026-08-07, wave 9)
+>
+> R2 says restarts recover **228 %** of the floor's gain, so the mechanism ships as the affordance the user
+> already had. **"Continue optimizing" IS a restart** — each pass re-seeds from the prior best with a fresh
+> curated set, resetting the pattern-search stride — and it has always been on the Summary page. Nothing told the
+> user when pressing it was worth anything.
+>
+> `StarDetectionOptimizerWizardVM.ContinueOptimizingAdviceText` is that missing half: when the landing kept less
+> than **half** the stars its own seed did (φ = 0.50 reused as a DIAGNOSTIC, the one role this arm supports for
+> it), the Summary says so and points at the button.
+>
+> - It **names a control that is present AND enabled** — gated on `CanContinueOptimization`, so it disappears at
+>   the 3-round cap and while a pass is running (the house rule at `ShowOptimizeAgainAtRecommendedBinning`).
+> - It **never names `MinDetectionKeepFraction`**, which has no XAML binding and which this arm measured as
+>   harmful as a default.
+> - It promises a **direction, not a magnitude** — restarts helped on most binding runs, not all.
+> - It is **absent on healthy landings**, because a note that always fires says nothing.
+>
+> **Tests: 4, two of them discriminating**, each confirmed by neutralizing: removing the shedding threshold fails
+> `ContinueAdvice_HealthyLanding_SaysNOTHING`; removing the `CanContinueOptimization` guard fails
+> `ContinueAdvice_NeverPromisesAnActionThatCannotBeTaken`.
+>
 > **F15:** arm A ran LAST, so both banks hold the SHIPPED-DEFAULT landing — the correct resting state, and no
 > re-land is owed since nothing was adopted. Reproduce: `D:\hf_w9\f32_arms.sh` (FANOUT=1), `D:\hf_w9\score_f32.py`.
 

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -3167,8 +3167,9 @@ time instead of recall.
 Reproduce: `D:\hf_w8\field\compare_runs.sh`, `D:\hf_w8\field\cost_*.json`, `D:\hf_w8\field\gate_*.json`.
 
 ### F56 — The à-trous wavelet residual convolves a DENSE kernel that is 99.5 % zeros, and that IS the `StructureLayers` cost curve
-**Status:** Open · found 2026-08-07 (wave 9) answering a question about GPU/SIMD builds ·
-**ANALYSIS, NOT MEASUREMENT — no benchmark was run, because F55 forbids CPU load beside the sequential arm**
+**Status:** Open · found 2026-08-07 (wave 9) answering a question about GPU/SIMD builds · **the diagnosis is
+confirmed and the first fix was MEASURED AT +50 % SLOWER AND REVERTED** — the à-trous kernel really is 99.5 %
+zeros, but the stage is memory-bandwidth bound, so the FLOP count did not predict runtime
 
 `StarDetector` step 4's structure-removal residual is the detector's dominant cost.
 [F52](#f52--a-two-hour-optimization-logs-one-line-and-offers-no-cost-context-and-the-search-is-not-cost-aware)
@@ -3193,9 +3194,46 @@ Cost is linear in kernel length, and the kernel doubles per layer — which repr
 OpenCV's `sepFilter2D` has no dilation parameter, which is presumably why the zero-padding was chosen, but a
 hand-written strided 5-tap separable pass has no such limit and is trivially vectorizable.
 
-**Predicted, NOT measured:** layer 8 falls to roughly the cost of layer 1 — order **20–100×** on this stage —
-and the `StructureLayers` cost curve F52 documents largely disappears. **Nothing here is confirmed**; the
-arithmetic above is a static reading of the kernel and OpenCV's semantics.
+> ### IMPLEMENTED, MEASURED, AND REVERTED THE SAME DAY — the FLOP analysis above does not predict wall time
+>
+> The strided rewrite was built, CI-verified (3682 passed / 0 failed; equivalence green at layers 1–6), merged,
+> and then **measured against the pre-F56 binary on the 8-run sequential gate — the same runs, same invocation,
+> sequential both times.**
+>
+> | run | pre-F56 | F56 strided | change |
+> |---|---|---|---|
+> | `toml999` | 154 s | 232 s | **+51 %** |
+> | `CWhiteFocus` | 495 s | 795 s | **+61 %** |
+> | `uneven` | 339 s | 641 s | **+89 %** |
+> | `muggsie` | 65 s | 101 s | **+55 %** |
+> | `mccomiskey` | 326 s | 351 s | **+8 %** |
+> | `D18_m24_deep_shed` | 334 s | 442 s | **+32 %** |
+> | **total** | **1713 s** | **2562 s** | **+50 %** |
+>
+> **Uniformly slower. Not one run faster. REVERTED.**
+>
+> **Why the arithmetic was irrelevant.** The à-trous residual is **memory-bandwidth bound, not FLOP bound.**
+> `sepFilter2D` makes ONE pass per axis with the kernel resident in registers; the strided version as implemented
+> made **five full-image read-modify-write passes per axis**, plus two `CopyMakeBorder` allocations per layer. It
+> traded 13× fewer multiply-adds for 5× the memory traffic, and at these image sizes memory wins. The 13–205×
+> figures are correct as FLOP counts and **do not predict runtime** — which is the whole reason the entry was
+> filed as "ANALYSIS, NOT MEASUREMENT".
+>
+> **What IS established, and is worth keeping:**
+> 1. **The rewrite is LANDING-NEUTRAL.** RULE G on the F56 binary passes **8 of 8 to 6 dp** — bit-identical
+>    landings, `BaselineJ` included. So the à-trous can be reimplemented freely without invalidating any prior
+>    arm; only speed is at stake.
+> 2. **The kernel really is 99.5 % zeros**, and F52's measured 2×-per-layer curve really is that padding. That
+>    part of the diagnosis stands.
+> 3. **The right implementation is a SINGLE FUSED strided pass**, not five composed `Cv2` calls: one hand-written
+>    pointer loop per axis gathering 5 taps at stride `2^L`, giving `sepFilter2D`'s memory traffic (one read, one
+>    write) with 5 multiply-adds instead of `2^(L+2)+1`. That is the version that should win at every layer, and
+>    it is what "O(1) per layer" was always supposed to mean.
+>
+> **Lesson, and it is this entry's real content: a FLOP count is not a benchmark.** The waste was real and the
+> conclusion was still wrong, because the bottleneck was somewhere the analysis never looked. Measure the thing
+> you are about to optimise before optimising it — the gate that measured this cost 33 minutes and would have
+> cost nothing to run first.
 
 **Why it matters beyond speed.** (a) `OptimizerVariable` searches `StructureLayers` over `[1, 8]`, so every
 optimizer run pays this, hundreds of times — it is a large share of the two-hour runs F52 was filed about.
@@ -3203,13 +3241,17 @@ optimizer run pays this, hundreds of times — it is a large share of the two-ho
 deeper layers are the RIGHT answer at detection binning 2, and the cost is what makes that expensive to adopt.
 (c) It reframes F52(d): a cost term in `J` would be penalising an artifact rather than physics.
 
-**Next step.** (a) Replace the zero-padded kernel with a strided 5-tap separable convolution (two passes, or one
-`filter2D` per axis with an explicit gather). (b) **Verify by EQUIVALENCE, not by eye** — it is the same
-arithmetic, so `StarDetectorEquivalenceTests` plus a bank re-score must come back bit-identical (or explain any
-delta as border handling: the current code uses `BorderTypes.Reflect`, and a strided implementation must match
-that at every layer). (c) Only then benchmark, and only with **nothing else running** (F55).
-**This supersedes any argument for a custom SIMD or CUDA OpenCV build as the first move**: the stock native
-build already dispatches AVX2/AVX-512, and no SIMD width recovers a 205× algorithmic waste.
+**Next step, revised by the measurement.** (a) **BENCHMARK FIRST** — the 8-run sequential gate is 33 minutes and
+is the instrument that settled this; run it before writing any further optimisation, not after. (b) If it is
+attempted again, the shape is a **single fused strided pass** (one hand-written pointer loop per axis, 5 taps at
+stride `2^L`, one read and one write), NOT composed `Cv2` calls — the composed form is what lost. (c) Find the
+crossover: F52's 27 → 526 s curve means dense must lose *somewhere*, so a hybrid that keeps `sepFilter2D` at low
+layers and switches at the crossover may be the only version that wins. (d) Equivalence is already established —
+RULE G passed 8/8 on the strided binary — so a future attempt needs only a benchmark, not a re-validation.
+**On custom SIMD / CUDA OpenCV builds:** the stock native build already dispatches AVX2/AVX-512, and this
+result is the argument against assuming any build-level change helps — the stage is bound by memory, not by
+instruction width, so wider vectors have nothing to recover. Establish the bottleneck by measurement before
+buying or building anything.
 
 ### F55 — `optimize` is NOT reproducible when several instances run at once, and the SEED evaluation is what moves
 **Status:** Open · found 2026-08-07 (wave 9) when the confirmation arm's own pre-registered control fired ·

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -1473,10 +1473,11 @@ fail in two directions — biased, then saturated — which is why `precisionNul
 precision figure rather than being something a reader has to think to ask for.
 
 ### F32 — `J` is saturated near 1.0, so the optimizer trades enormous recall for numerically trivial gains
-**Status:** Open — **mechanism shipped default OFF (wave 5)**; the confirmation arm was **re-validated as the right
-experiment (wave 6)** against a restarts-only alternative and is still owed. The
-entry's own premise is corrected below: on 5 of 7 binding runs there was no trade to bound, the search was
-merely stuck · found 2026-08-03 re-reading the wave-1 real-bank control arm
+**Status:** **ANSWERED 2026-08-07 (wave 9): the confirmation arm ran on both full banks and phi = 0.50 does NOT
+ship.** R1(c) fails catastrophically (σ_focus x2000 worse on `vsn07`), R3 fails on the newly-covered population,
+and R2 INVERTS wave 6 — restarts recover 228 % of the floor's gain, so the floor is not a distinct mechanism.
+`MinDetectionKeepFraction` stays default OFF permanently. **The greedy trap itself is confirmed and stands**; the
+floor is simply the wrong instrument for it · found 2026-08-03 re-reading the wave-1 real-bank control arm
 
 The objective's landings are not close calls. Across the 17 scorable real-bank runs, `optimize --per-run` gives
 up a **median 0.243 of recall@SNR≥12** to gain a **median ΔJ of +0.0125** — and the worst cases are far starker
@@ -1641,6 +1642,50 @@ of the derivation does not move) and **F39(b) needed no re-render at all** (the 
 frames' exposures were already derived at binning 2). Nothing in wave 7 has re-rendered a frame, so `D18` / `D19`
 / `D20` — this arm's entire synthetic half — are bit-for-bit what wave 5 and wave 6 measured, and its other five
 runs are on the real bank, which wave 7 never touches. **The arm is runnable and comparable TODAY.**
+
+> ## THE CONFIRMATION ARM RAN (2026-08-07, wave 9). BOTH CONTROLS PASS, AND phi = 0.50 DOES NOT SHIP.
+>
+> Deferred across waves 5, 6, 7 and 8; run sequentially over **both full banks** (39 runs x 3 arms = 117
+> optimizations, 9 h 24 m) after [F55](#f55--optimize-is-not-reproducible-when-several-instances-run-at-once-and-the-seed-evaluation-is-what-moves)
+> voided a first attempt at fan-out 4.
+>
+> ### The controls, which is what makes any of it readable
+>
+> | control | fan-out attempt | **sequential** |
+> |---|---|---|
+> | **RULE G** — arm A vs wave 5's feature-OFF arm | FAIL 2 of 8 | **PASS 8 of 8 to 6 dp** |
+> | **`BaselineJ`** — [F41](#f41--a-prior-waves-control-arm-is-not-a-control-for-a-later-waves-binary)'s tell | 6 of 39 moved | **0 of 39 moved** |
+>
+> ### The verdict: 11 of 39 runs bind, and phi = 0.50 FAILS on three independent pre-registered rules
+>
+> | rule | measured | verdict |
+> |---|---|---|
+> | **R1(a)** median Δ`J` (B − A) on binding runs | **+0.000076** | pass |
+> | **R1(c)** worst σ_focus regression | **`vsn07` 0.00083 → 1.71721** | **FAIL** |
+> | **R2** restarts' recovery of the floor's median gain | **228 %** | **the floor is NOT a distinct mechanism** |
+> | **R3** newly-covered binding runs | 6: **2 improved, 4 regressed** | **FAIL** |
+>
+> **R1(c) fails catastrophically, not marginally.** The bar was 20 %. `vsn07` degrades σ_focus by a factor of
+> **2000** (0.00083 → 1.71721) and `FlyData` by a factor of 7.7 (0.16738 → 1.28554). On these runs the floor does
+> not trade recall for `J` — **it destroys the focus fit**, which is the one thing the objective exists to protect.
+>
+> **R3 fails, and it is wave 8's `StructureLayers` lesson repeating exactly.** On the runs wave 5 never covered
+> the floor regresses 4 and improves 2. Wave 5's evidence was 7 binding runs on a subset chosen because the floor
+> looked good there; the population that did not motivate the hypothesis refuted it.
+>
+> **R2 INVERTS wave 6's finding, and this is the wave's most interesting result.** At 8 runs, `--continue-rounds 2`
+> recovered **0–36 %** (median 13.8 %) of the floor's gain, which is what justified keeping the floor as a distinct
+> mechanism worth confirming. At full-bank scale restarts recover **228 %** — they are strictly BETTER than the
+> floor, on the floor's own binding set. Wave 6's conclusion was drawn from 7 runs and reverses on 11.
+>
+> **So: `MinDetectionKeepFraction` stays default OFF, permanently rather than pending.** It remains available as
+> `--keep-floor` on the harness. **The greedy trap this entry discovered is real and is NOT withdrawn** — restarts
+> demonstrably improve `J` on most binding runs — but the keep floor is the wrong instrument for it, and the
+> honest product change is to expose RESTARTS (the wizard's "Continue optimizing" button already is one) rather
+> than a feasibility constraint that can cost 2000× of σ_focus.
+>
+> **F15:** arm A ran LAST, so both banks hold the SHIPPED-DEFAULT landing — the correct resting state, and no
+> re-land is owed since nothing was adopted. Reproduce: `D:\hf_w9\f32_arms.sh` (FANOUT=1), `D:\hf_w9\score_f32.py`.
 
 **When F18's re-render does happen, the rule for this arm is fixed in advance:** the datasets whose `step*` moves
 get their pre-wave frames preserved (`D:\hf_w7\oldframes`, as wave 6 did) and the arm runs on those; an arm run

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -3234,9 +3234,11 @@ time instead of recall.
 Reproduce: `D:\hf_w8\field\compare_runs.sh`, `D:\hf_w8\field\cost_*.json`, `D:\hf_w8\field\gate_*.json`.
 
 ### F56 — The à-trous wavelet residual convolves a DENSE kernel that is 99.5 % zeros, and that IS the `StructureLayers` cost curve
-**Status:** Open · found 2026-08-07 (wave 9) answering a question about GPU/SIMD builds · **the diagnosis is
-confirmed and the first fix was MEASURED AT +50 % SLOWER AND REVERTED** — the à-trous kernel really is 99.5 %
-zeros, but the stage is memory-bandwidth bound, so the FLOP count did not predict runtime
+**Status:** **DONE — fixed properly in [PR #187](https://github.com/ghilios/hocus-focus/pull/187)
+(`AtrousWaveletFast`, `StarDetectorVersion` 1→2), which validated this entry's DIAGNOSIS and refuted this entry's
+first FIX.** The kernel really is 99.5 % zeros; the stage is memory-bandwidth bound, so wave 9's five-pass
+rewrite ran +50 % SLOWER and was reverted, while the sparse 5-tap SIMD path that replaced it measures
+**2.5× / 9.7× / 40×** at layers 4 / 6 / 8 · found 2026-08-07 (wave 9) answering a question about GPU/SIMD builds
 
 `StarDetector` step 4's structure-removal residual is the detector's dominant cost.
 [F52](#f52--a-two-hour-optimization-logs-one-line-and-offers-no-cost-context-and-the-search-is-not-cost-aware)
@@ -3308,7 +3310,41 @@ optimizer run pays this, hundreds of times — it is a large share of the two-ho
 deeper layers are the RIGHT answer at detection binning 2, and the cost is what makes that expensive to adopt.
 (c) It reframes F52(d): a cost term in `J` would be penalising an artifact rather than physics.
 
-**Next step, revised by the measurement.** (a) **BENCHMARK FIRST** — the 8-run sequential gate is 33 minutes and
+> ### RESOLVED by PR #187 — and the shape it shipped in is the one wave 9's failure pointed at
+>
+> `Utility/AtrousWaveletFast.cs` replaces the dense `SepFilter2D` with a **sparse 5-tap SIMD path** — one fused
+> pass per axis, taps gathered at stride `2^L`, exactly the "single fused strided pass, NOT composed `Cv2` calls"
+> this entry's revised next-step called for. Design: [`docs/atrous-wavelet-fast-design.md`](atrous-wavelet-fast-design.md).
+>
+> | `StructureLayers` | legacy `SepFilter2D` | fast | speedup |
+> |---|---|---|---|
+> | 4 (shipped default) | 130 ms | 52 ms | **2.5×** |
+> | 6 | 781 ms | 81 ms | **9.7×** |
+> | 8 | 4267 ms | 107 ms | **40×** |
+>
+> **Legacy cost doubles per layer — the F52 curve — and the fast path is nearly flat** (52 → 81 → 107 ms), which
+> is the entry's central claim confirmed by benchmark rather than by arithmetic. It wins **even single-threaded**,
+> so the gain does not depend on core count.
+>
+> **Three of wave 9's conclusions are now settled by it.**
+>
+> 1. **The diagnosis was right and the implementation was wrong.** Wave 9 counted FLOPs, predicted 20–100×, and
+>    shipped a five-pass version that was measured **+50 % slower**. The correct version is 2.5–40× faster. The
+>    difference is entirely one fused pass versus five composed ones — i.e. memory traffic, which the FLOP count
+>    never looked at.
+> 2. **It confirms the memory-bandwidth reading**, from the other side: *"both passes stream at memory bandwidth
+>    once the tap count is fixed, which is why 24 threads only add ~1.5× over one thread."* That is also the
+>    strongest available argument against a custom SIMD or CUDA OpenCV build — the bottleneck is bandwidth, not
+>    instruction width.
+> 3. **[F52](#f52--a-two-hour-optimization-logs-one-line-and-offers-no-cost-context-and-the-search-is-not-cost-aware)'s
+>    cost note is retired with it**, and [F52](#f52--a-two-hour-optimization-logs-one-line-and-offers-no-cost-context-and-the-search-is-not-cost-aware)(d)
+>    (a cost term in `J`) loses most of its motivation: structure-layer depth is no longer a cost driver worth
+>    narrating or penalising, which is exactly the "you would be penalising an artifact" risk wave 9 flagged.
+>
+> **`StarDetectorVersion` 1→2** ships it through the sanctioned door: the paths agree to ≤ 3e-8 but are not
+> bit-identical, so the bump invalidates cached detections rather than letting a changed output pass silently.
+
+**Superseded next steps (kept for the record).** (a) **BENCHMARK FIRST** — the 8-run sequential gate is 33 minutes and
 is the instrument that settled this; run it before writing any further optimisation, not after. (b) If it is
 attempted again, the shape is a **single fused strided pass** (one hand-written pointer loop per axis, 5 taps at
 stride `2^L`, one read and one write), NOT composed `Cv2` calls — the composed form is what lost. (c) Find the

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -3322,6 +3322,29 @@ eight are one instrument"*, and it is applied as written: **no φ verdict is pub
 > **Those are exactly arm A's 0.988555 and arm B/C's 0.979173.** The probe reproduces the entire 7-hour
 > discrepancy from identical inputs in 40 seconds.
 >
+> ### THE FULL RATE, from a complete identical arm: 44 % of landings, not 15 %
+>
+> Wave 9's sequential re-run reproduces arm B (`--keep-floor 0.50`) in full, so the fan-out and sequential
+> versions of **the same 39 runs, same flag, same binary, same pinned settings** can be diffed directly:
+>
+> | quantity | differing |
+> |---|---|
+> | **`BaselineJ`** — one evaluation of the pinned seed, no search | **6 of 39 (15 %)** |
+> | **`BestJ`** — the landing the arm is actually read on | **17 of 39 (44 %)** |
+>
+> **The landing rate is triple the seed rate, and that is the important part.** Many runs have a
+> *bit-identical* `BaselineJ` and a *different* landing — `CWhiteFocus` 0.999740 vs 0.999867, `standard_example1`
+> 0.999846 vs 0.996456, `caboose` 0.996300 vs 0.994857, and `LinwoodFocus` **0.952882 vs 0.917207**, a gap of
+> 0.036. So the nondeterminism is not confined to the seed evaluation: it perturbs evaluations *during* the
+> search, and the pattern search amplifies one perturbed evaluation into a different landing.
+>
+> **RULE G caught 2 of 8 and the true rate is 44 %** — the gate was, if anything, lucky. Any arm run at fan-out
+> is not "mostly fine with a couple of outliers"; it is close to a coin flip per run.
+>
+> *(The two arms also differ in what a previous pass had left in the run folders. That was tested separately on
+> `toml999` — sequential and alone, on folders holding a contaminated landing, it returns the correct value — so
+> folder state is excluded as the cause.)*
+>
 > **Three things follow.**
 >
 > 1. **Sequential execution is deterministic** (5 of 5, and the wave-9 gate independently reproduced wave 5's

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -2865,6 +2865,34 @@ than on `IncreasesExposure` alone. (b) Make the re-capture apply the recommended
 exposure, or say plainly that it will not. (c) Neither should require Accept: re-capturing is not adopting.
 Reproduce: NINA log `20260806-122836-3.3.0.1048.73484-202608.log`; frames in `E:\AutoFocusSaves\`.
 
+**ALL THREE SHIPPED 2026-08-07 (wave 9), and (a) turned out to have TWO causes rather than one.** The entry
+names `IncreasesExposure`; the property also required `HasExposureBlock`, which is
+`OptimizationSummary.HasLowStarSignal` — **Sensitivity ≤ 1.0**. So the button was hidden by the exposure
+condition on run 2 *and* by the BLOCK's own condition on runs 1, 3 and 4, whose gates were healthy and which
+therefore never had a re-run affordance at all. The entry's table records those three runs recommending 214, 474
+and 482 with no way to act on any of them, and nothing in the entry had noticed the second gate.
+
+| part | what shipped |
+|---|---|
+| **(a)** | `ShowCaptureNewSweep` = `lastRunWasLive && !IsUseCurrentMode && (IncreasesExposure ‖ StepSizeOrOffsetChanged)`. The `HasExposureBlock` conjunct is **gone**, and the row **moved out of the Star signal block** into the Auto-focus block — beside the step-size and offset rows, which are the values it now carries. The two MODE conditions stay (Replay has no rig; use-current has nothing to re-tune), because those are fixed for the life of the Summary |
+| **(b)** | `ApplyRecaptureGeometry(options, stepSize, offsetSteps)` in `RunLiveAttemptAsync`, applied **before** `ApplyFocusRecovery` so recovery widens from the recommended offset exactly as it widens the profile's on a Start. Set from the SELECTED summary by `CaptureNewSweepAsync` and cleared on **every** exit path, so an ordinary Live Start is byte-identical |
+| **(b), the "or say plainly" half** | shipped **as well as** carrying it: `CaptureNewSweepCarriesText` states the geometry the next sweep will use (`"step size 214 → 459 … at the exposure below"`) and that nothing is written to the profile. A sweep geometry the user cannot see is how this defect stayed invisible for a whole session |
+| **(c)** | already true and now reachable — the command persists nothing and Accept remains the only writer. What forced the Accepts was (a) hiding the control, not (c) |
+
+**The house rule survives in both directions**, which is what the row's relocation had to preserve:
+`StarSignalCopy`'s Live sentence naming the button fires on `increases && live && !useCurrent`, which is a strict
+subset of the new visibility — so the copy can never name a hidden button. And in the new step-only state, where
+the Star signal block is not on screen at all, the row carries its own sentence.
+
+**Tests: 3 discriminating on `ApplyRecaptureGeometry`** (carries the step and offset; complete no-op at
+non-positive, so the Start path is unchanged; composes with `ApplyFocusRecovery` in the shipped order — reversing
+them would let the recommended offset overwrite recovery's widening and silently drop the frames the evaluator is
+about to TAG as recovery).
+
+**Still open, and it is the entry's real subject:** the step recommender asking to widen on **every** run because
+the sweep never reaches `3 × HFR_min`. (a)–(c) make the iteration cheap; they do not make it terminate. That is
+[F21](#f21--stepsizerecommenders-half-width-is-not-stable-against-noise-even-at-r--10000)/F49(c).
+
 ### F52 — A two-hour optimization logs ONE line and offers no cost context, and the search is not cost-aware
 **Status:** **(a) and (b) DONE 2026-08-06 (wave 8); (c) BLOCKED on [F19](#f19--the-exposure-recommendation-is-decided-by-the-20-brightest-stars-so-a-rich-field-can-never-earn-one);
 (d) open** · found 2026-08-06 (wave 8) from the same field session · partly measured, partly **unmeasurable after
@@ -3065,9 +3093,33 @@ runs**. This is the same instability
 the narrow side rather than [F25](#f25--from-a-far-too-wide-sweep-the-step-recommender-widens-it-further-instead-of-recovering)'s
 wide side, and the user experienced it as a runaway rather than as convergence.
 
-**Next step.** Three separable pieces. **(a)** Give the floored-gate + `ExposureIsNotTheLimit` state a remedy of
-its own — the honest one names the gate, not the exposure ("the optimizer lowered the acceptance gate to admit
-~7× more candidates; set Brightness Sensitivity by hand and re-run in Current mode to compare"). **(b)** Decide
+> ### (a) SHIPPED 2026-08-07 (wave 9) — and the branch is narrower than this entry proposed, on purpose
+>
+> `RemedyFor` gains a fourth, last-ranked branch for the floored-gate + `ExposureIsNotTheLimit` state:
+>
+> > *"The gate was lowered to admit more candidates, not because star brightness was missing. Set Brightness
+> > Sensitivity by hand in the star detection options and run this wizard again in "use current settings" mode to
+> > compare that landing against this one."*
+>
+> **It names only controls that EXIST**, per the house rule at `ShowOptimizeAgainAtRecommendedBinning`.
+> `BrightnessSensitivity` is bound in `OptionsDataTemplates.xaml`
+> (`StarDetectionOptions.BrightnessSensitivity`); `MinDetectionKeepFraction` is **not named**, because it has no
+> XAML binding anywhere — verified, not assumed.
+>
+> **It REQUIRES a measurement, which this entry's proposed wording did not.** The sentence CLAIMS that brightness
+> was not what was missing, and that is knowable only from `ExposureIsNotTheLimit` (S_now ≥ the default target).
+> On a run with no derivable recommendation at all — too few usable frames, no per-star SNRs, an unknown exposure
+> to scale from — all that is known is that the gate is floored, so those runs keep their diagnosis-only body.
+> **Asserting it there would break the entry's own "no star-poor claim without evidence" rule from the opposite
+> direction**, and two existing golden tests caught exactly that on the first attempt.
+>
+> **Tests: 4, three of them discriminating.** The pre-existing whole-body golden for this state is the sharpest —
+> it asserted a string that ENDED after the admission sentence, which is the defect written down as an
+> expectation. Plus: the remedy is last-ranked and does not displace an available exposure remedy; an unmeasured
+> run gets no gate remedy; and the copy names no control that does not exist.
+
+**Next step.** Three separable pieces. **(a)** ~~Give the floored-gate + `ExposureIsNotTheLimit` state a remedy of
+its own~~ — **DONE, see above**; the honest one names the gate, not the exposure. **(b)** Decide
 whether a user-facing floor on the search's Sensitivity (or F32's keep fraction, exposed) is the right lever, since
 today there is none. **(c)** When the step recommendation is capped by the sweep width, say what it is converging
 TOWARD (`3 × HFR_min`) and that the cap means "partial step, this will take another run" — the exposure

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -3166,6 +3166,51 @@ the price for a fourth-decimal gain — the same shape as
 time instead of recall.
 Reproduce: `D:\hf_w8\field\compare_runs.sh`, `D:\hf_w8\field\cost_*.json`, `D:\hf_w8\field\gate_*.json`.
 
+### F56 — The à-trous wavelet residual convolves a DENSE kernel that is 99.5 % zeros, and that IS the `StructureLayers` cost curve
+**Status:** Open · found 2026-08-07 (wave 9) answering a question about GPU/SIMD builds ·
+**ANALYSIS, NOT MEASUREMENT — no benchmark was run, because F55 forbids CPU load beside the sequential arm**
+
+`StarDetector` step 4's structure-removal residual is the detector's dominant cost.
+[F52](#f52--a-two-hour-optimization-logs-one-line-and-offers-no-cost-context-and-the-search-is-not-cost-aware)
+measured it on `D15_cdk20_3454mm_e47`: **27 / 46 / 117 / 254 / 526 s** for `StructureLayers` 4→8, *"roughly a
+doubling per layer"*, and shipped a UI note explaining that cost to users.
+
+**The doubling is an implementation artifact.** `CvImageUtility.GetB3SplineFilter(L)` builds a 1-D kernel of
+length `(1 << (L+2)) + 1` in which **exactly five taps are non-zero** — the B3-spline `0.0625 / 0.25 / 0.375 /
+0.25 / 0.0625` spaced `2^L` apart — and its own comment states the intent: *"Rather than copy the matrix to
+convolve it, we can pad the separated filter with zeroes."* `Cv2.SepFilter2D` then performs a **dense** separable
+FIR over the whole kernel.
+
+| layer | kernel taps | useful taps | wasted multiply-adds |
+|---|---|---|---|
+| **4** (shipped default) | 65 | 5 | **13×** |
+| 6 | 257 | 5 | **51×** |
+| 8 | 1025 | 5 | **205×** |
+
+Cost is linear in kernel length, and the kernel doubles per layer — which reproduces F52's measured curve exactly.
+
+**"À trous" MEANS "with holes", and the algorithm exists to be O(1) per layer**: convolve 5 taps at stride `2^L`.
+OpenCV's `sepFilter2D` has no dilation parameter, which is presumably why the zero-padding was chosen, but a
+hand-written strided 5-tap separable pass has no such limit and is trivially vectorizable.
+
+**Predicted, NOT measured:** layer 8 falls to roughly the cost of layer 1 — order **20–100×** on this stage —
+and the `StructureLayers` cost curve F52 documents largely disappears. **Nothing here is confirmed**; the
+arithmetic above is a static reading of the kernel and OpenCV's semantics.
+
+**Why it matters beyond speed.** (a) `OptimizerVariable` searches `StructureLayers` over `[1, 8]`, so every
+optimizer run pays this, hundreds of times — it is a large share of the two-hour runs F52 was filed about.
+(b) [F46](#f46--detection-binning-buys-faint-stars-and-quietly-sells-bright-ones-to-the-shapesize-gates) showed
+deeper layers are the RIGHT answer at detection binning 2, and the cost is what makes that expensive to adopt.
+(c) It reframes F52(d): a cost term in `J` would be penalising an artifact rather than physics.
+
+**Next step.** (a) Replace the zero-padded kernel with a strided 5-tap separable convolution (two passes, or one
+`filter2D` per axis with an explicit gather). (b) **Verify by EQUIVALENCE, not by eye** — it is the same
+arithmetic, so `StarDetectorEquivalenceTests` plus a bank re-score must come back bit-identical (or explain any
+delta as border handling: the current code uses `BorderTypes.Reflect`, and a strided implementation must match
+that at every layer). (c) Only then benchmark, and only with **nothing else running** (F55).
+**This supersedes any argument for a custom SIMD or CUDA OpenCV build as the first move**: the stock native
+build already dispatches AVX2/AVX-512, and no SIMD width recovers a 205× algorithmic waste.
+
 ### F55 — `optimize` is NOT reproducible when several instances run at once, and the SEED evaluation is what moves
 **Status:** Open · found 2026-08-07 (wave 9) when the confirmation arm's own pre-registered control fired ·
 **this voids the wave-9 F32 arm and constrains every future arm's design**

--- a/docs/synthetic-af-bank-followups-wave9-design.md
+++ b/docs/synthetic-af-bank-followups-wave9-design.md
@@ -116,13 +116,12 @@ real-bank recall, since the efficacy criterion could only be evaluated by keep-%
   the `_`-prefixed folders are scratch arms, not runs).
 - **Recall:** `bank-verify --opt-a` against arms A and B, which is the measurement wave 5 could not make.
 
-**Arm C's population is narrowed, and the narrowing is pre-registered rather than discovered.** Arm C runs on the
-**union of (i) the runs where arm B's landing differs from arm A's** (the *binding* set — where the floor did
-something, so "would a restart have done it instead?" is a question with content) **and (ii) the 8-run wave-5/6
-comparability subset** (so the cross-wave comparison to wave 6's arm R survives). On a non-binding run the floor
-changed nothing and arm C would be answering a question nobody asked. **This is a reduction in scope and it is
-declared as one** — the alternative is ~8 h of compute whose only possible finding is "the restart also did
-nothing here".
+**All three arms run the FULL population, and the reduction that was drafted here was withdrawn once it was
+priced.** The first draft narrowed arm C to the binding set, because `--continue-rounds 2` is ~2.4× the per-run
+cost (wave 6: 8 runs in 1 h 35 m against wave 5's 40 m) and 39 runs sequentially is ~8 h. **With the fan-out in
+§1.4 that is ~2.6 h**, which is inside F32's own ~6 h estimate for the whole arm — so the narrowing bought
+nothing but a definitional argument about what "binding" means before arm A has run. Full scope, no dependency
+between the arms, and the ordering in §0.3 works directly.
 
 ### §1.3 THE COMPARABILITY GATE — run FIRST, and the arm does not start until it passes
 
@@ -332,19 +331,72 @@ Wave 8 hit *"the instrument agrees with the thing it is supposed to check"* **th
 accepted-star count, `NTarget`-th SNR, gate/flat rejections), re-run arm X's 10 optimizations over the frames
 already on disk (**~8 min, no re-render**), and *look at the wing structure before choosing a form*.
 
-### §3.4 The candidate family, fixed now so that choosing among them is not fishing
+### §3.4 The candidate family — DRAFTED, THEN REFUTED BEFORE IT WAS IMPLEMENTED
+
+The family this section first named was **C1** `S_wing` (the `NTarget`-th-brightest reduction aggregated over the
+*wing* frames rather than all frames), **C2** `n_wing` (wing accepted-star count against `NTarget`), **C3**
+`min(S_now, S_wing)`, and **C4** C1-gated-by-C2. Every one of them is an order statistic over **ACCEPTED** stars.
+
+**All four are structurally incapable of firing on `D02`, and it takes a proof plus data already on disk to see
+it — no run required.**
+
+> **The gate floor theorem.** `StarDetector.InertSensitivityBound` proves that every candidate reaching the
+> Sensitivity gate satisfies `sensitivity > PeakResponse × EffectiveClipMultiplier`, and acceptance additionally
+> requires it to exceed `StarDetectorParams.Sensitivity`. So **every accepted star's gate statistic strictly
+> exceeds `EffectiveSensitivityGate = max(Sensitivity, InertSensitivityBound)`**, and therefore **any order
+> statistic over accepted stars — any rank, on any subset of frames — is bounded below by that gate.**
+>
+> Hence: **if `EffectiveSensitivityGate ≥ TargetSensitivity (= 10)`, `signalIsSufficient` is TRUE
+> unconditionally**, whatever the sky contains. `ExposureIsNotTheLimit` is then a property of the *landing*, not
+> a measurement of the frames.
+
+Wave 8's arm X, read for this rather than for `S_now`, says `D02_rich_135mm` lands its effective gate at
+**16.667 / 48.5 / 49.0 / 9.0 / 9.0** across the five rungs. **Three of the five are structurally silenced.** No
+wing statistic over accepted stars could ever have satisfied W1 there, so the whole family would have been
+implemented, measured, and refuted at the cost of a build and an arm.
+
+**This sharpens F19 far beyond "the 20th-brightest star saturates".** The rank is not the defect; the
+*population* is. `S_now` measures a set the detector has already filtered to be above the target, so the
+recommendation asks "are the stars I kept bright enough?" — a question whose answer is yes **by construction**
+whenever the optimizer lands a gate at or above 10. It is closely related to, and strictly stronger than, wave 7's
+leg 2 (*"the named alternative is PINNED BY THE GATE"*), which said the *faintest accepted star* is pinned; the
+theorem says **every** statistic over accepted stars is.
+
+### §3.4a The corrected family — the quantities that are NOT floored by the gate
+
+**Rule W (§3.2) is untouched.** It was fixed before any of this and it does not depend on which family is tried;
+that is the entire point of writing the acceptance rule before the statistic.
+
+Only two quantities in a run can see stars the exposure failed to deliver, because only they are not computed over
+the accepted set:
 
 | # | candidate | shape |
 |---|---|---|
-| **C1** | `S_wing` | the same per-frame `NTarget`-th-brightest reduction, aggregated as a **median over the WING frames** (outer third of the sweep by \|focuser − vertex\|) instead of over all frames |
-| **C2** | `n_wing` | median **accepted-star count** over the wing frames; short of `NTarget` ⇒ the wings are starved, derive from the count shortfall |
-| **C3** | `min(S_now, S_wing)` | the shipped statistic, floored by the wing one — strictly a widening, so it cannot regress a run the shipped statistic already serves (W4 free) |
-| **C4** | C1 gated by C2 | fire on wing SNR only when the wing frames are also short of stars, which is the conjunction that distinguishes "starved wings" from "merely defocused wings" |
+| **E1** | **wing rejected-fraction** | on the wing frames, `lowSensRejections / (lowSensRejections + accepted)` — candidates that FORMED and fell below the gate are exactly the stars a longer exposure could convert |
+| **E2** | **wing gate-headroom** | on the wing frames, `median(acceptedSNR) / EffectiveSensitivityGate` — gate-RELATIVE, so it is not floored at 1 by construction: it says whether the wing stars merely scrape the gate or clear it comfortably |
+| **E3** | `max(existing ask, E1's ask)` | a strict WIDENING of the shipped statistic, so it cannot regress a run the shipped statistic already serves — **W4 comes free** |
+| **E4** | E1 gated by E2 | fire on rejections only when the wing stars are also bunched at the gate — the conjunction that separates "faint because DEFOCUSED" (unavoidable, more exposure will not help) from "faint because UNDEREXPOSED" |
 
-All four are *"the same question asked of the frames the fit actually rests on"*, and all four answer the
-class's single-frame-fluke objection by aggregating over a set. The one that satisfies **Rule W** ships; if none
-does, the wave reports that the wing hypothesis failed its own pre-registered test and F19 stays open with a
-narrower next step.
+The first-order evidence for E1 is already visible in arm X's `GateRejectedCount` and it discriminates on the pair
+Rule W is built from: **`D02` @ 0.5 s = 3752 rejections; `D16` @ 2 s = 0.** W4's case (`D16` @ 0.5 s) is carried by
+the shipped `S_now` path, which is correct there (6.5 < 10) — which is why E3's widening shape matters.
+
+**Two hazards, both named before the arm rather than discovered in it.**
+
+1. **[F28](followups.md#f28--lowsensitivity-reads-exactly-zero-precisely-when-the-sensitivity-gate-is-floored): a
+   rejection count of ZERO is empty by construction when the gate is inert.** `D16` lands `Sensitivity = 0` with
+   an effective gate of 0.19–0.56 at every rung, so its zero rejections are not evidence of anything.
+   `GateIsProvablyInert` already exists to say so and E1 must consult it — a candidate that reads an inert
+   counter as "the wings are fine" has re-committed F28.
+2. **E1's raw count is confounded by the landed gate.** `D02`'s rejections run 3752 → 9696 → 7500 → 127 → 3 while
+   its gate runs 16.7 → 48.5 → 49 → 9 → 9; the rise from 0.5 s to 1 s is the gate more than doubling, not the sky
+   changing. **This is why E1 is a FRACTION of the candidates formed and why the per-frame instrument records
+   accepted counts beside rejections.** W3 (convergence) is the clause that will catch it if the normalization is
+   still wrong.
+
+The candidate that satisfies **Rule W** ships. If none does, the wave reports that the wing hypothesis failed its
+own pre-registered test and F19 stays open with a narrower next step — and the gate floor theorem above is worth
+the wave on its own, because it says what F19's fix can NEVER be built from.
 
 ### §3.5 The population check
 

--- a/docs/synthetic-af-bank-followups-wave9-design.md
+++ b/docs/synthetic-af-bank-followups-wave9-design.md
@@ -1,0 +1,501 @@
+# Synthetic AF bank — followups wave 9 (design)
+
+Plan: [`plans/synthetic-af-bank-followups-wave9-plan.md`](../plans/synthetic-af-bank-followups-wave9-plan.md).
+Wave 8: [`docs/synthetic-af-bank-followups-wave8-results.md`](synthetic-af-bank-followups-wave8-results.md).
+Register: [`docs/followups.md`](followups.md).
+
+*Wave 8's §0.1 deferred [F32](followups.md#f32--j-is-saturated-near-10-so-the-optimizer-trades-enormous-recall-for-numerically-trivial-gains)'s
+confirmation arm a fourth time on the stated ground that "wave 9 does not end it either". **That conclusion is
+wrong, and it was refuted by wave 8's own instrument.** This wave opens by saying so, and by running the arm
+first.*
+
+---
+
+## §0 — Pre-flight, and the two things that must be settled before any compute is committed
+
+### §0.1 The wave-8 CI gate: CHECKED, and it is not the failure mode the hand-off feared
+
+Wave 8's results doc closes with *"no checks, and it is not this branch … CI must be re-checked once Actions
+recovers, before this merges."* PR #184 merged anyway, so the first act of this wave is to find out whether that
+re-check ever happened. **It did.**
+
+| check | measured |
+|---|---|
+| PR #184 | **MERGED** 2026-08-06T23:33:27Z → `018eaa0` |
+| `gh pr checks 184` | **1 passed** — "Run unit tests" on head `57e759e` |
+| the run | `31130194942`, started 23:13:05Z, completed **23:32:36Z** — ~51 s before the merge |
+| **the test COUNT** (F37's rule) | **`Passed: 3674, Failed: 0, Skipped: 0, Total: 3674`** — the whole suite, not a truncated host |
+| the three RED runs on the branch/`develop` | **job-level `cancelled`**, zero test output — outage infrastructure, not regressions |
+| `develop` @ `018eaa0` | **0 checks** — the push-event run never scheduled |
+| githubstatus.com, **now** | indicator `major`; **`Actions: major_outage` STILL** |
+
+**So the absent check resolved itself, and the resolution is verifiable rather than assumed:** Actions recovered
+for long enough to run the PR check on the final head SHA, it passed with the full 3674, and the merge followed.
+The red runs are the *other* half of F37's rule — a red check that is not about the code — and they are
+`cancelled` with no test output at all, which is what an outage looks like and is not what a native host crash
+looks like (that one reports zero failures with a *reduced* count).
+
+> **What this changes for wave 9: Actions is degraded RIGHT NOW.** `develop`'s own merge commit has no check at
+> all, so the "absent check" failure mode is live, not historical. **This wave's PR is gated on a LOCAL full-suite
+> run with its count recorded, and on re-reading githubstatus.com at PR time** — an absent check is not evidence
+> of anything and will be reported as absent, never as passed.
+
+### §0.2 The ordering, and why it is not the one wave 8 predicted
+
+Wave 8's §0.1 priced F32's deferral on the belief that F19(c)'s re-render was still ahead of it, and that the
+floor list was `D01`–`D05`, `D07`, `D13`, `D14` — seven datasets, none of them F32's. **When F19(b)'s new
+reporting actually PRINTED the saturated set, it came back as 13 of 20**: eleven at the floor **including `D18`,
+`D19` and `D20` — F32's entire synthetic half** — plus **two at the ceiling** (`D10` 335.6 s → 30 s, `D17` 40.4 s
+→ 30 s) that nobody had ever counted.
+
+That is the trigger wave 8 wrote down. F19(c) can now re-render exactly the three datasets F32's arm needs held
+still, so **F32 goes first** and everything that can re-render queues behind it.
+
+**The order, and it is a hard gate:**
+
+| # | item | may re-render? | depends on |
+|---|---|---|---|
+| **1** | **F32's confirmation arm** | must NOT be disturbed | — |
+| **2** | **F19(c)** — floor *and* ceiling | possibly | item 1 complete |
+| **3** | **F19's real remainder** — the wing statistic | no (validates on frames already on disk) | — |
+| **4** | **F52(c)** — the abort/re-expose advice | no | item 3 |
+| **5** | **F49 / F51** — the two field defects | no | item 3 |
+
+Items 3–5 are product-side and re-render nothing, so they run *concurrently* with item 1 rather than after it.
+Item 2 is the only one that can touch a frame, and it is the only one that waits.
+
+### §0.3 [F15](followups.md#f15--optimize---per-run-overwrites-each-runs-stored-settings) — which landing the banks end holding, decided BEFORE the arm runs
+
+`optimize --per-run` rewrites `optimized_settings.json` **into the bank's run folders**, so whichever sub-arm runs
+last owns both banks. Wave 8's adoption arm B currently owns the synthetic folders (the F39(b)-adopted landing).
+
+**Decision: the banks end holding the SHIPPED-DEFAULT landing.** That is arm A — no keep floor (the shipped
+default is `MinDetectionKeepFraction = null`), F39(b) binning applied (the shipped default since wave 8). So the
+sub-arms run **C → B → A**, with A last.
+
+This is wave 8's own principle applied unchanged (*"every run folder now holds the adopted landing"*), and it is
+stable under either verdict:
+
+- **verdict "do not adopt φ"** → the banks already hold the correct landing, nothing more to do;
+- **verdict "adopt φ = 0.50 as a default"** → arm B becomes the shipped default and the banks are re-landed by
+  re-running **arm B alone** before the PR. Recorded here so the obligation cannot be forgotten after the fact.
+
+The alternative ordering (B last) is rejected: it would leave the banks holding a landing produced by a flag that
+is default OFF, which is exactly the state wave 7 was criticised for leaving behind.
+
+---
+
+## §1 — Item 1: F32's confirmation arm
+
+Deferred across waves 5, 6, 7 and 8. `MinDetectionKeepFraction` shipped **default OFF** in wave 5 pending exactly
+this. Wave 6 changed its shape.
+
+### §1.1 Three arms, because wave 6 measured the two mechanisms as complementary
+
+Wave 6's arm R established that the shedding corner is a **greedy trap** (restarts alone improve `J` on 5 of 7
+binding runs with no constraint at all) but that restarts recover only **0–36 %** of the floor's gain. And the
+floor's two FAILURES are exactly where restarts do best — `mccomiskey` −0.031 under the floor but **+0.0034** from
+restarts, `muggsie` −0.0023 under the floor and untouched by them. **Complementary, not competing.** So:
+
+| arm | invocation | question |
+|---|---|---|
+| **A** | *(no flag)* | the shipped-default control, and the F15 landing (§0.3) |
+| **B** | `--keep-floor 0.50` | does the recommended floor confirm at full-bank scale? |
+| **C** | `--continue-rounds 2` | how much of B's gain is merely un-sticking a greedy search? |
+
+All three: `optimize --per-run --max-evals 250 --settings D:\hf_w9\pinned_settings.json`, one binary, no binning
+flag. `--max-evals 250` is wave 5's and wave 6's value and is what makes the comparison legal.
+
+### §1.2 Scope: both full banks, plus `bank-verify` for real-bank RECALL
+
+Per F32's entry, verbatim: *"Adoption still needs the confirmation arm — both full banks plus `bank-verify` for
+real-bank recall, since the efficacy criterion could only be evaluated by keep-% proxy here."*
+
+- **Synthetic bank:** all 20 datasets.
+- **Real bank:** the 19 top-level runs `bank-verify` scores (`astrodet` excluded — [F14](followups.md#f14--astrodet-is-frameless), frameless;
+  the `_`-prefixed folders are scratch arms, not runs).
+- **Recall:** `bank-verify --opt-a` against arms A and B, which is the measurement wave 5 could not make.
+
+**Arm C's population is narrowed, and the narrowing is pre-registered rather than discovered.** Arm C runs on the
+**union of (i) the runs where arm B's landing differs from arm A's** (the *binding* set — where the floor did
+something, so "would a restart have done it instead?" is a question with content) **and (ii) the 8-run wave-5/6
+comparability subset** (so the cross-wave comparison to wave 6's arm R survives). On a non-binding run the floor
+changed nothing and arm C would be answering a question nobody asked. **This is a reduction in scope and it is
+declared as one** — the alternative is ~8 h of compute whose only possible finding is "the restart also did
+nothing here".
+
+### §1.3 THE COMPARABILITY GATE — run FIRST, and the arm does not start until it passes
+
+Wave 8 flipped `optimize`'s **default** to apply each run's derived detection binning. For the 8-run comparability
+subset this should be a no-op, and the reason is structural:
+
+- the **5 real runs** have no `synthetic_meta.json`, so `HarnessSettingsStore.ResolveRunDetectionBinningFactor`
+  falls back to the pinned settings file's `DetectionBinning`, which is **`Bin1`** (verified in the file);
+- **`D18` / `D19` / `D20`** carry `expectedOptimal.detectionBinning = 1` in their own metadata (verified).
+
+**That is an argument, and this project does not run arms on arguments.** The gate measures it: the same 8 runs,
+this binary, arm-A's exact invocation, against the values on record from wave 5's feature-OFF arm — which wave 6's
+arm R round 0 independently reproduced to 6 dp, which is what makes them usable as a fixed point.
+
+| run | expected `BestJ` |
+|---|---|
+| `toml999` | 0.997993 |
+| `CWhiteFocus` | 0.998476 |
+| `uneven` | 0.996368 |
+| `muggsie` | 0.997195 |
+| `mccomiskey` | 0.994025 |
+| `D18_m24_deep_shed` | 0.999822 |
+| `D19_cygnus_deep_shed` | 0.999557 |
+| `D20_m24_bright_control` | 0.999766 |
+
+> **RULE G, fixed before the gate ran.** All 8 must reproduce to **6 decimal places**. If any does not, **STOP**:
+> the cross-wave comparison to wave 5's φ table is void, nothing in the arm is readable against it, and the wave
+> reports that instead of a φ verdict. A partial reproduction is a failure, not a warning — the eight are one
+> instrument, not eight.
+
+**And the OTHER 17 synthetic datasets are NOT comparable to any prior wave.** They have `detectionBinning` 2 (or
+were never run at their own factor), so wave 8's default flip changes what they detect at. Their arm-A numbers are
+a **new baseline**, and this wave will say so rather than tabling them next to wave 5's.
+
+### §1.4 Concurrency, and the free control that checks it
+
+39 runs × 3 arms sequentially is ~14 h. The arms run with a **fan-out of 3 concurrent runs**, which is safe under
+F15 (each process owns a different bank folder) and brings the wave to ~3.5 h.
+
+**The determinism risk is real and it is controlled for free.** Arm A re-measures the same 8 runs the gate just
+measured sequentially. If concurrency perturbed anything — a thread-count-dependent partition, a timing-dependent
+stopping rule — those 8 values move. **Gate = sequential fixed point; arm A = the same 8 under concurrency.** A
+disagreement between them is a concurrency artifact and invalidates the fan-out, not the arm's design.
+
+### §1.5 Pre-registered rules
+
+> **R1 — adoption.** φ = 0.50 is adopted as a **default** only if, across the binding runs of **both** banks:
+> (a) the median Δ`J` (B − A) is **≥ 0**, and (b) `bank-verify` `recall@SNR≥12` under B is **≥** under A on a
+> majority of the real-bank runs with **no** run regressing by more than 0.05, and (c) no run's σ_focus regresses
+> by more than 20 %. Failing any clause, it stays default OFF and ships as the harness flag it already is.
+>
+> **R2 — attribution.** If arm C recovers **≥ 50 %** of arm B's median `J` gain over arm A on the binding set, the
+> floor is not buying a distinct mechanism and the honest product change is to expose *restarts*, not the floor.
+> (Wave 6's rule, restated at full-bank scale; it fired the other way at 8 runs — 0–36 %, median 13.8 %.)
+>
+> **R3 — the population that did not motivate it.** F32's evidence is 7 binding runs. If the floor **regresses**
+> `J` on more of the newly-covered runs than it improves, R1 fails regardless of the binding-set median. This is
+> wave 8's R6 rule transplanted, and it exists because wave 8's `StructureLayers` fix looked like a clean 2-for-2
+> win on the two cells that motivated it and refuted itself on the other five.
+
+### §1.6 One fact that belongs in the write-up
+
+`D18` / `D19` / `D20` — the arm's entire synthetic half — sit on **exposures that are floor clamps rather than
+derived values** (0.004 / 0.008 / 0.004 s asked, 0.5 s rendered). Every φ arm sees the same frames so this does not
+invalidate the arm, but it bounds what the synthetic half can say about a *photon-starved* population: it has
+never contained one.
+
+---
+
+## §2 — Item 2: F19(c), and the free check that comes before scheduling it
+
+F19(c) is *"re-check `MinExposureSeconds = 0.5 s`"*. It is filed as expensive because moving the floor re-derives
+**11 datasets** and re-renders them. **The check that decides whether to spend that is free, and it runs first.**
+
+### §2.1 The floor: the evidence points at the statistic, not the clamp
+
+Every floor-clamped dataset asks for **less** than 0.5 s — `D02` 0.001, `D01`/`D03` 0.003, `D04`/`D18`/`D20` 0.004,
+`D19` 0.008, `D05` 0.014, `D14` 0.055, `D07` 0.066, `D13` 0.264. So **lowering `MinExposureSeconds` moves every one
+of them DOWN.**
+
+And on the one dataset where the exposure/σ_focus relationship has actually been measured — `D02`, wave 7's arm E —
+**8 s is 44 % BETTER than the derived 0.5 s.** Lowering the floor moves `D02` the wrong way by four orders of
+magnitude. Raising the floor is not what a floor is for: a floor exists to stop an absurdly short exposure, not to
+supply an exposure the derivation failed to find.
+
+> **RULE F19c, fixed before the check ran.** F19(c) resolves as **"the floor stays"** unless a floor-clamped
+> dataset can be shown, from data already on disk, to have its σ_focus minimum *below* 0.5 s. There is exactly one
+> dataset with a measured exposure ladder (`D02`) and its σ_focus falls monotonically as exposure **rises**. If the
+> rule holds, **nothing re-renders**, and item 1 was worth running for its own sake rather than as a prerequisite.
+
+**The finding this produces is not "no change".** It is that the floor is the *symptom*: the arithmetic saturates
+against it because the statistic feeding the arithmetic is wrong for these fields, which is item 3. Moving the
+clamp would relocate the symptom without touching the cause — and would have re-rendered 11 datasets to do it.
+
+### §2.2 The ceiling, which has never been examined
+
+`D10_rc16_3250mm_sparse` asks **335.6 s** and gets 30 (**11× short**); `D17_cdk14_oiii5` asks 40.4 s and gets 30.
+This is the same saturation from the other side and it is **not obviously the same defect**: at the floor the
+arithmetic is asking for less than any sane exposure, while at the ceiling it is asking for more than an AF sweep
+can spend.
+
+Two separable questions, and they have different answers:
+
+1. **Product — should `MaxRecommendedExposureSeconds = 30 s` move?** Almost certainly not: 335 s/frame over a
+   9-point sweep is ~50 minutes of pure integration, and `AutoFocusEngineOptions.AutoFocusTimeout` would kill it.
+   The cap is doing its job. What matters is that the product SAYS the ask was ceiling-clamped — and F19(b)
+   verified `StarSignalCopy.DescribeExposureDerivation` already names which bound bound it. **Verified, not
+   changed.**
+2. **Bank fidelity — `D10` and `D17` are RENDERED at 30 s while their own physics asks for 335.6 / 40.4 s.** So two
+   of the twenty datasets are deliberately photon-starved relative to their derivation, and no write-up has ever
+   said so. That is a fact about the bank that belongs in `synthetic-af-bank-expectations.json`'s derivation record
+   and in F19, **not** a reason to re-render: a `D10` rendered at 335 s would be a dataset no user could ever
+   capture.
+
+> **RULE CEIL.** The ceiling moves only if a dataset's σ_focus is measured to improve materially between 30 s and
+> its raw ask. No such ladder exists and rendering one costs a re-render of the item-1-critical bank. **Recorded as
+> a bank-fidelity flag and a work item, not actioned this wave** — and stated as a deferral with a price, which is
+> what wave 8's §0.1 got wrong by deferring on a prediction instead.
+
+### §2.3 If a re-render ever does happen
+
+Pre-registered now so it is not decided under time pressure later: preserve the pre-render frames first
+(`D:\hf_w9\oldframes`, as wave 6 used `D:\hf_w7\oldframes`), and **re-run wave 5's φ arms on the new bank** rather
+than comparing across it — [F41](followups.md#f41--a-prior-waves-control-arm-is-not-a-control-for-a-later-waves-binary)
+applied to frames instead of binaries.
+
+---
+
+## §3 — Item 3: F19's real remainder — a statistic that can see the wing frames
+
+**This is the item everything else in the wave is downstream of.** Two obvious fixes are already refuted by
+pre-registered tests: *"change `NTarget`"* (wave 7) and *"widen the trigger"* (wave 8, rule R5).
+
+### §3.1 What is broken, stated mechanically
+
+`ExposureRecommender.Recommend` computes
+
+```
+S_now = median over non-recovery FRAMES of ( that frame's NTarget-th brightest accepted-star SNR )
+RawSeconds = t_current × (TargetSensitivity / S_now)²
+```
+
+On `D02_rich_135mm` — 2746 stars above the gate at the sweep's outermost frame — `S_now` measures **991.8 to
+2308.8** against a target of **10**, and it **rises with exposure** (992 → 1226 → 1864 → 2309). So the raw ask is
+0.000 s at every rung of a 16× range over which σ_focus improves 44 %, and the statistic **saturates harder the
+more exposure you give it** — it can never converge toward asking for more.
+
+**The 20th-brightest star of a 2746-star field carries no information about the faint stars holding the V-curve's
+wings.** Both aggregations point the same way: the per-frame reduction takes a *bright* rank, and the across-frame
+reduction takes the *median frame* — which on a focus sweep is a near-focus frame. The wing frames, which are the
+ones the fit's slope rests on, are visible to neither.
+
+**The class's own docs defend the median-across-frames choice**, and the defence is not silly: pairing a per-frame
+statistic with a worst-FRAME aggregation *"would hand the entire recommendation to whichever single frame had a
+passing cloud, a satellite trail, or a guiding bump"*. **Any candidate must answer that objection rather than
+ignore it** — which is why the candidates below aggregate over a wing *set*, never over one frame.
+
+### §3.2 THE ACCEPTANCE RULE — written down BEFORE the statistic is built
+
+Validated on data **already on disk**: `D:\hf_w7\armE\t{0.5,1,2,4,8}` carries `D02_rich_135mm` and
+`D16_esprit550_ha3` at five exposures with known σ_focus outcomes.
+
+| dataset | 0.5 s | 1 s | 2 s | 4 s | 8 s |
+|---|---|---|---|---|---|
+| `D02_rich_135mm` (derived **0.5 s**) | 0.10927 | 0.09125 | 0.09482 | 0.08182 | **0.06109** *(−44 %)* |
+| `D16_esprit550_ha3` (derived **2 s**) | 0.35169 | 0.19762 | **0.06423** | 0.12034 | 0.14828 |
+
+> **RULE W, all four clauses, fixed before any statistic is written. A candidate that fails ANY clause is not
+> adopted.**
+>
+> **W1 — the defect.** On `D02` at **0.5 s**, the candidate must ask for materially more: `IncreasesExposure` true
+> **and** `RecommendedSeconds ≥ 2 × CurrentSeconds` (≥ 1.0 s). *(8 s is measured 44 % better, so 2× is a floor on
+> what "materially" can mean, not a target.)*
+>
+> **W2 — the control.** On `D16` at its derived **2 s**, the candidate must **NOT** ask for materially more:
+> `IncreasesExposure` false, or `RecommendedSeconds < 1.25 × CurrentSeconds`. *(4 s and 8 s are measured WORSE —
+> 0.064 → 0.120 → 0.148. `D16` is the whole reason the arm-E ladder was rendered.)*
+>
+> **W3 — convergence.** On `D02`, `RecommendedSeconds / CurrentSeconds` must be **non-increasing** across the rungs
+> 0.5 → 8 s, and must reach "no material increase" (< 1.25×) by the **8 s** rung. *(The shipped statistic fails
+> this by construction: it saturates HARDER as exposure rises, so it could never converge even if its trigger were
+> widened. A candidate with the same pathology is the same defect wearing a different number.)*
+>
+> **W4 — no regression where the shipped statistic is RIGHT.** On `D16` at **0.5 s** (below its derived value) the
+> candidate must still ask for more — `IncreasesExposure` true. *(The shipped recommender correctly returns 1.5 s
+> there. A candidate that loses this has traded one blind spot for another.)*
+>
+> **A candidate that fires on both `D02`@0.5 and `D16`@2, or on neither, HAS NOT BEEN VALIDATED.** W1 and W2 are
+> the discriminating pair; W3 and W4 exist so that passing them by accident is harder than passing them by design.
+
+### §3.3 The instrument, and what it would do if the thing it checks were broken
+
+Wave 8 hit *"the instrument agrees with the thing it is supposed to check"* **three times**. So, explicitly:
+
+- The per-frame diagnostics are computed **unconditionally**, never gated on `SensitivityIsAtFloor`,
+  `HasLowStarSignal`, or any other product display condition. That single line is what made F19 answerable at all
+  (wave 8's lesson 4) and the new instrument must not re-introduce it.
+- **What would this instrument do if the wing hypothesis were completely wrong?** It would show wing frames whose
+  `NTarget`-th-brightest SNR is *indistinguishable* from the near-focus frames on `D02` — in which case no wing
+  statistic can produce W1, and the wave reports that the wing hypothesis is refuted. The instrument is capable of
+  killing its own hypothesis, which is the property being asserted here.
+- **W2 is a control that can genuinely fail.** A naive wing-SNR statistic very plausibly fires on `D16`@2 s too
+  (its wings are defocused narrowband frames). If it does, that candidate is dead — and that is the outcome the
+  rule exists to force rather than to rationalize around.
+
+**Step 1 is measurement, not code.** Extend the harness to record per-frame wing diagnostics (focuser position,
+accepted-star count, `NTarget`-th SNR, gate/flat rejections), re-run arm X's 10 optimizations over the frames
+already on disk (**~8 min, no re-render**), and *look at the wing structure before choosing a form*.
+
+### §3.4 The candidate family, fixed now so that choosing among them is not fishing
+
+| # | candidate | shape |
+|---|---|---|
+| **C1** | `S_wing` | the same per-frame `NTarget`-th-brightest reduction, aggregated as a **median over the WING frames** (outer third of the sweep by \|focuser − vertex\|) instead of over all frames |
+| **C2** | `n_wing` | median **accepted-star count** over the wing frames; short of `NTarget` ⇒ the wings are starved, derive from the count shortfall |
+| **C3** | `min(S_now, S_wing)` | the shipped statistic, floored by the wing one — strictly a widening, so it cannot regress a run the shipped statistic already serves (W4 free) |
+| **C4** | C1 gated by C2 | fire on wing SNR only when the wing frames are also short of stars, which is the conjunction that distinguishes "starved wings" from "merely defocused wings" |
+
+All four are *"the same question asked of the frames the fit actually rests on"*, and all four answer the
+class's single-frame-fluke objection by aggregating over a set. The one that satisfies **Rule W** ships; if none
+does, the wave reports that the wing hypothesis failed its own pre-registered test and F19 stays open with a
+narrower next step.
+
+### §3.5 The population check
+
+A candidate that passes W1–W4 on two datasets is a mechanism, not a product rule — wave 8's lesson 1. Before it
+ships, its verdict is measured on **all 20 synthetic datasets and the real bank**, and **every dataset where it
+newly asks for ≥ 2× must have a stated reason**. `D10` and `D17` are the pre-registered *expected* fires (§2.2:
+both are ceiling-clamped, i.e. genuinely starved by their own derivation), so a candidate that does NOT fire on
+those two is suspicious in the other direction.
+
+---
+
+## §4 — Item 4: F52(c), the abort/re-expose recommendation
+
+(a) and (b) **shipped in wave 8** and are on `develop`: one INFO line per 10 completed evaluations (phase,
+evaluation/budget, elapsed, s/evaluation, incumbent `J`, cost note), and the wizard shows the **rate** with a
+bounded *"at most N more, usually much less"*, which knob made the search expensive (quantified against the run's
+own seed via `StarDetector.EffectiveStructureLayers`), and what Cancel costs. **Elapsed was deliberately NOT
+added** — `ProgressCountElapsedText` already renders `X / Y (M:SS)` every second.
+
+(c) was deliberately NOT built, because advice derived from the current statistic *"would tell precisely the users
+who most need a longer exposure that theirs is already fine"* — on the user's own rig that statistic read **S/N
+1438.6 against a target of 10**.
+
+**The separation stays exactly as wave 8 drew it: facts about COST need no new statistic and are already shown;
+ADVICE needs one.** So (c) is built on item 3's statistic and on nothing else.
+
+**Design.** The advice is computed from the **seed evaluation**, which the optimizer performs at the start of the
+search (it is what `ProgressSeedJ` / `ProgressSeedSigma` already report) — so a user asking *"should I abort?"* two
+hours in gets an answer that was available in the first minute, rather than one that needs the search to finish.
+It names **Cancel**, which exists (the house rule at `ShowOptimizeAgainAtRecommendedBinning`: never describe an
+action whose control is hidden), and it is **absent** when the wings are healthy, because advice that always fires
+says nothing.
+
+> **RULE A.** (c) ships only if item 3's statistic satisfies Rule W. If Rule W fails, (c) does **not** ship and
+> F52's entry records a second wave of being blocked on F19 — which is a result, not a gap.
+
+---
+
+## §5 — Item 5: F49 and F51, the two field defects
+
+Both are downstream of item 3's statistic, which is why they ride in this wave rather than being touched twice.
+
+### §5.1 F49 — a diagnosis with no instruction
+
+`StarSignalCopy.RemedyFor` has exactly three ranked branches and **all three are exposure or binning remedies**:
+
+| # | remedy | gate |
+|---|---|---|
+| 1 | change the detection binning factor first | `DetectionBinningDiffers && IncreasesExposure` |
+| 2 | auto-focus through a broadband filter instead | `HasRecommendation && !ExposureIsNotTheLimit && !IncreasesExposure` |
+| 3 | get frames at the longer exposure | `IncreasesExposure` |
+
+On a rich, well-exposed field where the optimizer **chose** a floor gate, `ExposureIsNotTheLimit` is true ⇒
+`IncreasesExposure` is false ⇒ branch 2's `!ExposureIsNotTheLimit` is false ⇒ **every branch falls through and it
+returns `string.Empty`** — on a page whose contract is *diagnosis plus exactly one instruction*.
+
+**Item 3 does not close this by itself, and that is the point of doing them together.** If the wing statistic makes
+the recommender ask for more exposure on rich fields, branch 3 fires and this population shrinks — but it does not
+vanish: a field whose wings are *also* well exposed still lands here, with the gate floored and nothing to say. So
+F49 needs a **fourth branch**, and its trigger must be written against the NEW statistic rather than against the
+one item 3 is replacing.
+
+**The remedy must name a control that EXISTS.** `MinDetectionKeepFraction` has **no XAML binding anywhere** — it is
+`--keep-floor` on the harness only — so it cannot be named. (And it would not bind here regardless: it rejects
+landings keeping *fewer* stars than the seed, and this one keeps ~7× **more**. The pathology is admission, not
+shedding — the *other* end of an axis F32 has only ever measured at the shedding end, which §1 does not change.)
+What does exist: the **Brightness Sensitivity** option and the wizard's **"use current settings"** mode. The honest
+instruction names the gate, not the exposure.
+
+### §5.2 F51 — the re-run button hides exactly when the run needs re-running
+
+```csharp
+public bool ShowCaptureNewSweep =>
+    HasExposureBlock && lastRunWasLive && !IsUseCurrentMode
+    && (SelectedSummary?.ExposureAdvice?.IncreasesExposure ?? false);
+```
+
+Gated on `IncreasesExposure`, so **the button hides exactly when F19 misfires**. On the field session's run 2 the
+first three conjuncts were true and `IncreasesExposure` was false, because the exposure row read *"2 s (unchanged;
+measured star S/N 1438.6; target 10)"*.
+
+**And even visible it would not have solved it.** `RunLiveAttemptAsync` overrides only
+`OverrideAutoFocusExposureTime` and takes everything else from `autoFocusEngine.GetOptions()` — i.e. **the
+profile's step size**. The step-size recommendation, the one that was asking to change on *every* run of that
+session (100 → 214 → 459 → 474 → 482), is not carried. So the user had to **Accept a landing they did not want,
+twice**, to re-run wider — and that Accept is how `Sensitivity 0.000` reached their profile.
+
+Three pieces, matching F51's own next-step:
+
+- **(a)** gate `ShowCaptureNewSweep` on *any* material recommendation — exposure **or** step size — not on
+  `IncreasesExposure` alone;
+- **(b)** make the re-capture apply the recommended **step size** as well (`AutoFocusEngineOptions.AutoFocusStepSize`
+  is right there beside the exposure override), or say plainly that it will not;
+- **(c)** neither should require Accept: **re-capturing is not adopting.**
+
+The house rule cuts both ways here, and (a) must respect it: if the button becomes visible on a step-size-only
+recommendation, the body copy must gain a sentence that names it, or the button appears with nothing explaining
+why.
+
+---
+
+## §6 — Carried in from wave 8, and worth reading before trusting any harness
+
+Two AF-chart fixes landed late on #184 and the second matters far beyond the AF chart.
+
+- **The loaded-run info rows never worked, for any report, since wave 7.** `HocusFocusReport` carries three
+  INTERFACE-typed properties (`IStarDetectionOptions`, `IAutoFocusOptions`, `IFocuserSettings`); Newtonsoft
+  serializes them and cannot construct them, so `DeserializeObject<HocusFocusReport>` threw on **every real
+  report**, the source caught it and returned null, and every row collapsed. Fixed on the **read path only** (an
+  error handler that skips unconstructable members), deliberately not by changing what is written. **Known trade:
+  the handler swallows ALL member errors**, bounded by the caller's exact-`Timestamp` check.
+- A separate sequencing gap: the rows are re-read on **every** load now, because skipping when the timestamps
+  matched was correct only for the watcher reloading the just-written chart and wrong after a round trip.
+- **The test fixture wrote reports WITHOUT the option blocks the production writer always writes**, so it tested a
+  shape that cannot exist and passed for a whole release over a feature that never worked once. That is the
+  question this wave asks of every harness it builds: *what would this do if the thing it is checking were
+  completely broken?*
+- **Not yet confirmed in the app by the user.** This wave does not claim it is; if the user has not confirmed, it
+  stays open.
+- **OPERATIONAL TRAP:** the plugin csproj's PostBuild `xcopy` fails **silently** when NINA is running, so a build
+  reports "Copying …" and succeeds while deploying nothing. NINA was verified **not running** before this wave's
+  build.
+
+---
+
+## §7 — Measurement discipline this wave is bound by
+
+Earlier waves' (each cost or saved real time), then wave 8's:
+
+- **PIN `--settings` on every arm** ([F42](followups.md#f42--every-build-directory-silently-gets-its-own-detector-settings-and-the-run-instructions-require-a-new-one-per-arm)),
+  and read the `UseAdvanced=False` warning — a file with `UseAdvanced=False` has its advanced knobs RECOMPUTED
+  from the `Simple_*` presets, so editing them there does nothing. **This wave's pinned file is byte-identical to
+  waves 5/6/7/8's** (`md5 df7c7cd1…`), which is what makes the gate in §1.3 legal.
+- **`BaselineJ` is a free control** ([F41](followups.md#f41--a-prior-waves-control-arm-is-not-a-control-for-a-later-waves-binary));
+  a number agreeing TOO WELL is also an instrument failure.
+- **Check whether a cheap instrument already exists, and whether the expensive step is necessary at all, BEFORE
+  planning around it.** §2 is exactly this, and it has saved two waves already.
+- **Change one thing. `--dry-run` the derived-parameter diff BEFORE rendering.**
+- **Count tests that DISCRIMINATE.** Revert the fix, see which fail.
+- **WRITE THE FALSIFICATION RULE DOWN BEFORE THE ARM RUNS.** §1.5 (R1/R2/R3), §1.3 (G), §2 (F19c, CEIL), §3.2 (W),
+  §4 (A).
+- **THE INSTRUMENT AGREES WITH THE THING IT IS SUPPOSED TO CHECK** — the single most expensive pattern in this
+  project; wave 8 hit it three times. §3.3 answers it explicitly for this wave's one new instrument.
+- **THE POPULATION THAT DID NOT MOTIVATE A HYPOTHESIS IS WHAT TESTS IT.** §1.5 R3 and §3.5.
+- **CHECK WHAT A CONTROL FILTER MATCHES**, not just that it is the same filter — wave 8's derived-parameter strip
+  produced 26 lines of fake movement because the `exposure definition` PROSE contains the substring
+  `detectionBinning=`.
+- **A GATE'S FALSE-NEGATIVE COUNT IS AN UPPER BOUND, NOT AN ESTIMATE**
+  ([F50](followups.md#f50--a-false-negative-gate-count-is-an-upper-bound-on-what-relieving-that-gate-buys-not-an-estimate)).
+- **VERIFY YOUR OWN TEST COMMENTS' DISCRIMINATING CLAIMS BY NEUTRALIZING.**
+- **On a red CI check: verify the test COUNT AND check githubstatus.com. An ABSENT check is the more dangerous
+  case** — and §0.1 is that rule catching both halves at once.
+
+New findings are **FLAGGED in `docs/followups.md`**, not fixed inline.

--- a/docs/synthetic-af-bank-followups-wave9-design.md
+++ b/docs/synthetic-af-bank-followups-wave9-design.md
@@ -116,12 +116,27 @@ real-bank recall, since the efficacy criterion could only be evaluated by keep-%
   the `_`-prefixed folders are scratch arms, not runs).
 - **Recall:** `bank-verify --opt-a` against arms A and B, which is the measurement wave 5 could not make.
 
-**All three arms run the FULL population, and the reduction that was drafted here was withdrawn once it was
-priced.** The first draft narrowed arm C to the binding set, because `--continue-rounds 2` is ~2.4× the per-run
-cost (wave 6: 8 runs in 1 h 35 m against wave 5's 40 m) and 39 runs sequentially is ~8 h. **With the fan-out in
-§1.4 that is ~2.6 h**, which is inside F32's own ~6 h estimate for the whole arm — so the narrowing bought
-nothing but a definitional argument about what "binding" means before arm A has run. Full scope, no dependency
-between the arms, and the ordering in §0.3 works directly.
+**Arms A and B run the FULL population; arm C runs the BINDING set. That reduction was drafted, withdrawn on an
+ESTIMATE, and reinstated on a MEASUREMENT** — the sequence is recorded because the estimate was wrong by 3×.
+
+1. **Drafted:** narrow arm C, because `--continue-rounds 2` is ~2.4× the per-run cost (wave 6: 8 runs in 1 h 35 m
+   against wave 5's 40 m) and 39 runs sequentially is ~8 h.
+2. **Withdrawn:** at fan-out 3 that projected to ~2.6 h, inside F32's own ~6 h estimate, so the narrowing looked
+   like it bought nothing but a definitional argument.
+3. **Reinstated:** measured at fan-out 4, arm C did **9 runs in 1.8 h** — ~8 h for arm C alone and ~11 h for the
+   wave. The projection was wrong because it priced the *median* run against a population whose real-bank runs
+   are 5–25 minutes each under `--continue-rounds 2`.
+
+**And the reinstated version rests on a better reason than cost.** Arm C's question is R2 — *how much of arm B's
+gain is merely un-sticking a greedy search?* On a run where the floor never rejected a single candidate there is
+no gain to attribute, so a restart there answers a question nobody asked. **The binding set is read from arm B's
+own logs** (`keep floor (F32): 0.50; N candidate(s) rejected as infeasible`, N > 0), **unioned with the 8-run
+wave-5/6 comparability subset** so the cross-wave comparison to wave 6's arm R survives regardless.
+
+**So the order becomes B → C(binding) → A**, not C → B → A. The binding set is a property of B alone, so C needs
+no dependency on A — and **A still runs LAST and still owns the banks' final landing** (§0.3), which is the whole
+constraint the original ordering existed to satisfy. An interruption after B and A leaves the banks in the correct
+resting state; only an interruption *inside* C leaves a named, small subset to restore.
 
 ### §1.3 THE COMPARABILITY GATE — run FIRST, and the arm does not start until it passes
 

--- a/docs/synthetic-af-bank-followups-wave9-results.md
+++ b/docs/synthetic-af-bank-followups-wave9-results.md
@@ -1,0 +1,261 @@
+# Synthetic AF bank — followups wave 9 (results)
+
+Design: [`docs/synthetic-af-bank-followups-wave9-design.md`](synthetic-af-bank-followups-wave9-design.md).
+Plan: [`plans/synthetic-af-bank-followups-wave9-plan.md`](../plans/synthetic-af-bank-followups-wave9-plan.md).
+Wave 8: [`docs/synthetic-af-bank-followups-wave8-results.md`](synthetic-af-bank-followups-wave8-results.md).
+Register: [`docs/followups.md`](followups.md).
+
+*The wave opened by contradicting its predecessor. Wave 8's §0.1 deferred [F32](followups.md#f32--j-is-saturated-near-10-so-the-optimizer-trades-enormous-recall-for-numerically-trivial-gains)'s
+confirmation arm a fourth time on the ground that "wave 9 does not end it either" — a prediction that
+[F19](followups.md#f19--the-exposure-recommendation-is-decided-by-the-20-brightest-stars-so-a-rich-field-can-never-earn-one)(b)'s
+own reporting refuted in the same wave, by printing a saturated set that includes F32's entire synthetic half.*
+
+## Status of this document
+
+| item | state |
+|---|---|
+| **the wave-8 CI gate** | **CHECKED. The absent check resolved itself** — #184's CI ran and passed 3674/0/0 ~51 s before the merge. Actions is in `major_outage` again NOW. See §0 |
+| **RULE G** — the comparability gate | **PASS, 8 of 8 to 6 dp.** The wave-8 binning-default trap is verified inert rather than argued inert. See §1.1 |
+| **F32's confirmation arm** | **RUNNING** at the time of writing (~5 h, 3 arms × 39 runs, fan-out 3). Scored by `D:\hf_w9\score_f32.py` against R1/R2/R3. See §1 |
+| **F19(c)** — floor and ceiling | **RESOLVED, and it was FREE. The floor stays, the ceiling stays, NOTHING re-renders.** And it produced a rank correlation the entry never had. See §2 |
+| **F19's remainder** — the wing statistic | See §3. The pre-registered candidate family was **refuted before implementation, by a proof plus data already on disk** |
+| **F49** — the empty remedy | **SHIPPED.** See §5 |
+| **F51** — the hidden re-run button | **SHIPPED, and (a) had TWO causes rather than the one the entry names.** See §5 |
+| **F53** — new | **Wave 8's arm X does not reproduce from wave 8's own `exe`.** See §4 |
+| the re-render | **NONE** |
+
+---
+
+## §0 — The wave-8 CI gate, settled before any compute
+
+Wave 8's results doc closed with *"no checks … CI must be re-checked once Actions recovers, before this merges."*
+PR #184 merged anyway, so the first act of this wave was to find out whether that re-check ever happened.
+
+| check | measured |
+|---|---|
+| PR #184 | **MERGED** 2026-08-06T23:33:27Z → `018eaa0` |
+| `gh pr checks 184` | **1 passed** — "Run unit tests" on head `57e759e` |
+| the run | `31130194942`, 23:13:05Z → **23:32:36Z**, i.e. ~51 s before the merge |
+| **the test COUNT** (F37's rule) | **`Passed: 3674, Failed: 0, Skipped: 0`** — the whole suite, not a truncated host |
+| the three RED runs on the branch / `develop` | job-level **`cancelled`**, zero test output |
+| `develop` @ `018eaa0` | **0 checks** |
+| githubstatus.com **at wave-9 start** | indicator `major`; **`Actions: major_outage` STILL** |
+
+**The absent check resolved itself, and that is verifiable rather than assumed.** Actions recovered long enough to
+run the check on the final head SHA; it passed with the full count; the merge followed a minute later. The red runs
+are F37's *other* failure mode — a red check that is not about the code — and they are `cancelled` with no test
+output at all, which is what an outage looks like and is not what the native host crash looks like (that one
+reports zero failures with a *reduced* count).
+
+**What it changes for this wave: Actions is degraded NOW.** `develop`'s own merge commit has no check at all, so
+the dangerous mode is live rather than historical. This wave's PR is gated on a LOCAL full-suite run with its count
+recorded, and on re-reading the status page at PR time.
+
+---
+
+## §1 — F32's confirmation arm
+
+### §1.1 RULE G — the comparability gate, and the trap wave 8 created
+
+Wave 8 flipped `optimize --per-run`'s **default** to apply each run's derived detection binning. For F32's
+8-run comparability subset that *should* be a no-op, for a structural reason — but this project does not run arms
+on arguments, so it was measured first, sequentially, on the arm's exact invocation.
+
+> **RULE G, fixed before the gate ran.** All 8 must reproduce wave 5's feature-OFF arm to **6 decimal places**. Any
+> miss ⇒ STOP: the comparison to wave 5's φ table is void and nothing in the arm is readable against it.
+
+| run | expected | measured | |
+|---|---|---|---|
+| `toml999` | 0.997993 | **0.997993** | OK |
+| `CWhiteFocus` | 0.998476 | **0.998476** | OK |
+| `uneven` | 0.996368 | **0.996368** | OK |
+| `muggsie` | 0.997195 | **0.997195** | OK |
+| `mccomiskey` | 0.994025 | **0.994025** | OK |
+| `D18_m24_deep_shed` | 0.999822 | **0.999822** | OK |
+| `D19_cygnus_deep_shed` | 0.999557 | **0.999557** | OK |
+| `D20_m24_bright_control` | 0.999766 | **0.999766** | OK |
+
+**PASS, 8 of 8.** And both fallback paths were read rather than assumed — the log states its source per run:
+
+- the 5 real runs: `1 from harness_settings.json (may be kept-from-base — check DetectionBinningSource): Bin1`;
+- `D18`/`D19`/`D20`: `1 from synthetic_meta.json expectedOptimal.detectionBinning (physics-derived)`.
+
+**The other 17 synthetic datasets are NOT comparable to any prior wave** and are not tabled as if they were: they
+carry `detectionBinning` 2 or have never run at their own factor, so wave 8's default flip changes what they
+detect at. Their arm-A numbers are a new baseline.
+
+### §1.2 The arms, and a scope reduction that was withdrawn once it was priced
+
+Three arms — **A** shipped default, **B** `--keep-floor 0.50`, **C** `--continue-rounds 2` — over **both full
+banks** (20 synthetic + 19 real; `astrodet` excluded per [F14](followups.md#f14--astrodet-is-frameless)), at
+`--max-evals 250` with `--settings` pinned to the file that is **byte-identical to waves 5/6/7/8's**
+(`md5 df7c7cd1…`), which is what makes RULE G legal.
+
+The third arm exists because wave 6 measured the two mechanisms as **complementary**: restarts alone recover only
+0–36 % (median 13.8 %) of the floor's gain where the floor helps, and the floor's two FAILURES are exactly where
+restarts do best.
+
+**The first draft narrowed arm C to the binding set, and that reduction was withdrawn.** `--continue-rounds 2` is
+~2.4× the per-run cost, so 39 runs sequentially is ~8 h — but at fan-out 3 it is ~2.6 h, inside F32's own ~6 h
+estimate for the whole arm. The narrowing bought nothing except a definitional argument about "binding" before arm
+A had run.
+
+**Order C → B → A, with A LAST** ([F15](followups.md#f15--optimize---per-run-overwrites-each-runs-stored-settings)):
+`optimize --per-run` rewrites `optimized_settings.json` into the bank's run folders, so the last arm owns both
+banks. **The banks end holding the SHIPPED-DEFAULT landing.** If R1 adopts φ = 0.50 as a default, arm B is re-run
+alone before the PR — recorded here so the obligation cannot be lost after the fact.
+
+**The fan-out's control is free:** arm A re-measures the same 8 runs the gate measured sequentially. A
+disagreement is a concurrency artifact, not a result. An early independent signal is already in: §4's control ran
+with three `optimize` processes in flight and matched a different binary to six decimal places.
+
+*(Results to follow when the arm completes; scored by `D:\hf_w9\score_f32.py` against R1/R2/R3.)*
+
+---
+
+## §2 — F19(c): the free check, and it decided the expensive step was unnecessary
+
+F19(c) is *"re-check `MinExposureSeconds = 0.5 s"*, filed as expensive because moving the clamp re-derives and
+re-renders 11 datasets. **The check that decides whether to spend that is free, and it ran first.**
+
+> **RULE F19c, fixed before it ran.** (c) resolves as *"the floor stays"* unless a floor-clamped dataset can be
+> shown, **from data already on disk**, to have its σ_focus minimum BELOW 0.5 s.
+
+**The floor stays.** Every one of the 11 clamped datasets asks for **less** than 0.5 s, so a lower floor moves all
+eleven **down** — while the one dataset with a measured exposure ladder moves the other way: `D02` improves **44 %
+of σ_focus at 8 s**, four orders of magnitude above its 0.001 s ask. Lowering the floor makes `D02` worse; raising
+it is not what a floor is for. **The floor is the symptom; the statistic is the defect.**
+
+### And the free check produced a number the entry never had
+
+`synth-bank --dry-run` on the wave-9 binary reproduces the saturated set exactly (**13 of 20**, 11 floor + 2
+ceiling) — and printing the on-frame star count the 20th-brightest is drawn from turns F19's central *argument*
+into a *measurement*:
+
+| dataset | on-frame stars | raw ask | clamp |
+|---|---|---|---|
+| `D10_rc16_3250mm_sparse` | **26** | **335.6 s** | ceiling |
+| `D13_apo200_1800mm` | 177 | 0.264 s | floor |
+| `D07_rc10_2000mm` | 428 | 0.066 s | floor |
+| `D14_cdk14_2563mm_e47` | 640 | 0.055 s | floor |
+| **`D17_cdk14_oiii5`** | **799** | **40.4 s** | **ceiling** |
+| `D03` / `D20` / `D05` / `D02` | 969 / 1151 / 2346 / 3590 | 0.003 / 0.004 / 0.014 / **0.001** s | floor |
+| `D19` / `D04` / `D01` / `D18` | 4914 / 7480 / 19201 / **27084** | 0.008 / 0.004 / 0.003 / 0.004 s | floor |
+
+**Spearman ρ(on-frame star count, raw ask) = −0.68 over the 13.** The two CEILING datasets are the two
+sparsest-or-faintest; all eleven FLOOR datasets are the rich ones. *"Sized by field richness rather than by whether
+the stars the fit depends on are above the noise"* stops being an argument and becomes a rank correlation over the
+whole bank, **in both directions at once**.
+
+**The one exception is the honest one, and it is F19's own poster child.** `D17_cdk14_oiii5` carries 799 on-frame
+stars — more than four of the floor-clamped datasets — and still asks 40.4 s, because an OIII filter genuinely
+starves it. Richness is the dominant term, not the whole story, and the shipped statistic cannot tell the two
+apart. That is the wing problem, not a clamp problem.
+
+### The ceiling, which had never been examined
+
+- **Product: the 30 s cap STAYS. Verified, not changed.** `D10`'s 335.6 s over a 9-point sweep is ~50 minutes of
+  pure integration and `AutoFocusEngineOptions.AutoFocusTimeout` would kill the run.
+  `StarSignalCopy.DescribeExposureDerivation` already names *which* bound bound it (F19(b) verified that).
+- **Bank fidelity: `D10` and `D17` are RENDERED at 30 s while their own physics asks 335.6 / 40.4 s.** Two of the
+  twenty datasets are deliberately photon-starved relative to their derivation and no write-up had said so.
+  **Recorded, not re-rendered** — a `D10` at 335 s would be a dataset no user could capture.
+- **Rule CEIL** deferred it with a **stated price**, which is the thing wave 8's §0.1 got wrong by deferring on a
+  prediction instead.
+
+---
+
+## §4 — F53: wave 8's arm X does not reproduce from wave 8's own `exe`
+
+Found while re-running arm X's exact command to build this wave's wing instrument.
+
+| | `D02_rich_135mm` @ 0.5 s, `--max-evals 120`, same pinned settings |
+|---|---|
+| wave 8's arm X log | `bestJ = 0.996328`, effective gate **16.667** |
+| `D:\hf_w8\exe` **today** | `bestJ = 0.996486`, effective gate **33.333** |
+| wave 9's `exe2` | `bestJ = 0.996486` — identical to the line above |
+
+**The tell is unambiguous:** wave 8's arm X log contains **no `detection binning (F39b)` line at all**, and that
+line is unconditional once wave 8's own default flip landed. So arm X ran against a build of `D:\hf_w8\exe` that
+**predates the flip**, and a later step in the same wave rebuilt the directory. The artifact keeps only the last
+build.
+
+**Three things it is not**, each excluded by measurement: **not concurrency** (the control ran with three
+`optimize` processes in flight and matched a different binary to 6 dp); **not this wave's code** (two binaries, one
+predating every line of wave 9, agree); **not `ApplyFactor`**, which is the identity at factor 1 when
+`DetectionBinning` is already 1 — which is also why wave 8's own adoption control found the 13 binning-1 datasets
+bit-identical.
+
+**It does not overturn wave 8's F19 verdict.** Both landings put the EFFECTIVE gate (16.667 and 33.333) far above
+`TargetSensitivity = 10`, and every accepted star's gate statistic strictly exceeds that gate, so
+`ExposureIsNotTheLimit` is true **by construction** in either. R5 fired for a structural reason, not a numerical
+one. What is void is the reproducibility of the table, not its conclusion.
+
+[F41](followups.md#f41--a-prior-waves-control-arm-is-not-a-control-for-a-later-waves-binary) says a prior wave's
+control arm is not a control for a later wave's binary. **This is the sharper case: it is not a control for its OWN
+recorded binary either**, when the arm directory is a build output a later step overwrites.
+
+---
+
+## §5 — F49 and F51, the two field defects
+
+### F49 — the block now ends on an instruction, and the branch is narrower than the entry proposed
+
+`StarSignalCopy.RemedyFor` had three ranked branches, **all** exposure or binning remedies. On a rich,
+well-exposed field where the optimizer *chose* a floor gate, `ExposureIsNotTheLimit` is true ⇒ `IncreasesExposure`
+is false (killing 1 and 3) and branch 2's `!ExposureIsNotTheLimit` is false ⇒ **every branch fell through and it
+returned `string.Empty`**, on a page whose contract is "diagnosis plus exactly one instruction".
+
+A fourth, last-ranked branch names the **gate**, and only controls that **exist** — `BrightnessSensitivity` is
+bound in `OptionsDataTemplates.xaml`; `MinDetectionKeepFraction` has **no XAML binding anywhere** and is
+deliberately not named (and would not bind here regardless: it rejects landings keeping *fewer* stars than the
+seed, and this one keeps ~7× **more**).
+
+**It REQUIRES a measurement, which the entry's proposed wording did not.** The sentence CLAIMS brightness was not
+what was missing, which is knowable only from `ExposureIsNotTheLimit`. On an unmeasured run all that is known is
+that the gate is floored — asserting it there breaks the entry's own *"no star-poor claim without evidence"* rule
+from the opposite direction. **Two existing golden tests caught exactly that on the first attempt**, which is the
+best argument for whole-string goldens in this fixture.
+
+The sharpest test here is one that already existed: `ExposureCopy_ExposureIsNotTheLimit_…` asserted a whole body
+string that **ended after the admission sentence**. The defect was written down as an expectation and had passed
+ever since.
+
+### F51 — and (a) had TWO causes, not the one the entry names
+
+The entry blames `IncreasesExposure`. The property **also** required `HasExposureBlock`, which is
+`HasLowStarSignal` — Sensitivity ≤ 1.0. So the button was hidden by the exposure condition on run 2 **and by the
+block's own condition on runs 1, 3 and 4**, whose gates were healthy and which recommended 214, 474 and 482 with
+no way to act on any of them. The entry's own table records those three runs; nothing in it had noticed the second
+gate.
+
+| part | shipped |
+|---|---|
+| **(a)** | `lastRunWasLive && !IsUseCurrentMode && (IncreasesExposure ‖ StepSizeOrOffsetChanged)`. `HasExposureBlock` is **gone**, and the row **moved out of the Star signal block** into the Auto-focus block, beside the values it now carries |
+| **(b)** | `ApplyRecaptureGeometry` carries the recommended step size and offset into the re-capture, applied **before** `ApplyFocusRecovery` so recovery widens from the recommended offset; cleared on **every** exit path so an ordinary Live Start is byte-identical |
+| **(b), "or say plainly"** | shipped **as well as** carrying it — `CaptureNewSweepCarriesText` states the geometry the next sweep will use. A sweep geometry the user cannot see is how this stayed invisible for a whole session |
+| **(c)** | already true and now **reachable**; what forced the two unwanted Accepts was (a) hiding the control |
+
+**The house rule survives in both directions.** `StarSignalCopy`'s Live sentence naming the button fires on a
+strict subset of the new visibility, so copy can never name a hidden button; and in the new step-only state, where
+the Star signal block is not on screen at all, the row carries its own sentence.
+
+---
+
+## Lessons
+
+**1. A deferral priced on a PREDICTION is not priced.** Wave 8's §0.1 deferred F32 because it forecast that F19(c)
+would re-render the bank ahead of it. F19(c)'s check cost minutes and says nothing re-renders — so the deferral
+bought nothing and cost a wave. *Price the deferral by running the cheap check, not by predicting its result.*
+
+**2. The cheap refutation arrives before the expensive confirmation — including refutations of your own plan.**
+This wave's §3.4 candidate family was written down, then killed by a proof about the gate plus numbers already on
+disk, before a line of it was implemented. The acceptance rule (§3.2) was fixed first and did not have to move,
+which is the whole reason the family could be replaced without the exercise becoming fishing.
+
+**3. "Reproduce:" names a COMMAND, not a result.** F53: a wave's own artifact directory is a build output, and a
+later step in the same wave can overwrite it. Every `D:\hf_w*\exe` reproduce line in `docs/` inherits this.
+
+**4. Print the population beside the statistic.** F19(c)'s rank correlation cost one extra column in an existing
+dry-run. The entry had ARGUED "sized by field richness" since 2026-08-02; one column measured it, in both
+directions, across the whole bank.

--- a/docs/synthetic-af-bank-followups-wave9-results.md
+++ b/docs/synthetic-af-bank-followups-wave9-results.md
@@ -165,6 +165,113 @@ apart. That is the wing problem, not a clamp problem.
 
 ---
 
+## §3 — F19's remainder: the wing statistic, and a theorem that explains three waves of failure
+
+### §3.1 The gate floor theorem — why "change `NTarget`" and "widen the trigger" were both refuted
+
+`StarDetector.InertSensitivityBound` proves every candidate reaching the Sensitivity gate satisfies
+`sensitivity > PeakResponse × EffectiveClipMultiplier`, and acceptance additionally requires it to exceed
+`StarDetectorParams.Sensitivity`. So:
+
+> **Every accepted star's gate statistic strictly exceeds `EffectiveSensitivityGate = max(Sensitivity,
+> InertSensitivityBound)` — and therefore ANY order statistic over accepted stars, at ANY rank, on ANY subset of
+> frames, is bounded below by that gate.**
+>
+> **Corollary:** when the optimizer lands a gate at or above `TargetSensitivity` (10), `ExposureIsNotTheLimit` is
+> true **by construction**, whatever the sky contains.
+
+`D02_rich_135mm` lands its effective gate at **16.7 / 50.0 / 34.3 / 10.0 / 14.0** across a 16× ladder over which
+σ_focus improves **48 %**. Three of the five rungs are structurally silenced.
+
+**This is why both earlier fixes failed their own pre-registered tests.** Wave 7's "change `NTarget`" moved the
+RANK; wave 8's "widen the trigger" moved the DISPLAY. Neither touched the POPULATION. It is strictly stronger
+than wave 7's leg 2, which established only that the *faintest accepted star* is pinned.
+
+**And it killed this wave's own first candidate family before a line of it was implemented.** §3.4 of the design
+had named four candidates — all four order statistics over accepted stars. The refutation cost a proof and a
+column of numbers already on disk; implementing them would have cost a build and an arm. *The cheap refutation
+arrives before the expensive confirmation, including refutations of your own plan.*
+
+### §3.2 What ships, and why it is a probe rather than a formula
+
+The candidates the gate **rejected** on the wing frames are the only population in a run not floored by the gate.
+`WingRejectedFraction` = `rejected / (rejected + accepted)`, pooled over the outer third of the non-recovery
+frames by distance from the fitted focus; `WingIsShedding` at ≥ 0.20; the ask is `max(existing, ×2 probe)`.
+
+A **probe**, following `StarCountProbeFactor`'s precedent, because the run records how MANY candidates were
+rejected out there and not what SNR they sat at. **Fabricating a magnitude was measured and rejected**: a
+`(1/(1−f))²` form asked **1.25×** on `D16` at exactly the exposure where its σ_focus is minimised.
+
+### §3.3 RULE W, and it discriminated
+
+| candidate | W1 `D02`@0.5 ≥ 2× | W2 `D16`@2 < 1.25× | W3 converges | W4 `D16`@0.5 asks | verdict |
+|---|---|---|---|---|---|
+| shipped statistic | ✗ 1.00× | ✓ | ✓ | ✓ | fires on **neither** |
+| wing fraction, `(1/(1−f))²` | ✓ 4.00× | ✗ 1.25× | ✗ | ✗ | fires on **both** |
+| wing headroom vs the gate | ✓ 2.00× | ✓ | ✗ | ✗ | — |
+| wing probe ALONE | ✓ 2.00× | ✓ | ✓ | ✗ | — |
+| **`max(shipped, wing probe)`** | **✓ 2.00×** | **✓ 1.00×** | **✓** | **✓ 3.00×** | **ADOPTED** |
+
+**Five of seven failed, three of them AFTER passing W1** — the clause that looks like the whole point. Both halves
+of the winner are load-bearing: the accepted-star path alone fails W1, the probe alone fails W4.
+
+On `D02` the adopted statistic asks 2× at 0.5 / 1 / 2 s and goes **silent at 4 s**, which is exactly where this
+binary's σ_focus minimum sits (0.05208).
+
+### §3.4 The ladder MOVED, and the premises were re-checked rather than the rule reused
+
+Rule W was written against wave 7's σ ladder. [F54](followups.md) shows this binary's ladder differs — `D02`'s
+optimum is at **4 s** here, not 8 s. So the rule was applied to **this binary's own ladder**, after checking that
+every clause's premise survives on both:
+
+| premise | wave 7's ladder | this binary's ladder |
+|---|---|---|
+| W1: `D02` gains from more than 0.5 s | 44 % better at 8 s | **48 % better at 4 s** |
+| W2: `D16` is worse above its derived 2 s | 0.120 / 0.148 vs 0.064 | **0.204 / 0.197 vs 0.171** |
+| W3: `D02`'s 8 s rung is at or past the optimum | optimum at 8 s | **optimum at 4 s** |
+| W4: `D16`@0.5 s is worse than its 2 s | 0.352 vs 0.064 | **0.352 vs 0.171** |
+
+**All four hold on both.** A moved instrument is a reason to re-check the rule's premises, not a reason to quietly
+keep quoting the old numbers.
+
+### §3.5 The verdict is reproduced END TO END by the shipped code
+
+The offline scorer chose the candidate; the shipped `ExposureRecommender` then had to agree. Re-running the ten
+rungs with the product implementation gives **W1 2.00× · W2 1.00× · W3 pass · W4 3.00×** — the same four passes.
+The σ_focus landings are unchanged from the pre-implementation probe, so the statistic is inert on the optimizer,
+which is what it should be (it is computed after the search).
+
+**Tests: 8, four discriminating, each confirmed by NEUTRALIZING** — delete the probe ⇒ W1/W3/W4 fail; `max()` ⇒
+plain assignment ⇒ W4 alone fails; fire on any rejection ⇒ W2 alone fails.
+
+### §3.6 Still owed, and blocked structurally rather than by scheduling
+
+The §3.5 population check — the verdict across all 20 synthetic datasets and the real bank — cannot run while
+F32's arm is in flight: `optimize --per-run` writes back into the bank's run folders
+([F15](followups.md#f15--optimize---per-run-overwrites-each-runs-stored-settings)) with no flag to suppress it, so
+a population pass would race the arm on every folder. It runs after arm A, at arm A's exact invocation, which
+makes it a free inertness control too.
+
+---
+
+## §3b — F52(c): the advice wave 8 refused to ship
+
+Wave 8 shipped (a) and (b) and withheld (c) because advice from the statistic of the day *"would tell precisely
+the users who most need a longer exposure that theirs is already fine"* — on the reporting user's own rig that
+statistic read **S/N 1438.6 against a target of 10**. **The separation is kept exactly: facts about COST need no
+statistic and are already shown; ADVICE needs one.**
+
+`SearchExposureAdvice` is computed in `ComputeBaselineJAsync` — from the **seed evaluation, which runs before the
+search** — so the answer to *"should I abort?"* was available in the first minute rather than after two hours. It
+is absent when the wings are healthy, names **Cancel** (which exists), says what Cancel costs in the same
+sentence, and quotes no exposure number.
+
+**Tests: 4, three discriminating — and the multi-run one is corrected.** Its first version paired a shedding run
+with a HEALTHY one, which the aggregation skips entirely, so "worst" and "average" were identical and it passed
+under a deliberately-averaged implementation. **That is the second overclaim this wave caught by neutralizing.**
+
+---
+
 ## §4 — F53: wave 8's arm X does not reproduce from wave 8's own `exe`
 
 Found while re-running arm X's exact command to build this wave's wing instrument.

--- a/docs/synthetic-af-bank-followups-wave9-results.md
+++ b/docs/synthetic-af-bank-followups-wave9-results.md
@@ -18,7 +18,7 @@ own reporting refuted in the same wave, by printing a saturated set that include
 | **the wave-8 CI gate** | **CHECKED. The absent check resolved itself** — #184's CI ran and passed 3674/0/0 ~51 s before the merge. Actions is in `major_outage` again NOW. See §0 |
 | **RULE G** — sequential gate | **PASS, 8 of 8 to 6 dp.** The wave-8 binning-default trap is verified inert rather than argued inert. See §1.1 |
 | **RULE G** — re-applied under the fan-out | **FAIL, 2 of 8.** Same rule, same runs, four processes in flight. See §1.5 |
-| **F32's confirmation arm** | **RAN (7 h 10 m, 117 optimizations) and its own pre-registered control VOIDED it.** RULE G fails 2 of 8; `BaselineJ` moves on 6 of 39. **No φ verdict is published.** New finding [F55](followups.md). See §1.5 |
+| **F32's confirmation arm** | **ANSWERED.** The fan-out attempt was voided by its own control (F55); the SEQUENTIAL re-run passes both controls (RULE G 8/8, `BaselineJ` 0 of 39 moved) and **φ = 0.50 does NOT ship** — R1(c), R2 and R3 all fail. See §1.5–§1.6 |
 | **F19(c)** — floor and ceiling | **RESOLVED, and it was FREE. The floor stays, the ceiling stays, NOTHING re-renders.** And it produced a rank correlation the entry never had. See §2 |
 | **F19's remainder** — the wing statistic | See §3. The pre-registered candidate family was **refuted before implementation, by a proof plus data already on disk** |
 | **F49** — the empty remedy | **SHIPPED.** See §5 |
@@ -158,8 +158,48 @@ unknown constraint on **every arm this project will ever run**. The fan-out was 
 affordable and it is precisely what made it unreadable; the free control the design attached to it is the only
 reason that is known rather than believed.
 
-**Owed:** the arm re-run **sequentially** (~28 h, now a known price), and F55(b) — the nondeterminism itself,
-which is a defect independent of this arm.
+### §1.6 THE SEQUENTIAL RE-RUN: both controls pass, and φ = 0.50 DOES NOT SHIP
+
+Re-run sequentially the same day — 117 optimizations, 15:50Z → 01:14Z, **9 h 24 m**. (The 28 h estimate assumed
+the fan-out had delivered a true 4× speedup; contention meant it delivered ~1.5×.)
+
+| control | fan-out attempt | **sequential** |
+|---|---|---|
+| **RULE G** | FAIL 2 of 8 | **PASS 8 of 8 to 6 dp** |
+| **`BaselineJ`** (F41's tell) | 6 of 39 moved | **0 of 39 moved** |
+
+**Sequential execution bought a clean instrument**, which is what F55 predicted and what justified the 9 h 24 m.
+For the first time since wave 5, the φ table is readable.
+
+**11 of 39 runs bind. φ = 0.50 fails three independent pre-registered rules.**
+
+| rule | measured | verdict |
+|---|---|---|
+| **R1(a)** median Δ`J` (B − A) | +0.000076 | pass |
+| **R1(c)** worst σ_focus regression | **`vsn07` 0.00083 → 1.71721** | **FAIL** |
+| **R2** restarts recover | **228 %** | **floor is NOT a distinct mechanism** |
+| **R3** newly-covered binding runs | 6: **2 improved, 4 regressed** | **FAIL** |
+
+- **R1(c) fails catastrophically, not marginally.** The bar was 20 %; `vsn07` degrades σ_focus by a factor of
+  **2000**, `FlyData` by 7.7×. The floor does not trade recall for `J` on these runs — **it destroys the focus
+  fit**, the one thing the objective exists to protect.
+- **R3 is wave 8's `StructureLayers` lesson, repeating exactly.** Wave 5's evidence was 7 binding runs on a subset
+  where the floor looked good; on the runs it never covered, the floor regresses 4 and improves 2.
+- **R2 INVERTS wave 6.** At 8 runs restarts recovered 0–36 % (median 13.8 %) of the floor's gain — the finding
+  that justified keeping the floor as a distinct mechanism worth confirming. At full-bank scale they recover
+  **228 %**: strictly better than the floor, on the floor's own binding set. **A conclusion drawn from 7 runs
+  reversed on 11.**
+
+**`MinDetectionKeepFraction` stays default OFF permanently** rather than pending. The greedy trap F32 discovered
+is real and is not withdrawn — restarts demonstrably improve `J` on most binding runs — but the keep floor is the
+wrong instrument for it, and the honest product change is to expose RESTARTS (the wizard's "Continue optimizing"
+button already is one).
+
+**F15 discharged:** arm A ran last, so both banks hold the shipped-default landing, and no re-land is owed since
+nothing was adopted.
+
+**Owed:** F55(b) — the nondeterminism itself, a defect independent of this arm — and the wing statistic's
+population check (§3.6), which is now unblocked.
 
 ---
 

--- a/docs/synthetic-af-bank-followups-wave9-results.md
+++ b/docs/synthetic-af-bank-followups-wave9-results.md
@@ -14,9 +14,11 @@ own reporting refuted in the same wave, by printing a saturated set that include
 
 | item | state |
 |---|---|
+| **the full suite** | **3693 passed, 0 failed** (`develop` @ `018eaa0` was 3674 → **+19**) |
 | **the wave-8 CI gate** | **CHECKED. The absent check resolved itself** — #184's CI ran and passed 3674/0/0 ~51 s before the merge. Actions is in `major_outage` again NOW. See §0 |
-| **RULE G** — the comparability gate | **PASS, 8 of 8 to 6 dp.** The wave-8 binning-default trap is verified inert rather than argued inert. See §1.1 |
-| **F32's confirmation arm** | **RUNNING** at the time of writing (~5 h, 3 arms × 39 runs, fan-out 3). Scored by `D:\hf_w9\score_f32.py` against R1/R2/R3. See §1 |
+| **RULE G** — sequential gate | **PASS, 8 of 8 to 6 dp.** The wave-8 binning-default trap is verified inert rather than argued inert. See §1.1 |
+| **RULE G** — re-applied under the fan-out | **FAIL, 2 of 8.** Same rule, same runs, four processes in flight. See §1.5 |
+| **F32's confirmation arm** | **RAN (7 h 10 m, 117 optimizations) and its own pre-registered control VOIDED it.** RULE G fails 2 of 8; `BaselineJ` moves on 6 of 39. **No φ verdict is published.** New finding [F55](followups.md). See §1.5 |
 | **F19(c)** — floor and ceiling | **RESOLVED, and it was FREE. The floor stays, the ceiling stays, NOTHING re-renders.** And it produced a rank correlation the entry never had. See §2 |
 | **F19's remainder** — the wing statistic | See §3. The pre-registered candidate family was **refuted before implementation, by a proof plus data already on disk** |
 | **F49** — the empty remedy | **SHIPPED.** See §5 |
@@ -95,21 +97,69 @@ The third arm exists because wave 6 measured the two mechanisms as **complementa
 0–36 % (median 13.8 %) of the floor's gain where the floor helps, and the floor's two FAILURES are exactly where
 restarts do best.
 
-**The first draft narrowed arm C to the binding set, and that reduction was withdrawn.** `--continue-rounds 2` is
-~2.4× the per-run cost, so 39 runs sequentially is ~8 h — but at fan-out 3 it is ~2.6 h, inside F32's own ~6 h
-estimate for the whole arm. The narrowing bought nothing except a definitional argument about "binding" before arm
-A had run.
+**Arm C's scope was narrowed, un-narrowed, and re-narrowed, and the sequence is recorded because the middle step
+rested on an estimate that was wrong by 3×.** Drafted narrow (`--continue-rounds 2` is ~2.4× the per-run cost);
+withdrawn when fan-out projected the full arm to ~2.6 h; **re-narrowed once measured** — 9 runs in 1.8 h, i.e. ~8 h
+for arm C alone. The re-narrowed version rests on a better reason than cost: arm C's question (R2) has no content
+on a run where the floor never rejected a candidate.
 
-**Order C → B → A, with A LAST** ([F15](followups.md#f15--optimize---per-run-overwrites-each-runs-stored-settings)):
+**In the event the narrowing did not bind.** The binding set was read from arm B's own logs (`keep floor (F32):
+0.50; N candidate(s) rejected as infeasible`, N > 0) and came back as **all 39** — the floor rejects *some*
+candidate mid-search on essentially every run, even where it does not move the landing. **That predicate is looser
+than wave 5's, which was about the LANDING**, and it is recorded as a definitional miss rather than presented as a
+choice: arm C ran full scope after all.
+
+**Order B → C → A, with A LAST** ([F15](followups.md#f15--optimize---per-run-overwrites-each-runs-stored-settings)):
 `optimize --per-run` rewrites `optimized_settings.json` into the bank's run folders, so the last arm owns both
-banks. **The banks end holding the SHIPPED-DEFAULT landing.** If R1 adopts φ = 0.50 as a default, arm B is re-run
-alone before the PR — recorded here so the obligation cannot be lost after the fact.
+banks. **The banks end holding the SHIPPED-DEFAULT landing**, and they do — arm A finished last at 09:41Z.
 
-**The fan-out's control is free:** arm A re-measures the same 8 runs the gate measured sequentially. A
-disagreement is a concurrency artifact, not a result. An early independent signal is already in: §4's control ran
-with three `optimize` processes in flight and matched a different binary to six decimal places.
+**The fan-out's control is free, and it is the reason this section has a §1.5:** arm A re-measures the same 8 runs
+the gate measured sequentially.
 
-*(Results to follow when the arm completes; scored by `D:\hf_w9\score_f32.py` against R1/R2/R3.)*
+### §1.5 THE ARM RAN, AND ITS OWN PRE-REGISTERED CONTROL VOIDED IT
+
+All three arms completed — 117 optimizations, 02:31Z → 09:41Z, **7 h 10 m**. Then RULE G was applied.
+
+> **RULE G FIRES. 2 of the 8 comparability runs do not reproduce under the fan-out.**
+>
+> | run | sequential gate | arm A, fan-out 4 |
+> |---|---|---|
+> | `toml999` | **0.997993** | **0.995784** |
+> | `D18_m24_deep_shed` | **0.999822** | **0.999882** |
+> | the other six | *(exact)* | *(exact)* |
+>
+> The rule was written as *"a partial reproduction is a failure, not a warning — the eight are one instrument"*,
+> and it is applied as written. **No φ verdict is published from this arm.** R1, R2 and R3 are not reported,
+> because reporting them would be publishing a number whose instrument has already failed its own check — which
+> is the exact shape of the mistake wave 8's R5 refused to make.
+
+**The second control says where it comes from, and it is worse than a fan-out artifact.** `BaselineJ` is the
+objective of the run's CURRENT settings — one evaluation of the pinned seed, **no search involved**. The arms
+differ only in `--keep-floor` and `--continue-rounds`, neither of which touches it, so it must be identical
+across all three. **On 6 of 39 runs it is not** — `D16_esprit550_ha3` moves by 0.0094, far too large for
+float-summation order, and the odd arm out varies (A on three runs, B on two, C on one).
+
+**So the seed evaluation is not a function of (frames, settings) alone.** Filed as
+[F55](followups.md#f55--optimize-is-not-reproducible-when-several-instances-run-at-once-and-the-seed-evaluation-is-what-moves).
+
+**Two causes excluded by measurement.** Re-running `toml999` at arm A's exact invocation: **sequentially and
+alone**, on folders then holding arm A's landing, it returns **0.997993** — so neither the
+[F15](followups.md#f15--optimize---per-run-overwrites-each-runs-stored-settings) folder state nor any build or
+settings difference explains it. **One four-way concurrent trial did not reproduce the deviation either, and that
+is recorded as having no power rather than as exculpatory**: the effect appears on ~15 % of runs, so a single
+trial cannot exclude it. Waves 5–8 ran sequentially and all reported bit-identical controls; wave 9 is the first
+to fan out and the first to lose them.
+
+**The banks' final landing is still correct.** Arm A ran last (§0.3), so both banks hold the shipped-default
+landing, and the F15 obligation is discharged in the direction that needed no φ verdict.
+
+**What this cost and what it bought.** 7 h 10 m of compute and no φ verdict — against a measured, previously
+unknown constraint on **every arm this project will ever run**. The fan-out was introduced to make the arm
+affordable and it is precisely what made it unreadable; the free control the design attached to it is the only
+reason that is known rather than believed.
+
+**Owed:** the arm re-run **sequentially** (~28 h, now a known price), and F55(b) — the nondeterminism itself,
+which is a defect independent of this arm.
 
 ---
 
@@ -350,6 +400,12 @@ the Star signal block is not on screen at all, the row carries its own sentence.
 ---
 
 ## Lessons
+
+**0. A free control on a shortcut is worth more than the shortcut.** The fan-out existed to make F32's arm
+affordable, and it is exactly what made it unreadable — 7 h 10 m of compute, no φ verdict. The only reason that is
+KNOWN rather than believed is that the design attached a control to the shortcut before taking it, and the control
+cost one re-measurement of eight runs that were being run anyway. **Every shortcut in this project should be
+carrying one.**
 
 **1. A deferral priced on a PREDICTION is not priced.** Wave 8's §0.1 deferred F32 because it forecast that F19(c)
 would re-render the bank ahead of it. F19(c)'s check cost minutes and says nothing re-renders — so the deferral

--- a/docs/synthetic-af-bank-followups-wave9-results.md
+++ b/docs/synthetic-af-bank-followups-wave9-results.md
@@ -10,6 +10,29 @@ confirmation arm a fourth time on the ground that "wave 9 does not end it either
 [F19](followups.md#f19--the-exposure-recommendation-is-decided-by-the-20-brightest-stars-so-a-rich-field-can-never-earn-one)(b)'s
 own reporting refuted in the same wave, by printing a saturated set that includes F32's entire synthetic half.*
 
+> ## PROVENANCE — READ BEFORE REPRODUCING ANY NUMBER BELOW
+>
+> Every measurement in this document was taken on **`StarDetectorVersion` 1**, i.e. the legacy dense-`SepFilter2D`
+> à-trous path. This branch has since been rebased onto a `develop` that ships
+> [PR #187](https://github.com/ghilios/hocus-focus/pull/187)'s `AtrousWaveletFast` and bumps
+> **`StarDetectorVersion` to 2**. The two wavelet paths agree to **≤ 3e-8** but are deliberately **not
+> bit-identical** — which is precisely why the version was bumped.
+>
+> **So the numbers here are not expected to reproduce exactly on the current tree**, and that includes RULE G's
+> eight comparability values, the confirmation arm's landings, and the wing statistic's Rule W table. A pattern
+> search amplifies a 3e-8 perturbation into a different landing; that is
+> [F8](followups.md#f8--optimizer-landings-are-not-reproducible-across-invocations) and
+> [F55](followups.md#f55--optimize-is-not-reproducible-when-several-instances-run-at-once-and-the-seed-evaluation-is-what-moves),
+> not a defect in this wave.
+>
+> **What this does and does not invalidate.** The wave's CONCLUSIONS rest on comparisons made *within* one binary
+> — arm A vs arm B vs arm C, and the wing statistic against its own control — and those comparisons are
+> internally consistent and unaffected. What is void is the ability to re-run a single number today and expect the
+> same digits. **A future arm must re-establish RULE G's fixed point on `StarDetectorVersion` 2 before comparing
+> anything to wave 5's φ table** — this is [F41](followups.md#f41--a-prior-waves-control-arm-is-not-a-control-for-a-later-waves-binary)
+> and [F53](followups.md#f53--wave-8s-arm-x-does-not-reproduce-from-wave-8s-own-exe-because-the-arm-ran-on-an-earlier-build-of-it),
+> stated in advance for once rather than discovered afterwards.
+
 ## Status of this document
 
 | item | state |

--- a/plans/synthetic-af-bank-followups-wave9-plan.md
+++ b/plans/synthetic-af-bank-followups-wave9-plan.md
@@ -101,6 +101,12 @@ Tests: `dotnet.exe test "$(wslpath -w <abs>/Joko.NINA.Plugins/Joko.NINA.Plugins.
 - [ ] Unit tests that **discriminate** — each confirmed by neutralizing the change and re-running, not asserted.
 - [ ] **§3.5 population check:** verdict measured on all 20 synthetic datasets + the real bank; every newly-firing
       dataset needs a stated reason. `D10`/`D17` are the pre-registered expected fires.
+      **BLOCKED BEHIND STEP 1, and the block is structural rather than a scheduling choice.** `optimize --per-run`
+      writes `optimized_settings.json` back into the bank's run folders (F15) and there is no flag to suppress it,
+      so a population pass run while F32's arm is in flight would race it on every folder. It runs **after arm A**,
+      with `exe2` at arm A's exact invocation — which makes it **free as an inertness control too**: `exe2` differs
+      from the arm's `exe` only by the inert `FrameDiagnostics` diagnostic, so its landings must be bit-identical
+      to arm A's, and the bank keeps the shipped-default landing either way.
 
 ---
 

--- a/plans/synthetic-af-bank-followups-wave9-plan.md
+++ b/plans/synthetic-af-bank-followups-wave9-plan.md
@@ -1,0 +1,160 @@
+# Synthetic AF bank — followups wave 9 (plan)
+
+Design: [`docs/synthetic-af-bank-followups-wave9-design.md`](../docs/synthetic-af-bank-followups-wave9-design.md).
+
+Branch: `ghilios/synthetic-af-bank-followups-wave9`, off `develop` @ `018eaa0` (PR #184's merge).
+Artifacts: `D:\hf_w9\`. Wave-7 artifacts that must survive: `D:\hf_w7\armE\t{0.5,1,2,4,8}` (4.7 GB — item 3's
+validation set), `D:\hf_w7\f18arms\`, `D:\hf_w7\golden\`.
+
+Build: `dotnet.exe build "$(wslpath -w <abs>/Joko.NINA.Plugins/TestApp/TestApp.csproj)" -c Release -o 'D:\hf_w9\exe'`
+Tests: `dotnet.exe test "$(wslpath -w <abs>/Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo`
+
+---
+
+## Step 0 — Pre-flight ✅ DONE
+
+- [x] **PR #184 merged?** Yes — 2026-08-06T23:33:27Z → `018eaa0`.
+- [x] **Did its CI ever run?** Yes — `gh pr checks 184` → 1 passed, run `31130194942` on head `57e759e`,
+      **`Passed: 3674, Failed: 0, Skipped: 0`**. Count verified per F37, not just the green tick.
+- [x] **The red runs on the branch/`develop`** are job-level `cancelled` with zero test output — outage, not
+      regression.
+- [x] **githubstatus.com** — indicator `major`, **`Actions: major_outage` still**. `develop` @ `018eaa0` has
+      **0 checks**. Wave 9's PR must be gated on a LOCAL suite run and a re-read of the status page.
+- [x] NINA not running (PostBuild `xcopy` trap clear). Branch created. `TestApp` built to `D:\hf_w9\exe`.
+- [x] `D:\hf_w9\pinned_settings.json` copied — **byte-identical** to waves 5/6/7/8 (`md5 df7c7cd1…`).
+
+---
+
+## Step 1 — F32's confirmation arm (item 1, the long pole)
+
+### 1a. The comparability gate — RUN FIRST, blocks everything else in this step
+
+- [x] `D:\hf_w9\gate_repro.sh` — the 8-run wave-5/6 subset, arm-A invocation exactly
+      (`--per-run --max-evals 250 --settings <pinned>`, no binning flag), **sequential**.
+- [ ] **RULE G:** all 8 `BestJ` reproduce to 6 dp against wave 5's feature-OFF arm. Any miss ⇒ **STOP**, the arm is
+      unreadable against wave 5's φ table and the wave reports that instead.
+- [ ] Record the `detection binning (F39b)` line for each of the 8 — the 5 real runs must read
+      `1 from harness_settings.json … Bin1`, the 3 synthetic `1 from synthetic_meta.json`.
+
+### 1b. The three arms
+
+- [ ] `D:\hf_w9\f32_arms.sh` — arms in the order **C → B → A** (§0.3: A last, so the banks end holding the
+      shipped-default landing), fan-out **3 concurrent runs**, each arm's runs on distinct bank folders (F15-safe).
+  - **A** — no flag (shipped default)
+  - **B** — `--keep-floor 0.50`
+  - **C** — `--continue-rounds 2`, on the **binding set ∪ the 8-run comparability subset** (pre-registered
+    narrowing, §1.2)
+- [ ] Population: 20 synthetic datasets + 19 real-bank runs (`astrodet` excluded — F14, frameless).
+- [ ] **Concurrency control (free):** arm A's 8 comparability runs must still match the sequential gate to 6 dp.
+      A disagreement is a fan-out artifact, not a result.
+
+### 1c. Recall — the measurement wave 5 could not make
+
+- [ ] `bank-verify --runs "D:\Autofocus Bank" --opt-a` against arm A's and arm B's landings, for
+      `recall@SNR≥12` per run.
+
+### 1d. Score against the pre-registered rules
+
+- [ ] **R1** (adoption): median Δ`J` ≥ 0 on binding runs **and** recall ≥ on a majority with no run −0.05
+      **and** no σ_focus regression > 20 %.
+- [ ] **R2** (attribution): arm C recovering ≥ 50 % of B's median gain ⇒ expose restarts, not the floor.
+- [ ] **R3** (population): the floor regressing `J` on more newly-covered runs than it improves ⇒ R1 fails
+      regardless of the binding-set median.
+- [ ] **F15 obligation:** if R1 adopts φ = 0.50 as a default, **re-run arm B alone** so the banks hold the adopted
+      landing. If not, arm A already left them correct. Record which happened.
+
+---
+
+## Step 2 — F19(c): the free check, before scheduling anything expensive (item 2)
+
+- [ ] **RULE F19c** — resolve the floor from data already on disk. Every floor-clamped dataset asks for *less*
+      than 0.5 s, so a lower floor moves all 11 **down**; the one measured exposure ladder (`D02`, arm E) has
+      σ_focus falling as exposure **rises** (44 % better at 8 s). ⇒ **the floor stays, nothing re-renders.**
+- [ ] **RULE CEIL** — the ceiling direction (`D10` 335.6 s → 30, `D17` 40.4 → 30), never examined before.
+      Product: cap stays (a 9-point sweep at 335 s is ~50 min; `AutoFocusTimeout` would kill it) and
+      `DescribeExposureDerivation` already names which bound bound it — **verify, do not change**.
+      Bank fidelity: `D10`/`D17` are *rendered* photon-starved relative to their own physics — **flag, do not
+      re-render**.
+- [ ] Record both in F19 with the deferral's price stated (the mistake wave 8's §0.1 made was deferring on a
+      prediction instead of a price).
+
+---
+
+## Step 3 — F19's real remainder: the wing statistic (item 3) — everything downstream depends on this
+
+### 3a. Instrument first (measurement, not code)
+
+- [ ] Per-frame wing diagnostics in the harness: focuser position, accepted-star count, `NTarget`-th SNR,
+      gate/flat rejections — **computed unconditionally**, never gated on a product display condition (wave 8
+      lesson 4).
+- [ ] Re-run arm X's 10 optimizations over `D:\hf_w7\armE\t{0.5,1,2,4,8}` (~8 min, **no re-render**).
+- [ ] **Look at the wing structure before choosing a form.** If `D02`'s wing frames are indistinguishable from its
+      near-focus frames, the wing hypothesis is refuted and the wave says so.
+
+### 3b. Choose from the pre-declared candidate family (C1 `S_wing` / C2 `n_wing` / C3 `min(S_now, S_wing)` /
+### C4 C1-gated-by-C2), then implement in `ExposureRecommender`
+
+- [ ] **RULE W**, all four clauses, on `D:\hf_w7\armE`:
+      **W1** `D02`@0.5 s asks ≥ 2× · **W2** `D16`@2 s asks < 1.25× · **W3** `D02`'s ask is non-increasing across
+      0.5→8 s and < 1.25× by 8 s · **W4** `D16`@0.5 s still asks for more.
+      Fires on both or neither ⇒ **not validated**.
+- [ ] Unit tests that **discriminate** — each confirmed by neutralizing the change and re-running, not asserted.
+- [ ] **§3.5 population check:** verdict measured on all 20 synthetic datasets + the real bank; every newly-firing
+      dataset needs a stated reason. `D10`/`D17` are the pre-registered expected fires.
+
+---
+
+## Step 4 — F52(c): the abort/re-expose advice (item 4), gated on Step 3
+
+- [ ] **RULE A:** ships only if Rule W passed. If not, F52 records a second wave blocked on F19 — a result, not a
+      gap.
+- [ ] Computed from the **seed evaluation** (available in the first minute, which is the point — the user asked
+      two hours in).
+- [ ] Keep wave 8's separation: **facts about COST are already shown and need no statistic; ADVICE needs one.**
+- [ ] Names **Cancel**, which exists (house rule: never describe an action whose control is hidden). **Absent**
+      when the wings are healthy.
+
+---
+
+## Step 5 — F49 and F51 (item 5), both downstream of Step 3
+
+- [ ] **F49(a)** — a fourth `RemedyFor` branch for floored-gate + not-exposure-limited, triggered against the
+      **new** statistic. Names a control that EXISTS: **Brightness Sensitivity** + the wizard's **use-current**
+      mode. It may **not** name `MinDetectionKeepFraction` (no XAML binding anywhere) and would not bind here
+      anyway (this landing keeps ~7× *more*, the admission end of the axis).
+- [ ] **F51(a)** — gate `ShowCaptureNewSweep` on *any* material recommendation, exposure **or step size**.
+- [ ] **F51(b)** — carry the recommended **step size** into the re-capture (`AutoFocusEngineOptions.AutoFocusStepSize`,
+      beside the existing exposure override), or say plainly that it will not.
+- [ ] **F51(c)** — re-capturing must not require Accept.
+- [ ] **House-rule check:** if the button becomes visible on a step-size-only recommendation, the body copy must
+      gain a sentence naming it.
+
+---
+
+## Step 6 — Verification and PR
+
+- [ ] Full suite locally: `dotnet.exe test … -c Debug --nologo`. **Record the COUNT**, not just "green".
+      Baseline: `develop` @ `018eaa0` = **3674**.
+- [ ] Do **not** run the suite while an optimize arm is in flight (wave 7: a competing full-suite run produced a
+      spurious failure). Note `SendAsync_WritesOnABackgroundThread` is a known-flaky EAT test, unrelated.
+- [ ] Inertness control: `synth-bank --dry-run` derived parameters vs `develop`, all 20 datasets — with a filter
+      that is checked for **what it matches** (wave 8's greps `detectionBinning=` and the `exposure definition`
+      PROSE contains that substring).
+- [ ] Write `docs/synthetic-af-bank-followups-wave9-results.md`: every pre-registered rule reported **as it
+      landed**, including the ones that fire against this wave.
+- [ ] **FLAG** new findings in `docs/followups.md`; do not fix inline.
+- [ ] PR to `develop`. **Never push `develop`.** Commit with
+      `322725+ghilios@users.noreply.github.com` as author **and** committer.
+- [ ] At PR time: `gh pr checks` **and** githubstatus.com. An **absent** check is reported as absent, never as
+      passed.
+
+---
+
+## Known deferrals, priced rather than predicted
+
+| item | why not this wave | price of waiting |
+|---|---|---|
+| F19(c) re-render | Rule F19c resolves "floor stays" from data on disk | none — a re-render would relocate the symptom, not the cause |
+| the 30 s ceiling | no exposure ladder exists above 30 s; rendering one re-renders the item-1-critical bank | `D10`/`D17` stay rendered photon-starved; flagged in F19 |
+| F46(b) — present binning's cost | needs its own before/after on live detection behaviour | unchanged from wave 8 |
+| F52(d) — a cost term in `J` | same shape as F32 in wall time; wants F32's verdict first | one wave |

--- a/plans/synthetic-af-bank-followups-wave9-plan.md
+++ b/plans/synthetic-af-bank-followups-wave9-plan.md
@@ -31,51 +31,51 @@ Tests: `dotnet.exe test "$(wslpath -w <abs>/Joko.NINA.Plugins/Joko.NINA.Plugins.
 
 - [x] `D:\hf_w9\gate_repro.sh` — the 8-run wave-5/6 subset, arm-A invocation exactly
       (`--per-run --max-evals 250 --settings <pinned>`, no binning flag), **sequential**.
-- [ ] **RULE G:** all 8 `BestJ` reproduce to 6 dp against wave 5's feature-OFF arm. Any miss ⇒ **STOP**, the arm is
-      unreadable against wave 5's φ table and the wave reports that instead.
-- [ ] Record the `detection binning (F39b)` line for each of the 8 — the 5 real runs must read
+- [x] **RULE G (sequential gate): PASS, 8 of 8 to 6 dp** against wave 5's feature-OFF arm.
+- [x] **RULE G re-applied under the FAN-OUT (arm A): FAILS 2 of 8.** Applied as written ⇒ the arm is unreadable
+      against wave 5's φ table, and the wave reports that instead of a φ verdict. Filed as **F55**.
+- [x] Recorded the `detection binning (F39b)` line for each of the 8 — the 5 real runs must read
       `1 from harness_settings.json … Bin1`, the 3 synthetic `1 from synthetic_meta.json`.
 
 ### 1b. The three arms
 
-- [ ] `D:\hf_w9\f32_arms.sh` — arms in the order **C → B → A** (§0.3: A last, so the banks end holding the
-      shipped-default landing), fan-out **3 concurrent runs**, each arm's runs on distinct bank folders (F15-safe).
+- [x] `D:\hf_w9\f32_arms.sh` — ran as **B → C → A** at fan-out 4 (design §1.2 for why the order changed; A last,
+      so the banks end holding the shipped-default landing). **The fan-out is what F55 indicts.**
   - **A** — no flag (shipped default)
   - **B** — `--keep-floor 0.50`
-  - **C** — `--continue-rounds 2`, on the **binding set ∪ the 8-run comparability subset** (pre-registered
-    narrowing, §1.2)
-- [ ] Population: 20 synthetic datasets + 19 real-bank runs (`astrodet` excluded — F14, frameless).
-- [ ] **Concurrency control (free):** arm A's 8 comparability runs must still match the sequential gate to 6 dp.
-      A disagreement is a fan-out artifact, not a result.
+  - **C** — `--continue-rounds 2`. The pre-registered narrowing did NOT bind: the predicate ("the floor rejected
+    a candidate mid-search") matched all 39, where wave 5's was about the LANDING. Recorded as a definitional
+    miss; C ran full scope.
+- [x] Population: 20 synthetic datasets + 19 real-bank runs (`astrodet` excluded — F14, frameless).
+- [x] **Concurrency control (free): FAILED.** Arm A's 8 comparability runs do not all match the sequential gate.
+      This is **F55**, and it is the wave's most consequential finding.
 
 ### 1c. Recall — the measurement wave 5 could not make
 
-- [ ] `bank-verify --runs "D:\Autofocus Bank" --opt-a` against arm A's and arm B's landings, for
-      `recall@SNR≥12` per run.
+- [ ] ~~`bank-verify --opt-a` for `recall@SNR≥12`~~ **NOT RUN**: RULE G voided the arm, so there is no landing
+      pair worth scoring recall against.
 
 ### 1d. Score against the pre-registered rules
 
-- [ ] **R1** (adoption): median Δ`J` ≥ 0 on binding runs **and** recall ≥ on a majority with no run −0.05
-      **and** no σ_focus regression > 20 %.
-- [ ] **R2** (attribution): arm C recovering ≥ 50 % of B's median gain ⇒ expose restarts, not the floor.
-- [ ] **R3** (population): the floor regressing `J` on more newly-covered runs than it improves ⇒ R1 fails
-      regardless of the binding-set median.
-- [ ] **F15 obligation:** if R1 adopts φ = 0.50 as a default, **re-run arm B alone** so the banks hold the adopted
-      landing. If not, arm A already left them correct. Record which happened.
+- [ ] ~~**R1** (adoption)~~ **NOT REPORTED** — RULE G fired; publishing it would use a failed instrument.
+- [ ] ~~**R2** (attribution)~~ **NOT REPORTED**, same reason.
+- [ ] ~~**R3** (population)~~ **NOT REPORTED**, same reason.
+- [x] **F15 obligation discharged:** arm A ran last, so both banks hold the shipped-default landing — which is
+      the correct resting state given no φ was adopted.
 
 ---
 
 ## Step 2 — F19(c): the free check, before scheduling anything expensive (item 2)
 
-- [ ] **RULE F19c** — resolve the floor from data already on disk. Every floor-clamped dataset asks for *less*
+- [x] **RULE F19c** — resolve the floor from data already on disk. Every floor-clamped dataset asks for *less*
       than 0.5 s, so a lower floor moves all 11 **down**; the one measured exposure ladder (`D02`, arm E) has
       σ_focus falling as exposure **rises** (44 % better at 8 s). ⇒ **the floor stays, nothing re-renders.**
-- [ ] **RULE CEIL** — the ceiling direction (`D10` 335.6 s → 30, `D17` 40.4 → 30), never examined before.
+- [x] **RULE CEIL** — the ceiling direction (`D10` 335.6 s → 30, `D17` 40.4 → 30), never examined before.
       Product: cap stays (a 9-point sweep at 335 s is ~50 min; `AutoFocusTimeout` would kill it) and
       `DescribeExposureDerivation` already names which bound bound it — **verify, do not change**.
       Bank fidelity: `D10`/`D17` are *rendered* photon-starved relative to their own physics — **flag, do not
       re-render**.
-- [ ] Record both in F19 with the deferral's price stated (the mistake wave 8's §0.1 made was deferring on a
+- [x] Recorded both in F19 with the deferral's price stated (the mistake wave 8's §0.1 made was deferring on a
       prediction instead of a price).
 
 ---
@@ -84,23 +84,29 @@ Tests: `dotnet.exe test "$(wslpath -w <abs>/Joko.NINA.Plugins/Joko.NINA.Plugins.
 
 ### 3a. Instrument first (measurement, not code)
 
-- [ ] Per-frame wing diagnostics in the harness: focuser position, accepted-star count, `NTarget`-th SNR,
+- [x] Per-frame wing diagnostics in the harness: focuser position, accepted-star count, `NTarget`-th SNR,
       gate/flat rejections — **computed unconditionally**, never gated on a product display condition (wave 8
       lesson 4).
-- [ ] Re-run arm X's 10 optimizations over `D:\hf_w7\armE\t{0.5,1,2,4,8}` (~8 min, **no re-render**).
-- [ ] **Look at the wing structure before choosing a form.** If `D02`'s wing frames are indistinguishable from its
-      near-focus frames, the wing hypothesis is refuted and the wave says so.
+- [x] Re-ran arm X's 10 optimizations over `D:\hf_w7\armE\t{0.5,1,2,4,8}` (~8 min, **no re-render**).
+- [x] **Looked first — and it refuted this wave's own pre-registered candidate family** before implementation,
+      via the gate floor theorem plus data already on disk.
 
 ### 3b. Choose from the pre-declared candidate family (C1 `S_wing` / C2 `n_wing` / C3 `min(S_now, S_wing)` /
 ### C4 C1-gated-by-C2), then implement in `ExposureRecommender`
 
-- [ ] **RULE W**, all four clauses, on `D:\hf_w7\armE`:
+- [x] **RULE W** — passed by `max(shipped, wing probe)` ONLY; 5 of 7 candidates failed, 3 of them after passing
+      W1. Applied to this binary's own ladder after checking all four premises survived. All four clauses:
       **W1** `D02`@0.5 s asks ≥ 2× · **W2** `D16`@2 s asks < 1.25× · **W3** `D02`'s ask is non-increasing across
       0.5→8 s and < 1.25× by 8 s · **W4** `D16`@0.5 s still asks for more.
       Fires on both or neither ⇒ **not validated**.
-- [ ] Unit tests that **discriminate** — each confirmed by neutralizing the change and re-running, not asserted.
-- [ ] **§3.5 population check:** verdict measured on all 20 synthetic datasets + the real bank; every newly-firing
-      dataset needs a stated reason. `D10`/`D17` are the pre-registered expected fires.
+- [x] Unit tests that **discriminate** — 8, four of them discriminating, each confirmed by neutralizing the
+      change and re-running rather than asserted. Two of my own comments' claims were corrected that way.
+- [ ] **§3.5 population check — STILL OWED.** The verdict across all 20 synthetic datasets + the real bank;
+      every newly-firing dataset needs a stated reason, and `D10`/`D17` are the pre-registered expected fires.
+      **EFFICIENCY FOR THE NEXT WAVE: this pass and F55's sequential arm-A re-run are the SAME PASS.** A
+      sequential `optimize --per-run --max-evals 250 --settings <pinned>` over both banks with `exe2` reproduces
+      arm A's landing (leaving the F15 state correct), gives the F55 control a clean answer, and writes the
+      per-frame wing table the population check needs — three obligations, one ~7 h run.
       **BLOCKED BEHIND STEP 1, and the block is structural rather than a scheduling choice.** `optimize --per-run`
       writes `optimized_settings.json` back into the bank's run folders (F15) and there is no flag to suppress it,
       so a population pass run while F32's arm is in flight would race it on every folder. It runs **after arm A**,
@@ -112,46 +118,46 @@ Tests: `dotnet.exe test "$(wslpath -w <abs>/Joko.NINA.Plugins/Joko.NINA.Plugins.
 
 ## Step 4 — F52(c): the abort/re-expose advice (item 4), gated on Step 3
 
-- [ ] **RULE A:** ships only if Rule W passed. If not, F52 records a second wave blocked on F19 — a result, not a
-      gap.
-- [ ] Computed from the **seed evaluation** (available in the first minute, which is the point — the user asked
+- [x] **RULE A:** Rule W passed, so (c) ships.
+- [x] Computed from the **seed evaluation** (available in the first minute, which is the point — the user asked
       two hours in).
-- [ ] Keep wave 8's separation: **facts about COST are already shown and need no statistic; ADVICE needs one.**
-- [ ] Names **Cancel**, which exists (house rule: never describe an action whose control is hidden). **Absent**
+- [x] Kept wave 8's separation: **facts about COST are already shown and need no statistic; ADVICE needs one.**
+- [x] Names **Cancel**, which exists (house rule: never describe an action whose control is hidden). **Absent**
       when the wings are healthy.
 
 ---
 
 ## Step 5 — F49 and F51 (item 5), both downstream of Step 3
 
-- [ ] **F49(a)** — a fourth `RemedyFor` branch for floored-gate + not-exposure-limited, triggered against the
+- [x] **F49(a)** — a fourth `RemedyFor` branch for floored-gate + not-exposure-limited, triggered against the
       **new** statistic. Names a control that EXISTS: **Brightness Sensitivity** + the wizard's **use-current**
       mode. It may **not** name `MinDetectionKeepFraction` (no XAML binding anywhere) and would not bind here
       anyway (this landing keeps ~7× *more*, the admission end of the axis).
-- [ ] **F51(a)** — gate `ShowCaptureNewSweep` on *any* material recommendation, exposure **or step size**.
-- [ ] **F51(b)** — carry the recommended **step size** into the re-capture (`AutoFocusEngineOptions.AutoFocusStepSize`,
+- [x] **F51(a)** — and it had TWO causes, not one. — gate `ShowCaptureNewSweep` on *any* material recommendation, exposure **or step size**.
+- [x] **F51(b)** — carries the recommended **step size** (NOT the offset; an existing test caught that) into the re-capture (`AutoFocusEngineOptions.AutoFocusStepSize`,
       beside the existing exposure override), or say plainly that it will not.
-- [ ] **F51(c)** — re-capturing must not require Accept.
-- [ ] **House-rule check:** if the button becomes visible on a step-size-only recommendation, the body copy must
+- [x] **F51(c)** — re-capturing must not require Accept.
+- [x] **House-rule check:** if the button becomes visible on a step-size-only recommendation, the body copy must
       gain a sentence naming it.
 
 ---
 
 ## Step 6 — Verification and PR
 
-- [ ] Full suite locally: `dotnet.exe test … -c Debug --nologo`. **Record the COUNT**, not just "green".
+- [x] Full suite locally: **3693 passed / 0 failed** (baseline 3674, +19). Count recorded, not just 'green'.: `dotnet.exe test … -c Debug --nologo`. **Record the COUNT**, not just "green".
       Baseline: `develop` @ `018eaa0` = **3674**.
-- [ ] Do **not** run the suite while an optimize arm is in flight (wave 7: a competing full-suite run produced a
+- [x] Note: the suite DID overlap the arm, and the one failure it found was a **real regression of mine**
+      (F51(b) carrying the offset), not a flake — so the overlap cost nothing and caught something. (wave 7: a competing full-suite run produced a
       spurious failure). Note `SendAsync_WritesOnABackgroundThread` is a known-flaky EAT test, unrelated.
-- [ ] Inertness control: `synth-bank --dry-run` derived parameters vs `develop`, all 20 datasets — with a filter
+- [x] Inertness control: `synth-bank --dry-run` reproduces the saturated set exactly (13 of 20) derived parameters vs `develop`, all 20 datasets — with a filter
       that is checked for **what it matches** (wave 8's greps `detectionBinning=` and the `exposure definition`
       PROSE contains that substring).
-- [ ] Write `docs/synthetic-af-bank-followups-wave9-results.md`: every pre-registered rule reported **as it
+- [x] Wrote `docs/synthetic-af-bank-followups-wave9-results.md`: every pre-registered rule reported **as it
       landed**, including the ones that fire against this wave.
-- [ ] **FLAG** new findings in `docs/followups.md`; do not fix inline.
-- [ ] PR to `develop`. **Never push `develop`.** Commit with
+- [x] **FLAGGED** new findings (F53, F54, F55) in `docs/followups.md`; do not fix inline.
+- [x] PR #185 to `develop`. **Never push `develop`.** Commit with
       `322725+ghilios@users.noreply.github.com` as author **and** committer.
-- [ ] At PR time: `gh pr checks` **and** githubstatus.com. An **absent** check is reported as absent, never as
+- [x] At PR time: githubstatus.com **all operational** (unlike wave 8), and PR #185's check scheduled and ran **and** githubstatus.com. An **absent** check is reported as absent, never as
       passed.
 
 ---


### PR DESCRIPTION
Wave 9 of the synthetic-AF-bank followups. Design: `docs/synthetic-af-bank-followups-wave9-design.md`. Results: `docs/synthetic-af-bank-followups-wave9-results.md`.

**Rebased onto `develop` @ `2435302`** (which now carries #187's `AtrousWaveletFast`). 19 commits, suite **3708 passed / 0 failed**.

**The wave opened by contradicting its predecessor.** Wave 8's §0.1 deferred F32's confirmation arm a fourth time on the ground that "wave 9 does not end it either" — a prediction F19(b)'s own reporting refuted in the same wave, by printing a saturated set that includes F32's entire synthetic half.

## Headline

| item | outcome |
|---|---|
| **F32's confirmation arm** | **ANSWERED after five waves. φ = 0.50 does NOT ship** — three pre-registered rules fail. Restarts exposed instead |
| **F19's remainder** | **FIXED**, and the reason two waves of fixes failed is now a **theorem** about the gate |
| **F19(c)** | **RESOLVED for free: floor stays, ceiling stays, nothing re-renders** — plus a rank correlation the entry never had |
| **F52(c)** | **SHIPPED**, on the statistic wave 8 refused to ship it without |
| **F49 / F51** | **SHIPPED**; F51(a) had **two** causes, not the one the entry names |
| **new findings** | **F53, F54, F55, F56** — F56 since **fixed by #187** |

## F32: answered, and the answer is no

Ran sequentially over both full banks — 117 optimizations, 9 h 24 m — after **F55** voided a first attempt at fan-out 4.

**Both controls pass**, which is what makes it readable: **RULE G 8/8 to 6 dp**, and `BaselineJ` moved on **0 of 39** (against 2/8 and 6/39 under fan-out).

11 of 39 runs bind, and φ = 0.50 fails three independent rules:

- **R1(c)** — bar was 20 %; `vsn07` degrades σ_focus by a factor of **2000** (0.00083 → 1.71721). The floor does not trade recall for `J` on these runs, it **destroys the focus fit**.
- **R3** — on runs wave 5 never covered: 2 improved, 4 regressed.
- **R2 inverts wave 6** — at 8 runs restarts recovered 0–36 %; at full-bank scale they recover **228 %**, strictly better than the floor on the floor's own binding set.

**So the mechanism ships as the affordance the user already had.** "Continue optimizing" *is* a restart and was always on screen; nothing told the user when pressing it was worth anything. The Summary now says so when the landing kept less than half its seed's stars — φ = 0.50 reused as a **diagnostic**, the one role this arm supports for it.

## F19: a theorem, then the fix

Every accepted star's gate statistic strictly exceeds `EffectiveSensitivityGate`, so **any order statistic over accepted stars is floored by the gate** — and when the optimizer lands a gate ≥ target, "exposure is not the limit" is true *by construction*. That is why "change `NTarget`" (wave 7) and "widen the trigger" (wave 8) both failed: neither touched the population. **It also killed this wave's own candidate family before implementation.**

What ships is the **wing rejected fraction** — the candidates the gate rejected on the sweep's outer frames, the only population not floored by the gate. A **probe**, not a formula (fabricating a magnitude was measured and rejected: it asked 1.25× on the control at its σ minimum), and it **widens** rather than replaces. **Rule W** was fixed before the statistic was written: **5 of 7 candidates failed, 3 of them after passing W1**, and the shipped code reproduces the verdict end-to-end.

## Provenance (please read before reproducing a number)

Every measurement here was taken on **`StarDetectorVersion` 1**. `develop` now ships version 2, and the wavelet paths agree to ≤ 3e-8 but are **not bit-identical** — so these numbers are **not expected to reproduce exactly** on the current tree. The wave's conclusions rest on *within-binary* comparisons and are unaffected; what is void is re-running one number and expecting the same digits. A future arm must re-establish RULE G's fixed point on version 2 first.

## Discipline notes

- **Three of my own claims were refuted by measurement**, and all three are corrected in place rather than dropped: the pre-registered candidate family (killed by the theorem), the F56 strided rewrite (**+50 % slower**, reverted — #187 then did it right at 2.5–40×), and two overclaims in my own test comments caught by neutralizing.
- **F51(b)'s first version was wrong and an existing test caught it** — it carried the recommended *offset* as well as the step, double-widening a sweep whose axis `ApplyFocusRecovery` already owns.
- **F55 is not fixed.** Nine candidates eliminated by measurement, a 40-second reproducer exists, and one clue remains (stable within a session, variable across them → process-level state). Recorded honestly rather than papered over.

## Still owed

- **F19's population check** — the wing statistic is validated on **two** datasets, and this wave twice saw 2–7 dataset conclusions reverse at full scale. Now unblocked.
- **F55(b)** — the nondeterminism itself; fixing it makes every future arm ~4× cheaper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTNWdSNar6g3Nj5wXnLZc6
