### PR TITLE
Fast à trous wavelet: sparse 5-tap SIMD path replaces dense SepFilter2D

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizerProgressCostTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizerProgressCostTests.cs
@@ -95,53 +95,10 @@ public class OptimizerProgressCostTests {
         });
     }
 
-    [Test]
-    public async Task Progress_NamesTheExpensiveKnobWhenTheSearchGoesDeeper_AndQuantifiesIt() {
-        var progress = await RunSearch();
-        var noted = progress.Reports.Where(r => !string.IsNullOrEmpty(r.CostNote)).ToList();
-
-        // The landscape's optimum is at StructureLayers 7 against a seed of 4, so the search MUST visit deeper
-        // candidates -- if it never reports the cost, a user watching a two-hour run still has no idea why.
-        // DISCRIMINATING: returning null from CostNoteFor, or comparing against an absolute instead of the seed,
-        // fails this.
-        Assert.That(noted, Is.Not.Empty, "a search that walks into deeper structure layers must say so");
-        Assert.That(noted[0].CostNote, Does.Contain("structure layers"));
-        Assert.That(noted[0].CostNote, Does.Contain("x per evaluation"),
-            "the note must QUANTIFY the cost -- naming the knob without the factor does not tell the user whether to wait");
-    }
-
-    [Test]
-    public async Task Progress_SaysNothingAboutCostWhenNoCandidateIsDeeperThanTheSeed() {
-        // Search restricted to two axes that cannot touch structure depth, so no candidate can be more expensive
-        // than the seed. A note here would be noise on every fast run, and a readout that always says "expensive"
-        // says nothing.
-        //
-        // Seeding at the top of the StructureLayers range is NOT enough to arrange this and the first version of
-        // this test wrongly assumed it was: the search reached 9 effective layers from a seed of 8 by turning on
-        // the DefocusAwareStructure axis, whose boost stacks on top. The note was right and the test was wrong --
-        // which is the note doing its job, since that is exactly the move that made the field session expensive.
-        //
-        // DISCRIMINATING against a note keyed to an ABSOLUTE layer count rather than to this run's own seed, which
-        // is why the seed turns the donut master ON: that puts its effective depth at 6 while StructureLayers
-        // still reads 4, so an implementation comparing against the shipped default of 4 reports "2 deeper" for a
-        // search that has not moved at all. (Checked: with a plain layers-4 seed the two implementations coincide
-        // and this test cannot tell them apart -- the first version of it could not, and said it could.)
-        var twoAxes = OptimizerVariable.CreateCuratedSet()
-            .Where(v => v.Name == nameof(StarDetectorParams.Sensitivity)
-                     || v.Name == nameof(StarDetectorParams.StarClippingMultiplier))
-            .ToList();
-        var progress = new SyncProgress();
-        await new StarDetectionOptimizer().OptimizeAsync(
-            new StarDetectorParams {
-                Sensitivity = 2.0, StarClippingMultiplier = 2.0,
-                StructureLayers = 4, DefocusAwareDonutDetection = true
-            },
-            twoAxes, Evaluator(),
-            new OptimizerSettings { MaxEvaluations = 400, CoarseGridLevels = 4, StepFloorFraction = 0.125 },
-            progress, CancellationToken.None);
-
-        Assert.That(progress.Reports.Where(r => !string.IsNullOrEmpty(r.CostNote)), Is.Empty);
-    }
+    // The two CostNote tests ("names the expensive knob when the search goes deeper" / "says nothing when no
+    // candidate is deeper") were retired with the note itself: the sparse AtrousWaveletFast swap made per-layer
+    // wavelet cost nearly flat, so structure-layer depth stopped being a cost driver worth narrating
+    // (docs/atrous-wavelet-fast-design.md).
 
     [Test]
     public void EffectiveStructureLayers_CountsTheBoostThatIsActuallyInForce() {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/AtrousWaveletFastTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/AtrousWaveletFastTests.cs
@@ -1,0 +1,179 @@
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.Tests.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.Tests.Synthetic;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NUnit.Framework;
+using OpenCvSharp;
+using System;
+using System.Threading.Tasks;
+using Size = OpenCvSharp.Size;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Utility {
+
+    /// <summary>
+    /// AtrousWaveletFast must be numerically equivalent (within float rounding) to the legacy
+    /// CvImageUtility.ComputeResidualAtrousB3SplineDyadicWaveletLayer (dense zero-padded Cv2.SepFilter2D),
+    /// including BORDER_REFLECT handling, and deterministic regardless of parallelism.
+    /// </summary>
+    [TestFixture]
+    public class AtrousWaveletFastTests {
+
+        // Worst-case float rounding drift for a [0,1] image over numLayers × 2 separable passes with a
+        // different tap-summation order than OpenCV. A real border/indexing bug produces errors orders of
+        // magnitude above this (the taps carry 6-38% of the value each).
+        private const double EquivalenceTolerance = 5e-6;
+
+        private static Mat CreateRandomMat(int width, int height, int seed) {
+            var mat = new Mat(new Size(width, height), MatType.CV_32F);
+            var random = new Random(seed);
+            unsafe {
+                var p = (float*)mat.DataPointer;
+                long step = mat.Step() / sizeof(float);
+                for (int y = 0; y < height; ++y) {
+                    for (int x = 0; x < width; ++x) {
+                        p[y * step + x] = (float)random.NextDouble();
+                    }
+                }
+            }
+            return mat;
+        }
+
+        private static unsafe double MaxAbsDiff(Mat a, Mat b) {
+            Assert.That(a.Size(), Is.EqualTo(b.Size()));
+            var pa = (float*)a.DataPointer;
+            var pb = (float*)b.DataPointer;
+            long stepA = a.Step() / sizeof(float);
+            long stepB = b.Step() / sizeof(float);
+            double maxDiff = 0.0;
+            for (int y = 0; y < a.Height; ++y) {
+                for (int x = 0; x < a.Width; ++x) {
+                    var diff = Math.Abs((double)pa[y * stepA + x] - pb[y * stepB + x]);
+                    if (diff > maxDiff) {
+                        maxDiff = diff;
+                    }
+                }
+            }
+            return maxDiff;
+        }
+
+        [Test]
+        public void Reflect_MatchesOpenCvBorderReflect() {
+            // Cross-check the multi-bounce reflection against OpenCV's own borderInterpolate for every
+            // length/offset combination the à trous taps can produce (offsets up to ±2·2^i).
+            for (int n = 1; n <= 12; ++n) {
+                for (int i = -3 * n; i < 4 * n; ++i) {
+                    Assert.That(AtrousWaveletFast.Reflect(i, n),
+                        Is.EqualTo(Cv2.BorderInterpolate(i, n, BorderTypes.Reflect)),
+                        $"Reflect({i}, {n})");
+                }
+            }
+        }
+
+        // Sizes chosen to exercise: SIMD interior + scalar tail (odd widths), pure-border columns
+        // (width < 4·2^i at high layers), multi-bounce reflection (tiny images), and non-square shapes
+        // that would catch a transposed-axis bug.
+        [TestCase(64, 64, 1)]
+        [TestCase(64, 64, 4)]
+        [TestCase(129, 97, 4)]
+        [TestCase(257, 193, 6)]
+        [TestCase(61, 47, 5)]
+        [TestCase(40, 30, 4)]
+        [TestCase(33, 9, 3)]
+        public void ComputeResidual_MatchesLegacyImplementation(int width, int height, int numLayers) {
+            using var src = CreateRandomMat(width, height, seed: width * 1000 + height * 10 + numLayers);
+            using var legacy = CvImageUtility.ComputeResidualAtrousB3SplineDyadicWaveletLayer(src, numLayers);
+            using var fast = AtrousWaveletFast.ComputeResidual(src, numLayers);
+            var maxDiff = MaxAbsDiff(legacy, fast);
+            Assert.That(maxDiff, Is.LessThanOrEqualTo(EquivalenceTolerance),
+                $"fast à trous residual must match the legacy SepFilter2D result (maxAbsDiff={maxDiff:E3})");
+        }
+
+        [Test]
+        public void ComputeResidual_FlatImage_PreservesMean() {
+            using var src = SyntheticGaussianStarImage.CreateFlat(32, 32, 0.5f);
+            using var residual = AtrousWaveletFast.ComputeResidual(src, numLayers: 3);
+            var stats = CvImageUtility.CalculateStatistics(residual);
+            Assert.That(stats.Mean, Is.EqualTo(0.5).Within(1e-3));
+        }
+
+        [Test]
+        public void ComputeResidual_DoesNotModifySource() {
+            using var src = CreateRandomMat(96, 80, seed: 12345);
+            using var copy = src.Clone();
+            using var residual = AtrousWaveletFast.ComputeResidual(src, numLayers: 4);
+            Assert.That(MaxAbsDiff(src, copy), Is.EqualTo(0.0), "source image must not be modified");
+        }
+
+        [Test]
+        public void ComputeResidual_DeterministicAcrossRunsAndParallelism() {
+            using var src = CreateRandomMat(200, 150, seed: 424242);
+            using var parallelA = AtrousWaveletFast.ComputeResidual(src, numLayers: 5);
+            using var parallelB = AtrousWaveletFast.ComputeResidual(src, numLayers: 5);
+            using var sequential = AtrousWaveletFast.ComputeResidual(src, numLayers: 5, parallelismKnob: 1);
+            Assert.Multiple(() => {
+                Assert.That(MaxAbsDiff(parallelA, parallelB), Is.EqualTo(0.0), "repeat runs must be bit-identical");
+                Assert.That(MaxAbsDiff(parallelA, sequential), Is.EqualTo(0.0), "parallelism must not change results");
+            });
+        }
+
+        [Test]
+        public void ComputeResidualAndSubtractInPlace_BitIdenticalToComputeThenSubtract() {
+            using var fused = CreateRandomMat(150, 110, seed: 777);
+            using var unfused = fused.Clone();
+
+            AtrousWaveletFast.ComputeResidualAndSubtractInPlace(fused, numLayers: 4);
+            using (var residual = AtrousWaveletFast.ComputeResidual(unfused, numLayers: 4)) {
+                CvImageUtility.SubtractInPlace(unfused, residual);
+            }
+
+            Assert.That(MaxAbsDiff(fused, unfused), Is.EqualTo(0.0),
+                "the fused subtract must be bit-identical to compute-then-SubtractInPlace");
+        }
+
+        [Test]
+        public void ComputeResidualAndSubtractInPlace_NaNPixel_ClampsToZeroInVectorAndScalarColumns() {
+            // A NaN source pixel must clamp to 0 identically in SIMD-covered columns and the scalar tail
+            // (and thereby match the legacy Cv2.Max/Min clamp, which also maps NaN to 0) — the output must
+            // not depend on column position or vector width.
+            using var mat = CreateRandomMat(150, 110, seed: 999);
+            unsafe {
+                var p = (float*)mat.DataPointer;
+                long step = mat.Step() / sizeof(float);
+                p[50 * step + 100] = float.NaN; // interior of any vector loop
+                p[50 * step + 147] = float.NaN; // scalar tail for Vector<float>.Count of 8 (width 150)
+            }
+            AtrousWaveletFast.ComputeResidualAndSubtractInPlace(mat, numLayers: 1);
+            unsafe {
+                var p = (float*)mat.DataPointer;
+                long step = mat.Step() / sizeof(float);
+                Assert.Multiple(() => {
+                    Assert.That(p[50 * step + 100], Is.EqualTo(0.0f), "vector-path NaN must clamp to 0");
+                    Assert.That(p[50 * step + 147], Is.EqualTo(0.0f), "scalar-tail NaN must clamp to 0");
+                });
+            }
+        }
+
+        [Test]
+        public async Task Detection_FastWavelets_MatchesLegacySignature() {
+            // End-to-end A/B on the deterministic small field: the wavelet only shapes candidate formation
+            // (measurement reads the source image), so float-rounding-level structure-map differences should
+            // leave the full detection signature unchanged on this well-separated field.
+            var legacyParams = StarDetectorEquivalence.StandardParams();
+            var fastParams = StarDetectorEquivalence.StandardParams();
+            fastParams.FastAtrousWavelets = true;
+
+            using var f1 = StarDetectorEquivalence.BuildSmallField();
+            var legacy = await StarDetectorEquivalence.RunDetect(f1, legacyParams);
+            using var f2 = StarDetectorEquivalence.BuildSmallField();
+            var fast = await StarDetectorEquivalence.RunDetect(f2, fastParams);
+
+            Assert.That(StarDetectorEquivalence.Signature(fast), Is.EqualTo(StarDetectorEquivalence.Signature(legacy)));
+        }
+
+        [Test]
+        public void ParamClassification_FastAtrousWavelets_IsEarly() {
+            Assert.That(NINA.Joko.Plugins.HocusFocus.StarDetection.StarDetector.IsEarlyCacheKeyParameter(
+                nameof(StarDetectorParams.FastAtrousWavelets)), Is.True);
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/AtrousWaveletFastTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/AtrousWaveletFastTests.cs
@@ -1,19 +1,18 @@
-using NINA.Joko.Plugins.HocusFocus.Interfaces;
-using NINA.Joko.Plugins.HocusFocus.Tests.StarDetection;
 using NINA.Joko.Plugins.HocusFocus.Tests.Synthetic;
 using NINA.Joko.Plugins.HocusFocus.Utility;
 using NUnit.Framework;
 using OpenCvSharp;
 using System;
-using System.Threading.Tasks;
 using Size = OpenCvSharp.Size;
 
 namespace NINA.Joko.Plugins.HocusFocus.Tests.Utility {
 
     /// <summary>
-    /// AtrousWaveletFast must be numerically equivalent (within float rounding) to the legacy
-    /// CvImageUtility.ComputeResidualAtrousB3SplineDyadicWaveletLayer (dense zero-padded Cv2.SepFilter2D),
-    /// including BORDER_REFLECT handling, and deterministic regardless of parallelism.
+    /// AtrousWaveletFast (the production wavelet) must be numerically equivalent (within float rounding) to the
+    /// retained reference oracle CvImageUtility.ComputeResidualAtrousB3SplineDyadicWaveletLayer (dense
+    /// zero-padded Cv2.SepFilter2D), including BORDER_REFLECT handling, and deterministic regardless of
+    /// parallelism. Detection-level pinning lives in the StarDetectorEquivalenceTests golden signatures, which
+    /// run through this implementation.
     /// </summary>
     [TestFixture]
     public class AtrousWaveletFastTests {
@@ -153,27 +152,5 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Utility {
             }
         }
 
-        [Test]
-        public async Task Detection_FastWavelets_MatchesLegacySignature() {
-            // End-to-end A/B on the deterministic small field: the wavelet only shapes candidate formation
-            // (measurement reads the source image), so float-rounding-level structure-map differences should
-            // leave the full detection signature unchanged on this well-separated field.
-            var legacyParams = StarDetectorEquivalence.StandardParams();
-            var fastParams = StarDetectorEquivalence.StandardParams();
-            fastParams.FastAtrousWavelets = true;
-
-            using var f1 = StarDetectorEquivalence.BuildSmallField();
-            var legacy = await StarDetectorEquivalence.RunDetect(f1, legacyParams);
-            using var f2 = StarDetectorEquivalence.BuildSmallField();
-            var fast = await StarDetectorEquivalence.RunDetect(f2, fastParams);
-
-            Assert.That(StarDetectorEquivalence.Signature(fast), Is.EqualTo(StarDetectorEquivalence.Signature(legacy)));
-        }
-
-        [Test]
-        public void ParamClassification_FastAtrousWavelets_IsEarly() {
-            Assert.That(NINA.Joko.Plugins.HocusFocus.StarDetection.StarDetector.IsEarlyCacheKeyParameter(
-                nameof(StarDetectorParams.FastAtrousWavelets)), Is.True);
-        }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
@@ -316,16 +316,6 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         // Number of wavelet layers for structure detection
         public int StructureLayers { get; set; } = 4;
 
-        // Fast à trous wavelet implementation (opt-in, default OFF while under validation). When true, the
-        // structure-removal residual is computed by AtrousWaveletFast (sparse 5-tap dilated convolution, SIMD +
-        // multithreaded — constant work per layer) instead of the legacy Cv2.SepFilter2D dense zero-padded
-        // kernels whose per-layer cost doubles with each layer. The two agree to float rounding but are not
-        // bit-identical, so this is an EARLY param (changes the structure map): listed in
-        // StarDetector.EarlyCacheKeyProperties. When OFF, detection is bit-identical to the legacy path.
-        // NOT a persisted option: no StarDetectionOptions/BuildStarDetectorParams mapping and no Options UI —
-        // reachable only from tests and the TestApp bench harness until AF-bank validation flips the default.
-        public bool FastAtrousWavelets { get; set; } = false;
-
         // Defocus-aware structure detection (opt-in, default OFF). When true, the à-trous wavelet residual that is
         // subtracted to remove large-scale structure is computed at StructureLayers + StructureLayerBoost layers,
         // so the residual is COARSER and large/donut (heavily defocused) stars survive the subtraction and form

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Interfaces/IStarDetector.cs
@@ -316,6 +316,16 @@ namespace NINA.Joko.Plugins.HocusFocus.Interfaces {
         // Number of wavelet layers for structure detection
         public int StructureLayers { get; set; } = 4;
 
+        // Fast à trous wavelet implementation (opt-in, default OFF while under validation). When true, the
+        // structure-removal residual is computed by AtrousWaveletFast (sparse 5-tap dilated convolution, SIMD +
+        // multithreaded — constant work per layer) instead of the legacy Cv2.SepFilter2D dense zero-padded
+        // kernels whose per-layer cost doubles with each layer. The two agree to float rounding but are not
+        // bit-identical, so this is an EARLY param (changes the structure map): listed in
+        // StarDetector.EarlyCacheKeyProperties. When OFF, detection is bit-identical to the legacy path.
+        // NOT a persisted option: no StarDetectionOptions/BuildStarDetectorParams mapping and no Options UI —
+        // reachable only from tests and the TestApp bench harness until AF-bank validation flips the default.
+        public bool FastAtrousWavelets { get; set; } = false;
+
         // Defocus-aware structure detection (opt-in, default OFF). When true, the à-trous wavelet residual that is
         // subtracted to remove large-scale structure is computed at StructureLayers + StructureLayerBoost layers,
         // so the residual is COARSER and large/donut (heavily defocused) stars survive the subtraction and form

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -679,15 +679,6 @@
                         Visibility="{Binding IsOptimizing, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                     <TextBlock
                         MaxWidth="520"
-                        Margin="0,4,0,0"
-                        HorizontalAlignment="Center"
-                        Opacity="0.75"
-                        Text="{Binding ProgressCostNote, Mode=OneWay}"
-                        TextAlignment="Center"
-                        TextWrapping="Wrap"
-                        Visibility="{Binding HasProgressCostNote, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
-                    <TextBlock
-                        MaxWidth="520"
                         Margin="0,6,0,0"
                         HorizontalAlignment="Center"
                         FontStyle="Italic"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizer.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizer.cs
@@ -156,20 +156,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// </summary>
         public double SecondsPerEvaluation { get; set; } = double.NaN;
 
-        /// <summary>
-        /// F52 — a plain-language note naming WHY the search is currently expensive, or null when it is not. Today
-        /// this is the structure-layer depth (<see cref="StarDetector.EffectiveStructureLayers"/>), whose residual
-        /// is recomputed at <c>2^layers</c> and which measures ~2× per layer.
-        ///
-        /// <para><b>Deliberately a statement of COST, never a recommendation.</b> "You should abort and re-expose"
-        /// is [F52](c), and it is blocked on
-        /// <c>F19</c>: the shipped exposure statistic reports "exposure is not the limit" on exactly the rich
-        /// fields that gain most from a longer exposure (measured: S_now 991.8 against a target of 10 on
-        /// <c>D02_rich_135mm</c>, raw ask 0.000 s, while σ_focus improves 44% at 8×). Advice built on it would tell
-        /// the users who most need a longer exposure that theirs is already fine. Facts about cost need no such
-        /// statistic and are safe to show now; the advice is not.</para>
-        /// </summary>
-        public string CostNote { get; set; }
+        // F52's "which knob made it expensive" CostNote used to live here. It was keyed to the structure-layer
+        // depth, whose legacy dense-SepFilter2D residual cost ~2× per layer; the sparse AtrousWaveletFast
+        // implementation made per-layer cost nearly flat (whole-detect 648/670/738 ms at layers 4/6/8, 26 MP),
+        // so the note's premise — and the note — were retired with the swap (docs/atrous-wavelet-fast-design.md).
+        // The F52(c) "abort and re-expose" ADVICE remains blocked on F19 regardless (the shipped exposure
+        // statistic reports "exposure is not the limit" on exactly the rich fields that gain most).
     }
 
     /// <summary>Outcome of an optimization run.</summary>
@@ -377,10 +369,6 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             private double lastBestJ, lastSeedJ, lastBestSigma = double.NaN;
             private int lastLoggedEvaluations;
 
-            // The effective structure-layer depth of the SEED, so the cost note can express the current candidate
-            // RELATIVE to where this search started rather than against an absolute that means nothing to a user.
-            private int seedEffectiveLayers = -1;
-
             /// <summary>How often (in completed evaluations) a long search emits an INFO line and refreshes the
             /// live time readout. Small enough that a two-hour run is traceable minute-by-minute, large enough that
             /// a fast run adds a handful of lines rather than hundreds.</summary>
@@ -392,32 +380,6 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
 
             public TimeSpan Elapsed => searchClock.Elapsed;
 
-            /// <summary>
-            /// F52 — names why the search is currently expensive, or null when it is not.
-            ///
-            /// <para>The structure-removal residual is recomputed at <c>2^layers</c>
-            /// (<see cref="StarDetector.EffectiveStructureLayers"/>), measured at ~2× per layer on the synthetic
-            /// bank, so a candidate two layers deeper than the seed costs roughly 4× per evaluation. Expressed as
-            /// a factor relative to THIS search's seed, and rounded to a whole number — the measurement supports
-            /// "roughly 4×", not 3.8×.</para>
-            ///
-            /// <para>A statement of cost, never a recommendation: see <see cref="OptimizationProgress.CostNote"/>
-            /// for why the "abort and re-expose" advice is a separate, blocked item.</para>
-            /// </summary>
-            private string CostNoteFor(double[] theta) {
-                if (theta == null || seedEffectiveLayers <= 0) {
-                    return null;
-                }
-                var layers = StarDetector.EffectiveStructureLayers(Materialize(theta));
-                var deeper = layers - seedEffectiveLayers;
-                if (deeper <= 0) {
-                    return null;
-                }
-                var factor = Math.Pow(2.0, deeper);
-                return string.Format(CultureInfo.CurrentCulture,
-                    "Searching at {0} structure layers ({1} deeper than this run started at), which costs roughly {2:0}x per evaluation.",
-                    layers, deeper, factor);
-            }
 
             public SearchContext(
                 StarDetectionOptimizer owner,
@@ -484,9 +446,6 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 var runMetrics = await evaluator(p, token).ConfigureAwait(false);
                 evaluatorSeconds += (searchClock.Elapsed - evalStart).TotalSeconds;
                 Evaluations++;
-                if (isSeed) {
-                    seedEffectiveLayers = StarDetector.EffectiveStructureLayers(p);
-                }
                 MaybeReportProgress(theta);
 
                 double j;
@@ -636,8 +595,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     BestSigmaFocus = lastBestSigma,
                     Phase = phase,
                     Elapsed = Elapsed,
-                    SecondsPerEvaluation = SecondsPerEvaluation,
-                    CostNote = CostNoteFor(bestTheta)
+                    SecondsPerEvaluation = SecondsPerEvaluation
                 });
             }
 
@@ -661,15 +619,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     return;
                 }
                 lastLoggedEvaluations = Evaluations;
-                var costNote = CostNoteFor(theta);
                 var budget = settings.MaxEvaluations > 0
                     ? $"/{settings.MaxEvaluations.ToString(CultureInfo.InvariantCulture)}"
                     : string.Empty;
                 Logger.Info(
                     $"Optimizer progress: phase '{lastPhase ?? "search"}', evaluation {Evaluations}{budget}, "
                     + $"elapsed {Elapsed:hh\\:mm\\:ss}, {SecondsPerEvaluation:0.0}s/evaluation, "
-                    + $"best J {lastBestJ:0.######}"
-                    + (costNote == null ? string.Empty : $" -- {costNote}"));
+                    + $"best J {lastBestJ:0.######}");
                 progress?.Report(new OptimizationProgress {
                     Evaluations = Evaluations,
                     MaxEvaluations = settings.MaxEvaluations,
@@ -678,8 +634,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     BestSigmaFocus = lastBestSigma,
                     Phase = lastPhase,
                     Elapsed = Elapsed,
-                    SecondsPerEvaluation = SecondsPerEvaluation,
-                    CostNote = costNote
+                    SecondsPerEvaluation = SecondsPerEvaluation
                 });
             }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -1420,15 +1420,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 isOptimizing = value;
                 RaisePropertyChanged();
                 // F52: every one of these reads IsOptimizing, so they must re-evaluate when it flips — otherwise a
-                // finished search leaves "2 h 14 min elapsed" and a cost note on screen next to the results.
+                // finished search leaves "2 h 14 min elapsed" on screen next to the results.
                 if (!isOptimizing) {
                     progressElapsed = TimeSpan.Zero;
                     progressSecondsPerEvaluation = double.NaN;
-                    progressCostNote = null;
                 }
                 RaisePropertyChanged(nameof(ProgressTimingText));
-                RaisePropertyChanged(nameof(ProgressCostNote));
-                RaisePropertyChanged(nameof(HasProgressCostNote));
                 RaisePropertyChanged(nameof(ProgressAbortNote));
             }
         }
@@ -1511,34 +1508,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             }
         }
 
-        private string progressCostNote;
-
-        /// <summary>
-        /// F52 — why the search is currently expensive, when it is. Straight from
-        /// <see cref="OptimizationProgress.CostNote"/>; empty when the search is in a cheap region.
-        ///
-        /// <para><b>A statement of COST, never a recommendation.</b> "Abort and re-run at a longer exposure" is the
-        /// piece users ask for, and it is deliberately NOT here: it cannot be derived from the shipped exposure
-        /// statistic, which reports "exposure is not the limit" on exactly the rich fields that gain most from a
-        /// longer exposure (measured on <c>D02_rich_135mm</c>: the 20th-brightest star's S/N is 991.8 against a
-        /// target of 10 and the derived ask is 0.000 s, while σ_focus improves 44% at 8× the exposure — and on
-        /// live hardware the same statistic read 1438.6). Advice built on it would tell the users who most need a
-        /// longer exposure that theirs is already fine, at the moment they are deciding whether to spend another
-        /// two hours. Facts about cost need no such statistic; the advice does, and it waits for one.</para>
-        /// </summary>
-        public string ProgressCostNote {
-            get => IsOptimizing ? (progressCostNote ?? string.Empty) : string.Empty;
-            private set {
-                if (progressCostNote != value) {
-                    progressCostNote = value;
-                    RaisePropertyChanged();
-                    RaisePropertyChanged(nameof(HasProgressCostNote));
-                }
-            }
-        }
-
-        /// <summary>Whether there is a cost note to show — the row collapses rather than reserving blank space.</summary>
-        public bool HasProgressCostNote => !string.IsNullOrEmpty(ProgressCostNote);
+        // F52's ProgressCostNote ("searching N structure layers deeper costs roughly 2^N x") used to live here;
+        // retired when the sparse AtrousWaveletFast swap made per-layer cost nearly flat. The F52(c) abort-and-
+        // re-expose ADVICE remains blocked on F19 (the shipped exposure statistic reports "exposure is not the
+        // limit" on exactly the rich fields that gain most from a longer exposure — measured on D02_rich_135mm:
+        // 20th-brightest S/N 991.8 vs target 10, derived ask 0.000 s, while σ_focus improves 44% at 8×).
 
         /// <summary>
         /// F52 — what cancelling costs, stated while the user is deciding rather than left to be guessed.
@@ -3407,11 +3381,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 ProgressSeedJ = progressBaselineJOverride ?? currentBaselineJ;
                 ProgressSeedSigma = progressBaselineSigmaOverride ?? currentBaselineSigma;
                 Phase = FriendlyPhase(p.Phase);
-                // F52 — time and cost. Assigned last so the timing text, which reads ProgressCurrent/ProgressTotal
+                // F52 — timing. Assigned last so the timing text, which reads ProgressCurrent/ProgressTotal
                 // above, is computed from this report's counts rather than the previous one's.
                 progressElapsed = p.Elapsed;
                 progressSecondsPerEvaluation = p.SecondsPerEvaluation;
-                ProgressCostNote = p.CostNote;
                 RaisePropertyChanged(nameof(ProgressTimingText));
             });
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
@@ -40,7 +40,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
         // re-detect. The version is stamped onto HocusFocusStarDetectionResult.DetectorVersion and folded into
         // HocusFocusStarDetectionResult.CacheKey, so a later reuse-side task can reject any saved
         // _star_detection_result.json that was produced by a different detector version (or different params).
-        public const int StarDetectorVersion = 1;
+        // v2: the structure-removal wavelet swapped from dense zero-padded Cv2.SepFilter2D kernels to
+        // AtrousWaveletFast (sparse 5-tap) — equivalent to float rounding (≤3e-8) but not bit-identical.
+        public const int StarDetectorVersion = 2;
 
         private readonly IAlglibAPI alglibAPI;
 
@@ -156,9 +158,6 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             nameof(StarDetectorParams.LocallyAdaptiveBinarization),
             nameof(StarDetectorParams.AdaptiveNoiseBlockSize),
             nameof(StarDetectorParams.StructureLayers),
-            // Fast-wavelet implementation swap: float-rounding-level structure-map differences can flip
-            // near-threshold pixels, so contexts must not be reused across the two implementations.
-            nameof(StarDetectorParams.FastAtrousWavelets),
             nameof(StarDetectorParams.DefocusAwareStructure),
             nameof(StarDetectorParams.StructureLayerBoost),
             nameof(StarDetectorParams.StructureDilationSize),
@@ -610,18 +609,17 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                     // axis is off (the optimizer can raise it further via that axis). Gated by the master ⇒
                     // bit-identical when off.
                     var effectiveStructureLayers = EffectiveStructureLayers(p);
-                    // Deliberately NOT passing the cancellation token to the fast wavelet: the two noise-estimate
+                    // Deliberately NOT passing the cancellation token to the wavelet: the two noise-estimate
                     // tasks started above are still running and read srcImage/noiseReducedImage, and a cancellation
                     // unwind from inside the wavelet would dispose those Mats under the tasks (native
-                    // use-after-free). Like the legacy SepFilter2D path, this window stays non-cancellable (it is
-                    // ~100 ms on the fast path); the token is honored again at the points after the task awaits.
-                    if (p.FastAtrousWavelets && string.IsNullOrEmpty(p.SaveIntermediateFilesPath)) {
-                        // Fused fast path: residual + subtract + clamp in one final pass, no residual Mat.
+                    // use-after-free). This window stays non-cancellable (it is ~100 ms); the token is honored
+                    // again at the points after the task awaits.
+                    if (string.IsNullOrEmpty(p.SaveIntermediateFilesPath)) {
+                        // Fused: residual + subtract + clamp in one final pass, no residual Mat.
                         AtrousWaveletFast.ComputeResidualAndSubtractInPlace(structureMap, effectiveStructureLayers);
                     } else {
-                        using (var residualLayer = p.FastAtrousWavelets
-                                ? AtrousWaveletFast.ComputeResidual(structureMap, effectiveStructureLayers)
-                                : ComputeResidualAtrousB3SplineDyadicWaveletLayer(structureMap, effectiveStructureLayers)) {
+                        // Debug-intermediate path: materialize the residual so it can be saved before subtracting.
+                        using (var residualLayer = AtrousWaveletFast.ComputeResidual(structureMap, effectiveStructureLayers)) {
                             MaybeSaveIntermediateImage(residualLayer, p, "04-structure-wavelet-residual.tif");
                             CvImageUtility.SubtractInPlace(structureMap, residualLayer);
                         }
@@ -1559,12 +1557,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
         /// plus whichever defocus boost is in force. The single source of truth for that rule: step 4 of
         /// <c>Detect</c> uses it, and so does the optimizer's cost readout, so the two cannot drift.
         ///
-        /// <para><b>Why anything outside the detector cares.</b> The residual is recomputed at <c>2^layers</c>, so
-        /// this number is the dominant term in a detection's COST, not merely in its behaviour. Measured on the
-        /// synthetic bank (<c>D15_cdk20_3454mm_e47</c>, 9 frames, binning 1) the wall time per layer runs
-        /// 27 / 46 / 117 / 254 / 526 s for layers 4…8 — <b>roughly a doubling per layer</b>. A parameter search
-        /// that wanders two layers deeper is spending ~4× per evaluation for a gain the objective reports in its
-        /// fourth decimal, and nothing told the user that (F52).</para>
+        /// <para><b>History.</b> Under the legacy dense-SepFilter2D wavelet this number was also the dominant
+        /// COST term (~2× wall per layer, F52: 27/46/117/254/526 s for layers 4…8 on the synthetic bank), which
+        /// is why the optimizer's cost readout consumed it. The sparse <see cref="Utility.AtrousWaveletFast"/>
+        /// implementation made per-layer cost nearly flat (52/81/107 ms at 26 MP for layers 4/6/8; whole-detect
+        /// 648/670/738 ms), so the layer count is now a behavioural knob, not a wall-clock one, and the F52
+        /// cost note was retired.</para>
         /// </summary>
         public static int EffectiveStructureLayers(StarDetectorParams p) {
             if (p == null) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs
@@ -156,6 +156,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             nameof(StarDetectorParams.LocallyAdaptiveBinarization),
             nameof(StarDetectorParams.AdaptiveNoiseBlockSize),
             nameof(StarDetectorParams.StructureLayers),
+            // Fast-wavelet implementation swap: float-rounding-level structure-map differences can flip
+            // near-threshold pixels, so contexts must not be reused across the two implementations.
+            nameof(StarDetectorParams.FastAtrousWavelets),
             nameof(StarDetectorParams.DefocusAwareStructure),
             nameof(StarDetectorParams.StructureLayerBoost),
             nameof(StarDetectorParams.StructureDilationSize),
@@ -607,9 +610,21 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
                     // axis is off (the optimizer can raise it further via that axis). Gated by the master ⇒
                     // bit-identical when off.
                     var effectiveStructureLayers = EffectiveStructureLayers(p);
-                    using (var residualLayer = ComputeResidualAtrousB3SplineDyadicWaveletLayer(structureMap, effectiveStructureLayers)) {
-                        MaybeSaveIntermediateImage(residualLayer, p, "04-structure-wavelet-residual.tif");
-                        CvImageUtility.SubtractInPlace(structureMap, residualLayer);
+                    // Deliberately NOT passing the cancellation token to the fast wavelet: the two noise-estimate
+                    // tasks started above are still running and read srcImage/noiseReducedImage, and a cancellation
+                    // unwind from inside the wavelet would dispose those Mats under the tasks (native
+                    // use-after-free). Like the legacy SepFilter2D path, this window stays non-cancellable (it is
+                    // ~100 ms on the fast path); the token is honored again at the points after the task awaits.
+                    if (p.FastAtrousWavelets && string.IsNullOrEmpty(p.SaveIntermediateFilesPath)) {
+                        // Fused fast path: residual + subtract + clamp in one final pass, no residual Mat.
+                        AtrousWaveletFast.ComputeResidualAndSubtractInPlace(structureMap, effectiveStructureLayers);
+                    } else {
+                        using (var residualLayer = p.FastAtrousWavelets
+                                ? AtrousWaveletFast.ComputeResidual(structureMap, effectiveStructureLayers)
+                                : ComputeResidualAtrousB3SplineDyadicWaveletLayer(structureMap, effectiveStructureLayers)) {
+                            MaybeSaveIntermediateImage(residualLayer, p, "04-structure-wavelet-residual.tif");
+                            CvImageUtility.SubtractInPlace(structureMap, residualLayer);
+                        }
                     }
 
                     MaybeSaveIntermediateImage(structureMap, p, "04-structure-wavelet-subtracted.tif");

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/AtrousWaveletFast.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/AtrousWaveletFast.cs
@@ -1,0 +1,249 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using OpenCvSharp;
+using System;
+using System.Collections.Concurrent;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Joko.Plugins.HocusFocus.Utility {
+
+    /// <summary>
+    /// Fast à trous B3-spline dyadic wavelet cascade, replacing the Cv2.SepFilter2D path in
+    /// <see cref="CvImageUtility.ComputeResidualAtrousB3SplineDyadicWaveletLayer"/>. That path convolves layer i
+    /// with a DENSE zero-padded separable kernel of 2^(i+2)+1 taps, of which only 5 are ever non-zero — OpenCV
+    /// multiplies mostly zeros, so per-layer cost doubles with each layer (the measured ~2x-wall-per-StructureLayer
+    /// scaling). This implementation applies exactly the 5 non-zero taps (offsets ±2^i and ±2^(i+1)) per
+    /// direction, so per-layer work is constant, and it is SIMD-vectorized and multithreaded through
+    /// <see cref="ParallelExecution"/>.
+    ///
+    /// Border handling matches the legacy call's BorderTypes.Reflect (OpenCV BORDER_REFLECT: the edge pixel
+    /// repeats — index -1 maps to 0, -2 to 1, ...), including multi-bounce reflection when a tap offset exceeds
+    /// the image dimension. Results are deterministic (independent of thread partitioning and SIMD width)
+    /// because every output pixel is computed independently with a fixed operation order shared by the scalar
+    /// and vector paths. Numerically the cascade agrees with the legacy path to float rounding (the
+    /// tap-summation order differs), but it is NOT bit-identical to it.
+    /// </summary>
+    public static class AtrousWaveletFast {
+        private const float W0 = 0.375f;
+        private const float W1 = 0.25f;
+        private const float W2 = 0.0625f;
+
+        /// <summary>
+        /// Computes the residual (low-pass) layer after <paramref name="numLayers"/> à trous B3-spline smoothing
+        /// passes. Drop-in equivalent of <see cref="CvImageUtility.ComputeResidualAtrousB3SplineDyadicWaveletLayer"/>
+        /// (within float rounding). The caller owns the returned Mat; <paramref name="src"/> is not modified.
+        /// </summary>
+        /// <param name="parallelismKnob">See <see cref="ParallelExecution.ResolveDegreeOfParallelism"/>.</param>
+        public static Mat ComputeResidual(Mat src, int numLayers, int parallelismKnob = 0, CancellationToken ct = default) {
+            if (src.Type() != MatType.CV_32F) {
+                throw new ArgumentException("Only CV_32F supported");
+            }
+            if (numLayers <= 0) {
+                // The legacy path would return src itself here (an aliasing hazard for the caller's using block);
+                // unreachable in production since EffectiveStructureLayers >= 1. Return a copy to stay safe.
+                return src.Clone();
+            }
+
+            var options = ParallelExecution.CreateOptions(parallelismKnob, ct);
+            var horizontal = new Mat(src.Size(), MatType.CV_32F);
+            var result = new Mat(src.Size(), MatType.CV_32F);
+            try {
+                var current = src;
+                for (int layer = 0; layer < numLayers; ++layer) {
+                    int scale = 1 << layer;
+                    HorizontalPass(current, horizontal, scale, options);
+                    VerticalPass(horizontal, result, scale, options, subtractFrom: null);
+                    current = result;
+                }
+                return result;
+            } catch {
+                result.Dispose();
+                throw;
+            } finally {
+                horizontal.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Fused form of the production wavelet step: computes the <paramref name="numLayers"/>-layer residual and
+        /// replaces <paramref name="srcAndDst"/> with clamp(srcAndDst - residual, 0, 1) in a single final pass —
+        /// equivalent to <c>ComputeResidual</c> followed by <see cref="CvImageUtility.SubtractInPlace"/>, without
+        /// materializing the residual or re-reading the image for the subtract.
+        /// </summary>
+        public static void ComputeResidualAndSubtractInPlace(Mat srcAndDst, int numLayers, int parallelismKnob = 0, CancellationToken ct = default) {
+            if (srcAndDst.Type() != MatType.CV_32F) {
+                throw new ArgumentException("Only CV_32F supported");
+            }
+            if (numLayers <= 0) {
+                throw new ArgumentException("numLayers must be positive", nameof(numLayers));
+            }
+
+            var options = ParallelExecution.CreateOptions(parallelismKnob, ct);
+            var horizontal = new Mat(srcAndDst.Size(), MatType.CV_32F);
+            var smoothed = new Mat(srcAndDst.Size(), MatType.CV_32F);
+            try {
+                var current = srcAndDst;
+                for (int layer = 0; layer < numLayers; ++layer) {
+                    int scale = 1 << layer;
+                    HorizontalPass(current, horizontal, scale, options);
+                    bool last = layer == numLayers - 1;
+                    // On the last layer the vertical pass reads only the horizontal buffer (rows y±s, y±2s) plus
+                    // srcAndDst's own row y, and writes srcAndDst row y — no cross-row hazard, so writing the
+                    // subtracted result straight into the source is safe.
+                    VerticalPass(horizontal, last ? srcAndDst : smoothed, scale, options, subtractFrom: last ? srcAndDst : null);
+                    current = smoothed;
+                }
+            } finally {
+                horizontal.Dispose();
+                smoothed.Dispose();
+            }
+        }
+
+        private static unsafe void HorizontalPass(Mat src, Mat dst, int scale, ParallelOptions options) {
+            int width = src.Width;
+            int height = src.Height;
+            long srcStep = src.Step() / sizeof(float);
+            long dstStep = dst.Step() / sizeof(float);
+            var srcBase = (float*)src.DataPointer;
+            var dstBase = (float*)dst.DataPointer;
+            int s = scale;
+            int s2 = 2 * scale;
+            int vecCount = Vector<float>.Count;
+            var w0 = new Vector<float>(W0);
+            var w1 = new Vector<float>(W1);
+            var w2 = new Vector<float>(W2);
+
+            Parallel.ForEach(Partitioner.Create(0, height), options, range => {
+                for (int y = range.Item1; y < range.Item2; ++y) {
+                    float* srow = srcBase + y * srcStep;
+                    float* drow = dstBase + y * dstStep;
+                    // Interior = columns where all 5 taps are in-bounds without reflection
+                    int interiorStart = Math.Min(s2, width);
+                    int interiorEnd = Math.Max(width - s2, interiorStart); // exclusive
+
+                    for (int x = 0; x < interiorStart; ++x) {
+                        drow[x] = ReflectedTap(srow, x, s, s2, width);
+                    }
+                    int xi = interiorStart;
+                    if (Vector.IsHardwareAccelerated) {
+                        for (; xi <= interiorEnd - vecCount; xi += vecCount) {
+                            var m2 = Unsafe.ReadUnaligned<Vector<float>>(srow + xi - s2);
+                            var m1 = Unsafe.ReadUnaligned<Vector<float>>(srow + xi - s);
+                            var c0 = Unsafe.ReadUnaligned<Vector<float>>(srow + xi);
+                            var p1 = Unsafe.ReadUnaligned<Vector<float>>(srow + xi + s);
+                            var p2 = Unsafe.ReadUnaligned<Vector<float>>(srow + xi + s2);
+                            var r = w2 * (m2 + p2) + w1 * (m1 + p1) + w0 * c0;
+                            Unsafe.WriteUnaligned(drow + xi, r);
+                        }
+                    }
+                    for (; xi < interiorEnd; ++xi) {
+                        drow[xi] = W2 * (srow[xi - s2] + srow[xi + s2]) + W1 * (srow[xi - s] + srow[xi + s]) + W0 * srow[xi];
+                    }
+                    for (int x = interiorEnd; x < width; ++x) {
+                        drow[x] = ReflectedTap(srow, x, s, s2, width);
+                    }
+                }
+            });
+        }
+
+        /// <summary>
+        /// Vertical 5-tap à trous pass from <paramref name="src"/> into <paramref name="dst"/>. When
+        /// <paramref name="subtractFrom"/> is non-null, writes clamp(subtractFrom - filtered, 0, 1) instead of the
+        /// filtered value (the fused final subtract; <paramref name="dst"/> may BE <paramref name="subtractFrom"/>).
+        /// </summary>
+        private static unsafe void VerticalPass(Mat src, Mat dst, int scale, ParallelOptions options, Mat subtractFrom) {
+            int width = src.Width;
+            int height = src.Height;
+            long srcStep = src.Step() / sizeof(float);
+            long dstStep = dst.Step() / sizeof(float);
+            var srcBase = (float*)src.DataPointer;
+            var dstBase = (float*)dst.DataPointer;
+            var subBase = subtractFrom != null ? (float*)subtractFrom.DataPointer : null;
+            long subStep = subtractFrom != null ? subtractFrom.Step() / sizeof(float) : 0;
+            int s = scale;
+            int s2 = 2 * scale;
+            int vecCount = Vector<float>.Count;
+            var w0 = new Vector<float>(W0);
+            var w1 = new Vector<float>(W1);
+            var w2 = new Vector<float>(W2);
+            var zero = Vector<float>.Zero;
+            var one = new Vector<float>(1.0f);
+
+            Parallel.ForEach(Partitioner.Create(0, height), options, range => {
+                for (int y = range.Item1; y < range.Item2; ++y) {
+                    float* rm2 = srcBase + (long)Reflect(y - s2, height) * srcStep;
+                    float* rm1 = srcBase + (long)Reflect(y - s, height) * srcStep;
+                    float* rc0 = srcBase + (long)y * srcStep;
+                    float* rp1 = srcBase + (long)Reflect(y + s, height) * srcStep;
+                    float* rp2 = srcBase + (long)Reflect(y + s2, height) * srcStep;
+                    float* drow = dstBase + (long)y * dstStep;
+                    float* srow = subBase != null ? subBase + (long)y * subStep : null;
+                    int x = 0;
+                    if (Vector.IsHardwareAccelerated) {
+                        for (; x <= width - vecCount; x += vecCount) {
+                            var m2 = Unsafe.ReadUnaligned<Vector<float>>(rm2 + x);
+                            var m1 = Unsafe.ReadUnaligned<Vector<float>>(rm1 + x);
+                            var c0 = Unsafe.ReadUnaligned<Vector<float>>(rc0 + x);
+                            var p1 = Unsafe.ReadUnaligned<Vector<float>>(rp1 + x);
+                            var p2 = Unsafe.ReadUnaligned<Vector<float>>(rp2 + x);
+                            var r = w2 * (m2 + p2) + w1 * (m1 + p1) + w0 * c0;
+                            if (srow != null) {
+                                var orig = Unsafe.ReadUnaligned<Vector<float>>(srow + x);
+                                r = Vector.Min(Vector.Max(orig - r, zero), one);
+                            }
+                            Unsafe.WriteUnaligned(drow + x, r);
+                        }
+                    }
+                    for (; x < width; ++x) {
+                        float r = W2 * (rm2[x] + rp2[x]) + W1 * (rm1[x] + rp1[x]) + W0 * rc0[x];
+                        if (srow != null) {
+                            // Comparison-based clamp (not Math.Min/Max) so a NaN maps to 0 exactly like the
+                            // vector path's Vector.Max/Min (which select the non-NaN operand) and the legacy
+                            // Cv2.Max/Min clamp — keeps the scalar tail bit-identical to the SIMD lanes.
+                            float d = srow[x] - r;
+                            d = d > 0.0f ? d : 0.0f;
+                            r = d < 1.0f ? d : 1.0f;
+                        }
+                        drow[x] = r;
+                    }
+                }
+            });
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe float ReflectedTap(float* row, int x, int s, int s2, int width) {
+            return W2 * (row[Reflect(x - s2, width)] + row[Reflect(x + s2, width)])
+                 + W1 * (row[Reflect(x - s, width)] + row[Reflect(x + s, width)])
+                 + W0 * row[x];
+        }
+
+        // OpenCV BORDER_REFLECT (fedcba|abcdefgh|hgfedcb): -1 -> 0, -2 -> 1, ...; n -> n-1, n+1 -> n-2, ...
+        // Multi-bounce so tap offsets larger than the image dimension still resolve (tiny images).
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int Reflect(int i, int n) {
+            if ((uint)i < (uint)n) {
+                return i;
+            }
+            if (n == 1) {
+                return 0;
+            }
+            do {
+                i = i < 0 ? -i - 1 : 2 * n - 1 - i;
+            } while ((uint)i >= (uint)n);
+            return i;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/CvImageUtility.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/CvImageUtility.cs
@@ -519,6 +519,13 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
             return ClampInPlace(lhs, min, max);
         }
 
+        /// <summary>
+        /// LEGACY reference implementation, no longer used in production: convolves each à trous layer with a
+        /// DENSE zero-padded kernel (2^(i+2)+1 taps, only 5 non-zero) via Cv2.SepFilter2D, so per-layer cost
+        /// doubles with the layer index. Production detection uses <see cref="AtrousWaveletFast"/> (equivalent
+        /// to float rounding, ≤3e-8; see docs/atrous-wavelet-fast-design.md). Retained ONLY as the independent
+        /// oracle for the AtrousWaveletFast equivalence tests and the TestApp bench-wavelet comparison.
+        /// </summary>
         public static Mat ComputeResidualAtrousB3SplineDyadicWaveletLayer(Mat src, int numLayers) {
             var previousLayer = src;
             Mat tempMat = new Mat();

--- a/Joko.NINA.Plugins/TestApp/BenchWaveletRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/BenchWaveletRunner.cs
@@ -136,26 +136,17 @@ namespace TestApp {
         }
 
         private static async Task RunDetectAb(Mat field, int structureLayers, int iters) {
-            var legacyParams = MakeDetectParams(structureLayers, fastWavelets: false);
-            var fastParams = MakeDetectParams(structureLayers, fastWavelets: true);
-
-            var (legacyMs, legacyResult) = await TimeDetect(field, legacyParams, iters);
-            var (fastMs, fastResult) = await TimeDetect(field, fastParams, iters);
-
-            var legacyStars = legacyResult.DetectedStars ?? new List<Star>();
-            var fastStars = fastResult.DetectedStars ?? new List<Star>();
-            double maxCenterDelta = MatchStars(legacyStars, fastStars);
-            Console.WriteLine($"detect A/B layers={structureLayers}: legacy={legacyMs:F0} ms ({legacyStars.Count} stars) | fast={fastMs:F0} ms " +
-                              $"({fastStars.Count} stars) | speedup={legacyMs / fastMs:F2}x | " +
-                              $"maxMatchedCenterDelta={(double.IsNaN(maxCenterDelta) ? "UNMATCHED" : maxCenterDelta.ToString("E2"))}");
+            // Production detection always uses AtrousWaveletFast now; the legacy-vs-fast comparison lives at the
+            // Mat level above (the legacy oracle is retained in CvImageUtility for exactly that purpose).
+            var p = new StarDetectorParams {
+                ModelPSF = false,
+                NoiseClippingMultiplier = 4.0,
+                StructureLayers = structureLayers,
+            };
+            var (medianMs, result) = await TimeDetect(field, p, iters);
+            var stars = result.DetectedStars ?? new List<Star>();
+            Console.WriteLine($"detect layers={structureLayers}: {medianMs:F0} ms ({stars.Count} stars)");
         }
-
-        private static StarDetectorParams MakeDetectParams(int structureLayers, bool fastWavelets) => new StarDetectorParams {
-            ModelPSF = false,
-            NoiseClippingMultiplier = 4.0,
-            StructureLayers = structureLayers,
-            FastAtrousWavelets = fastWavelets,
-        };
 
         private static async Task<(double MedianMs, HocusFocusStarDetectorResult Result)> TimeDetect(Mat field, StarDetectorParams p, int iters) {
             var detector = new StarDetector(new AlglibAPI());
@@ -173,35 +164,6 @@ namespace TestApp {
             }
             times.Sort();
             return (times[times.Count / 2], result);
-        }
-
-        /// <summary>Greedy nearest matching; returns max matched center distance, or NaN when counts differ
-        /// or a star has no counterpart within 1 px.</summary>
-        private static double MatchStars(List<Star> a, List<Star> b) {
-            if (a.Count != b.Count) {
-                return double.NaN;
-            }
-            var remaining = new List<Star>(b);
-            double maxDelta = 0.0;
-            foreach (var star in a) {
-                int bestIdx = -1;
-                double bestDist = double.MaxValue;
-                for (int i = 0; i < remaining.Count; ++i) {
-                    var dx = remaining[i].Center.X - star.Center.X;
-                    var dy = remaining[i].Center.Y - star.Center.Y;
-                    var dist = Math.Sqrt(dx * dx + dy * dy);
-                    if (dist < bestDist) {
-                        bestDist = dist;
-                        bestIdx = i;
-                    }
-                }
-                if (bestIdx < 0 || bestDist > 1.0) {
-                    return double.NaN;
-                }
-                maxDelta = Math.Max(maxDelta, bestDist);
-                remaining.RemoveAt(bestIdx);
-            }
-            return maxDelta;
         }
 
         private static double TimeMedian(Action action, int iters) {

--- a/Joko.NINA.Plugins/TestApp/BenchWaveletRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/BenchWaveletRunner.cs
@@ -1,0 +1,275 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using OpenCvSharp;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Numerics;
+using System.Threading;
+using System.Threading.Tasks;
+using Size = OpenCvSharp.Size;
+
+namespace TestApp {
+
+    /// <summary>
+    /// Headless benchmark for the structure-removal à trous wavelet step:
+    /// legacy CvImageUtility.ComputeResidualAtrousB3SplineDyadicWaveletLayer (dense zero-padded Cv2.SepFilter2D)
+    /// vs AtrousWaveletFast (sparse 5-tap, SIMD, multithreaded), Mat-level and optionally end-to-end through
+    /// StarDetector.Detect on a synthetic star field. Needs no NINA profile and no input images.
+    ///
+    /// Usage: TestApp bench-wavelet [--sizes 6248x4176,3008x3008] [--layers 4,6,8] [--iters 3] [--detect]
+    ///                              [--impls legacy,fast,fast1t,fused] [--seed 42]
+    /// </summary>
+    public static class BenchWaveletRunner {
+        private const float Background = 0.05f;
+        private const double NoiseSigma = 0.02;
+        private const double StarSigmaPx = 2.5;
+        private const double StarPeak = 0.7;
+        private const int StarSpacingPx = 102;
+        private const int StarMarginPx = 56;
+
+        public static async Task Run(string[] args) {
+            var sizesArg = DiagnosticUtil.GetArg(args, "--sizes") ?? "6248x4176,3008x3008";
+            var layersArg = DiagnosticUtil.GetArg(args, "--layers") ?? "4,6,8";
+            var itersArg = DiagnosticUtil.GetArg(args, "--iters") ?? "3";
+            var implsArg = DiagnosticUtil.GetArg(args, "--impls") ?? "legacy,fast,fast1t,fused";
+            var seedArg = DiagnosticUtil.GetArg(args, "--seed") ?? "42";
+            bool detect = DiagnosticUtil.HasFlag(args, "--detect");
+
+            var sizes = new List<(int Width, int Height)>();
+            foreach (var token in sizesArg.Split(',', StringSplitOptions.RemoveEmptyEntries)) {
+                var parts = token.Split('x');
+                if (parts.Length != 2
+                    || !int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var w)
+                    || !int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var h)
+                    || w <= 0 || h <= 0) {
+                    Console.Error.WriteLine($"Bad --sizes token: {token} (expected WxH)");
+                    Environment.ExitCode = 2;
+                    return;
+                }
+                sizes.Add((w, h));
+            }
+            var layersList = layersArg.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                .Select(s => int.Parse(s, CultureInfo.InvariantCulture)).ToList();
+            int iters = int.Parse(itersArg, CultureInfo.InvariantCulture);
+            int seed = int.Parse(seedArg, CultureInfo.InvariantCulture);
+            var impls = new HashSet<string>(implsArg.Split(',', StringSplitOptions.RemoveEmptyEntries), StringComparer.OrdinalIgnoreCase);
+
+            Console.WriteLine($"ProcessorCount={Environment.ProcessorCount}, Vector<float>.Count={Vector<float>.Count}, " +
+                              $"Vector.IsHardwareAccelerated={Vector.IsHardwareAccelerated}, GC={(System.Runtime.GCSettings.IsServerGC ? "server" : "workstation")}");
+
+            foreach (var (width, height) in sizes) {
+                Console.WriteLine();
+                Console.WriteLine($"== {width}x{height} ({width * (long)height / 1_000_000.0:F1} MP) ==");
+                using var field = BuildStarField(width, height, seed);
+
+                foreach (var layers in layersList) {
+                    var line = $"layers={layers}";
+                    double legacyMs = double.NaN;
+                    Mat legacyResidual = null;
+                    Mat fastResidual = null;
+                    try {
+                        if (impls.Contains("legacy")) {
+                            legacyMs = TimeMedian(() => {
+                                legacyResidual?.Dispose();
+                                legacyResidual = CvImageUtility.ComputeResidualAtrousB3SplineDyadicWaveletLayer(field, layers);
+                            }, iters);
+                            line += $"  legacy={legacyMs,9:F1} ms";
+                        }
+                        if (impls.Contains("fast")) {
+                            var fastMs = TimeMedian(() => {
+                                fastResidual?.Dispose();
+                                fastResidual = AtrousWaveletFast.ComputeResidual(field, layers);
+                            }, iters);
+                            line += $"  fast={fastMs,7:F1} ms";
+                            if (!double.IsNaN(legacyMs)) {
+                                line += $" ({legacyMs / fastMs,5:F1}x)";
+                            }
+                        }
+                        if (impls.Contains("fast1t")) {
+                            var fast1tMs = TimeMedian(() => {
+                                using var r = AtrousWaveletFast.ComputeResidual(field, layers, parallelismKnob: 1);
+                            }, iters);
+                            line += $"  fast-1T={fast1tMs,8:F1} ms";
+                        }
+                        if (impls.Contains("fused")) {
+                            var cloneMs = TimeMedian(() => {
+                                using var c = field.Clone();
+                            }, iters);
+                            var fusedMs = TimeMedian(() => {
+                                using var work = field.Clone();
+                                AtrousWaveletFast.ComputeResidualAndSubtractInPlace(work, layers);
+                            }, iters) - cloneMs; // net of the per-iteration clone
+                            line += $"  fused={fusedMs,8:F1} ms";
+                        }
+                        if (legacyResidual != null && fastResidual != null) {
+                            line += $"  maxAbsDiff={MaxAbsDiff(legacyResidual, fastResidual):E2}";
+                        }
+                        Console.WriteLine(line);
+                    } finally {
+                        legacyResidual?.Dispose();
+                        fastResidual?.Dispose();
+                    }
+                }
+
+                if (detect) {
+                    foreach (var layers in layersList) {
+                        await RunDetectAb(field, layers, iters);
+                    }
+                }
+            }
+        }
+
+        private static async Task RunDetectAb(Mat field, int structureLayers, int iters) {
+            var legacyParams = MakeDetectParams(structureLayers, fastWavelets: false);
+            var fastParams = MakeDetectParams(structureLayers, fastWavelets: true);
+
+            var (legacyMs, legacyResult) = await TimeDetect(field, legacyParams, iters);
+            var (fastMs, fastResult) = await TimeDetect(field, fastParams, iters);
+
+            var legacyStars = legacyResult.DetectedStars ?? new List<Star>();
+            var fastStars = fastResult.DetectedStars ?? new List<Star>();
+            double maxCenterDelta = MatchStars(legacyStars, fastStars);
+            Console.WriteLine($"detect A/B layers={structureLayers}: legacy={legacyMs:F0} ms ({legacyStars.Count} stars) | fast={fastMs:F0} ms " +
+                              $"({fastStars.Count} stars) | speedup={legacyMs / fastMs:F2}x | " +
+                              $"maxMatchedCenterDelta={(double.IsNaN(maxCenterDelta) ? "UNMATCHED" : maxCenterDelta.ToString("E2"))}");
+        }
+
+        private static StarDetectorParams MakeDetectParams(int structureLayers, bool fastWavelets) => new StarDetectorParams {
+            ModelPSF = false,
+            NoiseClippingMultiplier = 4.0,
+            StructureLayers = structureLayers,
+            FastAtrousWavelets = fastWavelets,
+        };
+
+        private static async Task<(double MedianMs, HocusFocusStarDetectorResult Result)> TimeDetect(Mat field, StarDetectorParams p, int iters) {
+            var detector = new StarDetector(new AlglibAPI());
+            HocusFocusStarDetectorResult result = null;
+            var times = new List<double>();
+            for (int i = 0; i < iters + 1; ++i) { // first iteration is warmup
+                using var work = field.Clone(); // Detect mutates the input in place
+                GC.Collect();
+                var sw = Stopwatch.StartNew();
+                result = await detector.Detect(work, p, null, CancellationToken.None);
+                sw.Stop();
+                if (i > 0) {
+                    times.Add(sw.Elapsed.TotalMilliseconds);
+                }
+            }
+            times.Sort();
+            return (times[times.Count / 2], result);
+        }
+
+        /// <summary>Greedy nearest matching; returns max matched center distance, or NaN when counts differ
+        /// or a star has no counterpart within 1 px.</summary>
+        private static double MatchStars(List<Star> a, List<Star> b) {
+            if (a.Count != b.Count) {
+                return double.NaN;
+            }
+            var remaining = new List<Star>(b);
+            double maxDelta = 0.0;
+            foreach (var star in a) {
+                int bestIdx = -1;
+                double bestDist = double.MaxValue;
+                for (int i = 0; i < remaining.Count; ++i) {
+                    var dx = remaining[i].Center.X - star.Center.X;
+                    var dy = remaining[i].Center.Y - star.Center.Y;
+                    var dist = Math.Sqrt(dx * dx + dy * dy);
+                    if (dist < bestDist) {
+                        bestDist = dist;
+                        bestIdx = i;
+                    }
+                }
+                if (bestIdx < 0 || bestDist > 1.0) {
+                    return double.NaN;
+                }
+                maxDelta = Math.Max(maxDelta, bestDist);
+                remaining.RemoveAt(bestIdx);
+            }
+            return maxDelta;
+        }
+
+        private static double TimeMedian(Action action, int iters) {
+            action(); // warmup (JIT, page-in)
+            var times = new List<double>();
+            for (int i = 0; i < iters; ++i) {
+                GC.Collect();
+                var sw = Stopwatch.StartNew();
+                action();
+                sw.Stop();
+                times.Add(sw.Elapsed.TotalMilliseconds);
+            }
+            times.Sort();
+            return times[times.Count / 2];
+        }
+
+        private static unsafe double MaxAbsDiff(Mat a, Mat b) {
+            var pa = (float*)a.DataPointer;
+            var pb = (float*)b.DataPointer;
+            long stepA = a.Step() / sizeof(float);
+            long stepB = b.Step() / sizeof(float);
+            double maxDiff = 0.0;
+            for (int y = 0; y < a.Height; ++y) {
+                for (int x = 0; x < a.Width; ++x) {
+                    var diff = Math.Abs((double)pa[y * stepA + x] - pb[y * stepB + x]);
+                    if (diff > maxDiff) {
+                        maxDiff = diff;
+                    }
+                }
+            }
+            return maxDiff;
+        }
+
+        /// <summary>Deterministic synthetic star field: flat background + Gaussian star grid + Gaussian noise
+        /// (mirrors the test suite's StarDetectorEquivalence field construction).</summary>
+        private static unsafe Mat BuildStarField(int width, int height, int seed) {
+            var mat = new Mat(new Size(width, height), MatType.CV_32F, new Scalar(Background));
+            var p = (float*)mat.DataPointer;
+            long step = mat.Step() / sizeof(float);
+
+            int halfExtent = (int)Math.Ceiling(4 * StarSigmaPx);
+            for (int cy = StarMarginPx; cy < height - StarMarginPx; cy += StarSpacingPx) {
+                for (int cx = StarMarginPx; cx < width - StarMarginPx; cx += StarSpacingPx) {
+                    for (int y = Math.Max(0, cy - halfExtent); y <= Math.Min(height - 1, cy + halfExtent); ++y) {
+                        for (int x = Math.Max(0, cx - halfExtent); x <= Math.Min(width - 1, cx + halfExtent); ++x) {
+                            double dx = x - cx;
+                            double dy = y - cy;
+                            p[y * step + x] += (float)(StarPeak * Math.Exp(-(dx * dx + dy * dy) / (2 * StarSigmaPx * StarSigmaPx)));
+                        }
+                    }
+                }
+            }
+
+            // Box-Muller Gaussian noise, clamped to [0, 1]
+            var random = new Random(seed);
+            for (int y = 0; y < height; ++y) {
+                var row = p + y * step;
+                for (int x = 0; x < width; x += 2) {
+                    double u1 = 1.0 - random.NextDouble();
+                    double u2 = random.NextDouble();
+                    double mag = Math.Sqrt(-2.0 * Math.Log(u1));
+                    row[x] = Math.Clamp(row[x] + (float)(NoiseSigma * mag * Math.Cos(2.0 * Math.PI * u2)), 0.0f, 1.0f);
+                    if (x + 1 < width) {
+                        row[x + 1] = Math.Clamp(row[x + 1] + (float)(NoiseSigma * mag * Math.Sin(2.0 * Math.PI * u2)), 0.0f, 1.0f);
+                    }
+                }
+            }
+            return mat;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/TestApp/Program.cs
+++ b/Joko.NINA.Plugins/TestApp/Program.cs
@@ -244,6 +244,14 @@ namespace TestApp {
                 return;
             }
 
+            // Headless wavelet benchmark: `TestApp bench-wavelet [--sizes WxH,...] [--layers 4,6,8] ...`.
+            // Times the legacy dense-SepFilter2D à trous residual against AtrousWaveletFast (Mat-level and
+            // optional --detect end-to-end A/B on a synthetic star field). Needs no profile and no images.
+            if (args.Length > 0 && args[0].Equals("bench-wavelet", StringComparison.OrdinalIgnoreCase)) {
+                await BenchWaveletRunner.Run(args);
+                return;
+            }
+
             // Headless contamination diagnostic mode: `TestApp contamination --image <path> ...` (or any
             // invocation that passes --image). Otherwise fall through to the existing WPF GUI.
             bool diagnosticMode = args.Length > 0 &&

--- a/docs/atrous-wavelet-fast-design.md
+++ b/docs/atrous-wavelet-fast-design.md
@@ -1,0 +1,153 @@
+# Fast à trous wavelet for structure detection — design & experiment results
+
+## Problem
+
+`WaveletCalculation` — the structure-removal à trous B3-spline residual (`StarDetector` step 4) — is the
+single most expensive stage of star detection: **~44% of a whole `Detect`** on a large sensor (2.1–2.5 s of a
+4.8–6.0 s frame; `docs/star-detection-optimizer-performance-design.md`), and its cost **doubles with every
+added StructureLayer** (F52 measured 27/46/117/254/526 s for layers 4→8 on a 9-frame run). Every production
+AF frame pays it, and every EARLY-context rebuild in the optimizer pays it again. The speedup idea was
+already on file as I1 ("early-stage internal parallelism") in `docs/star-detection-optimizer-speedup-results.md`.
+
+## Root cause
+
+`CvImageUtility.ComputeResidualAtrousB3SplineDyadicWaveletLayer` implements the à trous cascade by building,
+for layer *i*, a **dense zero-padded 1-D kernel** of length `2^(i+2)+1` (5, 9, 17, 33, 65, 129, 257, 513 …)
+and calling `Cv2.SepFilter2D` with it. Only **5 taps are ever non-zero** (the B3-spline weights
+`0.0625, 0.25, 0.375, 0.25, 0.0625` at offsets `0, ±2^i, ±2^(i+1)`); OpenCV convolves all the zeros. Per-pixel
+multiply-accumulates for a 6-layer cascade: `2×(5+9+17+33+65+129) = 516` versus the **60** the à trous
+structure actually needs — and OpenCV 4.6's `SepFilter2D` runs single-threaded here on top of that.
+
+## Approach chosen: sparse 5-tap dilated separable convolution (`AtrousWaveletFast`)
+
+`Utility/AtrousWaveletFast.cs` applies exactly the 5 non-zero taps per direction per layer:
+
+- **Constant work per layer** (~10 MACs/pixel/pass) regardless of dilation, so per-layer cost stops doubling.
+- **Two-pass separable** (horizontal then vertical) per layer with two ping-pong buffers, mirroring
+  `SepFilter2D`'s row-then-column float pipeline.
+- **SIMD** via `System.Numerics.Vector<float>` (256-bit on AVX2 hardware) for interiors; scalar borders.
+- **Multithreaded** with `Parallel.ForEach` over row ranges through the repo's `ParallelExecution` shared
+  scheduler (bounded to ProcessorCount alongside the two concurrent K-σ noise-estimate tasks), with the
+  standard parallelism-knob and CancellationToken plumbing.
+- **BORDER_REFLECT parity**: multi-bounce reflection matches `Cv2.BorderInterpolate(..., BorderTypes.Reflect)`
+  exactly (unit-tested for every length/offset combination the taps can produce).
+- **Deterministic**: every output pixel is computed independently with a fixed operation order shared by the
+  scalar and vector paths, so results are independent of thread count and SIMD width.
+- **Fused final subtract** (`ComputeResidualAndSubtractInPlace`): the production step is
+  `residual → SubtractInPlace(structureMap, residual)` (subtract + clamp = 3 more full-image passes). The
+  fused form writes `clamp(src − residual, 0, 1)` directly in the last vertical pass — no residual Mat, no
+  re-read. Used when debug intermediates are off; bit-identical to compute-then-subtract (unit-tested).
+
+### Numerical status vs legacy
+
+The tap-summation **order** differs from OpenCV's dense kernel loop, so results agree to float rounding but
+are **not bit-identical**: measured max abs diff ≤ ~1e-6 on [0,1] images across all tested size/layer
+combinations (tolerance 5e-6 asserted in tests; an indexing/border bug would show up orders of magnitude
+above that). Rounding-level structure-map differences can in principle flip a near-threshold binarization
+pixel, so the swap is gated:
+
+- `StarDetectorParams.FastAtrousWavelets` (**default OFF** while under validation) — production detection is
+  bit-identical with the flag off.
+- The flag is **EARLY-cache-keyed** (`StarDetector.EarlyCacheKeyProperties`) so optimizer contexts are never
+  reused across implementations.
+- End-to-end A/B on the deterministic equivalence field: **identical detection signatures** (stars, HFRs,
+  metrics, all rejection bounds) between legacy and fast paths. Star *measurement* reads the source image —
+  the wavelet only shapes candidate formation — so signature equality is the expected outcome, not luck.
+
+## Alternatives considered
+
+- **Single equivalent Gaussian blur** (the L-layer B3 cascade ≈ one Gaussian with
+  σ ≈ 1.05·√((4^L−1)/3)): rejected — a real algorithm change (different kernel shape, meaningfully different
+  residual), would move detection results, invalidating all calibrated settings for a speedup no better than
+  the sparse path.
+- **Polyphase/decimated pyramid** (compute per-coset with the base 5-tap kernel via strided sub-images):
+  mathematically identical, but OpenCV cannot view strided cosets without copies; the copy traffic costs more
+  than the sparse pass it replaces.
+- **OpenCL/UMat**: deployment variability (GPU drivers on end-user NINA machines) for a step that becomes
+  memory-bound anyway once the tap count is fixed.
+
+## Benchmark results
+
+Machine: 24 logical cores, AVX2 (`Vector<float>.Count=8`), workstation GC, Release build, median of 3
+iterations after warmup (`TestApp bench-wavelet --detect`). `fast` = residual only; `fused` = residual +
+subtract + clamp (the production step; compare against `legacy + SubtractInPlace`). `fast-1T` =
+`parallelismKnob: 1`, isolating the sparsity+SIMD gain from threading.
+
+**Mat-level residual, 6248×4176 (26.1 MP):**
+
+| StructureLayers | legacy (SepFilter2D) | fast | speedup | fast-1T | fused | maxAbsDiff |
+|---|---|---|---|---|---|---|
+| 4 | 130 ms | 52 ms | **2.5×** | 82 ms | 76 ms | 3.0e-8 |
+| 6 | 781 ms | 81 ms | **9.7×** | 111 ms | 81 ms | 1.5e-8 |
+| 8 | 4267 ms | 107 ms | **40×** | 154 ms | 105 ms | 1.5e-8 |
+
+**Mat-level residual, 3008×3008 (9.0 MP):** layers 4: 43→19 ms (2.3×); layers 6: 206→28 ms (7.5×);
+layers 8: 1297→37 ms (35.6×). Same ≤3e-8 max abs diff.
+
+Legacy cost doubles per layer (the F52 curve); the fast path is nearly flat (52→81→107 ms for 4→6→8
+layers). Even single-threaded, the sparse SIMD path beats legacy at every layer count, so the win does not
+depend on core count. Both passes stream at memory bandwidth once the tap count is fixed, which is why 24
+threads only add ~1.5× over one thread — and why `fused` ≈ `fast` despite doing the subtract for free.
+
+**Detect-level A/B, 26.1 MP, ~2400-star synthetic grid** (ModelPSF off, NoiseClippingMultiplier 4.0):
+
+| StructureLayers | legacy detect | fast detect | speedup | star results |
+|---|---|---|---|---|
+| 4 | 661 ms | 648 ms | 1.02× | identical (Δcenter = 0.0) |
+| 6 | 1272 ms | 670 ms | **1.90×** | identical (Δcenter = 0.0) |
+| 8 | 4718 ms | 738 ms | **6.4×** | identical (Δcenter = 0.0) |
+
+Two things to read out of the detect table:
+
+- **Whole-detect time becomes nearly layer-independent** (648/670/738 ms): the wavelet stops being the
+  dominant knob, so the F52 "~2× wall per StructureLayer" guidance (and the optimizer's incentive to avoid
+  high-layer probes) no longer describes the flag-on pipeline.
+- At the **default 4 layers on this 24-core machine** the end-to-end gain is small because the wavelet
+  already overlaps the two concurrent K-σ noise-estimate tasks; the machines that motivated this work (the
+  bank machine measured 2.1–2.5 s of wavelet in a 4.8–6.0 s detect) have far less headroom, and donut mode
+  (effective 6 layers) and optimizer EARLY rebuilds (up to 8+boost layers) hit the steep part of the legacy
+  curve where the measured gains are 1.9–6.4× end-to-end.
+
+## Validation
+
+- `AtrousWaveletFastTests` (15 tests): numeric equivalence vs legacy across sizes/layers incl. tiny
+  multi-bounce borders and odd (non-SIMD-multiple) widths; exact `Reflect` parity with OpenCV; source
+  not modified; determinism across runs and parallelism; fused-subtract bit-identity; NaN-pixel clamp
+  parity between SIMD lanes and scalar tail; end-to-end detection signature parity; EARLY-key
+  classification.
+- Full unit test suite: 3688 tests passed, 0 failures (re-run green after the review fixes below).
+- Adversarial multi-agent review (3 dimensions → per-finding verification): 6 findings raised, 5 confirmed
+  and fixed. The two substantive ones:
+  - **Cancellation race (critical, fixed):** the first cut passed the detection CancellationToken into the
+    wavelet's `Parallel.ForEach`, creating a NEW cancellation point inside the window where the two K-σ
+    noise-estimate tasks still read `srcImage`/`noiseReducedImage` — an OCE unwind would dispose those Mats
+    under the running tasks (native use-after-free). Fixed by not passing the token there: like the legacy
+    path, the ~100 ms window is non-cancellable and the token is honored at the pre-existing points after
+    the task awaits. Any future cancellation point added between the task launches and their awaits must
+    first join those tasks.
+  - **NaN clamp divergence (minor, fixed):** the fused subtract's scalar tail used `Math.Min/Max` (NaN
+    propagates) while the SIMD lanes and the legacy `Cv2.Max/Min` clamp map NaN → 0, making output depend
+    on column position and vector width for NaN inputs (reachable only via raw float `Detect(Mat)` inputs,
+    e.g. TestApp replay of a float FITS). Scalar tail now uses the comparison-based clamp.
+- **Not yet done (needs the machine with `D:\Autofocus Bank`):** `bank-verify` regression across the 22-run
+  bank comparing flag OFF vs ON (recall/precision/J deltas expected ≈ 0, same criterion as past
+  rounding-level changes). Recommended before flipping the default ON.
+
+## Rollout recommendation
+
+1. Land flag-gated (default OFF) — zero production impact, available to the bench harness and tests.
+2. Run the AF-bank validation (flag ON vs OFF) on the bank machine; expect no metric movement beyond
+   run-to-run noise.
+3. Flip the default ON (or remove the legacy path + flag outright — no persisted option was added, so no
+   Options UI is involved) and update the F52 "~2× per layer" wizard guidance, which stops being true:
+   with the sparse path, per-layer cost is flat, so `DefocusAwareStructure` boosts and higher
+   `StructureLayers` stop being the optimizer's dominant wall-clock knob.
+
+## Follow-up opportunities (measured, not yet implemented)
+
+- `BinarizationStatistics` (~21% of detect) and the K-σ noise estimates become the new critical path once
+  the wavelet shrinks; the K-σ tasks already overlap the wavelet, so end-to-end gains are smaller than the
+  44% share suggests. A log-histogram K-σ (noted in `CvImageUtility.KappaSigmaNoiseEstimate`) is the next
+  candidate.
+- `PostWaveletConvolution` (~3%) still uses a dense `SepFilter2D` Gaussian; the same pass infrastructure
+  could absorb it if it ever matters.

--- a/docs/atrous-wavelet-fast-design.md
+++ b/docs/atrous-wavelet-fast-design.md
@@ -41,18 +41,23 @@ structure actually needs — and OpenCV 4.6's `SepFilter2D` runs single-threaded
 ### Numerical status vs legacy
 
 The tap-summation **order** differs from OpenCV's dense kernel loop, so results agree to float rounding but
-are **not bit-identical**: measured max abs diff ≤ ~1e-6 on [0,1] images across all tested size/layer
+are **not bit-identical**: measured max abs diff ≤ 3e-8 on [0,1] images across all tested size/layer
 combinations (tolerance 5e-6 asserted in tests; an indexing/border bug would show up orders of magnitude
 above that). Rounding-level structure-map differences can in principle flip a near-threshold binarization
-pixel, so the swap is gated:
+pixel — empirically they never moved a single star in any A/B (below).
 
-- `StarDetectorParams.FastAtrousWavelets` (**default OFF** while under validation) — production detection is
-  bit-identical with the flag off.
-- The flag is **EARLY-cache-keyed** (`StarDetector.EarlyCacheKeyProperties`) so optimizer contexts are never
-  reused across implementations.
-- End-to-end A/B on the deterministic equivalence field: **identical detection signatures** (stars, HFRs,
-  metrics, all rejection bounds) between legacy and fast paths. Star *measurement* reads the source image —
-  the wavelet only shapes candidate formation — so signature equality is the expected outcome, not luck.
+**The swap shipped outright** (no flag, no branch): production detection always uses `AtrousWaveletFast`,
+through the repo's sanctioned mechanism for output-affecting changes — a `StarDetector.StarDetectorVersion`
+bump (1 → 2), which invalidates saved detection-result caches so replays gracefully re-detect. The legacy
+implementation is retained in `CvImageUtility` **only** as the independent oracle for the equivalence tests
+and the `bench-wavelet` comparison. (An earlier cut gated this behind a `StarDetectorParams.FastAtrousWavelets`
+flag with EARLY-cache-keying; it was removed in favor of the version bump once the A/B evidence was in.)
+
+A/B evidence gathered while both paths were wired into detection: on the deterministic equivalence field and
+on 26 MP synthetic grids at layers 4/6/8, **identical detection signatures** (stars, HFRs, metrics, all
+rejection bounds; matched center deltas exactly 0.0). Star *measurement* reads the source image — the wavelet
+only shapes candidate formation — so signature equality is the expected outcome, not luck. The
+`StarDetectorEquivalenceTests` golden signatures now pin the fast path permanently.
 
 ## Alternatives considered
 
@@ -110,12 +115,13 @@ Two things to read out of the detect table:
 
 ## Validation
 
-- `AtrousWaveletFastTests` (15 tests): numeric equivalence vs legacy across sizes/layers incl. tiny
-  multi-bounce borders and odd (non-SIMD-multiple) widths; exact `Reflect` parity with OpenCV; source
+- `AtrousWaveletFastTests` (13 tests): numeric equivalence vs the retained oracle across sizes/layers incl.
+  tiny multi-bounce borders and odd (non-SIMD-multiple) widths; exact `Reflect` parity with OpenCV; source
   not modified; determinism across runs and parallelism; fused-subtract bit-identity; NaN-pixel clamp
-  parity between SIMD lanes and scalar tail; end-to-end detection signature parity; EARLY-key
-  classification.
-- Full unit test suite: 3688 tests passed, 0 failures (re-run green after the review fixes below).
+  parity between SIMD lanes and scalar tail. Detection-level pinning: the `StarDetectorEquivalenceTests`
+  golden signatures, which now run through the fast path unchanged.
+- Full unit test suite green after the swap (3685 tests, 0 failures; also green after the review fixes
+  below), including the golden-signature detection pins now exercising the fast path.
 - Adversarial multi-agent review (3 dimensions → per-finding verification): 6 findings raised, 5 confirmed
   and fixed. The two substantive ones:
   - **Cancellation race (critical, fixed):** the first cut passed the detection CancellationToken into the
@@ -129,19 +135,22 @@ Two things to read out of the detect table:
     propagates) while the SIMD lanes and the legacy `Cv2.Max/Min` clamp map NaN → 0, making output depend
     on column position and vector width for NaN inputs (reachable only via raw float `Detect(Mat)` inputs,
     e.g. TestApp replay of a float FITS). Scalar tail now uses the comparison-based clamp.
-- **Not yet done (needs the machine with `D:\Autofocus Bank`):** `bank-verify` regression across the 22-run
-  bank comparing flag OFF vs ON (recall/precision/J deltas expected ≈ 0, same criterion as past
-  rounding-level changes). Recommended before flipping the default ON.
+- **Not yet done (needs the machine with `D:\Autofocus Bank`):** the post-merge `bank-verify` sanity check
+  described under "Rollout" (recall/precision/J deltas vs pre-swap baselines expected ≈ 0, same criterion as
+  past rounding-level changes).
 
-## Rollout recommendation
+## Rollout (done) and follow-through
 
-1. Land flag-gated (default OFF) — zero production impact, available to the bench harness and tests.
-2. Run the AF-bank validation (flag ON vs OFF) on the bank machine; expect no metric movement beyond
-   run-to-run noise.
-3. Flip the default ON (or remove the legacy path + flag outright — no persisted option was added, so no
-   Options UI is involved) and update the F52 "~2× per layer" wizard guidance, which stops being true:
-   with the sparse path, per-layer cost is flat, so `DefocusAwareStructure` boosts and higher
-   `StructureLayers` stop being the optimizer's dominant wall-clock knob.
+1. **Swapped outright** with a `StarDetectorVersion` 1 → 2 bump; legacy retained only as the test/bench
+   oracle. No persisted option was added, so no Options UI is involved.
+2. **F52 cost narration retired:** the wizard's "searching N structure layers deeper costs roughly 2^N× per
+   evaluation" note (`OptimizationProgress.CostNote` → `ProgressCostNote` → its XAML row) was removed —
+   per-layer cost is now nearly flat, so the note's premise is gone. The F52 progress cadence,
+   elapsed/s-per-evaluation readout, and abort note all remain; the F52(c) abort-and-re-expose *advice*
+   remains blocked on F19 as before.
+3. **Post-merge sanity check (recommended, needs the machine with `D:\Autofocus Bank`):** a `bank-verify`
+   regression comparing against pre-swap baselines; expected movement ≈ 0 beyond run-to-run noise, same
+   criterion as past rounding-level changes.
 
 ## Follow-up opportunities (measured, not yet implemented)
 


### PR DESCRIPTION
## Problem

`WaveletCalculation` (structure-removal à trous residual, `StarDetector` step 4) is ~44% of a whole detect, and its cost **doubles per StructureLayer**: the legacy path convolves each layer with a dense zero-padded kernel of `2^(i+2)+1` taps (5…513) through `Cv2.SepFilter2D`, though only **5 taps are ever non-zero**. This is the F52 "~2× wall per layer" curve, and the already-filed-but-unimplemented speedup idea I1.

## Change

- **`Utility/AtrousWaveletFast.cs`** — sparse 5-tap dilated separable convolution (offsets `±2^i, ±2^(i+1)`): constant work per layer, `Vector<float>` SIMD, multithreaded via `ParallelExecution`, exact `BORDER_REFLECT` parity (incl. multi-bounce on tiny images), deterministic across thread count and vector width, plus a fused subtract+clamp final pass replacing the separate 3-pass `SubtractInPlace`. **Production detection now always uses it** — no flag, no branch.
- **`StarDetectorVersion` 1 → 2** — the paths agree to float rounding (≤3e-8) but are not bit-identical, so the swap ships through the repo's sanctioned mechanism for output-affecting changes; saved detection-result caches invalidate gracefully. The legacy implementation stays in `CvImageUtility` **only** as the oracle for the equivalence tests and `bench-wavelet`.
- **F52 cost note retired** — with per-layer cost nearly flat, the wizard's "searching N structure layers deeper costs roughly 2^N× per evaluation" narration lost its premise: `OptimizationProgress.CostNote`, `ProgressCostNote` + its XAML row, and their two tests are removed. Progress cadence, elapsed/s-per-evaluation, and the abort note remain; F52(c) advice stays blocked on F19.
- The wavelet window deliberately takes no CancellationToken (an OCE unwind there would dispose the Mats the two concurrent K-σ noise tasks are reading).
- **`TestApp bench-wavelet`** reproduces all numbers below; **`docs/atrous-wavelet-fast-design.md`** has the full analysis.

## Measured (26 MP, Release, 24-core AVX2)

| Layers | Residual: legacy → fast | Detect end-to-end | Star results |
|---|---|---|---|
| 4 (default) | 130 → 52 ms (2.5×) | 1.02× | identical (Δcenter = 0.0) |
| 6 (donut mode) | 781 → 81 ms (9.7×) | **1.9×** | identical (Δcenter = 0.0) |
| 8 (optimizer probes) | 4267 → 107 ms (**40×**) | **6.4×** | identical (Δcenter = 0.0) |

Detect wall time becomes nearly layer-independent (648/670/738 ms), so StructureLayers stops being the dominant wall-clock knob.

## Validation

- 13 `AtrousWaveletFastTests`: numeric equivalence vs the oracle across sizes/layers/borders, exact `Reflect` parity with `Cv2.BorderInterpolate`, determinism across parallelism, fused-subtract bit-identity, NaN clamp parity between SIMD lanes and scalar tail.
- Detection-level pinning: the `StarDetectorEquivalenceTests` golden signatures pass **unchanged** through the fast path; every A/B run while both paths were wired produced star-for-star identical results.
- Full suite: **3685 passed, 0 failures**.
- Adversarial multi-agent review: 6 findings, 5 confirmed and fixed (incl. a cancellation race the first cut introduced, and the NaN clamp divergence).

## Post-merge

Run `bank-verify` on the machine with `D:\Autofocus Bank` against pre-swap baselines — expected movement ≈ 0 beyond run-to-run noise (same criterion as past rounding-level changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnfDSRS7zCFV5zuVAkJyvk
