### PR TITLE
F56: the a-trous residual stops convolving a kernel that is 99.5% zeros

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/CvImageUtilityTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/CvImageUtilityTests.cs
@@ -261,6 +261,73 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Utility {
             Assert.That(stats.Mean, Is.EqualTo(0.5).Within(1e-3));
         }
 
+        /// <summary>A deterministic pseudo-random CV_32F image — fixed seed, so a failure is reproducible.</summary>
+        private static Mat NoiseImage(int width, int height, int seed) {
+            var mat = new Mat(new Size(width, height), MatType.CV_32F);
+            var rng = new Random(seed);
+            unsafe {
+                var p = (float*)mat.DataPointer;
+                for (var i = 0; i < width * height; ++i) {
+                    p[i] = (float)rng.NextDouble();
+                }
+            }
+            return mat;
+        }
+
+        private static double MaxAbsDiff(Mat a, Mat b) {
+            using var diff = new Mat();
+            Cv2.Absdiff(a, b, diff);
+            Cv2.MinMaxIdx(diff, out _, out double max);
+            return max;
+        }
+
+        [Test]
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(3)]
+        [TestCase(4)]   // the shipped StarDetectorParams.StructureLayers default
+        [TestCase(5)]
+        [TestCase(6)]
+        public void ComputeResidualAtrous_StridedMatchesTheDenseReference(int numLayers) {
+            // F56. The dense implementation expresses the a-trous stride by ZERO-PADDING the separable kernel to
+            // 2^(L+2)+1 taps, of which five are non-zero, and lets sepFilter2D convolve all the zeros -- which is
+            // why its cost DOUBLES per layer (F52 measured 27/46/117/254/526 s for layers 4..8). The strided form
+            // pads a border once and sums five shifted ROIs, so it is O(1) in the layer index.
+            //
+            // THE TWO MUST AGREE, because it is the same arithmetic. They are NOT bit-identical: five weighted
+            // accumulations are a different floating-point reduction than one long FIR, so this asserts agreement
+            // to float rounding rather than equality -- stated as a tolerance rather than hidden behind one.
+            //
+            // DISCRIMINATING: change any tap, the stride, or the border mode and this fails at every layer.
+            using var src = NoiseImage(96, 64, seed: 1234);
+            using var strided = CvImageUtility.ComputeResidualAtrousB3SplineDyadicWaveletLayer(src, numLayers);
+            using var dense = CvImageUtility.ComputeResidualAtrousB3SplineDyadicWaveletLayerDense(src, numLayers);
+
+            Assert.That(strided.Size(), Is.EqualTo(dense.Size()));
+            Assert.That(MaxAbsDiff(strided, dense), Is.LessThan(1e-5),
+                $"strided and dense a-trous must agree at layer {numLayers}");
+        }
+
+        [Test]
+        public void ComputeResidualAtrous_ActuallySmooths_SoANoOpImplementationCannotPass() {
+            // GUARD on the test above: two implementations that both did nothing would agree perfectly. The
+            // residual is a LOW-PASS, so on a noise image it must differ substantially from its input.
+            using var src = NoiseImage(96, 64, seed: 99);
+            using var residual = CvImageUtility.ComputeResidualAtrousB3SplineDyadicWaveletLayer(src, numLayers: 3);
+            Assert.That(MaxAbsDiff(residual, src), Is.GreaterThan(0.05),
+                "a residual that equals its input would make the equivalence test vacuous");
+        }
+
+        [Test]
+        public void ComputeResidualAtrous_DoesNotReturnTheCallersOwnMat() {
+            // The caller wraps this in `using`, so handing back `src` would dispose the caller's image out from
+            // under it. The dense version does exactly that at numLayers == 0; the strided one clones instead.
+            using var src = NoiseImage(16, 16, seed: 7);
+            using var residual = CvImageUtility.ComputeResidualAtrousB3SplineDyadicWaveletLayer(src, numLayers: 0);
+            Assert.That(ReferenceEquals(residual, src), Is.False);
+            Assert.That(MaxAbsDiff(residual, src), Is.EqualTo(0.0), "…but at 0 layers it is still a faithful copy");
+        }
+
         [Test]
         public void KappaSigmaNoiseEstimate_Reports_BackgroundMean_OnFlatImage() {
             using var mat = SyntheticGaussianStarImage.CreateFlat(16, 16, 0.42f);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/CvImageUtility.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/CvImageUtility.cs
@@ -519,7 +519,87 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
             return ClampInPlace(lhs, min, max);
         }
 
+        /// <summary>
+        /// The five non-zero B3-spline scaling coefficients, in kernel order. At dyadic layer <c>L</c> they sit
+        /// <c>2^L</c> apart — the "holes" the à-trous transform is named for.
+        /// </summary>
+        private static readonly float[] B3SplineTaps = { 0.0625f, 0.25f, 0.375f, 0.25f, 0.0625f };
+
+        /// <summary>
+        /// One à-trous scaling pass along a single axis: <c>out(x) = Σ_k tap[k] · in(x + (k−2)·stride)</c>, with
+        /// <see cref="BorderTypes.Reflect"/> at the edges — the same border
+        /// <see cref="ComputeResidualAtrousB3SplineDyadicWaveletLayer"/> has always used.
+        ///
+        /// <para><b>Why this is not a <c>SepFilter2D</c> call (F56).</b> <see cref="GetB3SplineFilter"/> expresses
+        /// the stride by ZERO-PADDING the kernel to length <c>2^(L+2)+1</c>, of which exactly five taps are
+        /// non-zero. <c>sepFilter2D</c> then runs a DENSE separable FIR over the whole thing, so its cost is
+        /// linear in kernel length and DOUBLES per layer — 13× wasted multiply-adds at the shipped default of 4,
+        /// and 205× at layer 8. That is precisely the cost curve F52 measured (27 / 46 / 117 / 254 / 526 s for
+        /// layers 4→8) and shipped a UI note to explain. OpenCV's <c>sepFilter2D</c> has no dilation parameter,
+        /// which is presumably why the padding was chosen; padding a border once and summing five shifted ROIs
+        /// has no such limit and is <b>O(1) in the layer index</b>.</para>
+        ///
+        /// <para>The shifted reads are plain ROI headers over one padded buffer — no pixel copying — so the work
+        /// is five weighted accumulations over the image regardless of how deep the layer is.</para>
+        /// </summary>
+        private static Mat ConvolveB3SplineStrided(Mat src, int stride, bool horizontal) {
+            var pad = 2 * stride;
+            using (var bordered = new Mat()) {
+                Cv2.CopyMakeBorder(src, bordered,
+                    top: horizontal ? 0 : pad, bottom: horizontal ? 0 : pad,
+                    left: horizontal ? pad : 0, right: horizontal ? pad : 0,
+                    borderType: BorderTypes.Reflect);
+                var dst = new Mat(src.Size(), MatType.CV_32F, Scalar.All(0));
+                for (var k = 0; k < B3SplineTaps.Length; ++k) {
+                    var offset = k * stride;
+                    var roi = horizontal
+                        ? new Rect(offset, 0, src.Width, src.Height)
+                        : new Rect(0, offset, src.Width, src.Height);
+                    using (var shifted = new Mat(bordered, roi)) {
+                        // dst += tap[k] * shifted. Accumulated in kernel order so the summation order matches the
+                        // dense implementation's as closely as a different reduction can.
+                        Cv2.AddWeighted(dst, 1.0, shifted, B3SplineTaps[k], 0.0, dst);
+                    }
+                }
+                return dst;
+            }
+        }
+
+        /// <summary>
+        /// The à-trous B3-spline scaling residual after <paramref name="numLayers"/> dyadic layers — the
+        /// "large structures" image <c>StarDetector</c>'s step 4 subtracts.
+        ///
+        /// <para><b>F56:</b> each layer is now a strided five-tap separable pass
+        /// (<see cref="ConvolveB3SplineStrided"/>) instead of a dense convolution against a kernel that is
+        /// <c>2^(L+2)+1</c> long and 99.5 % zeros. Mathematically identical; the cost stops doubling per
+        /// layer.</para>
+        ///
+        /// <para><b>Not bit-identical to the dense form, and that is expected.</b> Summing five weighted ROIs is a
+        /// different floating-point reduction than one long FIR, so results agree to float rounding rather than
+        /// exactly. <see cref="ComputeResidualAtrousB3SplineDyadicWaveletLayerDense"/> is retained as the
+        /// reference the equivalence test compares against.</para>
+        /// </summary>
         public static Mat ComputeResidualAtrousB3SplineDyadicWaveletLayer(Mat src, int numLayers) {
+            var previousLayer = src;
+            for (var i = 0; i < numLayers; ++i) {
+                var stride = 1 << i;
+                using (var horizontal = ConvolveB3SplineStrided(previousLayer, stride, horizontal: true)) {
+                    var next = ConvolveB3SplineStrided(horizontal, stride, horizontal: false);
+                    if (!ReferenceEquals(previousLayer, src)) {
+                        previousLayer.Dispose(); // every intermediate except the caller's src is ours to free
+                    }
+                    previousLayer = next;
+                }
+            }
+            // numLayers == 0 must not hand the caller its own src back as if it were a new Mat to dispose.
+            return ReferenceEquals(previousLayer, src) ? src.Clone() : previousLayer;
+        }
+
+        /// <summary>
+        /// The pre-F56 DENSE implementation, retained ONLY as the reference an equivalence test compares the
+        /// strided one against. Not used in production — it is the one whose cost doubles per layer.
+        /// </summary>
+        internal static Mat ComputeResidualAtrousB3SplineDyadicWaveletLayerDense(Mat src, int numLayers) {
             var previousLayer = src;
             Mat tempMat = new Mat();
             for (int i = 0; i < numLayers; ++i) {


### PR DESCRIPTION
Implements **F56** (filed in wave 9, PR #185): the à-trous wavelet residual — the detector's dominant cost — convolves a kernel that is 99.5 % zeros.

## The defect

`CvImageUtility.GetB3SplineFilter(L)` expresses the à-trous stride by **zero-padding** the separable kernel to `2^(L+2)+1` taps, of which exactly **five** are non-zero. Its own comment says so: *"Rather than copy the matrix to convolve it, we can pad the separated filter with zeroes."* `Cv2.SepFilter2D` then runs a **dense** separable FIR over all of it, so cost is linear in kernel length and doubles per layer.

| layer | kernel taps | useful taps | wasted multiply-adds |
|---|---|---|---|
| **4** (shipped default) | 65 | 5 | **13×** |
| 6 | 257 | 5 | **51×** |
| 8 | 1025 | 5 | **205×** |

That reproduces the cost curve F52 measured on `D15_cdk20_3454mm_e47` — **27 / 46 / 117 / 254 / 526 s** for layers 4→8 — and which F52 shipped a UI note to explain to users.

**"À trous" means "with holes"**, and the transform exists to be O(1) per layer: five taps at stride `2^L`. OpenCV's `sepFilter2D` has no dilation parameter, which is presumably why the padding was chosen. Padding a border once and summing five shifted ROIs has no such limit — and the shifted reads are ROI *headers* over one padded buffer, so no pixels are copied.

## Why it matters beyond raw speed

- `OptimizerVariable` searches `StructureLayers` over `[1, 8]`, so **every optimizer run pays this hundreds of times** — a large share of the two-hour runs F52 was filed about.
- **F46** established that deeper layers are the *right* answer at detection binning 2; cost is what makes that expensive to adopt.
- It reframes **F52(d)**: a cost term in `J` would have been penalising an implementation artifact rather than physics.

## Honesty about verification

**Not bit-identical to the dense form, and the tests say so rather than hiding it.** Five weighted accumulations are a different floating-point reduction than one long FIR. The dense implementation is retained as `ComputeResidualAtrousB3SplineDyadicWaveletLayerDense`, used **only** as the reference the equivalence test compares against — layers 1–6, tolerance `1e-5`, plus a guard test proving the residual actually smooths so two do-nothing implementations could not both pass.

Because it is not bit-identical, **optimizer landings may move**: the pattern search is chaotic, so a last-decimal change can select a different landing. That is expected and is not evidence of a defect.

**This was NOT built or tested locally.** F55 (wave 9) proves concurrent CPU load corrupts a running `optimize` arm, and the sequential F32 re-run is in flight on that machine — so CI is the verification here. The **benchmark and bank re-score follow the arm**, and neither number is claimed yet.

## Also fixed

A latent aliasing bug the rewrite exposed: at `numLayers == 0` the dense version returns the **caller's own `src`**, which the caller's `using` block would then dispose out from under it. Unreachable today (`EffectiveStructureLayers` floors at 1), but the strided version clones instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTNWdSNar6g3Nj5wXnLZc6
